### PR TITLE
Clean up anchor input error

### DIFF
--- a/src/frontend/src/components/anchorInput.ts
+++ b/src/frontend/src/components/anchorInput.ts
@@ -19,10 +19,16 @@ export const mkAnchorInput = (props: {
 
   const showHint = (message: string) => {
     withRef(divRef, (div) => {
-      if (!div.classList.contains("flash-error")) {
-        div.setAttribute("data-hint", message);
-        div.classList.add("flash-error");
-        setTimeout(() => div.classList.remove("flash-error"), 2000);
+      const error = "c-input__error--errored";
+      const hide = "is-hidden";
+      if (!div.classList.contains(error)) {
+        div.classList.add(error);
+        div.classList.remove(hide);
+        div.textContent = message;
+        setTimeout(() => {
+          div.classList.remove(error);
+          div.classList.add(hide);
+        }, 2000);
       }
     });
   };
@@ -77,7 +83,7 @@ export const mkAnchorInput = (props: {
     return result;
   };
 
-  const template = html` <div ${ref(divRef)} class="l-stack c-input--anchor">
+  const template = html` <div class="l-stack c-input--anchor">
     <label class="c-input--anchor__wrap" aria-label="Identity Anchor">
       <input
         ${ref(userNumberInput)}
@@ -97,6 +103,7 @@ export const mkAnchorInput = (props: {
         @focusout=${inputFilter(isDigits, onBadInput)}
         @keypress=${onKeyPress}
       />
+      <div ${ref(divRef)} class="c-card c-input__error is-hidden"></div>
     </label>
   </div>`;
 

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1100,17 +1100,23 @@ a:hover,
   z-index: 1;
 }
 
-.c-input--anchor.flash-error::after {
-  content: attr(data-hint);
-  padding: var(--rs-card-bezel); /* TODO */
-  position: absolute;
-  background: white;
-  border-radius: 20px;
-  top: 6rem;
+.c-input__error {
   left: 0px;
   right: 0px;
-  font-size: 70%;
+  position: absolute;
+
+  opacity: 0;
+  transition: opacity 0.2s ease-in;
+
+  min-width: 15rem;
+  text-align: left;
+  background-color: var(--rc-background);
+  color: var(--rc-text);
   z-index: var(--vz-tooltip);
+}
+
+.c-input__error--errored {
+  opacity: 1;
 }
 
 /* Needed to override the "reset" rules */


### PR DESCRIPTION
This removes a CSS hack using a `data-` attr to show the error message, and makes the anchor input style consistent with tooltips.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


Before:

<img width="375" alt="Screenshot 2022-09-30 at 12 36 26" src="https://user-images.githubusercontent.com/6930756/193252239-5b821823-c267-4a5b-ba46-f6ae69dc774d.png">


After:

<img width="375" alt="Screenshot 2022-09-30 at 12 36 17" src="https://user-images.githubusercontent.com/6930756/193252262-82c2ae5f-588f-4ac2-a715-22d1d182a002.png">
