### PR TITLE
Show version info in browser console

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -498,9 +498,15 @@ jobs:
       - name: "Deploy"
         run: |
           mv internet_identity_production.wasm internet_identity.wasm
+          version_info="Built from https://github.com/dfinity/internet-identity/commit/$GITHUB_SHA"
           wallet="cvthj-wyaaa-aaaad-aaaaq-cai"
+          # NOTE: The `$version_info` in `--argument` is a bit awkward since we need to wrap it in double quotes
+          # see https://github.com/dfinity/sdk/issues/2399 for a better solution
+          #
+          # NOTE: We don't force the upgrade even if the arguments has changed, meaning the version_info may show an
+          # outdated commit, if the more recent commits have not modified the actual wasm.
           dfx canister --network ic --wallet "$wallet" install --mode upgrade \
-            --argument '(null)' \
+            --argument '(opt record { version_info = opt "'"$version_info"'"; assigned_user_number_range = null })' \
             internet_identity
 
 

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -10,8 +10,23 @@ import { recoveryWizard } from "./flows/recovery/recoveryWizard";
 import { showWarningIfNecessary } from "./banner";
 import authorizeAuthentication from "./flows/authenticate";
 
+/**
+ * Shows some version information, retrieved from /version
+ */
+const showVersion = async () => {
+  const response = await fetch("/version");
+  if (response.ok) {
+    const versionInfo = await response.text();
+    console.log(`version: ${versionInfo}`);
+  } else {
+    throw Error(`Could not read version info from /version: ${response}`);
+  }
+};
+
 const init = async () => {
   const url = new URL(document.URL);
+
+  showVersion().catch((e) => console.log(e));
 
   // If the build is not "official", show a warning
   // https://github.com/dfinity/internet-identity#build-features

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -26,6 +26,8 @@ const showVersion = async () => {
 const init = async () => {
   const url = new URL(document.URL);
 
+  // Note: we don't await anything here because we don't want to block anything while
+  // waiting for the version information to be shown
   showVersion().catch((e) => console.log(e));
 
   // If the build is not "official", show a warning

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -6,6 +6,7 @@ type UserKey = PublicKey;
 type SessionKey = PublicKey;
 type FrontendHostname = text;
 type Timestamp = nat64;
+type VersionInfo = text;
 
 type HeaderField = record { text; text; };
 
@@ -125,7 +126,8 @@ type InternetIdentityStats = record {
 };
 
 type InternetIdentityInit = record {
-  assigned_user_number_range : record { nat64; nat64; };
+  assigned_user_number_range: opt record { nat64; nat64; };
+  version_info: opt VersionInfo;
 };
 
 type ChallengeKey = text;

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -58,13 +58,14 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
         // Technically this should only accept requests with 'accept: text/plain' but we don't
         // check headers anywhere else so neither do we here.
         "/version" => {
-            let version_info = crate::VERSION_INFO.with(|version_info| { version_info.borrow().clone() });
+            let version_info =
+                crate::VERSION_INFO.with(|version_info| version_info.borrow().clone());
             let mut headers = vec![
                 (
                     "Content-Type".to_string(),
                     "text/plain; version=0.0.4".to_string(),
-                    ),
-                    ("Content-Length".to_string(), version_info.len().to_string()),
+                ),
+                ("Content-Length".to_string(), version_info.len().to_string()),
             ];
             headers.append(&mut security_headers());
             HttpResponse {

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -53,6 +53,27 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                 },
             }
         }
+
+        // the /version endpoint returns information about the version.
+        // Technically this should only accept requests with 'accept: text/plain' but we don't
+        // check headers anywhere else so neither do we here.
+        "/version" => {
+            let version_info = crate::VERSION_INFO.with(|version_info| { version_info.borrow().clone() });
+            let mut headers = vec![
+                (
+                    "Content-Type".to_string(),
+                    "text/plain; version=0.0.4".to_string(),
+                    ),
+                    ("Content-Length".to_string(), version_info.len().to_string()),
+            ];
+            headers.append(&mut security_headers());
+            HttpResponse {
+                status_code: 200,
+                headers,
+                body: Cow::Owned(ByteBuf::from(version_info)),
+                streaming_strategy: None,
+            }
+        }
         probably_an_asset => {
             let certificate_header = STATE.with(|s| {
                 make_asset_certificate_header(

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -927,14 +927,11 @@ fn stats() -> InternetIdentityStats {
 
 #[init]
 fn init(maybe_arg: Option<InternetIdentityInit>) {
-
     init_version_info(&maybe_arg);
     init_assets();
     STATE.with(|state| {
         if let Some(range) = maybe_arg.map(|x| x.assigned_user_number_range).flatten() {
-            state
-                .storage
-                .replace(Storage::new(range));
+            state.storage.replace(Storage::new(range));
         }
         state.storage.borrow().flush();
         update_root_hash(&state.asset_hashes.borrow(), &state.sigs.borrow());
@@ -943,7 +940,6 @@ fn init(maybe_arg: Option<InternetIdentityInit>) {
 
 #[post_upgrade]
 fn retrieve_data(maybe_arg: Option<InternetIdentityInit>) {
-
     init_version_info(&maybe_arg);
     init_assets();
     STATE.with(|s| {
@@ -1219,7 +1215,11 @@ fn check_frontend_length(frontend: &FrontendHostname) {
 
 /// Initializes the version info global based on the init argument provided.
 fn init_version_info(maybe_arg: &Option<InternetIdentityInit>) {
-    if let Some(version_info) = maybe_arg.as_ref().map(|x| x.version_info.as_ref()).flatten() {
+    if let Some(version_info) = maybe_arg
+        .as_ref()
+        .map(|x| x.version_info.as_ref())
+        .flatten()
+    {
         VERSION_INFO.with(|v| {
             v.replace(version_info.clone());
         });

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -13,6 +13,7 @@ pub type Timestamp = u64; // in nanos since epoch
 pub type Signature = ByteBuf;
 pub type DeviceVerificationCode = String;
 pub type FailedAttemptsCounter = u8;
+pub type VersionInfo = String;
 
 pub struct Base64(pub String);
 
@@ -171,5 +172,6 @@ pub struct HttpResponse {
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct InternetIdentityInit {
-    pub assigned_user_number_range: (UserNumber, UserNumber),
+    pub assigned_user_number_range: Option<(UserNumber, UserNumber)>,
+    pub version_info: Option<VersionInfo>,
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,7 @@ function generateWebpackConfigForCanister(name, info) {
           }
 
           // basically everything _except_ for index.js, because we want live reload
-          devServer.app.get(['/', '/index.html', '/faq', '/faq', 'about' ], HttpProxyMiddlware.createProxyMiddleware( {
+          devServer.app.get(['/', '/index.html', '/faq', '/faq', '/about', '/version' ], HttpProxyMiddlware.createProxyMiddleware( {
               target: replicaHost,
               pathRewrite: (pathAndParams, req) => {
                   let queryParamsString = `?`;


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

This adds a browser console log showing the version of the deployed canister. In particular:

* A new endpoint, `/version`, is added to the canister's HTTP interface. What this endpoint returns is set by the deployment arguments to the canister.
* The webapp fetches `/version` on startup and displays its content asynchronously (@peterpeterparker can you double check the frontend just in case I did something stoopid?)
* The `deploy` job bakes in the commit when deploying.