### PR TITLE
Update ic-certified-map to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,8 +569,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certified-map"
-version = "0.2.0"
-source = "git+git://github.com/dfinity/cdk-rs?rev=129d1a8c595525c6f4c54e73bafa779143e568ce#129d1a8c595525c6f4c54e73bafa779143e568ce"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c7889064a08b87d6ccf3241e7a5b4dfded4863ec724d24441dfc16df2b3023"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -9,7 +9,7 @@ cubehash = { path = "../cubehash" }
 hex = "0.4"
 ic-cdk = "0.3.2"
 ic-cdk-macros = "0.3"
-ic-certified-map = { git = "https://github.com/dfinity/cdk-rs.git", rev = "129d1a8c595525c6f4c54e73bafa779143e568ce" }
+ic-certified-map = "0.3.0"
 ic-types = "0.1.1"
 serde = "1"
 serde_bytes = "0.11"


### PR DESCRIPTION
Updates ic-certified-map to officially released version 0.3.0.
