### PR TITLE
Run formatter

### DIFF
--- a/src/frontend/src/test-e2e/selenium.test.ts
+++ b/src/frontend/src/test-e2e/selenium.test.ts
@@ -37,8 +37,12 @@ import canister_ids2 from "../../../../demos/whoami/.dfx/local/canister_ids.json
 const IDENTITY_CANISTER = canister_ids1.internet_identity.local;
 const WHOAMI_CANISTER = canister_ids2.whoami.local;
 
-const REPLICA_URL = process.env.REPLICA_URL ? process.env.REPLICA_URL : "http://localhost:8000";
-const II_ORIGIN = process.env.II_ORIGIN ? process.env.II_ORIGIN : "http://localhost:8000";
+const REPLICA_URL = process.env.REPLICA_URL
+  ? process.env.REPLICA_URL
+  : "http://localhost:8000";
+const II_ORIGIN = process.env.II_ORIGIN
+  ? process.env.II_ORIGIN
+  : "http://localhost:8000";
 const II_URL = `${II_ORIGIN}/?canisterId=${IDENTITY_CANISTER}`;
 const FAQ_URL = `${II_ORIGIN}/faq?canisterId=${IDENTITY_CANISTER}`;
 const ABOUT_URL = `${II_ORIGIN}/about?canisterId=${IDENTITY_CANISTER}`;


### PR DESCRIPTION
Apparently it didn't run on the selenium specs. CI should push formatting changes in `src/frontend`, will investigate. For now, this prevents having formatting changes in unrelated PRs.