### PR TITLE
Fix one OAUTH regression

### DIFF
--- a/src/frontend/src/utils/oath.ts
+++ b/src/frontend/src/utils/oath.ts
@@ -3,7 +3,6 @@ import {
   DelegationChain,
   WebAuthnIdentity,
   Delegation,
-  SignedDelegation,
   Ed25519PublicKey,
   Ed25519KeyIdentity,
 } from "@dfinity/identity";


### PR DESCRIPTION
before we’d just put garbage in the `accessToken`. Now it’s less
garbage, but the signatures still doesn’t validate.