### PR TITLE
Remove --emulator selenium runs

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -217,7 +217,6 @@ jobs:
     needs: [docker-build, test-app-build]
     strategy:
       matrix:
-        start-flag: [ '', '--emulator' ]
         device: [ 'desktop', 'mobile' ]
       # Make sure that one failing test does not cancel all other matrix jobs
       fail-fast: false
@@ -263,7 +262,7 @@ jobs:
       - name: Build and start docker compose
         working-directory: docker-test-env
         run: |
-          docker compose build --build-arg dfx_emulator_flag=${{ matrix.start-flag }}
+          docker compose build
           docker compose up -d --wait
       - run: rm -v -f screenshots/*.png
       - run: npm ci
@@ -282,7 +281,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: e2e-test-log-${{ matrix.device }} ${{ matrix.start-flag }}
+          name: e2e-test-log-${{ matrix.device }}
           path: ./*.log
 
       - run: |
@@ -292,14 +291,14 @@ jobs:
       - name: Upload screenshots
         uses: actions/upload-artifact@v2
         with:
-          name: e2e-screenshots-${{ matrix.device }} ${{ matrix.start-flag }}
+          name: e2e-screenshots-${{ matrix.device }}
           path: screenshots/*.png
 
       - name: Archive test failures
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: e2e-test-failures-${{ matrix.device }} ${{ matrix.start-flag }}
+          name: e2e-test-failures-${{ matrix.device }}
           path: test-failures/*
           if-no-files-found: ignore
 

--- a/docker-test-env/dfx-docker/Dockerfile
+++ b/docker-test-env/dfx-docker/Dockerfile
@@ -6,5 +6,4 @@ RUN apt -yq update && apt -yqq install --no-install-recommends curl  ca-certific
 ENV DFX_VERSION=0.10.1
 RUN sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
 
-ARG dfx_emulator_flag
-ENTRYPOINT dfx start --clean --background $dfx_emulator_flag && dfx deploy && tail -f /dev/null
+ENTRYPOINT dfx start --clean --background && dfx deploy && tail -f /dev/null


### PR DESCRIPTION
Currently, the --emulator flags are broken, because it does not actually use the emulator.
To fix it, we would have to change the whole docker compose setup again to allow for unpredictable canister ids.
Since the benefit of running the selenium tests on emulator is questionable anyway, I think the pragmatic solution is just to no longer run the --emulator selenium tests.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
