### PR TITLE
Add block timestamps to exported metrics

### DIFF
--- a/src/idp_service/src/main.rs
+++ b/src/idp_service/src/main.rs
@@ -387,7 +387,7 @@ fn get_delegation(
 
 fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
     STATE.with(|s| {
-        w.encode_counter(
+        w.encode_gauge(
             "internet_identity_user_count",
             s.storage.borrow().user_count() as f64,
             "Number of users registered in this canister.",
@@ -406,14 +406,17 @@ fn http_request(req: HttpRequest) -> HttpResponse {
     let parts: Vec<&str> = req.url.split("?").collect();
     match parts[0] {
         "/metrics" => {
-            let mut writer = MetricsEncoder::new(vec![]);
+            let mut writer = MetricsEncoder::new(vec![], time() / 1_000_000);
             match encode_metrics(&mut writer) {
                 Ok(()) => {
                     let body = writer.into_inner();
                     HttpResponse {
                         status_code: 200,
                         headers: vec![
-                            ("Content-Type".to_string(), "text/plain".to_string()),
+                            (
+                                "Content-Type".to_string(),
+                                "text/plain; version=0.0.4".to_string(),
+                            ),
                             ("Content-Length".to_string(), body.len().to_string()),
                         ],
                         body: ByteBuf::from(body),

--- a/src/idp_service/src/metrics_encoder/test.rs
+++ b/src/idp_service/src/metrics_encoder/test.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 fn new_encoder() -> MetricsEncoder<Vec<u8>> {
-    MetricsEncoder::new(Vec::new())
+    MetricsEncoder::new(Vec::new(), 1234567890000)
 }
 
 fn as_text(e: MetricsEncoder<Vec<u8>>) -> String {
@@ -21,8 +21,7 @@ fn test_counter_encoding() {
         &as_text(w),
         r#"# HELP http_requests_total The total number of HTTP requests.
 # TYPE http_requests_total counter
-http_requests_total 1027
-
+http_requests_total 1027 1234567890000
 "#
     )
 }
@@ -50,15 +49,14 @@ fn test_histogram_encoding() {
         &as_text(w),
         r#"# HELP http_request_duration_seconds A histogram of the request duration.
 # TYPE http_request_duration_seconds histogram
-http_request_duration_seconds_bucket{le="0.05"} 24054
-http_request_duration_seconds_bucket{le="0.1"} 33444
-http_request_duration_seconds_bucket{le="0.2"} 100392
-http_request_duration_seconds_bucket{le="0.5"} 129389
-http_request_duration_seconds_bucket{le="1"} 133988
-http_request_duration_seconds_bucket{le="+Inf"} 144320
-http_request_duration_seconds_sum 53423
-http_request_duration_seconds_count 144320
-
+http_request_duration_seconds_bucket{le="0.05"} 24054 1234567890000
+http_request_duration_seconds_bucket{le="0.1"} 33444 1234567890000
+http_request_duration_seconds_bucket{le="0.2"} 100392 1234567890000
+http_request_duration_seconds_bucket{le="0.5"} 129389 1234567890000
+http_request_duration_seconds_bucket{le="1"} 133988 1234567890000
+http_request_duration_seconds_bucket{le="+Inf"} 144320 1234567890000
+http_request_duration_seconds_sum 53423 1234567890000
+http_request_duration_seconds_count 144320 1234567890000
 "#
     )
 }


### PR DESCRIPTION
This should allow Prometheus to drop duplicate or out-of-order samples collected
from replicas that have fallen behind. (Metrics are collected from arbitrary
replicas selected by boundary nodes, rather than always the same replica, as
would be ideal).