### PR TITLE
Update github actions to newer versions

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -32,7 +32,7 @@ runs:
     # NOTE: here we make sure to only cache ic-cdk-optimizer and _not_ e.g. the cargo target, since in some cases
     # (clean builds) we build from scratch
     # NOTE: we include the output of uname to ensure binary compatibility (e.g. same glibc)
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.cargo/bin
         key: cargo-bin-${{ steps.platform.outputs.platform-id }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-2

--- a/.github/actions/file-size/README.md
+++ b/.github/actions/file-size/README.md
@@ -8,7 +8,7 @@ A GitHub Action for recording file sizes in git notes.
   record-readme-size:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/file-size
         with:
           file: README.md

--- a/.github/actions/setup-dfx/action.yml
+++ b/.github/actions/setup-dfx/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           /usr/local/bin/dfx

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -8,6 +8,6 @@ runs:
       id: read-node-version
       run: echo "::set-output name=version::$(cat .node-version)"
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ steps.read-node-version.version }}

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -17,16 +17,16 @@ jobs:
   docker-build-base:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # We use buildx and its GitHub Actions caching support `type=gha`. For
       # more information, see
       # https://github.com/docker/build-push-action/issues/539
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build base Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile
@@ -66,13 +66,13 @@ jobs:
             II_DUMMY_AUTH: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build ${{ matrix.name }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile
@@ -88,7 +88,7 @@ jobs:
       - run: sha256sum out/internet_identity.wasm
       - run: mv out/internet_identity.wasm ${{ matrix.name }}
       - name: 'Upload ${{ matrix.name }}'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           # name is the name used to display and retrieve the artifact
           name: ${{ matrix.name }}
@@ -100,13 +100,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-base
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build Archive Canister
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: Dockerfile
@@ -118,7 +118,7 @@ jobs:
       - run: mv out/archive.wasm archive.wasm
       - run: sha256sum archive.wasm
       - name: 'Upload archive.wasm'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           # name is the name used to display and retrieve the artifact
           name: archive.wasm
@@ -130,9 +130,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-ii
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Download wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: internet_identity_production.wasm
           path: .
@@ -155,8 +155,8 @@ jobs:
   test-app-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -169,7 +169,7 @@ jobs:
         working-directory: demos/test-app
         run: ./build.sh
       - name: 'Upload test app'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           # name is the name used to display and retrieve the artifact
           name: test_app.wasm
@@ -190,7 +190,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # Pull a deep copy so that we can set meaningful timestamps across builds, based on the commit history
           fetch-depth: '0'
@@ -205,7 +205,7 @@ jobs:
         # due to the mtime changing on the checkout. Can be worked around by storing
         # the original mtime in the cache and by hashing all of src/canister_tests
         # (and then restoring the mtime).
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           # note on paths: we include the whole ~/.cargo/. (as opposed to just .cargo/git, etc.) because cargo stores crate
           # data as .crates(2?).{json,toml} without which the whole cache is invalidated. We may accumulate unnecessary
@@ -217,13 +217,13 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'src/**/Cargo.toml', 'rust-toolchain.toml') }}-3
 
       - name: 'Download II wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: internet_identity_test.wasm
           path: .
 
       - name: 'Download archive wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: archive.wasm
           path: .
@@ -282,7 +282,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
 
       - uses: ./.github/actions/setup-dfx
@@ -301,13 +301,13 @@ jobs:
         run: dfx start --background
 
       - name: 'Download II wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: internet_identity_test.wasm
           path: .
 
       - name: 'Download test app wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test_app.wasm
           path: demos/test-app
@@ -343,14 +343,14 @@ jobs:
 
       - name: Archive test logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: e2e-test-log-${{ matrix.device }}
           path: ./*.log
 
       - name: Archive test failures
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: e2e-test-failures-${{ matrix.device }}
           path: test-failures/*
@@ -360,7 +360,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-ii
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: |
           sudo apt-get update
@@ -381,7 +381,7 @@ jobs:
           dfx start --background
 
       - name: 'Download wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: internet_identity_dev.wasm
           path: .
@@ -440,13 +440,13 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/release-')
     needs: docker-build-ii
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: 'Install dfx'
         run: DFX_VERSION=0.10.1 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
 
       - name: 'Download wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: internet_identity_production.wasm
           path: .
@@ -476,22 +476,22 @@ jobs:
     needs: docker-build-ii
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: 'Download wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: internet_identity_test.wasm
           path: .
 
       - name: 'Download wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: internet_identity_dev.wasm
           path: .
 
       - name: 'Download wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: internet_identity_production.wasm
           path: .
@@ -529,9 +529,9 @@ jobs:
       matrix:
         os: [ ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-11, macos-12 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Download wasm'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: internet_identity_production.wasm
           path: .

--- a/.github/workflows/cargo-tests.yml
+++ b/.github/workflows/cargo-tests.yml
@@ -7,7 +7,7 @@ jobs:
   cargo-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # set a PAT so that add-and-commit can trigger
           # CI runs

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -7,7 +7,7 @@ jobs:
   frontend-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
       - run: npm ci
       - name: Run ESLint
@@ -24,7 +24,7 @@ jobs:
       # Make sure that one failing test does not cancel all other matrix jobs
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
       - run: rm -v -f screenshots/${{ matrix.device }}*.png
       - run: npm ci
@@ -46,7 +46,7 @@ jobs:
           shasum -a 256 screenshots/${{ matrix.device }}/*.png | sort -k2 # sort by 2nd column (filename)
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: e2e-screenshots-${{ matrix.device }}
           path: screenshots/${{ matrix.device }}/*.png
@@ -62,7 +62,7 @@ jobs:
     needs: screenshots
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # set a PAT so that add-and-commit can trigger CI runs
           token: ${{ secrets.GIX_BOT_PAT }}
@@ -71,13 +71,13 @@ jobs:
       - run: rm -v -f screenshots/*.png
 
       # Download the desktop screenshots artifacts
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: e2e-screenshots-desktop
           path: screenshots/desktop
 
       # Download the mobile screenshots artifacts
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: e2e-screenshots-mobile
           path: screenshots/mobile

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         os: [ ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-11, macos-12 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: "refs/tags/${{ needs.latest-release.outputs.ref }}"
 

--- a/.github/workflows/update-ic.yml
+++ b/.github/workflows/update-ic.yml
@@ -10,7 +10,7 @@ jobs:
   ic-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
         # First, iterate over all Cargo.toml files and check against IC GitHub for new commits.
       - name: Check new ic version

--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -11,7 +11,7 @@ jobs:
   node-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
         # First, check node's releases for a new version.
       - name: Check new node version

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -11,7 +11,7 @@ jobs:
   rust-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
         # First, check rust GitHub releases for a new version. We assume that the
         # latest version's tag name is the version.


### PR DESCRIPTION
This PR addresses the warnings about Node.js 12 being deprecated that showed up on our CI runs.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
