### PR TITLE
L2-280: Verify tentative device

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -82,6 +82,15 @@ type AddTentativeDeviceResponse = variant {
   tentative_device_already_exists;
 };
 
+type VerifyTentativeDeviceResponse = variant {
+  // The device was successfully verified.
+  verified;
+  // Wrong pin entered. Retry with correct pin.
+  wrong_pin_retry;
+  // Wrong pin entered. No retries.
+  wrong_pin;
+};
+
 type Delegation = record {
   pubkey: PublicKey;
   expiration: Timestamp;
@@ -134,7 +143,8 @@ service : (opt InternetIdentityInit) -> {
 
   enable_device_registration_mode : (UserNumber) -> (Timestamp);
   disable_device_registration_mode : (UserNumber) -> ();
-  add_tentative_device : (UserNumber, DeviceData) -> (AddTentativeDeviceResponse)
+  add_tentative_device : (UserNumber, DeviceData) -> (AddTentativeDeviceResponse);
+  verify_tentative_device : (UserNumber, pin: text);
 
   prepare_delegation : (UserNumber, FrontendHostname, SessionKey, maxTimeToLive : opt nat64) -> (UserKey, Timestamp);
   get_delegation: (UserNumber, FrontendHostname, SessionKey, Timestamp) -> (GetDelegationResponse) query;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -387,6 +387,7 @@ async fn verify_tentative_device(
 ) -> VerifyTentativeDeviceResponse {
     match check_add_tentative_device_prerequisites(user_number, user_pin) {
         Ok(device) => {
+            disable_device_registration_mode(user_number);
             add(user_number, device).await;
             VerifyTentativeDeviceResponse::Verified
         }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -416,6 +416,7 @@ fn check_add_tentative_device_prerequisites(
             None => trap("no tentative device to verify"),
             Some((device, pin, mut failed_attempts)) => {
                 if user_pin != pin {
+                    failed_attempts = failed_attempts + 1;
                     if failed_attempts >= MAX_DEVICE_REGISTRATION_ATTEMPTS {
                         // disable device registration mode
                         state
@@ -424,7 +425,6 @@ fn check_add_tentative_device_prerequisites(
                             .remove(&user_number);
                         return Err(VerifyTentativeDeviceResponse::WrongPin);
                     }
-                    failed_attempts = failed_attempts + 1;
                     tentative_devices.insert(user_number, (device, pin, failed_attempts));
                     return Err(VerifyTentativeDeviceResponse::WrongPinRetry);
                 }


### PR DESCRIPTION
This PR is part of the implementation of the new device registration flow.
It adds a canister call to verify a tentatively added device.
