### PR TITLE
Create a grid out of the showcase

### DIFF
--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -61,13 +61,59 @@ const iiPages: Record<string, () => void> = {
 
 // The showcase
 const pageContent = html`
-  <div>
-    <h1>showcase</h1>
-    <ul>
-      ${Object.entries(iiPages).map(([key, _]) => {
-        return html`<li><a href="/${key}">${key}</a></li>`;
-      })}
-    </ul>
+  <style>
+    .showcase-grid {
+      display: grid;
+      list-style-type: none;
+      width: 100vw;
+      grid-template-columns: repeat(auto-fill, minmax(25rem, 1fr));
+    }
+    .showcase-grid > aside {
+      position: relative;
+      aspect-ratio: 0.75;
+    }
+    .showcase-grid a {
+      position: absolute;
+      inset: 0;
+      overflow: hidden;
+      outline: 1px solid #ccc;
+    }
+
+    .showcase-grid iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 200%;
+      height: 200%;
+      transform-origin: 0 0;
+      transform: scale(0.5);
+      border: none;
+      pointer-events: none;
+      overflow: hidden;
+    }
+    .showcase-grid h2 {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      padding: 1rem;
+      background: rgba(255, 255, 255, 0.25);
+      margin: 0;
+      color: #202124;
+      backdrop-filter: blur(10px);
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
+    }
+  </style>
+  <h1>showcase</h1>
+  <div class="showcase-grid">
+    ${Object.entries(iiPages).map(([key, _]) => {
+      return html`<aside>
+        <a href="/${key}">
+          <iframe src="/${key}" title="${key}"></iframe>
+          <h2>${key}</h2>
+        </a>
+      </aside>`;
+    })}
   </div>
 `;
 

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -102,6 +102,7 @@ const pageContent = html`
       color: #202124;
       backdrop-filter: blur(10px);
       box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
+      font-size: 1.25rem;
     }
   </style>
   <h1>showcase</h1>


### PR DESCRIPTION
Makes the showcase a grid of iFrames. 

Makes it easier to see if something breaks and someone who is not familiar with a the view titles yet can easily work with it. ![Screenshot 2022-08-23 at 14 22 38](https://user-images.githubusercontent.com/608386/186156943-69bf3b5e-719c-44ea-87ba-cca4a524c2b8.png)