### PR TITLE
Record size of wasm in git notes

### DIFF
--- a/.github/actions/file-size/README.md
+++ b/.github/actions/file-size/README.md
@@ -1,0 +1,37 @@
+# File size
+
+A GitHub Action for recording file sizes in git notes.
+
+## Usage
+
+``` yaml
+  record-readme-size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/file-size
+        with:
+          file: README.md
+```
+
+To use the notes, first fetch them:
+
+``` bash
+$ git fetch origin refs/notes/file-size/*:refs/notes/file-size/*
+```
+
+Then, each note contains a number, which is the size in bytes. The following example plots the values:
+
+``` bash
+$ git log \
+    --reverse --notes="notes/file-size/README.md" \
+    --pretty='format:%h%x09%s%x09%N' | tail -n 10 \
+    | awk -F '\t' 'NF { printf("%s\t%s\t", $1,$2); if ($3 != "") { printf("Size: %s ", $3); i = 0; while (i++ < ($3 - 2035000) / 200) printf "■" }; print "" }'
+
+f3f0136 Add feature X             Size: 2039380 ■■■■■■■■■■■■■■■■■■■■■■
+95495ba Fix bug                   Size: 2039380 ■■■■■■■■■■■■■■■■■■■■■■
+5cbb463 Update logo               Size: 2039380 ■■■■■■■■■■■■■■■■■■■■■■
+8a9f4aa Minify javascript         Size: 2038689 ■■■■■■■■■■■■■■■■■■■
+da88075 Frobnicate with Aardvark  Size: 2045766 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
+...
+```

--- a/.github/actions/file-size/action.yml
+++ b/.github/actions/file-size/action.yml
@@ -1,0 +1,23 @@
+name: 'File Size'
+description: 'Record the file size in git notes'
+inputs:
+  file:
+    description: 'File of which to compute the size'
+    required: true
+  save:
+    description: 'When true (default), the size is uploaded to origin in a git note.'
+    required: true
+    default: true
+outputs:
+  size:
+    description: "The size of the file, in bytes"
+    value: ${{ steps.run-script.outputs.size }}
+runs:
+  using: "composite"
+  steps:
+    - id: run-script
+      run: ${{ github.action_path }}/run.sh
+      shell: bash
+      env:
+        INPUT_FILE: ${{ inputs.file }}
+        INPUT_SAVE: ${{ inputs.save }}

--- a/.github/actions/file-size/run.sh
+++ b/.github/actions/file-size/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Compute the size of the file and write it to 'notes/file-size/<filename>'
+
+set -euo pipefail
+
+filename=${INPUT_FILE:?"No filename provided"}
+save=${INPUT_SAVE}
+name="$filename"
+ref="notes/file-size/$name"
+
+# Pipe to xargs to trim whitespaces
+size="$(wc -c <"$filename" | xargs)"
+
+>&2 echo "Size: '$size'"
+echo "::set-output name=size::$size"
+
+logged() {
+    ( set -x && "$@" )
+}
+
+if [ "$save" = "true" ]
+then
+    >&2 echo "Saving size to git notes"
+    git config user.name "file-size action"
+    git config user.email "<>"
+
+    logged git fetch origin "refs/$ref:refs/$ref" || echo "could not fetch $ref, assuming doesn't exist yet"
+    logged git notes --ref "$ref" add --file <(echo -n "$size")
+
+    logged git push origin "refs/$ref"
+fi

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -95,6 +95,32 @@ jobs:
           # downloaded file
           path: ${{ matrix.name }}
 
+  wasm-size:
+    runs-on: ubuntu-latest
+    needs: docker-build
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Download wasm'
+        uses: actions/download-artifact@v2
+        with:
+          name: internet_identity_production.wasm
+          path: .
+      - id: record-size
+        uses: ./.github/actions/file-size
+        with:
+          file: internet_identity_production.wasm
+          save: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Check canister size"
+        run: |
+          max_size=3670016 # maximum canister size, in bytes
+          actual_size=${{ steps.record-size.outputs.size }}
+          if (( actual_size > max_size ))
+          then
+            echo "Canister size too big"
+            echo "($actual_size > $max_size)"
+            exit 1
+          fi
+
   #####################
   # The backend tests #
   #####################


### PR DESCRIPTION
This adds a CI step that computes the size of
`internet_identity_production.wasm` and records it in a git note. The
size is also checked against the maximum canister size. The git note is
created and pushed only on the main branch.

The logic is pulled into a GitHub action because the `canister-tests`
workflow file is getting gigantic.

<!--- We currently do not accept contributions. See .github/CONTRIBUTING.md. -->
