### PR TITLE
Change workflows to run on push

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -2,9 +2,6 @@ name: Backend tests
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
 
 jobs:
   backend-tests:

--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -2,9 +2,6 @@ name: Cargo tests
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
 
 jobs:
   cargo-tests:

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -2,9 +2,6 @@ name: Frontend checks and lints
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
 
 jobs:
   frontend-checks:

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -2,9 +2,6 @@ name: e2e tests
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
 
 jobs:
   tests:


### PR DESCRIPTION
This makes sure the GHA workflows run on any push. This means:

* The actual commit is used during the tests (as opposed to
  pull_request which uses a merge commit). This is simpler and anyway we
enforce that the branch must be up to date with master.
* The Actions tab show the commit name for the workflows
* Tests are run on branches too, meaning one doesn't have to create a
  draft PR just for the sake of running tests anymore
