### PR TITLE
Fix typo in field name

### DIFF
--- a/docs/ic-idp-spec.adoc
+++ b/docs/ic-idp-spec.adoc
@@ -126,13 +126,13 @@ where `msg` is a value with of type
  interface InternetIdentityAuthRequest {
    kind: "authorize-client";
    sessionPublicKey: Uint8Array;
-   maxTimetoLive?: bigint;
+   maxTimeToLive?: bigint;
  }
 
 where
 
 * the `sessionPublicKey` contains the public key of the session key pair.
-* the `maxTimetoLive`, if present, indicates the desired time span until the requested delegation should expire. The Identity Provider frontend is free to set an earlier expiry time, but should not create a larger.
+* the `maxTimeToLive`, if present, indicates the desired time span until the requested delegation should expire. The Identity Provider frontend is free to set an earlier expiry time, but should not create a larger.
 --
 6. Now it expects a message back, with data `event`.
 7. If `event.origin !== "https://identity.ic0.app"`, ignore this message.
@@ -227,7 +227,7 @@ service : {
   remove : (UserNumber, DeviceKey) -> ();
   lookup : (UserNumber) -> (vec DeviceData) query;
 
-  prepare_delegation : (UserNumber, FrontendHostname, SessionKey, maxTimetoLive : opt nat64) -> (UserKey, Timestamp);
+  prepare_delegation : (UserNumber, FrontendHostname, SessionKey, maxTimeToLive : opt nat64) -> (UserKey, Timestamp);
   get_delegation: (UserNumber, FrontendHostname, SessionKey, Timestamp) -> (GetDelegationResponse) query;
 }
 ....
@@ -280,7 +280,7 @@ The `prepare_delegation` method causes the Internet Identity Service backend to 
 
 This method returns the user’s identity that’s associated with the given Client Application Frontend Hostname. By returning this here, and not in the less secure `get_delegation` query, we prevent attacks that trick the user into using a wrong identity.
 
-The expiration timestamp is determined by the backend, but no more than `maxTimetoLive` (if present) nanoseconds in the future.
+The expiration timestamp is determined by the backend, but no more than `maxTimeToLive` (if present) nanoseconds in the future.
 
 The method returns the expiration timestamp of the delegation. This is returned purely so that the client can feed it back to the backend in `get_delegation`.
 

--- a/src/frontend/src/auth.ts
+++ b/src/frontend/src/auth.ts
@@ -7,7 +7,7 @@ import { IDPActor } from "./utils/idp_actor";
 interface AuthRequest {
     kind: "authorize-client";
     sessionPublicKey: Uint8Array;
-    maxTimetoLive?: BigInt;
+    maxTimeToLive?: BigInt;
 }
 
 interface AuthResponseSuccess {


### PR DESCRIPTION
https://github.com/dfinity/agent-js/blob/next/packages/auth-client/src/index.ts#L253

In the AuthClient package the field is called maxTimeToLive whereas in this repo it is called maxTimetoLive.
This PR fixes the casing so that both sides have the same name.
