### PR TITLE
Document flag needed for some platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ dfx start [--clean] [--background]
 In a different terminal, run the following command to install the Internet Identity canister:
 
 ```bash
+export NODE_OPTIONS=--openssl-legacy-provider # Needed if using npm 17 on Ubuntu 20.4 to handle npm ERR_OSSL_EVP_UNSUPPORTED
 II_ENV=development dfx deploy --no-wallet --argument '(null)'
 ```
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
If running the README instructions on Ubuntu 20.04 (long term release) and npm version 17, this error appears:
```
internet-identity (10)$ II_ENV=development dfx deploy --no-wallet --argument '(null)'
Deploying all canisters.
Creating canisters...
Creating canister "internet_identity"...
"internet_identity" canister created with canister id: "rwlgt-iiaaa-aaaaa-aaaaa-cai"
Building canisters...
Executing 'src/internet_identity/build.sh'
Compiling frontend assets

> internet_identity_assets@0.1.0 build
> NODE_ENV=production webpack

/home/max/dfn/internet-identity/node_modules/loader-runner/lib/LoaderRunner.js:146
		if(isError) throw e;
		            ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:67:19)
    at Object.createHash (node:crypto:130:10)
    at BulkUpdateDecorator.hashFactory (/home/max/dfn/internet-identity/node_modules/webpack/lib/util/createHash.js:145:18)
    at BulkUpdateDecorator.update (/home/max/dfn/internet-identity/node_modules/webpack/lib/util/createHash.js:46:50)
    at RawSource.updateHash (/home/max/dfn/internet-identity/node_modules/webpack-sources/lib/RawSource.js:64:8)
    at NormalModule._initBuildHash (/home/max/dfn/internet-identity/node_modules/webpack/lib/NormalModule.js:868:17)
    at handleParseResult (/home/max/dfn/internet-identity/node_modules/webpack/lib/NormalModule.js:934:10)
    at /home/max/dfn/internet-identity/node_modules/webpack/lib/NormalModule.js:1026:4
    at processResult (/home/max/dfn/internet-identity/node_modules/webpack/lib/NormalModule.js:743:11)
    at /home/max/dfn/internet-identity/node_modules/webpack/lib/NormalModule.js:807:5 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

This error can be avoided by either of:
- Run an old version of npm.  17 is the latest and greatest version but breaks, v14 works fine.
- Set the environment variable: `export NODE_OPTIONS=--openssl-legacy-provider`


## How Has This Been Tested?
- Execute instructions as in the [Contribute to frontend](https://github.com/dfinity/internet-identity#contributing-to-the-frontend) section.
- Encounter the error posted above
- Set the NODE_OPTIONS environment variable as recommended in this PR
- Execute the failing command again; it works.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
