### PR TITLE
Use node v14.x

### DIFF
--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -30,6 +30,11 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-selenium-${{ hashFiles('**/Cargo.lock') }}-1
 
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+
       - name: Install Rust
         run: |
           rustup update "$RUSTC_VERSION" --no-self-update


### PR DESCRIPTION
Our selenium test suite doesn't return on node v16.x, so we pin it to v14

See also https://github.com/dfinity/internet-identity/issues/483