### PR TITLE
Update Cargo.lock on ic dep update

### DIFF
--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -32,6 +32,12 @@ jobs:
 
           cat ./src/canister_tests/Cargo.toml
 
+      - uses: ./.github/actions/bootstrap
+
+        # Make sure Cargo.lock is up-to-date
+      - name: Update lockfile
+        run: cargo generate-lockfile
+
         # If the ic commit was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
@@ -39,7 +45,9 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
-          add-paths: ./src/canister_tests/Cargo.toml
+          add-paths: |
+            ./src/canister_tests/Cargo.toml
+            Cargo.lock
           commit-message: Update commit of IC dependencies
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>


### PR DESCRIPTION
This calls `cargo generate-lockfile` to ensure the `Cargo.lock`
is up-to-date after the ic dependencies were updated.


See new commit here: https://github.com/dfinity/internet-identity/pull/781/commits/0043e8404599b7e7fee1bdf56d9260a8503f4df9
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
