### PR TITLE
Fix Docker cached dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN mkdir -p src/internet_identity/src \
     && touch src/internet_identity_interface/src/lib.rs \
     && mkdir -p src/canister_tests/src \
     && touch src/canister_tests/src/lib.rs \
-    && cargo build --target wasm32-unknown-unknown --release -j1 \
+    && cargo build --manifest-path ./src/internet_identity/Cargo.toml --target wasm32-unknown-unknown --release -j1 \
     && rm -rf src
 
 FROM deps as build
@@ -72,6 +72,8 @@ ARG II_DUMMY_CAPTCHA=
 ARG II_DUMMY_AUTH=
 
 RUN touch src/internet_identity/src/lib.rs
+RUN touch src/internet_identity_interface/src/lib.rs
+RUN touch src/canister_tests/src/lib.rs
 RUN npm ci
 
 RUN ./src/internet_identity/build.sh


### PR DESCRIPTION
For reasons unclear, now that we have more than 1 crate involved in the
build, it makes a difference to cargo whether we specify the manifest
path or not during the first dependency build.

After specifying the manifest path, we now also need to `touch` the
updated, non-dummy `lib.rs`s; unclear why this wasn't needed before.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
