### PR TITLE
Expand doc and remove debug print

### DIFF
--- a/src/state_machine_client/README.md
+++ b/src/state_machine_client/README.md
@@ -10,6 +10,10 @@ The `ic-test-state-machine` is an _incomplete_ wrapper around the `ic-state-mach
 
 The prebuilt binary can be downloaded from https://download.dfinity.systems/ic/$sha/binaries/x86_64-$platform/ic-test-state-machine.gz, where `sha` is the commit sha of a commit on the master branch of the IC repository and `platform` is either `linux` or `darwin`.
 
+## Dependencies
+
+The `ic-test-state-machine` binary requires `openssl 3`. On MacOs it can be installed using homebrew by running `brew install openssl@3`.
+
 ## Disclaimer
 
 While testing with the `ic-test-state-machine` might help the development process, it is not a replacement for testing with the actual replica.

--- a/src/state_machine_client/src/lib.rs
+++ b/src/state_machine_client/src/lib.rs
@@ -219,7 +219,6 @@ impl StateMachine {
     fn send_request(&self, request: Request) {
         let mut cbor = vec![];
         ciborium::ser::into_writer(&request, &mut cbor).expect("failed to serialize request");
-        println!("send len {}", cbor.len());
         let mut child_in = self.child_in.borrow_mut();
         child_in
             .write(&(cbor.len() as u64).to_le_bytes())


### PR DESCRIPTION
This is a small clean-up PR that expands the doc to include the dependencies of the ic-test-state-machine binary. It also removes a superfluous print statement.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
