### PR TITLE
L2-381: Add metrics for device registrations

### DIFF
--- a/backend-tests/backend-tests.hs
+++ b/backend-tests/backend-tests.hs
@@ -771,6 +771,7 @@ tests wasm_file = testGroup "Tests" $ upgradeGroups $
 
     assertMetric metrics "internet_identity_user_count" 1.0
     assertMetric metrics "internet_identity_signature_count" 0.0
+    assertMetric metrics "internet_identity_users_in_registration_mode" 0.0
 
     when should_upgrade $ doUpgrade cid
 
@@ -779,11 +780,13 @@ tests wasm_file = testGroup "Tests" $ upgradeGroups $
     let sessionPK = toPublicKey sessionSK
     let delegationArgs = (userNumber, "front.end.com", sessionPK, Nothing)
     _ <- callII cid webauth1ID #prepare_delegation delegationArgs
+    _ <- callII cid webauth1ID #enter_device_registration_mode userNumber
 
     metrics <- callII cid webauth1ID #http_request (httpGet "/metrics") >>= mustParseMetrics
 
     assertMetric metrics "internet_identity_user_count" 2.0
     assertMetric metrics "internet_identity_signature_count" 1.0
+    assertMetric metrics "internet_identity_users_in_registration_mode" 1.0
 
   , withUpgrade $ \should_upgrade -> testGroup "HTTP Assets"
     [ iiTest asset $ \cid -> do

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -159,6 +159,11 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             s.inflight_challenges.borrow().len() as f64,
             "The number of inflight CAPTCHA challenges",
         )?;
+        w.encode_gauge(
+            "internet_identity_users_in_registration_mode",
+            s.tentative_device_registrations.borrow().len() as f64,
+            "The number of users in registration mode",
+        )?;
         Ok(())
     })
 }


### PR DESCRIPTION
This PR adds information about the number of users in device registration mode to the metrics endpoint.
