### PR TITLE
certified_map: update data hash when the value is modified

### DIFF
--- a/src/certified_map/src/rbtree.rs
+++ b/src/certified_map/src/rbtree.rs
@@ -237,6 +237,8 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> RbTree<K, V> {
                 match key.cmp((*root).key.as_ref()) {
                     Equal => {
                         f(&mut (*root).value);
+                        let value_hash = (*root).value.root_hash();
+                        (*root).data_hash = labeled_hash((*root).key.as_ref(), &value_hash);
                         (*root).subtree_hash = Node::subtree_hash(root);
                         return;
                     }

--- a/src/certified_map/src/rbtree/test.rs
+++ b/src/certified_map/src/rbtree/test.rs
@@ -204,4 +204,8 @@ fn test_nested_witness() {
         }
         other => panic!("expected a labeled tree, got {:?}", other),
     }
+
+    rb.modify(b"top", |m| m.delete(b"bottom"));
+    let ht = rb.nested_witness(&b"top"[..], |v| v.witness(&b"bottom"[..]));
+    assert_eq!(ht.reconstruct(), rb.root_hash());
 }


### PR DESCRIPTION
This change fixes a nasty bug in modify: we (or rather I) weren't
updating the data hash appropriately after the value was modified.