### PR TITLE
Add future breakage warning to lookup

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -142,6 +142,8 @@ service : (opt InternetIdentityInit) -> {
   register : (DeviceData, ChallengeResult) -> (RegisterResponse);
   add : (UserNumber, DeviceData) -> ();
   remove : (UserNumber, DeviceKey) -> ();
+  // Returns all devices of the user (authentication and recovery) but no information about device registrations.
+  // Note: Will be changed in the future to be more consistent with get_anchor_info.
   lookup : (UserNumber) -> (vec DeviceData) query;
   get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);
   get_principal : (UserNumber, FrontendHostname) -> (principal) query;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -765,6 +765,8 @@ fn check_challenge(res: ChallengeAttempt) -> Result<(), ()> {
     })
 }
 
+/// Returns all devices of the user (authentication and recovery) but no information about device registrations.
+/// Note: Will be changed in the future to be more consistent with get_anchor_info.
 #[query]
 fn lookup(user_number: UserNumber) -> Vec<DeviceData> {
     STATE.with(|s| {


### PR DESCRIPTION
Refactoring of lookup is planned. This gives consumers of the II canister a warning of future changes.