### PR TITLE
Port get_principal tests to rust

### DIFF
--- a/backend-tests/backend-tests.hs
+++ b/backend-tests/backend-tests.hs
@@ -352,12 +352,6 @@ tests wasm_file = testGroup "Tests" $ upgradeGroups $
     assertStats cid 0
     lookupIs cid 123 []
 
-  , withUpgrade $ \should_upgrade -> iiTest "register and get principal with wrong user" $ \cid -> do
-    queryIIReject cid webauth2ID #get_principal (10000, "front.end.com")
-    user_number <- register cid webauth1ID device1 >>= mustGetUserNumber
-    when should_upgrade $ doUpgrade cid
-    queryIIReject cid webauth2ID #get_principal (user_number, "front.end.com")
-
   , withUpgrade $ \should_upgrade -> iiTestWithInit "init range" (100, 103) $ \cid -> do
     s <- queryII cid dummyUserId #stats ()
     lift $ s .! #assigned_user_number_range @?= (100, 103)

--- a/src/canister_tests/src/api.rs
+++ b/src/canister_tests/src/api.rs
@@ -3,6 +3,7 @@ use crate::framework;
 use crate::framework::CallError;
 use ic_state_machine_tests::{CanisterId, PrincipalId, StateMachine};
 use internet_identity_interface as types;
+use sdk_ic_types::Principal;
 
 /// A fake "health check" method that just checks the canister is alive a well.
 pub fn health_check(env: &StateMachine, canister_id: CanisterId) {
@@ -79,6 +80,23 @@ pub fn get_delegation(
         sender,
         "get_delegation",
         (user_number, frontend_hostname, session_key, timestamp),
+    )
+    .map(|(x,)| x)
+}
+
+pub fn get_principal(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    sender: PrincipalId,
+    user_number: types::UserNumber,
+    frontend_hostname: types::FrontendHostname,
+) -> Result<Principal, CallError> {
+    framework::query_candid_as(
+        env,
+        canister_id,
+        sender,
+        "get_principal",
+        (user_number, frontend_hostname),
     )
     .map(|(x,)| x)
 }

--- a/src/canister_tests/src/tests.rs
+++ b/src/canister_tests/src/tests.rs
@@ -302,15 +302,19 @@ mod device_management_tests {
     }
 }
 
-/// Tests related to prepare_delegation and get_delegation II canister calls.
+/// Tests related to prepare_delegation, get_delegation and get_principal II canister calls.
 #[cfg(test)]
 mod delegation_tests {
-    use crate::framework::{expect_user_error_with_message, principal_1, principal_2, CallError};
+    use crate::framework::{
+        device_data_1, device_data_2, expect_user_error_with_message, principal_1, principal_2,
+        CallError,
+    };
     use crate::{api, flows, framework};
     use ic_error_types::ErrorCode::CanisterCalledTrap;
     use ic_state_machine_tests::StateMachine;
     use internet_identity_interface::GetDelegationResponse;
     use regex::Regex;
+    use sdk_ic_types::Principal;
     use serde_bytes::ByteBuf;
     use std::ops::Add;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -760,6 +764,121 @@ mod delegation_tests {
             Regex::new("[a-z\\d-]+ could not be authenticated.").unwrap(),
         );
         Ok(())
+    }
+
+    /// Verifies that get_principal and prepare_delegation return the same principal.
+    #[test]
+    fn get_principal_should_match_prepare_delegation() -> Result<(), CallError> {
+        let env = StateMachine::new();
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
+        let user_number = flows::register_anchor(&env, canister_id);
+        let frontend_hostname = "https://some-dapp.com";
+        let pub_session_key = ByteBuf::from("session public key");
+
+        let (canister_sig_key, _) = api::prepare_delegation(
+            &env,
+            canister_id,
+            principal_1(),
+            user_number,
+            frontend_hostname.to_string(),
+            pub_session_key.clone(),
+            None,
+        )?;
+
+        let principal = api::get_principal(
+            &env,
+            canister_id,
+            principal_1(),
+            user_number,
+            frontend_hostname.to_string(),
+        )?;
+        assert_eq!(Principal::self_authenticating(canister_sig_key), principal);
+        Ok(())
+    }
+
+    /// Verifies that get_principal returns different principals for different front end host names.
+    #[test]
+    fn should_return_different_principals_for_different_frontends() -> Result<(), CallError> {
+        let env = StateMachine::new();
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
+        let user_number = flows::register_anchor(&env, canister_id);
+        let frontend_hostname_1 = "https://dapp-1.com";
+        let frontend_hostname_2 = "https://dapp-2.com";
+
+        let dapp_principal_1 = api::get_principal(
+            &env,
+            canister_id,
+            principal_1(),
+            user_number,
+            frontend_hostname_1.to_string(),
+        )?;
+
+        let dapp_principal_2 = api::get_principal(
+            &env,
+            canister_id,
+            principal_1(),
+            user_number,
+            frontend_hostname_2.to_string(),
+        )?;
+
+        assert_ne!(dapp_principal_1, dapp_principal_2);
+        Ok(())
+    }
+
+    /// Verifies that get_principal returns different principals for different anchors.
+    #[test]
+    fn should_return_different_principals_for_different_users() -> Result<(), CallError> {
+        let env = StateMachine::new();
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
+        let user_number_1 =
+            flows::register_anchor_with(&env, canister_id, principal_1(), device_data_1());
+        let user_number_2 =
+            flows::register_anchor_with(&env, canister_id, principal_2(), device_data_2());
+        let frontend_hostname_1 = "https://dapp-1.com";
+
+        let dapp_principal_1 = api::get_principal(
+            &env,
+            canister_id,
+            principal_1(),
+            user_number_1,
+            frontend_hostname_1.to_string(),
+        )?;
+
+        let dapp_principal_2 = api::get_principal(
+            &env,
+            canister_id,
+            principal_2(),
+            user_number_2,
+            frontend_hostname_1.to_string(),
+        )?;
+
+        assert_ne!(dapp_principal_1, dapp_principal_2);
+        Ok(())
+    }
+
+    /// Verifies that get_principal requires authentication.
+    #[test]
+    fn should_not_allow_get_anchor_for_other_user() {
+        let env = StateMachine::new();
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
+        flows::register_anchor_with(&env, canister_id, principal_1(), device_data_1());
+        let user_number_2 =
+            flows::register_anchor_with(&env, canister_id, principal_2(), device_data_2());
+        let frontend_hostname_1 = "https://dapp-1.com";
+
+        let result = api::get_principal(
+            &env,
+            canister_id,
+            principal_1(),
+            user_number_2,
+            frontend_hostname_1.to_string(),
+        );
+
+        expect_user_error_with_message(
+            result,
+            CanisterCalledTrap,
+            Regex::new("[a-z\\d-]+ could not be authenticated\\.").unwrap(),
+        );
     }
 }
 

--- a/src/canister_tests/src/tests.rs
+++ b/src/canister_tests/src/tests.rs
@@ -833,23 +833,23 @@ mod delegation_tests {
         let user_number_1 =
             flows::register_anchor_with(&env, canister_id, principal_1(), device_data_1());
         let user_number_2 =
-            flows::register_anchor_with(&env, canister_id, principal_2(), device_data_2());
-        let frontend_hostname_1 = "https://dapp-1.com";
+            flows::register_anchor_with(&env, canister_id, principal_1(), device_data_1());
+        let frontend_hostname = "https://dapp-1.com";
 
         let dapp_principal_1 = api::get_principal(
             &env,
             canister_id,
             principal_1(),
             user_number_1,
-            frontend_hostname_1.to_string(),
+            frontend_hostname.to_string(),
         )?;
 
         let dapp_principal_2 = api::get_principal(
             &env,
             canister_id,
-            principal_2(),
+            principal_1(),
             user_number_2,
-            frontend_hostname_1.to_string(),
+            frontend_hostname.to_string(),
         )?;
 
         assert_ne!(dapp_principal_1, dapp_principal_2);
@@ -858,7 +858,7 @@ mod delegation_tests {
 
     /// Verifies that get_principal requires authentication.
     #[test]
-    fn should_not_allow_get_anchor_for_other_user() {
+    fn should_not_allow_get_principal_for_other_user() {
         let env = StateMachine::new();
         let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         flows::register_anchor_with(&env, canister_id, principal_1(), device_data_1());


### PR DESCRIPTION
Migrates tests for the get_principal query call to rust. The tests were added to the delegation test module as the functionality is closely related.
Changes to the haskell tests:
- a test was added to verify that the result of get_principal matches the prepare_delegation principal
- tests were added to make sure that the principals are unique per user_number and frontend hostname

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
