### PR TITLE
Make CI fail on rust warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,9 @@ jobs:
 
       - run: rustup component add clippy
       - name: Cargo clippy
+        # We run clippy twice (once without tests), so that it accurately reports dead code in the non-test configuration.
         # `manual_range_contains` is disabled because a >= x && a < y reads more clearly than (x..y).contains(a) and
         # there are additional caveats for floating point numbers (https://github.com/rust-lang/rust-clippy/issues/6455)
-        run: cargo clippy --tests --benches -- -D clippy::all -A clippy::manual_range_contains
+        run: |
+          cargo clippy -- -D clippy::all -D warnings -A clippy::manual_range_contains
+          cargo clippy --tests --benches -- -D clippy::all -D warnings -A clippy::manual_range_contains

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -231,6 +231,7 @@ impl<M: Memory> AnchorMemory<M> {
 
 pub enum StableMemory<M: Memory> {
     Single(M),
+    #[allow(dead_code)]
     Managed(M),
 }
 
@@ -239,6 +240,7 @@ pub struct Storage<M: Memory> {
     header: Header,
     header_memory: RestrictedMemory<M>,
     anchor_memory: AnchorMemory<M>,
+    #[allow(dead_code)]
     maybe_memory_manager: Option<MemoryManager<RestrictedMemory<M>>>,
 }
 


### PR DESCRIPTION
This changes the clippy check to fail on all rust warnings.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
