### PR TITLE
Fix not waiting for the recovery phrase to be added

### DIFF
--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -85,6 +85,10 @@ export const FLOWS = {
     await recoveryMethodSelectorView.seedPhraseContinue();
     await recoveryMethodSelectorView.seedPhraseFill();
 
+    // Wait for the main view to be displayed again to ensure that the recovery
+    // mechanism was added successfully.
+    await mainView.waitForDisplay();
+
     return seedPhrase;
   },
   readSeedPhrase: async (browser: WebdriverIO.Browser): Promise<string> => {


### PR DESCRIPTION
This PR adds an additional check in the `addRecoveryMechanismSeedPhrase` flow to ensure that the phrase is actually added before the test continues.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
