### PR TITLE
Add test for prefilled anchor number when authenticating for a dapp

### DIFF
--- a/src/frontend/src/test-e2e/selenium.test.ts
+++ b/src/frontend/src/test-e2e/selenium.test.ts
@@ -23,6 +23,9 @@ import {
 import { FLOWS } from "./flows";
 import {
   addVirtualAuthenticator,
+  addWebAuthnCredential,
+  getWebAuthnCredentials,
+  originToRpId,
   removeFeaturesWarning,
   removeVirtualAuthenticator,
   RunConfiguration,
@@ -595,3 +598,55 @@ test("Screenshots", async () => {
     }
   );
 }, 400_000);
+
+test("Register first then log into client application", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    const authenticatorId1 = await addVirtualAuthenticator(browser);
+
+    await browser.url(II_URL);
+    const userNumber = await FLOWS.registerNewIdentityWelcomeView(
+      DEVICE_NAME1,
+      browser
+    );
+
+    const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
+    expect(credentials).toHaveLength(1);
+
+    const demoAppView = new DemoAppView(browser);
+    await demoAppView.open(DEMO_APP_URL, II_URL);
+    await demoAppView.waitForDisplay();
+    expect(await demoAppView.getPrincipal()).toBe("2vxsx-fae");
+    await demoAppView.signin();
+
+    const authenticatorId2 = await switchToPopup(browser);
+    await addWebAuthnCredential(
+      browser,
+      authenticatorId2,
+      credentials[0],
+      originToRpId(II_ORIGIN)
+    );
+
+    const authenticateView = new AuthenticateView(browser);
+    await authenticateView.waitForDisplay();
+    await authenticateView.expectPrefilledAnchorToBe(userNumber);
+    await authenticateView.authenticate();
+    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
+    await recoveryMethodSelectorView.waitForDisplay();
+    await recoveryMethodSelectorView.skipRecovery();
+    const singleDeviceWarningView = new SingleDeviceWarningView(browser);
+    await singleDeviceWarningView.waitForDisplay();
+    await singleDeviceWarningView.remindLater();
+    await waitToClose(browser);
+    await demoAppView.waitForDisplay();
+    const principal = await demoAppView.getPrincipal();
+    expect(principal).not.toBe("2vxsx-fae");
+
+    expect(await demoAppView.whoami(REPLICA_URL, WHOAMI_CANISTER)).toBe(
+      principal
+    );
+
+    // default value
+    const exp = await browser.$("#expiration").getText();
+    expect(Number(exp) / (24 * 60 * 60_000_000_000)).toBeCloseTo(1);
+  });
+}, 300_000);

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -115,6 +115,10 @@ function parseRunConfiguration(): RunConfiguration {
   };
 }
 
+/**
+ * Adds custom commands for webauthn authenticator administration as documented here: https://webdriver.io/docs/customcommands/#add-more-webdriver-commands
+ * @param browser browser to add the commands to
+ */
 export async function addCustomCommands(
   browser: WebdriverIO.Browser
 ): Promise<void> {

--- a/src/frontend/test-setup.ts
+++ b/src/frontend/test-setup.ts
@@ -1,6 +1,13 @@
 import crypto from "@trust/webcrypto";
 import textEncoding = require("text-encoding");
 
+export type WebAuthnCredential = {
+  credentialId: string;
+  isResidentCredential: boolean;
+  privateKey: string;
+  signCount: number;
+};
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace WebdriverIO {
@@ -12,6 +19,19 @@ declare global {
         isUserConsenting: boolean
       ) => Promise<string>;
       removeVirtualWebAuth: (authenticatorId: string) => Promise<void>;
+      getWebauthnCredentials: (
+        authenticatorId: string
+      ) => Promise<WebAuthnCredential[]>;
+      addWebauthnCredential: (
+        authenticatorId: string,
+        rpId: string,
+        credentialId: string,
+        isResidentCredential: boolean,
+        privateKey: string,
+        signCount: number,
+        userHandle?: string,
+        largeBlob?: string
+      ) => Promise<void>;
     }
   }
 }


### PR DESCRIPTION
Adds a test for prefilled anchor number on the authorize login screen.

In order to do this, infrastructure had to be added that copies the credentials between virtual authenticators (which are bound to the windows they are created in).
