### PR TITLE
Fix candid spec upload

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -504,7 +504,6 @@ jobs:
             internet_identity_production.wasm
             internet_identity_dev.wasm
             internet_identity_test.wasm
-            internet_identity.did
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release


### PR DESCRIPTION
I had a brainfart and asked our release script to build/prepare the
candid interface. We just need to upload it, there's nothing to prepare.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
