### PR TITLE
compute asset hashes at build time

### DIFF
--- a/src/idp_service/Cargo.toml
+++ b/src/idp_service/Cargo.toml
@@ -21,3 +21,6 @@ sha2 = "0.9.1"
 [dev-dependencies]
 hex-literal = "0.2.1"
 rand = "0.8.3"
+
+[build-dependencies]
+sha2 = "0.9.1"

--- a/src/idp_service/build.rs
+++ b/src/idp_service/build.rs
@@ -1,0 +1,90 @@
+use sha2::Digest;
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+#[derive(Debug)]
+pub enum ContentEncoding {
+    Identity,
+    GZip,
+}
+
+fn hash_file(path: &str) -> [u8; 32] {
+    let bytes = fs::read(path).unwrap_or_else(|e| panic!("failed to read file {}: {}", path, e));
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(&bytes);
+    hasher.finalize().into()
+}
+
+fn main() -> Result<(), String> {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let assets_module_path = Path::new(&out_dir).join("assets.rs");
+    let asset_rel_paths = [
+        ("/", "../../dist/index.html", ContentEncoding::Identity),
+        (
+            "/index.html",
+            "../../dist/index.html",
+            ContentEncoding::Identity,
+        ),
+        ("/index.js", "../../dist/index.js.gz", ContentEncoding::GZip),
+        (
+            "/glitch-loop.webp",
+            "../../dist/glitch-loop.webp",
+            ContentEncoding::Identity,
+        ),
+        (
+            "/favicon.ico",
+            "../../dist/favicon.ico",
+            ContentEncoding::Identity,
+        ),
+    ];
+
+    for (_, path, _) in asset_rel_paths.iter() {
+        if !Path::new(path).exists() {
+            return Err(format!("asset file {} doesn't exist", path));
+        }
+    }
+
+    let mut assets_module = fs::File::create(&assets_module_path).map_err(|e| {
+        format!(
+            "failed to create file {}: {}",
+            assets_module_path.display(),
+            e
+        )
+    })?;
+    writeln!(
+        assets_module,
+        r#"
+#[derive(Debug, PartialEq, Eq)]
+pub enum ContentEncoding {{
+    Identity,
+    GZip,
+}}
+pub fn for_each_asset(mut f: impl FnMut(&'static str, ContentEncoding, &'static [u8], &[u8; 32])) {{
+"#
+    )
+    .unwrap();
+
+    for (name, path, encoding) in asset_rel_paths.iter() {
+        let hash = hash_file(path);
+        let abs_path = Path::new(path).canonicalize().unwrap();
+        writeln!(
+            assets_module,
+            "  f(\"{}\", ContentEncoding::{:?}, &include_bytes!(\"{}\")[..], &{:?});",
+            name,
+            encoding,
+            abs_path.display(),
+            hash
+        )
+        .unwrap();
+    }
+    writeln!(assets_module, "}}").unwrap();
+
+    println!("cargo:rerun-if-changed=build.rs");
+    for (_, path, _) in asset_rel_paths.iter() {
+        println!("cargo:rerun-if-changed={}", path);
+    }
+
+    Ok(())
+}

--- a/src/idp_service/src/assets.rs
+++ b/src/idp_service/src/assets.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/assets.rs"));


### PR DESCRIPTION
This change introduces a custom cargo build script that generates
assets module with pre-computed asset hashes.

This removes the need to compute hashes on init/upgrade, which takes a
significant amout of cycles.  Backend tests say it all:

Before:

    Tests
    without upgrade
        installs:                                 OK (28.33s)
        installs and upgrade:                     OK (53.17s)
        register with wrong user fails:           OK (28.83s)
        ...
    All 48 tests passed (655.16s)

After:

    Tests
    without upgrade
        installs:                                 OK (0.88s)
        installs and upgrade:                     OK (1.65s)
        register with wrong user fails:           OK (1.35s)
        ...
    All 48 tests passed (49.85s)

The script can later be extended to run `npm run build` automatically
to eliminate the chance of accidentally building a canister with
outdated assets if `cargo build` is used directly.

See https://doc.rust-lang.org/cargo/reference/build-script-examples.html
for more info on custom build scripts.