### PR TITLE
Run CI selenium tests without hot-reloading

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -273,16 +273,11 @@ jobs:
           dfx canister create --all
           dfx canister install test_app --wasm test_app.wasm
 
-      - name: Run II dev front-end
-        run: |
-          npm ci
-          npm run start &
-          sleep 10 # crude
-
       - name: Start docker compose
-        run: scripts/start-selenium-env
+        run: scripts/start-selenium-env --no-hot-reload
 
       - run: rm -v -f screenshots/*.png
+      - run: npm ci
       - run: npm test
       - run: npm run test:e2e-${{ matrix.device }}
       - name: Collect docker logs

--- a/docker-test-env/reverse_proxy/Dockerfile
+++ b/docker-test-env/reverse_proxy/Dockerfile
@@ -2,8 +2,10 @@ FROM nginx:latest
 
 ARG TEST_APP_CANISTER_ID
 ARG II_CANISTER_ID
+ARG II_PORT
 COPY ./nginx.conf /etc/nginx/nginx.conf
 
 RUN sed -i "s/II_CANISTER_ID/${II_CANISTER_ID}/g" /etc/nginx/nginx.conf
 RUN sed -i "s/TEST_APP_CANISTER_ID/${TEST_APP_CANISTER_ID}/g" /etc/nginx/nginx.conf
+RUN sed -i "s/II_PORT/${II_PORT}/g" /etc/nginx/nginx.conf
 COPY ./certs /etc/nginx/certs

--- a/docker-test-env/reverse_proxy/nginx.conf
+++ b/docker-test-env/reverse_proxy/nginx.conf
@@ -34,7 +34,7 @@ http {
         ssl_certificate_key  /etc/nginx/certs/identity.ic0.app.key;
 
         location / {
-            proxy_pass http://host.docker.internal:8080;
+            proxy_pass http://host.docker.internal:II_PORT;
             proxy_set_header Host II_CANISTER_ID.localhost;
 
             # include details about the original request

--- a/scripts/start-selenium-env
+++ b/scripts/start-selenium-env
@@ -17,7 +17,10 @@ function usage() {
     cat << EOF
 
 Usage:
-  $0
+  $0 [--no-hot-reload]
+
+Options:
+  --no-hot-reload   Uses dfx as the II host thus removing the dependency on the II dev server. By doing so, II will no longer hot reload front-end changes.
 EOF
 }
 
@@ -31,7 +34,7 @@ NOTE: This requires docker, docker-compose, a running dfx replica with II and th
 EOF
 
 }
-
+II_PORT=8080
 while [[ $# -gt 0  ]]
 do
     case "$1" in
@@ -41,6 +44,10 @@ do
             help
             exit 0
             ;;
+        --no-hot-reload)
+          II_PORT=8000
+          shift
+          ;;
         *)
             echo "ERROR: unknown argument $1"
             usage
@@ -55,7 +62,6 @@ II_CANISTER_ID=$( jq -r .internet_identity.local .dfx/local/canister_ids.json )
 TEST_APP_CANISTER_ID=$( jq -r .test_app.local demos/test-app/.dfx/local/canister_ids.json )
 
 cd "docker-test-env"
-sed "s/II_CANISTER_ID/$II_CANISTER_ID/g; s/TEST_APP_CANISTER_ID/$TEST_APP_CANISTER_ID/g" docker-compose.yml \
-    | docker compose -f - build --build-arg II_CANISTER_ID="$II_CANISTER_ID" --build-arg TEST_APP_CANISTER_ID="$TEST_APP_CANISTER_ID"
-sed "s/II_CANISTER_ID/$II_CANISTER_ID/g; s/TEST_APP_CANISTER_ID/$TEST_APP_CANISTER_ID/g" docker-compose.yml \
-    | docker compose -f - up -d --wait
+COMPOSE_CONFIG=$(sed "s/II_CANISTER_ID/$II_CANISTER_ID/g; s/TEST_APP_CANISTER_ID/$TEST_APP_CANISTER_ID/g" docker-compose.yml)
+echo "$COMPOSE_CONFIG" | docker compose -f - build --build-arg II_CANISTER_ID="$II_CANISTER_ID" --build-arg II_PORT="$II_PORT" --build-arg TEST_APP_CANISTER_ID="$TEST_APP_CANISTER_ID"
+echo "$COMPOSE_CONFIG" | docker compose -f - up -d --wait


### PR DESCRIPTION
This removes an unnecessary component from CI speeding it up by a few seconds.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
