### PR TITLE
Refactoring accesses to state's storage, for better isolation.

### DIFF
--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -202,7 +202,7 @@ pub fn register(device_data: DeviceData, challenge_result: ChallengeAttempt) -> 
         ));
     }
 
-    let allocation = state::storage_mut(|storage| storage.allocate_anchor());
+    let allocation = state::storage_borrow_mut(|storage| storage.allocate_anchor());
     let Some((anchor_number, mut anchor)) = allocation else {
         return RegisterResponse::CanisterFull;
     };
@@ -213,7 +213,7 @@ pub fn register(device_data: DeviceData, challenge_result: ChallengeAttempt) -> 
     activity_bookkeeping(&mut anchor, &device.pubkey);
 
     // write anchor to stable memory
-    state::storage_mut(|storage| {
+    state::storage_borrow_mut(|storage| {
         storage.write(anchor_number, anchor).unwrap_or_else(|err| {
             trap(&format!(
                 "failed to write data of anchor {anchor_number}: {err}"

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -108,7 +108,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
 }
 
 fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
-    state::storage(|storage| {
+    state::storage_borrow(|storage| {
         w.encode_gauge(
             "internet_identity_user_count",
             storage.anchor_count() as f64,

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -138,7 +138,7 @@ fn remove(anchor_number: AnchorNumber, device_key: DeviceKey) {
 #[query]
 #[candid_method(query)]
 fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
-    state::storage(|storage| {
+    state::storage_borrow(|storage| {
         storage
             .read(anchor_number)
             .unwrap_or_default()
@@ -277,7 +277,7 @@ fn stats() -> InternetIdentityStats {
             )
         });
 
-    state::storage(|storage| InternetIdentityStats {
+    state::storage_borrow(|storage| InternetIdentityStats {
         assigned_user_number_range: storage.assigned_anchor_number_range(),
         users_registered: storage.anchor_count() as u64,
         archive_info,
@@ -320,7 +320,7 @@ fn init(maybe_arg: Option<InternetIdentityInit>) {
     apply_install_arg(maybe_arg);
 
     // make sure the fully initialized storage configuration is written to stable memory
-    state::storage_mut(|storage| storage.flush());
+    state::storage_borrow_mut(|storage| storage.flush());
     update_root_hash();
 }
 
@@ -341,7 +341,7 @@ fn post_upgrade(maybe_arg: Option<InternetIdentityInit>) {
 fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
     if let Some(arg) = maybe_arg {
         if let Some(range) = arg.assigned_user_number_range {
-            state::storage_mut(|storage| {
+            state::storage_borrow_mut(|storage| {
                 storage.set_anchor_number_range(range);
             });
         }
@@ -405,9 +405,9 @@ fn authenticate_and_record_activity(anchor_number: AnchorNumber) {
     let mut anchor = state::anchor(anchor_number);
     let device_key = trap_if_not_authenticated(&anchor).pubkey.clone();
     anchor_management::activity_bookkeeping(&mut anchor, &device_key);
-    state::storage_mut(|storage| storage.write(anchor_number, anchor)).unwrap_or_else(|err| {
-        panic!("last_usage_timestamp update: unable to update anchor {anchor_number}: {err}")
-    })
+    state::storage_borrow_mut(|storage| storage.write(anchor_number, anchor)).unwrap_or_else(
+        |err| panic!("last_usage_timestamp update: unable to update anchor {anchor_number}: {err}"),
+    )
 }
 
 /// Authenticates the caller (traps if not authenticated) calls the provided function and handles all
@@ -432,9 +432,9 @@ fn authenticated_anchor_operation<R>(
     let result = op(&mut anchor);
 
     // write back anchor
-    state::storage_mut(|storage| storage.write(anchor_number, anchor)).unwrap_or_else(|err| {
-        panic!("unable to update anchor {anchor_number} in stable memory: {err}")
-    });
+    state::storage_borrow_mut(|storage| storage.write(anchor_number, anchor)).unwrap_or_else(
+        |err| panic!("unable to update anchor {anchor_number} in stable memory: {err}"),
+    );
 
     match result {
         Ok((ret, operation)) => {

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -207,15 +207,15 @@ pub fn salt() -> [u8; 32] {
 pub fn initialize_from_stable_memory() {
     STATE.with(|s| {
         s.last_upgrade_timestamp.set(time());
-        match Storage::from_memory(DefaultMemoryImpl::default()) {
-            Some(new_storage) => {
-                storage_replace(new_storage);
-            }
-            None => {
-                storage_borrow_mut(|storage| storage.flush());
-            }
-        }
     });
+    match Storage::from_memory(DefaultMemoryImpl::default()) {
+        Some(new_storage) => {
+            storage_replace(new_storage);
+        }
+        None => {
+            storage_borrow_mut(|storage| storage.flush());
+        }
+    }
 }
 
 pub fn save_persistent_state() {


### PR DESCRIPTION
State's storage can be accessed directly, or via helpers.  This PR directs all the accesses to use the helpers.
It also renames the helpers, to avoid ambiguity.