### PR TITLE
Allow the archive to use the full 32GB stable memory

### DIFF
--- a/src/archive/src/main.rs
+++ b/src/archive/src/main.rs
@@ -66,7 +66,7 @@ type AnchorIndex = StableBTreeMap<VirtualMemory<Memory>, AnchorIndexKey, ()>;
 
 const GIB: u64 = 1 << 30;
 const WASM_PAGE_SIZE: u64 = 65536;
-const MAX_STABLE_MEMORY_SIZE: u64 = 8 * GIB;
+const MAX_STABLE_MEMORY_SIZE: u64 = 32 * GIB;
 /// The maximum number of Wasm pages that we allow to use for the stable storage.
 const MAX_WASM_PAGES: u64 = MAX_STABLE_MEMORY_SIZE / WASM_PAGE_SIZE;
 


### PR DESCRIPTION
The archive was developed when the stable memory limit was still 8GB. This PR updates the limit to 32 GB.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
