### PR TITLE
Refactor compression in plugin and only for production

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,10 @@
-import { extname, resolve } from "path";
+import { resolve } from "path";
 import { defineConfig, UserConfig } from "vite";
-import viteCompression from "vite-plugin-compression";
-import { injectCanisterIdPlugin, stripInjectJsScript } from "./vite.plugins";
+import {
+  compression,
+  injectCanisterIdPlugin,
+  stripInjectJsScript,
+} from "./vite.plugins";
 
 const defaultConfig = (mode?: string): Omit<UserConfig, "root"> => {
   // Path "../../" have to be expressed relative to the "root".
@@ -38,19 +41,9 @@ const defaultConfig = (mode?: string): Omit<UserConfig, "root"> => {
     },
     plugins: [
       [...(mode === "development" ? [injectCanisterIdPlugin()] : [])],
-      [...(mode === "production" ? [stripInjectJsScript()] : [])],
       [
-        ...(mode !== "showcase"
-          ? [
-              viteCompression({
-                // II canister only supports one content type per resource. That is why we remove the original file.
-                deleteOriginFile: true,
-                filter: (file: string): boolean =>
-                  ![".html", ".css", ".webp", ".png", ".ico"].includes(
-                    extname(file)
-                  ),
-              }),
-            ]
+        ...(mode === "production"
+          ? [stripInjectJsScript(), compression()]
           : []),
       ],
     ],

--- a/vite.plugins.ts
+++ b/vite.plugins.ts
@@ -1,5 +1,8 @@
 import { assertNonNullish } from "@dfinity/utils";
 import { readFileSync } from "fs";
+import { extname } from "path";
+import { Plugin } from "vite";
+import viteCompression from "vite-plugin-compression";
 
 /**
  * Read the II canister ID from dfx's local state
@@ -58,3 +61,14 @@ export const stripInjectJsScript = (): {
     return html.replace(match, ``);
   },
 });
+
+/**
+ * GZip generated resources e.g. index.js => index.js.gz
+ */
+export const compression = (): Plugin =>
+  viteCompression({
+    // II canister only supports one content type per resource. That is why we remove the original file.
+    deleteOriginFile: true,
+    filter: (file: string): boolean =>
+      ![".html", ".css", ".webp", ".png", ".ico"].includes(extname(file)),
+  });


### PR DESCRIPTION
# Motivation

Simplify usage of the compression plugin.

- Refactor configuration to `vite.plugins.ts`. That way it's easier to comment it locally if required
- Use the compression plugin only for `production` build instead of if `not showcase`