### PR TITLE
Disable showcase workflow on non-main

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -164,6 +164,7 @@ jobs:
 
   # Deploy the showcase to GitHub Pages
   showcase:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -192,6 +193,5 @@ jobs:
         with:
           path: 'dist'
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main'
         uses: actions/deploy-pages@v1
         id: deployment


### PR DESCRIPTION
This disables the entire showcase deployment when the branch is not `main`. Previously only the last step was disabled which failed the job on PRs; the assumption here is that since the last step was disabled, the `environment` could not be set from its `.outputs`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
