### PR TITLE
Fix scroll top issue on navigation

### DIFF
--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -357,7 +357,7 @@ body {
   line-height: var(--rs-line-height-body);
   background: radial-gradient(circle at 50% 100%, var(--rg-brand-alt));
   background-size: 100% 100%;
-  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 /**


### PR DESCRIPTION
When navigating from a page/view that was longer to a shorter one. The content of the new page would not be aligned to the top of the viewport on Safari IOS.

I isolated the issue here:
https://codepen.io/meodai/pen/JjmWbOb/39d21a0c7ef0dc6a374a9faa9a7f00df

Steps to reroduce:

1. Open https://cdpn.io/pen/debug/JjmWbOb/39d21a0c7ef0dc6a374a9faa9a7f00df on Safari on IOS
2. Scroll to the bottom of the page
3. Tab anywhere to replace the div with an other one that has a random size.
4. Notice how numbers on top are cut off.

https://user-images.githubusercontent.com/608386/234009760-e5aee8f3-033e-41ba-952e-beed6ff051d0.mov

The issue was that we where using a `min-height` of `100vh`. Safari would would somehow not return to the top when navigating to a smaller content. 
`vh` (View height) is a static unit that is always as high as the browser window. `dvh` on the other hand is the browser's height counting in all UI elements the browser puts on top of the viewport. https://web.dev/viewport-units/



