### PR TITLE
Set default page and proper icons for showcase

### DIFF
--- a/src/frontend/src/flows/dappsExplorer/dapps.ts
+++ b/src/frontend/src/flows/dappsExplorer/dapps.ts
@@ -37,6 +37,9 @@ export const getDapps = async (): Promise<DappDescription[]> => {
   return dapps.map((dapp) => ({
     ...dapp,
     /* fix up logo path (inherited from dfinity/portal) to match our assets */
-    logo: dapp.logo.replace("/img/showcase/", "/icons/"),
+    logo: dapp.logo.replace(
+      "/img/showcase/",
+      import.meta.env.BASE_URL + "icons/"
+    ),
   }));
 };

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -643,9 +643,12 @@ const init = () => {
   // '/internet-identity/myPage' -> 'myPage'
   const baseUrl = import.meta.env.BASE_URL;
   const pageName = window.location.pathname.replace(baseUrl, "");
-  const page = iiPages[pageName] ?? (() => notFound({ baseUrl, pageName }));
-
-  page();
+  if(pageName === "") {
+      defaultPage();
+  } else {
+      const page = iiPages[pageName] ?? (() => notFound({ baseUrl, pageName }));
+      page();
+  }
 };
 
 init();


### PR DESCRIPTION
This defaults to showing the whole showcase on `/`, and fixes icon paths for when BASE_URL is set.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
