### PR TITLE
Disallow webauthn credentials without credential id

### DIFF
--- a/src/archive/tests/tests.rs
+++ b/src/archive/tests/tests.rs
@@ -674,7 +674,13 @@ mod stable_memory_tests {
         let add_entry = Entry {
             anchor: ANCHOR,
             operation: Operation::AddDevice {
-                device: DeviceDataWithoutAlias::from(device_data_2()),
+                device: DeviceDataWithoutAlias {
+                    pubkey: device_data_2().pubkey,
+                    credential_id: None,
+                    purpose: Purpose::Authentication,
+                    key_type: KeyType::Unknown,
+                    protection: DeviceProtection::Unprotected,
+                },
             },
             timestamp: TIMESTAMP,
             caller: Principal::from(principal_1()),

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -204,7 +204,7 @@ pub fn device_data_1() -> types::DeviceData {
     types::DeviceData {
         pubkey: ByteBuf::from(PUBKEY_1),
         alias: "My Device".to_string(),
-        credential_id: None,
+        credential_id: Some(ByteBuf::from("credential_id1")),
         purpose: types::Purpose::Authentication,
         key_type: types::KeyType::Unknown,
         protection: types::DeviceProtection::Unprotected,
@@ -215,7 +215,7 @@ pub fn device_data_2() -> types::DeviceData {
     types::DeviceData {
         pubkey: ByteBuf::from(PUBKEY_2),
         alias: "My second device".to_string(),
-        credential_id: None,
+        credential_id: Some(ByteBuf::from("credential_id2")),
         purpose: types::Purpose::Authentication,
         key_type: types::KeyType::Unknown,
         protection: types::DeviceProtection::Unprotected,

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -196,6 +196,12 @@ fn write_anchor_data(user_number: UserNumber, entries: Vec<DeviceDataInternal>) 
 fn check_device(device_data: &DeviceData, existing_devices: &[DeviceDataInternal]) {
     check_entry_limits(device_data);
 
+    if device_data.key_type != KeyType::SeedPhrase && device_data.credential_id.is_none() {
+        trap(&format!(
+            "All credentials except recovery phrases require a credential id"
+        ));
+    }
+
     if device_data.protection == DeviceProtection::Protected
         && device_data.key_type != KeyType::SeedPhrase
     {

--- a/src/internet_identity/tests/archive_integration_tests.rs
+++ b/src/internet_identity/tests/archive_integration_tests.rs
@@ -207,7 +207,7 @@ fn should_record_anchor_operations() -> Result<(), CallError> {
         operation: Operation::RegisterAnchor {
             device: DeviceDataWithoutAlias {
                 pubkey: device_data_1().pubkey,
-                credential_id: None,
+                credential_id: device_data_1().credential_id,
                 purpose: Purpose::Authentication,
                 key_type: KeyType::Unknown,
                 protection: DeviceProtection::Unprotected,

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -795,6 +795,24 @@ mod device_management_tests {
         );
     }
 
+    /// Verifies that webauthn credentials are only accepted if they have a credential id.
+    #[test]
+    fn should_not_add_webauthn_device_without_credential_id() {
+        let env = StateMachine::new();
+        let canister_id = install_ii_canister(&env, II_WASM.clone());
+        let user_number = flows::register_anchor(&env, canister_id);
+
+        let mut device = device_data_2();
+        device.credential_id = None;
+        let result = api::add(&env, canister_id, principal_1(), user_number, device);
+
+        expect_user_error_with_message(
+            result,
+            CanisterCalledTrap,
+            Regex::new("All credentials except recovery phrases require a credential id").unwrap(),
+        );
+    }
+
     /// Verifies that a new device can be added to anchors that were registered using the previous II release.
     #[test]
     fn should_add_additional_device_after_ii_upgrade() -> Result<(), CallError> {


### PR DESCRIPTION
Currently, II allows registering credentials without credential id that are also not recovery phrases. These credentials are useless in the context of II. No additional credentials of this type should be created.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
