### PR TITLE
Move loader CSS to main.css

### DIFF
--- a/src/frontend/src/components/loader.ts
+++ b/src/frontend/src/components/loader.ts
@@ -1,29 +1,12 @@
 import { html, render } from "lit-html";
 
-const loader = () => html`<style>
-    #loader {
-      position: fixed;
-      z-index: var(--vz-loader);
-      top: 0;
-      left: 0;
-      width: 100vw;
-      height: 100vh;
-      background: rgba(0, 0, 0, 0.75);
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    }
-    #loader img {
-      width: 125px;
-      min-width: 125px;
-      max-width: calc(100vw - 1rem);
-      margin: auto;
-      display: block;
-    }
-  </style>
-  <picture id="loader">
-    <img src=${process.env.BASER_URL ?? "" + "/loader.webp"} alt="loading" />
-  </picture>`;
+const loader = () => html` <div id="loader" class="c-loader">
+  <img
+    class="c-loader__image"
+    src=${process.env.BASER_URL ?? "" + "/loader.webp"}
+    alt="loading"
+  />
+</div>`;
 
 const startLoader = () => {
   const container = document.getElementById("loaderContainer") as HTMLElement;

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -81,6 +81,7 @@
   --vc-mist: rgba(255, 255, 255, 0.3);
   --vc-vapour: rgba(255, 255, 255, 0.6);
   --vc-shadow: rgba(32, 33, 36, 0.6);
+  --vc-night: rgba(32, 33, 36, 0.8);
 
   --vc-silver: #d9d9d9;
 
@@ -126,6 +127,8 @@
 
   --rc-dark-transparent: var(--vc-shadow);
   --rc-light-transparent: var(--vc-vapour);
+
+  --rc-overlay-backdrop: var(--vc-night);
 
   --rc-text: var(--rc-dark);
   --rc-text--disabled: var(--vc-shadow);
@@ -2038,6 +2041,23 @@ input[type="checkbox"] {
   100% {
     transform: rotate(360deg);
   }
+}
+
+.c-loader {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-loader);
+  background: var(--rc-overlay-backdrop);
+}
+
+.c-loader__image {
+  width: 125px;
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  user-select: none;
 }
 
 /* 


### PR DESCRIPTION
The CSS for the loader was in the loader component itself. 
Because of that I missed it when renaming the `z-index` variables.

- Move the loader styes from `loader.ts` to `main.css`
- Make use of design tokens for the loader css
- Make the CSS a bit nicer to read
- Make sure the loader icon is not "selectable"