### PR TITLE
Reduce screenshot sensitivity

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -119,7 +119,7 @@ jobs:
               exit 1
             fi
 
-            if (( metric <= 30 ))
+            if (( metric <= 100 ))
             then
               echo "Pixel difference ($metric) is too small, reverting"
               git checkout HEAD -- "$modified"


### PR DESCRIPTION
We're seeing spurious screenshot re-uploads. This increases the threshold (in # of pixels) from 30 to 100. Any meaningful change will modify much more than 100 pixels.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
