### PR TITLE
Fix cancel in add device flow

### DIFF
--- a/src/frontend/src/flows/addDevice/welcomeView/index.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/index.ts
@@ -25,7 +25,8 @@ const pageContent = (connection: Connection, userNumber?: bigint) => {
       <div class="c-button-group">
         <button
           @click="${
-            window.location.reload /* TODO: L2-309: do this without reload */
+            () =>
+              window.location.reload() /* TODO: L2-309: do this without reload */
           }"
           class="c-button c-button--secondary"
           id="addDeviceUserNumberCancel"


### PR DESCRIPTION
This makes sure the callback actually calls `window.location.reload()`. Before this, the callback was bound to `window.location.reload`, which may change over time, causing the "Cancel" button to call an invalid reference.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
