### PR TITLE
Fix error on deleting device used for login

### DIFF
--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -207,6 +207,14 @@ const init = async (
           }
           await removalConnection.remove(userNumber, device.pubkey);
         });
+
+        if (sameDevice) {
+          // clear anchor and reload the page.
+          // do not resolve, otherwise the management page will try to reload the list of devices which will cause an error
+          localStorage.clear();
+          location.reload();
+          return;
+        }
         resolve();
       };
     }


### PR DESCRIPTION
This fixes a bug showing an error loading the list of devices after deleting the device that was used to authenticate the current session with.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
