### PR TITLE
Make duplicate device error message understandable for users

### DIFF
--- a/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -10,13 +10,25 @@ import { displayError } from "../../../components/displayError";
 import { withLoader } from "../../../components/loader";
 import { authenticatorAttachmentToKeyType } from "../../../utils/authenticatorAttachment";
 import { Connection, creationOptions } from "../../../utils/iiConnection";
+import { setAnchorUsed } from "../../../utils/userNumber";
 import {
   unknownToString,
   unreachable,
   unreachableLax,
 } from "../../../utils/utils";
+import { isDuplicateDeviceError } from "../../../utils/webAuthnErrorUtils";
 import { deviceRegistrationDisabledInfo } from "./deviceRegistrationModeDisabled";
 import { showVerificationCode } from "./showVerificationCode";
+
+const displayAlreadyRegisteredDevice = () =>
+  displayError({
+    title: "Duplicate Device",
+    message:
+      "This device has already been added to your anchor. Try signing in directly.",
+    detail:
+      "Passkeys may be synchronized across devices automatically (e.g. Apple Passkeys) and do not need to be manually added to your Anchor.",
+    primaryButton: "Ok",
+  });
 
 /**
  * Prompts the user to enter a device alias. When clicking next, the device is added tentatively to the given identity anchor.
@@ -44,12 +56,19 @@ export const registerTentativeDevice = async (
   );
 
   if (result instanceof Error) {
-    await displayError({
-      title: "Error adding new device",
-      message: "Unable to register new WebAuthn Device.",
-      detail: result.message,
-      primaryButton: "Ok",
-    });
+    if (isDuplicateDeviceError(result)) {
+      // Given that this is a remote device where we get the result that authentication should work,
+      // let's help the user and fill in their anchor number.
+      setAnchorUsed(userNumber);
+      await displayAlreadyRegisteredDevice();
+    } else {
+      await displayError({
+        title: "Error adding new device",
+        message: "Unable to register new WebAuthn Device.",
+        detail: result.message,
+        primaryButton: "Ok",
+      });
+    }
     // TODO L2-309: do this without reload
     return window.location.reload() as never;
   }

--- a/src/frontend/src/utils/webAuthnErrorUtils.ts
+++ b/src/frontend/src/utils/webAuthnErrorUtils.ts
@@ -1,0 +1,8 @@
+/** Checks whether the error corresponds with the WebAuthnSpec for duplicate device:
+ *  * https://www.w3.org/TR/webauthn-2/#sctn-createCredential (Step 20)
+ *  * https://www.w3.org/TR/webauthn-2/#sctn-op-make-cred (Step 3)
+ * @param error error to check
+ */
+export function isDuplicateDeviceError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "InvalidStateError";
+}


### PR DESCRIPTION
This PR replaces the very unreadable error (technical) error message when trying to register an already registered device with something that users hopefully understand.

In particular, in replaces this message:
![image](https://user-images.githubusercontent.com/94825501/233953291-3932ea9a-193e-46df-a2d0-f6587034fa50.png)

New screen:
![Screenshot 2023-04-24 at 11 18 34](https://user-images.githubusercontent.com/94825501/233954381-0db06d0e-75aa-4782-8796-01effeddac6b.png)


Tested (so far) on MacOs for FF, Chrome and Safari. Other errors I could provoke (like deny auth on the WebAuthn prompt) did retain their own error message.
