### PR TITLE
Re-enable whoami check without ic-ref

### DIFF
--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -66,8 +66,19 @@ jobs:
 
       - run: rm -v -f screenshots/*.png
       - run: npm test
-      - run: npm run test:e2e-desktop
-      - run: npm run test:e2e-mobile
+      - run: |
+          # This is a horrible hack. The 'whoami' canister does not respond
+          # when running with the emulator, meaning we had to disable one check
+          # in our test suite. It is taking longer than expected to figure out
+          # why, so for the time being we make sure to at least run the full
+          # test suite when _not_ using the emulator.
+          if [ '${{ matrix.start-flag }}' == "--emulator" ]
+          then
+            export RUN_IN_EMULATOR=true
+          fi
+
+          npm run test:e2e-desktop
+          npm run test:e2e-mobile
       - run: dfx stop
 
       - name: Commit screenshots

--- a/src/frontend/src/test-e2e/selenium.test.ts
+++ b/src/frontend/src/test-e2e/selenium.test.ts
@@ -113,12 +113,19 @@ test("Log into client application, after registration", async () => {
     expect(principal).not.toBe("2vxsx-fae");
 
     /*
-    on dfx > 0.8.0 the woami container does not respond
-    TODO: this should be fixed asap (https://dfinity.atlassian.net/browse/II-74)
-    expect(await demoAppView.whoami(REPLICA_URL, WHOAMI_CANISTER)).toBe(
-      principal
-    );
-     */
+      This is a horrible hack. The 'whoami' canister does not respond
+      when running with the emulator, meaning we had to disable one check
+      in our test suite. It is taking longer than expected to figure out
+      why, so for the time being we make sure to at least run the full
+      test suite when _not_ using the emulator.
+
+      RUN_IN_EMULATOR is set by the GitHub Actions workflow.
+    */
+    if (process.env.RUN_IN_EMULATOR !== "true") {
+      expect(await demoAppView.whoami(REPLICA_URL, WHOAMI_CANISTER)).toBe(
+        principal
+      );
+    }
 
     // default value
     const exp = await browser.$("#expiration").getText();


### PR DESCRIPTION
This is a horrible hack. The 'whoami' canister does not respond when running with the emulator, meaning we had to disable one check in our test suite. It is taking longer than expected to figure out why, so for the time being we make sure to at least run the full test suite when _not_ using the emulator.
