### PR TITLE
Simplify value attribute of anchor input

### DIFF
--- a/src/frontend/src/components/anchorInput.ts
+++ b/src/frontend/src/components/anchorInput.ts
@@ -85,7 +85,7 @@ export const mkAnchorInput = (props: {
         id="${props.inputId}"
         class="c-input c-input--vip"
         placeholder="Enter anchor"
-        value="${props.userNumber !== undefined ? props.userNumber : ""}"
+        value="${props.userNumber}"
         @input=${inputFilter(isDigits, onBadInput)}
         @keydown=${inputFilter(isDigits, onBadInput)}
         @keyup=${inputFilter(isDigits, onBadInput)}


### PR DESCRIPTION
This removes a ternary operator defaulting to `""` because lit will do exactly that if the value is `undefined`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
