### PR TITLE
Remove manual memory growing from storage::flush

### DIFF
--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -210,7 +210,7 @@ pub fn initialize_from_stable_memory() {
                 s.storage.replace(storage);
             }
             None => {
-                s.storage.borrow().flush();
+                s.storage.borrow_mut().flush();
             }
         }
     });

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -256,20 +256,17 @@ impl<T: candid::CandidType + serde::de::DeserializeOwned, M: Memory> Storage<T, 
     }
 
     /// Make sure all the required metadata is recorded to stable memory.
-    pub fn flush(&self) {
-        if self.memory.size() < 1 {
-            let result = self.memory.grow(1);
-            if result == -1 {
-                trap("failed to grow stable memory to 1 page");
-            }
-        }
-        unsafe {
-            let slice = std::slice::from_raw_parts(
+    pub fn flush(&mut self) {
+        let slice = unsafe {
+            std::slice::from_raw_parts(
                 &self.header as *const _ as *const u8,
                 std::mem::size_of::<Header>(),
-            );
-            self.memory.write(0, &slice);
-        }
+            )
+        };
+        let mut writer = Writer::new(&mut self.memory, 0);
+
+        // this should never fail as this write only requires a memory of size 1
+        writer.write(slice).expect("bug: failed to grow memory");
     }
 
     pub fn user_count(&self) -> usize {


### PR DESCRIPTION
This was overlooked when implementing #968.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
