### PR TITLE
Show protected devices as 'lock'ed

### DIFF
--- a/src/frontend/src/components/deviceListItem.ts
+++ b/src/frontend/src/components/deviceListItem.ts
@@ -1,5 +1,5 @@
 import { TemplateResult, html } from "lit-html";
-import { Setting } from "../flows/manage/deviceSettings";
+import { Setting, settingName } from "../flows/manage/deviceSettings";
 import { warningIcon, dropdownIcon, lockIcon } from "./icons";
 
 // A simple representation of "device"s used on the manage page.
@@ -39,7 +39,7 @@ export const deviceListItem = ({
               class="c-tooltip c-tooltip--left c-icon c-icon--lock"
               tabindex="0"
               >${lockIcon}<span class="c-tooltip__message c-card c-card--tight"
-                >Your device is protected</span
+                >Your device is locked</span
               ></span
             >
           </div>`
@@ -75,7 +75,7 @@ export const deviceListItem = ({
                     data-action=${setting.label}
                     @click=${() => setting.fn()}
                   >
-                    ${setting.label}
+                    ${settingName[setting.label]}
                   </button>
                 </li>`;
               })}

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -21,7 +21,14 @@ import { IC_DERIVATION_PATH } from "../../utils/iiConnection";
 import { displaySeedPhrase } from "../recovery/displaySeedPhrase";
 
 // A particular device setting, e.g. remove, protect, etc
-export type Setting = { label: string; fn: () => void };
+export type Setting = { label: keyof typeof settingName; fn: () => void };
+
+export const settingName = {
+  protect: "Lock", // For users, protected devices are "lock"ed
+  unprotect: "Unlock",
+  remove: "Remove",
+  reset: "Reset",
+} as const;
 
 // Generate possible settings based on the device
 export const deviceSettings = ({
@@ -253,7 +260,7 @@ const protectDevice = async ({
     connection,
     userNumber,
     device,
-    "Please input your recovery phrase to protect it."
+    "Please input your recovery phrase to lock it."
   );
 
   await withLoader(async () => {
@@ -283,7 +290,7 @@ const unprotectDevice = async (
     connection,
     userNumber,
     device,
-    "Please input your recovery phrase to unprotect it."
+    "Please input your recovery phrase to unlock it."
   );
 
   await withLoader(async () => {

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -252,7 +252,7 @@ const iiPages: Record<string, () => void> = {
           isProtected: false,
           settings: [
             {
-              label: "Remove",
+              label: "remove",
               fn: () => Promise.resolve(),
             },
           ],
@@ -263,7 +263,7 @@ const iiPages: Record<string, () => void> = {
           isProtected: false,
           settings: [
             {
-              label: "Remove",
+              label: "remove",
               fn: () => Promise.resolve(),
             },
           ],
@@ -275,7 +275,7 @@ const iiPages: Record<string, () => void> = {
           warn: html`Something is rotten in the state of Device`,
           settings: [
             {
-              label: "Remove",
+              label: "remove",
               fn: () => Promise.resolve(),
             },
           ],
@@ -288,11 +288,11 @@ const iiPages: Record<string, () => void> = {
           isProtected: true,
           settings: [
             {
-              label: "Remove",
+              label: "remove",
               fn: () => Promise.resolve(),
             },
             {
-              label: "Protect",
+              label: "protect",
               fn: () => Promise.resolve(),
             },
           ],

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -421,11 +421,11 @@ impl fmt::Display for AnchorError {
             ),
             AnchorError::InvalidDeviceProtection { key_type } => write!(
                 f,
-                "Only recovery phrases can be protected but key type is {key_type:?}"
+                "Only recovery phrases can be locked but key type is {key_type:?}"
             ),
             AnchorError::MutationNotAllowed { actual_principal, authorized_principal } => write!(
                 f,
-                "Device is protected. Must be authenticated with this device to mutate: authorized principal {authorized_principal}, actual principal {actual_principal}"
+                "Device is locked. Must be authenticated with this device to mutate: authorized principal {authorized_principal}, actual principal {actual_principal}"
             ),
             AnchorError::MultipleRecoveryPhrases => write!(f, "There is already a recovery phrase and only one is allowed."),
             AnchorError::CannotModifyDeviceKey => write!(f, "Device key cannot be updated."),

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -425,7 +425,7 @@ mod registration_tests {
         expect_user_error_with_message(
             result,
             CanisterCalledTrap,
-            Regex::new("Only recovery phrases can be protected but key type is Unknown").unwrap(),
+            Regex::new("Only recovery phrases can be locked but key type is Unknown").unwrap(),
         );
         Ok(())
     }
@@ -1556,7 +1556,7 @@ mod device_management_tests {
             expect_user_error_with_message(
                 result,
                 CanisterCalledTrap,
-                Regex::new("Device is protected. Must be authenticated with this device to mutate")
+                Regex::new("Device is locked. Must be authenticated with this device to mutate")
                     .unwrap(),
             );
         }
@@ -1582,8 +1582,7 @@ mod device_management_tests {
             expect_user_error_with_message(
                 result,
                 CanisterCalledTrap,
-                Regex::new("Only recovery phrases can be protected but key type is Unknown")
-                    .unwrap(),
+                Regex::new("Only recovery phrases can be locked but key type is Unknown").unwrap(),
             );
         }
     }
@@ -1837,7 +1836,7 @@ mod device_management_tests {
         expect_user_error_with_message(
             result,
             CanisterCalledTrap,
-            Regex::new("Device is protected. Must be authenticated with this device to mutate")
+            Regex::new("Device is locked. Must be authenticated with this device to mutate")
                 .unwrap(),
         );
     }


### PR DESCRIPTION
This renames "protected" devices to "locked" in the UI.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
