### PR TITLE
Remove pruning signatures from anchor operations

### DIFF
--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -1,8 +1,8 @@
 use crate::archive::{archive_operation, device_diff};
+use crate::state;
 use crate::state::RegistrationState::DeviceTentativelyAdded;
 use crate::state::TentativeDeviceRegistration;
 use crate::storage::anchor::{Anchor, Device};
-use crate::{delegation, state};
 use ic_cdk::api::time;
 use ic_cdk::{caller, trap};
 use internet_identity_interface::archive::{DeviceDataWithoutAlias, Operation};
@@ -68,7 +68,6 @@ pub fn add(anchor_number: AnchorNumber, device_data: DeviceData) {
             device: DeviceDataWithoutAlias::from(new_device),
         },
     );
-    delegation::prune_expired_signatures();
 }
 
 pub fn update(user_number: AnchorNumber, device_key: DeviceKey, device_data: DeviceData) {
@@ -90,7 +89,6 @@ pub fn update(user_number: AnchorNumber, device_key: DeviceKey, device_data: Dev
         });
     write_anchor(user_number, anchor);
 
-    delegation::prune_expired_signatures();
     archive_operation(
         user_number,
         caller(),
@@ -124,7 +122,6 @@ pub fn replace(anchor_number: AnchorNumber, old_device: DeviceKey, new_device: D
             new_device: DeviceDataWithoutAlias::from(new_device),
         },
     );
-    delegation::prune_expired_signatures();
 }
 
 pub fn remove(anchor_number: AnchorNumber, device_key: DeviceKey) {
@@ -142,7 +139,6 @@ pub fn remove(anchor_number: AnchorNumber, device_key: DeviceKey) {
         caller(),
         Operation::RemoveDevice { device: device_key },
     );
-    delegation::prune_expired_signatures();
 }
 
 /// Writes the supplied entries to stable memory and updates the anchor operation metric.

--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -3,7 +3,7 @@ use crate::archive::archive_operation;
 use crate::state::ChallengeInfo;
 use crate::storage::anchor::Device;
 use crate::storage::Salt;
-use crate::{delegation, secs_to_nanos, state};
+use crate::{secs_to_nanos, state};
 use candid::Principal;
 use ic_cdk::api::time;
 use ic_cdk::{call, caller, trap};
@@ -21,8 +21,6 @@ const MAX_INFLIGHT_CHALLENGES: usize = 500;
 
 pub async fn create_challenge() -> Challenge {
     let mut rng = make_rng().await;
-
-    delegation::prune_expired_signatures();
 
     state::inflight_challenges_mut(|inflight_challenges| {
         let now = time();
@@ -155,7 +153,6 @@ fn check_challenge(res: ChallengeAttempt) -> Result<(), ()> {
 }
 
 pub fn register(device_data: DeviceData, challenge_result: ChallengeAttempt) -> RegisterResponse {
-    delegation::prune_expired_signatures();
     if let Err(()) = check_challenge(challenge_result) {
         return RegisterResponse::BadChallenge;
     }

--- a/src/internet_identity/src/delegation.rs
+++ b/src/internet_identity/src/delegation.rs
@@ -220,11 +220,11 @@ fn add_signature(sigs: &mut SignatureMap, pk: PublicKey, seed: Hash, expiration:
 
 /// Removes a batch of expired signatures from the signature map.
 ///
-/// This function is supposed to piggy back on update calls to
-/// amortize the cost of tree pruning.  Each operation on the signature map
+/// This function piggy-backs on update calls that create new signatures to
+/// amortize the cost of tree pruning. Each operation on the signature map
 /// will prune at most MAX_SIGS_TO_PRUNE other signatures.
 pub fn prune_expired_signatures() {
-    const MAX_SIGS_TO_PRUNE: usize = 10;
+    const MAX_SIGS_TO_PRUNE: usize = 50;
     let num_pruned = state::signature_map_mut(|sigs| sigs.prune_expired(time(), MAX_SIGS_TO_PRUNE));
     if num_pruned > 0 {
         update_root_hash();


### PR DESCRIPTION
This removes the delegation pruning from anchor operations to keep the code focused. Instead the pruning in prepare_delegation is a bit more aggressive now.

One call to prepare_delegation is still far below the cycles limit with about 300M cycles to create the new delegation and at most 300M cycles to prune 50 expired delegations.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
