### PR TITLE
Document IdentityAnchorInfo & DeviceRegistrationInfo

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -206,13 +206,22 @@ type ChallengeResult = record {
     chars : text;
 };
 
+// Extra information about registration status for new devices
 type DeviceRegistrationInfo = record {
+    // If present, the user has tentatively added a new device. This
+    // new device needs to be verified (see relevant endpoint) before
+    // 'expiration'.
     tentative_device : opt DeviceData;
+    // The timestamp at which the anchor will turn off registration mode
+    // (and the tentative device will be forgotten, if any, and if not verified)
     expiration: Timestamp;
 };
 
+// Information about the anchor
 type IdentityAnchorInfo = record {
+    // All devices that can authenticate to this anchor
     devices : vec DeviceWithUsage;
+    // Device registration status used when adding devices, see DeviceRegistrationInfo
     device_registration: opt DeviceRegistrationInfo;
 };
 


### PR DESCRIPTION
This adds some context to two types used in the device registration flow.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
