### PR TITLE
Disable autofocus in showcase

### DIFF
--- a/src/frontend/src/components/anchorPicker.ts
+++ b/src/frontend/src/components/anchorPicker.ts
@@ -7,6 +7,7 @@ type PickerProps = {
   savedAnchors: NonEmptyArray<bigint>;
   pick: PickCB;
   moreOptions: () => void;
+  focus?: boolean;
 };
 
 type PickCB = (userNumber: bigint) => void;
@@ -18,8 +19,9 @@ export const mkAnchorPicker = (
 ): {
   template: TemplateResult;
 } => {
+  const focus = props.focus ?? true;
   const elems = props.savedAnchors.map((anchor, i) =>
-    anchorItem({ anchor, pick: props.pick, focus: i === 0 })
+    anchorItem({ anchor, pick: props.pick, focus: focus && i === 0 })
   );
 
   const moreOptions = html` <li class="c-list__item c-list__item--noFocusStyle">

--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -28,6 +28,7 @@ export const promptCaptchaTemplate = <T>({
   verifyChallengeChars,
   onContinue,
   i18n,
+  focus: focus_,
 }: {
   cancel: () => void;
   requestChallenge: () => Promise<Challenge>;
@@ -37,7 +38,9 @@ export const promptCaptchaTemplate = <T>({
   }) => Promise<T | typeof badChallenge>;
   onContinue: (result: T) => void;
   i18n: I18n;
+  focus?: boolean;
 }) => {
+  const focus = focus_ ?? true;
   const copy = i18n.i18n(copyJson);
 
   const spinnerImg: TemplateResult = html`
@@ -157,7 +160,7 @@ export const promptCaptchaTemplate = <T>({
         <label>
           <strong class="t-strong">${copy.instructions}</strong>
           <input
-            ${autofocus}
+            ${focus ? autofocus : undefined}
             ${ref(input)}
             id="captchaInput"
             class="c-input ${asyncReplace(hasError)}"

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -458,6 +458,7 @@ const components = (): TemplateResult => {
           div.innerText = anchor.toString();
         }),
       moreOptions: () => console.log("More options requested"),
+          focus: false,
     }).template;
 
   const chan = new Chan<TemplateResult>(html`loading...`);
@@ -505,6 +506,7 @@ const components = (): TemplateResult => {
                     ),
                   onContinue: () => console.log("Done"),
                   i18n,
+                  focus: false,
                 },
                 container
               )


### PR DESCRIPTION
This removes the autofocus for the anchor picker & captcha when showcased. Otherwise the autofocus causes a jerky scroll.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
