### PR TITLE
Allow 0.0.0.0 for local development

### DIFF
--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -665,8 +665,12 @@ export const inferHost = (): string => {
   }
 
   if (
-    location.host === "127.0.0.1" ||
-    location.hostname.endsWith("localhost")
+    location.host === "127.0.0.1" /* typical development */ ||
+    location.host ===
+      "0.0.0.0" /* typical development, though no secure context (only usable with builds with WebAuthn disabled) */ ||
+    location.hostname.endsWith(
+      "localhost"
+    ) /* local canisters from icx-proxy like rdmx6-....-foo.localhost */
   ) {
     // If this is a local deployment, then assume the api and assets are collocated
     // and use this asset (page)'s URL.


### PR DESCRIPTION
This ensures the local API is used when developing on `0.0.0.0` instead of trying to use the `icp-api.io` API.

Recent changes introduced using `icp-api.io` for non local development. The heuristics for figuring out whether yes or no the page was served locally didn't include `0.0.0.0`, which (while uncommon) is a viable host for local development.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
