### PR TITLE
Make manage flows explicit

### DIFF
--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -59,7 +59,7 @@ export const authenticateBox = async (
         register: () => {
           resolve(registerIfAllowed(connection));
         },
-        recover: (userNumber) => useRecovery(connection, userNumber),
+        recover: (userNumber) => resolve(useRecovery(connection, userNumber)),
       });
 
       // If there _are_ some anchors, then we show the "pick" screen, otherwise

--- a/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
@@ -6,7 +6,6 @@ import { DeviceData } from "../../../../generated/internet_identity_types";
 import { WebAuthnIdentity } from "@dfinity/identity";
 import { promptDeviceAlias } from "../../../components/alias";
 import { withLoader } from "../../../components/loader";
-import { renderManage } from "../../manage";
 import { displayError } from "../../../components/displayError";
 import { setAnchorUsed } from "../../../utils/userNumber";
 
@@ -41,12 +40,12 @@ export const addLocalDevice = async (
     await displayFailedToAddDevice(
       error instanceof Error ? error : unknownError()
     );
-    return renderManage(userNumber, connection);
+    return;
   }
   const deviceName = await promptDeviceAlias({ title: "Add a Trusted Device" });
   if (deviceName === null) {
-    // user clicked "cancel", so we go back to "manage"
-    return await renderManage(userNumber, connection);
+    // user clicked "cancel", so we return
+    return;
   }
   try {
     await withLoader(() =>
@@ -66,7 +65,6 @@ export const addLocalDevice = async (
   }
 
   setAnchorUsed(userNumber);
-  await renderManage(userNumber, connection);
 };
 
 const unknownError = (): Error => {

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -1,6 +1,6 @@
 import { displayError } from "../../components/displayError";
 import { Connection, AuthenticatedConnection } from "../../utils/iiConnection";
-import { renderManage } from "../manage";
+import { LoginFlowResult } from "../../utils/flowResult";
 import { promptUserNumber } from "../../components/promptUserNumber";
 import { promptDeviceAlias } from "../../components/alias";
 import { phraseRecoveryPage } from "./recoverWith/phrase";
@@ -14,7 +14,7 @@ import { constructIdentity } from "../register/construct";
 export const useRecovery = async (
   connection: Connection,
   userNumber?: bigint
-): Promise<void> => {
+): Promise<LoginFlowResult> => {
   if (userNumber !== undefined) {
     return runRecovery(userNumber, connection);
   } else {
@@ -24,7 +24,7 @@ export const useRecovery = async (
     if (pUserNumber !== "canceled") {
       return runRecovery(pUserNumber, connection);
     } else {
-      return window.location.reload();
+      return window.location.reload() as never;
     }
   }
 };
@@ -32,7 +32,7 @@ export const useRecovery = async (
 const runRecovery = async (
   userNumber: bigint,
   connection: Connection
-): Promise<void> => {
+): Promise<LoginFlowResult> => {
   const recoveryDevices = await connection.lookupRecovery(userNumber);
   if (recoveryDevices.length === 0) {
     await displayError({
@@ -40,7 +40,7 @@ const runRecovery = async (
       message: `You do not have any recovery devices configured for anchor ${userNumber}. Did you mean to authenticate with one of your devices instead?`,
       primaryButton: "Go back",
     });
-    return window.location.reload();
+    return window.location.reload() as never;
   }
 
   const device =
@@ -54,7 +54,7 @@ const runRecovery = async (
 
   // If res is null, the user canceled the flow, so we go back to the main page.
   if (res.tag === "canceled") {
-    return window.location.reload();
+    return window.location.reload() as never;
   }
 
   const deviceAlias = await promptDeviceAlias({
@@ -71,7 +71,7 @@ const runRecovery = async (
     });
   }
 
-  void renderManage(res.userNumber, res.connection);
+  return res;
 };
 
 // Offer to enroll a new device


### PR DESCRIPTION
The `renderManage` page is the starting point for many flows, but all these flows also lead back to it. This was somewhat implicit.

These changes make the "infinite loop" nature of the management page explicit and updates all flows to _not_ decide what to do next; instead this is left to the caller (often `renderManage`). This makes the flows more modular and clarifies the return values. Another benefit is that calls to `renderManage` aren't nested anymore (js doesn't generally have tail recursion optimization).

This made an issue apparent in `pollForTentativeDevice`, where the loader was never exited; now fixed.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
