### PR TITLE
Fix deploy job to download gzipped artifact

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -557,7 +557,7 @@ jobs:
       - name: 'Download II wasm'
         uses: actions/download-artifact@v3
         with:
-          name: internet_identity_production.wasm
+          name: internet_identity_production.wasm.gz
           path: .
 
       - name: 'Download archive wasm'


### PR DESCRIPTION
The deploy job on the latest release failed due to a download action that was missed when switching to the gzipped production asset.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
