### PR TITLE
Use host as API for custom hosts

### DIFF
--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -675,6 +675,16 @@ export const inferHost = (): string => {
   }
 
   if (
+    location.hostname.endsWith("icp0.io") ||
+    location.hostname.endsWith("ic0.app") ||
+    location.hostname.endsWith("internetcomputer.org")
+  ) {
+    // If this is a canister running on one of the official IC domains, then return the
+    // official API endpoint
+    return "https://" + IC_API_DOMAIN;
+  }
+
+  if (
     location.host === "127.0.0.1" /* typical development */ ||
     location.host ===
       "0.0.0.0" /* typical development, though no secure context (only usable with builds with WebAuthn disabled) */ ||
@@ -687,6 +697,6 @@ export const inferHost = (): string => {
     return location.protocol + "//" + location.host;
   }
 
-  // In general, use the official IC HTTP domain.
-  return location.protocol + "//" + IC_API_DOMAIN;
+  // Otherwise assume it's a custom setup and use the host itself as API.
+  return location.protocol + "//" + location.host;
 };


### PR DESCRIPTION
This defaults the host used for API call as the host serving the webapp, now special casing for known official ICP domains (`ic0.app`, `icp0.io` & `internetcomputer.org`).

This ensures that when deployed on custom replicas/testnets the app doesn't try to reach `icp-api.io`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
