### PR TITLE
Don't force anchor entry on recovery for authorize page

### DIFF
--- a/src/frontend/src/flows/authenticate/index.ts
+++ b/src/frontend/src/flows/authenticate/index.ts
@@ -336,13 +336,7 @@ const initRecovery = () => {
   const recoverButton = document.getElementById(
     "recoverButton"
   ) as HTMLButtonElement;
-  recoverButton.onclick = () => {
-    const userNumber = readUserNumber();
-    if (userNumber !== undefined) {
-      return useRecovery(userNumber);
-    }
-    toggleErrorMessage("userNumberInput", "invalidAnchorMessage", true);
-  };
+  recoverButton.onclick = () => useRecovery(readUserNumber());
 };
 
 /**


### PR DESCRIPTION
Allow recovery when the anchor field is empty by showing the anchor input box again as part of the recovery flow.
