### PR TITLE
Remove legacy stable memory size constants

### DIFF
--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -1,5 +1,5 @@
 use crate::archive::{ArchiveData, ArchiveInfo, ArchiveState, ArchiveStatusCache};
-use crate::storage::DEFAULT_RANGE_SIZE_V1;
+use crate::storage::DEFAULT_RANGE_SIZE;
 use crate::{PersistentStateError, Salt, Storage};
 use candid::{CandidType, Deserialize, Principal};
 use ic_cdk::api::management_canister::main::CanisterStatusResponse;
@@ -175,7 +175,7 @@ impl Default for State {
             storage: RefCell::new(Storage::new(
                 (
                     FIRST_USER_ID,
-                    FIRST_USER_ID.saturating_add(DEFAULT_RANGE_SIZE_V1),
+                    FIRST_USER_ID.saturating_add(DEFAULT_RANGE_SIZE),
                 ),
                 DefaultMemoryImpl::default(),
             )),

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -19,10 +19,10 @@ fn should_match_actual_header_size() {
 }
 
 #[test]
-fn should_report_max_number_of_entries_for_8gb() {
+fn should_report_max_number_of_entries_for_32gb() {
     let memory = VectorMemory::default();
     let storage = Storage::new((1, 2), memory);
-    assert_eq!(storage.max_entries(), 3_774_873);
+    assert_eq!(storage.max_entries(), 8_178_860);
 }
 
 #[test]

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -1950,7 +1950,7 @@ mod http_tests {
         let (min_user_number, _) = parse_metric(&metrics, "internet_identity_min_user_number");
         let (max_user_number, _) = parse_metric(&metrics, "internet_identity_max_user_number");
         assert_eq!(min_user_number, 10_000);
-        assert_eq!(max_user_number, 3_784_872);
+        assert_eq!(max_user_number, 8_188_859);
         Ok(())
     }
 


### PR DESCRIPTION
This PR prepares II to make use of the whole 32 GB stable memory for anchor records.
Note: this PR does not yet allow changing the user range, this will be added in a separate PR.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
