### PR TITLE
Use obj as arguments for register

### DIFF
--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -192,9 +192,13 @@ export const promptCaptcha = ({
     promptCaptchaPage({
       cancel: () => resolve(cancel),
       verifyChallengeChars: async ({ chars, challenge }) => {
-        const result = await connection.register(identity, alias, {
-          key: challenge.challenge_key,
-          chars,
+        const result = await connection.register({
+          identity,
+          alias,
+          challengeResult: {
+            key: challenge.challenge_key,
+            chars,
+          },
         });
 
         switch (result.kind) {

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -105,11 +105,15 @@ export interface IdentifiableIdentity extends SignIdentity {
 export class Connection {
   public constructor(readonly canisterId: string) {}
 
-  register = async (
-    identity: IdentifiableIdentity,
-    alias: string,
-    challengeResult: ChallengeResult
-  ): Promise<RegisterResult> => {
+  register = async ({
+    identity,
+    alias,
+    challengeResult,
+  }: {
+    identity: IdentifiableIdentity;
+    alias: string;
+    challengeResult: ChallengeResult;
+  }): Promise<RegisterResult> => {
     let delegationIdentity: DelegationIdentity;
     try {
       delegationIdentity = await this.requestFEDelegation(identity);


### PR DESCRIPTION
This is a very minor refactoring which changes the typescript `register()` method to take in named parameters, to avoid confusion.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
