### PR TITLE
Split and move auth.ts to flows/authenticate

### DIFF
--- a/src/frontend/src/auth.ts
+++ b/src/frontend/src/auth.ts
@@ -1,0 +1,44 @@
+import { UserNumber } from "../generated/internet_identity_types";
+import { IIConnection } from "./utils/iiConnection";
+import { handleAuthRequest } from "./flows/authenticate/fetchDelegation";
+import { READY_MESSAGE } from "./flows/authenticate/postMessageInterface";
+
+/**
+ * Setup an event listener to listen to authorize requests from the client.
+ *
+ * This method expects to be called after the login flow.
+ */
+export default async function setup(
+  userNumber: UserNumber,
+  connection: IIConnection
+): Promise<void> {
+  // Set up an event listener for receiving messages from the client.
+  window.addEventListener("message", async (event) => {
+    const message = event.data;
+    if (message.kind === "authorize-client") {
+      console.log("Handling authorize-client request.");
+      const response = await handleAuthRequest(
+        connection,
+        userNumber,
+        message,
+        event.origin
+      );
+      (event.source as Window).postMessage(response, event.origin);
+    } else {
+      console.log(`Message of unknown kind received: ${message}`);
+    }
+  });
+
+  // Send a message to indicate we're ready.
+  // NOTE: Because `window.opener.origin` cannot be accessed, this message
+  // is sent with "*" as the target origin. This is safe as no sensitive
+  // information is being communicated here.
+  if (window.opener !== null) {
+    window.opener.postMessage(READY_MESSAGE, "*");
+  } else {
+    // If there's no `window.opener` a user has manually navigated to "/#authorize". Let's
+    // redirect them to the non-hash version.
+    window.location.hash = "";
+    window.location.reload();
+  }
+}

--- a/src/frontend/src/flows/authenticate/fetchDelegation.ts
+++ b/src/frontend/src/flows/authenticate/fetchDelegation.ts
@@ -1,87 +1,16 @@
-import { Principal } from "@dfinity/principal";
+import { IIConnection } from "../../utils/iiConnection";
 import {
   FrontendHostname,
   PublicKey,
   SignedDelegation,
   UserNumber,
-} from "../generated/internet_identity_types";
-import { withLoader } from "./components/loader";
-import { confirmRedirect } from "./flows/confirmRedirect";
-import { IIConnection } from "./utils/iiConnection";
-import { hasOwnProperty } from "./utils/utils";
+} from "../../../generated/internet_identity_types";
+import { withLoader } from "../../components/loader";
+import { confirmRedirect } from "../confirmRedirect";
+import { hasOwnProperty } from "../../utils/utils";
+import { AuthRequest, AuthResponse } from "./postMessageInterface";
 
-interface AuthRequest {
-  kind: "authorize-client";
-  sessionPublicKey: Uint8Array;
-  maxTimeToLive?: bigint;
-}
-
-interface AuthResponseSuccess {
-  kind: "authorize-client-success";
-  delegations: {
-    delegation: {
-      pubkey: Uint8Array;
-      expiration: bigint;
-      targets?: Principal[];
-    };
-    signature: Uint8Array;
-  }[];
-  userPublicKey: Uint8Array;
-}
-
-interface AuthResponseFailure {
-  kind: "authorize-client-failure";
-  text: string;
-}
-
-type AuthResponse = AuthResponseSuccess | AuthResponseFailure;
-
-// A message to signal that the II is ready to receive authorization requests.
-const READY_MESSAGE = {
-  kind: "authorize-ready",
-};
-
-/**
- * Setup an event listener to listen to authorize requests from the client.
- *
- * This method expects to be called after the login flow.
- */
-export default async function setup(
-  userNumber: UserNumber,
-  connection: IIConnection
-): Promise<void> {
-  // Set up an event listener for receiving messages from the client.
-  window.addEventListener("message", async (event) => {
-    const message = event.data;
-    if (message.kind === "authorize-client") {
-      console.log("Handling authorize-client request.");
-      const response = await handleAuthRequest(
-        connection,
-        userNumber,
-        message,
-        event.origin
-      );
-      (event.source as Window).postMessage(response, event.origin);
-    } else {
-      console.log(`Message of unknown kind received: ${message}`);
-    }
-  });
-
-  // Send a message to indicate we're ready.
-  // NOTE: Because `window.opener.origin` cannot be accessed, this message
-  // is sent with "*" as the target origin. This is safe as no sensitive
-  // information is being communicated here.
-  if (window.opener !== null) {
-    window.opener.postMessage(READY_MESSAGE, "*");
-  } else {
-    // If there's no `window.opener` a user has manually navigated to "/#authorize". Let's
-    // redirect them to the non-hash version.
-    window.location.hash = "";
-    window.location.reload();
-  }
-}
-
-async function handleAuthRequest(
+export async function handleAuthRequest(
   connection: IIConnection,
   userNumber: UserNumber,
   request: AuthRequest,

--- a/src/frontend/src/flows/authenticate/postMessageInterface.ts
+++ b/src/frontend/src/flows/authenticate/postMessageInterface.ts
@@ -1,7 +1,4 @@
 import { Principal } from "@dfinity/principal";
-import { UserNumber } from "../../../generated/internet_identity_types";
-import { IIConnection } from "../../utils/iiConnection";
-import { handleAuthRequest } from "./fetchDelegation";
 
 export interface AuthRequest {
   kind: "authorize-client";
@@ -9,16 +6,18 @@ export interface AuthRequest {
   maxTimeToLive?: bigint;
 }
 
+export interface Delegation {
+  delegation: {
+    pubkey: Uint8Array;
+    expiration: bigint;
+    targets?: Principal[];
+  };
+  signature: Uint8Array;
+}
+
 export interface AuthResponseSuccess {
   kind: "authorize-client-success";
-  delegations: {
-    delegation: {
-      pubkey: Uint8Array;
-      expiration: bigint;
-      targets?: Principal[];
-    };
-    signature: Uint8Array;
-  }[];
+  delegations: Delegation[];
   userPublicKey: Uint8Array;
 }
 
@@ -30,46 +29,6 @@ export interface AuthResponseFailure {
 export type AuthResponse = AuthResponseSuccess | AuthResponseFailure;
 
 // A message to signal that the II is ready to receive authorization requests.
-const READY_MESSAGE = {
+export const READY_MESSAGE = {
   kind: "authorize-ready",
 };
-
-/**
- * Setup an event listener to listen to authorize requests from the client.
- *
- * This method expects to be called after the login flow.
- */
-export default async function setup(
-  userNumber: UserNumber,
-  connection: IIConnection
-): Promise<void> {
-  // Set up an event listener for receiving messages from the client.
-  window.addEventListener("message", async (event) => {
-    const message = event.data;
-    if (message.kind === "authorize-client") {
-      console.log("Handling authorize-client request.");
-      const response = await handleAuthRequest(
-        connection,
-        userNumber,
-        message,
-        event.origin
-      );
-      (event.source as Window).postMessage(response, event.origin);
-    } else {
-      console.log(`Message of unknown kind received: ${message}`);
-    }
-  });
-
-  // Send a message to indicate we're ready.
-  // NOTE: Because `window.opener.origin` cannot be accessed, this message
-  // is sent with "*" as the target origin. This is safe as no sensitive
-  // information is being communicated here.
-  if (window.opener !== null) {
-    window.opener.postMessage(READY_MESSAGE, "*");
-  } else {
-    // If there's no `window.opener` a user has manually navigated to "/#authorize". Let's
-    // redirect them to the non-hash version.
-    window.location.hash = "";
-    window.location.reload();
-  }
-}

--- a/src/frontend/src/flows/authenticate/postMessageInterface.ts
+++ b/src/frontend/src/flows/authenticate/postMessageInterface.ts
@@ -1,0 +1,75 @@
+import { Principal } from "@dfinity/principal";
+import { UserNumber } from "../../../generated/internet_identity_types";
+import { IIConnection } from "../../utils/iiConnection";
+import { handleAuthRequest } from "./fetchDelegation";
+
+export interface AuthRequest {
+  kind: "authorize-client";
+  sessionPublicKey: Uint8Array;
+  maxTimeToLive?: bigint;
+}
+
+export interface AuthResponseSuccess {
+  kind: "authorize-client-success";
+  delegations: {
+    delegation: {
+      pubkey: Uint8Array;
+      expiration: bigint;
+      targets?: Principal[];
+    };
+    signature: Uint8Array;
+  }[];
+  userPublicKey: Uint8Array;
+}
+
+export interface AuthResponseFailure {
+  kind: "authorize-client-failure";
+  text: string;
+}
+
+export type AuthResponse = AuthResponseSuccess | AuthResponseFailure;
+
+// A message to signal that the II is ready to receive authorization requests.
+const READY_MESSAGE = {
+  kind: "authorize-ready",
+};
+
+/**
+ * Setup an event listener to listen to authorize requests from the client.
+ *
+ * This method expects to be called after the login flow.
+ */
+export default async function setup(
+  userNumber: UserNumber,
+  connection: IIConnection
+): Promise<void> {
+  // Set up an event listener for receiving messages from the client.
+  window.addEventListener("message", async (event) => {
+    const message = event.data;
+    if (message.kind === "authorize-client") {
+      console.log("Handling authorize-client request.");
+      const response = await handleAuthRequest(
+        connection,
+        userNumber,
+        message,
+        event.origin
+      );
+      (event.source as Window).postMessage(response, event.origin);
+    } else {
+      console.log(`Message of unknown kind received: ${message}`);
+    }
+  });
+
+  // Send a message to indicate we're ready.
+  // NOTE: Because `window.opener.origin` cannot be accessed, this message
+  // is sent with "*" as the target origin. This is safe as no sensitive
+  // information is being communicated here.
+  if (window.opener !== null) {
+    window.opener.postMessage(READY_MESSAGE, "*");
+  } else {
+    // If there's no `window.opener` a user has manually navigated to "/#authorize". Let's
+    // redirect them to the non-hash version.
+    window.location.hash = "";
+    window.location.reload();
+  }
+}

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -1,6 +1,5 @@
 import "./styles/main.css";
 import { login } from "./flows/login";
-import auth from "./auth";
 import { renderManage } from "./flows/manage";
 import { compatibilityNotice } from "./flows/compatibilityNotice";
 import { aboutView } from "./flows/about";
@@ -9,6 +8,7 @@ import { intentFromUrl } from "./utils/userIntent";
 import { checkRequiredFeatures } from "./utils/featureDetection";
 import { recoveryWizard } from "./flows/recovery/recoveryWizard";
 import { showWarningIfNecessary } from "./banner";
+import postMessageInterface from "./flows/authenticate/postMessageInterface";
 
 const init = async () => {
   const url = new URL(document.URL);
@@ -44,7 +44,7 @@ const init = async () => {
   switch (userIntent.kind) {
     // Authenticate to a third party service
     case "auth": {
-      return auth(userNumber, connection);
+      return postMessageInterface(userNumber, connection);
     }
     // Open the management page
     case "manage": {

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -8,7 +8,7 @@ import { intentFromUrl } from "./utils/userIntent";
 import { checkRequiredFeatures } from "./utils/featureDetection";
 import { recoveryWizard } from "./flows/recovery/recoveryWizard";
 import { showWarningIfNecessary } from "./banner";
-import postMessageInterface from "./flows/authenticate/postMessageInterface";
+import auth from "./auth";
 
 const init = async () => {
   const url = new URL(document.URL);
@@ -44,7 +44,7 @@ const init = async () => {
   switch (userIntent.kind) {
     // Authenticate to a third party service
     case "auth": {
-      return postMessageInterface(userNumber, connection);
+      return auth(userNumber, connection);
     }
     // Open the management page
     case "manage": {


### PR DESCRIPTION
Splits and moves the contents related to postMessages and fetching of delegations out of `auth.ts` in preparation for #642.
