### PR TITLE
readme: explain how to run tests and build Wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ So running the usual `cargo build --target wasm32-unknown-unknow -p idp_service`
 Use the following command to build the backend canister Wasm file instead:
 
 ```bash
-npm install
-src/idp_service/build.sh
+dfx build idp_service
 ```
 
 The Wasm file will be located at `target/wasm32-unknown-unknown/release/idp_service.wasm`.


### PR DESCRIPTION
This change extends the README.md file to include instructions on how
to run the test suite for the Rust code and how to build the backend
canister.