### PR TITLE
Introduce get_anchor_credentials method as a replacement for lookup

### DIFF
--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -5,7 +5,7 @@ use ic_test_state_machine_client::{
 };
 use internet_identity_interface as types;
 use internet_identity_interface::archive::BufferedEntry;
-use internet_identity_interface::GetDeviceCredentialsResponse;
+use internet_identity_interface::AnchorCredentials;
 use serde_bytes::ByteBuf;
 
 /** The functions here are derived (manually) from Internet Identity's Candid file */
@@ -114,12 +114,12 @@ pub fn lookup(
     query_candid(env, canister_id, "lookup", (anchor_number,)).map(|(x,)| x)
 }
 
-pub fn get_device_credentials(
+pub fn get_anchor_credentials(
     env: &StateMachine,
     canister_id: CanisterId,
     anchor_number: types::AnchorNumber,
-) -> Result<GetDeviceCredentialsResponse, CallError> {
-    query_candid(env, canister_id, "get_device_credentials", (anchor_number,)).map(|(x,)| x)
+) -> Result<AnchorCredentials, CallError> {
+    query_candid(env, canister_id, "get_anchor_credentials", (anchor_number,)).map(|(x,)| x)
 }
 
 pub fn add(

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -5,6 +5,7 @@ use ic_test_state_machine_client::{
 };
 use internet_identity_interface as types;
 use internet_identity_interface::archive::BufferedEntry;
+use internet_identity_interface::GetCredentialsResponse;
 use serde_bytes::ByteBuf;
 
 /** The functions here are derived (manually) from Internet Identity's Candid file */
@@ -111,6 +112,14 @@ pub fn lookup(
     anchor_number: types::AnchorNumber,
 ) -> Result<Vec<types::DeviceData>, CallError> {
     query_candid(env, canister_id, "lookup", (anchor_number,)).map(|(x,)| x)
+}
+
+pub fn get_credentials(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    anchor_number: types::AnchorNumber,
+) -> Result<GetCredentialsResponse, CallError> {
+    query_candid(env, canister_id, "get_credentials", (anchor_number,)).map(|(x,)| x)
 }
 
 pub fn add(

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -5,7 +5,7 @@ use ic_test_state_machine_client::{
 };
 use internet_identity_interface as types;
 use internet_identity_interface::archive::BufferedEntry;
-use internet_identity_interface::GetCredentialsResponse;
+use internet_identity_interface::GetDeviceCredentialsResponse;
 use serde_bytes::ByteBuf;
 
 /** The functions here are derived (manually) from Internet Identity's Candid file */
@@ -118,7 +118,7 @@ pub fn get_credentials(
     env: &StateMachine,
     canister_id: CanisterId,
     anchor_number: types::AnchorNumber,
-) -> Result<GetCredentialsResponse, CallError> {
+) -> Result<GetDeviceCredentialsResponse, CallError> {
     query_candid(env, canister_id, "get_credentials", (anchor_number,)).map(|(x,)| x)
 }
 

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -114,12 +114,12 @@ pub fn lookup(
     query_candid(env, canister_id, "lookup", (anchor_number,)).map(|(x,)| x)
 }
 
-pub fn get_credentials(
+pub fn get_device_credentials(
     env: &StateMachine,
     canister_id: CanisterId,
     anchor_number: types::AnchorNumber,
 ) -> Result<GetDeviceCredentialsResponse, CallError> {
-    query_candid(env, canister_id, "get_credentials", (anchor_number,)).map(|(x,)| x)
+    query_candid(env, canister_id, "get_device_credentials", (anchor_number,)).map(|(x,)| x)
 }
 
 pub fn add(

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -252,7 +252,7 @@ pub fn device_data_1() -> DeviceData {
     DeviceData {
         pubkey: ByteBuf::from(PUBKEY_1),
         alias: "My Device".to_string(),
-        credential_id: None,
+        credential_id: Some(ByteBuf::from("credential id 1")),
         purpose: Purpose::Authentication,
         key_type: KeyType::Unknown,
         protection: DeviceProtection::Unprotected,
@@ -264,7 +264,7 @@ pub fn device_data_2() -> DeviceData {
     DeviceData {
         pubkey: ByteBuf::from(PUBKEY_2),
         alias: "My second device".to_string(),
-        credential_id: None,
+        credential_id: Some(ByteBuf::from("credential id 2")),
         purpose: Purpose::Authentication,
         key_type: KeyType::Unknown,
         protection: DeviceProtection::Unprotected,

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -80,15 +80,6 @@ export const idlFactory = ({ IDL }) => {
     'devices' : IDL.Vec(DeviceWithUsage),
     'device_registration' : IDL.Opt(DeviceRegistrationInfo),
   });
-  const Credential = IDL.Record({
-    'pubkey' : PublicKey,
-    'credentialId' : CredentialId,
-  });
-  const GetCredentialsResponse = IDL.Record({
-    'recovery_phrase' : IDL.Bool,
-    'credentials' : IDL.Vec(Credential),
-    'recovery_credentials' : IDL.Vec(Credential),
-  });
   const FrontendHostname = IDL.Text;
   const SessionKey = PublicKey;
   const Delegation = IDL.Record({
@@ -103,6 +94,15 @@ export const idlFactory = ({ IDL }) => {
   const GetDelegationResponse = IDL.Variant({
     'no_such_delegation' : IDL.Null,
     'signed_delegation' : SignedDelegation,
+  });
+  const DeviceCredential = IDL.Record({
+    'pubkey' : PublicKey,
+    'credentialId' : CredentialId,
+  });
+  const GetDeviceCredentialsResponse = IDL.Record({
+    'recovery_phrase' : IDL.Bool,
+    'credentials' : IDL.Vec(DeviceCredential),
+    'recovery_credentials' : IDL.Vec(DeviceCredential),
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
@@ -174,14 +174,14 @@ export const idlFactory = ({ IDL }) => {
     'exit_device_registration_mode' : IDL.Func([UserNumber], [], []),
     'fetch_entries' : IDL.Func([], [IDL.Vec(BufferedArchiveEntry)], []),
     'get_anchor_info' : IDL.Func([UserNumber], [IdentityAnchorInfo], []),
-    'get_credentials' : IDL.Func(
-        [UserNumber],
-        [GetCredentialsResponse],
-        ['query'],
-      ),
     'get_delegation' : IDL.Func(
         [UserNumber, FrontendHostname, SessionKey, Timestamp],
         [GetDelegationResponse],
+        ['query'],
+      ),
+    'get_device_credentials' : IDL.Func(
+        [UserNumber],
+        [GetDeviceCredentialsResponse],
         ['query'],
       ),
     'get_principal' : IDL.Func(

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -80,6 +80,15 @@ export const idlFactory = ({ IDL }) => {
     'devices' : IDL.Vec(DeviceWithUsage),
     'device_registration' : IDL.Opt(DeviceRegistrationInfo),
   });
+  const Credential = IDL.Record({
+    'pubkey' : PublicKey,
+    'credentialId' : CredentialId,
+  });
+  const GetCredentialsResponse = IDL.Record({
+    'recovery_phrase' : IDL.Bool,
+    'credentials' : IDL.Vec(Credential),
+    'recovery_credentials' : IDL.Vec(Credential),
+  });
   const FrontendHostname = IDL.Text;
   const SessionKey = PublicKey;
   const Delegation = IDL.Record({
@@ -165,6 +174,11 @@ export const idlFactory = ({ IDL }) => {
     'exit_device_registration_mode' : IDL.Func([UserNumber], [], []),
     'fetch_entries' : IDL.Func([], [IDL.Vec(BufferedArchiveEntry)], []),
     'get_anchor_info' : IDL.Func([UserNumber], [IdentityAnchorInfo], []),
+    'get_credentials' : IDL.Func(
+        [UserNumber],
+        [GetCredentialsResponse],
+        ['query'],
+      ),
     'get_delegation' : IDL.Func(
         [UserNumber, FrontendHostname, SessionKey, Timestamp],
         [GetDelegationResponse],

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -67,7 +67,7 @@ export const idlFactory = ({ IDL }) => {
     'credentialId' : CredentialId,
   });
   const AnchorCredentials = IDL.Record({
-    'recovery_phrase' : IDL.Bool,
+    'recovery_phrase' : IDL.Vec(PublicKey),
     'credentials' : IDL.Vec(WebauthnCredential),
     'recovery_credentials' : IDL.Vec(WebauthnCredential),
   });

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -62,6 +62,15 @@ export const idlFactory = ({ IDL }) => {
     'anchor_number' : UserNumber,
     'timestamp' : Timestamp,
   });
+  const WebauthnCredential = IDL.Record({
+    'pubkey' : PublicKey,
+    'credentialId' : CredentialId,
+  });
+  const AnchorCredentials = IDL.Record({
+    'recovery_phrase' : IDL.Bool,
+    'credentials' : IDL.Vec(WebauthnCredential),
+    'recovery_credentials' : IDL.Vec(WebauthnCredential),
+  });
   const DeviceWithUsage = IDL.Record({
     'alias' : IDL.Text,
     'last_usage' : IDL.Opt(Timestamp),
@@ -94,15 +103,6 @@ export const idlFactory = ({ IDL }) => {
   const GetDelegationResponse = IDL.Variant({
     'no_such_delegation' : IDL.Null,
     'signed_delegation' : SignedDelegation,
-  });
-  const DeviceCredential = IDL.Record({
-    'pubkey' : PublicKey,
-    'credentialId' : CredentialId,
-  });
-  const GetDeviceCredentialsResponse = IDL.Record({
-    'recovery_phrase' : IDL.Bool,
-    'credentials' : IDL.Vec(DeviceCredential),
-    'recovery_credentials' : IDL.Vec(DeviceCredential),
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
@@ -173,15 +173,15 @@ export const idlFactory = ({ IDL }) => {
     'enter_device_registration_mode' : IDL.Func([UserNumber], [Timestamp], []),
     'exit_device_registration_mode' : IDL.Func([UserNumber], [], []),
     'fetch_entries' : IDL.Func([], [IDL.Vec(BufferedArchiveEntry)], []),
+    'get_anchor_credentials' : IDL.Func(
+        [UserNumber],
+        [AnchorCredentials],
+        ['query'],
+      ),
     'get_anchor_info' : IDL.Func([UserNumber], [IdentityAnchorInfo], []),
     'get_delegation' : IDL.Func(
         [UserNumber, FrontendHostname, SessionKey, Timestamp],
         [GetDelegationResponse],
-        ['query'],
-      ),
-    'get_device_credentials' : IDL.Func(
-        [UserNumber],
-        [GetDeviceCredentialsResponse],
         ['query'],
       ),
     'get_principal' : IDL.Func(

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -10,7 +10,7 @@ export type AddTentativeDeviceResponse = {
     }
   };
 export interface AnchorCredentials {
-  'recovery_phrase' : boolean,
+  'recovery_phrase' : Array<PublicKey>,
   'credentials' : Array<WebauthnCredential>,
   'recovery_credentials' : Array<WebauthnCredential>,
 }

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -9,6 +9,11 @@ export type AddTentativeDeviceResponse = {
       'device_registration_timeout' : Timestamp,
     }
   };
+export interface AnchorCredentials {
+  'recovery_phrase' : boolean,
+  'credentials' : Array<WebauthnCredential>,
+  'recovery_credentials' : Array<WebauthnCredential>,
+}
 export interface ArchiveConfig {
   'polling_interval_ns' : bigint,
   'entries_buffer_limit' : bigint,
@@ -40,10 +45,6 @@ export interface Delegation {
 export type DeployArchiveResult = { 'creation_in_progress' : null } |
   { 'success' : Principal } |
   { 'failed' : string };
-export interface DeviceCredential {
-  'pubkey' : PublicKey,
-  'credentialId' : CredentialId,
-}
 export interface DeviceData {
   'alias' : string,
   'origin' : [] | [string],
@@ -73,11 +74,6 @@ export interface DeviceWithUsage {
 export type FrontendHostname = string;
 export type GetDelegationResponse = { 'no_such_delegation' : null } |
   { 'signed_delegation' : SignedDelegation };
-export interface GetDeviceCredentialsResponse {
-  'recovery_phrase' : boolean,
-  'credentials' : Array<DeviceCredential>,
-  'recovery_credentials' : Array<DeviceCredential>,
-}
 export type HeaderField = [string, string];
 export interface HttpRequest {
   'url' : string,
@@ -140,6 +136,10 @@ export type VerifyTentativeDeviceResponse = {
   { 'verified' : null } |
   { 'wrong_code' : { 'retries_left' : number } } |
   { 'no_device_to_verify' : null };
+export interface WebauthnCredential {
+  'pubkey' : PublicKey,
+  'credentialId' : CredentialId,
+}
 export interface _SERVICE {
   'acknowledge_entries' : (arg_0: bigint) => Promise<undefined>,
   'add' : (arg_0: UserNumber, arg_1: DeviceData) => Promise<undefined>,
@@ -151,6 +151,7 @@ export interface _SERVICE {
   'enter_device_registration_mode' : (arg_0: UserNumber) => Promise<Timestamp>,
   'exit_device_registration_mode' : (arg_0: UserNumber) => Promise<undefined>,
   'fetch_entries' : () => Promise<Array<BufferedArchiveEntry>>,
+  'get_anchor_credentials' : (arg_0: UserNumber) => Promise<AnchorCredentials>,
   'get_anchor_info' : (arg_0: UserNumber) => Promise<IdentityAnchorInfo>,
   'get_delegation' : (
       arg_0: UserNumber,
@@ -158,9 +159,6 @@ export interface _SERVICE {
       arg_2: SessionKey,
       arg_3: Timestamp,
     ) => Promise<GetDelegationResponse>,
-  'get_device_credentials' : (arg_0: UserNumber) => Promise<
-      GetDeviceCredentialsResponse
-    >,
   'get_principal' : (arg_0: UserNumber, arg_1: FrontendHostname) => Promise<
       Principal
     >,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -31,10 +31,6 @@ export interface Challenge {
 }
 export type ChallengeKey = string;
 export interface ChallengeResult { 'key' : ChallengeKey, 'chars' : string }
-export interface Credential {
-  'pubkey' : PublicKey,
-  'credentialId' : CredentialId,
-}
 export type CredentialId = Array<number>;
 export interface Delegation {
   'pubkey' : PublicKey,
@@ -44,6 +40,10 @@ export interface Delegation {
 export type DeployArchiveResult = { 'creation_in_progress' : null } |
   { 'success' : Principal } |
   { 'failed' : string };
+export interface DeviceCredential {
+  'pubkey' : PublicKey,
+  'credentialId' : CredentialId,
+}
 export interface DeviceData {
   'alias' : string,
   'origin' : [] | [string],
@@ -71,13 +71,13 @@ export interface DeviceWithUsage {
   'credential_id' : [] | [CredentialId],
 }
 export type FrontendHostname = string;
-export interface GetCredentialsResponse {
-  'recovery_phrase' : boolean,
-  'credentials' : Array<Credential>,
-  'recovery_credentials' : Array<Credential>,
-}
 export type GetDelegationResponse = { 'no_such_delegation' : null } |
   { 'signed_delegation' : SignedDelegation };
+export interface GetDeviceCredentialsResponse {
+  'recovery_phrase' : boolean,
+  'credentials' : Array<DeviceCredential>,
+  'recovery_credentials' : Array<DeviceCredential>,
+}
 export type HeaderField = [string, string];
 export interface HttpRequest {
   'url' : string,
@@ -152,13 +152,15 @@ export interface _SERVICE {
   'exit_device_registration_mode' : (arg_0: UserNumber) => Promise<undefined>,
   'fetch_entries' : () => Promise<Array<BufferedArchiveEntry>>,
   'get_anchor_info' : (arg_0: UserNumber) => Promise<IdentityAnchorInfo>,
-  'get_credentials' : (arg_0: UserNumber) => Promise<GetCredentialsResponse>,
   'get_delegation' : (
       arg_0: UserNumber,
       arg_1: FrontendHostname,
       arg_2: SessionKey,
       arg_3: Timestamp,
     ) => Promise<GetDelegationResponse>,
+  'get_device_credentials' : (arg_0: UserNumber) => Promise<
+      GetDeviceCredentialsResponse
+    >,
   'get_principal' : (arg_0: UserNumber, arg_1: FrontendHostname) => Promise<
       Principal
     >,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -31,6 +31,10 @@ export interface Challenge {
 }
 export type ChallengeKey = string;
 export interface ChallengeResult { 'key' : ChallengeKey, 'chars' : string }
+export interface Credential {
+  'pubkey' : PublicKey,
+  'credentialId' : CredentialId,
+}
 export type CredentialId = Array<number>;
 export interface Delegation {
   'pubkey' : PublicKey,
@@ -67,6 +71,11 @@ export interface DeviceWithUsage {
   'credential_id' : [] | [CredentialId],
 }
 export type FrontendHostname = string;
+export interface GetCredentialsResponse {
+  'recovery_phrase' : boolean,
+  'credentials' : Array<Credential>,
+  'recovery_credentials' : Array<Credential>,
+}
 export type GetDelegationResponse = { 'no_such_delegation' : null } |
   { 'signed_delegation' : SignedDelegation };
 export type HeaderField = [string, string];
@@ -143,6 +152,7 @@ export interface _SERVICE {
   'exit_device_registration_mode' : (arg_0: UserNumber) => Promise<undefined>,
   'fetch_entries' : () => Promise<Array<BufferedArchiveEntry>>,
   'get_anchor_info' : (arg_0: UserNumber) => Promise<IdentityAnchorInfo>,
+  'get_credentials' : (arg_0: UserNumber) => Promise<GetCredentialsResponse>,
   'get_delegation' : (
       arg_0: UserNumber,
       arg_1: FrontendHostname,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -216,6 +216,17 @@ type IdentityAnchorInfo = record {
     device_registration: opt DeviceRegistrationInfo;
 };
 
+type GetCredentialsResponse = record {
+    credentials : vec Credential;
+    recovery_credentials : vec Credential;
+    recovery_phrase: bool;
+};
+
+type Credential = record {
+    credentialId : CredentialId;
+    pubkey: PublicKey;
+};
+
 type DeployArchiveResult = variant {
     // The archive was deployed successfully and the supplied wasm module has been installed. The principal of the archive
     // canister is returned.
@@ -245,8 +256,9 @@ service : (opt InternetIdentityInit) -> {
     remove : (UserNumber, DeviceKey) -> ();
     // Returns all devices of the user (authentication and recovery) but no information about device registrations.
     // Note: Clears out the 'alias' fields on the devices. Use 'get_anchor_info' to obtain the full information.
-    // Note: Will be changed in the future to be more consistent with get_anchor_info.
+    // Deprecated: Use 'get_credentials' instead.
     lookup : (UserNumber) -> (vec DeviceData) query;
+    get_credentials : (UserNumber) -> (GetCredentialsResponse) query;
     get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);
     get_principal : (UserNumber, FrontendHostname) -> (principal) query;
     stats : () -> (InternetIdentityStats) query;

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -216,13 +216,13 @@ type IdentityAnchorInfo = record {
     device_registration: opt DeviceRegistrationInfo;
 };
 
-type GetDeviceCredentialsResponse = record {
-    credentials : vec DeviceCredential;
-    recovery_credentials : vec DeviceCredential;
+type AnchorCredentials = record {
+    credentials : vec WebauthnCredential;
+    recovery_credentials : vec WebauthnCredential;
     recovery_phrase: bool;
 };
 
-type DeviceCredential = record {
+type WebauthnCredential = record {
     credentialId : CredentialId;
     pubkey: PublicKey;
 };
@@ -256,9 +256,9 @@ service : (opt InternetIdentityInit) -> {
     remove : (UserNumber, DeviceKey) -> ();
     // Returns all devices of the user (authentication and recovery) but no information about device registrations.
     // Note: Clears out the 'alias' fields on the devices. Use 'get_anchor_info' to obtain the full information.
-    // Deprecated: Use 'get_device_credentials' instead.
+    // Deprecated: Use 'get_anchor_credentials' instead.
     lookup : (UserNumber) -> (vec DeviceData) query;
-    get_device_credentials : (UserNumber) -> (GetDeviceCredentialsResponse) query;
+    get_anchor_credentials : (UserNumber) -> (AnchorCredentials) query;
     get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);
     get_principal : (UserNumber, FrontendHostname) -> (principal) query;
     stats : () -> (InternetIdentityStats) query;

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -219,7 +219,7 @@ type IdentityAnchorInfo = record {
 type AnchorCredentials = record {
     credentials : vec WebauthnCredential;
     recovery_credentials : vec WebauthnCredential;
-    recovery_phrase: bool;
+    recovery_phrase: vec PublicKey;
 };
 
 type WebauthnCredential = record {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -216,13 +216,13 @@ type IdentityAnchorInfo = record {
     device_registration: opt DeviceRegistrationInfo;
 };
 
-type GetCredentialsResponse = record {
-    credentials : vec Credential;
-    recovery_credentials : vec Credential;
+type GetDeviceCredentialsResponse = record {
+    credentials : vec DeviceCredential;
+    recovery_credentials : vec DeviceCredential;
     recovery_phrase: bool;
 };
 
-type Credential = record {
+type DeviceCredential = record {
     credentialId : CredentialId;
     pubkey: PublicKey;
 };
@@ -258,7 +258,7 @@ service : (opt InternetIdentityInit) -> {
     // Note: Clears out the 'alias' fields on the devices. Use 'get_anchor_info' to obtain the full information.
     // Deprecated: Use 'get_credentials' instead.
     lookup : (UserNumber) -> (vec DeviceData) query;
-    get_credentials : (UserNumber) -> (GetCredentialsResponse) query;
+    get_device_credentials : (UserNumber) -> (GetDeviceCredentialsResponse) query;
     get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);
     get_principal : (UserNumber, FrontendHostname) -> (principal) query;
     stats : () -> (InternetIdentityStats) query;

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -256,7 +256,7 @@ service : (opt InternetIdentityInit) -> {
     remove : (UserNumber, DeviceKey) -> ();
     // Returns all devices of the user (authentication and recovery) but no information about device registrations.
     // Note: Clears out the 'alias' fields on the devices. Use 'get_anchor_info' to obtain the full information.
-    // Deprecated: Use 'get_credentials' instead.
+    // Deprecated: Use 'get_device_credentials' instead.
     lookup : (UserNumber) -> (vec DeviceData) query;
     get_device_credentials : (UserNumber) -> (GetDeviceCredentialsResponse) query;
     get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -97,7 +97,7 @@ fn remove(anchor_number: AnchorNumber, device_key: DeviceKey) {
 }
 
 /// Returns all devices of the anchor (authentication and recovery) but no information about device registrations.
-/// Note: Will be changed in the future to be more consistent with get_anchor_info.
+/// Deprecated: use `get_credentials` instead
 #[query]
 fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
     state::storage(|storage| {
@@ -114,6 +114,24 @@ fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
             })
             .collect()
     })
+}
+
+#[query]
+fn get_credentials(anchor_number: AnchorNumber) -> GetCredentialsResponse {
+    let anchor = state::anchor(anchor_number);
+
+    let credentials = anchor.get_credentials(|d| d.purpose == Purpose::Authentication);
+    let recovery_credentials = anchor.get_credentials(|d| d.purpose == Purpose::Recovery);
+    let recovery_phrase = anchor
+        .devices()
+        .iter()
+        .any(|d| d.key_type == KeyType::SeedPhrase);
+
+    GetCredentialsResponse {
+        credentials,
+        recovery_credentials,
+        recovery_phrase,
+    }
 }
 
 #[update] // this is an update call because queries are not (yet) certified

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -117,17 +117,17 @@ fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
 }
 
 #[query]
-fn get_credentials(anchor_number: AnchorNumber) -> GetCredentialsResponse {
+fn get_device_credentials(anchor_number: AnchorNumber) -> GetDeviceCredentialsResponse {
     let anchor = state::anchor(anchor_number);
 
-    let credentials = anchor.get_credentials(|d| d.purpose == Purpose::Authentication);
-    let recovery_credentials = anchor.get_credentials(|d| d.purpose == Purpose::Recovery);
+    let credentials = anchor.get_device_credentials(|d| d.purpose == Purpose::Authentication);
+    let recovery_credentials = anchor.get_device_credentials(|d| d.purpose == Purpose::Recovery);
     let recovery_phrase = anchor
         .devices()
         .iter()
         .any(|d| d.key_type == KeyType::SeedPhrase);
 
-    GetCredentialsResponse {
+    GetDeviceCredentialsResponse {
         credentials,
         recovery_credentials,
         recovery_phrase,

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -133,13 +133,11 @@ fn get_anchor_credentials(anchor_number: AnchorNumber) -> AnchorCredentials {
     AnchorCredentials {
         credentials: auth_devices
             .into_iter()
-            .map(WebauthnCredential::try_from)
-            .flatten()
+            .flat_map(WebauthnCredential::try_from)
             .collect(),
         recovery_credentials: recovery_devices
             .into_iter()
-            .map(WebauthnCredential::try_from)
-            .flatten()
+            .flat_map(WebauthnCredential::try_from)
             .collect(),
         recovery_phrase,
     }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -97,7 +97,7 @@ fn remove(anchor_number: AnchorNumber, device_key: DeviceKey) {
 }
 
 /// Returns all devices of the anchor (authentication and recovery) but no information about device registrations.
-/// Deprecated: use `get_credentials` instead
+/// Deprecated: use [get_device_credentials] instead
 #[query]
 fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
     state::storage(|storage| {

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -164,8 +164,8 @@ impl Anchor {
         &self.devices
     }
 
-    /// Returns matching [Credential]s.
-    pub fn get_credentials<P>(&self, filter: P) -> Vec<Credential>
+    /// Returns matching [DeviceCredential]s.
+    pub fn get_device_credentials<P>(&self, filter: P) -> Vec<DeviceCredential>
     where
         P: Fn(&&Device) -> bool,
     {
@@ -173,10 +173,12 @@ impl Anchor {
             .iter()
             .filter(filter)
             .flat_map(|d| {
-                d.credential_id.clone().map(|credential_id| Credential {
-                    pubkey: d.pubkey.clone(),
-                    credential_id,
-                })
+                d.credential_id
+                    .clone()
+                    .map(|credential_id| DeviceCredential {
+                        pubkey: d.pubkey.clone(),
+                        credential_id,
+                    })
             })
             .collect()
     }

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -211,20 +211,6 @@ impl Device {
     }
 }
 
-impl TryFrom<Device> for WebauthnCredential {
-    type Error = ();
-
-    fn try_from(device: Device) -> Result<Self, Self::Error> {
-        let Some(credential_id) = device.credential_id else {
-            return Err(());
-        };
-        Ok(Self {
-            pubkey: device.pubkey,
-            credential_id,
-        })
-    }
-}
-
 fn check_mutation_allowed(device: &Device) -> Result<(), AnchorError> {
     match device.protection {
         DeviceProtection::Unprotected => (),

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -164,6 +164,23 @@ impl Anchor {
         &self.devices
     }
 
+    /// Returns matching [Credential]s.
+    pub fn get_credentials<P>(&self, filter: P) -> Vec<Credential>
+    where
+        P: Fn(&&Device) -> bool,
+    {
+        self.devices()
+            .iter()
+            .filter(filter)
+            .flat_map(|d| {
+                d.credential_id.clone().map(|credential_id| Credential {
+                    pubkey: d.pubkey.clone(),
+                    credential_id,
+                })
+            })
+            .collect()
+    }
+
     /// Consumes self and exposes the devices.
     pub fn into_devices(self) -> Vec<Device> {
         self.devices

--- a/src/internet_identity/tests/archive_integration_tests_pull.rs
+++ b/src/internet_identity/tests/archive_integration_tests_pull.rs
@@ -262,7 +262,7 @@ mod pull_entries_tests {
             operation: Operation::RegisterAnchor {
                 device: DeviceDataWithoutAlias {
                     pubkey: device_data_1().pubkey,
-                    credential_id: None,
+                    credential_id: device_data_1().credential_id,
                     purpose: Purpose::Authentication,
                     key_type: KeyType::Unknown,
                     protection: DeviceProtection::Unprotected,

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -1631,7 +1631,7 @@ mod device_management_tests {
                 recovery_webauthn_device.clone(),
             )?;
 
-            let response = api::get_credentials(&env, canister_id, user_number)?;
+            let response = api::get_device_credentials(&env, canister_id, user_number)?;
 
             assert_eq!(response.credentials.len(), 2);
             assert!(response.credentials.contains(&DeviceCredential {
@@ -1663,7 +1663,7 @@ mod device_management_tests {
             let canister_id = install_ii_canister(&env, II_WASM.clone());
             let user_number = flows::register_anchor(&env, canister_id);
 
-            let response = api::get_credentials(&env, canister_id, user_number)?;
+            let response = api::get_device_credentials(&env, canister_id, user_number)?;
 
             assert_eq!(
                 response.credentials,

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -1634,18 +1634,18 @@ mod device_management_tests {
             let response = api::get_credentials(&env, canister_id, user_number)?;
 
             assert_eq!(response.credentials.len(), 2);
-            assert!(response.credentials.contains(&Credential {
+            assert!(response.credentials.contains(&DeviceCredential {
                 pubkey: device_data_1().pubkey,
                 credential_id: device_data_1().credential_id.unwrap()
             }));
-            assert!(response.credentials.contains(&Credential {
+            assert!(response.credentials.contains(&DeviceCredential {
                 pubkey: device_data_2().pubkey,
                 credential_id: device_data_2().credential_id.unwrap()
             }));
 
             assert_eq!(
                 response.recovery_credentials,
-                vec![Credential {
+                vec![DeviceCredential {
                     pubkey: recovery_webauthn_device.pubkey.clone(),
                     credential_id: recovery_webauthn_device.credential_id.unwrap()
                 }]
@@ -1667,7 +1667,7 @@ mod device_management_tests {
 
             assert_eq!(
                 response.credentials,
-                vec![Credential {
+                vec![DeviceCredential {
                     pubkey: device_data_1().pubkey,
                     credential_id: device_data_1().credential_id.unwrap()
                 }]

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -1589,10 +1589,10 @@ mod device_management_tests {
     }
 
     #[cfg(test)]
-    mod get_credentials {
+    mod get_anchor_credentials {
         use super::*;
 
-        /// Verifies that get_credentials returns the expected credentials.
+        /// Verifies that get_anchor_credentials returns the expected credentials.
         #[test]
         fn should_get_credentials() -> Result<(), CallError> {
             let env = env();
@@ -1651,12 +1651,15 @@ mod device_management_tests {
                 }]
             );
 
-            assert!(response.recovery_phrase);
+            assert_eq!(
+                response.recovery_phrases,
+                vec![recovery_device_data_1().pubkey]
+            );
 
             Ok(())
         }
 
-        /// Verifies that get_credentials returns the expected credentials (i.e. no recovery credentials if there are none).
+        /// Verifies that get_anchor_credentials returns the expected credentials (i.e. no recovery credentials if there are none).
         #[test]
         fn should_not_get_recovery_credentials_if_there_are_none() -> Result<(), CallError> {
             let env = env();
@@ -1673,7 +1676,7 @@ mod device_management_tests {
                 }]
             );
             assert_eq!(response.recovery_credentials, vec![]);
-            assert!(!response.recovery_phrase);
+            assert_eq!(response.recovery_phrases, Vec::<PublicKey>::new());
 
             Ok(())
         }

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -1588,6 +1588,97 @@ mod device_management_tests {
         }
     }
 
+    #[cfg(test)]
+    mod get_credentials {
+        use super::*;
+
+        /// Verifies that get_credentials returns the expected credentials.
+        #[test]
+        fn should_get_credentials() -> Result<(), CallError> {
+            let env = env();
+            let canister_id = install_ii_canister(&env, II_WASM.clone());
+            let user_number = flows::register_anchor(&env, canister_id);
+
+            let recovery_webauthn_device = DeviceData {
+                pubkey: ByteBuf::from("recovery device"),
+                alias: "Recovery Device".to_string(),
+                credential_id: Some(ByteBuf::from("recovery credential id")),
+                purpose: Purpose::Recovery,
+                key_type: KeyType::CrossPlatform,
+                protection: DeviceProtection::Unprotected,
+                origin: None,
+            };
+
+            api::add(
+                &env,
+                canister_id,
+                principal_1(),
+                user_number,
+                device_data_2(),
+            )?;
+            api::add(
+                &env,
+                canister_id,
+                principal_1(),
+                user_number,
+                recovery_device_data_1(),
+            )?;
+            api::add(
+                &env,
+                canister_id,
+                principal_1(),
+                user_number,
+                recovery_webauthn_device.clone(),
+            )?;
+
+            let response = api::get_credentials(&env, canister_id, user_number)?;
+
+            assert_eq!(response.credentials.len(), 2);
+            assert!(response.credentials.contains(&Credential {
+                pubkey: device_data_1().pubkey,
+                credential_id: device_data_1().credential_id.unwrap()
+            }));
+            assert!(response.credentials.contains(&Credential {
+                pubkey: device_data_2().pubkey,
+                credential_id: device_data_2().credential_id.unwrap()
+            }));
+
+            assert_eq!(
+                response.recovery_credentials,
+                vec![Credential {
+                    pubkey: recovery_webauthn_device.pubkey.clone(),
+                    credential_id: recovery_webauthn_device.credential_id.unwrap()
+                }]
+            );
+
+            assert!(response.recovery_phrase);
+
+            Ok(())
+        }
+
+        /// Verifies that get_credentials returns the expected credentials (i.e. no recovery credentials if there are none).
+        #[test]
+        fn should_not_get_recovery_credentials_if_there_are_none() -> Result<(), CallError> {
+            let env = env();
+            let canister_id = install_ii_canister(&env, II_WASM.clone());
+            let user_number = flows::register_anchor(&env, canister_id);
+
+            let response = api::get_credentials(&env, canister_id, user_number)?;
+
+            assert_eq!(
+                response.credentials,
+                vec![Credential {
+                    pubkey: device_data_1().pubkey,
+                    credential_id: device_data_1().credential_id.unwrap()
+                }]
+            );
+            assert_eq!(response.recovery_credentials, vec![]);
+            assert!(!response.recovery_phrase);
+
+            Ok(())
+        }
+    }
+
     /// Verifies that a device can be removed.
     #[test]
     fn should_remove_device() -> Result<(), CallError> {

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -1631,21 +1631,21 @@ mod device_management_tests {
                 recovery_webauthn_device.clone(),
             )?;
 
-            let response = api::get_device_credentials(&env, canister_id, user_number)?;
+            let response = api::get_anchor_credentials(&env, canister_id, user_number)?;
 
             assert_eq!(response.credentials.len(), 2);
-            assert!(response.credentials.contains(&DeviceCredential {
+            assert!(response.credentials.contains(&WebauthnCredential {
                 pubkey: device_data_1().pubkey,
                 credential_id: device_data_1().credential_id.unwrap()
             }));
-            assert!(response.credentials.contains(&DeviceCredential {
+            assert!(response.credentials.contains(&WebauthnCredential {
                 pubkey: device_data_2().pubkey,
                 credential_id: device_data_2().credential_id.unwrap()
             }));
 
             assert_eq!(
                 response.recovery_credentials,
-                vec![DeviceCredential {
+                vec![WebauthnCredential {
                     pubkey: recovery_webauthn_device.pubkey.clone(),
                     credential_id: recovery_webauthn_device.credential_id.unwrap()
                 }]
@@ -1663,11 +1663,11 @@ mod device_management_tests {
             let canister_id = install_ii_canister(&env, II_WASM.clone());
             let user_number = flows::register_anchor(&env, canister_id);
 
-            let response = api::get_device_credentials(&env, canister_id, user_number)?;
+            let response = api::get_anchor_credentials(&env, canister_id, user_number)?;
 
             assert_eq!(
                 response.credentials,
-                vec![DeviceCredential {
+                vec![WebauthnCredential {
                     pubkey: device_data_1().pubkey,
                     credential_id: device_data_1().credential_id.unwrap()
                 }]

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -191,15 +191,15 @@ impl IdentityAnchorInfo {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub struct Credential {
+pub struct DeviceCredential {
     pub pubkey: DeviceKey,
     pub credential_id: CredentialId,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct GetCredentialsResponse {
-    pub credentials: Vec<Credential>,
-    pub recovery_credentials: Vec<Credential>,
+pub struct GetDeviceCredentialsResponse {
+    pub credentials: Vec<DeviceCredential>,
+    pub recovery_credentials: Vec<DeviceCredential>,
     pub recovery_phrase: bool,
 }
 

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -190,6 +190,19 @@ impl IdentityAnchorInfo {
     }
 }
 
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct Credential {
+    pub pubkey: DeviceKey,
+    pub credential_id: CredentialId,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct GetCredentialsResponse {
+    pub credentials: Vec<Credential>,
+    pub recovery_credentials: Vec<Credential>,
+    pub recovery_phrase: bool,
+}
+
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct InternetIdentityInit {
     pub assigned_user_number_range: Option<(AnchorNumber, AnchorNumber)>,

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -191,15 +191,15 @@ impl IdentityAnchorInfo {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub struct DeviceCredential {
+pub struct WebauthnCredential {
     pub pubkey: DeviceKey,
     pub credential_id: CredentialId,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct GetDeviceCredentialsResponse {
-    pub credentials: Vec<DeviceCredential>,
-    pub recovery_credentials: Vec<DeviceCredential>,
+pub struct AnchorCredentials {
+    pub credentials: Vec<WebauthnCredential>,
+    pub recovery_credentials: Vec<WebauthnCredential>,
     pub recovery_phrase: bool,
 }
 

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -200,7 +200,7 @@ pub struct WebauthnCredential {
 pub struct AnchorCredentials {
     pub credentials: Vec<WebauthnCredential>,
     pub recovery_credentials: Vec<WebauthnCredential>,
-    pub recovery_phrase: bool,
+    pub recovery_phrases: Vec<PublicKey>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]


### PR DESCRIPTION
`lookup` provides more information than necessary for a public endpoint.
This is why it is being deprecated. As a replacement `get_device_credentials` is introduced
which is more tailored to just provide the information required for authentication.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
