### PR TITLE
Set platform attachment on device registration / addition

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
@@ -8,6 +8,7 @@ import { promptDeviceAlias } from "../../../components/alias";
 import { withLoader } from "../../../components/loader";
 import { displayError } from "../../../components/displayError";
 import { setAnchorUsed } from "../../../utils/userNumber";
+import { authenticatorAttachmentToKeyType } from "../../../utils/authenticatorAttachment";
 
 const displayFailedToAddDevice = (error: Error) =>
   displayError({
@@ -51,7 +52,9 @@ export const addLocalDevice = async (
     await withLoader(() =>
       connection.add(
         deviceName,
-        { unknown: null },
+        authenticatorAttachmentToKeyType(
+          newDevice.getAuthenticatorAttachment()
+        ),
         { authentication: null },
         newDevice.getPublicKey().toDer(),
         { unprotected: null },

--- a/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -16,6 +16,7 @@ import { showVerificationCode } from "./showVerificationCode";
 import { withLoader } from "../../../components/loader";
 import { promptDeviceAlias } from "../../../components/alias";
 import { displayError } from "../../../components/displayError";
+import { authenticatorAttachmentToKeyType } from "../../../utils/authenticatorAttachment";
 
 /**
  * Prompts the user to enter a device alias. When clicking next, the device is added tentatively to the given identity anchor.
@@ -60,7 +61,9 @@ export const registerTentativeDevice = async (
       alias: alias,
       protection: { unprotected: null },
       pubkey: Array.from(new Uint8Array(result.getPublicKey().toDer())),
-      key_type: { unknown: null },
+      key_type: authenticatorAttachmentToKeyType(
+        result.getAuthenticatorAttachment()
+      ),
       purpose: { authentication: null },
       credential_id: [Array.from(new Uint8Array(result.rawId))],
     };

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -10,6 +10,7 @@ import { isRecoveryPhrase } from "../../utils/recoveryDevice";
 import { setAnchorUsed } from "../../utils/userNumber";
 import { unknownToString, unreachableLax } from "../../utils/utils";
 import { constructIdentity } from "../register/construct";
+import { authenticatorAttachmentToKeyType } from "../../utils/authenticatorAttachment";
 
 export const useRecovery = async (
   connection: Connection,
@@ -152,7 +153,7 @@ const enrollAuthenticator = async ({
   try {
     await connection.add(
       deviceAlias,
-      { unknown: null },
+      authenticatorAttachmentToKeyType(newDevice.getAuthenticatorAttachment()),
       { authentication: null },
       newDevice.getPublicKey().toDer(),
       { unprotected: null },

--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -7,7 +7,7 @@ import { Chan } from "../../utils/utils";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
 import { LoginFlowCanceled, cancel } from "../../utils/flowResult";
 import {
-  IdentifiableIdentity,
+  IIWebAuthnIdentity,
   Connection,
   RegisterResult,
 } from "../../utils/iiConnection";
@@ -222,7 +222,7 @@ export const promptCaptcha = ({
   challenge,
 }: {
   connection: Connection;
-  identity: IdentifiableIdentity;
+  identity: IIWebAuthnIdentity;
   alias: string;
   challenge?: Promise<Challenge>;
 }): Promise<RegisterResult | LoginFlowCanceled> => {

--- a/src/frontend/src/flows/register/construct.ts
+++ b/src/frontend/src/flows/register/construct.ts
@@ -2,7 +2,7 @@ import { WebAuthnIdentity } from "@dfinity/identity";
 import { html, render } from "lit-html";
 import { DeviceData } from "../../../generated/internet_identity_types";
 import {
-  IdentifiableIdentity,
+  IIWebAuthnIdentity,
   DummyIdentity,
   creationOptions,
 } from "../../utils/iiConnection";
@@ -43,7 +43,7 @@ export const constructIdentity = async ({
 }: {
   devices?: () => Promise<Array<DeviceData>>;
   message?: string;
-}): Promise<IdentifiableIdentity> => {
+}): Promise<IIWebAuthnIdentity> => {
   renderConstructing({ message });
   await tick();
 

--- a/src/frontend/src/utils/authenticatorAttachment.ts
+++ b/src/frontend/src/utils/authenticatorAttachment.ts
@@ -1,0 +1,21 @@
+import { KeyType } from "../../generated/internet_identity_types";
+
+/**
+ * Converts a WebAuthn authenticator attachment to an II key type
+ */
+export function authenticatorAttachmentToKeyType(
+  authenticatorAttachment: AuthenticatorAttachment | undefined
+): KeyType {
+  let keyType: KeyType = { unknown: null };
+  switch (authenticatorAttachment) {
+    case "cross-platform":
+      keyType = { cross_platform: null };
+      break;
+    case "platform":
+      keyType = { platform: null };
+      break;
+    default:
+      break;
+  }
+  return keyType;
+}

--- a/src/frontend/src/utils/authenticatorAttachment.ts
+++ b/src/frontend/src/utils/authenticatorAttachment.ts
@@ -6,16 +6,11 @@ import { KeyType } from "../../generated/internet_identity_types";
 export function authenticatorAttachmentToKeyType(
   authenticatorAttachment: AuthenticatorAttachment | undefined
 ): KeyType {
-  let keyType: KeyType = { unknown: null };
-  switch (authenticatorAttachment) {
-    case "cross-platform":
-      keyType = { cross_platform: null };
-      break;
-    case "platform":
-      keyType = { platform: null };
-      break;
-    default:
-      break;
+  if (authenticatorAttachment === "cross-platform") {
+    return { cross_platform: null };
+  } else if (authenticatorAttachment === "platform") {
+    return { platform: null };
+  } else {
+    return { unknown: null };
   }
-  return keyType;
 }

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -50,7 +50,7 @@ import { authenticatorAttachmentToKeyType } from "./authenticatorAttachment";
  */
 export class DummyIdentity
   extends Ed25519KeyIdentity
-  implements IdentifiableIdentity
+  implements IIWebAuthnIdentity
 {
   public rawId: ArrayBuffer;
 
@@ -100,7 +100,11 @@ type SeedPhraseFail = { kind: "seedPhraseFail" };
 
 export type { ChallengeResult } from "../../generated/internet_identity_types";
 
-export interface IdentifiableIdentity extends SignIdentity {
+/**
+ * Interface around the agent-js WebAuthnIdentity that allows us to provide
+ * alternate implementations (such as the dummy identity).
+ */
+export interface IIWebAuthnIdentity extends SignIdentity {
   rawId: ArrayBuffer;
 
   getAuthenticatorAttachment(): AuthenticatorAttachment | undefined;
@@ -114,7 +118,7 @@ export class Connection {
     alias,
     challengeResult,
   }: {
-    identity: IdentifiableIdentity;
+    identity: IIWebAuthnIdentity;
     alias: string;
     challengeResult: ChallengeResult;
   }): Promise<RegisterResult> => {

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -41,6 +41,7 @@ import * as tweetnacl from "tweetnacl";
 import { fromMnemonicWithoutValidation } from "../crypto/ed25519";
 import { features } from "../features";
 import { isRecoveryDevice, RecoveryDevice } from "./recoveryDevice";
+import { authenticatorAttachmentToKeyType } from "./authenticatorAttachment";
 
 /*
  * A (dummy) identity that always uses the same keypair. The secret key is
@@ -101,6 +102,8 @@ export type { ChallengeResult } from "../../generated/internet_identity_types";
 
 export interface IdentifiableIdentity extends SignIdentity {
   rawId: ArrayBuffer;
+
+  getAuthenticatorAttachment(): AuthenticatorAttachment | undefined;
 }
 
 export class Connection {
@@ -140,7 +143,9 @@ export class Connection {
           alias,
           pubkey,
           credential_id: [credential_id],
-          key_type: { unknown: null },
+          key_type: authenticatorAttachmentToKeyType(
+            identity.getAuthenticatorAttachment()
+          ),
           purpose: { authentication: null },
           protection: { unprotected: null },
           origin: readDeviceOrigin(),


### PR DESCRIPTION
This PR add platform attachment information to newly registered / added devices.

By adding it right away
we are no longer dependent on the hacky update on usage. This will be changed in an upcoming PR.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
