### PR TITLE
Add 'S' -> 's' to captcha normalization

### DIFF
--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -129,6 +129,7 @@ lazy_static! {
     static ref CHAR_REPLACEMENTS: HashMap<char, char> = vec![
         ('C', 'c'),
         ('l', '1'),
+        ('S', 's'),
         ('X', 'x'),
         ('Y', 'y'),
         ('Z', 'z'),


### PR DESCRIPTION
This makes sure `S` characters are not used in captcha, and that only `s` characters are used instead (though both are accepted as `s`).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
