### PR TITLE
Checkout slack action on failure

### DIFF
--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -50,6 +50,7 @@ jobs:
 
         # Since the release build check is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.
+      - uses: actions/checkout@v3 # checks out the latest slack action
       - name: Notify Slack on failure
         uses: ./.github/actions/slack
         if: ${{ failure() }}


### PR DESCRIPTION
The release check build checks out a particular release, which

* may have failed (the checkout)
* may not contain the latest slack action

so we make sure to re-checkout before running the slack action.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
