### PR TITLE
Add helper for rendering page

### DIFF
--- a/src/frontend/src/components/alias/index.ts
+++ b/src/frontend/src/components/alias/index.ts
@@ -1,6 +1,7 @@
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
 import { withRef } from "../../utils/lit-html";
-import { html, render, TemplateResult } from "lit-html";
+import { html, TemplateResult } from "lit-html";
+import { renderPage } from "../../utils/lit-html";
 import { validateAlias } from "../../utils/validateAlias";
 import { I18n } from "../../i18n";
 import { mainWindow } from "../../components/mainWindow";
@@ -90,19 +91,7 @@ export const promptDeviceAliasTemplate = (props: {
   });
 };
 
-export const promptDeviceAliasPage = (props: {
-  title: string;
-  message?: string | TemplateResult;
-  cancelText?: string;
-  cancel: () => void;
-  continue: (alias: string) => void;
-  container?: HTMLElement;
-  i18n: I18n;
-}): void => {
-  const container =
-    props.container ?? (document.getElementById("pageContent") as HTMLElement);
-  render(promptDeviceAliasTemplate(props), container);
-};
+export const promptDeviceAliasPage = renderPage(promptDeviceAliasTemplate);
 
 export const promptDeviceAlias = ({
   title,

--- a/src/frontend/src/components/alias/test.ts
+++ b/src/frontend/src/components/alias/test.ts
@@ -6,13 +6,15 @@ test("can be canceled", () => {
   const ctn = jest.fn((_str) => {
     /* */
   });
-  promptDeviceAliasPage({
-    title: "Title",
-    continue: ctn,
-    cancel,
-    container: document.body,
-    i18n: new I18n(),
-  });
+  promptDeviceAliasPage(
+    {
+      title: "Title",
+      continue: ctn,
+      cancel,
+      i18n: new I18n(),
+    },
+    document.body
+  );
 
   const elem = document.querySelector("#pickAliasCancel") as HTMLElement;
   elem.click();
@@ -25,13 +27,15 @@ test("can be picked", () => {
   const ctn = jest.fn((_str) => {
     /* */
   });
-  promptDeviceAliasPage({
-    title: "Title",
-    continue: ctn,
-    cancel,
-    container: document.body,
-    i18n: new I18n(),
-  });
+  promptDeviceAliasPage(
+    {
+      title: "Title",
+      continue: ctn,
+      cancel,
+      i18n: new I18n(),
+    },
+    document.body
+  );
 
   const input = document.querySelector("#pickAliasInput") as HTMLInputElement;
   input.value = "foo";

--- a/src/frontend/src/components/promptUserNumber.ts
+++ b/src/frontend/src/components/promptUserNumber.ts
@@ -1,4 +1,5 @@
-import { html, render, TemplateResult } from "lit-html";
+import { html, TemplateResult } from "lit-html";
+import { renderPage } from "../utils/lit-html";
 import { Ref, ref, createRef } from "lit-html/directives/ref.js";
 import { mkAnchorInput } from "./anchorInput";
 import { mainWindow } from "./mainWindow";
@@ -50,14 +51,7 @@ const promptUserNumberTemplate = ({
   });
 };
 
-export const promptUserNumberPage = (
-  props: Parameters<typeof promptUserNumberTemplate>[0],
-  container?: HTMLElement
-): void => {
-  const contain =
-    container ?? (document.getElementById("pageContent") as HTMLElement);
-  render(promptUserNumberTemplate(props), contain);
-};
+export const promptUserNumberPage = renderPage(promptUserNumberTemplate);
 
 export const promptUserNumber = ({
   title,

--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -1,8 +1,9 @@
-import { html, render } from "lit-html";
+import { html } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { AsyncCountdown } from "../../../utils/countdown";
 import { AuthenticatedConnection } from "../../../utils/iiConnection";
 import { delayMillis } from "../../../utils/utils";
+import { renderPage } from "../../../utils/lit-html";
 import {
   DeviceData,
   Timestamp,
@@ -67,14 +68,9 @@ const pollForTentativeDeviceTemplate = ({
   });
 };
 
-export const pollForTentativeDevicePage = (
-  props: Parameters<typeof pollForTentativeDeviceTemplate>[0],
-  container?: HTMLElement
-): void => {
-  const contain =
-    container ?? (document.getElementById("pageContent") as HTMLElement);
-  render(pollForTentativeDeviceTemplate(props), contain);
-};
+export const pollForTentativeDevicePage = renderPage(
+  pollForTentativeDeviceTemplate
+);
 
 /**
  * Polls for a tentative device to be added and shows instructions on how to continue the device registration process on the new device.

--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -1,8 +1,8 @@
-import { html, render } from "lit-html";
+import { html } from "lit-html";
 import { unreachableLax, unknownToString } from "../../../utils/utils";
 import { createRef, ref } from "lit-html/directives/ref.js";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
-import { withRef } from "../../../utils/lit-html";
+import { withRef, renderPage } from "../../../utils/lit-html";
 import { AuthenticatedConnection } from "../../../utils/iiConnection";
 import { withLoader } from "../../../components/loader";
 import { displayError } from "../../../components/displayError";
@@ -115,14 +115,9 @@ const verifyTentativeDeviceTemplate = ({
   });
 };
 
-export const verifyTentativeDevicePage = (
-  props: Parameters<typeof verifyTentativeDeviceTemplate>[0],
-  container?: HTMLElement
-): void => {
-  const contain =
-    container ?? (document.getElementById("pageContent") as HTMLElement);
-  render(verifyTentativeDeviceTemplate(props), contain);
-};
+export const verifyTentativeDevicePage = renderPage(
+  verifyTentativeDeviceTemplate
+);
 
 /**
  * Page to verify the tentative device: the device verification code can be entered and is the checked on the canister.

--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -1,4 +1,5 @@
-import { html, render } from "lit-html";
+import { html } from "lit-html";
+import { renderPage } from "../../../utils/lit-html";
 import { mainWindow } from "../../../components/mainWindow";
 import { LEGACY_II_URL_NO_PROTOCOL } from "../../../config";
 
@@ -62,14 +63,9 @@ const deviceRegistrationDisabledInfoTemplate = ({
   });
 };
 
-export const deviceRegistrationDisabledInfoPage = (
-  props: Parameters<typeof deviceRegistrationDisabledInfoTemplate>[0],
-  container?: HTMLElement
-): void => {
-  const contain =
-    container ?? (document.getElementById("pageContent") as HTMLElement);
-  render(deviceRegistrationDisabledInfoTemplate(props), contain);
-};
+export const deviceRegistrationDisabledInfoPage = renderPage(
+  deviceRegistrationDisabledInfoTemplate
+);
 
 /**
  * Error page which is shown if the identy anchor does not have device registration mode enabled.

--- a/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
@@ -1,7 +1,8 @@
-import { html, render } from "lit-html";
+import { html } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { Connection } from "../../../utils/iiConnection";
 import { delayMillis } from "../../../utils/utils";
+import { renderPage } from "../../../utils/lit-html";
 import {
   AddTentativeDeviceResponse,
   CredentialId,
@@ -64,14 +65,9 @@ const showVerificationCodeTemplate = ({
   });
 };
 
-export const showVerificationCodePage = (
-  props: Parameters<typeof showVerificationCodeTemplate>[0],
-  container?: HTMLElement
-): void => {
-  const contain =
-    container ?? (document.getElementById("pageContent") as HTMLElement);
-  render(showVerificationCodeTemplate(props), contain);
-};
+export const showVerificationCodePage = renderPage(
+  showVerificationCodeTemplate
+);
 
 /**
  * Page to display the verification code which is received after successfully registering a tentative device.

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -1,4 +1,5 @@
-import { TemplateResult, render, html } from "lit-html";
+import { TemplateResult, html } from "lit-html";
+import { renderPage } from "../../utils/lit-html";
 import { LEGACY_II_URL } from "../../config";
 import { Connection, AuthenticatedConnection } from "../../utils/iiConnection";
 import { withLoader } from "../../components/loader";
@@ -195,14 +196,7 @@ export const renderManage = async (
   }
 };
 
-export const displayManagePage = (
-  props: Parameters<typeof displayManageTemplate>[0],
-  container?: HTMLElement
-): void => {
-  const contain =
-    container ?? (document.getElementById("pageContent") as HTMLElement);
-  render(displayManageTemplate(props), contain);
-};
+export const displayManagePage = renderPage(displayManageTemplate);
 
 export const displayManage = (
   userNumber: bigint,

--- a/src/frontend/src/flows/recovery/chooseRecoveryMechanism.ts
+++ b/src/frontend/src/flows/recovery/chooseRecoveryMechanism.ts
@@ -1,4 +1,5 @@
-import { html, render, TemplateResult } from "lit-html";
+import { html, TemplateResult } from "lit-html";
+import { renderPage } from "../../utils/lit-html";
 import { DeviceData } from "../../../generated/internet_identity_types";
 import { securityKeyIcon, seedPhraseIcon } from "../../components/icons";
 import { mainWindow } from "../../components/mainWindow";
@@ -74,14 +75,9 @@ export type ChooseRecoveryProps = Pick<
   "title" | "message" | "cancelText"
 >;
 
-export const chooseRecoveryMechanismPage = (
-  props: TemplateProps,
-  container?: HTMLElement
-): void => {
-  const contain =
-    container ?? (document.getElementById("pageContent") as HTMLElement);
-  render(chooseRecoveryMechanismTemplate(props), contain);
-};
+export const chooseRecoveryMechanismPage = renderPage(
+  chooseRecoveryMechanismTemplate
+);
 
 export const chooseRecoveryMechanism = ({
   devices,

--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -1,8 +1,8 @@
 import { Challenge } from "../../../generated/internet_identity_types";
 import { spinner } from "../../components/icons";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
-import { html, render, TemplateResult } from "lit-html";
-import { withRef, autofocus } from "../../utils/lit-html";
+import { html, TemplateResult } from "lit-html";
+import { withRef, autofocus, renderPage } from "../../utils/lit-html";
 import { Chan } from "../../utils/utils";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
 import { LoginFlowCanceled, cancel } from "../../utils/flowResult";
@@ -204,14 +204,16 @@ export const promptCaptchaTemplate = <T>({
   });
 };
 
-export const promptCaptchaPage = <T>(
-  props: Parameters<typeof promptCaptchaTemplate<T>>[0],
+type TemplateProps<T> = Parameters<typeof promptCaptchaTemplate<T>>[0];
+
+export function promptCaptchaPage<T>(
+  props: TemplateProps<T>,
   container?: HTMLElement
-): void => {
-  const contain =
-    container ?? (document.getElementById("pageContent") as HTMLElement);
-  render(promptCaptchaTemplate(props), contain);
-};
+): void {
+  return renderPage<(props: TemplateProps<T>) => TemplateResult>(
+    promptCaptchaTemplate
+  )(props, container);
+}
 
 export const promptCaptcha = ({
   connection,

--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -1,6 +1,6 @@
-import { html, render } from "lit-html";
+import { html } from "lit-html";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
-import { withRef } from "../../utils/lit-html";
+import { withRef, renderPage } from "../../utils/lit-html";
 import { warnBox } from "../../components/warnBox";
 import { mainWindow } from "../../components/mainWindow";
 import { checkmarkIcon, copyIcon } from "../../components/icons";
@@ -73,14 +73,7 @@ export const displayUserNumberTemplate = ({
   });
 };
 
-export const displayUserNumberPage = (
-  props: Parameters<typeof displayUserNumberTemplate>[0],
-  container?: HTMLElement
-): void => {
-  const contain =
-    container ?? (document.getElementById("pageContent") as HTMLElement);
-  render(displayUserNumberTemplate(props), contain);
-};
+export const displayUserNumberPage = renderPage(displayUserNumberTemplate);
 
 export const displayUserNumber = (userNumber: bigint): Promise<void> => {
   return new Promise((resolve) =>

--- a/src/frontend/src/utils/lit-html.ts
+++ b/src/frontend/src/utils/lit-html.ts
@@ -1,5 +1,6 @@
 /* A couple of lit-html helpers */
 
+import { render, TemplateResult } from "lit-html";
 import { Ref, ref } from "lit-html/directives/ref.js";
 import { DirectiveResult } from "lit-html/directive.js";
 import { toast } from "../components/toast";
@@ -64,3 +65,14 @@ export const autofocus = mount((elem: Element) => {
     elem.focus();
   }
 });
+
+/* A wrapper for lit-html's render, rendering a page to the "pageContent" element */
+export function renderPage<
+  T extends (props: Parameters<T>[0]) => TemplateResult
+>(template: T): (props: Parameters<T>[0], container?: HTMLElement) => void {
+  return (props, container) => {
+    const contain =
+      container ?? (document.getElementById("pageContent") as HTMLElement);
+    render(template(props), contain);
+  };
+}


### PR DESCRIPTION
This adds a helper function that renders a page to `#pageContent`, which is the element to which we attach content.

The logic for attaching to `#pageContent` can be removed from pretty much all pages.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
