### PR TITLE
Drop iter_mut in pubkey uniqueness check

### DIFF
--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -447,7 +447,11 @@ async fn add(user_number: UserNumber, device_data: DeviceData) {
 
         trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
 
-        if entries.iter().find(|e| e.pubkey == device_data.pubkey).is_some() {
+        if entries
+            .iter()
+            .find(|e| e.pubkey == device_data.pubkey)
+            .is_some()
+        {
             trap("Device already added.");
         }
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -447,10 +447,8 @@ async fn add(user_number: UserNumber, device_data: DeviceData) {
 
         trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
 
-        for e in entries.iter_mut() {
-            if e.pubkey == device_data.pubkey {
-                trap("Device already added.");
-            }
+        if entries.iter().find(|e| e.pubkey == device_data.pubkey).is_some() {
+            trap("Device already added.");
         }
 
         if entries.len() >= MAX_ENTRIES_PER_USER {


### PR DESCRIPTION
We used to get a mutable iterator for checking each entry's pubkey,
which was unnecessary. I've also updated the code to be a little more
explicit.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
