### PR TITLE
Spec: Explain why we do _not_ use canister_inspect_message

### DIFF
--- a/docs/ic-idp-spec.adoc
+++ b/docs/ic-idp-spec.adoc
@@ -243,6 +243,22 @@ Together with the `UserKey` returned by `prepare_delegation`, the result of this
 
 This section, which is to be expanded, describes interesting design choices about the internals of the Internet Identity Service Canister. In particular
 
+=== Why we do not use `canister_inspect_message`
+
+The system allows canisters to inspect ingress messages before they are actually ingressed, and decide if they want to pay for them (see https://docs.dfinity.systems/public/#system-api-inspect-message[the interface spec]). Because the Internet Identity canisters run on the NNS subnet, cycles are not actually charged, but we still want to avoid wasting resources.
+
+It seems that this implies that we should use `canister_inspect_message` to reject messages that would, for example, not pass authentication.
+
+But upon closer inspection (heh), this is not actually useful.
+
+ * One justification for this mechanism would be if we expect a high number of accidentally invalid calls. But we have no reason to expect them at the moment.
+
+ * Another is to protect against a malicious actor. But that is only useful if the malicious actor doesn’t have an equally effective attack vector anyways, and in our case they do: If they want to flood the NNS with calls, they can use calls that do authenticate (e.g. keeping removing and adding devices, or preparing delegations); these calls would pass message inspection.
+
+On the flip side, implementing `canister_inspect_message` adds code, and thus a risk for bugs. In particular it increases the risk that some engineer might wrongly assume that the authentication checkin `canister_inspect_message` is sufficient and will not do it again the actual method, which could lead to a serious bug.
+
+Therefore the Internet Identity Canister intentionally does not implement `canister_inspect_message`.
+
 === Internal data model and data structures used
 
 The primary data structure used by the backend is a map from user number to the list of user devices.


### PR DESCRIPTION
as discussed with Björn