### PR TITLE
Skip enrollment in test

### DIFF
--- a/src/frontend/src/test-e2e/recovery.test.ts
+++ b/src/frontend/src/test-e2e/recovery.test.ts
@@ -76,6 +76,7 @@ test("Reset unprotected recovery phrase, when authenticated with phrase", async 
     await recoveryView.waitForSeedInputDisplay();
     await recoveryView.enterSeedPhrase(seedPhrase);
     await recoveryView.enterSeedPhraseContinue();
+    await recoveryView.skipDeviceEnrollment();
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
 
     // Ensure the settings dropdown is in view


### PR DESCRIPTION
Recent changes conflicted in a test, where a new test didn't know how to skip device enrollment. The test is now fixed.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
