### PR TITLE
Make gix-bot author of automated PRs

### DIFF
--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -44,7 +44,7 @@ jobs:
           add-paths: ./rust-toolchain.toml
           commit-message: Update rust version
           committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-rust-update
           delete-branch: true
           title: 'Update rust version'


### PR DESCRIPTION
This makes sure that @gix-bot is used as the author of the rust update
PRs. The previous value, `github.actor`, would use whomever last edited
the workflow file (me).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
