### PR TITLE
Fix canisterId not set error being show unnecessarily

### DIFF
--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -73,7 +73,7 @@ if (typeof canisterId === "undefined") {
   }).then(() => {
     window.location.reload();
   });
-  throw "canisterId is undefined"; // abort further execution of this script
+  throw new Error("canisterId is undefined"); // abort further execution of this script
 }
 
 export const canisterIdPrincipal: Principal = Principal.fromText(canisterId);

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -64,7 +64,7 @@ export class DummyIdentity
 }
 
 // Check if the canister ID was defined before we even try to read it
-if (typeof canisterId !== undefined) {
+if (typeof canisterId === "undefined") {
   displayError({
     title: "Canister ID not set",
     message:
@@ -73,6 +73,7 @@ if (typeof canisterId !== undefined) {
   }).then(() => {
     window.location.reload();
   });
+  throw "canisterId is undefined"; // abort further execution of this script
 }
 
 export const canisterIdPrincipal: Principal = Principal.fromText(canisterId);


### PR DESCRIPTION
So far this was not a bigger problem, because most pages rerender over the error immediately.
To stop this from happening in the future, an error is now thrown.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
