### PR TITLE
Autoupdate rust toolchain

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -417,6 +417,10 @@ jobs:
     if: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          # set a PAT so that add-and-commit can trigger
+          # CI runs
+          token: ${{ secrets.GIX_BOT_PAT }}
 
       # Make sure old screenshots don't pollute the commit
       - run: rm -v -f screenshots/*.png

--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # set a PAT so that add-and-commit can trigger
+          # CI runs
+          token: ${{ secrets.GIX_BOT_PAT }}
       - uses: ./.github/actions/bootstrap
 
       - name: Cargo fmt

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -1,0 +1,50 @@
+# A GitHub Actions workflow that regularly checks for new Rust toolchain release
+# and creates a PR on new versions.
+name: Rust Update
+
+on:
+  schedule:
+    # check for new rust versions daily at 7:30
+    - cron:  '30 7 * * *'
+
+jobs:
+  rust-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+        # First, check rust GitHub releases for a new version. We assume that the
+        # latest version's tag name is the version.
+      - name: Check new rust version
+        id: update
+        run: |
+          current_rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
+          echo "current rust version '$current_rust_version'"
+          latest_rust_version=$(curl --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/rust-lang/rust/releases/latest | jq -cMr .tag_name)
+          echo "latest rust version '$latest_rust_version'"
+
+          if [ "$current_rust_version" != "$latest_rust_version" ]
+          then
+            echo rust toolchain needs an update
+            sed -i -e "s/$current_rust_version/$latest_rust_version/g" ./rust-toolchain.toml
+            echo "::set-output name=updated::1"
+          else
+            echo "::set-output name=updated::0"
+          fi
+
+          cat ./rust-toolchain.toml
+
+        # If the rust-toolchain was updated, create a PR.
+      - name: Create Pull Request
+        if: ${{ steps.update.outputs.updated == '1' }}
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GIX_BOT_PAT }}
+          base: main
+          add-paths: ./rust-toolchain.toml
+          commit-message: Update rust version
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          branch: bot-rust-update
+          delete-branch: true
+          title: 'Update rust version'

--- a/HACKING.md
+++ b/HACKING.md
@@ -11,8 +11,8 @@ This document explains how to build the Wasm module of the Internet Identity can
 The build requires the following dependencies:
 
 * [`dfx`](https://github.com/dfinity/sdk/releases/latest) version 0.8.3 or later
-* [`ic-cdk-optimizer`](https://github.com/dfinity/cdk-rs/tree/main/src/ic-cdk-optimizer) version 0.3.1
-* Rust version 1.58.1 or later, with target `wasm32-unknown-unknown` (see [rustup instructions](https://rust-lang.github.io/rustup/cross-compilation.html))
+* [`ic-cdk-optimizer`](https://github.com/dfinity/cdk-rs/tree/main/src/ic-cdk-optimizer), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
+* Rustup with target `wasm32-unknown-unknown` (see [rustup instructions](https://rust-lang.github.io/rustup/cross-compilation.html)), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
 * Node.js v16+
 * CMake
 


### PR DESCRIPTION
This adds a GitHub Action workflow that checks for new rust toolchain
versions daily. If a new version is found, the workflow creates a PR.

Note: I had to add a PAT (Private Access Token) from our newly created
`gix-bot` machine user so that the new PRs could start CI runs. While I
was at it I changed the two committer jobs (cargo fmt + selenium
screenshots) to use it as well.

I've also updated the HACKING instructions to remove all hard coded
references to the rust toolchain version.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
