### PR TITLE
Fix device removal warning bug

### DIFF
--- a/src/frontend/src/flows/manage.ts
+++ b/src/frontend/src/flows/manage.ts
@@ -106,16 +106,12 @@ const bindRemoveListener = (
 
     // Otherwise, remove identity
     try {
-      await withLoader(() =>
-        connection.remove(userNumber, publicKey).then(() => {
-          listItem.parentElement?.removeChild(listItem);
-        })
-      );
-
+      await withLoader(() => connection.remove(userNumber, publicKey));
       if (sameDevice) {
         localStorage.clear();
         location.reload();
       }
+      renderManage(userNumber, connection)
     } catch (err) {
       await displayError({
         title: "Failed to remove the device",


### PR DESCRIPTION
the code had a logic bug: If you have two devices, and remove one, and
then the other, you would not get the “this is your last device”
warning.

The cause was that the `isOnlyDevice` property was calculated when
hooking up the handlers, not when they fire, and removing one device
doesn’t reload the page, but simply removes the DOM elements.

Fixed by calculating that property when handling the event, so it is not
stale.

Found while writing tests. Surprisingly effective, writing tests.
Sometimes.