### PR TITLE
Don't read canister ID as global

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
@@ -1,6 +1,5 @@
 import {
   creationOptions,
-  Connection,
   AuthenticatedConnection,
 } from "../../../utils/iiConnection";
 import { DeviceData } from "../../../../generated/internet_identity_types";

--- a/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
@@ -1,7 +1,7 @@
 import {
   creationOptions,
-  IIConnection,
   Connection,
+  AuthenticatedConnection,
 } from "../../../utils/iiConnection";
 import { DeviceData } from "../../../../generated/internet_identity_types";
 import { WebAuthnIdentity } from "@dfinity/identity";
@@ -23,14 +23,13 @@ const displayFailedToAddDevice = (error: Error) =>
  * Add a new device (i.e. a device connected to the browser the user is
  * currently using, like a YubiKey, or FaceID, or, or. Not meant to be used to
  * add e.g. _another_ browser, macbook or iPhone.)
- * @param userNumber anchor to add the device to
  * @param connection authenticated II connection
+ * @param userNumber anchor to add the device to
  * @param devices already existing devices
  */
 export const addLocalDevice = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection,
   devices: DeviceData[]
 ): Promise<void> => {
   let newDevice: WebAuthnIdentity;
@@ -42,12 +41,12 @@ export const addLocalDevice = async (
     await displayFailedToAddDevice(
       error instanceof Error ? error : unknownError()
     );
-    return renderManage(conn, userNumber, connection);
+    return renderManage(connection, userNumber);
   }
   const deviceName = await pickDeviceAlias();
   if (deviceName === null) {
     // user clicked "cancel", so we go back to "manage"
-    return await renderManage(conn, userNumber, connection);
+    return await renderManage(connection, userNumber);
   }
   try {
     await withLoader(() =>
@@ -65,7 +64,7 @@ export const addLocalDevice = async (
       error instanceof Error ? error : unknownError()
     );
   }
-  await renderManage(conn, userNumber, connection);
+  await renderManage(connection, userNumber);
 };
 
 const unknownError = (): Error => {

--- a/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
@@ -23,13 +23,13 @@ const displayFailedToAddDevice = (error: Error) =>
  * Add a new device (i.e. a device connected to the browser the user is
  * currently using, like a YubiKey, or FaceID, or, or. Not meant to be used to
  * add e.g. _another_ browser, macbook or iPhone.)
- * @param connection authenticated II connection
  * @param userNumber anchor to add the device to
+ * @param connection authenticated II connection
  * @param devices already existing devices
  */
 export const addLocalDevice = async (
-  connection: AuthenticatedConnection,
   userNumber: bigint,
+  connection: AuthenticatedConnection,
   devices: DeviceData[]
 ): Promise<void> => {
   let newDevice: WebAuthnIdentity;
@@ -41,12 +41,12 @@ export const addLocalDevice = async (
     await displayFailedToAddDevice(
       error instanceof Error ? error : unknownError()
     );
-    return renderManage(connection, userNumber);
+    return renderManage(userNumber, connection);
   }
   const deviceName = await pickDeviceAlias();
   if (deviceName === null) {
     // user clicked "cancel", so we go back to "manage"
-    return await renderManage(connection, userNumber);
+    return await renderManage(userNumber, connection);
   }
   try {
     await withLoader(() =>
@@ -64,7 +64,7 @@ export const addLocalDevice = async (
       error instanceof Error ? error : unknownError()
     );
   }
-  await renderManage(connection, userNumber);
+  await renderManage(userNumber, connection);
 };
 
 const unknownError = (): Error => {

--- a/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
@@ -1,4 +1,8 @@
-import { creationOptions, IIConnection } from "../../../utils/iiConnection";
+import {
+  creationOptions,
+  IIConnection,
+  Connection,
+} from "../../../utils/iiConnection";
 import { DeviceData } from "../../../../generated/internet_identity_types";
 import { WebAuthnIdentity } from "@dfinity/identity";
 import { pickDeviceAlias } from "./addDevicePickAlias";
@@ -24,6 +28,7 @@ const displayFailedToAddDevice = (error: Error) =>
  * @param devices already existing devices
  */
 export const addLocalDevice = async (
+  conn: Connection,
   userNumber: bigint,
   connection: IIConnection,
   devices: DeviceData[]
@@ -37,12 +42,12 @@ export const addLocalDevice = async (
     await displayFailedToAddDevice(
       error instanceof Error ? error : unknownError()
     );
-    return renderManage(userNumber, connection);
+    return renderManage(conn, userNumber, connection);
   }
   const deviceName = await pickDeviceAlias();
   if (deviceName === null) {
     // user clicked "cancel", so we go back to "manage"
-    return await renderManage(userNumber, connection);
+    return await renderManage(conn, userNumber, connection);
   }
   try {
     await withLoader(() =>
@@ -60,7 +65,7 @@ export const addLocalDevice = async (
       error instanceof Error ? error : unknownError()
     );
   }
-  await renderManage(userNumber, connection);
+  await renderManage(conn, userNumber, connection);
 };
 
 const unknownError = (): Error => {

--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -1,8 +1,5 @@
 import { html, render } from "lit-html";
-import {
-  AuthenticatedConnection,
-  Connection,
-} from "../../../utils/iiConnection";
+import { AuthenticatedConnection } from "../../../utils/iiConnection";
 import { renderManage } from "../../manage";
 import { withLoader } from "../../../components/loader";
 import { verifyDevice } from "./verifyTentativeDevice";

--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -1,5 +1,5 @@
 import { html, render } from "lit-html";
-import { IIConnection } from "../../../utils/iiConnection";
+import { IIConnection, Connection } from "../../../utils/iiConnection";
 import { renderManage } from "../../manage";
 import { withLoader } from "../../../components/loader";
 import { verifyDevice } from "./verifyTentativeDevice";
@@ -52,6 +52,7 @@ const pageContent = (userNumber: bigint) => html`
  * @param connection authenticated II connection
  */
 export const pollForTentativeDevice = async (
+  conn: Connection,
   userNumber: bigint,
   connection: IIConnection
 ): Promise<void> => {
@@ -63,11 +64,17 @@ export const pollForTentativeDevice = async (
     const tentativeDevice = getTentativeDevice(userInfo);
     if (tentativeDevice) {
       // directly show the verification screen if the tentative device already exists
-      await verifyDevice(userNumber, tentativeDevice, timestamp, connection);
+      await verifyDevice(
+        conn,
+        userNumber,
+        tentativeDevice,
+        timestamp,
+        connection
+      );
     } else {
       const container = document.getElementById("pageContent") as HTMLElement;
       render(pageContent(userNumber), container);
-      init(userNumber, timestamp, connection);
+      init(conn, userNumber, timestamp, connection);
     }
   });
 };
@@ -90,6 +97,7 @@ const poll = (
 };
 
 const init = (
+  conn: Connection,
   userNumber: bigint,
   endTimestamp: bigint,
   connection: IIConnection
@@ -104,7 +112,7 @@ const init = (
           'The timeout has been reached. For security reasons the "add device" process has been aborted.',
         primaryButton: "Ok",
       });
-      await renderManage(userNumber, connection);
+      await renderManage(conn, userNumber, connection);
     }
   );
 
@@ -112,7 +120,7 @@ const init = (
     async (device) => {
       if (!countdown.hasStopped() && device) {
         countdown.stop();
-        await verifyDevice(userNumber, device, endTimestamp, connection);
+        await verifyDevice(conn, userNumber, device, endTimestamp, connection);
       }
     }
   );
@@ -123,7 +131,7 @@ const init = (
   cancelButton.onclick = async () => {
     countdown.stop();
     await withLoader(() => connection.exitDeviceRegistrationMode());
-    await renderManage(userNumber, connection);
+    await renderManage(conn, userNumber, connection);
   };
 };
 

--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -1,5 +1,8 @@
 import { html, render } from "lit-html";
-import { AuthenticatedConnection, Connection } from "../../../utils/iiConnection";
+import {
+  AuthenticatedConnection,
+  Connection,
+} from "../../../utils/iiConnection";
 import { renderManage } from "../../manage";
 import { withLoader } from "../../../components/loader";
 import { verifyDevice } from "./verifyTentativeDevice";
@@ -53,7 +56,7 @@ const pageContent = (userNumber: bigint) => html`
  */
 export const pollForTentativeDevice = async (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> => {
   await withLoader(async () => {
     const [timestamp, userInfo] = await Promise.all([
@@ -63,12 +66,7 @@ export const pollForTentativeDevice = async (
     const tentativeDevice = getTentativeDevice(userInfo);
     if (tentativeDevice) {
       // directly show the verification screen if the tentative device already exists
-      await verifyDevice(
-        connection,
-        userNumber,
-        tentativeDevice,
-        timestamp,
-      );
+      await verifyDevice(connection, userNumber, tentativeDevice, timestamp);
     } else {
       const container = document.getElementById("pageContent") as HTMLElement;
       render(pageContent(userNumber), container);
@@ -97,7 +95,7 @@ const poll = (
 const init = (
   connection: AuthenticatedConnection,
   userNumber: bigint,
-  endTimestamp: bigint,
+  endTimestamp: bigint
 ) => {
   const countdown = setupCountdown(
     endTimestamp,

--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -1,5 +1,5 @@
 import { html, render } from "lit-html";
-import { IIConnection } from "../../../utils/iiConnection";
+import { IIConnection, Connection } from "../../../utils/iiConnection";
 import { withLoader } from "../../../components/loader";
 import { renderManage } from "../../manage";
 import { hasOwnProperty } from "../../../utils/utils";
@@ -58,6 +58,7 @@ const pageContent = (alias: string) => html`
  * @param connection authenticated II connection
  */
 export const verifyDevice = async (
+  conn: Connection,
   userNumber: bigint,
   tentativeDevice: DeviceData,
   endTimestamp: bigint,
@@ -65,10 +66,11 @@ export const verifyDevice = async (
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(tentativeDevice.alias), container);
-  init(userNumber, connection, endTimestamp);
+  init(conn, userNumber, connection, endTimestamp);
 };
 
 const init = (
+  conn: Connection,
   userNumber: bigint,
   connection: IIConnection,
   endTimestamp: bigint
@@ -83,7 +85,7 @@ const init = (
           'The timeout has been reached. For security reasons the "add device" process has been aborted.',
         primaryButton: "Ok",
       });
-      await renderManage(userNumber, connection);
+      await renderManage(conn, userNumber, connection);
     }
   );
 
@@ -93,7 +95,7 @@ const init = (
   cancelButton.onclick = async () => {
     countdown.stop();
     await withLoader(() => connection.exitDeviceRegistrationMode());
-    await renderManage(userNumber, connection);
+    await renderManage(conn, userNumber, connection);
   };
 
   const pinInput = document.getElementById(
@@ -124,7 +126,7 @@ const init = (
     if (hasOwnProperty(result, "verified")) {
       countdown.stop();
       toggleErrorMessage("tentativeDeviceCode", "wrongCodeMessage", false);
-      await renderManage(userNumber, connection);
+      await renderManage(conn, userNumber, connection);
     } else if (hasOwnProperty(result, "wrong_code")) {
       if (result.wrong_code.retries_left > 0) {
         toggleErrorMessage("tentativeDeviceCode", "wrongCodeMessage", true);
@@ -135,7 +137,7 @@ const init = (
             "Adding the device has been aborted due to too many invalid code entries.",
           primaryButton: "Continue",
         });
-        await renderManage(userNumber, connection);
+        await renderManage(conn, userNumber, connection);
       }
     } else if (hasOwnProperty(result, "device_registration_mode_off")) {
       await displayError({
@@ -144,7 +146,7 @@ const init = (
           "Verification not possible because device registration is no longer enabled. Either the timeout has been reached or device registration was disabled using another device.",
         primaryButton: "Continue",
       });
-      await renderManage(userNumber, connection);
+      await renderManage(conn, userNumber, connection);
     } else if (hasOwnProperty(result, "no_device_to_verify")) {
       await displayError({
         title: "No Device To Verify",
@@ -152,7 +154,7 @@ const init = (
           "Verification not possible because the device is no longer in a state to be verified.",
         primaryButton: "Continue",
       });
-      await renderManage(userNumber, connection);
+      await renderManage(conn, userNumber, connection);
     } else {
       await displayError({
         title: "Something Went Wrong",

--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -1,5 +1,8 @@
 import { html, render } from "lit-html";
-import { AuthenticatedConnection, Connection } from "../../../utils/iiConnection";
+import {
+  AuthenticatedConnection,
+  Connection,
+} from "../../../utils/iiConnection";
 import { withLoader } from "../../../components/loader";
 import { renderManage } from "../../manage";
 import { hasOwnProperty } from "../../../utils/utils";
@@ -61,7 +64,7 @@ export const verifyDevice = async (
   connection: AuthenticatedConnection,
   userNumber: bigint,
   tentativeDevice: DeviceData,
-  endTimestamp: bigint,
+  endTimestamp: bigint
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(tentativeDevice.alias), container);

--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -61,19 +61,19 @@ const pageContent = (alias: string) => html`
  * @param connection authenticated II connection
  */
 export const verifyDevice = async (
-  connection: AuthenticatedConnection,
   userNumber: bigint,
+  connection: AuthenticatedConnection,
   tentativeDevice: DeviceData,
   endTimestamp: bigint
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(tentativeDevice.alias), container);
-  init(connection, userNumber, endTimestamp);
+  init(userNumber, connection, endTimestamp);
 };
 
 const init = (
-  connection: AuthenticatedConnection,
   userNumber: bigint,
+  connection: AuthenticatedConnection,
   endTimestamp: bigint
 ) => {
   const countdown = setupCountdown(
@@ -86,7 +86,7 @@ const init = (
           'The timeout has been reached. For security reasons the "add device" process has been aborted.',
         primaryButton: "Ok",
       });
-      await renderManage(connection, userNumber);
+      await renderManage(userNumber, connection);
     }
   );
 
@@ -96,7 +96,7 @@ const init = (
   cancelButton.onclick = async () => {
     countdown.stop();
     await withLoader(() => connection.exitDeviceRegistrationMode());
-    await renderManage(connection, userNumber);
+    await renderManage(userNumber, connection);
   };
 
   const pinInput = document.getElementById(
@@ -127,7 +127,7 @@ const init = (
     if (hasOwnProperty(result, "verified")) {
       countdown.stop();
       toggleErrorMessage("tentativeDeviceCode", "wrongCodeMessage", false);
-      await renderManage(connection, userNumber);
+      await renderManage(userNumber, connection);
     } else if (hasOwnProperty(result, "wrong_code")) {
       if (result.wrong_code.retries_left > 0) {
         toggleErrorMessage("tentativeDeviceCode", "wrongCodeMessage", true);
@@ -138,7 +138,7 @@ const init = (
             "Adding the device has been aborted due to too many invalid code entries.",
           primaryButton: "Continue",
         });
-        await renderManage(connection, userNumber);
+        await renderManage(userNumber, connection);
       }
     } else if (hasOwnProperty(result, "device_registration_mode_off")) {
       await displayError({
@@ -147,7 +147,7 @@ const init = (
           "Verification not possible because device registration is no longer enabled. Either the timeout has been reached or device registration was disabled using another device.",
         primaryButton: "Continue",
       });
-      await renderManage(connection, userNumber);
+      await renderManage(userNumber, connection);
     } else if (hasOwnProperty(result, "no_device_to_verify")) {
       await displayError({
         title: "No Device To Verify",
@@ -155,7 +155,7 @@ const init = (
           "Verification not possible because the device is no longer in a state to be verified.",
         primaryButton: "Continue",
       });
-      await renderManage(connection, userNumber);
+      await renderManage(userNumber, connection);
     } else {
       await displayError({
         title: "Something Went Wrong",

--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -1,8 +1,5 @@
 import { html, render } from "lit-html";
-import {
-  AuthenticatedConnection,
-  Connection,
-} from "../../../utils/iiConnection";
+import { AuthenticatedConnection } from "../../../utils/iiConnection";
 import { withLoader } from "../../../components/loader";
 import { renderManage } from "../../manage";
 import { hasOwnProperty } from "../../../utils/utils";

--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -1,4 +1,5 @@
 import { html, render } from "lit-html";
+import { Connection } from "../../../utils/iiConnection";
 import {
   addTentativeDevice,
   TentativeDeviceInfo,
@@ -42,14 +43,16 @@ const pageContent = (userNumber: bigint) => html`
  * @param tentativeDeviceInfo Information about the device to be added so that the user does not have to enter everything again after enabling device registration mode.
  */
 export const deviceRegistrationDisabledInfo = async (
+  conn: Connection,
   tentativeDeviceInfo: TentativeDeviceInfo
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(tentativeDeviceInfo[0]), container);
-  return init(tentativeDeviceInfo);
+  return init(conn, tentativeDeviceInfo);
 };
 
 const init = async (
+  conn: Connection,
   tentativeDeviceInfo: TentativeDeviceInfo
 ): Promise<void> => {
   const cancelButton = document.getElementById(
@@ -66,6 +69,6 @@ const init = async (
   ) as HTMLButtonElement;
 
   retryButton.onclick = async () => {
-    await addTentativeDevice(tentativeDeviceInfo);
+    await addTentativeDevice(conn, tentativeDeviceInfo);
   };
 };

--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -43,16 +43,16 @@ const pageContent = (userNumber: bigint) => html`
  * @param tentativeDeviceInfo Information about the device to be added so that the user does not have to enter everything again after enabling device registration mode.
  */
 export const deviceRegistrationDisabledInfo = async (
-  conn: Connection,
+  connection: Connection,
   tentativeDeviceInfo: TentativeDeviceInfo
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(tentativeDeviceInfo[0]), container);
-  return init(conn, tentativeDeviceInfo);
+  return init(connection, tentativeDeviceInfo);
 };
 
 const init = async (
-  conn: Connection,
+  connection: Connection,
   tentativeDeviceInfo: TentativeDeviceInfo
 ): Promise<void> => {
   const cancelButton = document.getElementById(
@@ -69,6 +69,6 @@ const init = async (
   ) as HTMLButtonElement;
 
   retryButton.onclick = async () => {
-    await addTentativeDevice(conn, tentativeDeviceInfo);
+    await addTentativeDevice(connection, tentativeDeviceInfo);
   };
 };

--- a/src/frontend/src/flows/addDevice/welcomeView/index.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/index.ts
@@ -29,8 +29,8 @@ const pageContent = (userNumber: bigint | null) => html`
  * This shows a prompt to enter the identity anchor to add this new device to.
  */
 export const addRemoteDevice = async (
-  connection: Connection,
-  userNumber: bigint | null
+  userNumber: bigint | null,
+  connection: Connection
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber), container);
@@ -66,7 +66,7 @@ const init = (connection: Connection) => {
     const userNumber = parseUserNumber(userNumberInput.value);
     if (userNumber !== null) {
       toggleErrorMessage("addDeviceUserNumber", "invalidAnchorMessage", false);
-      await registerTentativeDevice(connection, userNumber);
+      await registerTentativeDevice(userNumber, connection);
     } else {
       toggleErrorMessage("addDeviceUserNumber", "invalidAnchorMessage", true);
       userNumberInput.placeholder = "Please enter your Identity Anchor first";

--- a/src/frontend/src/flows/addDevice/welcomeView/index.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/index.ts
@@ -29,15 +29,15 @@ const pageContent = (userNumber: bigint | null) => html`
  * This shows a prompt to enter the identity anchor to add this new device to.
  */
 export const addRemoteDevice = async (
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint | null
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber), container);
-  return init(conn);
+  return init(connection);
 };
 
-const init = (conn: Connection) => {
+const init = (connection: Connection) => {
   const cancelButton = document.getElementById(
     "addDeviceUserNumberCancel"
   ) as HTMLButtonElement;
@@ -66,7 +66,7 @@ const init = (conn: Connection) => {
     const userNumber = parseUserNumber(userNumberInput.value);
     if (userNumber !== null) {
       toggleErrorMessage("addDeviceUserNumber", "invalidAnchorMessage", false);
-      await registerTentativeDevice(conn, userNumber);
+      await registerTentativeDevice(connection, userNumber);
     } else {
       toggleErrorMessage("addDeviceUserNumber", "invalidAnchorMessage", true);
       userNumberInput.placeholder = "Please enter your Identity Anchor first";

--- a/src/frontend/src/flows/addDevice/welcomeView/index.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/index.ts
@@ -2,6 +2,7 @@ import { html, render } from "lit-html";
 import { parseUserNumber } from "../../../utils/userNumber";
 import { registerTentativeDevice } from "./registerTentativeDevice";
 import { toggleErrorMessage } from "../../../utils/errorHelper";
+import { Connection } from "../../../utils/iiConnection";
 
 const pageContent = (userNumber: bigint | null) => html`
   <div class="container">
@@ -28,14 +29,15 @@ const pageContent = (userNumber: bigint | null) => html`
  * This shows a prompt to enter the identity anchor to add this new device to.
  */
 export const addRemoteDevice = async (
+  conn: Connection,
   userNumber: bigint | null
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber), container);
-  return init();
+  return init(conn);
 };
 
-const init = () => {
+const init = (conn: Connection) => {
   const cancelButton = document.getElementById(
     "addDeviceUserNumberCancel"
   ) as HTMLButtonElement;
@@ -64,7 +66,7 @@ const init = () => {
     const userNumber = parseUserNumber(userNumberInput.value);
     if (userNumber !== null) {
       toggleErrorMessage("addDeviceUserNumber", "invalidAnchorMessage", false);
-      await registerTentativeDevice(userNumber);
+      await registerTentativeDevice(conn, userNumber);
     } else {
       toggleErrorMessage("addDeviceUserNumber", "invalidAnchorMessage", true);
       userNumberInput.placeholder = "Please enter your Identity Anchor first";

--- a/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -1,9 +1,5 @@
 import { html, render } from "lit-html";
-import {
-  creationOptions,
-  IIConnection,
-  Connection,
-} from "../../../utils/iiConnection";
+import { creationOptions, Connection } from "../../../utils/iiConnection";
 import { WebAuthnIdentity } from "@dfinity/identity";
 import { deviceRegistrationDisabledInfo } from "./deviceRegistrationModeDisabled";
 import { DerEncodedPublicKey } from "@dfinity/agent";

--- a/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -42,12 +42,12 @@ const pageContent = () => html`
  * @param userNumber anchor to add the tentative device to.
  */
 export const registerTentativeDevice = async (
-  connection: Connection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: Connection
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
-  return init(connection, userNumber);
+  return init(userNumber, connection);
 };
 
 export type TentativeDeviceInfo = [
@@ -69,8 +69,8 @@ export const addTentativeDevice = async (
 
   if (hasOwnProperty(result, "added_tentatively")) {
     await showVerificationCode(
-      connection,
       tentativeDeviceInfo[0],
+      connection,
       tentativeDeviceInfo[1],
       result.added_tentatively,
       Array.from(new Uint8Array(tentativeDeviceInfo[5]))
@@ -93,7 +93,7 @@ export const addTentativeDevice = async (
   }
 };
 
-const init = async (connection: Connection, userNumber: bigint) => {
+const init = async (userNumber: bigint, connection: Connection) => {
   const existingAuthenticators = await withLoader(() =>
     connection.lookupAuthenticators(userNumber)
   );

--- a/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -1,5 +1,9 @@
 import { html, render } from "lit-html";
-import { creationOptions, IIConnection } from "../../../utils/iiConnection";
+import {
+  creationOptions,
+  IIConnection,
+  Connection,
+} from "../../../utils/iiConnection";
 import { WebAuthnIdentity } from "@dfinity/identity";
 import { deviceRegistrationDisabledInfo } from "./deviceRegistrationModeDisabled";
 import { DerEncodedPublicKey } from "@dfinity/agent";
@@ -38,11 +42,12 @@ const pageContent = () => html`
  * @param userNumber anchor to add the tentative device to.
  */
 export const registerTentativeDevice = async (
+  conn: Connection,
   userNumber: bigint
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
-  return init(userNumber);
+  return init(conn, userNumber);
 };
 
 export type TentativeDeviceInfo = [
@@ -55,21 +60,23 @@ export type TentativeDeviceInfo = [
 ];
 
 export const addTentativeDevice = async (
+  conn: Connection,
   tentativeDeviceInfo: TentativeDeviceInfo
 ): Promise<void> => {
   const result = await withLoader(() =>
-    IIConnection.addTentativeDevice(...tentativeDeviceInfo)
+    conn.addTentativeDevice(...tentativeDeviceInfo)
   );
 
   if (hasOwnProperty(result, "added_tentatively")) {
     await showVerificationCode(
+      conn,
       tentativeDeviceInfo[0],
       tentativeDeviceInfo[1],
       result.added_tentatively,
       Array.from(new Uint8Array(tentativeDeviceInfo[5]))
     );
   } else if (hasOwnProperty(result, "device_registration_mode_off")) {
-    await deviceRegistrationDisabledInfo(tentativeDeviceInfo);
+    await deviceRegistrationDisabledInfo(conn, tentativeDeviceInfo);
   } else if (hasOwnProperty(result, "another_device_tentatively_added")) {
     await displayError({
       title: "Tentative Device Already Exists",
@@ -86,9 +93,9 @@ export const addTentativeDevice = async (
   }
 };
 
-const init = async (userNumber: bigint) => {
+const init = async (conn: Connection, userNumber: bigint) => {
   const existingAuthenticators = await withLoader(() =>
-    IIConnection.lookupAuthenticators(userNumber)
+    conn.lookupAuthenticators(userNumber)
   );
   const cancelButton = document.getElementById(
     "registerTentativeDeviceCancel"
@@ -144,6 +151,6 @@ const init = async (userNumber: bigint) => {
       newDevice.getPublicKey().toDer(),
       newDevice.rawId,
     ];
-    await addTentativeDevice(tentativeDeviceInfo);
+    await addTentativeDevice(conn, tentativeDeviceInfo);
   };
 };

--- a/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -42,12 +42,12 @@ const pageContent = () => html`
  * @param userNumber anchor to add the tentative device to.
  */
 export const registerTentativeDevice = async (
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
-  return init(conn, userNumber);
+  return init(connection, userNumber);
 };
 
 export type TentativeDeviceInfo = [
@@ -60,23 +60,23 @@ export type TentativeDeviceInfo = [
 ];
 
 export const addTentativeDevice = async (
-  conn: Connection,
+  connection: Connection,
   tentativeDeviceInfo: TentativeDeviceInfo
 ): Promise<void> => {
   const result = await withLoader(() =>
-    conn.addTentativeDevice(...tentativeDeviceInfo)
+    connection.addTentativeDevice(...tentativeDeviceInfo)
   );
 
   if (hasOwnProperty(result, "added_tentatively")) {
     await showVerificationCode(
-      conn,
+      connection,
       tentativeDeviceInfo[0],
       tentativeDeviceInfo[1],
       result.added_tentatively,
       Array.from(new Uint8Array(tentativeDeviceInfo[5]))
     );
   } else if (hasOwnProperty(result, "device_registration_mode_off")) {
-    await deviceRegistrationDisabledInfo(conn, tentativeDeviceInfo);
+    await deviceRegistrationDisabledInfo(connection, tentativeDeviceInfo);
   } else if (hasOwnProperty(result, "another_device_tentatively_added")) {
     await displayError({
       title: "Tentative Device Already Exists",
@@ -93,9 +93,9 @@ export const addTentativeDevice = async (
   }
 };
 
-const init = async (conn: Connection, userNumber: bigint) => {
+const init = async (connection: Connection, userNumber: bigint) => {
   const existingAuthenticators = await withLoader(() =>
-    conn.lookupAuthenticators(userNumber)
+    connection.lookupAuthenticators(userNumber)
   );
   const cancelButton = document.getElementById(
     "registerTentativeDeviceCancel"
@@ -151,6 +151,6 @@ const init = async (conn: Connection, userNumber: bigint) => {
       newDevice.getPublicKey().toDer(),
       newDevice.rawId,
     ];
-    await addTentativeDevice(conn, tentativeDeviceInfo);
+    await addTentativeDevice(connection, tentativeDeviceInfo);
   };
 };

--- a/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
@@ -44,7 +44,7 @@ const pageContent = (
  * @param credentialToBeVerified Credential id of the device to be verified. When this id appears in the list of authenticators, verification was successful.
  */
 export const showVerificationCode = async (
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint,
   alias: string,
   tentativeRegistrationInfo: TentativeRegistrationInfo,
@@ -53,7 +53,7 @@ export const showVerificationCode = async (
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber, alias, tentativeRegistrationInfo), container);
   return init(
-    conn,
+    connection,
     userNumber,
     tentativeRegistrationInfo.device_registration_timeout,
     credentialToBeVerified
@@ -61,12 +61,12 @@ export const showVerificationCode = async (
 };
 
 function poll(
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint,
   credentialToBeVerified: Array<number>,
   shouldStop: () => boolean
 ): Promise<boolean> {
-  return conn.lookupAuthenticators(userNumber).then((deviceData) => {
+  return connection.lookupAuthenticators(userNumber).then((deviceData) => {
     if (shouldStop()) {
       return false;
     }
@@ -79,12 +79,12 @@ function poll(
         }
       }
     }
-    return poll(conn, userNumber, credentialToBeVerified, shouldStop);
+    return poll(connection, userNumber, credentialToBeVerified, shouldStop);
   });
 }
 
 const init = async (
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint,
   endTimestamp: bigint,
   credentialToBeVerified: CredentialId
@@ -103,7 +103,7 @@ const init = async (
       window.location.reload();
     }
   );
-  poll(conn, userNumber, credentialToBeVerified, () =>
+  poll(connection, userNumber, credentialToBeVerified, () =>
     countdown.hasStopped()
   ).then((verified) => {
     if (verified) {

--- a/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
@@ -1,5 +1,5 @@
 import { html, render } from "lit-html";
-import { IIConnection, Connection } from "../../../utils/iiConnection";
+import { Connection } from "../../../utils/iiConnection";
 import {
   CredentialId,
   Timestamp,

--- a/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
@@ -44,8 +44,8 @@ const pageContent = (
  * @param credentialToBeVerified Credential id of the device to be verified. When this id appears in the list of authenticators, verification was successful.
  */
 export const showVerificationCode = async (
-  connection: Connection,
   userNumber: bigint,
+  connection: Connection,
   alias: string,
   tentativeRegistrationInfo: TentativeRegistrationInfo,
   credentialToBeVerified: CredentialId
@@ -53,16 +53,16 @@ export const showVerificationCode = async (
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber, alias, tentativeRegistrationInfo), container);
   return init(
-    connection,
     userNumber,
+    connection,
     tentativeRegistrationInfo.device_registration_timeout,
     credentialToBeVerified
   );
 };
 
 function poll(
-  connection: Connection,
   userNumber: bigint,
+  connection: Connection,
   credentialToBeVerified: Array<number>,
   shouldStop: () => boolean
 ): Promise<boolean> {
@@ -79,13 +79,13 @@ function poll(
         }
       }
     }
-    return poll(connection, userNumber, credentialToBeVerified, shouldStop);
+    return poll(userNumber, connection, credentialToBeVerified, shouldStop);
   });
 }
 
 const init = async (
-  connection: Connection,
   userNumber: bigint,
+  connection: Connection,
   endTimestamp: bigint,
   credentialToBeVerified: CredentialId
 ): Promise<void> => {
@@ -103,7 +103,7 @@ const init = async (
       window.location.reload();
     }
   );
-  poll(connection, userNumber, credentialToBeVerified, () =>
+  poll(userNumber, connection, credentialToBeVerified, () =>
     countdown.hasStopped()
   ).then((verified) => {
     if (verified) {

--- a/src/frontend/src/flows/authenticate/fetchDelegation.ts
+++ b/src/frontend/src/flows/authenticate/fetchDelegation.ts
@@ -1,4 +1,4 @@
-import { IIConnection } from "../../utils/iiConnection";
+import { AuthenticatedConnection } from "../../utils/iiConnection";
 import { AuthContext, Delegation } from "./postMessageInterface";
 import {
   PublicKey,
@@ -16,7 +16,7 @@ import { hasOwnProperty } from "../../utils/utils";
 export const fetchDelegation = async (
   loginResult: {
     userNumber: bigint;
-    connection: IIConnection;
+    connection: AuthenticatedConnection;
   },
   authContext: AuthContext
 ): Promise<[PublicKey, Delegation]> => {
@@ -57,7 +57,7 @@ export const fetchDelegation = async (
 };
 
 const retryGetDelegation = async (
-  connection: IIConnection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
   hostname: string,
   sessionKey: PublicKey,

--- a/src/frontend/src/flows/confirmRegister.ts
+++ b/src/frontend/src/flows/confirmRegister.ts
@@ -7,7 +7,6 @@ import {
   LoginFlowResult,
 } from "./login/flowResult";
 import { Challenge } from "../../generated/internet_identity_types";
-import { Principal } from "@dfinity/principal";
 import { withLoader } from "../components/loader";
 import {
   IdentifiableIdentity,

--- a/src/frontend/src/flows/confirmRegister.ts
+++ b/src/frontend/src/flows/confirmRegister.ts
@@ -11,7 +11,6 @@ import { Principal } from "@dfinity/principal";
 import { withLoader } from "../components/loader";
 import {
   IdentifiableIdentity,
-  canisterIdPrincipal,
   ChallengeResult,
   Connection,
 } from "../utils/iiConnection";
@@ -40,7 +39,7 @@ export const confirmRegister = (
 ): Promise<LoginFlowResult | null> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent, container);
-  return init(connection, canisterIdPrincipal, identity, alias, captcha);
+  return init(connection, identity, alias, captcha);
 };
 
 const tryRegister = (
@@ -150,7 +149,6 @@ export const makeCaptcha = (connection: Connection): Promise<Challenge> =>
 
 const init = (
   connection: Connection,
-  canisterIdPrincipal: Principal,
   identity: IdentifiableIdentity,
   alias: string,
   captcha: Promise<Challenge>

--- a/src/frontend/src/flows/login/flowResult.ts
+++ b/src/frontend/src/flows/login/flowResult.ts
@@ -1,11 +1,11 @@
-import { IIConnection, ApiResult } from "../../utils/iiConnection";
+import { AuthenticatedConnection, ApiResult } from "../../utils/iiConnection";
 
 export type LoginFlowResult = LoginFlowSuccess | LoginFlowError;
 
 export type LoginFlowSuccess = {
   tag: "ok";
   userNumber: bigint;
-  connection: IIConnection;
+  connection: AuthenticatedConnection;
 };
 
 export type LoginFlowError = {

--- a/src/frontend/src/flows/login/index.ts
+++ b/src/frontend/src/flows/login/index.ts
@@ -1,5 +1,5 @@
 import { displayError } from "../../components/displayError";
-import { IIConnection } from "../../utils/iiConnection";
+import { IIConnection, Connection } from "../../utils/iiConnection";
 import { getUserNumber } from "../../utils/userNumber";
 import { unknownToString } from "../../utils/utils";
 import { loginUnknownAnchor } from "./unknownAnchor";
@@ -8,12 +8,14 @@ import { LoginFlowResult } from "./flowResult";
 
 // We retry logging in until we get a successful Identity Anchor connection pair
 // If we encounter an unexpected error we reload to be safe
-export const login = async (): Promise<{
+export const login = async (
+  conn: Connection
+): Promise<{
   userNumber: bigint;
   connection: IIConnection;
 }> => {
   try {
-    const x = await tryLogin();
+    const x = await tryLogin(conn);
 
     switch (x.tag) {
       case "ok": {
@@ -21,7 +23,7 @@ export const login = async (): Promise<{
       }
       case "err": {
         await displayError({ ...x, primaryButton: "Try again" });
-        return login();
+        return login(conn);
       }
     }
   } catch (err: unknown) {
@@ -37,11 +39,11 @@ export const login = async (): Promise<{
   }
 };
 
-const tryLogin = async (): Promise<LoginFlowResult> => {
+const tryLogin = async (conn: Connection): Promise<LoginFlowResult> => {
   const userNumber = getUserNumber();
   if (userNumber === undefined) {
-    return loginUnknownAnchor();
+    return loginUnknownAnchor(conn);
   } else {
-    return loginKnownAnchor(userNumber);
+    return loginKnownAnchor(conn, userNumber);
   }
 };

--- a/src/frontend/src/flows/login/index.ts
+++ b/src/frontend/src/flows/login/index.ts
@@ -44,6 +44,6 @@ const tryLogin = async (connection: Connection): Promise<LoginFlowResult> => {
   if (userNumber === undefined) {
     return loginUnknownAnchor(connection);
   } else {
-    return loginKnownAnchor(connection, userNumber);
+    return loginKnownAnchor(userNumber, connection);
   }
 };

--- a/src/frontend/src/flows/login/index.ts
+++ b/src/frontend/src/flows/login/index.ts
@@ -1,5 +1,5 @@
 import { displayError } from "../../components/displayError";
-import { IIConnection, Connection } from "../../utils/iiConnection";
+import { AuthenticatedConnection, Connection } from "../../utils/iiConnection";
 import { getUserNumber } from "../../utils/userNumber";
 import { unknownToString } from "../../utils/utils";
 import { loginUnknownAnchor } from "./unknownAnchor";
@@ -9,13 +9,13 @@ import { LoginFlowResult } from "./flowResult";
 // We retry logging in until we get a successful Identity Anchor connection pair
 // If we encounter an unexpected error we reload to be safe
 export const login = async (
-  conn: Connection
+  connection: Connection
 ): Promise<{
   userNumber: bigint;
-  connection: IIConnection;
+  connection: AuthenticatedConnection;
 }> => {
   try {
-    const x = await tryLogin(conn);
+    const x = await tryLogin(connection);
 
     switch (x.tag) {
       case "ok": {
@@ -23,7 +23,7 @@ export const login = async (
       }
       case "err": {
         await displayError({ ...x, primaryButton: "Try again" });
-        return login(conn);
+        return login(connection);
       }
     }
   } catch (err: unknown) {
@@ -39,11 +39,11 @@ export const login = async (
   }
 };
 
-const tryLogin = async (conn: Connection): Promise<LoginFlowResult> => {
+const tryLogin = async (connection: Connection): Promise<LoginFlowResult> => {
   const userNumber = getUserNumber();
   if (userNumber === undefined) {
-    return loginUnknownAnchor(conn);
+    return loginUnknownAnchor(connection);
   } else {
-    return loginKnownAnchor(conn, userNumber);
+    return loginKnownAnchor(connection, userNumber);
   }
 };

--- a/src/frontend/src/flows/login/knownAnchor.ts
+++ b/src/frontend/src/flows/login/knownAnchor.ts
@@ -4,7 +4,7 @@ import { footer } from "../../components/footer";
 import { icLogo } from "../../components/icons";
 import { withLoader } from "../../components/loader";
 import { logoutSection, initLogout } from "../../components/logout";
-import { IIConnection } from "../../utils/iiConnection";
+import { IIConnection, Connection } from "../../utils/iiConnection";
 import { loginUnknownAnchor } from "./unknownAnchor";
 import { apiResultToLoginFlowResult, LoginFlowResult } from "./flowResult";
 import { useRecovery } from "../recovery/useRecovery";
@@ -34,14 +34,18 @@ const pageContent = (userNumber: bigint) => html` <style>
   ${footer}`;
 
 export const loginKnownAnchor = async (
+  conn: Connection,
   userNumber: bigint
 ): Promise<LoginFlowResult> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber), container);
-  return init(userNumber);
+  return init(conn, userNumber);
 };
 
-const init = async (userNumber: bigint): Promise<LoginFlowResult> => {
+const init = async (
+  conn: Connection,
+  userNumber: bigint
+): Promise<LoginFlowResult> => {
   return new Promise((resolve) => {
     initLogout();
     const loginButton = document.querySelector("#login") as HTMLButtonElement;
@@ -52,18 +56,18 @@ const init = async (userNumber: bigint): Promise<LoginFlowResult> => {
     loginButton.onclick = async (ev) => {
       ev.preventDefault();
       ev.stopPropagation();
-      const result = await withLoader(() => IIConnection.login(userNumber));
+      const result = await withLoader(() => conn.login(userNumber));
       resolve(apiResultToLoginFlowResult(result));
     };
 
     loginDifferentButton.onclick = async (ev) => {
       ev.preventDefault();
       ev.stopPropagation();
-      resolve(await loginUnknownAnchor());
+      resolve(await loginUnknownAnchor(conn));
     };
     const recoverButton = document.getElementById(
       "recoverButton"
     ) as HTMLAnchorElement;
-    recoverButton.onclick = () => useRecovery(userNumber);
+    recoverButton.onclick = () => useRecovery(conn, userNumber);
   });
 };

--- a/src/frontend/src/flows/login/knownAnchor.ts
+++ b/src/frontend/src/flows/login/knownAnchor.ts
@@ -4,7 +4,7 @@ import { footer } from "../../components/footer";
 import { icLogo } from "../../components/icons";
 import { withLoader } from "../../components/loader";
 import { logoutSection, initLogout } from "../../components/logout";
-import { IIConnection, Connection } from "../../utils/iiConnection";
+import { Connection } from "../../utils/iiConnection";
 import { loginUnknownAnchor } from "./unknownAnchor";
 import { apiResultToLoginFlowResult, LoginFlowResult } from "./flowResult";
 import { useRecovery } from "../recovery/useRecovery";

--- a/src/frontend/src/flows/login/knownAnchor.ts
+++ b/src/frontend/src/flows/login/knownAnchor.ts
@@ -34,17 +34,17 @@ const pageContent = (userNumber: bigint) => html` <style>
   ${footer}`;
 
 export const loginKnownAnchor = async (
-  conn: Connection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: Connection
 ): Promise<LoginFlowResult> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber), container);
-  return init(conn, userNumber);
+  return init(userNumber, connection);
 };
 
 const init = async (
-  conn: Connection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: Connection
 ): Promise<LoginFlowResult> => {
   return new Promise((resolve) => {
     initLogout();
@@ -56,18 +56,18 @@ const init = async (
     loginButton.onclick = async (ev) => {
       ev.preventDefault();
       ev.stopPropagation();
-      const result = await withLoader(() => conn.login(userNumber));
+      const result = await withLoader(() => connection.login(userNumber));
       resolve(apiResultToLoginFlowResult(result));
     };
 
     loginDifferentButton.onclick = async (ev) => {
       ev.preventDefault();
       ev.stopPropagation();
-      resolve(await loginUnknownAnchor(conn));
+      resolve(await loginUnknownAnchor(connection));
     };
     const recoverButton = document.getElementById(
       "recoverButton"
     ) as HTMLAnchorElement;
-    recoverButton.onclick = () => useRecovery(conn, userNumber);
+    recoverButton.onclick = () => useRecovery(connection, userNumber);
   });
 };

--- a/src/frontend/src/flows/login/unknownAnchor.ts
+++ b/src/frontend/src/flows/login/unknownAnchor.ts
@@ -88,20 +88,20 @@ const pageContent = () => html` <style>
   ${footer}`;
 
 export const loginUnknownAnchor = async (
-  conn: Connection
+  connection: Connection
 ): Promise<LoginFlowResult> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
   return new Promise((resolve, reject) => {
-    initLogin(conn, resolve);
-    initLinkDevice(conn);
-    initRegister(conn, resolve, reject);
-    initRecovery(conn);
+    initLogin(connection, resolve);
+    initLinkDevice(connection);
+    initRegister(connection, resolve, reject);
+    initRecovery(connection);
   });
 };
 
 const initRegister = (
-  conn: Connection,
+  connection: Connection,
   resolve: (res: LoginFlowResult) => void,
   reject: (err: Error) => void
 ) => {
@@ -109,7 +109,7 @@ const initRegister = (
     "registerButton"
   ) as HTMLButtonElement;
   registerButton.onclick = () => {
-    registerIfAllowed(conn)
+    registerIfAllowed(connection)
       .then((res) => {
         if (res === null) {
           window.location.reload();
@@ -121,15 +121,15 @@ const initRegister = (
   };
 };
 
-const initRecovery = (conn: Connection) => {
+const initRecovery = (connection: Connection) => {
   const recoverButton = document.getElementById(
     "recoverButton"
   ) as HTMLAnchorElement;
-  recoverButton.onclick = () => useRecovery(conn);
+  recoverButton.onclick = () => useRecovery(connection);
 };
 
 const initLogin = (
-  conn: Connection,
+  connection: Connection,
   resolve: (res: LoginFlowResult) => void
 ) => {
   const userNumberInput = document.getElementById(
@@ -156,7 +156,7 @@ const initLogin = (
         message: `${userNumber} doesn't parse as a number`,
       });
     }
-    const result = await withLoader(() => conn.login(userNumber));
+    const result = await withLoader(() => connection.login(userNumber));
     if (result.kind === "loginSuccess") {
       setUserNumber(userNumber);
     }
@@ -164,7 +164,7 @@ const initLogin = (
   };
 };
 
-const initLinkDevice = (conn: Connection) => {
+const initLinkDevice = (connection: Connection) => {
   const addNewDeviceButton = document.getElementById(
     "addNewDeviceButton"
   ) as HTMLButtonElement;
@@ -175,6 +175,6 @@ const initLinkDevice = (conn: Connection) => {
     ) as HTMLInputElement;
 
     const userNumber = parseUserNumber(userNumberInput.value);
-    await addRemoteDevice(conn, userNumber);
+    await addRemoteDevice(connection, userNumber);
   };
 };

--- a/src/frontend/src/flows/login/unknownAnchor.ts
+++ b/src/frontend/src/flows/login/unknownAnchor.ts
@@ -1,5 +1,5 @@
 import { render, html } from "lit-html";
-import { Connection, IIConnection } from "../../utils/iiConnection";
+import { Connection } from "../../utils/iiConnection";
 import { parseUserNumber, setUserNumber } from "../../utils/userNumber";
 import { withLoader } from "../../components/loader";
 import { icLogo } from "../../components/icons";

--- a/src/frontend/src/flows/login/unknownAnchor.ts
+++ b/src/frontend/src/flows/login/unknownAnchor.ts
@@ -175,6 +175,6 @@ const initLinkDevice = (connection: Connection) => {
     ) as HTMLInputElement;
 
     const userNumber = parseUserNumber(userNumberInput.value);
-    await addRemoteDevice(connection, userNumber);
+    await addRemoteDevice(userNumber, connection);
   };
 };

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -7,7 +7,7 @@ import { unreachable } from "../../utils/utils";
 import { footer } from "../../components/footer";
 import { DeviceData } from "../../../generated/internet_identity_types";
 import { hasOwnProperty } from "../../utils/utils";
-import { Connection } from "../../utils/iiConnection";
+import { AuthenticatedConnection, Connection } from "../../utils/iiConnection";
 import { phraseRecoveryPage } from "../recovery/recoverWith/phrase";
 
 // The "device settings" page where users can view information about a device,
@@ -68,29 +68,28 @@ const isRecovery = (device: DeviceData): boolean =>
 
 // Get the list of devices from canister and actually display the page
 export const deviceSettings = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection,
   device: DeviceData,
   isOnlyDevice: boolean
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
 
   render(pageContent(userNumber, device, isOnlyDevice), container);
-  return init(conn, userNumber, connection, device, isOnlyDevice);
+  return init(connection, userNumber, device, isOnlyDevice);
 };
 
 // Get a connection that's authenticated with the given device
 // NOTE: this expects a recovery phrase device
 const deviceConnection = async (
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint,
   device: DeviceData,
   recoveryPhraseMessage: string
 ): Promise<IIConnection | null> => {
   try {
     const loginResult = await phraseRecoveryPage(
-      conn,
+      connection,
       userNumber,
       device,
       undefined,
@@ -119,9 +118,8 @@ const deviceConnection = async (
 
 // Initializes the device settings page
 const init = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection,
   device: DeviceData,
   isOnlyDevice: boolean
 ): Promise<void> =>
@@ -144,7 +142,7 @@ const init = async (
         // but we do it to make sure one last time that the user can actually successfully authenticate
         // with the device.
         const newConnection = await deviceConnection(
-          conn,
+          connection,
           userNumber,
           device,
           "Please input your recovery phrase to protect it."
@@ -167,9 +165,8 @@ const init = async (
           );
         });
         await deviceSettings(
-          conn,
-          userNumber,
           connection,
+          userNumber,
           device,
           isOnlyDevice
         );
@@ -206,7 +203,7 @@ const init = async (
         // NOTE: the user may be authenticated with the device already, but for consistency we still ask them to input their recovery phrase
         const removalConnection = isProtected(device)
           ? await deviceConnection(
-              conn,
+              connection,
               userNumber,
               device,
               "Please input your recovery phrase to remove it."

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -1,13 +1,16 @@
 import { render, html } from "lit-html";
 import { DerEncodedPublicKey } from "@dfinity/agent";
-import { bufferEqual, IIConnection } from "../../utils/iiConnection";
+import {
+  bufferEqual,
+  AuthenticatedConnection,
+  Connection,
+} from "../../utils/iiConnection";
 import { displayError } from "../../components/displayError";
 import { withLoader } from "../../components/loader";
 import { unreachable } from "../../utils/utils";
 import { footer } from "../../components/footer";
 import { DeviceData } from "../../../generated/internet_identity_types";
 import { hasOwnProperty } from "../../utils/utils";
-import { AuthenticatedConnection, Connection } from "../../utils/iiConnection";
 import { phraseRecoveryPage } from "../recovery/recoverWith/phrase";
 
 // The "device settings" page where users can view information about a device,
@@ -86,7 +89,7 @@ const deviceConnection = async (
   userNumber: bigint,
   device: DeviceData,
   recoveryPhraseMessage: string
-): Promise<IIConnection | null> => {
+): Promise<AuthenticatedConnection | null> => {
   try {
     const loginResult = await phraseRecoveryPage(
       userNumber,

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -164,12 +164,7 @@ const init = async (
             device.credential_id
           );
         });
-        await deviceSettings(
-          connection,
-          userNumber,
-          device,
-          isOnlyDevice
-        );
+        await deviceSettings(connection, userNumber, device, isOnlyDevice);
         resolve();
       };
     }

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -68,15 +68,15 @@ const isRecovery = (device: DeviceData): boolean =>
 
 // Get the list of devices from canister and actually display the page
 export const deviceSettings = async (
-  connection: AuthenticatedConnection,
   userNumber: bigint,
+  connection: AuthenticatedConnection,
   device: DeviceData,
   isOnlyDevice: boolean
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
 
   render(pageContent(userNumber, device, isOnlyDevice), container);
-  return init(connection, userNumber, device, isOnlyDevice);
+  return init(userNumber, connection, device, isOnlyDevice);
 };
 
 // Get a connection that's authenticated with the given device
@@ -89,8 +89,8 @@ const deviceConnection = async (
 ): Promise<IIConnection | null> => {
   try {
     const loginResult = await phraseRecoveryPage(
-      connection,
       userNumber,
+      connection,
       device,
       undefined,
       recoveryPhraseMessage
@@ -118,8 +118,8 @@ const deviceConnection = async (
 
 // Initializes the device settings page
 const init = async (
-  connection: AuthenticatedConnection,
   userNumber: bigint,
+  connection: AuthenticatedConnection,
   device: DeviceData,
   isOnlyDevice: boolean
 ): Promise<void> =>
@@ -164,7 +164,7 @@ const init = async (
             device.credential_id
           );
         });
-        await deviceSettings(connection, userNumber, device, isOnlyDevice);
+        await deviceSettings(userNumber, connection, device, isOnlyDevice);
         resolve();
       };
     }

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -232,8 +232,8 @@ const recoveryNag = () => html`
 
 // Get the list of devices from canister and actually display the page
 export const renderManage = async (
-  connection: AuthenticatedConnection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: AuthenticatedConnection
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
 
@@ -244,21 +244,21 @@ export const renderManage = async (
     await displayFailedToListDevices(
       error instanceof Error ? error : unknownError()
     );
-    return renderManage(connection, userNumber);
+    return renderManage(userNumber, connection);
   }
   if (anchorInfo.device_registration.length !== 0) {
     // we are actually in a device registration process
-    await pollForTentativeDevice(connection, userNumber);
+    await pollForTentativeDevice(userNumber, connection);
   } else {
     render(pageContent(userNumber, anchorInfo.devices), container);
-    init(connection, userNumber, anchorInfo.devices);
+    init(userNumber, connection, anchorInfo.devices);
   }
 };
 
 // Initializes the management page.
 const init = async (
-  connection: AuthenticatedConnection,
   userNumber: bigint,
+  connection: AuthenticatedConnection,
   devices: DeviceData[]
 ) => {
   // TODO - Check alias for current identity, and populate #nameSpan
@@ -274,16 +274,16 @@ const init = async (
     const nextAction = await chooseDeviceAddFlow();
     if (nextAction === null) {
       // user clicked 'cancel'
-      await renderManage(connection, userNumber);
+      await renderManage(userNumber, connection);
       return;
     }
     switch (nextAction) {
       case "local": {
-        await addLocalDevice(connection, userNumber, devices);
+        await addLocalDevice(userNumber, connection, devices);
         return;
       }
       case "remote": {
-        await pollForTentativeDevice(connection, userNumber);
+        await pollForTentativeDevice(userNumber, connection);
         return;
       }
     }
@@ -294,15 +294,15 @@ const init = async (
     "#addRecovery"
   ) as HTMLButtonElement;
   setupRecoveryButton.onclick = async () => {
-    await setupRecovery(connection, userNumber);
-    renderManage(connection, userNumber);
+    await setupRecovery(userNumber, connection);
+    renderManage(userNumber, connection);
   };
-  renderDevices(connection, userNumber, devices);
+  renderDevices(userNumber, connection, devices);
 };
 
 const renderDevices = async (
-  connection: AuthenticatedConnection,
   userNumber: bigint,
+  connection: AuthenticatedConnection,
   devices: DeviceData[]
 ) => {
   const list = document.createElement("ul");
@@ -320,8 +320,8 @@ const renderDevices = async (
     if (buttonSettings !== null) {
       buttonSettings.onclick = async () => {
         await deviceSettings(
-          connection,
           userNumber,
+          connection,
           device,
           isOnlyDevice
         ).catch((e) =>
@@ -332,7 +332,7 @@ const renderDevices = async (
             primaryButton: "Ok",
           })
         );
-        await renderManage(connection, userNumber);
+        await renderManage(userNumber, connection);
       };
     }
     hasOwnProperty(device.purpose, "recovery")

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -1,5 +1,5 @@
 import { render, html } from "lit-html";
-import { AuthenticatedConnection, Connection } from "../../utils/iiConnection";
+import { AuthenticatedConnection } from "../../utils/iiConnection";
 import { withLoader } from "../../components/loader";
 import { initLogout, logoutSection } from "../../components/logout";
 import { navbar } from "../../components/navbar";

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -233,7 +233,7 @@ const recoveryNag = () => html`
 // Get the list of devices from canister and actually display the page
 export const renderManage = async (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
 
@@ -244,7 +244,7 @@ export const renderManage = async (
     await displayFailedToListDevices(
       error instanceof Error ? error : unknownError()
     );
-    return renderManage(connection,userNumber);
+    return renderManage(connection, userNumber);
   }
   if (anchorInfo.device_registration.length !== 0) {
     // we are actually in a device registration process

--- a/src/frontend/src/flows/recovery/displaySafariWarning.ts
+++ b/src/frontend/src/flows/recovery/displaySafariWarning.ts
@@ -53,24 +53,24 @@ const pageContent = () => html`
 `;
 
 export const displaySafariWarning = async (
-  connection: AuthenticatedConnection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: AuthenticatedConnection
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
-  return init(connection, userNumber);
+  return init(userNumber, connection);
 };
 
 const init = (
-  connection: AuthenticatedConnection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: AuthenticatedConnection
 ): Promise<void> =>
   new Promise((resolve) => {
     const displayWarningAddRecovery = document.getElementById(
       "displayWarningAddRecovery"
     ) as HTMLButtonElement;
     displayWarningAddRecovery.onclick = () => {
-      setupRecovery(connection, userNumber).then(() => resolve());
+      setupRecovery(userNumber, connection).then(() => resolve());
     };
     const displayWarningRemindLater = document.getElementById(
       "displayWarningRemindLater"

--- a/src/frontend/src/flows/recovery/displaySafariWarning.ts
+++ b/src/frontend/src/flows/recovery/displaySafariWarning.ts
@@ -1,7 +1,7 @@
 import { html, render } from "lit-html";
 import { warningIcon } from "../../components/icons";
 import { setupRecovery } from "./setupRecovery";
-import { IIConnection, Connection } from "../../utils/iiConnection";
+import { AuthenticatedConnection } from "../../utils/iiConnection";
 
 const pageContent = () => html`
   <style>
@@ -53,26 +53,24 @@ const pageContent = () => html`
 `;
 
 export const displaySafariWarning = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
-  return init(conn, userNumber, connection);
+  return init(connection, userNumber);
 };
 
 const init = (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection
 ): Promise<void> =>
   new Promise((resolve) => {
     const displayWarningAddRecovery = document.getElementById(
       "displayWarningAddRecovery"
     ) as HTMLButtonElement;
     displayWarningAddRecovery.onclick = () => {
-      setupRecovery(conn, userNumber, connection).then(() => resolve());
+      setupRecovery(connection, userNumber).then(() => resolve());
     };
     const displayWarningRemindLater = document.getElementById(
       "displayWarningRemindLater"

--- a/src/frontend/src/flows/recovery/displaySafariWarning.ts
+++ b/src/frontend/src/flows/recovery/displaySafariWarning.ts
@@ -54,7 +54,7 @@ const pageContent = () => html`
 
 export const displaySafariWarning = async (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
@@ -63,7 +63,7 @@ export const displaySafariWarning = async (
 
 const init = (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> =>
   new Promise((resolve) => {
     const displayWarningAddRecovery = document.getElementById(

--- a/src/frontend/src/flows/recovery/displaySafariWarning.ts
+++ b/src/frontend/src/flows/recovery/displaySafariWarning.ts
@@ -1,7 +1,7 @@
 import { html, render } from "lit-html";
 import { warningIcon } from "../../components/icons";
 import { setupRecovery } from "./setupRecovery";
-import { IIConnection } from "../../utils/iiConnection";
+import { IIConnection, Connection } from "../../utils/iiConnection";
 
 const pageContent = () => html`
   <style>
@@ -53,21 +53,26 @@ const pageContent = () => html`
 `;
 
 export const displaySafariWarning = async (
+  conn: Connection,
   userNumber: bigint,
   connection: IIConnection
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
-  return init(userNumber, connection);
+  return init(conn, userNumber, connection);
 };
 
-const init = (userNumber: bigint, connection: IIConnection): Promise<void> =>
+const init = (
+  conn: Connection,
+  userNumber: bigint,
+  connection: IIConnection
+): Promise<void> =>
   new Promise((resolve) => {
     const displayWarningAddRecovery = document.getElementById(
       "displayWarningAddRecovery"
     ) as HTMLButtonElement;
     displayWarningAddRecovery.onclick = () => {
-      setupRecovery(userNumber, connection).then(() => resolve());
+      setupRecovery(conn, userNumber, connection).then(() => resolve());
     };
     const displayWarningRemindLater = document.getElementById(
       "displayWarningRemindLater"

--- a/src/frontend/src/flows/recovery/displaySingleDeviceWarning.ts
+++ b/src/frontend/src/flows/recovery/displaySingleDeviceWarning.ts
@@ -54,7 +54,7 @@ const pageContent = () => html`
 
 export const displaySingleDeviceWarning = async (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
@@ -63,7 +63,7 @@ export const displaySingleDeviceWarning = async (
 
 const init = (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> =>
   new Promise((resolve) => {
     const displayWarningAddRecovery = document.getElementById(

--- a/src/frontend/src/flows/recovery/displaySingleDeviceWarning.ts
+++ b/src/frontend/src/flows/recovery/displaySingleDeviceWarning.ts
@@ -1,7 +1,7 @@
 import { html, render } from "lit-html";
 import { warningIcon } from "../../components/icons";
 import { setupRecovery } from "./setupRecovery";
-import { IIConnection } from "../../utils/iiConnection";
+import { IIConnection, Connection } from "../../utils/iiConnection";
 
 const pageContent = () => html`
   <style>
@@ -53,21 +53,26 @@ const pageContent = () => html`
 `;
 
 export const displaySingleDeviceWarning = async (
+  conn: Connection,
   userNumber: bigint,
   connection: IIConnection
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
-  return init(userNumber, connection);
+  return init(conn, userNumber, connection);
 };
 
-const init = (userNumber: bigint, connection: IIConnection): Promise<void> =>
+const init = (
+  conn: Connection,
+  userNumber: bigint,
+  connection: IIConnection
+): Promise<void> =>
   new Promise((resolve) => {
     const displayWarningAddRecovery = document.getElementById(
       "displayWarningAddRecovery"
     ) as HTMLButtonElement;
     displayWarningAddRecovery.onclick = () => {
-      setupRecovery(userNumber, connection).then(() => resolve());
+      setupRecovery(conn, userNumber, connection).then(() => resolve());
     };
     const displayWarningRemindLater = document.getElementById(
       "displayWarningRemindLater"

--- a/src/frontend/src/flows/recovery/displaySingleDeviceWarning.ts
+++ b/src/frontend/src/flows/recovery/displaySingleDeviceWarning.ts
@@ -53,24 +53,24 @@ const pageContent = () => html`
 `;
 
 export const displaySingleDeviceWarning = async (
-  connection: AuthenticatedConnection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: AuthenticatedConnection
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
-  return init(connection, userNumber);
+  return init(userNumber, connection);
 };
 
 const init = (
-  connection: AuthenticatedConnection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: AuthenticatedConnection
 ): Promise<void> =>
   new Promise((resolve) => {
     const displayWarningAddRecovery = document.getElementById(
       "displayWarningAddRecovery"
     ) as HTMLButtonElement;
     displayWarningAddRecovery.onclick = () => {
-      setupRecovery(connection, userNumber).then(() => resolve());
+      setupRecovery(userNumber, connection).then(() => resolve());
     };
     const displayWarningRemindLater = document.getElementById(
       "displayWarningRemindLater"

--- a/src/frontend/src/flows/recovery/displaySingleDeviceWarning.ts
+++ b/src/frontend/src/flows/recovery/displaySingleDeviceWarning.ts
@@ -1,7 +1,7 @@
 import { html, render } from "lit-html";
 import { warningIcon } from "../../components/icons";
 import { setupRecovery } from "./setupRecovery";
-import { IIConnection, Connection } from "../../utils/iiConnection";
+import { AuthenticatedConnection } from "../../utils/iiConnection";
 
 const pageContent = () => html`
   <style>
@@ -53,26 +53,24 @@ const pageContent = () => html`
 `;
 
 export const displaySingleDeviceWarning = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(), container);
-  return init(conn, userNumber, connection);
+  return init(connection, userNumber);
 };
 
 const init = (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection
 ): Promise<void> =>
   new Promise((resolve) => {
     const displayWarningAddRecovery = document.getElementById(
       "displayWarningAddRecovery"
     ) as HTMLButtonElement;
     displayWarningAddRecovery.onclick = () => {
-      setupRecovery(conn, userNumber, connection).then(() => resolve());
+      setupRecovery(connection, userNumber).then(() => resolve());
     };
     const displayWarningRemindLater = document.getElementById(
       "displayWarningRemindLater"

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -8,7 +8,7 @@ import {
   LoginFlowCanceled,
 } from "../../login/flowResult";
 import { DeviceData } from "../../../../generated/internet_identity_types";
-import { IIConnection, Connection } from "../../../utils/iiConnection";
+import { Connection } from "../../../utils/iiConnection";
 
 const pageContent = (userNumber: bigint) => html`
   <style>

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -29,18 +29,18 @@ const pageContent = (userNumber: bigint) => html`
 `;
 
 export const deviceRecoveryPage = async (
-  connection: Connection,
   userNumber: bigint,
+  connection: Connection,
   device: DeviceData
 ): Promise<LoginFlowSuccess | LoginFlowCanceled> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber), container);
-  return init(connection, userNumber, device);
+  return init(userNumber, connection, device);
 };
 
 const init = (
-  connection: Connection,
   userNumber: bigint,
+  connection: Connection,
   device: DeviceData
 ): Promise<LoginFlowSuccess | LoginFlowCanceled> =>
   new Promise((resolve) => {
@@ -59,7 +59,7 @@ const init = (
             break;
           case "err":
             await displayError({ ...result, primaryButton: "Try again" });
-            deviceRecoveryPage(connection, userNumber, device).then((res) =>
+            deviceRecoveryPage(userNumber, connection, device).then((res) =>
               resolve(res)
             );
             break;

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -8,7 +8,7 @@ import {
   LoginFlowCanceled,
 } from "../../login/flowResult";
 import { DeviceData } from "../../../../generated/internet_identity_types";
-import { IIConnection } from "../../../utils/iiConnection";
+import { IIConnection, Connection } from "../../../utils/iiConnection";
 
 const pageContent = (userNumber: bigint) => html`
   <style>
@@ -29,15 +29,17 @@ const pageContent = (userNumber: bigint) => html`
 `;
 
 export const deviceRecoveryPage = async (
+  conn: Connection,
   userNumber: bigint,
   device: DeviceData
 ): Promise<LoginFlowSuccess | LoginFlowCanceled> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber), container);
-  return init(userNumber, device);
+  return init(conn, userNumber, device);
 };
 
 const init = (
+  conn: Connection,
   userNumber: bigint,
   device: DeviceData
 ): Promise<LoginFlowSuccess | LoginFlowCanceled> =>
@@ -48,7 +50,7 @@ const init = (
     if (buttonContinue !== null) {
       buttonContinue.onclick = async () => {
         const result = apiResultToLoginFlowResult(
-          await IIConnection.fromWebauthnDevices(userNumber, [device])
+          await conn.fromWebauthnDevices(userNumber, [device])
         );
 
         switch (result.tag) {
@@ -57,7 +59,9 @@ const init = (
             break;
           case "err":
             await displayError({ ...result, primaryButton: "Try again" });
-            deviceRecoveryPage(userNumber, device).then((res) => resolve(res));
+            deviceRecoveryPage(conn, userNumber, device).then((res) =>
+              resolve(res)
+            );
             break;
           default:
             unreachable(result);

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -29,17 +29,17 @@ const pageContent = (userNumber: bigint) => html`
 `;
 
 export const deviceRecoveryPage = async (
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint,
   device: DeviceData
 ): Promise<LoginFlowSuccess | LoginFlowCanceled> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber), container);
-  return init(conn, userNumber, device);
+  return init(connection, userNumber, device);
 };
 
 const init = (
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint,
   device: DeviceData
 ): Promise<LoginFlowSuccess | LoginFlowCanceled> =>
@@ -50,7 +50,7 @@ const init = (
     if (buttonContinue !== null) {
       buttonContinue.onclick = async () => {
         const result = apiResultToLoginFlowResult(
-          await conn.fromWebauthnDevices(userNumber, [device])
+          await connection.fromWebauthnDevices(userNumber, [device])
         );
 
         switch (result.tag) {
@@ -59,7 +59,7 @@ const init = (
             break;
           case "err":
             await displayError({ ...result, primaryButton: "Try again" });
-            deviceRecoveryPage(conn, userNumber, device).then((res) =>
+            deviceRecoveryPage(connection, userNumber, device).then((res) =>
               resolve(res)
             );
             break;

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -108,20 +108,20 @@ const pageContent = (userNumber: bigint, message?: string) => html`
 `;
 
 export const phraseRecoveryPage = async (
-  connection: Connection,
   userNumber: bigint,
+  connection: Connection,
   device: DeviceData,
   prefilledPhrase?: string,
   message?: string
 ): Promise<LoginFlowSuccess | LoginFlowCanceled> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber, message), container);
-  return init(connection, userNumber, device, prefilledPhrase);
+  return init(userNumber, connection, device, prefilledPhrase);
 };
 
 const init = (
-  connection: Connection,
   userNumber: bigint,
+  connection: Connection,
   device: DeviceData,
   prefilledPhrase?: string /* if set, prefilled as input */,
   message?: string
@@ -197,8 +197,8 @@ const init = (
         case "err":
           await displayError({ ...result, primaryButton: "Try again" });
           phraseRecoveryPage(
-            connection,
             userNumber,
+            connection,
             device,
             inputValue,
             message

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -7,7 +7,7 @@ import {
   LoginFlowSuccess,
 } from "../../login/flowResult";
 import { dropLeadingUserNumber } from "../../../crypto/mnemonic";
-import { IIConnection, Connection } from "../../../utils/iiConnection";
+import { Connection } from "../../../utils/iiConnection";
 import { displayError } from "../../../components/displayError";
 import { unreachable } from "../../../utils/utils";
 import {

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -108,7 +108,7 @@ const pageContent = (userNumber: bigint, message?: string) => html`
 `;
 
 export const phraseRecoveryPage = async (
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint,
   device: DeviceData,
   prefilledPhrase?: string,
@@ -116,11 +116,11 @@ export const phraseRecoveryPage = async (
 ): Promise<LoginFlowSuccess | LoginFlowCanceled> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(userNumber, message), container);
-  return init(conn, userNumber, device, prefilledPhrase);
+  return init(connection, userNumber, device, prefilledPhrase);
 };
 
 const init = (
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint,
   device: DeviceData,
   prefilledPhrase?: string /* if set, prefilled as input */,
@@ -187,7 +187,7 @@ const init = (
       const inputValue = inputSeedPhraseInput.value.trim();
       const mnemonic = dropLeadingUserNumber(inputValue);
       const result = apiResultToLoginFlowResult(
-        await conn.fromSeedPhrase(userNumber, mnemonic, device)
+        await connection.fromSeedPhrase(userNumber, mnemonic, device)
       );
 
       switch (result.tag) {
@@ -197,7 +197,7 @@ const init = (
         case "err":
           await displayError({ ...result, primaryButton: "Try again" });
           phraseRecoveryPage(
-            conn,
+            connection,
             userNumber,
             device,
             inputValue,

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -5,36 +5,36 @@ import { displaySafariWarning } from "./displaySafariWarning";
 import { iOSOrSafari } from "../../utils/utils";
 
 export const recoveryWizard = async (
-  connection: AuthenticatedConnection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: AuthenticatedConnection
 ): Promise<void> =>
   iOSOrSafari()
-    ? await recoveryWizardSafari(connection, userNumber)
-    : await recoveryWizardDefault(connection, userNumber);
+    ? await recoveryWizardSafari(userNumber, connection)
+    : await recoveryWizardDefault(userNumber, connection);
 
 const recoveryWizardSafari = async (
-  connection: AuthenticatedConnection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: AuthenticatedConnection
 ): Promise<void> => {
   // Here, we let the user know about the quirks of Safari. The menu will take
   // them to the device picker, if they choose to.
   if ((await connection.lookupRecovery(userNumber)).length === 0) {
-    await displaySafariWarning(connection, userNumber);
+    await displaySafariWarning(userNumber, connection);
   }
 };
 
 const recoveryWizardDefault = async (
-  connection: AuthenticatedConnection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: AuthenticatedConnection
 ): Promise<void> => {
   // Here, if the user doesn't have any recovery device, we prompt them to add
   // one. If after returning from the prompt they still haven't added one, then
   // we display a big warning with full explanation about the risks of having a
   // single authentication device and not having a recovery device.
   if ((await connection.lookupRecovery(userNumber)).length === 0) {
-    await setupRecovery(connection, userNumber);
+    await setupRecovery(userNumber, connection);
     if ((await connection.lookupRecovery(userNumber)).length === 0) {
-      await displaySingleDeviceWarning(connection, userNumber);
+      await displaySingleDeviceWarning(userNumber, connection);
     }
   }
 };

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -6,7 +6,7 @@ import { iOSOrSafari } from "../../utils/utils";
 
 export const recoveryWizard = async (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> =>
   iOSOrSafari()
     ? await recoveryWizardSafari(connection, userNumber)
@@ -14,7 +14,7 @@ export const recoveryWizard = async (
 
 const recoveryWizardSafari = async (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> => {
   // Here, we let the user know about the quirks of Safari. The menu will take
   // them to the device picker, if they choose to.
@@ -25,7 +25,7 @@ const recoveryWizardSafari = async (
 
 const recoveryWizardDefault = async (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> => {
   // Here, if the user doesn't have any recovery device, we prompt them to add
   // one. If after returning from the prompt they still haven't added one, then

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -1,29 +1,32 @@
-import { IIConnection } from "../../utils/iiConnection";
+import { IIConnection, Connection } from "../../utils/iiConnection";
 import { setupRecovery } from "./setupRecovery";
 import { displaySingleDeviceWarning } from "./displaySingleDeviceWarning";
 import { displaySafariWarning } from "./displaySafariWarning";
 import { iOSOrSafari } from "../../utils/utils";
 
 export const recoveryWizard = async (
+  conn: Connection,
   userNumber: bigint,
   connection: IIConnection
 ): Promise<void> =>
   iOSOrSafari()
-    ? await recoveryWizardSafari(userNumber, connection)
-    : await recoveryWizardDefault(userNumber, connection);
+    ? await recoveryWizardSafari(conn, userNumber, connection)
+    : await recoveryWizardDefault(conn, userNumber, connection);
 
 const recoveryWizardSafari = async (
+  conn: Connection,
   userNumber: bigint,
   connection: IIConnection
 ): Promise<void> => {
   // Here, we let the user know about the quirks of Safari. The menu will take
   // them to the device picker, if they choose to.
-  if ((await IIConnection.lookupRecovery(userNumber)).length === 0) {
-    await displaySafariWarning(userNumber, connection);
+  if ((await conn.lookupRecovery(userNumber)).length === 0) {
+    await displaySafariWarning(conn, userNumber, connection);
   }
 };
 
 const recoveryWizardDefault = async (
+  conn: Connection,
   userNumber: bigint,
   connection: IIConnection
 ): Promise<void> => {
@@ -31,10 +34,10 @@ const recoveryWizardDefault = async (
   // one. If after returning from the prompt they still haven't added one, then
   // we display a big warning with full explanation about the risks of having a
   // single authentication device and not having a recovery device.
-  if ((await IIConnection.lookupRecovery(userNumber)).length === 0) {
-    await setupRecovery(userNumber, connection);
-    if ((await IIConnection.lookupRecovery(userNumber)).length === 0) {
-      await displaySingleDeviceWarning(userNumber, connection);
+  if ((await conn.lookupRecovery(userNumber)).length === 0) {
+    await setupRecovery(conn, userNumber, connection);
+    if ((await conn.lookupRecovery(userNumber)).length === 0) {
+      await displaySingleDeviceWarning(conn, userNumber, connection);
     }
   }
 };

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -1,43 +1,40 @@
-import { IIConnection, Connection } from "../../utils/iiConnection";
+import { AuthenticatedConnection } from "../../utils/iiConnection";
 import { setupRecovery } from "./setupRecovery";
 import { displaySingleDeviceWarning } from "./displaySingleDeviceWarning";
 import { displaySafariWarning } from "./displaySafariWarning";
 import { iOSOrSafari } from "../../utils/utils";
 
 export const recoveryWizard = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection
 ): Promise<void> =>
   iOSOrSafari()
-    ? await recoveryWizardSafari(conn, userNumber, connection)
-    : await recoveryWizardDefault(conn, userNumber, connection);
+    ? await recoveryWizardSafari(connection, userNumber)
+    : await recoveryWizardDefault(connection, userNumber);
 
 const recoveryWizardSafari = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection
 ): Promise<void> => {
   // Here, we let the user know about the quirks of Safari. The menu will take
   // them to the device picker, if they choose to.
-  if ((await conn.lookupRecovery(userNumber)).length === 0) {
-    await displaySafariWarning(conn, userNumber, connection);
+  if ((await connection.lookupRecovery(userNumber)).length === 0) {
+    await displaySafariWarning(connection, userNumber);
   }
 };
 
 const recoveryWizardDefault = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection
 ): Promise<void> => {
   // Here, if the user doesn't have any recovery device, we prompt them to add
   // one. If after returning from the prompt they still haven't added one, then
   // we display a big warning with full explanation about the risks of having a
   // single authentication device and not having a recovery device.
-  if ((await conn.lookupRecovery(userNumber)).length === 0) {
-    await setupRecovery(conn, userNumber, connection);
-    if ((await conn.lookupRecovery(userNumber)).length === 0) {
-      await displaySingleDeviceWarning(conn, userNumber, connection);
+  if ((await connection.lookupRecovery(userNumber)).length === 0) {
+    await setupRecovery(connection, userNumber);
+    if ((await connection.lookupRecovery(userNumber)).length === 0) {
+      await displaySingleDeviceWarning(connection, userNumber);
     }
   }
 };

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -14,7 +14,7 @@ import { displaySeedPhrase } from "./displaySeedPhrase";
 
 export const setupRecovery = async (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> => {
   const devices = await connection.lookupAll(userNumber);
   const recoveryMechanism = await chooseRecoveryMechanism(devices);

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -13,8 +13,8 @@ import { chooseRecoveryMechanism } from "./chooseRecoveryMechanism";
 import { displaySeedPhrase } from "./displaySeedPhrase";
 
 export const setupRecovery = async (
-  connection: AuthenticatedConnection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: AuthenticatedConnection
 ): Promise<void> => {
   const devices = await connection.lookupAll(userNumber);
   const recoveryMechanism = await chooseRecoveryMechanism(devices);
@@ -39,7 +39,7 @@ export const setupRecovery = async (
             detail: unknownToString(err, "Unknown error"),
             primaryButton: "Try a different method",
           });
-          return setupRecovery(connection, userNumber);
+          return setupRecovery(userNumber, connection);
         }
 
         return await withLoader(() =>

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -7,16 +7,18 @@ import {
   creationOptions,
   IC_DERIVATION_PATH,
   IIConnection,
+  Connection,
 } from "../../utils/iiConnection";
 import { unknownToString } from "../../utils/utils";
 import { chooseRecoveryMechanism } from "./chooseRecoveryMechanism";
 import { displaySeedPhrase } from "./displaySeedPhrase";
 
 export const setupRecovery = async (
+  conn: Connection,
   userNumber: bigint,
   connection: IIConnection
 ): Promise<void> => {
-  const devices = await IIConnection.lookupAll(userNumber);
+  const devices = await conn.lookupAll(userNumber);
   const recoveryMechanism = await chooseRecoveryMechanism(devices);
   if (recoveryMechanism === null) {
     return;
@@ -39,7 +41,7 @@ export const setupRecovery = async (
             detail: unknownToString(err, "Unknown error"),
             primaryButton: "Try a different method",
           });
-          return setupRecovery(userNumber, connection);
+          return setupRecovery(conn, userNumber, connection);
         }
 
         return await withLoader(() =>

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -6,19 +6,17 @@ import { generate } from "../../crypto/mnemonic";
 import {
   creationOptions,
   IC_DERIVATION_PATH,
-  IIConnection,
-  Connection,
+  AuthenticatedConnection,
 } from "../../utils/iiConnection";
 import { unknownToString } from "../../utils/utils";
 import { chooseRecoveryMechanism } from "./chooseRecoveryMechanism";
 import { displaySeedPhrase } from "./displaySeedPhrase";
 
 export const setupRecovery = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection
 ): Promise<void> => {
-  const devices = await conn.lookupAll(userNumber);
+  const devices = await connection.lookupAll(userNumber);
   const recoveryMechanism = await chooseRecoveryMechanism(devices);
   if (recoveryMechanism === null) {
     return;
@@ -41,7 +39,7 @@ export const setupRecovery = async (
             detail: unknownToString(err, "Unknown error"),
             primaryButton: "Try a different method",
           });
-          return setupRecovery(conn, userNumber, connection);
+          return setupRecovery(connection, userNumber);
         }
 
         return await withLoader(() =>

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -8,15 +8,15 @@ import { deviceRecoveryPage } from "./recoverWith/device";
 import { pickRecoveryDevice } from "./pickRecoveryDevice";
 
 export const useRecovery = async (
-  conn: Connection,
+  connection: Connection,
   userNumber?: bigint
 ): Promise<void> => {
   if (userNumber !== undefined) {
-    return runRecovery(conn, userNumber);
+    return runRecovery(connection, userNumber);
   } else {
     const pUserNumber = await promptUserNumber("Recover Identity Anchor", null);
     if (pUserNumber !== null) {
-      return runRecovery(conn, pUserNumber);
+      return runRecovery(connection, pUserNumber);
     } else {
       return window.location.reload();
     }
@@ -24,10 +24,10 @@ export const useRecovery = async (
 };
 
 const runRecovery = async (
-  conn: Connection,
+  connection: Connection,
   userNumber: bigint
 ): Promise<void> => {
-  const recoveryDevices = await conn.lookupRecovery(userNumber);
+  const recoveryDevices = await connection.lookupRecovery(userNumber);
   if (recoveryDevices.length === 0) {
     await displayError({
       title: "Failed to recover",
@@ -44,13 +44,13 @@ const runRecovery = async (
       : await pickRecoveryDevice(recoveryDevices);
 
   const res = hasOwnProperty(device.key_type, "seed_phrase")
-    ? await phraseRecoveryPage(conn, userNumber, device)
-    : await deviceRecoveryPage(conn, userNumber, device);
+    ? await phraseRecoveryPage(connection, userNumber, device)
+    : await deviceRecoveryPage(connection, userNumber, device);
 
   // If res is null, the user canceled the flow, so we go back to the main page.
   if (res.tag === "canceled") {
     return window.location.reload();
   }
 
-  renderManage(conn, res.userNumber, res.connection);
+  renderManage(res.connection, res.userNumber);
 };

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -12,11 +12,11 @@ export const useRecovery = async (
   userNumber?: bigint
 ): Promise<void> => {
   if (userNumber !== undefined) {
-    return runRecovery(connection, userNumber);
+    return runRecovery(userNumber, connection);
   } else {
     const pUserNumber = await promptUserNumber("Recover Identity Anchor", null);
     if (pUserNumber !== null) {
-      return runRecovery(connection, pUserNumber);
+      return runRecovery(pUserNumber, connection);
     } else {
       return window.location.reload();
     }
@@ -24,8 +24,8 @@ export const useRecovery = async (
 };
 
 const runRecovery = async (
-  connection: Connection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: Connection
 ): Promise<void> => {
   const recoveryDevices = await connection.lookupRecovery(userNumber);
   if (recoveryDevices.length === 0) {
@@ -44,13 +44,13 @@ const runRecovery = async (
       : await pickRecoveryDevice(recoveryDevices);
 
   const res = hasOwnProperty(device.key_type, "seed_phrase")
-    ? await phraseRecoveryPage(connection, userNumber, device)
-    : await deviceRecoveryPage(connection, userNumber, device);
+    ? await phraseRecoveryPage(userNumber, connection, device)
+    : await deviceRecoveryPage(userNumber, connection, device);
 
   // If res is null, the user canceled the flow, so we go back to the main page.
   if (res.tag === "canceled") {
     return window.location.reload();
   }
 
-  renderManage(res.connection, res.userNumber);
+  renderManage(res.userNumber, res.connection);
 };

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -1,5 +1,5 @@
 import { displayError } from "../../components/displayError";
-import { IIConnection, Connection } from "../../utils/iiConnection";
+import { Connection } from "../../utils/iiConnection";
 import { hasOwnProperty } from "../../utils/utils";
 import { renderManage } from "../manage";
 import { promptUserNumber } from "../promptUserNumber";

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -1,5 +1,5 @@
 import { displayError } from "../../components/displayError";
-import { IIConnection } from "../../utils/iiConnection";
+import { IIConnection, Connection } from "../../utils/iiConnection";
 import { hasOwnProperty } from "../../utils/utils";
 import { renderManage } from "../manage";
 import { promptUserNumber } from "../promptUserNumber";
@@ -7,21 +7,27 @@ import { phraseRecoveryPage } from "./recoverWith/phrase";
 import { deviceRecoveryPage } from "./recoverWith/device";
 import { pickRecoveryDevice } from "./pickRecoveryDevice";
 
-export const useRecovery = async (userNumber?: bigint): Promise<void> => {
+export const useRecovery = async (
+  conn: Connection,
+  userNumber?: bigint
+): Promise<void> => {
   if (userNumber !== undefined) {
-    return runRecovery(userNumber);
+    return runRecovery(conn, userNumber);
   } else {
     const pUserNumber = await promptUserNumber("Recover Identity Anchor", null);
     if (pUserNumber !== null) {
-      return runRecovery(pUserNumber);
+      return runRecovery(conn, pUserNumber);
     } else {
       return window.location.reload();
     }
   }
 };
 
-const runRecovery = async (userNumber: bigint): Promise<void> => {
-  const recoveryDevices = await IIConnection.lookupRecovery(userNumber);
+const runRecovery = async (
+  conn: Connection,
+  userNumber: bigint
+): Promise<void> => {
+  const recoveryDevices = await conn.lookupRecovery(userNumber);
   if (recoveryDevices.length === 0) {
     await displayError({
       title: "Failed to recover",
@@ -38,13 +44,13 @@ const runRecovery = async (userNumber: bigint): Promise<void> => {
       : await pickRecoveryDevice(recoveryDevices);
 
   const res = hasOwnProperty(device.key_type, "seed_phrase")
-    ? await phraseRecoveryPage(userNumber, device)
-    : await deviceRecoveryPage(userNumber, device);
+    ? await phraseRecoveryPage(conn, userNumber, device)
+    : await deviceRecoveryPage(conn, userNumber, device);
 
   // If res is null, the user canceled the flow, so we go back to the main page.
   if (res.tag === "canceled") {
     return window.location.reload();
   }
 
-  renderManage(res.userNumber, res.connection);
+  renderManage(conn, res.userNumber, res.connection);
 };

--- a/src/frontend/src/flows/register.ts
+++ b/src/frontend/src/flows/register.ts
@@ -36,11 +36,11 @@ const constructingContent = html`
 `;
 
 export const register = async (
-  conn: Connection
+  connection: Connection
 ): Promise<LoginFlowResult | null> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent, container);
-  return init(conn);
+  return init(connection);
 };
 
 const renderConstructing = () => {
@@ -48,7 +48,7 @@ const renderConstructing = () => {
   render(constructingContent, container);
 };
 
-const init = (conn: Connection): Promise<LoginFlowResult | null> =>
+const init = (connection: Connection): Promise<LoginFlowResult | null> =>
   new Promise((resolve, reject) => {
     const form = document.getElementById("registerForm") as HTMLFormElement;
     const registerCancel = document.getElementById(
@@ -81,7 +81,7 @@ const init = (conn: Connection): Promise<LoginFlowResult | null> =>
       try {
         // Kick-start both the captcha creation and the identity
         Promise.all([
-          makeCaptcha(conn),
+          makeCaptcha(connection),
           createIdentity() as Promise<IdentifiableIdentity>,
         ])
           .catch((error) => {
@@ -91,7 +91,7 @@ const init = (conn: Connection): Promise<LoginFlowResult | null> =>
           })
           .then(([captcha, identity]) => {
             confirmRegister(
-              conn,
+              connection,
               Promise.resolve(captcha),
               identity,
               alias

--- a/src/frontend/src/flows/register.ts
+++ b/src/frontend/src/flows/register.ts
@@ -5,6 +5,7 @@ import {
   IdentifiableIdentity,
   DummyIdentity,
   creationOptions,
+  Connection,
 } from "../utils/iiConnection";
 import { confirmRegister, makeCaptcha } from "./confirmRegister";
 import {
@@ -34,10 +35,12 @@ const constructingContent = html`
   </div>
 `;
 
-export const register = async (): Promise<LoginFlowResult | null> => {
+export const register = async (
+  conn: Connection
+): Promise<LoginFlowResult | null> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent, container);
-  return init();
+  return init(conn);
 };
 
 const renderConstructing = () => {
@@ -45,7 +48,7 @@ const renderConstructing = () => {
   render(constructingContent, container);
 };
 
-const init = (): Promise<LoginFlowResult | null> =>
+const init = (conn: Connection): Promise<LoginFlowResult | null> =>
   new Promise((resolve, reject) => {
     const form = document.getElementById("registerForm") as HTMLFormElement;
     const registerCancel = document.getElementById(
@@ -78,7 +81,7 @@ const init = (): Promise<LoginFlowResult | null> =>
       try {
         // Kick-start both the captcha creation and the identity
         Promise.all([
-          makeCaptcha(),
+          makeCaptcha(conn),
           createIdentity() as Promise<IdentifiableIdentity>,
         ])
           .catch((error) => {
@@ -87,9 +90,12 @@ const init = (): Promise<LoginFlowResult | null> =>
             return 0 as unknown as [Challenge, IdentifiableIdentity];
           })
           .then(([captcha, identity]) => {
-            confirmRegister(Promise.resolve(captcha), identity, alias).then(
-              resolve
-            );
+            confirmRegister(
+              conn,
+              Promise.resolve(captcha),
+              identity,
+              alias
+            ).then(resolve);
           });
       } catch (err) {
         reject(err);

--- a/src/frontend/src/flows/successfulDeviceAddition.ts
+++ b/src/frontend/src/flows/successfulDeviceAddition.ts
@@ -1,6 +1,6 @@
 import { html, render } from "lit-html";
 import { initLogout, logoutSection } from "../components/logout";
-import { AuthenticatedConnection, Connection } from "../utils/iiConnection";
+import { AuthenticatedConnection } from "../utils/iiConnection";
 import { renderManage } from "./manage";
 
 const pageContent = (name: string) => html`

--- a/src/frontend/src/flows/successfulDeviceAddition.ts
+++ b/src/frontend/src/flows/successfulDeviceAddition.ts
@@ -17,7 +17,7 @@ const pageContent = (name: string) => html`
 export const successfullyAddedDevice = async (
   connection: AuthenticatedConnection,
   name: string,
-  userNumber: bigint,
+  userNumber: bigint
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(name), container);
@@ -27,11 +27,10 @@ export const successfullyAddedDevice = async (
 
 const init = async (
   connection: AuthenticatedConnection,
-  userNumber: bigint,
+  userNumber: bigint
 ) => {
   const manageDevicesButton = document.getElementById(
     "manageDevicesButton"
   ) as HTMLButtonElement;
-  manageDevicesButton.onclick = () =>
-    renderManage(connection, userNumber);
+  manageDevicesButton.onclick = () => renderManage(connection, userNumber);
 };

--- a/src/frontend/src/flows/successfulDeviceAddition.ts
+++ b/src/frontend/src/flows/successfulDeviceAddition.ts
@@ -22,15 +22,15 @@ export const successfullyAddedDevice = async (
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(name), container);
   initLogout();
-  init(connection, userNumber);
+  init(userNumber, connection);
 };
 
 const init = async (
-  connection: AuthenticatedConnection,
-  userNumber: bigint
+  userNumber: bigint,
+  connection: AuthenticatedConnection
 ) => {
   const manageDevicesButton = document.getElementById(
     "manageDevicesButton"
   ) as HTMLButtonElement;
-  manageDevicesButton.onclick = () => renderManage(connection, userNumber);
+  manageDevicesButton.onclick = () => renderManage(userNumber, connection);
 };

--- a/src/frontend/src/flows/successfulDeviceAddition.ts
+++ b/src/frontend/src/flows/successfulDeviceAddition.ts
@@ -1,6 +1,6 @@
 import { html, render } from "lit-html";
 import { initLogout, logoutSection } from "../components/logout";
-import { IIConnection, Connection } from "../utils/iiConnection";
+import { AuthenticatedConnection, Connection } from "../utils/iiConnection";
 import { renderManage } from "./manage";
 
 const pageContent = (name: string) => html`
@@ -15,25 +15,23 @@ const pageContent = (name: string) => html`
 `;
 
 export const successfullyAddedDevice = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   name: string,
   userNumber: bigint,
-  connection: IIConnection
 ): Promise<void> => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(name), container);
   initLogout();
-  init(conn, userNumber, connection);
+  init(connection, userNumber);
 };
 
 const init = async (
-  conn: Connection,
+  connection: AuthenticatedConnection,
   userNumber: bigint,
-  connection: IIConnection
 ) => {
   const manageDevicesButton = document.getElementById(
     "manageDevicesButton"
   ) as HTMLButtonElement;
   manageDevicesButton.onclick = () =>
-    renderManage(conn, userNumber, connection);
+    renderManage(connection, userNumber);
 };

--- a/src/frontend/src/flows/successfulDeviceAddition.ts
+++ b/src/frontend/src/flows/successfulDeviceAddition.ts
@@ -1,6 +1,6 @@
 import { html, render } from "lit-html";
 import { initLogout, logoutSection } from "../components/logout";
-import { IIConnection } from "../utils/iiConnection";
+import { IIConnection, Connection } from "../utils/iiConnection";
 import { renderManage } from "./manage";
 
 const pageContent = (name: string) => html`
@@ -15,6 +15,7 @@ const pageContent = (name: string) => html`
 `;
 
 export const successfullyAddedDevice = async (
+  conn: Connection,
   name: string,
   userNumber: bigint,
   connection: IIConnection
@@ -22,12 +23,17 @@ export const successfullyAddedDevice = async (
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(name), container);
   initLogout();
-  init(userNumber, connection);
+  init(conn, userNumber, connection);
 };
 
-const init = async (userNumber: bigint, connection: IIConnection) => {
+const init = async (
+  conn: Connection,
+  userNumber: bigint,
+  connection: IIConnection
+) => {
   const manageDevicesButton = document.getElementById(
     "manageDevicesButton"
   ) as HTMLButtonElement;
-  manageDevicesButton.onclick = () => renderManage(userNumber, connection);
+  manageDevicesButton.onclick = () =>
+    renderManage(conn, userNumber, connection);
 };

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -67,18 +67,17 @@ const init = async () => {
   const userIntent = intentFromUrl(url);
 
   // TODO: proper error handling
-  const conn = new Connection(readCanisterId());
+  const connection = new Connection(readCanisterId());
 
   switch (userIntent.kind) {
     // Authenticate to a third party service
     case "auth": {
       // show the application 'authorize authentication' screen. The user can authenticate, create a new anchor or jump to other pages to recover and manage.
-      const authSuccess = await authorizeAuthentication(conn);
+      const authSuccess = await authorizeAuthentication(connection);
       // show the recovery wizard before sending the window post message, otherwise the II window will be closed
       await recoveryWizard(
-        conn,
+        authSuccess.connection,
         authSuccess.userNumber,
-        authSuccess.connection
       );
       // send the delegation back to the dapp window (which will then close the II window)
       authSuccess.sendDelegationMessage();
@@ -87,12 +86,12 @@ const init = async () => {
     // Open the management page
     case "manage": {
       // Go through the login flow, potentially creating an anchor.
-      const { userNumber, connection } = await login(conn);
+      const { userNumber, connection } = await login(connection);
       // Here, if the user doesn't have any recovery device, we prompt them to add
       // one. The exact flow depends on the device they use.
-      await recoveryWizard(conn, userNumber, connection);
+      await recoveryWizard(connection, userNumber);
       // From here on, the user is authenticated to II.
-      return renderManage(conn, userNumber, connection);
+      return renderManage(connection, userNumber);
     }
   }
 };

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -17,7 +17,6 @@ import { Connection } from "./utils/iiConnection";
  * The canister injects the canister ID as a `data-canister-id` attribute on the script tag, which we then read to figure out where to make the IC calls.
  */
 const readCanisterId = (): string => {
-
   // The backend uses a known element ID so that we can pick up the value from here
   const setupJs = document.querySelector("#setupJs") as HTMLElement;
   if (setupJs === null || setupJs.dataset.canisterId === undefined) {

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -18,7 +18,7 @@ import { Connection } from "./utils/iiConnection";
  */
 const readCanisterId = (): string => {
   // The backend uses a known element ID so that we can pick up the value from here
-  const setupJs = document.querySelector("#setupJs") as HTMLElement;
+  const setupJs = document.querySelector("#setupJs") as HTMLElement | null;
   if (setupJs === null || setupJs.dataset.canisterId === undefined) {
     displayError({
       title: "Canister ID not set",

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -12,9 +12,15 @@ import authorizeAuthentication from "./flows/authenticate";
 import { displayError } from "./components/displayError";
 import { Connection } from "./utils/iiConnection";
 
+/** Reads the canister ID from the <script> tag.
+ *
+ * The canister injects the canister ID as a `data-canister-id` attribute on the script tag, which we then read to figure out where to make the IC calls.
+ */
 const readCanisterId = (): string => {
+
+  // The backend uses a known element ID so that we can pick up the value from here
   const setupJs = document.querySelector("#setupJs") as HTMLElement;
-  if (setupJs === null) {
+  if (setupJs === null || setupJs.dataset.canisterId === undefined) {
     displayError({
       title: "Canister ID not set",
       message:
@@ -26,21 +32,7 @@ const readCanisterId = (): string => {
     throw new Error("canisterId is undefined"); // abort further execution of this script
   }
 
-  const canisterId = setupJs.dataset.canisterId;
-
-  if (canisterId === undefined) {
-    displayError({
-      title: "Canister ID not set",
-      message:
-        "There was a problem contacting the IC. The host serving this page did not give us a canister ID. Try reloading the page and contact support if the problem persists.",
-      primaryButton: "Reload",
-    }).then(() => {
-      window.location.reload();
-    });
-    throw new Error("canisterId is undefined"); // abort further execution of this script
-  }
-
-  return canisterId;
+  return setupJs.dataset.canisterId;
 };
 
 const init = async () => {
@@ -66,7 +58,7 @@ const init = async () => {
 
   const userIntent = intentFromUrl(url);
 
-  // TODO: proper error handling
+  // Prepare the actor/connection to talk to the canister
   const connection = new Connection(readCanisterId());
 
   switch (userIntent.kind) {

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -75,7 +75,7 @@ const init = async () => {
       // show the application 'authorize authentication' screen. The user can authenticate, create a new anchor or jump to other pages to recover and manage.
       const authSuccess = await authorizeAuthentication(connection);
       // show the recovery wizard before sending the window post message, otherwise the II window will be closed
-      await recoveryWizard(authSuccess.connection, authSuccess.userNumber);
+      await recoveryWizard(authSuccess.userNumber, authSuccess.connection);
       // send the delegation back to the dapp window (which will then close the II window)
       authSuccess.sendDelegationMessage();
       return;
@@ -83,12 +83,14 @@ const init = async () => {
     // Open the management page
     case "manage": {
       // Go through the login flow, potentially creating an anchor.
-      const { userNumber, connection } = await login(connection);
+      const { userNumber, connection: authenticatedConnection } = await login(
+        connection
+      );
       // Here, if the user doesn't have any recovery device, we prompt them to add
       // one. The exact flow depends on the device they use.
-      await recoveryWizard(connection, userNumber);
+      await recoveryWizard(userNumber, authenticatedConnection);
       // From here on, the user is authenticated to II.
-      return renderManage(connection, userNumber);
+      return renderManage(userNumber, authenticatedConnection);
     }
   }
 };

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -75,10 +75,7 @@ const init = async () => {
       // show the application 'authorize authentication' screen. The user can authenticate, create a new anchor or jump to other pages to recover and manage.
       const authSuccess = await authorizeAuthentication(connection);
       // show the recovery wizard before sending the window post message, otherwise the II window will be closed
-      await recoveryWizard(
-        authSuccess.connection,
-        authSuccess.userNumber,
-      );
+      await recoveryWizard(authSuccess.connection, authSuccess.userNumber);
       // send the delegation back to the dapp window (which will then close the II window)
       authSuccess.sendDelegationMessage();
       return;

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -9,6 +9,40 @@ import { checkRequiredFeatures } from "./utils/featureDetection";
 import { recoveryWizard } from "./flows/recovery/recoveryWizard";
 import { showWarningIfNecessary } from "./banner";
 import authorizeAuthentication from "./flows/authenticate";
+import { displayError } from "./components/displayError";
+
+const readCanisterId = (): string => {
+
+    const setupJs = document.querySelector("#setupJs") as HTMLElement;
+    if(setupJs === null) {
+
+        displayError({
+            title: "Canister ID not set",
+            message:
+                "There was a problem contacting the IC. The host serving this page did not give us a canister ID. Try reloading the page and contact support if the problem persists.",
+            primaryButton: "Reload",
+        }).then(() => {
+            window.location.reload();
+        });
+        throw new Error("canisterId is undefined"); // abort further execution of this script
+    }
+
+    const canisterId = setupJs.dataset.canisterId;
+
+    if(canisterId === undefined) {
+        displayError({
+            title: "Canister ID not set",
+            message:
+                "There was a problem contacting the IC. The host serving this page did not give us a canister ID. Try reloading the page and contact support if the problem persists.",
+            primaryButton: "Reload",
+        }).then(() => {
+            window.location.reload();
+        });
+        throw new Error("canisterId is undefined"); // abort further execution of this script
+    }
+
+    return canisterId;
+}
 
 const init = async () => {
   const url = new URL(document.URL);

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -38,7 +38,6 @@ import { Principal } from "@dfinity/principal";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 import { hasOwnProperty } from "./utils";
 import * as tweetnacl from "tweetnacl";
-import { displayError } from "../components/displayError";
 import { fromMnemonicWithoutValidation } from "../crypto/ed25519";
 import { features } from "../features";
 
@@ -348,20 +347,20 @@ export class Connection {
   };
 
   requestFEDelegation = async (
-      identity: SignIdentity
+    identity: SignIdentity
   ): Promise<DelegationIdentity> => {
-      const sessionKey = Ed25519KeyIdentity.generate();
-      const tenMinutesInMsec = 10 * 1000 * 60;
-      // Here the security device is used. Besides creating new keys, this is the only place.
-      const chain = await DelegationChain.create(
-          identity,
-          sessionKey.getPublicKey(),
-          new Date(Date.now() + tenMinutesInMsec),
-          {
-              targets: [Principal.from(this.canisterId)],
-          }
-      );
-      return DelegationIdentity.fromDelegation(sessionKey, chain);
+    const sessionKey = Ed25519KeyIdentity.generate();
+    const tenMinutesInMsec = 10 * 1000 * 60;
+    // Here the security device is used. Besides creating new keys, this is the only place.
+    const chain = await DelegationChain.create(
+      identity,
+      sessionKey.getPublicKey(),
+      new Date(Date.now() + tenMinutesInMsec),
+      {
+        targets: [Principal.from(this.canisterId)],
+      }
+    );
+    return DelegationIdentity.fromDelegation(sessionKey, chain);
   };
 }
 
@@ -495,7 +494,6 @@ export class AuthenticatedConnection extends Connection {
     );
   };
 }
-
 
 // The options sent to the browser when creating the credentials.
 // Credentials (key pair) creation is signed with a private key that is unique per device

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -378,7 +378,9 @@ export class IIConnection extends Connection {
     public delegationIdentity: DelegationIdentity,
     public userNumber: bigint,
     public actor?: ActorSubclass<_SERVICE>
-  ) { super(connection.canisterId); }
+  ) {
+    super(connection.canisterId);
+  }
   async getActor(): Promise<ActorSubclass<_SERVICE>> {
     for (const { delegation } of this.delegationIdentity.getDelegation()
       .delegations) {

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -117,9 +117,7 @@ export interface IdentifiableIdentity extends SignIdentity {
 }
 
 export class Connection {
-  public constructor(
-    readonly canisterId: string // TODO: should this be an actor?
-  ) {}
+  public constructor(readonly canisterId: string) {}
 
   register = async (
     identity: IdentifiableIdentity,
@@ -350,8 +348,6 @@ export class Connection {
   };
 
   // Create an actor representing the backend
-  // TODO: why is this part of 'Connection'?
-  // Can this actor be re-used?
   createActor = async (
     delegationIdentity?: DelegationIdentity
   ): Promise<ActorSubclass<_SERVICE>> => {
@@ -369,10 +365,7 @@ export class Connection {
   };
 }
 
-// TODO: Split between "connection" and "authenticatedConnection" and make sure connection
-// has canister ID baked in (read from readCanisterId() in index.ts)
 export class AuthenticatedConnection extends Connection {
-  // TODO shouldn't be public
   public constructor(
     public canisterId: string,
     public identity: SignIdentity,

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -113,6 +113,8 @@ export interface IdentifiableIdentity extends SignIdentity {
   rawId: ArrayBuffer;
 }
 
+// TODO: Split between "connection" and "authenticatedConnection" and make sure connection 
+// has canister ID baked in (read from readCanisterId() in index.ts)
 export class IIConnection {
   protected constructor(
     public identity: SignIdentity,

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -1,3 +1,6 @@
+/**
+ * This module contains everything related to connecting to the canister.
+ */
 import {
   Actor,
   ActorSubclass,
@@ -173,7 +176,7 @@ export class Connection {
       return {
         kind: "loginSuccess",
         connection: new AuthenticatedConnection(
-          this,
+          this.canisterId,
           identity,
           delegationIdentity,
           userNumber,
@@ -250,7 +253,7 @@ export class Connection {
       kind: "loginSuccess",
       userNumber,
       connection: new AuthenticatedConnection(
-        this,
+        this.canisterId,
         // eslint-disable-next-line
         identity,
         delegationIdentity,
@@ -286,7 +289,7 @@ export class Connection {
       kind: "loginSuccess",
       userNumber,
       connection: new AuthenticatedConnection(
-        this,
+        this.canisterId,
         identity,
         delegationIdentity,
         userNumber,
@@ -371,13 +374,13 @@ export class Connection {
 export class AuthenticatedConnection extends Connection {
   // TODO shouldn't be public
   public constructor(
-    public connection: Connection, // TODO: don't need this, only canisterId
+    public canisterId: string,
     public identity: SignIdentity,
     public delegationIdentity: DelegationIdentity,
     public userNumber: bigint,
     public actor?: ActorSubclass<_SERVICE>
   ) {
-    super(connection.canisterId);
+    super(canisterId);
   }
   async getActor(): Promise<ActorSubclass<_SERVICE>> {
     for (const { delegation } of this.delegationIdentity.getDelegation()
@@ -392,7 +395,7 @@ export class AuthenticatedConnection extends Connection {
     if (this.actor === undefined) {
       // Create our actor with a DelegationIdentity to avoid re-prompting auth
       this.delegationIdentity = await requestFEDelegation(this.identity);
-      this.actor = await this.connection.createActor(this.delegationIdentity);
+      this.actor = await this.createActor(this.delegationIdentity);
     }
 
     return this.actor;

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -96,7 +96,7 @@ export type RegisterResult =
 
 type LoginSuccess = {
   kind: "loginSuccess";
-  connection: IIConnection;
+  connection: AuthenticatedConnection;
   userNumber: bigint;
 };
 
@@ -172,7 +172,7 @@ export class Connection {
       console.log(`registered Identity Anchor ${userNumber}`);
       return {
         kind: "loginSuccess",
-        connection: new IIConnection(
+        connection: new AuthenticatedConnection(
           this,
           identity,
           delegationIdentity,
@@ -249,7 +249,7 @@ export class Connection {
     return {
       kind: "loginSuccess",
       userNumber,
-      connection: new IIConnection(
+      connection: new AuthenticatedConnection(
         this,
         // eslint-disable-next-line
         identity,
@@ -285,7 +285,7 @@ export class Connection {
     return {
       kind: "loginSuccess",
       userNumber,
-      connection: new IIConnection(
+      connection: new AuthenticatedConnection(
         this,
         identity,
         delegationIdentity,
@@ -366,11 +366,9 @@ export class Connection {
   };
 }
 
-export type AuthenticatedConnection = IIConnection;
-
 // TODO: Split between "connection" and "authenticatedConnection" and make sure connection
 // has canister ID baked in (read from readCanisterId() in index.ts)
-export class IIConnection extends Connection {
+export class AuthenticatedConnection extends Connection {
   // TODO shouldn't be public
   public constructor(
     public connection: Connection, // TODO: don't need this, only canisterId

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -373,12 +373,12 @@ export type AuthenticatedConnection = IIConnection;
 export class IIConnection extends Connection {
   // TODO shouldn't be public
   public constructor(
-    public conn: Connection, // TODO: don't need this, only canisterId
+    public connection: Connection, // TODO: don't need this, only canisterId
     public identity: SignIdentity,
     public delegationIdentity: DelegationIdentity,
     public userNumber: bigint,
     public actor?: ActorSubclass<_SERVICE>
-  ) { super(conn.canisterId); }
+  ) { super(connection.canisterId); }
   async getActor(): Promise<ActorSubclass<_SERVICE>> {
     for (const { delegation } of this.delegationIdentity.getDelegation()
       .delegations) {
@@ -392,7 +392,7 @@ export class IIConnection extends Connection {
     if (this.actor === undefined) {
       // Create our actor with a DelegationIdentity to avoid re-prompting auth
       this.delegationIdentity = await requestFEDelegation(this.identity);
-      this.actor = await this.conn.createActor(this.delegationIdentity);
+      this.actor = await this.connection.createActor(this.delegationIdentity);
     }
 
     return this.actor;

--- a/src/frontend/src/utils/registerAllowedCheck.ts
+++ b/src/frontend/src/utils/registerAllowedCheck.ts
@@ -1,6 +1,7 @@
 import { LoginFlowResult } from "../flows/login/flowResult";
 import { register } from "../flows/register";
 import { registerDisabled } from "../flows/registerDisabled";
+import { Connection } from "../utils/iiConnection";
 
 /** Check that the current origin is not the explicit canister id or a raw url.
  *  Explanation why we need to do this:
@@ -12,6 +13,8 @@ function isRegistrationAllowed() {
   );
 }
 
-export const registerIfAllowed = async (): Promise<LoginFlowResult | null> => {
-  return isRegistrationAllowed() ? register() : registerDisabled();
+export const registerIfAllowed = async (
+  conn: Connection
+): Promise<LoginFlowResult | null> => {
+  return isRegistrationAllowed() ? register(conn) : registerDisabled();
 };

--- a/src/frontend/src/utils/registerAllowedCheck.ts
+++ b/src/frontend/src/utils/registerAllowedCheck.ts
@@ -14,7 +14,7 @@ function isRegistrationAllowed() {
 }
 
 export const registerIfAllowed = async (
-  conn: Connection
+  connection: Connection
 ): Promise<LoginFlowResult | null> => {
-  return isRegistrationAllowed() ? register(conn) : registerDisabled();
+  return isRegistrationAllowed() ? register(connection) : registerDisabled();
 };

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -22,13 +22,10 @@ pub enum ContentType {
     SVG,
 }
 
-lazy_static! {
-    // The <script> tag that sets the canister ID and loads the 'index.js'
-    static ref INDEX_HTML_SETUP_JS: String = {
-        let canister_id = api::id();
-        format!(r#"var canisterId = '{canister_id}';let s = document.createElement('script');s.async = true;s.src = 'index.js';document.head.appendChild(s);"#)
-    };
+// The <script> tag that loads the 'index.js'
+const INDEX_HTML_SETUP_JS: &str = "let s = document.createElement('script');s.async = true;s.src = 'index.js';document.head.appendChild(s);";
 
+lazy_static! {
     // The SRI sha256 hash of the script tag, used by the CSP policy.
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
     pub static ref INDEX_HTML_SETUP_JS_SRI_HASH: String = {

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -41,10 +41,11 @@ lazy_static! {
     // injected
     static ref INDEX_HTML_STR: String = {
         let index_html = include_str!("../../../dist/index.html");
+        let canister_id = api::id();
         let setup_js: String = INDEX_HTML_SETUP_JS.to_string();
         let index_html = index_html.replace(
             r#"<script id="setupJs"></script>"#,
-            &format!(r#"<script id="setupJs">{setup_js}</script>"#).to_string()
+            &format!(r#"<script data-canister-id="{canister_id}" id="setupJs">{setup_js}</script>"#).to_string()
         );
         index_html
     };


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

Before this change, the `canisterId` was set in the `index.html` as a global value and the `iiConnection.ts` module would read it upon initialization. This was done so as to minimize code changes when we started injecting the canister ID from the canister.

The major drawback was that `iiConnection.ts` would fail if there was no global `canisterId`, and would fail _during_ initialization, meaning whenever the module was imported (and not necessarily used).

The `IIConnection` class was used to issue IC calls to the canister. Some `static` methods would read the (global value) canister ID and would be used to talk to the canister. Once the user was authenticated, an actual instance of the `IIConnection` class would be used (which then contained the user's Identity object used to authenticate).

The major drawback here was that the entire codebase would use those `static` methods directly, making it impossible to mock the canister behavior.

This PR changes a few dependent things, which prepare the ground for mocking `IIConnection`/`Connection` (i.e. the interface with the canister):
* The canister ID is now added as an HTML tag dataset (as opposed to inlined as a global js value) and read on startup. A `Connection` is now created using this canister ID and is used instead of calling the `static` methods from `IIConnection`. This new object is threaded to all pages that need to talk to the IC.
* The `IIConnection` (the instantiated one) was renamed to `AuthenticatedConnection` to better reflect the difference with `Connection`. This object is _still_ threaded to all pages that need to issue _authenticated_ requests to the IC.
* I took the liberty to homogenize the order of `connection` and `userNumber` arguments to always have them in the same order: first `userNumber`, then `connection`. That's the convention that most of the codebase uses but recent PRs have introduced inconsistencies.