### PR TITLE
Replace __get_candid_interface_tmp_hack with metadata section

### DIFF
--- a/demos/test-app/build.sh
+++ b/demos/test-app/build.sh
@@ -9,3 +9,4 @@ npm ci
 npm run build
 cargo build --release --target wasm32-unknown-unknown
 ic-wasm "target/wasm32-unknown-unknown/release/test_app.wasm" -o "./test_app.wasm" shrink
+ic-wasm test_app.wasm -o test_app.wasm metadata candid:service -f test_app.did -v public

--- a/scripts/build
+++ b/scripts/build
@@ -128,6 +128,7 @@ function build_canister() {
             "$CARGO_TARGET_DIR/$TARGET/release/$canister.wasm" \
             -o "./$canister.wasm" \
             shrink
+        ic-wasm "$canister.wasm" -o "$canister.wasm" metadata candid:service -f "$SRC_DIR/$canister.did" -v public
         gzip --no-name --force --keep "$canister.wasm"
     fi
 }

--- a/src/archive/src/main.rs
+++ b/src/archive/src/main.rs
@@ -681,14 +681,6 @@ async fn status() -> ArchiveStatus {
     }
 }
 
-/// This makes this Candid service self-describing, so that for example Candid UI, but also other
-/// tools, can seamlessly integrate with it. The concrete interface (method name etc.) is
-/// provisional, but works.
-#[query]
-fn __get_candid_interface_tmp_hack() -> String {
-    include_str!("../archive.did").to_string()
-}
-
 fn main() {}
 
 // Order dependent: do not move above any function annotated with #[candid_method]!

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -198,14 +198,6 @@ fn get_principal(anchor_number: AnchorNumber, frontend: FrontendHostname) -> Pri
     delegation::get_principal(anchor_number, frontend)
 }
 
-/// This makes this Candid service self-describing, so that for example Candid UI, but also other
-/// tools, can seamlessly integrate with it. The concrete interface (method name etc.) is
-/// provisional, but works.
-#[query]
-fn __get_candid_interface_tmp_hack() -> String {
-    include_str!("../internet_identity.did").to_string()
-}
-
 #[update]
 #[candid_method]
 async fn prepare_delegation(


### PR DESCRIPTION
This replaces the candid interface hack with the proper public metadata section added with `ic-wasm`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
