### PR TITLE
Refactor HTTP gateway interface types

### DIFF
--- a/src/archive/src/main.rs
+++ b/src/archive/src/main.rs
@@ -51,6 +51,7 @@ use ic_stable_structures::{
     RestrictedMemory, StableBTreeMap, Storable,
 };
 use internet_identity_interface::archive::*;
+use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
 use internet_identity_interface::*;
 use serde_bytes::ByteBuf;
 use std::borrow::Cow;
@@ -549,6 +550,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                         status_code: 200,
                         headers,
                         body: Cow::Owned(ByteBuf::from(body)),
+                        upgrade: None,
                         streaming_strategy: None,
                     }
                 }
@@ -556,6 +558,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                     status_code: 500,
                     headers: vec![],
                     body: Cow::Owned(ByteBuf::from(format!("Failed to encode metrics: {err}"))),
+                    upgrade: None,
                     streaming_strategy: None,
                 },
             }
@@ -564,6 +567,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
             status_code: 404,
             headers: vec![],
             body: Cow::Owned(ByteBuf::from(format!("Asset {path} not found."))),
+            upgrade: None,
             streaming_strategy: None,
         },
     }

--- a/src/canister_tests/src/api.rs
+++ b/src/canister_tests/src/api.rs
@@ -1,6 +1,6 @@
 use ic_cdk::api::management_canister::main::CanisterId;
 use ic_test_state_machine_client::{query_candid, CallError, StateMachine};
-use internet_identity_interface::{HttpRequest, HttpResponse};
+use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
 
 pub mod archive;
 pub mod internet_identity;

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -12,6 +12,7 @@ use ic_types::crypto::Signable;
 use ic_types::messages::Delegation;
 use ic_types::Time;
 use internet_identity_interface::archive::*;
+use internet_identity_interface::http_gateway::{HeaderField, HttpRequest};
 use internet_identity_interface::*;
 use lazy_static::lazy_static;
 use regex::Regex;

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -120,6 +120,7 @@ export const idlFactory = ({ IDL }) => {
   const HttpResponse = IDL.Record({
     'body' : IDL.Vec(IDL.Nat8),
     'headers' : IDL.Vec(HeaderField),
+    'upgrade' : IDL.Opt(IDL.Bool),
     'streaming_strategy' : IDL.Opt(StreamingStrategy),
     'status_code' : IDL.Nat16,
   });

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -79,6 +79,7 @@ export interface HttpRequest {
 export interface HttpResponse {
   'body' : Array<number>,
   'headers' : Array<HeaderField>,
+  'upgrade' : [] | [boolean],
   'streaming_strategy' : [] | [StreamingStrategy],
   'status_code' : number,
 }

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -23,6 +23,7 @@ type HttpResponse = record {
     status_code: nat16;
     headers: vec HeaderField;
     body: blob;
+    upgrade : opt bool;
     streaming_strategy: opt StreamingStrategy;
 };
 

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -8,7 +8,7 @@ use ic_cdk::api::{data_certificate, time};
 use ic_cdk::trap;
 use ic_certified_map::HashTree;
 use ic_metrics_encoder::MetricsEncoder;
-use internet_identity_interface::{HeaderField, HttpRequest, HttpResponse};
+use internet_identity_interface::http_gateway::{HeaderField, HttpRequest, HttpResponse};
 use serde::Serialize;
 use serde_bytes::{ByteBuf, Bytes};
 use std::borrow::Cow;
@@ -39,6 +39,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                     .to_string(),
             )],
             body: Cow::Owned(ByteBuf::new()),
+            upgrade: None,
             streaming_strategy: None,
         },
         "/metrics" => {
@@ -58,6 +59,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                         status_code: 200,
                         headers,
                         body: Cow::Owned(ByteBuf::from(body)),
+                        upgrade: None,
                         streaming_strategy: None,
                     }
                 }
@@ -65,6 +67,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                     status_code: 500,
                     headers: security_headers(),
                     body: Cow::Owned(ByteBuf::from(format!("Failed to encode metrics: {err}"))),
+                    upgrade: None,
                     streaming_strategy: None,
                 },
             }
@@ -82,6 +85,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                         status_code: 200,
                         headers,
                         body: Cow::Borrowed(Bytes::new(value)),
+                        upgrade: None,
                         streaming_strategy: None,
                     }
                 }
@@ -91,6 +95,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                     body: Cow::Owned(ByteBuf::from(format!(
                         "Asset {probably_an_asset} not found."
                     ))),
+                    upgrade: None,
                     streaming_strategy: None,
                 },
             })

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -7,6 +7,7 @@ use ic_cdk::api::{caller, set_certified_data, trap};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use ic_certified_map::AsHashTree;
 use internet_identity_interface::archive::BufferedEntry;
+use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
 use internet_identity_interface::*;
 use serde_bytes::ByteBuf;
 use storage::{Salt, Storage};

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -8,6 +8,7 @@ use ic_cdk::{call, trap};
 use ic_certified_map::{Hash, RbTree};
 use ic_stable_structures::DefaultMemoryImpl;
 use internet_identity::signature_map::SignatureMap;
+use internet_identity_interface::http_gateway::HeaderField;
 use internet_identity_interface::*;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -6,6 +6,7 @@ use canister_tests::flows;
 use canister_tests::framework::*;
 use ic_test_state_machine_client::CallError;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
+use internet_identity_interface::http_gateway::HttpRequest;
 use internet_identity_interface::*;
 use regex::Regex;
 use serde_bytes::ByteBuf;

--- a/src/internet_identity_interface/src/http_gateway.rs
+++ b/src/internet_identity_interface/src/http_gateway.rs
@@ -1,3 +1,6 @@
+//! Types as defined by the HTTP gateway spec.
+//! See https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-gateway-interface
+
 use candid::{CandidType, Deserialize, Func};
 use serde_bytes::{ByteBuf, Bytes};
 use std::borrow::Cow;

--- a/src/internet_identity_interface/src/http_gateway.rs
+++ b/src/internet_identity_interface/src/http_gateway.rs
@@ -1,0 +1,36 @@
+use candid::{CandidType, Deserialize, Func};
+use serde_bytes::{ByteBuf, Bytes};
+use std::borrow::Cow;
+
+pub type HeaderField = (String, String);
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct Token {}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum StreamingStrategy {
+    Callback { callback: Func, token: Token },
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct StreamingCallbackHttpResponse {
+    pub body: ByteBuf,
+    pub token: Option<Token>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct HttpRequest {
+    pub method: String,
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+    pub body: ByteBuf,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct HttpResponse {
+    pub status_code: u16,
+    pub headers: Vec<HeaderField>,
+    pub body: Cow<'static, Bytes>,
+    pub upgrade: Option<bool>,
+    pub streaming_strategy: Option<StreamingStrategy>,
+}

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -1,9 +1,11 @@
-use candid::{CandidType, Deserialize, Func, Principal};
-use serde_bytes::{ByteBuf, Bytes};
-use std::borrow::Cow;
+use candid::{CandidType, Deserialize, Principal};
+use serde_bytes::ByteBuf;
 
 /// types related to the archive
 pub mod archive;
+/// types as specified by the HTTP gateway protocol.
+/// See https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-gateway-interface
+pub mod http_gateway;
 
 pub type AnchorNumber = u64;
 pub type CredentialId = ByteBuf;
@@ -186,38 +188,6 @@ impl IdentityAnchorInfo {
     pub fn into_device_data(self) -> Vec<DeviceData> {
         self.devices.into_iter().map(DeviceData::from).collect()
     }
-}
-
-pub type HeaderField = (String, String);
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct Token {}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub enum StreamingStrategy {
-    Callback { callback: Func, token: Token },
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct StreamingCallbackHttpResponse {
-    pub body: ByteBuf,
-    pub token: Option<Token>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct HttpRequest {
-    pub method: String,
-    pub url: String,
-    pub headers: Vec<(String, String)>,
-    pub body: ByteBuf,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct HttpResponse {
-    pub status_code: u16,
-    pub headers: Vec<HeaderField>,
-    pub body: Cow<'static, Bytes>,
-    pub streaming_strategy: Option<StreamingStrategy>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -4,7 +4,7 @@ use serde_bytes::ByteBuf;
 /// types related to the archive
 pub mod archive;
 /// types as specified by the HTTP gateway protocol.
-/// See https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-gateway-interface
+/// See https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-gateway
 pub mod http_gateway;
 
 pub type AnchorNumber = u64;


### PR DESCRIPTION
This PR separates the types used to implement the `http_request`
and `http_request_update` canister methods into their own module.

Additionally the `upgrade` flag is introduce in preparation for the fix
the /faq redirect (which will need to set that flag).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
