### PR TITLE
certified_map: do not cache data subtree

### DIFF
--- a/src/certified_map/src/rbtree.rs
+++ b/src/certified_map/src/rbtree.rs
@@ -92,11 +92,8 @@ impl<K: 'static + AsRef<[u8]>, V: AsHashTree + 'static> Node<K, V> {
     }
 
     unsafe fn data_hash(n: *mut Self) -> Hash {
-        if n.is_null() {
-            Empty.reconstruct()
-        } else {
-            labeled_hash((*n).key.as_ref(), &(*n).value.root_hash())
-        }
+        debug_assert!(!n.is_null());
+        labeled_hash((*n).key.as_ref(), &(*n).value.root_hash())
     }
 
     unsafe fn left_hash_tree<'a>(n: *mut Self) -> HashTree<'a> {


### PR DESCRIPTION
This change removes cached data_hash value from the node and
re-computes it on demand instead. Rationale:

  1. Our values are tiny, we don't gain much by storing the hash.
  2. We save heap space.
  3. This hash constantly causes troubles on tree modification
     because I keep forgetting to recompute it.

This time I forgot to update the the data hash in one of the rare
cases in delete() function.