### PR TITLE
Remove static copy

### DIFF
--- a/src/frontend/src/components/alias/index.ts
+++ b/src/frontend/src/components/alias/index.ts
@@ -19,10 +19,6 @@ export const promptDeviceAliasTemplate = (props: {
 }): TemplateResult => {
   const copy = props.i18n.i18n(copyJson);
 
-  // static copy required because lit doesn't support template attributes (placeholder)
-  // https://github.com/lit/lit/issues/1862
-  const staticCopy = props.i18n.staticLang(copyJson);
-
   const aliasInput: Ref<HTMLInputElement> = createRef();
   const promptDeviceAliasSlot = html`
     <hgroup class="t-centered">
@@ -59,7 +55,7 @@ export const promptDeviceAliasTemplate = (props: {
           );
           e.currentTarget.setCustomValidity(message);
         }}
-        placeholder=${staticCopy.placeholder}
+        placeholder=${copy.placeholder}
         aria-label="device name"
         type="text"
         required

--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -9,7 +9,7 @@ import {
   LoginFlowSuccess,
 } from "../utils/flowResult";
 import { Connection } from "../utils/iiConnection";
-import { withRef } from "../utils/lit-html";
+import { TemplateElement, withRef } from "../utils/lit-html";
 import { registerIfAllowed } from "../utils/registerAllowedCheck";
 import {
   getAnchors,
@@ -29,12 +29,8 @@ import { promptUserNumber } from "./promptUserNumber";
 export type AuthnTemplates = {
   firstTime: {
     slot: TemplateResult;
-    useExistingText:
-      | string
-      | TemplateResult /** text shown on the button leading to "useExisting" */;
-    createAnchorText:
-      | string
-      | TemplateResult /** text shown on the button leading to anchor creation */;
+    useExistingText: TemplateElement /** text shown on the button leading to "useExisting" */;
+    createAnchorText: TemplateElement /** text shown on the button leading to "useExisting" */;
   };
   useExisting: {
     slot: TemplateResult;

--- a/src/frontend/src/components/displayError.ts
+++ b/src/frontend/src/components/displayError.ts
@@ -1,12 +1,13 @@
-import { html, render, TemplateResult } from "lit-html";
+import { html, render } from "lit-html";
+import { TemplateElement } from "../utils/lit-html";
 import { mainWindow } from "./mainWindow";
 import { warnBox } from "./warnBox";
 
 export type ErrorOptions = {
-  title: string | TemplateResult;
-  message: string | TemplateResult;
-  detail?: string | TemplateResult;
-  primaryButton: string | TemplateResult;
+  title: TemplateElement;
+  message: TemplateElement;
+  detail?: TemplateElement;
+  primaryButton: TemplateElement;
 };
 
 const pageContent = (options: ErrorOptions) =>

--- a/src/frontend/src/components/irregularity.ts
+++ b/src/frontend/src/components/irregularity.ts
@@ -1,8 +1,9 @@
 import { html, TemplateResult } from "lit-html";
+import { TemplateElement } from "../utils/lit-html";
 import { closeIcon, warningIcon } from "./icons";
 
 interface irregularityProps {
-  message: string | TemplateResult;
+  message: TemplateElement;
   closeFn: () => void;
 }
 

--- a/src/frontend/src/components/message.ts
+++ b/src/frontend/src/components/message.ts
@@ -1,12 +1,12 @@
 import { html, TemplateResult } from "lit-html";
 import { ifDefined } from "lit-html/directives/if-defined.js";
-import { renderPage } from "../utils/lit-html";
+import { renderPage, TemplateElement } from "../utils/lit-html";
 
 const showMessageTemplate = ({
   message,
   role,
 }: {
-  message: TemplateResult | string;
+  message: TemplateElement;
   role?: string;
 }): TemplateResult => {
   return html`<h1
@@ -24,7 +24,7 @@ export const showMessage = ({
   message,
   role,
 }: {
-  message: TemplateResult | string;
+  message: TemplateElement;
   role?: string;
 }): void =>
   showMessagePage({

--- a/src/frontend/src/components/toast.ts
+++ b/src/frontend/src/components/toast.ts
@@ -1,4 +1,5 @@
-import { html, render } from "lit-html";
+import { render } from "lit-html";
+import { TemplateElement } from "../utils/lit-html";
 import { irregularity } from "./irregularity";
 
 export const removeToast = (toast: HTMLElement): void => {
@@ -8,8 +9,7 @@ export const removeToast = (toast: HTMLElement): void => {
   toast.classList.add("c-toast--closing");
 };
 
-const createToast = (messageStr: string): HTMLDivElement => {
-  const message = html`${messageStr}`;
+const createToast = (message: TemplateElement): HTMLDivElement => {
   const toastEl = document.createElement("div");
   toastEl.classList.add("c-toast");
   render(
@@ -52,7 +52,7 @@ const getOrCreateToaster = (): Element | null => {
  * use like: toast.error("Something went wrong");
  */
 export const toast = {
-  error: (message: string): void => {
+  error: (message: TemplateElement): void => {
     const toasterEl = getOrCreateToaster();
     const toastEl = createToast(message);
     toasterEl?.appendChild(toastEl);

--- a/src/frontend/src/components/warnBox.ts
+++ b/src/frontend/src/components/warnBox.ts
@@ -1,4 +1,5 @@
 import { html, TemplateResult } from "lit-html";
+import { TemplateElement } from "../utils/lit-html";
 import { warningIcon } from "./icons";
 
 // The Warning Component can be reused with following custom properties: title, message, slot and htmlElement.
@@ -7,8 +8,8 @@ import { warningIcon } from "./icons";
 // By default the component will be an <aside>. The other option is a <div> wrapper.
 
 interface warnBoxProps {
-  title: string | TemplateResult;
-  message: string | TemplateResult;
+  title: TemplateElement;
+  message: TemplateElement;
   slot?: TemplateResult;
   htmlElement?: "div" | "aside";
   additionalClasses?: string[];

--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -32,7 +32,6 @@ const pollForTentativeDeviceTemplate = ({
   i18n: I18n;
 }) => {
   const copy = i18n.i18n(copyJson);
-  const staticCopy = i18n.staticLang(copyJson);
   const link = addDeviceLink({ userNumber, origin });
   const copyLink_ = () => navigator.clipboard.writeText(link);
 
@@ -45,8 +44,8 @@ const pollForTentativeDeviceTemplate = ({
         linkCopyElement.classList.add("is-copied");
       });
     } catch (e: unknown) {
-      toast.error(staticCopy.could_not_copy_link);
-      console.error(staticCopy.could_not_copy_link, e);
+      toast.error(copy.could_not_copy_link);
+      console.error(copy.could_not_copy_link, e);
     }
   };
 
@@ -71,8 +70,8 @@ const pollForTentativeDeviceTemplate = ({
       <button
         ${ref(linkCopyElement)}
         @click=${() => copyLink()}
-        aria-label=${staticCopy.copy_to_clipboard}
-        title=${staticCopy.copy_to_clipboard}
+        aria-label=${copy.copy_to_clipboard}
+        title=${copy.copy_to_clipboard}
         id="seedCopy"
         data-action="copy-link"
         class="c-button__icon"

--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -7,9 +7,9 @@ import {
 import { displayError } from "../../components/displayError";
 import { caretDownIcon, spinner } from "../../components/icons";
 import { showMessage } from "../../components/message";
-import { I18n } from "../../i18n";
+import { DynamicKey, I18n } from "../../i18n";
 import { Connection } from "../../utils/iiConnection";
-import { withRef } from "../../utils/lit-html";
+import { TemplateElement, withRef } from "../../utils/lit-html";
 import { unreachable } from "../../utils/utils";
 import { recoveryWizard } from "../recovery/recoveryWizard";
 import { authenticationProtocol } from "./postMessageInterface";
@@ -38,7 +38,7 @@ export const authnTemplateAuthorize = ({
         })
       : undefined;
 
-  const wrap = (title: string | TemplateResult) => html`
+  const wrap = (title: DynamicKey) => html`
     <div class="t-centered">
       <h1 class="t-title t-title--main">${title}</h1>
       <p class="t-lead">
@@ -74,9 +74,8 @@ export const authFlowAuthorize = async (
   const i18n = new I18n();
   const container = document.getElementById("pageContent") as HTMLElement;
   const copy = i18n.i18n(copyJson);
-  const staticCopy = i18n.staticLang(copyJson);
   render(html`<h1>${copy.starting_authentication}</h1>`, container);
-  const loadingMessage = (msg: string | TemplateResult) =>
+  const loadingMessage = (msg: TemplateElement) =>
     render(
       html`
         <div class="l-container c-card c-card--highlight t-centered">
@@ -145,7 +144,7 @@ export const authFlowAuthorize = async (
     case "success":
       showMessage({
         role: "notify-auth-success",
-        message: staticCopy.auth_success,
+        message: copy.auth_success,
       });
       break;
     default:

--- a/src/frontend/src/flows/dappsExplorer/index.ts
+++ b/src/frontend/src/flows/dappsExplorer/index.ts
@@ -21,12 +21,11 @@ const dappsExplorerTemplate = ({
   back: () => void;
 }) => {
   const copy = i18n.i18n(copyJson);
-  const staticCopy = i18n.staticLang(copyJson);
 
   const pageContent = html`
     <button
       class="c-card__close"
-      aria-label=${staticCopy.back_to_the_previous_page}
+      aria-label=${copy.back_to_the_previous_page}
       @click=${() => back()}
     >
       ${closeIcon}

--- a/src/frontend/src/flows/recovery/displaySeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/displaySeedPhrase.ts
@@ -25,7 +25,6 @@ const displaySeedPhraseTemplate = ({
   i18n: I18n;
 }) => {
   const copy = i18n.i18n(copyJson);
-  const staticCopy = i18n.staticLang(copyJson);
 
   const phraseCopyElement: Ref<HTMLElement> = createRef();
 
@@ -43,8 +42,8 @@ const displaySeedPhraseTemplate = ({
         phraseCopyElement.classList.add("is-copied");
       });
     } catch (e: unknown) {
-      toast.error(staticCopy.unable_to_copy_phrase);
-      console.error(staticCopy.unable_to_copy_phrase, e);
+      toast.error(copy.unable_to_copy_phrase);
+      console.error(copy.unable_to_copy_phrase, e);
     }
   };
 
@@ -78,8 +77,8 @@ const displaySeedPhraseTemplate = ({
           <i
             ${ref(phraseCopyElement)}
             @click=${() => copyPhrase()}
-            aria-label=${staticCopy.copy_to_clipboard}
-            title=${staticCopy.copy_to_clipboard}
+            aria-label=${copy.copy_to_clipboard}
+            title=${copy.copy_to_clipboard}
             tabindex="0"
             id="seedCopy"
             class="c-button__icon"

--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -4,7 +4,7 @@ import { createRef, ref, Ref } from "lit-html/directives/ref.js";
 import { Challenge } from "../../../generated/internet_identity_types";
 import { spinner } from "../../components/icons";
 import { mainWindow } from "../../components/mainWindow";
-import { I18n } from "../../i18n";
+import { DynamicKey, I18n } from "../../i18n";
 import { cancel, LoginFlowCanceled } from "../../utils/flowResult";
 import {
   Connection,
@@ -48,13 +48,13 @@ export const promptCaptchaTemplate = <T>({
   const input: Ref<HTMLInputElement> = createRef();
 
   // The error shown on bad input
-  const errorText = new Chan<TemplateResult | undefined>();
+  const errorText = new Chan<DynamicKey | undefined>();
   const hasError = errorText.map((e) => (e !== undefined ? "has-error" : ""));
 
   // The "next" button behavior
   const next = new Chan<((e: SubmitEvent) => void) | undefined>();
   const nextDisabled = next.map((f) => f === undefined);
-  const nextCaption = new Chan<TemplateResult>();
+  const nextCaption = new Chan<DynamicKey>();
 
   // The "retry" button behavior
   const retry = new Chan<(() => void) | undefined>();

--- a/src/frontend/src/i18n.ts
+++ b/src/frontend/src/i18n.ts
@@ -2,6 +2,7 @@
  * the officially supported languages */
 
 import { I18n as BaseI18n } from "./utils/i18n";
+export type { DynamicKey } from "./utils/i18n";
 
 const supportedLanguages = ["en"] as const;
 export type SupportedLanguage = typeof supportedLanguages[number];

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -107,11 +107,11 @@ const init = async () => {
     await registerTentativeDevice(addDeviceAnchor, connection);
 
     const i18n = new I18n();
-    const staticCopy = i18n.staticLang(copyJson);
+    const copy = i18n.i18n(copyJson);
 
     // Show a good bye message
     showMessage({
-      message: staticCopy.close_page_device_added,
+      message: copy.close_page_device_added,
       role: "notify-device-added",
     });
     return;

--- a/src/frontend/src/utils/i18n.ts
+++ b/src/frontend/src/utils/i18n.ts
@@ -3,7 +3,7 @@
  * This module provides helper for loading multi-language copy definitions and updating the lit templates
  * depending on the user-selected language dynamically. */
 
-import { html, TemplateResult } from "lit-html";
+import { DirectiveResult } from "lit-html/async-directive.js";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { Chan } from "./utils";
 
@@ -12,8 +12,11 @@ type StringCopy<Keys extends string, Lang extends string> = {
   [key in Lang]: { [key in Keys]: string };
 };
 
+// The keys of the dynamic copy (just an async directive result that can be inserted as-in in a template)
+export type DynamicKey = DirectiveResult;
+
 // The dynamic templates, i.e. { some_key_title: <language-dependent template> }
-type DynamicCopy<Keys extends string> = { [key in Keys]: TemplateResult };
+type DynamicCopy<Keys extends string> = { [key in Keys]: DynamicKey };
 
 /// A class that converts a string copy definition into dynamic lit templates dependent on the
 // currently selected language.
@@ -42,19 +45,11 @@ export class I18n<Lang extends string> {
         return copy[lang][k];
       });
 
-      acc[k] = html`${asyncReplace(value)}`;
+      acc[k] = asyncReplace(value);
       return acc;
     }, {} as DynamicCopy<Keys>);
 
     return internationalized;
-  }
-
-  // A "static" (i.e. "string" instead of "TemplateResult") version of the copy, for cases that require
-  // strings (under the assumption that the language won't change)
-  staticLang<Keys extends string>(
-    copy: StringCopy<Keys, Lang>
-  ): { [key in Keys]: string } {
-    return copy[this.lang];
   }
 
   // Set the language, causing all templates to update

--- a/src/frontend/src/utils/lit-html.ts
+++ b/src/frontend/src/utils/lit-html.ts
@@ -5,6 +5,9 @@ import { DirectiveResult } from "lit-html/directive.js";
 import { Ref, ref } from "lit-html/directives/ref.js";
 import { toast } from "../components/toast";
 
+// Helper for types that can (meaningfully) be inserted in a template
+export type TemplateElement = string | TemplateResult | DirectiveResult;
+
 // Read a "lit-html" ref, showing an error message (in the console) in case the
 // element is not available.
 export function withRef<A, B>(ref: Ref<A>, f: (val: A) => B): B | undefined {


### PR DESCRIPTION
Static versions of copy were used in places where a `TemplateResult` couldn't get inlined in an another `TemplateResult` (for instance, in HTML attribute values). On the other hand, `DirectiveResult`s can be inlined nicely, so this changes the `DynamicCopy` to produce `DirectiveResult`s instead of `TemplateResult`s.

A new helper type is introduced (`TemplateElement`) for all "elements" that can be inserted in templates (strings, etc).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
