### PR TITLE
Change deploy job to deploy on release

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -490,10 +490,10 @@ jobs:
           default_author: github_actions
           message: "🤖 Selenium screenshots auto-update"
 
-  # This deploys the production build to mainnet, to a canister that we use for testing.
+  # This deploys the production build to mainnet, to a canister that we use for release testing.
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: startsWith(github.ref, 'refs/tags/release-')
     needs: docker-build
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Deploying on merge would override the deployment used for testing. A separate canister will be introduced to deploy to on merge at a later stage.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
