### PR TITLE
Update rust cdk git link to address git protocol update

### DIFF
--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -9,7 +9,7 @@ cubehash = { path = "../cubehash" }
 hex = "0.4"
 ic-cdk = "0.3.2"
 ic-cdk-macros = "0.3"
-ic-certified-map = { git = "git://github.com/dfinity/cdk-rs", rev = "129d1a8c595525c6f4c54e73bafa779143e568ce" }
+ic-certified-map = { git = "https://github.com/dfinity/cdk-rs.git", rev = "129d1a8c595525c6f4c54e73bafa779143e568ce" }
 ic-types = "0.1.1"
 serde = "1"
 serde_bytes = "0.11"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Several security changes were made to git protocols late last year, one of which relates to the secure references to a github repository. This applies to cloning from a GitHub repo, as is necessary when deploying the internet identity to a local canister. Therefore, the reference to the rust cdk must be updated to prevent a git protocol error as shown in the stacktrace below.
* Reference to this update - [https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting](https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting)


### Machine
Macbook Pro running 11.4 Big Sur
<!--- Describe your changes in detail -->

## Motivation and Context
Attempting to deploy Internet Identity locally resulted in the following error

```
internet-identity % II_ENV=development dfx deploy --no-wallet --argument '(null)'
Deploying all canisters.
All canisters have already been created.
Building canisters...
Executing 'src/internet_identity/build.sh'
Compiling frontend assets

> internet_identity_assets@0.1.0 build
> NODE_ENV=production webpack

assets by status 1.2 MiB [big]
  asset index.js 708 KiB [compared for emit] [minimized] [big] (name: index) 2 related assets
  asset loader.webp 526 KiB [compared for emit] [from: src/frontend/assets/loader.webp] [copied] [big]
asset favicon.ico 15 KiB [compared for emit] [from: src/frontend/assets/favicon.ico] [copied]
asset index.html 1.08 KiB [compared for emit] [from: src/frontend/assets/index.html] [copied]
orphan modules 275 KiB [orphan] 43 modules
runtime modules 1.16 KiB 6 modules
javascript modules 1.02 MiB
  modules by path ./node_modules/ 893 KiB 59 modules
  modules by path ./src/frontend/ 151 KiB 52 modules
  crypto (ignored) 15 bytes [built] [code generated]
  util (ignored) 15 bytes [built] [code generated]
  util (ignored) 15 bytes [built] [code generated]
optional modules 159 KiB [optional] 10 modules

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  index.js (708 KiB)
  loader.webp (526 KiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  index (708 KiB)
      index.js


WARNING in webpack performance recommendations:
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/

webpack 5.45.1 compiled with 3 warnings in 7223 ms
Running cargo build --manifest-path src/internet_identity/Cargo.toml --target wasm32-unknown-unknown --release -j1
    Updating git repository `git://github.com/dfinity/cdk-rs`
warning: spurious network error (2 tries remaining): remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
; class=Net (12)
warning: spurious network error (1 tries remaining): remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
; class=Net (12)
error: failed to get `ic-certified-map` as a dependency of package `internet_identity v0.1.0 (/Users/byronbecker/Workspace/Cloned_Dfinity_Projects/internet-identity/src/internet_identity)`

Caused by:
  failed to load source for dependency `ic-certified-map`

Caused by:
  Unable to update git://github.com/dfinity/cdk-rs?rev=129d1a8c595525c6f4c54e73bafa779143e568ce#129d1a8c

Caused by:
  failed to fetch into: /Users/myuser/.cargo/git/db/cdk-rs-2e583f5b96e295fb

Caused by:
  network failure seems to have happened
  if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
  ; class=Net (12)
The build step failed for canister 'rkp4c-7iaaa-aaaaa-aaaca-cai' with an embedded error: The custom tool failed
```

## How Has This Been Tested?
* This was tested by making the change, then rerunning the local deployment via the `II_ENV=development dfx deploy --no-wallet --argument '(null)'` command mentioned in [https://github.com/dfinity/internet-identity#running-locally](https://github.com/dfinity/internet-identity#running-locally)

After fix screenshot
![Screen Shot 2022-01-12 at 11 37 42](https://user-images.githubusercontent.com/17368530/149209781-82a9fd7a-f2ad-489f-a290-e41af8e09994.png)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
