### PR TITLE
Remove unused assets

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -247,12 +247,10 @@ jobs:
           mkdir dist
           touch dist/index.html
           touch dist/about.html
-          touch dist/faq.html
           touch dist/index.js.gz
           touch dist/index.css
           touch dist/loader.webp
           touch dist/favicon.ico
-          touch dist/ic-badge.svg
 
       # Caching ~/.cargo
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,6 @@ jobs:
           touch dist/index.css
           touch dist/loader.webp
           touch dist/favicon.ico
-          touch dist/ic-badge.svg
 
       - run: rustup component add clippy
       - name: Cargo clippy


### PR DESCRIPTION
Some assets were removed from the frontend recently but were kept in the rust jobs because the rust caches are not invalidated by frontend changes, meaning they still expected those assets to exist.

The caches have since been rebuilt and the assets can be officially dropped.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
