### PR TITLE
Update rust editions and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,6 @@ dependencies = [
  "candid",
  "flate2",
  "hex",
- "ic-cdk",
  "ic-certification",
  "ic-crypto-internal-basic-sig-iccsa",
  "ic-error-types",
@@ -488,6 +487,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
+ "serde",
  "time 0.1.44",
  "wasm-bindgen",
  "winapi",
@@ -867,8 +867,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
 ]
 
 [[package]]
@@ -886,12 +896,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote 1.0.21",
+ "strsim",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core 0.14.1",
  "quote 1.0.21",
  "syn 1.0.99",
 ]
@@ -1524,28 +1559,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70693199b3cf4552f3fa720b54163927a3ebed2aef240efaf556033ab336a11"
-dependencies = [
- "hex-literal-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
-name = "hex-literal-impl"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59448fc2f82a5fb6907f78c3d69d843e82ff5b051923313cc4438cb0c7b745a8"
-dependencies = [
- "proc-macro-hack",
-]
 
 [[package]]
 name = "http"
@@ -2314,7 +2330,7 @@ source = "git+https://github.com/dfinity/ic?rev=50c53c8e996e7b00b88c2f43120c4653
 dependencies = [
  "fe-derive",
  "hex",
- "hex-literal 0.3.4",
+ "hex-literal",
  "ic-crypto-internal-hmac",
  "ic-crypto-internal-seed",
  "ic-crypto-internal-types",
@@ -3083,21 +3099,6 @@ dependencies = [
 
 [[package]]
 name = "ic-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e78ec6f58886cdc252d6f912dc794211bd6bbc39ddc9dcda434b2dc16c335b3"
-dependencies = [
- "base32",
- "crc32fast",
- "hex",
- "serde",
- "serde_bytes",
- "sha2 0.9.9",
- "thiserror",
-]
-
-[[package]]
-name = "ic-types"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a7d9569a4c91d5c9c202c1666f799a9761bab70a2b59464ee78c45b005e47b8"
@@ -3144,7 +3145,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "strum",
  "strum_macros",
  "thiserror",
@@ -3250,11 +3251,10 @@ dependencies = [
  "candid",
  "captcha",
  "hex",
- "hex-literal 0.2.2",
+ "hex-literal",
  "ic-cdk",
  "ic-cdk-macros",
  "ic-certified-map",
- "ic-types 0.3.0",
  "internet_identity_interface",
  "lazy_static",
  "lodepng",
@@ -3264,8 +3264,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "serde_with",
- "sha2 0.9.9",
+ "serde_with 2.0.1",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -4241,12 +4241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4653,9 +4647,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.34"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3603b7d71ca82644f79b5a06d1220e9a58ede60bd32255f698cb1af8838b8db3"
+checksum = "c3b221de559e4a29df3b957eec92bc0de6bc8eaf6ca9cfed43e5e1d67ff65a34"
 dependencies = [
  "bytemuck",
 ]
@@ -4903,7 +4897,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
+dependencies = [
+ "base64 0.13.0",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros 2.0.1",
+ "time 0.3.14",
 ]
 
 [[package]]
@@ -4912,7 +4922,19 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+dependencies = [
+ "darling 0.14.1",
  "proc-macro2",
  "quote 1.0.21",
  "syn 1.0.99",
@@ -5369,6 +5391,7 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "serde",
  "time-macros",
 ]
 
@@ -5485,9 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.10"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
+checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5743,9 +5766,9 @@ checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]

--- a/demos/test-app/Cargo.toml
+++ b/demos/test-app/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "test_app"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -12,14 +12,14 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-base64 = "0.13.0"
+base64 = "0.13"
 lazy_static = "1.4"
 candid = "0.7"
 ic-cdk = "0.5"
 ic-cdk-macros = "0.5"
 ic-certified-map = "0.3"
-sha2 = "^0.9" # set bound to match ic-certified-map bound
+sha2 = "^0.10" # set bound to match ic-certified-map bound
 serde = "1"
 serde_bytes = "0.11"
 serde_cbor = "0.11"
-serde_with = "1.14"
+serde_with = "2.0"

--- a/src/canister_tests/Cargo.toml
+++ b/src/canister_tests/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "canister_tests"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dev-dependencies]
 base64 = "0.13.0"
 flate2 = "1.0"
 hex = "0.4.3"
 lazy_static = "1.4"
-regex = "1.5.6"
+regex = "1.5"
 serde = "1"
 serde_cbor = "0.11"
 serde_bytes = "0.11"
@@ -18,7 +18,6 @@ internet_identity_interface = { path = "../internet_identity_interface" }
 
 # All IC deps
 candid = "0.7"
-ic-cdk = "0.5"
 ic-types = { git = "https://github.com/dfinity/ic", rev = "50c53c8e996e7b00b88c2f43120c46534cc499f6" }
 ic-certification = { git = "https://github.com/dfinity/ic", rev = "50c53c8e996e7b00b88c2f43120c46534cc499f6" }
 ic-crypto-internal-basic-sig-iccsa = { git = "https://github.com/dfinity/ic", rev = "50c53c8e996e7b00b88c2f43120c46534cc499f6" }

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "internet_identity"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 
@@ -12,8 +12,8 @@ lazy_static = "1.4"
 serde = "1"
 serde_bytes = "0.11"
 serde_cbor = "0.11"
-serde_with = "1.14"
-sha2 = "^0.9" # set bound to match ic-certified-map bound
+serde_with = "2.0"
+sha2 = "^0.10" # set bound to match ic-certified-map bound
 
 # Captcha deps
 lodepng = "*"
@@ -29,10 +29,9 @@ candid = "0.7"
 ic-cdk = "0.5"
 ic-cdk-macros = "0.5"
 ic-certified-map = "0.3"
-ic-types = "0.3"
 
 [dev-dependencies]
-hex-literal = "0.2.1"
+hex-literal = "0.3"
 
 [features]
 # the dummy_captcha feature which ensures the captcha string is always "a"

--- a/src/internet_identity_interface/Cargo.toml
+++ b/src/internet_identity_interface/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 serde_bytes = "0.11"
-candid = "0.7.14"
+candid = "0.7"
 serde = "1"


### PR DESCRIPTION
Rust edition is now consistently 2021.
All dependencies are up to date except for sha2 (due to ic-certified-map).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
