### PR TITLE
Don't clear the #authorize hash from the URL when logging out.

### DIFF
--- a/src/frontend/src/flows/addDevice.ts
+++ b/src/frontend/src/flows/addDevice.ts
@@ -109,7 +109,8 @@ const parseNewDeviceParam = (
 
 export const clearHash = () => {
   history.pushState(
-    "",
+    // Preserve the #authorize hash if it's present.
+    /authorize/.test(window.location.hash) ? "authorize" : "",
     document.title,
     window.location.pathname + window.location.search
   );


### PR DESCRIPTION
This fixes the flow where a user clicks the login button from a client app, then logs out in the IDP canister, then logs into a new account, then authorizes the client app.