### PR TITLE
Store IC commit in .ic-commit

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -343,7 +343,9 @@ jobs:
         run: |
           uname_sys=$(uname -s | tr '[:upper:]' '[:lower:]')
           echo "uname_sys: $uname_sys"
-          curl -sLO "https://download.dfinity.systems/ic/a26b66d0bf5dea702e20da7218ceb6a5ee16fbbb/binaries/x86_64-$uname_sys/ic-test-state-machine.gz"
+          commit_sha=$(sed <.ic-commit 's/#.*$//' | sed '/^$/d')
+          echo "commit sha: $commit_sha"
+          curl -sLO "https://download.dfinity.systems/ic/$commit_sha/binaries/x86_64-$uname_sys/ic-test-state-machine.gz"
           gzip -d ic-test-state-machine.gz
           chmod a+x ic-test-state-machine
           ./ic-test-state-machine --version

--- a/.github/workflows/update-state-machine.yml
+++ b/.github/workflows/update-state-machine.yml
@@ -45,8 +45,7 @@ jobs:
           fi
 
           # Compare the current and latest shas, and potentially update the relevant files
-          current_sha=$(sed <.github/workflows/canister-tests.yml -n \
-            's$.*curl.*https://download.dfinity.systems/ic/\([^/]*\)/binaries.*$\1$p')
+          current_sha=$(sed <.ic-commit 's/#.*$//' | sed '/^$/d')
 
           echo current sha is "$current_sha"
 
@@ -54,7 +53,7 @@ jobs:
             echo "updating $current_sha to $latest_sha"
             sed -i -e \
               "s/$current_sha/$latest_sha/g" \
-              ".github/workflows/canister-tests.yml"
+              ".ic-commit"
             
             # This updates the download hint when tests are run with a missing binary
             sed -i -e \
@@ -66,7 +65,7 @@ jobs:
             echo "updated=0" >> "$GITHUB_OUTPUT"
           fi
 
-          cat ".github/workflows/canister-tests.yml"
+          cat ".ic-commit"
 
       # If the ic commit was updated, create a PR.
       - name: Create Pull Request

--- a/.ic-commit
+++ b/.ic-commit
@@ -1,0 +1,3 @@
+# the commit used to pull the state machine executable
+# see rust canister tests for more info
+a26b66d0bf5dea702e20da7218ceb6a5ee16fbbb

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -153,13 +153,11 @@ pub fn env() -> StateMachine {
 
         I looked for it at {:?}. You can specify another path with the environment variable STATE_MACHINE_BINARY (note that I run from {:?}).
 
-        In order to get the binary:
-            * Download:
-                * linux: curl -sLO https://download.dfinity.systems/ic/a26b66d0bf5dea702e20da7218ceb6a5ee16fbbb/binaries/x86_64-linux/ic-test-state-machine.gz
-                * mac:   curl -sLO https://download.dfinity.systems/ic/a26b66d0bf5dea702e20da7218ceb6a5ee16fbbb/binaries/x86_64-darwin/ic-test-state-machine.gz
-            * Make it executable:
-                gzip -d ic-test-state-machine.gz
-                chmod +x ic-test-state-machine
+        Run the following command to get the binary:
+            curl -sLO https://download.dfinity.systems/ic/$commit/binaries/$platform/ic-test-state-machine.gz
+            gzip -d ic-test-state-machine.gz
+            chmod +x ic-test-state-machine
+        where $commit can be read from `.ic-commit` and $platform is 'x86_64-linux' for Linux and 'x86_64-darwin' for Intel/rosetta-enabled Darwin.
         ", &path, &env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));
     }
 


### PR DESCRIPTION
Similar to how we store and update the node version, this introduces a new file `.ic-commit` which is used by CI to fetch the correct state machine tests executable given the IC repo commit, as well as update the commit.

This prevents some token authorization concerns that surface when editing workflow files in a workflow.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
