### PR TITLE
Fail CI on bad ts formatting

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -12,15 +12,4 @@ jobs:
       - name: Run ESLint
         run: npm run lint
       - name: Check formatting
-        run: npm run format
-      - name: Commit Formatting changes
-        uses: EndBug/add-and-commit@v7.2.0
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          add: src/frontend
-          author_name: Formatting Committer
-          author_email: "<nobody@example.com>"
-          message: "Updating frontend formatting"
-          # do not pull: if this branch is behind, then we might as well let
-          # the pushing fail
-          pull_strategy: "NO-PULL"
+        run: npm run format-check

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:e2e-mobile": "SCREEN=mobile npm run test:e2e",
     "lint": "eslint --max-warnings 0 --cache --cache-location node_modules/.cache/eslint 'src/frontend/**/*.ts*'",
     "format": "prettier --write src/frontend",
+    "format-check": "prettier --check src/frontend",
     "install-webdrivers": "selenium-standalone install --config ./selenium-standalone.config.js"
   },
   "devDependencies": {

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -239,14 +239,16 @@ export async function switchToPopup(
 export async function removeFlavorsWarning(
   browser: WebdriverIO.Browser
 ): Promise<void> {
-    const warningContainer = await browser.$(".flavors-warning-container");
-    await warningContainer.waitForDisplayed();
-    await browser.execute(() => {
-        const warningContainer = document.querySelector('.flavors-warning-container');
-        if(warningContainer) {
-            warningContainer.remove();
-        }
-    });
+  const warningContainer = await browser.$(".flavors-warning-container");
+  await warningContainer.waitForDisplayed();
+  await browser.execute(() => {
+    const warningContainer = document.querySelector(
+      ".flavors-warning-container"
+    );
+    if (warningContainer) {
+      warningContainer.remove();
+    }
+  });
 }
 
 export async function waitToClose(browser: WebdriverIO.Browser): Promise<void> {


### PR DESCRIPTION
This fails the CI checks if the ts code isn't properly formatted. Before
this, the CI would commit the formatted files. This was annoying
because:
* It would push to the branch, meaning developers had to pull or
  force-push
* The commit would not trigger a CI run due to GHA limitations