### PR TITLE
Work around empty arrays for bash <4.4

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -535,15 +535,6 @@ jobs:
         with:
           name: internet_identity_production.wasm
           path: .
-      # Install recent bash (default bash 3 is lacking important features)
-      - run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew update
-          brew install bash
-          echo "/usr/local/bin" >> $GITHUB_PATH
-          echo bash --version
-          bash --version
-        if: ${{ startsWith(matrix.os, 'mac') }}
       - run: |
           sha256=$(shasum -a 256 ./internet_identity_production.wasm | cut -d ' ' -f1)
           echo "::set-output name=sha256::$sha256"

--- a/scripts/build
+++ b/scripts/build
@@ -109,7 +109,8 @@ function build_canister() {
         --release
         -j1
         )
-    cargo_build_args+=("${extra_build_args[@]}")
+    # XXX: for bash > 4.4, empty arrays are considered unset, so do some substitution
+    cargo_build_args+=(${extra_build_args[@]+"${extra_build_args[@]}"})
 
     echo Running cargo build "${cargo_build_args[@]}"
     echo RUSTFLAGS: "$RUSTFLAGS"
@@ -144,7 +145,8 @@ function build_internet_identity() {
       echo "USING DUMMY CAPTCHA"
       extra_build_args+=( --features dummy_captcha )
   fi
-  build_canister "internet_identity" "${extra_build_args[@]}"
+  # XXX: for bash > 4.4, empty arrays are considered unset, so do some substitution
+  build_canister "internet_identity" ${extra_build_args[@]+"${extra_build_args[@]}"}
 }
 
 for canister in "${CANISTERS[@]}"


### PR DESCRIPTION
This adds a workaround for accessing an empty array in bash versions older than 4.4, as well as removing the bash upgrade on CI.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
