### PR TITLE
Use strict boolean checks for strings (and numbers)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,12 @@
       "@typescript-eslint"
     ],
     "rules": {
-      "@typescript-eslint/strict-boolean-expressions": 2
+      "@typescript-eslint/strict-boolean-expressions": [
+          2,
+          { "allowString" : false,
+            "allowNumber" : false
+          }
+      ]
     },
     "ignorePatterns": ["src/**/*.test.ts", "src/frontend/generated/*"]
   }

--- a/src/frontend/src/flows/addDevice.ts
+++ b/src/frontend/src/flows/addDevice.ts
@@ -128,7 +128,7 @@ const parseNewDeviceParam = (
     return null;
   }
   const publicKey = derBlobFromBlob(blobFromHex(segments[1]));
-  const rawId = segments[2] ? blobFromHex(segments[2]) : undefined;
+  const rawId = segments[2] !== "" ? blobFromHex(segments[2]) : undefined;
   return { userNumber, publicKey, rawId };
 };
 

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -19,7 +19,7 @@ export async function startWebdriver(): Promise<ChildProcess | undefined> {
   let webdriverProcess: ChildProcess | undefined;
   let retryCount = 0;
   let error;
-  while (!webdriverProcess && retryCount < 10) {
+  while (webdriverProcess === undefined && retryCount < 10) {
     try {
       error = undefined;
       webdriverProcess = await SeleniumStandalone.start();

--- a/src/frontend/src/utils/userIntent.ts
+++ b/src/frontend/src/utils/userIntent.ts
@@ -8,7 +8,7 @@ export type AddDeviceIntent = { kind: "addDevice" };
 export const intentFromUrl = (url: URL): UserIntent => {
   if (url.hash == "#authorize") {
     return { kind: "auth" };
-  } else if (url.hash?.split("device=")[1]) {
+  } else if (url.hash?.split("device=")[1] !== undefined) {
     return { kind: "addDevice" };
   } else {
     return { kind: "manage" };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This sets the `strict-boolean-expressions` options for `allowString` and
`allowNumber` to `false`, making sure all empty strings and zeros are
checked explicitly. Some occurrences of lax checks were updated.
