### PR TITLE
Only import from lit-html

### DIFF
--- a/src/frontend/src/components/mainWindow.ts
+++ b/src/frontend/src/components/mainWindow.ts
@@ -1,5 +1,5 @@
 import { html, TemplateResult } from "lit-html";
-import { ifDefined } from "lit/directives/if-defined.js";
+import { ifDefined } from "lit-html/directives/if-defined.js";
 import { footer } from "./footer";
 import { icLogo } from "./icons";
 

--- a/src/frontend/src/components/toast.ts
+++ b/src/frontend/src/components/toast.ts
@@ -1,6 +1,6 @@
 import { html, render, TemplateResult } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
-import { repeat } from "lit/directives/repeat.js";
+import { repeat } from "lit-html/directives/repeat.js";
 import { TemplateElement } from "../utils/lit-html";
 import { Chan } from "../utils/utils";
 import { closeIcon, warningIcon } from "./icons";


### PR DESCRIPTION
This ensures that all our lit imports (directives, etc) come from the `lit-html` package and not from `lit`. The `lit` imports may work but only because `lit` is a transitive dependency (through `lit-ssr`).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
