### PR TITLE
Ignore compose setup in docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,3 +25,6 @@ Dockerfile
 scripts/
 !scripts/build
 !scripts/bootstrap
+
+# docker build doesn't depend on the docker-compose setup
+docker-test-env/


### PR DESCRIPTION
The docker compose setup may depend on the docker builds, but not the other way around. By ignoring the compose setup we avoid unnecessary docker rebuilds on docker compose changes.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
