### PR TITLE
Actually build dummy captcha in Docker

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -65,6 +65,8 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          build-args:
+            - USE_DUMMY_CAPTCHA=1
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: ./out

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -65,8 +65,8 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          build-args:
-            - USE_DUMMY_CAPTCHA=1
+          build-args: |
+            USE_DUMMY_CAPTCHA=1
           cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: ./out

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ FROM deps as build
 COPY . .
 
 ARG II_ENV=production
+ARG USE_DUMMY_CAPTCHA=
 
 RUN touch src/internet_identity/src/lib.rs
 RUN npm ci

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -9,18 +9,26 @@ SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "$SCRIPTS_DIR/.."
 
-II_ENV=${II_ENV:-}
-
-echo "II_ENV: '$II_ENV'"
 echo "PWD: $PWD"
 
 image_name="internet-identity"
 docker_build_args=( --target scratch )
 
+II_ENV=${II_ENV:-}
+echo "II_ENV: '$II_ENV'"
+
 if [ -n "$II_ENV" ]
 then
     docker_build_args+=( --build-arg II_ENV="$II_ENV" )
     image_name="$image_name-$II_ENV"
+fi
+
+USE_DUMMY_CAPTCHA=${USE_DUMMY_CAPTCHA:-}
+echo "USE_DUMMY_CAPTCHA: '$USE_DUMMY_CAPTCHA'"
+
+if [[ "$USE_DUMMY_CAPTCHA" == "1" ]]
+then
+    docker_build_args+=( --build-arg USE_DUMMY_CAPTCHA="$USE_DUMMY_CAPTCHA" )
 fi
 
 docker_build_args+=(--tag "$image_name" .)

--- a/src/internet_identity/build.sh
+++ b/src/internet_identity/build.sh
@@ -33,6 +33,7 @@ cargo_build_args=(
 # EVAR.
 if [ "${USE_DUMMY_CAPTCHA:-}" == "1" ]
 then
+    echo "USING DUMMY CAPTCHA"
     cargo_build_args+=( --features dummy_captcha )
 fi
 


### PR DESCRIPTION
Actually forgot to specify the `--build-arg` in the GitHub actions for
building with `USE_DUMMY_CAPTCHA=1`. The value is now read by the docker
file.