### PR TITLE
Clarify pass for certs

### DIFF
--- a/docker-test-env/reverse_proxy/README.md
+++ b/docker-test-env/reverse_proxy/README.md
@@ -8,8 +8,8 @@ Nginx is used to terminate tls. This allows the use of the actual domain `https:
 We still need the `--ignore-certificate-errors` because we don't add the certificates to the browser truststore.
 
 The certificates are self-signed and created using the following commands:
-1. `openssl genrsa -aes256 -passout pass:gsahdg -out server.key 4096`
-2. Strip away password protection: `openssl rsa -in server.key -out server.key`
+1. `openssl genrsa -aes256 -passout pass:foo -out server.key 4096`
+2. Strip away password protection: `openssl rsa -in server.key -out server.key` (using password `foo`)
 3. `openssl req -new -key server.key -out server.csr`
     * This will ask for information. Note that the `Common Name (CN)` must match the host name.
 4. `openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt`


### PR DESCRIPTION
When generating new certs, I stared at the password prompt for a minute or so without realizing I had set the password with `pass:...`. This updates the docs to clarify.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
