### PR TITLE
Fix selenium test upon removing last device

### DIFF
--- a/src/frontend/src/selenium.test.ts
+++ b/src/frontend/src/selenium.test.ts
@@ -779,14 +779,13 @@ test("Screenshots", async () => {
     expect(alertText1).toBe(
       "This will remove your current device and you will be logged out"
     );
+    await driver.wait(until.alertIsPresent());
     const alert2 = driver.switchTo().alert();
     const alertText2 = await alert2.getText();
     await alert2.accept();
-    expect(alertText2).toBe(
-      "This will remove your only remaining identity and may impact your ability to log in to accounts you have linked"
-    );
-
-    await on_Welcome(driver);
+    expect(alertText2).toBe("You can not remove your last registered device.");
+    // device still present. You can't remove your last device.
+    await on_Main(DEVICE_NAME1, driver);
 
     // Compatibility notice page
     await driver.get("about:blank");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

I noticed this part of the selenium tests were failing when for my other README changes, so tried to fix it.

## Description
<!--- Describe your changes in detail -->

I think the tests had not been updated upon https://github.com/dfinity/internet-identity/pull/297

The old test asserted that you could remove the last device after an alert, and then would be sent back to the Welcome screen.
Now it asserts you can't, and you stay on the same page with the device *not* removed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* moving towards green tests
* notably, there's still a selenium test that fails
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
* github ci + selenium
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] test fix

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
