### PR TITLE
Limit the size of variable fields across all devices

### DIFF
--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -239,6 +239,17 @@ pub fn device_data_2() -> types::DeviceData {
     }
 }
 
+pub fn max_size_device() -> types::DeviceData {
+    types::DeviceData {
+        pubkey: ByteBuf::from([255u8; 300]),
+        alias: "a".repeat(64).to_string(),
+        credential_id: Some(ByteBuf::from([7u8; 200])),
+        purpose: types::Purpose::Authentication,
+        key_type: types::KeyType::Unknown,
+        protection: types::DeviceProtection::Unprotected,
+    }
+}
+
 pub fn recovery_device_data_1() -> types::DeviceData {
     types::DeviceData {
         pubkey: ByteBuf::from(RECOVERY_PUBKEY_1),

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -41,6 +41,14 @@ pub struct DeviceDataInternal {
     pub protection: Option<DeviceProtection>,
 }
 
+impl DeviceDataInternal {
+    pub fn variable_fields_len(&self) -> usize {
+        self.alias.len()
+            + self.pubkey.len()
+            + self.credential_id.as_ref().map(|id| id.len()).unwrap_or(0)
+    }
+}
+
 impl From<DeviceData> for DeviceDataInternal {
     fn from(device_data: DeviceData) -> Self {
         Self {


### PR DESCRIPTION
This PR introduces a limit on total size of variable fields across all devices. This limit is equal to the current total anchor size so it will not impact any anchors before the stable memory migration.

After the memory migration, this limit makes sure that anchors do not fill up the additional space with more device data. In the future, the additional space will be uesful when adding additional fields and / or changing the candid type of anchors in stable memory.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
