### PR TITLE
Update selenium instructions in HACKING

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -101,7 +101,7 @@ into the following issues:
 
 #### Test suites
 
-We have a set of Selenium tests that run through the various flows. To set up a local deployment follow the steps in `.github/workflows/selenium.yml`.
+We have a set of Selenium tests that run through the various flows. To set up a local deployment follow the steps of the `selenium` job in `.github/workflows/canister-tests.yml`.
 The tests can be executed by running:
 
 ```bash


### PR DESCRIPTION
The selenium workflow doesn't exist anymore, it's part of
canister-tests. Instructions still aren't ideal, but at least they are
correct.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
