### PR TITLE
Add aliases for utils and generated modules

### DIFF
--- a/src/frontend/src/components/anchorInput.ts
+++ b/src/frontend/src/components/anchorInput.ts
@@ -1,8 +1,8 @@
 import { html, TemplateResult } from "lit-html";
-import { withRef, mount } from "../utils/lit-html";
+import { withRef, mount } from "@utils/lit-html";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
 import { ifDefined } from "lit-html/directives/if-defined.js";
-import { parseUserNumber } from "../utils/userNumber";
+import { parseUserNumber } from "@utils/userNumber";
 
 /** A component for inputting an anchor number */
 export const mkAnchorInput = ({

--- a/src/frontend/src/components/anchorPicker.ts
+++ b/src/frontend/src/components/anchorPicker.ts
@@ -1,7 +1,7 @@
 import { html, TemplateResult } from "lit-html";
 import { arrowRight } from "./icons";
-import { autofocus } from "../utils/lit-html";
-import { NonEmptyArray } from "../utils/utils";
+import { autofocus } from "@utils/lit-html";
+import { NonEmptyArray } from "@utils/utils";
 
 type PickerProps = {
   savedAnchors: NonEmptyArray<bigint>;

--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -1,23 +1,23 @@
 import { html, render, TemplateResult } from "lit-html";
 import { promptUserNumber } from "./promptUserNumber";
 import { registerTentativeDevice } from "../flows/addDevice/welcomeView/registerTentativeDevice";
-import { NonEmptyArray } from "../utils/utils";
+import { NonEmptyArray } from "@utils/utils";
 import { withLoader } from "./loader";
 import { mkAnchorPicker } from "./anchorPicker";
 import { mkAnchorInput } from "./anchorInput";
-import { getAnchors, setAnchorUsed } from "../utils/userNumber";
-import { unreachable, isNonEmptyArray } from "../utils/utils";
-import { Connection } from "../utils/iiConnection";
+import { getAnchors, setAnchorUsed } from "@utils/userNumber";
+import { unreachable, isNonEmptyArray } from "@utils/utils";
+import { Connection } from "@utils/iiConnection";
 import {
   apiResultToLoginFlowResult,
   LoginFlowResult,
   LoginFlowSuccess,
   LoginFlowError,
   LoginData,
-} from "../utils/flowResult";
+} from "@utils/flowResult";
 import { displayError } from "./displayError";
 import { useRecovery } from "../flows/recovery/useRecovery";
-import { registerIfAllowed } from "../utils/registerAllowedCheck";
+import { registerIfAllowed } from "@utils/registerAllowedCheck";
 import { mainWindow } from "./mainWindow";
 
 /** Template used for rendering specific authentication screens. See `authnPages` below

--- a/src/frontend/src/crypto/mnemonic.ts
+++ b/src/frontend/src/crypto/mnemonic.ts
@@ -1,6 +1,6 @@
 import { entropyToMnemonic, wordlists, validateMnemonic } from "bip39";
 import { toHexString } from "@dfinity/identity/lib/cjs/buffer";
-import { isUserNumber } from "../utils/userNumber";
+import { isUserNumber } from "@utils/userNumber";
 
 /**
  * @returns A random BIP39 mnemonic with 256 bits of entropy (generates a list of 24 words)

--- a/src/frontend/src/flows/addDevice/manage/addDevicePickAlias.ts
+++ b/src/frontend/src/flows/addDevice/manage/addDevicePickAlias.ts
@@ -1,6 +1,6 @@
 import { html, render } from "lit-html";
 import { logoutSection } from "../../../components/logout";
-import { validateAlias } from "../../../utils/validateAlias";
+import { validateAlias } from "@utils/validateAlias";
 // Regex Pattern for input: All characters, must be alphabet or number
 // Can have hyphen(s), space(s) or underscore(s) in the middle.
 // Good examples: "2019_macbook", "2019-Macbook", "2019 Macbook"

--- a/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
@@ -1,8 +1,5 @@
-import {
-  creationOptions,
-  AuthenticatedConnection,
-} from "../../../utils/iiConnection";
-import { DeviceData } from "../../../../generated/internet_identity_types";
+import { creationOptions, AuthenticatedConnection } from "@utils/iiConnection";
+import { DeviceData } from "@generated/internet_identity_types";
 import { WebAuthnIdentity } from "@dfinity/identity";
 import { pickDeviceAlias } from "./addDevicePickAlias";
 import { withLoader } from "../../../components/loader";

--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -1,13 +1,13 @@
 import { html, render } from "lit-html";
-import { AuthenticatedConnection } from "../../../utils/iiConnection";
+import { AuthenticatedConnection } from "@utils/iiConnection";
 import { renderManage } from "../../manage";
 import { withLoader } from "../../../components/loader";
 import { verifyTentativeDevice } from "./verifyTentativeDevice";
-import { setupCountdown } from "../../../utils/countdown";
+import { setupCountdown } from "@utils/countdown";
 import {
   DeviceData,
   IdentityAnchorInfo,
-} from "../../../../generated/internet_identity_types";
+} from "@generated/internet_identity_types";
 import { displayError } from "../../../components/displayError";
 import { mainWindow } from "../../../components/mainWindow";
 

--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -1,15 +1,15 @@
 import { html, render } from "lit-html";
-import { unreachableLax, unknownToString } from "../../../utils/utils";
+import { unreachableLax, unknownToString } from "@utils/utils";
 import { createRef, ref } from "lit-html/directives/ref.js";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
-import { withRef } from "../../../utils/lit-html";
-import { AuthenticatedConnection } from "../../../utils/iiConnection";
+import { withRef } from "@utils/lit-html";
+import { AuthenticatedConnection } from "@utils/iiConnection";
 import { withLoader } from "../../../components/loader";
 import { displayError } from "../../../components/displayError";
-import { Chan } from "../../../utils/utils";
-import { AsyncCountdown } from "../../../utils/countdown";
+import { Chan } from "@utils/utils";
+import { AsyncCountdown } from "@utils/countdown";
 import { mainWindow } from "../../../components/mainWindow";
-import { VerifyTentativeDeviceResponse } from "../../../../generated/internet_identity_types";
+import { VerifyTentativeDeviceResponse } from "@generated/internet_identity_types";
 
 // The type that we return, pretty much the result of the canister
 // except that all retries have been exhausted

--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -1,5 +1,5 @@
 import { html, render } from "lit-html";
-import { Connection } from "../../../utils/iiConnection";
+import { Connection } from "@utils/iiConnection";
 import {
   addTentativeDevice,
   TentativeDeviceInfo,

--- a/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -1,5 +1,5 @@
 import { html, render } from "lit-html";
-import { creationOptions, Connection } from "../../../utils/iiConnection";
+import { creationOptions, Connection } from "@utils/iiConnection";
 import { WebAuthnIdentity } from "@dfinity/identity";
 import { deviceRegistrationDisabledInfo } from "./deviceRegistrationModeDisabled";
 import { DerEncodedPublicKey } from "@dfinity/agent";
@@ -9,7 +9,7 @@ import {
 } from "../../../../generated/internet_identity_types";
 import { showVerificationCode } from "./showVerificationCode";
 import { withLoader } from "../../../components/loader";
-import { toggleErrorMessage } from "../../../utils/errorHelper";
+import { toggleErrorMessage } from "@utils/errorHelper";
 import { displayError } from "../../../components/displayError";
 import { mainWindow } from "../../../components/mainWindow";
 

--- a/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
@@ -1,13 +1,13 @@
 import { html, render } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
-import { Connection } from "../../../utils/iiConnection";
-import { delayMillis } from "../../../utils/utils";
+import { Connection } from "@utils/iiConnection";
+import { delayMillis } from "@utils/utils";
 import {
   AddTentativeDeviceResponse,
   CredentialId,
 } from "../../../../generated/internet_identity_types";
-import { setAnchorUsed } from "../../../utils/userNumber";
-import { AsyncCountdown } from "../../../utils/countdown";
+import { setAnchorUsed } from "@utils/userNumber";
+import { AsyncCountdown } from "@utils/countdown";
 import { displayError } from "../../../components/displayError";
 import { mainWindow } from "../../../components/mainWindow";
 

--- a/src/frontend/src/flows/authorize/fetchDelegation.ts
+++ b/src/frontend/src/flows/authorize/fetchDelegation.ts
@@ -1,4 +1,4 @@
-import { AuthenticatedConnection } from "../../utils/iiConnection";
+import { AuthenticatedConnection } from "@utils/iiConnection";
 import { AuthContext, Delegation } from "./postMessageInterface";
 import {
   PublicKey,

--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -1,9 +1,9 @@
 import { html, render, TemplateResult } from "lit-html";
-import { withRef } from "../../utils/lit-html";
+import { withRef } from "@utils/lit-html";
 import { caretDownIcon } from "../../components/icons";
 import { ref, createRef, Ref } from "lit-html/directives/ref.js";
-import { unreachable } from "../../utils/utils";
-import { Connection } from "../../utils/iiConnection";
+import { unreachable } from "@utils/utils";
+import { Connection } from "@utils/iiConnection";
 import { displayError } from "../../components/displayError";
 import { spinner } from "../../components/icons";
 import { recoveryWizard } from "../recovery/recoveryWizard";

--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -3,8 +3,8 @@
 import { Principal } from "@dfinity/principal";
 import { fetchDelegation } from "./fetchDelegation";
 import { validateDerivationOrigin } from "./validateDerivationOrigin";
-import { unknownToRecord } from "../../utils/utils";
-import { LoginData } from "../../utils/flowResult";
+import { unknownToRecord } from "@utils/utils";
+import { LoginData } from "@utils/flowResult";
 
 export interface Delegation {
   delegation: {

--- a/src/frontend/src/flows/authorize/validateDerivationOrigin.ts
+++ b/src/frontend/src/flows/authorize/validateDerivationOrigin.ts
@@ -1,5 +1,5 @@
 import { Principal } from "@dfinity/principal";
-import { wrapError } from "../../utils/utils";
+import { wrapError } from "@utils/utils";
 
 const ORIGIN_VALIDATION_REGEX = /^https:\/\/([\w-]+)(?:\.raw)?\.ic0\.app$/;
 const MAX_ALTERNATIVE_ORIGINS = 10;

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -4,11 +4,11 @@ import {
   bufferEqual,
   AuthenticatedConnection,
   Connection,
-} from "../../utils/iiConnection";
+} from "@utils/iiConnection";
 import { displayError } from "../../components/displayError";
 import { withLoader } from "../../components/loader";
-import { unreachable } from "../../utils/utils";
-import { DeviceData } from "../../../generated/internet_identity_types";
+import { unreachable } from "@utils/utils";
+import { DeviceData } from "@generated/internet_identity_types";
 import { phraseRecoveryPage } from "../recovery/recoverWith/phrase";
 import { mainWindow } from "../../components/mainWindow";
 

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -1,13 +1,13 @@
 import { TemplateResult, render, html } from "lit-html";
-import { Connection, AuthenticatedConnection } from "../../utils/iiConnection";
+import { Connection, AuthenticatedConnection } from "@utils/iiConnection";
 import { withLoader } from "../../components/loader";
-import { unreachable } from "../../utils/utils";
+import { unreachable } from "@utils/utils";
 import { logoutSection } from "../../components/logout";
 import { deviceSettings } from "./deviceSettings";
 import {
   DeviceData,
   IdentityAnchorInfo,
-} from "../../../generated/internet_identity_types";
+} from "@generated/internet_identity_types";
 import { settingsIcon, warningIcon } from "../../components/icons";
 import { displayError } from "../../components/displayError";
 import {

--- a/src/frontend/src/flows/recovery/chooseRecoveryMechanism.ts
+++ b/src/frontend/src/flows/recovery/chooseRecoveryMechanism.ts
@@ -1,5 +1,5 @@
 import { html, render } from "lit-html";
-import { DeviceData } from "../../../generated/internet_identity_types";
+import { DeviceData } from "@generated/internet_identity_types";
 import { securityKeyIcon, seedPhraseIcon } from "../../components/icons";
 import { mainWindow } from "../../components/mainWindow";
 

--- a/src/frontend/src/flows/recovery/displaySafariWarning.ts
+++ b/src/frontend/src/flows/recovery/displaySafariWarning.ts
@@ -1,7 +1,7 @@
 import { html, render } from "lit-html";
 import { warnBox } from "../../components/warnBox";
 import { setupRecovery } from "./setupRecovery";
-import { AuthenticatedConnection } from "../../utils/iiConnection";
+import { AuthenticatedConnection } from "@utils/iiConnection";
 import { mainWindow } from "../../components/mainWindow";
 
 const pageContent = () => {

--- a/src/frontend/src/flows/recovery/displaySingleDeviceWarning.ts
+++ b/src/frontend/src/flows/recovery/displaySingleDeviceWarning.ts
@@ -1,6 +1,6 @@
 import { html, render } from "lit-html";
 import { setupRecovery } from "./setupRecovery";
-import { AuthenticatedConnection } from "../../utils/iiConnection";
+import { AuthenticatedConnection } from "@utils/iiConnection";
 import { mainWindow } from "../../components/mainWindow";
 
 const pageContent = () => {

--- a/src/frontend/src/flows/recovery/pickRecoveryDevice.ts
+++ b/src/frontend/src/flows/recovery/pickRecoveryDevice.ts
@@ -1,5 +1,5 @@
 import { html, render } from "lit-html";
-import { DeviceData } from "../../../generated/internet_identity_types";
+import { DeviceData } from "@generated/internet_identity_types";
 import { mainWindow } from "../../components/mainWindow";
 import { securityKeyIcon, seedPhraseIcon } from "../../components/icons";
 

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -1,14 +1,14 @@
 import { html, render } from "lit-html";
 import { displayError } from "../../../components/displayError";
-import { unreachable } from "../../../utils/utils";
+import { unreachable } from "@utils/utils";
 import {
   apiResultToLoginFlowResult,
   cancel,
   LoginFlowSuccess,
   LoginFlowCanceled,
-} from "../../../utils/flowResult";
-import { DeviceData } from "../../../../generated/internet_identity_types";
-import { Connection } from "../../../utils/iiConnection";
+} from "@utils/flowResult";
+import { DeviceData } from "@generated/internet_identity_types";
+import { Connection } from "@utils/iiConnection";
 import { mainWindow } from "../../../components/mainWindow";
 
 const pageContent = () => {

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -1,15 +1,15 @@
 import { html, nothing, render, TemplateResult } from "lit-html";
-import { DeviceData } from "../../../../generated/internet_identity_types";
+import { DeviceData } from "@generated/internet_identity_types";
 import {
   apiResultToLoginFlowResult,
   LoginFlowCanceled,
   cancel,
   LoginFlowSuccess,
-} from "../../../utils/flowResult";
+} from "@utils/flowResult";
 import { dropLeadingUserNumber } from "../../../crypto/mnemonic";
-import { Connection } from "../../../utils/iiConnection";
+import { Connection } from "@utils/iiConnection";
 import { displayError } from "../../../components/displayError";
-import { unreachable } from "../../../utils/utils";
+import { unreachable } from "@utils/utils";
 import {
   Warning,
   RECOVERYPHRASE_WORDCOUNT,

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -1,8 +1,8 @@
-import { AuthenticatedConnection } from "../../utils/iiConnection";
+import { AuthenticatedConnection } from "@utils/iiConnection";
 import { setupRecovery } from "./setupRecovery";
 import { displaySingleDeviceWarning } from "./displaySingleDeviceWarning";
 import { displaySafariWarning } from "./displaySafariWarning";
-import { iOSOrSafari } from "../../utils/utils";
+import { iOSOrSafari } from "@utils/utils";
 
 export const recoveryWizard = async (
   userNumber: bigint,

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -7,8 +7,8 @@ import {
   creationOptions,
   IC_DERIVATION_PATH,
   AuthenticatedConnection,
-} from "../../utils/iiConnection";
-import { unknownToString } from "../../utils/utils";
+} from "@utils/iiConnection";
+import { unknownToString } from "@utils/utils";
 import { chooseRecoveryMechanism } from "./chooseRecoveryMechanism";
 import { displaySeedPhrase } from "./displaySeedPhrase";
 

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -1,5 +1,5 @@
 import { displayError } from "../../components/displayError";
-import { Connection } from "../../utils/iiConnection";
+import { Connection } from "@utils/iiConnection";
 import { renderManage } from "../manage";
 import { promptUserNumber } from "../../components/promptUserNumber";
 import { phraseRecoveryPage } from "./recoverWith/phrase";

--- a/src/frontend/src/flows/register/alias.ts
+++ b/src/frontend/src/flows/register/alias.ts
@@ -1,7 +1,7 @@
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
-import { withRef } from "../../utils/lit-html";
+import { withRef } from "@utils/lit-html";
 import { html, render, TemplateResult } from "lit-html";
-import { validateAlias } from "../../utils/validateAlias";
+import { validateAlias } from "@utils/validateAlias";
 import { mainWindow } from "../../components/mainWindow";
 
 /* Everything (template, component, page) related to picking a device alias */

--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -1,16 +1,16 @@
-import { Challenge } from "../../../generated/internet_identity_types";
+import { Challenge } from "@generated/internet_identity_types";
 import { spinner } from "../../components/icons";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { html, render, TemplateResult } from "lit-html";
-import { withRef, autofocus } from "../../utils/lit-html";
-import { Chan } from "../../utils/utils";
+import { withRef, autofocus } from "@utils/lit-html";
+import { Chan } from "@utils/utils";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
-import { LoginFlowCanceled, cancel } from "../../utils/flowResult";
+import { LoginFlowCanceled, cancel } from "@utils/flowResult";
 import {
   IdentifiableIdentity,
   Connection,
   RegisterResult,
-} from "../../utils/iiConnection";
+} from "@utils/iiConnection";
 import { mainWindow } from "../../components/mainWindow";
 
 // A symbol that we can differentiate from generic `T` types

--- a/src/frontend/src/flows/register/construct.ts
+++ b/src/frontend/src/flows/register/construct.ts
@@ -4,7 +4,7 @@ import {
   IdentifiableIdentity,
   DummyIdentity,
   creationOptions,
-} from "../../utils/iiConnection";
+} from "@utils/iiConnection";
 import { nextTick } from "process";
 import { spinner } from "../../components/icons";
 import { mainWindow } from "../../components/mainWindow";

--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -1,6 +1,6 @@
 import { html, render } from "lit-html";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
-import { withRef } from "../../utils/lit-html";
+import { withRef } from "@utils/lit-html";
 import { warnBox } from "../../components/warnBox";
 import { mainWindow } from "../../components/mainWindow";
 import { checkmarkIcon, copyIcon } from "../../components/icons";

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -1,12 +1,12 @@
-import { Connection } from "../../utils/iiConnection";
-import { unknownToString } from "../../utils/utils";
-import { setAnchorUsed } from "../../utils/userNumber";
+import { Connection } from "@utils/iiConnection";
+import { unknownToString } from "@utils/utils";
+import { setAnchorUsed } from "@utils/userNumber";
 import { promptCaptcha } from "./captcha";
 import {
   apiResultToLoginFlowResult,
   LoginFlowResult,
   cancel,
-} from "../../utils/flowResult";
+} from "@utils/flowResult";
 import { constructIdentity } from "./construct";
 import { promptDeviceAlias } from "./alias";
 import { displayUserNumber } from "./finish";

--- a/src/frontend/src/flows/registerDisabled.ts
+++ b/src/frontend/src/flows/registerDisabled.ts
@@ -1,6 +1,6 @@
 import { html, render } from "lit-html";
 import { warnBox } from "../components/warnBox";
-import { LoginFlowCanceled, cancel } from "../utils/flowResult";
+import { LoginFlowCanceled, cancel } from "@utils/flowResult";
 import { mainWindow } from "../components/mainWindow";
 
 const pageContent = (onCancel: () => void) => {

--- a/src/frontend/src/i18n.ts
+++ b/src/frontend/src/i18n.ts
@@ -1,7 +1,7 @@
 /** The copy and internationalization used in Internet Identity, based on
  * the officially supported languages */
 
-import { I18n as BaseI18n } from "./utils/i18n";
+import { I18n as BaseI18n } from "@utils/i18n";
 
 const supportedLanguages = ["en"] as const;
 export type SupportedLanguage = typeof supportedLanguages[number];

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -3,12 +3,12 @@ import { authFlowManage } from "./flows/manage";
 import { authFlowAuthorize } from "./flows/authorize";
 import { compatibilityNotice } from "./flows/compatibilityNotice";
 import { aboutView } from "./flows/about";
-import { intentFromUrl } from "./utils/userIntent";
+import { intentFromUrl } from "@utils/userIntent";
 import { version } from "./version";
-import { checkRequiredFeatures } from "./utils/featureDetection";
+import { checkRequiredFeatures } from "@utils/featureDetection";
 import { showWarningIfNecessary } from "./banner";
 import { displayError } from "./components/displayError";
-import { Connection } from "./utils/iiConnection";
+import { Connection } from "@utils/iiConnection";
 import { anyFeatures, features } from "./features";
 
 /** Reads the canister ID from the <script> tag.

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -4,16 +4,16 @@
 import "./styles/main.css";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
-import { Chan, NonEmptyArray, asNonEmptyArray } from "./utils/utils";
-import { I18n } from "./utils/i18n";
-import { withRef, mount } from "./utils/lit-html";
+import { Chan, NonEmptyArray, asNonEmptyArray } from "@utils/utils";
+import { I18n } from "@utils/i18n";
+import { withRef, mount } from "@utils/lit-html";
 import { TemplateResult, html, render } from "lit-html";
 import {
   Challenge,
   DeviceData,
   Timestamp,
-} from "../generated/internet_identity_types";
-import { AuthenticatedConnection } from "./utils/iiConnection";
+} from "@generated/internet_identity_types";
+import { AuthenticatedConnection } from "@utils/iiConnection";
 import { styleguide } from "./styleguide";
 import { compatibilityNotice } from "./flows/compatibilityNotice";
 import { aboutView } from "./flows/about";

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -1,6 +1,6 @@
 import { remote } from "webdriverio";
 import { command } from "webdriver";
-import { wrapError, randomString } from "../utils/utils";
+import { wrapError, randomString } from "@utils/utils";
 import { WebAuthnCredential } from "../../test-setup";
 import { ChromeOptions } from "@wdio/types/build/Capabilities";
 import * as fsasync from "fs/promises";

--- a/src/frontend/src/utils/countdown.ts
+++ b/src/frontend/src/utils/countdown.ts
@@ -1,5 +1,5 @@
 import { render } from "lit-html";
-import { delayMillis } from "./utils";
+import { delayMillis } from "@utils/utils";
 
 /**
  * Countdown implementation which calls the supplied update function approximately every second until the endTimestamp is reached.

--- a/src/frontend/src/utils/featureDetection.ts
+++ b/src/frontend/src/utils/featureDetection.ts
@@ -1,5 +1,5 @@
 import { features } from "../features";
-import { wrapError } from "./utils";
+import { wrapError } from "@utils/utils";
 
 export const checkRequiredFeatures = async (
   url: URL

--- a/src/frontend/src/utils/i18n.ts
+++ b/src/frontend/src/utils/i18n.ts
@@ -5,7 +5,7 @@
 
 import { TemplateResult, html } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
-import { Chan } from "./utils";
+import { Chan } from "@utils/utils";
 
 // The type of raw copy, i.e. { lang: { some_key_title: "Welcome!" } }
 type StringCopy<Keys extends string, Lang extends string> = {

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -8,7 +8,7 @@ import {
   HttpAgent,
   SignIdentity,
 } from "@dfinity/agent";
-import { idlFactory as internet_identity_idl } from "../../generated/internet_identity_idl";
+import { idlFactory as internet_identity_idl } from "@generated/internet_identity_idl";
 import {
   _SERVICE,
   AddTentativeDeviceResponse,
@@ -28,7 +28,7 @@ import {
   Timestamp,
   UserNumber,
   VerifyTentativeDeviceResponse,
-} from "../../generated/internet_identity_types";
+} from "@generated/internet_identity_types";
 import {
   DelegationChain,
   DelegationIdentity,
@@ -36,7 +36,7 @@ import {
 } from "@dfinity/identity";
 import { Principal } from "@dfinity/principal";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
-import { unreachable } from "./utils";
+import { unreachable } from "@utils/utils";
 import * as tweetnacl from "tweetnacl";
 import { fromMnemonicWithoutValidation } from "../crypto/ed25519";
 import { features } from "../features";
@@ -96,7 +96,7 @@ type ApiError = { kind: "apiError"; error: Error };
 type RegisterNoSpace = { kind: "registerNoSpace" };
 type SeedPhraseFail = { kind: "seedPhraseFail" };
 
-export type { ChallengeResult } from "../../generated/internet_identity_types";
+export type { ChallengeResult } from "@generated/internet_identity_types";
 
 export interface IdentifiableIdentity extends SignIdentity {
   rawId: ArrayBuffer;

--- a/src/frontend/src/utils/registerAllowedCheck.ts
+++ b/src/frontend/src/utils/registerAllowedCheck.ts
@@ -1,7 +1,7 @@
 import { LoginFlowResult } from "./flowResult";
 import { register } from "../flows/register";
 import { registerDisabled } from "../flows/registerDisabled";
-import { Connection } from "../utils/iiConnection";
+import { Connection } from "@utils/iiConnection";
 
 /** Check that the current origin is not the explicit canister id or a raw url.
  *  Explanation why we need to do this:

--- a/src/frontend/src/utils/userNumber.ts
+++ b/src/frontend/src/utils/userNumber.ts
@@ -1,4 +1,4 @@
-import { hasNumberProperty, unknownToRecord } from "./utils";
+import { hasNumberProperty, unknownToRecord } from "@utils/utils";
 
 /** The Anchor type as stored in local storage, including hint of the frequency
  * at which the anchor is used.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,12 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["node", "jest", "webdriverio/async"]
+    "types": ["node", "jest", "webdriverio/async"],
+    "baseUrl": "./",
+    "paths": {
+      "@generated/*": ["src/frontend/generated/*"],
+      "@utils/*": ["src/frontend/src/utils/*"]
+    }
   },
   "exclude": [
     "src/**/*.test.ts",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -117,6 +117,10 @@ const defaults = {
     fallback: {
       stream: "stream-browserify",
     },
+    alias: {
+      "@generated": path.resolve(__dirname, "src/frontend/generated/"),
+      "@utils": path.resolve(__dirname, "src/frontend/src/utils/"),
+    },
   },
   module: {
     rules: [


### PR DESCRIPTION
This introduces webpack & ts aliases for the `generated` and `utils` modules, which are used from many places and used to include lots of directory changes (`../../../utils/`, etc)

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
