### PR TITLE
Fix /faq redirect

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -176,6 +176,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
+    'http_request_update' : IDL.Func([HttpRequest], [HttpResponse], []),
     'init_salt' : IDL.Func([], [], []),
     'lookup' : IDL.Func([UserNumber], [IDL.Vec(DeviceData)], ['query']),
     'prepare_delegation' : IDL.Func(

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -153,6 +153,7 @@ export interface _SERVICE {
       Principal
     >,
   'http_request' : (arg_0: HttpRequest) => Promise<HttpResponse>,
+  'http_request_update' : (arg_0: HttpRequest) => Promise<HttpResponse>,
   'init_salt' : () => Promise<undefined>,
   'lookup' : (arg_0: UserNumber) => Promise<Array<DeviceData>>,
   'prepare_delegation' : (

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -260,6 +260,7 @@ service : (opt InternetIdentityInit) -> {
     get_delegation: (UserNumber, FrontendHostname, SessionKey, Timestamp) -> (GetDelegationResponse) query;
 
     http_request: (request: HttpRequest) -> (HttpResponse) query;
+    http_request_update: (request: HttpRequest) -> (HttpResponse);
 
     deploy_archive: (wasm: blob) -> (DeployArchiveResult);
     /// Returns a batch of entries _sorted by sequence number_ to be archived.

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -39,6 +39,9 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                     .to_string(),
             )],
             body: Cow::Owned(ByteBuf::new()),
+            // Redirects are not allowed as query because certification V1 does not cover headers.
+            // Upgrading to update fixes this. This flag can be removed when switching to
+            // certification V2.
             upgrade: Some(true),
             streaming_strategy: None,
         },

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -39,7 +39,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                     .to_string(),
             )],
             body: Cow::Owned(ByteBuf::new()),
-            upgrade: None,
+            upgrade: Some(true),
             streaming_strategy: None,
         },
         "/metrics" => {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -163,6 +163,11 @@ fn http_request(req: HttpRequest) -> HttpResponse {
     http::http_request(req)
 }
 
+#[update]
+fn http_request_update(req: HttpRequest) -> HttpResponse {
+    http::http_request(req)
+}
+
 #[query]
 fn stats() -> InternetIdentityStats {
     let archive_info = match state::archive_state() {


### PR DESCRIPTION
This PR fixes the /faq link redirect by setting the upgrade to update flag on the redirect and allowing http_requests to be sent as update calls.

The redirects can be certified for query calls with the V2 certification at which point the support to receive http assets via update call can be dropped again.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
