### PR TITLE
signature map: add a test exercising random modifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,18 @@ checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -453,6 +464,7 @@ dependencies = [
  "ic-cdk",
  "ic-cdk-macros",
  "ic-types",
+ "rand",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -664,6 +676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d70072c20945e1ab871c472a285fc772aefd4f5407723c206242f2c6f94595d6"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +731,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,7 +782,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -984,6 +1042,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/src/idp_service/Cargo.toml
+++ b/src/idp_service/Cargo.toml
@@ -19,3 +19,4 @@ sha2 = "0.9.1"
 
 [dev-dependencies]
 hex-literal = "0.2.1"
+rand = "0.8.3"

--- a/src/idp_service/src/signature_map/test.rs
+++ b/src/idp_service/src/signature_map/test.rs
@@ -67,3 +67,44 @@ fn test_signature_expiration_limit() {
         assert!(map.witness(seed(i), message(i)).is_some());
     }
 }
+
+#[test]
+fn test_random_modifications() {
+    use rand::prelude::*;
+
+    let mut map = SignatureMap::default();
+    let mut rng = rand::thread_rng();
+    let window_size = 5;
+
+    let mut pairs = Vec::new();
+
+    for round in 1..100 {
+        let n_seeds = rng.gen_range(0..5);
+        for _i in 0..n_seeds {
+            let mut seed_hash = Hash::default();
+            rng.fill_bytes(&mut seed_hash);
+
+            let n_messages = rng.gen_range(0..5);
+            for _k in 0..n_messages {
+                let mut message_hash = Hash::default();
+                rng.fill_bytes(&mut message_hash);
+
+                pairs.push((seed_hash.clone(), message_hash.clone()));
+                map.put(seed_hash.clone(), message_hash, round);
+            }
+        }
+
+        map.prune_expired(round.saturating_sub(window_size), 1000);
+
+        for (k, v) in pairs.iter() {
+            if let Some(witness) = map.witness(*k, *v) {
+                assert_eq!(
+                    witness.reconstruct(),
+                    map.root_hash(),
+                    "produced a bad witness: {:?}",
+                    witness
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change adds a signature map test that exercises random insertions
an prunning in the way that is similar to real map usage.

Thanks to this test, I found and fixed 2 bugs in the certified map:

  1. Modify() was only updating the hash of the modified node, but not
     hashes of all the parents. Now I'm confident that modify() is
     correct.

  2. One of the cases in delete() was missing a hash recomputation.