### PR TITLE
Use DUMMY_AUTH from features

### DIFF
--- a/src/frontend/src/flows/register/construct.ts
+++ b/src/frontend/src/flows/register/construct.ts
@@ -5,6 +5,7 @@ import { html, render } from "lit-html";
 import { nextTick } from "process";
 import { spinner } from "../../components/icons";
 import { mainWindow } from "../../components/mainWindow";
+import { features } from "../../features";
 import {
   creationOptions,
   DummyIdentity,
@@ -53,15 +54,11 @@ export const constructIdentity = async ({
     : creationOptions(await devices());
 
   /* The Identity (i.e. key pair) used when creating the anchor.
-   * If "II_DUMMY_AUTH" is set, we create a dummy identity. The same identity must then be used in iiConnection when authenticating.
+   * If the "DUMMY_AUTH" feature is set, we create a dummy identity. The same identity must then be used in iiConnection when authenticating.
    */
-  const createIdentity =
-    process.env.II_DUMMY_AUTH === "1"
-      ? () => Promise.resolve(new DummyIdentity())
-      : () =>
-          WebAuthnIdentity.create({
-            publicKey: opts,
-          });
+  const createIdentity = features.DUMMY_AUTH
+    ? () => Promise.resolve(new DummyIdentity())
+    : () => WebAuthnIdentity.create({ publicKey: opts });
 
   return createIdentity();
 };

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -227,20 +227,19 @@ export class Connection {
     devices: Omit<DeviceData, "alias">[]
   ): Promise<LoginResult> => {
     /* Recover the Identity (i.e. key pair) used when creating the anchor.
-     * If "II_DUMMY_AUTH" is set, we use a dummy identity, the same identity
+     * If the "DUMMY_AUTH" feature is set, we use a dummy identity, the same identity
      * that is used in the register flow.
      */
-    const identity =
-      process.env.II_DUMMY_AUTH === "1"
-        ? new DummyIdentity()
-        : MultiWebAuthnIdentity.fromCredentials(
-            devices.flatMap((device) =>
-              device.credential_id.map((credentialId: CredentialId) => ({
-                pubkey: derFromPubkey(device.pubkey),
-                credentialId: Buffer.from(credentialId),
-              }))
-            )
-          );
+    const identity = features.DUMMY_AUTH
+      ? new DummyIdentity()
+      : MultiWebAuthnIdentity.fromCredentials(
+          devices.flatMap((device) =>
+            device.credential_id.map((credentialId: CredentialId) => ({
+              pubkey: derFromPubkey(device.pubkey),
+              credentialId: Buffer.from(credentialId),
+            }))
+          )
+        );
     let delegationIdentity: DelegationIdentity;
     try {
       delegationIdentity = await this.requestFEDelegation(identity);


### PR DESCRIPTION
This removes all occurrences of II_DUMMY_AUTH (outside of features.ts) and instead uses the `features` object. This reduces the footprint of `process.env` in the codebase.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
