### PR TITLE
Add some checks when using release API

### DIFF
--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -22,7 +22,14 @@ jobs:
     steps:
       - name: Get latest release information
         run: |
-          latest_release_ref=$(curl --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/dfinity/internet-identity/releases/latest | jq -cMr .tag_name)
+          release_data=$(curl --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/dfinity/internet-identity/releases/latest)
+          latest_release_ref=$(echo -n "$release_data" | jq -cMr .tag_name)
+          # The GitHub API has some hiccups, so we check the value before going further
+          if [ -z "$latest_release_ref" ] || [ "$latest_release_ref" = "null" ]
+          then
+            echo "expected a release ref, got '$latest_release_ref'"
+            exit 1
+          fi
           curl --silent -SL "https://github.com/dfinity/internet-identity/releases/download/$latest_release_ref/internet_identity_production.wasm" -o internet_identity_previous.wasm
           latest_release_sha256=$(shasum -a 256 ./internet_identity_previous.wasm | cut -d ' ' -f1)
           echo latest release is "$latest_release_ref"

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -4,8 +4,8 @@ name: Rust Update
 
 on:
   schedule:
-    # check for new rust versions daily at 7:30
-    - cron:  '30 7 * * *'
+    # check for new rust versions weekly
+    - cron:  '30 3 * * FRI'
 
 jobs:
   rust-update:
@@ -20,7 +20,18 @@ jobs:
         run: |
           current_rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:space:]]"\(.*\)"/\1/p')
           echo "current rust version '$current_rust_version'"
-          latest_rust_version=$(curl --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/rust-lang/rust/releases/latest | jq -cMr .tag_name)
+          release_data=$(curl --silent -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/rust-lang/rust/releases/latest)
+          latest_rust_version=$(echo -n "$release_data" | jq -cMr .tag_name)
+
+          # The GitHub API has some hiccups, so we check the value before going further
+          if [ -z "$latest_rust_version" ] || [ "$latest_rust_version" = "null" ]
+          then
+            echo "expected a rust version, got '$latest_rust_version'"
+            echo "data received from API:"
+            echo "$release_data"
+            exit 1
+          fi
+
           echo "latest rust version '$latest_rust_version'"
 
           if [ "$current_rust_version" != "$latest_rust_version" ]


### PR DESCRIPTION
The GitHub API has been returning some bad data, though not reproducibly. This adds some logging and aborts the rust update early (before writing the new toolchain version).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
