### PR TITLE
Move HTTP gateway types to interface

### DIFF
--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -6,41 +6,10 @@ use ic_cdk::trap;
 use ic_certified_map::HashTree;
 use internet_identity::metrics_encoder::MetricsEncoder;
 use internet_identity::signature_map::SignatureMap;
+use internet_identity_interface::{HeaderField, HttpRequest, HttpResponse};
 use serde::Serialize;
 use serde_bytes::{ByteBuf, Bytes};
 use std::borrow::Cow;
-
-pub type HeaderField = (String, String);
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct Token {}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-enum StreamingStrategy {
-    Callback { callback: Func, token: Token },
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct StreamingCallbackHttpResponse {
-    body: ByteBuf,
-    token: Option<Token>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct HttpRequest {
-    method: String,
-    url: String,
-    headers: Vec<(String, String)>,
-    body: ByteBuf,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct HttpResponse {
-    status_code: u16,
-    headers: Vec<HeaderField>,
-    body: Cow<'static, Bytes>,
-    streaming_strategy: Option<StreamingStrategy>,
-}
 
 impl ContentType {
     pub fn to_mime_type_string(&self) -> String {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1,5 +1,4 @@
 use crate::assets::init_assets;
-use crate::http::{HeaderField, HttpRequest, HttpResponse};
 use crate::AddTentativeDeviceResponse::{AddedTentatively, AnotherDeviceTentativelyAdded};
 use crate::RegistrationState::{DeviceRegistrationModeActive, DeviceTentativelyAdded};
 use crate::VerifyTentativeDeviceResponse::{NoDeviceToVerify, WrongCode};

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -1,5 +1,6 @@
-use candid::{CandidType, Deserialize, Principal};
-use serde_bytes::ByteBuf;
+use candid::{CandidType, Deserialize, Func, Principal};
+use serde_bytes::{ByteBuf, Bytes};
+use std::borrow::Cow;
 
 pub type UserNumber = u64;
 pub type CredentialId = ByteBuf;
@@ -125,4 +126,36 @@ pub struct DeviceRegistrationInfo {
 pub struct IdentityAnchorInfo {
     pub devices: Vec<DeviceData>,
     pub device_registration: Option<DeviceRegistrationInfo>,
+}
+
+pub type HeaderField = (String, String);
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct Token {}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum StreamingStrategy {
+    Callback { callback: Func, token: Token },
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct StreamingCallbackHttpResponse {
+    pub body: ByteBuf,
+    pub token: Option<Token>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct HttpRequest {
+    pub method: String,
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+    pub body: ByteBuf,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct HttpResponse {
+    pub status_code: u16,
+    pub headers: Vec<HeaderField>,
+    pub body: Cow<'static, Bytes>,
+    pub streaming_strategy: Option<StreamingStrategy>,
 }


### PR DESCRIPTION
This change is in preparation for the rust asset certifiation test that uses these types.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
