### PR TITLE
Refactor displayManage

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -111,7 +111,7 @@ const MAX_AUTHENTICATORS = 8;
 // that they add a recovery device. If the user _does_ have at least one
 // recovery device, then we do not display a "nag box", but we list the
 // recovery devices.
-const pageContent = ({
+const displayManageTemplate = ({
   userNumber,
   authenticators,
   recoveries,
@@ -326,12 +326,20 @@ export const renderManage = async (
   }
 };
 
+export const displayManagePage = (
+  props: Parameters<typeof displayManageTemplate>[0],
+  container?: HTMLElement
+): void => {
+  const contain =
+    container ?? (document.getElementById("pageContent") as HTMLElement);
+  render(displayManageTemplate(props), contain);
+};
+
 export const displayManage = (
   userNumber: bigint,
   connection: AuthenticatedConnection,
   devices: DeviceData[]
 ): void => {
-  const container = document.getElementById("pageContent") as HTMLElement;
   const hasSingleDevice = devices.length <= 1;
 
   const _devices = devices.map((device) => ({
@@ -355,7 +363,7 @@ export const displayManage = (
     isRecovery: isRecoveryDevice(device),
   }));
 
-  const template = pageContent({
+  displayManagePage({
     userNumber,
     authenticators: _devices.filter((device) => !device.isRecovery),
     recoveries: _devices.filter((device) => device.isRecovery),
@@ -401,8 +409,6 @@ export const displayManage = (
         Create
       </button> `);
   }
-
-  render(template, container);
 };
 
 // Whether the user has a recovery phrase or not

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -30,7 +30,7 @@ import { promptCaptchaPage, badChallenge } from "./flows/register/captcha";
 import { displayUserNumberPage } from "./flows/register/finish";
 import { chooseRecoveryMechanismPage } from "./flows/recovery/chooseRecoveryMechanism";
 import { displaySingleDeviceWarning } from "./flows/recovery/displaySingleDeviceWarning";
-import { displayManage, authnTemplateManage } from "./flows/manage";
+import { displayManagePage, authnTemplateManage } from "./flows/manage";
 import { chooseDeviceAddFlow } from "./flows/addDevice/manage";
 import { pickDeviceAliasPage } from "./flows/addDevice/manage/addDevicePickAlias";
 import { deviceSettingsPage } from "./flows/manage/deviceSettings";
@@ -248,12 +248,52 @@ const iiPages: Record<string, () => void> = {
       }
     ),
   displayManage: () =>
-    displayManage(userNumber, dummyConnection, [
-      ...simpleDevices,
-      recoveryPhrase,
-    ]),
+    displayManagePage({
+      userNumber,
+      authenticators: [
+        {
+          label: "Chrome on iPhone",
+          isRecovery: false,
+          openSettings: () => Promise.resolve(),
+        },
+        {
+          label: "Yubikey Blue",
+          isRecovery: false,
+          openSettings: () => Promise.resolve(),
+        },
+      ],
+      recoveries: [
+        {
+          label: "Recovery Phrase",
+          isRecovery: true,
+          openSettings: () => Promise.resolve(),
+        },
+      ],
+      onAddDevice: () => {
+        console.log("add device requested");
+      },
+      onAddRecovery: () => {
+        console.log("add recovery requested");
+      },
+    }),
   displayManageSingle: () =>
-    displayManage(userNumber, dummyConnection, [simpleDevices[0]]),
+    displayManagePage({
+      userNumber,
+      authenticators: [
+        {
+          label: "Chrome on iPhone",
+          isRecovery: false,
+          openSettings: () => Promise.resolve(),
+        },
+      ],
+      recoveries: [],
+      onAddDevice: () => {
+        console.log("add device requested");
+      },
+      onAddRecovery: () => {
+        console.log("add recovery requested");
+      },
+    }),
   chooseDeviceAddFlow: () => chooseDeviceAddFlow(),
   renderPollForTentativeDevicePage: () =>
     renderPollForTentativeDevicePage(userNumber),


### PR DESCRIPTION
Previously `displayManage` would mix logic for figuring out devices and actual rendering. This extracts the rendering to `diplayManagePage`, making it more consistent with other pages.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
