### PR TITLE
Make sure seed phrase is not translated

### DIFF
--- a/src/frontend/src/flows/recovery/displaySeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/displaySeedPhrase.ts
@@ -21,7 +21,7 @@ const pageContent = (seedPhrase: string) => html`
       </div>
     </div>
     <label>Your seed phrase</label>
-    <div id="seedPhrase" class="highlightBox">${seedPhrase}</div>
+    <div id="seedPhrase" translate="no" class="highlightBox">${seedPhrase}</div>
     <button id="seedCopy" data-clipboard-target="#seedPhrase">Copy</button>
     <button id="displaySeedPhraseContinue" class="primary hidden">
       Continue


### PR DESCRIPTION
Some users (using chrome's translation features) have reported that chrome translates the seed phrase. This prevents chrome from translating the seed phrase.

Reference:
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate


https://user-images.githubusercontent.com/6930756/138692795-e6ac4d7a-7ff2-4ac2-baf0-19f630e20c61.mov

