### PR TITLE
Run mobile and desktop in different steps

### DIFF
--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -74,9 +74,8 @@ jobs:
 
       - run: rm -v -f screenshots/*.png
       - run: npm test
-      - run: |
-          npm run test:e2e-desktop
-          npm run test:e2e-mobile
+      - run: npm run test:e2e-desktop
+      - run: npm run test:e2e-mobile
       - run: dfx stop
 
       - name: Commit screenshots


### PR DESCRIPTION
This clarifies error reporting. GitHub Actions uses the first line as
label when reporting an error; this means that an error in the mobile
e2e-tests will be reported as "Run npm run test:e2e-desktop" failing.
