### PR TITLE
Clean up recovery setup

### DIFF
--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -140,7 +140,7 @@ export const resetPhrase = async ({
 
     if (res === "confirmed") {
       await withLoader(() => opConnection.replace(oldKey, device));
-    } else if (res !== "error" && res !== "canceled") {
+    } else if (res !== "canceled") {
       unreachableLax(res);
     }
   } catch (e: unknown) {

--- a/src/frontend/src/flows/recovery/chooseRecoveryMechanism.ts
+++ b/src/frontend/src/flows/recovery/chooseRecoveryMechanism.ts
@@ -86,13 +86,13 @@ export const chooseRecoveryMechanism = ({
   cancelText,
 }: {
   devices: Omit<DeviceData, "alias">[];
-} & ChooseRecoveryProps): Promise<RecoveryMechanism | null> => {
+} & ChooseRecoveryProps): Promise<RecoveryMechanism | "canceled"> => {
   return new Promise((resolve) => {
     return chooseRecoveryMechanismPage({
       disablePhrase: hasRecoveryPhrase(devices),
       disableKey: hasRecoveryKey(devices),
       pick: resolve,
-      cancel: () => resolve(null),
+      cancel: () => resolve("canceled"),
 
       title,
       message,

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -1,5 +1,6 @@
 import { WebAuthnIdentity } from "@dfinity/identity";
 import { displayError } from "../../components/displayError";
+import { DeviceData } from "../../../generated/internet_identity_types";
 import { withLoader } from "../../components/loader";
 import { fromMnemonicWithoutValidation } from "../../crypto/ed25519";
 import { generate } from "../../crypto/mnemonic";
@@ -28,76 +29,152 @@ export const setupRecovery = async ({
   userNumber: bigint;
   connection: AuthenticatedConnection;
 } & ChooseRecoveryProps): Promise<void> => {
-  const devices = await connection.lookupAll(userNumber);
-  const recoveryMechanism = await chooseRecoveryMechanism({
-    devices,
-    title,
-    message,
-    cancelText,
-  });
-  if (recoveryMechanism === null) {
-    return;
-  }
-
-  try {
-    switch (recoveryMechanism) {
-      case "securityKey": {
-        const name = "Recovery key";
-        let recoverIdentity: WebAuthnIdentity;
-        try {
-          recoverIdentity = await WebAuthnIdentity.create({
-            publicKey: creationOptions(devices, "cross-platform"),
-          });
-        } catch (err: unknown) {
-          await displayError({
-            title: "Authentication failure",
-            message:
-              "Failed to set up a security key as your recovery method. If you don't have an additional security key you can use a recovery phrase instead.",
-            detail: unknownToString(err, "Unknown error"),
-            primaryButton: "Try a different method",
-          });
-          return setupRecovery({
-            userNumber,
-            connection,
-            title,
-            message,
-            cancelText,
-          });
-        }
-
-        return await withLoader(() =>
-          connection.add(
-            name,
-            { cross_platform: null },
-            { recovery: null },
-            recoverIdentity.getPublicKey().toDer(),
-            { unprotected: null },
-            recoverIdentity.rawId
-          )
-        );
-      }
-      case "seedPhrase": {
-        await setupPhrase(userNumber, connection);
-        break;
-      }
-    }
-  } catch (err: unknown) {
-    await displayError({
-      title: "Failed to set up recovery",
-      message: "We failed to set up recovery for this Identity Anchor.",
-      detail: unknownToString(err, "Unkwnown error"),
-      primaryButton: "Continue",
+  // Retry until user explicitly cancels or until a device is added successfully
+  for (;;) {
+    // Fetch all devices, which are used when offering recovery options & when setting up
+    // a recovery device
+    const devices = await withLoader(() => connection.lookupAll(userNumber));
+    const recoveryMechanism = await chooseRecoveryMechanism({
+      devices,
+      title,
+      message,
+      cancelText,
     });
+    if (recoveryMechanism === "canceled") {
+      return;
+    }
+
+    // For phrases, we kick start the phrase setup wizard
+    if (recoveryMechanism === "seedPhrase") {
+      const res = await setupPhrase(userNumber, connection);
+      if (res === "ok" || res === "canceled") {
+        return;
+      }
+
+      if (res === "error") {
+        await displayError({
+          title: "Failed to set up recovery",
+          message: "We failed to set up recovery for this Identity Anchor.",
+          primaryButton: "Retry",
+        });
+        continue;
+      }
+
+      return unreachable(res, "Unexpected return value when creating phrase");
+    }
+
+    // For recovery keys, we retry until a key was successfully added (or the user explicitely cancels
+    // when choosing a recovery mechanism upon retry)
+    if (recoveryMechanism === "securityKey") {
+      const res = await setupKey({ connection, devices });
+
+      if (res === "ok") {
+        return;
+      }
+
+      if ("error" in res) {
+        await displayError({
+          title: "Authentication failure",
+          message:
+            "Failed to set up a security key as your recovery method. If you don't have an additional security key you can use a recovery phrase instead.",
+          detail: unknownToString(res.error, "Unknown error"),
+          primaryButton: "Continue",
+        });
+        continue;
+      }
+
+      // exhaust return values
+      return unreachable(res, "Unexpected return value when adding recovery");
+    }
+
+    return unreachable(
+      recoveryMechanism,
+      "Unexpected return value when choosing recovery"
+    );
   }
 };
 
+// Set up a recovery device
+export const setupKey = async ({
+  devices,
+  connection,
+}: {
+  devices: Omit<DeviceData, "alias">[];
+  connection: AuthenticatedConnection;
+}): Promise<"ok" | { error: unknown }> => {
+  const name = "Recovery key";
+  try {
+    // Create the WebAuthn credentials and upload them to the canister
+    await withLoader(async () => {
+      const recoverIdentity = await WebAuthnIdentity.create({
+        publicKey: creationOptions(devices, "cross-platform"),
+      });
+
+      await connection.add(
+        name,
+        { cross_platform: null },
+        { recovery: null },
+        recoverIdentity.getPublicKey().toDer(),
+        { unprotected: null },
+        recoverIdentity.rawId
+      );
+    });
+  } catch (error: unknown) {
+    return { error };
+  }
+
+  return "ok";
+};
+
+// Set up a recovery phrase
+export const setupPhrase = async (
+  userNumber: bigint,
+  connection: AuthenticatedConnection
+): Promise<"ok" | "error" | "canceled"> => {
+  const name = "Recovery phrase";
+  const seedPhrase = generate().trim();
+  const recoverIdentity = await fromMnemonicWithoutValidation(
+    seedPhrase,
+    IC_DERIVATION_PATH
+  );
+
+  const phrase = userNumber.toString(10) + " " + seedPhrase;
+  const res = await displayAndConfirmPhrase({ phrase, operation: "create" });
+
+  if (res === "canceled") {
+    return res;
+  }
+
+  // exhaust return values
+  if (res !== "confirmed") {
+    return unreachable(res, "Unexpected return value when setting up phrase");
+  }
+
+  try {
+    await withLoader(() =>
+      connection.add(
+        name,
+        { seed_phrase: null },
+        { recovery: null },
+        recoverIdentity.getPublicKey().toDer(),
+        { unprotected: null }
+      )
+    );
+  } catch (e: unknown) {
+    return "error";
+  }
+
+  return "ok";
+};
+
+// Show the new recovery phrase and ask for confirmation
 export const displayAndConfirmPhrase = async ({
   operation,
   phrase,
 }: {
   operation: "create" | "reset";
   phrase: string;
-}): Promise<"confirmed" | "error" | "canceled"> => {
+}): Promise<"confirmed" | "canceled"> => {
   // Loop until the user has confirmed the phrase
   for (;;) {
     const displayResult = await displaySeedPhrase({
@@ -111,8 +188,7 @@ export const displayAndConfirmPhrase = async ({
 
     if (displayResult !== "ok") {
       // According to typescript, should never happen
-      unreachable(displayResult, "unexpected return value");
-      return "error";
+      return unreachable(displayResult, "unexpected return value");
     }
 
     const result = await confirmSeedPhrase({ phrase });
@@ -128,39 +204,4 @@ export const displayAndConfirmPhrase = async ({
 
     unreachableLax(result);
   }
-};
-
-export const setupPhrase = async (
-  userNumber: bigint,
-  connection: AuthenticatedConnection
-) => {
-  const name = "Recovery phrase";
-  const seedPhrase = generate().trim();
-  const recoverIdentity = await fromMnemonicWithoutValidation(
-    seedPhrase,
-    IC_DERIVATION_PATH
-  );
-
-  const phrase = userNumber.toString(10) + " " + seedPhrase;
-
-  const res = await displayAndConfirmPhrase({ phrase, operation: "create" });
-
-  if (res === "error" || res === "canceled") {
-    return;
-  }
-
-  if (res !== "confirmed") {
-    unreachableLax(res);
-    return;
-  }
-
-  await withLoader(() =>
-    connection.add(
-      name,
-      { seed_phrase: null },
-      { recovery: null },
-      recoverIdentity.getPublicKey().toDer(),
-      { unprotected: null }
-    )
-  );
 };


### PR DESCRIPTION
This refactors the `setupRecovery` module to be more readable, and fixes a few UI issues:

* A loader is now displayed on every canister call, whereas previously e.g. fetching devices would just show a frozen screen
* The "infinite loop" nature of `setupRecovery` is made explicit by removing recursion (also avoiding potentially blowing up the call stack)
* The return type for cancelation in `chooseRecoveryMechanism` is made more explicit (was `null`, now `"canceled"`)
* A new function `setupKey` is extracted from `setupRecovery`, to better mirror `setupPhrase`
* Replace switches with if branches

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
