### PR TITLE
feat(highlightbox): semantics

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -26,8 +26,15 @@ const pageContent = (alias: string) => html`
         verification codes that you received any other way.`,
     })}
     <p>Verify that this is your device:</p>
-    <label>Alias</label>
-    <div class="highlightBox">${alias}</div>
+    <label>
+      <strong>Alias</strong>
+      <input
+        type="text"
+        readonly="readonly"
+        class="highlightBox"
+        value="${alias}"
+      />
+    </label>
     <label>Device Verification Code</label>
     <div id="wrongCodeMessage" class="error-message-hidden">
       The entered verification code was invalid. Please try again.

--- a/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
@@ -25,12 +25,24 @@ const pageContent = (
       this device using the verification code below. After successful
       verification this page will automatically refresh.
     </p>
-    <label>Alias</label>
-    <div class="highlightBox">${alias}</div>
+    <label>
+      <strong>Alias</strong>
+      <input
+        type="text"
+        readonly="readonly"
+        class="highlightBox"
+        value="${alias}"
+      />
+    </label>
     <label>Device Verification Code</label>
-    <div id="verificationCode" class="highlightBox">
-      ${tentativeRegistrationInfo.verification_code}
-    </div>
+    <input
+      id="verificationCode"
+      type="text"
+      aria-label="host name"
+      readonly="readonly"
+      class="highlightBox host-name hostName"
+      value="${tentativeRegistrationInfo.verification_code}"
+    />
     <p>Time remaining: <span id="timer"></span></p>
     <button id="showCodeCancel">Cancel</button>
   </div>

--- a/src/frontend/src/flows/authenticate/index.ts
+++ b/src/frontend/src/flows/authenticate/index.ts
@@ -129,7 +129,13 @@ const pageContent = (
     ${icLogo}
     <h1>Internet Identity</h1>
     <p>Authenticate to service:</p>
-    <div class="host-name highlightBox hostName">${hostName}</div>
+    <input
+      type="text"
+      aria-label="host name"
+      readonly="readonly"
+      class="highlightBox host-name hostName"
+      value="${hostName}"
+    />
     ${derivationOrigin !== undefined && derivationOrigin !== hostName
       ? derivationOriginSection(derivationOrigin)
       : ""}
@@ -179,8 +185,13 @@ const pageContent = (
 const derivationOriginSection = (derivationOrigin: string) => html` <p>
     This service is an alias of:
   </p>
-  <div class="host-name highlightBox hostName">${derivationOrigin}</div>`;
-
+  <input
+    type="text"
+    aria-label="host name"
+    readonly="readonly"
+    class="highlightBox host-name hostName"
+    value="${derivationOrigin}"
+  />`;
 export interface AuthSuccess {
   userNumber: bigint;
   connection: AuthenticatedConnection;

--- a/src/frontend/src/flows/displayUserNumber.ts
+++ b/src/frontend/src/flows/displayUserNumber.ts
@@ -10,8 +10,15 @@ const pageContent = (userNumber: bigint) => html`
       message:
         "Please record your new Identity Anchor. Keep a backup on a storage medium and write it down. You will need it later to use Internet Identity or to add additional devices. If you lose your Identity Anchor, you will no longer be able to use this identity to authenticate to dApps.",
     })}
-    <label>Identity Anchor:</label>
-    <div class="highlightBox">${userNumber}</div>
+    <label>
+      <strong>Identity Anchor:</strong>
+      <input
+        type="text"
+        readonly="readonly"
+        class="highlightBox"
+        value="${userNumber}"
+      />
+    </label>
     <button id="displayUserContinue" class="primary">Continue</button>
   </div>
 `;

--- a/src/frontend/src/flows/login/knownAnchor.ts
+++ b/src/frontend/src/flows/login/knownAnchor.ts
@@ -18,7 +18,13 @@ const pageContent = (userNumber: bigint) => html` <style>
     ${icLogo}
     <h1>Welcome back!</h1>
     <p>Authenticate using Internet Identity.</p>
-    <div class="highlightBox">${userNumber}</div>
+    <input
+      type="text"
+      aria-label="Internet Identity user number"
+      readonly="readonly"
+      class="highlightBox"
+      value="${userNumber}"
+    />
     <button type="button" id="login" class="primary">Authenticate</button>
     <p style="text-align: center;">Or</p>
     <button type="button" id="loginDifferent">

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -159,8 +159,14 @@ const pageContent = (userNumber: bigint, devices: DeviceData[]) => html`
     </p>
     ${!hasRecoveryDevice(devices) ? recoveryNag() : undefined}
     <aside>
-      <h2 class="label">Identity Anchor</h2>
-      <div class="highlightBox">${userNumber}</div>
+      <h2 id="ii-anchor-title" class="label">Identity Anchor</h2>
+      <input
+        type="text"
+        readonly="readonly"
+        aria-labelledby="ii-anchor-title"
+        class="highlightBox"
+        value="${userNumber}"
+      />
     </aside>
 
     <aside>

--- a/src/frontend/src/flows/recovery/displaySeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/displaySeedPhrase.ts
@@ -21,7 +21,14 @@ const pageContent = (seedPhrase: string) => html`
     </aside>
     <label>
       <strong>Your seed phrase</strong>
-      <textarea id="seedPhrase" translate="no" class="highlightBox">${seedPhrase}</textarea>
+      <textarea
+        id="seedPhrase"
+        translate="no"
+        class="highlightBox"
+        readonly="readonly"
+      >
+${seedPhrase}</textarea
+      >
     </label>
     <button id="seedCopy" data-clipboard-target="#seedPhrase">Copy</button>
     <button id="displaySeedPhraseContinue" class="primary hidden">

--- a/src/frontend/src/flows/recovery/displaySeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/displaySeedPhrase.ts
@@ -19,8 +19,10 @@ const pageContent = (seedPhrase: string) => html`
         to this Identity Anchor!
       </div>
     </aside>
-    <label>Your seed phrase</label>
-    <div id="seedPhrase" translate="no" class="highlightBox">${seedPhrase}</div>
+    <label>
+      <strong>Your seed phrase</strong>
+      <textarea id="seedPhrase" translate="no" class="highlightBox">${seedPhrase}</textarea>
+    </label>
     <button id="seedCopy" data-clipboard-target="#seedPhrase">Copy</button>
     <button id="displaySeedPhraseContinue" class="primary hidden">
       Continue

--- a/src/frontend/src/flows/successfulDeviceAddition.ts
+++ b/src/frontend/src/flows/successfulDeviceAddition.ts
@@ -7,8 +7,15 @@ const pageContent = (name: string) => html`
   <div class="container">
     <h1>Success!</h1>
     <p>You have successfully added your new device.</p>
-    <label>Device name:</label>
-    <div class="highlightBox">${name}</div>
+    <label>
+      <strong>Device name:</strong>
+      <input
+        type="text"
+        readonly="readonly"
+        class="highlightBox"
+        value="${name}"
+      />
+    </label>
     <button id="manageDevicesButton" class="primary">Manage devices</button>
     ${logoutSection()}
   </div>

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -303,6 +303,7 @@ textarea.highlightBox {
 
 input.highlightBox {
   font: inherit;
+  font-weight: 600;
 }
 
 .warningBox {

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -301,6 +301,10 @@ textarea.highlightBox {
   min-height: 6.5rem;
 }
 
+input.highlightBox {
+  font: inherit;
+}
+
 .warningBox {
   border: 1px var(--grey-200) solid;
   border-radius: 4px;

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -226,6 +226,10 @@ label {
   margin-bottom: 0.5rem;
 }
 
+label strong {
+  margin-bottom: 0.5rem;
+}
+
 main::before,
 main::after {
   content: "";
@@ -291,6 +295,10 @@ main {
   overflow-wrap: break-word;
   font-size: 1.5rem;
   font-weight: 500;
+}
+
+textarea.highlightBox {
+  min-height: 6.5rem;
 }
 
 .warningBox {

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -73,7 +73,7 @@ export class RegisterView extends View {
   }
 
   async registerGetIdentity(): Promise<string> {
-    return await this.browser.$(".highlightBox").getText();
+    return await this.browser.$(".highlightBox").getAttribute("value");
   }
 
   async registerConfirmIdentity(): Promise<void> {
@@ -83,7 +83,7 @@ export class RegisterView extends View {
   async registerIdentityFixup(): Promise<void> {
     const elem = await this.browser.$(".highlightBox");
     await this.browser.execute(
-      "arguments[0].innerText = arguments[1];",
+      "arguments[0].value = arguments[1];",
       elem,
       "12345"
     );
@@ -187,7 +187,7 @@ export class MainView extends View {
   async fixup(): Promise<void> {
     const elem = await this.browser.$(".highlightBox");
     await this.browser.execute(
-      "arguments[0].innerText = arguments[1];",
+      "arguments[0].value = arguments[1];",
       elem,
       "12345"
     );
@@ -405,7 +405,7 @@ export class WelcomeBackView extends View {
   }
 
   async getIdentityAnchor(): Promise<string> {
-    return await this.browser.$(".highlightBox").getText();
+    return await this.browser.$(".highlightBox").getAttribute("value");
   }
 
   async login(): Promise<void> {
@@ -415,7 +415,7 @@ export class WelcomeBackView extends View {
   async fixup(): Promise<void> {
     const elem = await this.browser.$(".highlightBox");
     await this.browser.execute(
-      "arguments[0].innerText = arguments[1];",
+      "arguments[0].value = arguments[1];",
       elem,
       "12345"
     );

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -73,7 +73,7 @@ export class RegisterView extends View {
   }
 
   async registerGetIdentity(): Promise<string> {
-    return await this.browser.$(".highlightBox").getAttribute("value");
+    return await this.browser.$(".highlightBox").getValue();
   }
 
   async registerConfirmIdentity(): Promise<void> {
@@ -405,7 +405,7 @@ export class WelcomeBackView extends View {
   }
 
   async getIdentityAnchor(): Promise<string> {
-    return await this.browser.$(".highlightBox").getAttribute("value");
+    return await this.browser.$(".highlightBox").getValue();
   }
 
   async login(): Promise<void> {


### PR DESCRIPTION
Makes highlight boxes more accessible and semantically nicer.

- Makes the ID's accessible by tab
- Someone with a screenreader now knows what this number is supposed to be
- An alternative would be to use the `output` element, but as I understand it, its meant more for the result of a direct user interaction (ex. a value that is calculated from a range slider)