### PR TITLE
Don't duplicate logo fixup

### DIFF
--- a/src/frontend/src/flows/dappsExplorer/index.ts
+++ b/src/frontend/src/flows/dappsExplorer/index.ts
@@ -61,11 +61,7 @@ const dappTemplate = ({
       rel="noopener noreferrer"
     >
       <div class="c-action-list__icon" aria-hidden="true">
-        <img
-          src=${logo.replace("/img/showcase/", "/icons/")}
-          alt=${name}
-          loading="lazy"
-        />
+        <img src=${logo} alt=${name} loading="lazy" />
       </div>
       <div class="c-action-list__label c-action-list__label--stacked">
         <h3 class="t-title t-title--list">${name}</h3>


### PR DESCRIPTION
This removes a replace function that cleaned up a dapp's logo path. The logo is already cleaned up by the `getDapps` function.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
