### PR TITLE
Enable dynamic certified assets

### DIFF
--- a/src/archive/src/main.rs
+++ b/src/archive/src/main.rs
@@ -553,7 +553,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                     HttpResponse {
                         status_code: 200,
                         headers,
-                        body: Cow::Owned(ByteBuf::from(body)),
+                        body: ByteBuf::from(body),
                         upgrade: None,
                         streaming_strategy: None,
                     }
@@ -561,7 +561,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
                 Err(err) => HttpResponse {
                     status_code: 500,
                     headers: vec![],
-                    body: Cow::Owned(ByteBuf::from(format!("Failed to encode metrics: {err}"))),
+                    body: ByteBuf::from(format!("Failed to encode metrics: {err}")),
                     upgrade: None,
                     streaming_strategy: None,
                 },
@@ -570,7 +570,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
         path => HttpResponse {
             status_code: 404,
             headers: vec![],
-            body: Cow::Owned(ByteBuf::from(format!("Asset {path} not found."))),
+            body: ByteBuf::from(format!("Asset {path} not found.")),
             upgrade: None,
             streaming_strategy: None,
         },

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -70,7 +70,7 @@ lazy_static! {
 pub fn init_assets() {
     state::assets_and_hashes_mut(|assets, asset_hashes| {
         for (path, content, content_encoding, content_type) in get_assets() {
-            asset_hashes.insert(path, sha2::Sha256::digest(content).into());
+            asset_hashes.insert(path.clone(), sha2::Sha256::digest(&content).into());
             let mut headers = match content_encoding {
                 ContentEncoding::Identity => vec![],
                 ContentEncoding::GZip => {
@@ -88,57 +88,57 @@ pub fn init_assets() {
 
 // Get all the assets. Duplicated assets like index.html are shared and generally all assets are
 // prepared only once (like injecting the canister ID).
-fn get_assets() -> [(&'static str, &'static [u8], ContentEncoding, ContentType); 8] {
-    let index_html: &[u8] = INDEX_HTML_STR.as_bytes();
-    let about_html: &[u8] = ABOUT_HTML_STR.as_bytes();
+fn get_assets() -> [(String, Vec<u8>, ContentEncoding, ContentType); 8] {
+    let index_html: Vec<u8> = INDEX_HTML_STR.as_bytes().to_vec();
+    let about_html: Vec<u8> = ABOUT_HTML_STR.as_bytes().to_vec();
     [
         (
-            "/",
-            index_html,
+            "/".to_string(),
+            index_html.clone(),
             ContentEncoding::Identity,
             ContentType::HTML,
         ),
         (
-            "/about",
+            "/about".to_string(),
             about_html,
             ContentEncoding::Identity,
             ContentType::HTML,
         ),
         (
-            "/index.html",
+            "/index.html".to_string(),
             index_html,
             ContentEncoding::Identity,
             ContentType::HTML,
         ),
         (
-            "/index.js",
-            include_bytes!("../../../dist/index.js.gz"),
+            "/index.js".to_string(),
+            include_bytes!("../../../dist/index.js.gz").to_vec(),
             ContentEncoding::GZip,
             ContentType::JS,
         ),
         (
-            "/index.css",
-            include_bytes!("../../../dist/index.css"),
+            "/index.css".to_string(),
+            include_bytes!("../../../dist/index.css").to_vec(),
             ContentEncoding::Identity,
             ContentType::CSS,
         ),
         (
-            "/loader.webp",
-            include_bytes!("../../../dist/loader.webp"),
+            "/loader.webp".to_string(),
+            include_bytes!("../../../dist/loader.webp").to_vec(),
             ContentEncoding::Identity,
             ContentType::WEBP,
         ),
         (
-            "/favicon.ico",
-            include_bytes!("../../../dist/favicon.ico"),
+            "/favicon.ico".to_string(),
+            include_bytes!("../../../dist/favicon.ico").to_vec(),
             ContentEncoding::Identity,
             ContentType::ICO,
         ),
         // Required to make II available on the identity.internetcomputer.org domain.
         // See https://github.com/r-birkner/portal/blob/rjb/custom-domains-docs-v2/docs/developer-docs/production/custom-domain/custom-domain.md#custom-domains-on-the-boundary-nodes
         (
-            "/.well-known/ic-domains",
-            b"identity.internetcomputer.org",
+            "/.well-known/ic-domains".to_string(),
+            b"identity.internetcomputer.org".to_vec(),
             ContentEncoding::Identity,
             ContentType::OCTETSTREAM,
         ),

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -10,8 +10,7 @@ use ic_certified_map::HashTree;
 use ic_metrics_encoder::MetricsEncoder;
 use internet_identity_interface::http_gateway::{HeaderField, HttpRequest, HttpResponse};
 use serde::Serialize;
-use serde_bytes::{ByteBuf, Bytes};
-use std::borrow::Cow;
+use serde_bytes::ByteBuf;
 use std::time::Duration;
 
 impl ContentType {
@@ -39,7 +38,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                 "https://support.dfinity.org/hc/en-us/sections/8730568843412-Internet-Identity"
                     .to_string(),
             )],
-            body: Cow::Owned(ByteBuf::new()),
+            body: ByteBuf::new(),
             // Redirects are not allowed as query because certification V1 does not cover headers.
             // Upgrading to update fixes this. This flag can be removed when switching to
             // certification V2.
@@ -62,7 +61,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                     HttpResponse {
                         status_code: 200,
                         headers,
-                        body: Cow::Owned(ByteBuf::from(body)),
+                        body: ByteBuf::from(body),
                         upgrade: None,
                         streaming_strategy: None,
                     }
@@ -70,7 +69,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                 Err(err) => HttpResponse {
                     status_code: 500,
                     headers: security_headers(),
-                    body: Cow::Owned(ByteBuf::from(format!("Failed to encode metrics: {err}"))),
+                    body: ByteBuf::from(format!("Failed to encode metrics: {err}")),
                     upgrade: None,
                     streaming_strategy: None,
                 },
@@ -88,7 +87,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                     HttpResponse {
                         status_code: 200,
                         headers,
-                        body: Cow::Borrowed(Bytes::new(value)),
+                        body: ByteBuf::from(value.clone()),
                         upgrade: None,
                         streaming_strategy: None,
                     }
@@ -96,9 +95,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                 None => HttpResponse {
                     status_code: 404,
                     headers,
-                    body: Cow::Owned(ByteBuf::from(format!(
-                        "Asset {probably_an_asset} not found."
-                    ))),
+                    body: ByteBuf::from(format!("Asset {probably_an_asset} not found.")),
                     upgrade: None,
                     streaming_strategy: None,
                 },

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -14,8 +14,8 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::time::Duration;
 
-pub type Assets = HashMap<&'static str, (Vec<HeaderField>, &'static [u8])>;
-pub type AssetHashes = RbTree<&'static str, Hash>;
+pub type Assets = HashMap<String, (Vec<HeaderField>, Vec<u8>)>;
+pub type AssetHashes = RbTree<String, Hash>;
 
 // Default value for max number of delegation origins to store in the list of latest used delegation origins
 const MAX_NUM_DELEGATION_ORIGINS: u64 = 1000;

--- a/src/internet_identity_interface/src/http_gateway.rs
+++ b/src/internet_identity_interface/src/http_gateway.rs
@@ -2,8 +2,7 @@
 //! See https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-gateway-interface
 
 use candid::{CandidType, Deserialize, Func};
-use serde_bytes::{ByteBuf, Bytes};
-use std::borrow::Cow;
+use serde_bytes::ByteBuf;
 
 pub type HeaderField = (String, String);
 
@@ -33,7 +32,7 @@ pub struct HttpRequest {
 pub struct HttpResponse {
     pub status_code: u16,
     pub headers: Vec<HeaderField>,
-    pub body: Cow<'static, Bytes>,
+    pub body: ByteBuf,
     pub upgrade: Option<bool>,
     pub streaming_strategy: Option<StreamingStrategy>,
 }


### PR DESCRIPTION
This PR enables dynamic certified assets by creating a copy on the heap and another copy when assembling the http response. While less elegant, the data is small enough to not justify a more complex solution.

This is a prerequisite to have the showcase dapp list served as a certified json file hosted on II. It will also allow serving assets from stable memory in the future.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
