### PR TITLE
Add version to non-docker builds

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Infer version
         id: version
         run: |
-          version=$(./scripts/version)
-          echo "Inferred version: $version"
+          version="$(./scripts/version)"
+          echo "Inferred version: '$version'"
           echo 'version<<EOF' >> "$GITHUB_OUTPUT"
           echo "$version" >> "$GITHUB_OUTPUT"
           echo 'EOF' >> "$GITHUB_OUTPUT"

--- a/scripts/build
+++ b/scripts/build
@@ -71,6 +71,12 @@ do
     esac
 done
 
+export II_VERSION=${II_VERSION:-$(./scripts/version)}
+echo "The following version will be used:"
+echo "---"
+echo "$II_VERSION"
+echo "---"
+
 # build II by default
 if [ ${#CANISTERS[@]} -eq 0 ]; then
     CANISTERS=("internet_identity")

--- a/scripts/version
+++ b/scripts/version
@@ -48,6 +48,7 @@ then
     dirty="dirty"
 else
     log "commit is clean"
+    dirty="clean"
 fi
 
 echo "$commit"


### PR DESCRIPTION
This updates the `./scripts/build` to set `II_VERSION` using `./scripts/version`, if the environment variable isn't already set.

This also slightly changes the version format to _always_ print a value for the "dirty" line (either `"dirty"` or `"clean"`) since it's otherwise quite difficult to read the output of the script in bash (as bash will strip trailing empty new lines in command substitution).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
