### PR TITLE
Remove webpack chunk name hint

### DIFF
--- a/src/frontend/src/crypto/mnemonic.ts
+++ b/src/frontend/src/crypto/mnemonic.ts
@@ -18,7 +18,7 @@ export function generate(): string {
 export const RECOVERYPHRASE_WORDCOUNT = 24;
 
 /** The list of words used to make the recovery phrase */
-// NOTE: "english" is the only one actually bundled in (see webpack config)
+// NOTE: "english" is the only one actually bundled in (see bundler config)
 export const RECOVERYPHRASE_WORDLIST: string[] = wordlists.english;
 
 /**

--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -171,8 +171,7 @@ const poll = (
 // Dynamically load the QR code module
 const loadQrCreator = async (): Promise<typeof QrCreator | undefined> => {
   try {
-    return (await import(/* webpackChunkName: "qr-creator" */ "qr-creator"))
-      .default;
+    return (await import("qr-creator")).default;
   } catch (e) {
     console.error(e);
     return undefined;

--- a/src/frontend/src/flows/dappsExplorer/dapps.ts
+++ b/src/frontend/src/flows/dappsExplorer/dapps.ts
@@ -17,8 +17,7 @@ export type DappDescription = ElementOf<typeof dappsJson>;
 // Dynamically load the dapps list
 const loadDapps = async (): Promise<DappDescription[] | undefined> => {
   try {
-    return (await import(/* webpackChunkName: "dapps" */ "./dapps.json"))
-      .default;
+    return (await import("./dapps.json")).default;
   } catch (e) {
     console.error(e);
     return undefined;


### PR DESCRIPTION
# Motivation

We do not need the Webpack hint in code used to set a name to lazy loaded chunks anymore.
