### PR TITLE
Confirm recovery phrase on reset

### DIFF
--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -9,6 +9,7 @@ import { withLoader } from "../../components/loader";
 import { unreachable } from "../../utils/utils";
 import { DeviceData } from "../../../generated/internet_identity_types";
 import { phraseRecoveryPage } from "../recovery/recoverWith/phrase";
+import { displayAndConfirmPhrase } from "../recovery/setupRecovery";
 import {
   isRecoveryDevice,
   isRecoveryPhrase,
@@ -18,7 +19,6 @@ import {
 import { generate } from "../../crypto/mnemonic";
 import { fromMnemonicWithoutValidation } from "../../crypto/ed25519";
 import { IC_DERIVATION_PATH } from "../../utils/iiConnection";
-import { displaySeedPhrase } from "../recovery/displaySeedPhrase";
 
 // A particular device setting, e.g. remove, protect, etc
 export type Setting = { label: keyof typeof settingName; fn: () => void };
@@ -234,8 +234,10 @@ const resetPhrase = async ({
   );
 
   try {
+    const phrase = userNumber.toString(10) + " " + recoveryPhrase;
+
+    await displayAndConfirmPhrase({ phrase });
     await withLoader(() => opConnection.replace(oldKey, device));
-    await displaySeedPhrase(userNumber.toString(10) + " " + recoveryPhrase);
   } catch (e: unknown) {
     await displayError({
       title: "Could not reset recovery phrase",

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -87,19 +87,11 @@ export const setupRecovery = async ({
   }
 };
 
-export const setupPhrase = async (
-  userNumber: bigint,
-  connection: AuthenticatedConnection
-) => {
-  const name = "Recovery phrase";
-  const seedPhrase = generate().trim();
-  const recoverIdentity = await fromMnemonicWithoutValidation(
-    seedPhrase,
-    IC_DERIVATION_PATH
-  );
-
-  const phrase = userNumber.toString(10) + " " + seedPhrase;
-
+export const displayAndConfirmPhrase = async ({
+  phrase,
+}: {
+  phrase: string;
+}) => {
   // Loop until the user has confirmed the phrase
   for (;;) {
     await displaySeedPhrase(phrase);
@@ -117,6 +109,22 @@ export const setupPhrase = async (
 
     unreachableLax(result);
   }
+};
+
+export const setupPhrase = async (
+  userNumber: bigint,
+  connection: AuthenticatedConnection
+) => {
+  const name = "Recovery phrase";
+  const seedPhrase = generate().trim();
+  const recoverIdentity = await fromMnemonicWithoutValidation(
+    seedPhrase,
+    IC_DERIVATION_PATH
+  );
+
+  const phrase = userNumber.toString(10) + " " + seedPhrase;
+
+  await displayAndConfirmPhrase({ phrase });
 
   await withLoader(() =>
     connection.add(

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -93,6 +93,7 @@ export const FLOWS = {
     const seedPhrase = await recoveryMethodSelectorView.getSeedPhrase();
     await recoveryMethodSelectorView.acknowledgeCheckbox();
     await recoveryMethodSelectorView.seedPhraseContinue();
+    await recoveryMethodSelectorView.seedPhraseFill();
 
     return seedPhrase;
   },


### PR DESCRIPTION
Recovery phrase confirmation was only asked upon phrase creation but not reset. This fixes this issue by always going through the display-and-confirm flow.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
