### PR TITLE
Use single-line version string

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -76,9 +76,7 @@ jobs:
         run: |
           version="$(./scripts/version)"
           echo "Inferred version: '$version'"
-          echo 'version<<EOF' >> "$GITHUB_OUTPUT"
-          echo "$version" >> "$GITHUB_OUTPUT"
-          echo 'EOF' >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v2

--- a/scripts/build
+++ b/scripts/build
@@ -72,10 +72,7 @@ do
 done
 
 export II_VERSION=${II_VERSION:-$(./scripts/version)}
-echo "The following version will be used:"
-echo "---"
-echo "$II_VERSION"
-echo "---"
+echo "The following version will be used: '$II_VERSION'"
 
 # build II by default
 if [ ${#CANISTERS[@]} -eq 0 ]; then

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -78,11 +78,8 @@ function build() {
 
     tmp_outdir=$(mktemp -d)
 
-    local version=$(./scripts/version)
-    echo "The following version will be used:"
-    echo "---"
-    echo "$version"
-    echo "---"
+    local version="$(./scripts/version)"
+    echo "The following version will be used: '$version'"
 
     set -x
     DOCKER_BUILDKIT=1 docker build \

--- a/scripts/version
+++ b/scripts/version
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Infer the "version" of the codebase using the git state.
-# Prints three lines to stdout:
+# Prints three comma-separated strings to stdout:
 #   1. the first line is the commit (script returns with 1 if no commit is found)
 #   2. the second line represent the release the commit is tagged with, possibly the empty
 #       string if none
@@ -51,6 +51,4 @@ else
     dirty="clean"
 fi
 
-echo "$commit"
-echo "$release"
-echo "$dirty"
+echo "$commit,$release,$dirty"

--- a/src/frontend/src/version.ts
+++ b/src/frontend/src/version.ts
@@ -1,6 +1,6 @@
 /** parse the II_VERSION, see ./scripts/version for more information */
 export const versionString = process.env.II_VERSION ?? "";
-export const versionList = versionString.split("\n");
+export const versionList = versionString.split(",");
 
 export type VersionInfo = {
   commit: string;


### PR DESCRIPTION
This changes the version string "foo\nbar\n" to "foo,bar,baz". The multiline string caused issues all over the place, from being read in bash command substitution to docker push-action arguments.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
