### PR TITLE
Fix docker-build comment

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,5 +1,4 @@
-# The "official" docker build. This is a pretty long build (~20mn) which we
-# only run on master.
+# The "official" docker build.
 name: Docker build
 
 on:


### PR DESCRIPTION
It wasn't up-to-date; the builds now take ~3mn and run on every push.
