### PR TITLE
Mock import.meta.env

### DIFF
--- a/src/frontend/src/environment.ts
+++ b/src/frontend/src/environment.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = import.meta.env.BASE_URL;

--- a/src/frontend/src/flows/dappsExplorer/dapps.ts
+++ b/src/frontend/src/flows/dappsExplorer/dapps.ts
@@ -1,4 +1,5 @@
 import { toast } from "$src/components/toast";
+import { BASE_URL } from "$src/environment";
 import { isNullish } from "@dfinity/utils";
 
 // The list of dapps. This is derived from https://github.com/dfinity/portal:
@@ -37,9 +38,6 @@ export const getDapps = async (): Promise<DappDescription[]> => {
   return dapps.map((dapp) => ({
     ...dapp,
     /* fix up logo path (inherited from dfinity/portal) to match our assets */
-    logo: dapp.logo.replace(
-      "/img/showcase/",
-      import.meta.env.BASE_URL + "icons/"
-    ),
+    logo: dapp.logo.replace("/img/showcase/", BASE_URL + "icons/"),
   }));
 };

--- a/src/frontend/test-setup.ts
+++ b/src/frontend/test-setup.ts
@@ -1,6 +1,7 @@
 import crypto from "@trust/webcrypto";
 import { TextEncoder } from "util";
 
+// We mock the environment variable because jest is not able to load import.meta.env
 jest.mock("./src/environment.ts", () => ({
   BASE_URL: "/",
 }));

--- a/src/frontend/test-setup.ts
+++ b/src/frontend/test-setup.ts
@@ -2,7 +2,6 @@ import crypto from "@trust/webcrypto";
 import { TextEncoder } from "util";
 
 jest.mock("./src/environment.ts", () => ({
-  ...jest.requireActual("./src/environment.ts"),
   BASE_URL: "/",
 }));
 

--- a/src/frontend/test-setup.ts
+++ b/src/frontend/test-setup.ts
@@ -1,6 +1,11 @@
 import crypto from "@trust/webcrypto";
 import { TextEncoder } from "util";
 
+jest.mock("./src/environment.ts", () => ({
+  ...jest.requireActual("./src/environment.ts"),
+  BASE_URL: "/",
+}));
+
 export type WebAuthnCredential = {
   credentialId: string;
   isResidentCredential: boolean;


### PR DESCRIPTION
# Motivation

Jest are failing with following errors:

>     src/frontend/src/environment.ts:1:25 - error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
>    
>        1 export const BASE_URL = import.meta.env.BASE_URL;

To overcome the issue, in NNS-dapp, we regroup the env in a unique file and mock the values for jest test.