### PR TITLE
Add notify call to report asset loads

### DIFF
--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -298,5 +298,14 @@ pub fn acknowledge_entries(
     )
 }
 
+pub fn notify_asset_load(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    path: &str,
+    status_code: u16,
+) -> Result<(), CallError> {
+    call_candid(env, canister_id, "notify_asset_load", (path, status_code))
+}
+
 /// A "compatibility" module for the previous version of II to handle API changes.
 pub mod compat {}

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -127,12 +127,18 @@ export const idlFactory = ({ IDL }) => {
     'archive_config' : IDL.Opt(ArchiveConfig),
     'archive_canister' : IDL.Opt(IDL.Principal),
   });
+  const AssetRequestInfo = IDL.Record({
+    'asset' : IDL.Text,
+    'num_request' : IDL.Nat64,
+    'status_code' : IDL.Nat16,
+  });
   const InternetIdentityStats = IDL.Record({
     'storage_layout_version' : IDL.Nat8,
     'users_registered' : IDL.Nat64,
     'assigned_user_number_range' : IDL.Tuple(IDL.Nat64, IDL.Nat64),
     'archive_info' : ArchiveInfo,
     'canister_creation_cycles_cost' : IDL.Nat64,
+    'asset_requests' : IDL.Vec(AssetRequestInfo),
   });
   const VerifyTentativeDeviceResponse = IDL.Variant({
     'device_registration_mode_off' : IDL.Null,
@@ -167,6 +173,7 @@ export const idlFactory = ({ IDL }) => {
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'init_salt' : IDL.Func([], [], []),
     'lookup' : IDL.Func([UserNumber], [IDL.Vec(DeviceData)], ['query']),
+    'notify_asset_load' : IDL.Func([IDL.Text, IDL.Nat16], [], []),
     'prepare_delegation' : IDL.Func(
         [UserNumber, FrontendHostname, SessionKey, IDL.Opt(IDL.Nat64)],
         [UserKey, Timestamp],

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -19,6 +19,11 @@ export interface ArchiveInfo {
   'archive_config' : [] | [ArchiveConfig],
   'archive_canister' : [] | [Principal],
 }
+export interface AssetRequestInfo {
+  'asset' : string,
+  'num_request' : bigint,
+  'status_code' : number,
+}
 export interface BufferedArchiveEntry {
   'sequence_number' : bigint,
   'entry' : Array<number>,
@@ -87,6 +92,7 @@ export interface InternetIdentityStats {
   'assigned_user_number_range' : [bigint, bigint],
   'archive_info' : ArchiveInfo,
   'canister_creation_cycles_cost' : bigint,
+  'asset_requests' : Array<AssetRequestInfo>,
 }
 export type KeyType = { 'platform' : null } |
   { 'seed_phrase' : null } |
@@ -144,6 +150,7 @@ export interface _SERVICE {
   'http_request' : (arg_0: HttpRequest) => Promise<HttpResponse>,
   'init_salt' : () => Promise<undefined>,
   'lookup' : (arg_0: UserNumber) => Promise<Array<DeviceData>>,
+  'notify_asset_load' : (arg_0: string, arg_1: number) => Promise<undefined>,
   'prepare_delegation' : (
       arg_0: UserNumber,
       arg_1: FrontendHostname,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -140,6 +140,13 @@ type InternetIdentityStats = record {
     };
     archive_info: ArchiveInfo;
     canister_creation_cycles_cost: nat64;
+    asset_requests: vec AssetRequestInfo;
+};
+
+type AssetRequestInfo = record {
+    asset: text;
+    status_code: nat16;
+    num_request: nat64;
 };
 
 // Configuration parameters related to the archive.
@@ -235,6 +242,9 @@ service : (opt InternetIdentityInit) -> {
     lookup : (UserNumber) -> (vec DeviceData) query;
     get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);
     get_principal : (UserNumber, FrontendHostname) -> (principal) query;
+
+    // Notify II backend that an asset has been loaded. Used to collect metrics on front-end usage.
+    notify_asset_load : (path: text, status_code: nat16) -> ();
     stats : () -> (InternetIdentityStats) query;
 
     enter_device_registration_mode : (UserNumber) -> (Timestamp);

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -27,6 +27,8 @@ impl ContentType {
 }
 
 pub const FAQ_PATH: &str = "/faq";
+pub const FAQ_STATUS: u16 = 301;
+pub const ASSET_STATUS: u16 = 200;
 
 pub fn http_request(req: HttpRequest) -> HttpResponse {
     let parts: Vec<&str> = req.url.split('?').collect();
@@ -34,7 +36,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
         // The FAQ used to live in '/faq' but we now use an external website. We redirect in order to not
         // break existing links in the wild.
         FAQ_PATH => HttpResponse {
-            status_code: 301,
+            status_code: FAQ_STATUS,
             headers: vec![(
                 "location".to_string(),
                 "https://support.dfinity.org/hc/en-us/sections/8730568843412-Internet-Identity"
@@ -81,7 +83,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                     headers.append(&mut asset_headers.clone());
 
                     HttpResponse {
-                        status_code: 200,
+                        status_code: ASSET_STATUS,
                         headers,
                         body: Cow::Borrowed(Bytes::new(value)),
                         streaming_strategy: None,

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -162,6 +162,18 @@ fn http_request(req: HttpRequest) -> HttpResponse {
     http::http_request(req)
 }
 
+#[update]
+fn notify_asset_load(path: String, status_code: u16) {
+    const PATH_LIMIT: usize = 1024;
+    if path.len() > PATH_LIMIT {
+        trap(&format!(
+            "path is too long: size {}, limit {PATH_LIMIT}",
+            path.len()
+        ))
+    }
+    assets::increase_asset_counter(path, status_code)
+}
+
 #[query]
 fn stats() -> InternetIdentityStats {
     let archive_info = match state::archive_state() {
@@ -183,6 +195,7 @@ fn stats() -> InternetIdentityStats {
 
     let canister_creation_cycles_cost =
         state::persistent_state(|persistent_state| persistent_state.canister_creation_cycles_cost);
+    let asset_requests = state::asset_request_stats();
 
     state::storage(|storage| InternetIdentityStats {
         assigned_user_number_range: storage.assigned_anchor_number_range(),
@@ -190,6 +203,7 @@ fn stats() -> InternetIdentityStats {
         archive_info,
         canister_creation_cycles_cost,
         storage_layout_version: storage.version(),
+        asset_requests,
     })
 }
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -171,7 +171,7 @@ fn notify_asset_load(path: String, status_code: u16) {
             path.len()
         ))
     }
-    assets::increase_asset_counter(path, status_code)
+    assets::increment_asset_counter(path, status_code)
 }
 
 #[query]

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -2818,6 +2818,24 @@ mod stats_tests {
         );
     }
 
+    /// Verifies that asset loads for existing assets with failure status code (i.e. not 2xx and 3xx)
+    /// are tracked.
+    #[test]
+    fn should_allow_failure_status_code_for_existing_assets() -> Result<(), CallError> {
+        let env = env();
+        let canister_id = install_ii_canister(&env, II_WASM.clone());
+
+        api::notify_asset_load(&env, canister_id, "/about", 501)?;
+
+        let stats = api::stats(&env, canister_id)?;
+        assert!(stats.asset_requests.contains(&AssetRequestInfo {
+            asset: "/about".to_string(),
+            status_code: 501,
+            num_request: 1,
+        }));
+        Ok(())
+    }
+
     /// Verifies that asset loads for the least used asset is pruned when adding a new one.
     #[test]
     fn should_prune_least_used_asset_when_limit_reached() -> Result<(), CallError> {

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -187,6 +187,15 @@ pub struct InternetIdentityStats {
     pub archive_info: ArchiveInfo,
     pub canister_creation_cycles_cost: u64,
     pub storage_layout_version: u8,
+    pub asset_requests: Vec<AssetRequestInfo>,
+}
+
+/// Information about how many time each asset has been loaded since the last deployment.
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct AssetRequestInfo {
+    pub asset: String,
+    pub status_code: u16,
+    pub num_request: u64,
 }
 
 /// Information about the archive.


### PR DESCRIPTION
This PR introduces a new method to report asset loads. It will be used to collect basic page load metrics for the II front-end.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
