### PR TITLE
Change misleading function name

### DIFF
--- a/src/frontend/src/test-e2e/selenium.test.ts
+++ b/src/frontend/src/test-e2e/selenium.test.ts
@@ -659,7 +659,7 @@ test("Screenshots", async () => {
       // Make sure last device cannot be removed
       await mainView.deviceSettings(DEVICE_NAME1);
       await settingsView.waitForDisplay();
-      await settingsView.removeDisabled();
+      await settingsView.removeNotDisplayed();
       await settingsView.back();
 
       // device still present. You can't remove your last device.

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -222,7 +222,7 @@ export class DeviceSettingsView extends View {
     await recoveryView.enterSeedPhraseContinue();
   }
 
-  async removeDisabled(): Promise<void> {
+  async removeNotDisplayed(): Promise<void> {
     await this.browser
       .$("button[data-action='remove']")
       .waitForDisplayed({ reverse: true });


### PR DESCRIPTION
The misleading name was introduced in #721 due to a late refactoring.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
