### PR TITLE
Add link to forum in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-    🔗 <a href="https://identity.ic0.app">https://identity.ic0.app</a> | 📜 <a href="https://internetcomputer.org/docs/current/references/ii-spec">Specification</a> | 🚑 <a href="https://github.com/dfinity/internet-identity/issues/new">Report an Issue</a> | 📞 <a href="https://discord.gg/E9FxceAg2j">Discord</a>
+    🔗 <a href="https://identity.ic0.app">https://identity.ic0.app</a> • 📜 <a href="https://internetcomputer.org/docs/current/references/ii-spec">Specification</a> <br/> ― <br/>📚 <a href="https://forum.dfinity.org/c/internet-identity/32">Forum</a> • 🚑 <a href="https://github.com/dfinity/internet-identity/issues/new">Report an Issue</a> • 📞 <a href="https://discord.gg/E9FxceAg2j">Discord</a>
 </p>
 
 ---


### PR DESCRIPTION

This updates the README to add a link to the II category on the forum. This is added before other "reach out" options because often this should be the first place users search for answers.


<img width="1052" alt="Screenshot 2023-01-12 at 14 34 02" src="https://user-images.githubusercontent.com/6930756/212080449-51c3fe5d-a8d7-4fe0-bac5-7f117907b23e.png">

[(rendered)](https://github.com/dfinity/internet-identity/blob/nm-forum-link/README.md)

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
