### PR TITLE
Rename recovery_phrase to recovery_phrases

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -67,7 +67,7 @@ export const idlFactory = ({ IDL }) => {
     'credentialId' : CredentialId,
   });
   const AnchorCredentials = IDL.Record({
-    'recovery_phrase' : IDL.Vec(PublicKey),
+    'recovery_phrases' : IDL.Vec(PublicKey),
     'credentials' : IDL.Vec(WebAuthnCredential),
     'recovery_credentials' : IDL.Vec(WebAuthnCredential),
   });

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -10,7 +10,7 @@ export type AddTentativeDeviceResponse = {
     }
   };
 export interface AnchorCredentials {
-  'recovery_phrase' : Array<PublicKey>,
+  'recovery_phrases' : Array<PublicKey>,
   'credentials' : Array<WebAuthnCredential>,
   'recovery_credentials' : Array<WebAuthnCredential>,
 }

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -228,7 +228,7 @@ type IdentityAnchorInfo = record {
 type AnchorCredentials = record {
     credentials : vec WebAuthnCredential;
     recovery_credentials : vec WebAuthnCredential;
-    recovery_phrase: vec PublicKey;
+    recovery_phrases: vec PublicKey;
 };
 
 type WebAuthnCredential = record {


### PR DESCRIPTION
This fixes an error introduced in a late change on #1280 that introduced
the `get_credentials` endpoint.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
