### PR TITLE
Expose archive canister status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "candid",
  "flate2",
  "hex",
+ "ic-cdk",
  "ic-certification",
  "ic-crypto-iccsa",
  "ic-state-machine-tests",

--- a/src/archive/archive.did
+++ b/src/archive/archive.did
@@ -126,7 +126,7 @@ type StreamingStrategy = variant {
 
 // management canister types: https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-candid
 
-type DefiniteCanisterCettings = record {
+type DefiniteCanisterSettings = record {
     controllers : vec principal;
     compute_allocation : nat;
     memory_allocation : nat;
@@ -139,7 +139,7 @@ type CanisterStatus = record {
         stopping;
         stopped
     };
-    settings: DefiniteCanisterCettings;
+    settings: DefiniteCanisterSettings;
     module_hash: opt blob;
     memory_size: nat;
     cycles: nat;

--- a/src/archive/archive.did
+++ b/src/archive/archive.did
@@ -124,6 +124,28 @@ type StreamingStrategy = variant {
     };
 };
 
+// management canister types: https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-candid
+
+type DefiniteCanisterCettings = record {
+    controllers : vec principal;
+    compute_allocation : nat;
+    memory_allocation : nat;
+    freezing_threshold : nat;
+};
+
+type CanisterStatus = record {
+    status : variant {
+        running;
+        stopping;
+        stopped
+    };
+    settings: DefiniteCanisterCettings;
+    module_hash: opt blob;
+    memory_size: nat;
+    cycles: nat;
+    idle_cycles_burned_per_day: nat;
+}
+
 service : (ArchiveInit) -> {
     // Returns the entries for the given anchor. If a timestamp is given, only the entries starting from that timestamp are
     // returned. Use the Cursor to skip to later entries.
@@ -148,4 +170,7 @@ service : (ArchiveInit) -> {
 
     // HTTP endpoint to expose metrics for Prometheus.
     http_request: (request: HttpRequest) -> (HttpResponse) query;
+
+    // Exposes the canister status of this canister.
+    status : () -> (CanisterStatus);
 }

--- a/src/archive/tests/tests.rs
+++ b/src/archive/tests/tests.rs
@@ -47,6 +47,16 @@ fn should_keep_entries_across_upgrades() -> Result<(), CallError> {
     Ok(())
 }
 
+/// Should expose status to anonymous callers.
+#[test]
+fn should_expose_status() -> Result<(), CallError> {
+    let env = StateMachine::new();
+    let canister_id = install_archive_canister(&env, ARCHIVE_WASM.clone());
+    let status = api::status(&env, canister_id)?;
+    assert_eq!(status.cycles, 0);
+    Ok(())
+}
+
 #[cfg(test)]
 mod rollback_tests {
     use super::*;

--- a/src/canister_tests/Cargo.toml
+++ b/src/canister_tests/Cargo.toml
@@ -18,6 +18,7 @@ internet_identity_interface = { path = "../internet_identity_interface" }
 
 # All IC deps
 candid = "0.8"
+ic-cdk = "0.6"
 ic-types = { git = "https://github.com/dfinity/ic", rev = "5248f11c18ca564881bbb82a4eb6915efb7ca62f" }
 ic-sdk-types = { package="ic-types", version="0.6" }
 ic-certification = { git = "https://github.com/dfinity/ic", rev = "5248f11c18ca564881bbb82a4eb6915efb7ca62f" }

--- a/src/canister_tests/src/api/archive.rs
+++ b/src/canister_tests/src/api/archive.rs
@@ -1,5 +1,6 @@
 use crate::framework;
 use crate::framework::CallError;
+use ic_cdk::api::management_canister::main::CanisterStatusResponse;
 use ic_state_machine_tests::{CanisterId, PrincipalId, StateMachine};
 use internet_identity_interface as types;
 
@@ -43,6 +44,13 @@ pub fn get_anchor_entries(
         (anchor, cursor, limit),
     )
     .map(|(x,)| x)
+}
+
+pub fn status(
+    env: &StateMachine,
+    canister_id: CanisterId,
+) -> Result<CanisterStatusResponse, CallError> {
+    framework::call_candid(env, canister_id, "status", ()).map(|(x,)| x)
 }
 
 pub fn http_request(


### PR DESCRIPTION
This PR adds a public method to retrieve the archive canister status. Since II is the only controller of the archive there is currently no way of knowing the cycles balance of the archive canister. Adding a public status method fixes this.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
