### PR TITLE
Add II_ENV=development to 'Contributing to the frontend' dfx deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The fastest workflow to get the development environment running is to deploy onc
 ```bash
 npm ci
 dfx start [--clean] [--background]
-dfx deploy --no-wallet --argument '(null)'
+II_ENV=development dfx deploy --no-wallet --argument '(null)'
 ```
 
 Then, run `CANISTER_ID=$(dfx canister id internet_identity) npm start` to start webpack-dev-server.


### PR DESCRIPTION
This applies the change from #303 to another section of the README.

## Description
Add the `II_ENV=development` environment variable to the `dfx deploy` command under the instructions for contributing locally. 

## Motivation and Context
Without this, we see the "Fail to verify certificate" error when trying to register locally when following the instructions for contributing locally.

## How Has This Been Tested?
I tried this out locally and it worked.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
