### PR TITLE
Update spec to include CAPTCHA

### DIFF
--- a/docs/internet-identity-spec.adoc
+++ b/docs/internet-identity-spec.adoc
@@ -235,13 +235,15 @@ service : {
 
 The `init_salt` method is mostly internal, see <<salt>>.
 
-=== The `register` method
+=== The `register` and `create_challenge` methods
 
 The `register` method is used to create a new user. The Internet Identity Service backend creates a _fresh_ Identity Anchor, creates the account record, and adds the given device as the first device.
 
 *Authorization*: This request must be sent to the canister with `caller` that is the self-authenticating id derived from the given `DeviceKey`.
 
-In order to protect the Internet Computer from too many “free” update calls, and to protect the Internet Identity Service from too many user registrations, this call is protected using a proof of work obligation. The `register` call can only succeed if
+In order to protect the Internet Computer from too many “free” update calls, and to protect the Internet Identity Service from too many user registrations, this call is protected using a CAPTCHA challenge. The `register` call can only succeed if the `ChallengeResult` contains a `key` for a challenge that was created with `create_challenge` (see below) in the last 5 minutes _and_ if the `chars` match the characters that the Internet Identity Service has stored internally for that `key`.
+
+In to protect the Internet Identity Service from too many expensive CAPTCHA creations, the `create_challenge` call is protected using a proof of work obligation. The `create_challenge` call can only succeed if
 
  * the `timestamp` in the `ProofOfWork` parameter is within 5min of the current time as seen by the Canister
  * the calculation of `H("\10ic-proof-of-work" · timestamp · nonce · |cid| · cid )` (where `H` is the https://cubehash.cr.yp.to/[CubeHash160+16/32+160-256] function, `·` is concatenation, `|…|` is a single byte encoding the length of the raw canister id in bytes, `cid` is the canister id and numbers are encoded as 8-byte little endian values), yields a hash value where leading 2 bytes are `0x00`.


### PR DESCRIPTION
This updates the spec to include the updated `register` method and the new `create_challenge` method.