### PR TITLE
Add usage warning to the alternative origins feature

### DIFF
--- a/docs/internet-identity-spec.adoc
+++ b/docs/internet-identity-spec.adoc
@@ -133,7 +133,7 @@ where
 
 * the `sessionPublicKey` contains the public key of the session key pair.
 * the `maxTimeToLive`, if present, indicates the desired time span (in nanoseconds) until the requested delegation should expire. The Identity Provider frontend is free to set an earlier expiry time, but should not create a larger.
-* the `derivationOrigin`, if present, indicates an origin that should be used for principal derivation instead of the client origin. Values must match the following regular expression: `^https:\/\/[\w-]*(\.raw)?\.ic0\.app$`. Internet Identity will only accept values that are also listed in the HTTP resource `https://<canister_id>.ic0.app/.well-known/ii-alternative-origins` of the corresponding canister (see <<alternative-frontend-origins>>).
+* the `derivationOrigin`, if present, indicates an origin that should be used for principal derivation instead of the client origin. Values must match the following regular expression: `^https:\/\/[\w-]+(\.raw)?\.ic0\.app$`. Internet Identity will only accept values that are also listed in the HTTP resource `https://<canister_id>.ic0.app/.well-known/ii-alternative-origins` of the corresponding canister (see <<alternative-frontend-origins>>).
 --
 6. Now the client application window expects a message back, with data `event`.
 7. If `event.origin !== "https://identity.ic0.app"`, ignore this message.
@@ -180,6 +180,11 @@ The Internet Identity frontend will use `event.origin` as the “Frontend URL”
 [#alternative-frontend-origins]
 === Alternative Frontend Origins
 To allow flexibility regarding the canister frontend URL, the client may choose to provide the canonical canister frontend URL (`https://<canister_id>.ic0.app` or `https://<canister_id>.raw.ic0.app`) as the `derivationOrigin` (see <<client-auth-protocol>>). This means that Internet Identity will issue the same principals to the frontend (which uses a different origin) as it would if it were using one of the canonical URLs.
+
+[IMPORTANT]
+--
+This feature is intended to allow more flexibility with respect to the origins of a _single_ service. Do _not_ use this feature to allow _third party_ services to use the same principals. Only add origins you fully control to `/.well-known/ii-alternative-origins` and never set origins you do not control as `derivationOrigin`!
+--
 
 *Note:* `https://<canister_id>.ic0.app` and `https://<canister_id>.raw.ic0.app` do _not_ issue the same principals by default. However, this feature can also be used to map `https://<canister_id>.raw.ic0.app` to `https://<canister_id>.ic0.app` principals or vice versa.
 

--- a/src/frontend/src/flows/authenticate/validateDerivationOrigin.ts
+++ b/src/frontend/src/flows/authenticate/validateDerivationOrigin.ts
@@ -17,18 +17,24 @@ export const validateDerivationOrigin = async (
   }
 
   // check format of derivationOrigin
-  const matches = /^https:\/\/([\w-]*)(\.raw)?\.ic0\.app$/.exec(
+  const matches = /^https:\/\/([\w-]+)(\.raw)?\.ic0\.app$/.exec(
     derivationOrigin
   );
   if (matches === null) {
     return {
       result: "invalid",
       message:
-        'derivationOrigin does not match regex "^https:\\/\\/([\\w-]*)(\\.raw)?\\.ic0\\.app$"',
+        'derivationOrigin does not match regex "^https:\\/\\/([\\w-]+)(\\.raw)?\\.ic0\\.app$"',
     };
   }
 
   try {
+    if (matches.length < 2) {
+      return {
+        result: "invalid",
+        message: "invalid regex match result. No value for capture group 1.",
+      };
+    }
     const canisterId = Principal.fromText(matches[1]); // verifies that a valid canister id was matched
     const alternativeOriginsUrl = `https://${canisterId.toText()}.ic0.app/.well-known/ii-alternative-origins`;
     const response = await fetch(

--- a/src/frontend/src/test-e2e/selenium.test.ts
+++ b/src/frontend/src/test-e2e/selenium.test.ts
@@ -966,7 +966,7 @@ test("Should not issue delegation when derivationOrigin is malformed", async () 
       '"https://some-random-disallowed-url.com" is not a valid derivation origin for "https://nice-name.com"'
     );
     expect(await errorView.getErrorDetail()).toEqual(
-      'derivationOrigin does not match regex "^https:\\/\\/([\\w-]*)(\\.raw)?\\.ic0\\.app$"'
+      'derivationOrigin does not match regex "^https:\\/\\/([\\w-]+)(\\.raw)?\\.ic0\\.app$"'
     );
   });
 }, 300_000);


### PR DESCRIPTION
Additionally, the validation regex now ensures a non empty canister id.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
