### PR TITLE
Add version_info to canister and autodeploy

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -469,6 +469,48 @@ jobs:
           default_author: github_actions
           message: "🤖 Selenium screenshots auto-update"
 
+  # This deploys the production build to mainnet, to a canister that we use for testing.
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: docker-build
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: 'Install dfx'
+        # TODO: set version
+        run: sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+
+      - name: 'Download wasm'
+        uses: actions/download-artifact@v2
+        with:
+          name: internet_identity_production.wasm
+          path: .
+
+      - name: 'Install key'
+        env:
+          DFX_DEPLOY_KEY: ${{ secrets.DFX_DEPLOY_KEY }}
+        run: |
+          key_pem=$(mktemp)
+          printenv "DFX_DEPLOY_KEY" > "$key_pem"
+          dfx identity import --disable-encryption --force default "$key_pem"
+          rm "$key_pem"
+
+      - name: "Deploy"
+        run: |
+          mv internet_identity_production.wasm internet_identity.wasm
+          version_info="Built from https://github.com/dfinity/internet-identity/commit/$GITHUB_SHA"
+          wallet="cvthj-wyaaa-aaaad-aaaaq-cai"
+          # NOTE: The `$version_info` in `--argument` is a bit awkward since we need to wrap it in double quotes
+          # see https://github.com/dfinity/sdk/issues/2399 for a better solution
+          #
+          # NOTE: We don't force the upgrade even if the arguments has changed, meaning the version_info may show an
+          # outdated commit, if the more recent commits have not modified the actual wasm.
+          dfx canister --network ic --wallet "$wallet" install --mode upgrade \
+            --argument '(opt record { version_info = opt "'"$version_info"'"; assigned_user_number_range = null })' \
+            internet_identity
+
+
   # This ... releases
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -478,8 +478,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: 'Install dfx'
-        # TODO: set version
-        run: sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+        run: DFX_VERSION=0.10.1 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
 
       - name: 'Download wasm'
         uses: actions/download-artifact@v2

--- a/src/canister_tests/src/tests.rs
+++ b/src/canister_tests/src/tests.rs
@@ -182,7 +182,8 @@ mod registration_tests {
             &env,
             framework::II_WASM.clone(),
             Some(InternetIdentityInit {
-                assigned_user_number_range: (127, 129),
+                assigned_user_number_range: Some((127, 129)),
+                version_info: None,
             }),
         );
 
@@ -1844,7 +1845,8 @@ mod http_tests {
             &env,
             framework::II_WASM.clone(),
             Some(InternetIdentityInit {
-                assigned_user_number_range: (127, 129),
+                assigned_user_number_range: Some((127, 129)),
+                version_info: None,
             }),
         );
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -125,7 +125,8 @@ type InternetIdentityStats = record {
 };
 
 type InternetIdentityInit = record {
-  assigned_user_number_range : record { nat64; nat64; };
+  assigned_user_number_range : opt record { nat64; nat64; };
+  version_info : opt text;
 };
 
 type ChallengeKey = text;

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -26,7 +26,10 @@ lazy_static! {
     // The <script> tag that sets the canister ID and loads the 'index.js'
     static ref INDEX_HTML_SETUP_JS: String = {
         let canister_id = api::id();
-        format!(r#"var canisterId = '{canister_id}';let s = document.createElement('script');s.async = true;s.src = 'index.js';document.head.appendChild(s);"#)
+
+        let version_info = crate::arg_data().version_info.unwrap_or("no version info".to_string());
+
+        format!(r#"console.log('{version_info}');var canisterId = '{canister_id}';let s = document.createElement('script');s.async = true;s.src = 'index.js';document.head.appendChild(s);"#)
     };
 
     // The SRI sha256 hash of the script tag, used by the CSP policy.

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -171,5 +171,6 @@ pub struct HttpResponse {
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct InternetIdentityInit {
-    pub assigned_user_number_range: (UserNumber, UserNumber),
+    pub assigned_user_number_range: Option<(UserNumber, UserNumber)>,
+    pub version_info: Option<String>,
 }


### PR DESCRIPTION
This adds a `version_info` field to the init args that is used to
bake in some build-time information, which is later shown in the browser
console. This helps track which version was installed.

This also adds a deploy step to the CI runs on the `main` branch that
deploys to our mainnet test canister.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
