### PR TITLE
L2-308: Retrieve identity anchor information

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -134,7 +134,7 @@ type ChallengeResult = record {
 type IdentityAnchorInfo = record {
     devices : vec DeviceData;
     tentative_device : opt DeviceData;
-    device_registration_mode: opt Timestamp;
+    device_registration_mode_expiration: opt Timestamp;
 }
 
 service : (opt InternetIdentityInit) -> {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -135,7 +135,7 @@ type IdentityAnchorInfo = record {
     devices : vec DeviceData;
     tentative_device : opt DeviceData;
     device_registration_mode_expiration: opt Timestamp;
-}
+};
 
 service : (opt InternetIdentityInit) -> {
   init_salt: () -> ();

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -144,14 +144,14 @@ service : (opt InternetIdentityInit) -> {
   add : (UserNumber, DeviceData) -> ();
   remove : (UserNumber, DeviceKey) -> ();
   lookup : (UserNumber) -> (vec DeviceData) query;
-  get_anchor_info : (UserNumber) -> IdentityAnchorInfo;
+  get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);
   get_principal : (UserNumber, FrontendHostname) -> (principal) query;
   stats : () -> (InternetIdentityStats) query;
 
   enable_device_registration_mode : (UserNumber) -> (Timestamp);
   disable_device_registration_mode : (UserNumber) -> ();
   add_tentative_device : (UserNumber, DeviceData) -> (AddTentativeDeviceResponse);
-  verify_tentative_device : (UserNumber, pin: text);
+  verify_tentative_device : (UserNumber, pin: text) -> (VerifyTentativeDeviceResponse);
 
   prepare_delegation : (UserNumber, FrontendHostname, SessionKey, maxTimeToLive : opt nat64) -> (UserKey, Timestamp);
   get_delegation: (UserNumber, FrontendHostname, SessionKey, Timestamp) -> (GetDelegationResponse) query;

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -131,6 +131,12 @@ type ChallengeResult = record {
     chars : text;
 };
 
+type IdentityAnchorInfo = record {
+    devices : vec DeviceData;
+    tentative_device : opt DeviceData;
+    device_registration_mode: opt Timestamp;
+}
+
 service : (opt InternetIdentityInit) -> {
   init_salt: () -> ();
   create_challenge : (ProofOfWork) -> (Challenge);
@@ -138,6 +144,7 @@ service : (opt InternetIdentityInit) -> {
   add : (UserNumber, DeviceData) -> ();
   remove : (UserNumber, DeviceKey) -> ();
   lookup : (UserNumber) -> (vec DeviceData) query;
+  get_anchor_info : (UserNumber) -> IdentityAnchorInfo;
   get_principal : (UserNumber, FrontendHostname) -> (principal) query;
   stats : () -> (InternetIdentityStats) query;
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -837,6 +837,7 @@ fn get_anchor_info(user_number: UserNumber) -> IdentityAnchorInfo {
             .collect();
 
         let device_registration_mode_expiration = state
+            .device_registrations
             .users_in_device_reg_mode
             .borrow()
             .get(&user_number)
@@ -845,6 +846,7 @@ fn get_anchor_info(user_number: UserNumber) -> IdentityAnchorInfo {
         match device_registration_mode_expiration {
             Some(expiration) if expiration > time() => {
                 let tentative_device = state
+                    .device_registrations
                     .tentative_devices
                     .borrow()
                     .get(&user_number)


### PR DESCRIPTION
This PR is part of the implementation of the new device registration flow.
It adds a canister call to query the anchor information including registration mode and tentative device.
It is implemented as an update call because queries are not (yet) certified.