### PR TITLE
Speed up CI docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ screenshots
 target
 out
 arg.in
+Dockerfile
 *.wasm
 
 # filter out all "hidden" files and directories

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -4,26 +4,41 @@ name: Docker build
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: docker build -t internet-identity .
-      - run: mkdir out/
-      - run: docker run --rm --entrypoint cat internet-identity /internet_identity.wasm > out/internet_identity.wasm
-      - run: docker run --rm --entrypoint tar internet-identity -c -f - dist| tar -C out -x
+
+      # We use buildx and its GitHub Actions caching support `type=gha`. For
+      # more information, see
+      # https://github.com/docker/build-push-action/issues/539
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build base Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          cache-from: type=gha,scope=cached-stage
+          cache-to: type=gha,scope=cached-stage,mode=max
+          outputs: type=cacheonly
+          target: deps
+
+      - name: Build internet identity
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          cache-from: type=gha,scope=cached-stage
+          # Exports the artefacts from the final stage
+          outputs: ./out
+
       - run: sha256sum out/internet_identity.wasm
       - name: 'Upload artifacts'
         uses: actions/upload-artifact@v2
         with:
           name: Backend wasm module
           path: out/internet_identity.wasm
-      - name: 'Upload more artifacts'
-        uses: actions/upload-artifact@v2
-        with:
-          name: Frontend assets
-          path: out/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,20 +47,19 @@ ENV CARGO_HOME=/cargo \
 # (keep version in sync with src/internet_identity/build.sh)
 RUN cargo install ic-cdk-optimizer --version 0.3.1
 
-# warm up the cache. Since cargo doesn't have a flag to only build the
-# dependecies, we copy all the files (Cargo.toml, Cargo.lock, vendored deps)
-# _except_ for the actual internet identity code, which we replace with a dummy.
+# Pre-build all cargo dependencies. Because cargo doesn't have a build option
+# to build only the dependecies, we pretend that our project is a simple, empty
+# `lib.rs`. Then we remove the dummy source files to make sure cargo rebuild
+# everything once the actual source code is COPYed (and e.g. doesn't trip on
+# timestamps being older)
 COPY Cargo.lock .
 COPY Cargo.toml .
 COPY src/cubehash src/cubehash
 COPY src/internet_identity/Cargo.toml src/internet_identity/Cargo.toml
-# NOTE: we make the timestamp of src/lib.rs very old so that cargo knows to
-# rebuild the real file when we copy it
-RUN mkdir -p src/internet_identity/src && touch -t 197001010000 src/internet_identity/src/lib.rs
-RUN cargo build --target wasm32-unknown-unknown --release -j1
+RUN mkdir -p src/internet_identity/src && touch src/internet_identity/src/lib.rs && cargo build --target wasm32-unknown-unknown --release -j1 && rm -rf src
 
-# copy the actual code
-RUN rm -rf src
+FROM deps as build
+
 COPY . .
 
 ENV CANISTER_ID=rdmx6-jaaaa-aaaaa-aaadq-cai

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 # The docker image. To update, run `docker pull ubuntu` locally, and update the
 # sha256:... accordingly.
-FROM ubuntu@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322
+FROM ubuntu@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322 as deps
 
 ARG rust_version=1.51.0
 ENV NODE_VERSION=14.15.4
@@ -70,6 +70,8 @@ RUN npm run build
 RUN cargo build --target wasm32-unknown-unknown --release -j1
 RUN sha256sum dist/*
 RUN sha256sum /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm
-RUN ic-cdk-optimizer /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm -o /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm
-RUN cp /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm .
-RUN sha256sum internet_identity.wasm
+RUN ic-cdk-optimizer /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm -o /internet_identity.wasm
+RUN sha256sum /internet_identity.wasm
+
+FROM scratch AS scratch
+COPY --from=build /internet_identity.wasm /

--- a/dfx.json
+++ b/dfx.json
@@ -4,8 +4,7 @@
       "type": "custom",
       "candid": "src/internet_identity/internet_identity.did",
       "wasm": "target/wasm32-unknown-unknown/release/internet_identity.wasm",
-      "build": "src/internet_identity/build.sh",
-      "source": ["dist"]
+      "build": "src/internet_identity/build.sh"
     }
   },
   "defaults": {

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -1,0 +1,65 @@
+#/usr/bin/env bash
+# vim: ft=bash
+# Build internet-identity.wasm inside docker. This outputs a single file, internet-identity.wasm,
+# in the top-level directory.
+
+set -euo pipefail
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd "$SCRIPTS_DIR/.."
+
+II_ENV=${II_ENV:-}
+
+echo "II_ENV: '$II_ENV'"
+echo "PWD: $PWD"
+
+image_name="internet-identity"
+docker_build_args=( --target scratch )
+
+if [ -n "$II_ENV" ]
+then
+    docker_build_args+=( --build-arg II_ENV="$II_ENV" )
+    image_name="$image_name-$II_ENV"
+fi
+
+docker_build_args+=(--tag "$image_name" .)
+
+echo "The following image name will be used: $image_name"
+
+set -x
+docker build "${docker_build_args[@]}"
+set +x
+
+# use no-op as a command, doesn't matter since the container is never run
+container_id=$(docker create "$image_name" no-op)
+
+echo "created container with id $container_id"
+
+success=true
+
+copy() {
+    local container_id="$1"
+    local container_path="$2"
+    local local_path="$3"
+
+    if docker cp $container_id:/"$container_path" "$local_path"
+    then
+        echo "$container_path -> $local_path (from container $container_id)"
+        return 0
+    else
+        echo "could not copy $container_path from container $container_id"
+        return 1
+    fi
+}
+
+copy "$container_id" "internet_identity.wasm" "internet_identity.wasm" || success=false
+
+if [[ $success = true ]]
+then
+    echo "Removing container $container_id"
+    docker rm --volumes "$container_id"
+else
+    echo "container is left for inspection, once done run:"
+    echo "  docker rm -v $container_id"
+fi

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -1,6 +1,6 @@
 #/usr/bin/env bash
 # vim: ft=bash
-# Build internet-identity.wasm inside docker. This outputs a single file, internet-identity.wasm,
+# Build internet_identity.wasm inside docker. This outputs a single file, internet_identity.wasm,
 # in the top-level directory.
 
 set -euo pipefail


### PR DESCRIPTION
This updates our docker setup a bit to speed up the builds and allow more flexibility. In particular:

* Clean up the cargo deps build
* Add proper multi-stage build and a scratch target
* Add `docker-build`, which builds `internet_identity.wasm` through docker
* Simplify `dfx.json` by removing the unused `dist/` `source` directory
* Use `buildx` and github actions caching support and make docker build run on every branch (not only master)

[Docker build duration latest main](https://github.com/dfinity/internet-identity/runs/4919639553?check_suite_focus=true): 16mn18s
[Docker build duration here](https://github.com/dfinity/internet-identity/runs/4936107543?check_suite_focus=true): 2mn20s

[sha256sum main](https://github.com/dfinity/internet-identity/runs/4919639553?check_suite_focus=true#step:7:4): 5d6b74a95aae3e8237f1758021cc20b5e344f6a1a4e80311eefcc6aae78dc4fc
[sha256sum here](https://github.com/dfinity/internet-identity/runs/4936107543?check_suite_focus=true#step:6:4): 5d6b74a95aae3e8237f1758021cc20b5e344f6a1a4e80311eefcc6aae78dc4fc