### PR TITLE
Use 'satisfies' instead of 'assertType'

### DIFF
--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -6,7 +6,7 @@ import {
 } from "../../utils/iiConnection";
 import { displayError } from "../../components/displayError";
 import { withLoader } from "../../components/loader";
-import { unreachable, unknownToString, assertType } from "../../utils/utils";
+import { unreachable, unknownToString } from "../../utils/utils";
 import { DeviceData } from "../../../generated/internet_identity_types";
 import { phraseRecoveryPage } from "../recovery/recoverWith/phrase";
 import { phraseWizard } from "../recovery/setupRecovery";
@@ -139,7 +139,7 @@ export const resetPhrase = async ({
     });
     return reload();
   } else {
-    assertType<{ canceled: void }>(res);
+    res satisfies { canceled: void };
     return reload();
   }
 };

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -14,7 +14,6 @@ import {
   unknownToString,
   unreachable,
   unreachableLax,
-  assertType,
 } from "../../utils/utils";
 import type { ChooseRecoveryProps } from "./chooseRecoveryMechanism";
 import { chooseRecoveryMechanism } from "./chooseRecoveryMechanism";
@@ -158,7 +157,7 @@ export const setupPhrase = async (
   } else if ("error" in res) {
     return "error";
   } else {
-    assertType<{ canceled: void }>(res);
+    res satisfies { canceled: void };
     return "canceled";
   }
 };
@@ -186,7 +185,7 @@ export const phraseWizard = async ({
     return { canceled: undefined };
   }
 
-  assertType<"confirmed">(res);
+  res satisfies "confirmed";
 
   try {
     const pubkey = recoverIdentity.getPublicKey().toDer();

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -1,8 +1,3 @@
-// Ensures the argument has a given type (from ts' perspective, not js)
-export function assertType<T>(_: T) {
-  /* */
-}
-
 // Turns an 'unknown' into a string, if possible, otherwise use the default
 // `def` parameter.
 export function unknownToString(obj: unknown, def: string): string {


### PR DESCRIPTION
TypeScript 4.9 shipped with the `satisfies` keyboard which can be used instead of our custom `assertType` to ensure a value satisfies a given type.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
