### PR TITLE
Ports the stable memory restore tests to rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "base64 0.13.0",
  "candid",
  "flate2",
+ "hex",
  "ic-cdk",
  "ic-certified-vars",
  "ic-crypto-internal-basic-sig-iccsa",
@@ -915,7 +916,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1137,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "fe-derive"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "hex",
  "num-bigint-dig 0.8.1",
@@ -1543,7 +1544,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "ic-base-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base32",
  "byte-unit",
@@ -1563,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-canister"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bitcoin",
  "byteorder",
@@ -1589,7 +1590,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "candid",
  "serde",
@@ -1599,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-protobuf",
  "serde",
@@ -1609,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-sandbox-backend-lib"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-base-types",
  "ic-canister-sandbox-common",
@@ -1636,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-sandbox-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bincode",
  "bytes",
@@ -1655,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-sandbox-replica-controller"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-canister-sandbox-backend-lib",
  "ic-canister-sandbox-common",
@@ -1683,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "ic-canonical-state"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-base-types",
  "ic-certification-version",
@@ -1730,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "ic-certification-version"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "strum",
  "strum_macros",
@@ -1750,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "ic-certified-vars"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "hex",
  "ic-crypto-tree-hash",
@@ -1764,7 +1765,7 @@ dependencies = [
 [[package]]
 name = "ic-config"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base64 0.11.0",
  "ic-base-types",
@@ -1781,12 +1782,12 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 
 [[package]]
 name = "ic-context-logger"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "slog",
 ]
@@ -1794,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "arrayvec",
  "async-trait",
@@ -1857,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-hash"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-sha",
  "ic-interfaces",
@@ -1867,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-cose"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-internal-basic-sig-ecdsa-secp256r1",
@@ -1881,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "hex",
  "ic-types 0.8.0",
@@ -1891,7 +1892,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ecdsa-secp256k1"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base64 0.11.0",
  "hex",
@@ -1910,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ecdsa-secp256r1"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base64 0.11.0",
  "hex",
@@ -1928,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base64 0.11.0",
  "curve25519-dalek",
@@ -1949,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-iccsa"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base64 0.11.0",
  "hex",
@@ -1968,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-rsa-pkcs1"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-sha",
@@ -1983,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12381-common"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bls12_381",
  "getrandom 0.2.6",
@@ -1999,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12381-serde-miracl"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-internal-types",
  "miracl_core_bls12381",
@@ -2008,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-csp"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "async-trait",
  "base64 0.11.0",
@@ -2038,6 +2039,7 @@ dependencies = [
  "ic-crypto-tls-interfaces",
  "ic-interfaces",
  "ic-logger",
+ "ic-metrics",
  "ic-protobuf",
  "ic-types 0.8.0",
  "ic-utils",
@@ -2065,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-fs-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "hex",
  "ic-crypto-internal-bls12381-common",
@@ -2081,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2089,16 +2091,18 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-logmon"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-metrics",
  "prometheus",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base64 0.11.0",
  "bls12_381",
@@ -2118,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "hex",
  "ic-crypto-sha",
@@ -2132,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "openssl",
  "sha2 0.9.9",
@@ -2141,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-test-vectors"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base64 0.11.0",
  "hex",
@@ -2152,7 +2156,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "arrayvec",
  "base64 0.11.0",
@@ -2183,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381-der"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "simple_asn1 0.6.2",
 ]
@@ -2191,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "fe-derive",
  "hex",
@@ -2217,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-tls"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base64 0.11.0",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2232,7 +2236,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "arrayvec",
  "base64 0.11.0",
@@ -2250,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "serde",
  "zeroize",
@@ -2259,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2267,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "chrono",
  "dfn_core",
@@ -2283,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-interfaces"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "async-trait",
  "ic-protobuf",
@@ -2298,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha",
@@ -2310,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base64 0.11.0",
  "ed25519-consensus",
@@ -2325,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-threshold-sig"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base64 0.11.0",
  "ic-crypto-internal-threshold-sig-bls12381",
@@ -2337,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-threshold-sig-der"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-internal-threshold-sig-bls12381-der",
 ]
@@ -2345,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "ic-cycles-account-manager"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-base-types",
  "ic-config",
@@ -2364,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "ic-embedders"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "anyhow",
  "ic-config",
@@ -2387,6 +2391,7 @@ dependencies = [
  "prometheus",
  "serde",
  "slog",
+ "slog-term",
  "wasmtime",
  "wasmtime-environ",
  "wasmtime-runtime",
@@ -2395,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "serde",
  "strum",
@@ -2405,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "ic-execution-environment"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "candid",
  "escargot",
@@ -2458,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "candid",
  "float-cmp 0.9.0",
@@ -2477,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "ic-interfaces"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2505,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "ic-interfaces-state-manager"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-tree-hash",
  "ic-types 0.8.0",
@@ -2516,7 +2521,7 @@ dependencies = [
 [[package]]
 name = "ic-logger"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "chrono",
  "ic-config",
@@ -2533,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "ic-messaging"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-base-types",
  "ic-certification-version",
@@ -2566,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "ic-metrics"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "libc",
  "procfs",
@@ -2576,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-base-types",
  "lazy_static",
@@ -2585,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bincode",
  "candid",
@@ -2600,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-client-fake"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-interfaces",
  "ic-types 0.8.0",
@@ -2609,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-client-helpers"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-ic00-types",
  "ic-interfaces",
@@ -2626,7 +2631,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-common-proto"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "prost",
 ]
@@ -2634,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2646,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-proto-data-provider"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bytes",
  "ic-interfaces",
@@ -2660,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-provisional-whitelist"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2669,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2680,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "candid",
  "ic-ic00-types",
@@ -2691,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -2703,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bytes",
  "candid",
@@ -2715,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "ic-replicated-state"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bitcoin",
  "cvt",
@@ -2753,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "ic-state-layout"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bitcoin",
  "hex",
@@ -2779,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "ic-state-machine-tests"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "candid",
  "ic-config",
@@ -2821,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "ic-state-manager"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bit-vec 0.6.3",
  "crossbeam-channel",
@@ -2859,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "hex",
  "ic-crypto-sha",
@@ -2873,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "ic-system-api"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2898,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "ic-test-utilities-metrics"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-metrics",
  "prometheus",
@@ -2907,7 +2912,7 @@ dependencies = [
 [[package]]
 name = "ic-test-utilities-registry"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto",
  "ic-interfaces",
@@ -2939,7 +2944,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "base32",
  "base64 0.11.0",
@@ -2979,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bitflags",
  "cvt",
@@ -2998,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "ic-wasm-types"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-sha",
  "ic-sys",
@@ -3385,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "memory_tracker"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "bit-vec 0.5.1",
  "ic-config",
@@ -3678,7 +3683,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 
 [[package]]
 name = "once_cell"
@@ -3920,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "candid",
  "serde",
@@ -4825,7 +4830,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "stable-structures"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 
 [[package]]
 name = "stable_deref_trait"
@@ -5318,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "tree-deserializer"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=cd78fa32c23317b74025e0a44d95df1b2eb13484#cd78fa32c23317b74025e0a44d95df1b2eb13484"
+source = "git+https://github.com/dfinity/ic?rev=61b2814fcc69153b51fa403b126de93bb203aaeb#61b2814fcc69153b51fa403b126de93bb203aaeb"
 dependencies = [
  "ic-crypto-tree-hash",
  "leb128",

--- a/backend-tests/backend-tests.hs
+++ b/backend-tests/backend-tests.hs
@@ -360,50 +360,7 @@ tests wasm_file = testGroup "Tests" $ upgradeGroups $
     when should_upgrade $ doUpgrade cid
     assertStats cid 0
     lookupIs cid 123 []
-
-  , withUpgrade $ \should_upgrade -> testCase "upgrade from stable memory backup" $ withIC $ do
-    -- See test-stable-memory-rdmx6-jaaaa-aaaaa-aaadq-cai.md for providence
-    t <- getTimestamp
-    -- Need a fixed id for this to work
-    let cid = fromPrincipal "rdmx6-jaaaa-aaaaa-aaadq-cai"
-    createEmptyCanister (EntityId cid) (S.singleton controllerId) t
-    -- Load a backup. This backup is taking from the messaging subnet installation
-    -- on 2021-04-29
-    stable_memory <- lift $ BS.readFile "test-stable-memory-rdmx6-jaaaa-aaaaa-aaadq-cai.bin"
-    -- Upload a dummy module that populates the stable memory
-    upload_wasm <- lift $ BS.readFile "stable-memory-setter.wasm"
-    callManagement controllerId #install_code $ empty
-      .+ #mode .== enum #install
-      .+ #canister_id .== Candid.Principal cid
-      .+ #wasm_module .== upload_wasm
-      .+ #arg .== stable_memory
-    doUpgrade cid
-
-    when should_upgrade $ doUpgrade cid
-    s <- queryII cid dummyUserId #stats ()
-    lift $ s .! #users_registered @?= 31
-    -- The actual value in the dump is 8B, but it's way too large
-    -- and should be auto-corrected on upgrade
-    lift $ s .! #assigned_user_number_range @?= (10_000, 10_000 + 3_774_873)
-    lookupIs cid 9_999 []
-    lookupIs cid 10_000 [#alias .== "Desktop" .+ #credential_id .== Just "c\184\175\179\134\221u}\250[\169U\v\202f\147g\ETBvo9[\175\173\144R\163\132\237\196F\177\DC2(\188\185\203hI\128\187Z\129'\v1\212\185V\ETB\135)m@ M1\233l\ESC8kI\132" .+ #pubkey .== "0^0\f\ACK\n+\ACK\SOH\EOT\SOH\131\184C\SOH\SOH\ETXN\NUL\165\SOH\STX\ETX& \SOH!X \238o!-\ESC\148\252\192\DC4\240P\176\135\240j\211AW\255S\193\153\129\227\151hB\177dK\n\FS\"X \rk\197\238\a{\210\&0\v<\134\223\135\170_\223\144\210V\208\DC3\RS\251\228D$3\r\232\176\EOTq" .+ #purpose .== enum #authentication .+ #key_type .== enum #unknown .+ #protection .== enum #unprotected]
-    lookupIs cid 10_000 [#alias .== "Desktop" .+ #credential_id .== Just "c\184\175\179\134\221u}\250[\169U\v\202f\147g\ETBvo9[\175\173\144R\163\132\237\196F\177\DC2(\188\185\203hI\128\187Z\129'\v1\212\185V\ETB\135)m@ M1\233l\ESC8kI\132" .+ #pubkey .== "0^0\f\ACK\n+\ACK\SOH\EOT\SOH\131\184C\SOH\SOH\ETXN\NUL\165\SOH\STX\ETX& \SOH!X \238o!-\ESC\148\252\192\DC4\240P\176\135\240j\211AW\255S\193\153\129\227\151hB\177dK\n\FS\"X \rk\197\238\a{\210\&0\v<\134\223\135\170_\223\144\210V\208\DC3\RS\251\228D$3\r\232\176\EOTq" .+ #purpose .== enum #authentication .+ #key_type .== enum #unknown .+ #protection .== enum #unprotected]
-    lookupIs cid 10_002 [#protection .== enum #unprotected .+ #alias .== "andrew-mbp" .+ #credential_id .== Just "\SOH\191#%\217u\247\178L-K\182\254\249J.m\187\179_I\ACK\137\244`\163o\SI\150qz\197Hz\214\&8\153\239\213\159\208\RS\243\138\171\138\"\139\173\170\ESC\148\205\129\149ri\\Dn,7\151\146\175\DEL" .+ #pubkey .== "0^0\f\ACK\n+\ACK\SOH\EOT\SOH\131\184C\SOH\SOH\ETXN\NUL\165\SOH\STX\ETX& \SOH!X rMm*\229BDe\SOH4\228u\170\206\216\216-ER\v\166r\217\137,\141\227M*@\230\243\"X \225\248\159\191\242\224Z>\241\163\\\GS\155\178\222\139^\136V\253q\v\SUBSJ\bA\131\\\183\147\170" .+ #purpose .== enum #authentication .+ #key_type .== enum #unknown,#alias .== "andrew phone chrome" .+ #credential_id .== Just ",\235x\NUL\a\140`~\148\248\233C/\177\205\158\ETX0\129\167" .+ #pubkey .== "0^0\f\ACK\n+\ACK\SOH\EOT\SOH\131\184C\SOH\SOH\ETXN\NUL\165\SOH\STX\ETX& \SOH!X \140\169\203@\ETX\CAN\ETB,\177\153\179\223/|`\US\STX\252r\190s(.\188\136\171\SI\181V*\174@\"X \245<\174AbV\225\234\ENQ\146\247\129\245\ACK\200\205\217\250g\219\179)\197\252\164i\172kXh\180\205" .+ #purpose .== enum #authentication .+ #key_type .== enum #unknown .+ #protection .== enum #unprotected]
-    lookupIs cid 10_029 [#alias .== "Pixel" .+ #credential_id .== Just "\SOH\146\238\160b\223\132\205\231b\239\243F\170\163\167\251D\241\170\EM\216\136\174@r\149\183|LuKu[+{\144\217\ETBL\f\244\GS>\179\146\143\RS\179\DLE\227\179\164\188\NULDQy\223\SI\132\183\248\177\219" .+ #pubkey .== "0^0\f\ACK\n+\ACK\SOH\EOT\SOH\131\184C\SOH\SOH\ETXN\NUL\165\SOH\STX\ETX& \SOH!X \200B>\DEL\GS\248\220\145\245\153\221\&6\131\243uAQCAd>\145k\nw\233\&5\218\SUB~_\244\"X O]7\167=n\ESC\SUB\198\235\208\215s\158\191Gz\143\136\237i\146\203\&6\182\196\129\239\238\SOH\180b" .+ #purpose .== enum #authentication .+ #key_type .== enum #unknown .+ #protection .== enum #unprotected]
-    -- This user record has been created manullay with dfx and our test
-    -- webauth1PK has been added, so that we can actually log into this now
-    let dfxPK =  "0*0\ENQ\ACK\ETX+ep\ETX!\NUL\241\186;\128\206$\243\130\250\&2\253\a#<\235\142\&0]W\218\254j\211\209\192\SO@\DC3\NAKi&1"
-    lookupIs cid 10_030 [#protection .== enum #unprotected .+ #alias .== "dfx" .+ #credential_id .== Nothing .+ #pubkey .== dfxPK .+ #purpose .== enum #authentication .+ #key_type .== enum #unknown,#alias .== "testkey" .+ #credential_id .== Nothing .+ #pubkey .== webauth1PK .+ #purpose .== enum #authentication .+ #key_type .== enum #unknown .+ #protection .== enum #unprotected]
-    callII cid webauth1ID #remove (10_030, dfxPK)
-    lookupIs cid 10_030 [#alias .== "testkey" .+ #credential_id .== Nothing .+ #pubkey .== webauth1PK .+ #purpose .== enum #authentication .+ #key_type .== enum #unknown .+ #protection .== enum #unprotected]
-    let delegationArgs = (10_030, "example.com", "dummykey", Nothing)
-    (userPK,_) <- callII cid webauth1ID #prepare_delegation delegationArgs
-    -- Check that we get the same user key; this proves that the salt was
-    -- recovered from the backup
-    lift $ userPK @?= "0<0\x0c\&\x06\&\x0a\&+\x06\&\x01\&\x04\&\x01\&\x83\&\xb8\&C\x01\&\x02\&\x03\&,\x00\&\x0a\&\x00\&\x00\&\x00\&\x00\&\x00\&\x00\&\x00\&\x07\&\x01\&\x01\&:\x89\&&\x91\&M\xd1\&\xc8\&6\xec\&g\xba\&f\xac\&d%\xc2\&\x1d\&\xff\&\xd3\&\xca\&\x5c\&Yh\x85\&_\x87\&x\x0a\&\x1e\&\xc5\&y\x85\&"
   ]
-
-
   where
     withIC act = do
       ic <- initialIC

--- a/src/canister_tests/Cargo.toml
+++ b/src/canister_tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [dev-dependencies]
 base64 = "0.13.0"
 flate2 = "1.0"
+hex = "0.4.3"
 lazy_static = "1.4"
 regex = "1.5.6"
 serde = "1"
@@ -19,9 +20,9 @@ internet_identity_interface = { path = "../internet_identity_interface" }
 candid = "0.7"
 ic-cdk = "0.5"
 sdk-ic-types = { version = "0.3", package = "ic-types" }
-ic-interfaces = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
-ic-types = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
-ic-certified-vars = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
-ic-crypto-internal-basic-sig-iccsa = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
-ic-error-types = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
-ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "cd78fa32c23317b74025e0a44d95df1b2eb13484" }
+ic-interfaces = { git = "https://github.com/dfinity/ic", rev = "61b2814fcc69153b51fa403b126de93bb203aaeb" }
+ic-types = { git = "https://github.com/dfinity/ic", rev = "61b2814fcc69153b51fa403b126de93bb203aaeb" }
+ic-certified-vars = { git = "https://github.com/dfinity/ic", rev = "61b2814fcc69153b51fa403b126de93bb203aaeb" }
+ic-crypto-internal-basic-sig-iccsa = { git = "https://github.com/dfinity/ic", rev = "61b2814fcc69153b51fa403b126de93bb203aaeb" }
+ic-error-types = { git = "https://github.com/dfinity/ic", rev = "61b2814fcc69153b51fa403b126de93bb203aaeb" }
+ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "61b2814fcc69153b51fa403b126de93bb203aaeb" }

--- a/src/canister_tests/src/tests.rs
+++ b/src/canister_tests/src/tests.rs
@@ -300,6 +300,191 @@ mod registration_tests {
     }
 }
 
+/// Tests related to stable memory. In particular, the tests in this module make sure that II can be recovered from a stable memory backup.
+mod stable_memory_tests {
+    use crate::framework::CallError;
+    use crate::{api, framework};
+    use ic_state_machine_tests::{PrincipalId, StateMachine};
+    use internet_identity_interface::DeviceData;
+    use internet_identity_interface::DeviceProtection::Unprotected;
+    use internet_identity_interface::KeyType::Unknown;
+    use internet_identity_interface::Purpose::Authentication;
+    use sdk_ic_types::Principal;
+    use serde_bytes::ByteBuf;
+    use std::path::PathBuf;
+
+    /// Tests that some known anchors with their respective devices are available after stable memory restore.
+    #[test]
+    fn should_recover_anchors_and_devices_from_backup() -> Result<(), CallError> {
+        const CREDENTIAL_ID_1: &str = "63b8afb386dd757dfa5ba9550bca66936717766f395bafad9052a384edc446b11228bcb9cb684980bb5a81270b31d4b9561787296d40204d31e96c1b386b4984";
+        const PUB_KEY_1: &str = "305e300c060a2b0601040183b8430101034e00a5010203262001215820ee6f212d1b94fcc014f050b087f06ad34157ff53c19981e3976842b1644b0a1c2258200d6bc5ee077bd2300b3c86df87aa5fdf90d256d0131efbe44424330de8b00471";
+        const CREDENTIAL_ID_2: &str = "01bf2325d975f7b24c2d4bb6fef94a2e6dbbb35f490689f460a36f0f96717ac5487ad63899efd59fd01ef38aab8a228badaa1b94cd819572695c446e2c379792af7f";
+        const PUB_KEY_2: &str = "305e300c060a2b0601040183b8430101034e00a5010203262001215820724d6d2ae54244650134e475aaced8d82d45520ba672d9892c8de34d2a40e6f3225820e1f89fbff2e05a3ef1a35c1d9bb2de8b5e8856fd710b1a534a0841835cb793aa";
+        const CREDENTIAL_ID_3: &str = "2ceb7800078c607e94f8e9432fb1cd9e033081a7";
+        const PUB_KEY_3: &str = "305e300c060a2b0601040183b8430101034e00a50102032620012158208ca9cb400318172cb199b3df2f7c601f02fc72be73282ebc88ab0fb5562aae40225820f53cae416256e1ea0592f781f506c8cdd9fa67dbb329c5fca469ac6b5868b4cd";
+        const CREDENTIAL_ID_4: &str = "0192eea062df84cde762eff346aaa3a7fb44f1aa19d888ae407295b77c4c754b755b2b7b90d9174c0cf41d3eb3928f1eb310e3b3a4bc00445179df0f84b7f8b1db";
+        const PUB_KEY_4: &str = "305e300c060a2b0601040183b8430101034e00a5010203262001215820c8423e7f1df8dc91f599dd3683f37541514341643e916b0a77e935da1a7e5ff42258204f5d37a73d6e1b1ac6ebd0d7739ebf477a8f88ed6992cb36b6c481efee01b462";
+        const PUB_KEY_5: &str =
+        "302a300506032b6570032100f1ba3b80ce24f382fa32fd07233ceb8e305d57dafe6ad3d1c00e401315692631";
+        const PUB_KEY_6: &str = "305e300c060a2b0601040183b8430101034e00a50102032620012158206c52bead5df52c208a9b1c7be0a60847573e5be4ac4fe08ea48036d0ba1d2acf225820b33daeb83bc9c77d8ad762fd68e3eab08684e463c49351b3ab2a14a400138387";
+
+        let device1 = DeviceData {
+            pubkey: ByteBuf::from(hex::decode(PUB_KEY_1).unwrap()),
+            alias: "Desktop".to_string(),
+            purpose: Authentication,
+            credential_id: Some(ByteBuf::from(hex::decode(CREDENTIAL_ID_1).unwrap())),
+            key_type: Unknown,
+            protection: Unprotected,
+        };
+        let device2 = DeviceData {
+            pubkey: ByteBuf::from(hex::decode(PUB_KEY_2).unwrap()),
+            alias: "andrew-mbp".to_string(),
+            purpose: Authentication,
+            credential_id: Some(ByteBuf::from(hex::decode(CREDENTIAL_ID_2).unwrap())),
+            key_type: Unknown,
+            protection: Unprotected,
+        };
+        let device3 = DeviceData {
+            pubkey: ByteBuf::from(hex::decode(PUB_KEY_3).unwrap()),
+            alias: "andrew phone chrome".to_string(),
+            purpose: Authentication,
+            credential_id: Some(ByteBuf::from(hex::decode(CREDENTIAL_ID_3).unwrap())),
+            key_type: Unknown,
+            protection: Unprotected,
+        };
+        let device4 = DeviceData {
+            pubkey: ByteBuf::from(hex::decode(PUB_KEY_4).unwrap()),
+            alias: "Pixel".to_string(),
+            purpose: Authentication,
+            credential_id: Some(ByteBuf::from(hex::decode(CREDENTIAL_ID_4).unwrap())),
+            key_type: Unknown,
+            protection: Unprotected,
+        };
+        let device5 = DeviceData {
+            pubkey: ByteBuf::from(hex::decode(PUB_KEY_5).unwrap()),
+            alias: "dfx".to_string(),
+            purpose: Authentication,
+            credential_id: None,
+            key_type: Unknown,
+            protection: Unprotected,
+        };
+        let device6 = DeviceData {
+            pubkey: ByteBuf::from(hex::decode(PUB_KEY_6).unwrap()),
+            alias: "testkey".to_string(),
+            purpose: Authentication,
+            credential_id: None,
+            key_type: Unknown,
+            protection: Unprotected,
+        };
+
+        let env = StateMachine::new();
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
+
+        let stable_memory_backup = std::fs::read(PathBuf::from(
+            "../../backend-tests/test-stable-memory-rdmx6-jaaaa-aaaaa-aaadq-cai.bin",
+        ))
+        .unwrap();
+        env.set_stable_memory(canister_id, &stable_memory_backup);
+        // upgrade again to reset cached header info in II storage module
+        framework::upgrade_ii_canister(&env, canister_id, framework::II_WASM.clone());
+
+        // check known anchors in the backup
+        let devices = api::lookup(&env, canister_id, 10_000)?;
+        assert_eq!(devices, vec![device1]);
+
+        let mut devices = api::lookup(&env, canister_id, 10_002)?;
+        devices.sort_by(|a, b| a.pubkey.cmp(&b.pubkey));
+        assert_eq!(devices, vec![device2, device3]);
+
+        let devices = api::lookup(&env, canister_id, 10_029)?;
+        assert_eq!(devices, vec![device4]);
+
+        let devices = api::lookup(&env, canister_id, 10_030)?;
+        assert_eq!(devices, vec![device5, device6]);
+
+        Ok(())
+    }
+
+    /// Tests that II will issue the same principals after stable memory restore.
+    #[test]
+    fn should_issue_same_principal_after_restoring_backup() -> Result<(), CallError> {
+        const PUBLIC_KEY: &str = "305e300c060a2b0601040183b8430101034e00a50102032620012158206c52bead5df52c208a9b1c7be0a60847573e5be4ac4fe08ea48036d0ba1d2acf225820b33daeb83bc9c77d8ad762fd68e3eab08684e463c49351b3ab2a14a400138387";
+        const DELEGATION_PRINCIPAL: &str = "303c300c060a2b0601040183b8430102032c000a000000000000000001013a8926914dd1c836ec67ba66ac6425c21dffd3ca5c5968855f87780a1ec57985";
+        let principal = PrincipalId(Principal::self_authenticating(
+            hex::decode(PUBLIC_KEY).unwrap(),
+        ));
+
+        let env = StateMachine::new();
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
+
+        let stable_memory_backup = std::fs::read(PathBuf::from(
+            "../../backend-tests/test-stable-memory-rdmx6-jaaaa-aaaaa-aaadq-cai.bin",
+        ))
+        .unwrap();
+        env.set_stable_memory(canister_id, &stable_memory_backup);
+        // upgrade again to reset cached header info in II storage module
+        framework::upgrade_ii_canister(&env, canister_id, framework::II_WASM.clone());
+
+        let (user_key, _) = api::prepare_delegation(
+            &env,
+            canister_id,
+            principal,
+            10_030,
+            "example.com".to_string(),
+            ByteBuf::from("dummykey"),
+            None,
+        )?;
+
+        // check that we get the same user key; this proves that the salt was recovered from the backup
+        assert_eq!(
+            user_key.clone().into_vec(),
+            hex::decode(DELEGATION_PRINCIPAL).unwrap()
+        );
+
+        let principal = api::get_principal(
+            &env,
+            canister_id,
+            principal,
+            10_030,
+            "example.com".to_string(),
+        )?;
+        assert_eq!(Principal::self_authenticating(user_key), principal);
+        Ok(())
+    }
+
+    /// Tests that anchors can still be modified after stable memory restore.
+    #[test]
+    fn should_modify_devices_after_restoring_backup() -> Result<(), CallError> {
+        let public_key = hex::decode("305e300c060a2b0601040183b8430101034e00a50102032620012158206c52bead5df52c208a9b1c7be0a60847573e5be4ac4fe08ea48036d0ba1d2acf225820b33daeb83bc9c77d8ad762fd68e3eab08684e463c49351b3ab2a14a400138387").unwrap();
+        let principal = PrincipalId(Principal::self_authenticating(public_key.clone()));
+        let env = StateMachine::new();
+        let canister_id = framework::install_ii_canister(&env, framework::II_WASM.clone());
+
+        let stable_memory_backup = std::fs::read(PathBuf::from(
+            "../../backend-tests/test-stable-memory-rdmx6-jaaaa-aaaaa-aaadq-cai.bin",
+        ))
+        .unwrap();
+        env.set_stable_memory(canister_id, &stable_memory_backup);
+        // upgrade again to reset cached header info in II storage module
+        framework::upgrade_ii_canister(&env, canister_id, framework::II_WASM.clone());
+
+        let devices = api::lookup(&env, canister_id, 10_030)?;
+
+        assert_eq!(devices.len(), 2);
+        api::remove(
+            &env,
+            canister_id,
+            principal,
+            10_030,
+            ByteBuf::from(public_key),
+        )?;
+
+        let devices = api::lookup(&env, canister_id, 10_030)?;
+        assert_eq!(devices.len(), 1);
+        Ok(())
+    }
+}
+
 /// Tests related to local device management (add, remove, lookup, get_anchor_info).
 /// Tests for the 'add remote device flow' are in the module [remote_device_registration_tests].
 #[cfg(test)]


### PR DESCRIPTION
The haskell test has been split into multiple test cases in the rust version.
Also, the expected principal has been modified to reflect the fact, that the II canister has a different canister Id on the rust test infrastructure.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
