### PR TITLE
sensible defaults so you don't always need to pass a canister id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # frontend code
 node_modules/
 dist/
+.env
 
 # Cargo build output
 target/

--- a/README.md
+++ b/README.md
@@ -74,3 +74,9 @@ dfx deploy
 Then, run `npm start` to start webpack-dev-server.
 
 Unit tests are tbd. They can be run with `npm run test`. To run tests throughout your development cycle, run `npm run test -- --watchAll` or use [wallaby.js](https://wallabyjs.com/) as a test-runner. Frontend tests are not required to pass at this time.
+
+To customize your canister ID for deployment or particular local development, create a `.env` file in the root of the project and add a `CANISTER_ID` attribute. It should look something like
+
+```
+CANISTER_ID=rrkah-fqaaa-aaaaa-aaaaq-cai
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "buffer": "6.0.3",
         "concurrently": "^6.0.2",
         "copy-webpack-plugin": "^8.1.1",
+        "dotenv": "^8.2.0",
         "events": "3.3.0",
         "express": "^4.17.1",
         "file-loader": "^6.2.0",
@@ -1353,6 +1354,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -3398,6 +3400,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -4769,6 +4772,15 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -4990,7 +5002,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -8214,6 +8227,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -19731,6 +19745,12 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "buffer": "6.0.3",
     "concurrently": "^6.0.2",
     "copy-webpack-plugin": "^8.1.1",
+    "dotenv": "^8.2.0",
     "events": "3.3.0",
     "express": "^4.17.1",
     "file-loader": "^6.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,22 +3,28 @@ const webpack = require("webpack");
 const CopyPlugin = require("copy-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const dfxJson = require("./dfx.json");
+require("dotenv").config();
+
+const localCanister = require("./.dfx/local/canister_ids.json").idp_service
+  .local;
 
 /**
  * Generate a webpack configuration for a canister.
  */
 function generateWebpackConfigForCanister(name, info) {
-  const devtool =
-    process.env.NODE_ENV === "production" ? undefined : "source-map";
+  const isProduction = process.env.NODE_ENV === "production";
+  const devtool = isProduction ? undefined : "source-map";
+
+  process.env.CANISTER_ID = process.env.CANISTER_ID ?? localCanister;
 
   return {
-    mode: process.env.NODE_ENV === "production" ? "production" : "development",
+    mode: isProduction ? "production" : "development",
     entry: {
       index: path.join(__dirname, "src", "frontend", "src", "index"),
     },
     devtool,
     optimization: {
-      minimize: process.env.NODE_ENV === "production",
+      minimize: isProduction,
       minimizer: [new TerserPlugin()],
     },
     resolve: {
@@ -71,9 +77,7 @@ function generateWebpackConfigForCanister(name, info) {
         Buffer: [require.resolve("buffer/"), "Buffer"],
         process: require.resolve("process/browser"),
       }),
-      new webpack.EnvironmentPlugin([
-        'CANISTER_ID'
-      ])
+      new webpack.EnvironmentPlugin(["CANISTER_ID"]),
     ],
   };
 }


### PR DESCRIPTION
It will attempt to read from dfx by default, but will accept `CANISTER_ID` from a `.env` file