### PR TITLE
[IC-155] prune canister signatures after 10 min

### DIFF
--- a/src/idp_service/src/main.rs
+++ b/src/idp_service/src/main.rs
@@ -9,6 +9,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 
 const DEFAULT_EXPIRATION_PERIOD_NS: u64 = 31_536_000_000_000_000;
+const DEFAULT_SIGNATURE_EXPIRATION_PERIOD_NS: u64 = 600_000_000_000;
 
 type UserId = u64;
 type CredentialId = Vec<u8>;
@@ -80,6 +81,9 @@ fn register(user_id: UserId, alias: Alias, pk: PublicKey, credential_id: Option<
         if m.get(&user_id).is_some() {
             trap("This user is already registered");
         }
+
+        prune_expired_signatures(&mut s.sigs.borrow_mut());
+
         let expiration = time() as u64 + DEFAULT_EXPIRATION_PERIOD_NS;
         m.insert(
             user_id,
@@ -101,11 +105,13 @@ fn add(user_id: UserId, alias: Alias, pk: PublicKey, credential: Option<Credenti
                     e.2 = expiration;
                     e.3 = credential;
                     add_signature(&mut s.sigs.borrow_mut(), user_id, pk, expiration);
+                    prune_expired_signatures(&mut s.sigs.borrow_mut());
                     return;
                 }
             }
             entries.push((alias, pk.clone(), expiration, credential));
             add_signature(&mut s.sigs.borrow_mut(), user_id, pk, expiration);
+            prune_expired_signatures(&mut s.sigs.borrow_mut());
         } else {
             trap("This user is not registered yet");
         }
@@ -115,6 +121,8 @@ fn add(user_id: UserId, alias: Alias, pk: PublicKey, credential: Option<Credenti
 #[update]
 fn remove(user_id: UserId, pk: PublicKey) {
     STATE.with(|s| {
+        prune_expired_signatures(&mut s.sigs.borrow_mut());
+
         let mut remove_user = false;
         if let Some(entries) = s.map.borrow_mut().get_mut(&user_id) {
             if let Some(i) = entries.iter().position(|e| e.1 == pk) {
@@ -211,14 +219,9 @@ fn retrieve_data() {
                 // Restore user map.
                 s.map.replace(map);
 
-                // Recompute the signatures based on the user map.
-                let mut sigs = SignatureMap::default();
-                for (user_id, entries) in s.map.borrow().iter() {
-                    for (_, pk, expiration, _) in entries.iter() {
-                        add_signature(&mut sigs, *user_id, pk.clone(), *expiration);
-                    }
-                }
-                s.sigs.replace(sigs);
+                // We drop all the signatures on upgrade, users will
+                // re-request them if needed.
+                update_root_hash(&s.sigs.borrow());
             });
         }
         Err(err) => ic_cdk::trap(&format!(
@@ -228,7 +231,7 @@ fn retrieve_data() {
     }
 }
 
-fn seed_hash(user_id: UserId) -> Hash {
+fn hash_seed(user_id: UserId) -> Hash {
     hash::hash_string(user_id.to_string().as_str())
 }
 
@@ -266,7 +269,7 @@ fn get_signature(
         expiration,
         targets: None,
     });
-    let witness = sigs.witness(seed_hash(user_id), msg_hash)?;
+    let witness = sigs.witness(hash_seed(user_id), msg_hash)?;
     let tree = HashTree::Labeled(&b"sig"[..], Box::new(witness));
 
     #[derive(Serialize)]
@@ -290,7 +293,8 @@ fn add_signature(sigs: &mut SignatureMap, user_id: UserId, pk: PublicKey, expira
         expiration,
         targets: None,
     });
-    sigs.put(seed_hash(user_id), msg_hash);
+    let expires_at = time() as u64 + DEFAULT_SIGNATURE_EXPIRATION_PERIOD_NS;
+    sigs.put(hash_seed(user_id), msg_hash, expires_at);
     update_root_hash(&sigs);
 }
 
@@ -305,8 +309,22 @@ fn remove_signature(
         expiration,
         targets: None,
     });
-    sigs.delete(seed_hash(user_id), msg_hash);
+    sigs.delete(hash_seed(user_id), msg_hash);
     update_root_hash(sigs);
+}
+
+/// Removes a batch of expired signatures from the signature map.
+///
+/// This function is supposed to piggy back on update calls to
+/// amortize the cost of tree pruning.  Each operation on the signature map
+/// will prune at most MAX_SIGS_TO_PRUNE other signatures.
+fn prune_expired_signatures(sigs: &mut SignatureMap) {
+    const MAX_SIGS_TO_PRUNE: usize = 10;
+    let num_pruned = sigs.prune_expired(time() as u64, MAX_SIGS_TO_PRUNE);
+
+    if num_pruned > 0 {
+        update_root_hash(sigs);
+    }
 }
 
 fn main() {}

--- a/src/idp_service/src/signature_map.rs
+++ b/src/idp_service/src/signature_map.rs
@@ -1,5 +1,6 @@
 use certified_map::{AsHashTree, RbTree};
 use hashtree::{leaf_hash, Hash, HashTree};
+use std::collections::BinaryHeap;
 
 struct Unit;
 
@@ -12,42 +13,92 @@ impl AsHashTree for Unit {
     }
 }
 
+#[derive(PartialEq, Eq)]
+struct SigExpiration {
+    expires_at: u64,
+    seed_hash: Hash,
+    msg_hash: Hash,
+}
+
+impl Ord for SigExpiration {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // BinaryHeap is a max heap, but we want expired entries
+        // first, hence the inversed order.
+        other.expires_at.cmp(&self.expires_at)
+    }
+}
+
+impl PartialOrd for SigExpiration {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
 #[derive(Default)]
-pub struct SignatureMap(RbTree<Hash, RbTree<Hash, Unit>>);
+pub struct SignatureMap {
+    certified_map: RbTree<Hash, RbTree<Hash, Unit>>,
+    expiration_queue: BinaryHeap<SigExpiration>,
+}
 
 impl SignatureMap {
-    pub fn put(&mut self, seed: Hash, message: Hash) {
-        if self.0.get(&seed[..]).is_none() {
+    pub fn put(&mut self, seed: Hash, message: Hash, signature_expires_at: u64) {
+        if self.certified_map.get(&seed[..]).is_none() {
             let mut submap = RbTree::new();
             submap.insert(message, Unit);
-            self.0.insert(seed, submap);
+            self.certified_map.insert(seed, submap);
         } else {
-            self.0.modify(&seed[..], |submap| {
+            self.certified_map.modify(&seed[..], |submap| {
                 submap.insert(message, Unit);
             });
         }
+        self.expiration_queue.push(SigExpiration {
+            seed_hash: seed,
+            msg_hash: message,
+            expires_at: signature_expires_at,
+        });
     }
 
     pub fn delete(&mut self, seed: Hash, message: Hash) {
         let mut is_empty = false;
-        self.0.modify(&seed[..], |m| {
+        self.certified_map.modify(&seed[..], |m| {
             m.delete(&message[..]);
             is_empty = m.is_empty();
         });
         if is_empty {
-            self.0.delete(&seed[..]);
+            self.certified_map.delete(&seed[..]);
         }
     }
 
+    pub fn prune_expired(&mut self, now: u64, max_to_prune: usize) -> usize {
+        let mut num_pruned = 0;
+
+        for _step in 0..max_to_prune {
+            if let Some(expiration) = self.expiration_queue.peek() {
+                if expiration.expires_at > now {
+                    return num_pruned;
+                }
+            }
+            if let Some(expiration) = self.expiration_queue.pop() {
+                self.delete(expiration.seed_hash, expiration.msg_hash);
+            }
+            num_pruned += 1;
+        }
+
+        num_pruned
+    }
+
     pub fn root_hash(&self) -> Hash {
-        self.0.root_hash()
+        self.certified_map.root_hash()
     }
 
     pub fn witness(&self, seed: Hash, message: Hash) -> Option<HashTree<'_>> {
-        self.0.get(&seed[..])?.get(&message[..])?;
+        self.certified_map.get(&seed[..])?.get(&message[..])?;
         let witness = self
-            .0
+            .certified_map
             .nested_witness(&seed[..], |nested| nested.witness(&message[..]));
         Some(witness)
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/src/idp_service/src/signature_map/test.rs
+++ b/src/idp_service/src/signature_map/test.rs
@@ -1,0 +1,69 @@
+use super::*;
+use hashtree::Hash;
+use sha2::{Digest, Sha256};
+
+fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_ref());
+    hasher.finalize().into()
+}
+
+fn seed(x: u64) -> Hash {
+    hash_bytes(x.to_be_bytes())
+}
+
+fn message(x: u64) -> Hash {
+    hash_bytes(x.to_le_bytes())
+}
+
+#[test]
+fn test_signature_lookup() {
+    let mut map = SignatureMap::default();
+    map.put(seed(1), message(1), 10);
+    assert_eq!(
+        map.witness(seed(1), message(1))
+            .expect("failed to get a witness")
+            .reconstruct(),
+        map.root_hash()
+    );
+    assert!(map.witness(seed(1), message(2)).is_none());
+    assert!(map.witness(seed(2), message(1)).is_none());
+
+    map.delete(seed(1), message(1));
+    assert!(map.witness(seed(1), message(1)).is_none());
+}
+
+#[test]
+fn test_signature_expiration() {
+    let mut map = SignatureMap::default();
+
+    map.put(seed(1), message(1), 10);
+    map.put(seed(1), message(2), 20);
+    map.put(seed(2), message(1), 15);
+    map.put(seed(2), message(2), 25);
+
+    assert_eq!(2, map.prune_expired(/*time now*/ 19, /*max_to_prune*/ 10));
+    assert!(map.witness(seed(1), message(1)).is_none());
+    assert!(map.witness(seed(2), message(1)).is_none());
+
+    assert!(map.witness(seed(1), message(2)).is_some());
+    assert!(map.witness(seed(2), message(2)).is_some());
+}
+
+#[test]
+fn test_signature_expiration_limit() {
+    let mut map = SignatureMap::default();
+
+    for i in 0..10 {
+        map.put(seed(i), message(i), 10 * i);
+    }
+
+    assert_eq!(5, map.prune_expired(/*time now*/ 100, /*max_to_prune*/ 5));
+
+    for i in 0..5 {
+        assert!(map.witness(seed(i), message(i)).is_none());
+    }
+    for i in 5..10 {
+        assert!(map.witness(seed(i), message(i)).is_some());
+    }
+}


### PR DESCRIPTION
This change adds code to limit the lifetime of signatures to
approximately 10min.

The cost of removal is amortized across updates: each update call will
do some cleanup of the signature tree. This way the prunning can
always keep up with the addition of new signatures while keeping the
cost of pruning quite low (if there is nothing to do, the pruning
executes only a few instructions).

This implementation requires extra memory to maintain a priority
queue, 72 bytes per signature.