### PR TITLE
Remove hasOwnProperty

### DIFF
--- a/src/frontend/src/utils/userNumber.ts
+++ b/src/frontend/src/utils/userNumber.ts
@@ -1,4 +1,4 @@
-import { hasNumberProperty, unknownToRecord } from "./utils";
+import { unknownToRecord } from "./utils";
 
 /** The Anchor type as stored in local storage, including hint of the frequency
  * at which the anchor is used.
@@ -165,11 +165,11 @@ const asAnchor = (msg: unknown): Anchor | undefined => {
     return undefined;
   }
 
-  if (!hasNumberProperty(obj, "lastUsedTimestamp")) {
-    return undefined;
+  if ("lastUsedTimestamp" in obj && typeof obj.lastUsedTimestamp === "number") {
+    return { ...obj, lastUsedTimestamp: obj.lastUsedTimestamp };
   }
 
-  return obj;
+  return undefined;
 };
 
 const writeAnchors = (anchors: Anchors) => {

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -1,20 +1,3 @@
-// A `hasOwnProperty` that produces evidence for the typechecker
-export function hasOwnProperty<
-  X extends Record<string, unknown>,
-  Y extends PropertyKey
->(obj: X, prop: Y): obj is X & Record<Y, unknown> {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-}
-
-// A `hasOwnProperty` variant that checks that the property is a number
-// and produces evidence for the typechecked
-export function hasNumberProperty<
-  X extends Record<string, unknown>,
-  Y extends PropertyKey
->(obj: X, prop: Y): obj is X & Record<Y, number> {
-  return hasOwnProperty(obj, prop) && typeof obj[prop] === "number";
-}
-
 // Turns an 'unknown' into a string, if possible, otherwise use the default
 // `def` parameter.
 export function unknownToString(obj: unknown, def: string): string {


### PR DESCRIPTION
Our own `hasOwnProperty` was a helper that can be replaced with `in` pretty much everywhere in modern TypeScript.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
