### PR TITLE
Separate anchor activity bookkeeping from post-operation bookkeeping

### DIFF
--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -55,7 +55,9 @@ pub fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
 /// * Records anchor activity within aggregated activity stats
 /// * Updates the last usage timestamp
 ///
-/// Note: modifies the anchor but not does not write to storage.
+/// Note: modifies the anchor but not does not write to storage. It is the responsibility of the
+/// caller to persist the changes. This allows anchor operations to write to storage only once,
+/// combining the modifications for bookkeeping reasons (made here) with other changes to the anchor.
 pub fn activity_bookkeeping(anchor: &mut Anchor, current_device_key: &DeviceKey) {
     let previous_activity = anchor.last_activity();
     active_anchor_stats::update_active_anchors_stats(previous_activity);

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -51,20 +51,27 @@ pub fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
     })
 }
 
+/// Handles all the bookkeeping required on anchor activity:
+/// * Records anchor activity within aggregated activity stats
+/// * Updates the last usage timestamp
+///
+/// Note: modifies the anchor but not does not write to storage.
+pub fn activity_bookkeeping(anchor: &mut Anchor, current_device_key: &DeviceKey) {
+    let previous_activity = anchor.last_activity();
+    active_anchor_stats::update_active_anchors_stats(previous_activity);
+    anchor
+        .set_device_usage_timestamp(current_device_key, time())
+        .expect("unable to update last usage timestamp");
+}
+
 /// Handles all the bookkeeping required after a successful anchor operation:
 /// * Adds the operation to the archive buffer
 /// * Increments the anchor operation counter
-/// * Records anchor activity
-pub fn anchor_operation_bookkeeping(
-    anchor_number: AnchorNumber,
-    operation: Operation,
-    previous_activity: Option<Timestamp>,
-) {
+pub fn post_operation_bookkeeping(anchor_number: AnchorNumber, operation: Operation) {
     archive_operation(anchor_number, caller(), operation);
     state::usage_metrics_mut(|metrics| {
         metrics.anchor_operation_counter += 1;
     });
-    active_anchor_stats::update_active_anchors_stats(previous_activity);
 }
 
 /// Adds a device to the given anchor and returns the operation to be archived.
@@ -130,19 +137,4 @@ pub fn remove(anchor: &mut Anchor, device_key: DeviceKey) -> Operation {
         .unwrap_or_else(|err| trap(&format!("failed to remove device: {err}")));
 
     Operation::RemoveDevice { device: device_key }
-}
-
-/// Updates the device on the anchor to reflect the current usage.
-/// Note: This is considered internal bookkeeping and is not recorded in the archive and does not increase anchor operation counter.
-pub fn update_last_device_usage(
-    anchor_number: AnchorNumber,
-    mut anchor: Anchor,
-    device_key: &DeviceKey,
-) {
-    anchor
-        .set_device_usage_timestamp(device_key, time())
-        .expect("last_usage_timestamp update: unable to update last usage timestamp");
-    state::storage_mut(|storage| storage.write(anchor_number, anchor)).unwrap_or_else(|err| {
-        panic!("last_usage_timestamp update: unable to update anchor {anchor_number}: {err}")
-    })
 }

--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -1,4 +1,4 @@
-use crate::anchor_management::anchor_operation_bookkeeping;
+use crate::anchor_management::{activity_bookkeeping, post_operation_bookkeeping};
 use crate::state::ChallengeInfo;
 use crate::storage::anchor::Device;
 use crate::storage::Salt;
@@ -193,9 +193,7 @@ pub fn register(device_data: DeviceData, challenge_result: ChallengeAttempt) -> 
         return RegisterResponse::BadChallenge;
     }
 
-    let mut device = Device::from(device_data);
-    device.last_usage_timestamp = Some(time());
-
+    let device = Device::from(device_data);
     if caller() != Principal::self_authenticating(&device.pubkey) {
         trap(&format!(
             "{} could not be authenticated against {:?}",
@@ -212,6 +210,7 @@ pub fn register(device_data: DeviceData, challenge_result: ChallengeAttempt) -> 
     anchor
         .add_device(device.clone())
         .unwrap_or_else(|err| trap(&format!("failed to register anchor {anchor_number}: {err}")));
+    activity_bookkeeping(&mut anchor, &device.pubkey);
 
     // write anchor to stable memory
     state::storage_mut(|storage| {
@@ -225,7 +224,7 @@ pub fn register(device_data: DeviceData, challenge_result: ChallengeAttempt) -> 
     let operation = Operation::RegisterAnchor {
         device: DeviceDataWithoutAlias::from(device),
     };
-    anchor_operation_bookkeeping(anchor_number, operation, None);
+    post_operation_bookkeeping(anchor_number, operation);
     RegisterResponse::Registered {
         user_number: anchor_number,
     }

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -88,6 +88,10 @@ pub async fn add_tentative_device(
     })
 }
 
+/// Verifies the tentative device using the submitted `user_verification_code` and returns
+/// a result of [VerifyTentativeDeviceResponse]. [VerifyTentativeDeviceResponse] is used both as
+/// a success and an error type because it corresponds to the candid variant unifying success and
+/// error cases. See `authenticated_anchor_operation` for more details on how the [Result] is handled.
 pub fn verify_tentative_device(
     anchor: &mut Anchor,
     anchor_number: AnchorNumber,

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1,9 +1,9 @@
-use crate::anchor_management::{anchor_operation_bookkeeping, tentative_device_registration};
+use crate::anchor_management::{post_operation_bookkeeping, tentative_device_registration};
 use crate::archive::ArchiveState;
 use crate::assets::init_assets;
 use crate::storage::anchor::{Anchor, Device};
 use candid::{candid_method, Principal};
-use ic_cdk::api::{caller, set_certified_data, time, trap};
+use ic_cdk::api::{caller, set_certified_data, trap};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use ic_certified_map::AsHashTree;
 use internet_identity_interface::archive::{BufferedEntry, Operation};
@@ -68,8 +68,13 @@ fn verify_tentative_device(
     anchor_number: AnchorNumber,
     user_verification_code: DeviceVerificationCode,
 ) -> VerifyTentativeDeviceResponse {
-    authenticate_and_record_activity(anchor_number);
-    tentative_device_registration::verify_tentative_device(anchor_number, user_verification_code)
+    authenticated_anchor_operation(anchor_number, |anchor| {
+        tentative_device_registration::verify_tentative_device(
+            anchor,
+            anchor_number,
+            user_verification_code,
+        )
+    })
 }
 
 #[update]
@@ -88,7 +93,7 @@ fn register(device_data: DeviceData, challenge_result: ChallengeAttempt) -> Regi
 #[candid_method]
 fn add(anchor_number: AnchorNumber, device_data: DeviceData) {
     authenticated_anchor_operation(anchor_number, |anchor| {
-        anchor_management::add(anchor, device_data)
+        Ok(((), anchor_management::add(anchor, device_data)))
     })
 }
 
@@ -96,7 +101,10 @@ fn add(anchor_number: AnchorNumber, device_data: DeviceData) {
 #[candid_method]
 fn update(anchor_number: AnchorNumber, device_key: DeviceKey, device_data: DeviceData) {
     authenticated_anchor_operation(anchor_number, |anchor| {
-        anchor_management::update(anchor, device_key, device_data)
+        Ok((
+            (),
+            anchor_management::update(anchor, device_key, device_data),
+        ))
     })
 }
 
@@ -104,7 +112,10 @@ fn update(anchor_number: AnchorNumber, device_key: DeviceKey, device_data: Devic
 #[candid_method]
 fn replace(anchor_number: AnchorNumber, device_key: DeviceKey, device_data: DeviceData) {
     authenticated_anchor_operation(anchor_number, |anchor| {
-        anchor_management::replace(anchor, device_key, device_data)
+        Ok((
+            (),
+            anchor_management::replace(anchor, device_key, device_data),
+        ))
     })
 }
 
@@ -112,7 +123,7 @@ fn replace(anchor_number: AnchorNumber, device_key: DeviceKey, device_data: Devi
 #[candid_method]
 fn remove(anchor_number: AnchorNumber, device_key: DeviceKey) {
     authenticated_anchor_operation(anchor_number, |anchor| {
-        anchor_management::remove(anchor, device_key)
+        Ok(((), anchor_management::remove(anchor, device_key)))
     })
 }
 
@@ -363,36 +374,43 @@ fn update_root_hash() {
 
 /// Authenticates the caller (traps if not authenticated) and updates the device used to authenticate
 /// reflecting the current activity. Also updates the aggregated stats on daily and monthly active users.
+///
+/// Note: this function reads / writes the anchor from / to stable memory. It is intended to be used by functions that
+/// do not further modify the anchor.
 fn authenticate_and_record_activity(anchor_number: AnchorNumber) {
-    let anchor = state::anchor(anchor_number);
+    let mut anchor = state::anchor(anchor_number);
     let device_key = trap_if_not_authenticated(&anchor).pubkey.clone();
-    let previous_activity = anchor.last_activity();
-    anchor_management::update_last_device_usage(anchor_number, anchor, &device_key);
-    active_anchor_stats::update_active_anchors_stats(previous_activity);
+    anchor_management::activity_bookkeeping(&mut anchor, &device_key);
+    state::storage_mut(|storage| storage.write(anchor_number, anchor)).unwrap_or_else(|err| {
+        panic!("last_usage_timestamp update: unable to update anchor {anchor_number}: {err}")
+    })
 }
 
 /// Authenticates the caller (traps if not authenticated) calls the provided function and handles all
 /// the necessary bookkeeping for anchor operations.
-fn authenticated_anchor_operation(
+fn authenticated_anchor_operation<R>(
     anchor_number: AnchorNumber,
-    op: impl FnOnce(&mut Anchor) -> Operation,
-) {
+    op: impl FnOnce(&mut Anchor) -> Result<(R, Operation), R>,
+) -> R {
     // load anchor
     let mut anchor = state::anchor(anchor_number);
-    let device = trap_if_not_authenticated(&anchor);
+    let device_key = trap_if_not_authenticated(&anchor).pubkey.clone();
+    anchor_management::activity_bookkeeping(&mut anchor, &device_key);
 
-    let previous_activity = anchor.last_activity();
-    anchor
-        .set_device_usage_timestamp(&device.pubkey.clone(), time())
-        .expect("last_usage_timestamp update: unable to update last usage timestamp");
-
-    let operation = op(&mut anchor);
+    let result = op(&mut anchor);
 
     // write back anchor
     state::storage_mut(|storage| storage.write(anchor_number, anchor)).unwrap_or_else(|err| {
         panic!("unable to update anchor {anchor_number} in stable memory: {err}")
     });
-    anchor_operation_bookkeeping(anchor_number, operation, previous_activity);
+
+    match result {
+        Ok((ret, operation)) => {
+            post_operation_bookkeeping(anchor_number, operation);
+            ret
+        }
+        Err(err) => err,
+    }
 }
 
 /// Checks if the caller is authenticated against the anchor provided and returns a reference to the device used.

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -393,6 +393,9 @@ fn authenticate_and_record_activity(anchor_number: AnchorNumber) {
 /// * op: Function that modifies an anchor and returns a value `R` wrapped in a [Result] indicating
 ///       success or failure which determines whether additional bookkeeping (on success) is required.
 ///       On success, the function must also return an [Operation] which is used for archiving purposes.
+///       The type `R` is usually bound to an interface type specified in the candid file. This type
+///       is either unit or a variant unifying success and error cases (which is why the [Result] has
+///       `R` in both success and error positions).
 fn authenticated_anchor_operation<R>(
     anchor_number: AnchorNumber,
     op: impl FnOnce(&mut Anchor) -> Result<(R, Operation), R>,

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -388,6 +388,11 @@ fn authenticate_and_record_activity(anchor_number: AnchorNumber) {
 
 /// Authenticates the caller (traps if not authenticated) calls the provided function and handles all
 /// the necessary bookkeeping for anchor operations.
+///
+/// * anchor_number: indicates the anchor to be provided op should be called on
+/// * op: Function that modifies an anchor and provides a result indicating success or failure, which
+///       determines whether additional bookkeeping (on success) is required. On success, the
+///       function must also return an [Operation] which is used for archiving purposes.
 fn authenticated_anchor_operation<R>(
     anchor_number: AnchorNumber,
     op: impl FnOnce(&mut Anchor) -> Result<(R, Operation), R>,

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -390,9 +390,9 @@ fn authenticate_and_record_activity(anchor_number: AnchorNumber) {
 /// the necessary bookkeeping for anchor operations.
 ///
 /// * anchor_number: indicates the anchor to be provided op should be called on
-/// * op: Function that modifies an anchor and provides a result indicating success or failure, which
-///       determines whether additional bookkeeping (on success) is required. On success, the
-///       function must also return an [Operation] which is used for archiving purposes.
+/// * op: Function that modifies an anchor and returns a value `R` wrapped in a [Result] indicating
+///       success or failure which determines whether additional bookkeeping (on success) is required.
+///       On success, the function must also return an [Operation] which is used for archiving purposes.
 fn authenticated_anchor_operation<R>(
     anchor_number: AnchorNumber,
     op: impl FnOnce(&mut Anchor) -> Result<(R, Operation), R>,


### PR DESCRIPTION
In addition, the `authenticated_anchor_operation` wrapper is made more flexible to allow also funneling through return values. This has two benefits:
* verifyTentativeDevice can now also make use of the wrapper
* it prepares the other anchor operations to be able to provide proper errors (which will be required in the future)

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
