### PR TITLE
Move test infrastructure back to canister_tests crate

### DIFF
--- a/src/canister_tests/src/api.rs
+++ b/src/canister_tests/src/api.rs
@@ -1,0 +1,2 @@
+pub mod archive;
+pub mod internet_identity;

--- a/src/canister_tests/src/api/archive.rs
+++ b/src/canister_tests/src/api/archive.rs
@@ -1,5 +1,5 @@
-use canister_tests::framework;
-use canister_tests::framework::CallError;
+use crate::framework;
+use crate::framework::CallError;
 use ic_state_machine_tests::{CanisterId, PrincipalId, StateMachine};
 use internet_identity_interface as types;
 

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -1,9 +1,10 @@
-/** The functions here are derived (manually) from Internet Identity's Candid file */
+use crate::framework;
+use crate::framework::CallError;
 use candid::Principal;
-use canister_tests::framework;
-use framework::CallError;
 use ic_state_machine_tests::{CanisterId, PrincipalId, StateMachine};
 use internet_identity_interface as types;
+
+/** The functions here are derived (manually) from Internet Identity's Candid file */
 
 /// A fake "health check" method that just checks the canister is alive a well.
 pub fn health_check(env: &StateMachine, canister_id: CanisterId) {

--- a/src/canister_tests/src/flows.rs
+++ b/src/canister_tests/src/flows.rs
@@ -1,5 +1,5 @@
-use crate::api::{create_challenge, http_request, register};
-use canister_tests::framework::{device_data_1, principal_1};
+use crate::api::internet_identity::{create_challenge, http_request, register};
+use crate::framework::{device_data_1, principal_1};
 use ic_state_machine_tests::{CanisterId, PrincipalId, StateMachine};
 use internet_identity_interface::{
     ChallengeAttempt, DeviceData, HttpRequest, RegisterResponse, UserNumber,

--- a/src/canister_tests/src/lib.rs
+++ b/src/canister_tests/src/lib.rs
@@ -1,11 +1,13 @@
-/**
- * Here you'll find modules related to testing the canisters:
- *  * `framework`: Helpers of various kinds for writing tests.
- *  * `certificate_validation`: Validation logic for asset certification
- *
- * Most changes should happen in the canister specific `tests` folders. The split was done this way so that `tests` is as simple
- * as possible to make tests easy to read and write.
- */
-pub mod framework;
-
+//! Here you'll find modules related to testing the canisters:
+//!  * `api`: Rust-bindings for the II and archive canisters
+//!  * `certificate_validation`: Validation logic for asset certification
+//!  * `flows`: Reusable flows consisting of multiple canister interactions
+//!  * `framework`: Helpers of various kinds for writing tests.
+//!
+//! Most changes should happen in the canister specific `tests` folders. The split was done this way so that `tests` is as simple
+//! as possible to make tests easy to read and write.
+//!
+pub mod api;
 pub mod certificate_validation;
+pub mod flows;
+pub mod framework;

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -1,5 +1,7 @@
 use candid::Principal;
+use canister_tests::api::internet_identity as api;
 use canister_tests::certificate_validation::validate_certification;
+use canister_tests::flows;
 use canister_tests::framework::*;
 use ic_state_machine_tests::{ErrorCode::CanisterCalledTrap, PrincipalId, StateMachine};
 use internet_identity_interface::*;
@@ -8,20 +10,6 @@ use serde_bytes::ByteBuf;
 use std::ops::Add;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-/**
- * There are various modules related to testing the II canister:
- *  * `api`: Rust-bindings for the II canister
- *  * `flows`: Reusable flows consisting of multiple II interactions
- *
- * Most changes should happen in the `tests` module. The split was done this way so that `tests` is a simple
- * as possible to make tests easy to read and write.
- *
- * The submodules modules are split into folders because the tests folder has special rules regarding top level files:
- * See https://doc.rust-lang.org/book/ch11-03-test-organization.html#submodules-in-integration-tests
- */
-mod api;
-mod flows;
 
 #[test]
 fn ii_canister_can_be_installed() {


### PR DESCRIPTION
This makes it easier to write tests that use multiple canisters and is a preparation for the upcominig archive <-> II integration PR.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
