### PR TITLE
Nuke unnecessary assets

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -266,11 +266,7 @@ jobs:
         run: |
           mkdir dist
           touch dist/index.html
-          touch dist/about.html
           touch dist/index.js.gz
-          touch dist/index.css
-          touch dist/loader.webp
-          touch dist/favicon.ico
 
       # Caching ~/.cargo
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,12 +37,6 @@ jobs:
       - name: Create dummy assets
         run: |
           mkdir dist
-          touch dist/index.html
-          touch dist/about.html
-          touch dist/index.js.gz
-          touch dist/index.css
-          touch dist/loader.webp
-          touch dist/favicon.ico
 
       - run: rustup component add clippy
       - name: Cargo clippy


### PR DESCRIPTION
Removes dummy test assets that aren't required anymore since we simply bundle the whole dist and don't test for separate assets.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
