### PR TITLE
Fix tests using the wrong II wasm

### DIFF
--- a/src/canister_tests/src/tests.rs
+++ b/src/canister_tests/src/tests.rs
@@ -46,7 +46,7 @@ fn ii_canister_can_be_upgraded_and_rolled_back() {
 #[test]
 fn registration_with_mismatched_sender_fails() {
     let env = StateMachine::new();
-    let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
+    let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
     let challenge = api::create_challenge(&env, canister_id);
     let result = api::register(
         &env,
@@ -90,7 +90,7 @@ mod remote_device_registration_tests {
     #[test]
     fn can_enter_device_registration_mode() -> Result<(), CallError> {
         let env = StateMachine::new();
-        let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         let user_number = flows::register_anchor(&env, canister_id);
 
         let result =
@@ -104,7 +104,7 @@ mod remote_device_registration_tests {
     #[test]
     fn can_not_enter_device_registration_mode_for_other_user() {
         let env = StateMachine::new();
-        let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         let user_number = flows::register_anchor(&env, canister_id);
 
         let result =
@@ -121,7 +121,7 @@ mod remote_device_registration_tests {
     #[test]
     fn can_register_remote_device() -> Result<(), CallError> {
         let env = StateMachine::new();
-        let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         let user_number = flows::register_anchor(&env, canister_id);
 
         api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -157,7 +157,7 @@ mod remote_device_registration_tests {
     #[test]
     fn can_verify_remote_device_after_failed_attempt() -> Result<(), CallError> {
         let env = StateMachine::new();
-        let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         let user_number = flows::register_anchor(&env, canister_id);
 
         api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -206,7 +206,7 @@ mod remote_device_registration_tests {
     #[test]
     fn anchor_info_should_return_tentative_device() -> Result<(), CallError> {
         let env = StateMachine::new();
-        let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         let user_number = flows::register_anchor(&env, canister_id);
 
         api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -234,7 +234,7 @@ mod remote_device_registration_tests {
     #[test]
     fn reject_tentative_device_if_not_in_registration_mode() -> Result<(), CallError> {
         let env = StateMachine::new();
-        let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         let user_number = flows::register_anchor(&env, canister_id);
 
         api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -259,7 +259,7 @@ mod remote_device_registration_tests {
     fn reject_tentative_device_if_registration_mode_is_expired() -> Result<(), CallError> {
         const REGISTRATION_MODE_EXPIRATION: Duration = Duration::from_secs(900);
         let env = StateMachine::new();
-        let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         let user_number = flows::register_anchor(&env, canister_id);
 
         api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -286,7 +286,7 @@ mod remote_device_registration_tests {
     #[test]
     fn reject_verification_without_tentative_device() -> Result<(), CallError> {
         let env = StateMachine::new();
-        let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         let user_number = flows::register_anchor(&env, canister_id);
 
         api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -310,7 +310,7 @@ mod remote_device_registration_tests {
     fn reject_verification_with_wrong_code() -> Result<(), CallError> {
         const MAX_RETRIES: u8 = 3;
         let env = StateMachine::new();
-        let canister_id = framework::install_ii_canister(&env, framework::II_WASM_PREVIOUS.clone());
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         let user_number = flows::register_anchor(&env, canister_id);
 
         api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;


### PR DESCRIPTION
The errors were introduced when initially creating the tests using the update test as a template.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
