### PR TITLE
Drop obsolete network (`alpha`)

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -18,10 +18,6 @@
       "bind": "127.0.0.1:8000",
       "type": "ephemeral"
     },
-    "alpha": {
-      "providers": ["https://mercury.dfinity.network"],
-      "type": "persistent"
-    },
     "messaging": {
       "providers": ["http://10.12.36.13:8080"],
       "type": "persistent"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

DFINITY has a mainnet now. No need for an `alpha` network.

## Description
<!--- Describe your changes in detail -->

Dropped the `alpha` network from `dfx.json`. It is not possible to `ping` it:
```
$ ping mercury.dfinity.network
PING mercury.dfinity.network (212.71.124.121): 56 data bytes
Request timeout for icmp_seq 0
Request timeout for icmp_seq 1
Request timeout for icmp_seq 2
```
It is useless.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
