### PR TITLE
Rename WebauthnCredential to WebAuthnCredential

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -62,14 +62,14 @@ export const idlFactory = ({ IDL }) => {
     'anchor_number' : UserNumber,
     'timestamp' : Timestamp,
   });
-  const WebauthnCredential = IDL.Record({
+  const WebAuthnCredential = IDL.Record({
     'pubkey' : PublicKey,
     'credentialId' : CredentialId,
   });
   const AnchorCredentials = IDL.Record({
     'recovery_phrase' : IDL.Vec(PublicKey),
-    'credentials' : IDL.Vec(WebauthnCredential),
-    'recovery_credentials' : IDL.Vec(WebauthnCredential),
+    'credentials' : IDL.Vec(WebAuthnCredential),
+    'recovery_credentials' : IDL.Vec(WebAuthnCredential),
   });
   const DeviceWithUsage = IDL.Record({
     'alias' : IDL.Text,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -11,8 +11,8 @@ export type AddTentativeDeviceResponse = {
   };
 export interface AnchorCredentials {
   'recovery_phrase' : Array<PublicKey>,
-  'credentials' : Array<WebauthnCredential>,
-  'recovery_credentials' : Array<WebauthnCredential>,
+  'credentials' : Array<WebAuthnCredential>,
+  'recovery_credentials' : Array<WebAuthnCredential>,
 }
 export interface ArchiveConfig {
   'polling_interval_ns' : bigint,
@@ -136,7 +136,7 @@ export type VerifyTentativeDeviceResponse = {
   { 'verified' : null } |
   { 'wrong_code' : { 'retries_left' : number } } |
   { 'no_device_to_verify' : null };
-export interface WebauthnCredential {
+export interface WebAuthnCredential {
   'pubkey' : PublicKey,
   'credentialId' : CredentialId,
 }

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -217,12 +217,12 @@ type IdentityAnchorInfo = record {
 };
 
 type AnchorCredentials = record {
-    credentials : vec WebauthnCredential;
-    recovery_credentials : vec WebauthnCredential;
+    credentials : vec WebAuthnCredential;
+    recovery_credentials : vec WebAuthnCredential;
     recovery_phrase: vec PublicKey;
 };
 
-type WebauthnCredential = record {
+type WebAuthnCredential = record {
     credentialId : CredentialId;
     pubkey: PublicKey;
 };

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -130,7 +130,7 @@ fn get_anchor_credentials(anchor_number: AnchorNumber) -> AnchorCredentials {
             if device.key_type == KeyType::SeedPhrase {
                 credentials.recovery_phrases.push(device.pubkey);
             } else if let Some(credential_id) = device.credential_id {
-                let credential = WebauthnCredential {
+                let credential = WebAuthnCredential {
                     pubkey: device.pubkey,
                     credential_id,
                 };

--- a/src/internet_identity/tests/tests.rs
+++ b/src/internet_identity/tests/tests.rs
@@ -1633,18 +1633,18 @@ mod device_management_tests {
             let response = api::get_anchor_credentials(&env, canister_id, user_number)?;
 
             assert_eq!(response.credentials.len(), 2);
-            assert!(response.credentials.contains(&WebauthnCredential {
+            assert!(response.credentials.contains(&WebAuthnCredential {
                 pubkey: device_data_1().pubkey,
                 credential_id: device_data_1().credential_id.unwrap()
             }));
-            assert!(response.credentials.contains(&WebauthnCredential {
+            assert!(response.credentials.contains(&WebAuthnCredential {
                 pubkey: device_data_2().pubkey,
                 credential_id: device_data_2().credential_id.unwrap()
             }));
 
             assert_eq!(
                 response.recovery_credentials,
-                vec![WebauthnCredential {
+                vec![WebAuthnCredential {
                     pubkey: recovery_webauthn_device.pubkey.clone(),
                     credential_id: recovery_webauthn_device.credential_id.unwrap()
                 }]
@@ -1669,7 +1669,7 @@ mod device_management_tests {
 
             assert_eq!(
                 response.credentials,
-                vec![WebauthnCredential {
+                vec![WebAuthnCredential {
                     pubkey: device_data_1().pubkey,
                     credential_id: device_data_1().credential_id.unwrap()
                 }]

--- a/src/internet_identity_interface/src/lib.rs
+++ b/src/internet_identity_interface/src/lib.rs
@@ -191,15 +191,15 @@ impl IdentityAnchorInfo {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub struct WebauthnCredential {
+pub struct WebAuthnCredential {
     pub pubkey: DeviceKey,
     pub credential_id: CredentialId,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct AnchorCredentials {
-    pub credentials: Vec<WebauthnCredential>,
-    pub recovery_credentials: Vec<WebauthnCredential>,
+    pub credentials: Vec<WebAuthnCredential>,
+    pub recovery_credentials: Vec<WebAuthnCredential>,
     pub recovery_phrases: Vec<PublicKey>,
 }
 


### PR DESCRIPTION
This renaming makes the name consistent with the usual capitalization of WebAuthn.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
