### PR TITLE
Wait on archive in release and deploy CI jobs

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -511,7 +511,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/release-')
-    needs: docker-build-ii
+    needs: [docker-build-ii, docker-build-archive]
     steps:
       - uses: actions/checkout@v3
 
@@ -555,7 +555,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/release-')
-    needs: docker-build-ii
+    needs: [docker-build-ii, docker-build-archive]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This CI dependency was overlooked in #998 and #983.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
