### PR TITLE
Build dummy captcha on Docker

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -5,7 +5,7 @@ on:
   push:
 
 jobs:
-  docker-build:
+  docker-build-base:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,6 +26,15 @@ jobs:
           outputs: type=cacheonly
           target: deps
 
+  docker-build-official:
+    runs-on: ubuntu-latest
+    needs: docker-build-base
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Build internet identity
         uses: docker/build-push-action@v2
         with:
@@ -36,8 +45,33 @@ jobs:
           outputs: ./out
 
       - run: sha256sum out/internet_identity.wasm
-      - name: 'Upload artifacts'
+      - name: 'Upload official wasm'
         uses: actions/upload-artifact@v2
         with:
-          name: Backend wasm module
+          name: internet_identity.wasm
+          path: out/internet_identity.wasm
+
+  docker-build-dummy-captcha:
+    runs-on: ubuntu-latest
+    needs: docker-build-base
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build internet identity
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          cache-from: type=gha,scope=cached-stage
+          # Exports the artefacts from the final stage
+          outputs: ./out
+
+      - run: sha256sum out/internet_identity.wasm
+      - name: 'Upload dummy captcha wasm'
+        uses: actions/upload-artifact@v2
+        with:
+          name: internet_identity_dummy_captcha.wasm
           path: out/internet_identity.wasm


### PR DESCRIPTION
This makes sure that the dummy captcha build is performed in docker as
well, and its result stored as an artifact.
