### PR TITLE
Make Chan more robust

### DIFF
--- a/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
@@ -165,11 +165,7 @@ export const wordTemplate = ({
       ${ref(word.elem)}
       data-expected=${word.word}
       ?autofocus=${word.shouldFocus}
-      data-state=${asyncReplace(
-        state.map(
-          (x) => x
-        ) /* workaround because chan supports only one .recv() */
-      )}
+      data-state=${asyncReplace(state)}
       @input=${() => {
         /* On input, immediately show word as correct when correct, but don't show if a
          * word is incorrect (done only when leaving the field) to not freak out user as they type */

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -245,11 +245,7 @@ export const wordTemplate = ({
       class="c-recoveryInput"
       ${ref(wordRef)}
       data-role="recovery-word-input"
-      data-state=${asyncReplace(
-        state.map(
-          (x: State) => x
-        ) /* workaround because chan supports only one .recv() */
-      )}
+      data-state=${asyncReplace(state)}
       @input=${(e: InputEvent) =>
         withElement(e, (_e, element) => {
           // Reset validity

--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -147,18 +147,14 @@ export const promptCaptchaTemplate = <T>({
   const promptCaptchaSlot = html`
     <article>
       <h1 class="t-title t-title--main">${copy.title}</h1>
-      <form
-        autocomplete="off"
-        @submit=${asyncReplace(next.recv())}
-        class="l-stack"
-      >
+      <form autocomplete="off" @submit=${asyncReplace(next)} class="l-stack">
         <div class="c-input c-input--icon">
-          ${asyncReplace(img.recv())}
+          ${asyncReplace(img)}
           <i
             tabindex="0"
             id="seedCopy"
             class="c-button__icon"
-            @click=${asyncReplace(retry.recv())}
+            @click=${asyncReplace(retry)}
             ?disabled=${asyncReplace(retryDisabled)}
           >
             <span>${copy.retry}</span>
@@ -172,9 +168,7 @@ export const promptCaptchaTemplate = <T>({
             id="captchaInput"
             class="c-input ${asyncReplace(hasError)}"
           />
-          <strong class="c-input__message">
-            ${asyncReplace(errorText.recv())}
-          </strong>
+          <strong class="c-input__message">${asyncReplace(errorText)}</strong>
         </label>
         <p class="t-paragraph confirm-paragraph"></p>
         <div class="c-button-group">
@@ -191,7 +185,7 @@ export const promptCaptchaTemplate = <T>({
             id="confirmRegisterButton"
             ?disabled=${asyncReplace(nextDisabled)}
           >
-            ${asyncReplace(nextCaption.recv())}
+            ${asyncReplace(nextCaption)}
           </button>
         </div>
       </form>

--- a/src/frontend/src/showcase.ts
+++ b/src/frontend/src/showcase.ts
@@ -464,7 +464,7 @@ const components = (): TemplateResult => {
         <button class="c-button" ${ref(
           updateSavedAnchors
         )} @click="${update}">update</button>
-        <div>${asyncReplace(chan.recv())}</div>
+        <div>${asyncReplace(chan)}</div>
     <div ${ref(
       showSelected
     )} class="c-input c-input--readonly">Please select anchor</div></div>

--- a/src/frontend/src/utils/i18n.ts
+++ b/src/frontend/src/utils/i18n.ts
@@ -60,7 +60,6 @@ export class I18n<Lang extends string> {
 
   // Retrieve the currently selected language
   getLanguageAsync(): AsyncIterable<Lang> {
-    // Workaround to copy the chan
-    return this.chan.map((x) => x);
+    return this.chan.values();
   }
 }

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -144,7 +144,7 @@ export function wrapError(err: unknown): string {
  * Values can be sent (`send()`) and received (`recv()`) asynchronously
  * on the other end.
  */
-export class Chan<A> {
+export class Chan<A> implements AsyncIterable<A> {
   /* The `recv` function will read values both from a blocking `snd` function
    * and from a buffer. We always _first_ write to `snd` and _then_ write
    * to `buffer` and _first_ read from the buffer and _then_ read from `snd`
@@ -165,7 +165,7 @@ export class Chan<A> {
   // sent to us
   // We use weak references to the channels so that they do not need to deregister explicitely,
   // but instead we simply drop them when they're gone.
-  private listeners: WeakRef<Chan<A>>[] = [];
+  private listeners: WeakRef<{ send: (a: A) => void }>[] = [];
 
   private latest?: A;
 
@@ -203,8 +203,8 @@ export class Chan<A> {
 
   // Receive all values sent to this `Chan`. Note that this effectively
   // consumes the values: if you need to read the value from different
-  // places use `.map()` instead.
-  async *recv(): AsyncIterable<A> {
+  // places use `.values()` instead.
+  protected async *recv(): AsyncIterable<A> {
     if (this.latest !== undefined) {
       yield this.latest;
     }
@@ -225,19 +225,24 @@ export class Chan<A> {
     }
   }
 
-  // Return a new generator yielding the values or `.recv()`, mapped
-  // with `f`.
-  map<B>(f: (a: A) => B): AsyncIterable<B> {
-    const input = new Chan<A>(this.latest);
-    this.listeners.push(new WeakRef(input));
+  // Return a new Chan mapped with `f`.
+  map<B>(f: (a: A) => B): Chan<B> {
+    const latest = this.latest === undefined ? undefined : f(this.latest);
+    const input = new Chan<B>(latest);
+    this.listeners.push(new WeakRef({ send: (a) => input.send(f(a)) }));
 
-    return {
-      async *[Symbol.asyncIterator]() {
-        for await (const val of input.recv()) {
-          yield f(val);
-        }
-      },
-    };
+    return input;
+  }
+
+  // Read all the values sent to this `Chan`.
+  values(): AsyncIterable<A> {
+    const dup = this.map((x) => x);
+    return dup.recv();
+  }
+
+  // When used directly as an async iterator, return values()
+  [Symbol.asyncIterator](): AsyncIterator<A> {
+    return this.values()[Symbol.asyncIterator]();
   }
 }
 


### PR DESCRIPTION
This makes the `Chan` class a bit more robust by preventing callers from using the internal method `.recv()`, which consumes all values.

* The `.recv()` method is made `protected`
* A new method `.values()` is introduced, which creates a new listener instead of just consuming the values directly
* The `.values()` function is used to implement `AsyncIterable` for `Chan`, meaning `Chan`s can be used directly with e.g. `asyncReplace`

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
