### PR TITLE
Fix hash equality

### DIFF
--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -95,7 +95,7 @@ const init = async () => {
   const connection = new Connection(readCanisterId());
 
   // Simple, #-based routing
-  if (url.hash == "#authorize") {
+  if (url.hash === "#authorize") {
     // User was brought here by a dapp for authorization
     void authFlowAuthorize(connection);
   } else {


### PR DESCRIPTION
This uses the recommended `===` instead of `==` for (string) hash comparison. Typo the first time around.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
