### PR TITLE
Make sure tooltip is shown on iOS

### DIFF
--- a/src/frontend/src/flows/confirmRedirect.ts
+++ b/src/frontend/src/flows/confirmRedirect.ts
@@ -55,7 +55,7 @@ const pageContent = (hostName: string, principal: string) => html`
     <button id="confirmRedirect" class="primary">Proceed</button>
     <button id="cancelRedirect">Cancel</button>
     <div id="confirmRedirectPrincipal" class="highlightBox">
-      <span class="tooltip">
+      <span class="tooltip" onclick="">
         <span class="tooltiptext">${textTooltip}</span>
         Application-specific
       </span>
@@ -70,9 +70,21 @@ export const confirmRedirect = async (
   hostName: FrontendHostname,
   userPrincipal: string
 ): Promise<boolean> => {
+  // In order to make the ":hover" work on mobile, we set "onclick" on the
+  // tooltip (which makes the tooltip actually show) and we set "onclick" on
+  // the body (which makes the tooltip disappear. Here we make sure that upon
+  // exit we reinstate the original body onclick.
+  const originalBodyOnclick = document.body.onclick;
+
+  // make sure tooltip is closed when user clicks/touches out
+  document.body.onclick = () => { return;};
+
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(hostName, userPrincipal), container);
-  return init();
+  return init().then((resolve) => {
+    document.body.onclick = originalBodyOnclick;
+    return resolve;
+  });
 };
 
 const init = (): Promise<boolean> =>

--- a/src/frontend/src/flows/confirmRedirect.ts
+++ b/src/frontend/src/flows/confirmRedirect.ts
@@ -77,7 +77,9 @@ export const confirmRedirect = async (
   const originalBodyOnclick = document.body.onclick;
 
   // make sure tooltip is closed when user clicks/touches out
-  document.body.onclick = () => { return;};
+  document.body.onclick = () => {
+    return;
+  };
 
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(hostName, userPrincipal), container);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This adds an `onclick` to the `tooptip` span, effectively triggering
Safari on iOS to actually show the tooltip on click (default on e.g. Android).

A dummy `onclick` must also be registered on `document.body`. Special care is taken to make sure the original body's `onclick` is reinstated.


## How Has This Been Tested?

This was tested manually on Safari (iPadOS, iOS, macOS).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
