### PR TITLE
Add job to auto-update state machine

### DIFF
--- a/.github/workflows/update-state-machine.yml
+++ b/.github/workflows/update-state-machine.yml
@@ -1,0 +1,88 @@
+# A GitHub Actions workflow that regularly creates a pull request to update the IC artefacts
+name: IC Artefacts Update
+
+on:
+  schedule:
+    # create a new pull request every monday
+    - cron:  '0 0 * * MON'
+
+jobs:
+  ic-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+        # First, check if there is a newer version and update the file referencing the version
+      - name: Check new ic version
+        id: update
+        run: |
+          # Not all ic commits are built and released, so we go through the last commits until we found one
+          # which has associated artefacts
+          while read -r sha
+          do
+              echo "sha: $sha"
+              # Send a HEAD to the URL to see if it exists
+              if curl --fail --head --silent --location \
+                  "https://download.dfinity.systems/ic/$sha/binaries/x86_64-linux/ic-test-state-machine.gz"
+              then
+                  echo "$sha appears to have associated binary, using"
+                  latest_sha="$sha"
+                  break
+              else
+                  echo "$sha does not seem to have associated binary"
+              fi
+          done < <(curl \
+              -SsL \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/dfinity/ic/commits | jq -cMr '.[] | .sha')
+
+          # If we couldn't find any sha with associated artefacts, abort
+          if [ -z "${latest_sha:-}" ]
+          then
+              echo no sha found
+              exit 1
+          fi
+
+          # Compare the current and latest shas, and potentially update the relevant files
+          current_sha=$(sed <.github/workflows/canister-tests.yml -n \
+            's$.*curl.*https://download.dfinity.systems/ic/\([^/]*\)/binaries.*$\1$p')
+
+          echo current sha is "$current_sha"
+
+          if [ "$current_sha" != "$latest_sha" ]; then
+            echo "updating $current_sha to $latest_sha"
+            sed -i -e \
+              "s/$current_sha/$latest_sha/g" \
+              ".github/workflows/canister-tests.yml"
+            echo "updated=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "not updating $current_sha"
+            echo "updated=0" >> "$GITHUB_OUTPUT"
+          fi
+
+          cat ".github/workflows/canister-tests.yml"
+
+      # If the ic commit was updated, create a PR.
+      - name: Create Pull Request
+        if: ${{ steps.update.outputs.updated == '1' }}
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GIX_BOT_PAT }}
+          base: main
+          add-paths: .github/workflows/canister-tests.yml
+          commit-message: Update commit of IC artefacts
+          committer: GitHub <noreply@github.com>
+          author: gix-bot <gix-bot@users.noreply.github.com>
+          branch: bot-ic-update
+          delete-branch: true
+          title: 'Update commit of IC artefacts'
+
+            # Since the this is a scheduled job, a failure won't be shown on any
+            # PR status. To notify the team, we send a message to our Slack channel on failure.
+      - name: Notify Slack on failure
+        uses: ./.github/actions/slack
+        if: ${{ failure() }}
+        with:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MESSAGE: "IC artefacts update failed"


### PR DESCRIPTION
This adds a GitHub action job that checks for IC updates weekly, so that we always get the latest state machine executable.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
