### PR TITLE
Revert "Remove CODEOWNERS"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The codebase is owned by the Governance & Identity Experience team at DFINITY
+# For questions, reach out to: <gix@dfinity.org>


### PR DESCRIPTION
Reverts dfinity/internet-identity#759

For visibility we still want to have the (empty) CODEOWNERS so that people know how to reach us.