### PR TITLE
Fix typescript config for showcase

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generate": "npm run generate:types && npm run generate:js",
     "generate:types": "didc bind ./src/internet_identity/internet_identity.did -t ts > src/frontend/generated/internet_identity_types.d.ts",
     "generate:js": "didc bind ./src/internet_identity/internet_identity.did -t js > src/frontend/generated/internet_identity_idl.js",
-    "build:showcase": "vite build --mode showcase",
+    "build:showcase": "tsc --noEmit && vite build --mode showcase",
     "screenshots": "npm run opts -- ./src/frontend/screenshots.ts",
     "test": "jest --maxWorkers 1 --roots ./src/frontend --verbose --testPathIgnorePatterns=\"src/frontend/src/test-e2e\"",
     "test:e2e": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config=./jest.e2e.config.ts --roots ./src/frontend --verbose --testPathPattern=\"src/frontend/src/test-e2e\"",

--- a/src/frontend/env.d.ts
+++ b/src/frontend/env.d.ts
@@ -1,5 +1,0 @@
-/**
- * See Vite documentation: https://vitejs.dev/guide/assets.html
- */
-/// <reference types="vite/client" />
-declare module "envConfig";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["node", "jest", "@wdio/globals/types"],
+    "types": ["node", "jest", "@wdio/globals/types", "vite/client"],
     "paths": {
       "$generated": ["./src/frontend/generated"],
       "$generated/*": ["./src/frontend/generated/*"]


### PR DESCRIPTION
This fixes the up `tsconfig` for the showcase (add `vite/client` types globally, remove `src/frontend/env.d.ts`) and ensures `tsc --noEmit` is run when building the showcase.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
