### PR TITLE
Bump threshold for updating screenshots

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -467,7 +467,7 @@ jobs:
               exit 1
             fi
 
-            if (( metric <= 8 ))
+            if (( metric <= 30 ))
             then
               echo "Pixel difference ($metric) is too small, reverting"
               git checkout HEAD -- "$modified"


### PR DESCRIPTION
Before uploading new screenshots, we use imagemagick to check how many
pixels have changed. Until now the threshold for considering an image
changed was 8 pixels. It looks like this isn't enough however as new
pixels with irrelevant 26 pixel changes are being updated. This bumps
the threashold to 30 pixels.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
