### PR TITLE
Fix showcase deploy

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -150,16 +150,7 @@ jobs:
 
   # Deploy the showcase to GitHub Pages
   showcase:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-    permissions:
-      pages: write
-      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
@@ -168,16 +159,31 @@ jobs:
       # Build the showcase with a special base URL (used in links and esp. routing)
       # to match the deploy URL: https://dfinity.github.io/internet-identity/
       - run: BASE_URL='/internet-identity' npm run build:showcase
-      # the showcase needs the same index.html served on all routes. In the devServer this is
-      # done by using `historyApiFallback`; on GH pages we just show a fake 404 page that is
-      # actually the index.
-      - run: cp dist/index.html dist/404.html
+      # the showcase needs the same index.html served on all routes; on GH pages we just show a fake 404 page
+      # that is actually the index.
+      - run: cp dist-showcase/index.html dist-showcase/404.html
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: 'dist'
+          path: 'dist-showcase'
+
+  # Deploy the showcase to GitHub Pages
+  showcase-deploy:
+    runs-on: ubuntu-latest
+    needs: showcase
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      pages: write
+      id-token: write
+
+    steps:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v1
         id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # frontend code
 node_modules/
 dist/
+dist-showcase/
 .env
 lib
 wdio.log

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,7 +79,7 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
       publicDir: "../frontend/assets",
       build: {
         ...build,
-        outDir: "../../showcase",
+        outDir: "../../dist-showcase",
       },
     };
   }


### PR DESCRIPTION
This updates the `showcase` CI job to use the correct showcase dist directory. The showcase output dir is also renamed for clarity (showcase -> dist-showcase) and the dir added to the gitignore. Finally, the CI job is changed to run on all branches (the build is; the deploy is left to only run on main).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
