### PR TITLE
Add hover effect on list-actions

### DIFF
--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1330,6 +1330,16 @@ a:hover,
   align-items: center;
 }
 
+.c-action-list__action {
+  cursor: pointer;
+  color: var(--rc-text);
+  transition: 100ms color linear;
+}
+
+.c-action-list__action:hover {
+  color: var(--rc-interaction);
+}
+
 .c-action-list__action svg {
   transition: 200ms opacity linear;
 }


### PR DESCRIPTION
As requested I added a hover effect to the settings icon. 

Hovers don’t make things look clickable, on touch devices there is no hover. 
The visual affordance is not bad imho. But I can try to make it look more clickable at some point. 

https://user-images.githubusercontent.com/608386/217272549-f61e8852-d2d3-4604-9c18-ab39a64c055e.mov


