### PR TITLE
Include archive in releases

### DIFF
--- a/.github/actions/release/README.md
+++ b/.github/actions/release/README.md
@@ -15,9 +15,10 @@ $ # The list of files for which we compute the sha256
 $ # (those file must exist, though they don't need to have meaningful content)
 $ export INPUT_ASSETS='internet_identity_production.wasm
 internet_identity_dev.wasm
-internet_identity_test.wasm'
-$ export RELEASE_TAG=release-2022-03-30 # Any tag
+internet_identity_test.wasm
+archive.wasm'
+$ export RELEASE_TAG=release-2022-10-28 # Any tag
 $ export GITHUB_SHA=$(git rev-parse $RELEASE_TAG)
-$ export RELEASE_TAG_PREVIOUS=release-2022-03-15 # Any tag older than RELEASE_TAG
+$ export RELEASE_TAG_PREVIOUS=release-2022-10-20_2 # Any tag older than RELEASE_TAG
 $ ./.github/actions/release/run # finally, run the action
 ```

--- a/.github/actions/release/run
+++ b/.github/actions/release/run
@@ -55,8 +55,9 @@ do
 
     # Find out the Job ID
     # XXX: Unfortunately GitHub actions doesn't give us a way to find out the Job ID explicitely.
-    # Instead, we find the job name that includes "$filename" and assume that's the Job ID. This works
-    # because our build matrix takes in the filename as argument, which is added to the job name.
+    # Instead, we find the job name that includes "$filename" without the .wasm extension and assume that's the Job ID.
+    # This works because our jobs contain the filename without extension
+    # (either added manually or by build matrix which takes in the filename as argument and adds it to the job name).
     # https://github.community/t/get-action-job-id/17365/7
     if [ -z "${GITHUB_RUN_ID:-}" ]
     then
@@ -66,8 +67,8 @@ do
     else
         job_id=$(curl --silent "https://api.github.com/repos/dfinity/internet-identity/actions/runs/$GITHUB_RUN_ID/jobs" \
             | jq -cMr \
-            --arg filename "$filename" \
-            '.jobs[] | select(.name | contains($filename)) | .id')
+            --arg search_string "${filename%.wasm}" \
+            '.jobs[] | select(.name | contains($search_string)) | .id')
                     >&2 echo "Found job id: $job_id"
 
         # Now get the URL that we'll link to for verification of the sha

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -577,6 +577,12 @@ jobs:
           name: internet_identity_production.wasm
           path: .
 
+      - name: 'Download wasm'
+        uses: actions/download-artifact@v3
+        with:
+          name: archive.wasm
+          path: .
+
       - name: Prepare release
         uses: ./.github/actions/release
         id: prepare-release
@@ -585,6 +591,7 @@ jobs:
             internet_identity_production.wasm
             internet_identity_dev.wasm
             internet_identity_test.wasm
+            archive.wasm
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release
@@ -596,7 +603,8 @@ jobs:
             internet_identity_production.wasm \
             internet_identity_dev.wasm \
             internet_identity_test.wasm \
-            src/internet_identity/internet_identity.did
+            src/internet_identity/internet_identity.did \
+            archive.wasm
         env:
           # populated by GitHub Actions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow


### PR DESCRIPTION
This PR adds the archive to the auto-generated release notes. This required minor changes on the release script because manual jobs cannot contain the file name (due to the . character being forbidden).

The PR also updates the readme to include tags that already know about the archive.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
