### PR TITLE
Test that issued principals are the same on legacy

### DIFF
--- a/docker-test-env/docker-compose.yml
+++ b/docker-test-env/docker-compose.yml
@@ -18,6 +18,8 @@ services:
           - identity.internetcomputer.org
           # test app, TEST_APP_CANISTER_ID is substituted by the start-selenium-env script
           - TEST_APP_CANISTER_ID.icp0.io
+          # test app as above, but on legacy domain
+          - TEST_APP_CANISTER_ID.ic0.app
           - nice-name.com
           # also handle the *.raw origins, but nginx will just respond with status 400
           - TEST_APP_CANISTER_ID.raw.icp0.io

--- a/docker-test-env/reverse_proxy/nginx.conf
+++ b/docker-test-env/reverse_proxy/nginx.conf
@@ -62,10 +62,31 @@ http {
         }
     }
 
-    # (a mock of) the legacy IC, which we use to e.g. query for alternative origins
+    # (a mock of) the IC, which we use to e.g. query for alternative origins
     server {
         listen       443 ssl;
         server_name  "~^(.*)\.icp0\.io";
+
+        ssl_certificate      /etc/nginx/certs/wildcard.icp0.io.crt;
+        ssl_certificate_key  /etc/nginx/certs/wildcard.icp0.io.key;
+
+        location / {
+            proxy_pass http://host.docker.internal:4943;
+            proxy_set_header Host $1.localhost;
+
+            # include details about the original request
+            proxy_set_header X-Original-Host $http_host;
+            proxy_set_header X-Original-Scheme $scheme;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_redirect off;
+        }
+    }
+
+    # (a mock of) the IC as above, but used for ensuring consistency between legacy
+    # and official domain
+    server {
+        listen       443 ssl;
+        server_name  "~^(.*)\.ic0\.app";
 
         ssl_certificate      /etc/nginx/certs/wildcard.icp0.io.crt;
         ssl_certificate_key  /etc/nginx/certs/wildcard.icp0.io.key;

--- a/src/frontend/src/test-e2e/constants.ts
+++ b/src/frontend/src/test-e2e/constants.ts
@@ -4,6 +4,7 @@ import test_app_canister_ids from "../../../../demos/test-app/.dfx/local/caniste
 
 export const TEST_APP_CANISTER_ID = test_app_canister_ids.test_app.local;
 export const TEST_APP_CANONICAL_URL = `https://${TEST_APP_CANISTER_ID}.icp0.io`;
+export const TEST_APP_CANONICAL_URL_LEGACY = `https://${TEST_APP_CANISTER_ID}.ic0.app`;
 export const TEST_APP_NICE_URL = "https://nice-name.com";
 export const REPLICA_URL = "https://icp-api.io";
 export const II_URL = "https://identity.internetcomputer.org";

--- a/src/frontend/src/test-e2e/misc.test.ts
+++ b/src/frontend/src/test-e2e/misc.test.ts
@@ -16,6 +16,7 @@ import {
   TEST_APP_NICE_URL,
   DEVICE_NAME1,
   TEST_APP_CANONICAL_URL,
+  TEST_APP_CANONICAL_URL_LEGACY,
   REPLICA_URL,
 } from "./constants";
 
@@ -153,6 +154,52 @@ test("Should issue the same principal to nice url and canonical url", async () =
     await waitToClose(browser);
 
     const principal2 = await niceDemoAppView.getPrincipal();
+    expect(principal1).toEqual(principal2);
+  });
+}, 300_000);
+
+test("Should issue the same principal to dapps on legacy & official domains", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    // create a new anchor
+    const registrationAuthenticator = await addVirtualAuthenticator(browser);
+    await browser.url(II_URL);
+    const userNumber = await FLOWS.registerNewIdentityWelcomeView(
+      DEVICE_NAME1,
+      browser
+    );
+    await FLOWS.addRecoveryMechanismSeedPhrase(browser); // avoids being prompted later during authz
+    const credentials = await getWebAuthnCredentials(
+      browser,
+      registrationAuthenticator
+    );
+    expect(credentials).toHaveLength(1);
+
+    // Authenticate to the test dapp using the provided URL, returning the principal
+    const authenticate = async (url: string): Promise<string> => {
+      const canonicalDemoAppView = new DemoAppView(browser);
+      await canonicalDemoAppView.open(url, II_URL);
+      await canonicalDemoAppView.waitForDisplay();
+      await canonicalDemoAppView.signin();
+
+      const authzAuthenticator = await switchToPopup(browser);
+      await addWebAuthnCredential(
+        browser,
+        authzAuthenticator,
+        credentials[0],
+        originToRelyingPartyId(II_URL)
+      );
+      let authenticateView = new AuthenticateView(browser);
+      await authenticateView.waitForDisplay();
+      await authenticateView.pickAnchor(userNumber);
+      await waitToClose(browser);
+
+      return await canonicalDemoAppView.getPrincipal();
+    };
+
+    // Compare that principals issues for ic0.app & icp0.io are the same
+    const principal1 = await authenticate(TEST_APP_CANONICAL_URL);
+    const principal2 = await authenticate(TEST_APP_CANONICAL_URL_LEGACY);
+
     expect(principal1).toEqual(principal2);
   });
 }, 300_000);


### PR DESCRIPTION
This adds an integration test that signs in to the same app on both ic0.app & icp0.io and checks that the principals generated by II are the same on both domains.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
