### PR TITLE
Stronger prompt for recording identity anchor

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "generate:js": "didc bind ./src/internet_identity/internet_identity.did -t js > src/frontend/generated/internet_identity_idl.js",
     "build": "NODE_ENV=production webpack",
     "test": "jest --roots ./src/frontend --verbose --testPathIgnorePatterns=\"src/frontend/src/test-e2e\"",
-    "test:e2e": "jest --roots ./src/frontend --verbose --testPathPattern=\"src/frontend/src/test-e2e\"",
+    "test:e2e": "jest --roots ./src/frontend --verbose --testPathPattern=\"src/frontend/src/test-e2e\" --detectOpenHandles",
     "test:e2e-desktop": "SCREEN=desktop npm run test:e2e",
     "test:e2e-mobile": "SCREEN=mobile npm run test:e2e",
     "lint": "eslint --cache --cache-location node_modules/.cache/eslint 'src/frontend/**/*.ts*'",

--- a/src/frontend/src/flows/displayUserNumber.ts
+++ b/src/frontend/src/flows/displayUserNumber.ts
@@ -1,5 +1,5 @@
 import { html, render } from "lit-html";
-import {warningIcon} from "../components/icons";
+import { warningIcon } from "../components/icons";
 
 const pageContent = (userNumber: bigint) => html`
   <div class="container">

--- a/src/frontend/src/flows/displayUserNumber.ts
+++ b/src/frontend/src/flows/displayUserNumber.ts
@@ -1,12 +1,24 @@
 import { html, render } from "lit-html";
+import {warningIcon} from "../components/icons";
 
 const pageContent = (userNumber: bigint) => html`
   <div class="container">
     <h1>Congratulations!</h1>
     <p>
-      Please record your new Identity Anchor. You will need it later to use
-      Internet Identity or to add additional devices.
+     Your new Identity Anchor has been created. You will need it later to use
+     Internet Identity or to add additional devices.
     </p>
+    <div class="nagBox">
+      <div class="nagIcon">${warningIcon}</div>
+      <div class="nagContent">
+        <div class="nagTitle">Record Your Identity Anchor</div>
+        <div class="nagMessage">
+          Do <b>NOT</b> forget to save this Identity Anchor. Save a backup on a
+          storage medium and write it down.</br>
+          Note: It is advised to keep Identity Anchors secret in order to stay anonymous.
+        </div>
+      </div>
+    </div>
     <label>Identity Anchor:</label>
     <div class="highlightBox">${userNumber}</div>
     <button id="displayUserContinue" class="primary">Continue</button>

--- a/src/frontend/src/flows/displayUserNumber.ts
+++ b/src/frontend/src/flows/displayUserNumber.ts
@@ -10,9 +10,12 @@ const pageContent = (userNumber: bigint) => html`
       <div class="nagContent">
         <div class="nagTitle">Record Your Identity Anchor</div>
         <div class="nagMessage">
-          Do not forget to save this Identity Anchor. Save a backup on a storage
+          Please record your new Identity Anchor. Keep a backup on a storage
           medium and write it down. You will need it later to use Internet
-          Identity or to add additional devices.
+          Identity or to add additional devices. If you lose your Identity
+          Anchor, you will no longer be able to use this identity to
+          authenticate to dApps and you will lose access to the associated
+          profiles and data.
         </div>
       </div>
     </div>

--- a/src/frontend/src/flows/displayUserNumber.ts
+++ b/src/frontend/src/flows/displayUserNumber.ts
@@ -14,8 +14,7 @@ const pageContent = (userNumber: bigint) => html`
         <div class="nagTitle">Record Your Identity Anchor</div>
         <div class="nagMessage">
           Do <b>NOT</b> forget to save this Identity Anchor. Save a backup on a
-          storage medium and write it down.</br>
-          Note: It is advised to keep Identity Anchors secret in order to stay anonymous.
+          storage medium and write it down.
         </div>
       </div>
     </div>

--- a/src/frontend/src/flows/displayUserNumber.ts
+++ b/src/frontend/src/flows/displayUserNumber.ts
@@ -4,17 +4,15 @@ import { warningIcon } from "../components/icons";
 const pageContent = (userNumber: bigint) => html`
   <div class="container">
     <h1>Congratulations!</h1>
-    <p>
-      Your new Identity Anchor has been created. You will need it later to use
-      Internet Identity or to add additional devices.
-    </p>
+    <p>Your new Identity Anchor has been created.</p>
     <div class="nagBox">
       <div class="nagIcon">${warningIcon}</div>
       <div class="nagContent">
         <div class="nagTitle">Record Your Identity Anchor</div>
         <div class="nagMessage">
-          Do <b>NOT</b> forget to save this Identity Anchor. Save a backup on a
-          storage medium and write it down.
+          Do not forget to save this Identity Anchor. Save a backup on a storage
+          medium and write it down. You will need it later to use Internet
+          Identity or to add additional devices.
         </div>
       </div>
     </div>

--- a/src/frontend/src/flows/displayUserNumber.ts
+++ b/src/frontend/src/flows/displayUserNumber.ts
@@ -5,8 +5,8 @@ const pageContent = (userNumber: bigint) => html`
   <div class="container">
     <h1>Congratulations!</h1>
     <p>
-     Your new Identity Anchor has been created. You will need it later to use
-     Internet Identity or to add additional devices.
+      Your new Identity Anchor has been created. You will need it later to use
+      Internet Identity or to add additional devices.
     </p>
     <div class="nagBox">
       <div class="nagIcon">${warningIcon}</div>

--- a/src/frontend/src/flows/displayUserNumber.ts
+++ b/src/frontend/src/flows/displayUserNumber.ts
@@ -14,8 +14,7 @@ const pageContent = (userNumber: bigint) => html`
           medium and write it down. You will need it later to use Internet
           Identity or to add additional devices. If you lose your Identity
           Anchor, you will no longer be able to use this identity to
-          authenticate to dApps and you will lose access to the associated
-          profiles and data.
+          authenticate to dApps.
         </div>
       </div>
     </div>

--- a/src/frontend/src/flows/manage.ts
+++ b/src/frontend/src/flows/manage.ts
@@ -57,50 +57,6 @@ const displayFailedToListDevices = (error: Error) =>
 // The styling of the page
 
 const style = () => html`<style>
-  .nagBox {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 1rem;
-    margin-bottom: 2rem;
-    box-sizing: border-box;
-    border-style: double;
-    border-width: 2px;
-    border-radius: 4px;
-    border-image-slice: 1;
-    outline: none;
-    border-image-source: linear-gradient(
-      270.05deg,
-      #29abe2 10.78%,
-      #522785 22.2%,
-      #ed1e79 42.46%,
-      #f15a24 59.41%,
-      #fbb03b 77.09%
-    );
-  }
-  .nagIcon {
-    align-self: flex-start;
-  }
-  .recoveryNag {
-    display: flex;
-    flex-direction: column;
-  }
-  .recoveryNagTitle {
-    font-weight: 600;
-    font-size: 1.1rem;
-  }
-  .recoveryNagMessage {
-    margin-top: 0.5rem;
-    margin-bottom: 1rem;
-    font-size: 1rem;
-  }
-  .recoveryNagButton {
-    padding: 0.2rem 0.4rem;
-    border-radius: 2px;
-    width: fit-content;
-    align-self: flex-end;
-    margin: 0;
-  }
   .labelWithAction {
     margin-top: 1rem;
     display: flex;
@@ -179,12 +135,12 @@ const deviceListItem = (alias: string) => html`
 const recoveryNag = () => html`
   <div class="nagBox">
     <div class="nagIcon">${warningIcon}</div>
-    <div class="recoveryNag">
-      <div class="recoveryNagTitle">Recovery Mechanism</div>
-      <div class="recoveryNagMessage">
+    <div class="nagContent">
+      <div class="nagTitle">Recovery Mechanism</div>
+      <div class="nagMessage">
         Add a recovery mechanism to help protect this Identity Anchor.
       </div>
-      <button id="addRecovery" class="primary recoveryNagButton">
+      <button id="addRecovery" class="primary nagButton">
         Add Recovery Key
       </button>
     </div>

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -525,12 +525,12 @@ hr {
   border-image-slice: 1;
   outline: none;
   border-image-source: linear-gradient(
-          270.05deg,
-          #29abe2 10.78%,
-          #522785 22.2%,
-          #ed1e79 42.46%,
-          #f15a24 59.41%,
-          #fbb03b 77.09%
+    270.05deg,
+    #29abe2 10.78%,
+    #522785 22.2%,
+    #ed1e79 42.46%,
+    #f15a24 59.41%,
+    #fbb03b 77.09%
   );
 }
 .nagIcon {

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -511,3 +511,49 @@ hr {
   min-width: 1rem;
   padding: 1rem;
 }
+
+.nagBox {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  margin-bottom: 2rem;
+  box-sizing: border-box;
+  border-style: double;
+  border-width: 2px;
+  border-radius: 4px;
+  border-image-slice: 1;
+  outline: none;
+  border-image-source: linear-gradient(
+          270.05deg,
+          #29abe2 10.78%,
+          #522785 22.2%,
+          #ed1e79 42.46%,
+          #f15a24 59.41%,
+          #fbb03b 77.09%
+  );
+}
+.nagIcon {
+  align-self: flex-start;
+}
+
+.nagContent {
+  display: flex;
+  flex-direction: column;
+}
+.nagTitle {
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+.nagMessage {
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+  font-size: 1rem;
+}
+.nagButton {
+  padding: 0.2rem 0.4rem;
+  border-radius: 2px;
+  width: fit-content;
+  align-self: flex-end;
+  margin: 0;
+}


### PR DESCRIPTION
Added stronger wording on the prompt to record the Identity Anchor.

Without the Identity Anchor identities can only be recovered with a recovery seed phrase. If the Identity Anchor is lost (e.g. by deleting the browser data) before creating a seed phrase, the identity itself is lost.