### PR TITLE
Make error message on missing platform auth more actionable

### DIFF
--- a/src/frontend/src/utils/featureDetection.ts
+++ b/src/frontend/src/utils/featureDetection.ts
@@ -17,9 +17,9 @@ export const checkRequiredFeatures = async (
   try {
     return (await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable())
       ? true
-      : "UserVerifyingPlatformAuthenticator is not available";
+      : "This device does not offer WebAuthn authentication. Please make sure you have biometrics (fingerprint / Touch ID / Face ID) enabled and try again.";
   } catch (error) {
-    return `An error occured when checking for compatibility: ${wrapError(
+    return `An error occurred when checking for compatibility: ${wrapError(
       error
     )}`;
   }


### PR DESCRIPTION
This changes the error message that we show on mobile if there is no platform authenticator to something more understandable.

It is not quite clear (yet) when this check fails. However, [there is evidence](https://forum.dfinity.org/t/two-phones-same-chrome-version-different-experience/18838/4) that it is related to biometrics being disabled. Given that the previous error message was meaningless to users, this should be an improvement at least for those cases where the relation to biometrics is given.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
