### PR TITLE
Move registration screens out of captcha

### DIFF
--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -1,5 +1,7 @@
 import { Connection } from "../../utils/iiConnection";
 import { unknownToString } from "../../utils/utils";
+import { setAnchorUsed } from "../../utils/userNumber";
+import { displayUserNumber } from "./finish";
 import { confirmRegister } from "./captcha";
 import { makeCaptcha } from "./captcha";
 import { LoginFlowResult, cancel } from "../../utils/flowResult";
@@ -29,6 +31,14 @@ export const register = async ({
       identity,
       alias
     );
+
+    if (result.tag === "ok") {
+      // Write user number to storage
+      setAnchorUsed(result.userNumber);
+
+      // Congratulate user
+      await displayUserNumber(result.userNumber);
+    }
 
     return result;
   } catch (e) {


### PR DESCRIPTION
Before this, the captcha module dealt with general login error handling (duplicating the work of `apiResultToLoginFlowResult`) and other registration matters like showing the user their anchor.

These are now moved to `register/index.ts`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
