### PR TITLE
Sync chromedriver version with GHA

### DIFF
--- a/selenium-standalone.config.js
+++ b/selenium-standalone.config.js
@@ -2,7 +2,7 @@ module.exports = {
   drivers: {
     chrome: {
       // This version needs to match the chrome version on GitHub Actions
-      version: '96.0.4664.45',
+      version: '98.0.4758.80',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },


### PR DESCRIPTION
GitHub Actions regularly update their Chrome version, and we need to
keep our chromedriver version in sync, otherwise [see failure on
master](https://github.com/dfinity/internet-identity/actions/runs/1822887830)
