### PR TITLE
.did file: Use blob, not `vec nat8`

### DIFF
--- a/src/idp_service/idp_service.did
+++ b/src/idp_service/idp_service.did
@@ -1,8 +1,8 @@
 type UserId = nat64;
-type CredentialId = vec nat8;
+type CredentialId = blob;
 type Alias = text;
 type Timestamp = nat64;
-type PublicKey = vec nat8;
+type PublicKey = blob;
 type HeaderField = record { text; text; };
 type HttpRequest = record {
   method: text;


### PR DESCRIPTION
they are compatible in terms of Candid interfaces, but using `blob`
tends lead to better results when importing the `.did` file (e.g. in
Motoko or Haskell, potentially also TypeScript/JavaScript)