### PR TITLE
Replace npm run start with npm run dev

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -64,7 +64,7 @@ To serve the frontend locally (recommended during development), run
 the following:
 
 ```bash
-npm run start
+npm run dev
 ```
 
 Then open `http://localhost:8080` in your browser. The page is reloaded whenever you save changes to files. To ensure your changes pass our formatting and linter checks, run the following command:
@@ -78,7 +78,7 @@ Finally, to test workflows like authentication from a client application, you st
 ```bash
 cd demos/selenium-test-app
 npm ci
-npm run start
+npm run dev
 ```
 
 Then open `http://localhost:8081` in your browser.

--- a/demos/test-app/README.md
+++ b/demos/test-app/README.md
@@ -29,4 +29,4 @@ Note: These steps are intended to do development on the test-app. To simply run 
 2. Run the local replica `dfx start --clean`
 3. Deploy the canister to the local replica `dfx deploy`
 4. Visit the running site at http://localhost:4943?<canister_id>
-   1. alternatively the dev server can be started by running `npm run start` which can be accessed on http://localhost:8080
+   1. alternatively the dev server can be started by running `npm run dev` which can be accessed on http://localhost:8080

--- a/demos/test-app/package.json
+++ b/demos/test-app/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "start": "vite",
+    "dev": "vite",
     "lint:fix": "npm run lint -- --fix",
     "make:docs/reference": "",
     "publish:release": "",

--- a/demos/using-dev-build/README.md
+++ b/demos/using-dev-build/README.md
@@ -134,7 +134,7 @@ _If you actually use the webapp, make sure that the "Internet Identity URL" fiel
 
 Figuring the canister IDs, and using the `canisterId=...` query parameter is all a bit cumbersome. Here are some commands you might like:
 
-- `npm run start`: Build the app and serve it on `localhost:8080` with hot reload on code changes, ideal for hacking on the webapp.
+- `npm run dev`: Build the app and serve it on `localhost:8080` with hot reload on code changes, ideal for hacking on the webapp.
 - `npm run proxy`: Start a proxy that serves Internet Identity on `localhost:8086` and the webapp on `localhost:8087` for easy access.
 - `npm run test`: Start the proxy and run browser tests against the `internet_identity` canister.
 

--- a/demos/using-dev-build/package.json
+++ b/demos/using-dev-build/package.json
@@ -8,7 +8,7 @@
     "test": "ts-node --esm ./test.ts",
     "format": "prettier --write --plugin-search-dir=. .",
     "build": "tsc --noEmit && vite build",
-    "start": "vite",
+    "dev": "vite",
     "proxy": "ts-node --esm ./test.ts --no-run"
   },
   "devDependencies": {

--- a/docker-test-env/README.md
+++ b/docker-test-env/README.md
@@ -18,7 +18,7 @@ To run selenium tests, do the following:
    1. The `--background` flag can be added to run in the background.
 2. Run `II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=1 dfx deploy --no-wallet`.
 3. Switch to the `demos/test-app` directory and run `dfx deploy --no-wallet`.
-4. Run `npm run start` from the repository root.
+4. Run `npm run dev` from the repository root.
 5. Run `scripts/start-selenium-env` from the repository root.
    1. The docker compose setup can be shut down by running `docker compose down` in the `docker-test-env` directory.
    2. The docker compose setup has to be restarted only if the canister ids change. Additional `dfx deploy` commands or changes to the front-end of II do not require a restart of the docker compose project.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "keywords": [],
   "scripts": {
-    "start": "II_FETCH_ROOT_KEY=1 vite",
+    "dev": "II_FETCH_ROOT_KEY=1 vite",
     "host": "II_FETCH_ROOT_KEY=1 vite --host",
     "showcase": "II_FETCH_ROOT_KEY=1 vite --mode showcase",
     "build": "tsc --noEmit && vite build",

--- a/scripts/start-selenium-env
+++ b/scripts/start-selenium-env
@@ -30,7 +30,7 @@ function help() {
 Launches docker based Selenium test infrastructure (selenium and nginx containers).
 Run "docker compose down" in the docker-test-env folder to stop again.
 
-NOTE: This requires docker, docker-compose, a running dfx replica with II and the test app deployed and running II dev server (npm run start).
+NOTE: This requires docker, docker-compose, a running dfx replica with II and the test app deployed and running II dev server (npm run dev).
 EOF
 
 }

--- a/scripts/with-docker-env
+++ b/scripts/with-docker-env
@@ -27,7 +27,7 @@ function help() {
 
 Starts the docker compose environment, executes the subcommand and stops docker compose again.
 
-NOTE: This requires docker, docker-compose, a running dfx replica with II and the test app deployed and running II dev server (npm run start).
+NOTE: This requires docker, docker-compose, a running dfx replica with II and the test app deployed and running II dev server (npm run dev).
 EOF
 }
 


### PR DESCRIPTION
# Motivation

Use default development command and the one used in NNS-dapp and gix-cmp to run local development.

# Changes

- `npm run start` 👉 `npm run dev`