### PR TITLE
Use aria-expanded for chasm

### DIFF
--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -153,16 +153,15 @@ const mkChasm = ({ info, message }: ChasmOpts): TemplateResult => {
     withRef(chasmRef, (chasm) => {
       const classes = chasm.classList;
 
-      if (classes.contains("c-chasm--closed")) {
-        classes.remove("c-chasm--closed");
-        classes.add("c-chasm--open");
+      const expanded = chasm.getAttribute("aria-expanded") === "true";
+      if (!expanded) {
+        chasm.setAttribute("aria-expanded", "true");
 
         withRef(chasmToggleRef, (arrow) =>
           arrow.classList.add("c-chasm__button--flipped")
         );
-      } else if (classes.contains("c-chasm--open")) {
-        classes.remove("c-chasm--open");
-        classes.add("c-chasm--closed");
+      } else {
+        chasm.setAttribute("aria-expanded", "false");
 
         withRef(chasmToggleRef, (arrow) =>
           arrow.classList.remove("c-chasm__button--flipped")
@@ -174,7 +173,7 @@ const mkChasm = ({ info, message }: ChasmOpts): TemplateResult => {
     <p class="t-paragraph t-weak"><span id="alternative-origin-chasm-toggle" class="t-action" @click="${chasmToggle}" >${info} <span ${ref(
     chasmToggleRef
   )} class="t-link__icon c-chasm__button">${caretDownIcon}</span></span>
-      <div ${ref(chasmRef)} class="c-chasm c-chasm--closed">
+      <div ${ref(chasmRef)} class="c-chasm" aria-expanded="false">
         <div class="c-chasm__arrow"></div>
         <div class="t-weak c-chasm__content">
             ${message}

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1143,13 +1143,13 @@ a:hover,
   margin-right: calc(-1.25 * var(--rs-card-bezel));
 }
 
-.c-chasm--closed {
+.c-chasm[aria-expanded="false"] {
   max-height: 0;
   visibility: hidden;
   transition: max-height 0.15s ease-out;
 }
 
-.c-chasm--open {
+.c-chasm[aria-expanded="true"] {
   max-height: calc(5em * var(--vs-line-height) + var(--rs-card-bezel) * 2);
   visibility: visible;
   transition: max-height 400ms cubic-bezier(0.3, 0.7, 0, 1);


### PR DESCRIPTION
This simplifies the chasm logic and uses an a11y aware attribute.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
