### PR TITLE
trap if the data certificate is not available

### DIFF
--- a/src/idp_service/src/main.rs
+++ b/src/idp_service/src/main.rs
@@ -354,7 +354,9 @@ fn get_signature(
     pk: PublicKey,
     expiration: Timestamp,
 ) -> Option<Vec<u8>> {
-    let certificate = data_certificate()?;
+    let certificate = data_certificate().unwrap_or_else(|| {
+        trap("data certificate is only available in query calls");
+    });
     let msg_hash = delegation_signature_msg_hash(&Delegation {
         pubkey: pk,
         expiration,


### PR DESCRIPTION
DFX sends all call through the wallet canister by default, which makes
the data certificate unavailable.

This change makes idP canister trap if the certificate is not
available to simplify the troubleshooting if the signature is not
available.