### PR TITLE
Fix deploy on release to use downloaded wasm

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -540,11 +540,11 @@ jobs:
 
       - name: "Deploy II"
         run: |
-          mv internet_identity_production.wasm internet_identity.wasm
           wallet="cvthj-wyaaa-aaaad-aaaaq-cai"
           sha=$(shasum -a 256 ./archive.wasm | cut -d ' ' -f1 | sed 's/../\\&/g')
           dfx canister --network ic --wallet "$wallet" install --mode upgrade \
             --argument "(opt record {archive_module_hash = opt blob \"$sha\"; canister_creation_cycles_cost = opt (1000000000000:nat64); })" \
+            --wasm internet_identity_production.wasm \
             internet_identity
 
       - name: "Deploy archive"


### PR DESCRIPTION
This error was introduced with #1001.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
