### PR TITLE
Don't prefix used variables with underscore

### DIFF
--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -255,25 +255,23 @@ const page = (slot: TemplateResult) => {
 
 // Start the "remote device" add flow by prompting for an anchor, and then
 // adding a device to that anchor.
-const addRemoteDevice = async (
-  connection: Connection,
-  userNumber_?: bigint
-) => {
+const addRemoteDevice = async (connection: Connection, userNumber?: bigint) => {
   // Prompt the user for an anchor (only used if we don't know the anchor already)
   const askUserNumber = async () => {
-    const userNumber = await promptUserNumber({
+    const result = await promptUserNumber({
       title: "Add a Trusted Device",
       message: "What’s your Identity Anchor?",
     });
-    if (userNumber === "canceled") {
+    if (result === "canceled") {
       // TODO L2-309: do this without reload
       return window.location.reload() as never;
     }
 
-    return userNumber;
+    return result;
   };
 
-  const userNumber = userNumber_ ?? (await askUserNumber());
-
-  return registerTentativeDevice(userNumber, connection);
+  return registerTentativeDevice(
+    userNumber ?? (await askUserNumber()),
+    connection
+  );
 };

--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -255,22 +255,25 @@ const page = (slot: TemplateResult) => {
 
 // Start the "remote device" add flow by prompting for an anchor, and then
 // adding a device to that anchor.
-const addRemoteDevice = async (connection: Connection, userNumber?: bigint) => {
+const addRemoteDevice = async (
+  connection: Connection,
+  userNumber_?: bigint
+) => {
   // Prompt the user for an anchor (only used if we don't know the anchor already)
   const askUserNumber = async () => {
-    const _userNumber = await promptUserNumber({
+    const userNumber = await promptUserNumber({
       title: "Add a Trusted Device",
       message: "What’s your Identity Anchor?",
     });
-    if (_userNumber === "canceled") {
+    if (userNumber === "canceled") {
       // TODO L2-309: do this without reload
       return window.location.reload() as never;
     }
 
-    return _userNumber;
+    return userNumber;
   };
 
-  const _userNumber = userNumber ?? (await askUserNumber());
+  const userNumber = userNumber_ ?? (await askUserNumber());
 
-  return registerTentativeDevice(_userNumber, connection);
+  return registerTentativeDevice(userNumber, connection);
 };

--- a/src/frontend/src/components/devicesSection.ts
+++ b/src/frontend/src/components/devicesSection.ts
@@ -27,20 +27,20 @@ const dedupLabels = (authenticators: Device[]): DedupDevice[] => {
 };
 
 export const devicesSection = ({
-  authenticators,
+  authenticators: authenticators_,
   onAddDevice,
 }: {
   authenticators: Device[];
   onAddDevice: () => void;
 }): TemplateResult => {
   const wrapClasses = ["l-stack"];
-  const isWarning = authenticators.length < 2;
+  const isWarning = authenticators_.length < 2;
 
   if (isWarning === true) {
     wrapClasses.push("c-card", "c-card--narrow", "c-card--warning");
   }
 
-  const _authenticators = dedupLabels(authenticators);
+  const authenticators = dedupLabels(authenticators_);
 
   return html`
     <aside class="${wrapClasses.join(" ")}">
@@ -58,7 +58,7 @@ export const devicesSection = ({
             <span class="c-tooltip__message c-card c-card--tight">
               You can register up to ${MAX_AUTHENTICATORS} authenticator
               devices (recovery devices excluded)</span>
-              (${_authenticators.length}/${MAX_AUTHENTICATORS})
+              (${authenticators.length}/${MAX_AUTHENTICATORS})
             </span>
           </span>
         </div>
@@ -73,12 +73,12 @@ export const devicesSection = ({
 
         <div class="c-action-list">
           <ul>
-          ${_authenticators.map((device, index) =>
+          ${authenticators.map((device, index) =>
             deviceListItem({ device, index: `authenticator-${index}` })
           )}</ul>
           <div class="c-action-list__actions">
             <button
-              ?disabled=${_authenticators.length >= MAX_AUTHENTICATORS}
+              ?disabled=${authenticators.length >= MAX_AUTHENTICATORS}
               class="c-button c-button--primary c-tooltip c-tooltip--onDisabled c-tooltip--left"
               @click="${() => onAddDevice()}"
               id="addAdditionalDevice"

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -201,12 +201,12 @@ export const displayManagePage = renderPage(displayManageTemplate);
 export const displayManage = (
   userNumber: bigint,
   connection: AuthenticatedConnection,
-  devices: DeviceData[]
+  devices_: DeviceData[]
 ): Promise<void | AuthenticatedConnection> =>
   new Promise((resolve) => {
-    const hasSingleDevice = devices.length <= 1;
+    const hasSingleDevice = devices_.length <= 1;
 
-    const _devices: Device[] = devices.map((device) => {
+    const devices: Device[] = devices_.map((device) => {
       return {
         settings: deviceSettings({
           userNumber,
@@ -227,8 +227,8 @@ export const displayManage = (
 
     displayManagePage({
       userNumber,
-      authenticators: _devices.filter((device) => !device.isRecovery),
-      recoveries: _devices.filter((device) => device.isRecovery),
+      authenticators: devices.filter((device) => !device.isRecovery),
+      recoveries: devices.filter((device) => device.isRecovery),
       onAddDevice: async () => {
         const nextAction = await chooseDeviceAddFlow();
         switch (nextAction) {
@@ -237,7 +237,7 @@ export const displayManage = (
             break;
           }
           case "local": {
-            await addLocalDevice(userNumber, connection, devices);
+            await addLocalDevice(userNumber, connection, devices_);
             resolve();
             break;
           }
@@ -263,7 +263,7 @@ export const displayManage = (
     // recovery _device_ would be tied to the domain (which we want to avoid).
     if (
       window.location.origin === LEGACY_II_URL &&
-      !hasRecoveryPhrase(devices)
+      !hasRecoveryPhrase(devices_)
     ) {
       const elem = showWarning(html`<strong class="t-strong">Important!</strong>
         Create a recovery phrase.


### PR DESCRIPTION
This replaces a few (used) variables like `_foo` with `foo`.

Some local variables were prefixed with an underscore to differentiate them from a similarly named argument, e.g.:

```js
function foo(bar) {
  const _bar = bar +1;
}
```

Now instead the argument has an underscore appended:

```js
function foo(bar_) {
  const bar = bar_ +1;
}
```

this ensures that by default, `bar` is used.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
