### PR TITLE
Add authenticate page to showcase

### DIFF
--- a/src/frontend/src/flows/authenticate/index.ts
+++ b/src/frontend/src/flows/authenticate/index.ts
@@ -192,7 +192,9 @@ export interface AuthSuccess {
  * the delegation to the application window. After having received the delegation the application will close the
  * Internet Identity window.
  */
-export default async (connection: Connection): Promise<AuthSuccess> => {
+export const authorizeAuthentication = async (
+  connection: Connection
+): Promise<AuthSuccess> => {
   const [authContext, validationResult]: [AuthContext, ValidationResult] =
     await withLoader(async () => {
       const authContext = await waitForAuthRequest();
@@ -387,11 +389,11 @@ const authenticateUser = async (
   return init(connection, authContext, userNumber);
 };
 
-const displayPage = (
+export const displayPage = (
   origin: string,
   userNumber?: bigint,
   derivationOrigin?: string
-) => {
+): void => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent(origin, userNumber, derivationOrigin), container);
 };

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -8,7 +8,7 @@ import { intentFromUrl } from "./utils/userIntent";
 import { checkRequiredFeatures } from "./utils/featureDetection";
 import { recoveryWizard } from "./flows/recovery/recoveryWizard";
 import { showWarningIfNecessary } from "./banner";
-import authorizeAuthentication from "./flows/authenticate";
+import { authorizeAuthentication } from "./flows/authenticate";
 import { displayError } from "./components/displayError";
 import { Connection } from "./utils/iiConnection";
 

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -11,6 +11,7 @@ import { displayUserNumber } from "./flows/displayUserNumber";
 import { loginKnownAnchor } from "./flows/login/knownAnchor";
 import { loginUnknownAnchor } from "./flows/login/unknownAnchor";
 import { pickRecoveryDevice } from "./flows/recovery/pickRecoveryDevice";
+import { displayPage } from "./flows/authenticate";
 import { DeviceData } from "../generated/internet_identity_types";
 import { register } from "./flows/register";
 
@@ -52,6 +53,7 @@ const iiPages: Record<string, () => void> = {
   pickRecoveryDevice: () =>
     pickRecoveryDevice([recoveryPhrase, recoveryDevice]),
   register: () => register(dummyConnection),
+  authenticate: () => displayPage("https://nowhere.com", BigInt(10000)),
 };
 
 // The showcase


### PR DESCRIPTION
This adds the `authorizeAuthentication` page/function to the showcase.
Unfortunately the page is very static as button logic does somewhat
depend on extra input like local storage; if we want button logic (like
clicking the edit icon to edit the anchor) we'll have the refactor
things a little first.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
