### PR TITLE
Don't warn about last device if irrelevant

### DIFF
--- a/src/frontend/src/flows/manage.ts
+++ b/src/frontend/src/flows/manage.ts
@@ -340,7 +340,7 @@ const bindRemoveListener = (
     } else {
       if (sameDevice) {
         const shouldProceed = confirm(
-          "This will remove your current device and you will be logged out"
+          "This will remove your current device and you will be logged out."
         );
         if (!shouldProceed) {
           return;

--- a/src/frontend/src/test-e2e/selenium.test.ts
+++ b/src/frontend/src/test-e2e/selenium.test.ts
@@ -354,7 +354,7 @@ test("Screenshots", async () => {
           }
         );
         expect(await browser2.getAlertText()).toBe(
-          "This will remove your current device and you will be logged out"
+          "This will remove your current device and you will be logged out."
         );
         await browser2.dismissAlert();
         await browser2.deleteSession();
@@ -404,18 +404,8 @@ test("Screenshots", async () => {
       await screenshots.take("after-removal", browser);
 
       await mainView.removeDevice(DEVICE_NAME1);
-      const alertText1 = await browser.getAlertText();
-      expect(alertText1).toBe(
-        "This will remove your current device and you will be logged out"
-      );
-      await browser.acceptAlert();
-
-      await browser.waitUntil(async () => !!(await browser.getAlertText()), {
-        timeout: 1_000,
-        timeoutMsg: "expected alert to be displayed after 1s",
-      });
-      const alertText2 = await browser.getAlertText();
-      expect(alertText2).toBe("You can not remove your last device.");
+      const alertText = await browser.getAlertText();
+      expect(alertText).toBe("You can not remove your last device.");
       await browser.acceptAlert();
 
       // device still present. You can't remove your last device.


### PR DESCRIPTION
When deleting the last device, it's useless to tell the user that
they'll be logged out, since we won't allow them to remove the device
anyway. Instead, we only tell them they cannot remove their last device.

--- 

# before

https://user-images.githubusercontent.com/6930756/138845962-3db14416-5fad-4912-a7cc-b105298fdc7e.mov

---

# after


https://user-images.githubusercontent.com/6930756/138846010-9f1baf91-2b80-4689-a6b7-2624fbd6fac8.mov


