### PR TITLE
certified_map: add debug code checking unsafe memory usage

### DIFF
--- a/src/certified_map/src/rbtree/debug_alloc.rs
+++ b/src/certified_map/src/rbtree/debug_alloc.rs
@@ -1,0 +1,38 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
+
+thread_local! {
+    static ALLOCATED_POINTERS: RefCell<HashSet<*const ()>> = RefCell::new(HashSet::new());
+}
+
+/// Marks the specified pointer as being reachable.
+/// Should be invoked right after the memory is allocated.
+pub fn mark_pointer_allocated<T>(ptr: *const T) {
+    ALLOCATED_POINTERS.with(move |ptrs| {
+        assert!(ptrs.borrow_mut().insert(ptr as *const ()));
+    })
+}
+
+/// Marks the specified pointer as deleted.
+/// Should be invoked right after the pointer is freed.
+pub fn mark_pointer_deleted<T>(ptr: *const T) {
+    ALLOCATED_POINTERS.with(move |ptrs| {
+        assert!(
+            ptrs.borrow_mut().remove(&(ptr as *const ())),
+            "DOUBLE FREE: deleted pointer {:?} that is not allocated",
+            ptr
+        );
+    })
+}
+
+/// Returns the number of pointer that were allocated and not yet
+/// deleted.
+pub fn count_allocated_pointers() -> usize {
+    ALLOCATED_POINTERS.with(|ptrs| ptrs.borrow().len())
+}
+
+/// Returns true if the specified pointer was allocated and not yet
+/// deleted.
+pub fn is_live<T>(ptr: *const T) -> bool {
+    ALLOCATED_POINTERS.with(move |ptrs| ptrs.borrow().contains(&(ptr as *const ())))
+}

--- a/src/certified_map/src/rbtree/test.rs
+++ b/src/certified_map/src/rbtree/test.rs
@@ -180,6 +180,7 @@ fn map_model_test() {
             assert_eq!(hm.get(k), rb.get(k));
         }
     }
+    assert_eq!(super::debug_alloc::count_allocated_pointers(), 0);
 }
 
 #[test]


### PR DESCRIPTION
This change adds more debug code to the RbTree.

The new checks keep track of the pointers that are currently live and
crash if

  1. We delete a node that hasn't been allocated / has already been
     deleted (which would indicate a double free bug).

  2. Removing a node from the tree results in dangling pointers.

  3. There are some live pointers after the model test is
     completed (which would indicate a memory leak in delete()).

The new debug code didn't catch any bugs (because I'm almost sure
there are no bugs related to the correctness of memory allocation).
The tests do fail however if I intentionally introduce a memory leak /
double free (which is also detected by malloc itself).