### PR TITLE
Add human readable errors for cancel / timeout

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addLocalDevice.ts
@@ -9,7 +9,10 @@ import {
   creationOptions,
 } from "../../../utils/iiConnection";
 import { setAnchorUsed } from "../../../utils/userNumber";
-import { isDuplicateDeviceError } from "../../../utils/webAuthnErrorUtils";
+import {
+  isCancelOrTimeout,
+  isDuplicateDeviceError,
+} from "../../../utils/webAuthnErrorUtils";
 import { renderAddDeviceSuccess } from "./addDeviceSuccess";
 
 const displayFailedToAddDevice = (error: Error) =>
@@ -27,6 +30,14 @@ const displayAlreadyRegisteredDevice = () =>
     message: "This device has already been added to your anchor.",
     detail:
       "Passkeys may be synchronized across devices automatically (e.g. Apple Passkeys) and do not need to be manually added to your Anchor.",
+    primaryButton: "Back to manage",
+  });
+
+const displayCancelOrTimeout = () =>
+  displayError({
+    title: "Operation canceled",
+    message:
+      "The interaction with your security device was canceled or timed out. Please try again.",
     primaryButton: "Back to manage",
   });
 
@@ -51,6 +62,8 @@ export const addLocalDevice = async (
   } catch (error: unknown) {
     if (isDuplicateDeviceError(error)) {
       await displayAlreadyRegisteredDevice();
+    } else if (isCancelOrTimeout(error)) {
+      await displayCancelOrTimeout();
     } else {
       await displayFailedToAddDevice(
         error instanceof Error ? error : unknownError()

--- a/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -16,7 +16,10 @@ import {
   unreachable,
   unreachableLax,
 } from "../../../utils/utils";
-import { isDuplicateDeviceError } from "../../../utils/webAuthnErrorUtils";
+import {
+  isCancelOrTimeout,
+  isDuplicateDeviceError,
+} from "../../../utils/webAuthnErrorUtils";
 import { deviceRegistrationDisabledInfo } from "./deviceRegistrationModeDisabled";
 import { showVerificationCode } from "./showVerificationCode";
 
@@ -27,6 +30,14 @@ const displayAlreadyRegisteredDevice = () =>
       "This device has already been added to your anchor. Try signing in directly.",
     detail:
       "Passkeys may be synchronized across devices automatically (e.g. Apple Passkeys) and do not need to be manually added to your Anchor.",
+    primaryButton: "Ok",
+  });
+
+const displayCancelOrTimeout = () =>
+  displayError({
+    title: "Operation canceled",
+    message:
+      "The interaction with your security device was canceled or timed out. Please try again.",
     primaryButton: "Ok",
   });
 
@@ -61,6 +72,8 @@ export const registerTentativeDevice = async (
       // let's help the user and fill in their anchor number.
       setAnchorUsed(userNumber);
       await displayAlreadyRegisteredDevice();
+    } else if (isCancelOrTimeout(result)) {
+      await displayCancelOrTimeout();
     } else {
       await displayError({
         title: "Error adding new device",

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -7,6 +7,7 @@ import {
 import { Connection } from "../../utils/iiConnection";
 import { setAnchorUsed } from "../../utils/userNumber";
 import { unknownToString } from "../../utils/utils";
+import { isCancelOrTimeout } from "../../utils/webAuthnErrorUtils";
 import { promptCaptcha } from "./captcha";
 import { constructIdentity } from "./construct";
 import { displayUserNumber } from "./finish";
@@ -46,6 +47,14 @@ export const register = async ({
       return result;
     }
   } catch (e) {
+    if (isCancelOrTimeout(e)) {
+      return {
+        tag: "err",
+        title: "Operation Canceled",
+        message:
+          "The interaction with your security device was canceled or timed out. Please try again.",
+      };
+    }
     return {
       tag: "err",
       title: "Failed to create anchor",

--- a/src/frontend/src/utils/flowResult.ts
+++ b/src/frontend/src/utils/flowResult.ts
@@ -89,5 +89,13 @@ export const apiResultToLoginFlowResult = (
           "Failed to authenticate using this seed phrase. Did you enter it correctly?",
       };
     }
+    case "cancelOrTimeout": {
+      return {
+        tag: "err",
+        title: "Operation Canceled",
+        message:
+          "The interaction with your security device was canceled or timed out. Please try again.",
+      };
+    }
   }
 };

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -43,6 +43,7 @@ import { features } from "../features";
 import { authenticatorAttachmentToKeyType } from "./authenticatorAttachment";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 import { isRecoveryDevice, RecoveryDevice } from "./recoveryDevice";
+import { isCancelOrTimeout } from "./webAuthnErrorUtils";
 
 /*
  * A (dummy) identity that always uses the same keypair. The secret key is
@@ -78,13 +79,15 @@ export type LoginResult =
   | UnknownUser
   | AuthFail
   | ApiError
-  | SeedPhraseFail;
+  | SeedPhraseFail
+  | CancelOrTimeout;
 export type RegisterResult =
   | LoginSuccess
   | AuthFail
   | ApiError
   | RegisterNoSpace
-  | BadChallenge;
+  | BadChallenge
+  | CancelOrTimeout;
 
 type LoginSuccess = {
   kind: "loginSuccess";
@@ -98,6 +101,7 @@ type AuthFail = { kind: "authFail"; error: Error };
 type ApiError = { kind: "apiError"; error: Error };
 type RegisterNoSpace = { kind: "registerNoSpace" };
 type SeedPhraseFail = { kind: "seedPhraseFail" };
+type CancelOrTimeout = { kind: "cancelOrTimeout" };
 
 export type { ChallengeResult } from "../../generated/internet_identity_types";
 
@@ -241,6 +245,9 @@ export class Connection {
     try {
       delegationIdentity = await this.requestFEDelegation(identity);
     } catch (e: unknown) {
+      if (isCancelOrTimeout(e)) {
+        return { kind: "cancelOrTimeout" };
+      }
       if (e instanceof Error) {
         return { kind: "authFail", error: e };
       } else {

--- a/src/frontend/src/utils/webAuthnErrorUtils.ts
+++ b/src/frontend/src/utils/webAuthnErrorUtils.ts
@@ -6,3 +6,18 @@
 export function isDuplicateDeviceError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "InvalidStateError";
 }
+
+/** Checks whether the error corresponds with the WebAuthnSpec for cancelling the operation:
+ *  * https://www.w3.org/TR/webauthn-2/#sctn-createCredential (Step 16)
+ *  * https://www.w3.org/TR/webauthn-2/#sctn-getAssertion (Step 12)
+ *
+ * Note: there are many more cases where `NotAllowedError`s can be thrown, however
+ * those cases mostly correspond to situations that should never happen with II
+ * (such as using an opaque origin for the rpId or trying to register a WebAuthn
+ * credential in a cross-origin iFrame).
+ *
+ * @param error error to check
+ */
+export function isCancelOrTimeout(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "NotAllowedError";
+}


### PR DESCRIPTION
This PR changes the error message for errors that are most likely caused by the user explicitly pressing cancel on the WebAuthn prompt (or the prompt timing out due to inaction).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
