### PR TITLE
Use correct BASE_URL in showcase routing

### DIFF
--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -621,8 +621,7 @@ const init = () => {
   // This is not very user friendly (in particular we don't show anything like a
   // 404) but this is an dev page anyway.
   const route = window.location.pathname
-    .replace(import.meta.env.BASE_URL ?? "", "")
-    .substring(1);
+    .replace(import.meta.env.BASE_URL ?? "/", "");
   const page = iiPages[route] ?? defaultPage;
 
   page();

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -621,7 +621,7 @@ const init = () => {
   // This is not very user friendly (in particular we don't show anything like a
   // 404) but this is an dev page anyway.
   const route = window.location.pathname
-    .replace(process.env.BASE_URL ?? "", "")
+    .replace(import.meta.env.BASE_URL ?? "", "")
     .substring(1);
   const page = iiPages[route] ?? defaultPage;
 


### PR DESCRIPTION
This ensures the correct base url (set by `--base` when running vite) is used; otherwise the showcase routing does not work.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
