### PR TITLE
Signature map expiry: 1 min

### DIFF
--- a/backend-tests/backend-tests.hs
+++ b/backend-tests/backend-tests.hs
@@ -656,18 +656,18 @@ tests wasm_file = testGroup "Tests" $ upgradeGroups $
     (userPK, ts1) <- callII cid webauthID #prepare_delegation delegationArgs
     getAndValidate cid sessionPK userPK webauthID delegationArgs ts1
 
-    setCanisterTimeTo cid (7*60*1000_000_000)
+    setCanisterTimeTo cid (30*1000_000_000)
     (userPK, ts2) <- callII cid webauthID #prepare_delegation delegationArgs
     getAndValidate cid sessionPK userPK webauthID delegationArgs ts1
     getAndValidate cid sessionPK userPK webauthID delegationArgs ts2
 
-    setCanisterTimeTo cid (14*60*1000_000_000)
+    setCanisterTimeTo cid (70*1000_000_000)
     (userPK, ts3) <- callII cid webauthID #prepare_delegation delegationArgs
     getButNotThere cid webauthID delegationArgs ts1
     getAndValidate cid sessionPK userPK webauthID delegationArgs ts2
     getAndValidate cid sessionPK userPK webauthID delegationArgs ts3
 
-    setCanisterTimeTo cid (21*60*1000_000_000)
+    setCanisterTimeTo cid (120*1000_000_000)
     (userPK, ts4) <- callII cid webauthID #prepare_delegation delegationArgs
     getButNotThere cid webauthID delegationArgs ts1
     getButNotThere cid webauthID delegationArgs ts2

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -26,8 +26,8 @@ const fn secs_to_nanos(secs: u64) -> u64 {
 const DEFAULT_EXPIRATION_PERIOD_NS: u64 = secs_to_nanos(30 * 60);
 // 8 days
 const MAX_EXPIRATION_PERIOD_NS: u64 = secs_to_nanos(8 * 24 * 60 * 60);
-// 10 mins
-const DEFAULT_SIGNATURE_EXPIRATION_PERIOD_NS: u64 = secs_to_nanos(600);
+// 1 min
+const DEFAULT_SIGNATURE_EXPIRATION_PERIOD_NS: u64 = secs_to_nanos(60);
 // 5 mins
 const POW_NONCE_LIFETIME: u64 = secs_to_nanos(300);
 


### PR DESCRIPTION
This time span needs to be long enough to in the typical case cover
these actions:
An update call is executed.
The polling client notices (via state read)
The client performs a query calls.

Probably 10s would be enough in most cases and 1min is still plenty.