### PR TITLE
Add support for json and svg assets

### DIFF
--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -21,11 +21,13 @@ pub enum ContentEncoding {
 pub enum ContentType {
     HTML,
     JS,
+    JSON,
     ICO,
     WEBP,
     CSS,
     OCTETSTREAM,
     PNG,
+    SVG,
 }
 
 // The <script> tag that loads the 'index.js'
@@ -118,8 +120,10 @@ fn collect_assets_from_dir(dir: &Dir) -> Vec<(String, Vec<u8>, ContentEncoding, 
                 ContentType::HTML,
             ),
             "ico" => (file_bytes, ContentEncoding::Identity, ContentType::ICO),
+            "json" => (file_bytes, ContentEncoding::Identity, ContentType::JSON),
             "js.gz" => (file_bytes, ContentEncoding::GZip, ContentType::JS),
             "png" => (file_bytes, ContentEncoding::Identity, ContentType::PNG),
+            "svg" => (file_bytes, ContentEncoding::Identity, ContentType::SVG),
             "webp" => (file_bytes, ContentEncoding::Identity, ContentType::WEBP),
             _ => panic!("Unknown asset type: {}", asset.path().display()),
         };

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -18,11 +18,13 @@ impl ContentType {
         match self {
             ContentType::HTML => "text/html".to_string(),
             ContentType::JS => "text/javascript".to_string(),
+            ContentType::JSON => "application/json".to_string(),
             ContentType::CSS => "text/css".to_string(),
             ContentType::ICO => "image/vnd.microsoft.icon".to_string(),
             ContentType::WEBP => "image/webp".to_string(),
             ContentType::OCTETSTREAM => "application/octet-stream".to_string(),
             ContentType::PNG => "image/png".to_string(),
+            ContentType::SVG => "image/svg+xml".to_string(),
         }
     }
 }


### PR DESCRIPTION
This PR adds support for `.json` and `.svg` files in the dist folder.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
