### PR TITLE
Remove iFrame integration from specification

### DIFF
--- a/docs/internet-identity-spec.adoc
+++ b/docs/internet-identity-spec.adoc
@@ -102,9 +102,7 @@ This section describes the Internet Identity Service from the point of view of a
 
 1. The client application frontend creates a session key pair (e.g., Ed25519).
 2. It installs a `message` event handler on its own `window`.
-3. It loads the url `https://identity.ic0.app/#authorize` in an `<iframe>` or separate tab. Let `identityWindow` be the `Window` object returned from this.
-+
-If using an `<iframe>`, include `allow = "publickey-credentials-get"`, as per https://www.w3.org/TR/webauthn-2/#sctn-iframe-guidance[the Web Authentication recommendation].
+3. It loads the url `https://identity.ic0.app/#authorize` in a separate tab. Let `identityWindow` be the `Window` object returned from this.
 4. In the `identityWindow`, the user logs in, and the `identityWindow` invokes
 +
 --


### PR DESCRIPTION
iFrame integration of Internet Identity currently does not work because of headers set by boundary nodes. This change brings the spec back inline with reality.

## Description
Removes mentions of iFrame integration from the specification.

## Motivation and Context
Resolves developer confusion on how to integrate dapps with Internet Identity.

## How Has This Been Tested?
n/a since there are no changes in functionality.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
