### PR TITLE
Better release notes

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -1,0 +1,14 @@
+name: 'release notes'
+description: 'Prepares release notes, including download links for our artifacts.'
+inputs:
+    assets:
+        description: "Assets to upload"
+        required: true
+        default: ""
+outputs:
+  notes-file:
+    description: The notes file
+runs:
+    using: 'node12'
+    main: 'main.js'
+    post: 'main.js'

--- a/.github/actions/release/main.js
+++ b/.github/actions/release/main.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('child_process').execFileSync(`${__dirname}/run`, { stdio: 'inherit' });

--- a/.github/actions/release/run
+++ b/.github/actions/release/run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This script creates a nice markdown table with he build artifacts' shas, links to download
+# This script creates a nice markdown table with the build artifacts' shas, links to download
 # the Wasm modules, and links to the `sha256sum` steps in CI for verification.
 
 set -euo pipefail

--- a/.github/actions/release/run
+++ b/.github/actions/release/run
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# This script creates a nice markdown table with he build artifacts' shas, links to download
+# the Wasm modules, and links to the `sha256sum` steps in CI for verification.
+
+set -euo pipefail
+
+# This script sets "RELEASE_ACTION_BODY_FILE" to the path of the generated file. The script is run twice
+# (once when called with 'uses: ', once in post) meaning we can differentiate the first from second run
+# by reading "RELEASE_ACTION_BODY_FILE". On the "post" run, we just cleanup and exit.
+if [ -n "${RELEASE_ACTION_BODY_FILE:-}" ]
+then
+    >&2 echo "Cleaning up body file $RELEASE_ACTION_BODY_FILE"
+    if ! [ -f "$RELEASE_ACTION_BODY_FILE" ]
+    then
+        >&2 echo "strange, no file to remove"
+    else
+        rm "$RELEASE_ACTION_BODY_FILE"
+    fi
+    exit 0
+fi
+
+# The file where we'll progressively dump the release body content
+body=$(mktemp)
+>&2 echo "Using '$body' for body"
+
+# Start the body with a paragraph and table headers
+
+# NOTE: we link to the current release (not to master) because things might change
+if [ -z "${GITHUB_REF_NAME:-}" ]
+then
+    >&2 echo "No github ref name set"
+    rm "$body"
+    exit 1
+fi
+
+cat > "$body" <<EOF
+Read more in the [Build flavors](https://github.com/dfinity/internet-identity/tree/$GITHUB_REF_NAME#build-flavors) section of the README.
+| Filename | sha256 | Verify |
+| --- | --- | --- |
+EOF
+
+# Read all "INPUT_ASSETS" (where "ASSETS" is the input specified in action.yml)
+# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#example-specifying-inputs
+while IFS= read -r filename
+do
+    if [ -z "$filename" ]; then continue; fi
+    >&2 echo working on asset "$filename"
+
+    # Find out the Job ID
+    # XXX: Unfortunately GitHub actions doesn't give us a way to find out the Job ID explicitely.
+    # Instead, we find the job name that includes "$filename" and assume that's the Job ID. This works
+    # because our build matrix takes in the filename as argument, which is added to the job name.
+    # https://github.community/t/get-action-job-id/17365/7
+    job_id=$(curl --silent "https://api.github.com/repos/dfinity/internet-identity/actions/runs/$GITHUB_RUN_ID/jobs" \
+        | jq -cMr \
+            --arg filename "$filename" \
+            '.jobs[] | select(.name | contains($filename)) | .id')
+    >&2 echo "Found job id: $job_id"
+
+    # Now get the URL that we'll link to for verification of the sha
+    html_url=$(curl --silent "https://api.github.com/repos/dfinity/internet-identity/actions/runs/$GITHUB_RUN_ID/jobs" \
+        | jq -cMr \
+            --argjson job_id "$job_id" \
+            '.jobs[] | select(.id == $job_id) | .html_url')
+    >&2 echo "Found html_url: $html_url"
+
+    # Additionally grab the step number of the 'sha256sum' step
+    step=$(curl --silent "https://api.github.com/repos/dfinity/internet-identity/actions/runs/$GITHUB_RUN_ID/jobs" \
+        | jq -cMr \
+            --argjson job_id "$job_id" \
+            '.jobs[] | select(.id == $job_id) | .steps[] | select(.name | contains("sha256sum")) | .number')
+    >&2 echo "Found step: $step"
+
+    # Prepare the cells:
+    # | [filename.wasm](<download link>) | <sha256> | [CI Run](<run link>) |
+    download_link="https://github.com/dfinity/internet-identity/releases/download/$GITHUB_REF_NAME/$filename"
+    download="[\2]($download_link)"
+
+    # shellcheck disable=SC2016
+    sha='`\1`'
+
+    run_link="$html_url#step:$step:1"
+    run="[CI Run]($run_link)"
+
+    # Get the shasum and capture the sha (using only POSIX sed)
+    shasum -a 256 "$filename"  | sed -r "s%^([a-z0-9]+)[[:space:]][[:space:]](.*)$%|$download|$sha|$run|%" >> "$body"
+done <<< "$INPUT_ASSETS"
+
+>&2 echo "body complete:"
+
+cat "$body"
+
+echo "::set-output name=notes-file::$body"
+
+echo "RELEASE_ACTION_BODY_FILE=$body" >>"$GITHUB_ENV"

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -352,9 +352,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
-    # Only run on release tags
-    if: startsWith(github.ref, 'refs/tags/release-')
-
     needs: docker-build
 
     steps:
@@ -378,12 +375,26 @@ jobs:
           name: internet_identity_production.wasm
           path: .
 
-      - run: |
-          ./scripts/release --tag ${{ github.ref }} -- \
+      - name: Prepare release
+        uses: ./.github/actions/release
+        id: prepare-release
+        with:
+          assets: |
+            internet_identity_test.wasm
+            internet_identity_dev.wasm
+            internet_identity_production.wasm
+
+      - name: Publish release
+        if: startsWith(github.ref, 'refs/tags/release-')
+        run: |
+          ./scripts/release \
+            --tag ${{ github.ref }} \
+            --notes-file ${{ steps.prepare-release.outputs.notes-file }} \
+            --generate-notes \
+            -- \
             internet_identity_test.wasm \
             internet_identity_dev.wasm \
             internet_identity_production.wasm
-
         env:
           # populated by GitHub Actions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -39,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-base
     strategy:
+      # NOTE: the 'name' in the matrix should match the asset filename, because it is used in 
+      # .github/actions/release to figure out the job ID.
       matrix:
         include:
           # The production build

--- a/scripts/release
+++ b/scripts/release
@@ -3,6 +3,8 @@ set -euo pipefail
 
 declare -a filenames=( )
 declare tag_name
+declare generate_notes=
+declare notes_file=
 
 #########
 # USAGE #
@@ -16,10 +18,12 @@ function usage() {
     cat << EOF
 
 Usage:
-  release --tag TAG [-- FILE...]
+  release --tag TAG [--generate-notes] [--notes-file FILE] [-- FILE...]
 
 Options:
-  --tag TAG     specify the tag to release
+  --tag TAG             specify the tag to release
+  --generate-notes      add GitHub generated notes
+  --notes-file FILE     use FILE as notes (prepended to generated notes if set)
 
 Environment:
   GITHUB_TOKEN  (required) Personal Access Token for GitHub
@@ -134,8 +138,17 @@ function gh_post_tgz() {
 # The response returned by GitHub includes "upload_url", which is a URL where assets
 # can be POSTed.
 function do_release() {
+
+    jq_args=(
+        --arg tag_name "$tag_name"
+        --rawfile body "$notes_file"
+        --argjson generate_release_notes "$([ "$generate_notes" == 1 ] && echo "true" || echo "false")"
+    )
+
     local release_json
-    release_json=$(jq -n --arg tag_name "$tag_name" '{ tag_name: $tag_name }' \
+    release_json=$(jq -n \
+        "${jq_args[@]}" \
+        '{ tag_name: $tag_name, generate_release_notes: $generate_release_notes, body: $body }' \
         | gh_post_json /repos/dfinity/internet-identity/releases)
 
     local release_id; release_id=$(echo "$release_json" | jq -cMr '.id')
@@ -176,11 +189,18 @@ do
             exit 0
             ;;
         --tag)
-            echo "$@"
             tag_name="${2:?missing value for '--tag'}"
             shift; # shift past --tag and value
             shift;
-            echo "$@"
+            ;;
+        --generate-notes)
+            generate_notes=1
+            shift;
+            ;;
+        --notes-file)
+            notes_file="${2:?missing value for '--notes-file'}"
+            shift; # shift past --notes-file and value
+            shift;
             ;;
         --)
             shift


### PR DESCRIPTION
This includes better release notes. In particular:
* Adds a table with asset names, download link, sha256, and CI run link.
* Contributor info (generated by GH)
* "What's changed" (generated by GH)

<img width="1568" alt="Screenshot 2022-03-14 at 12 40 50" src="https://user-images.githubusercontent.com/6930756/158165222-d43893df-6a91-41aa-968b-fb17a57c13dc.png">


The release notes are generated by a GitHub action that uses the GitHub Actions environment to generate useful data.
<!--- We currently do not accept contributions. See .github/CONTRIBUTING.md. -->
