### PR TITLE
Fix add-and-commit warning

### DIFF
--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -20,9 +20,5 @@ jobs:
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
           add: src
-          author_name: Formatting Committer
-          author_email: "<nobody@example.com>"
-          message: "Updating rust formatting"
-          # do not pull: if this branch is behind, then we might as well let
-          # the pushing fail
-          pull_strategy: "NO-PULL"
+          default_author: github_actions
+          message: "🤖 cargo-fmt auto-update"


### PR DESCRIPTION
The `add-and-commit` action was updated to a version that deprecated
some action inputs. This fixes the inputs and makes the message more
consistent with the selenium screenshot committer.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
