### PR TITLE
Deploy showcase to GitHub Pages

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -161,3 +161,37 @@ jobs:
           add: screenshots
           default_author: github_actions
           message: "🤖 Selenium screenshots auto-update"
+
+  # Deploy the showcase to GitHub Pages
+  showcase:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-node
+      - run: npm ci
+
+      # Build the showcase with a special base URL (used in links and esp. routing)
+      # to match the deploy URL: https://dfinity.github.io/internet-identity/
+      - run: BASE_URL='/internet-identity' npm run build:showcase
+      # the showcase needs the same index.html served on all routes. In the devServer this is
+      # done by using `historyApiFallback`; on GH pages we just show a fake 404 page that is
+      # actually the index.
+      - run: cp dist/index.html dist/404.html
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'dist'
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: actions/deploy-pages@v1
+        id: deployment

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate:types": "didc bind ./src/internet_identity/internet_identity.did -t ts > src/frontend/generated/internet_identity_types.d.ts",
     "generate:js": "didc bind ./src/internet_identity/internet_identity.did -t js > src/frontend/generated/internet_identity_idl.js",
     "build": "NODE_ENV=production npm run opts -- webpack --config-name app",
+    "build:showcase": "npm run opts -- webpack --config-name showcase",
     "showcase": "II_FETCH_ROOT_KEY=1 npm run opts -- webpack serve --config-name showcase",
     "screenshots": "npm run opts -- ./src/frontend/screenshots.ts",
     "test": "jest --maxWorkers 1 --roots ./src/frontend --verbose --testPathIgnorePatterns=\"src/frontend/src/test-e2e\"",

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -275,8 +275,8 @@ const showcase: TemplateResult = html`
   <div class="showcase-grid l-stack">
     ${Object.entries(iiPages).map(([key, _]) => {
       return html`<aside>
-        <a data-page-name="${key}" href="/${key}">
-          <iframe src="/${key}" title="${key}"></iframe>
+        <a data-page-name="${key}" href="${key}">
+          <iframe src="${key}" title="${key}"></iframe>
           <h2>${key}</h2>
         </a>
       </aside>`;
@@ -407,7 +407,9 @@ const init = async () => {
   // If we can't find a page to route to, we just show the default page.
   // This is not very user friendly (in particular we don't show anything like a
   // 404) but this is an dev page anyway.
-  const route = window.location.pathname.substring(1);
+  const route = window.location.pathname
+    .replace(process.env.BASE_URL ?? "", "")
+    .substring(1);
   const page = iiPages[route] ?? defaultPage;
 
   page();

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -220,6 +220,12 @@ export default [
   {
     ...defaults,
     name: "showcase",
+    plugins: [
+      ...defaults.plugins,
+      new webpack.EnvironmentPlugin({
+        BASE_URL: "",
+      }),
+    ],
     entry: {
       showcase: path.join(__dirname, "src", "frontend", "src", "showcase"),
     },


### PR DESCRIPTION
This introduces a GH actions job to push the built showcase to GitHub Pages, so that external people & support can easily browse the current state of our screens.

rendered: http://dfinity.github.io/internet-identity/

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
