### PR TITLE
prepare cover build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN touch src/canister_tests/src/lib.rs
 RUN npm ci
 
 RUN ./scripts/build
-RUN sha256sum /internet_identity.wasm
+RUN sha256sum .dfx/ic/canisters/internet_identity/internet_identity.wasm
 
 FROM scratch AS scratch
-COPY --from=build /internet_identity.wasm /
+COPY --from=build .dfx/ic/canisters/internet_identity/internet_identity.wasm /

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,7 +1,7 @@
 {
   "internet_identity": {
     "identity": "rdmx6-jaaaa-aaaaa-aaadq-cai",
-    "ic": "awp6e-faaaa-aaaak-qanlq-cai",
+    "ic": "fgte5-ciaaa-aaaad-aaatq-cai",
     "nnsdapp": "qjdve-lqaaa-aaaaa-aaaeq-cai"
   }
 }

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,7 +1,7 @@
 {
   "internet_identity": {
     "identity": "rdmx6-jaaaa-aaaaa-aaadq-cai",
-    "ic": "fgte5-ciaaa-aaaad-aaatq-cai",
+    "ic": "awp6e-faaaa-aaaak-qanlq-cai",
     "nnsdapp": "qjdve-lqaaa-aaaaa-aaaeq-cai"
   }
 }

--- a/dfx.json
+++ b/dfx.json
@@ -3,7 +3,7 @@
     "internet_identity": {
       "type": "custom",
       "candid": "src/internet_identity/internet_identity.did",
-      "wasm": "internet_identity.wasm",
+      "wasm": ".dfx/ic/canisters/internet_identity/internet_identity.wasm",
       "build": "scripts/build"
     }
   },

--- a/scripts/build
+++ b/scripts/build
@@ -64,18 +64,23 @@ done
 # XXX: we currently cannot check for the exact version of ic-cdk-optimizer
 # because of https://github.com/dfinity/cdk-rs/issues/181
 # Once the issue is fixed, we can ensure that the correct version is installed
-if ! command -v ic-cdk-optimizer
+if [[ ! "$(command -v ic-cdk-optimizer)" || "$(ic-cdk-optimizer --version)" != "ic-cdk-optimizer 0.3.4" ]]
 then
-    echo could not find ic-cdk-optimizer
-    echo "ic-cdk-optimizer version 0.3.1 is needed, please run the following command:"
-    echo "  cargo install ic-cdk-optimizer --version 0.3.1"
-    exit 1
+    cargo install ic-cdk-optimizer --version 0.3.4
 fi
 
 if [ "$ONLY_DEPS" != "1" ]
 then
     # Compile frontend assets to dist
     echo Compiling frontend assets
+    export NODE_VERSION=14.15.4
+    curl --fail -sSf https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+    export NVM_DIR=${HOME}/.nvm
+    . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+    . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+    . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+    export PATH="${NVM_DIR}/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+    npm ci
     npm run build
 fi
 
@@ -112,7 +117,8 @@ if [ "$ONLY_DEPS" != "1" ]
 then
     CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$II_DIR/../../target/}"
 
+    mkdir -p .dfx/ic/canisters/internet_identity
     ic-cdk-optimizer \
         "$CARGO_TARGET_DIR/$TARGET/release/internet_identity.wasm" \
-        -o "./internet_identity.wasm"
+        -o ".dfx/ic/canisters/internet_identity/internet_identity.wasm"
 fi


### PR DESCRIPTION
Update to make internet_identity build compatible with cover: https://mzsvw-zqaaa-aaaam-qafqq-cai.ic0.app/

Note that dfx version is set to 0.10.0 in the cover builder to prevent postprocessing done by dfx after executing script/build.