### PR TITLE
Clean up device HTML

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -224,19 +224,10 @@ const devicesSection = ({
         }
 
         <div class="c-action-list">
-          <div id="deviceList">
           <ul>
-          ${_authenticators.map((device, index) => {
-            return html`
-              <li class="c-action-list__item">
-                ${deviceListItem({
-                  device,
-                  index: `authenticator-${index}`,
-                })}
-              </li>
-            `;
-          })}</ul>
-          </div>
+          ${_authenticators.map((device, index) =>
+            deviceListItem({ device, index: `authenticator-${index}` })
+          )}</ul>
           <div class="c-action-list__actions">
             <button
               ?disabled=${_authenticators.length >= MAX_AUTHENTICATORS}
@@ -274,21 +265,14 @@ const recoverySection = ({
               <h2>Recovery methods</h2>
             </div>
             <div class="c-action-list">
-              <div id="recoveryList">
-                <ul>
-                  ${recoveries.map(
-                    (device, index) =>
-                      html`
-                        <li class="c-action-list__item">
-                          ${deviceListItem({
-                            device,
-                            index: `recovery-${index}`,
-                          })}
-                        </li>
-                      `
-                  )}
-                </ul>
-              </div>
+              <ul>
+                ${recoveries.map((device, index) =>
+                  deviceListItem({
+                    device,
+                    index: `recovery-${index}`,
+                  })
+                )}
+              </ul>
               <div class="c-action-list__actions">
                 <button
                   @click="${onAddRecovery}"
@@ -312,60 +296,63 @@ const deviceListItem = ({
   index: string;
 }) => {
   return html`
-    <div class="c-action-list__label" data-device=${device.label}>
-      ${device.label}
-      ${device.dupCount !== undefined && device.dupCount > 0
-        ? html`<i class="t-muted">&nbsp;(${device.dupCount})</i>`
+    <li class="c-action-list__item" data-device=${device.label}>
+      <div class="c-action-list__label">
+        ${device.label}
+        ${device.dupCount !== undefined && device.dupCount > 0
+          ? html`<i class="t-muted">&nbsp;(${device.dupCount})</i>`
+          : undefined}
+      </div>
+      ${device.isProtected
+        ? html`<div class="c-action-list__action" data-role="protected">
+            <span
+              class="c-tooltip c-tooltip--left c-icon c-icon--lock"
+              tabindex="0"
+              >${lockIcon}<span class="c-tooltip__message c-card c-card--tight"
+                >Your device is protected</span
+              ></span
+            >
+          </div>`
         : undefined}
-    </div>
-    ${device.isProtected
-      ? html`<div class="c-action-list__action">
-          <span
-            class="c-tooltip c-tooltip--left c-icon c-icon--lock"
-            tabindex="0"
-            >${lockIcon}<span class="c-tooltip__message c-card c-card--tight"
-              >Your device is protected</span
-            ></span
-          >
-        </div>`
-      : undefined}
-    ${device.warn !== undefined
-      ? html`<div class="c-action-list__action">
-          <span
-            class="c-tooltip c-tooltip--left c-icon c-icon--warning"
-            tabindex="0"
-            >${warningIcon}<span class="c-tooltip__message c-card c-card--tight"
-              >${device.warn}</span
-            ></span
-          >
-        </div>`
-      : undefined}
-    ${device.settings.length > 0
-      ? html` <div class="c-action-list__action c-dropdown">
-          <button
-            class="c-dropdown__trigger c-action-list__action"
-            aria-expanded="false"
-            aria-controls="dropdown-${index}"
-            data-device=${device.label}
-          >
-            ${dropdownIcon}
-          </button>
-          <ul class="c-dropdown__menu" id="dropdown-${index}">
-            ${device.settings.map((setting) => {
-              return html` <li class="c-dropdown__item">
-                <button
-                  class="c-dropdown__link"
-                  data-device=${device.label}
-                  data-action=${setting.label}
-                  @click=${() => setting.fn()}
-                >
-                  ${setting.label}
-                </button>
-              </li>`;
-            })}
-          </ul>
-        </div>`
-      : undefined}
+      ${device.warn !== undefined
+        ? html`<div class="c-action-list__action">
+            <span
+              class="c-tooltip c-tooltip--left c-icon c-icon--warning"
+              tabindex="0"
+              >${warningIcon}<span
+                class="c-tooltip__message c-card c-card--tight"
+                >${device.warn}</span
+              ></span
+            >
+          </div>`
+        : undefined}
+      ${device.settings.length > 0
+        ? html` <div class="c-action-list__action c-dropdown">
+            <button
+              class="c-dropdown__trigger c-action-list__action"
+              aria-expanded="false"
+              aria-controls="dropdown-${index}"
+              data-device=${device.label}
+            >
+              ${dropdownIcon}
+            </button>
+            <ul class="c-dropdown__menu" id="dropdown-${index}">
+              ${device.settings.map((setting) => {
+                return html` <li class="c-dropdown__item">
+                  <button
+                    class="c-dropdown__link"
+                    data-device=${device.label}
+                    data-action=${setting.label}
+                    @click=${() => setting.fn()}
+                  >
+                    ${setting.label}
+                  </button>
+                </li>`;
+              })}
+            </ul>
+          </div>`
+        : undefined}
+    </li>
   `;
 };
 

--- a/src/frontend/src/test-e2e/recovery.test.ts
+++ b/src/frontend/src/test-e2e/recovery.test.ts
@@ -62,9 +62,11 @@ test("Make recovery protected", async () => {
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     const seedPhrase = await FLOWS.addRecoveryMechanismSeedPhrase(browser);
     await mainView.waitForDisplay();
+    await mainView.assertDeviceUnprotected(RECOVERY_PHRASE_NAME);
     // Ensure the settings dropdown is in view
     await browser.execute("window.scrollTo(0, document.body.scrollHeight)");
     await mainView.protect(RECOVERY_PHRASE_NAME, seedPhrase);
+    await mainView.assertDeviceProtected(RECOVERY_PHRASE_NAME);
   });
 }, 300_000);
 

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -155,13 +155,13 @@ export class MainView extends View {
 
   async waitForDeviceDisplay(deviceName: string): Promise<void> {
     await this.browser
-      .$(`//div[@data-device="${deviceName}"]`)
+      .$(`//li[@data-device="${deviceName}"]`)
       .waitForDisplayed({ timeout: 10_000 });
   }
 
   async waitForDeviceNotDisplay(deviceName: string): Promise<void> {
     await this.browser
-      .$(`//div[@data-device="${deviceName}"]`)
+      .$(`//li[@data-device="${deviceName}"]`)
       .waitForDisplayed({ timeout: 10_000, reverse: true });
   }
 
@@ -197,6 +197,18 @@ export class MainView extends View {
     await recoveryView.waitForSeedInputDisplay();
     await recoveryView.enterSeedPhrase(seedPhrase);
     await recoveryView.enterSeedPhraseContinue();
+  }
+
+  async assertDeviceProtected(deviceName: string): Promise<void> {
+    await this.browser
+      .$(`//li[@data-device="${deviceName}"]/div[@data-role="protected"]`)
+      .waitForDisplayed({ timeout: 10_000 });
+  }
+
+  async assertDeviceUnprotected(deviceName: string): Promise<void> {
+    await this.browser
+      .$(`//li[@data-device="${deviceName}"]/div[@data-role="protected"]`)
+      .waitForDisplayed({ timeout: 10_000, reverse: true });
   }
 
   async remove(deviceName: string): Promise<void> {


### PR DESCRIPTION
This modifies the device list HTML to be more useful from tests:
* An unused `div` wrapper is removed (both from authenticators and recoveries)
* The `data-device` attribute is hoisted to the top-level `li` element, so that sub-element can be selected more easily
* The "protected" `div` has a new `data-role="protected"` attribute so that tests can check that a device is indeed shown as protected
* Tests are updated to use `data-role="protected"`

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
