### PR TITLE
Add 'W' -> 'w' to captcha normalization

### DIFF
--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -134,6 +134,7 @@ lazy_static! {
         ('Y', 'y'),
         ('Z', 'z'),
         ('P', 'p'),
+        ('W', 'w'),
     ].into_iter().collect();
 }
 


### PR DESCRIPTION
This makes sure `W` characters are not used in captcha, and that only `w` characters are used instead (though both are accepted as `w`).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
