### PR TITLE
Import loader.webp without process.env

### DIFF
--- a/jest-transform.cjs
+++ b/jest-transform.cjs
@@ -1,0 +1,18 @@
+const path = require("path");
+
+/**
+ * Jest cannot process images imported within the code. This loads their path as modules for test purpose.
+ *
+ * e.g.
+ * import loaderUrl from "../../assets/loader.webp";
+ */
+module.exports = {
+  process(sourceText, sourcePath, options) {
+    return {
+      code: `module.exports = ${JSON.stringify(path.basename(sourcePath))};`,
+    };
+  },
+  getCacheKey() {
+    return "img-transform";
+  },
+};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,6 +17,9 @@ export default {
 
   // These two transform options make sure that jest can process files that include ES modules
   // (in particular, files that have lit-html import)
-  transform: { "\\.[jt]sx?$": "ts-jest" },
+  transform: {
+    "\\.[jt]sx?$": "ts-jest",
+    "\\.(svg|png|webp)$": "<rootDir>/jest-transform.cjs",
+  },
   transformIgnorePatterns: ["node_modules/(?!@?lit)"],
 };

--- a/src/frontend/env.d.ts
+++ b/src/frontend/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+declare module "envConfig";

--- a/src/frontend/env.d.ts
+++ b/src/frontend/env.d.ts
@@ -1,2 +1,5 @@
+/**
+ * See Vite documentation: https://vitejs.dev/guide/assets.html
+ */
 /// <reference types="vite/client" />
 declare module "envConfig";

--- a/src/frontend/src/components/loader.ts
+++ b/src/frontend/src/components/loader.ts
@@ -1,11 +1,8 @@
 import { html, render } from "lit-html";
+import loaderUrl from "../../assets/loader.webp";
 
 const loader = () => html` <div id="loader" class="c-loader">
-  <img
-    class="c-loader__image"
-    src=${process.env.BASER_URL ?? "" + "/loader.webp"}
-    alt="loading"
-  />
+  <img class="c-loader__image" src=${loaderUrl} alt="loading" />
 </div>`;
 
 const startLoader = () => {


### PR DESCRIPTION
# Motivation

Use Vite static asset handling to import `loader.webp`.

https://vitejs.dev/guide/assets.html

Note:

- because we explicitely set chunk name in the build config, the keep its name during build process (as currently) - i.e. no timestamp is added to the filename as displayed in the documentation

- not sure it would make contribution easy but we could transform `dapps.json` to a `dapps.ts` and use the same pattern if we want to