### PR TITLE
Notify on slack on release build failure

### DIFF
--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -47,3 +47,13 @@ jobs:
         with:
           # we check that ubuntu builds match the latest release build
           sha256: ${{ startsWith(matrix.os, 'ubuntu') && needs.latest-release.outputs.sha256 || '' }}
+
+        # Since the release build check is a scheduled job, a failure won't be shown on any
+        # PR status. To notify the team, we send a message to our Slack channel on failure.
+      - name: Notify Slack on failure
+        if: ${{ failure() }}
+        run: |
+          echo '{}' | jq --arg text "Release build check failed" '.text = $text' | \
+            curl -X POST -H 'Content-Type: application/json' --data @- "$SLACK_WEBHOOK_URL"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Since the release build check is a scheduled job, a failure won't be shown on any
PR status. To notify the team, we send a message to our Slack channel on failure.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
