### PR TITLE
Add 'P' -> 'p' to captcha normalization (#1327)

### DIFF
--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -133,6 +133,7 @@ lazy_static! {
         ('X', 'x'),
         ('Y', 'y'),
         ('Z', 'z'),
+        ('P', 'p'),
     ].into_iter().collect();
 }
 


### PR DESCRIPTION
This makes sure `P` characters are not used in captcha, and that only `p` characters are used instead (though both are accepted as `p`).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
