### PR TITLE
Deferring storage init till InternetIdentityInit is available.

### DIFF
--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -324,6 +324,7 @@ fn acknowledge_entries(sequence_number: u64) {
 #[init]
 fn init(maybe_arg: Option<InternetIdentityInit>) {
     init_assets();
+    state::init_new();
 
     apply_install_arg(maybe_arg);
 
@@ -335,7 +336,7 @@ fn init(maybe_arg: Option<InternetIdentityInit>) {
 #[post_upgrade]
 fn post_upgrade(maybe_arg: Option<InternetIdentityInit>) {
     init_assets();
-    state::initialize_from_stable_memory();
+    state::init_from_stable_memory();
 
     // We drop all the signatures on upgrade, users will
     // re-request them if needed.


### PR DESCRIPTION
Changing the default `State` to be created with an uninitialised storage, so that it can be properly initialised once initialisation config is available.  
Also, fixing `save_persistent_state` to use a storage-access helper, rather than directly (this was accidentally omitted previously).