### PR TITLE
Regroup recovery functions

### DIFF
--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -9,7 +9,12 @@ import { withLoader } from "../../components/loader";
 import { unreachable } from "../../utils/utils";
 import { DeviceData } from "../../../generated/internet_identity_types";
 import { phraseRecoveryPage } from "../recovery/recoverWith/phrase";
-import { isRecoveryDevice, RecoveryDevice } from "../../utils/recoveryDevice";
+import {
+  isRecoveryDevice,
+  isRecoveryPhrase,
+  isProtected,
+  RecoveryDevice,
+} from "../../utils/recoveryDevice";
 
 // A particular device setting, e.g. remove, protect, etc
 export type Setting = { label: string; fn: () => void };
@@ -57,12 +62,7 @@ export const deviceSettings = ({
 const shouldOfferToProtect = (
   device: DeviceData
 ): device is RecoveryDevice & DeviceData =>
-  "recovery" in device.purpose &&
-  "seed_phrase" in device.key_type &&
-  !isProtected(device);
-
-const isProtected = (device: DeviceData): boolean =>
-  "protected" in device.protection;
+  isRecoveryPhrase(device) && !isProtected(device);
 
 // Get a connection that's authenticated with the given device
 // NOTE: this expects a recovery phrase device
@@ -122,7 +122,7 @@ const deleteDevice = async (
       )
     : confirm(
         `Do you really want to remove the ${
-          "recovery" in device.purpose ? "" : "device "
+          isRecoveryDevice(device) ? "" : "device "
         }"${device.alias}"?`
       );
   if (!shouldProceed) {

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -26,6 +26,9 @@ import { mainWindow } from "../../components/mainWindow";
 import {
   isRecoveryDevice,
   recoveryDeviceToLabel,
+  isProtected,
+  hasRecoveryPhrase,
+  isRecoveryPhrase,
 } from "../../utils/recoveryDevice";
 
 // A simple representation of "device"s used on the manage page.
@@ -518,16 +521,6 @@ const domainWarning = (device: DeviceData): TemplateResult | undefined => {
 
   return undefined;
 };
-
-// Whether the user has a recovery phrase or not
-const hasRecoveryPhrase = (devices: DeviceData[]): boolean =>
-  devices.some((device) => device.alias === "Recovery phrase");
-
-const isProtected = (device: DeviceData): boolean =>
-  "protected" in device.protection;
-
-const isRecoveryPhrase = (device: DeviceData): boolean =>
-  "seed_phrase" in device.key_type;
 
 const unknownError = (): Error => {
   return new Error("Unknown error");

--- a/src/frontend/src/flows/recovery/chooseRecoveryMechanism.ts
+++ b/src/frontend/src/flows/recovery/chooseRecoveryMechanism.ts
@@ -2,6 +2,7 @@ import { html, render, TemplateResult } from "lit-html";
 import { DeviceData } from "../../../generated/internet_identity_types";
 import { securityKeyIcon, seedPhraseIcon } from "../../components/icons";
 import { mainWindow } from "../../components/mainWindow";
+import { hasRecoveryPhrase, hasRecoveryKey } from "../../utils/recoveryDevice";
 
 export type RecoveryMechanism = "securityKey" | "seedPhrase";
 
@@ -103,13 +104,3 @@ export const chooseRecoveryMechanism = async ({
     });
   });
 };
-
-const hasRecoveryPhrase = (devices: Omit<DeviceData, "alias">[]): boolean =>
-  devices.some(
-    (device) => "seed_phrase" in device.key_type && "recovery" in device.purpose
-  );
-const hasRecoveryKey = (devices: Omit<DeviceData, "alias">[]): boolean =>
-  devices.some(
-    (device) =>
-      !("seed_phrase" in device.key_type) && "recovery" in device.purpose
-  );

--- a/src/frontend/src/flows/recovery/pickRecoveryDevice.ts
+++ b/src/frontend/src/flows/recovery/pickRecoveryDevice.ts
@@ -4,6 +4,7 @@ import { securityKeyIcon, seedPhraseIcon } from "../../components/icons";
 import {
   RecoveryDevice,
   recoveryDeviceToLabel,
+  isRecoveryPhrase,
 } from "../../utils/recoveryDevice";
 
 const pageContent = () => {
@@ -47,7 +48,7 @@ export const init = (devices: RecoveryDevice[]): Promise<RecoveryDevice> =>
         html`<div class="deviceItemAlias">
           <button class="c-button c-button--secondary">
             <span aria-hidden="true"
-              >${"seed_phrase" in device.key_type
+              >${isRecoveryPhrase(device)
                 ? seedPhraseIcon
                 : securityKeyIcon}</span
             >

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -5,6 +5,7 @@ import { promptUserNumber } from "../../components/promptUserNumber";
 import { phraseRecoveryPage } from "./recoverWith/phrase";
 import { deviceRecoveryPage } from "./recoverWith/device";
 import { pickRecoveryDevice } from "./pickRecoveryDevice";
+import { isRecoveryPhrase } from "../../utils/recoveryDevice";
 
 export const useRecovery = async (
   connection: Connection,
@@ -43,10 +44,9 @@ const runRecovery = async (
       ? recoveryDevices[0]
       : await pickRecoveryDevice(recoveryDevices);
 
-  const res =
-    "seed_phrase" in device.key_type
-      ? await phraseRecoveryPage(userNumber, connection, device)
-      : await deviceRecoveryPage(userNumber, connection, device);
+  const res = isRecoveryPhrase(device)
+    ? await phraseRecoveryPage(userNumber, connection, device)
+    : await deviceRecoveryPage(userNumber, connection, device);
 
   // If res is null, the user canceled the flow, so we go back to the main page.
   if (res.tag === "canceled") {

--- a/src/frontend/src/utils/recoveryDevice.ts
+++ b/src/frontend/src/utils/recoveryDevice.ts
@@ -11,5 +11,25 @@ export const recoveryDeviceToLabel = (device: RecoveryDevice): string => {
   return "External Hardware";
 };
 export const isRecoveryDevice = (
-  device: Omit<DeviceData, "alias">
+  device: Pick<DeviceData, "purpose">
 ): device is RecoveryDevice => "recovery" in device.purpose;
+
+// Whether the user has a recovery phrase or not
+export const hasRecoveryPhrase = (
+  devices: Pick<DeviceData, "key_type">[]
+): boolean => devices.some(isRecoveryPhrase);
+
+// Whether the user has a recovery key (i.e. recovery but not phrase) or not
+export const hasRecoveryKey = (
+  devices: Pick<DeviceData, "key_type" | "purpose">[]
+): boolean =>
+  devices.some(
+    (device) => isRecoveryDevice(device) && !isRecoveryPhrase(device)
+  );
+
+export const isProtected = (device: DeviceData): boolean =>
+  "protected" in device.protection;
+
+export const isRecoveryPhrase = ({
+  key_type,
+}: Pick<DeviceData, "key_type">): boolean => "seed_phrase" in key_type;


### PR DESCRIPTION
This moves all our checks for recovery, recovery phrase, recovery device, etc into a single module (`recoveryDevice`), deduplicating a lot of logic.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
