### PR TITLE
Use 127.0.0.1 in webpack configs

### DIFF
--- a/demos/test-app/webpack.config.js
+++ b/demos/test-app/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
     // Set up a proxy that redirects API calls and /index.html to the
     // replica; the rest we serve from here.
     setupMiddlewares: (middlewares, devServer) => {
-      const replicaHost = "http://localhost:4943";
+      const replicaHost = "http://127.0.0.1:4943";
 
       const canisterIdsJson = "./.dfx/local/canister_ids.json";
       let canisterId;
@@ -65,7 +65,7 @@ module.exports = {
     port: 8081,
     proxy: {
       // Make sure /api calls land on the replica (and not on webpack)
-      "/api": "http://localhost:4943",
+      "/api": "http://127.0.0.1:4943",
     },
     allowedHosts: [".localhost", ".local", ".ngrok.io"],
   },

--- a/demos/using-dev-build/webpack.config.js
+++ b/demos/using-dev-build/webpack.config.js
@@ -78,7 +78,7 @@ module.exports = {
   devServer: {
     proxy: {
       "/api": {
-        target: "http://localhost:4943",
+        target: "http://127.0.0.1:4943",
         changeOrigin: true,
         pathRewrite: {
           "^/api": "/api",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -191,7 +191,7 @@ export default [
       // Set up a proxy that redirects API calls to the replica.
       proxy: {
         // Make sure /api calls land on the replica (and not on webpack)
-        "/api": "http://localhost:4943",
+        "/api": "http://127.0.0.1:4943",
       },
       historyApiFallback: {
         // Make sure that visiting links like `/about` serves the correct HTML


### PR DESCRIPTION
The recent move to node 18 means that 127.0.0.1 should be preferred over `localhost` for local development. Otherwise webpack cannot proxy to the canister.

c.f.: https://github.com/dfinity/internet-identity/pull/1387

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
