### PR TITLE
Clean up webpack configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "test:e2e-desktop": "SCREEN=desktop npm run test:e2e",
     "test:e2e-mobile": "SCREEN=mobile npm run test:e2e",
     "lint": "eslint --max-warnings 0 --cache --cache-location node_modules/.cache/eslint 'src/frontend/**/*.ts*'",
-    "format": "prettier --write src/frontend .eslintrc.json",
-    "format-check": "prettier --check src/frontend .eslintrc.json"
+    "format": "prettier --write src/frontend .eslintrc.json webpack.config.js",
+    "format-check": "prettier --check src/frontend .eslintrc.json webpack.config.js"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,6 @@ const HttpProxyMiddlware = require("http-proxy-middleware");
 const dfxJson = require("./dfx.json");
 require("dotenv").config();
 
-
 /** Read the replica host from dfx.json */
 function readReplicaHost() {
   const dfxJson = "./dfx.json";
@@ -30,7 +29,6 @@ function readReplicaHost() {
 
 /** Read the II canister ID from dfx's local state */
 function readCanisterId() {
-    console.log("Summoned");
   const canisterIdsJson = "./.dfx/local/canister_ids.json";
 
   let canisterId;
@@ -41,7 +39,7 @@ function readCanisterId() {
     throw Error(`Could get canister ID from ${canisterIdsJson}: ${e}`);
   }
 
-  console.log("Reading can id", canisterId);
+  console.log("Read canister ID:", canisterId);
 
   return canisterId;
 }
@@ -80,7 +78,6 @@ function generateWebpackConfigForCanister(name, info) {
       // Set up a proxy that redirects API calls and /index.html to the
       // replica; the rest we serve from here.
       onBeforeSetupMiddleware: (devServer) => {
-
         // canisterId singleton, read lazily
         let canisterId = null;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,129 +44,112 @@ function readCanisterId() {
   return canisterId;
 }
 
+const isProduction = process.env.NODE_ENV === "production";
+const devtool = isProduction ? undefined : "source-map";
+
 /**
  * Generate a webpack configuration for a canister.
  */
-function generateWebpackConfigForCanister(name, info) {
-  const isProduction = process.env.NODE_ENV === "production";
-  const devtool = isProduction ? undefined : "source-map";
+module.exports = {
+  mode: isProduction ? "production" : "development",
+  entry: {
+    index: path.join(__dirname, "src", "frontend", "src", "index"),
+  },
+  devtool,
+  optimization: {
+    minimize: isProduction,
+  },
+  resolve: {
+    extensions: [".js", ".ts", ".jsx", ".tsx"],
+    fallback: {
+      assert: require.resolve("assert/"),
+      buffer: require.resolve("buffer/"),
+      events: require.resolve("events/"),
+      stream: require.resolve("stream-browserify/"),
+      util: require.resolve("util/"),
+    },
+  },
+  output: {
+    filename: "[name].js",
+    path: path.join(__dirname, "dist"),
+  },
+  devServer: {
+    // Set up a proxy that redirects API calls and /index.html to the
+    // replica; the rest we serve from here.
+    onBeforeSetupMiddleware: (devServer) => {
+      // canisterId singleton, read lazily
+      let canisterId = null;
 
-  return {
-    mode: isProduction ? "production" : "development",
-    entry: {
-      index: path.join(__dirname, "src", "frontend", "src", "index"),
+      // basically everything _except_ for index.js, because we want live reload
+      devServer.app.get(
+        ["/", "/index.html", "/faq", "/about"],
+        HttpProxyMiddlware.createProxyMiddleware({
+          // Read the replica host from dfx.json. The replica does not need to be running, which is convenient
+          // in case we just load pages that don't talk to the canister (then we wouldn't want to have to start the replica or build the canister)
+          target: readReplicaHost(),
+
+          // For path rewriting we use a function that lazily (i.e. when first called, using a singleton) reads
+          // the canister ID from the local dfx state and returns a new request path that includes
+          // the ?canisterId=foo atrocity
+          pathRewrite: (pathAndParams, req) => {
+            let queryParamsString = `?`;
+
+            const [path, params] = pathAndParams.split("?");
+
+            if (params) {
+              queryParamsString += `${params}&`;
+            }
+
+            if (canisterId === null) {
+              canisterId = readCanisterId();
+            }
+
+            queryParamsString += `canisterId=${canisterId}`;
+
+            return path + queryParamsString;
+          },
+        })
+      );
     },
-    devtool,
-    optimization: {
-      minimize: isProduction,
+    port: 8080,
+    proxy: {
+      // Make sure /api calls land on the replica (and not on webpack)
+      "/api": "http://localhost:8000",
     },
-    resolve: {
-      extensions: [".js", ".ts", ".jsx", ".tsx"],
-      fallback: {
-        assert: require.resolve("assert/"),
-        buffer: require.resolve("buffer/"),
-        events: require.resolve("events/"),
-        stream: require.resolve("stream-browserify/"),
-        util: require.resolve("util/"),
+    allowedHosts: [".localhost", ".local", ".ngrok.io"],
+  },
+
+  module: {
+    rules: [
+      { test: /\.(ts|tsx)$/, loader: "ts-loader" },
+      { test: /\.css$/, use: ["style-loader", "css-loader"] },
+      {
+        test: /\.(png|jpg|gif)$/i,
+        type: "asset/resource",
       },
-    },
-    output: {
-      filename: "[name].js",
-      path: path.join(__dirname, "dist"),
-    },
-    devServer: {
-      // Set up a proxy that redirects API calls and /index.html to the
-      // replica; the rest we serve from here.
-      onBeforeSetupMiddleware: (devServer) => {
-        // canisterId singleton, read lazily
-        let canisterId = null;
-
-        // basically everything _except_ for index.js, because we want live reload
-        devServer.app.get(
-          ["/", "/index.html", "/faq", "/about"],
-          HttpProxyMiddlware.createProxyMiddleware({
-            // Read the replica host from dfx.json. The replica does not need to be running, which is convenient
-            // in case we just load pages that don't talk to the canister (then we wouldn't want to have to start the replica or build the canister)
-            target: readReplicaHost(),
-
-            // For path rewriting we use a function that lazily (i.e. when first called, using a singleton) reads
-            // the canister ID from the local dfx state and returns a new request path that includes
-            // the ?canisterId=foo atrocity
-            pathRewrite: (pathAndParams, req) => {
-              let queryParamsString = `?`;
-
-              const [path, params] = pathAndParams.split("?");
-
-              if (params) {
-                queryParamsString += `${params}&`;
-              }
-
-              if (canisterId === null) {
-                canisterId = readCanisterId();
-              }
-
-              queryParamsString += `canisterId=${canisterId}`;
-
-              return path + queryParamsString;
-            },
-          })
-        );
-      },
-      port: 8080,
-      proxy: {
-        // Make sure /api calls land on the replica (and not on webpack)
-        "/api": "http://localhost:8000",
-      },
-      allowedHosts: [".localhost", ".local", ".ngrok.io"],
-    },
-
-    // Depending in the language or framework you are using for
-    // front-end development, add module loaders to the default
-    // webpack configuration. For example, if you are using React
-    // modules and CSS as described in the "Adding a stylesheet"
-    // tutorial, uncomment the following lines:
-    module: {
-      rules: [
-        { test: /\.(ts|tsx)$/, loader: "ts-loader" },
-        { test: /\.css$/, use: ["style-loader", "css-loader"] },
+    ],
+  },
+  plugins: [
+    new CopyPlugin({
+      patterns: [
         {
-          test: /\.(png|jpg|gif)$/i,
-          type: "asset/resource",
+          from: path.join(__dirname, "src", "frontend", "assets"),
+          to: path.join(__dirname, "dist"),
         },
       ],
-    },
-    plugins: [
-      new CopyPlugin({
-        patterns: [
-          {
-            from: path.join(__dirname, "src", "frontend", "assets"),
-            to: path.join(__dirname, "dist"),
-          },
-        ],
-      }),
-      new webpack.ProvidePlugin({
-        Buffer: [require.resolve("buffer/"), "Buffer"],
-        process: require.resolve("process/browser"),
-      }),
-      new webpack.EnvironmentPlugin({
-        II_FETCH_ROOT_KEY: "0",
-        II_DUMMY_AUTH: "0",
-        II_DUMMY_CAPTCHA: "0",
-      }),
-      new CompressionPlugin({
-        test: /\.js(\?.*)?$/i,
-      }),
-      new webpack.IgnorePlugin(/^\.\/wordlists\/(?!english)/, /bip39\/src$/),
-    ],
-  };
-}
-
-// If you have additional webpack configurations you want to build
-//  as part of this configuration, add them to the section below.
-module.exports = [
-  ...Object.entries(dfxJson.canisters)
-    .map(([name, info]) => {
-      return generateWebpackConfigForCanister(name, info);
-    })
-    .filter((x) => !!x),
-];
+    }),
+    new webpack.ProvidePlugin({
+      Buffer: [require.resolve("buffer/"), "Buffer"],
+      process: require.resolve("process/browser"),
+    }),
+    new webpack.EnvironmentPlugin({
+      II_FETCH_ROOT_KEY: "0",
+      II_DUMMY_AUTH: "0",
+      II_DUMMY_CAPTCHA: "0",
+    }),
+    new CompressionPlugin({
+      test: /\.js(\?.*)?$/i,
+    }),
+    new webpack.IgnorePlugin(/^\.\/wordlists\/(?!english)/, /bip39\/src$/),
+  ],
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,53 +38,54 @@ function generateWebpackConfigForCanister(name, info) {
       path: path.join(__dirname, "dist"),
     },
     devServer: {
-
       // Set up a proxy that redirects API calls and /index.html to the
       // replica; the rest we serve from here.
       onBeforeSetupMiddleware: (devServer) => {
-          const dfxJson = './dfx.json';
-          let replicaHost;
+        const dfxJson = "./dfx.json";
+        let replicaHost;
 
-          try {
-              replicaHost = require(dfxJson).networks.local.bind;
-          } catch (e) {
-              throw Error(`Could get host from ${dfxJson}: ${e}`);
-          }
+        try {
+          replicaHost = require(dfxJson).networks.local.bind;
+        } catch (e) {
+          throw Error(`Could get host from ${dfxJson}: ${e}`);
+        }
 
-          // If the replicaHost lacks protocol (e.g. 'localhost:8000') the
-          // requests are not forwarded properly
-          if(!replicaHost.startsWith("http://")) {
-              replicaHost = `http://${replicaHost}`;
-          }
+        // If the replicaHost lacks protocol (e.g. 'localhost:8000') the
+        // requests are not forwarded properly
+        if (!replicaHost.startsWith("http://")) {
+          replicaHost = `http://${replicaHost}`;
+        }
 
-          const canisterIdsJson = './.dfx/local/canister_ids.json';
+        const canisterIdsJson = "./.dfx/local/canister_ids.json";
 
-          let canisterId;
+        let canisterId;
 
-          try {
-              canisterId = require(canisterIdsJson).internet_identity.local;
-          } catch (e) {
-              throw Error(`Could get canister ID from ${canisterIdsJson}: ${e}`);
-          }
+        try {
+          canisterId = require(canisterIdsJson).internet_identity.local;
+        } catch (e) {
+          throw Error(`Could get canister ID from ${canisterIdsJson}: ${e}`);
+        }
 
-          // basically everything _except_ for index.js, because we want live reload
-          devServer.app.get(['/', '/index.html', '/faq', '/about' ], HttpProxyMiddlware.createProxyMiddleware( {
-              target: replicaHost,
-              pathRewrite: (pathAndParams, req) => {
-                  let queryParamsString = `?`;
+        // basically everything _except_ for index.js, because we want live reload
+        devServer.app.get(
+          ["/", "/index.html", "/faq", "/about"],
+          HttpProxyMiddlware.createProxyMiddleware({
+            target: replicaHost,
+            pathRewrite: (pathAndParams, req) => {
+              let queryParamsString = `?`;
 
-                  const [path, params] = pathAndParams.split("?");
+              const [path, params] = pathAndParams.split("?");
 
-                  if (params) {
-                      queryParamsString += `${params}&`;
-                  }
+              if (params) {
+                queryParamsString += `${params}&`;
+              }
 
-                  queryParamsString += `canisterId=${canisterId}`;
+              queryParamsString += `canisterId=${canisterId}`;
 
-                  return path + queryParamsString;
-              },
-
-          }));
+              return path + queryParamsString;
+            },
+          })
+        );
       },
       port: 8080,
       proxy: {
@@ -123,9 +124,9 @@ function generateWebpackConfigForCanister(name, info) {
         process: require.resolve("process/browser"),
       }),
       new webpack.EnvironmentPlugin({
-        "II_FETCH_ROOT_KEY": "0",
-        "II_DUMMY_AUTH": "0",
-        "II_DUMMY_CAPTCHA": "0",
+        II_FETCH_ROOT_KEY: "0",
+        II_DUMMY_AUTH: "0",
+        II_DUMMY_CAPTCHA: "0",
       }),
       new CompressionPlugin({
         test: /\.js(\?.*)?$/i,


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

This updates our webpack config a bit. The main improvement is that requests that do not need to be routed to the canister can be made with `npm run start` _without_ having to spin up `dfx` first (which would originally crash because there was no local dfx state to read the canister ID from). This is in preparation for the static pages showcase which should greatly improve CSS hacking workflows.

See individual commits for more information.