### PR TITLE
Save anchor after device added

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
@@ -8,6 +8,7 @@ import { pickDeviceAlias } from "./addDevicePickAlias";
 import { withLoader } from "../../../components/loader";
 import { renderManage } from "../../manage";
 import { displayError } from "../../../components/displayError";
+import { setAnchorUsed } from "../../../utils/userNumber";
 
 const displayFailedToAddDevice = (error: Error) =>
   displayError({
@@ -63,6 +64,8 @@ export const addLocalDevice = async (
       error instanceof Error ? error : unknownError()
     );
   }
+
+  setAnchorUsed(userNumber);
   await renderManage(userNumber, connection);
 };
 


### PR DESCRIPTION
This ensures that the anchor is saved (and then displayed on the landing page) when a local device is added.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
