### PR TITLE
Fix cargo fmt CI job not formatting rust tests and interface

### DIFF
--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -35,7 +35,7 @@ jobs:
         # We don't want to commit formatting changes to main
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
-          add: src/internet_identity
+          add: src
           author_name: Formatting Committer
           author_email: "<nobody@example.com>"
           message: "Updating rust formatting"

--- a/src/canister_tests/src/api.rs
+++ b/src/canister_tests/src/api.rs
@@ -1,5 +1,4 @@
 /** The functions here are derived (manually) from Internet Identity's Candid file */
-
 use crate::framework;
 use ic_state_machine_tests::{CanisterId, StateMachine};
 use internet_identity_interface as types;
@@ -7,7 +6,8 @@ use internet_identity_interface as types;
 /// A fake "health check" method that just checks the canister is alive a well.
 pub fn health_check(env: &StateMachine, canister_id: CanisterId) {
     let user_number: types::UserNumber = 0;
-    let _: (Vec<types::DeviceData>,) = framework::call_candid(env, canister_id, "lookup", (user_number,)).unwrap();
+    let _: (Vec<types::DeviceData>,) =
+        framework::call_candid(env, canister_id, "lookup", (user_number,)).unwrap();
 }
 
 pub fn create_challenge(env: &StateMachine, canister_id: CanisterId) -> types::Challenge {
@@ -15,15 +15,36 @@ pub fn create_challenge(env: &StateMachine, canister_id: CanisterId) -> types::C
     c
 }
 
-pub fn register(env: &StateMachine, canister_id: CanisterId, device_data: types::DeviceData, challenge_attempt: types::ChallengeAttempt) -> types::RegisterResponse {
-    match framework::call_candid_as(env, canister_id, framework::some_principal(), "register", (device_data, challenge_attempt)) {
+pub fn register(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    device_data: types::DeviceData,
+    challenge_attempt: types::ChallengeAttempt,
+) -> types::RegisterResponse {
+    match framework::call_candid_as(
+        env,
+        canister_id,
+        framework::some_principal(),
+        "register",
+        (device_data, challenge_attempt),
+    ) {
         Ok((r,)) => r,
         Err(e) => panic!("Failed to register: {:?}", e),
     }
 }
 
-pub fn lookup(env: &StateMachine, canister_id: CanisterId, user_number: types::UserNumber) -> Vec<types::DeviceData> {
-    match framework::call_candid_as(env, canister_id, framework::some_principal(), "lookup", (user_number,)) {
+pub fn lookup(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    user_number: types::UserNumber,
+) -> Vec<types::DeviceData> {
+    match framework::call_candid_as(
+        env,
+        canister_id,
+        framework::some_principal(),
+        "lookup",
+        (user_number,),
+    ) {
         Ok((r,)) => r,
         Err(e) => panic!("Failed to lookup: {:?}", e),
     }

--- a/src/canister_tests/src/tests.rs
+++ b/src/canister_tests/src/tests.rs
@@ -1,7 +1,7 @@
+use crate::api;
+use crate::framework;
 use ic_state_machine_tests::StateMachine;
 use internet_identity_interface as types;
-use crate::framework;
-use crate::api;
 
 #[test]
 fn ii_canister_can_be_installed() {
@@ -24,7 +24,15 @@ fn ii_upgrade_retains_anchors() {
     let env = StateMachine::new();
     let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
     let challenge = api::create_challenge(&env, canister_id);
-    let user_number = match api::register(&env, canister_id, framework::some_device_data(), types::ChallengeAttempt { chars: "a".to_string(), key: challenge.challenge_key }) {
+    let user_number = match api::register(
+        &env,
+        canister_id,
+        framework::some_device_data(),
+        types::ChallengeAttempt {
+            chars: "a".to_string(),
+            key: challenge.challenge_key,
+        },
+    ) {
         types::RegisterResponse::Registered { user_number } => user_number,
         response => panic!("could not register: {:?}", response),
     };

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -1,5 +1,5 @@
-use serde_bytes::ByteBuf;
 use candid::{CandidType, Deserialize, Principal};
+use serde_bytes::ByteBuf;
 
 pub type UserNumber = u64;
 pub type CredentialId = ByteBuf;
@@ -61,8 +61,6 @@ pub struct Challenge {
 }
 
 pub type ChallengeKey = String;
-
-
 
 // The user's attempt
 #[derive(Clone, Debug, CandidType, Deserialize)]


### PR DESCRIPTION
The CI job needs to be adapted to the new file structure introduced with the rust canister tests.
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
