### PR TITLE
Fix confirmSeedPhrase test by adding missing shouldFocus prop to word

### DIFF
--- a/src/frontend/src/flows/recovery/confirmSeedPhrase.test.ts
+++ b/src/frontend/src/flows/recovery/confirmSeedPhrase.test.ts
@@ -7,7 +7,7 @@ const i18n = new I18n("en");
 
 test("word changes state", async () => {
   const template = wordTemplate({
-    word: { check: true, elem: createRef(), word: "hello" },
+    word: { check: true, elem: createRef(), word: "hello", shouldFocus: true },
     update: () => {
       /* */
     },


### PR DESCRIPTION
Fix the broken test for "confirmSeedPhrase" the "shouldFocus" prop was missing in the test.