### PR TITLE
Replace CSP placeholder

### DIFF
--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -4,10 +4,8 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="CSP_POLICY_PLACEHOLDER"
-    />
+    <!-- CSP directives injected by the canister -->
+    <meta replaceme-with-csp />
     <title>Internet Identity</title>
     <link rel="shortcut icon" type="image/jpg" href="./favicon.ico" />
     <!-- We set "inject" to false in production, where we explicitly link to the stylesheet

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -45,10 +45,7 @@ lazy_static! {
             r#"<script id="setupJs"></script>"#,
             &format!(r#"<script data-canister-id="{canister_id}" id="setupJs">{setup_js}</script>"#).to_string()
         );
-        let index_html = index_html.replace(
-            "CSP_POLICY_PLACEHOLDER",
-            &http::content_security_policy_meta()
-        );
+        let index_html = index_html.replace("<meta replaceme-with-csp/>", &format!(r#"<meta http-equiv="Content-Security-Policy" content="{}" />"#,&http::content_security_policy_meta() ));
         index_html
     };
 }


### PR DESCRIPTION
This replaces the CSP placeholder with a tag that is ignored by the browser. The previous `<meta>` tag with `http-equiv` was interpreted as a real CSP tag and the browser would show an error because of the `CSP_POLICY_PLACEHOLDER` value.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
