### PR TITLE
Automatically commit generated type interfaces

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -8,12 +8,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # set a PAT so that add-and-commit can trigger CI runs
+          token: ${{ secrets.GIX_BOT_PAT }}
       - uses: ./.github/actions/setup-node
       - run: npm ci
       - name: Run ESLint
         run: npm run lint
       - name: Check formatting
         run: npm run format-check
+      - name: Install didc
+        run: |
+          # A somewhat old release, but the generated file format has changed a bit since
+          # and we need to update our files manually before upgrading to something more recent
+          didc_release=2021-09-09
+
+          # Actual install
+          mkdir -p ~/.local/bin
+          curl --location --silent --show-error \
+            https://github.com/dfinity/candid/releases/download/$didc_release/didc-linux64 \
+            -o ~/.local/bin/didc
+          chmod +x ~/.local/bin/didc
+          ~/.local/bin/didc --version
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Generate type interfaces
+        run: npm run generate
+      - name: Commit type interfaces
+        uses: EndBug/add-and-commit@v9
+        # We don't want to commit automatic changes to main
+        if: ${{ github.ref != 'refs/heads/main' }}
+        with:
+          add: src/frontend/generated
+          default_author: github_actions
+          message: "🤖 npm run generate auto-update"
 
   # Job that starts the showcase and takes a screenshot of every page
   screenshots:

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -2,6 +2,9 @@ export const idlFactory = ({ IDL }) => {
   const ArchiveConfig = IDL.Record({
     'polling_interval_ns' : IDL.Nat64,
     'entries_buffer_limit' : IDL.Nat64,
+    'archive_integration' : IDL.Opt(
+      IDL.Variant({ 'pull' : IDL.Null, 'push' : IDL.Null })
+    ),
     'module_hash' : IDL.Vec(IDL.Nat8),
     'entries_fetch_limit' : IDL.Nat16,
   });
@@ -55,6 +58,12 @@ export const idlFactory = ({ IDL }) => {
     'creation_in_progress' : IDL.Null,
     'success' : IDL.Principal,
     'failed' : IDL.Text,
+  });
+  const BufferedArchiveEntry = IDL.Record({
+    'sequence_number' : IDL.Nat64,
+    'entry' : IDL.Vec(IDL.Nat8),
+    'anchor_number' : UserNumber,
+    'timestamp' : Timestamp,
   });
   const DeviceRegistrationInfo = IDL.Record({
     'tentative_device' : IDL.Opt(DeviceData),
@@ -135,6 +144,7 @@ export const idlFactory = ({ IDL }) => {
     'no_device_to_verify' : IDL.Null,
   });
   return IDL.Service({
+    'acknowledge_entries' : IDL.Func([IDL.Nat64], [], []),
     'add' : IDL.Func([UserNumber, DeviceData], [], []),
     'add_tentative_device' : IDL.Func(
         [UserNumber, DeviceData],
@@ -145,6 +155,7 @@ export const idlFactory = ({ IDL }) => {
     'deploy_archive' : IDL.Func([IDL.Vec(IDL.Nat8)], [DeployArchiveResult], []),
     'enter_device_registration_mode' : IDL.Func([UserNumber], [Timestamp], []),
     'exit_device_registration_mode' : IDL.Func([UserNumber], [], []),
+    'fetch_entries' : IDL.Func([], [IDL.Vec(BufferedArchiveEntry)], []),
     'get_anchor_info' : IDL.Func([UserNumber], [IdentityAnchorInfo], []),
     'get_delegation' : IDL.Func(
         [UserNumber, FrontendHostname, SessionKey, Timestamp],
@@ -183,6 +194,9 @@ export const init = ({ IDL }) => {
   const ArchiveConfig = IDL.Record({
     'polling_interval_ns' : IDL.Nat64,
     'entries_buffer_limit' : IDL.Nat64,
+    'archive_integration' : IDL.Opt(
+      IDL.Variant({ 'pull' : IDL.Null, 'push' : IDL.Null })
+    ),
     'module_hash' : IDL.Vec(IDL.Nat8),
     'entries_fetch_limit' : IDL.Nat16,
   });

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -12,12 +12,19 @@ export type AddTentativeDeviceResponse = {
 export interface ArchiveConfig {
   'polling_interval_ns' : bigint,
   'entries_buffer_limit' : bigint,
+  'archive_integration' : [] | [{ 'pull' : null } | { 'push' : null }],
   'module_hash' : Array<number>,
   'entries_fetch_limit' : number,
 }
 export interface ArchiveInfo {
   'archive_config' : [] | [ArchiveConfig],
   'archive_canister' : [] | [Principal],
+}
+export interface BufferedArchiveEntry {
+  'sequence_number' : bigint,
+  'entry' : Array<number>,
+  'anchor_number' : UserNumber,
+  'timestamp' : Timestamp,
 }
 export interface Challenge {
   'png_base64' : string,
@@ -115,6 +122,7 @@ export type VerifyTentativeDeviceResponse = {
   { 'wrong_code' : { 'retries_left' : number } } |
   { 'no_device_to_verify' : null };
 export interface _SERVICE {
+  'acknowledge_entries' : (arg_0: bigint) => Promise<undefined>,
   'add' : (arg_0: UserNumber, arg_1: DeviceData) => Promise<undefined>,
   'add_tentative_device' : (arg_0: UserNumber, arg_1: DeviceData) => Promise<
       AddTentativeDeviceResponse
@@ -123,6 +131,7 @@ export interface _SERVICE {
   'deploy_archive' : (arg_0: Array<number>) => Promise<DeployArchiveResult>,
   'enter_device_registration_mode' : (arg_0: UserNumber) => Promise<Timestamp>,
   'exit_device_registration_mode' : (arg_0: UserNumber) => Promise<undefined>,
+  'fetch_entries' : () => Promise<Array<BufferedArchiveEntry>>,
   'get_anchor_info' : (arg_0: UserNumber) => Promise<IdentityAnchorInfo>,
   'get_delegation' : (
       arg_0: UserNumber,


### PR DESCRIPTION
This ensures that type interfaces between rust and typescript are kept up to date by committing generated changes automatically.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
