### PR TITLE
Make active anchor counter counting logic pluggable

### DIFF
--- a/src/internet_identity/src/active_anchor_stats.rs
+++ b/src/internet_identity/src/active_anchor_stats.rs
@@ -8,52 +8,58 @@ use internet_identity_interface::{
 mod stats_maintenance;
 
 pub fn update_active_anchors_stats(previous_activity_timestamp: Option<Timestamp>) {
-    state::persistent_state_mut(
-        |persistent_state| match persistent_state.active_anchor_stats {
-            None => {
-                let mut stats = new_active_anchor_statistics(time());
-                increment_stats_on_activity(&mut stats, previous_activity_timestamp);
-                persistent_state.active_anchor_stats = Some(stats)
-            }
-            Some(ref mut stats) => {
-                stats_maintenance::process_active_anchor_stats(stats);
-                increment_stats_on_activity(stats, previous_activity_timestamp);
-            }
-        },
-    )
+    state::persistent_state_mut(|persistent_state| {
+        update_activity_stats(&mut persistent_state.active_anchor_stats, |counter| {
+            update_active_anchor_counter(counter, previous_activity_timestamp)
+        })
+    })
 }
 
-/// Increases the counter on all windows, where the `previous_activity_timestamp` (if any) lies before
-/// their respective `start_timestamp` (i.e. all windows where the anchor has not yet had any activity in).
-///
-/// For any given anchor and window the `previous_activity_timestamp` is only absent or before the
-/// `window.start_timestamp` once because:
-/// * `previous_activity_timestamp` of the given anchor is set to `ic_cdk::time()` in this call
-/// * `window.start_timestamp` is <= `ic_cdk::time()` for any active window
-fn increment_stats_on_activity(
-    stats: &mut ActiveAnchorStatistics,
-    previous_activity_timestamp: Option<Timestamp>,
+fn update_activity_stats(
+    stats: &mut Option<ActiveAnchorStatistics>,
+    update: impl Fn(&mut ActiveAnchorCounter),
 ) {
-    // increase all counters and exit early if there is no previous activity
-    let Some(timestamp) = previous_activity_timestamp else {
-        stats.ongoing.daily_active_anchors.counter += 1;
-        stats.ongoing.monthly_active_anchors.iter_mut().for_each(|monthly_stats| monthly_stats.counter +=1 );
-        return;
-    };
-
-    if stats.ongoing.daily_active_anchors.start_timestamp > timestamp {
-        stats.ongoing.daily_active_anchors.counter += 1;
+    match stats {
+        None => {
+            let mut new_stats = new_active_anchor_statistics(time());
+            update_counters(&mut new_stats, update);
+            *stats = Some(new_stats)
+        }
+        Some(ref mut stats) => {
+            stats_maintenance::process_stats(stats);
+            update_counters(stats, update);
+        }
     }
+}
 
+fn update_counters(stats: &mut ActiveAnchorStatistics, update: impl Fn(&mut ActiveAnchorCounter)) {
+    update(&mut stats.ongoing.daily_active_anchors);
     stats
         .ongoing
         .monthly_active_anchors
         .iter_mut()
-        .for_each(|monthly_stats| {
-            if monthly_stats.start_timestamp > timestamp {
-                monthly_stats.counter += 1;
-            }
-        });
+        .for_each(update);
+}
+
+/// Increases the counter on a window if the `previous_activity_timestamp` lies before
+/// the `start_timestamp` (i.e. a window where the anchor has not yet had any activity in).
+///
+/// For any given anchor and window the `previous_activity_timestamp` is only absent or before the
+/// `window.start_timestamp` once because:
+/// * `previous_activity_timestamp` of the given anchor is set to `ic_cdk::time()` in this canister call
+/// * `window.start_timestamp` is <= `ic_cdk::time()` for any active window
+fn update_active_anchor_counter(
+    counter: &mut ActiveAnchorCounter,
+    previous_activity_timestamp: Option<Timestamp>,
+) {
+    if let Some(timestamp) = previous_activity_timestamp {
+        if counter.start_timestamp > timestamp {
+            counter.counter += 1;
+        }
+    } else {
+        // increase counter if there is no previous activity
+        counter.counter += 1;
+    }
 }
 
 fn new_active_anchor_statistics(time: Timestamp) -> ActiveAnchorStatistics {

--- a/src/internet_identity/src/active_anchor_stats/stats_maintenance.rs
+++ b/src/internet_identity/src/active_anchor_stats/stats_maintenance.rs
@@ -4,7 +4,7 @@ use ic_cdk::api::time;
 use internet_identity_interface::ActiveAnchorStatistics;
 
 /// Updates the active anchor counters if an ongoing collection bucket has completed.
-pub fn process_active_anchor_stats(stats: &mut ActiveAnchorStatistics) {
+pub fn process_stats(stats: &mut ActiveAnchorStatistics) {
     process_daily_stats(stats);
     process_monthly_stats(stats);
 }


### PR DESCRIPTION
This PR serparates the logic responsible for iterating over counters from the logic on how to update a counter. This is a refactoring in preparation for the domain specific activity counters.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
