### PR TITLE
implement hashing for delegations

### DIFF
--- a/src/idp_service/src/hash.rs
+++ b/src/idp_service/src/hash.rs
@@ -1,21 +1,22 @@
 //! Provides helper functions to calculate the representation independent hash of structured data.
+use hashtree::Hash;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::convert::AsRef;
 
 #[derive(Clone, Serialize, Deserialize)]
-enum Value {
-    Bytes(#[serde(with = "serde_bytes")] Vec<u8>),
-    String(String),
+pub enum Value<'a> {
+    Bytes(#[serde(with = "serde_bytes")] &'a [u8]),
+    String(&'a str),
     U64(u64),
-    Array(Vec<Value>),
+    Array(Vec<Value<'a>>),
 }
 
-#[allow(dead_code)]
-fn hash_of_map<S: ToString>(map: &BTreeMap<S, Value>) -> [u8; 32] {
+pub fn hash_of_map<S: AsRef<str>>(map: HashMap<S, Value>) -> Hash {
     let mut hashes: Vec<Vec<u8>> = Vec::new();
-    for (key, val) in map.iter() {
-        hashes.push(hash_key_val(key.to_string(), val.clone()));
+    for (key, val) in map.into_iter() {
+        hashes.push(hash_key_val(key.as_ref(), val));
     }
 
     // Computes hash by first sorting by "field name" hash, which is the
@@ -32,26 +33,26 @@ fn hash_of_map<S: ToString>(map: &BTreeMap<S, Value>) -> [u8; 32] {
     hasher.finalize().into()
 }
 
-fn hash_key_val(key: String, val: Value) -> Vec<u8> {
-    let mut key_hash = hash_string(key);
+fn hash_key_val(key: &str, val: Value<'_>) -> Vec<u8> {
+    let mut key_hash = hash_string(key).to_vec();
     let mut val_hash = hash_val(val);
-    key_hash.append(&mut val_hash);
+    key_hash.extend_from_slice(&mut val_hash[..]);
     key_hash
 }
 
-fn hash_string(value: String) -> Vec<u8> {
+fn hash_string(value: &str) -> Hash {
     let mut hasher = Sha256::new();
     hasher.update(value.as_bytes());
-    hasher.finalize().to_vec()
+    hasher.finalize().into()
 }
 
-fn hash_bytes(value: Vec<u8>) -> Vec<u8> {
+fn hash_bytes(value: &[u8]) -> Hash {
     let mut hasher = Sha256::new();
     hasher.update(&value);
-    hasher.finalize().to_vec()
+    hasher.finalize().into()
 }
 
-fn hash_u64(value: u64) -> Vec<u8> {
+fn hash_u64(value: u64) -> Hash {
     // We need at most ⌈ 64 / 7 ⌉ = 10 bytes to encode a 64 bit
     // integer in LEB128.
     let mut buf = [0u8; 10];
@@ -71,21 +72,21 @@ fn hash_u64(value: u64) -> Vec<u8> {
         }
     }
 
-    hash_bytes(buf[..=i].to_vec())
+    hash_bytes(&buf[..=i])
 }
 
 // Arrays encoded as the concatenation of the hashes of the encodings of the
 // array elements.
-fn hash_array(elements: Vec<Value>) -> Vec<u8> {
+fn hash_array(elements: Vec<Value<'_>>) -> Hash {
     let mut hasher = Sha256::new();
     elements
         .into_iter()
         // Hash the encoding of all the array elements.
-        .for_each(|e| hasher.update(hash_val(e).as_slice()));
-    hasher.finalize().to_vec() // hash the concatenation of the hashes.
+        .for_each(|e| hasher.update(&hash_val(e)[..]));
+    hasher.finalize().into() // hash the concatenation of the hashes.
 }
 
-fn hash_val(val: Value) -> Vec<u8> {
+fn hash_val(val: Value<'_>) -> Hash {
     match val {
         Value::String(string) => hash_string(string),
         Value::Bytes(bytes) => hash_bytes(bytes),
@@ -102,10 +103,7 @@ mod tests {
     #[test]
     fn message_id_icf_key_val_reference_1() {
         assert_eq!(
-            hash_key_val(
-                "request_type".to_string(),
-                Value::String("call".to_string())
-            ),
+            hash_key_val("request_type", Value::String("call")),
             hex!(
                 "
                 769e6f87bdda39c859642b74ce9763cdd37cb1cd672733e8c54efaa33ab78af9
@@ -140,7 +138,7 @@ mod tests {
     #[test]
     fn message_id_string_reference_1() {
         assert_eq!(
-            hash_string("request_type".to_string()),
+            hash_string("request_type"),
             hex!("769e6f87bdda39c859642b74ce9763cdd37cb1cd672733e8c54efaa33ab78af9"),
         );
     }
@@ -148,7 +146,7 @@ mod tests {
     #[test]
     fn message_id_string_reference_2() {
         assert_eq!(
-            hash_string("call".to_string()),
+            hash_string("call"),
             hex!("7edb360f06acaef2cc80dba16cf563f199d347db4443da04da0c8173e3f9e4ed"),
         );
     }
@@ -156,7 +154,7 @@ mod tests {
     #[test]
     fn message_id_string_reference_3() {
         assert_eq!(
-            hash_string("callee".to_string()),
+            hash_string("callee"),
             hex!("92ca4c0ced628df1e7b9f336416ead190bd0348615b6f71a64b21d1b68d4e7e2"),
         );
     }
@@ -164,7 +162,7 @@ mod tests {
     #[test]
     fn message_id_string_reference_4() {
         assert_eq!(
-            hash_string("method_name".to_string()),
+            hash_string("method_name"),
             hex!("293536232cf9231c86002f4ee293176a0179c002daa9fc24be9bb51acdd642b6"),
         );
     }
@@ -172,7 +170,7 @@ mod tests {
     #[test]
     fn message_id_string_reference_5() {
         assert_eq!(
-            hash_string("hello".to_string()),
+            hash_string("hello"),
             hex!("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"),
         );
     }
@@ -180,7 +178,7 @@ mod tests {
     #[test]
     fn message_id_string_reference_6() {
         assert_eq!(
-            hash_string("arg".to_string()),
+            hash_string("arg"),
             hex!("b25f03dedd69be07f356a06fe35c1b0ddc0de77dcd9066c4be0c6bbde14b23ff"),
         );
     }
@@ -188,7 +186,7 @@ mod tests {
     #[test]
     fn message_id_array_reference_1() {
         assert_eq!(
-            hash_array(vec![Value::String("a".to_string())]),
+            hash_array(vec![Value::String("a")]),
             // hash(hash("a"))
             hex!("bf5d3affb73efd2ec6c36ad3112dd933efed63c4e1cbffcfa88e2759c144f2d8"),
         );
@@ -197,10 +195,7 @@ mod tests {
     #[test]
     fn message_id_array_reference_2() {
         assert_eq!(
-            hash_array(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string()),
-            ]),
+            hash_array(vec![Value::String("a"), Value::String("b"),]),
             // hash(concat(hash("a"), hash("b"))
             hex!("e5a01fee14e0ed5c48714f22180f25ad8365b53f9779f79dc4a3d7e93963f94a"),
         );
@@ -210,8 +205,8 @@ mod tests {
     fn message_id_array_reference_3() {
         assert_eq!(
             hash_array(vec![
-                Value::Bytes(vec![97]), // "a" as a byte string.
-                Value::String("b".to_string()),
+                Value::Bytes(&[97][..]), // "a" as a byte string.
+                Value::String("b"),
             ]),
             // hash(concat(hash("a"), hash("b"))
             hex!("e5a01fee14e0ed5c48714f22180f25ad8365b53f9779f79dc4a3d7e93963f94a"),
@@ -221,7 +216,7 @@ mod tests {
     #[test]
     fn message_id_array_reference_4() {
         assert_eq!(
-            hash_array(vec![Value::Array(vec![Value::String("a".to_string())])]),
+            hash_array(vec![Value::Array(vec![Value::String("a")])]),
             // hash(hash(hash("a"))
             hex!("eb48bdfa15fc43dbea3aabb1ee847b6e69232c0f0d9705935e50d60cce77877f"),
         );
@@ -231,8 +226,8 @@ mod tests {
     fn message_id_array_reference_5() {
         assert_eq!(
             hash_array(vec![Value::Array(vec![
-                Value::String("a".to_string()),
-                Value::String("b".to_string())
+                Value::String("a"),
+                Value::String("b")
             ])]),
             // hash(hash(concat(hash("a"), hash("b")))
             hex!("029fd80ca2dd66e7c527428fc148e812a9d99a5e41483f28892ef9013eee4a19"),
@@ -243,11 +238,8 @@ mod tests {
     fn message_id_array_reference_6() {
         assert_eq!(
             hash_array(vec![
-                Value::Array(vec![
-                    Value::String("a".to_string()),
-                    Value::String("b".to_string())
-                ]),
-                Value::Bytes(vec![97]), // "a" in bytes
+                Value::Array(vec![Value::String("a"), Value::String("b")]),
+                Value::Bytes(&[97][..]), // "a" in bytes
             ]),
             // hash(concat(hash(concat(hash("a"), hash("b")), hash(100))
             hex!("aec3805593d9ec6df50da070597f73507050ce098b5518d0456876701ada7bb7"),
@@ -259,7 +251,7 @@ mod tests {
         assert_eq!(
             // D    I    D    L    \0   \253 *"
             // 68   73   68   76   0    253  42
-            hash_bytes(vec![68, 73, 68, 76, 0, 253, 42]),
+            hash_bytes(&[68, 73, 68, 76, 0, 253, 42][..]),
             hex!("6c0b2ae49718f6995c02ac5700c9c789d7b7862a0d53e6d40a73f1fcd2f70189")
         );
     }

--- a/src/idp_service/src/main.rs
+++ b/src/idp_service/src/main.rs
@@ -200,4 +200,21 @@ fn init() {
     });
 }
 
+#[allow(dead_code)]
+fn delegation_hash(d: &Delegation) -> Hash {
+    use hash::{hash_of_map, Value};
+
+    let mut m = HashMap::new();
+    m.insert("pubkey", Value::Bytes(d.pubkey.as_slice()));
+    m.insert("expiration", Value::U64(d.expiration));
+    if let Some(targets) = d.targets.as_ref() {
+        let mut arr = Vec::with_capacity(targets.len());
+        for t in targets.iter() {
+            arr.push(Value::Bytes(t.as_ref()));
+        }
+        m.insert("targets", Value::Array(arr));
+    }
+    hash_of_map(m)
+}
+
 fn main() {}


### PR DESCRIPTION
This change gets rid of some unnecessary allocations in the hash module
and implements a function computing hash of a delegation.