### PR TITLE
Add modals without form

### DIFF
--- a/src/frontend/src/components/modal.ts
+++ b/src/frontend/src/components/modal.ts
@@ -17,7 +17,6 @@ export const createModal = ({ slot }: { slot: TemplateResult }) => {
   const removeContainer = () => container.remove();
 
   // dialog role="dialog": closes modal on Esc
-  // form method="dialog": closes modal on submit
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
   const modalHtml = html`
     <dialog
@@ -51,6 +50,8 @@ export const createModal = ({ slot }: { slot: TemplateResult }) => {
 // (but _not_ when the form is closed via the close button)
 export const formModal = ({ slot }: { slot: TemplateResult }): Promise<void> =>
   new Promise((resolve) =>
+    // form method="dialog": closes modal on submit
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
     createModal({
       slot: html`
         <form @submit=${() => resolve()} method="dialog">

--- a/src/frontend/src/components/modal.ts
+++ b/src/frontend/src/components/modal.ts
@@ -5,13 +5,7 @@ import { withRef } from "../utils/lit-html";
 /**
  * creates a modal that contains arbitrary content
  **/
-export const createModal = ({
-  slot,
-  submit,
-}: {
-  slot: TemplateResult;
-  submit: () => void;
-}) => {
+export const createModal = ({ slot }: { slot: TemplateResult }) => {
   const modalElement: Ref<HTMLDialogElement> = createRef();
 
   // Close modal using the browser API
@@ -33,11 +27,7 @@ export const createModal = ({
       class="c-modal"
       aria-modal
     >
-      <form
-        @submit=${() => submit()}
-        method="dialog"
-        class="c-modal__content c-card c-card--modal"
-      >
+      <div class="c-modal__content c-card c-card--modal">
         <div class="c-modal__inner">
           <button
             @click=${() => closeModal()}
@@ -47,11 +37,8 @@ export const createModal = ({
             &times;
           </button>
           ${slot}
-          <div class="c-modal__footer">
-            <button type="submit" class="c-button c-button--primary">OK</button>
-          </div>
         </div>
-      </form>
+      </div>
     </dialog>
   `;
 
@@ -60,6 +47,18 @@ export const createModal = ({
   withRef(modalElement, (modalElement) => modalElement.showModal());
 };
 
-// Create a modal. The promise resolves iff the "OK" button is clicked.
-export const modal = ({ slot }: { slot: TemplateResult }): Promise<void> =>
-  new Promise((resolve) => createModal({ slot, submit: () => resolve() }));
+// Create a modal with a form "OK" button, which resolves when "OK" is clicked
+// (but _not_ when the form is closed via the close button)
+export const formModal = ({ slot }: { slot: TemplateResult }): Promise<void> =>
+  new Promise((resolve) =>
+    createModal({
+      slot: html`
+        <form @submit=${() => resolve()} method="dialog">
+          ${slot}
+          <div class="c-modal__footer">
+            <button type="submit" class="c-button c-button--primary">OK</button>
+          </div>
+        </form>
+      `,
+    })
+  );

--- a/src/frontend/src/styleguide.ts
+++ b/src/frontend/src/styleguide.ts
@@ -9,7 +9,7 @@ import {
   warningIcon,
 } from "./components/icons";
 import { irregularity } from "./components/irregularity";
-import { modal } from "./components/modal";
+import { formModal } from "./components/modal";
 import { toast } from "./components/toast";
 import { warnBox } from "./components/warnBox";
 import "./styles/main.css";
@@ -515,7 +515,7 @@ export const styleguide = html`
           <button
             class="c-button c-button--primary"
             @click=${async () =>
-              await modal({
+              await formModal({
                 slot: html`<h1>I am a modal</h1>`,
               })}
           >


### PR DESCRIPTION
Before this, modals could not be created without forms. This allows creating modals that can be closed though do not necessarily contain forms.

The previous default behavior (a modal with form) is moved to `formModal`. I'm not sure we need it but leaving it because it's used in the style guide.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
