### PR TITLE
Switch the production asset to the gzipped version

### DIFF
--- a/.github/actions/check-build/action.yml
+++ b/.github/actions/check-build/action.yml
@@ -1,5 +1,5 @@
 name: 'Check build'
-description: This action performs a clean, non-Docker build of II, and optionally checks the Wasm module sha256 against the 'sha256' argument. Nothing is cached except for the bootstrap environment.
+description: This action performs a clean, non-Docker build of II, and optionally checks the gzipped Wasm module sha256 against the 'sha256' argument. Nothing is cached except for the bootstrap environment.
 inputs:
   sha256:
     description: The expected sha256 of the final Wasm module
@@ -19,7 +19,7 @@ runs:
     - name: Check output hash
       shell: bash
       run: |
-        sha256=$(shasum -a 256 ./internet_identity.wasm | cut -d ' ' -f1)
+        sha256=$(shasum -a 256 ./internet_identity.wasm.gz | cut -d ' ' -f1)
         echo got sha "$sha256"
         if [ -n "${{ inputs.sha256 }}" ]
         then

--- a/.github/actions/release/run.sh
+++ b/.github/actions/release/run.sh
@@ -42,7 +42,7 @@ To build the wasm modules yourself and verify their hashes, run the following co
 git pull # to ensure you have the latest changes.
 git checkout $GITHUB_SHA
 ./scripts/docker-build
-sha256sum internet_identity.wasm
+sha256sum internet_identity.wasm.gz
 ./scripts/docker-build --archive
 sha256sum archive.wasm
 \`\`\`

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -581,7 +581,7 @@ jobs:
           sha=$(shasum -a 256 ./archive.wasm | cut -d ' ' -f1 | sed 's/../\\&/g')
           dfx canister --network ic --wallet "$wallet" install --mode upgrade \
             --argument "(opt record {archive_config = record { module_hash = blob \"$sha\"; entries_buffer_limit = 10000:nat64; entries_fetch_limit = 1000:nat16; polling_interval_ns = 60000000000:nat64}; canister_creation_cycles_cost = opt (1000000000000:nat64); })" \
-            --wasm internet_identity_production.wasm \
+            --wasm internet_identity_production.wasm.gz \
             internet_identity
 
       - name: "Deploy archive"
@@ -651,7 +651,7 @@ jobs:
             internet_identity_test.wasm
             internet_identity_test.wasm.gz
             archive.wasm
-          production_asset: internet_identity_production.wasm
+          production_asset: internet_identity_production.wasm.gz
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release
@@ -685,10 +685,10 @@ jobs:
       - name: 'Download wasm.gz'
         uses: actions/download-artifact@v3
         with:
-          name: internet_identity_production.wasm
+          name: internet_identity_production.wasm.gz
           path: .
       - run: |
-          sha256=$(shasum -a 256 ./internet_identity_production.wasm | cut -d ' ' -f1)
+          sha256=$(shasum -a 256 ./internet_identity_production.wasm.gz | cut -d ' ' -f1)
           echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
         id: sha256
 

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -30,7 +30,7 @@ jobs:
             echo "expected a release ref, got '$latest_release_ref'"
             exit 1
           fi
-          curl --silent -SL "https://github.com/dfinity/internet-identity/releases/download/$latest_release_ref/internet_identity_production.wasm" -o internet_identity_previous.wasm
+          curl --silent -SL "https://github.com/dfinity/internet-identity/releases/download/$latest_release_ref/internet_identity_production.wasm.gz" -o internet_identity_previous.wasm.gz
           latest_release_sha256=$(shasum -a 256 ./internet_identity_previous.wasm | cut -d ' ' -f1)
           echo latest release is "$latest_release_ref"
           echo latest release sha256 is "$latest_release_sha256"


### PR DESCRIPTION
This PR switches the production asset to be the gzipped wasm instead of the uncompressed wasm. This means that the build recproducibility checks are run against the gzipped wasm as well.

Note: Since the release-build-check checks the release build using the check-build action of when the release was made, we cannot yet adapt this workflow. This must be done after the next release.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
