### PR TITLE
Fix flakiness in using-dev-build

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -268,6 +268,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - run: |
+          sudo apt-get update
+          sudo apt-get --only-upgrade install google-chrome-stable
+          google-chrome --version
+
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
@@ -317,7 +322,6 @@ jobs:
 
           # Clean up our download
           rm internet_identity.wasm
-
       - name: Stop replica
         run: |
           dfx stop

--- a/demos/using-dev-build/package-lock.json
+++ b/demos/using-dev-build/package-lock.json
@@ -12,7 +12,7 @@
         "@wdio/local-runner": "^7.16.13",
         "@wdio/mocha-framework": "^7.16.13",
         "@wdio/spec-reporter": "^7.16.13",
-        "chromedriver": "^97.0.0",
+        "chromedriver": "^100.0.0",
         "prettier": "^2.5.0",
         "proxy": "git+https://github.com/nmattia/dfx-proxy",
         "ts-node": "^10.4.0",
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@testim/chrome-version": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
-      "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.2.tgz",
+      "integrity": "sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==",
       "dev": true
     },
     "node_modules/@tsconfig/node10": {
@@ -1116,12 +1116,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/balanced-match": {
@@ -1487,14 +1487,14 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "97.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-97.0.0.tgz",
-      "integrity": "sha512-SZ9MW+/6/Ypz20CNdRKocsmRM2AJ/YwHaWpA1Np2QVPFUbhjhus6vBtqFD+l8M5qrktLWPQSjTwIsDckNfXIRg==",
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-100.0.0.tgz",
+      "integrity": "sha512-oLfB0IgFEGY9qYpFQO/BNSXbPw7bgfJUN5VX8Okps9W2qNT4IqKh5hDwKWtpUIQNI6K3ToWe2/J5NdpurTY02g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@testim/chrome-version": "^1.0.7",
-        "axios": "^0.21.2",
+        "@testim/chrome-version": "^1.1.2",
+        "axios": "^0.24.0",
         "del": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
@@ -5814,9 +5814,9 @@
       }
     },
     "@testim/chrome-version": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
-      "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.2.tgz",
+      "integrity": "sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==",
       "dev": true
     },
     "@tsconfig/node10": {
@@ -6594,12 +6594,12 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "balanced-match": {
@@ -6866,13 +6866,13 @@
       }
     },
     "chromedriver": {
-      "version": "97.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-97.0.0.tgz",
-      "integrity": "sha512-SZ9MW+/6/Ypz20CNdRKocsmRM2AJ/YwHaWpA1Np2QVPFUbhjhus6vBtqFD+l8M5qrktLWPQSjTwIsDckNfXIRg==",
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-100.0.0.tgz",
+      "integrity": "sha512-oLfB0IgFEGY9qYpFQO/BNSXbPw7bgfJUN5VX8Okps9W2qNT4IqKh5hDwKWtpUIQNI6K3ToWe2/J5NdpurTY02g==",
       "dev": true,
       "requires": {
-        "@testim/chrome-version": "^1.0.7",
-        "axios": "^0.21.2",
+        "@testim/chrome-version": "^1.1.2",
+        "axios": "^0.24.0",
         "del": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",

--- a/demos/using-dev-build/package.json
+++ b/demos/using-dev-build/package.json
@@ -12,7 +12,7 @@
     "@wdio/local-runner": "^7.16.13",
     "@wdio/mocha-framework": "^7.16.13",
     "@wdio/spec-reporter": "^7.16.13",
-    "chromedriver": "^97.0.0",
+    "chromedriver": "^100.0.0",
     "prettier": "^2.5.0",
     "proxy": "git+https://github.com/nmattia/dfx-proxy",
     "ts-node": "^10.4.0",

--- a/demos/using-dev-build/wdio.conf.ts
+++ b/demos/using-dev-build/wdio.conf.ts
@@ -3,6 +3,8 @@ import { existsSync, mkdirSync } from "fs";
 export const config: WebdriverIO.Config = {
   baseUrl: process.env.II_DAPP_URL || "http://localhost:8080",
 
+  waitForTimeout: 10_000,
+
   autoCompileOpts: {
     autoCompile: true,
     tsNodeOpts: {

--- a/selenium-standalone.config.js
+++ b/selenium-standalone.config.js
@@ -2,7 +2,7 @@ module.exports = {
   drivers: {
     chrome: {
       // This version needs to match the chrome version on GitHub Actions
-      version: '98.0.4758.80',
+      version: '100.0.4896.60',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },


### PR DESCRIPTION
This fixes (most of) the flakiness in `using-dev-build`. There were
several issues:

* ChromeDriver was out of date and couldn't be updated; fixed by
  https://github.com/giggio/node-chromedriver/pull/358 and by then
  updating to work well with Chrome 100
* Tests sometimes started before proxy was up; we now wait for the proxy
  to be up before we start the tests
* Some tests timed out waiting for an element to appear; global timeout
  was changed from 5s to 10s.

<!--- We currently do not accept contributions. See .github/CONTRIBUTING.md. -->

NOTE: with those changes I had 30 consecutive successes (3 CI runs with 10 jobs each: https://github.com/dfinity/internet-identity/commits/nm-fail-using-dev-build) as opposed to one failure in every 2 to 5 runs previously

NOTE: I ended up updating the chrome config for the selenium tests as well, apparently they got jealous and started failing.
