### PR TITLE
Update docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
-.git
-.github
+# These are all the files and directories that are _not_ included in the docker
+# build. They are not used in the docker build and including them would simply
+# invalidate the layer cache.
 backend-tests
 node_modules
 demos
@@ -7,5 +8,10 @@ docs
 dist
 screenshots
 target
-.dfx
 out
+arg.in
+*.wasm
+
+# filter out all "hidden" files and directories
+# (.git, .dfx, .*ignore, etc)
+.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ RUN cargo install ic-cdk-optimizer --version 0.3.1
 COPY . .
 
 ENV CANISTER_ID=rdmx6-jaaaa-aaaaa-aaadq-cai
+ARG II_ENV=production
+
 RUN npm ci
 RUN npm run build
 RUN cargo build --target wasm32-unknown-unknown --release -j1

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Then open `http://localhost:8080` in your browser. Webpack will reload the page 
 npm run format && npm run lint
 ```
 
-To customize your canister ID for deployment or particular local development, create a `.env` file in the root of the project and add a `CANISTER_ID` attribute. It should look something like
+To customize your canister ID for deployment or particular local development, create a [`.env`](https://www.npmjs.com/package/dotenv) file in the root of the project and add a `CANISTER_ID` attribute. It should look something like
 ```
 CANISTER_ID=rrkah-fqaaa-aaaaa-aaaaq-cai
 ```

--- a/docs/internet-identity-spec.adoc
+++ b/docs/internet-identity-spec.adoc
@@ -702,15 +702,14 @@ Once the deployment went through, tag the commit with `mainnet-<date-from-propos
 
 ==== Building the canister for the identity testnet
 
-Because we need to fetch the root key for all networks that are not mainnet, we can not use the regular Docker build.
-Instead we build ourselves with the `II_ENV` environment variable set to `development`.
+Because we need to fetch the root key for all networks that are not mainnet, we
+need to build with `II_ENV=development`:
 
 [source,bash]
 ----
 didc encode '(null)' | xxd -r -p > arg.in
-npm ci
-II_ENV=development dfx build --network identity
-cp target/wasm32-unknown-unknown/release/internet_identity.wasm .
+docker build -t internet-identity-development . --build-arg II_ENV=development
+docker run --rm --entrypoint cat internet-identity-development /internet_identity.wasm > internet_identity.wasm
 ----
 
 This will create the Wasm file you want to use for the following deployment steps at `./internet_identity.wasm`.


### PR DESCRIPTION
This updates the Docker setup to:

* be reused in non-official builds (with `--build-arg
  II_ENV=development`) and
* include fewer irrelevant files in the docker context.

The build instructions are also updated.
