### PR TITLE
adds a protocol to the Add Device Link

### DIFF
--- a/src/frontend/src/flows/loginUnknown.ts
+++ b/src/frontend/src/flows/loginUnknown.ts
@@ -144,9 +144,9 @@ const initLinkDevice = () => {
       const rawId = blobToHex(identity.rawId);
 
       // TODO: Maybe we should add a checksum here, to make sure the user didn't copy a cropped link
-
+      const protocol = /localhost/.test(location.host) ? "http" : "https";
       const link = encodeURI(
-        `${location.host}#device=${userNumber};${blobToHex(publicKey)};${rawId}`
+        `${protocol}://${location.host}#device=${userNumber};${blobToHex(publicKey)};${rawId}`
       );
 
       displayAddDeviceLink(link);


### PR DESCRIPTION
This way it gets recognized by QR Code readers. We need `https` to function anywhere but on `localhost` anyway.