### PR TITLE
Don't panic in get_anchor_credentials

### DIFF
--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -158,7 +158,7 @@ fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
 #[query]
 #[candid_method(query)]
 fn get_anchor_credentials(anchor_number: AnchorNumber) -> AnchorCredentials {
-    let anchor = state::anchor(anchor_number);
+    let anchor = state::storage_borrow(|storage| storage.read(anchor_number).unwrap_or_default());
 
     anchor.into_devices().into_iter().fold(
         AnchorCredentials {

--- a/src/internet_identity/tests/integration/anchor_management/device_management.rs
+++ b/src/internet_identity/tests/integration/anchor_management/device_management.rs
@@ -456,6 +456,18 @@ fn should_get_credentials() -> Result<(), CallError> {
     Ok(())
 }
 
+/// Verifies that get_anchor_credentials returns an empty list of credentials for invalid anchor numbers.
+#[test]
+fn should_return_empty_credentials_on_invalid_anchor_number() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+
+    let response = api::get_anchor_credentials(&env, canister_id, 1234564)?;
+
+    assert_eq!(response, AnchorCredentials::default());
+    Ok(())
+}
+
 /// Verifies that get_anchor_credentials returns the expected credentials (i.e. no recovery credentials if there are none).
 #[test]
 fn should_not_get_recovery_credentials_if_there_are_none() -> Result<(), CallError> {

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -155,7 +155,7 @@ pub struct WebAuthnCredential {
     pub credential_id: CredentialId,
 }
 
-#[derive(Clone, Debug, CandidType, Deserialize)]
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq, Default)]
 pub struct AnchorCredentials {
     pub credentials: Vec<WebAuthnCredential>,
     pub recovery_credentials: Vec<WebAuthnCredential>,


### PR DESCRIPTION
This PR fixes a panic when supplying an invalid anchor number. Instead, empty `AnchorCredentials` is returned.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
