### PR TITLE
Avoid double hashing of in delegation_signature_msg

### DIFF
--- a/src/idp_service/build.sh
+++ b/src/idp_service/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 IDP_DIR="$(dirname "$0")"
 TARGET="wasm32-unknown-unknown"
 

--- a/src/idp_service/src/main.rs
+++ b/src/idp_service/src/main.rs
@@ -1,6 +1,5 @@
-use hash::hash_bytes;
 use hashtree::{Hash, HashTree};
-use ic_cdk::api::{caller, data_certificate, set_certified_data, time};
+use ic_cdk::api::{data_certificate, set_certified_data, time, trap};
 use ic_cdk::export::candid::{CandidType, Deserialize, Principal};
 use ic_cdk::storage::{stable_restore, stable_save};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};


### PR DESCRIPTION
The “payload” according to the spec is the concatenation of the domain
separator and the raw signature. `delegation_signature_msg` was already
hashing, so let’s not hash again.

(It probably was like this before I verschlimmbessert Roman’s PR, sorry
for that.)