### PR TITLE
CRP-1540 replace crypto internal iccsa sig crate with a public re-export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
  "flate2",
  "hex",
  "ic-certification",
- "ic-crypto-internal-basic-sig-iccsa",
+ "ic-crypto-iccsa",
  "ic-error-types",
  "ic-state-machine-tests",
  "ic-types 0.8.0",
@@ -2002,6 +2002,14 @@ version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=016e7d68bff38d921b9dd168fc11ac1f0a98995e#016e7d68bff38d921b9dd168fc11ac1f0a98995e"
 dependencies = [
  "getrandom 0.2.7",
+]
+
+[[package]]
+name = "ic-crypto-iccsa"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=016e7d68bff38d921b9dd168fc11ac1f0a98995e#016e7d68bff38d921b9dd168fc11ac1f0a98995e"
+dependencies = [
+ "ic-crypto-internal-basic-sig-iccsa",
 ]
 
 [[package]]

--- a/src/canister_tests/Cargo.toml
+++ b/src/canister_tests/Cargo.toml
@@ -20,6 +20,6 @@ internet_identity_interface = { path = "../internet_identity_interface" }
 candid = "0.7"
 ic-types = { git = "https://github.com/dfinity/ic", rev = "016e7d68bff38d921b9dd168fc11ac1f0a98995e" }
 ic-certification = { git = "https://github.com/dfinity/ic", rev = "016e7d68bff38d921b9dd168fc11ac1f0a98995e" }
-ic-crypto-internal-basic-sig-iccsa = { git = "https://github.com/dfinity/ic", rev = "016e7d68bff38d921b9dd168fc11ac1f0a98995e" }
+ic-crypto-iccsa = { git = "https://github.com/dfinity/ic", rev = "016e7d68bff38d921b9dd168fc11ac1f0a98995e" }
 ic-error-types = { git = "https://github.com/dfinity/ic", rev = "016e7d68bff38d921b9dd168fc11ac1f0a98995e" }
 ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "016e7d68bff38d921b9dd168fc11ac1f0a98995e" }

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -1,7 +1,7 @@
 use candid::utils::{decode_args, encode_args, ArgumentDecoder, ArgumentEncoder};
 use candid::{parser::value::IDLValue, IDLArgs, Principal};
-use ic_crypto_internal_basic_sig_iccsa::types::SignatureBytes;
-use ic_crypto_internal_basic_sig_iccsa::{public_key_bytes_from_der, verify};
+use ic_crypto_iccsa::types::SignatureBytes;
+use ic_crypto_iccsa::{public_key_bytes_from_der, verify};
 use ic_error_types::ErrorCode;
 use ic_state_machine_tests::{CanisterId, PrincipalId, StateMachine, UserError, WasmResult};
 use ic_types::crypto::Signable;


### PR DESCRIPTION
Removes the dependency on an internal `crypto` package by substituting the public re-export. This removes the last remaining instance of accessing internal packages of the IC repository.