### PR TITLE
Fix dapps reference in chunkArray

### DIFF
--- a/src/frontend/src/flows/dappsExplorer/teaser.ts
+++ b/src/frontend/src/flows/dappsExplorer/teaser.ts
@@ -89,6 +89,6 @@ const chunkArray = <T>({
   arr: T[];
   chunkSize: number;
 }): T[][] =>
-  Array.from(new Array(Math.ceil(dapps.length / chunkSize)), (_, index) =>
+  Array.from(new Array(Math.ceil(arr.length / chunkSize)), (_, index) =>
     arr.slice(index * chunkSize, index * chunkSize + chunkSize)
   );


### PR DESCRIPTION
The `chunkArray` helper was erroneously refering to the global `dapps` value, instead of its parameter `arr`. By chance, until now both were the same.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
