### PR TITLE
Update chromedriver version to match GitHub

### DIFF
--- a/selenium-standalone.config.js
+++ b/selenium-standalone.config.js
@@ -2,7 +2,7 @@ module.exports = {
   drivers: {
     chrome: {
       // This version needs to match the chrome version on GitHub Actions
-      version: '94.0.4606.41',
+      version: '96.0.4664.45',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },


### PR DESCRIPTION
This makes sure that our version of chromedriver matches the chrome
version provided by GitHub Actions.
