### PR TITLE
Add --upgrade to backend-tests

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -105,6 +105,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
+        upgrade: [ with, without ]
     env:
       GHC_VERSION: 8.8.4
 
@@ -142,7 +143,7 @@ jobs:
       - name: Run Tests
         shell: bash
         working-directory: backend-tests
-        run: mv ../internet_identity_test.wasm ../internet_identity.wasm && cabal run
+        run: mv ../internet_identity_test.wasm ../internet_identity.wasm && cabal run backend-tests -- --upgrade ${{ matrix.upgrade }}
 
   ######################
   # The selenium tests #


### PR DESCRIPTION
This adds an option for running tests WITH upgrade, WITHOUT upgrade, or
both WITH and WITHOUT.

<!--- We currently do not accept contributions. See .github/CONTRIBUTING.md. -->
