### PR TITLE
Show banner if origin isn't identity.ic0.app

### DIFF
--- a/src/frontend/src/banner.ts
+++ b/src/frontend/src/banner.ts
@@ -1,0 +1,72 @@
+import { render, html, TemplateResult } from "lit-html";
+import { anyFeatures } from "./features";
+
+// Show a warning banner if the build is not "official". This happens if either the build
+// is a flavored build, or if the origin is not 'identity.ic0.app'.
+export const showWarningIfNecessary = (): void => {
+  const officialUrl = "https://identity.ic0.app";
+  if (anyFeatures()) {
+    showWarning(html`This is an insecure development version of Internet
+      Identity.
+      <a
+        class="features-warning-btn"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://github.com/dfinity/internet-identity#build-features"
+        >more</a
+      >`);
+  } else if (window.location.origin !== officialUrl) {
+    showWarning(html`This is not the official Internet Identity.
+      <a
+        class="features-warning-btn"
+        target="_blank"
+        rel="noopener noreferrer"
+        href=${officialUrl}
+        >go to official</a
+      >`);
+  }
+};
+
+export const showWarning = (message: TemplateResult): void => {
+  const container = document.createElement("div");
+  container.className = "features-warning-container";
+  const razzmatazz = "#ED1E79";
+  const white = "#FFFFFF";
+
+  const warning = html`
+    <style>
+      .features-warning-container {
+        background: ${razzmatazz};
+        color: ${white};
+        width: 100%;
+        box-sizing: border-box;
+        padding: 0.5em 1em;
+        text-align: center;
+      }
+
+      .features-warning-btn {
+        display: inline-block;
+        margin-left: 1em;
+        border-radius: 4px;
+        border: ${white} solid 1px;
+        padding: 0.2em 0.4em;
+        text-decoration: none;
+      }
+
+      .features-warning-btn:link,
+      .features-warning-btn:visited {
+        color: ${white};
+      }
+
+      .features-warning-btn:hover,
+      .features-warning-btn:focus {
+        background: ${white};
+        color: ${razzmatazz};
+      }
+    </style>
+    ${message}
+  `;
+
+  render(warning, container);
+  document.body.prepend(container);
+};

--- a/src/frontend/src/features.ts
+++ b/src/frontend/src/features.ts
@@ -1,8 +1,6 @@
 // Contains code related to the "build features". Features should be accessed
 // from the `features` object below. This file also contains helper functions
 // for displaying a banner if features are enabled.
-import { render, html } from "lit-html";
-
 export const features = {
   FETCH_ROOT_KEY: process.env.II_FETCH_ROOT_KEY === "1",
   DUMMY_AUTH: process.env.II_DUMMY_AUTH === "1",
@@ -11,61 +9,4 @@ export const features = {
 
 export const anyFeatures = (): boolean => {
   return Object.values(features).indexOf(true) >= 0;
-};
-
-export const showWarningOnFeatures = (): void => {
-  if (anyFeatures()) {
-    showWarning();
-  }
-};
-
-export const showWarning = (): void => {
-  const container = document.createElement("div");
-  container.className = "features-warning-container";
-  const razzmatazz = "#ED1E79";
-  const white = "#FFFFFF";
-
-  const warning = html`
-    <style>
-      .features-warning-container {
-        background: ${razzmatazz};
-        color: ${white};
-        width: 100%;
-        box-sizing: border-box;
-        padding: 0.5em 1em;
-        text-align: center;
-      }
-
-      .features-warning-btn {
-        display: inline-block;
-        margin-left: 1em;
-        border-radius: 4px;
-        border: ${white} solid 1px;
-        padding: 0.2em 0.4em;
-        text-decoration: none;
-      }
-
-      .features-warning-btn:link,
-      .features-warning-btn:visited {
-        color: ${white};
-      }
-
-      .features-warning-btn:hover,
-      .features-warning-btn:focus {
-        background: ${white};
-        color: ${razzmatazz};
-      }
-    </style>
-    This is an insecure development version of Internet Identity.
-    <a
-      class="features-warning-btn"
-      target="_blank"
-      rel="noopener noreferrer"
-      href="https://github.com/dfinity/internet-identity#build-features"
-      >more</a
-    >
-  `;
-
-  render(warning, container);
-  document.body.prepend(container);
 };

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -8,14 +8,14 @@ import { faqView } from "./flows/faq";
 import { intentFromUrl } from "./utils/userIntent";
 import { checkRequiredFeatures } from "./utils/featureDetection";
 import { recoveryWizard } from "./flows/recovery/recoveryWizard";
-import { showWarningOnFeatures } from "./features";
+import { showWarningIfNecessary } from "./banner";
 
 const init = async () => {
   const url = new URL(document.URL);
 
-  // If the build contains any "features", show a warning
+  // If the build is not "official", show a warning
   // https://github.com/dfinity/internet-identity#build-features
-  showWarningOnFeatures();
+  showWarningIfNecessary();
 
   // Custom routing to the FAQ page
   if (window.location.pathname === "/faq") {


### PR DESCRIPTION
We should make sure that unsuspecting users do not land on testing
builds of II. While we can't ensure that, we can at least let them know
that something is wrong. So far we've displayed a banner if the build
included features; this adds a banner if the origin is not
identity.ic0.app.

<!--- We currently do not accept contributions. See .github/CONTRIBUTING.md. -->
