### PR TITLE
Extract domainWarning from manage page

### DIFF
--- a/src/frontend/src/flows/manage/domainWarning.ts
+++ b/src/frontend/src/flows/manage/domainWarning.ts
@@ -1,0 +1,44 @@
+import { DeviceData } from "$generated/internet_identity_types";
+import { LEGACY_II_URL } from "$src/config";
+import { isRecoveryPhrase } from "$src/utils/recoveryDevice";
+import { isNullish } from "@dfinity/utils";
+import { html, TemplateResult } from "lit-html";
+
+// Show a domain-related warning, if necessary.
+export const domainWarning = (
+  device: DeviceData
+): TemplateResult | undefined => {
+  // Recovery phrases are not FIDO devices, meaning they are not tied to a particular origin (unless most authenticators like TouchID, etc, and e.g. recovery _devices_ in the case of YubiKeys and the like)
+  if (isRecoveryPhrase(device)) {
+    return undefined;
+  }
+
+  // XXX: work around didc-generated oddities in types
+  const deviceOrigin =
+    device.origin.length === 0 ? undefined : device.origin[0];
+
+  // If this is the _old_ II (ic0.app) and no origin was recorded, then we can't infer much and don't show a warning.
+  if (window.origin === LEGACY_II_URL && isNullish(deviceOrigin)) {
+    return undefined;
+  }
+
+  // If this is the _old_ II (ic0.app) and the device has an origin that is _not_ ic0.app, then the device was probably migrated and can't be used on ic0.app anymore.
+  if (window.origin === LEGACY_II_URL && deviceOrigin !== window.origin) {
+    return html`This device may not be usable on the current URL
+    (${window.origin})`;
+  }
+
+  // In general, if this is _not_ the _old_ II, then it's most likely the _new_ II, meaning all devices should have an origin attached.
+  if (isNullish(deviceOrigin)) {
+    return html`This device may not be usable on the current URL
+    (${window.origin})`;
+  }
+
+  // Finally, in general if the device has an origin but this is not _this_ origin, we issue a warning
+  if (deviceOrigin !== window.origin) {
+    return html`This device may not be usable on the current URL
+    (${window.origin})`;
+  }
+
+  return undefined;
+};

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -37,6 +37,7 @@ import {
   resetPhrase,
   unprotectDevice,
 } from "./deviceSettings";
+import { domainWarning } from "./domainWarning";
 import { recoveryMethodsSection } from "./recoveryMethodsSection";
 import { Devices, Protection, RecoveryKey, RecoveryPhrase } from "./types";
 
@@ -396,45 +397,6 @@ export const devicesFromDeviceDatas = ({
     },
     { authenticators: [], recoveries: {}, dupPhrase: false, dupKey: false }
   );
-};
-
-// Show a domain-related warning, if necessary.
-export const domainWarning = (
-  device: DeviceData
-): TemplateResult | undefined => {
-  // Recovery phrases are not FIDO devices, meaning they are not tied to a particular origin (unless most authenticators like TouchID, etc, and e.g. recovery _devices_ in the case of YubiKeys and the like)
-  if (isRecoveryPhrase(device)) {
-    return undefined;
-  }
-
-  // XXX: work around didc-generated oddities in types
-  const deviceOrigin =
-    device.origin.length === 0 ? undefined : device.origin[0];
-
-  // If this is the _old_ II (ic0.app) and no origin was recorded, then we can't infer much and don't show a warning.
-  if (window.origin === LEGACY_II_URL && isNullish(deviceOrigin)) {
-    return undefined;
-  }
-
-  // If this is the _old_ II (ic0.app) and the device has an origin that is _not_ ic0.app, then the device was probably migrated and can't be used on ic0.app anymore.
-  if (window.origin === LEGACY_II_URL && deviceOrigin !== window.origin) {
-    return html`This device may not be usable on the current URL
-    (${window.origin})`;
-  }
-
-  // In general, if this is _not_ the _old_ II, then it's most likely the _new_ II, meaning all devices should have an origin attached.
-  if (isNullish(deviceOrigin)) {
-    return html`This device may not be usable on the current URL
-    (${window.origin})`;
-  }
-
-  // Finally, in general if the device has an origin but this is not _this_ origin, we issue a warning
-  if (deviceOrigin !== window.origin) {
-    return html`This device may not be usable on the current URL
-    (${window.origin})`;
-  }
-
-  return undefined;
 };
 
 const unknownError = (): Error => {

--- a/src/frontend/src/flows/manage/migration.test.ts
+++ b/src/frontend/src/flows/manage/migration.test.ts
@@ -1,5 +1,5 @@
 import { DeviceData } from "$generated/internet_identity_types";
-import { domainWarning } from "$src/flows/manage";
+import { domainWarning } from "$src/flows/manage/domainWarning";
 
 function onOrigin(origin: string, fn: () => void) {
   const oldOrigin = window.origin;


### PR DESCRIPTION
This ensures the domaim warning can be used from the migration tests without depending on the management page. Jest cannot load the management page because it uses next-gen Vite features.

We'll need to move to vitest or find a workaround.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
