### PR TITLE
Introduce new method for public anchor information

### DIFF
--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -184,7 +184,7 @@ pub fn get_anchor_info(
     canister_id: CanisterId,
     sender: Principal,
     anchor_number: types::AnchorNumber,
-) -> Result<types::IdentityAnchorInfo, CallError> {
+) -> Result<types::AnchorInfo, CallError> {
     call_candid_as(
         env,
         canister_id,

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -179,6 +179,14 @@ pub fn remove(
     )
 }
 
+pub fn get_public_anchor_info(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    anchor_number: types::AnchorNumber,
+) -> Result<types::PublicAnchorInfo, CallError> {
+    call_candid(env, canister_id, "get_public_anchor_info", (anchor_number,)).map(|(x,)| x)
+}
+
 pub fn get_anchor_info(
     env: &StateMachine,
     canister_id: CanisterId,

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -69,7 +69,7 @@ export const idlFactory = ({ IDL }) => {
     'tentative_device' : IDL.Opt(DeviceData),
     'expiration' : Timestamp,
   });
-  const IdentityAnchorInfo = IDL.Record({
+  const AnchorInfo = IDL.Record({
     'devices' : IDL.Vec(DeviceData),
     'device_registration' : IDL.Opt(DeviceRegistrationInfo),
   });
@@ -87,6 +87,16 @@ export const idlFactory = ({ IDL }) => {
   const GetDelegationResponse = IDL.Variant({
     'no_such_delegation' : IDL.Null,
     'signed_delegation' : SignedDelegation,
+  });
+  const PublicDeviceData = IDL.Record({
+    'protection' : DeviceProtection,
+    'pubkey' : DeviceKey,
+    'key_type' : KeyType,
+    'purpose' : Purpose,
+    'credential_id' : IDL.Opt(CredentialId),
+  });
+  const PublicAnchorInfo = IDL.Record({
+    'devices' : IDL.Vec(PublicDeviceData),
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
@@ -156,7 +166,7 @@ export const idlFactory = ({ IDL }) => {
     'enter_device_registration_mode' : IDL.Func([UserNumber], [Timestamp], []),
     'exit_device_registration_mode' : IDL.Func([UserNumber], [], []),
     'fetch_entries' : IDL.Func([], [IDL.Vec(BufferedArchiveEntry)], []),
-    'get_anchor_info' : IDL.Func([UserNumber], [IdentityAnchorInfo], []),
+    'get_anchor_info' : IDL.Func([UserNumber], [AnchorInfo], []),
     'get_delegation' : IDL.Func(
         [UserNumber, FrontendHostname, SessionKey, Timestamp],
         [GetDelegationResponse],
@@ -167,6 +177,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Principal],
         ['query'],
       ),
+    'get_public_anchor_info' : IDL.Func([UserNumber], [PublicAnchorInfo], []),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'init_salt' : IDL.Func([], [], []),
     'lookup' : IDL.Func([UserNumber], [IDL.Vec(DeviceData)], ['query']),

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -9,6 +9,10 @@ export type AddTentativeDeviceResponse = {
       'device_registration_timeout' : Timestamp,
     }
   };
+export interface AnchorInfo {
+  'devices' : Array<DeviceData>,
+  'device_registration' : [] | [DeviceRegistrationInfo],
+}
 export interface ArchiveConfig {
   'polling_interval_ns' : bigint,
   'entries_buffer_limit' : bigint,
@@ -72,10 +76,6 @@ export interface HttpResponse {
   'streaming_strategy' : [] | [StreamingStrategy],
   'status_code' : number,
 }
-export interface IdentityAnchorInfo {
-  'devices' : Array<DeviceData>,
-  'device_registration' : [] | [DeviceRegistrationInfo],
-}
 export interface InternetIdentityInit {
   'upgrade_persistent_state' : [] | [boolean],
   'assigned_user_number_range' : [] | [[bigint, bigint]],
@@ -93,6 +93,14 @@ export type KeyType = { 'platform' : null } |
   { 'seed_phrase' : null } |
   { 'cross_platform' : null } |
   { 'unknown' : null };
+export interface PublicAnchorInfo { 'devices' : Array<PublicDeviceData> }
+export interface PublicDeviceData {
+  'protection' : DeviceProtection,
+  'pubkey' : DeviceKey,
+  'key_type' : KeyType,
+  'purpose' : Purpose,
+  'credential_id' : [] | [CredentialId],
+}
 export type PublicKey = Array<number>;
 export type Purpose = { 'authentication' : null } |
   { 'recovery' : null };
@@ -132,7 +140,7 @@ export interface _SERVICE {
   'enter_device_registration_mode' : (arg_0: UserNumber) => Promise<Timestamp>,
   'exit_device_registration_mode' : (arg_0: UserNumber) => Promise<undefined>,
   'fetch_entries' : () => Promise<Array<BufferedArchiveEntry>>,
-  'get_anchor_info' : (arg_0: UserNumber) => Promise<IdentityAnchorInfo>,
+  'get_anchor_info' : (arg_0: UserNumber) => Promise<AnchorInfo>,
   'get_delegation' : (
       arg_0: UserNumber,
       arg_1: FrontendHostname,
@@ -142,6 +150,7 @@ export interface _SERVICE {
   'get_principal' : (arg_0: UserNumber, arg_1: FrontendHostname) => Promise<
       Principal
     >,
+  'get_public_anchor_info' : (arg_0: UserNumber) => Promise<PublicAnchorInfo>,
   'http_request' : (arg_0: HttpRequest) => Promise<HttpResponse>,
   'init_salt' : () => Promise<undefined>,
   'lookup' : (arg_0: UserNumber) => Promise<Array<DeviceData>>,

--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -6,7 +6,7 @@ import { verifyTentativeDevice } from "./verifyTentativeDevice";
 import { setupCountdown } from "../../../utils/countdown";
 import {
   DeviceData,
-  IdentityAnchorInfo,
+  AnchorInfo,
 } from "../../../../generated/internet_identity_types";
 import { displayError } from "../../../components/displayError";
 import { mainWindow } from "../../../components/mainWindow";
@@ -150,9 +150,7 @@ const init = (
   };
 };
 
-const getTentativeDevice = (
-  userInfo: IdentityAnchorInfo
-): DeviceData | null => {
+const getTentativeDevice = (userInfo: AnchorInfo): DeviceData | null => {
   if (
     userInfo.device_registration.length === 1 &&
     userInfo.device_registration[0].tentative_device.length === 1

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -6,7 +6,7 @@ import { logoutSection } from "../../components/logout";
 import { deviceSettings } from "./deviceSettings";
 import {
   DeviceData,
-  IdentityAnchorInfo,
+  AnchorInfo,
 } from "../../../generated/internet_identity_types";
 import { settingsIcon, warningIcon } from "../../components/icons";
 import { displayError } from "../../components/displayError";
@@ -259,7 +259,7 @@ export const renderManage = async (
   userNumber: bigint,
   connection: AuthenticatedConnection
 ): Promise<void> => {
-  let anchorInfo: IdentityAnchorInfo;
+  let anchorInfo: AnchorInfo;
   try {
     anchorInfo = await withLoader(() => connection.getAnchorInfo());
   } catch (error: unknown) {

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -19,7 +19,7 @@ import {
   DeviceKey,
   FrontendHostname,
   GetDelegationResponse,
-  IdentityAnchorInfo,
+  AnchorInfo,
   KeyType,
   PublicKey,
   Purpose,
@@ -464,7 +464,7 @@ export class AuthenticatedConnection extends Connection {
     return this.actor;
   }
 
-  getAnchorInfo = async (): Promise<IdentityAnchorInfo> => {
+  getAnchorInfo = async (): Promise<AnchorInfo> => {
     const actor = await this.getActor();
     return await actor.get_anchor_info(this.userNumber);
   };

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -214,9 +214,21 @@ type DeviceRegistrationInfo = record {
     expiration: Timestamp;
 };
 
-type IdentityAnchorInfo = record {
+type AnchorInfo = record {
     devices : vec DeviceData;
     device_registration: opt DeviceRegistrationInfo;
+};
+
+type PublicAnchorInfo = record {
+    devices : vec PublicDeviceData;
+};
+
+type PublicDeviceData = record {
+    pubkey: DeviceKey;
+    credential_id: opt  CredentialId;
+    purpose: Purpose;
+    key_type: KeyType;
+    protection: DeviceProtection;
 };
 
 type DeployArchiveResult = variant {
@@ -248,9 +260,10 @@ service : (opt InternetIdentityInit) -> {
     remove : (UserNumber, DeviceKey) -> ();
     // Returns all devices of the user (authentication and recovery) but no information about device registrations.
     // Note: Clears out the 'alias' fields on the devices. Use 'get_anchor_info' to obtain the full information.
-    // Note: Will be changed in the future to be more consistent with get_anchor_info.
+    // Deprecated: Use get_anchor_info instead.
     lookup : (UserNumber) -> (vec DeviceData) query;
-    get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);
+    get_public_anchor_info : (UserNumber) -> (PublicAnchorInfo);
+    get_anchor_info : (UserNumber) -> (AnchorInfo);
     get_principal : (UserNumber, FrontendHostname) -> (principal) query;
     stats : () -> (InternetIdentityStats) query;
 

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -11,7 +11,7 @@ use internet_identity_interface::*;
 pub mod registration;
 pub mod tentative_device_registration;
 
-pub fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
+pub fn get_anchor_info(anchor_number: AnchorNumber) -> AnchorInfo {
     let devices = state::anchor(anchor_number)
         .into_devices()
         .into_iter()
@@ -27,7 +27,7 @@ pub fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
                     DeviceTentativelyAdded {
                         tentative_device, ..
                     },
-            }) if *expiration > now => IdentityAnchorInfo {
+            }) if *expiration > now => AnchorInfo {
                 devices,
                 device_registration: Some(DeviceRegistrationInfo {
                     expiration: *expiration,
@@ -35,7 +35,7 @@ pub fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
                 }),
             },
             Some(TentativeDeviceRegistration { expiration, .. }) if *expiration > now => {
-                IdentityAnchorInfo {
+                AnchorInfo {
                     devices,
                     device_registration: Some(DeviceRegistrationInfo {
                         expiration: *expiration,
@@ -43,7 +43,7 @@ pub fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
                     }),
                 }
             }
-            None | Some(_) => IdentityAnchorInfo {
+            None | Some(_) => AnchorInfo {
                 devices,
                 device_registration: None,
             },

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -96,8 +96,9 @@ fn remove(anchor_number: AnchorNumber, device_key: DeviceKey) {
 }
 
 /// Returns all devices of the anchor (authentication and recovery) but no information about device registrations.
-/// Note: Will be changed in the future to be more consistent with get_anchor_info.
+/// Deprecated: Use [get_anchor_info].instead
 #[query]
+#[deprecated(note = "use `get_public_anchor_info` instead")]
 fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
     state::storage(|storage| {
         storage
@@ -115,8 +116,16 @@ fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
     })
 }
 
+/// Returns _public_ information about the given anchor. Does not require authentication.
+#[query]
+fn get_public_anchor_info(anchor_number: AnchorNumber) -> PublicAnchorInfo {
+    let anchor = state::anchor(anchor_number);
+    PublicAnchorInfo::from(anchor)
+}
+
+/// Returns information about the given anchor. Requires authentication.
 #[update] // this is an update call because queries are not (yet) certified
-fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
+fn get_anchor_info(anchor_number: AnchorNumber) -> AnchorInfo {
     trap_if_not_authenticated(&state::anchor(anchor_number));
     anchor_management::get_anchor_info(anchor_number)
 }

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -53,6 +53,18 @@ impl From<Device> for DeviceDataWithoutAlias {
     }
 }
 
+impl From<Anchor> for PublicAnchorInfo {
+    fn from(anchor: Anchor) -> Self {
+        Self {
+            devices: anchor
+                .devices
+                .into_iter()
+                .map(PublicDeviceData::from)
+                .collect(),
+        }
+    }
+}
+
 impl Anchor {
     /// Creation of new anchors is restricted in order to make sure that the device checks are
     /// not accidentally bypassed.

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -922,6 +922,33 @@ mod device_management_tests {
         Ok(())
     }
 
+    /// Verifies that the get_public_anchor_info endpoint returns the expected results.
+    #[test]
+    fn should_give_public_anchor_info() -> Result<(), CallError> {
+        let env = env();
+        let canister_id = install_ii_canister(&env, II_WASM.clone());
+        let user_number = flows::register_anchor(&env, canister_id);
+        api::add(
+            &env,
+            canister_id,
+            principal_1(),
+            user_number,
+            recovery_device_data_1(),
+        )?;
+
+        let public_info = api::get_public_anchor_info(&env, canister_id, user_number)?;
+        assert_eq!(public_info.devices.len(), 2);
+        assert!(public_info
+            .devices
+            .iter()
+            .any(|device| device == &PublicDeviceData::from(device_data_1())));
+        assert!(public_info
+            .devices
+            .iter()
+            .any(|device| device == &PublicDeviceData::from(recovery_device_data_1())));
+        Ok(())
+    }
+
     /// Verifies that the same device cannot be added twice.
     #[test]
     fn should_not_add_existing_device() -> Result<(), CallError> {

--- a/src/internet_identity_interface/src/archive.rs
+++ b/src/internet_identity_interface/src/archive.rs
@@ -1,10 +1,12 @@
 use crate::{
-    AnchorNumber, CredentialId, DeviceData, DeviceKey, DeviceProtection, KeyType, PublicKey,
-    Purpose, Timestamp,
+    AnchorNumber, CredentialId, DeviceProtection, KeyType, PublicDeviceData, PublicKey, Purpose,
+    Timestamp,
 };
 use candid::{CandidType, Deserialize, Principal};
 use ic_cdk::api::management_canister::main::CanisterStatusResponse;
 use serde_bytes::ByteBuf;
+
+pub type DeviceDataWithoutAlias = PublicDeviceData;
 
 #[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
 pub enum Operation {
@@ -35,27 +37,6 @@ pub struct Entry {
     pub caller: Principal,
     // global sequence number to detect lost messages (if any)
     pub sequence_number: u64,
-}
-
-#[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
-pub struct DeviceDataWithoutAlias {
-    pub pubkey: DeviceKey,
-    pub credential_id: Option<CredentialId>,
-    pub purpose: Purpose,
-    pub key_type: KeyType,
-    pub protection: DeviceProtection,
-}
-
-impl From<DeviceData> for DeviceDataWithoutAlias {
-    fn from(device_data: DeviceData) -> Self {
-        Self {
-            pubkey: device_data.pubkey,
-            credential_id: device_data.credential_id,
-            purpose: device_data.purpose,
-            key_type: device_data.key_type,
-            protection: device_data.protection,
-        }
-    }
 }
 
 // If present, the attribute has been changed to the value given.

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -30,6 +30,27 @@ pub struct DeviceData {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
+pub struct PublicDeviceData {
+    pub pubkey: DeviceKey,
+    pub credential_id: Option<CredentialId>,
+    pub purpose: Purpose,
+    pub key_type: KeyType,
+    pub protection: DeviceProtection,
+}
+
+impl From<DeviceData> for PublicDeviceData {
+    fn from(device_data: DeviceData) -> Self {
+        Self {
+            pubkey: device_data.pubkey,
+            credential_id: device_data.credential_id,
+            purpose: device_data.purpose,
+            key_type: device_data.key_type,
+            protection: device_data.protection,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
 pub enum Purpose {
     #[serde(rename = "recovery")]
     Recovery,
@@ -135,9 +156,14 @@ pub struct DeviceRegistrationInfo {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct IdentityAnchorInfo {
+pub struct AnchorInfo {
     pub devices: Vec<DeviceData>,
     pub device_registration: Option<DeviceRegistrationInfo>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct PublicAnchorInfo {
+    pub devices: Vec<PublicDeviceData>,
 }
 
 pub type HeaderField = (String, String);


### PR DESCRIPTION
This PR introduces a new method to retrieve public anchor info to replace
the existing `lookup` method. The `lookup` method is replaced for the
following reasons:
* The vec DeviceData type no longer matches the information give (since the alias is stripped).
* The vec type offers no flexibility with regards to additional information unrelated to devices.
* Introducing a new type for the public data gives us more flexibility going forward to add information to the device that should only be available for authenticated callers.

This PR is the first step in replacing the `lookup` method. The next step is to change the front-end to no longer use the `lookup` method.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
