### PR TITLE
Fix comment typo in canister IDL

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -46,7 +46,7 @@ type DeviceData = record {
 type RegisterResponse = variant {
   // A new user was successfully registered.
   registered: record { user_number: UserNumber; };
-  // No more registrations are possible in this instance of the II service caniser.
+  // No more registrations are possible in this instance of the II service canister.
   canister_full;
 };
 


### PR DESCRIPTION
A just a comment typo.
