### PR TITLE
Fix issues in release-script action

### DIFF
--- a/.github/actions/release/README.md
+++ b/.github/actions/release/README.md
@@ -14,11 +14,15 @@ $  export GITHUB_TOKEN="..."
 $ # The list of files for which we compute the sha256
 $ # (those file must exist, though they don't need to have meaningful content)
 $ export INPUT_ASSETS='internet_identity_production.wasm
+internet_identity_production.wasm.gz
 internet_identity_dev.wasm
 internet_identity_test.wasm
 archive.wasm'
+$ export INPUT_PRODUCTION_ASSET=internet_identity_production.wasm
 $ export RELEASE_TAG=release-2022-10-28 # Any tag
 $ export GITHUB_SHA=$(git rev-parse $RELEASE_TAG)
 $ export RELEASE_TAG_PREVIOUS=release-2022-10-20_2 # Any tag older than RELEASE_TAG
-$ ./.github/actions/release/run # finally, run the action
+# If you want to test the CI links to the sha256sum steps, also provide a valid GITHUB_RUN_ID
+$ export GITHUB_RUN_ID=4533081403
+$ ./.github/actions/release/run.sh # finally, run the action
 ```

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -5,6 +5,10 @@ inputs:
         description: "Assets to upload"
         required: true
         default: ""
+    production_asset:
+        description: "Name of the production asset"
+        required: true
+        default: ""
     token:
         description: "GitHub authentication token"
         required: true
@@ -20,6 +24,7 @@ runs:
         shell: bash
         id: release-notes
         env:
+          INPUT_PRODUCTION_ASSET: ${{ inputs.production_asset }}
           INPUT_ASSETS: ${{ inputs.assets }}
           INPUT_TOKEN: ${{ inputs.token }}
         run: |

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -637,6 +637,7 @@ jobs:
             internet_identity_dev.wasm
             internet_identity_test.wasm
             archive.wasm
+          production_asset: internet_identity_production.wasm
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release


### PR DESCRIPTION
This PR fixes various issues in the release-script action:
* Fix links to CI runs to verify hashes for filenames that are a subset of each other
* Explicit production asset so that the link in the intro is not repeated for the wasm and wasm.gz
* Update readme with latest changes
* Move shellcheck suppression to the appropriate line

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
