### PR TITLE
Fix path to candid description in release

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -515,7 +515,7 @@ jobs:
             internet_identity_production.wasm \
             internet_identity_dev.wasm \
             internet_identity_test.wasm \
-            internet_identity.did
+            src/internet_identity/internet_identity.did
         env:
           # populated by GitHub Actions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

--- a/scripts/release
+++ b/scripts/release
@@ -163,12 +163,12 @@ function do_release() {
         echo "uploading assets"
         for filename in "${filenames[@]}"
         do
+            filepath="$filename"
             filename=$(basename "$filename")
-            echo -n " - $filename"
-            echo "$release_json" | jq
+            echo -n " - $filename ($filepath)"
             local upload_url; upload_url=$(echo "$release_json" | jq -cMr '.upload_url' | sed "s/{.*}/?name=$filename/")
-            echo "upload url: $upload_url"
-            gh_post_tgz "$upload_url" "$filename" >/dev/null
+            echo -n "upload url: $upload_url"
+            gh_post_tgz "$upload_url" "$filepath" >/dev/null
             echo " (done)"
         done
     fi


### PR DESCRIPTION
We added the candid description as a released asset, however there were
two issues:

* The (relative) path to the `.did` was incorrect,
* The release script didn't support files outside of the top-level
  directory.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
