### PR TITLE
Make retrying possible on bad recovery

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,13 @@
             { "allowString" : false,
                 "allowNumber" : false
             }
+        ],
+        "@typescript-eslint/no-unused-vars": [
+            "warn",
+            {  "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }
         ]
     },
     "ignorePatterns": ["src/**/*.test.ts", "src/frontend/generated/*"]

--- a/src/frontend/src/flows/login/flowResult.ts
+++ b/src/frontend/src/flows/login/flowResult.ts
@@ -18,7 +18,7 @@ export type LoginFlowError = {
 /** The result of a login flow that was canceled */
 export type LoginFlowCanceled = { tag: "canceled" };
 export function canceled(): LoginFlowCanceled {
-    return { tag: "canceled" };
+  return { tag: "canceled" };
 }
 
 export const apiResultToLoginFlowResult = (

--- a/src/frontend/src/flows/login/flowResult.ts
+++ b/src/frontend/src/flows/login/flowResult.ts
@@ -1,17 +1,19 @@
 import { IIConnection, ApiResult } from "../../utils/iiConnection";
 
-export type LoginFlowResult =
-  | {
-      tag: "ok";
-      userNumber: bigint;
-      connection: IIConnection;
-    }
-  | {
-      tag: "err";
-      title: string;
-      message: string;
-      detail?: string;
-    };
+export type LoginFlowResult = LoginFlowSuccess | LoginFlowError;
+
+export type LoginFlowSuccess = {
+  tag: "ok";
+  userNumber: bigint;
+  connection: IIConnection;
+};
+
+export type LoginFlowError = {
+  tag: "err";
+  title: string;
+  message: string;
+  detail?: string;
+};
 
 export const apiResultToLoginFlowResult = (
   result: ApiResult

--- a/src/frontend/src/flows/login/flowResult.ts
+++ b/src/frontend/src/flows/login/flowResult.ts
@@ -15,6 +15,12 @@ export type LoginFlowError = {
   detail?: string;
 };
 
+/** The result of a login flow that was canceled */
+export type LoginFlowCanceled = { tag: "canceled" };
+export function canceled(): LoginFlowCanceled {
+    return { tag: "canceled" };
+}
+
 export const apiResultToLoginFlowResult = (
   result: ApiResult
 ): LoginFlowResult => {

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -42,30 +42,34 @@ const init = (
   new Promise((resolve) => {
     const buttonContinue = document.getElementById(
       "recover-with-device__continue"
-    ) as HTMLButtonElement;
-    buttonContinue.onclick = async () => {
-      const result = apiResultToLoginFlowResult(
-        await IIConnection.fromWebauthnDevices(userNumber, [device])
-      );
+    ) as HTMLButtonElement | null;
+    if (buttonContinue !== null) {
+      buttonContinue.onclick = async () => {
+        const result = apiResultToLoginFlowResult(
+          await IIConnection.fromWebauthnDevices(userNumber, [device])
+        );
 
-      switch (result.tag) {
-        case "ok":
-          resolve(result);
-          break;
-        case "err":
-          await displayError({ ...result, primaryButton: "Try again" });
-          deviceRecoveryPage(userNumber, device).then((res) => resolve(res));
-          break;
-        default:
-          unreachable(result);
-          break;
-      }
-    };
+        switch (result.tag) {
+          case "ok":
+            resolve(result);
+            break;
+          case "err":
+            await displayError({ ...result, primaryButton: "Try again" });
+            deviceRecoveryPage(userNumber, device).then((res) => resolve(res));
+            break;
+          default:
+            unreachable(result);
+            break;
+        }
+      };
+    }
 
     const buttonCancel = document.getElementById(
       "recover-with-device__cancel"
-    ) as HTMLButtonElement;
-    buttonCancel.onclick = async () => {
-      resolve(null);
-    };
+    ) as HTMLButtonElement | null;
+    if (buttonCancel !== null) {
+      buttonCancel.onclick = async () => {
+        resolve(null);
+      };
+    }
   });

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -1,0 +1,71 @@
+import { html, render } from "lit-html";
+import { displayError } from "../../../components/displayError";
+import { unreachable } from "../../../utils/utils";
+import {
+  apiResultToLoginFlowResult,
+  LoginFlowSuccess,
+} from "../../login/flowResult";
+import { DeviceData } from "../../../../generated/internet_identity_types";
+import { IIConnection } from "../../../utils/iiConnection";
+
+const pageContent = (userNumber: bigint) => html`
+  <style>
+    .full-width {
+      width: 100%;
+    }
+  </style>
+  <div class="container full-width">
+    <h1>Recovery for ${userNumber}</h1>
+    <p>
+      You are about to recover your anchor using a recovery device. Please click
+      "continue" and then follow your browser's instructions to connect your
+      device.
+    </p>
+    <button id="recover-with-device__continue" class="primary">Continue</button>
+    <button id="recover-with-device__cancel">Cancel</button>
+  </div>
+`;
+
+export const deviceRecoveryPage = async (
+  userNumber: bigint,
+  device: DeviceData
+): Promise<LoginFlowSuccess | null> => {
+  const container = document.getElementById("pageContent") as HTMLElement;
+  render(pageContent(userNumber), container);
+  return init(userNumber, device);
+};
+
+const init = (
+  userNumber: bigint,
+  device: DeviceData
+): Promise<LoginFlowSuccess | null> =>
+  new Promise((resolve) => {
+    const buttonContinue = document.getElementById(
+      "recover-with-device__continue"
+    ) as HTMLButtonElement;
+    buttonContinue.onclick = async () => {
+      const result = apiResultToLoginFlowResult(
+        await IIConnection.fromWebauthnDevices(userNumber, [device])
+      );
+
+      switch (result.tag) {
+        case "ok":
+          resolve(result);
+          break;
+        case "err":
+          await displayError({ ...result, primaryButton: "Try again" });
+          deviceRecoveryPage(userNumber, device).then((res) => resolve(res));
+          break;
+        default:
+          unreachable(result);
+          break;
+      }
+    };
+
+    const buttonCancel = document.getElementById(
+      "recover-with-device__cancel"
+    ) as HTMLButtonElement;
+    buttonCancel.onclick = async () => {
+      resolve(null);
+    };
+  });

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -3,7 +3,9 @@ import { displayError } from "../../../components/displayError";
 import { unreachable } from "../../../utils/utils";
 import {
   apiResultToLoginFlowResult,
+  canceled,
   LoginFlowSuccess,
+  LoginFlowCanceled,
 } from "../../login/flowResult";
 import { DeviceData } from "../../../../generated/internet_identity_types";
 import { IIConnection } from "../../../utils/iiConnection";
@@ -29,7 +31,7 @@ const pageContent = (userNumber: bigint) => html`
 export const deviceRecoveryPage = async (
   userNumber: bigint,
   device: DeviceData
-): Promise<LoginFlowSuccess | null> => {
+): Promise<LoginFlowSuccess | LoginFlowCanceled> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber), container);
   return init(userNumber, device);
@@ -38,7 +40,7 @@ export const deviceRecoveryPage = async (
 const init = (
   userNumber: bigint,
   device: DeviceData
-): Promise<LoginFlowSuccess | null> =>
+): Promise<LoginFlowSuccess | LoginFlowCanceled> =>
   new Promise((resolve) => {
     const buttonContinue = document.getElementById(
       "recover-with-device__continue"
@@ -69,7 +71,7 @@ const init = (
     ) as HTMLButtonElement | null;
     if (buttonCancel !== null) {
       buttonCancel.onclick = async () => {
-        resolve(null);
+        resolve(canceled());
       };
     }
   });

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -1,14 +1,22 @@
 import { html, nothing, render, TemplateResult } from "lit-html";
+import { DeviceData } from "../../../../generated/internet_identity_types";
+import {
+  apiResultToLoginFlowResult,
+  LoginFlowSuccess,
+} from "../../login/flowResult";
+import { dropLeadingUserNumber } from "../../../crypto/mnemonic";
+import { IIConnection } from "../../../utils/iiConnection";
+import { displayError } from "../../../components/displayError";
+import { unreachable } from "../../../utils/utils";
 import {
   Warning,
   RECOVERYPHRASE_WORDCOUNT,
-  dropLeadingUserNumber,
   getWarnings,
-} from "../../crypto/mnemonic";
-import { warningIcon } from "../../components/icons";
-import { questions } from "../faq";
+} from "../../../crypto/mnemonic";
+import { warningIcon } from "../../../components/icons";
+import { questions } from "../../faq";
 
-const pageContent = () => html`
+const pageContent = (userNumber: bigint) => html`
   <style>
 
     /* Flash the warnings box if warnings were generated */
@@ -83,7 +91,9 @@ const pageContent = () => html`
   <div class="container full-width">
     <h1>Your seed phrase</h1>
     <p>Please provide your seed phrase</p>
-    <textarea id="inputSeedPhrase" placeholder="Your seed phrase"></textarea>
+    <textarea id="inputSeedPhrase" placeholder="${
+      userNumber + " above squirrel ..."
+    }"></textarea>
     <details class="warnings-box hidden">
         <summary><span class="warnings-box-summary">Phrase may not be valid<span></summary>
         <div id="warnings"></div>
@@ -94,14 +104,20 @@ const pageContent = () => html`
 `;
 
 export const inputSeedPhrase = async (
-  userNumber: bigint
-): Promise<string | null> => {
+  userNumber: bigint,
+  device: DeviceData,
+  prefilledPhrase?: string
+): Promise<LoginFlowSuccess | null> => {
   const container = document.getElementById("pageContent") as HTMLElement;
-  render(pageContent(), container);
-  return init(userNumber);
+  render(pageContent(userNumber), container);
+  return init(userNumber, device, prefilledPhrase);
 };
 
-const init = (userNumber: bigint): Promise<string | null> =>
+const init = (
+  userNumber: bigint,
+  device: DeviceData,
+  prefilledPhrase?: string /* if set, prefilled as input */
+): Promise<LoginFlowSuccess | null> =>
   new Promise((resolve) => {
     const inputSeedPhraseInput = document.getElementById(
       "inputSeedPhrase"
@@ -144,6 +160,9 @@ const init = (userNumber: bigint): Promise<string | null> =>
       }, 500);
     };
 
+    if (prefilledPhrase !== undefined) {
+      inputSeedPhraseInput.value = prefilledPhrase;
+    }
     inputSeedPhraseInput.oninput = () => {
       debouncedWarnings();
     };
@@ -157,10 +176,26 @@ const init = (userNumber: bigint): Promise<string | null> =>
       resolve(null);
     };
     inputSeedPhraseContinue.onclick = async () => {
-      const inputValue = dropLeadingUserNumber(
-        inputSeedPhraseInput.value.trim()
+      const inputValue = inputSeedPhraseInput.value.trim();
+      const mnemonic = dropLeadingUserNumber(inputValue);
+      const result = apiResultToLoginFlowResult(
+        await IIConnection.fromSeedPhrase(userNumber, mnemonic, device)
       );
-      resolve(inputValue);
+
+      switch (result.tag) {
+        case "ok":
+          resolve(result);
+          break;
+        case "err":
+          await displayError({ ...result, primaryButton: "Try again" });
+          inputSeedPhrase(userNumber, device, inputValue).then((res) =>
+            resolve(res)
+          );
+          break;
+        default:
+          unreachable(result);
+          break;
+      }
     };
   });
 

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -2,6 +2,8 @@ import { html, nothing, render, TemplateResult } from "lit-html";
 import { DeviceData } from "../../../../generated/internet_identity_types";
 import {
   apiResultToLoginFlowResult,
+  LoginFlowCanceled,
+  canceled,
   LoginFlowSuccess,
 } from "../../login/flowResult";
 import { dropLeadingUserNumber } from "../../../crypto/mnemonic";
@@ -107,7 +109,7 @@ export const inputSeedPhrase = async (
   userNumber: bigint,
   device: DeviceData,
   prefilledPhrase?: string
-): Promise<LoginFlowSuccess | null> => {
+): Promise<LoginFlowSuccess | LoginFlowCanceled> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber), container);
   return init(userNumber, device, prefilledPhrase);
@@ -117,7 +119,7 @@ const init = (
   userNumber: bigint,
   device: DeviceData,
   prefilledPhrase?: string /* if set, prefilled as input */
-): Promise<LoginFlowSuccess | null> =>
+): Promise<LoginFlowSuccess | LoginFlowCanceled> =>
   new Promise((resolve) => {
     const inputSeedPhraseInput = document.getElementById(
       "inputSeedPhrase"
@@ -173,7 +175,7 @@ const init = (
       "inputSeedPhraseCancel"
     ) as HTMLButtonElement;
     inputSeedPhraseCancel.onclick = () => {
-      resolve(null);
+      resolve(canceled());
     };
     inputSeedPhraseContinue.onclick = async () => {
       const inputValue = inputSeedPhraseInput.value.trim();

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -105,7 +105,7 @@ const pageContent = (userNumber: bigint) => html`
   </div>
 `;
 
-export const inputSeedPhrase = async (
+export const phraseRecoveryPage = async (
   userNumber: bigint,
   device: DeviceData,
   prefilledPhrase?: string
@@ -190,7 +190,7 @@ const init = (
           break;
         case "err":
           await displayError({ ...result, primaryButton: "Try again" });
-          inputSeedPhrase(userNumber, device, inputValue).then((res) =>
+          phraseRecoveryPage(userNumber, device, inputValue).then((res) =>
             resolve(res)
           );
           break;

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -33,7 +33,7 @@ export const useRecovery = async (userNumber?: bigint): Promise<void> => {
     : await deviceRecoveryPage(userNumber, device);
 
   // If res is null, the user canceled the flow, so we go back to the main page.
-  if (res === null) {
+  if (res.tag === "canceled") {
     return window.location.reload();
   }
 

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -3,7 +3,7 @@ import { IIConnection } from "../../utils/iiConnection";
 import { hasOwnProperty } from "../../utils/utils";
 import { renderManage } from "../manage";
 import { promptUserNumber } from "../promptUserNumber";
-import { inputSeedPhrase } from "./recoverWith/phrase";
+import { phraseRecoveryPage } from "./recoverWith/phrase";
 import { deviceRecoveryPage } from "./recoverWith/device";
 import { pickRecoveryDevice } from "./pickRecoveryDevice";
 
@@ -29,7 +29,7 @@ export const useRecovery = async (userNumber?: bigint): Promise<void> => {
       : await pickRecoveryDevice(recoveryDevices);
 
   const res = hasOwnProperty(device.key_type, "seed_phrase")
-    ? await inputSeedPhrase(userNumber, device)
+    ? await phraseRecoveryPage(userNumber, device)
     : await deviceRecoveryPage(userNumber, device);
 
   // If res is null, the user canceled the flow, so we go back to the main page.

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -81,3 +81,8 @@ export function iOSOrSafari(): boolean {
   // For details, see https://stackoverflow.com/a/23522755/2716377
   return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 }
+
+/* A function that can never be called. Can be used to prove that all type alternatives have been exhausted. */
+export function unreachable(_: never): never {
+  throw new Error("The impossible happened");
+}


### PR DESCRIPTION
Before this, the recovery experience wasn't great if it didn't Just Work™. In particular:

* When inputting an invalid recovery phrase, clicking "Try again" took
  you back to the beginning (had to re-enter anchor + re type phrase)
* Both the phrase and device recoveries didn't actually allow you to
  cancel; there was no way to go back to the origin without reloading
  the page.

Now, when clicking "Try again" on the recovery phrase page you don't
have to re-enter your anchor, and whatever you typed previously is
prefilled; there's also a working "cancel" button.. On the device recovery page, there's now an opportunity to
cancel as well.


Behavior before:

https://user-images.githubusercontent.com/6930756/168829077-1a10710c-305d-4751-b962-370eae8db4a4.mov

Behavior after:

https://user-images.githubusercontent.com/6930756/168829155-4f6da65a-89ea-488a-9c27-7366e747195f.mov
