### PR TITLE
Remove Init arguments

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -207,7 +207,7 @@ jobs:
         run: |
           mv internet_identity_test.wasm internet_identity.wasm
           dfx canister --no-wallet create --all
-          dfx canister --no-wallet install internet_identity --argument '(null)'
+          dfx canister --no-wallet install internet_identity
 
       - name: Deploy whoami canister
         run: cd demos/whoami && dfx deploy --no-wallet
@@ -315,7 +315,7 @@ jobs:
           EOF
 
           chmod +x $curl_dir/curl
-          PATH=$curl_dir:$PATH dfx deploy --no-wallet --argument '(null)' && rm -rf "$curl_dir" && rm $witness
+          PATH=$curl_dir:$PATH dfx deploy --no-wallet && rm -rf "$curl_dir" && rm $witness
 
           npm ci
           npm run test

--- a/HACKING.md
+++ b/HACKING.md
@@ -28,7 +28,7 @@ dfx start [--clean] [--background]
 In a different terminal, run the following command to install the Internet Identity canister:
 
 ```bash
-II_FETCH_ROOT_KEY=1 dfx deploy --no-wallet --argument '(null)'
+II_FETCH_ROOT_KEY=1 dfx deploy --no-wallet
 ```
 
 Then the canister can be used as
@@ -55,7 +55,7 @@ The fastest workflow to get the development environment running is to deploy onc
 ```bash
 npm ci
 dfx start [--clean] [--background]
-II_FETCH_ROOT_KEY=1 dfx deploy --no-wallet --argument '(null)'
+II_FETCH_ROOT_KEY=1 dfx deploy --no-wallet
 ```
 
 To serve the frontend locally via webpack (recommended during development), run

--- a/backend-tests/backend-tests.hs
+++ b/backend-tests/backend-tests.hs
@@ -863,7 +863,7 @@ tests wasm_file = testGroup "Tests" $ upgradeGroups $
         .+ #mode .== V.IsJust #install ()
         .+ #canister_id .== Candid.Principal cid
         .+ #wasm_module .== wasm
-        .+ #arg .== Candid.encode (Nothing :: Maybe InternetIdentityInit) -- default value
+        .+ #arg .== Candid.encode ()
       act cid
 
     withUpgrade act = ([act False], [act True])

--- a/demos/using-dev-build/README.md
+++ b/demos/using-dev-build/README.md
@@ -8,7 +8,7 @@ The following commands will start a replica, install the development Internet Id
 
 ```bash
 $ dfx start # in a different terminal
-$ dfx deploy --no-wallet --argument '(null)'
+$ dfx deploy --no-wallet
 $ npm ci
 $ npm run test
 ```

--- a/docs/internet-identity-spec.adoc
+++ b/docs/internet-identity-spec.adoc
@@ -363,20 +363,6 @@ type UserDeviceList = vec(record {
 });
 ....
 
-=== Initialization
-
-The Internet Identity canister is designed for sharded deployments.
-There can be many simultaneously installed instances of the canister code, each serving requests of a subset of users.
-As users are identified by their Identity Anchor, we split the range of Identity Anchors into continuous non-overlapping half-closed intervals and assign each region to one canister instance.
-The assigned range is passed to the canister as an init argument, encoded in Candid:
-
-....
-type InternetIdentityInit = record {
-  // Half-closed interval of Identity Anchors assigned to this canister, [ left_bound, right_bound )
-  assigned_user_number_range: record { nat64; nat64; };
-};
-....
-
 === Approach to upgrades
 
 We don't need any logic recovery logic in pre/post-upgrade hooks because we place all user data to stable memory in a way that can be accessed directly.
@@ -602,15 +588,9 @@ shasum -a 256 internet_identity.wasm
 
 Double-check that this is the same SHA256 that is observed on CI. Go to the corresponding commit, find the CI job “docker build” and look at the output of step “Run sha256sum out/internet_identity.wasm”.
 
-=== Initial installation (should happen only once)
+=== Initial installation
 
-Next, you will need `didc` to be able to produce the binary encoded Candid argument needed for installation. Either download it from https://github.com/dfinity/candid/releases/[the latest candid release] or build it from source.
-
-The canister accepts a range of user ids that it's responsible for in `canister_init`. Currently, we only use one canister, so we don't really need to set a range. However, we still need to pass in some value to satisfy the interface. Run the following to get a file with the binary encoded value needed:
-[source,bash]
-----
-didc encode '(null)' | xxd -r -p > arg.in
-----
+This describes the first ever installation of the Internet Identity canister, which should happen only once.
 
 ==== Submitting proposal for installation and voting on mainnet
 
@@ -665,7 +645,6 @@ need to build with `II_FETCH_ROOT_KEY=1`:
 
 [source,bash]
 ----
-didc encode '(null)' | xxd -r -p > arg.in
 II_FETCH_ROOT_KEY=1 ./scripts/docker-build
 ----
 
@@ -676,7 +655,7 @@ This will create the Wasm file you want to use for the following deployment step
 Submit the proposal to install the canister on our `identity` testnet (replace for other testnets as appropriate):
 [source,bash]
 ----
-ic-admin --nns-url "http://[2a00:fb01:400:42:5000:60ff:fed5:8464]:8080/" propose-to-change-nns-canister --test-neuron-proposer --canister-id rdmx6-jaaaa-aaaaa-aaadq-cai --mode reinstall --wasm-module-path internet_identity.wasm --arg arg.in
+ic-admin --nns-url "http://[2a00:fb01:400:42:5000:60ff:fed5:8464]:8080/" propose-to-change-nns-canister --test-neuron-proposer --canister-id rdmx6-jaaaa-aaaaa-aaadq-cai --mode reinstall --wasm-module-path internet_identity.wasm
 ----
 
 You can check http://[2a00:fb01:400:42:5000:60ff:fed5:8464]:8080/_/dashboard[our testnet's dashboard] to confirm the hash of the wasm installed on the canister matches the one you took note of in the previous steps.

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -1,7 +1,4 @@
 export const idlFactory = ({ IDL }) => {
-  const InternetIdentityInit = IDL.Record({
-    'assigned_user_number_range' : IDL.Tuple(IDL.Nat64, IDL.Nat64),
-  });
   const UserNumber = IDL.Nat64;
   const PublicKey = IDL.Vec(IDL.Nat8);
   const DeviceKey = PublicKey;
@@ -151,9 +148,4 @@ export const idlFactory = ({ IDL }) => {
       ),
   });
 };
-export const init = ({ IDL }) => {
-  const InternetIdentityInit = IDL.Record({
-    'assigned_user_number_range' : IDL.Tuple(IDL.Nat64, IDL.Nat64),
-  });
-  return [IDL.Opt(InternetIdentityInit)];
-};
+export const init = ({ IDL }) => { return []; };

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -53,9 +53,6 @@ export interface IdentityAnchorInfo {
   'devices' : Array<DeviceData>,
   'device_registration' : [] | [DeviceRegistrationInfo],
 }
-export interface InternetIdentityInit {
-  'assigned_user_number_range' : [bigint, bigint],
-}
 export interface InternetIdentityStats {
   'users_registered' : bigint,
   'assigned_user_number_range' : [bigint, bigint],

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -115,10 +115,6 @@ type InternetIdentityStats = record {
   assigned_user_number_range: record { nat64; nat64; };
 };
 
-type InternetIdentityInit = record {
-  assigned_user_number_range : record { nat64; nat64; };
-};
-
 type ChallengeKey = text;
 
 type ChallengeResult = record {
@@ -136,7 +132,7 @@ type IdentityAnchorInfo = record {
     device_registration: opt DeviceRegistrationInfo;
 };
 
-service : (opt InternetIdentityInit) -> {
+service : {
   init_salt: () -> ();
   create_challenge : () -> (Challenge);
   register : (DeviceData, ChallengeResult) -> (RegisterResponse);

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -204,6 +204,7 @@ mod storage;
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 struct InternetIdentityStats {
+    assigned_user_number_range: (UserNumber, UserNumber),
     users_registered: u64,
 }
 
@@ -953,6 +954,7 @@ fn stats() -> InternetIdentityStats {
     STATE.with(|state| {
         let storage = state.storage.borrow();
         InternetIdentityStats {
+            assigned_user_number_range: storage.assigned_user_number_range(),
             users_registered: storage.user_count() as u64,
         }
     })


### PR DESCRIPTION
The init arguments allow us to specify different anchor ranges when
deploying the II canister, the goal being that anchors can be sharded
across different instances.

We don't actually support that, and I don't think those arguments have
ever been used, but they are a real hassle when deploying (due to the
dependency on didc) and they are very confusing. Moreover, if/when we
start sharding II, it's likely things will have changed and that the
arguments won't actually be usable as is.

I've left a comment in the code pointing the reader to the correct
commit if they start looking for ways to set new `id_range_{lo,hi}`
values.

<!--- We currently do not accept contributions. See .github/CONTRIBUTING.md. -->
