### PR TITLE
IC-128: First iteration of serving assets

### DIFF
--- a/src/idp_service/idp_service.did
+++ b/src/idp_service/idp_service.did
@@ -2,10 +2,23 @@ type UserId = nat64;
 type CredentialId = vec nat8;
 type Alias = text;
 type PublicKey = vec nat8;
+type HeaderField = record { text; text; };
+type HttpRequest = record {
+  method: text;
+  url: text;
+  headers: vec HeaderField;
+  body: blob;
+};
+type HttpResponse = record {
+  status_code: nat16;
+  headers: vec HeaderField;
+  body: blob;
+};
 
 service : {
   register : (UserId, Alias, PublicKey, opt CredentialId) -> ();
   add : (UserId, Alias, PublicKey, opt CredentialId) -> ();
   remove : (UserId, PublicKey) -> ();
   lookup : (UserId) -> (vec record {Alias; PublicKey; opt CredentialId}) query;
+  http_request: (request: HttpRequest) -> (HttpResponse) query;
 }


### PR DESCRIPTION
This adds a very first implementation of serving assets from the IdP canister. I'm using two hard-coded assets for now to be able to implement the basic pieces of the interface. It basically initializes a map of assets during `canister_init` and then exposes the `http_request` query function required for the HTTP gateway to ask for assets.

Work left for future PRs:
* This does not include the `StreamingStrategy` yet in the interface (see [here](https://www.notion.so/Design-HTTP-Requests-to-Canisters-d6bc980830a947a88bf9148a25169613) for what's a `StreamingStrategy`), I need to figure out how to do that in Rust in a way that Candid understands.
* Assets should be dynamically set during `canister_init`, likely as an input argument.

### Testing

To install the canister locally:

```
cd idp_service/src
dfx start --background
dfx canister create idp_service
dfx build idp_service
dfx canister install idp_service
```

Then you can ask for an asset:
```
dfx canister call idp_service http_request '(record {method="GET"; url="/sample-asset.txt"; headers=vec {}; body=vec{};})'
(
  record {
    1_092_319_906 = blob "This is a sample asset!\0a";
    1_661_489_734 = vec {};
    3_475_804_314 = 200;
  },
)
```

If an asset does not exist:
```
dfx canister call idp_service http_request '(record {method="GET"; url="/where-is-my-asset.txt"; headers=vec {}; body=vec{};})'
(
  record {
    1_092_319_906 = blob "Asset /where-is-my-asset.txt not found.";
    1_661_489_734 = vec {};
    3_475_804_314 = 404;
  },
)
```