### PR TITLE
Don't ask for confirmation on webauthn failure

### DIFF
--- a/src/frontend/src/flows/register.ts
+++ b/src/frontend/src/flows/register.ts
@@ -62,16 +62,18 @@ const init = (): Promise<LoginResult | null> =>
         });
         await tick();
         // Kick-start both the captcha creation and the identity
-        const captcha = makeCaptcha();
-        pendingIdentity
-          .catch((error) => {
+        Promise.all([
+          makeCaptcha(),
+          pendingIdentity.catch((error) => {
             resolve(apiResultToLoginResult({ kind: "authFail", error }));
             // We can never get here, but TS doesn't understand that
             return 0 as unknown as WebAuthnIdentity;
-          })
-          .then((identity) => {
-            confirmRegister(captcha, identity, alias).then(resolve);
-          });
+          }),
+        ]).then(([captcha, identity]) => {
+          confirmRegister(Promise.resolve(captcha), identity, alias).then(
+            resolve
+          );
+        });
       } catch (err) {
         reject(err);
       }


### PR DESCRIPTION
Before this change, and since the introduction of CAPTCHA, canceling the
identity creation would display the "Error" screen _but_ we would then
show the anchor creation confirmation form nonetheless as soon as the
CAPTCHA would be ready.

This makes sure we do either, or.
