### PR TITLE
Retire ubuntu-18.04 jobs

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -636,7 +636,7 @@ jobs:
     needs: docker-build-ii
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-11, macos-12 ]
+        os: [ ubuntu-22.04, ubuntu-20.04, macos-11, macos-12 ]
     steps:
       - uses: actions/checkout@v3
       - name: 'Download wasm'

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -44,7 +44,7 @@ jobs:
     needs: latest-release
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, macos-11, macos-12 ]
+        os: [ ubuntu-22.04, ubuntu-20.04, macos-11, macos-12 ]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Those runners were deprecated: https://github.com/actions/runner-images/issues/6002

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
