### PR TITLE
Fix 'to open the front-end...' command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dfx canister call internet_identity register '(123, "test", vec {1; 2; 3}, null)
 To open the front-end, you can run the following and open the URL.
 
 ```bash
-echo "http://localhost:8000?canisterId=$(dfx canister id frontend)"
+echo "http://localhost:8000?canisterId=$(dfx canister id internet_identity)"
 ```
 
 ### Contributing to the frontend


### PR DESCRIPTION
Fix 'to open the front-end...' command in README.md. The old version didn't work.

FWIW, I also noticed that the sample `dfx canister call internet_identity register '(123, "test", vec {1; 2; 3}, null)'` command also doesn't work, but I'm not sure exactly how to improve it to something that matches the `register` rust fn signature, e.g. with DeviceInfo.

## Description
Previously, there must have been a canister in dfx.json called 'frontend', but now there isn't, so the command didn't work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A README that can easily be followed to learn the codebase or how to operate II
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested this command locally.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  * A selenium test fails when removing a device, which I think has been failing on main since https://github.com/dfinity/internet-identity/pull/297
