### PR TITLE
Reverse anchor input control flow

### DIFF
--- a/src/frontend/src/components/anchorInput.ts
+++ b/src/frontend/src/components/anchorInput.ts
@@ -2,11 +2,11 @@ import { html, TemplateResult } from "lit-html";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
 
 /** A component for inputting an anchor number */
-export const mkAnchorInput = (
-  inputId: string,
-  userNumber?: bigint,
-  onKeyPress?: (e: KeyboardEvent) => void
-): { template: TemplateResult; userNumberInput: Ref<HTMLInputElement> } => {
+export const mkAnchorInput = (props: {
+  inputId: string;
+  userNumber?: bigint;
+  onKeyPress?: (e: KeyboardEvent) => void;
+}): { template: TemplateResult; userNumberInput: Ref<HTMLInputElement> } => {
   const divRef = createRef();
   const userNumberInput: Ref<HTMLInputElement> = createRef();
 
@@ -24,10 +24,10 @@ export const mkAnchorInput = (
       <input
         ${ref(userNumberInput)}
         type="text"
-        id="${inputId}"
+        id="${props.inputId}"
         class="c-input c-input--vip"
         placeholder="Enter anchor"
-        value="${userNumber !== undefined ? userNumber : ""}"
+        value="${props.userNumber !== undefined ? props.userNumber : ""}"
         @input=${inputFilter(isDigits, onBadInput)}
         @keydown=${inputFilter(isDigits, onBadInput)}
         @keyup=${inputFilter(isDigits, onBadInput)}
@@ -37,7 +37,7 @@ export const mkAnchorInput = (
         @contextmenu=${inputFilter(isDigits, onBadInput)}
         @drop=${inputFilter(isDigits, onBadInput)}
         @focusout=${inputFilter(isDigits, onBadInput)}
-        @keypress=${onKeyPress}
+        @keypress=${props.onKeyPress}
       />
     </label>
 

--- a/src/frontend/src/flows/addDevice/welcomeView/index.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/index.ts
@@ -1,79 +1,58 @@
 import { html, render } from "lit-html";
-import { parseUserNumber } from "../../../utils/userNumber";
 import { registerTentativeDevice } from "./registerTentativeDevice";
-import { toggleErrorMessage } from "../../../utils/errorHelper";
 import { mkAnchorInput } from "../../../components/anchorInput";
 import { Connection } from "../../../utils/iiConnection";
 
-const pageContent = (userNumber?: bigint) => html`
-  <div class="l-container c-card c-card--highlight">
-    <hgroup>
-      <h1 class="t-title t-title--main">New Device</h1>
-      <p class="t-paragraph t-lead">
-        Please provide the Identity Anchor to which you want to add your device.
-      </p>
-      <p id="invalidAnchorMessage" class="is-hidden">
-        Please enter a valid Identity Anchor.
-      </p>
-    </hgroup>
-    ${mkAnchorInput({ inputId: "addDeviceUserNumber", userNumber }).template}
-    <div class="c-button-group">
-      <button
-        @click="${
-          window.location.reload /* TODO: L2-309: do this without reload */
-        }"
-        class="c-button c-button--secondary"
-        id="addDeviceUserNumberCancel"
-      >
-        Cancel
-      </button>
-      <button
-        class="c-button c-button--primary"
-        id="addDeviceUserNumberContinue"
-      >
-        Continue
-      </button>
+const pageContent = (connection: Connection, userNumber?: bigint) => {
+  const anchorInput = mkAnchorInput({
+    inputId: "addDeviceUserNumber",
+    userNumber,
+    onSubmit: (userNumber) => registerTentativeDevice(userNumber, connection),
+  });
+
+  return html`
+    <div class="l-container c-card c-card--highlight">
+      <hgroup>
+        <h1 class="t-title t-title--main">New Device</h1>
+        <p class="t-paragraph t-lead">
+          Please provide the Identity Anchor to which you want to add your
+          device.
+        </p>
+        <p id="invalidAnchorMessage" class="is-hidden">
+          Please enter a valid Identity Anchor.
+        </p>
+      </hgroup>
+      ${anchorInput.template}
+      <div class="c-button-group">
+        <button
+          @click="${
+            window.location.reload /* TODO: L2-309: do this without reload */
+          }"
+          class="c-button c-button--secondary"
+          id="addDeviceUserNumberCancel"
+        >
+          Cancel
+        </button>
+        <button
+          @click="${anchorInput.submit}"
+          class="c-button c-button--primary"
+          id="addDeviceUserNumberContinue"
+        >
+          Continue
+        </button>
+      </div>
     </div>
-  </div>
-`;
+  `;
+};
 
 /**
  * Entry point for the flow of adding a new authenticator when starting from the welcome view (by clicking 'Already have an anchor but using a new device?').
  * This shows a prompt to enter the identity anchor to add this new device to.
  */
-export const addRemoteDevice = async (
+export const addRemoteDevice = (
   connection: Connection,
   userNumber?: bigint
-): Promise<void> => {
+): void => {
   const container = document.getElementById("pageContent") as HTMLElement;
-  render(pageContent(userNumber), container);
-  return init(connection);
-};
-
-const init = (connection: Connection) => {
-  const continueButton = document.getElementById(
-    "addDeviceUserNumberContinue"
-  ) as HTMLButtonElement;
-  const userNumberInput = document.getElementById(
-    "addDeviceUserNumber"
-  ) as HTMLInputElement;
-
-  userNumberInput.onkeypress = (e) => {
-    // submit if user hits enter
-    if (e.key === "Enter") {
-      e.preventDefault();
-      continueButton.click();
-    }
-  };
-
-  continueButton.onclick = async () => {
-    const userNumber = parseUserNumber(userNumberInput.value);
-    if (userNumber !== null) {
-      toggleErrorMessage("addDeviceUserNumber", "invalidAnchorMessage", false);
-      await registerTentativeDevice(userNumber, connection);
-    } else {
-      toggleErrorMessage("addDeviceUserNumber", "invalidAnchorMessage", true);
-      userNumberInput.placeholder = "Please enter your Identity Anchor first";
-    }
-  };
+  render(pageContent(connection, userNumber), container);
 };

--- a/src/frontend/src/flows/addDevice/welcomeView/index.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/index.ts
@@ -16,7 +16,7 @@ const pageContent = (userNumber?: bigint) => html`
         Please enter a valid Identity Anchor.
       </p>
     </hgroup>
-    ${mkAnchorInput("addDeviceUserNumber", userNumber).template}
+    ${mkAnchorInput({ inputId: "addDeviceUserNumber", userNumber }).template}
     <div class="c-button-group">
       <button
         @click="${

--- a/src/frontend/src/flows/authenticate/index.ts
+++ b/src/frontend/src/flows/authenticate/index.ts
@@ -1,11 +1,7 @@
 import { html, render, TemplateResult } from "lit-html";
 import { icLogo, attentionIcon } from "../../components/icons";
 import { footer } from "../../components/footer";
-import {
-  getUserNumber,
-  parseUserNumber,
-  setUserNumber,
-} from "../../utils/userNumber";
+import { getUserNumber, setUserNumber } from "../../utils/userNumber";
 import { withLoader } from "../../components/loader";
 import { mkAnchorInput } from "../../components/anchorInput";
 import { AuthenticatedConnection, Connection } from "../../utils/iiConnection";
@@ -17,7 +13,6 @@ import {
 import { displayError } from "../../components/displayError";
 import { useRecovery } from "../recovery/useRecovery";
 import waitForAuthRequest, { AuthContext } from "./postMessageInterface";
-import { toggleErrorMessage } from "../../utils/errorHelper";
 import { fetchDelegation } from "./fetchDelegation";
 import { registerIfAllowed } from "../../utils/registerAllowedCheck";
 import {
@@ -35,6 +30,7 @@ type PageElements = {
 const pageContent = (
   connection: Connection,
   hostName: string,
+  onContinue: (arg: bigint) => void,
   userNumber?: bigint,
   derivationOrigin?: string
 ): PageElements & { template: TemplateResult } => {
@@ -43,21 +39,16 @@ const pageContent = (
     window.location.reload();
   };
 
-  const onRecoverClick = () => useRecovery(connection, readUserNumber());
-
   const authorizeButton: Ref<HTMLButtonElement> = createRef();
   const registerButton: Ref<HTMLLinkElement> = createRef();
   const anchorInput = mkAnchorInput({
     inputId: "userNumberInput",
     userNumber,
-    onKeyPress: (e) => {
-      if (e.key === "Enter") {
-        // authenticate if user hits enter
-        e.preventDefault();
-        withRef(authorizeButton, (authorizeButton) => authorizeButton.click());
-      }
-    },
+    onSubmit: onContinue,
   });
+
+  const onRecoverClick = () =>
+    useRecovery(connection, anchorInput.readUserNumber());
 
   const template = html` <div class="l-container c-card c-card--highlight">
       <!-- The title is hidden but used for accessibility -->
@@ -81,7 +72,12 @@ const pageContent = (
 
       ${anchorInput.template}
 
-      <button ${ref(authorizeButton)} id="authorizeButton" class="c-button">
+      <button
+        @click="${anchorInput.submit}"
+        ${ref(authorizeButton)}
+        id="authorizeButton"
+        class="c-button"
+      >
         Authorize
       </button>
       <div class="l-stack">
@@ -195,21 +191,29 @@ const init = (
   authContext: AuthContext,
   userNumber?: bigint
 ): Promise<AuthSuccess> => {
-  const { authorizeButton, userNumberInput, registerButton } = displayPage(
-    connection,
-    authContext.requestOrigin,
-    userNumber,
-    authContext.authRequest.derivationOrigin
-  );
-
-  // only focus on the button if the anchor is set and was previously used successfully (i.e. is in local storage)
-  if (userNumber !== undefined && userNumber === getUserNumber()) {
-    withRef(authorizeButton, (authorizeButton) => authorizeButton.focus());
-  } else {
-    withRef(userNumberInput, (userNumberInput) => userNumberInput.select());
-  }
-
   return new Promise((resolve) => {
+    const { authorizeButton, userNumberInput, registerButton } = displayPage(
+      connection,
+      authContext.requestOrigin,
+      async (userNumber) => {
+        const authSuccess = await authenticateUser(
+          connection,
+          authContext,
+          userNumber
+        );
+        resolve(authSuccess);
+      },
+      userNumber,
+      authContext.authRequest.derivationOrigin
+    );
+
+    // only focus on the button if the anchor is set and was previously used successfully (i.e. is in local storage)
+    if (userNumber !== undefined && userNumber === getUserNumber()) {
+      withRef(authorizeButton, (authorizeButton) => authorizeButton.focus());
+    } else {
+      withRef(userNumberInput, (userNumberInput) => userNumberInput.select());
+    }
+
     // Resolve either on successful authentication or after registration
     withRef(registerButton, (registerButton) =>
       initRegistration(
@@ -219,15 +223,6 @@ const init = (
         userNumber
       ).then(resolve)
     );
-    withRef(authorizeButton, (authorizeButton) => {
-      authorizeButton.onclick = () => {
-        authenticateUser(connection, authContext).then((authSuccess) => {
-          if (authSuccess !== null) {
-            resolve(authSuccess);
-          }
-        });
-      };
-    });
   });
 };
 
@@ -263,14 +258,10 @@ const initRegistration = async (
 
 const authenticateUser = async (
   connection: Connection,
-  authContext: AuthContext
-): Promise<AuthSuccess | null> => {
-  const userNumber = readUserNumber();
+  authContext: AuthContext,
+  userNumber: bigint
+): Promise<AuthSuccess> => {
   try {
-    if (userNumber === undefined) {
-      toggleErrorMessage("userNumberInput", "invalidAnchorMessage", true);
-      return null;
-    }
     const result = await withLoader(() => connection.login(userNumber));
     const loginResult = apiResultToLoginFlowResult(result);
     if (loginResult.tag === "ok") {
@@ -298,11 +289,18 @@ const authenticateUser = async (
 export const displayPage = (
   connection: Connection,
   origin: string,
+  onContinue: (arg: bigint) => void,
   userNumber?: bigint,
   derivationOrigin?: string
 ): PageElements => {
   const container = document.getElementById("pageContent") as HTMLElement;
-  const ret = pageContent(connection, origin, userNumber, derivationOrigin);
+  const ret = pageContent(
+    connection,
+    origin,
+    onContinue,
+    userNumber,
+    derivationOrigin
+  );
   render(ret.template, container);
 
   return ret;
@@ -329,14 +327,3 @@ async function handleAuthSuccess(
       }),
   };
 }
-
-/**
- * Read and parse the user number from the input field.
- */
-const readUserNumber = () => {
-  const parsedUserNumber = parseUserNumber(
-    (document.getElementById("userNumberInput") as HTMLInputElement).value
-  );
-  // get rid of null, we use undefined for 'not set'
-  return parsedUserNumber === null ? undefined : parsedUserNumber;
-};

--- a/src/frontend/src/flows/authenticate/index.ts
+++ b/src/frontend/src/flows/authenticate/index.ts
@@ -47,12 +47,16 @@ const pageContent = (
 
   const authorizeButton: Ref<HTMLButtonElement> = createRef();
   const registerButton: Ref<HTMLLinkElement> = createRef();
-  const anchorInput = mkAnchorInput("userNumberInput", userNumber, (e) => {
-    if (e.key === "Enter") {
-      // authenticate if user hits enter
-      e.preventDefault();
-      withRef(authorizeButton, (authorizeButton) => authorizeButton.click());
-    }
+  const anchorInput = mkAnchorInput({
+    inputId: "userNumberInput",
+    userNumber,
+    onKeyPress: (e) => {
+      if (e.key === "Enter") {
+        // authenticate if user hits enter
+        e.preventDefault();
+        withRef(authorizeButton, (authorizeButton) => authorizeButton.click());
+      }
+    },
   });
 
   const template = html` <div class="l-container c-card c-card--highlight">

--- a/src/frontend/src/flows/login/unknownAnchor.ts
+++ b/src/frontend/src/flows/login/unknownAnchor.ts
@@ -11,6 +11,7 @@ import { useRecovery } from "../recovery/useRecovery";
 import { apiResultToLoginFlowResult, LoginFlowResult } from "./flowResult";
 import { addRemoteDevice } from "../addDevice/welcomeView";
 import { registerIfAllowed } from "../../utils/registerAllowedCheck";
+import { withRef } from "../../utils/utils";
 
 const pageContent = (props: {
   onContinue: (res: bigint) => void;
@@ -74,6 +75,10 @@ export const loginUnknownAnchor = async (
       onContinue: (userNumber) => resolve(doLogin(userNumber, connection)),
     });
     render(content.template, container);
+    // always select the input
+    withRef(content.userNumberInput, (userNumberInput) =>
+      userNumberInput.select()
+    );
     initLinkDevice(connection);
     initRegister(connection, resolve, reject);
     initRecovery(connection);

--- a/src/frontend/src/flows/login/unknownAnchor.ts
+++ b/src/frontend/src/flows/login/unknownAnchor.ts
@@ -17,7 +17,7 @@ const pageContent = (): {
   template: TemplateResult;
   userNumberInput: Ref<HTMLInputElement>;
 } => {
-  const anchorInput = mkAnchorInput("registerUserNumber");
+  const anchorInput = mkAnchorInput({ inputId: "registerUserNumber" });
   const template = html`
   <section class="l-container c-card c-card--highlight" aria-label="Authentication">
     <div class="c-logo">${icLogo}</div>

--- a/src/frontend/src/flows/login/unknownAnchor.ts
+++ b/src/frontend/src/flows/login/unknownAnchor.ts
@@ -11,7 +11,6 @@ import { useRecovery } from "../recovery/useRecovery";
 import { apiResultToLoginFlowResult, LoginFlowResult } from "./flowResult";
 import { addRemoteDevice } from "../addDevice/welcomeView";
 import { registerIfAllowed } from "../../utils/registerAllowedCheck";
-import { withRef } from "../../utils/utils";
 
 const pageContent = (props: {
   onContinue: (res: bigint) => void;

--- a/src/frontend/src/flows/promptUserNumber.ts
+++ b/src/frontend/src/flows/promptUserNumber.ts
@@ -10,10 +10,10 @@ const pageContent = (
   callbacks: { onContinue: (ret: bigint) => void; onCancel: () => void }
 ): { template: TemplateResult; userNumberInput: Ref<HTMLInputElement> } => {
   const userNumberContinue: Ref<HTMLButtonElement> = createRef();
-  const anchorInput = mkAnchorInput(
-    "userNumberInput",
-    userNumber ?? undefined,
-    (e) => {
+  const anchorInput = mkAnchorInput({
+    inputId: "userNumberInput",
+    userNumber: userNumber ?? undefined,
+    onKeyPress: (e) => {
       // submit if user hits enter
       if (e.key === "Enter") {
         e.preventDefault();
@@ -21,8 +21,8 @@ const pageContent = (
           userNumberContinue.click()
         );
       }
-    }
-  );
+    },
+  });
 
   const onContinue = () =>
     withRef(anchorInput.userNumberInput, (userNumberInput) => {

--- a/src/frontend/src/flows/promptUserNumber.ts
+++ b/src/frontend/src/flows/promptUserNumber.ts
@@ -1,6 +1,5 @@
 import { html, render, TemplateResult } from "lit-html";
 import { Ref, ref, createRef } from "lit-html/directives/ref.js";
-import { parseUserNumber } from "../utils/userNumber";
 import { withRef } from "../utils/utils";
 import { mkAnchorInput } from "../components/anchorInput";
 
@@ -13,27 +12,10 @@ const pageContent = (
   const anchorInput = mkAnchorInput({
     inputId: "userNumberInput",
     userNumber: userNumber ?? undefined,
-    onKeyPress: (e) => {
-      // submit if user hits enter
-      if (e.key === "Enter") {
-        e.preventDefault();
-        withRef(userNumberContinue, (userNumberContinue) =>
-          userNumberContinue.click()
-        );
-      }
+    onSubmit: (userNumber: bigint) => {
+      callbacks.onContinue(userNumber);
     },
   });
-
-  const onContinue = () =>
-    withRef(anchorInput.userNumberInput, (userNumberInput) => {
-      const userNumber = parseUserNumber(userNumberInput.value);
-      if (userNumber !== null) {
-        callbacks.onContinue(userNumber);
-      } else {
-        userNumberInput.classList.toggle("has-error", true);
-        userNumberInput.placeholder = "Please enter an Identity Anchor first";
-      }
-    });
 
   const template = html`
     <div class="l-container c-card c-card--highlight">
@@ -52,7 +34,7 @@ const pageContent = (
         </button>
         <button
           ${ref(userNumberContinue)}
-          @click="${onContinue}"
+          @click="${anchorInput.submit}"
           id="userNumberContinue"
           class="c-button"
         >

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -123,6 +123,7 @@ const iiPages: Record<string, () => void> = {
     displayPage(
       dummyConnection,
       "https://nowhere.com",
+      console.log,
       BigInt(10000),
       "http://jqajs-xiaaa-aaaad-aab5q-cai.ic0.app"
     ),

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1101,7 +1101,7 @@ a:hover,
 }
 
 .c-input--anchor.flash-error::after {
-  content: "Anchors only consist of digits";
+  content: attr(data-hint);
   padding: var(--rs-card-bezel); /* TODO */
   position: absolute;
   background: white;

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1110,6 +1110,7 @@ a:hover,
   left: 0px;
   right: 0px;
   font-size: 70%;
+  z-index: var(--vz-tooltip);
 }
 
 /* Needed to override the "reset" rules */


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

Fixes #866 

This changes the control flow for the anchor input component. Before this, the component needed an ID, which was then used by the caller to lookup the element, read the actual anchor number, etc.

Now, the anchor input component takes in an `onSubmit(userNumber: bigint): void` callback, which takes care of read and parsing the anchor number, potentially showing an error if the anchor number is not valid. The submission is triggered by either an "enter" keypress or a call to a new function, `.submit()`.

Not only does this simplify the types and reduce the error surface (by removing a lot of element lookups by ID) but also improves the feedback on bad anchor (hence making #866 moot). A lot de duplication is also removed (around parsing the anchor number & e.g. handling Enter keypresses, CC @peterpeterparker).