### PR TITLE
Adds script to run the backend test

### DIFF
--- a/run-backend-tests.sh
+++ b/run-backend-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+#
+# This script runs the backend tests against the backend.
+# Does not build the wasm to for you, please build when needed
+# This uses nix and the nix cache to fetch the build script for you.
+# Normally, nothing should be built by this command.
+#
+
+echo "Running against ./target/wasm32-unknown-unknown/release/idp_service.wasm"
+echo "Did you build? If not, Ctrl-C and run ./src/idp_service/build.sh now!"
+
+nix run '((import (builtins.fetchGit { url = "git@github.com:dfinity-lab/ic-ref"; ref = "joachim/ic-idp-tester";}) {}).ic-ref)' -c ic-idp-test --wasm ./target/wasm32-unknown-unknown/release/idp_service.wasm "$@"


### PR DESCRIPTION
```
~/dfinity/idp-service $ ./run-backend-tests.sh  -p credential
Running against ./target/wasm32-unknown-unknown/release/idp_service.wasm
Did you build? If not, Ctrl-C and run ./src/idp_service/build.sh now!
Tests
  without upgrading
    register and lookup (with credential id): OK (0.31s)
  with upgrading
    register and lookup (with credential id): OK (8.87s)

All 2 tests passed (9.19s)
```