### PR TITLE
L2-279: Implement add device tentatively

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -71,6 +71,17 @@ type RegisterResponse = variant {
   bad_challenge;
 };
 
+type AddTentativeDeviceResponse = variant {
+  // The device was tentatively added.
+  added_tentatively: record { pin: text; };
+  // Device registration mode disabled for this user.
+  device_registration_mode_disabled;
+  // Device already exists on this user.
+  device_already_added;
+  // There is another device already added tentatively
+  tentative_device_already_exists;
+};
+
 type Delegation = record {
   pubkey: PublicKey;
   expiration: Timestamp;
@@ -123,6 +134,7 @@ service : (opt InternetIdentityInit) -> {
 
   enable_registration_mode : (UserNumber) -> (Timestamp);
   disable_registration_mode : (UserNumber) -> ();
+  add_tentative_device : (UserNumber, DeviceData) -> (AddTentativeDeviceResponse)
 
   prepare_delegation : (UserNumber, FrontendHostname, SessionKey, maxTimeToLive : opt nat64) -> (UserKey, Timestamp);
   get_delegation: (UserNumber, FrontendHostname, SessionKey, Timestamp) -> (GetDelegationResponse) query;

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -76,8 +76,6 @@ type AddTentativeDeviceResponse = variant {
   added_tentatively: record { pin: text; };
   // Device registration mode disabled for this user.
   device_registration_mode_disabled;
-  // Device already exists on this user.
-  device_already_added;
   // There is another device already added tentatively
   tentative_device_already_exists;
 };

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -134,7 +134,7 @@ service : (opt InternetIdentityInit) -> {
 
   enable_device_registration_mode : (UserNumber) -> (Timestamp);
   disable_device_registration_mode : (UserNumber) -> ();
-  add_tentative_device : (UserNumber, DeviceData) -> (AddTentativeDeviceResponse)
+  add_tentative_device : (UserNumber, DeviceData) -> (AddTentativeDeviceResponse);
 
   prepare_delegation : (UserNumber, FrontendHostname, SessionKey, maxTimeToLive : opt nat64) -> (UserKey, Timestamp);
   get_delegation: (UserNumber, FrontendHostname, SessionKey, Timestamp) -> (GetDelegationResponse) query;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -191,8 +191,6 @@ enum AddTentativeDeviceResponse {
     AddedTentatively { pin: String },
     #[serde(rename = "device_registration_mode_disabled")]
     DeviceRegistrationModeDisabled,
-    #[serde(rename = "device_already_added")]
-    DeviceAlreadyAdded,
     #[serde(rename = "tentative_device_already_exists")]
     TentativeDeviceAlreadyExists,
 }
@@ -416,24 +414,6 @@ fn check_tentative_device_reg_prerequisites(
         {
             // some tentative device already exists
             return Err(AddTentativeDeviceResponse::TentativeDeviceAlreadyExists);
-        }
-
-        let existing_devices = state
-            .storage
-            .borrow()
-            .read(user_number)
-            .unwrap_or_else(|err| {
-                trap(&format!(
-                    "failed to read device data of user {}: {}",
-                    user_number, err
-                ))
-            });
-
-        let tentative_principal = Principal::self_authenticating(&device_data.pubkey);
-        for existing_device in existing_devices {
-            if Principal::self_authenticating(existing_device.pubkey) == tentative_principal {
-                return Err(AddTentativeDeviceResponse::DeviceAlreadyAdded);
-            }
         }
         Ok(())
     })

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -372,12 +372,7 @@ async fn generate_pin() -> String {
         Ok((res, )) => res,
         Err((_, err)) => trap(&format!("failed to get randomness: {}", err)),
     };
-    let rand = u32::from_be_bytes(res[..4].try_into().unwrap_or_else(|foo| {
-        trap(&format!(
-            "expected raw randomness to be at least 4 bytes, got {}",
-            res.len()
-        ))
-    }));
+    let rand = u32::from_be_bytes(res[..4].try_into().unwrap());
     (rand % 1_000_000).to_string()
 }
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -5,8 +5,8 @@ use std::convert::TryInto;
 
 #[cfg(not(feature = "dummy_captcha"))]
 use captcha::filters::Wave;
-use ic_cdk::api::call::call;
 use ic_cdk::api::{caller, data_certificate, id, set_certified_data, time, trap};
+use ic_cdk::api::call::call;
 use ic_cdk::export::candid::{CandidType, Deserialize, Principal};
 use ic_cdk_macros::{init, post_upgrade, query, update};
 use ic_certified_map::{AsHashTree, Hash, HashTree, RbTree};
@@ -429,8 +429,9 @@ fn check_tentative_device_reg_prerequisites(
                 ))
             });
 
+        let tentative_principal = Principal::self_authenticating(&device_data.pubkey);
         for existing_device in existing_devices {
-            if existing_device.pubkey == device_data.pubkey {
+            if Principal::self_authenticating(existing_device.pubkey) == tentative_principal {
                 return Err(AddTentativeDeviceResponse::DeviceAlreadyAdded);
             }
         }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -392,8 +392,8 @@ fn check_tentative_device_reg_prerequisites(
     STATE.with(|state| {
         clean_expired_device_reg_mode_flags(state);
 
-        match state
-            .device_registrations
+        let device_registrations = &state.device_registrations;
+        match device_registrations
             .users_in_device_reg_mode
             .borrow_mut()
             .get(&user_number)
@@ -408,8 +408,7 @@ fn check_tentative_device_reg_prerequisites(
             }
         }
 
-        if state
-            .device_registrations
+        if device_registrations
             .tentative_devices
             .borrow()
             .get(&user_number)


### PR DESCRIPTION
This PR is part of the implementation of the new device registration flow.
It adds the canister call to register a new device tentatively.