### PR TITLE
Regroup phrase creation functions

### DIFF
--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -6,18 +6,15 @@ import {
 } from "../../utils/iiConnection";
 import { displayError } from "../../components/displayError";
 import { withLoader } from "../../components/loader";
-import { unreachable, unreachableLax } from "../../utils/utils";
+import { unreachable, unknownToString, assertType } from "../../utils/utils";
 import { DeviceData } from "../../../generated/internet_identity_types";
 import { phraseRecoveryPage } from "../recovery/recoverWith/phrase";
-import { displayAndConfirmPhrase } from "../recovery/setupRecovery";
+import { phraseWizard } from "../recovery/setupRecovery";
 import {
   isRecoveryDevice,
   isProtected,
   RecoveryPhrase,
 } from "../../utils/recoveryDevice";
-import { generate } from "../../crypto/mnemonic";
-import { fromMnemonicWithoutValidation } from "../../crypto/ed25519";
-import { IC_DERIVATION_PATH } from "../../utils/iiConnection";
 
 /* Remove the device and return */
 export const deleteDevice = async ({
@@ -84,7 +81,7 @@ export const resetPhrase = async ({
   connection: AuthenticatedConnection;
   device: DeviceData & RecoveryPhrase;
   reload: (connection?: AuthenticatedConnection) => void;
-}) => {
+}): Promise<void> => {
   const confirmed = confirm(
     "Reset your Recovery Phrase\n\nWas your recovery phrase compromised? Delete your recovery phrase and generate a new one by confirming."
   );
@@ -92,24 +89,10 @@ export const resetPhrase = async ({
     return;
   }
 
-  // Create a new recovery phrase
-  const recoveryPhrase = generate().trim();
-  const recoverIdentity = await fromMnemonicWithoutValidation(
-    recoveryPhrase,
-    IC_DERIVATION_PATH
-  );
-
-  // Figure out if we need a new connection
-  // NOTE: we create this _before_ replacing the phrase, just in case something
-  // goes wrong it goes wrong before we've replaced the phrase.
-  let nextConnection: AuthenticatedConnection | undefined;
   const sameDevice = bufferEqual(
     connection.identity.getPublicKey().toDer(),
     new Uint8Array(device.pubkey).buffer as DerEncodedPublicKey
   );
-  if (sameDevice) {
-    nextConnection = await connection.fromIdentity(userNumber, recoverIdentity);
-  }
 
   // The connection used in the replace op
   // (if the phrase is protected, this prompts for the phrase and builds a new connection)
@@ -122,37 +105,43 @@ export const resetPhrase = async ({
       )
     : connection;
   if (opConnection === null) {
-    // User aborted, just return
-    reload();
-    return;
+    // User aborted
+    return reload();
   }
 
-  // Save the old pubkey (used as index for replace)
-  const oldKey = device.pubkey;
-  device.pubkey = Array.from(
-    new Uint8Array(recoverIdentity.getPublicKey().toDer())
-  );
+  const uploadPhrase = (pubkey: DerEncodedPublicKey): Promise<void> =>
+    withLoader(() =>
+      opConnection.replace(device.pubkey, {
+        ...device,
+        pubkey: Array.from(new Uint8Array(pubkey)),
+      })
+    );
 
-  try {
-    const phrase = userNumber.toString(10) + " " + recoveryPhrase;
+  const res = await phraseWizard({
+    userNumber,
+    operation: "reset",
+    uploadPhrase,
+  });
 
-    const res = await displayAndConfirmPhrase({ phrase, operation: "reset" });
-
-    if (res === "confirmed") {
-      await withLoader(() => opConnection.replace(oldKey, device));
-    } else if (res !== "canceled") {
-      unreachableLax(res);
-    }
-  } catch (e: unknown) {
+  if (typeof res === "object" && "ok" in res) {
+    // If the user was authenticated with the phrase, then replace the connection
+    // to use the new phrase to void logging them out
+    const nextConnection = sameDevice
+      ? await connection.fromIdentity(userNumber, res.ok)
+      : undefined;
+    return reload(nextConnection);
+  } else if (typeof res === "object" && "error" in res) {
     await displayError({
       title: "Could not reset recovery phrase",
       message: "An unexpected error occurred",
-      detail: e instanceof Error ? e.toString() : "unknown error",
+      detail: unknownToString(res.error, "unknown error"),
       primaryButton: "Ok",
     });
+    return reload();
+  } else {
+    assertType<"canceled">(res);
+    return reload();
   }
-
-  reload(nextConnection);
 };
 
 /* Protect the device and re-render the device settings (with the updated device) */

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -123,14 +123,14 @@ export const resetPhrase = async ({
     uploadPhrase,
   });
 
-  if (typeof res === "object" && "ok" in res) {
+  if ("ok" in res) {
     // If the user was authenticated with the phrase, then replace the connection
     // to use the new phrase to void logging them out
     const nextConnection = sameDevice
       ? await connection.fromIdentity(userNumber, res.ok)
       : undefined;
     return reload(nextConnection);
-  } else if (typeof res === "object" && "error" in res) {
+  } else if ("error" in res) {
     await displayError({
       title: "Could not reset recovery phrase",
       message: "An unexpected error occurred",
@@ -139,7 +139,7 @@ export const resetPhrase = async ({
     });
     return reload();
   } else {
-    assertType<"canceled">(res);
+    assertType<{ canceled: void }>(res);
     return reload();
   }
 };

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -1,4 +1,5 @@
 import { WebAuthnIdentity } from "@dfinity/identity";
+import { DerEncodedPublicKey } from "@dfinity/agent";
 import { displayError } from "../../components/displayError";
 import { DeviceData } from "../../../generated/internet_identity_types";
 import { withLoader } from "../../components/loader";
@@ -13,11 +14,13 @@ import {
   unknownToString,
   unreachable,
   unreachableLax,
+  assertType,
 } from "../../utils/utils";
 import type { ChooseRecoveryProps } from "./chooseRecoveryMechanism";
 import { chooseRecoveryMechanism } from "./chooseRecoveryMechanism";
 import { displaySeedPhrase } from "./displaySeedPhrase";
 import { confirmSeedPhrase } from "./confirmSeedPhrase";
+import { SignIdentity } from "@dfinity/agent";
 
 export const setupRecovery = async ({
   userNumber,
@@ -131,7 +134,40 @@ export const setupPhrase = async (
   userNumber: bigint,
   connection: AuthenticatedConnection
 ): Promise<"ok" | "error" | "canceled"> => {
-  const name = "Recovery phrase";
+  const res = await phraseWizard({
+    userNumber,
+    operation: "create",
+    uploadPhrase: (pubkey) =>
+      withLoader(() =>
+        connection.add(
+          "Recovery phrase",
+          { seed_phrase: null },
+          { recovery: null },
+          pubkey,
+          { unprotected: null }
+        )
+      ),
+  });
+
+  if (typeof res === "object" && "ok" in res) {
+    return "ok";
+  } else if (typeof res === "object" && "error" in res) {
+    return "error";
+  } else {
+    return res;
+  }
+};
+
+// Set up a recovery phrase
+export const phraseWizard = async ({
+  userNumber,
+  operation,
+  uploadPhrase,
+}: {
+  userNumber: bigint;
+  operation: "create" | "reset";
+  uploadPhrase: (pubkey: DerEncodedPublicKey) => Promise<void>;
+}): Promise<{ ok: SignIdentity } | { error: unknown } | "canceled"> => {
   const seedPhrase = generate().trim();
   const recoverIdentity = await fromMnemonicWithoutValidation(
     seedPhrase,
@@ -139,32 +175,21 @@ export const setupPhrase = async (
   );
 
   const phrase = userNumber.toString(10) + " " + seedPhrase;
-  const res = await displayAndConfirmPhrase({ phrase, operation: "create" });
+  const res = await displayAndConfirmPhrase({ phrase, operation });
 
   if (res === "canceled") {
     return res;
   }
 
-  // exhaust return values
-  if (res !== "confirmed") {
-    return unreachable(res, "Unexpected return value when setting up phrase");
-  }
+  assertType<"confirmed">(res);
 
   try {
-    await withLoader(() =>
-      connection.add(
-        name,
-        { seed_phrase: null },
-        { recovery: null },
-        recoverIdentity.getPublicKey().toDer(),
-        { unprotected: null }
-      )
-    );
-  } catch (e: unknown) {
-    return "error";
+    const pubkey = recoverIdentity.getPublicKey().toDer();
+    await withLoader(() => uploadPhrase(pubkey));
+    return { ok: recoverIdentity };
+  } catch (error: unknown) {
+    return { error };
   }
-
-  return "ok";
 };
 
 // Show the new recovery phrase and ask for confirmation

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -149,12 +149,13 @@ export const setupPhrase = async (
       ),
   });
 
-  if (typeof res === "object" && "ok" in res) {
+  if ("ok" in res) {
     return "ok";
-  } else if (typeof res === "object" && "error" in res) {
+  } else if ("error" in res) {
     return "error";
   } else {
-    return res;
+    assertType<{ canceled: void }>(res);
+    return "canceled";
   }
 };
 
@@ -167,7 +168,7 @@ export const phraseWizard = async ({
   userNumber: bigint;
   operation: "create" | "reset";
   uploadPhrase: (pubkey: DerEncodedPublicKey) => Promise<void>;
-}): Promise<{ ok: SignIdentity } | { error: unknown } | "canceled"> => {
+}): Promise<{ ok: SignIdentity } | { error: unknown } | { canceled: void }> => {
   const seedPhrase = generate().trim();
   const recoverIdentity = await fromMnemonicWithoutValidation(
     seedPhrase,
@@ -178,7 +179,7 @@ export const phraseWizard = async ({
   const res = await displayAndConfirmPhrase({ phrase, operation });
 
   if (res === "canceled") {
-    return res;
+    return { canceled: undefined };
   }
 
   assertType<"confirmed">(res);

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -1,3 +1,8 @@
+// Ensures the argument has a given type (from ts' perspective, not js)
+export function assertType<T>(_: T) {
+  /* */
+}
+
 // Turns an 'unknown' into a string, if possible, otherwise use the default
 // `def` parameter.
 export function unknownToString(obj: unknown, def: string): string {


### PR DESCRIPTION
This introduces `phraseWizard`, a function that creates a phrase, asks user for confirmation, and uploads the phrase. This avoids duplicating the phrase creation and confirmation code.

A helper is also introduced, `assertType`, used to exhaust type altneratives. This simplifies handling of return values.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
