### PR TITLE
Remove non-gzipped wasms from build infrastructure

### DIFF
--- a/.github/actions/release/README.md
+++ b/.github/actions/release/README.md
@@ -13,11 +13,10 @@ $ # history file.
 $  export GITHUB_TOKEN="..."
 $ # The list of files for which we compute the sha256
 $ # (those file must exist, though they don't need to have meaningful content)
-$ export INPUT_ASSETS='internet_identity_production.wasm
-internet_identity_production.wasm.gz
-internet_identity_dev.wasm
-internet_identity_test.wasm
-archive.wasm'
+$ export INPUT_ASSETS='internet_identity_production.wasm.gz
+internet_identity_dev.wasm.gz
+internet_identity_test.wasm.gz
+archive.wasm.gz'
 $ export INPUT_PRODUCTION_ASSET=internet_identity_production.wasm
 $ export RELEASE_TAG=release-2022-10-28 # Any tag
 $ export GITHUB_SHA=$(git rev-parse $RELEASE_TAG)

--- a/.github/actions/release/run.sh
+++ b/.github/actions/release/run.sh
@@ -44,7 +44,7 @@ git checkout $GITHUB_SHA
 ./scripts/docker-build
 sha256sum internet_identity.wasm.gz
 ./scripts/docker-build --archive
-sha256sum archive.wasm
+sha256sum archive.wasm.gz
 \`\`\`
 EOF
 

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         include:
           # The production build
-          - name: internet_identity_production.wasm
+          - name: internet_identity_production.wasm.gz
             II_FETCH_ROOT_KEY: 0
             II_DUMMY_CAPTCHA: 0
             II_DUMMY_AUTH: 0
@@ -54,7 +54,7 @@ jobs:
 
           # No captcha and fetching the root key, used in (our) tests, backend and
           # selenium.
-          - name: internet_identity_test.wasm
+          - name: internet_identity_test.wasm.gz
             II_FETCH_ROOT_KEY: 1
             II_DUMMY_CAPTCHA: 1
             II_DUMMY_AUTH: 0
@@ -62,7 +62,7 @@ jobs:
 
           # Everything disabled, used by third party developers who only care
           # about the login flow
-          - name: internet_identity_dev.wasm
+          - name: internet_identity_dev.wasm.gz
             II_FETCH_ROOT_KEY: 1
             II_DUMMY_CAPTCHA: 1
             II_DUMMY_AUTH: 1
@@ -97,10 +97,8 @@ jobs:
           outputs: ./out
           target: scratch_internet_identity
 
-      - run: mv out/internet_identity.wasm ${{ matrix.name }}
-      - run: mv out/internet_identity.wasm.gz ${{ matrix.name }}.gz
+      - run: mv out/internet_identity.wasm.gz ${{ matrix.name }}
       - run: sha256sum ${{ matrix.name }}
-      - run: sha256sum ${{ matrix.name }}.gz
       - name: 'Upload ${{ matrix.name }}'
         uses: actions/upload-artifact@v3
         with:
@@ -109,14 +107,6 @@ jobs:
           # path is the name used as the file to upload and the name of the
           # downloaded file
           path: ${{ matrix.name }}
-      - name: 'Upload ${{ matrix.name }}.gz'
-        uses: actions/upload-artifact@v3
-        with:
-          # name is the name used to display and retrieve the artifact
-          name: ${{ matrix.name }}.gz
-          # path is the name used as the file to upload and the name of the
-          # downloaded file
-          path: ${{ matrix.name }}.gz
 
   docker-build-archive:
     runs-on: ubuntu-latest
@@ -137,18 +127,8 @@ jobs:
           outputs: ./out
           target: scratch_archive
 
-      - run: mv out/archive.wasm archive.wasm
       - run: mv out/archive.wasm.gz archive.wasm.gz
-      - run: sha256sum archive.wasm
       - run: sha256sum archive.wasm.gz
-      - name: 'Upload archive.wasm'
-        uses: actions/upload-artifact@v3
-        with:
-          # name is the name used to display and retrieve the artifact
-          name: archive.wasm
-          # path is the name used as the file to upload and the name of the
-          # downloaded file
-          path: archive.wasm
       - name: 'Upload archive.wasm.gz'
         uses: actions/upload-artifact@v3
         with:
@@ -365,23 +345,23 @@ jobs:
       - name: 'Download II wasm'
         uses: actions/download-artifact@v3
         with:
-          name: internet_identity_test.wasm
+          name: internet_identity_test.wasm.gz
           path: .
 
       - name: 'Download archive wasm'
         uses: actions/download-artifact@v3
         with:
-          name: archive.wasm
+          name: archive.wasm.gz
           path: .
 
       - name: Run Tests
         run: |
-          mv internet_identity_test.wasm internet_identity.wasm
+          mv internet_identity_test.wasm.gz internet_identity.wasm.gz
           # NOTE: Here we download changing assets (i.e. the latest release) meaning that in some rare cases (after a new release)
           # PRs that used to be green may become red (if the new release broke something). While this is not CI best practice, it's
           # a relatively small price to pay to make sure PRs are always tested against the latest release.
-          curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_test.wasm -o internet_identity_previous.wasm
-          curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/archive.wasm -o archive_previous.wasm
+          curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_test.wasm.gz -o internet_identity_previous.wasm.gz
+          curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/archive.wasm.gz -o archive_previous.wasm.gz
           cargo test --release
         env:
           RUST_BACKTRACE: 1
@@ -559,7 +539,7 @@ jobs:
       - name: 'Download archive wasm'
         uses: actions/download-artifact@v3
         with:
-          name: archive.wasm
+          name: archive.wasm.gz
           path: .
 
       - name: 'Install key'
@@ -574,14 +554,14 @@ jobs:
       - name: "Deploy II"
         run: |
           wallet="cvthj-wyaaa-aaaad-aaaaq-cai"
-          sha=$(shasum -a 256 ./archive.wasm | cut -d ' ' -f1 | sed 's/../\\&/g')
+          sha=$(shasum -a 256 ./archive.wasm.gz | cut -d ' ' -f1 | sed 's/../\\&/g')
           dfx canister --network ic --wallet "$wallet" install --mode upgrade \
             --argument "(opt record {archive_config = record { module_hash = blob \"$sha\"; entries_buffer_limit = 10000:nat64; entries_fetch_limit = 1000:nat16; polling_interval_ns = 60000000000:nat64}; canister_creation_cycles_cost = opt (1000000000000:nat64); })" \
             --wasm internet_identity_production.wasm.gz \
             internet_identity
 
       - name: "Deploy archive"
-        run: scripts/deploy-archive --wasm archive.wasm --canister-id internet_identity --network ic
+        run: scripts/deploy-archive --wasm archive.wasm.gz --canister-id internet_identity --network ic
 
 
   # This ... releases
@@ -593,22 +573,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: 'Download wasm'
-        uses: actions/download-artifact@v3
-        with:
-          name: internet_identity_test.wasm
-          path: .
-
       - name: 'Download wasm.gz'
         uses: actions/download-artifact@v3
         with:
           name: internet_identity_test.wasm.gz
-          path: .
-
-      - name: 'Download wasm'
-        uses: actions/download-artifact@v3
-        with:
-          name: internet_identity_dev.wasm
           path: .
 
       - name: 'Download wasm.gz'
@@ -617,22 +585,10 @@ jobs:
           name: internet_identity_dev.wasm.gz
           path: .
 
-      - name: 'Download wasm'
-        uses: actions/download-artifact@v3
-        with:
-          name: internet_identity_production.wasm
-          path: .
-
       - name: 'Download wasm.gz'
         uses: actions/download-artifact@v3
         with:
           name: internet_identity_production.wasm.gz
-          path: .
-
-      - name: 'Download wasm'
-        uses: actions/download-artifact@v3
-        with:
-          name: archive.wasm
           path: .
 
       - name: Prepare release
@@ -640,13 +596,10 @@ jobs:
         id: prepare-release
         with:
           assets: |
-            internet_identity_production.wasm
             internet_identity_production.wasm.gz
-            internet_identity_dev.wasm
             internet_identity_dev.wasm.gz
-            internet_identity_test.wasm
             internet_identity_test.wasm.gz
-            archive.wasm
+            archive.wasm.gz
           production_asset: internet_identity_production.wasm.gz
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -656,14 +609,11 @@ jobs:
             --tag ${{ github.ref }} \
             --notes-file ${{ steps.prepare-release.outputs.notes-file }} \
             -- \
-            internet_identity_production.wasm \
             internet_identity_production.wasm.gz \
-            internet_identity_dev.wasm \
             internet_identity_dev.wasm.gz \
-            internet_identity_test.wasm \
             internet_identity_test.wasm.gz \
             src/internet_identity/internet_identity.did \
-            archive.wasm
+            archive.wasm.gz
         env:
           # populated by GitHub Actions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,6 @@ RUN touch src/canister_tests/src/lib.rs
 RUN npm ci
 
 RUN ./scripts/build
-RUN sha256sum /internet_identity.wasm
 RUN sha256sum /internet_identity.wasm.gz
 
 FROM deps as build_archive
@@ -91,13 +90,10 @@ RUN touch src/archive/src/lib.rs
 RUN touch src/canister_tests/src/lib.rs
 
 RUN ./scripts/build --archive
-RUN sha256sum /archive.wasm
 RUN sha256sum /archive.wasm.gz
 
 FROM scratch AS scratch_internet_identity
-COPY --from=build_internet_identity /internet_identity.wasm /
 COPY --from=build_internet_identity /internet_identity.wasm.gz /
 
 FROM scratch AS scratch_archive
-COPY --from=build_archive /archive.wasm /
 COPY --from=build_archive /archive.wasm.gz /

--- a/HACKING.md
+++ b/HACKING.md
@@ -141,7 +141,7 @@ Use the following command to build the backend canister Wasm file instead:
 dfx build internet_identity
 ```
 
-This will produce `./internet_identity.wasm`.
+This will produce `./internet_identity.wasm.gz`.
 
 [releases]: https://github.com/dfinity/internet-identity/releases
 [docker-build]: ./README.md#building-with-docker

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To get the canister (Wasm module) for Internet Identity, you can either **downlo
 $ ./scripts/docker-build
 ```
 
-The [`Dockerfile`](./Dockerfile) specifies build instructions for Internet Identity. Building the `Dockerfile` will result in a scratch container that contains the Wasm module at `/internet_identity.wasm`.
+The [`Dockerfile`](./Dockerfile) specifies build instructions for Internet Identity. Building the `Dockerfile` will result in a scratch container that contains the Wasm module at `/internet_identity.wasm.gz`.
 
 > 💡 The build can be customized with [build features](#build-features-and-flavors).
 

--- a/dfx.json
+++ b/dfx.json
@@ -3,7 +3,7 @@
     "internet_identity": {
       "type": "custom",
       "candid": "src/internet_identity/internet_identity.did",
-      "wasm": "internet_identity.wasm",
+      "wasm": "internet_identity.wasm.gz",
       "build": "scripts/build",
       "shrink" : false
     }

--- a/scripts/build
+++ b/scripts/build
@@ -129,7 +129,7 @@ function build_canister() {
             -o "./$canister.wasm" \
             shrink
         ic-wasm "$canister.wasm" -o "$canister.wasm" metadata candid:service -f "$SRC_DIR/$canister.did" -v public
-        gzip --no-name --force --keep "$canister.wasm"
+        gzip --no-name --force "$canister.wasm"
     fi
 }
 

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # vim: ft=bash
-# Build internet_identity.wasm inside docker. This outputs a single file, internet_identity.wasm,
-# in the top-level directory.
+# Build internet_identity.wasm inside docker. This outputs internet_identity.wasm.gz,
+# and / or archive.wasm.gz depending on the provided arguments in the top-level directory.
 
 set -euo pipefail
 
@@ -34,7 +34,7 @@ EOF
 function help() {
     cat << EOF
 
-This will create (and override) "./internet_identity.wasm". For more information on build features, see:
+This will create (and override) "./internet_identity.wasm.gz" or "./archive.wasm.gz". For more information on build features, see:
     https://github.com/dfinity/internet-identity#build-features-and-flavors
 EOF
 }
@@ -89,7 +89,6 @@ function build() {
     set +x
 
     echo "Copying build output from $tmp_outdir to $PWD"
-    cp "$tmp_outdir/$canister.wasm" .
     cp "$tmp_outdir/$canister.wasm.gz" .
 
     echo "Removing $tmp_outdir"

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -29,9 +29,9 @@ use std::time::{Duration, SystemTime};
 /* The first few lines deal with actually getting the Wasm module(s) to test */
 
 lazy_static! {
-    /** The Wasm module for the current II build, i.e. the one we're testing */
+    /** The gzipped Wasm module for the current II build, i.e. the one we're testing */
     pub static ref II_WASM: Vec<u8> = {
-        let def_path = path::PathBuf::from("..").join("..").join("internet_identity.wasm");
+        let def_path = path::PathBuf::from("..").join("..").join("internet_identity.wasm.gz");
         let err = format!("
         Could not find Internet Identity Wasm module for current build.
 
@@ -43,9 +43,9 @@ lazy_static! {
         get_wasm_path("II_WASM".to_string(), &def_path).expect(&err)
     };
 
-    /** The Wasm module for the current archive build, i.e. the one we're testing */
+    /** The gzipped Wasm module for the current archive build, i.e. the one we're testing */
     pub static ref ARCHIVE_WASM: Vec<u8> = {
-        let def_path = path::PathBuf::from("..").join("..").join("archive.wasm");
+        let def_path = path::PathBuf::from("..").join("..").join("archive.wasm.gz");
         let err = format!("
         Could not find Archive Wasm module for current build.
 
@@ -57,22 +57,22 @@ lazy_static! {
         get_wasm_path("ARCHIVE_WASM".to_string(), &def_path).expect(&err)
     };
 
-    /** The Wasm module for the _previous_ II build, or latest release, which is used when testing
+    /** The gzipped Wasm module for the _previous_ II build, or latest release, which is used when testing
      * upgrades and downgrades */
     pub static ref II_WASM_PREVIOUS: Vec<u8> = {
-        let def_path = path::PathBuf::from("..").join("..").join("internet_identity_previous.wasm");
+        let def_path = path::PathBuf::from("..").join("..").join("internet_identity_previous.wasm.gz");
         let err = format!("
         Could not find Internet Identity Wasm module for previous build/latest release.
 
         I will look for it at {:?}, and you can specify another path with the environment variable II_WASM_PREVIOUS (note that I run from {:?}).
 
         In order to get the Wasm module, please run the following command:
-            curl -SL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_test.wasm -o internet_identity_previous.wasm
+            curl -SL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_test.wasm.gz -o internet_identity_previous.wasm.gz
         ", &def_path, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));
         get_wasm_path("II_WASM_PREVIOUS".to_string(), &def_path).expect(&err)
     };
 
-        /** The Wasm module for the _previous_ archive build, or latest release, which is used when testing
+        /** The gzipped Wasm module for the _previous_ archive build, or latest release, which is used when testing
             * upgrades and downgrades */
     pub static ref ARCHIVE_WASM_PREVIOUS: Vec<u8> = {
         let def_path = path::PathBuf::from("..").join("..").join("archive_previous.wasm");
@@ -82,7 +82,7 @@ lazy_static! {
         I will look for it at {:?}, and you can specify another path with the environment variable ARCHIVE_WASM_PREVIOUS (note that I run from {:?}).
 
         In order to get the Wasm module, please run the following command:
-            curl -SL https://github.com/dfinity/internet-identity/releases/latest/download/archive.wasm -o archive_previous.wasm
+            curl -SL https://github.com/dfinity/internet-identity/releases/latest/download/archive.wasm.gz -o archive_previous.wasm.gz
         ", &def_path, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));
         get_wasm_path("ARCHIVE_WASM_PREVIOUS".to_string(), &def_path).expect(&err)
     };


### PR DESCRIPTION
This PR removes the dual use of non-gzipped and gzipped wasms in favour of having gzipped wasms everywhere. This change only concerns the II canister and the archive but not the test or demo app (that use orthogonal build infrastructure anyway).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
