### PR TITLE
Add back button to recovery confirmation

### DIFF
--- a/src/frontend/src/flows/recovery/confirmSeedPhrase.json
+++ b/src/frontend/src/flows/recovery/confirmSeedPhrase.json
@@ -2,6 +2,7 @@
   "en": {
     "title": "Confirm your Recovery Phrase",
     "header": "To ensure you properly stored your recovery phrase, please fill in the specific words below.",
-    "continue": "Continue"
+    "continue": "Continue",
+    "back": "Back"
   }
 }

--- a/src/frontend/src/flows/recovery/confirmSeedPhrase.test.ts
+++ b/src/frontend/src/flows/recovery/confirmSeedPhrase.test.ts
@@ -56,6 +56,9 @@ test("words can be completed", async () => {
       confirm: () => {
         /* */
       },
+      back: () => {
+        /* */
+      },
       i18n,
     },
     document.body

--- a/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
@@ -27,10 +27,12 @@ const checkWord = (word: Word): boolean =>
 const confirmSeedPhraseTemplate = ({
   words: words_,
   confirm,
+  back,
   i18n,
 }: {
   words: Omit<Word, "elem">[];
   confirm: () => void;
+  back: () => void;
   i18n: I18n;
 }) => {
   const copy = i18n.i18n(copyJson);
@@ -71,7 +73,14 @@ const confirmSeedPhraseTemplate = ({
         </ol>
       </div>
 
-      <div class="l-stack">
+      <div class="c-button-group">
+        <button
+          @click=${() => back()}
+          data-action="back"
+          class="c-button c-button--secondary"
+        >
+          ${copy.back}
+        </button>
         <button
           @click=${() => confirm()}
           data-action="next"
@@ -143,7 +152,7 @@ export const confirmSeedPhrase = ({
   phrase,
 }: {
   phrase: string;
-}): Promise<void> => {
+}): Promise<"confirmed" | "back"> => {
   return new Promise((resolve) => {
     const i18n = new I18n();
     confirmSeedPhrasePage({
@@ -151,7 +160,8 @@ export const confirmSeedPhrase = ({
         word,
         check: checkIndices.includes(i),
       })),
-      confirm: () => resolve(),
+      confirm: () => resolve("confirmed"),
+      back: () => resolve("back"),
       i18n,
     });
   });

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -381,6 +381,7 @@ const iiPages: Record<string, () => void> = {
   confirmSeedPhrase: () =>
     confirmSeedPhrasePage({
       confirm: () => console.log("confirmed"),
+      back: () => console.log("back"),
       words: recoveryPhraseText.split(" ").map((word, i) => ({
         word,
         check: checkIndices.includes(i),


### PR DESCRIPTION
This allows the user to go back to the page that displays the recovery phrase, from the phrase confirmation/input page.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
