### PR TITLE
Bump rustc to 1.58.1

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     env:
-      RUSTC_VERSION: 1.51.0
+      RUSTC_VERSION: 1.58.1
       GHC_VERSION: 8.8.4
 
     steps:
@@ -22,7 +22,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-dummy-captcha-${{ hashFiles('**/Cargo.lock') }}-1
+          key: ${{ runner.os }}-cargo-${{ env.RUSTC_VERSION }}-dummy-captcha-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Cache ~/.cabal/store
         uses: actions/cache@v2

--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     env:
-      RUSTC_VERSION: 1.51.0
+      RUSTC_VERSION: 1.58.1
 
     steps:
       - uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+          key: ${{ runner.os }}-cargo-${{ env.RUSTC_VERSION }}-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Install Rust
         run: |
@@ -49,7 +49,7 @@ jobs:
   cargo-fmt:
     runs-on: ubuntu-latest
     env:
-      RUSTC_VERSION: 1.51.0
+      RUSTC_VERSION: 1.58.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
     env:
       DFX_VERSION: 0.8.3
-      RUSTC_VERSION: 1.51.0
+      RUSTC_VERSION: 1.58.1
 
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-selenium-${{ hashFiles('**/Cargo.lock') }}-1
+          key: ${{ runner.os }}-cargo-${{ env.RUSTC_VERSION }}-selenium-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # sha256:... accordingly.
 FROM ubuntu@sha256:626ffe58f6e7566e00254b638eb7e0f3b11d4da9675088f4781a50ae288f3322 as deps
 
-ARG rust_version=1.51.0
+ARG rust_version=1.58.1
 ENV NODE_VERSION=14.15.4
 
 ENV TZ=UTC

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.51.0"
+channel = "1.58.1"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This bumps our outdated rust toolchain version to something more recent.