### PR TITLE
Use build.sh in Dockerfile

### DIFF
--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -40,6 +40,25 @@ jobs:
           rustup default "$RUSTC_VERSION"
           rustup target add wasm32-unknown-unknown
 
+      # Cache the ic-cdk-optimizer
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.local/bin/ic-cdk-optimizer
+            target
+          key: ${{ runner.os }}-ic-cdk-optimizer-${{ env.IC_CDK_OPTIMIZER_VERSION }}
+
+      - name: Install ic-cdk-optimizer
+        run: |
+          install_dir="$HOME/.local/bin/"
+          mkdir -p "$install_dir"
+          if [ ! -x "$install_dir/ic-cdk-optimizer" ]
+          then
+            cargo install --version "0.3.1" ic-cdk-optimizer
+            cp $HOME/.cargo/bin/ic-cdk-optimizer "$install_dir"
+            echo "$install_dir" >> $GITHUB_PATH
+          fi
+
       # This step hangs on Github actions on Darwin for some reason, that
       # is why we run this only on Linux for now
       - name: Install DFX

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,14 +64,11 @@ COPY . .
 
 ARG II_ENV=production
 
-RUN npm ci
-RUN npm run build
-
 RUN touch src/internet_identity/src/lib.rs
-RUN cargo build --target wasm32-unknown-unknown --release -j1
-RUN sha256sum dist/*
-RUN sha256sum /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm
-RUN ic-cdk-optimizer /cargo_target/wasm32-unknown-unknown/release/internet_identity.wasm -o /internet_identity.wasm
+RUN npm ci
+
+RUN ./src/internet_identity/build.sh
+RUN cp "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/internet_identity.wasm" /internet_identity.wasm
 RUN sha256sum /internet_identity.wasm
 
 FROM scratch AS scratch

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Our CI also performs these steps; you can compare the SHA256 with the output the
 
 
 
-## Software versions
+## Dependencies
 
 - `dfx` version 0.8.3
+
+- [`ic-cdk-optimizer`](https://github.com/dfinity/cdk-rs/tree/main/src/ic-cdk-optimizer) version 0.3.1
 
 - Rust version 1.51
 

--- a/src/internet_identity/build.sh
+++ b/src/internet_identity/build.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Checking for dependencies
+# XXX: we currently cannot check for the exact version of ic-cdk-optimizer
+# because of https://github.com/dfinity/cdk-rs/issues/181
+# Once the issue is fixed, we can ensure that the correct version is installed
+if ! command -v ic-cdk-optimizer
+then
+    echo could not find ic-cdk-optimizer
+    echo "ic-cdk-optimizer version 0.3.1 is needed, please run the following command:"
+    echo "  cargo install ic-cdk-optimizer --version 0.3.1"
+    exit 1
+fi
+
 # Compile frontend assets to dist
 echo Compiling frontend assets
 npm run build
@@ -28,17 +40,8 @@ echo Running cargo build "${cargo_build_args[@]}"
 
 cargo build "${cargo_build_args[@]}"
 
-# keep version in sync with Dockerfile
-cargo install ic-cdk-optimizer --version 0.3.1 --root "$II_DIR"/../../target
-STATUS=$?
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$II_DIR/../../target/}"
 
-if [ "$STATUS" -eq "0" ]; then
-      "$II_DIR"/../../target/bin/ic-cdk-optimizer \
-      "$II_DIR/../../target/$TARGET/release/internet_identity.wasm" \
-      -o "$II_DIR/../../target/$TARGET/release/internet_identity.wasm"
-
-  true
-else
-  echo Could not install ic-cdk-optimizer.
-  false
-fi
+ic-cdk-optimizer \
+    "$CARGO_TARGET_DIR/$TARGET/release/internet_identity.wasm" \
+    -o "$CARGO_TARGET_DIR/$TARGET/release/internet_identity.wasm"


### PR DESCRIPTION
This makes sure the docker build uses the same commands as `dfx build`.
We're now specifying `ic-cdk-optimizer` as a dependency -- as it should
be -- potentially trivially resolving https://github.com/dfinity/internet-identity/issues/381