### PR TITLE
fix: build on Apple M1 chip

### DIFF
--- a/src/internet_identity/build.sh
+++ b/src/internet_identity/build.sh
@@ -11,13 +11,13 @@ TARGET="wasm32-unknown-unknown"
 cargo build --manifest-path "$II_DIR/Cargo.toml" --target $TARGET --release -j1
 
 # keep version in sync with Dockerfile
-cargo install ic-cdk-optimizer --version 0.3.1 --root "$II_DIR"/../../target
+cargo install ic-cdk-optimizer --version 0.3.1
 STATUS=$?
 
 if [ "$STATUS" -eq "0" ]; then
-      "$II_DIR"/../../target/bin/ic-cdk-optimizer \
-      "$II_DIR/../../target/$TARGET/release/internet_identity.wasm" \
-      -o "$II_DIR/../../target/$TARGET/release/internet_identity.wasm"
+  ic-cdk-optimizer \
+    ./target/$TARGET/release/internet_identity.wasm \
+    -o ./target/$TARGET/release/internet_identity.wasm
 
   true
 else


### PR DESCRIPTION
## Description

when running `II_ENV=development dfx deploy --no-wallet --argument '(null)'` on apple M1 chip the build fails with:

Check #381 

```
error: failed to add native library /var/folders/z8/06mhg00s4lzd_dzykt3q0s6m0000gn/T/cargo-installNkJZeH/release/build/wabt-sys-0c5d3f90b9057634/out/build/libwabt.a: file too small to be an archive

error: aborting due to previous error

error: could not compile wabt-sys
```

## Motivation and Context

This PR is primarily intended as an opening to discussions on how to fix the above build issue in general. By applying this change, the build script installs `ic-cdk-optimizer` to your home dir `~/.cargo/bin/ic-cdk-optimizer` instead of the local target folder. For whatever reason this works. I'm not a rust expert.

## How Has This Been Tested?

It works on my machine :)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
