### PR TITLE
Allow focus on protected device lock

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -317,7 +317,9 @@ const deviceListItem = ({
     </div>
     ${device.isProtected
       ? html`<div class="c-action-list__action">
-          <span class="c-tooltip c-tooltip--left c-icon c-icon--lock"
+          <span
+            class="c-tooltip c-tooltip--left c-icon c-icon--lock"
+            tabindex="0"
             >${lockIcon}<span class="c-tooltip__message c-card c-card--tight"
               >Your device is protected</span
             ></span


### PR DESCRIPTION
This adds a `tabindex="0"` on the lock element that triggers the "your device is protected" tooltip. This ensures (among other things) that the tooltip can be triggered on mobile.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
