### PR TITLE
Use a fixed release in stable memory migration integration tests

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -352,6 +352,7 @@ jobs:
           # PRs that used to be green may become red (if the new release broke something). While this is not CI best practice, it's
           # a relatively small price to pay to make sure PRs are always tested against the latest release.
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_test.wasm -o internet_identity_previous.wasm
+          curl -SL https://github.com/dfinity/internet-identity/releases/download/release-2022-11-23/internet_identity_test.wasm -o internet_identity_v1_storage.wasm
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/archive.wasm -o archive_previous.wasm
           cargo test --release
         env:

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -69,6 +69,22 @@ lazy_static! {
         get_wasm_path("II_WASM_PREVIOUS".to_string(), &def_path).expect(&err)
     };
 
+
+        /** The Wasm module for the last II build that still initializes storage as V1, which is used when testing
+            * the stable memory migration */
+    pub static ref II_WASM_V1_LAYOUT: Vec<u8> = {
+        let def_path = path::PathBuf::from("..").join("..").join("internet_identity_v1_storage.wasm");
+        let err = format!("
+        Could not find Internet Identity Wasm module for release with v1 storage layout.
+
+        I will look for it at {:?}, and you can specify another path with the environment variable II_WASM_V1_LAYOUT (note that I run from {:?}).
+
+        In order to get the Wasm module, please run the following command:
+            curl -SL https://github.com/dfinity/internet-identity/releases/download/release-2022-11-23/internet_identity_test.wasm -o internet_identity_v1_storage.wasm
+        ", &def_path, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or("an unknown directory".to_string()));
+        get_wasm_path("II_WASM_V1_LAYOUT".to_string(), &def_path).expect(&err)
+    };
+
         /** The Wasm module for the _previous_ archive build, or latest release, which is used when testing
             * upgrades and downgrades */
     pub static ref ARCHIVE_WASM_PREVIOUS: Vec<u8> = {

--- a/src/internet_identity/tests/stable_memory_migration_tests.rs
+++ b/src/internet_identity/tests/stable_memory_migration_tests.rs
@@ -8,7 +8,7 @@ use serde_bytes::ByteBuf;
 #[test]
 fn should_migrate_anchors() -> Result<(), CallError> {
     let env = StateMachine::new();
-    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
+    let canister_id = install_ii_canister(&env, II_WASM_V1_LAYOUT.clone());
 
     for _ in 0..10 {
         flows::register_anchor(&env, canister_id);
@@ -66,7 +66,7 @@ fn should_migrate_anchors() -> Result<(), CallError> {
 #[test]
 fn should_keep_anchors_intact_when_migrating() -> Result<(), CallError> {
     let env = StateMachine::new();
-    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
+    let canister_id = install_ii_canister(&env, II_WASM_V1_LAYOUT.clone());
 
     let anchor0 = flows::register_anchor(&env, canister_id);
     let device_anchor0 = DeviceData {
@@ -230,7 +230,7 @@ fn should_keep_anchors_intact_when_migrating() -> Result<(), CallError> {
 #[test]
 fn should_upgrade_during_migration() -> Result<(), CallError> {
     let env = StateMachine::new();
-    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
+    let canister_id = install_ii_canister(&env, II_WASM_V1_LAYOUT.clone());
 
     for _ in 0..10 {
         flows::register_anchor(&env, canister_id);
@@ -292,7 +292,7 @@ fn should_upgrade_during_migration() -> Result<(), CallError> {
 #[test]
 fn should_start_and_pause_migration() -> Result<(), CallError> {
     let env = StateMachine::new();
-    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
+    let canister_id = install_ii_canister(&env, II_WASM_V1_LAYOUT.clone());
 
     for _ in 0..10 {
         flows::register_anchor(&env, canister_id);
@@ -366,7 +366,7 @@ fn should_start_and_pause_migration() -> Result<(), CallError> {
 #[test]
 fn should_not_migrate_anchors_if_not_configured() -> Result<(), CallError> {
     let env = StateMachine::new();
-    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
+    let canister_id = install_ii_canister(&env, II_WASM_V1_LAYOUT.clone());
 
     for _ in 0..10 {
         flows::register_anchor(&env, canister_id);


### PR DESCRIPTION
This PR removes the assumption that II_WASM_PREVIOUS initializes storage in layout v1 from the stable memory migration tests.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
