### PR TITLE
Add last usage timestamp to devices

### DIFF
--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -456,6 +456,26 @@ pub fn assert_devices_equal(
     assert_eq!(devices, expected_devices, "expected devices to match");
 }
 
+pub fn assert_device_last_used(
+    anchor_info: &IdentityAnchorInfo,
+    device_key: &DeviceKey,
+    expected_timestamp: u64,
+) {
+    let device = anchor_info
+        .devices
+        .iter()
+        .find(|d| d.pubkey == device_key)
+        .unwrap();
+    assert_eq!(device.last_usage_timestamp, Some(expected_timestamp));
+}
+
+pub fn time(env: &StateMachine) -> u64 {
+    env.time()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64
+}
+
 pub fn verify_delegation(user_key: UserKey, signed_delegation: &SignedDelegation, root_key: &[u8]) {
     // transform delegation into ic typed delegation so that we have access to the signature domain separator
     // (via as_signed_bytes)

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -466,7 +466,7 @@ pub fn assert_device_last_used(
         .iter()
         .find(|d| d.pubkey == device_key)
         .unwrap();
-    assert_eq!(device.last_usage_timestamp, Some(expected_timestamp));
+    assert_eq!(device.last_usage, Some(expected_timestamp));
 }
 
 pub fn time(env: &StateMachine) -> u64 {

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -62,12 +62,21 @@ export const idlFactory = ({ IDL }) => {
     'anchor_number' : UserNumber,
     'timestamp' : Timestamp,
   });
+  const ReadOnlyDeviceData = IDL.Record({
+    'alias' : IDL.Text,
+    'protection' : DeviceProtection,
+    'pubkey' : DeviceKey,
+    'key_type' : KeyType,
+    'last_usage_timestamp' : IDL.Opt(Timestamp),
+    'purpose' : Purpose,
+    'credential_id' : IDL.Opt(CredentialId),
+  });
   const DeviceRegistrationInfo = IDL.Record({
     'tentative_device' : IDL.Opt(DeviceData),
     'expiration' : Timestamp,
   });
   const IdentityAnchorInfo = IDL.Record({
-    'devices' : IDL.Vec(DeviceData),
+    'devices' : IDL.Vec(ReadOnlyDeviceData),
     'device_registration' : IDL.Opt(DeviceRegistrationInfo),
   });
   const FrontendHostname = IDL.Text;

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -62,12 +62,13 @@ export const idlFactory = ({ IDL }) => {
     'anchor_number' : UserNumber,
     'timestamp' : Timestamp,
   });
-  const ReadOnlyDeviceData = IDL.Record({
+  const DeviceWithUsage = IDL.Record({
     'alias' : IDL.Text,
+    'last_usage' : IDL.Opt(Timestamp),
+    'origin' : IDL.Opt(IDL.Text),
     'protection' : DeviceProtection,
     'pubkey' : DeviceKey,
     'key_type' : KeyType,
-    'last_usage_timestamp' : IDL.Opt(Timestamp),
     'purpose' : Purpose,
     'credential_id' : IDL.Opt(CredentialId),
   });
@@ -76,7 +77,7 @@ export const idlFactory = ({ IDL }) => {
     'expiration' : Timestamp,
   });
   const IdentityAnchorInfo = IDL.Record({
-    'devices' : IDL.Vec(ReadOnlyDeviceData),
+    'devices' : IDL.Vec(DeviceWithUsage),
     'device_registration' : IDL.Opt(DeviceRegistrationInfo),
   });
   const FrontendHostname = IDL.Text;

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -73,7 +73,7 @@ export interface HttpResponse {
   'status_code' : number,
 }
 export interface IdentityAnchorInfo {
-  'devices' : Array<DeviceData>,
+  'devices' : Array<ReadOnlyDeviceData>,
   'device_registration' : [] | [DeviceRegistrationInfo],
 }
 export interface InternetIdentityInit {
@@ -95,6 +95,15 @@ export type KeyType = { 'platform' : null } |
 export type PublicKey = Array<number>;
 export type Purpose = { 'authentication' : null } |
   { 'recovery' : null };
+export interface ReadOnlyDeviceData {
+  'alias' : string,
+  'protection' : DeviceProtection,
+  'pubkey' : DeviceKey,
+  'key_type' : KeyType,
+  'last_usage_timestamp' : [] | [Timestamp],
+  'purpose' : Purpose,
+  'credential_id' : [] | [CredentialId],
+}
 export type RegisterResponse = { 'bad_challenge' : null } |
   { 'canister_full' : null } |
   { 'registered' : { 'user_number' : UserNumber } };

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -56,6 +56,16 @@ export interface DeviceRegistrationInfo {
   'tentative_device' : [] | [DeviceData],
   'expiration' : Timestamp,
 }
+export interface DeviceWithUsage {
+  'alias' : string,
+  'last_usage' : [] | [Timestamp],
+  'origin' : [] | [string],
+  'protection' : DeviceProtection,
+  'pubkey' : DeviceKey,
+  'key_type' : KeyType,
+  'purpose' : Purpose,
+  'credential_id' : [] | [CredentialId],
+}
 export type FrontendHostname = string;
 export type GetDelegationResponse = { 'no_such_delegation' : null } |
   { 'signed_delegation' : SignedDelegation };
@@ -73,7 +83,7 @@ export interface HttpResponse {
   'status_code' : number,
 }
 export interface IdentityAnchorInfo {
-  'devices' : Array<ReadOnlyDeviceData>,
+  'devices' : Array<DeviceWithUsage>,
   'device_registration' : [] | [DeviceRegistrationInfo],
 }
 export interface InternetIdentityInit {
@@ -95,15 +105,6 @@ export type KeyType = { 'platform' : null } |
 export type PublicKey = Array<number>;
 export type Purpose = { 'authentication' : null } |
   { 'recovery' : null };
-export interface ReadOnlyDeviceData {
-  'alias' : string,
-  'protection' : DeviceProtection,
-  'pubkey' : DeviceKey,
-  'key_type' : KeyType,
-  'last_usage_timestamp' : [] | [Timestamp],
-  'purpose' : Purpose,
-  'credential_id' : [] | [CredentialId],
-}
 export type RegisterResponse = { 'bad_challenge' : null } |
   { 'canister_full' : null } |
   { 'registered' : { 'user_number' : UserNumber } };

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -75,6 +75,16 @@ type DeviceData = record {
     origin: opt text;
 };
 
+type ReadOnlyDeviceData = record {
+    pubkey : DeviceKey;
+    alias : text;
+    credential_id : opt CredentialId;
+    purpose: Purpose;
+    key_type: KeyType;
+    protection: DeviceProtection;
+    last_usage_timestamp: opt Timestamp;
+};
+
 type RegisterResponse = variant {
     // A new user was successfully registered.
     registered: record {
@@ -198,7 +208,7 @@ type DeviceRegistrationInfo = record {
 };
 
 type IdentityAnchorInfo = record {
-    devices : vec DeviceData;
+    devices : vec ReadOnlyDeviceData;
     device_registration: opt DeviceRegistrationInfo;
 };
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -75,14 +75,16 @@ type DeviceData = record {
     origin: opt text;
 };
 
-type ReadOnlyDeviceData = record {
+// The same as `DeviceData` but with the `last_usage` field.
+// This field cannot be written, hence the separate type.
+type DeviceWithUsage = record {
     pubkey : DeviceKey;
     alias : text;
     credential_id : opt CredentialId;
     purpose: Purpose;
     key_type: KeyType;
     protection: DeviceProtection;
-    last_usage_timestamp: opt Timestamp;
+    last_usage: opt Timestamp;
 };
 
 type RegisterResponse = variant {
@@ -208,7 +210,7 @@ type DeviceRegistrationInfo = record {
 };
 
 type IdentityAnchorInfo = record {
-    devices : vec ReadOnlyDeviceData;
+    devices : vec DeviceWithUsage;
     device_registration: opt DeviceRegistrationInfo;
 };
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -84,6 +84,7 @@ type DeviceWithUsage = record {
     purpose: Purpose;
     key_type: KeyType;
     protection: DeviceProtection;
+    origin: opt text;
     last_usage: opt Timestamp;
 };
 

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -108,7 +108,6 @@ pub fn replace(anchor_number: AnchorNumber, old_device: DeviceKey, new_device: D
             "failed to replace device of anchor {anchor_number}: {err}"
         ))
     });
-
     let new_device = Device::from(new_device);
     anchor.add_device(new_device.clone()).unwrap_or_else(|err| {
         trap(&format!(

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -15,7 +15,7 @@ pub fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
     let devices = state::anchor(anchor_number)
         .into_devices()
         .into_iter()
-        .map(DeviceData::from)
+        .map(ReadOnlyDeviceData::from)
         .collect();
     let now = time();
 
@@ -77,7 +77,8 @@ pub fn update(user_number: AnchorNumber, device_key: DeviceKey, device_data: Dev
         trap("Could not find device to update, check device key")
     };
 
-    let new_device = Device::from(device_data);
+    let mut new_device = existing_device.clone();
+    new_device.apply_device_data(device_data);
     let diff = device_diff(existing_device, &new_device);
 
     anchor
@@ -107,6 +108,7 @@ pub fn replace(anchor_number: AnchorNumber, old_device: DeviceKey, new_device: D
             "failed to replace device of anchor {anchor_number}: {err}"
         ))
     });
+
     let new_device = Device::from(new_device);
     anchor.add_device(new_device.clone()).unwrap_or_else(|err| {
         trap(&format!(
@@ -154,4 +156,19 @@ fn write_anchor(anchor_number: AnchorNumber, anchor: Anchor) {
     state::usage_metrics_mut(|metrics| {
         metrics.anchor_operation_counter += 1;
     });
+}
+
+/// Updates the device on the anchor to reflect the current usage.
+/// Note: This is considered internal bookkeeping and is not recorded in the archive and does not increase anchor operation counter.
+pub fn update_last_device_usage(
+    anchor_number: AnchorNumber,
+    mut anchor: Anchor,
+    device_key: &DeviceKey,
+) {
+    anchor
+        .set_device_usage_timestamp(device_key, time())
+        .expect("last_usage_timestamp update: unable to update last usage timestamp");
+    state::storage_mut(|storage| storage.write(anchor_number, anchor)).unwrap_or_else(|err| {
+        panic!("last_usage_timestamp update: unable to update anchor {anchor_number}: {err}")
+    })
 }

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -15,7 +15,7 @@ pub fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
     let devices = state::anchor(anchor_number)
         .into_devices()
         .into_iter()
-        .map(ReadOnlyDeviceData::from)
+        .map(DeviceWithUsage::from)
         .collect();
     let now = time();
 

--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -157,7 +157,8 @@ pub fn register(device_data: DeviceData, challenge_result: ChallengeAttempt) -> 
         return RegisterResponse::BadChallenge;
     }
 
-    let device = Device::from(device_data);
+    let mut device = Device::from(device_data);
+    device.last_usage_timestamp = Some(time());
 
     if caller() != Principal::self_authenticating(&device.pubkey) {
         trap(&format!(

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -24,6 +24,7 @@ impl Device {
         self.purpose = device_data.purpose;
         self.key_type = device_data.key_type;
         self.protection = device_data.protection;
+        self.origin = device_data.origin;
     }
 }
 
@@ -65,6 +66,7 @@ impl From<Device> for DeviceWithUsage {
             purpose: device.purpose,
             key_type: device.key_type,
             protection: device.protection,
+            origin: device.origin,
             last_usage: device.last_usage_timestamp,
         }
     }
@@ -196,11 +198,8 @@ pub struct Device {
     pub purpose: Purpose,
     pub key_type: KeyType,
     pub protection: DeviceProtection,
-<<<<<<< HEAD
     pub origin: Option<String>,
-=======
     pub last_usage_timestamp: Option<Timestamp>,
->>>>>>> 2157e4b3 (Add last usage timestamp to devices)
 }
 
 impl Device {

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -16,6 +16,7 @@ pub struct Anchor {
 }
 
 impl Device {
+    /// Applies the values of `device_data` to self while leaving the other fields intact.
     pub fn apply_device_data(&mut self, device_data: DeviceData) {
         self.pubkey = device_data.pubkey;
         self.alias = device_data.alias;
@@ -23,7 +24,6 @@ impl Device {
         self.purpose = device_data.purpose;
         self.key_type = device_data.key_type;
         self.protection = device_data.protection;
-        self.last_usage_timestamp = None;
     }
 }
 
@@ -56,7 +56,7 @@ impl From<Device> for DeviceData {
     }
 }
 
-impl From<Device> for ReadOnlyDeviceData {
+impl From<Device> for DeviceWithUsage {
     fn from(device: Device) -> Self {
         Self {
             pubkey: device.pubkey,
@@ -65,7 +65,7 @@ impl From<Device> for ReadOnlyDeviceData {
             purpose: device.purpose,
             key_type: device.key_type,
             protection: device.protection,
-            last_usage_timestamp: device.last_usage_timestamp,
+            last_usage: device.last_usage_timestamp,
         }
     }
 }

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -15,6 +15,18 @@ pub struct Anchor {
     devices: Vec<Device>,
 }
 
+impl Device {
+    pub fn apply_device_data(&mut self, device_data: DeviceData) {
+        self.pubkey = device_data.pubkey;
+        self.alias = device_data.alias;
+        self.credential_id = device_data.credential_id;
+        self.purpose = device_data.purpose;
+        self.key_type = device_data.key_type;
+        self.protection = device_data.protection;
+        self.last_usage_timestamp = None;
+    }
+}
+
 impl From<DeviceData> for Device {
     fn from(device_data: DeviceData) -> Self {
         Self {
@@ -25,6 +37,7 @@ impl From<DeviceData> for Device {
             key_type: device_data.key_type,
             protection: device_data.protection,
             origin: device_data.origin,
+            last_usage_timestamp: None,
         }
     }
 }
@@ -39,6 +52,20 @@ impl From<Device> for DeviceData {
             key_type: device.key_type,
             protection: device.protection,
             origin: device.origin,
+        }
+    }
+}
+
+impl From<Device> for ReadOnlyDeviceData {
+    fn from(device: Device) -> Self {
+        Self {
+            pubkey: device.pubkey,
+            alias: device.alias,
+            credential_id: device.credential_id,
+            purpose: device.purpose,
+            key_type: device.key_type,
+            protection: device.protection,
+            last_usage_timestamp: device.last_usage_timestamp,
         }
     }
 }
@@ -139,6 +166,22 @@ impl Anchor {
     pub fn into_devices(self) -> Vec<Device> {
         self.devices
     }
+
+    /// Sets the timestamp on the given device.
+    /// **Note:** Does not check invariants, based on the assumption that no invariant can be
+    /// violated by changing the last usage timestamp on a device. See also the documentation on
+    /// [check_invariants](Anchor::check_invariants).
+    pub fn set_device_usage_timestamp(
+        &mut self,
+        device_key: &DeviceKey,
+        time: Timestamp,
+    ) -> Result<(), AnchorError> {
+        let Some(device) = self.devices.iter_mut().find(|d| d.pubkey == device_key) else {
+            return Err(AnchorError::NotFound { device_key: device_key.clone() })
+        };
+        device.last_usage_timestamp = Some(time);
+        Ok(())
+    }
 }
 
 /// This is an internal version of `DeviceData` useful to provide a
@@ -153,7 +196,11 @@ pub struct Device {
     pub purpose: Purpose,
     pub key_type: KeyType,
     pub protection: DeviceProtection,
+<<<<<<< HEAD
     pub origin: Option<String>,
+=======
+    pub last_usage_timestamp: Option<Timestamp>,
+>>>>>>> 2157e4b3 (Add last usage timestamp to devices)
 }
 
 impl Device {

--- a/src/internet_identity/src/storage/anchor/tests.rs
+++ b/src/internet_identity/src/storage/anchor/tests.rs
@@ -1,6 +1,6 @@
 use crate::storage::anchor::{Anchor, AnchorError, Device};
 use candid::Principal;
-use internet_identity_interface::{DeviceProtection, KeyType, Purpose, Timestamp};
+use internet_identity_interface::{DeviceData, DeviceProtection, KeyType, Purpose, Timestamp};
 use serde_bytes::ByteBuf;
 
 const TEST_CALLER_PUBKEY: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -336,6 +336,23 @@ fn should_update_timestamp() {
         anchor.device(&device.pubkey).unwrap().last_usage_timestamp,
         Some(TIMESTAMP)
     );
+}
+
+/// Tests that `apply_data` actually applies all the writeable fields.
+#[test]
+fn should_apply_all_fields() {
+    let device_data = DeviceData {
+        pubkey: ByteBuf::from("some different public key"),
+        alias: "some different alias".to_string(),
+        credential_id: Some(ByteBuf::from("some different credential id")),
+        purpose: Purpose::Recovery,
+        key_type: KeyType::CrossPlatform,
+        protection: DeviceProtection::Protected,
+    };
+    let mut device = sample_device();
+    device.apply_device_data(device_data.clone());
+
+    assert_eq!(DeviceData::from(device), device_data);
 }
 
 fn sample_device() -> Device {

--- a/src/internet_identity/src/storage/anchor/tests.rs
+++ b/src/internet_identity/src/storage/anchor/tests.rs
@@ -121,11 +121,8 @@ fn should_enforce_cumulative_device_limit() {
         purpose: Purpose::Recovery,
         key_type: KeyType::Unknown,
         protection: DeviceProtection::Unprotected,
-<<<<<<< HEAD
         origin: None,
-=======
         last_usage_timestamp: None,
->>>>>>> 2157e4b3 (Add last usage timestamp to devices)
     };
 
     let result = anchor.add_device(device);
@@ -164,11 +161,8 @@ fn should_allow_protection_only_on_recovery_phrases() {
         purpose: Purpose::Recovery,
         key_type: KeyType::Unknown,
         protection: DeviceProtection::Protected,
-<<<<<<< HEAD
         origin: None,
-=======
         last_usage_timestamp: None,
->>>>>>> 2157e4b3 (Add last usage timestamp to devices)
     });
 
     assert!(matches!(
@@ -348,6 +342,7 @@ fn should_apply_all_fields() {
         purpose: Purpose::Recovery,
         key_type: KeyType::CrossPlatform,
         protection: DeviceProtection::Protected,
+        origin: Some("https://some.other.origin".to_string()),
     };
     let mut device = sample_device();
     device.apply_device_data(device_data.clone());

--- a/src/internet_identity/src/storage/anchor/tests.rs
+++ b/src/internet_identity/src/storage/anchor/tests.rs
@@ -1,6 +1,6 @@
 use crate::storage::anchor::{Anchor, AnchorError, Device};
 use candid::Principal;
-use internet_identity_interface::{DeviceProtection, KeyType, Purpose};
+use internet_identity_interface::{DeviceProtection, KeyType, Purpose, Timestamp};
 use serde_bytes::ByteBuf;
 
 const TEST_CALLER_PUBKEY: [u8; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -121,7 +121,11 @@ fn should_enforce_cumulative_device_limit() {
         purpose: Purpose::Recovery,
         key_type: KeyType::Unknown,
         protection: DeviceProtection::Unprotected,
+<<<<<<< HEAD
         origin: None,
+=======
+        last_usage_timestamp: None,
+>>>>>>> 2157e4b3 (Add last usage timestamp to devices)
     };
 
     let result = anchor.add_device(device);
@@ -160,7 +164,11 @@ fn should_allow_protection_only_on_recovery_phrases() {
         purpose: Purpose::Recovery,
         key_type: KeyType::Unknown,
         protection: DeviceProtection::Protected,
+<<<<<<< HEAD
         origin: None,
+=======
+        last_usage_timestamp: None,
+>>>>>>> 2157e4b3 (Add last usage timestamp to devices)
     });
 
     assert!(matches!(
@@ -313,6 +321,23 @@ fn should_not_allow_modification_of_device_key() {
     assert_eq!(anchor.devices()[0], sample_device());
 }
 
+#[test]
+fn should_update_timestamp() {
+    let mut anchor = Anchor::new();
+    let device = sample_device();
+    const TIMESTAMP: Timestamp = 7896546556;
+    anchor.add_device(device.clone()).unwrap();
+
+    anchor
+        .set_device_usage_timestamp(&device.pubkey, TIMESTAMP)
+        .unwrap();
+
+    assert_eq!(
+        anchor.device(&device.pubkey).unwrap().last_usage_timestamp,
+        Some(TIMESTAMP)
+    );
+}
+
 fn sample_device() -> Device {
     Device {
         pubkey: ByteBuf::from("public key of some sample device"),
@@ -322,6 +347,7 @@ fn sample_device() -> Device {
         key_type: KeyType::Platform,
         protection: DeviceProtection::Unprotected,
         origin: Some("https://fooo.bar".to_string()),
+        last_usage_timestamp: Some(465789),
     }
 }
 
@@ -334,6 +360,7 @@ fn device(n: u8) -> Device {
         key_type: KeyType::Platform,
         protection: DeviceProtection::Unprotected,
         origin: Some(format!("https://foo{n}.bar")),
+        last_usage_timestamp: Some(n as u64),
     }
 }
 
@@ -347,6 +374,7 @@ fn large_device(n: u8) -> Device {
         key_type: KeyType::Unknown,
         protection: DeviceProtection::Unprotected,
         origin: Some("https://rdmx6-jaaaa-aaaaa-aaadq-cai.foobar.icp0.io".to_string()),
+        last_usage_timestamp: Some(12345679),
     }
 }
 
@@ -359,6 +387,7 @@ fn recovery_phrase(n: u8, protection: DeviceProtection) -> Device {
         key_type: KeyType::SeedPhrase,
         protection,
         origin: None,
+        last_usage_timestamp: None,
     }
 }
 

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -67,7 +67,7 @@ fn should_read_previous_write() {
 
 #[test]
 fn should_serialize_first_record() {
-    const EXPECTED_LENGTH: usize = 200;
+    const EXPECTED_LENGTH: usize = 208;
     let memory = VectorMemory::default();
     let mut storage = Storage::new((123, 456), memory.clone());
     let (anchor_number, mut anchor) = storage.allocate_anchor().unwrap();
@@ -84,7 +84,7 @@ fn should_serialize_first_record() {
 
 #[test]
 fn should_serialize_subsequent_record_to_expected_memory_location() {
-    const EXPECTED_LENGTH: usize = 200;
+    const EXPECTED_LENGTH: usize = 208;
     const EXPECTED_RECORD_OFFSET: u64 = 409_600; // 100 * max anchor size
     let memory = VectorMemory::default();
     let mut storage = Storage::new((123, 456), memory.clone());
@@ -327,6 +327,7 @@ fn sample_device() -> Device {
         key_type: KeyType::Unknown,
         protection: DeviceProtection::Unprotected,
         origin: None,
+        last_usage_timestamp: Some(1234),
     }
 }
 

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -67,7 +67,7 @@ fn should_read_previous_write() {
 
 #[test]
 fn should_serialize_first_record() {
-    const EXPECTED_LENGTH: usize = 208;
+    const EXPECTED_LENGTH: usize = 217;
     let memory = VectorMemory::default();
     let mut storage = Storage::new((123, 456), memory.clone());
     let (anchor_number, mut anchor) = storage.allocate_anchor().unwrap();
@@ -84,7 +84,7 @@ fn should_serialize_first_record() {
 
 #[test]
 fn should_serialize_subsequent_record_to_expected_memory_location() {
-    const EXPECTED_LENGTH: usize = 208;
+    const EXPECTED_LENGTH: usize = 217;
     const EXPECTED_RECORD_OFFSET: u64 = 409_600; // 100 * max anchor size
     let memory = VectorMemory::default();
     let mut storage = Storage::new((123, 456), memory.clone());

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -269,8 +269,9 @@ mod rollback_tests {
         upgrade_ii_canister(&env, canister_id, II_WASM_PREVIOUS.clone());
 
         // use anchor
-        let devices = api::get_anchor_info(&env, canister_id, principal_1(), user_number)?.devices;
-        assert_eq!(devices, [device_data_1()]);
+        let devices =
+            api::get_anchor_info(&env, canister_id, principal_1(), user_number)?.into_device_data();
+        assert_eq!(devices, vec![device_data_1()]);
 
         let (user_key, _) = api::prepare_delegation(
             &env,
@@ -1760,7 +1761,8 @@ mod device_management_tests {
             user_number,
             device_data_2(),
         )?;
-        let devices = api::get_anchor_info(&env, canister_id, principal_1(), user_number)?.devices;
+        let devices =
+            api::get_anchor_info(&env, canister_id, principal_1(), user_number)?.into_device_data();
         assert!(devices.iter().any(|device| device == &device_data_2()));
 
         upgrade_ii_canister(&env, canister_id, II_WASM.clone());
@@ -1773,7 +1775,8 @@ mod device_management_tests {
             device_data_2().pubkey,
         )?;
 
-        let devices = api::get_anchor_info(&env, canister_id, principal_1(), user_number)?.devices;
+        let devices =
+            api::get_anchor_info(&env, canister_id, principal_1(), user_number)?.into_device_data();
         assert_eq!(devices.len(), 1);
         assert!(!devices.iter().any(|device| device == &device_data_2()));
         Ok(())

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -655,7 +655,7 @@ mod last_usage_timestamp_tests {
             .devices
             .clone()
             .into_iter()
-            .map(|d| DeviceData::from(d))
+            .map(DeviceData::from)
             .any(|d| d == device_to_be_updated));
 
         assert_device_last_used(&anchor_info, &device_data_2().pubkey, expected_timestamp_1);

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -39,6 +39,7 @@ impl From<DeviceWithUsage> for DeviceData {
             purpose: device.purpose,
             key_type: device.key_type,
             protection: device.protection,
+            origin: device.origin,
         }
     }
 }
@@ -51,6 +52,7 @@ pub struct DeviceWithUsage {
     pub purpose: Purpose,
     pub key_type: KeyType,
     pub protection: DeviceProtection,
+    pub origin: Option<String>,
     pub last_usage: Option<Timestamp>,
 }
 
@@ -63,6 +65,7 @@ impl From<DeviceData> for DeviceWithUsage {
             purpose: device.purpose,
             key_type: device.key_type,
             protection: device.protection,
+            origin: device.origin,
             last_usage: None,
         }
     }

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -30,6 +30,44 @@ pub struct DeviceData {
     pub origin: Option<String>,
 }
 
+impl From<ReadOnlyDeviceData> for DeviceData {
+    fn from(device: ReadOnlyDeviceData) -> Self {
+        Self {
+            pubkey: device.pubkey,
+            alias: device.alias,
+            credential_id: device.credential_id,
+            purpose: device.purpose,
+            key_type: device.key_type,
+            protection: device.protection,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
+pub struct ReadOnlyDeviceData {
+    pub pubkey: DeviceKey,
+    pub alias: String,
+    pub credential_id: Option<CredentialId>,
+    pub purpose: Purpose,
+    pub key_type: KeyType,
+    pub protection: DeviceProtection,
+    pub last_usage_timestamp: Option<Timestamp>,
+}
+
+impl From<DeviceData> for ReadOnlyDeviceData {
+    fn from(device: DeviceData) -> Self {
+        Self {
+            pubkey: device.pubkey,
+            alias: device.alias,
+            credential_id: device.credential_id,
+            purpose: device.purpose,
+            key_type: device.key_type,
+            protection: device.protection,
+            last_usage_timestamp: None,
+        }
+    }
+}
+
 #[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
 pub enum Purpose {
     #[serde(rename = "recovery")]
@@ -137,8 +175,14 @@ pub struct DeviceRegistrationInfo {
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct IdentityAnchorInfo {
-    pub devices: Vec<DeviceData>,
+    pub devices: Vec<ReadOnlyDeviceData>,
     pub device_registration: Option<DeviceRegistrationInfo>,
+}
+
+impl IdentityAnchorInfo {
+    pub fn into_device_data(self) -> Vec<DeviceData> {
+        self.devices.into_iter().map(DeviceData::from).collect()
+    }
 }
 
 pub type HeaderField = (String, String);

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -30,8 +30,8 @@ pub struct DeviceData {
     pub origin: Option<String>,
 }
 
-impl From<ReadOnlyDeviceData> for DeviceData {
-    fn from(device: ReadOnlyDeviceData) -> Self {
+impl From<DeviceWithUsage> for DeviceData {
+    fn from(device: DeviceWithUsage) -> Self {
         Self {
             pubkey: device.pubkey,
             alias: device.alias,
@@ -44,17 +44,17 @@ impl From<ReadOnlyDeviceData> for DeviceData {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
-pub struct ReadOnlyDeviceData {
+pub struct DeviceWithUsage {
     pub pubkey: DeviceKey,
     pub alias: String,
     pub credential_id: Option<CredentialId>,
     pub purpose: Purpose,
     pub key_type: KeyType,
     pub protection: DeviceProtection,
-    pub last_usage_timestamp: Option<Timestamp>,
+    pub last_usage: Option<Timestamp>,
 }
 
-impl From<DeviceData> for ReadOnlyDeviceData {
+impl From<DeviceData> for DeviceWithUsage {
     fn from(device: DeviceData) -> Self {
         Self {
             pubkey: device.pubkey,
@@ -63,7 +63,7 @@ impl From<DeviceData> for ReadOnlyDeviceData {
             purpose: device.purpose,
             key_type: device.key_type,
             protection: device.protection,
-            last_usage_timestamp: None,
+            last_usage: None,
         }
     }
 }
@@ -175,7 +175,7 @@ pub struct DeviceRegistrationInfo {
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct IdentityAnchorInfo {
-    pub devices: Vec<ReadOnlyDeviceData>,
+    pub devices: Vec<DeviceWithUsage>,
     pub device_registration: Option<DeviceRegistrationInfo>,
 }
 


### PR DESCRIPTION
This PR introduces the last_usage_timestamp on devices when reading
from get_anchor_info.
To make clear that this field cannot be written, get_anchor_info
now returns a different type from the type used to modify devices.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
