### PR TITLE
Add screenshots screens to showcase

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -65,11 +65,15 @@ export const pollForTentativeDevice = async (
       // directly show the verification screen if the tentative device already exists
       await verifyDevice(userNumber, connection, tentativeDevice, timestamp);
     } else {
-      const container = document.getElementById("pageContent") as HTMLElement;
-      render(pageContent(userNumber), container);
+      renderPollForTentativeDevicePage(userNumber);
       init(userNumber, connection, timestamp);
     }
   });
+};
+
+export const renderPollForTentativeDevicePage = (userNumber: bigint): void => {
+  const container = document.getElementById("pageContent") as HTMLElement;
+  render(pageContent(userNumber), container);
 };
 
 const poll = (

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -232,8 +232,6 @@ export const renderManage = async (
   userNumber: bigint,
   connection: AuthenticatedConnection
 ): Promise<void> => {
-  const container = document.getElementById("pageContent") as HTMLElement;
-
   let anchorInfo: IdentityAnchorInfo;
   try {
     anchorInfo = await withLoader(() => connection.getAnchorInfo());
@@ -247,9 +245,18 @@ export const renderManage = async (
     // we are actually in a device registration process
     await pollForTentativeDevice(userNumber, connection);
   } else {
-    render(pageContent(userNumber, anchorInfo.devices), container);
-    init(userNumber, connection, anchorInfo.devices);
+    displayManage(userNumber, connection, anchorInfo.devices);
   }
+};
+
+export const displayManage = async (
+  userNumber: bigint,
+  connection: AuthenticatedConnection,
+  devices: DeviceData[]
+): Promise<void> => {
+  const container = document.getElementById("pageContent") as HTMLElement;
+  render(pageContent(userNumber, devices), container);
+  init(userNumber, connection, devices);
 };
 
 // Initializes the management page.

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -3,7 +3,16 @@
  * working on HTML and CSS. */
 import "./styles/main.css";
 import { html, render } from "lit-html";
-import { Connection } from "./utils/iiConnection";
+import {
+  Challenge,
+  DeviceData,
+  CredentialId,
+  Timestamp,
+} from "../generated/internet_identity_types";
+import {
+  IdentifiableIdentity,
+  AuthenticatedConnection,
+} from "./utils/iiConnection";
 import { compatibilityNotice } from "./flows/compatibilityNotice";
 import { aboutView } from "./flows/about";
 import { faqView } from "./flows/faq";
@@ -13,11 +22,25 @@ import { loginUnknownAnchor } from "./flows/login/unknownAnchor";
 import { pickRecoveryDevice } from "./flows/recovery/pickRecoveryDevice";
 import { phraseRecoveryPage } from "./flows/recovery/recoverWith/phrase";
 import { displayPage } from "./flows/authenticate";
-import { DeviceData } from "../generated/internet_identity_types";
 import { register, renderConstructing } from "./flows/register";
+import { confirmRegister } from "./flows/confirmRegister";
+import { chooseRecoveryMechanism } from "./flows/recovery/chooseRecoveryMechanism";
+import { displaySingleDeviceWarning } from "./flows/recovery/displaySingleDeviceWarning";
+import { displayManage } from "./flows/manage";
+import { chooseDeviceAddFlow } from "./flows/addDevice/manage";
+import { deviceSettings } from "./flows/manage/deviceSettings";
+import { renderPollForTentativeDevicePage } from "./flows/addDevice/manage/pollForTentativeDevice";
+import { addRemoteDevice } from "./flows/addDevice/welcomeView";
+import {
+  registerTentativeDevice,
+  TentativeDeviceInfo,
+} from "./flows/addDevice/welcomeView/registerTentativeDevice";
+import { deviceRegistrationDisabledInfo } from "./flows/addDevice/welcomeView/deviceRegistrationModeDisabled";
+import { showVerificationCode } from "./flows/addDevice/welcomeView/showVerificationCode";
+import { verifyDevice } from "./flows/addDevice/manage/verifyTentativeDevice";
 
 // A "dummy" connection which actually is just undefined, hoping pages won't call it
-const dummyConnection = undefined as unknown as Connection;
+const dummyConnection = undefined as unknown as AuthenticatedConnection;
 const userNumber = BigInt(10000);
 
 const recoveryPhrase: DeviceData = {
@@ -38,11 +61,30 @@ const recoveryDevice: DeviceData = {
   credential_id: [],
 };
 
+const simpleDevice: DeviceData = {
+  alias: "Chrome on iPhone",
+  protection: { unprotected: null },
+  pubkey: [1, 2, 3, 4],
+  key_type: { unknown: null },
+  purpose: { authentication: null },
+  credential_id: [],
+};
+
 const defaultPage = () => {
   document.title = "Showcase";
   const container = document.getElementById("pageContent") as HTMLElement;
   render(pageContent, container);
 };
+
+// A challenge with a base64 CAPTCHA, apologies for the length
+const dummyChallenge: Challenge = {
+  png_base64:
+    "iVBORw0KGgoAAAANSUhEUgAAANwAAAB4CAAAAAC8vMOlAAALq0lEQVR4nO1cCVgURxZ+g9yHcikiEg+8QERUNBI8CMFoMB4RlWg4NDFCXDVxV11XE4MblSgx7kKMoLuK4onAGhWVBEHxVogKAmvERBRBEeQWEGZmq6pnenqgB6V7hnX4+n3263p10X9X9av3XtUokkLHJZEATgAngBPACeAEcNBxSQAngBPACeAEcAI4AZwATgAngFMX6YBW0fLDZZ6Hm5JesbZWjZxVd/tk0JHAwDvBEfqvUF+LwHUyqENMTAneR41ePum0Z1p2NayD6LVvloWZTkBSium0v7+0idaM3HsPcyC14gOcLLaYnozvejedOgS4uIxw2N7VVy7Wj8rGtxkJHQJcmTUMn7iRkXE59Gf89Hf6t9ZKO745z24gymRiA/dPMZfGgNaDawyWwIrHynkzaw0Q39jqV6cV03LAXdBvaJHrlYZ5oZ3qdloxct8BDLnbIjd1OeY9fwLtBjcN4BcWzeFMeDZoNbiGBQDvsOQHpWP+1QKVDXXh9afJZ8Amma3AlvAilQ21YeSOATw5zVbQrxTzUx6gveCk/ojNZS0yI7wOtBecCI/MANYifQnmN4aBVoJ7jtlX6JrPXi4SYW4K2gjuGja5HuBp9wF7hSap1oJbmrXhS4A3FoJ8TWtButWYn56johReV+rTxSqVSu1BV3cVtcoJ76dd4PRMK+jnx2blCBX1yGIAg9gLX9dpaVYBi0aIFgGalxbbkZy0ir3esETM/bNYC3mMXJ0RiDuBRuijjPI9VYuhyCgK6/pjOKu3iqrEoO4+RM3gJHPE72/44ez3oHaqOnwANgWiRA9w/dUXms7jTFsVlW9i9p6ItYy7PyfeTZxheOsiqJtMa41n7qGSK53mQe5gnEofy1651wPEfp7AVsR95K6uo+6X3qioArXSilootJClQ/oC3KYQs1fOwdiGsmLjoVDSCjE3iPd6WK3fFdRINd/BZ3JsgLDBA5JSEWLej9lqUDM4gs08zPdM5MnG0oGgNrrqCN//qJRT3NqT7kTXlNnsZTxiKLOPIOa3F7/RlOJA39HLQT1kXAfNHurTf2F+y4Wtdg32DIrY1Q2PpYDMExfCvSFtd8KsXsCPqBd9vK6Ff1PP4M0pDF02KlQpj0W8J2Zys2iXITjMBD4kEhF1eN0P4MdmRcSxkVlazSh5M4DlL6B2cO6YmcilvMHihIfcO0O+iwUJifjWgXmXZoUGhD9laZYyvQl6pwxRP7hJmL2QS71RlMPlJMeusFtW+AynatAL+qx5MfUGC1gaTq6H2TdV+ap8wBlYIlZJi3adoYLbxCQe53AquLoGPdKS5hVsCM9v0bBmFXq3h7uABsARD/m/CvFPyNy81OZORJQzLQuH4M/NjVYPy3fd90xfv4H6uuFmZbOmKwdsAq8LrfTNx+VZevUQnFOIM5HiCszTa1MXMfNH3qmakUjLBU3IUJSlZxtjE8xTqjvBkcjZKb7Mpk0XwxH/xKOV3vmMnM5euWlEyBnhure7bV24+F+rLGLYN1vQNYZKLjxCzEspNK13Js6HeP/vjJa9TD3x7ZPrhZoBB3qTARRmMzHCEtvWw/BYJXu/AeMh43RgNTI95lEzNsnEjdyP/42u+M7IB9TOSP00nwrNgIMTEhgziN5beoSMsGQjMG9rL1HBiJ3zRMxgH8jWzxFojpcGSRLxmElEV4iR3hQn2rkXrQin6+3LMyCCeinF2RbuVZoAVw1RXaCcDm/0uYNYzcFKURu7CYlGbPxZxBZOBeiM7JS+okHQKLXyhIvEaJHek80PnZB083WiqUaF0zdIRz6Tt2+o2tGgbnANT8bMGzYMSsLlGWR+PJsT7CzXgG0mrGz7IDX4B9yvJKpuxUiS7xA6j9wlkn9XboPGyG/XrobR0XJf4IZrcFcPb+97LbrjoS03nczKwt/ISp/eZJUtIuBKu0aBjhREABxM8jx0WUJu+PaBMjvVxvUqubs7nq+kYkGu2VcKKK0ZJC3YT9Uqg+pLeB6pD1xteA2560icob7EHiQpWOqEDWnfeMRM246vGhuRFlOS5ofQWQ6yu/kJmDgqJHRb3Po6IzdZnmh3peVekjKxc3LzGqpGcEcJtomSyIDrYAgHP1xBTEMX/Jn7Y3Axm52dQ0NVNGYHToI9JRf671Jk0ebHILhhiXbpXMBIUaiXoD921Zqk3NIa9r/CHRwxDXSieupeW2IdCnMiKeNkrjFiPlZlAIfQhLrTolWNzBIZ68bSJbEeL+Q7MLJMFEnLlg30YcGsLstUPiJ3cL9h5tkbsUjQLdtKsOl2I0av3mwUajyBEi0ddKN9Obm59yQj09m6JOvxu0xs0Piyx+jSShl3cER9jKfSa+DGWQCPzIPm1JsOQODqq83ouvlXYBblt3T6CK1X3cvYg/tEJfRVyqoFHsR9KSCvhT4GkmYIZn4Z0z0pyR0H748q6n4dEHBCIaWVgR9rl2QXUXms0PwGY+BI3MFZYWZNiw+WVC/tQ0tofOAQLdUgnLGKlvGg04O1S7IUP1fKwjomEDgS5wBR8A7ErjPUggh67XhXls7vj0b2sZVMikE7h3rFcknco+TtVGZPtIGyGsdD3j/OLHPOAf0szqE1ziM3jjwoI2MrFPjI03hWNsXLJbwWNcbJpfQSULGdRr7KUqWsHGQrcA8bcgbnjR035vryxXgQ75QLo9F1UJZ+SHw+eloeAT1f9i6JxV3cxMjBa8PnwJk4g7P5GJodAUGeeIg8iBKArvOPqPQ+Ery6LIsSSP4DkyzZuyQfcCEzmrAV2dIczVRMnL+5IhTzWLmJkYGXZ1sZ2jJbpPO2/JmknfIscFDu61AipY+HA8qzkv7kiNMDhxSK9IzPC+B17o7zyPVAUZtTzAxsSxbL5qkVDhVQ0/J6Hmw3RPd9VEk8GE9V0aMD2SBQxEQ2TnlhuBn4EPelIMkMspXsDGxZbJOl8bmYDJKKBduZGA7lkEgTYaqJig57EtVLv7CyNXWQvwL4EHdw5tXQbxxDHos+Fqe/Uul6vHWHl6jGbpF/KUrGmpK4m5d0Hh07qNwNmZWeZxH7lgSOZV7MEF1r28VSO+BF3ME5uEM+U6F0RleuLG2IA5h4ET/1FOmWidhXj8Xh23iwmMjWF563MIUkt6T9hnYFvG6LbxdFAk/i4Ymjr8MtSiEyVTjRlmiIKmLBZSixJyEOK9JE8GXdZiNW6GBXzOPnjN5p7Z72w6HBwJt4bGGd3PETVNBG+VuXQeGjSfE7u+US/XlDONrYysZ7TzMS4NqbcMarWSdkVi4jG+u7w/Ll7devAXUQj5HzOWqs8LGeKkXyRW8AHrnYBjJoQ/CQnChHk9LWk7Un6tSa/zbyxVrDns3qwcYv+lWVJXGSOT0Jykc6ieGMYlbeJP4WhK4XcZAAfux/juwXgd6EjQv/afzFk8xAfjpSQfxOpx/+EN5+dsWwUTyM7BnQfeVhV2jSadiHQUKJHfoePSJGwNVRzTvAs9K+QGGEFPYENRK/41F+5ZWrwDzuG0eCTWHhOg7/FeA0mFJn7bpNQs7cxc3gMIq1E3+GgaVWbLx/VxBmJt9wMlikOG+zlVheQTGUFD+L3L78pkXrQGROP7YBTRH/H03sDdIhlvG6jxWv/YkdcobsY2SqscGW7PjmtPz1hlcamNSAxoj/wbY+VU6bjCMCpGsZUyoIYVt1X672l2FsLlIa2wW5G2iWBhEaxKamn7uUdJMqeSb7kW2Z6yiXrmBtGEYfu7vlepOKn9Ybwbw2bnn9P8A1o+cmMCKD8TfQvz/ocxxumdELSeIfy0Cs2RORGund2FQpqIO0qDvzjAoJ/9dGrBQt1/BpT82clFXak9h4FyIX05Jb5oDo1LF6umKVx/DUR+3wE7OH9kzJLRPGpet2fgbjzoGmqb1/P4ewYdrvwfcs1atQux/g7iSG8Hr9udAe1M7g5qfe+j0I2ouE/1VDACeAE8AJ4ARwAjgBnABOACeAE8BBxyUBnABOACeAE8AJ4DoyuP8B9QJKpv91V+kAAAAASUVORK5CYII=",
+  challenge_key: "unimportant",
+};
+
+const dummyIdentity: IdentifiableIdentity =
+  undefined as unknown as IdentifiableIdentity;
 
 const iiPages: Record<string, () => void> = {
   displayUserNumber: () => displayUserNumber(userNumber),
@@ -58,6 +100,48 @@ const iiPages: Record<string, () => void> = {
   recoverWithPhrase: () =>
     phraseRecoveryPage(userNumber, dummyConnection, recoveryPhrase),
   constructing: () => renderConstructing(),
+  confirmRegister: () =>
+    confirmRegister(
+      dummyConnection,
+      Promise.resolve(dummyChallenge),
+      dummyIdentity /* not used */,
+      "hello" /* not used */
+    ),
+  chooseRecoveryMechanism: () => chooseRecoveryMechanism([]),
+  displaySingleDeviceWarning: () =>
+    displaySingleDeviceWarning(userNumber, dummyConnection),
+  displayManage: () =>
+    displayManage(userNumber, dummyConnection, [simpleDevice, recoveryPhrase]),
+  chooseDeviceAddFlow: () => chooseDeviceAddFlow(),
+  renderPollForTentativeDevicePage: () =>
+    renderPollForTentativeDevicePage(userNumber),
+  addRemoteDevice: () => addRemoteDevice(null, dummyConnection),
+  registerTentativeDevice: () =>
+    registerTentativeDevice(userNumber, dummyConnection),
+  deviceRegistrationDisabledInfo: () =>
+    deviceRegistrationDisabledInfo(dummyConnection, [
+      userNumber,
+    ] as unknown as TentativeDeviceInfo),
+  showVerificationCode: () =>
+    showVerificationCode(
+      userNumber,
+      dummyConnection,
+      simpleDevice.alias,
+      {
+        verification_code: "123456",
+        device_registration_timeout: undefined as unknown as Timestamp,
+      },
+      undefined as unknown as CredentialId
+    ),
+  verifyDevice: () =>
+    verifyDevice(
+      userNumber,
+      dummyConnection,
+      simpleDevice,
+      undefined as unknown as bigint
+    ),
+  deviceSettings: () =>
+    deviceSettings(userNumber, dummyConnection, simpleDevice, false),
 };
 
 // The showcase


### PR DESCRIPTION
This adds all screens recorded on screenshots to the showcase. Not only
does this mean that most if not all screens can be tweaked from the
showcase, but this prepare the showcase code to take over the screenshot
tests.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
