### PR TITLE
Pin verison of ic-cdk-optimizer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ ENV CARGO_HOME=/cargo \
     PATH=/cargo/bin:$PATH
 
 # Install IC CDK optimizer
-RUN cargo install ic-cdk-optimizer
+# (keep version in sync with src/internet_identity/build.sh)
+RUN cargo install ic-cdk-optimizer --version 0.3.0
 
 COPY . .
 

--- a/src/internet_identity/build.sh
+++ b/src/internet_identity/build.sh
@@ -10,7 +10,8 @@ TARGET="wasm32-unknown-unknown"
 
 cargo build --manifest-path "$II_DIR/Cargo.toml" --target $TARGET --release -j1
 
-cargo install ic-cdk-optimizer --root "$II_DIR"/../../target
+# keep version in sync with Dockerfile
+cargo install ic-cdk-optimizer --version 0.3.0 --root "$II_DIR"/../../target
 STATUS=$?
 
 if [ "$STATUS" -eq "0" ]; then


### PR DESCRIPTION
it is important to make our build as hermetic as possible, so that
different people, even at different times, can reproduce the `.wasm`
that we deployed. The build infrastructure we use (Docker) is not fully
hermetic by default, so we need to root out possible variations
manually.

This pins the version of ic-cdk-optimizer.