### PR TITLE
Fix misleading github actions step name

### DIFF
--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
         # First, check ic GitHub for new commits.
-      - name: Check new rust version
+      - name: Check new ic version
         id: update
         run: |
           current_ic_commit=$(cat ./src/canister_tests/Cargo.toml | sed -n 's/.*{\s*git\s*=\s*"https:\/\/github\.com\/dfinity\/ic",\s*rev\s*=\s*"\([a-z0-9]*\)" }.*/\1/p' | head -n 1)


### PR DESCRIPTION
Copy/paster error from using the rust update workflow as a template.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
