### PR TITLE
Change internal representation of anchor

### DIFF
--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -1,6 +1,6 @@
 use crate::archive::{archive_operation, device_diff};
 use crate::state::RegistrationState::DeviceTentativelyAdded;
-use crate::state::{DeviceDataInternal, TentativeDeviceRegistration};
+use crate::state::{Anchor, DeviceDataInternal, TentativeDeviceRegistration};
 use crate::{delegation, state, trap_if_not_authenticated};
 use candid::Principal;
 use ic_cdk::api::time;
@@ -11,10 +11,10 @@ pub mod registration;
 pub mod tentative_device_registration;
 
 pub fn get_anchor_info(user_number: UserNumber) -> IdentityAnchorInfo {
-    let entries = state::anchor_devices(user_number);
-    trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
+    let anchor = state::anchor(user_number);
+    trap_if_not_authenticated(&anchor);
 
-    let devices = entries.into_iter().map(DeviceData::from).collect();
+    let devices = anchor.devices.into_iter().map(DeviceData::from).collect();
     let now = time();
 
     state::tentative_device_registrations(|tentative_device_registrations| {
@@ -52,15 +52,16 @@ pub fn get_anchor_info(user_number: UserNumber) -> IdentityAnchorInfo {
 pub async fn add(user_number: UserNumber, device_data: DeviceData) {
     const MAX_ENTRIES_PER_USER: usize = 10;
 
-    let mut entries = state::anchor_devices(user_number);
+    let mut anchor = state::anchor(user_number);
     // must be called before the first await because it requires caller()
-    trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
+    trap_if_not_authenticated(&anchor);
     let caller = caller(); // caller is only available before await
     state::ensure_salt_set().await;
 
-    check_device(&device_data, &entries);
+    check_device(&device_data, &anchor.devices);
 
-    if entries
+    if anchor
+        .devices
         .iter()
         .find(|e| e.pubkey == device_data.pubkey)
         .is_some()
@@ -68,15 +69,17 @@ pub async fn add(user_number: UserNumber, device_data: DeviceData) {
         trap("Device already added.");
     }
 
-    if entries.len() >= MAX_ENTRIES_PER_USER {
+    if anchor.devices.len() >= MAX_ENTRIES_PER_USER {
         trap(&format!(
             "at most {} authentication information entries are allowed per user",
             MAX_ENTRIES_PER_USER,
         ));
     }
 
-    entries.push(DeviceDataInternal::from(device_data.clone()));
-    write_anchor_data(user_number, entries);
+    anchor
+        .devices
+        .push(DeviceDataInternal::from(device_data.clone()));
+    write_anchor_data(user_number, anchor);
 
     delegation::prune_expired_signatures();
 
@@ -139,14 +142,14 @@ pub async fn update(user_number: UserNumber, device_key: DeviceKey, device_data:
     if device_key != device_data.pubkey {
         trap("device key may not be updated");
     }
-    let mut entries = state::anchor_devices(user_number);
+    let mut anchor = state::anchor(user_number);
 
-    trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
-    check_device(&device_data, &entries);
+    trap_if_not_authenticated(&anchor);
+    check_device(&device_data, &anchor.devices);
 
-    let operation = mutate_device_or_trap(&mut entries, device_key, Some(device_data));
+    let operation = mutate_device_or_trap(&mut anchor.devices, device_key, Some(device_data));
 
-    write_anchor_data(user_number, entries);
+    write_anchor_data(user_number, anchor);
 
     delegation::prune_expired_signatures();
 
@@ -154,26 +157,26 @@ pub async fn update(user_number: UserNumber, device_key: DeviceKey, device_data:
 }
 
 pub async fn remove(user_number: UserNumber, device_key: DeviceKey) {
-    let mut entries = state::anchor_devices(user_number);
+    let mut anchor = state::anchor(user_number);
     // must be called before the first await because it requires caller()
-    trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
+    trap_if_not_authenticated(&anchor);
 
     let caller = caller(); // caller is only available before await
     state::ensure_salt_set().await;
     delegation::prune_expired_signatures();
 
-    let operation = mutate_device_or_trap(&mut entries, device_key, None);
-    write_anchor_data(user_number, entries);
+    let operation = mutate_device_or_trap(&mut anchor.devices, device_key, None);
+    write_anchor_data(user_number, anchor);
 
     archive_operation(user_number, caller, operation);
 }
 
 /// Writes the supplied entries to stable memory and updates the anchor operation metric.
-fn write_anchor_data(user_number: UserNumber, entries: Vec<DeviceDataInternal>) {
+fn write_anchor_data(user_number: UserNumber, anchor: Anchor) {
     state::storage_mut(|storage| {
-        storage.write(user_number, entries).unwrap_or_else(|err| {
+        storage.write(user_number, anchor).unwrap_or_else(|err| {
             trap(&format!(
-                "failed to write device data of user {}: {}",
+                "failed to write data of anchor {}: {}",
                 user_number, err
             ))
         });

--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -1,6 +1,6 @@
 use crate::anchor_management::{check_device, write_anchor_data};
 use crate::archive::archive_operation;
-use crate::state::{ChallengeInfo, DeviceDataInternal};
+use crate::state::{Anchor, ChallengeInfo, DeviceDataInternal};
 use crate::storage::Salt;
 use crate::{delegation, secs_to_nanos, state};
 use candid::Principal;
@@ -179,7 +179,9 @@ pub async fn register(
         Some(user_number) => {
             write_anchor_data(
                 user_number,
-                vec![DeviceDataInternal::from(device_data.clone())],
+                Anchor {
+                    devices: vec![DeviceDataInternal::from(device_data.clone())],
+                },
             );
             archive_operation(
                 user_number,

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -21,8 +21,7 @@ const MAX_DEVICE_REGISTRATION_ATTEMPTS: u8 = 3;
 /// Enables device registration mode for the given user and returns the expiration timestamp (when it will be disabled again).
 /// If the device registration mode is already active it will just return the expiration timestamp again.
 pub fn enter_device_registration_mode(user_number: UserNumber) -> Timestamp {
-    let entries = state::anchor_devices(user_number);
-    trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
+    trap_if_not_authenticated(&state::anchor(user_number));
 
     state::tentative_device_registrations_mut(|registrations| {
         prune_expired_tentative_device_registrations(registrations);
@@ -48,8 +47,7 @@ pub fn enter_device_registration_mode(user_number: UserNumber) -> Timestamp {
 }
 
 pub fn exit_device_registration_mode(user_number: UserNumber) {
-    let entries = state::anchor_devices(user_number);
-    trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
+    trap_if_not_authenticated(&state::anchor(user_number));
 
     state::tentative_device_registrations_mut(|registrations| {
         prune_expired_tentative_device_registrations(registrations);
@@ -111,8 +109,7 @@ fn get_verified_device(
     user_number: UserNumber,
     user_verification_code: DeviceVerificationCode,
 ) -> Result<DeviceData, VerifyTentativeDeviceResponse> {
-    let entries = state::anchor_devices(user_number);
-    trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
+    trap_if_not_authenticated(&state::anchor(user_number));
 
     state::tentative_device_registrations_mut(|registrations| {
         prune_expired_tentative_device_registrations(registrations);

--- a/src/internet_identity/src/delegation.rs
+++ b/src/internet_identity/src/delegation.rs
@@ -27,9 +27,8 @@ pub async fn prepare_delegation(
     session_key: SessionKey,
     max_time_to_live: Option<u64>,
 ) -> (UserKey, Timestamp) {
-    let entries = state::anchor_devices(user_number);
     // must be called before the first await because it requires caller()
-    trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
+    trap_if_not_authenticated(&state::anchor(user_number));
 
     state::ensure_salt_set().await;
     prune_expired_signatures();
@@ -63,9 +62,7 @@ pub fn get_delegation(
     expiration: Timestamp,
 ) -> GetDelegationResponse {
     check_frontend_length(&frontend);
-
-    let entries = state::anchor_devices(user_number);
-    trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
+    trap_if_not_authenticated(&state::anchor(user_number));
 
     state::asset_hashes_and_sigs(|asset_hashes, sigs| {
         match get_signature(
@@ -91,8 +88,7 @@ pub fn get_delegation(
 pub fn get_principal(user_number: UserNumber, frontend: FrontendHostname) -> Principal {
     check_frontend_length(&frontend);
 
-    let entries = state::anchor_devices(user_number);
-    trap_if_not_authenticated(entries.iter().map(|e| &e.pubkey));
+    trap_if_not_authenticated(&state::anchor(user_number));
 
     let seed = calculate_seed(user_number, &frontend);
     let public_key = der_encode_canister_sig_key(seed.to_vec());


### PR DESCRIPTION
Instead of using `Vec<DeviceDataInternal>` the II backend code will now use an `Anchor` struct with a single field called `devices`. This PR is a preparation for the upcoming stable memory migration.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
