### PR TITLE
Selenium tests: Use elem.clear()

### DIFF
--- a/src/frontend/src/selenium.test.ts
+++ b/src/frontend/src/selenium.test.ts
@@ -461,8 +461,7 @@ async function run_in_browser_common(
 
 async function fillText(driver: ThenableWebDriver, id: string, text: string) {
   const elem = await driver.findElement(By.id(id));
-  elem.sendKeys(Key.CONTROL + "a");
-  elem.sendKeys(Key.DELETE);
+  elem.clear();
   elem.sendKeys(text);
 }
 


### PR DESCRIPTION
TIL that the WebDriver API provides `.clear()`, which is a cleaner way
to clear an input box than Ctrl-A Delete, and should work also on OSX.