### PR TITLE
Use root for favicon

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -7,7 +7,7 @@
     <!-- CSP directives injected by the canister -->
     <meta replaceme-with-csp />
     <title>Internet Identity</title>
-    <link rel="shortcut icon" href="assets/favicon.ico" />
+    <link rel="shortcut icon" href="/favicon.ico" />
     <link rel="stylesheet" href="src/styles/main.css" />
     <script type="module" src="src/index.ts"></script>
   </head>

--- a/src/showcase/index.html
+++ b/src/showcase/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Internet Identity</title>
-    <link rel="shortcut icon" href="assets/favicon.ico" />
+    <link rel="shortcut icon" href="/favicon.ico" />
     <script type="module" src="src/showcase.ts"></script>
   </head>
   <body>


### PR DESCRIPTION
# Motivation

> files in the public directory are served at the root path.
> Instead of /assets/favicon.ico, use /favicon.ico.