### PR TITLE
Fix screenshot ordering

### DIFF
--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -174,9 +174,9 @@ export class Screenshots {
   constructor(private directory: string) {}
 
   async take(name: string, browser: WebdriverIO.Browser): Promise<void> {
-    this.count++;
     // Make sure that all screenshots are prefixed with "01-", "02-", ...
     const countStr: string = this.count.toFixed().padStart(2, "0");
+    this.count++;
     await browser.saveScreenshot(`${this.directory}/${countStr}-${name}.png`);
   }
 }


### PR DESCRIPTION
Before the new screenshot setup, screenshots started as 00-, not 01-.
