### PR TITLE
Split CI runs between mobile and desktop

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [ '1.51.0' ]
-        ghc: ["8.8.4"]
         os: [ ubuntu-latest, macos-latest ]
+    env:
+      RUSTC_VERSION: 1.51.0
+      GHC_VERSION: 8.8.4
 
     steps:
       - uses: actions/checkout@v2
@@ -31,25 +32,25 @@ jobs:
         with:
           path: |
             ~/.cabal/store
-          key: cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('backend-tests/cabal.project', 'backend-tests//cabal.project.freeze') }}
-          restore-keys: cabal-${{ runner.os }}-${{ matrix.ghc }}-
+          key: cabal-${{ runner.os }}-${{ env.GHC_VERSION }}-${{ hashFiles('backend-tests/cabal.project', 'backend-tests//cabal.project.freeze') }}
+          restore-keys: cabal-${{ runner.os }}-${{ env.GHC_VERSION }}-
 
       - name: Install Rust
         run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
+          rustup update "$RUSTC_VERSION" --no-self-update
+          rustup default "$RUSTC_VERSION"
           rustup target add wasm32-unknown-unknown
 
       - uses: actions/setup-haskell@v1.1.3
         with:
-          ghc-version: ${{ matrix.ghc }}
+          ghc-version: ${{ env.GHC_VERSION }}
           cabal-version: "3.2"
 
       - name: Build test runner
         run: |
           cd backend-tests
           cabal update
-          cabal install -w ghc-${{ matrix.ghc }} --overwrite-policy=always  --installdir=$HOME/bin
+          cabal install -w ghc-${{ env.GHC_VERSION }} --overwrite-policy=always  --installdir=$HOME/bin
 
       - name: Create fake assets
         run : |

--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -11,8 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [ '1.51.0' ]
         os: [ ubuntu-latest, macos-latest ]
+    env:
+      RUSTC_VERSION: 1.51.0
 
     steps:
       - uses: actions/checkout@v2
@@ -27,8 +28,8 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
+          rustup update "$RUSTC_VERSION" --no-self-update
+          rustup default "$RUSTC_VERSION"
           rustup target add wasm32-unknown-unknown
 
       - name: Create fake assets

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,10 +1,11 @@
+# The "official" docker build. This is a pretty long build (~20mn) which we
+# only run on master.
 name: Docker build
 
 on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   docker-build:

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  e2e:
+  tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -79,18 +79,6 @@ jobs:
       - run: npm run test:e2e-${{ matrix.device }}
       - run: dfx stop
 
-      - name: Commit screenshots
-        uses: EndBug/add-and-commit@v7.4.0
-        if: ${{ github.event_name == 'pull_request' && matrix.start-flag == ''}}
-        with:
-          add: screenshots
-          author_name: Screenshot Committer
-          author_email: "<nobody@example.com>"
-          message: "Update selenium ${{ matrix.device }} screenshots"
-          # --rebase: make sure both the mobile and desktop screenshots can be
-          # uploaded
-          pull: "--rebase"
-
       - name: Archive test logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
@@ -104,3 +92,38 @@ jobs:
         with:
           name: e2e-screenshots-${{ matrix.device }} ${{ matrix.start-flag }}
           path: screenshots/**/*.png
+
+  # This uploads the screenshots from both the (non-emulated) 'desktop' and
+  # 'mobile' runs.
+  upload-screenshots:
+    runs-on: ubuntu-latest
+
+    # Run after all the tests completed succesfully (and have uploaded their
+    # artifacts)
+    needs: tests
+
+    # Only run on PRs, we don't want to commit new screenshots to master
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v2
+
+      # Download the desktop screenshots artifacts
+      - uses: actions/download-artifact@v2
+        with:
+          name: e2e-screenshots-desktop
+
+      # Download the mobile screenshots artifacts
+      - uses: actions/download-artifact@v2
+        with:
+          name: e2e-screenshots-mobile
+
+      - name: Commit screenshots
+        uses: EndBug/add-and-commit@v7.4.0
+        with:
+          add: screenshots
+          author_name: Screenshot Committer
+          author_email: "<nobody@example.com>"
+          message: "Update selenium ${{ matrix.device }} screenshots"
+          # do not pull: if this branch is behind, then we might as well let
+          # the pushing fail
+          pull: "NO-PULL"

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -75,7 +75,7 @@ jobs:
       - name: install selenium webdrivers
         run: npm run install-webdrivers
 
-      - run: rm -v -f screenshots/*.png
+      - run: rm -v -f screenshots/*-${{ matrix.device }}.png
       - run: npm test
       - run: npm run test:e2e-${{ matrix.device }}
       - run: dfx stop
@@ -87,10 +87,10 @@ jobs:
           add: screenshots
           author_name: Screenshot Committer
           author_email: "<nobody@example.com>"
-          message: "Updating selenium screenshots"
-          # do not pull: if this branch is behind, then we might as well let
-          # the pushing fail
-          pull_strategy: "NO-PULL"
+          message: "Update selenium ${{ matrix.device }} screenshots"
+          # --rebase: make sure both the mobile and desktop screenshots can be
+          # uploaded
+          pull: "--rebase"
 
       - name: Archive test logs
         if: ${{ always() }}

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -15,6 +15,7 @@ jobs:
         os: [ ubuntu-latest ]
         dfx: [ '0.8.3' ]
         start-flag: [ '', '--emulator' ]
+        device: [ 'desktop', 'mobile' ]
 
     steps:
       - uses: actions/checkout@v2
@@ -74,8 +75,7 @@ jobs:
 
       - run: rm -v -f screenshots/*.png
       - run: npm test
-      - run: npm run test:e2e-desktop
-      - run: npm run test:e2e-mobile
+      - run: npm run test:e2e-${{ matrix.device }}
       - run: dfx stop
 
       - name: Commit screenshots

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -16,6 +16,8 @@ jobs:
         dfx: [ '0.8.3' ]
         start-flag: [ '', '--emulator' ]
         device: [ 'desktop', 'mobile' ]
+      # Make sure that one failing test does not cancel all other matrix jobs
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -1,4 +1,4 @@
-name: Selenium and npm tests
+name: e2e tests
 
 on:
   push:
@@ -7,17 +7,17 @@ on:
   pull_request:
 
 jobs:
-  selenium-tests:
-    runs-on: ${{ matrix.os }}
+  e2e:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ '1.51.0' ]
-        os: [ ubuntu-latest ]
-        dfx: [ '0.8.3' ]
         start-flag: [ '', '--emulator' ]
         device: [ 'desktop', 'mobile' ]
       # Make sure that one failing test does not cancel all other matrix jobs
       fail-fast: false
+    env:
+      DFX_VERSION: 0.8.3
+      RUSTC_VERSION: 1.51.0
 
     steps:
       - uses: actions/checkout@v2
@@ -32,16 +32,15 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
+          rustup update "$RUSTC_VERSION" --no-self-update
+          rustup default "$RUSTC_VERSION"
           rustup target add wasm32-unknown-unknown
 
       # This step hangs on Github actions on Darwin for some reason, that
       # is why we run this only on Linux for now
       - name: Install DFX
         run: |
-          export DFX_VERSION=${{ matrix.dfx }}
-          echo Install DFX Version: $DFX_VERSION
+          echo Install DFX Version: "$DFX_VERSION"
           yes | sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
           echo "$HOME/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -117,6 +117,10 @@ jobs:
         with:
           name: e2e-screenshots-mobile
 
+      - run: |
+          echo the following screenshots were recovered
+          find ./screenshots -name '*.png' -maxdepth 1 -type f -print0 | sort -z | xargs -r0 shasum -a 256
+
       - name: Commit screenshots
         uses: EndBug/add-and-commit@v7.4.0
         with:

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -80,7 +80,7 @@ jobs:
       - run: dfx stop
 
       - name: Commit screenshots
-        uses: EndBug/add-and-commit@v7.2.0
+        uses: EndBug/add-and-commit@v7.4.0
         if: ${{ github.event_name == 'pull_request' && matrix.start-flag == ''}}
         with:
           add: screenshots
@@ -95,12 +95,12 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: e2e-test-log ${{ matrix.start-flag }}
+          name: e2e-test-log-${{ matrix.device }} ${{ matrix.start-flag }}
           path: wdio.log
 
       - name: Archive screenshots
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: e2e-screenshots ${{ matrix.start-flag }}
+          name: e2e-screenshots-${{ matrix.device }} ${{ matrix.start-flag }}
           path: screenshots/**/*.png


### PR DESCRIPTION
A few changes for our CI config:

* Split e2e tests between mobile and desktop: Not only will this clarify the CI status in case of errors (desktop and mobile are now two different checks), but it will also shave ~2mn30s off the CI run. It will consume more GH actions
minutes.
* Docker builds are only run on master: those shouldn't actually break (build failures are caught in the npm and cargo builds) and are only useful when deploying to mainnet (we check a locally computed hash with the one from GH actions). Since this is by far the longest job, we only run it on master.
* Disable fail-fast: this means that a failing e.g. --emulator build won't fail all jobs, which helps clarify if a failure is isolated (e.g. to --emulator) or general.
* Move a bunch of `matrix` parameters out of the matrix, for check legibility (all matrix attributes params are shown on the GH check, making it very verbose and obfuscating actually important matrix params)
