### PR TITLE
Fix /about in devServer

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,7 @@ function generateWebpackConfigForCanister(name, info) {
           }
 
           // basically everything _except_ for index.js, because we want live reload
-          devServer.app.get(['/', '/index.html', '/faq', '/faq', 'about' ], HttpProxyMiddlware.createProxyMiddleware( {
+          devServer.app.get(['/', '/index.html', '/faq', '/about' ], HttpProxyMiddlware.createProxyMiddleware( {
               target: replicaHost,
               pathRewrite: (pathAndParams, req) => {
                   let queryParamsString = `?`;


### PR DESCRIPTION
There was a typo on the `/about` route in local development which would
lead to a 404 when trying to get the page

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
