### PR TITLE
Fix up add device success

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/addDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addDevice.ts
@@ -6,7 +6,7 @@ import { displayError } from "$src/components/displayError";
 import { withLoader } from "$src/components/loader";
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
 import { isNullish } from "@dfinity/utils";
-import { renderAddDeviceSuccess } from "./addDeviceSuccess";
+import { addDeviceSuccess } from "./addDeviceSuccess";
 import { addFIDODevice } from "./addFIDODevice";
 import { pollForTentativeDevice } from "./pollForTentativeDevice";
 import { verifyTentativeDevice } from "./verifyTentativeDevice";
@@ -63,11 +63,13 @@ export const addDevice = async ({
 
   const { alias } = tentativeDevice;
 
-  await verifyTentativeDevice({
+  const result = await verifyTentativeDevice({
     connection,
     alias,
     endTimestamp: timestamp,
   });
 
-  await renderAddDeviceSuccess({ deviceAlias: alias });
+  if (result === "verified") {
+    await addDeviceSuccess({ deviceAlias: alias });
+  }
 };

--- a/src/frontend/src/flows/addDevice/manage/addDeviceSuccess.ts
+++ b/src/frontend/src/flows/addDevice/manage/addDeviceSuccess.ts
@@ -49,7 +49,7 @@ const addDeviceSuccessTemplate = ({
 
 export const addDeviceSuccessPage = renderPage(addDeviceSuccessTemplate);
 
-export const renderAddDeviceSuccess = (
+export const addDeviceSuccess = (
   props: Pick<AddDeviceSuccessTemplateProps, "deviceAlias">
 ): Promise<void> =>
   new Promise<void>((resolve) => {

--- a/src/frontend/src/flows/addDevice/manage/addFIDODevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addFIDODevice.ts
@@ -14,7 +14,7 @@ import {
   isDuplicateDeviceError,
 } from "$src/utils/webAuthnErrorUtils";
 import { WebAuthnIdentity } from "@dfinity/identity";
-import { renderAddDeviceSuccess } from "./addDeviceSuccess";
+import { addDeviceSuccess } from "./addDeviceSuccess";
 
 const displayFailedToAddDevice = (error: Error) =>
   displayError({
@@ -83,7 +83,7 @@ export const addFIDODevice = async (
       )
     );
 
-    await renderAddDeviceSuccess({ deviceAlias: deviceName });
+    await addDeviceSuccess({ deviceAlias: deviceName });
   } catch (error: unknown) {
     await displayFailedToAddDevice(
       error instanceof Error ? error : unknownError()

--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -5,7 +5,7 @@ import { mainWindow } from "$src/components/mainWindow";
 import { AsyncCountdown } from "$src/utils/countdown";
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
 import { renderPage, withRef } from "$src/utils/lit-html";
-import { Chan, unknownToString, unreachableLax } from "$src/utils/utils";
+import { Chan, unknownToString } from "$src/utils/utils";
 import { html } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { createRef, ref } from "lit-html/directives/ref.js";
@@ -132,7 +132,7 @@ export const verifyTentativeDevice = async ({
   connection: AuthenticatedConnection;
   alias: string;
   endTimestamp: bigint;
-}): Promise<"verified" | undefined> => {
+}): Promise<"verified" | "failed"> => {
   const countdown: AsyncCountdown<VerifyResult | "canceled"> =
     AsyncCountdown.fromNanos(endTimestamp);
 
@@ -171,13 +171,13 @@ export const verifyTentativeDevice = async ({
 
 const handleVerifyResult = async (
   result: VerifyResult | "canceled" | typeof AsyncCountdown.timeout
-): Promise<"verified" | undefined> => {
+): Promise<"verified" | "failed"> => {
   // If the verification worked or the user canceled, then we don't show anything special
   if (result === "canceled") {
-    return;
+    return "failed";
   } else if (typeof result === "object" && "verified" in result) {
     result satisfies VerifyResult;
-    return;
+    return "verified";
   }
 
   // otherwise it's an error, and we tell the user what happened
@@ -190,32 +190,38 @@ const handleVerifyResult = async (
       message:
         'The timeout has been reached. For security reasons the "add device" process has been aborted.',
     });
-    return;
+    return "failed";
   } else if ("too_many_attempts" in result) {
     await showError({
       title: "Too Many Wrong Verification Codes Entered",
       message:
         "Adding the device has been aborted due to too many invalid code entries.",
     });
+    return "failed";
   } else if ("device_registration_mode_off" in result) {
     await showError({
       title: "Device Registration Not Enabled",
       message:
         "Verification not possible because device registration is no longer enabled. Either the timeout has been reached or device registration was disabled using another device.",
     });
+    return "failed";
   } else if ("timeout" in result) {
     await showError({
       title: "Timeout Reached",
       message:
         'The timeout has been reached. For security reasons the "add device" process has been aborted.',
     });
+    return "failed";
   } else if ("no_device_to_verify" in result) {
     await showError({
       title: "No Device To Verify",
       message:
         "Verification not possible because the device is no longer in a state to be verified.",
     });
+    return "failed";
   } else {
+    result satisfies never;
+
     await displayError({
       title: "Something Went Wrong",
       message: "Device could not be verified.",
@@ -223,7 +229,6 @@ const handleVerifyResult = async (
       primaryButton: "Continue",
     });
 
-    // If something really unexpected happens then we just return control to the caller
-    unreachableLax(result);
+    return "failed";
   }
 };

--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -132,7 +132,7 @@ export const verifyTentativeDevice = async ({
   connection: AuthenticatedConnection;
   alias: string;
   endTimestamp: bigint;
-}): Promise<void> => {
+}): Promise<"verified" | undefined> => {
   const countdown: AsyncCountdown<VerifyResult | "canceled"> =
     AsyncCountdown.fromNanos(endTimestamp);
 
@@ -171,7 +171,7 @@ export const verifyTentativeDevice = async ({
 
 const handleVerifyResult = async (
   result: VerifyResult | "canceled" | typeof AsyncCountdown.timeout
-) => {
+): Promise<"verified" | undefined> => {
   // If the verification worked or the user canceled, then we don't show anything special
   if (result === "canceled") {
     return;


### PR DESCRIPTION
This only shows the "success" add device message on successful device verification and renames the `addDeviceSuccess` screen to be more consistent with other screens.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
