### PR TITLE
Normalize ambiguous characters in captcha

### DIFF
--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -13,7 +13,7 @@ use rand_core::{RngCore, SeedableRng};
 use std::collections::HashMap;
 
 #[cfg(not(feature = "dummy_captcha"))]
-use captcha::filters::{Grid, Wave};
+use captcha::filters::Wave;
 use lazy_static::lazy_static;
 
 // 5 mins

--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -166,7 +166,7 @@ fn check_challenge(res: ChallengeAttempt) -> Result<(), ()> {
     }
     // Normalize challenge attempts by replacing characters that are not in the captcha character set
     // with the respective replacement from CHAR_REPLACEMENTS.
-    let normalized_challenge: String = res
+    let normalized_challenge_res: String = res
         .chars
         .chars()
         .map(|c| *CHAR_REPLACEMENTS.get(&c).unwrap_or(&c))
@@ -175,7 +175,7 @@ fn check_challenge(res: ChallengeAttempt) -> Result<(), ()> {
     state::inflight_challenges_mut(|inflight_challenges| {
         match inflight_challenges.remove(&res.key) {
             Some(challenge) => {
-                if normalized_challenge != challenge.chars {
+                if normalized_challenge_res != challenge.chars {
                     return Err(());
                 }
                 Ok(())

--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -10,9 +10,11 @@ use ic_cdk::{call, caller, trap};
 use internet_identity_interface::archive::{DeviceDataWithoutAlias, Operation};
 use internet_identity_interface::*;
 use rand_core::{RngCore, SeedableRng};
+use std::collections::HashMap;
 
 #[cfg(not(feature = "dummy_captcha"))]
-use captcha::filters::Wave;
+use captcha::filters::{Grid, Wave};
+use lazy_static::lazy_static;
 
 // 5 mins
 const CAPTCHA_CHALLENGE_LIFETIME: u64 = secs_to_nanos(300);
@@ -118,11 +120,30 @@ fn create_captcha<T: RngCore>(rng: T) -> (Base64, String) {
     return (resp, captcha.chars_as_string());
 }
 
+lazy_static! {
+    /// Map of problematic characters that are easily mixed up by humans to the "normalized" replacement.
+    /// I.e. the captcha will never contain any of the characters in the key set and any input provided
+    /// will be mapped to the matching value.
+    /// Note: the captcha library already excludes the characters o, O and 0.
+    static ref CHAR_REPLACEMENTS: HashMap<char, char> = vec![
+        ('C', 'c'),
+        ('l', '1'),
+        ('X', 'x'),
+        ('Y', 'y'),
+        ('Z', 'z'),
+    ].into_iter().collect();
+}
+
+const CAPTCHA_LENGTH: usize = 5;
 #[cfg(not(feature = "dummy_captcha"))]
 fn create_captcha<T: RngCore>(rng: T) -> (Base64, String) {
     let mut captcha = captcha::RngCaptcha::from_rng(rng);
+    let mut chars = captcha.supported_chars();
+    chars.retain(|c| !CHAR_REPLACEMENTS.contains_key(c));
+
     let captcha = captcha
-        .add_chars(5)
+        .set_chars(&chars)
+        .add_chars(CAPTCHA_LENGTH as u32)
         .apply_filter(Wave::new(2.0, 20.0).horizontal())
         .apply_filter(Wave::new(2.0, 20.0).vertical())
         .view(220, 120);
@@ -139,10 +160,22 @@ fn create_captcha<T: RngCore>(rng: T) -> (Base64, String) {
 
 // Check whether the CAPTCHA challenge was solved
 fn check_challenge(res: ChallengeAttempt) -> Result<(), ()> {
+    // avoid processing too many characters
+    if res.chars.len() > CAPTCHA_LENGTH {
+        return Err(());
+    }
+    // Normalize challenge attempts by replacing characters that are not in the captcha character set
+    // with the respective replacement from CHAR_REPLACEMENTS.
+    let normalized_challenge: String = res
+        .chars
+        .chars()
+        .map(|c| *CHAR_REPLACEMENTS.get(&c).unwrap_or(&c))
+        .collect();
+
     state::inflight_challenges_mut(|inflight_challenges| {
         match inflight_challenges.remove(&res.key) {
             Some(challenge) => {
-                if res.chars != challenge.chars {
+                if normalized_challenge != challenge.chars {
                     return Err(());
                 }
                 Ok(())


### PR DESCRIPTION
This PR makes the captcha easier to solve for humans by normalizing confusing characters (such as `l` and `1`).

E.g. this means that no captcha containing l will be generated and all inputs into captcha solutions will map `l` to `1`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
