### PR TITLE
Don't symlink to candid file from demo

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -344,27 +344,48 @@ jobs:
           path: .
 
       - name: Deploy II and run tests
-        working-directory: demos/using-dev-build
         run: |
           set -euo pipefail
 
+          # Copy example to make sure it does not rely on living inside the II repo
+          builddir=$(mktemp -d)
+          cp -r ./demos/using-dev-build/. "$builddir"
+          pushd "$builddir"
+
+          # Install npm deps
           npm ci
 
-          # Create a fake curl so that we use this build's wasm; also create a "witness"
-          # file to make sure the fake curl was run (rm $witness will fail otherwise)
-          curl_dir=$(mktemp -d); witness=$(mktemp)
+          # Create a fake curl so that we use this build's wasm and did files; also create "witness"
+          # files to make sure the fake curl was run (rm $witness_foo will fail otherwise)
+          curl_dir=$(mktemp -d); witness_wasm=$(mktemp)
+          curl_dir=$(mktemp -d); witness_did=$(mktemp)
           cat > "$curl_dir/curl" << EOF
           #!/usr/bin/env bash
-          cp ../../internet_identity_dev.wasm ./internet_identity.wasm && touch $witness
+          case "\$*" in
+            *"internet_identity.wasm"*)
+              cp "$GITHUB_WORKSPACE"/internet_identity_dev.wasm ./internet_identity.wasm && touch $witness_wasm
+              ;;
+            *"internet_identity.did"*)
+              cp "$GITHUB_WORKSPACE"/src/internet_identity/internet_identity.did ./internet_identity.did && touch $witness_did
+              ;;
+            *)
+              echo "unexpected arguments: \$*"
+              exit 1
+              ;;
+          esac
           EOF
 
           chmod +x $curl_dir/curl
-          PATH=$curl_dir:$PATH dfx deploy --no-wallet --argument '(null)' && rm -rf "$curl_dir" && rm $witness
+          PATH=$curl_dir:$PATH dfx deploy --no-wallet --argument '(null)'
+          rm -rf "$curl_dir"; rm $witness_wasm; rm $witness_did
 
           npm run test
 
-          # Clean up our download
-          rm internet_identity.wasm
+          # Clean up temp files
+          rm internet_identity.wasm; rm internet_identity.did
+          popd
+          rm -rf "$builddir"
+
       - name: Stop replica
         run: |
           dfx stop
@@ -482,6 +503,7 @@ jobs:
             internet_identity_production.wasm
             internet_identity_dev.wasm
             internet_identity_test.wasm
+            internet_identity.did
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release
@@ -492,7 +514,8 @@ jobs:
             -- \
             internet_identity_production.wasm \
             internet_identity_dev.wasm \
-            internet_identity_test.wasm
+            internet_identity_test.wasm \
+            internet_identity.did
         env:
           # populated by GitHub Actions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -357,8 +357,9 @@ jobs:
 
           # Create a fake curl so that we use this build's wasm and did files; also create "witness"
           # files to make sure the fake curl was run (rm $witness_foo will fail otherwise)
-          curl_dir=$(mktemp -d); witness_wasm=$(mktemp)
-          curl_dir=$(mktemp -d); witness_did=$(mktemp)
+          witnesses=$(mktemp -d); witness_wasm="$witnesses/wasm"; witness_did="$witnesses/did"
+          curl_dir=$(mktemp -d)
+
           cat > "$curl_dir/curl" << EOF
           #!/usr/bin/env bash
           case "\$*" in
@@ -377,7 +378,7 @@ jobs:
 
           chmod +x $curl_dir/curl
           PATH=$curl_dir:$PATH dfx deploy --no-wallet --argument '(null)'
-          rm -rf "$curl_dir"; rm $witness_wasm; rm $witness_did
+          rm -rf "$curl_dir"; rm "$witness_wasm"; rm "$witness_did"; rmdir "$witnesses"
 
           npm run test
 

--- a/demos/using-dev-build/dfx.json
+++ b/demos/using-dev-build/dfx.json
@@ -9,8 +9,9 @@
       "wasm": "internet_identity.wasm",
 
       "__1": "There is no standard way to pull remote canisters, so instead we have a dummy build script that",
-      "__2": "simply downloads the Internet Identity canister. See also: https://github.com/dfinity/sdk/issues/2085",
-      "build": "curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm -o internet_identity.wasm"
+      "__2": "simply downloads the Internet Identity canister and Candid description.",
+      "__3": "See also: https://github.com/dfinity/sdk/issues/2085",
+      "build": "./scripts/download-did-and-wasm"
     },
 
     "whoami": {

--- a/demos/using-dev-build/internet_identity.did
+++ b/demos/using-dev-build/internet_identity.did
@@ -1,1 +1,0 @@
-../../src/internet_identity/internet_identity.did

--- a/demos/using-dev-build/scripts/download-did-and-wasm
+++ b/demos/using-dev-build/scripts/download-did-and-wasm
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download the Internet Identity canister's development wasm as well as its candid interface file. See dfx.json for details.
+curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm -o internet_identity.wasm
+curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity.did


### PR DESCRIPTION
Fixes #725 

Before this the candid file was symlinked from `using-dev-build`. We do
however suggest to copy the directory out of the repo for users to start
their II-enabled projects, which would lead to a broken symlink.

Instead of suggesting to copy the target file as well, we simply put the
candid file in the release (as also suggested in https://github.com/dfinity/internet-identity/issues/651) and download it
like we download the wasm file.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
