### PR TITLE
Add release script and release on tag push

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -87,7 +87,8 @@ jobs:
         with:
           # name is the name used to display and retrieve the artifact
           name: ${{ matrix.name }}
-          # path is the name used as the file to upload, and the created when downloaded
+          # path is the name used as the file to upload and the name of the
+          # downloaded file
           path: ${{ matrix.name }}
 
   #####################
@@ -137,7 +138,7 @@ jobs:
       - name: Run Tests
         shell: bash
         working-directory: backend-tests
-        run: mv internet_identity_test.wasm internet_identity.wasm && cabal run
+        run: mv ../internet_identity_test.wasm ../internet_identity.wasm && cabal run
 
   ######################
   # The selenium tests #

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -81,11 +81,14 @@ jobs:
           outputs: ./out
 
       - run: sha256sum out/internet_identity.wasm
+      - run: mv out/internet_identity.wasm ${{ matrix.name }}
       - name: 'Upload ${{ matrix.name }}'
         uses: actions/upload-artifact@v2
         with:
+          # name is the name used to display and retrieve the artifact
           name: ${{ matrix.name }}
-          path: out/internet_identity.wasm
+          # path is the name used as the file to upload, and the created when downloaded
+          path: ${{ matrix.name }}
 
   #####################
   # The backend tests #
@@ -134,7 +137,7 @@ jobs:
       - name: Run Tests
         shell: bash
         working-directory: backend-tests
-        run: cabal run
+        run: mv internet_identity_test.wasm internet_identity.wasm && cabal run
 
   ######################
   # The selenium tests #
@@ -197,6 +200,7 @@ jobs:
 
       - name: Deploy Internet Identity
         run: |
+          mv internet_identity_test.wasm internet_identity.wasm
           dfx canister --no-wallet create --all
           dfx canister --no-wallet install internet_identity --argument '(null)'
 
@@ -286,6 +290,7 @@ jobs:
       - name: Deploy II
         run: |
           echo installing
+          mv ./internet_identity_dev.wasm ./internet_identity.wasm
           shasum -a 256 ./internet_identity.wasm
 
           dfx canister --no-wallet create --all
@@ -346,10 +351,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
-    needs: docker-build
-
     # Only run on release tags
     if: startsWith(github.ref, 'refs/tags/release-')
+
+    needs: docker-build
 
     steps:
       - uses: actions/checkout@v2
@@ -377,6 +382,7 @@ jobs:
             internet_identity_test.wasm \
             internet_identity_dev.wasm \
             internet_identity_production.wasm
+
         env:
           # populated by GitHub Actions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -341,3 +341,17 @@ jobs:
           # do not pull: if this branch is behind, then we might as well let
           # the pushing fail
           pull: "NO-PULL"
+
+  # This ... releases
+  release:
+    runs-on: ubuntu-latest
+
+    # Only run on release tags
+    if: startsWith(github.ref, 'refs/tags/release-')
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: ./scripts/release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -346,13 +346,37 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    needs: docker-build
+
     # Only run on release tags
     if: startsWith(github.ref, 'refs/tags/release-')
 
     steps:
       - uses: actions/checkout@v2
 
-      - run: ./scripts/release --tag ${{ github.ref }}
+      - name: 'Download wasm'
+        uses: actions/download-artifact@v2
+        with:
+          name: internet_identity_test.wasm
+          path: .
+
+      - name: 'Download wasm'
+        uses: actions/download-artifact@v2
+        with:
+          name: internet_identity_dev.wasm
+          path: .
+
+      - name: 'Download wasm'
+        uses: actions/download-artifact@v2
+        with:
+          name: internet_identity_production.wasm
+          path: .
+
+      - run: |
+          ./scripts/release --tag ${{ github.ref }} -- \
+            internet_identity_test.wasm \
+            internet_identity_dev.wasm \
+            internet_identity_production.wasm
         env:
           # populated by GitHub Actions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -352,6 +352,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: ./scripts/release
+      - run: ./scripts/release --tag ${{ github.ref }}
         env:
+          # populated by GitHub Actions
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/release
+++ b/scripts/release
@@ -29,13 +29,13 @@ function check_token() {
 
 function gh() {
     local path=$1
+    shift
     if [[ $path != https://* ]]
     then
         path="https://api.github.com/${path#"/"}"
     fi
-    shift
 
-    local output=$(mktemp)
+    local output; output=$(mktemp)
     local http_code
     # NOTE: cannot use `--fail-with-body` because it's not available on GHA
     http_code=$(curl -w '%{http_code}' -o "$output" --silent  \
@@ -49,8 +49,8 @@ function gh() {
         cat "$output"
         rm "$output"
     else
-        >&2 echo "Failed ($?) request to '$path' with '$@'"
-        cat "$output" | >&2 jq
+        >&2 echo "Failed ($?) request to '$path' with '$*'"
+        >&2 jq <"$output"
         rm "$output"
         exit 1
     fi
@@ -76,7 +76,9 @@ function gh_post_tgz() {
 # Actual release function
 
 function do_release() {
-    local release_json; release_json=$(jq -n --arg tag_name "$tag_name" '{ tag_name: $tag_name }' | gh_post_json /repos/dfinity/internet-identity/releases)
+    local release_json
+    release_json=$(jq -n --arg tag_name "$tag_name" '{ tag_name: $tag_name }' \
+        | gh_post_json /repos/dfinity/internet-identity/releases)
 
     local release_id; release_id=$(echo "$release_json" | jq -cMr '.id')
     local html_url; html_url="$(echo "$release_json" | jq -cMr '.html_url')"

--- a/scripts/release
+++ b/scripts/release
@@ -21,6 +21,9 @@ Usage:
 Options:
   --tag TAG     specify the tag to release
 
+Environment:
+  GITHUB_TOKEN  (required) Personal Access Token for GitHub
+
 EOF
 }
 

--- a/scripts/release
+++ b/scripts/release
@@ -17,6 +17,7 @@ function need_cmd() {
 
 # GitHub Helpers
 
+# needs repo/public_repo
 function check_token() {
     if [ -z "${GITHUB_TOKEN:-}" ]
     then
@@ -31,15 +32,23 @@ function gh() {
     then
         path="https://api.github.com/${path#"/"}"
     fi
-
     shift
-    if ! curl --silent --fail \
+
+    local output=$(mktemp)
+    local http_code
+    http_code=$(curl -w '%{http_code}' -o "$output" --silent  \
             --header "accept: application/vnd.github.v3+json" \
             --header "authorization: token $GITHUB_TOKEN" \
             "$path" \
-            "$@"
+            "$@")
+    if [[ $http_code == 2* ]]
     then
-        >&2 echo "Failed request to '$path' with '$@'"
+        cat "$output"
+        rm "$output"
+    else
+        >&2 echo "Failed ($?) request to '$path' with '$@'"
+        cat "$output" | >&2 jq
+        rm "$output"
         exit 1
     fi
 }
@@ -63,7 +72,7 @@ function gh_post_tgz() {
 # Actual release function
 
 function do_release() {
-    local res; res=$(jq -n '{ tag_name: "nm-this-is-a-test" }' | gh_post_json /repos/dfinity/internet-identity/releases)
+    local res; res=$(jq -n --arg tag_name "$tag_name" '{ tag_name: $tag_name }' | gh_post_json /repos/dfinity/internet-identity/releases)
 
     local release_id; release_id=$(echo "$res" | jq -cMr '.id')
     local html_url; html_url="$(echo "$res" | jq -cMr '.html_url')"
@@ -122,6 +131,13 @@ do
 done
 
 check_token
+
+if [ -z "$tag_name" ]
+then
+    echo no tag name
+    usage
+    exit 1
+fi
 
 need_cmd "curl"
 need_cmd "jq"

--- a/scripts/release
+++ b/scripts/release
@@ -16,8 +16,9 @@ function need_cmd() {
 }
 
 # GitHub Helpers
+# https://docs.github.com/en/rest/reference/releases#list-releases
 
-# needs repo/public_repo
+# token needs repo/public_repo scope
 function check_token() {
     if [ -z "${GITHUB_TOKEN:-}" ]
     then
@@ -42,6 +43,7 @@ function gh() {
             --header "authorization: token $GITHUB_TOKEN" \
             "$path" \
             "$@")
+
     if [[ $http_code == 2* ]]
     then
         cat "$output"
@@ -64,19 +66,20 @@ function gh_post_json() {
 
 function gh_post_tgz() {
     local path="$1"
-    shift
+    local filename="$2"
+    shift; shift
     gh "$path" --header "content-type: application/gzip" \
-        --data-binary @- \
+        --data-binary "@$filename" \
         "$@"
 }
 
 # Actual release function
 
 function do_release() {
-    local res; res=$(jq -n --arg tag_name "$tag_name" '{ tag_name: $tag_name }' | gh_post_json /repos/dfinity/internet-identity/releases)
+    local release_json; release_json=$(jq -n --arg tag_name "$tag_name" '{ tag_name: $tag_name }' | gh_post_json /repos/dfinity/internet-identity/releases)
 
-    local release_id; release_id=$(echo "$res" | jq -cMr '.id')
-    local html_url; html_url="$(echo "$res" | jq -cMr '.html_url')"
+    local release_id; release_id=$(echo "$release_json" | jq -cMr '.id')
+    local html_url; html_url="$(echo "$release_json" | jq -cMr '.html_url')"
 
     echo "created release $release_id ($html_url)"
 
@@ -89,8 +92,10 @@ function do_release() {
         do
             filename=$(basename "$filename")
             echo -n " - $filename"
-            local upload_url; upload_url=$(echo "$res" | jq -cMr '.upload_url' | sed "s/{.*}/?name=$filename/")
-            res=$(cat "$filename" | gh_post_tgz "$upload_url")
+            echo "$release_json" | jq
+            local upload_url; upload_url=$(echo "$release_json" | jq -cMr '.upload_url' | sed "s/{.*}/?name=$filename/")
+            echo "upload url: $upload_url"
+            gh_post_tgz "$upload_url" "$filename" >/dev/null
             echo " (done)"
         done
     fi

--- a/scripts/release
+++ b/scripts/release
@@ -4,8 +4,31 @@ set -euo pipefail
 declare -a filenames=( )
 declare tag_name
 
+function title() {
+    echo "Release Internet Identity"
+}
+
 function usage() {
-    echo "USAGE:"
+    cat << EOF
+Usage:
+  release --tag TAG [-- FILE...]
+
+Options:
+  --tag TAG     specify the tag to release
+EOF
+}
+
+function help() {
+    cat << EOF
+
+
+Any files specified after '--' will be uploaded as release assets.
+
+NOTE: This does not generate release notes. A link will be displayed when the
+release is created. Visit that link to write release notes and click "Auto-generate release notes"
+to add contributions and commit information.
+EOF
+
 }
 
 function need_cmd() {
@@ -112,7 +135,9 @@ while [[ $# -gt 0 ]]
 do
     case $1 in
         --help)
+            title
             usage
+            help
             exit 0
             ;;
         --tag)
@@ -133,6 +158,8 @@ do
         *)
             echo "ERROR: unknown argument $1"
             usage
+            echo
+            echo "Use 'release --help' for more information."
             exit 1
             ;;
     esac

--- a/scripts/release
+++ b/scripts/release
@@ -4,53 +4,71 @@ set -euo pipefail
 declare -a filenames=( )
 declare tag_name
 
+#########
+# USAGE #
+#########
+
 function title() {
     echo "Release Internet Identity"
 }
 
 function usage() {
     cat << EOF
+
 Usage:
   release --tag TAG [-- FILE...]
 
 Options:
   --tag TAG     specify the tag to release
+
 EOF
 }
 
 function help() {
     cat << EOF
 
-
 Any files specified after '--' will be uploaded as release assets.
 
 NOTE: This does not generate release notes. A link will be displayed when the
 release is created. Visit that link to write release notes and click "Auto-generate release notes"
 to add contributions and commit information.
+
 EOF
 
 }
 
+# Check that the command "$1" is installed
 function need_cmd() {
     if ! command -v "$1" >/dev/null
     then
         echo "please install $1"
+        exit 1
     fi
 }
 
-# GitHub Helpers
+##################
+# GITHUB HELPERS #
+##################
+
+# See also
 # https://docs.github.com/en/rest/reference/releases#list-releases
 
+# Ensure that GITHUB_TOKEN is set
 # token needs repo/public_repo scope
 function check_token() {
     if [ -z "${GITHUB_TOKEN:-}" ]
     then
+        echo "Please set GITHUB_TOKEN"
         echo "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
         exit 1
     fi
 }
 
+# Basic curl wrapper to perform a GitHub request.
 function gh() {
+
+    # The request path, can be absolute (https://...) or relative
+    # (in which case it will be prepended with https://api.github.com)
     local path=$1
     shift
     if [[ $path != https://* ]]
@@ -58,9 +76,16 @@ function gh() {
         path="https://api.github.com/${path#"/"}"
     fi
 
+    # Here we want to fail the script if the request is not successful.
+    # Regular curl can do this with --fail; unfortunately when doing so
+    # the body isn't returned, which makes debugging really complicated.
+    # Recent curls have '--fail-with-body', but it isn't available on
+    # GitHub Actions at the time of writing. March 2022
+    #
+    # Instead we write the body to a file and the status code to stdout,
+    # and check that the status code is 2XX.
     local output; output=$(mktemp)
     local http_code
-    # NOTE: cannot use `--fail-with-body` because it's not available on GHA
     http_code=$(curl -w '%{http_code}' -o "$output" --silent  \
             --header "accept: application/vnd.github.v3+json" \
             --header "authorization: token $GITHUB_TOKEN" \
@@ -79,6 +104,7 @@ function gh() {
     fi
 }
 
+# Curl wrapper for sending a JSON document (read from stdin)
 function gh_post_json() {
     local path="$1"
     shift
@@ -87,6 +113,7 @@ function gh_post_json() {
         "$@"
 }
 
+# Curl wrapper for sending a gzipped file (read from stdin)
 function gh_post_tgz() {
     local path="$1"
     local filename="$2"
@@ -96,8 +123,13 @@ function gh_post_tgz() {
         "$@"
 }
 
-# Actual release function
+###########
+# RELEASE #
+###########
 
+# This performs the release by first _creating_ a release (using the value from --tag).
+# The response returned by GitHub includes "upload_url", which is a URL where assets
+# can be POSTed.
 function do_release() {
     local release_json
     release_json=$(jq -n --arg tag_name "$tag_name" '{ tag_name: $tag_name }' \

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -a filenames=( )
+declare tag_name
+
+function usage() {
+    echo "USAGE:"
+}
+
+function need_cmd() {
+    if ! command -v "$1" >/dev/null
+    then
+        echo "please install $1"
+    fi
+}
+
+# GitHub Helpers
+
+function check_token() {
+    if [ -z "${GITHUB_TOKEN:-}" ]
+    then
+        echo "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token"
+        exit 1
+    fi
+}
+
+function gh() {
+    local path=$1
+    if [[ $path != https://* ]]
+    then
+        path="https://api.github.com/${path#"/"}"
+    fi
+
+    shift
+    if ! curl --silent --fail \
+            --header "accept: application/vnd.github.v3+json" \
+            --header "authorization: token $GITHUB_TOKEN" \
+            "$path" \
+            "$@"
+    then
+        >&2 echo "Failed request to '$path' with '$@'"
+        exit 1
+    fi
+}
+
+function gh_post_json() {
+    local path="$1"
+    shift
+    gh "$path" --header "content-type: application/json" \
+        --data-binary @- \
+        "$@"
+}
+
+function gh_post_tgz() {
+    local path="$1"
+    shift
+    gh "$path" --header "content-type: application/gzip" \
+        --data-binary @- \
+        "$@"
+}
+
+# Actual release function
+
+function do_release() {
+    local res; res=$(jq -n '{ tag_name: "nm-this-is-a-test" }' | gh_post_json /repos/dfinity/internet-identity/releases)
+
+    local release_id; release_id=$(echo "$res" | jq -cMr '.id')
+    local html_url; html_url="$(echo "$res" | jq -cMr '.html_url')"
+
+    echo "created release $release_id ($html_url)"
+
+    if [ ${#filenames[@]} -eq 0 ]
+    then
+        echo "no files to upload"
+    else
+        echo "uploading assets"
+        for filename in "${filenames[@]}"
+        do
+            filename=$(basename "$filename")
+            echo -n " - $filename"
+            local upload_url; upload_url=$(echo "$res" | jq -cMr '.upload_url' | sed "s/{.*}/?name=$filename/")
+            res=$(cat "$filename" | gh_post_tgz "$upload_url")
+            echo " (done)"
+        done
+    fi
+
+    echo "done creating release"
+    echo "  $html_url"
+}
+
+# ARGUMENT PARSING
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        --help)
+            usage
+            exit 0
+            ;;
+        --tag)
+            echo "$@"
+            tag_name="${2:?missing value for '--tag'}"
+            shift; # shift past --tag and value
+            shift;
+            echo "$@"
+            ;;
+        --)
+            shift
+            for filename in "$@"
+            do
+                filenames+=( "$filename" )
+                shift
+            done
+            ;;
+        *)
+            echo "ERROR: unknown argument $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+check_token
+
+need_cmd "curl"
+need_cmd "jq"
+
+do_release

--- a/scripts/release
+++ b/scripts/release
@@ -36,6 +36,7 @@ function gh() {
 
     local output=$(mktemp)
     local http_code
+    # NOTE: cannot use `--fail-with-body` because it's not available on GHA
     http_code=$(curl -w '%{http_code}' -o "$output" --silent  \
             --header "accept: application/vnd.github.v3+json" \
             --header "authorization: token $GITHUB_TOKEN" \


### PR DESCRIPTION
<!--- We currently do not accept contributions. See .github/CONTRIBUTING.md. -->

This adds a script, `scripts/release`, that creates a release based on a tag:

```
~/internet-identity$ ./scripts/release --help
Release Internet Identity

Usage:
  release --tag TAG [-- FILE...]

Options:
  --tag TAG     specify the tag to release

Environment:
  GITHUB_TOKEN  (required) Personal Access Token for GitHub


Any files specified after '--' will be uploaded as release assets.

NOTE: This does not generate release notes. A link will be displayed when the
release is created. Visit that link to write release notes and click "Auto-generate release notes"
to add contributions and commit information.
```

This also adds a `release` job that creates a release (with all three builds generated on CI) when tags starting with `release-` are pushed to GitHub. There are existing GitHub actions allowing us to do that, here are the advantages from a custom script:
* More flexibility when creating the release
* Script can be run locally as opposed to just on CI
* We don't need to review (potentially compiled) code that has access to our github token

Also the script is just two `curl` calls with lots of comments around it.