### PR TITLE
Move InternetIdentityInit to interface

### DIFF
--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -98,11 +98,6 @@ struct InternetIdentityStats {
     users_registered: u64,
 }
 
-#[derive(Clone, Debug, CandidType, Deserialize)]
-struct InternetIdentityInit {
-    assigned_user_number_range: (UserNumber, UserNumber),
-}
-
 type AssetHashes = RbTree<&'static str, Hash>;
 
 struct TentativeDeviceRegistration {

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -159,3 +159,8 @@ pub struct HttpResponse {
     pub body: Cow<'static, Bytes>,
     pub streaming_strategy: Option<StreamingStrategy>,
 }
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct InternetIdentityInit {
+    pub assigned_user_number_range: (UserNumber, UserNumber),
+}


### PR DESCRIPTION
This change is made in preparation for tests for the init ranges.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
