### PR TITLE
Avoid using take since it's unstable for older rust versions

### DIFF
--- a/src/idp_service/src/main.rs
+++ b/src/idp_service/src/main.rs
@@ -199,7 +199,8 @@ fn init() {
 #[pre_upgrade]
 fn persist_data() {
     STATE.with(|s| {
-        if let Err(err) = stable_save((s.map.take(),)) {
+        let map = s.map.replace(Default::default());
+        if let Err(err) = stable_save((map,)) {
             ic_cdk::trap(&format!(
                 "An error occurred while saving data to stable memory: {}",
                 err


### PR DESCRIPTION
Using `take` results in an error in older rust versions (like the one we have on dfinity), so replacing it with the equivalent using `replace`.

Thanks to Islam for pointing it out.