### PR TITLE
Remove macos-10.15 builds

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -527,7 +527,7 @@ jobs:
     needs: docker-build
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, macos-12 ]
+        os: [ ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-11, macos-12 ]
     steps:
       - uses: actions/checkout@v2
       - name: 'Download wasm'

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -37,7 +37,7 @@ jobs:
     needs: latest-release
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11, macos-12 ]
+        os: [ ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-11, macos-12 ]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
GitHub Actions has deprecated it and will remove it end of August:
https://github.com/actions/virtual-environments/issues/5583

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
