### PR TITLE
Show proper dimensions for dummy captcha

### DIFF
--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -527,7 +527,7 @@ async fn make_rng() -> rand_chacha::ChaCha20Rng {
 #[cfg(feature = "dummy_captcha")]
 fn create_captcha<T: RngCore>(rng: T) -> (Base64, String) {
     let mut captcha = captcha::RngCaptcha::from_rng(rng);
-    let captcha = captcha.set_chars(&vec!['a']).add_chars(1).view(10, 10);
+    let captcha = captcha.set_chars(&vec!['a']).add_chars(1).view(96,48);
 
     let resp = match captcha.as_base64() {
         Some(png_base64) => Base64(png_base64),


### PR DESCRIPTION
This shows the full letter ("a") when the dummy captcha is used.
Previously it was very zoomed in and no one could make out what the
captcha value actually was.
<img width="443" alt="Screenshot 2022-02-14 at 15 16 03" src="https://user-images.githubusercontent.com/6930756/153880817-15d6437a-b170-49a7-afb2-3347484fd67a.png">
