### PR TITLE
Wrap words

### DIFF
--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -677,7 +677,7 @@ a:hover,
   background: var(--rc-input);
   color: var(--rc-onInput);
   border: calc(var(--vs-line) * 2) solid var(--rc-line);
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .c-input.has-error,

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -677,6 +677,7 @@ a:hover,
   background: var(--rc-input);
   color: var(--rc-onInput);
   border: calc(var(--vs-line) * 2) solid var(--rc-line);
+  word-break: break-all;
 }
 
 .c-input.has-error,


### PR DESCRIPTION
This ensures that longs inputs (like a long URL when authenticating) are
wrapped.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

Before: 
<img width="946" alt="Screenshot 2022-09-02 at 10 38 51" src="https://user-images.githubusercontent.com/6930756/188100116-433f5753-66eb-4e73-be0c-c9bfe99193d1.png">


After:

<img width="902" alt="Screenshot 2022-09-02 at 10 39 10" src="https://user-images.githubusercontent.com/6930756/188100158-44c90e81-149e-45eb-8772-cc532f693fc8.png">
