### PR TITLE
Don't mention alternative origin of self

### DIFF
--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -28,7 +28,7 @@ export const authnTemplateAuthorize = ({
 }): AuthnTemplates => {
   const copy = i18n.i18n(copyJson);
   const chasm =
-    derivationOrigin !== undefined
+    derivationOrigin !== undefined && derivationOrigin !== origin
       ? mkChasm({
           info: "shared identity",
           message: html`<span class="t-strong">${origin}</span>


### PR DESCRIPTION
This avoids showing the "shared identity" prompt for alternative origins if the derivation origin is the origin itself.

This may happen when a dapp is served on multiple domains. Technically the dapp shouldn't have to specify a derivation origin when it's being served on the derivation origin itself, but just in case, we don't show the message.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
