### PR TITLE
Skip canister_tests build if necessary

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -163,6 +163,9 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Pull a deep copy so that we can set meaningful timestamps across builds, based on the commit history
+          fetch-depth: '0'
 
       - uses: ./.github/actions/bootstrap
 
@@ -184,21 +187,24 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('src/**/Cargo.lock', 'rust-toolchain.toml') }}-2
 
-      - name: Create fake assets
-        run : |
-          mkdir dist
-          touch dist/index.html
-          touch dist/index.js
-          touch dist/index.js.gz
-          touch dist/loader.webp
-          touch dist/favicon.ico
-          touch dist/ic-badge.svg
-
       - name: 'Download wasm'
         uses: actions/download-artifact@v2
         with:
           name: internet_identity_test.wasm
           path: .
+
+        # For each file involved in the build, set the mtime back to the commit date of the last edit. This means we get
+        # meaningful mtimes that cargo can work use to decide what part of the target/ cache to invalidate as opposed
+        # to just thrashing everything. This means that the build is a no-op for anything that doesn't change the actual test code.
+      - name: 'Set timestamps'
+        run: |
+          git ls-tree -r --name-only HEAD ./src/canister_tests/ ./src/internet_identity_interface/ Cargo.* | \
+            while read filename
+            do
+              git_time=$(TZ=UTC0 git log -1 --date='format-local:%Y%m%d%H%M' --format='%cd' -- "$filename")
+              echo "Setting $filename to $git_time"
+              TZ=UTC0 touch -t "$git_time" "$filename"
+            done
 
       # We split the test build and run so that it's clear from the GHA steps how long each took
       - name: Build Tests


### PR DESCRIPTION
This greatly improves cache reuse for canister tests build on GHA.

This adds a step that sets the mtime of all files relevant in the
canister tests builds to the date they were last edited, according to
the git history. This means that in most cases (e.g. when the canister
tests' code is not changed) the build is skipped entirely (though tests
are still run).

In order to achieve this the checkout step is changed to fetch the
entire git history, which takes 4s instead of 3s for a time gain of
about 5mn.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
