### PR TITLE
#776: fix local development CSP issues in Safari

### DIFF
--- a/demos/using-dev-build/webpack.config.js
+++ b/demos/using-dev-build/webpack.config.js
@@ -1,8 +1,6 @@
 const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const TerserPlugin = require("terser-webpack-plugin");
-const CopyPlugin = require("copy-webpack-plugin");
 
 let canisters;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "process": "0.11.10",
         "stream-browserify": "3.0.0",
         "style-loader": "^3.2.1",
-        "terser-webpack-plugin": "5.1.4",
         "ts-jest": "^27.0.3",
         "ts-loader": "9.2.3",
         "ts-node": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "process": "0.11.10",
     "stream-browserify": "3.0.0",
     "style-loader": "^3.2.1",
-    "terser-webpack-plugin": "5.1.4",
     "ts-jest": "^27.0.3",
     "ts-loader": "9.2.3",
     "ts-node": "^10.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,32 +1,9 @@
 const path = require("path");
 const webpack = require("webpack");
 const CopyPlugin = require("copy-webpack-plugin");
-const TerserPlugin = require("terser-webpack-plugin");
 const CompressionPlugin = require("compression-webpack-plugin");
-const HttpProxyMiddlware = require("http-proxy-middleware");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const dfxJson = require("./dfx.json");
 require("dotenv").config();
-
-/** Read the replica host from dfx.json */
-function readReplicaHost() {
-  const dfxJson = "./dfx.json";
-  let replicaHost;
-
-  try {
-    replicaHost = require(dfxJson).networks.local.bind;
-  } catch (e) {
-    throw Error(`Could get host from ${dfxJson}: ${e}`);
-  }
-
-  // If the replicaHost lacks protocol (e.g. 'localhost:8000') the
-  // requests are not forwarded properly
-  if (!replicaHost.startsWith("http://")) {
-    replicaHost = `http://${replicaHost}`;
-  }
-
-  return replicaHost;
-}
 
 /** Read the II canister ID from dfx's local state */
 function readCanisterId() {
@@ -43,6 +20,27 @@ function readCanisterId() {
   console.log("Read canister ID:", canisterId);
 
   return canisterId;
+}
+
+// This plugin emulates the behaviour of http.rs while using webpack dev server locally
+// so we don't need to proxy to the backend canister for the index.html file.
+// This overcomes some issues with Safari and the CSP headers set in http.rs.
+class InjectCanisterIdPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap("InjectCanisterIdPlugin", (compilation) => {
+      HtmlWebpackPlugin.getHooks(compilation).beforeEmit.tapAsync(
+        "InjectCanisterIdPlugin",
+        (data, cb) => {
+          data.html = data.html.replace(
+            '<script id="setupJs"></script>',
+            `<script data-canister-id="${readCanisterId()}" id="setupJs"></script>`
+          );
+
+          cb(null, data);
+        }
+      );
+    });
+  }
 }
 
 const isProduction = process.env.NODE_ENV === "production";
@@ -74,42 +72,7 @@ module.exports = [
       path: path.join(__dirname, "dist"),
     },
     devServer: {
-      // Set up a proxy that redirects API calls and /index.html to the
-      // replica; the rest we serve from here.
-      onBeforeSetupMiddleware: (devServer) => {
-        // canisterId singleton, read lazily
-        let canisterId = null;
-
-        // basically everything _except_ for index.js, because we want live reload
-        devServer.app.get(
-          ["/", "/index.html", "/faq", "/about"],
-          HttpProxyMiddlware.createProxyMiddleware({
-            // Read the replica host from dfx.json. The replica does not need to be running, which is convenient
-            // in case we just load pages that don't talk to the canister (then we wouldn't want to have to start the replica or build the canister)
-            target: readReplicaHost(),
-
-            // For path rewriting we use a function that lazily (i.e. when first called, using a singleton) reads
-            // the canister ID from the local dfx state and returns a new request path that includes
-            // the ?canisterId=foo atrocity
-            pathRewrite: (pathAndParams, req) => {
-              let queryParamsString = `?`;
-              const [path, params] = pathAndParams.split("?");
-
-              if (params) {
-                queryParamsString += `${params}&`;
-              }
-
-              if (canisterId === null) {
-                canisterId = readCanisterId();
-              }
-
-              queryParamsString += `canisterId=${canisterId}`;
-
-              return path + queryParamsString;
-            },
-          })
-        );
-      },
+      // Set up a proxy that redirects API calls to the replica.
       port: 8080,
       proxy: {
         // Make sure /api calls land on the replica (and not on webpack)
@@ -134,9 +97,26 @@ module.exports = [
           {
             from: path.join(__dirname, "src", "frontend", "assets"),
             to: path.join(__dirname, "dist"),
+            // allow HtmlWebpackPlugin to handle serving the index.html file locally
+            // this avoids some Safari issues with the CSP headers served by http.rs
+            filter: isProduction
+              ? undefined
+              : async (resourcePath) => {
+                  return !resourcePath.endsWith("index.html");
+                },
           },
         ],
       }),
+      // allow HtmlWebpackPlugin to handle serving the index.html file locally
+      // this avoids some Safari issues with the CSP headers served by http.rs
+      ...(isProduction
+        ? []
+        : [
+            new HtmlWebpackPlugin({
+              template: "src/frontend/assets/index.html",
+            }),
+            new InjectCanisterIdPlugin(),
+          ]),
       new webpack.ProvidePlugin({
         Buffer: [require.resolve("buffer/"), "Buffer"],
         process: require.resolve("process/browser"),


### PR DESCRIPTION
This fixes: https://github.com/dfinity/internet-identity/issues/776

Safari seems to be taking a different approach to the CSP headers on localhost compared to other browsers. Chrome for example, ignores the upgrade-insecure-requests directive on localhost, but Safari respects it and forces index.js to be loaded over https, but it's not being served over https by webpack dev server.

Handling this in webpack only, means we don't need to change any application code to work around the issue.
