### PR TITLE
Add all II flavours as gzipped variant to releases

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -603,10 +603,22 @@ jobs:
           name: internet_identity_test.wasm
           path: .
 
+      - name: 'Download wasm.gz'
+        uses: actions/download-artifact@v3
+        with:
+          name: internet_identity_test.wasm.gz
+          path: .
+
       - name: 'Download wasm'
         uses: actions/download-artifact@v3
         with:
           name: internet_identity_dev.wasm
+          path: .
+
+      - name: 'Download wasm.gz'
+        uses: actions/download-artifact@v3
+        with:
+          name: internet_identity_dev.wasm.gz
           path: .
 
       - name: 'Download wasm'
@@ -635,7 +647,9 @@ jobs:
             internet_identity_production.wasm
             internet_identity_production.wasm.gz
             internet_identity_dev.wasm
+            internet_identity_dev.wasm.gz
             internet_identity_test.wasm
+            internet_identity_test.wasm.gz
             archive.wasm
           production_asset: internet_identity_production.wasm
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -649,7 +663,9 @@ jobs:
             internet_identity_production.wasm \
             internet_identity_production.wasm.gz \
             internet_identity_dev.wasm \
+            internet_identity_dev.wasm.gz \
             internet_identity_test.wasm \
+            internet_identity_test.wasm.gz \
             src/internet_identity/internet_identity.did \
             archive.wasm
         env:


### PR DESCRIPTION
The switch to ic-wasm makes the not-gzipped wasm file too large for deployment in a single message (i.e. what `dfx deploy` does).

In order to have access to a deployable version of the latest prebuilt II, the releases should have all flavours attached as gzipped variant too.

I have updated the [latest release](https://github.com/dfinity/internet-identity/releases/tag/release-2023-03-27) manually now.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
