### PR TITLE
Add missing aria-label

### DIFF
--- a/src/frontend/src/flows/manage/settingsDropdown.ts
+++ b/src/frontend/src/flows/manage/settingsDropdown.ts
@@ -15,6 +15,7 @@ export const settingsDropdown = ({
       class="c-dropdown__trigger c-action-list__action"
       aria-expanded="false"
       aria-controls="dropdown-${id}"
+      aria-label="Open settings"
       data-device=${alias}
     >
       ${dropdownIcon}


### PR DESCRIPTION
The label is a simple string because the management page has not been i18n-ified yet.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
