### PR TITLE
Update II spec links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ We recommend using the [`docker-build`](./scripts/docker-build) script. It simpl
 
 ### Integration with Internet Identity
 
-The [`using-dev-build`](./demos/using-dev-build) demo shows a documented example project that integrates Internet Identity. For more, please refer to the [Client Authentication Protocol section](https://internetcomputer.org/docs/current/references/ii-spec#client-auth-protocol) of the [Internet Identity Specification][spec] to integration Internet Identity in your app from scratch. For a just-add-water approach using the [agent-js](https://github.com/dfinity/agent-js) library (also used by `using-dev-build`), check out Kyle Peacock's [blogpost](http://kyle-peacock.com/blog/dfinity/integrating-internet-identity/).
+The [`using-dev-build`](./demos/using-dev-build) demo shows a documented example project that integrates Internet Identity. For more, please refer to the [Client Authentication Protocol section](https://internetcomputer.org/docs/current/references/ii-spec#client-authentication-protocol) of the [Internet Identity Specification][spec] to integration Internet Identity in your app from scratch. For a just-add-water approach using the [agent-js](https://github.com/dfinity/agent-js) library (also used by `using-dev-build`), check out Kyle Peacock's [blogpost](http://kyle-peacock.com/blog/dfinity/integrating-internet-identity/).
 
 If you're interested in the infrastructure of how to get the Internet Identity canister and how to test it within your app, check out [`using-dev-build`](./demos/using-dev-build), which uses the Internet Identity development canister.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-    🔗 <a href="https://identity.ic0.app">https://identity.ic0.app</a> | 📜 <a href="https://github.com/dfinity/internet-identity/blob/main/docs/ii-spec.md">Specification</a> | 🚑 <a href="https://github.com/dfinity/internet-identity/issues/new">Report an Issue</a> | 📞 <a href="https://discord.gg/E9FxceAg2j">Discord</a>
+    🔗 <a href="https://identity.ic0.app">https://identity.ic0.app</a> | 📜 <a href="https://internetcomputer.org/docs/current/references/ii-spec">Specification</a> | 🚑 <a href="https://github.com/dfinity/internet-identity/issues/new">Report an Issue</a> | 📞 <a href="https://discord.gg/E9FxceAg2j">Discord</a>
 </p>
 
 ---
@@ -74,7 +74,7 @@ We recommend using the [`docker-build`](./scripts/docker-build) script. It simpl
 
 ### Integration with Internet Identity
 
-The [`using-dev-build`](./demos/using-dev-build) demo shows a documented example project that integrates Internet Identity. For more, please refer to the [Client Authentication Protocol section](docs/ii-spec.md#client-auth-protocol) of the [Internet Identity Specification][spec] to integration Internet Identity in your app from scratch. For a just-add-water approach using the [agent-js](https://github.com/dfinity/agent-js) library (also used by `using-dev-build`), check out Kyle Peacock's [blogpost](http://kyle-peacock.com/blog/dfinity/integrating-internet-identity/).
+The [`using-dev-build`](./demos/using-dev-build) demo shows a documented example project that integrates Internet Identity. For more, please refer to the [Client Authentication Protocol section](https://internetcomputer.org/docs/current/references/ii-spec#client-auth-protocol) of the [Internet Identity Specification][spec] to integration Internet Identity in your app from scratch. For a just-add-water approach using the [agent-js](https://github.com/dfinity/agent-js) library (also used by `using-dev-build`), check out Kyle Peacock's [blogpost](http://kyle-peacock.com/blog/dfinity/integrating-internet-identity/).
 
 If you're interested in the infrastructure of how to get the Internet Identity canister and how to test it within your app, check out [`using-dev-build`](./demos/using-dev-build), which uses the Internet Identity development canister.
 
@@ -144,7 +144,7 @@ We're here to help! Here are some ways you can reach out for help if you get stu
 
 [HACKING]: ./HACKING.md#running-locally
 [ic]: https://internetcomputer.org
-[spec]: https://github.com/dfinity/internet-identity/blob/main/docs/ii-spec.md
+[spec]: https://internetcomputer.org/docs/current/references/ii-spec
 [releases]: https://github.com/dfinity/internet-identity/releases
 [Docker]: https://docker.io
 [links]: #links


### PR DESCRIPTION
The spec has moved, and the official page is the one on
[internetcomputer.org](https://internetcomputer.org/docs/current/references/ii-spec). The code still lives in this repo.


EDIT: for context, see also https://github.com/dfinity/internet-identity/tree/main/docs#specification
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
