### PR TITLE
Allow unprotecting recovery phrases

### DIFF
--- a/src/frontend/src/test-e2e/recovery.test.ts
+++ b/src/frontend/src/test-e2e/recovery.test.ts
@@ -70,6 +70,26 @@ test("Make recovery protected", async () => {
   });
 }, 300_000);
 
+test("Make recovery unprotected", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    await addVirtualAuthenticator(browser);
+    await browser.url(II_URL);
+    await FLOWS.registerNewIdentityWelcomeView(DEVICE_NAME1, browser);
+    const mainView = new MainView(browser);
+    await mainView.waitForDeviceDisplay(DEVICE_NAME1);
+    const seedPhrase = await FLOWS.addRecoveryMechanismSeedPhrase(browser);
+    await mainView.waitForDisplay();
+    await mainView.assertDeviceUnprotected(RECOVERY_PHRASE_NAME);
+    // Ensure the settings dropdown is in view
+    await browser.execute("window.scrollTo(0, document.body.scrollHeight)");
+    await mainView.protect(RECOVERY_PHRASE_NAME, seedPhrase);
+    await mainView.assertDeviceProtected(RECOVERY_PHRASE_NAME);
+
+    await mainView.unprotect(RECOVERY_PHRASE_NAME, seedPhrase);
+    await mainView.assertDeviceUnprotected(RECOVERY_PHRASE_NAME);
+  });
+}, 300_000);
+
 test("Remove protected recovery phrase", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -205,6 +205,24 @@ export class MainView extends View {
       .waitForDisplayed({ timeout: 10_000 });
   }
 
+  async unprotect(deviceName: string, seedPhrase: string): Promise<void> {
+    // Ensure the dropdown is open by hovering/clicking (clicking is needed for mobile)
+    await this.browser
+      .$(`button.c-dropdown__trigger[data-device="${deviceName}"]`)
+      .click();
+    await this.browser
+      .$(`button[data-device="${deviceName}"][data-action='unprotect']`)
+      .waitForClickable();
+    await this.browser
+      .$(`button[data-device="${deviceName}"][data-action='unprotect']`)
+      .click();
+
+    const recoveryView = new RecoverView(this.browser);
+    await recoveryView.waitForSeedInputDisplay();
+    await recoveryView.enterSeedPhrase(seedPhrase);
+    await recoveryView.enterSeedPhraseContinue();
+  }
+
   async assertDeviceUnprotected(deviceName: string): Promise<void> {
     await this.browser
       .$(`//li[@data-device="${deviceName}"]/div[@data-role="protected"]`)


### PR DESCRIPTION
This adds an option on the management page to unprotect recovery phrases. Upon unprotection, the user is prompted to enter their recovery phrase. After that, the device is unprotected and can be deleted at will.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
