### PR TITLE
Use more appropriate custom HTML attr

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -309,7 +309,7 @@ const deviceListItem = ({
   index: string;
 }) => {
   return html`
-    <div class="c-action-list__label" device=${device.label}>
+    <div class="c-action-list__label" data-device=${device.label}>
       ${device.label}
       ${device.dupCount !== undefined && device.dupCount > 0
         ? html`<i class="t-muted">&nbsp;(${device.dupCount})</i>`

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -155,13 +155,13 @@ export class MainView extends View {
 
   async waitForDeviceDisplay(deviceName: string): Promise<void> {
     await this.browser
-      .$(`//div[@device="${deviceName}"]`)
+      .$(`//div[@data-device="${deviceName}"]`)
       .waitForDisplayed({ timeout: 10_000 });
   }
 
   async waitForDeviceNotDisplay(deviceName: string): Promise<void> {
     await this.browser
-      .$(`//div[@device="${deviceName}"]`)
+      .$(`//div[@data-device="${deviceName}"]`)
       .waitForDisplayed({ timeout: 10_000, reverse: true });
   }
 


### PR DESCRIPTION
We use a custom HTML attribute to attach data to an HTML element for tests to find it more easily. Custom HTML attributes should start with `data-`, so this replaces the custom `device` attribute with `data-device`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
