### PR TITLE
Make testnet_app more deploy-friendly

### DIFF
--- a/demos/testnet_app/dfx.json
+++ b/demos/testnet_app/dfx.json
@@ -23,7 +23,6 @@
       "packtool": ""
     }
   },
-  "dfx": "0.8.3",
   "networks": {
     "local": {
       "bind": "127.0.0.1:8000",

--- a/demos/testnet_app/src/testnet_app_assets/src/index.js
+++ b/demos/testnet_app/src/testnet_app_assets/src/index.js
@@ -5,7 +5,7 @@ import { idlFactory as testnet_app_idl, canisterId as testnet_app_id } from '../
 
 // Autofills the <input> for the II Url to point to our testnet.
 document.body.onload = () => {
-  const testnetII = "https://rdmx6-jaaaa-aaaaa-aaadq-cai.identity.dfinity.network/"
+  const testnetII = process.env.II_URL;
   document.getElementById("iiUrl").value = testnetII;
 };
 

--- a/demos/testnet_app/webpack.config.js
+++ b/demos/testnet_app/webpack.config.js
@@ -100,7 +100,8 @@ module.exports = {
     }),
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'development',
-      TESTNET_APP_CANISTER_ID: canisters["testnet_app"]
+      TESTNET_APP_CANISTER_ID: canisters["testnet_app"],
+      II_URL: process.env.II_URL || "https://rdmx6-jaaaa-aaaaa-aaadq-cai.identity.dfinity.network/",
     }),
     new webpack.ProvidePlugin({
       Buffer: [require.resolve("buffer/"), "Buffer"],


### PR DESCRIPTION
This instructs `testnet_app` to read `II_URL`, and removes the hardcoded
dfx version (which was just annoying).

<!--- We currently do not accept contributions. See .github/CONTRIBUTING.md. -->
