### PR TITLE
Add CSP Header

### DIFF
--- a/backend-tests/backend-tests.hs
+++ b/backend-tests/backend-tests.hs
@@ -437,8 +437,8 @@ validateSecurityHeaders resp = do
     \window-placement=(),\
     \xr-spatial-tracking=()"
   validateHeaderMatches resp "Content-Security-Policy" "^default-src 'none';\
-    \img-src 'self';\
-    \script-src 'sha256-[a-zA-Z0-9\\/=+]+' 'unsafe-inline' 'strict-dynamic' https: http:;\
+    \img-src 'self' data:;\
+    \script-src 'sha256-[a-zA-Z0-9\\/=+]+' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;\
     \base-uri 'none';\
     \frame-ancestors 'none';\
     \form-action 'none';\

--- a/backend-tests/backend-tests.hs
+++ b/backend-tests/backend-tests.hs
@@ -439,7 +439,7 @@ validateSecurityHeaders resp = do
   validateHeaderMatches resp "Content-Security-Policy" "^default-src 'none';\
     \connect-src 'self';\
     \img-src 'self' data:;\
-    \script-src 'sha256-[a-zA-Z0-9\\/=+]+' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;\
+    \script-src 'sha256-[a-zA-Z0-9\\/=+]+' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https:;\
     \base-uri 'none';\
     \frame-ancestors 'none';\
     \form-action 'none';\

--- a/backend-tests/backend-tests.hs
+++ b/backend-tests/backend-tests.hs
@@ -445,7 +445,8 @@ validateSecurityHeaders resp = do
     \form-action 'none';\
     \style-src 'self' 'unsafe-inline' https:\\/\\/fonts\\.googleapis\\.com;\
     \style-src-elem 'unsafe-inline' https:\\/\\/fonts\\.googleapis\\.com;\
-    \font-src https:\\/\\/fonts\\.gstatic\\.com$"
+    \font-src https:\\/\\/fonts\\.gstatic\\.com;\
+    \upgrade-insecure-requests;$"
 
 validateStaticHeader :: HasCallStack => HttpResponse -> CI T.Text -> CI T.Text -> M ()
 validateStaticHeader resp headerName expectedValue = do

--- a/backend-tests/backend-tests.hs
+++ b/backend-tests/backend-tests.hs
@@ -395,15 +395,6 @@ validateSecurityHeaders resp = do
   validateStaticHeader resp "X-Frame-Options" "DENY"
   validateStaticHeader resp "X-Content-Type-Options" "nosniff"
   validateStaticHeader resp "Referrer-Policy" "same-origin"
-  validateStaticHeader resp "Content-Security-Policy" "default-src 'none';\
-    \img-src 'self';\
-    \script-src 'sha256-Jv0sAUkSG6MPh2x4LKtLcTk/t4cxuu/fPen13STeEsw=' 'unsafe-inline' 'strict-dynamic' https: http:;\
-    \base-uri 'none';\
-    \frame-ancestors 'none';\
-    \form-action 'none';\
-    \style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;\
-    \style-src-elem 'unsafe-inline' https://fonts.googleapis.com;\
-    \font-src https://fonts.gstatic.com"
   validateStaticHeader resp "Permissions-Policy" "accelerometer=(),\
     \ambient-light-sensor=(),\
     \autoplay=(),\
@@ -445,6 +436,15 @@ validateSecurityHeaders resp = do
     \web-share=(),\
     \window-placement=(),\
     \xr-spatial-tracking=()"
+  validateHeaderMatches resp "Content-Security-Policy" "^default-src 'none';\
+    \img-src 'self';\
+    \script-src 'sha256-[a-zA-Z0-9\\/=+]+' 'unsafe-inline' 'strict-dynamic' https: http:;\
+    \base-uri 'none';\
+    \frame-ancestors 'none';\
+    \form-action 'none';\
+    \style-src 'self' 'unsafe-inline' https:\\/\\/fonts\\.googleapis\\.com;\
+    \style-src-elem 'unsafe-inline' https:\\/\\/fonts\\.googleapis\\.com;\
+    \font-src https:\\/\\/fonts\\.gstatic\\.com$"
 
 validateStaticHeader :: HasCallStack => HttpResponse -> CI T.Text -> CI T.Text -> M ()
 validateStaticHeader resp headerName expectedValue = do

--- a/backend-tests/backend-tests.hs
+++ b/backend-tests/backend-tests.hs
@@ -437,6 +437,7 @@ validateSecurityHeaders resp = do
     \window-placement=(),\
     \xr-spatial-tracking=()"
   validateHeaderMatches resp "Content-Security-Policy" "^default-src 'none';\
+    \connect-src 'self';\
     \img-src 'self' data:;\
     \script-src 'sha256-[a-zA-Z0-9\\/=+]+' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;\
     \base-uri 'none';\

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -20,12 +20,13 @@
     (or if you do, update the CSP hash)
     -->
     <script>
-        const scripts = [ 'index.js'];
-        scripts.forEach(function(scriptUrl) {
-            let s = document.createElement('script');
-            s.async = false; s.src = scriptUrl;
-            document.head.appendChild(s);
-        });
+      const scripts = ["index.js"];
+      scripts.forEach(function (scriptUrl) {
+        let s = document.createElement("script");
+        s.async = false;
+        s.src = scriptUrl;
+        document.head.appendChild(s);
+      });
     </script>
   </body>
 </html>

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -13,12 +13,11 @@
     <div id="loaderContainer"></div>
     <!--
     Note: we cannot use a normal script tag like this
-
-    <script src="index.js" integrity="sha256-QKc0t+gyMRWWDNty0lxQKWpPz18K4pD8q3S0YoeQMdo=" defer></script>
-
+        <script src="index.js" integrity="sha256-QKc0t+gyMRWWDNty0lxQKWpPz18K4pD8q3S0YoeQMdo=" defer></script>
     because Firefox does not support SRI with CSP: https://bugzilla.mozilla.org/show_bug.cgi?id=1409200
 
-    DO NOT MODIFY! (or if you do, update the CSP hash)
+    DO NOT MODIFY THE INLINE SCRIPT CONTENT!
+    (or if you do, update the CSP hash)
     -->
     <script>
         const scripts = [ 'index.js'];

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -11,6 +11,22 @@
     <main id="pageContent" aria-live="polite"></main>
     <div id="notification"></div>
     <div id="loaderContainer"></div>
-    <script src="index.js" defer></script>
+    <!--
+    Note: we cannot use a normal script tag like this
+
+    <script src="index.js" integrity="sha256-QKc0t+gyMRWWDNty0lxQKWpPz18K4pD8q3S0YoeQMdo=" defer></script>
+
+    because Firefox does not support SRI with CSP: https://bugzilla.mozilla.org/show_bug.cgi?id=1409200
+
+    DO NOT MODIFY! (or if you do, update the CSP hash)
+    -->
+    <script>
+        const scripts = [ 'index.js'];
+        scripts.forEach(function(scriptUrl) {
+            let s = document.createElement('script');
+            s.async = false; s.src = scriptUrl;
+            document.head.appendChild(s);
+        });
+    </script>
   </body>
 </html>

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -813,6 +813,23 @@ fn security_headers() -> Vec<HeaderField> {
     vec![
         ("X-Frame-Options".to_string(), "DENY".to_string()),
         ("X-Content-Type-Options".to_string(), "nosniff".to_string()),
+
+        // Note: trusted types cannot be used -> FF issue
+        (
+            "Content-Security-Policy".to_string(),
+            "object-src 'none';\
+             script-src 'sha256-Jv0sAUkSG6MPh2x4LKtLcTk/t4cxuu/fPen13STeEsw=' 'unsafe-inline' 'strict-dynamic' https: http:;\
+             base-uri 'none';\
+             default-src 'self';\
+             child-src 'none';\
+             frame-ancestors 'none';\
+             form-action 'none';\
+
+             style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;\
+             style-src-elem 'unsafe-inline' https://fonts.googleapis.com;\
+             font-src https://fonts.gstatic.com"
+                .to_string()
+        ),
         (
             "Strict-Transport-Security".to_string(),
             "max-age=31536000 ; includeSubDomains".to_string(),

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -820,7 +820,7 @@ fn security_headers() -> Vec<HeaderField> {
             "Content-Security-Policy".to_string(),
             "default-src 'none';\
              img-src 'self';\
-             script-src 'sha256-Jv0sAUkSG6MPh2x4LKtLcTk/t4cxuu/fPen13STeEsw=' 'unsafe-inline' 'strict-dynamic' https: http:;\
+             script-src 'sha256-syYd+YuWeLD80uCtKwbaGoGom63a0pZE5KqgtA7W1d8=' 'unsafe-inline' 'strict-dynamic' https: http:;\
              base-uri 'none';\
              frame-ancestors 'none';\
              form-action 'none';\

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -815,8 +815,6 @@ fn security_headers() -> Vec<HeaderField> {
         ("X-Content-Type-Options".to_string(), "nosniff".to_string()),
 
         // Content Security Policy
-        // General overview: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
-        // Additional resources: https://csp.withgoogle.com/docs/index.html and https://csp-evaluator.withgoogle.com/
         //
         // The sha256 hash matches the inline script in index.html. This inline script is a workaround
         // for Firefox not supporting SRI (recommended here https://csp.withgoogle.com/docs/faq.html#static-content).

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -823,8 +823,7 @@ fn security_headers() -> Vec<HeaderField> {
         // script-src 'unsafe-eval' is required because agent-js uses a WebAssembly module for the
         // validation of bls signatures.
         // There is currently no other way to allow execution of WebAssembly modules with CSP.
-        // See https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md and
-        // https://dfinity.atlassian.net/browse/FOLLOW-383.
+        // See https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md.
         //
         // script-src 'unsafe-inline' https: are only there for backwards compatibility and ignored
         // by modern browsers.

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -815,13 +815,20 @@ fn security_headers() -> Vec<HeaderField> {
         ("X-Content-Type-Options".to_string(), "nosniff".to_string()),
 
         // Note: trusted types cannot be used due to firefox not supporting SRI.
-        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1409200
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1409200.
+        //
+        // script-src 'unsafe-eval' is required because agent-js uses a WebAssembly module for bls signatures.
+        // There is currently no other way to allow execution of WebAssembly modules with CSP.
+        // See https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md.
+        //
+        // script-src 'unsafe-inline' https: are only there for backwards compatibility and ignored
+        // by modern browsers.
         (
             "Content-Security-Policy".to_string(),
             "default-src 'none';\
              connect-src 'self';\
              img-src 'self' data:;\
-             script-src 'sha256-syYd+YuWeLD80uCtKwbaGoGom63a0pZE5KqgtA7W1d8=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;\
+             script-src 'sha256-syYd+YuWeLD80uCtKwbaGoGom63a0pZE5KqgtA7W1d8=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https:;\
              base-uri 'none';\
              frame-ancestors 'none';\
              form-action 'none';\

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -814,17 +814,16 @@ fn security_headers() -> Vec<HeaderField> {
         ("X-Frame-Options".to_string(), "DENY".to_string()),
         ("X-Content-Type-Options".to_string(), "nosniff".to_string()),
 
-        // Note: trusted types cannot be used -> FF issue
+        // Note: trusted types cannot be used due to firefox not supporting SRI.
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1409200
         (
             "Content-Security-Policy".to_string(),
-            "object-src 'none';\
+            "default-src 'none';\
+             img-src 'self';\
              script-src 'sha256-Jv0sAUkSG6MPh2x4LKtLcTk/t4cxuu/fPen13STeEsw=' 'unsafe-inline' 'strict-dynamic' https: http:;\
              base-uri 'none';\
-             default-src 'self';\
-             child-src 'none';\
              frame-ancestors 'none';\
              form-action 'none';\
-
              style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;\
              style-src-elem 'unsafe-inline' https://fonts.googleapis.com;\
              font-src https://fonts.gstatic.com"

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -819,8 +819,9 @@ fn security_headers() -> Vec<HeaderField> {
         (
             "Content-Security-Policy".to_string(),
             "default-src 'none';\
-             img-src 'self';\
-             script-src 'sha256-syYd+YuWeLD80uCtKwbaGoGom63a0pZE5KqgtA7W1d8=' 'unsafe-inline' 'strict-dynamic' https: http:;\
+             connect-src 'self';\
+             img-src 'self' data:;\
+             script-src 'sha256-syYd+YuWeLD80uCtKwbaGoGom63a0pZE5KqgtA7W1d8=' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;\
              base-uri 'none';\
              frame-ancestors 'none';\
              form-action 'none';\

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -819,7 +819,8 @@ fn security_headers() -> Vec<HeaderField> {
         //
         // script-src 'unsafe-eval' is required because agent-js uses a WebAssembly module for bls signatures.
         // There is currently no other way to allow execution of WebAssembly modules with CSP.
-        // See https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md.
+        // See https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md and
+        // https://dfinity.atlassian.net/browse/FOLLOW-383.
         //
         // script-src 'unsafe-inline' https: are only there for backwards compatibility and ignored
         // by modern browsers.

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -828,6 +828,10 @@ fn security_headers() -> Vec<HeaderField> {
         //
         // script-src 'unsafe-inline' https: are only there for backwards compatibility and ignored
         // by modern browsers.
+        //
+        // style-src 'unsafe-inline' is currently required due to the way styles are handled by the
+        // application. Adding hashes would require a big restructuring of the application and build
+        // infrastructure.
         (
             "Content-Security-Policy".to_string(),
             "default-src 'none';\

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -814,10 +814,16 @@ fn security_headers() -> Vec<HeaderField> {
         ("X-Frame-Options".to_string(), "DENY".to_string()),
         ("X-Content-Type-Options".to_string(), "nosniff".to_string()),
 
-        // Note: trusted types cannot be used due to firefox not supporting SRI.
-        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1409200.
+        // Content Security Policy
+        // General overview: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+        // Additional resources: https://csp.withgoogle.com/docs/index.html and https://csp-evaluator.withgoogle.com/
         //
-        // script-src 'unsafe-eval' is required because agent-js uses a WebAssembly module for bls signatures.
+        // The sha256 hash matches the inline script in index.html. This inline script is a workaround
+        // for Firefox not supporting SRI (recommended here https://csp.withgoogle.com/docs/faq.html#static-content).
+        // This also prevents use of trusted-types. See https://bugzilla.mozilla.org/show_bug.cgi?id=1409200.
+        //
+        // script-src 'unsafe-eval' is required because agent-js uses a WebAssembly module for the
+        // validation of bls signatures.
         // There is currently no other way to allow execution of WebAssembly modules with CSP.
         // See https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md and
         // https://dfinity.atlassian.net/browse/FOLLOW-383.
@@ -835,7 +841,8 @@ fn security_headers() -> Vec<HeaderField> {
              form-action 'none';\
              style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;\
              style-src-elem 'unsafe-inline' https://fonts.googleapis.com;\
-             font-src https://fonts.gstatic.com"
+             font-src https://fonts.gstatic.com;\
+             upgrade-insecure-requests;"
                 .to_string()
         ),
         (


### PR DESCRIPTION
Adds CSP header to HTTP responses as a defense-in-depth mechanism against XSS.