### PR TITLE
Add script that allows executing a command with the docker compose env

### DIFF
--- a/scripts/with-docker-env
+++ b/scripts/with-docker-env
@@ -39,5 +39,5 @@ ret=0
 echo "'$*' returned with $ret"
 
 cd docker-test-env
-docker compose down
+docker compose down || echo "docker compose failed to shut down!"
 exit "$ret"

--- a/scripts/with-docker-env
+++ b/scripts/with-docker-env
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Make sure we always run from the root
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPTS_DIR/.."
+
+#########
+# USAGE #
+#########
+
+function title() {
+    echo "Execute a command between starting and stopping the docker compose environment"
+}
+
+function usage() {
+    cat << EOF
+
+Usage:
+  $0 <subcommand>
+
+EOF
+}
+
+function help() {
+    cat << EOF
+
+Starts the docker compose environment, executes the subcommand and stops docker compose again.
+
+NOTE: This requires docker, docker-compose, a running dfx replica with II and the test app deployed and running II dev server (npm run start).
+EOF
+}
+
+scripts/start-selenium-env
+
+ret=0
+"$@" || ret="$?"
+
+echo "'$*' returned with $ret"
+
+cd docker-test-env
+docker compose down
+exit "$ret"


### PR DESCRIPTION
The script encapsulates starting and stopping the docker environment and executes the supplied command while the environment is up.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
