### PR TITLE
Show tooltip for recovery phrase

### DIFF
--- a/src/frontend/src/flows/manage/recoveryMethodsSection.ts
+++ b/src/frontend/src/flows/manage/recoveryMethodsSection.ts
@@ -159,7 +159,12 @@ export const recoveryKeyItem = ({
 const checkmark = (): TemplateResult => {
   return html`
     <div class="c-action-list__status">
-      <span class="c-icon c-icon--ok">${checkmarkRoundIcon}</span>
+      <span class="c-icon c-icon--ok c-tooltip"
+        >${checkmarkRoundIcon}
+        <span class="c-tooltip__message c-card c-card--tight"
+          >You enabled a recovery phrase.</span
+        >
+      </span>
     </div>
   `;
 };


### PR DESCRIPTION
This adds a tooltip displayed when the green "recovery phrase" checkmark is hoverd. This makes the checkmark more consistent with the warning signs shown on missing recoveries.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
