### PR TITLE
start selenium before tests and increase screenshot test waits

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "generate:types": "didc bind ./src/internet_identity/internet_identity.did -t ts > src/frontend/generated/internet_identity_types.d.ts",
     "generate:js": "didc bind ./src/internet_identity/internet_identity.did -t js > src/frontend/generated/internet_identity_idl.js",
     "build": "NODE_ENV=production webpack",
-    "test": "jest --verbose",
+    "test": "npm run start-selenium-server > /dev/null 2>&1 & jest --verbose",
     "lint": "eslint --cache --cache-location node_modules/.cache/eslint 'src/frontend/**/*.ts*'",
     "format": "prettier --write src/frontend",
-    "install-webdrivers" : "selenium-standalone install"
+    "install-webdrivers": "selenium-standalone install",
+    "start-selenium-server": "selenium-standalone start"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/src/frontend/src/test-e2e/selenium.test.ts
+++ b/src/frontend/src/test-e2e/selenium.test.ts
@@ -296,6 +296,7 @@ test("Screenshots", async () => {
       await browser.pause(3000);
       await welcomeBackView.login();
       await singleDeviceWarningView.waitForDisplay();
+      await browser.pause(3000);
       await singleDeviceWarningView.continue();
       await recoveryMethodSelectorView.waitForDisplay();
       await recoveryMethodSelectorView.skipRecovery();
@@ -307,6 +308,7 @@ test("Screenshots", async () => {
       await addDeviceView.waitForAliasDisplay();
       await screenshots.take("new-device-alias", browser);
       await addDeviceView.addDeviceAlias(DEVICE_NAME2);
+      await browser.pause(3000);
       await addDeviceView.addDeviceAliasContinue();
       await addDeviceView.waitForAddDeviceSuccess();
       await screenshots.take("new-device-done", browser);
@@ -324,6 +326,7 @@ test("Screenshots", async () => {
         browser2
       );
       await recoveryMethodSelectorView2.waitForDisplay();
+      await browser.pause(3000);
       await recoveryMethodSelectorView2.skipRecovery();
       const mainView2 = new MainView(browser2);
       await mainView2.waitForDeviceDisplay(DEVICE_NAME2);

--- a/src/frontend/src/test-e2e/selenium.test.ts
+++ b/src/frontend/src/test-e2e/selenium.test.ts
@@ -293,6 +293,7 @@ test("Screenshots", async () => {
       await welcomeBackView.waitForDisplay();
       await welcomeBackView.fixup();
       await screenshots.take("new-device-login", browser);
+      await browser.pause(3000);
       await welcomeBackView.login();
       await singleDeviceWarningView.waitForDisplay();
       await singleDeviceWarningView.continue();

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -1,7 +1,5 @@
 import { remote } from "webdriverio";
 import { command } from "webdriver";
-import * as SeleniumStandalone from "selenium-standalone";
-import { ChildProcess } from "selenium-standalone";
 
 export async function runInBrowser(
   test: (browser: WebdriverIO.Browser) => Promise<void>
@@ -15,39 +13,10 @@ export async function runInNestedBrowser(
   await runInBrowserCommon(false, test);
 }
 
-export async function startWebdriver(): Promise<ChildProcess | undefined> {
-  let webdriverProcess: ChildProcess | undefined;
-  let retryCount = 0;
-  let error;
-  while (!webdriverProcess && retryCount < 10) {
-    try {
-      error = undefined;
-      webdriverProcess = await SeleniumStandalone.start();
-    } catch (e) {
-      // port may still be used from previous stopped webdriver, try again
-      error = e;
-      retryCount++;
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-  }
-  if (error !== undefined) {
-    console.warn(
-      'selenium could not be started. Make sure you installed the required webdrivers ("install-webdrivers")'
-    );
-    console.error(error);
-  }
-  return webdriverProcess;
-}
-
 export async function runInBrowserCommon(
   outer: boolean,
   test: (browser: WebdriverIO.Browser) => Promise<void>
 ): Promise<void> {
-  let webdriverProcess;
-  if (outer) {
-    webdriverProcess = await startWebdriver();
-  }
-
   const browser = await remote({
     capabilities: {
       browserName: "chrome",
@@ -82,7 +51,6 @@ export async function runInBrowserCommon(
     if (outer) {
       // only close outer session
       await browser.deleteSession();
-      webdriverProcess?.kill();
     }
   }
 }

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -47,11 +47,6 @@ export async function runInBrowserCommon(
       "An error occurred during e2e test execution. Logs can be found in the wdio.log file and an additional error screenshot was saved under screenshots/error. On Github Actions you can find the log and screenshots under 'Artifacts'."
     );
     throw e;
-  } finally {
-    if (outer) {
-      // only close outer session
-      await browser.deleteSession();
-    }
   }
 }
 


### PR DESCRIPTION
## Description
- start selenium server outside of test script to avoid killing and restarting it for each "test" method
- add some temporary explicit waits in screenshot test to increase stability. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
