### PR TITLE
canister: expose metrics HTTP endpoint

### DIFF
--- a/src/idp_service/src/lib.rs
+++ b/src/idp_service/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod metrics_encoder;
 pub mod nonce_cache;
 pub mod signature_map;

--- a/src/idp_service/src/metrics_encoder.rs
+++ b/src/idp_service/src/metrics_encoder.rs
@@ -1,0 +1,94 @@
+use std::io;
+
+/// MetricsEncoder provides methods to encode metrics in a text format
+/// that can be understood by Prometheus.
+///
+/// See [Exposition Formats][1] for an informal specification of the text format.
+///
+/// [1] https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md
+pub struct MetricsEncoder<W: io::Write> {
+    writer: W,
+}
+
+impl<W: io::Write> MetricsEncoder<W> {
+    /// Constructs a new encoder dumping text into the specified
+    /// writer.
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    /// Returns the internal buffer that was used to record the
+    /// metrics.
+    pub fn into_inner(self) -> W {
+        self.writer
+    }
+
+    fn encode_header(&mut self, name: &str, help: &str, typ: &str) -> io::Result<()> {
+        writeln!(self.writer, "# HELP {} {}", name, help)?;
+        writeln!(self.writer, "# TYPE {} {}", name, typ)
+    }
+
+    /// Encodes the metadata and the value of a histogram.
+    ///
+    /// SUM is the sum of all observed values, before they were put
+    /// into buckets.
+    ///
+    /// BUCKETS is a list (key, value) pairs, where KEY is the bucket
+    /// and VALUE is the number of items *in* this bucket (i.e., it's
+    /// not a cumulative value).
+    pub fn encode_histogram(
+        &mut self,
+        name: &str,
+        buckets: impl Iterator<Item = (f64, f64)>,
+        sum: f64,
+        help: &str,
+    ) -> io::Result<()> {
+        self.encode_header(name, help, "histogram")?;
+        let mut total: f64 = 0.0;
+        let mut saw_infinity = false;
+        for (bucket, v) in buckets {
+            total += v;
+            if bucket == std::f64::INFINITY {
+                saw_infinity = true;
+                writeln!(self.writer, "{}_bucket{{le=\"+Inf\"}} {}", name, total)?;
+            } else {
+                writeln!(
+                    self.writer,
+                    "{}_bucket{{le=\"{}\"}} {}",
+                    name, bucket, total
+                )?;
+            }
+        }
+        if !saw_infinity {
+            writeln!(self.writer, "{}_bucket{{le=\"+Inf\"}} {}", name, total)?;
+        }
+        writeln!(self.writer, "{}_sum {}", name, sum)?;
+        writeln!(self.writer, "{}_count {}", name, total)?;
+        writeln!(self.writer)
+    }
+
+    pub fn encode_single_value(
+        &mut self,
+        typ: &str,
+        name: &str,
+        value: f64,
+        help: &str,
+    ) -> io::Result<()> {
+        self.encode_header(name, help, typ)?;
+        writeln!(self.writer, "{} {}", name, value)?;
+        writeln!(self.writer)
+    }
+
+    /// Encodes the metadata and the value of a counter.
+    pub fn encode_counter(&mut self, name: &str, value: f64, help: &str) -> io::Result<()> {
+        self.encode_single_value("counter", name, value, help)
+    }
+
+    /// Encodes the metadata and the value of a gauge.
+    pub fn encode_gauge(&mut self, name: &str, value: f64, help: &str) -> io::Result<()> {
+        self.encode_single_value("gauge", name, value, help)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/src/idp_service/src/metrics_encoder/test.rs
+++ b/src/idp_service/src/metrics_encoder/test.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+fn new_encoder() -> MetricsEncoder<Vec<u8>> {
+    MetricsEncoder::new(Vec::new())
+}
+
+fn as_text(e: MetricsEncoder<Vec<u8>>) -> String {
+    String::from_utf8(e.into_inner()).unwrap()
+}
+
+#[test]
+fn test_counter_encoding() {
+    let mut w = new_encoder();
+    w.encode_counter(
+        "http_requests_total",
+        1027.0,
+        "The total number of HTTP requests.",
+    )
+    .unwrap();
+    assert_eq!(
+        &as_text(w),
+        r#"# HELP http_requests_total The total number of HTTP requests.
+# TYPE http_requests_total counter
+http_requests_total 1027
+
+"#
+    )
+}
+
+#[test]
+fn test_histogram_encoding() {
+    let mut w = new_encoder();
+    w.encode_histogram(
+        "http_request_duration_seconds",
+        [
+            (0.05, 24054.0),
+            (0.1, 9390.0),
+            (0.2, 66948.0),
+            (0.5, 28997.0),
+            (1.0, 4599.0),
+            (std::f64::INFINITY, 10332.0),
+        ]
+        .iter()
+        .cloned(),
+        53423.0,
+        "A histogram of the request duration.",
+    )
+    .unwrap();
+    assert_eq!(
+        &as_text(w),
+        r#"# HELP http_request_duration_seconds A histogram of the request duration.
+# TYPE http_request_duration_seconds histogram
+http_request_duration_seconds_bucket{le="0.05"} 24054
+http_request_duration_seconds_bucket{le="0.1"} 33444
+http_request_duration_seconds_bucket{le="0.2"} 100392
+http_request_duration_seconds_bucket{le="0.5"} 129389
+http_request_duration_seconds_bucket{le="1"} 133988
+http_request_duration_seconds_bucket{le="+Inf"} 144320
+http_request_duration_seconds_sum 53423
+http_request_duration_seconds_count 144320
+
+"#
+    )
+}

--- a/src/idp_service/src/signature_map.rs
+++ b/src/idp_service/src/signature_map.rs
@@ -87,6 +87,14 @@ impl SignatureMap {
         num_pruned
     }
 
+    pub fn len(&self) -> usize {
+        self.expiration_queue.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.expiration_queue.is_empty()
+    }
+
     pub fn root_hash(&self) -> Hash {
         self.certified_map.root_hash()
     }


### PR DESCRIPTION
This change adds a new HTTP endpoint that renders metrics in a text
format that can be understood by Prometheus.

For now we return:
  * Number of users registered.
  * Number of signatures that haven't expired yet.

I'll add more metrics in subsequent PRs.