### PR TITLE
Update docker-build documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # Use this with
 #
 #  docker build -t internet-identity .
-#  docker run --rm --entrypoint cat internet-identity /internet_identity.wasm > internet_identity.wasm
+#  or use ./scripts/docker-build
 #
-# and find the .wasmfile in out/
-
 # The docker image. To update, run `docker pull ubuntu` locally, and update the
 # sha256:... accordingly.
 FROM ubuntu@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322 as deps

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ can validate that we really deploy what we claim to deploy.
 We try to achieve some level of reproducibility using a Dockerized build
 environment. The following steps _should_ build the official Wasm image
 
-    docker build -t internet-identity-service .
-    docker run --rm --entrypoint cat internet-identity-service /internet_identity.wasm > internet_identity.wasm
+    ./scripts/docker-build
     sha256sum internet_identity.wasm
 
 The resulting `internet_identity.wasm` is ready for deployment as

--- a/docs/internet-identity-spec.adoc
+++ b/docs/internet-identity-spec.adoc
@@ -630,8 +630,7 @@ For installation or upgrade, you should build it the “official” way.
 In a checkout of this repository, run the following to build the official image:
 [source,bash]
 ----
-docker build -t internet-identity-service .
-docker run --rm --entrypoint cat internet-identity-service /internet_identity.wasm > internet_identity.wasm
+./scripts/docker-build
 ----
 
 The resulting `internet_identity.wasm` is ready for deployment on `mainnet`.
@@ -708,8 +707,7 @@ need to build with `II_ENV=development`:
 [source,bash]
 ----
 didc encode '(null)' | xxd -r -p > arg.in
-docker build -t internet-identity-development . --build-arg II_ENV=development
-docker run --rm --entrypoint cat internet-identity-development /internet_identity.wasm > internet_identity.wasm
+II_ENV=development ./scripts/docker-build
 ----
 
 This will create the Wasm file you want to use for the following deployment steps at `./internet_identity.wasm`.

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 # vim: ft=bash
 # Build internet_identity.wasm inside docker. This outputs a single file, internet_identity.wasm,
 # in the top-level directory.


### PR DESCRIPTION
This updates the doc on how to run the docker build and fixes the
shebang in `scripts/docker-build`.
