### PR TITLE
Tighten glob on canister tests cache

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -147,7 +147,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src/**/Cargo.lock', 'rust-toolchain.toml') }}
 
       - uses: ./.github/actions/bootstrap
 


### PR DESCRIPTION
The previous value would also match the demos/test-app/cargo.lock leading to unnecessary cache misses.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
