### PR TITLE
Accept device reference in register

### DIFF
--- a/src/canister_tests/src/api.rs
+++ b/src/canister_tests/src/api.rs
@@ -29,7 +29,7 @@ pub fn register(
     env: &StateMachine,
     canister_id: CanisterId,
     sender: PrincipalId,
-    device_data: types::DeviceData,
+    device_data: &types::DeviceData,
     challenge_attempt: types::ChallengeAttempt,
 ) -> Result<types::RegisterResponse, CallError> {
     framework::call_candid_as(

--- a/src/canister_tests/src/flows.rs
+++ b/src/canister_tests/src/flows.rs
@@ -8,14 +8,14 @@ use internet_identity_interface::{
 use serde_bytes::ByteBuf;
 
 pub fn register_anchor(env: &StateMachine, canister_id: CanisterId) -> UserNumber {
-    register_anchor_with(env, canister_id, principal_1(), device_data_1())
+    register_anchor_with(env, canister_id, principal_1(), &device_data_1())
 }
 
 pub fn register_anchor_with(
     env: &StateMachine,
     canister_id: CanisterId,
     sender: PrincipalId,
-    device_data: DeviceData,
+    device_data: &DeviceData,
 ) -> UserNumber {
     let challenge = create_challenge(&env, canister_id);
     let user_number = match register(

--- a/src/canister_tests/src/tests.rs
+++ b/src/canister_tests/src/tests.rs
@@ -52,7 +52,7 @@ fn registration_with_mismatched_sender_fails() {
         &env,
         canister_id,
         principal_2(),
-        device_data_1(),
+        &device_data_1(),
         types::ChallengeAttempt {
             chars: "a".to_string(),
             key: challenge.challenge_key,
@@ -135,9 +135,9 @@ mod device_management_tests {
     fn should_not_add_device_for_different_user() {
         let env = StateMachine::new();
         let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
-        flows::register_anchor_with(&env, canister_id, principal_1(), device_data_1());
+        flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
         let user_number_2 =
-            flows::register_anchor_with(&env, canister_id, principal_2(), device_data_2());
+            flows::register_anchor_with(&env, canister_id, principal_2(), &device_data_2());
 
         let result = api::add(
             &env,
@@ -233,9 +233,9 @@ mod device_management_tests {
     fn should_not_remove_device_of_different_user() {
         let env = StateMachine::new();
         let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
-        flows::register_anchor_with(&env, canister_id, principal_1(), device_data_1());
+        flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
         let user_number_2 =
-            flows::register_anchor_with(&env, canister_id, principal_2(), device_data_2());
+            flows::register_anchor_with(&env, canister_id, principal_2(), &device_data_2());
 
         let result = api::remove(
             &env,
@@ -831,9 +831,9 @@ mod delegation_tests {
         let env = StateMachine::new();
         let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
         let user_number_1 =
-            flows::register_anchor_with(&env, canister_id, principal_1(), device_data_1());
+            flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
         let user_number_2 =
-            flows::register_anchor_with(&env, canister_id, principal_1(), device_data_1());
+            flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
         let frontend_hostname = "https://dapp-1.com";
 
         let dapp_principal_1 = api::get_principal(
@@ -861,9 +861,9 @@ mod delegation_tests {
     fn should_not_allow_get_principal_for_other_user() {
         let env = StateMachine::new();
         let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
-        flows::register_anchor_with(&env, canister_id, principal_1(), device_data_1());
+        flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
         let user_number_2 =
-            flows::register_anchor_with(&env, canister_id, principal_2(), device_data_2());
+            flows::register_anchor_with(&env, canister_id, principal_2(), &device_data_2());
         let frontend_hostname_1 = "https://dapp-1.com";
 
         let result = api::get_principal(
@@ -1150,7 +1150,7 @@ mod http_tests {
             &env,
             canister_id,
             principal_1(),
-            device_data_1(),
+            &device_data_1(),
             ChallengeAttempt {
                 chars: "a".to_string(),
                 key: challenge_1.challenge_key,


### PR DESCRIPTION
This changes the test flow function `register` to accept a reference to
a device instead of moving the data.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
