### PR TITLE
Fix instructions for adding device

### DIFF
--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -35,7 +35,6 @@ const deviceRegistrationDisabledInfoTemplate = ({
           >Add new device</strong
         >”
       </li>
-      <li>Select “<strong class="t-string">Browser</strong>”</li>
     </ol>
     <p class="t-paragraph t-strong">Then, press Retry below.</p>
     <div class="l-stack">


### PR DESCRIPTION
We've recently defaulted "Add device" to "browser", meaning the user does not have to select it explicitly anymore. This updates the instructions to reflect that.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
