### PR TITLE
Switch from ic-cdk-optimizer to ic-wasm

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -28,14 +28,14 @@ runs:
                 ;;
         esac
 
-    # cache ic-cdk-optimizer
-    # NOTE: here we make sure to only cache ic-cdk-optimizer and _not_ e.g. the cargo target, since in some cases
+    # cache ic-wasm
+    # NOTE: here we make sure to only cache ic-wasm and _not_ e.g. the cargo target, since in some cases
     # (clean builds) we build from scratch
     # NOTE: we include the output of uname to ensure binary compatibility (e.g. same glibc)
     - uses: actions/cache@v3
       with:
         path: ~/.cargo/bin
-        key: cargo-bin-${{ steps.platform.outputs.platform-id }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-2
+        key: cargo-bin-${{ steps.platform.outputs.platform-id }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-3
 
     - name: Bootstrap
       shell: bash

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -166,12 +166,12 @@ jobs:
       - name: 'Download wasm'
         uses: actions/download-artifact@v3
         with:
-          name: internet_identity_production.wasm
+          name: internet_identity_production.wasm.gz
           path: .
       - id: record-size
         uses: ./.github/actions/file-size
         with:
-          file: internet_identity_production.wasm
+          file: internet_identity_production.wasm.gz
           save: ${{ github.ref == 'refs/heads/main' }}
       - name: "Check canister size"
         run: |

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -513,7 +513,7 @@ jobs:
       - name: 'Download wasm'
         uses: actions/download-artifact@v3
         with:
-          name: internet_identity_dev.wasm
+          name: internet_identity_dev.wasm.gz
           path: .
 
       - name: Deploy II and run tests
@@ -524,14 +524,14 @@ jobs:
           builddir=$(mktemp -d)
           cp -r ./demos/using-dev-build/. "$builddir"
           
-          ii_wasm="$PWD/internet_identity_dev.wasm"
+          ii_wasm="$PWD/internet_identity_dev.wasm.gz"
           ii_did="$PWD/src/internet_identity/internet_identity.did"
           
           pushd "$builddir"
 
           # Install npm deps
           npm ci
-          sed -i "s;https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm;$ii_wasm;" ./dfx.json
+          sed -i "s;https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz;$ii_wasm;" ./dfx.json
           sed -i "s;https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did;$ii_did;" ./dfx.json
 
           dfx deploy --no-wallet

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -433,7 +433,7 @@ jobs:
       - name: 'Download II wasm'
         uses: actions/download-artifact@v3
         with:
-          name: internet_identity_test.wasm
+          name: internet_identity_test.wasm.gz
           path: .
 
       - name: 'Download test app wasm'
@@ -445,7 +445,7 @@ jobs:
       - name: Deploy Internet Identity
         run: |
           dfx canister create --all
-          dfx canister install internet_identity --wasm internet_identity_test.wasm
+          dfx canister install internet_identity --wasm internet_identity_test.wasm.gz
 
       - name: Deploy test app
         working-directory: demos/test-app

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ members = [
 ]
 
 [profile.release]
-debug = false # stripped by ic-cdk-optimizer anyway
+debug = false # stripped by ic-wasm anyway
 lto = true
 opt-level = 'z'

--- a/HACKING.md
+++ b/HACKING.md
@@ -13,7 +13,7 @@ The build requires the following dependencies:
 * [`dfx`](https://github.com/dfinity/sdk/releases/latest) version 0.10.0 or later
 * Rustup with target `wasm32-unknown-unknown` (see [rustup instructions](https://rust-lang.github.io/rustup/cross-compilation.html)), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
 * CMake
-* [`ic-cdk-optimizer`](https://github.com/dfinity/cdk-rs/tree/main/src/ic-cdk-optimizer), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
+* [`ic-wasm`](https://github.com/dfinity/ic-wasm), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
 * Node.js v16+
 
 > NOTE! If you're only going to hack on the HTML and CSS code, just run `npm run showcase`. This will start a minimal web server which serves a showcase of the pages used in the app.

--- a/demos/test-app/build.sh
+++ b/demos/test-app/build.sh
@@ -8,4 +8,4 @@ cd "$SCRIPT_DIR"
 npm ci
 npm run build
 cargo build --release --target wasm32-unknown-unknown
-ic-cdk-optimizer "target/wasm32-unknown-unknown/release/test_app.wasm" -o "./test_app.wasm"
+ic-wasm "target/wasm32-unknown-unknown/release/test_app.wasm" -o "./test_app.wasm" shrink

--- a/demos/using-dev-build/dfx.json
+++ b/demos/using-dev-build/dfx.json
@@ -6,7 +6,7 @@
       "__0": "The development build of Internet Identity. For more information, see https://github.com/dfinity/internet-identity#build-features-and-flavors",
       "type": "custom",
       "candid": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did",
-      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm",
+      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz",
 
       "__2": "The remote block indicates that this canister is only used locally and should not be deployed on the IC.",
       "remote": {

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# install build dependencies (rustup + ic-cdk-optimizer)
+# install build dependencies (rustup + ic-wasm)
 
 set -euo pipefail
 
@@ -22,9 +22,9 @@ echo "using rust version '$rust_version'"
 # here we set the toolchain to 'none' and rustup will pick up on ./rust-toolchain.toml
 run curl --fail https://sh.rustup.rs -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
 
-echo "looking for ic-cdk-optimizer 0.3.4"
-if [[ ! "$(command -v ic-cdk-optimizer)" || "$(ic-cdk-optimizer --version)" != "ic-cdk-optimizer 0.3.4" ]]
+echo "looking for ic-wasm 0.3.5"
+if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.3.5" ]]
 then
-    echo "installing ic-cdk-optimizer 0.3.4"
-    run cargo install ic-cdk-optimizer --version 0.3.4
+    echo "installing ic-wasm 0.3.5"
+    run cargo install ic-wasm --version 0.3.5
 fi

--- a/scripts/build
+++ b/scripts/build
@@ -32,7 +32,7 @@ function help() {
 
 Builds the Internet Identity and the Archive canister.
 
-NOTE: This requires a working rust toolchain as well as ic-cdk-optimizer.
+NOTE: This requires a working rust toolchain as well as ic-wasm.
 EOF
 
 }
@@ -80,11 +80,11 @@ if [ ${#CANISTERS[@]} -eq 0 ]; then
 fi
 
 # Checking for dependencies
-if [[ ! "$(command -v ic-cdk-optimizer)" || "$(ic-cdk-optimizer --version)" != "ic-cdk-optimizer 0.3.4" ]]
+if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.3.5" ]]
 then
-    echo "could not find ic-cdk-optimizer 0.3.4"
-    echo "ic-cdk-optimizer version 0.3.4 is needed, please run the following command:"
-    echo "  cargo install ic-cdk-optimizer --version 0.3.4"
+    echo "could not find ic-wasm 0.3.5"
+    echo "ic-wasm version 0.3.5 is needed, please run the following command:"
+    echo "  cargo install ic-wasm --version 0.3.5"
     exit 1
 fi
 
@@ -124,9 +124,10 @@ function build_canister() {
     then
         CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$SRC_DIR/../../target/}"
 
-        ic-cdk-optimizer \
+        ic-wasm \
             "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" \
-            -o "./$canister.wasm"
+            -o "./$canister.wasm" \
+            shrink
         gzip --no-name --force --keep "$canister.wasm"
     fi
 }


### PR DESCRIPTION
This PR introduces `ic-wasm` in place of the deprecated `ic-cdk-optimizer`.
`ic-wasm` will allow to modify the medatada sections of the generated
wasm files.

However, `ic-wasm shrink` does not achieve the same
level of size reduction as `ic-cdk-optimizer` did. This is why
the production asset will be switched to the gzipped wasm in an upcoming
PR.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
