### PR TITLE
Don't thread userNumber for IIConnection

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
@@ -47,7 +47,6 @@ export const addLocalDevice = async (
   try {
     await withLoader(() =>
       connection.add(
-        userNumber,
         deviceName,
         { unknown: null },
         { authentication: null },

--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -57,8 +57,8 @@ export const pollForTentativeDevice = async (
 ): Promise<void> => {
   await withLoader(async () => {
     const [timestamp, userInfo] = await Promise.all([
-      connection.enterDeviceRegistrationMode(userNumber),
-      connection.getAnchorInfo(userNumber),
+      connection.enterDeviceRegistrationMode(),
+      connection.getAnchorInfo(),
     ]);
     const tentativeDevice = getTentativeDevice(userInfo);
     if (tentativeDevice) {
@@ -77,7 +77,7 @@ const poll = (
   userNumber: bigint,
   shouldStop: () => boolean
 ): Promise<DeviceData | null> => {
-  return connection.getAnchorInfo(userNumber).then((response) => {
+  return connection.getAnchorInfo().then((response) => {
     if (shouldStop()) {
       return null;
     }
@@ -122,7 +122,7 @@ const init = (
   ) as HTMLButtonElement;
   cancelButton.onclick = async () => {
     countdown.stop();
-    await withLoader(() => connection.exitDeviceRegistrationMode(userNumber));
+    await withLoader(() => connection.exitDeviceRegistrationMode());
     await renderManage(userNumber, connection);
   };
 };

--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -92,7 +92,7 @@ const init = (
   ) as HTMLButtonElement;
   cancelButton.onclick = async () => {
     countdown.stop();
-    await withLoader(() => connection.exitDeviceRegistrationMode(userNumber));
+    await withLoader(() => connection.exitDeviceRegistrationMode());
     await renderManage(userNumber, connection);
   };
 
@@ -118,7 +118,7 @@ const init = (
       return;
     }
     const result = await withLoader(() =>
-      connection.verifyTentativeDevice(userNumber, pinInput.value)
+      connection.verifyTentativeDevice(pinInput.value)
     );
 
     if (hasOwnProperty(result, "verified")) {

--- a/src/frontend/src/flows/authenticate/fetchDelegation.ts
+++ b/src/frontend/src/flows/authenticate/fetchDelegation.ts
@@ -29,7 +29,6 @@ export const fetchDelegation = async (
       : authContext.requestOrigin;
 
   const [userKey, timestamp] = await loginResult.connection.prepareDelegation(
-    loginResult.userNumber,
     derivationOrigin,
     sessionKey,
     authContext.authRequest.maxTimeToLive
@@ -70,12 +69,7 @@ const retryGetDelegation = async (
     await new Promise((resolve) => {
       setInterval(resolve, 1000 * i);
     });
-    const res = await connection.getDelegation(
-      userNumber,
-      hostname,
-      sessionKey,
-      timestamp
-    );
+    const res = await connection.getDelegation(hostname, sessionKey, timestamp);
     if (hasOwnProperty(res, "signed_delegation")) {
       return res.signed_delegation;
     }

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -152,7 +152,6 @@ const init = async (
           }
 
           await newConnection.update(
-            userNumber,
             device.pubkey,
             device.alias,
             device.key_type,
@@ -207,7 +206,7 @@ const init = async (
             await resolve();
             return;
           }
-          await removalConnection.remove(userNumber, device.pubkey);
+          await removalConnection.remove(device.pubkey);
         });
 
         if (sameDevice) {

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -211,7 +211,7 @@ export const renderManage = async (
 
   let anchorInfo: IdentityAnchorInfo;
   try {
-    anchorInfo = await withLoader(() => connection.getAnchorInfo(userNumber));
+    anchorInfo = await withLoader(() => connection.getAnchorInfo());
   } catch (error: unknown) {
     await displayFailedToListDevices(
       error instanceof Error ? error : unknownError()

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -44,7 +44,6 @@ export const setupRecovery = async (
 
         return await withLoader(() =>
           connection.add(
-            userNumber,
             name,
             { cross_platform: null },
             { recovery: null },
@@ -63,7 +62,6 @@ export const setupRecovery = async (
         );
         await withLoader(() =>
           connection.add(
-            userNumber,
             name,
             { seed_phrase: null },
             { recovery: null },

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -117,6 +117,7 @@ export class IIConnection {
   protected constructor(
     public identity: SignIdentity,
     public delegationIdentity: DelegationIdentity,
+    public userNumber: bigint,
     public actor?: ActorSubclass<_SERVICE>
   ) {}
 
@@ -174,7 +175,12 @@ export class IIConnection {
       console.log(`registered Identity Anchor ${userNumber}`);
       return {
         kind: "loginSuccess",
-        connection: new IIConnection(identity, delegationIdentity, actor),
+        connection: new IIConnection(
+          identity,
+          delegationIdentity,
+          userNumber,
+          actor
+        ),
         userNumber,
       };
     } else if (hasOwnProperty(registerResponse, "bad_challenge")) {
@@ -249,6 +255,7 @@ export class IIConnection {
         // eslint-disable-next-line
         identity,
         delegationIdentity,
+        userNumber,
         actor
       ),
     };
@@ -279,7 +286,12 @@ export class IIConnection {
     return {
       kind: "loginSuccess",
       userNumber,
-      connection: new IIConnection(identity, delegationIdentity, actor),
+      connection: new IIConnection(
+        identity,
+        delegationIdentity,
+        userNumber,
+        actor
+      ),
     };
   }
 
@@ -370,37 +382,29 @@ export class IIConnection {
     return this.actor;
   }
 
-  getAnchorInfo = async (
-    userNumber: UserNumber
-  ): Promise<IdentityAnchorInfo> => {
+  getAnchorInfo = async (): Promise<IdentityAnchorInfo> => {
     const actor = await this.getActor();
-    return await actor.get_anchor_info(userNumber);
+    return await actor.get_anchor_info(this.userNumber);
   };
 
-  enterDeviceRegistrationMode = async (
-    userNumber: UserNumber
-  ): Promise<Timestamp> => {
+  enterDeviceRegistrationMode = async (): Promise<Timestamp> => {
     const actor = await this.getActor();
-    return await actor.enter_device_registration_mode(userNumber);
+    return await actor.enter_device_registration_mode(this.userNumber);
   };
 
-  exitDeviceRegistrationMode = async (
-    userNumber: UserNumber
-  ): Promise<void> => {
+  exitDeviceRegistrationMode = async (): Promise<void> => {
     const actor = await this.getActor();
-    return await actor.exit_device_registration_mode(userNumber);
+    return await actor.exit_device_registration_mode(this.userNumber);
   };
 
   verifyTentativeDevice = async (
-    userNumber: UserNumber,
     pin: string
   ): Promise<VerifyTentativeDeviceResponse> => {
     const actor = await this.getActor();
-    return await actor.verify_tentative_device(userNumber, pin);
+    return await actor.verify_tentative_device(this.userNumber, pin);
   };
 
   add = async (
-    userNumber: UserNumber,
     alias: string,
     keyType: KeyType,
     purpose: Purpose,
@@ -409,7 +413,7 @@ export class IIConnection {
     credentialId?: ArrayBuffer
   ): Promise<void> => {
     const actor = await this.getActor();
-    return await actor.add(userNumber, {
+    return await actor.add(this.userNumber, {
       alias,
       pubkey: Array.from(new Uint8Array(newPublicKey)),
       credential_id: credentialId
@@ -422,7 +426,6 @@ export class IIConnection {
   };
 
   update = async (
-    userNumber: UserNumber,
     publicKey: PublicKey,
     alias: string,
     keyType: KeyType,
@@ -431,7 +434,7 @@ export class IIConnection {
     credentialId: [] | [CredentialId]
   ): Promise<void> => {
     const actor = await this.getActor();
-    return await actor.update(userNumber, publicKey, {
+    return await actor.update(this.userNumber, publicKey, {
       alias,
       pubkey: publicKey,
       credential_id: credentialId,
@@ -441,34 +444,22 @@ export class IIConnection {
     });
   };
 
-  remove = async (
-    userNumber: UserNumber,
-    publicKey: PublicKey
-  ): Promise<void> => {
+  remove = async (publicKey: PublicKey): Promise<void> => {
     const actor = await this.getActor();
-    await actor.remove(userNumber, publicKey);
-  };
-
-  getPrincipal = async (
-    userNumber: UserNumber,
-    frontend: FrontendHostname
-  ): Promise<Principal> => {
-    const actor = await this.getActor();
-    return await actor.get_principal(userNumber, frontend);
+    await actor.remove(this.userNumber, publicKey);
   };
 
   prepareDelegation = async (
-    userNumber: UserNumber,
     hostname: FrontendHostname,
     sessionKey: SessionKey,
     maxTimeToLive?: bigint
   ): Promise<[PublicKey, bigint]> => {
     console.log(
-      `prepare_delegation(user: ${userNumber}, hostname: ${hostname}, session_key: ${sessionKey})`
+      `prepare_delegation(user: ${this.userNumber}, hostname: ${hostname}, session_key: ${sessionKey})`
     );
     const actor = await this.getActor();
     return await actor.prepare_delegation(
-      userNumber,
+      this.userNumber,
       hostname,
       sessionKey,
       maxTimeToLive !== undefined ? [maxTimeToLive] : []
@@ -476,17 +467,16 @@ export class IIConnection {
   };
 
   getDelegation = async (
-    userNumber: UserNumber,
     hostname: FrontendHostname,
     sessionKey: SessionKey,
     timestamp: Timestamp
   ): Promise<GetDelegationResponse> => {
     console.log(
-      `get_delegation(user: ${userNumber}, hostname: ${hostname}, session_key: ${sessionKey}, timestamp: ${timestamp})`
+      `get_delegation(user: ${this.userNumber}, hostname: ${hostname}, session_key: ${sessionKey}, timestamp: ${timestamp})`
     );
     const actor = await this.getActor();
     return await actor.get_delegation(
-      userNumber,
+      this.userNumber,
       hostname,
       sessionKey,
       timestamp


### PR DESCRIPTION
This lets IIConnection store the `userNumber` (which never changes) as
opposed to specifying it for every call.

The `getPrincipal` function was also removed because it wasn't being
used.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
