### PR TITLE
Update the metrics encoder

### DIFF
--- a/src/metrics_encoder/src/test.rs
+++ b/src/metrics_encoder/src/test.rs
@@ -1,62 +1,65 @@
-use super::*;
+use super::{validate_prometheus_name, MetricsEncoder};
 
-fn new_encoder() -> MetricsEncoder<Vec<u8>> {
-    MetricsEncoder::new(Vec::new(), 1234567890000)
-}
-
-fn as_text(e: MetricsEncoder<Vec<u8>>) -> String {
-    String::from_utf8(e.into_inner()).unwrap()
+fn as_string(encoder: MetricsEncoder<Vec<u8>>) -> String {
+    String::from_utf8(encoder.into_inner()).unwrap()
 }
 
 #[test]
-fn test_counter_encoding() {
-    let mut w = new_encoder();
-    w.encode_counter(
-        "http_requests_total",
-        1027.0,
-        "The total number of HTTP requests.",
-    )
-    .unwrap();
+fn test_labeled_counter_metrics() {
+    let mut encoder = MetricsEncoder::new(vec![0u8; 0], 1395066363000);
+    encoder
+        .counter_vec("http_requests_total", "The total number of HTTP requests.")
+        .unwrap()
+        .value(&[("method", "post"), ("code", "200")], 1027.0)
+        .unwrap()
+        .value(&[("method", "post"), ("code", "400")], 3.0)
+        .unwrap();
+
     assert_eq!(
-        &as_text(w),
         r#"# HELP http_requests_total The total number of HTTP requests.
 # TYPE http_requests_total counter
-http_requests_total 1027 1234567890000
-"#
-    )
+http_requests_total{method="post",code="200"} 1027 1395066363000
+http_requests_total{method="post",code="400"} 3 1395066363000
+"#,
+        as_string(encoder)
+    );
 }
 
 #[test]
-fn test_histogram_encoding() {
-    let mut w = new_encoder();
-    w.encode_histogram(
-        "http_request_duration_seconds",
-        [
-            (0.05, 24054.0),
-            (0.1, 9390.0),
-            (0.2, 66948.0),
-            (0.5, 28997.0),
-            (1.0, 4599.0),
-            (std::f64::INFINITY, 10332.0),
-        ]
-        .iter()
-        .cloned(),
-        53423.0,
-        "A histogram of the request duration.",
-    )
-    .unwrap();
+fn test_labeled_gauge_metrics() {
+    let mut encoder = MetricsEncoder::new(vec![0u8; 0], 1395066363000);
+    encoder
+        .gauge_vec("cpu_temperature", "CPU temperature in celsius.")
+        .unwrap()
+        .value(&[("core", "1")], 40.0)
+        .unwrap()
+        .value(&[("core", "2")], 43.0)
+        .unwrap();
+
     assert_eq!(
-        &as_text(w),
-        r#"# HELP http_request_duration_seconds A histogram of the request duration.
-# TYPE http_request_duration_seconds histogram
-http_request_duration_seconds_bucket{le="0.05"} 24054 1234567890000
-http_request_duration_seconds_bucket{le="0.1"} 33444 1234567890000
-http_request_duration_seconds_bucket{le="0.2"} 100392 1234567890000
-http_request_duration_seconds_bucket{le="0.5"} 129389 1234567890000
-http_request_duration_seconds_bucket{le="1"} 133988 1234567890000
-http_request_duration_seconds_bucket{le="+Inf"} 144320 1234567890000
-http_request_duration_seconds_sum 53423 1234567890000
-http_request_duration_seconds_count 144320 1234567890000
-"#
-    )
+        r#"# HELP cpu_temperature CPU temperature in celsius.
+# TYPE cpu_temperature gauge
+cpu_temperature{core="1"} 40 1395066363000
+cpu_temperature{core="2"} 43 1395066363000
+"#,
+        as_string(encoder)
+    );
+}
+
+#[test]
+#[should_panic(expected = "Empty names are not allowed")]
+fn validate_empty_name() {
+    validate_prometheus_name("")
+}
+
+#[test]
+#[should_panic(expected = "Name '⇒Γ' does not match pattern [a-zA-Z_][a-zA-Z0-9_]")]
+fn validate_unicode_name() {
+    validate_prometheus_name("⇒Γ")
+}
+
+#[test]
+#[should_panic(expected = "Name 'http:rule' does not match pattern [a-zA-Z_][a-zA-Z0-9_]")]
+fn validate_rule_name() {
+    validate_prometheus_name("http:rule")
 }


### PR DESCRIPTION
The archive requires more features of the metrics encoder. This PR adds the latest changes from the IC metrics encoder to this repo.

To avoid having to do such PRs in the future, I am also in the process of [opensourcing the metrics encoder](https://github.com/dfinity/metrics-encoder) as a standalone crate. This PR just bridges the gap until we have it ready.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
