### PR TITLE
Remove webauthn compatibilitiy check when DUMMY_AUTH is enabled

### DIFF
--- a/src/frontend/src/utils/featureDetection.ts
+++ b/src/frontend/src/utils/featureDetection.ts
@@ -1,6 +1,12 @@
+import { features } from "../features";
+
 export const checkRequiredFeatures = async (
   url: URL
 ): Promise<true | string> => {
+  if (features.DUMMY_AUTH) {
+    // do not check for webauthn compatibility if DUMMY_AUTH is enabled
+    return true;
+  }
   if (window.PublicKeyCredential === undefined)
     return "window.PublicKeyCredential is not defined";
   if (url.hash === "#compatibilityNotice")


### PR DESCRIPTION
The check unnecessarily restricts devs when using II in their dev environment.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
