### PR TITLE
Clarify tentative device registration flow

### DIFF
--- a/src/frontend/src/components/alias/index.ts
+++ b/src/frontend/src/components/alias/index.ts
@@ -11,7 +11,7 @@ import copyJson from "./index.json";
 
 export const promptDeviceAliasTemplate = (props: {
   title: string;
-  message?: string;
+  message?: string | TemplateResult;
   cancelText?: string;
   continue: (alias: string) => void;
   cancel: () => void;
@@ -92,7 +92,7 @@ export const promptDeviceAliasTemplate = (props: {
 
 export const promptDeviceAliasPage = (props: {
   title: string;
-  message?: string;
+  message?: string | TemplateResult;
   cancelText?: string;
   cancel: () => void;
   continue: (alias: string) => void;
@@ -110,7 +110,7 @@ export const promptDeviceAlias = ({
   cancelText,
 }: {
   title: string;
-  message?: string;
+  message?: string | TemplateResult;
   cancelText?: string;
 }): Promise<string | null> =>
   new Promise((resolve) => {

--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -78,11 +78,11 @@ export const deviceRegistrationDisabledInfoPage = (
 export const deviceRegistrationDisabledInfo = (
   userNumber: bigint
 ): Promise<"canceled" | "retry"> => {
-  return new Promise((resolve) => {
-    return deviceRegistrationDisabledInfoPage({
+  return new Promise((resolve) =>
+    deviceRegistrationDisabledInfoPage({
       userNumber,
       cancel: () => resolve("canceled"),
       retry: () => resolve("retry"),
-    });
-  });
+    })
+  );
 };

--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -1,13 +1,16 @@
 import { html, render } from "lit-html";
-import { Connection } from "../../../utils/iiConnection";
-import {
-  addTentativeDevice,
-  TentativeDeviceInfo,
-} from "./registerTentativeDevice";
 import { mainWindow } from "../../../components/mainWindow";
 import { LEGACY_II_URL_NO_PROTOCOL } from "../../../config";
 
-const pageContent = (userNumber: bigint) => {
+const deviceRegistrationDisabledInfoTemplate = ({
+  userNumber,
+  cancel,
+  retry,
+}: {
+  userNumber: bigint;
+  cancel: () => void;
+  retry: () => void;
+}) => {
   const pageContentSlot = html` <article>
     <hgroup>
       <h1 class="t-title t-title--main">
@@ -35,10 +38,17 @@ const pageContent = (userNumber: bigint) => {
     </ol>
     <p class="t-paragraph t-strong">Then, press Retry below.</p>
     <div class="l-stack">
-      <button id="deviceRegModeDisabledRetry" class="c-button">Retry</button>
+      <button
+        id="deviceRegModeDisabledRetry"
+        class="c-button"
+        @click=${() => retry()}
+      >
+        Retry
+      </button>
       <button
         id="deviceRegModeDisabledCancel"
         class="c-button c-button--secondary"
+        @click=${() => cancel()}
       >
         Cancel
       </button>
@@ -51,38 +61,28 @@ const pageContent = (userNumber: bigint) => {
     slot: pageContentSlot,
   });
 };
+
+export const deviceRegistrationDisabledInfoPage = (
+  props: Parameters<typeof deviceRegistrationDisabledInfoTemplate>[0],
+  container?: HTMLElement
+): void => {
+  const contain =
+    container ?? (document.getElementById("pageContent") as HTMLElement);
+  render(deviceRegistrationDisabledInfoTemplate(props), contain);
+};
+
 /**
  * Error page which is shown if the identy anchor does not have device registration mode enabled.
  * It shows instructions to the user on how to continue.
- * @param tentativeDeviceInfo Information about the device to be added so that the user does not have to enter everything again after enabling device registration mode.
  */
 export const deviceRegistrationDisabledInfo = (
-  connection: Connection,
-  tentativeDeviceInfo: TentativeDeviceInfo
-): void => {
-  const container = document.getElementById("pageContent") as HTMLElement;
-  render(pageContent(tentativeDeviceInfo[0]), container);
-  return init(connection, tentativeDeviceInfo);
-};
-
-const init = (
-  connection: Connection,
-  tentativeDeviceInfo: TentativeDeviceInfo
-): void => {
-  const cancelButton = document.getElementById(
-    "deviceRegModeDisabledCancel"
-  ) as HTMLButtonElement;
-
-  cancelButton.onclick = () => {
-    // TODO L2-309: do this without reload
-    window.location.reload();
-  };
-
-  const retryButton = document.getElementById(
-    "deviceRegModeDisabledRetry"
-  ) as HTMLButtonElement;
-
-  retryButton.onclick = async () => {
-    await addTentativeDevice(connection, tentativeDeviceInfo);
-  };
+  userNumber: bigint
+): Promise<"canceled" | "retry"> => {
+  return new Promise((resolve) => {
+    return deviceRegistrationDisabledInfoPage({
+      userNumber,
+      cancel: () => resolve("canceled"),
+      retry: () => resolve("retry"),
+    });
+  });
 };

--- a/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -92,9 +92,8 @@ const createDevice = async ({
   const existingAuthenticators = await connection.lookupAuthenticators(
     userNumber
   );
-  let newDevice: WebAuthnIdentity;
   try {
-    newDevice = await WebAuthnIdentity.create({
+    return await WebAuthnIdentity.create({
       publicKey: creationOptions(existingAuthenticators),
     });
   } catch (error: unknown) {
@@ -104,7 +103,6 @@ const createDevice = async ({
       return new Error(unknownToString(error, "unknown error"));
     }
   }
-  return newDevice;
 };
 
 type AddDeviceSuccess = Extract<

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -33,11 +33,7 @@ import { displaySingleDeviceWarning } from "./flows/recovery/displaySingleDevice
 import { displayManagePage, authnTemplateManage } from "./flows/manage";
 import { chooseDeviceAddFlow } from "./flows/addDevice/manage";
 import { pollForTentativeDevicePage } from "./flows/addDevice/manage/pollForTentativeDevice";
-import {
-  registerTentativeDevice,
-  TentativeDeviceInfo,
-} from "./flows/addDevice/welcomeView/registerTentativeDevice";
-import { deviceRegistrationDisabledInfo } from "./flows/addDevice/welcomeView/deviceRegistrationModeDisabled";
+import { deviceRegistrationDisabledInfoPage } from "./flows/addDevice/welcomeView/deviceRegistrationModeDisabled";
 import { showVerificationCodePage } from "./flows/addDevice/welcomeView/showVerificationCode";
 import { verifyTentativeDevicePage } from "./flows/addDevice/manage/verifyTentativeDevice";
 import { mkAnchorPicker } from "./components/anchorPicker";
@@ -335,12 +331,12 @@ const iiPages: Record<string, () => void> = {
         },
       },
     }),
-  registerTentativeDevice: () =>
-    registerTentativeDevice(userNumber, dummyConnection),
   deviceRegistrationDisabledInfo: () =>
-    deviceRegistrationDisabledInfo(dummyConnection, [
+    deviceRegistrationDisabledInfoPage({
       userNumber,
-    ] as unknown as TentativeDeviceInfo),
+      retry: () => console.log("retry"),
+      cancel: () => console.log("canceled"),
+    }),
   showVerificationCode: () =>
     showVerificationCodePage({
       alias: simpleDevices[0].alias,

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -298,7 +298,7 @@ export class AddDeviceFlowSelectorView extends View {
 export class AddRemoteDeviceAliasView extends View {
   async waitForDisplay(): Promise<void> {
     await this.browser
-      .$("#registerTentativeDeviceContinue")
+      .$("#pickAliasSubmit")
       .waitForDisplayed({ timeout: 5_000 });
 
     // Make sure the loader is gone
@@ -306,7 +306,7 @@ export class AddRemoteDeviceAliasView extends View {
   }
 
   async selectAlias(alias: string): Promise<void> {
-    await this.browser.$("#tentativeDeviceAlias").setValue(alias);
+    await this.browser.$("#pickAliasInput").setValue(alias);
   }
 
   async continue(): Promise<void> {
@@ -314,7 +314,7 @@ export class AddRemoteDeviceAliasView extends View {
     await this.browser.execute(
       "window.scrollTo(0, document.body.scrollHeight)"
     );
-    await this.browser.$("#registerTentativeDeviceContinue").click();
+    await this.browser.$("#pickAliasSubmit").click();
   }
 }
 

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -394,22 +394,11 @@ export class Connection {
 
   addTentativeDevice = async (
     userNumber: UserNumber,
-    alias: string,
-    keyType: KeyType,
-    purpose: Purpose,
-    newPublicKey: DerEncodedPublicKey,
-    credentialId?: ArrayBuffer
+    device: Omit<DeviceData, "origin">
   ): Promise<AddTentativeDeviceResponse> => {
     const actor = await this.createActor();
     return await actor.add_tentative_device(userNumber, {
-      alias,
-      pubkey: Array.from(new Uint8Array(newPublicKey)),
-      credential_id: credentialId
-        ? [Array.from(new Uint8Array(credentialId))]
-        : [],
-      key_type: keyType,
-      purpose,
-      protection: { unprotected: null },
+      ...device,
       origin: window?.origin === undefined ? [] : [window.origin],
     });
   };


### PR DESCRIPTION
This updates the code for device registration by making it a bit more modular:

* Looping (mostly for retries) is made explicit
* More idiomatic lit constructs are used
* Return types are made to reflect what the code does; in particular the `Promise` returned by `registerTentativeDevice` now only resolves once the flow is over (previously it resolved instantly)
* The temporary `TentativeDeviceInfo` type is removed since it was just `DeviceData` in disguise
* The `deviceRegistrationModeDisabled` screen now returns the user result (cancel or retry) and lets the caller decide what to do next

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
