### PR TITLE
Extract index message and copy

### DIFF
--- a/src/frontend/src/components/message.ts
+++ b/src/frontend/src/components/message.ts
@@ -1,0 +1,33 @@
+import { html, TemplateResult } from "lit-html";
+import { ifDefined } from "lit-html/directives/if-defined.js";
+import { renderPage } from "../utils/lit-html";
+
+const showMessageTemplate = ({
+  message,
+  role,
+}: {
+  message: string;
+  role?: string;
+}): TemplateResult => {
+  return html`<h1
+    style="position: absolute; max-width: 100%; top: 50%; transform: translate(0, -50%);"
+    data-role=${ifDefined(role)}
+  >
+    ${message}
+  </h1>`;
+};
+
+export const showMessagePage = renderPage(showMessageTemplate);
+
+// Show a simple, centered message (with optional "data-role" attribute)
+export const showMessage = ({
+  message,
+  role,
+}: {
+  message: string;
+  role?: string;
+}): void =>
+  showMessagePage({
+    message,
+    role,
+  });

--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -6,6 +6,7 @@ import {
 } from "../../components/authenticateBox";
 import { displayError } from "../../components/displayError";
 import { caretDownIcon, spinner } from "../../components/icons";
+import { showMessage } from "../../components/message";
 import { I18n } from "../../i18n";
 import { Connection } from "../../utils/iiConnection";
 import { withRef } from "../../utils/lit-html";
@@ -73,8 +74,9 @@ export const authFlowAuthorize = async (
   const i18n = new I18n();
   const container = document.getElementById("pageContent") as HTMLElement;
   const copy = i18n.i18n(copyJson);
+  const staticCopy = i18n.staticLang(copyJson);
   render(html`<h1>${copy.starting_authentication}</h1>`, container);
-  const showMessage = (msg: string | TemplateResult) =>
+  const loadingMessage = (msg: string | TemplateResult) =>
     render(
       html`
         <div class="l-container c-card c-card--highlight t-centered">
@@ -111,13 +113,13 @@ export const authFlowAuthorize = async (
     onProgress: (status) => {
       switch (status) {
         case "waiting":
-          showMessage(copy.waiting_for_auth_data);
+          loadingMessage(copy.waiting_for_auth_data);
           break;
         case "validating":
-          showMessage(copy.validating_auth_data);
+          loadingMessage(copy.validating_auth_data);
           break;
         case "fetching delegation":
-          showMessage(copy.finalizing_auth);
+          loadingMessage(copy.finalizing_auth);
           break;
         default:
           unreachable(status);
@@ -141,15 +143,10 @@ export const authFlowAuthorize = async (
       render(html`<h1>${copy.auth_failed}</h1>`, container);
       break;
     case "success":
-      render(
-        html`<h1
-          style="position: absolute; max-width: 100%; top: 50%; transform: translate(0, -50%);"
-          data-role="notify-auth-success"
-        >
-          ${copy.auth_success}
-        </h1>`,
-        container
-      );
+      showMessage({
+        role: "notify-auth-success",
+        message: staticCopy.auth_success,
+      });
       break;
     default:
       unreachable(result);

--- a/src/frontend/src/index.json
+++ b/src/frontend/src/index.json
@@ -1,0 +1,1 @@
+{ "en": { "close_page_device_added": "You may close this page." } }

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -1,17 +1,20 @@
-import { html, render } from "lit-html";
 import { showWarningIfNecessary } from "./banner";
 import { displayError } from "./components/displayError";
+import { showMessage } from "./components/message";
 import { anyFeatures, features } from "./features";
 import { aboutView } from "./flows/about";
 import { registerTentativeDevice } from "./flows/addDevice/welcomeView/registerTentativeDevice";
 import { authFlowAuthorize } from "./flows/authorize";
 import { compatibilityNotice } from "./flows/compatibilityNotice";
 import { authFlowManage } from "./flows/manage";
+import { I18n } from "./i18n";
 import "./styles/main.css";
 import { getAddDeviceAnchor } from "./utils/addDeviceLink";
 import { checkRequiredFeatures } from "./utils/featureDetection";
 import { Connection } from "./utils/iiConnection";
 import { version } from "./version";
+
+import copyJson from "./index.json";
 
 /** Reads the canister ID from the <script> tag.
  *
@@ -103,17 +106,14 @@ const init = async () => {
     // Register this device (tentatively)
     await registerTentativeDevice(addDeviceAnchor, connection);
 
+    const i18n = new I18n();
+    const staticCopy = i18n.staticLang(copyJson);
+
     // Show a good bye message
-    const container = document.getElementById("pageContent") as HTMLElement;
-    render(
-      html`<h1
-        style="position: absolute; max-width: 100%; top: 50%; transform: translate(0, -50%);"
-        data-role="notify-auth-success"
-      >
-        You may close this page.
-      </h1>`,
-      container
-    );
+    showMessage({
+      message: staticCopy.close_page_device_added,
+      role: "notify-device-added",
+    });
     return;
   }
 


### PR DESCRIPTION
This extracts a `showMessage` component/function from the index and extracts the copy too.

The new `showMessage` is also reused in other places that need to display a centered message, and the `data-role` is fixed (in index.ts, the attribute had been copy/pasted but was incorrectly suggesting some authorization was successful).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
