### PR TITLE
Also update state machine download hint with latest ic commit sha

### DIFF
--- a/.github/workflows/update-state-machine.yml
+++ b/.github/workflows/update-state-machine.yml
@@ -55,6 +55,11 @@ jobs:
             sed -i -e \
               "s/$current_sha/$latest_sha/g" \
               ".github/workflows/canister-tests.yml"
+            
+            # This updates the download hint when tests are run with a missing binary
+            sed -i -e \
+                "s/$current_sha/$latest_sha/g" \
+                "src/canister_tests/src/framework.rs"
             echo "updated=1" >> "$GITHUB_OUTPUT"
           else
             echo "not updating $current_sha"


### PR DESCRIPTION
The framework module also contains the IC commit sha in an error message. This makes sure, that this message does not get out of sync with what's happening on CI.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
