### PR TITLE
Add Cargo.lock to canister test cache key

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -182,7 +182,7 @@ jobs:
           path: |
             ~/.cargo
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('src/**/Cargo.lock', 'rust-toolchain.toml') }}-2
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'src/**/Cargo.toml', 'rust-toolchain.toml') }}-2
 
       - name: 'Download wasm'
         uses: actions/download-artifact@v2


### PR DESCRIPTION
For unknown reasons, the Cargo.lock wasn't added to the cache key,
meaning that a Cargo.{lock,toml} update would not invalidate the cache.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
