### PR TITLE
Ensure canister code cache is invalidated when dependencies change

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -224,8 +224,8 @@ jobs:
           echo "::set-output name=commit_deps::$commit_deps"
           echo "deps: $commit_deps"
 
-          # Last time the canister code was modified
-          commit_canister=$(git log -1 --pretty=format:%H -- 'src/**' ':^src/frontend')
+          # Last time dependencies or toolchain or the canister code was modified
+          commit_canister=$(git log -1 --pretty=format:%H -- 'Cargo.*' 'rust-toolchain.toml' 'src/**' ':^src/frontend')
           echo "::set-output name=commit_canister::$commit_canister"
           echo "canister: $commit_canister"
 


### PR DESCRIPTION
This PR makes sure that the check for last canister code change matches strictly more files than the dependencies check. Otherwise the `commit_canister` could be a commit older than `commit_deps` leading to a subsequent error when telling cargo to build with `--frozen`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
