### PR TITLE
chore: `dfx` 0.7 is out

### DIFF
--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         rust: [ '1.51.0' ]
         os: [ ubuntu-latest ]
-        dfx: [ '0.7.0-beta.6' ]
+        dfx: [ '0.7.0' ]
         start-flag: [ '', '--emulator' ]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Our CI also performs these steps; you can compare the SHA256 with the output the
 
 ## Software versions
 
-- `dfx` version 0.7.0-beta.6
+- `dfx` version 0.7.0
 
 - Rust version 1.51
 
@@ -88,9 +88,9 @@ Run the following command in the root of the repository to execute the test suit
 cargo test
 ```
 
-The backed canister is also used to serve the frontend assets.
+The backend canister is also used to serve the frontend assets.
 This creates a dependency between the frontend and the backend.
-So running the usual `cargo build --target wasm32-unknown-unknow -p internet_identity` might not work or include an outdated version of the frontend.
+So running the usual `cargo build --target wasm32-unknown-unknown -p internet_identity` might not work or include an outdated version of the frontend.
 
 Use the following command to build the backend canister Wasm file instead:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Advertise current `dfx` (which is 0.7.0) and also fix two typos in the README.

Also transition the test actions to use `0.7.0` final of `dfx`.

## Motivation and Context

The typos could confuse folks.

## How Has This Been Tested?

Only changing human-readable text, no code  changes.

## The observed selenium fail

```
    Expected: "This will remove your only remaining identity and may impact your ability to log in to accounts you have linked"
427
    Received: "You can not remove your last registered device."
428
```
Most probably not related to this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
