### PR TITLE
Add anchor picker to showcase

### DIFF
--- a/src/frontend/src/components/anchorPicker.test.ts
+++ b/src/frontend/src/components/anchorPicker.test.ts
@@ -1,0 +1,63 @@
+import { mkAnchorPicker } from "./anchorPicker";
+import { render } from "lit-html";
+
+test("first anchor is focused", async () => {
+  const picker = mkAnchorPicker({
+    savedAnchors: [BigInt(10000), BigInt(9990042)],
+    pick: () => {},
+  });
+  render(picker.template, document.body);
+  // Tick once, otherwise element isn't focused yet
+  await tick();
+  const elem = document.activeElement as HTMLElement;
+  expect(elem.dataset.anchorId).toBe("10000");
+});
+
+test("pick saved anchor", async () => {
+  let picked: bigint | undefined = undefined;
+  const picker = mkAnchorPicker({
+    savedAnchors: [BigInt(10000), BigInt(9990042)],
+    pick: (anchor) => {
+      picked = anchor;
+    },
+  });
+  render(picker.template, document.body);
+  // Tick once, otherwise element isn't focused yet
+  await tick();
+  const elem = document.querySelector(
+    '[data-anchor-id="10000"]'
+  ) as HTMLElement;
+  elem.click();
+  expect(picked).toBe(BigInt(10000));
+});
+
+test("pick custom anchor", async () => {
+  let picked: bigint | undefined = undefined;
+  const picker = mkAnchorPicker({
+    savedAnchors: [BigInt(10000), BigInt(9990042)],
+    pick: (anchor) => {
+      picked = anchor;
+    },
+  });
+  render(picker.template, document.body);
+  // Tick once, otherwise element isn't focused yet
+  await tick();
+  const elem = document.querySelector(
+    '[data-role="use-another-anchor"]'
+  ) as HTMLElement;
+  elem.click();
+  await tick();
+  const input = document.querySelector(
+    '[data-role="anchor-input"]'
+  ) as HTMLInputElement;
+  input.value = "1234";
+
+  const create = document.querySelector(
+    '[data-role="anchor-create"]'
+  ) as HTMLInputElement;
+  create.click();
+
+  expect(picked).toBe(BigInt(1234));
+});
+
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve));

--- a/src/frontend/src/components/anchorPicker.ts
+++ b/src/frontend/src/components/anchorPicker.ts
@@ -1,0 +1,136 @@
+import { html, TemplateResult } from "lit-html";
+import { arrowRight } from "./icons";
+import { mount } from "../utils/lit-html";
+import { mkAnchorInput } from "./anchorInput";
+import { until } from "lit-html/directives/until.js";
+
+type PickerProps = {
+  savedAnchors: bigint[];
+  pick: PickCB;
+};
+
+type PickCB = (userNumber: bigint) => void;
+
+/** A component for picking an anchor number. One big list where the first
+ * elements are (clickable) anchors, and the last (and sometimes only) element
+ * is a menu for using any anchor or creating a new anchor. */
+export const mkAnchorPicker = (
+  props: PickerProps
+): {
+  template: TemplateResult;
+} => {
+  const template = html`<ul class="c-list c-list--anchors l-stack">
+    ${elements(props)}
+  </ul>`;
+
+  return { template };
+};
+
+// The list elements, including the anchor creation menu
+function elements(props: PickerProps): TemplateResult[] {
+  const otherAnchorMenuTpl = otherAnchorMenu({ pick: props.pick });
+  const savedAnchorsTpl = props.savedAnchors.map((anchor, i) =>
+    anchorItem({ anchor, pick: props.pick, focus: i == 0 })
+  );
+
+  let elems = [];
+
+  if (savedAnchorsTpl.length > 0) {
+    // If there are saved anchors, show those, and then an expandable menu
+    // for "other anchor".
+
+    // Function that replaces the "other anchor" button with the "other anchor" menu
+    // (actually a reference written when the template is created)
+    let otherAnchorOpen: (() => void) | undefined = undefined;
+
+    const otherAnchorOffer: TemplateResult = html`
+      <button
+        class="t-link c-list__parcel c-list__parcel--fullwidth c-list__parcel--summary"
+        @click="${() => {
+          otherAnchorOpen?.();
+        }}"
+        @focus="${() => {
+          otherAnchorOpen?.();
+        }}"
+        data-role="use-another-anchor"
+      >
+        Use another anchor<i class="c-list__icon"> … </i>
+      </button>
+    `;
+
+    elems = savedAnchorsTpl;
+    elems.push(html` <li class="c-list__item c-list__item--noFocusStyle">
+      ${until(
+        // replace the "use another anchor" button with actual menu when ready (clicked)
+        new Promise<void>((resolve) => {
+          otherAnchorOpen = resolve;
+        }).then(() => Promise.resolve(otherAnchorMenu({ pick: props.pick }))),
+        otherAnchorOffer
+      )}
+    </li>`);
+  } else {
+    // If there are no saved anchors, just show the (expanded) "other anchor" menu.
+    elems.push(
+      html` <li class="c-list__item c-list__item--noFocusStyle">
+        ${otherAnchorMenuTpl}
+      </li>`
+    );
+  }
+
+  return elems;
+}
+
+const anchorItem = (props: {
+  anchor: bigint;
+  pick: PickCB;
+  focus: boolean /* when 'true' the element will be focused when created */;
+}): TemplateResult => html`
+  <li class="c-list__item c-list__item--vip c-list__item--icon icon-trigger">
+    <button
+      ${props.focus
+        ? mount((e) => {
+            if (e instanceof HTMLElement) {
+              e.focus();
+            }
+          })
+        : ""}
+      data-anchor-id=${props.anchor}
+      class="c-list__parcel c-list__parcel--select"
+      @click="${() => props.pick(props.anchor)}"
+      tabindex="0"
+    >
+      ${props.anchor}
+    </button>
+    <i class="c-list__icon c-list__icon--masked"> ${arrowRight} </i>
+  </li>
+`;
+
+function otherAnchorMenu(props: { pick: PickCB }): TemplateResult {
+  const anchorInput = mkAnchorInput({ onSubmit: props.pick });
+
+  return html`
+    <div
+      class="c-list__parcel c-list__parcel--fullwidth c-list__parcel--detail"
+    >
+      ${anchorInput.template}
+      <button
+        class="c-button"
+        data-role="anchor-create"
+        @click="${anchorInput.submit}"
+      >
+        Oh ouiiii
+      </button>
+      <p class="l-stack">
+        An <b class="t-strong">Identity Anchor</b> is a
+        <b class="t-strong">unique ID</b> that is used to authenticate yourself.
+        You will be able to use it to <b class="t-strong">log in</b> to all
+        kinds of apps.
+      </p>
+      <div class="l-stack">
+        <button class="c-button c-button--secondary">
+          Create a new anchor
+        </button>
+      </div>
+    </div>
+  `;
+}

--- a/src/frontend/src/components/icons.ts
+++ b/src/frontend/src/components/icons.ts
@@ -271,3 +271,21 @@ export const caretDownIcon = html`
     </g>
   </svg>
 `;
+
+export const arrowRight = html`
+  <svg
+    viewBox="0 0 23 21"
+    xmlns="http://www.w3.org/2000/svg"
+    class="icon icon--arrow-right"
+  >
+    <style>
+      .icon--arrow-right g {
+        stroke-width: var(--stroke-width, 1);
+      }
+    </style>
+    <g vector-effect="non-scaling-stroke" fill="none" stroke="currentColor">
+      <path d="M 15.5 5 L 21 10 L 15.5 15" />
+      <line x1="0" y1="10" x2="21" y2="10" />
+    </g>
+  </svg>
+`;

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -949,6 +949,160 @@ a:hover,
   list-style-type: decimal;
 }
 
+.c-list__item--vip {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.c-list__parcel--select:hover {
+  transition: background-color 400ms cubic-bezier(0.3, 0.7, 0, 1);
+}
+
+.c-list--anchors {
+  --border-radius: 8px;
+  width: 40rem;
+}
+
+.c-list__item--icon {
+  position: relative;
+}
+
+.c-list__item--icon .c-list__parcel:last-of-type {
+  padding-right: calc(1.5em + 0.8em * 2);
+}
+
+.c-list--anchors .c-list__item {
+  display: flex;
+  flex-wrap: wrap;
+  border: var(--vs-line) var(--rc-line) solid;
+  position: relative;
+}
+
+.c-list--anchors .c-list__item:focus-within,
+.c-list--anchors .c-list__item:focus,
+.c-list--anchors .c-list__item--focus {
+  z-index: var(--vz-foreground);
+}
+
+.c-list--anchors .c-list__item::before {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  inset: 0;
+  will-change: filter;
+  background-image: linear-gradient(270deg, var(--rg-brand));
+  filter: blur(20px);
+  opacity: 0;
+  transform: scaleX(0.1) scaleY(0.7);
+  transition: 300ms opacity linear, 600ms transform cubic-bezier(0.3, 0.7, 0, 1);
+}
+
+.c-list--anchors .c-list__item:focus-within::before,
+.c-list--anchors .c-list__item--focus::before {
+  opacity: 1;
+  transform: scaleX(1) scaleY(0.8);
+}
+
+.c-list--anchors .c-list__item--noFocusStyle::before {
+  display: none;
+}
+
+.c-list--anchors .c-list__item:first-of-type {
+  border-top-left-radius: var(--border-radius);
+  border-top-right-radius: var(--border-radius);
+}
+
+.c-list--anchors .c-list__item:first-of-type .c-list__parcel:first-of-type {
+  border-top-left-radius: var(--border-radius);
+}
+
+.c-list--anchors .c-list__item:first-of-type .c-list__parcel:last-of-type {
+  border-top-right-radius: var(--border-radius);
+}
+
+.c-list--anchors
+  .c-list__item:first-of-type
+  .c-list__parcel--fullwidth:first-of-type {
+  border-top-left-radius: var(--border-radius);
+  border-top-right-radius: var(--border-radius);
+}
+
+.c-list--anchors .c-list__item:last-of-type {
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+}
+
+.c-list--anchors .c-list__item:last-of-type .c-list__parcel:first-of-type {
+  border-bottom-left-radius: var(--border-radius);
+}
+
+.c-list--anchors .c-list__item:last-of-type .c-list__parcel:last-of-type {
+  border-bottom-right-radius: var(--border-radius);
+}
+
+.c-list--anchors
+  .c-list__item:last-of-type
+  .c-list__parcel--fullwidth:last-of-type {
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+}
+
+.c-list--anchors .c-list__item + .c-list__item {
+  margin-top: calc(-1 * var(--vs-line));
+}
+
+.c-list__parcel {
+  position: relative;
+  padding: var(--vs-bezel) 0.8em;
+  border: var(--vs-line) solid var(--rc-line);
+  flex-grow: 1;
+  margin: calc(-1 * var(--vs-line));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background: var(--rc-input);
+}
+
+.c-list__parcel--detail {
+  overflow: hidden;
+  white-space: inherit;
+  padding: var(--vs-bezel) 0.8em;
+}
+
+.c-list__parcel--fullwidth {
+  flex: 1 0 100%;
+  width: 100%;
+}
+
+.c-list__icon {
+  position: absolute;
+  top: 50%;
+  right: calc(var(--vs-bezel) * 1.5);
+  transform: translateY(-50%);
+  width: 1.5em;
+  height: 1.5em;
+  --stroke-width: 2;
+}
+
+/* This is a workaround for animating the arrow icon on all major browsers
+ * (Safari, Chrome, Firefox). SVG path update doesn't work on Safari, and
+ * svg transform is glitchy on Firefox. So instead we hide part of the
+ * arrow and "unhide" it on hover, which looks like the arrow is growing.
+ */
+.c-list__icon--masked {
+  clip-path: inset(0 0 0 35%);
+  transition: clip-path 300ms cubic-bezier(0.3, 0.7, 0, 1);
+}
+
+.c-list--anchors .c-list__item:hover .c-list__icon--masked {
+  clip-path: inset(0 0 0 0%);
+}
+
+.c-list__icon svg {
+  display: block;
+  width: 100%;
+}
+
 /**
  *  Tooltip component
  *  This is a CSS only tooltip that shows on hover

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -101,3 +101,56 @@ export function wrapError(err: unknown): string {
 
   return unknownError;
 }
+
+/** A channel (Chan) between two execution environments.
+ * Values can be sent (`send()`) and received (`recv()`) asynchronously
+ * on the other end.
+ */
+export class Chan<A> {
+  /* The `recv` function will read values both from a blocking `snd` function
+   * and from a buffer. We always _first_ write to `snd` and _then_ write
+   * to `buffer` and _first_ read from the buffer and _then_ read from `snd`
+   * to maintain a correct ordering.
+   *
+   * `snd` is a set by `recv` as `resolve` from a promise that `recv` blocks
+   * on.
+   */
+
+  // Write to `recv`'s blocking promise
+  private snd?: (value: A) => void;
+
+  // Buffer where values are stored in between direct writes
+  // to the promise
+  private buffer: A[] = [];
+
+  send(a: A): void {
+    if (this.snd !== undefined) {
+      this.snd(a);
+      // After the promise was resolved, set as undefined so that
+      // future `send`s go to the buffer.
+      this.snd = undefined;
+    } else {
+      this.buffer.push(a);
+    }
+  }
+
+  async *recv(): AsyncIterable<A> {
+    // Forever loop, yielding entire buffers and then blocking
+    // on `snd` (which prevents hot looping)
+    while (true) {
+      // Yield the buffer first
+      while (true) {
+        const val = this.buffer.shift();
+        if (val === undefined) {
+          break;
+        }
+        yield val;
+      }
+
+      // then block and yield a value when received
+      yield await new Promise((resolve: (value: A) => void) => {
+        this.snd = resolve;
+      });
+    }
+  }
+}


### PR DESCRIPTION



This introduces a new component (an anchor _picker_) that allows picking one of many anchors. The picker is not yet integrated with any of the pages; this PR only adds the picker code, the tests, and an integration in the showcase.

Texts still have to be agreed on; current text is only placeholder.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


https://user-images.githubusercontent.com/6930756/198989572-7bf70fba-66dd-4731-8684-88940e7fa541.mov
