### PR TITLE
Don't reload devices when closing explorer

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -223,55 +223,55 @@ export const displayManage = (
       );
     }
     const display = () =>
-    displayManagePage({
-      userNumber,
-      devices,
-      onAddDevice: async () => {
-        const nextAction = await chooseDeviceAddFlow();
-        switch (nextAction) {
-          case "canceled": {
-            resolve();
-            break;
+      displayManagePage({
+        userNumber,
+        devices,
+        onAddDevice: async () => {
+          const nextAction = await chooseDeviceAddFlow();
+          switch (nextAction) {
+            case "canceled": {
+              resolve();
+              break;
+            }
+            case "local": {
+              await addLocalDevice(userNumber, connection, devices_);
+              resolve();
+              break;
+            }
+            case "remote": {
+              await addRemoteDevice({ userNumber, connection });
+              resolve();
+              break;
+            }
+            default:
+              unreachable(nextAction);
+              resolve();
+              break;
           }
-          case "local": {
-            await addLocalDevice(userNumber, connection, devices_);
-            resolve();
-            break;
+        },
+        addRecoveryPhrase: async () => {
+          await setupPhrase(userNumber, connection);
+          resolve();
+        },
+        addRecoveryKey: async () => {
+          const confirmed = confirm(
+            "Add a Recovery Device\n\nUse a FIDO Security Key, like a YubiKey, as an additional recovery method."
+          );
+          if (!confirmed) {
+            // No resolve here because we don't need to reload the screen
+            return;
           }
-          case "remote": {
-            await addRemoteDevice({ userNumber, connection });
-            resolve();
-            break;
-          }
-          default:
-            unreachable(nextAction);
-            resolve();
-            break;
-        }
-      },
-      addRecoveryPhrase: async () => {
-        await setupPhrase(userNumber, connection);
-        resolve();
-      },
-      addRecoveryKey: async () => {
-        const confirmed = confirm(
-          "Add a Recovery Device\n\nUse a FIDO Security Key, like a YubiKey, as an additional recovery method."
-        );
-        if (!confirmed) {
-          // No resolve here because we don't need to reload the screen
-          return;
-        }
-        await setupKey({ connection });
-        resolve();
-      },
-      exploreDapps: async () => {
-        await dappsExplorer();
-        // We know that the user couldn't have changed anything (the user can't delete e.g. delete
-        // a device from the explorer), so we just re-display without reloading devices etc.
-        // the page without
-        display();
-      },
-    });
+          await setupKey({ connection });
+          resolve();
+        },
+        exploreDapps: async () => {
+          await dappsExplorer();
+          // We know that the user couldn't have changed anything (the user can't delete e.g. delete
+          // a device from the explorer), so we just re-display without reloading devices etc.
+          // the page without
+          display();
+        },
+      });
 
     display();
 

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -222,6 +222,7 @@ export const displayManage = (
         "More than one recovery keys are registered, which is unexpected. Only one will be shown."
       );
     }
+    const display = () =>
     displayManagePage({
       userNumber,
       devices,
@@ -265,9 +266,14 @@ export const displayManage = (
       },
       exploreDapps: async () => {
         await dappsExplorer();
-        resolve();
+        // We know that the user couldn't have changed anything (the user can't delete e.g. delete
+        // a device from the explorer), so we just re-display without reloading devices etc.
+        // the page without
+        display();
       },
     });
+
+    display();
 
     // When visiting the legacy URL (ic0.app) we extra-nudge the users to create a recovery phrase,
     // if they don't have one already. We lead them straight to recovery phrase creation, because


### PR DESCRIPTION
This ensures the management page doesn't reload when coming back from the explorer. Reloading (e.g. fetching devices) takes time and isn't very user-frienly. Since the user couldn't have e.g. modified devices from the explorer, we just re-display the page as we had originally displayed.

NOTE: the first commit makes the actual change, and the second one is only formatting.

Before:


https://user-images.githubusercontent.com/6930756/232828821-c7bee1de-8df3-4d3c-8f6e-bbd75bfd7546.mov


After:


https://user-images.githubusercontent.com/6930756/232828904-9d27f4f9-0874-4e87-b73d-04a035a8a76d.mov


<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
