### PR TITLE
Change the order of dependencies in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -11,10 +11,10 @@ This document explains how to build the Wasm module of the Internet Identity can
 The build requires the following dependencies:
 
 * [`dfx`](https://github.com/dfinity/sdk/releases/latest) version 0.10.0 or later
-* [`ic-cdk-optimizer`](https://github.com/dfinity/cdk-rs/tree/main/src/ic-cdk-optimizer), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
 * Rustup with target `wasm32-unknown-unknown` (see [rustup instructions](https://rust-lang.github.io/rustup/cross-compilation.html)), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
-* Node.js v16+
 * CMake
+* [`ic-cdk-optimizer`](https://github.com/dfinity/cdk-rs/tree/main/src/ic-cdk-optimizer), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
+* Node.js v16+
 
 > NOTE! If you're only going to hack on the HTML and CSS code, just run `npm run showcase`. This will start a minimal web server which serves a showcase of the pages used in the app.
 


### PR DESCRIPTION
Change the order of dependencies in HACKING.md such that fulfilling a dependency doesn't require dependency listed below it.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
