### PR TITLE
Don't override optimized build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,6 @@ RUN touch src/internet_identity/src/lib.rs
 RUN npm ci
 
 RUN ./src/internet_identity/build.sh
-RUN cp "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/internet_identity.wasm" /internet_identity.wasm
 RUN sha256sum /internet_identity.wasm
 
 FROM scratch AS scratch


### PR DESCRIPTION
When making https://github.com/dfinity/internet-identity/pull/531 I forgot to _stop_ copying the cargo output in the docker build. This means that the optimized wasm was being overwritten by the stock one.
