### PR TITLE
Invalidate boostrap cache

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -35,7 +35,7 @@ runs:
     - uses: actions/cache@v2
       with:
         path: ~/.cargo/bin
-        key: cargo-bin-${{ steps.platform.outputs.platform-id }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+        key: cargo-bin-${{ steps.platform.outputs.platform-id }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-2
 
     - name: Bootstrap
       shell: bash


### PR DESCRIPTION
We've bumped the ic-cdk-optimizer version and the GitHub actions cache
still contain the old version. Instead of carrying the old version
around forever, we invalidate the cache.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
