### PR TITLE
Extract CSS to file for production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "html-webpack-plugin": "^5.3.2",
         "jest": "^27.0.6",
         "jest-cli": "^27.0.6",
+        "mini-css-extract-plugin": "^2.6.1",
         "prettier": "2.3.2",
         "process": "0.11.10",
         "stream-browserify": "3.0.0",
@@ -11656,6 +11657,78 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mini-css-extract-plugin": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz",
+      "integrity": "sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==",
+      "dev": true,
+      "dependencies": {
+        "schema-utils": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.8.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -24257,6 +24330,56 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
+    },
+    "mini-css-extract-plugin": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz",
+      "integrity": "sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==",
+      "dev": true,
+      "requires": {
+        "schema-utils": "^4.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.3"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+          "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "ajv": "^8.8.0",
+            "ajv-formats": "^2.1.1",
+            "ajv-keywords": "^5.0.0"
+          }
+        }
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "html-webpack-plugin": "^5.3.2",
     "jest": "^27.0.6",
     "jest-cli": "^27.0.6",
+    "mini-css-extract-plugin": "^2.6.1",
     "prettier": "2.3.2",
     "process": "0.11.10",
     "stream-browserify": "3.0.0",

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -369,7 +369,7 @@ base-uri 'none';\
 frame-ancestors 'none';\
 form-action 'none';\
 style-src 'self' 'unsafe-inline' https://fonts\\.googleapis\\.com;\
-style-src-elem 'unsafe-inline' https://fonts\\.googleapis\\.com;\
+style-src-elem 'self' 'unsafe-inline' https://fonts\\.googleapis\\.com;\
 font-src https://fonts\\.gstatic\\.com;\
 upgrade-insecure-requests;$"
     )

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Internet Identity</title>
     <link rel="shortcut icon" type="image/jpg" href="./favicon.ico" />
+    <!-- We set "inject" to false in production, where we explicitly link to the stylesheet
+        with a <link> tag (instead of the "style-loader"-development-loaded one) -->
+    <% if (! htmlWebpackPlugin.options.inject) { %>
+    <link rel="stylesheet" href="./index.css" />
+    <% } %>
   </head>
   <body>
     <main id="pageContent" class="l-wrap" aria-live="polite"></main>

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -20,6 +20,7 @@ pub enum ContentType {
     ICO,
     WEBP,
     SVG,
+    CSS,
 }
 
 // The <script> tag that loads the 'index.js'
@@ -75,7 +76,7 @@ pub fn init_assets() {
 
 // Get all the assets. Duplicated assets like index.html are shared and generally all assets are
 // prepared only once (like injecting the canister ID).
-fn get_assets() -> [(&'static str, &'static [u8], ContentEncoding, ContentType); 8] {
+fn get_assets() -> [(&'static str, &'static [u8], ContentEncoding, ContentType); 9] {
     let index_html: &[u8] = INDEX_HTML_STR.as_bytes();
     [
         (
@@ -108,6 +109,12 @@ fn get_assets() -> [(&'static str, &'static [u8], ContentEncoding, ContentType);
             include_bytes!("../../../dist/index.js.gz"),
             ContentEncoding::GZip,
             ContentType::JS,
+        ),
+        (
+            "/index.css",
+            include_bytes!("../../../dist/index.css"),
+            ContentEncoding::Identity,
+            ContentType::CSS,
         ),
         (
             "/loader.webp",

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -15,6 +15,7 @@ impl ContentType {
         match self {
             ContentType::HTML => "text/html".to_string(),
             ContentType::JS => "text/javascript".to_string(),
+            ContentType::CSS => "text/css".to_string(),
             ContentType::ICO => "image/vnd.microsoft.icon".to_string(),
             ContentType::WEBP => "image/webp".to_string(),
             ContentType::SVG => "image/svg+xml".to_string(),
@@ -190,7 +191,7 @@ fn security_headers() -> Vec<HeaderField> {
              frame-ancestors 'none';\
              form-action 'none';\
              style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;\
-             style-src-elem 'unsafe-inline' https://fonts.googleapis.com;\
+             style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com;\
              font-src https://fonts.gstatic.com;\
              upgrade-insecure-requests;"
             )


### PR DESCRIPTION
This stops using "style-loader" in production, and instead uses a separate CSS file served by the canister.

This is the recommended "production"-way by "style-loader" itself: https://github.com/webpack-contrib/style-loader#recommend

> For production builds it's recommended to extract the CSS from your bundle being able to use parallel loading of CSS/JS resources later on. This can be achieved by using the mini-css-extract-plugin, because it creates separate css files. For development mode (including webpack-dev-server) you can use style-loader, because it injects CSS into the DOM using multiple <style></style> and works faster.

This updates the HTML template to read the CSS from the canister in production; the devServer workflow stays the same. Additionally, the `dist/` directory is wiped before build, as this sometimes caused issues hard to debug (`output: clean: true`).

Note: the CSP rules had to be updated to allow loading the stylesheet from the canister.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
