### PR TITLE
Check frontend length

### DIFF
--- a/src/idp_service/src/main.rs
+++ b/src/idp_service/src/main.rs
@@ -513,7 +513,7 @@ fn check_entry_limits(device_data: &DeviceData) {
 }
 
 fn check_frontend_length(frontend: &FrontendHostname) {
-    const FRONTEND_HOSTNAME_LIMIT: usize = 256;
+    const FRONTEND_HOSTNAME_LIMIT: usize = 255;
 
     let n = frontend.len();
     if frontend.len() > FRONTEND_HOSTNAME_LIMIT {


### PR DESCRIPTION
This patch checks the frontend length and traps if it's more than 256 bytes (since we won't be able to encode it's length as a single byte for the seed calculation). It should be ok to add as reasonable nice names should fit well within 256 bytes.

Other conversions are fine I believe since:
1. seed (if we end up using it) is going to be 32 bytes.
2. user number ASCII encoding is less than 256 bytes (the max u64 is quite smaller than this)
3. the bitstring in der encoding, i.e. canister_id + seed, will be 32 (or is it 29?) + 32, so well below 256 as well.