### PR TITLE
Don't use templates in attributes

### DIFF
--- a/src/frontend/src/flows/recovery/displaySeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/displaySeedPhrase.ts
@@ -78,8 +78,8 @@ const displaySeedPhraseTemplate = ({
           <i
             ${ref(phraseCopyElement)}
             @click=${() => copyPhrase()}
-            aria-label=${copy.copy_to_clipboard}
-            title=${copy.copy_to_clipboard}
+            aria-label=${staticCopy.copy_to_clipboard}
+            title=${staticCopy.copy_to_clipboard}
             tabindex="0"
             id="seedCopy"
             class="c-button__icon"


### PR DESCRIPTION
Unfortunately `lit-html` does not support `TemplateResult`s for attributes (which I keep forgetting and which I don't know just yet how to check for/prevent). This updates some attributes to use `string`s instead.

before:

<img width="502" alt="Screenshot 2023-04-13 at 15 42 52" src="https://user-images.githubusercontent.com/6930756/231778378-3d33428d-bcc6-4096-8f35-730f9182f8ef.png">

after:

<img width="498" alt="Screenshot 2023-04-13 at 15 43 16" src="https://user-images.githubusercontent.com/6930756/231778414-189a001e-02c2-491f-b28d-e82d082ca35b.png">


<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
