### PR TITLE
Make expiration periods more readable

### DIFF
--- a/src/internet_identity/src/delegation.rs
+++ b/src/internet_identity/src/delegation.rs
@@ -14,12 +14,22 @@ use serde::Serialize;
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 
-// 30 mins
-const DEFAULT_EXPIRATION_PERIOD_NS: u64 = secs_to_nanos(30 * 60);
-// 30 days
-const MAX_EXPIRATION_PERIOD_NS: u64 = secs_to_nanos(30 * 24 * 60 * 60);
-// 1 min
-const DEFAULT_SIGNATURE_EXPIRATION_PERIOD_NS: u64 = secs_to_nanos(60);
+// Some time helpers
+const MINUTE: u64 = secs_to_nanos(60);
+const HOUR: u64 = 60 * MINUTE;
+const DAY: u64 = 24 * HOUR;
+
+// The expiration used for delegations if none is specified
+// (calculated as now() + this)
+const DEFAULT_EXPIRATION_PERIOD_NS: u64 = 30 * MINUTE;
+
+// The maximum expiration time for delegation
+// (calculated as now() + this)
+const MAX_EXPIRATION_PERIOD_NS: u64 = 30 * DAY;
+
+// The expiration used for signatures
+#[allow(clippy::identity_op)]
+const SIGNATURE_EXPIRATION_PERIOD_NS: u64 = 1 * MINUTE;
 
 pub async fn prepare_delegation(
     anchor_number: AnchorNumber,
@@ -213,7 +223,7 @@ fn add_signature(sigs: &mut SignatureMap, pk: PublicKey, seed: Hash, expiration:
         expiration,
         targets: None,
     });
-    let expires_at = time().saturating_add(DEFAULT_SIGNATURE_EXPIRATION_PERIOD_NS);
+    let expires_at = time().saturating_add(SIGNATURE_EXPIRATION_PERIOD_NS);
     sigs.put(hash::hash_bytes(seed), msg_hash, expires_at);
 }
 


### PR DESCRIPTION
This changes the way expiration periods are defined:

* Comments are made more meaningful (instead of repeating the actual value, which may get out of sync)
* Some helpers (minutes, hours, days) are introduced to make the values of expiration periods clear
* The signature expiration period is not called "default" anymore, since it's the only possible expiratin period

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
