### PR TITLE
Adapt time handling to infrastructure changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "fe-derive"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "hex",
  "num-bigint-dig 0.8.1",
@@ -1543,7 +1543,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "ic-base-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base32",
  "byte-unit",
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-canister"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bitcoin",
  "byteorder",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "candid",
  "serde",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-protobuf",
  "serde",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-sandbox-backend-lib"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-base-types",
  "ic-canister-sandbox-common",
@@ -1636,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-sandbox-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bincode",
  "bytes",
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-sandbox-replica-controller"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-canister-sandbox-backend-lib",
  "ic-canister-sandbox-common",
@@ -1683,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "ic-canonical-state"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-base-types",
  "ic-certification-version",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "ic-certification-version"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "strum",
  "strum_macros",
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "ic-certified-vars"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "hex",
  "ic-crypto-tree-hash",
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "ic-config"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base64 0.11.0",
  "ic-base-types",
@@ -1781,12 +1781,12 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 
 [[package]]
 name = "ic-context-logger"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "slog",
 ]
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "arrayvec",
  "async-trait",
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-hash"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-sha",
  "ic-interfaces",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-cose"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-internal-basic-sig-ecdsa-secp256r1",
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "hex",
  "ic-types 0.8.0",
@@ -1891,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ecdsa-secp256k1"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base64 0.11.0",
  "hex",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ecdsa-secp256r1"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base64 0.11.0",
  "hex",
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base64 0.11.0",
  "curve25519-dalek",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-iccsa"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base64 0.11.0",
  "hex",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-rsa-pkcs1"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-sha",
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12381-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bls12_381",
  "getrandom 0.2.6",
@@ -1999,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12381-serde-miracl"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-internal-types",
  "miracl_core_bls12381",
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-csp"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "async-trait",
  "base64 0.11.0",
@@ -2027,6 +2027,7 @@ dependencies = [
  "ic-crypto-internal-fs-ni-dkg",
  "ic-crypto-internal-logmon",
  "ic-crypto-internal-multi-sig-bls12381",
+ "ic-crypto-internal-seed",
  "ic-crypto-internal-test-vectors",
  "ic-crypto-internal-threshold-sig-bls12381",
  "ic-crypto-internal-threshold-sig-ecdsa",
@@ -2064,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-fs-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "hex",
  "ic-crypto-internal-bls12381-common",
@@ -2080,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2088,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-logmon"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-metrics",
  "prometheus",
@@ -2097,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base64 0.11.0",
  "bls12_381",
@@ -2115,9 +2116,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-crypto-internal-seed"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+dependencies = [
+ "hex",
+ "ic-crypto-sha",
+ "ic-types 0.8.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "openssl",
  "sha2 0.9.9",
@@ -2126,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-test-vectors"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base64 0.11.0",
  "hex",
@@ -2137,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "arrayvec",
  "base64 0.11.0",
@@ -2168,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381-der"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "simple_asn1 0.6.2",
 ]
@@ -2176,12 +2191,13 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "fe-derive",
  "hex",
  "hex-literal 0.3.4",
  "ic-crypto-internal-hmac",
+ "ic-crypto-internal-seed",
  "ic-crypto-internal-types",
  "ic-crypto-sha",
  "ic-types 0.8.0",
@@ -2192,6 +2208,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
+ "serde_bytes",
  "serde_cbor",
  "subtle",
  "zeroize",
@@ -2200,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-tls"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base64 0.11.0",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2215,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "arrayvec",
  "base64 0.11.0",
@@ -2233,7 +2250,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "serde",
  "zeroize",
@@ -2242,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2250,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "chrono",
  "dfn_core",
@@ -2266,7 +2283,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-interfaces"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "async-trait",
  "ic-protobuf",
@@ -2281,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha",
@@ -2293,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base64 0.11.0",
  "ed25519-consensus",
@@ -2308,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-threshold-sig"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base64 0.11.0",
  "ic-crypto-internal-threshold-sig-bls12381",
@@ -2320,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-threshold-sig-der"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-internal-threshold-sig-bls12381-der",
 ]
@@ -2328,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "ic-cycles-account-manager"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-base-types",
  "ic-config",
@@ -2347,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "ic-embedders"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "anyhow",
  "ic-config",
@@ -2378,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "serde",
  "strum",
@@ -2388,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "ic-execution-environment"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "candid",
  "escargot",
@@ -2441,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "candid",
  "float-cmp 0.9.0",
@@ -2460,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "ic-interfaces"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2488,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "ic-interfaces-state-manager"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-tree-hash",
  "ic-types 0.8.0",
@@ -2499,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "ic-logger"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "chrono",
  "ic-config",
@@ -2516,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "ic-messaging"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-base-types",
  "ic-certification-version",
@@ -2549,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "ic-metrics"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "libc",
  "procfs",
@@ -2559,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-base-types",
  "lazy_static",
@@ -2568,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bincode",
  "candid",
@@ -2583,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-client-fake"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-interfaces",
  "ic-types 0.8.0",
@@ -2592,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-client-helpers"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-ic00-types",
  "ic-interfaces",
@@ -2609,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-common-proto"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "prost",
 ]
@@ -2617,7 +2634,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2629,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-proto-data-provider"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bytes",
  "ic-interfaces",
@@ -2643,7 +2660,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-provisional-whitelist"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2652,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2663,7 +2680,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "candid",
  "ic-ic00-types",
@@ -2674,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2686,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bytes",
  "candid",
@@ -2698,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "ic-replicated-state"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bitcoin",
  "cvt",
@@ -2736,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "ic-state-layout"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bitcoin",
  "hex",
@@ -2762,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "ic-state-machine-tests"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "candid",
  "ic-config",
@@ -2804,7 +2821,7 @@ dependencies = [
 [[package]]
 name = "ic-state-manager"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bit-vec 0.6.3",
  "crossbeam-channel",
@@ -2842,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "hex",
  "ic-crypto-sha",
@@ -2856,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "ic-system-api"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2881,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "ic-test-utilities-metrics"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-metrics",
  "prometheus",
@@ -2890,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "ic-test-utilities-registry"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto",
  "ic-interfaces",
@@ -2922,7 +2939,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "base32",
  "base64 0.11.0",
@@ -2962,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bitflags",
  "cvt",
@@ -2981,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "ic-wasm-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-sha",
  "ic-sys",
@@ -3368,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "memory_tracker"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "bit-vec 0.5.1",
  "ic-config",
@@ -3661,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 
 [[package]]
 name = "once_cell"
@@ -3903,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "candid",
  "serde",
@@ -4808,7 +4825,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "stable-structures"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 
 [[package]]
 name = "stable_deref_trait"
@@ -5301,7 +5318,7 @@ dependencies = [
 [[package]]
 name = "tree-deserializer"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=d0492fc0153edf16fa6f79675cf05bb99a2bd4ab#d0492fc0153edf16fa6f79675cf05bb99a2bd4ab"
+source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
 dependencies = [
  "ic-crypto-tree-hash",
  "leb128",

--- a/src/canister_tests/Cargo.toml
+++ b/src/canister_tests/Cargo.toml
@@ -19,9 +19,9 @@ internet_identity_interface = { path = "../internet_identity_interface" }
 candid = "0.7"
 ic-cdk = "0.5"
 sdk-ic-types = { version = "0.3", package = "ic-types" }
-ic-interfaces = { git = "https://github.com/dfinity/ic", rev = "d0492fc0153edf16fa6f79675cf05bb99a2bd4ab" }
-ic-types = { git = "https://github.com/dfinity/ic", rev = "d0492fc0153edf16fa6f79675cf05bb99a2bd4ab" }
-ic-certified-vars = { git = "https://github.com/dfinity/ic", rev = "d0492fc0153edf16fa6f79675cf05bb99a2bd4ab" }
-ic-crypto-internal-basic-sig-iccsa = { git = "https://github.com/dfinity/ic", rev = "d0492fc0153edf16fa6f79675cf05bb99a2bd4ab" }
-ic-error-types = { git = "https://github.com/dfinity/ic", rev = "d0492fc0153edf16fa6f79675cf05bb99a2bd4ab" }
-ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "d0492fc0153edf16fa6f79675cf05bb99a2bd4ab" }
+ic-interfaces = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
+ic-types = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
+ic-certified-vars = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
+ic-crypto-internal-basic-sig-iccsa = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
+ic-error-types = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
+ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }


### PR DESCRIPTION
The state machine has been changed to no longer start at time 0 by default.
This allows us to remove some instances of advancing time.
Additionally the test `should_get_multiple_valid_delegations` has been changed to not set time to 0.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
