### PR TITLE
Don't cache ic-cdk-optimizer

### DIFF
--- a/.github/actions/check-build/action.yml
+++ b/.github/actions/check-build/action.yml
@@ -20,12 +20,6 @@ runs:
         rustup default "${{ inputs.rust-version }}"
         rustup target add wasm32-unknown-unknown
 
-    # cache and store ic-cdk-optimizer and skip install on cache hit
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cargo/bin/ic-cdk-optimizer # that's where cargo installs it
-        key: ic-cdk-optimizer-${{ inputs.ic-cdk-optimizer-version }}-${{ runner.os }}-check-build
-
     - run: |
         if [ ! -e "$HOME/.cargo/bin/ic-cdk-optimizer" ]
         then


### PR DESCRIPTION
Because we build across many different Ubuntu versions, it can be that a
recent Ubuntu (with recent glibc) builds ic-cdk-optimizer, which then
can't be used on older Ubuntus, but older Ubuntus will still get a cache
hit.

What we could do is add the current version of Ubuntu/macOS to the cache
key, but really this only runs on 'main', so for now it's acceptable to
have an extra 4mn in the build.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
