### PR TITLE
Enable e2e-tests on identity.ic0.app

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -380,6 +380,8 @@ jobs:
     strategy:
       matrix:
         device: [ 'desktop', 'mobile' ]
+        # We run the integration tests on both the official and legacy domains, to make sure
+        # the webapp (routes, csp, etc) works on both.
         domain: [ 'https://identity.internetcomputer.org', 'https://identity.ic0.app' ]
         # Specify some shards for jest (a jest instance will only run a subset of files
         # based on the shard assigned to it)

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -380,6 +380,7 @@ jobs:
     strategy:
       matrix:
         device: [ 'desktop', 'mobile' ]
+        domain: [ 'https://identity.internetcomputer.org', 'https://identity.ic0.app' ]
         # Specify some shards for jest (a jest instance will only run a subset of files
         # based on the shard assigned to it)
         # The jest parameter is actually 1/N, 2/N etc but we use a artifact-friendly
@@ -435,7 +436,7 @@ jobs:
 
       - run: npm ci
       - run: npm test
-      - run: "SCREEN=${{ matrix.device }} npm run test:e2e -- --shard=$(tr <<<'${{ matrix.shard }}' -s _ /)" # replace 1_N with 1/N
+      - run: "II_URL=${{ matrix.domain }} SCREEN=${{ matrix.device }} npm run test:e2e -- --shard=$(tr <<<'${{ matrix.shard }}' -s _ /)" # replace 1_N with 1/N
       - name: Collect docker logs
         working-directory: docker-test-env
         if: ${{ always() }}

--- a/docker-test-env/docker-compose.yml
+++ b/docker-test-env/docker-compose.yml
@@ -16,6 +16,7 @@ services:
           - icp-api.io
           # internet identity
           - identity.internetcomputer.org
+          - identity.ic0.app
           # test app, TEST_APP_CANISTER_ID is substituted by the start-selenium-env script
           - TEST_APP_CANISTER_ID.icp0.io
           # test app as above, but on legacy domain

--- a/docker-test-env/reverse_proxy/nginx.conf
+++ b/docker-test-env/reverse_proxy/nginx.conf
@@ -48,6 +48,27 @@ http {
         }
     }
 
+    # (a mock of) the legacy internet identity server/domain, used to ensure we're still compatible
+    server {
+        listen       443 ssl;
+        server_name  identity.ic0.app;
+
+        # The certificate and key are wrong, but tests don't check certificates
+        ssl_certificate      /etc/nginx/certs/identity.internetcomputer.org.crt;
+        ssl_certificate_key  /etc/nginx/certs/identity.internetcomputer.org.key;
+
+        location / {
+            proxy_pass http://host.docker.internal:II_PORT;
+            proxy_set_header Host II_CANISTER_ID.localhost;
+
+            # include details about the original request
+            proxy_set_header X-Original-Host $http_host;
+            proxy_set_header X-Original-Scheme $scheme;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_redirect off;
+        }
+    }
+
     # This makes all requests to raw return 400
     server {
         listen       443 ssl;

--- a/src/frontend/src/test-e2e/constants.ts
+++ b/src/frontend/src/test-e2e/constants.ts
@@ -7,7 +7,8 @@ export const TEST_APP_CANONICAL_URL = `https://${TEST_APP_CANISTER_ID}.icp0.io`;
 export const TEST_APP_CANONICAL_URL_LEGACY = `https://${TEST_APP_CANISTER_ID}.ic0.app`;
 export const TEST_APP_NICE_URL = "https://nice-name.com";
 export const REPLICA_URL = "https://icp-api.io";
-export const II_URL = "https://identity.internetcomputer.org";
+export const II_URL =
+  process.env.II_URL ?? "https://identity.internetcomputer.org";
 export const ABOUT_URL = `${II_URL}/about`;
 
 export const DEVICE_NAME1 = "Virtual WebAuthn device";


### PR DESCRIPTION
This makes CI run all e2e tests on https://identity.ic0.app, in addition to those already running on https://identity.internetcomputer.org. We do this to ensure both domains are supported.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
