### PR TITLE
Simplify webpack config

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -136,13 +136,13 @@ export default [
       index: path.join(__dirname, "src", "frontend", "src", "index"),
     },
     devServer: {
+      magicHtml: false,
+      static: false,
       // Set up a proxy that redirects API calls to the replica.
-      port: 8080,
       proxy: {
         // Make sure /api calls land on the replica (and not on webpack)
         "/api": "http://localhost:4943",
       },
-      allowedHosts: [".localhost", ".local", ".ngrok.io"],
     },
     plugins: [
       ...defaults.plugins,
@@ -158,7 +158,8 @@ export default [
       showcase: path.join(__dirname, "src", "frontend", "src", "showcase"),
     },
     devServer: {
-      port: 8080,
+      magicHtml: false,
+      static: false,
       historyApiFallback: true, // serves the app on all routes, which we use because the app itself does the routing
     },
   },


### PR DESCRIPTION
This cleans up the dev server by

* removing the port setting (was set to default)
* disabling "magicHtml" which tries to serve js files like `index.js` on `/index` with basic HTMl, but which is just confusing in practice
* explicitly disabling `static` assets serving, since we serve everything from our webpack pipeline
* Resetting allowed hosts to the default `"auto"` because custom values weren't used anymore

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
