### PR TITLE
Add CI badges for our GHA checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Internet Identity Service
 
+[![Canister tests](https://github.com/dfinity/internet-identity/actions/workflows/canister-tests.yml/badge.svg)](https://github.com/dfinity/internet-identity/actions/workflows/canister-tests.yml)
+[![Cargo tests](https://github.com/dfinity/internet-identity/actions/workflows/cargo-tests.yml/badge.svg)](https://github.com/dfinity/internet-identity/actions/workflows/cargo-tests.yml)
+[![Frontend checks and lints](https://github.com/dfinity/internet-identity/actions/workflows/frontend-checks.yml/badge.svg)](https://github.com/dfinity/internet-identity/actions/workflows/frontend-checks.yml)
+
 See `./docs/internet-identity-spec.adoc` for a details specification and technical
 documentation.
 


### PR DESCRIPTION
This way other users can know if the repo because unhealthy, and we can
spot issues faster.

<img width="929" alt="Screenshot 2022-03-10 at 10 04 04" src="https://user-images.githubusercontent.com/6930756/157627890-c7e98032-bc62-49eb-b6b9-b2d3d358c684.png">


<!--- We currently do not accept contributions. See .github/CONTRIBUTING.md. -->
