### PR TITLE
Collect list of latest used delegation origins

### DIFF
--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -307,4 +307,29 @@ pub fn acknowledge_entries(
 }
 
 /// A "compatibility" module for the previous version of II to handle API changes.
-pub mod compat {}
+pub mod compat {
+    use super::*;
+    use candid::{CandidType, Deserialize};
+    use internet_identity_interface::internet_identity::types::{
+        ActiveAnchorCounter, ActiveAnchorStatistics, AnchorNumber, ArchiveInfo,
+        DomainActiveAnchorCounter,
+    };
+
+    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+    pub struct InternetIdentityStats {
+        pub assigned_user_number_range: (AnchorNumber, AnchorNumber),
+        pub users_registered: u64,
+        pub archive_info: ArchiveInfo,
+        pub canister_creation_cycles_cost: u64,
+        pub storage_layout_version: u8,
+        pub active_anchor_stats: Option<ActiveAnchorStatistics<ActiveAnchorCounter>>,
+        pub domain_active_anchor_stats: Option<ActiveAnchorStatistics<DomainActiveAnchorCounter>>,
+    }
+
+    pub fn stats(
+        env: &StateMachine,
+        canister_id: CanisterId,
+    ) -> Result<InternetIdentityStats, CallError> {
+        query_candid(env, canister_id, "stats", ()).map(|(x,)| x)
+    }
+}

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -177,6 +177,7 @@ pub fn arg_with_wasm_hash(wasm: Vec<u8>) -> Option<InternetIdentityInit> {
         }),
         canister_creation_cycles_cost: Some(0),
         register_rate_limit: None,
+        max_num_latest_delegation_origins: None,
     })
 }
 
@@ -186,6 +187,7 @@ pub fn arg_with_rate_limit(rate_limit: RateLimitConfig) -> Option<InternetIdenti
         archive_config: None,
         canister_creation_cycles_cost: None,
         register_rate_limit: Some(rate_limit),
+        max_num_latest_delegation_origins: None,
     })
 }
 
@@ -197,6 +199,7 @@ pub fn arg_with_anchor_range(
         archive_config: None,
         canister_creation_cycles_cost: None,
         register_rate_limit: None,
+        max_num_latest_delegation_origins: None,
     })
 }
 

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -10,6 +10,7 @@ export const idlFactory = ({ IDL }) => {
     'time_per_token_ns' : IDL.Nat64,
   });
   const InternetIdentityInit = IDL.Record({
+    'max_num_latest_delegation_origins' : IDL.Opt(IDL.Nat64),
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
@@ -190,7 +191,9 @@ export const idlFactory = ({ IDL }) => {
     'storage_layout_version' : IDL.Nat8,
     'users_registered' : IDL.Nat64,
     'domain_active_anchor_stats' : IDL.Opt(DomainActiveAnchorStatistics),
+    'max_num_latest_delegation_origins' : IDL.Nat64,
     'assigned_user_number_range' : IDL.Tuple(IDL.Nat64, IDL.Nat64),
+    'latest_delegation_origins' : IDL.Vec(FrontendHostname),
     'archive_info' : ArchiveInfo,
     'canister_creation_cycles_cost' : IDL.Nat64,
     'active_anchor_stats' : IDL.Opt(ActiveAnchorStatistics),
@@ -267,6 +270,7 @@ export const init = ({ IDL }) => {
     'time_per_token_ns' : IDL.Nat64,
   });
   const InternetIdentityInit = IDL.Record({
+    'max_num_latest_delegation_origins' : IDL.Opt(IDL.Nat64),
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -125,6 +125,7 @@ export interface IdentityAnchorInfo {
   'device_registration' : [] | [DeviceRegistrationInfo],
 }
 export interface InternetIdentityInit {
+  'max_num_latest_delegation_origins' : [] | [bigint],
   'assigned_user_number_range' : [] | [[bigint, bigint]],
   'archive_config' : [] | [ArchiveConfig],
   'canister_creation_cycles_cost' : [] | [bigint],
@@ -134,7 +135,9 @@ export interface InternetIdentityStats {
   'storage_layout_version' : number,
   'users_registered' : bigint,
   'domain_active_anchor_stats' : [] | [DomainActiveAnchorStatistics],
+  'max_num_latest_delegation_origins' : bigint,
   'assigned_user_number_range' : [bigint, bigint],
+  'latest_delegation_origins' : Array<FrontendHostname>,
   'archive_info' : ArchiveInfo,
   'canister_creation_cycles_cost' : bigint,
   'active_anchor_stats' : [] | [ActiveAnchorStatistics],

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -156,6 +156,8 @@ type InternetIdentityStats = record {
     canister_creation_cycles_cost: nat64;
     active_anchor_stats: opt ActiveAnchorStatistics;
     domain_active_anchor_stats: opt DomainActiveAnchorStatistics;
+    max_num_latest_delegation_origins: nat64;
+    latest_delegation_origins: vec FrontendHostname
 };
 
 // Configuration parameters related to the archive.
@@ -264,6 +266,9 @@ type InternetIdentityInit = record {
     canister_creation_cycles_cost : opt nat64;
     // Rate limit for the `register` call.
     register_rate_limit : opt RateLimitConfig;
+    // Maximum number of latest delegation origins to track.
+    // Default: 1000
+    max_num_latest_delegation_origins : opt nat64;
 };
 
 type ChallengeKey = text;

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -370,5 +370,7 @@ fn sample_persistent_state() -> PersistentState {
             },
         }),
         domain_active_anchor_stats: None,
+        latest_delegation_origins: None,
+        max_num_latest_delegation_origins: None,
     }
 }

--- a/src/internet_identity/tests/integration/archive_integration.rs
+++ b/src/internet_identity/tests/integration/archive_integration.rs
@@ -49,6 +49,7 @@ mod deployment_tests {
                 }),
                 canister_creation_cycles_cost: Some(100_000_000_000), // current cost in application subnets
                 register_rate_limit: None,
+                max_num_latest_delegation_origins: None,
             }),
         );
         env.add_cycles(ii_canister, 150_000_000_000);
@@ -187,6 +188,7 @@ mod deployment_tests {
                 }),
                 canister_creation_cycles_cost: None, // current cost in application subnets
                 register_rate_limit: None,
+                max_num_latest_delegation_origins: None,
             }),
         )
         .unwrap();

--- a/src/internet_identity/tests/integration/latest_delegation_origins.rs
+++ b/src/internet_identity/tests/integration/latest_delegation_origins.rs
@@ -32,7 +32,7 @@ fn should_record_used_delegation_origin() -> Result<(), CallError> {
 #[test]
 fn should_record_max_delegation_origins() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_low_latest_origin_limit(&env);
+    let canister_id = install_ii_with_latest_origin_limit(&env, 10);
     let user_number = flows::register_anchor(&env, canister_id);
 
     for i in 0..11 {
@@ -51,7 +51,7 @@ fn should_record_max_delegation_origins() -> Result<(), CallError> {
 #[test]
 fn should_drop_orgins_after_30_days() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_low_latest_origin_limit(&env);
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
     let user_number = flows::register_anchor(&env, canister_id);
 
     delegation_for_origin(&env, canister_id, user_number, "https://dropped.com")?;
@@ -85,12 +85,12 @@ fn should_keep_latest_origins_across_upgrades() -> Result<(), CallError> {
     Ok(())
 }
 
-fn install_ii_with_low_latest_origin_limit(env: &StateMachine) -> CanisterId {
+fn install_ii_with_latest_origin_limit(env: &StateMachine, limit: u64) -> CanisterId {
     install_ii_canister_with_arg(
         env,
         II_WASM.clone(),
         Some(InternetIdentityInit {
-            max_num_latest_delegation_origins: Some(10),
+            max_num_latest_delegation_origins: Some(limit),
             ..Default::default()
         }),
     )

--- a/src/internet_identity/tests/integration/latest_delegation_origins.rs
+++ b/src/internet_identity/tests/integration/latest_delegation_origins.rs
@@ -1,0 +1,115 @@
+//! Tests for tracking the latest delegation origins.
+
+use canister_tests::api::internet_identity as api;
+use canister_tests::flows;
+use canister_tests::framework::{
+    env, install_ii_canister, install_ii_canister_with_arg, principal_1, upgrade_ii_canister,
+    II_WASM,
+};
+use ic_cdk::api::management_canister::main::CanisterId;
+use ic_test_state_machine_client::{CallError, StateMachine};
+use internet_identity_interface::internet_identity::types::{AnchorNumber, InternetIdentityInit};
+use serde_bytes::ByteBuf;
+use std::time::Duration;
+
+const DAY_SECONDS: u64 = 24 * 60 * 60;
+
+/// Verifies that origins are recorded.
+#[test]
+fn should_record_used_delegation_origin() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let user_number = flows::register_anchor(&env, canister_id);
+
+    delegation_for_origin(&env, canister_id, user_number, "https://some-dapp.com")?;
+
+    let latest_origins = api::stats(&env, canister_id)?.latest_delegation_origins;
+    assert_eq!(latest_origins, vec!["https://some-dapp.com".to_string()]);
+    Ok(())
+}
+
+/// Verifies that the configured limit for the number of latest used origins is respected.
+#[test]
+fn should_record_max_delegation_origins() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_with_low_latest_origin_limit(&env);
+    let user_number = flows::register_anchor(&env, canister_id);
+
+    for i in 0..11 {
+        delegation_for_origin(&env, canister_id, user_number, &format!("dapp-{}", i))?;
+        env.advance_time(Duration::from_secs(1)); // let time pass so the ordering is deterministic
+    }
+    let latest_origins = api::stats(&env, canister_id)?.latest_delegation_origins;
+
+    assert_eq!(latest_origins.len(), 10);
+    assert!(!latest_origins.contains(&"dapp-0".to_string())); // the oldest has been pruned
+    assert!(latest_origins.contains(&"dapp-10".to_string()));
+    Ok(())
+}
+
+/// Verifies that the latest origins are dropped after 30 days.
+#[test]
+fn should_drop_orgins_after_30_days() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_with_low_latest_origin_limit(&env);
+    let user_number = flows::register_anchor(&env, canister_id);
+
+    delegation_for_origin(&env, canister_id, user_number, "https://dropped.com")?;
+    delegation_for_origin(&env, canister_id, user_number, "https://not-dropped.com")?;
+    env.advance_time(Duration::from_secs(15 * DAY_SECONDS));
+    // repeated activity to refresh the timestamp (for only one origin)
+    delegation_for_origin(&env, canister_id, user_number, "https://not-dropped.com")?;
+    env.advance_time(Duration::from_secs(15 * DAY_SECONDS));
+    // activity to refresh the list
+    delegation_for_origin(&env, canister_id, user_number, "https://unrelated.com")?;
+
+    let latest_origins = api::stats(&env, canister_id)?.latest_delegation_origins;
+
+    assert!(latest_origins.contains(&"https://not-dropped.com".to_string()));
+    assert!(!latest_origins.contains(&"https://dropped.com".to_string()));
+    Ok(())
+}
+
+/// Verifies that the latest origins are kept across upgrades.
+#[test]
+fn should_keep_latest_origins_across_upgrades() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let user_number = flows::register_anchor(&env, canister_id);
+
+    delegation_for_origin(&env, canister_id, user_number, "https://some-dapp.com")?;
+    upgrade_ii_canister(&env, canister_id, II_WASM.clone());
+
+    let latest_origins = api::stats(&env, canister_id)?.latest_delegation_origins;
+    assert_eq!(latest_origins, vec!["https://some-dapp.com".to_string()]);
+    Ok(())
+}
+
+fn install_ii_with_low_latest_origin_limit(env: &StateMachine) -> CanisterId {
+    install_ii_canister_with_arg(
+        env,
+        II_WASM.clone(),
+        Some(InternetIdentityInit {
+            max_num_latest_delegation_origins: Some(10),
+            ..Default::default()
+        }),
+    )
+}
+
+fn delegation_for_origin(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    user_number: AnchorNumber,
+    frontend_hostname: &str,
+) -> Result<(), CallError> {
+    api::prepare_delegation(
+        env,
+        canister_id,
+        principal_1(),
+        user_number,
+        frontend_hostname.to_string(),
+        ByteBuf::from("session public key"),
+        None,
+    )?;
+    Ok(())
+}

--- a/src/internet_identity/tests/integration/main.rs
+++ b/src/internet_identity/tests/integration/main.rs
@@ -9,6 +9,7 @@ mod anchor_management;
 mod archive_integration;
 mod delegation;
 mod http;
+mod latest_delegation_origins;
 mod rollback;
 mod stable_memory;
 mod upgrade;

--- a/src/internet_identity/tests/integration/upgrade.rs
+++ b/src/internet_identity/tests/integration/upgrade.rs
@@ -151,7 +151,7 @@ fn ii_upgrade_should_allow_same_user_range() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
 
-    let stats = api::stats(&env, canister_id)?;
+    let stats = api::compat::stats(&env, canister_id)?;
 
     let result = upgrade_ii_canister_with_arg(
         &env,

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -162,12 +162,13 @@ pub struct AnchorCredentials {
     pub recovery_phrases: Vec<PublicKey>,
 }
 
-#[derive(Clone, Debug, CandidType, Deserialize)]
+#[derive(Clone, Debug, CandidType, Deserialize, Default)]
 pub struct InternetIdentityInit {
     pub assigned_user_number_range: Option<(AnchorNumber, AnchorNumber)>,
     pub archive_config: Option<ArchiveConfig>,
     pub canister_creation_cycles_cost: Option<u64>,
     pub register_rate_limit: Option<RateLimitConfig>,
+    pub max_num_latest_delegation_origins: Option<u64>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -179,6 +180,8 @@ pub struct InternetIdentityStats {
     pub storage_layout_version: u8,
     pub active_anchor_stats: Option<ActiveAnchorStatistics<ActiveAnchorCounter>>,
     pub domain_active_anchor_stats: Option<ActiveAnchorStatistics<DomainActiveAnchorCounter>>,
+    pub max_num_latest_delegation_origins: u64,
+    pub latest_delegation_origins: Vec<FrontendHostname>,
 }
 
 /// Information about the archive.


### PR DESCRIPTION
This PR introduces the list of latest used delegation origins
containing origins that had at least one delegation issued in the
last 30 days. At most `max_num_latest_delegation_origins`
(default 1000) origins are tracked. If the limit is reached, the
least recently used origin is discarded.

This is part of a bigger feature to provide a list of dapps integrating
with II in the II front-end.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
