### PR TITLE
Offer to enroll device upon recovery

### DIFF
--- a/src/frontend/src/components/alias/index.ts
+++ b/src/frontend/src/components/alias/index.ts
@@ -11,6 +11,8 @@ import copyJson from "./index.json";
 
 export const promptDeviceAliasTemplate = (props: {
   title: string;
+  message?: string;
+  cancelText?: string;
   continue: (alias: string) => void;
   cancel: () => void;
   i18n: I18n;
@@ -25,7 +27,9 @@ export const promptDeviceAliasTemplate = (props: {
   const promptDeviceAliasSlot = html`
     <hgroup class="t-centered">
       <h1 class="t-title t-title--main">${props.title}</h1>
-      <p class="t-lead t-paragraph l-stack">${copy.specify_alias}</p>
+      <p class="t-lead t-paragraph l-stack">
+        ${props.message ?? copy.specify_alias}
+      </p>
     </hgroup>
     <form
       id="registerForm"
@@ -71,7 +75,7 @@ export const promptDeviceAliasTemplate = (props: {
           class="c-button c-button--secondary"
           @click="${() => props.cancel()}"
         >
-          ${copy.cancel}
+          ${props.cancelText ?? copy.cancel}
         </button>
         <button id="pickAliasSubmit" type="submit" class="c-button">
           ${copy.next}
@@ -88,6 +92,8 @@ export const promptDeviceAliasTemplate = (props: {
 
 export const promptDeviceAliasPage = (props: {
   title: string;
+  message?: string;
+  cancelText?: string;
   cancel: () => void;
   continue: (alias: string) => void;
   container?: HTMLElement;
@@ -100,13 +106,19 @@ export const promptDeviceAliasPage = (props: {
 
 export const promptDeviceAlias = ({
   title,
+  message,
+  cancelText,
 }: {
   title: string;
+  message?: string;
+  cancelText?: string;
 }): Promise<string | null> =>
   new Promise((resolve) => {
     const i18n = new I18n();
     promptDeviceAliasPage({
       title,
+      message,
+      cancelText,
       cancel: () => resolve(null),
       continue: resolve,
       i18n,

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -25,7 +25,7 @@ export const register = async ({
 
     const [captcha, identity] = await Promise.all([
       connection.createChallenge(),
-      constructIdentity(),
+      constructIdentity({}),
     ]);
 
     const captchaResult = await promptCaptcha({

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -197,7 +197,7 @@ const iiPages: Record<string, () => void> = {
     phraseRecoveryPage(userNumber, dummyConnection, recoveryPhrase),
   recoverWithDevice: () =>
     deviceRecoveryPage(userNumber, dummyConnection, recoveryDevice),
-  constructing: () => renderConstructing(),
+  constructing: () => renderConstructing({}),
   promptCaptcha: () =>
     promptCaptchaPage({
       cancel: () => console.log("canceled"),
@@ -359,7 +359,7 @@ const iiPages: Record<string, () => void> = {
         },
       },
     }),
-  loader: () => withLoader(() => new Promise(() => renderConstructing())),
+  loader: () => withLoader(() => new Promise(() => renderConstructing({}))),
   displaySafariWarning: () =>
     displaySafariWarning(userNumber, dummyConnection, (_anchor, _conn) => {
       return Promise.resolve();

--- a/src/frontend/src/test-e2e/recovery.test.ts
+++ b/src/frontend/src/test-e2e/recovery.test.ts
@@ -27,6 +27,7 @@ test("Recover access, after registration", async () => {
     await recoveryView.waitForSeedInputDisplay();
     await recoveryView.enterSeedPhrase(seedPhrase);
     await recoveryView.enterSeedPhraseContinue();
+    await recoveryView.skipDeviceEnrollment();
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
   });
 }, 300_000);

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -575,6 +575,10 @@ export class RecoverView extends View {
     await this.browser.$("#inputSeedPhraseContinue").click();
   }
 
+  async skipDeviceEnrollment(): Promise<void> {
+    await this.browser.$("#pickAliasCancel").click();
+  }
+
   async waitForInvalidSeedPhraseDisplay(): Promise<void> {
     await this.browser.$("h3=Invalid Seed Phrase").waitForDisplayed();
   }


### PR DESCRIPTION
This adds a prompt right after the user has recovered their anchor, asking them if they want to enroll a new authenticator. The prompt offers to "skip" if the user does not want to enroll a new device.

_If_ the user decides to enroll a new device, then a new WebAuthn identity is constructed and `add`ed to the anchor.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
