### PR TITLE
Enable Ubuntu reproducibility checks

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -537,6 +537,7 @@ jobs:
 
   clean-build:
     runs-on: ${{ matrix.os }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: docker-build
     strategy:
       matrix:

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -537,15 +537,25 @@ jobs:
 
   clean-build:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: docker-build
     strategy:
       matrix:
         os: [ ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, macos-12 ]
     steps:
       - uses: actions/checkout@v2
+      - name: 'Download wasm'
+        uses: actions/download-artifact@v2
+        with:
+          name: internet_identity_production.wasm
+          path: .
+      - run: |
+          sha256=$(shasum -a 256 ./internet_identity_production.wasm | cut -d ' ' -f1)
+          echo "::set-output name=sha256::$sha256"
+        id: sha256
 
       - uses: ./.github/actions/check-build
         with:
-          sha256: '' # tell the build check to _not_ check the hash until we have reproducibility
+          # we check that ubuntu builds match the docker build
+          sha256: ${{ startsWith(matrix.os, 'ubuntu') && steps.sha256.outputs.sha256 || '' }}
           rust-version: 1.58.1
           ic-cdk-optimizer-version: 0.3.1

--- a/src/internet_identity/build.sh
+++ b/src/internet_identity/build.sh
@@ -20,6 +20,10 @@ npm run build
 II_DIR="$(dirname "$0")"
 TARGET="wasm32-unknown-unknown"
 
+# standardize source references
+CARGO_HOME="${CARGO_HOME:-"$HOME/.cargo"}"
+RUSTFLAGS="--remap-path-prefix $CARGO_HOME=/cargo"
+
 cargo_build_args=(
     --manifest-path "$II_DIR/Cargo.toml"
     --target "$TARGET"
@@ -38,8 +42,9 @@ then
 fi
 
 echo Running cargo build "${cargo_build_args[@]}"
+echo RUSTFLAGS: "$RUSTFLAGS"
 
-cargo build "${cargo_build_args[@]}"
+RUSTFLAGS="$RUSTFLAGS" cargo build "${cargo_build_args[@]}"
 
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$II_DIR/../../target/}"
 


### PR DESCRIPTION
This checks the Ubuntu-generated modules' checksums against the docker-generated module's checksum. This asks rustc to map the path to sources to a standard (across our builds) `/cargo`, to avoid the user home's popping up in our builds.

First commit adds the failing check, second commit makes the builds reproducible.