### PR TITLE
Pause for 0.5s before taking screenshot

### DIFF
--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -203,6 +203,9 @@ export class Screenshots {
     // Make sure that all screenshots are prefixed with "01-", "02-", ...
     const countStr: string = this.count.toFixed().padStart(2, "0");
     this.count++;
+    // Here we pause for half a second to make sure the browser has had time to
+    // render everything (fonts loaded, etc)
+    await browser.pause(500);
     await browser.saveScreenshot(
       `${this.directory}/${countStr}-${name}-${this.suffix}.png`
     );


### PR DESCRIPTION
We have some flakiness in screenshots that can't really be explained.
The best hypothesis thus far is that the screenshot is taken after the
first rendering pass, but before it has settled on exactly how to render
everything, leading to a few (8) pixels having different colors. If this
doesn't solve the issue, then we'll need to hack and change how screenshots are
committed, and only commit if the image was modified beyond some
threshold.

Here are the culprits:

https://user-images.githubusercontent.com/6930756/139709344-477ddd6f-d196-4f52-ae28-a6fcaef24bbf.mov

