### PR TITLE
Refactor test infrastrucutre regarding metrics

### DIFF
--- a/src/canister_tests/src/api.rs
+++ b/src/canister_tests/src/api.rs
@@ -1,2 +1,16 @@
+use ic_cdk::api::management_canister::main::CanisterId;
+use internet_identity_interface::{HttpRequest, HttpResponse};
+use state_machine_client::{query_candid, CallError, StateMachine};
+
 pub mod archive;
 pub mod internet_identity;
+
+// api methods common to all canisters
+
+pub fn http_request(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    http_request: HttpRequest,
+) -> Result<HttpResponse, CallError> {
+    query_candid(env, canister_id, "http_request", (http_request,)).map(|(x,)| x)
+}

--- a/src/canister_tests/src/api/archive.rs
+++ b/src/canister_tests/src/api/archive.rs
@@ -52,11 +52,3 @@ pub fn status(
 ) -> Result<CanisterStatusResponse, CallError> {
     call_candid(env, canister_id, "status", ()).map(|(x,)| x)
 }
-
-pub fn http_request(
-    env: &StateMachine,
-    canister_id: CanisterId,
-    http_request: HttpRequest,
-) -> Result<HttpResponse, CallError> {
-    query_candid(env, canister_id, "http_request", (http_request,)).map(|(x,)| x)
-}

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -17,14 +17,6 @@ pub fn health_check(env: &StateMachine, canister_id: CanisterId) {
         call_candid(env, canister_id, "lookup", (user_number,)).unwrap();
 }
 
-pub fn http_request(
-    env: &StateMachine,
-    canister_id: CanisterId,
-    http_request: types::HttpRequest,
-) -> Result<types::HttpResponse, CallError> {
-    query_candid(env, canister_id, "http_request", (http_request,)).map(|(x,)| x)
-}
-
 pub fn create_challenge(
     env: &StateMachine,
     canister_id: CanisterId,

--- a/src/canister_tests/src/flows.rs
+++ b/src/canister_tests/src/flows.rs
@@ -1,11 +1,8 @@
-use crate::api::internet_identity::{create_challenge, http_request, register};
+use crate::api::internet_identity::{create_challenge, register};
 use crate::framework::{device_data_1, principal_1};
 use candid::Principal;
 use ic_cdk::api::management_canister::main::CanisterId;
-use internet_identity_interface::{
-    AnchorNumber, ChallengeAttempt, DeviceData, HttpRequest, RegisterResponse,
-};
-use serde_bytes::ByteBuf;
+use internet_identity_interface::{AnchorNumber, ChallengeAttempt, DeviceData, RegisterResponse};
 use state_machine_client::StateMachine;
 
 pub fn register_anchor(env: &StateMachine, canister_id: CanisterId) -> AnchorNumber {
@@ -33,19 +30,4 @@ pub fn register_anchor_with(
         response => panic!("could not register: {:?}", response),
     };
     user_number
-}
-
-pub fn get_metrics(env: &StateMachine, canister_id: CanisterId) -> String {
-    let response = http_request(
-        env,
-        canister_id,
-        HttpRequest {
-            method: "GET".to_string(),
-            url: "/metrics".to_string(),
-            headers: vec![],
-            body: ByteBuf::new(),
-        },
-    )
-    .expect("HTTP request to /metrics failed");
-    String::from_utf8_lossy(&response.body).to_string()
 }

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -1,4 +1,5 @@
 use crate::api;
+use crate::api::http_request;
 use candid::Principal;
 use flate2::read::GzDecoder;
 use flate2::{Compression, GzBuilder};
@@ -420,20 +421,35 @@ frame-ancestors 'none';$"
     .is_match(csp));
 }
 
-pub fn parse_metric(body: &str, metric: &str) -> (u64, SystemTime) {
+pub fn get_metrics(env: &StateMachine, canister_id: CanisterId) -> String {
+    let response = http_request(
+        env,
+        canister_id,
+        HttpRequest {
+            method: "GET".to_string(),
+            url: "/metrics".to_string(),
+            headers: vec![],
+            body: ByteBuf::new(),
+        },
+    )
+    .expect("HTTP request to /metrics failed");
+    String::from_utf8_lossy(&response.body).to_string()
+}
+
+pub fn parse_metric(body: &str, metric: &str) -> (f64, SystemTime) {
     let metric = metric.replace('{', "\\{").replace('}', "\\}");
     let metric_capture = Regex::new(&format!("(?m)^{} (\\d+) (\\d+)$", metric))
         .unwrap()
         .captures(body)
         .unwrap_or_else(|| panic!("metric {} not found", metric));
 
-    let metric: u64 = metric_capture.get(1).unwrap().as_str().parse().unwrap();
+    let metric: f64 = metric_capture.get(1).unwrap().as_str().parse().unwrap();
     let metric_timestamp = SystemTime::UNIX_EPOCH
         + Duration::from_millis(metric_capture.get(2).unwrap().as_str().parse().unwrap());
     (metric, metric_timestamp)
 }
 
-pub fn assert_metric(metrics: &str, metric_name: &str, expected: u64) {
+pub fn assert_metric(metrics: &str, metric_name: &str, expected: f64) {
     let (value, _) = parse_metric(metrics, metric_name);
     assert_eq!(value, expected);
 }


### PR DESCRIPTION
This PR removes some duplication with regards to http_request canister calls and getting metrics.

Additionally, it changes the metrics to be (correctly) parsed as f64.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
