### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# The codebase is owned by the Governance & Identity Experience team at DFINITY
-# For questions, reach out to: <gix@dfinity.org>


### PR DESCRIPTION
The CODEOWNERS was empty and hence not useful.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
