### PR TITLE
Make build more reproducible

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   docker-build:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 jobs:
   docker-build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@
 #
 # and find the .wasmfile in out/
 
-FROM ubuntu:20.10
+# The docker image. To update, run `docker pull ubuntu` locally, and update the
+# sha256:... accordingly.
+FROM ubuntu@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322
 
 ARG rust_version=1.51.0
 ENV NODE_VERSION=14.15.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,9 @@ COPY Cargo.lock .
 COPY Cargo.toml .
 COPY src/cubehash src/cubehash
 COPY src/internet_identity/Cargo.toml src/internet_identity/Cargo.toml
-RUN mkdir -p src/internet_identity/src && touch src/internet_identity/src/lib.rs
+# NOTE: we make the timestamp of src/lib.rs very old so that cargo knows to
+# rebuild the real file when we copy it
+RUN mkdir -p src/internet_identity/src && touch -t 197001010000 src/internet_identity/src/lib.rs
 RUN cargo build --target wasm32-unknown-unknown --release -j1
 
 # copy the actual code

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN npm ci
 RUN npm run build
 RUN cargo build --target wasm32-unknown-unknown --release -j1
 RUN sha256sum dist/*
+RUN sha256sum /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm
 RUN ic-cdk-optimizer /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm -o /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm
 RUN cp /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm .
 RUN sha256sum internet_identity.wasm


### PR DESCRIPTION
This improves the Docker set up a bit to help with issues #350 and #452. In particular:

* The docker image is pinned with a digest,
* The shasum of the generated wasm is printed before the cdk optimization (for more insight into _when_ the hash changes),
* The cargo dependencies are built before the code is added to the docker build to make sure the layer is cached.

Commit https://github.com/dfinity/internet-identity/pull/490/commits/1907674938b4ddd717b2da23a5f324b65f69ed37 enabled the Docker build on PRs to make sure everything still works (reverted in https://github.com/dfinity/internet-identity/pull/490/commits/32d566a54eafb7162a8bdecc65ce705abc89c599).

---

sha256 of release wasm before this PR: 953e4947759511b5c286189fe94e694de6125746d3298f161b75d56159cf2d73

---

sha256 of release wasm with this PR: 953e4947759511b5c286189fe94e694de6125746d3298f161b75d56159cf2d73
