### PR TITLE
Catch error on key type update

### DIFF
--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -243,7 +243,11 @@ export class Connection {
 
     const attachmentInfo = identity.getAuthenticatorAttachment();
     if (attachmentInfo !== undefined) {
-      this.updateKeyTypeIfNecessary(devices, attachmentInfo, connection);
+      try {
+        this.updateKeyTypeIfNecessary(devices, attachmentInfo, connection);
+      } catch (e) {
+        console.warn("Could not update key type:", e);
+      }
     }
 
     return {
@@ -283,7 +287,10 @@ export class Connection {
           device.key_type = { platform: null };
           break;
         default:
-          unreachable(attachmentInfo.authenticatorAttachment);
+          unreachable(
+            attachmentInfo.authenticatorAttachment,
+            `unexpected authenticator attachment: ${attachmentInfo.authenticatorAttachment}`
+          );
           break;
       }
       // we purposely do not await the promise as we just optimistically update

--- a/src/frontend/src/utils/multiWebAuthnIdentity.ts
+++ b/src/frontend/src/utils/multiWebAuthnIdentity.ts
@@ -79,7 +79,9 @@ export class MultiWebAuthnIdentity extends SignIdentity {
     | undefined {
     if (
       this._actualIdentity === undefined ||
-      this._authenticatorAttachment === undefined
+      this._authenticatorAttachment === undefined ||
+      this._authenticatorAttachment ===
+        null /* on Windows the attachment is 'null' */
     ) {
       return undefined;
     }

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -133,8 +133,8 @@ export function iOSOrSafari(): boolean {
 }
 
 /* A function that can never be called. Can be used to prove that all type alternatives have been exhausted. */
-export function unreachable(_: never): never {
-  throw new Error("The impossible happened");
+export function unreachable(_: never, reason?: string): never {
+  throw new Error(`Unexpected error ${reason ?? ""}`);
 }
 
 /* Wrap an unknown value as an error and try to extract a string from it */


### PR DESCRIPTION
This is a workaround for unexpected authenticator attachments.

On Windows the attachment may be `null`, which we now treat as `undefined`. In general this also updates the error handling to ensure the key type update does not throw an exception, and updates the "Impossible happened" error message.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
