### PR TITLE
Only allow resetting recovery phrases

### DIFF
--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -13,8 +13,12 @@ import {
   isRecoveryDevice,
   isRecoveryPhrase,
   isProtected,
-  RecoveryDevice,
+  RecoveryPhrase,
 } from "../../utils/recoveryDevice";
+import { generate } from "../../crypto/mnemonic";
+import { fromMnemonicWithoutValidation } from "../../crypto/ed25519";
+import { IC_DERIVATION_PATH } from "../../utils/iiConnection";
+import { displaySeedPhrase } from "../recovery/displaySeedPhrase";
 
 // A particular device setting, e.g. remove, protect, etc
 export type Setting = { label: string; fn: () => void };
@@ -36,53 +40,47 @@ export const deviceSettings = ({
 }): Setting[] => {
   const settings: Setting[] = [];
 
-  // Whether the device can be protected or not
-  if (shouldOfferToProtect(device)) {
-    settings.push({
-      label: "protect",
-      fn: () => protectDevice({ userNumber, connection, device, reload }),
-    });
+  // Whether the device can be (un)protected or not (only recovery phrases can be protected)
+  if (isRecoveryPhrase(device)) {
+    if (!isProtected(device)) {
+      settings.push({
+        label: "protect",
+        fn: () => protectDevice({ userNumber, connection, device, reload }),
+      });
+    } else {
+      settings.push({
+        label: "unprotect",
+        fn: () =>
+          unprotectDevice(userNumber, connection, device, isOnlyDevice, reload),
+      });
+    }
   }
 
-  // Whether the device can be unprotected or not
-  if (shouldOfferToUnprotect(device)) {
+  // For recovery phrases, we only allow resetting, not removing
+  if (isRecoveryPhrase(device)) {
     settings.push({
-      label: "unprotect",
-      fn: () =>
-        unprotectDevice(userNumber, connection, device, isOnlyDevice, reload),
+      label: "reset",
+      fn: () => resetPhrase({ userNumber, connection, device, reload }),
     });
-  }
-
-  // If this is _not_ the only device, then we allow removing it
-  if (!isOnlyDevice) {
-    settings.push({
-      label: "remove",
-      fn: () => deleteDevice({ userNumber, connection, device, reload }),
-    });
+  } else {
+    // For all other devices, we allow removing (unless it's the only device)
+    if (!isOnlyDevice) {
+      settings.push({
+        label: "remove",
+        fn: () => deleteDevice({ connection, device, reload }),
+      });
+    }
   }
 
   return settings;
 };
-
-// We offer to protect unprotected recovery phrases only, although in the
-// future we may offer to protect all devices
-const shouldOfferToProtect = (
-  device: DeviceData
-): device is RecoveryDevice & DeviceData =>
-  isRecoveryPhrase(device) && !isProtected(device);
-
-// We offer to unprotect protected recovery phrases only
-const shouldOfferToUnprotect = (
-  device: DeviceData
-): device is RecoveryDevice & DeviceData =>
-  isRecoveryPhrase(device) && isProtected(device);
 
 // Get a connection that's authenticated with the given device
 // NOTE: this expects a recovery phrase device
 const deviceConnection = async (
   connection: Connection,
   userNumber: bigint,
-  device: DeviceData & RecoveryDevice,
+  device: DeviceData & RecoveryPhrase,
   recoveryPhraseMessage: string
 ): Promise<AuthenticatedConnection | null> => {
   try {
@@ -104,9 +102,9 @@ const deviceConnection = async (
     }
   } catch (error: unknown) {
     await displayError({
-      title: "Could not delete device",
+      title: "Could not modify device",
       message:
-        "An unexpected error occurred when trying to read recovery phrase for device deletion.",
+        "An unexpected error occurred when trying to read recovery phrase for device modification.",
       detail: error instanceof Error ? error.toString() : "unknown error",
       primaryButton: "Ok",
     });
@@ -116,12 +114,10 @@ const deviceConnection = async (
 
 /* Remove the device and return */
 const deleteDevice = async ({
-  userNumber,
   connection,
   device,
   reload,
 }: {
-  userNumber: bigint;
   connection: AuthenticatedConnection;
   device: DeviceData;
   reload: () => void;
@@ -146,25 +142,8 @@ const deleteDevice = async ({
     return;
   }
 
-  // If the device is protected then we need to be authenticated with the device to remove it
-  // NOTE: the user may be authenticated with the device already, but for consistency we still ask them to input their recovery phrase
-  const removalConnection =
-    isRecoveryDevice(device) && isProtected(device)
-      ? await deviceConnection(
-          connection,
-          userNumber,
-          device,
-          "Please input your recovery phrase to remove it."
-        )
-      : connection;
-
   await withLoader(async () => {
-    // if null then user canceled so we just redraw the manage page
-    if (removalConnection == null) {
-      await reload();
-      return;
-    }
-    await removalConnection.remove(device.pubkey);
+    await connection.remove(device.pubkey);
   });
 
   if (sameDevice) {
@@ -178,6 +157,69 @@ const deleteDevice = async ({
   }
 };
 
+/* Reset the device and return to caller */
+const resetPhrase = async ({
+  userNumber,
+  connection,
+  device,
+  reload,
+}: {
+  userNumber: bigint;
+  connection: AuthenticatedConnection;
+  device: DeviceData & RecoveryPhrase;
+  reload: () => void;
+}) => {
+  const confirmed = confirm(
+    "Reset your recovery phrase\n\nWas your recovery phrase compromised? Delete your recovery phrase and generate a new one by confirming."
+  );
+  if (!confirmed) {
+    return;
+  }
+
+  // Create a new recovery phrase
+  const recoveryPhrase = generate().trim();
+  const recoverIdentity = await fromMnemonicWithoutValidation(
+    recoveryPhrase,
+    IC_DERIVATION_PATH
+  );
+
+  // If the phrase is protected, prompt for the phrase
+  const newConnection = isProtected(device)
+    ? await deviceConnection(
+        connection,
+        userNumber,
+        device,
+        "Please input your recovery phrase to reset it."
+      )
+    : connection;
+
+  if (newConnection === null) {
+    // User aborted, just return
+    reload();
+    return;
+  }
+
+  // Save the old pubkey (used as index for replace)
+  const oldKey = device.pubkey;
+  device.pubkey = Array.from(
+    new Uint8Array(recoverIdentity.getPublicKey().toDer())
+  );
+
+  try {
+    await withLoader(() => newConnection.replace(oldKey, device));
+    await displaySeedPhrase(userNumber.toString(10) + " " + recoveryPhrase);
+  } catch (e: unknown) {
+    await displayError({
+      title: "Could not reset recovery phrase",
+      message: "An unexpected error occurred",
+      detail: e instanceof Error ? e.toString() : "unknown error",
+      primaryButton: "Ok",
+    });
+  }
+
+  reload();
+};
+
 /* Protect the device and re-render the device settings (with the updated device) */
 const protectDevice = async ({
   userNumber,
@@ -187,7 +229,7 @@ const protectDevice = async ({
 }: {
   userNumber: bigint;
   connection: AuthenticatedConnection;
-  device: DeviceData & RecoveryDevice;
+  device: DeviceData & RecoveryPhrase;
   reload: () => void;
 }) => {
   device.protection = { protected: null };
@@ -218,7 +260,7 @@ const protectDevice = async ({
 const unprotectDevice = async (
   userNumber: bigint,
   connection: AuthenticatedConnection,
-  device: DeviceData & RecoveryDevice,
+  device: DeviceData & RecoveryPhrase,
   isOnlyDevice: boolean,
   back: () => void
 ) => {

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -205,7 +205,8 @@ export const displayManage = (
         connection,
         device,
         isOnlyDevice: hasSingleDevice,
-        reload: () => renderManage(userNumber, connection),
+        reload: (newConnection?: AuthenticatedConnection) =>
+          renderManage(userNumber, newConnection ?? connection),
       }),
       label: isRecoveryDevice(device)
         ? recoveryDeviceToLabel(device)

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -86,4 +86,13 @@ export const FLOWS = {
 
     return seedPhrase;
   },
+  readSeedPhrase: async (browser: WebdriverIO.Browser): Promise<string> => {
+    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
+    await recoveryMethodSelectorView.waitForSeedPhrase();
+    const seedPhrase = await recoveryMethodSelectorView.getSeedPhrase();
+    await recoveryMethodSelectorView.acknowledgeCheckbox();
+    await recoveryMethodSelectorView.seedPhraseContinue();
+
+    return seedPhrase;
+  },
 };

--- a/src/frontend/src/test-e2e/recovery.test.ts
+++ b/src/frontend/src/test-e2e/recovery.test.ts
@@ -31,7 +31,7 @@ test("Recover access, after registration", async () => {
   });
 }, 300_000);
 
-test("Remove unprotected recovery phrase", async () => {
+test("Reset unprotected recovery phrase", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
@@ -45,11 +45,10 @@ test("Remove unprotected recovery phrase", async () => {
 
     // Ensure the settings dropdown is in view
     await browser.execute("window.scrollTo(0, document.body.scrollHeight)");
-    await mainView.remove(RECOVERY_PHRASE_NAME);
+    await mainView.reset(RECOVERY_PHRASE_NAME);
     await browser.acceptAlert();
-
+    const _seedPhrase = await FLOWS.readSeedPhrase(browser);
     await mainView.waitForDisplay();
-    await mainView.waitForDeviceNotDisplay(RECOVERY_PHRASE_NAME);
   });
 }, 300_000);
 
@@ -90,7 +89,7 @@ test("Make recovery unprotected", async () => {
   });
 }, 300_000);
 
-test("Remove protected recovery phrase", async () => {
+test("Reset protected recovery phrase", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
@@ -105,19 +104,21 @@ test("Remove protected recovery phrase", async () => {
     await mainView.protect(RECOVERY_PHRASE_NAME, seedPhrase);
 
     await mainView.waitForDisplay();
-    await mainView.remove(RECOVERY_PHRASE_NAME);
+    await mainView.reset(RECOVERY_PHRASE_NAME);
     await browser.acceptAlert();
 
     const recoveryView = new RecoverView(browser);
     await recoveryView.waitForSeedInputDisplay();
     await recoveryView.enterSeedPhrase(seedPhrase);
     await recoveryView.enterSeedPhraseContinue();
+
+    const _seedPhrase = await FLOWS.readSeedPhrase(browser);
+
     await mainView.waitForDisplay();
-    await mainView.waitForDeviceNotDisplay(RECOVERY_PHRASE_NAME);
   });
 }, 300_000);
 
-test("Remove protected recovery phrase, confirm with empty seed phrase", async () => {
+test("Reset protected recovery phrase, confirm with empty seed phrase", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
@@ -131,7 +132,7 @@ test("Remove protected recovery phrase, confirm with empty seed phrase", async (
     await browser.execute("window.scrollTo(0, document.body.scrollHeight)");
     await mainView.protect(RECOVERY_PHRASE_NAME, seedPhrase);
     await mainView.waitForDisplay();
-    await mainView.remove(RECOVERY_PHRASE_NAME);
+    await mainView.reset(RECOVERY_PHRASE_NAME);
 
     await browser.acceptAlert();
 

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -242,6 +242,19 @@ export class MainView extends View {
       .click();
   }
 
+  async reset(deviceName: string): Promise<void> {
+    // Ensure the dropdown is open by hovering/clicking (clicking is needed for mobile)
+    await this.browser
+      .$(`button.c-dropdown__trigger[data-device="${deviceName}"]`)
+      .click();
+    await this.browser
+      .$(`button[data-device="${deviceName}"][data-action='reset']`)
+      .waitForClickable();
+    await this.browser
+      .$(`button[data-device="${deviceName}"][data-action='reset']`)
+      .click();
+  }
+
   async removeNotDisplayed(deviceName: string): Promise<void> {
     await this.browser.$(`button[data-device="${deviceName}"]`).click();
     await this.browser

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -319,6 +319,22 @@ export class Connection {
     }
   }
 
+  fromIdentity = async (
+    userNumber: bigint,
+    identity: SignIdentity
+  ): Promise<AuthenticatedConnection> => {
+    const delegationIdentity = await this.requestFEDelegation(identity);
+    const actor = await this.createActor(delegationIdentity);
+
+    return new AuthenticatedConnection(
+      this.canisterId,
+      identity,
+      delegationIdentity,
+      userNumber,
+      actor
+    );
+  };
+
   fromSeedPhrase = async (
     userNumber: bigint,
     seedPhrase: string,

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -526,6 +526,11 @@ export class AuthenticatedConnection extends Connection {
     return await actor.update(this.userNumber, device.pubkey, device);
   };
 
+  replace = async (pubkey: DeviceKey, device: DeviceData): Promise<void> => {
+    const actor = await this.getActor();
+    return await actor.replace(this.userNumber, pubkey, device);
+  };
+
   remove = async (publicKey: PublicKey): Promise<void> => {
     const actor = await this.getActor();
     await actor.remove(this.userNumber, publicKey);

--- a/src/frontend/src/utils/recoveryDevice.ts
+++ b/src/frontend/src/utils/recoveryDevice.ts
@@ -4,6 +4,10 @@ export type RecoveryDevice = Omit<DeviceData, "alias"> & {
   purpose: { recovery: null };
 };
 
+export type RecoveryPhrase = RecoveryDevice & {
+  key_type: { seed_phrase: null };
+};
+
 export const recoveryDeviceToLabel = (device: RecoveryDevice): string => {
   if ("seed_phrase" in device.key_type) {
     return "Recovery Phrase";
@@ -30,6 +34,6 @@ export const hasRecoveryKey = (
 export const isProtected = (device: DeviceData): boolean =>
   "protected" in device.protection;
 
-export const isRecoveryPhrase = ({
-  key_type,
-}: Pick<DeviceData, "key_type">): boolean => "seed_phrase" in key_type;
+export const isRecoveryPhrase = (
+  device: Pick<DeviceData, "key_type">
+): device is RecoveryPhrase => "seed_phrase" in device.key_type;


### PR DESCRIPTION
In order to avoid users forgetting to add a new recovery phrase after removing an old one, we only allow _resetting_, meaning a new phrase is created upon removal. The `remove` setting is replaced with a `reset` setting.

Note:
* this is only a webapp matter and is not enforced by the canister.
* the phrase is replaced _before_ the user has confirmed they have copied the new phrase (but _after_ they have confirmed they want to reset it). This is not ideal and will be changed subsequently since the behavior also needs to be changed upon initial phrase creation.
* the phrase is not actually removed and a new one created, but `replace`d atomically.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
