### PR TITLE
Add role=alert to toast messages

### DIFF
--- a/src/frontend/src/components/toast.ts
+++ b/src/frontend/src/components/toast.ts
@@ -48,6 +48,7 @@ const toastTemplate = (toast: Toast): TemplateResult => {
   };
 
   return html` <div
+    role="alert"
     class="c-toast ${asyncReplace(
       closing.map((closing) => (closing ? "c-toast--closing" : undefined))
     )}"


### PR DESCRIPTION
The `role="alert"` attribute (equivalent to setting `aria-live="assertive"`) is used to communicate an important and usually time-sensitive message to the user, like toast errors.


Addresses https://github.com/dfinity/internet-identity/pull/1431/files#r1166919990
Related: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
