### PR TITLE
Don't nest auth prompts

### DIFF
--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -45,12 +45,33 @@ type ChasmOpts = {
 
 /** Authentication box component which authenticates a user
  * to II or to another dapp */
-export const authenticateBox = (
+export const authenticateBox = async (
   connection: Connection,
   templates: AuthTemplates
 ): Promise<LoginData> => {
-  const retryOnError = async (result: LoginFlowResult): Promise<LoginData> => {
+  const promptAuth = () =>
+    new Promise<LoginFlowResult>((resolve) => {
+      authenticateBoxTemplate({
+        templates,
+        addDevice: () => addRemoteDevice(connection),
+        onContinue: (userNumber) => {
+          resolve(authenticate(connection, userNumber));
+        },
+        register: () => {
+          resolve(registerIfAllowed(connection));
+        },
+        recoverAnchor: (userNumber) => useRecovery(connection, userNumber),
+        userNumber: getUserNumber(),
+      });
+    });
+
+  // Retry until user has successfully authenticated
+  for (;;) {
+    const result = await promptAuth();
     switch (result.tag) {
+      case "ok":
+        setUserNumber(result.userNumber);
+        return result;
       case "err":
         await displayError({
           title: result.title,
@@ -58,39 +79,14 @@ export const authenticateBox = (
           detail: result.detail !== "" ? result.detail : undefined,
           primaryButton: "Try again",
         });
-        return authenticateBox(connection, templates);
-      case "ok":
-        return result;
+        break;
       case "canceled":
-        return authenticateBox(connection, templates);
+        break;
       default:
         unreachable(result);
         break;
     }
-  };
-
-  return new Promise<LoginData>((resolve) => {
-    authenticateBoxTemplate({
-      templates,
-      addDevice: () => addRemoteDevice(connection),
-      onContinue: async (userNumber) => {
-        const loginData = await authenticate(connection, userNumber).then(
-          retryOnError
-        );
-        setUserNumber(loginData.userNumber);
-        resolve(loginData);
-      },
-      register: async () => {
-        const loginData = await registerIfAllowed(connection).then(
-          retryOnError
-        );
-        setUserNumber(loginData.userNumber);
-        resolve(loginData);
-      },
-      recoverAnchor: (userNumber) => useRecovery(connection, userNumber),
-      userNumber: getUserNumber(),
-    });
-  });
+  }
 };
 
 export const authenticateBoxTemplate = (props: PageProps): void => {


### PR DESCRIPTION
This changes the error/cancelation handling in the authentication flow. Previously, a top-level function would be called, and each error would nest a new function call. This makes sure we have only a single function call and use a loop instead to check for the result.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
