### PR TITLE
Clarify the Word phrase parameter

### DIFF
--- a/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
@@ -31,7 +31,7 @@ const confirmSeedPhraseTemplate = ({
   back,
   i18n,
 }: {
-  words: Omit<Word, "elem" | "shouldFocus">[];
+  words: Pick<Word, "word" | "check">[];
   confirm: () => void;
   back: () => void;
   i18n: I18n;


### PR DESCRIPTION
This updates an argument's type to reflect the fields we actually need in that function (`Pick`) as opposed to the ones we don't (`Omit`).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
