### PR TITLE
replace ClipboardJS with clipboard API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@dfinity/principal": "0.10.2",
         "biguintle": "^1.0.3",
         "bip39": "^3.0.4",
-        "clipboard": "^2.0.8",
         "kjua": "^0.9.0",
         "lit-html": "^1.4.1",
         "text-encoding": "^0.7.0"
@@ -4231,16 +4230,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/clipboard": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-      "dependencies": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -4941,11 +4930,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "node_modules/delimit-stream": {
       "version": "0.1.0",
@@ -6621,14 +6605,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dependencies": {
-        "delegate": "^3.1.2"
       }
     },
     "node_modules/got": {
@@ -13071,11 +13047,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
-    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -13961,11 +13932,6 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
-    },
-    "node_modules/tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -18562,16 +18528,6 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
-    "clipboard": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -19129,11 +19085,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "delimit-stream": {
       "version": "0.1.0",
@@ -20413,14 +20364,6 @@
         "ignore": "^5.1.4",
         "merge2": "^1.3.0",
         "slash": "^3.0.0"
-      }
-    },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "requires": {
-        "delegate": "^3.1.2"
       }
     },
     "got": {
@@ -25299,11 +25242,6 @@
         "node-gyp-build": "^4.2.0"
       }
     },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
-    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -26015,11 +25953,6 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
-    },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@dfinity/principal": "0.10.2",
     "biguintle": "^1.0.3",
     "bip39": "^3.0.4",
-    "clipboard": "^2.0.8",
     "kjua": "^0.9.0",
     "lit-html": "^1.4.1",
     "text-encoding": "^0.7.0"

--- a/src/frontend/src/flows/recovery/displaySeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/displaySeedPhrase.ts
@@ -1,4 +1,3 @@
-import ClipboardJS from "clipboard";
 import { html, render } from "lit-html";
 import { checkmarkIcon, warningIcon } from "../../components/icons";
 
@@ -43,10 +42,31 @@ const init = (): Promise<void> =>
     displaySeedPhraseContinue.onclick = () => resolve();
 
     const seedCopy = document.getElementById("seedCopy") as HTMLButtonElement;
-    new ClipboardJS(seedCopy).on("success", () => {
-      const seedCopy = document.getElementById("seedCopy") as HTMLButtonElement;
-      displaySeedPhraseContinue.classList.toggle("hidden", false);
-      render(checkmarkIcon, seedCopy);
-      seedCopy.title = "copied";
+    const seedPhrase = document.getElementById("seedPhrase")
+      ?.innerText as string;
+
+    const selectText = (element: HTMLElement) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const selection = window.getSelection()!;
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    };
+
+    seedCopy.addEventListener("click", () => {
+      navigator.clipboard
+        .writeText(seedPhrase)
+        .then(() => {
+          const seedPhraseDiv = document.getElementById("seedPhrase");
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          selectText(seedPhraseDiv!);
+          displaySeedPhraseContinue.classList.toggle("hidden", false);
+          render(checkmarkIcon, seedCopy);
+          seedCopy.title = "copied";
+        })
+        .catch((e) => {
+          console.error("Unable to copy seed phrase", e);
+        });
     });
   });


### PR DESCRIPTION
# Replacing clipboardJs library with async [clipboard API ](https://www.w3.org/TR/clipboard-apis/#async-clipboard-api)
- Motivation: Apparently ClipboardJS uses execCommand("copy") which is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand)
- Changes: 
     - used navigator.clipboard.writeText async method
     - replicated the auto selection method that clipboardJs used - which selects the seed phrase (you see text highlighted in blue)
![Screen Shot 2022-07-12 at 6 38 27 PM](https://user-images.githubusercontent.com/38238542/178629937-923fa6c1-07df-4df9-a735-b761b465c11f.png)

     
