### PR TITLE
Properly indent the slack action yml file

### DIFF
--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - run: |
-      echo '{}' | jq --arg text "$MESSAGE: https://github.com/dfinity/internet-identity/actions/runs/$GITHUB_RUN_ID" '.text = $text' | \
+        echo '{}' | jq --arg text "$MESSAGE: https://github.com/dfinity/internet-identity/actions/runs/$GITHUB_RUN_ID" '.text = $text' | \
             curl -X POST -H 'Content-Type: application/json' --data @- "$WEBHOOK_URL"
       shell: bash
       env:


### PR DESCRIPTION
This PR properly indents the yml file of our slack action. The slack action
failed on the last execution due to this: https://github.com/dfinity/internet-identity/actions/runs/3727222006/jobs/6321170886#step:7:1

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
