### PR TITLE
Upload screenshots on branch runs

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -347,8 +347,8 @@ jobs:
     # artifacts)
     needs: selenium
 
-    # Only run on PRs, we don't want to commit new screenshots to master
-    if: ${{ github.event_name == 'pull_request' }}
+    # We don't want to commit new screenshots to main
+    if: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We recently made the workflows run on all pulls and not only PRs. What I
missed was that the uploader on runs on "PR" runs.

This change ensures that the screenshots are correctly uploaded.