### PR TITLE
Switch to non-extractable session keys

### DIFF
--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -1,4 +1,4 @@
-import { Ed25519KeyIdentity } from "@dfinity/identity";
+import { ECDSAKeyIdentity } from "@dfinity/identity";
 import { html, TemplateResult } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
@@ -219,7 +219,9 @@ export const promptCaptcha = ({
     promptCaptchaPage({
       cancel: () => resolve(cancel),
       verifyChallengeChars: async ({ chars, challenge }) => {
-        const tempIdentity = Ed25519KeyIdentity.generate();
+        const tempIdentity = await ECDSAKeyIdentity.generate({
+          extractable: false,
+        });
         const result = await connection.register({
           identity,
           tempIdentity,

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -11,6 +11,7 @@ import {
 import {
   DelegationChain,
   DelegationIdentity,
+  ECDSAKeyIdentity,
   Ed25519KeyIdentity,
 } from "@dfinity/identity";
 import { Principal } from "@dfinity/principal";
@@ -431,7 +432,7 @@ export class Connection {
   requestFEDelegation = async (
     identity: SignIdentity
   ): Promise<DelegationIdentity> => {
-    const sessionKey = Ed25519KeyIdentity.generate();
+    const sessionKey = await ECDSAKeyIdentity.generate({ extractable: false });
     const tenMinutesInMsec = 10 * 1000 * 60;
     // Here the security device is used. Besides creating new keys, this is the only place.
     const chain = await DelegationChain.create(


### PR DESCRIPTION
This PR fixes a long standing security issue with regards to II front-end delegation: The private keys have been held in memory, vulnerable to XSS attacks. Now, the session private keys are being managed through the SubtleCrypto API which does not allow to directly access the private key.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
