### PR TITLE
Fix error in persistent state reading

### DIFF
--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -366,29 +366,59 @@ impl<T: candid::CandidType + serde::de::DeserializeOwned, M: Memory> Storage<T, 
     /// Reads the persistent state from stable memory just outside of the space allocated to the highest user number.
     /// This is only used to restore state in `post_upgrade`.
     pub fn read_persistent_state(&self) -> Result<PersistentState, PersistentStateError> {
+        const WASM_PAGE_SIZE: u64 = 65536;
         let address = self.unused_memory_start();
+
+        if address > self.memory.size() * WASM_PAGE_SIZE {
+            // the address where the persistent state would be is not allocated yet
+            return Err(PersistentStateError::NotFound);
+        }
+
         let mut reader = Reader::new(&self.memory, address);
-
         let mut magic_buf: [u8; 4] = [0; 4];
-        reader
+        let bytes_read = reader
             .read(&mut magic_buf)
-            .map_err(|err| PersistentStateError::ReadError(err))?;
+            // if we hit out of bounds here, this means that the persistent state has not been
+            // written at the expected location and thus cannot be found
+            .map_err(|_| PersistentStateError::NotFound)?;
 
-        if magic_buf != PERSISTENT_STATE_MAGIC {
+        if bytes_read != 4 || magic_buf != PERSISTENT_STATE_MAGIC {
+            // less than the expected number of bytes were read or the magic does not match
+            // --> this is not the persistent state
             return Err(PersistentStateError::NotFound);
         }
 
         let mut size_buf: [u8; 8] = [0; 8];
-        reader
+        let bytes_read = reader
             .read(&mut size_buf)
-            .map_err(|err| PersistentStateError::ReadError(err))?;
+            .map_err(|err| PersistentStateError::ReadError(err))? as u64;
+
+        // check if we actually read the required amount of data
+        // note: this will only happen if we hit the memory bounds during read
+        if bytes_read != 8 {
+            let max_address = address + 4 + bytes_read;
+            return Err(PersistentStateError::ReadError(OutOfBounds {
+                max_address,
+                attempted_read_address: max_address + 1,
+            }));
+        }
 
         let size = u64::from_le_bytes(size_buf);
         let mut data_buf = Vec::new();
         data_buf.resize(size as usize, 0);
-        reader
+        let bytes_read = reader
             .read(data_buf.as_mut_slice())
-            .map_err(|err| PersistentStateError::ReadError(err))?;
+            .map_err(|err| PersistentStateError::ReadError(err))? as u64;
+
+        // check if we actually read the required amount of data
+        // note: this will only happen if we hit the memory bounds during read
+        if bytes_read != size {
+            let max_address = address + 4 + 8 + bytes_read;
+            return Err(PersistentStateError::ReadError(OutOfBounds {
+                max_address,
+                attempted_read_address: max_address + 1,
+            }));
+        }
 
         candid::decode_one(&data_buf).map_err(|err| PersistentStateError::CandidError(err))
     }


### PR DESCRIPTION
This PR fixes issues with regards to persistent state reading when none has been written. I.e. it adds additional checks to make sure that the code does not attempt to read memory that it should not.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
