### PR TITLE
Decouple captcha solving from WebAuthn register

### DIFF
--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -24,20 +24,34 @@ pub fn create_challenge(
     call_candid(env, canister_id, "create_challenge", ()).map(|(x,)| x)
 }
 
+pub fn check_challenge(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    sender: Principal,
+    challenge_attempt: &types::ChallengeAttempt,
+) -> Result<(), CallError> {
+    call_candid_as(
+        env,
+        canister_id,
+        sender,
+        "check_challenge",
+        (challenge_attempt,),
+    )
+}
+
 pub fn register(
     env: &StateMachine,
     canister_id: CanisterId,
     sender: Principal,
     device_data: &types::DeviceData,
-    challenge_attempt: &types::ChallengeAttempt,
-    temp_key: Option<Principal>,
+    challenge_attempt: &Option<types::ChallengeAttempt>,
 ) -> Result<types::RegisterResponse, CallError> {
     call_candid_as(
         env,
         canister_id,
         sender,
         "register",
-        (device_data, challenge_attempt, temp_key),
+        (device_data, challenge_attempt),
     )
     .map(|(x,)| x)
 }
@@ -309,27 +323,22 @@ pub fn acknowledge_entries(
 /// A "compatibility" module for the previous version of II to handle API changes.
 pub mod compat {
     use super::*;
-    use candid::{CandidType, Deserialize};
-    use internet_identity_interface::internet_identity::types::{
-        ActiveAnchorCounter, ActiveAnchorStatistics, AnchorNumber, ArchiveInfo,
-        DomainActiveAnchorCounter,
-    };
 
-    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-    pub struct InternetIdentityStats {
-        pub assigned_user_number_range: (AnchorNumber, AnchorNumber),
-        pub users_registered: u64,
-        pub archive_info: ArchiveInfo,
-        pub canister_creation_cycles_cost: u64,
-        pub storage_layout_version: u8,
-        pub active_anchor_stats: Option<ActiveAnchorStatistics<ActiveAnchorCounter>>,
-        pub domain_active_anchor_stats: Option<ActiveAnchorStatistics<DomainActiveAnchorCounter>>,
-    }
-
-    pub fn stats(
+    pub fn register(
         env: &StateMachine,
         canister_id: CanisterId,
-    ) -> Result<InternetIdentityStats, CallError> {
-        query_candid(env, canister_id, "stats", ()).map(|(x,)| x)
+        sender: Principal,
+        device_data: &types::DeviceData,
+        challenge_attempt: &types::ChallengeAttempt,
+        temp_key: Option<Principal>,
+    ) -> Result<types::RegisterResponse, CallError> {
+        call_candid_as(
+            env,
+            canister_id,
+            sender,
+            "register",
+            (device_data, challenge_attempt, temp_key),
+        )
+        .map(|(x,)| x)
     }
 }

--- a/src/canister_tests/src/flows.rs
+++ b/src/canister_tests/src/flows.rs
@@ -1,4 +1,4 @@
-use crate::api::internet_identity::{create_challenge, register};
+use crate::api::internet_identity::{compat::register, create_challenge};
 use crate::framework::{device_data_1, principal_1};
 use candid::Principal;
 use ic_cdk::api::management_canister::main::CanisterId;

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -67,6 +67,16 @@ export const idlFactory = ({ IDL }) => {
     }),
   });
   const ChallengeKey = IDL.Text;
+  const ChallengeResult = IDL.Record({
+    'key' : ChallengeKey,
+    'chars' : IDL.Text,
+  });
+  const ChallengeCheckResult = IDL.Variant({
+    'invalid_caller' : IDL.Null,
+    'rate_limit_exceeded' : IDL.Null,
+    'bad_challenge' : IDL.Null,
+    'success' : IDL.Null,
+  });
   const Challenge = IDL.Record({
     'png_base64' : IDL.Text,
     'challenge_key' : ChallengeKey,
@@ -155,10 +165,6 @@ export const idlFactory = ({ IDL }) => {
     'status_code' : IDL.Nat16,
   });
   const UserKey = PublicKey;
-  const ChallengeResult = IDL.Record({
-    'key' : ChallengeKey,
-    'chars' : IDL.Text,
-  });
   const RegisterResponse = IDL.Variant({
     'bad_challenge' : IDL.Null,
     'canister_full' : IDL.Null,
@@ -227,6 +233,11 @@ export const idlFactory = ({ IDL }) => {
         [AddTentativeDeviceResponse],
         [],
       ),
+    'check_challenge' : IDL.Func(
+        [ChallengeResult],
+        [IDL.Opt(ChallengeCheckResult)],
+        [],
+      ),
     'create_challenge' : IDL.Func([], [Challenge], []),
     'deploy_archive' : IDL.Func([IDL.Vec(IDL.Nat8)], [DeployArchiveResult], []),
     'enter_device_registration_mode' : IDL.Func([UserNumber], [Timestamp], []),
@@ -258,7 +269,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'register' : IDL.Func(
-        [DeviceData, ChallengeResult, IDL.Opt(IDL.Principal)],
+        [DeviceData, IDL.Opt(ChallengeResult)],
         [RegisterResponse],
         [],
       ),

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -44,6 +44,10 @@ export interface Challenge {
   'png_base64' : string,
   'challenge_key' : ChallengeKey,
 }
+export type ChallengeCheckResult = { 'invalid_caller' : null } |
+  { 'rate_limit_exceeded' : null } |
+  { 'bad_challenge' : null } |
+  { 'success' : null };
 export type ChallengeKey = string;
 export interface ChallengeResult { 'key' : ChallengeKey, 'chars' : string }
 export interface CompletedActiveAnchorStats {
@@ -203,6 +207,10 @@ export interface _SERVICE {
     [UserNumber, DeviceData],
     AddTentativeDeviceResponse
   >,
+  'check_challenge' : ActorMethod<
+    [ChallengeResult],
+    [] | [ChallengeCheckResult]
+  >,
   'create_challenge' : ActorMethod<[], Challenge>,
   'deploy_archive' : ActorMethod<[Uint8Array | number[]], DeployArchiveResult>,
   'enter_device_registration_mode' : ActorMethod<[UserNumber], Timestamp>,
@@ -224,7 +232,7 @@ export interface _SERVICE {
     [UserKey, Timestamp]
   >,
   'register' : ActorMethod<
-    [DeviceData, ChallengeResult, [] | [Principal]],
+    [DeviceData, [] | [ChallengeResult]],
     RegisterResponse
   >,
   'remove' : ActorMethod<[UserNumber, DeviceKey], undefined>,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -103,6 +103,13 @@ type MetadataMap = vec record {
     variant { map : MetadataMap; string : text; bytes : vec nat8 };
 };
 
+type ChallengeCheckResult = variant {
+    success;
+    bad_challenge;
+    invalid_caller;
+    rate_limit_exceeded;
+};
+
 type RegisterResponse = variant {
     // A new user was successfully registered.
     registered: record {
@@ -339,11 +346,23 @@ type BufferedArchiveEntry = record {
     entry: blob;
 };
 
-
 service : (opt InternetIdentityInit) -> {
     init_salt: () -> ();
+
     create_challenge : () -> (Challenge);
-    register : (DeviceData, ChallengeResult, opt principal) -> (RegisterResponse);
+    // Submit a challenge result to check if it is valid.
+    // A valid challenge allows the caller to call the `register` endpoint within the next 10 minutes.
+    check_challenge : (ChallengeResult) -> (opt ChallengeCheckResult);
+    // Registers a new anchor (with the given device added).
+    //
+    // In order to register a new anchor the caller has to meet the prerequisites:
+    //   1. the caller must create a challenge using `create_challenge`
+    //   2. the caller must submit a valid solution to the `check_challenge` endpoint
+    //
+    // The `challenge_result` parameter is deprecated and will be removed in the future.
+    // Submit the ChallengeResult using `check_challenge` instead (using the same caller identity).
+    register : (DeviceData, challenge_result: opt ChallengeResult) -> (RegisterResponse);
+
     add : (UserNumber, DeviceData) -> ();
     update : (UserNumber, DeviceKey, DeviceData) -> ();
     // Atomically replace device matching the device key with the new device data

--- a/src/internet_identity/src/state/temp_keys.rs
+++ b/src/internet_identity/src/state/temp_keys.rs
@@ -1,4 +1,4 @@
-use crate::MINUTE_NS;
+use crate::{state, MINUTE_NS};
 use candid::Principal;
 use ic_cdk::api::time;
 use internet_identity_interface::internet_identity::types::{AnchorNumber, DeviceKey, Timestamp};
@@ -7,8 +7,22 @@ use std::collections::{HashMap, VecDeque};
 // Expiration for temp keys, the same as the front-end delegation expiry
 const TEMP_KEY_EXPIRATION_NS: u64 = 10 * MINUTE_NS;
 
+/// Temporary keys are used as a session mechanism for the onboarding of new anchors.
+/// Temporary keys are created like regular session keys (with a delegation), but work without
+/// a signed delegation (since the anchor is new, there is no device to sign the delegation).
+///
+/// There are two kinds of temporary keys:
+/// - onboarding keys:   these keys are used to track a session before the corresponding anchor has been created
+/// - device bound keys: these keys are attached to a newly created anchor and device. They are used
+///                      to avoid having users interact with a newly created WebAuthn device immediately.
+///                      See below for more details.
 #[derive(Default, Debug)]
 pub struct TempKeys {
+    /// A map of temporary keys that solved a captcha and can be used for registration (without
+    /// submitting another captcha solution). The principals are mapped to their expiration time\
+    /// (which is the only metadata we keep about onboarding keys).
+    onboarding_keys: HashMap<Principal, Timestamp>,
+
     /// A map of "temporary keys" attached to devices (and a specific anchor). A temporary key can be used in lieu
     /// of the device but has a short expiration time. These keys are used as a workaround for WebAuthn
     /// needing two users interactions: one for "create" and one for "sign". So instead we only "create"
@@ -25,48 +39,90 @@ pub struct TempKeys {
     ///
     /// Since temp keys can only be added during registration, the the max number of temp keys is
     /// bounded by the registration rate limit.
-    temp_keys: HashMap<DeviceKey, TempKey>,
+    device_bound_keys: HashMap<DeviceKey, DeviceBoundTempKey>,
 
     /// Deque to efficiently prune expired temp keys
     expirations: VecDeque<TempKeyExpiration>,
 }
 
 impl TempKeys {
-    pub fn add_temp_key(
+    pub fn add_onboarding_temp_key(&mut self, temp_key: Principal) -> Result<(), ()> {
+        self.prune_expired_keys();
+
+        // tie the max number of onboarding keys to the registration rate limit
+        if self.onboarding_keys.len() as u64
+            > state::persistent_state(|ps| {
+                ps.registration_rate_limit
+                    .as_ref()
+                    .map(|rate_limit| rate_limit.max_tokens)
+                    .unwrap_or(20_000)
+            })
+        {
+            return Err(());
+        }
+
+        let expiration = time() + TEMP_KEY_EXPIRATION_NS;
+        self.expirations.push_back(TempKeyExpiration::Onboarding {
+            principal: temp_key,
+            expiration,
+        });
+        self.onboarding_keys.insert(temp_key, expiration);
+        Ok(())
+    }
+
+    pub fn add_device_bound_temp_key(
         &mut self,
         device_key: &DeviceKey,
         anchor: AnchorNumber,
         temp_key: Principal,
     ) {
-        let tmp_key = TempKey {
+        // Remove the temp key from onboarding keys if it exists
+        self.onboarding_keys.remove(&temp_key);
+
+        let tmp_key = DeviceBoundTempKey {
             principal: temp_key,
             anchor,
             expiration: time() + TEMP_KEY_EXPIRATION_NS,
         };
 
-        self.expirations.push_back(TempKeyExpiration {
+        self.expirations.push_back(TempKeyExpiration::DeviceBound {
             device_key: device_key.clone(),
             expiration: tmp_key.expiration,
         });
-        self.temp_keys.insert(device_key.clone(), tmp_key);
+        self.device_bound_keys.insert(device_key.clone(), tmp_key);
     }
 
     /// Removes the temporary key for the given device if it exists and is linked to the provided anchor.
     pub fn remove_temp_key(&mut self, anchor: AnchorNumber, device_key: &DeviceKey) {
         // we can skip the removal from expirations because there it will be removed
         // during amortized clean-up operations
-        if let Some(temp_key) = self.temp_keys.get(device_key) {
+        if let Some(temp_key) = self.device_bound_keys.get(device_key) {
             if temp_key.anchor == anchor {
                 // Only remove temp key if the anchor matches
-                self.temp_keys.remove(device_key);
+                self.device_bound_keys.remove(device_key);
             }
         }
+    }
+
+    /// Checks that the temporary key is a valid onboarding key (i.e. has solved the captcha).
+    ///
+    /// Requires a mutable reference because it does amortized clean-up of expired temp keys.
+    pub fn check_onboarding_temp_key(&mut self, caller: &Principal) -> Result<(), ()> {
+        self.prune_expired_keys();
+
+        let Some(expiration) = self.onboarding_keys.get(caller) else {
+            return Err(());
+        };
+        if expiration < &time() {
+            return Err(());
+        }
+        Ok(())
     }
 
     /// Checks that the temporary key is valid for the given device and anchor.
     ///
     /// Requires a mutable reference because it does amortized clean-up of expired temp keys.
-    pub fn check_temp_key(
+    pub fn check_device_bound_temp_key(
         &mut self,
         caller: &Principal,
         device_key: &DeviceKey,
@@ -74,7 +130,7 @@ impl TempKeys {
     ) -> Result<(), ()> {
         self.prune_expired_keys();
 
-        let Some(temp_key) = self.temp_keys.get(device_key) else {
+        let Some(temp_key) = self.device_bound_keys.get(device_key) else {
             return Err(());
         };
         if temp_key.expiration < time() {
@@ -101,21 +157,29 @@ impl TempKeys {
             // The expirations are sorted by expiration time because the expiration is constant
             // (10 minutes) and time() is monotonous
             // -> we can stop pruning once we reach a temp key that is not expired
-            if expiration.expiration > now {
+            if expiration.expiration() > now {
                 break;
             }
-            self.temp_keys.remove(&expiration.device_key);
+
+            match expiration {
+                TempKeyExpiration::DeviceBound { device_key, .. } => {
+                    self.device_bound_keys.remove(device_key);
+                }
+                TempKeyExpiration::Onboarding { principal, .. } => {
+                    self.onboarding_keys.remove(principal);
+                }
+            };
             self.expirations.pop_front();
         }
     }
 
     pub fn num_temp_keys(&self) -> usize {
-        self.temp_keys.len()
+        self.device_bound_keys.len()
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TempKey {
+pub struct DeviceBoundTempKey {
     /// The temp key principal
     principal: Principal,
     /// The anchor the temporary key is linked to
@@ -125,9 +189,26 @@ pub struct TempKey {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TempKeyExpiration {
-    /// The device key the temp key is linked to
-    pub device_key: DeviceKey,
-    /// The expiration timestamp of the temp key
-    pub expiration: Timestamp,
+pub enum TempKeyExpiration {
+    DeviceBound {
+        /// The device key the temp key is linked to
+        device_key: DeviceKey,
+        /// The expiration timestamp of the temp key
+        expiration: Timestamp,
+    },
+    Onboarding {
+        /// The principal of the onboarding temp key
+        principal: Principal,
+        /// The expiration timestamp of the temp key
+        expiration: Timestamp,
+    },
+}
+
+impl TempKeyExpiration {
+    pub fn expiration(&self) -> Timestamp {
+        match self {
+            TempKeyExpiration::DeviceBound { expiration, .. } => *expiration,
+            TempKeyExpiration::Onboarding { expiration, .. } => *expiration,
+        }
+    }
 }

--- a/src/internet_identity/src/state/temp_keys.rs
+++ b/src/internet_identity/src/state/temp_keys.rs
@@ -80,13 +80,14 @@ impl TempKeys {
         // It is ok for the temp key to not exist as long as we still support
         // providing the captcha solution on `register`. Afterwards it will
         // become an error.
-        self.onboarding_keys.remove(&temp_key);
+        let onboarding_key = self.onboarding_keys.remove(&temp_key);
 
         let tmp_key = DeviceBoundTempKey {
             anchor,
             temp_key: TempKeyInfo {
                 principal: temp_key,
-                expiration: time() + TEMP_KEY_EXPIRATION_NS,
+                // carry over the expiration for existing temp keys
+                expiration: onboarding_key.unwrap_or(time() + TEMP_KEY_EXPIRATION_NS),
             },
         };
 

--- a/src/internet_identity/tests/integration/anchor_management/registration/mod.rs
+++ b/src/internet_identity/tests/integration/anchor_management/registration/mod.rs
@@ -68,7 +68,7 @@ fn should_assign_correct_user_numbers() -> Result<(), CallError> {
     assert_eq!(user_number, 128);
 
     let challenge = api::create_challenge(&env, canister_id)?;
-    let result = api::register(
+    let result = api::compat::register(
         &env,
         canister_id,
         principal_1(),
@@ -90,7 +90,7 @@ fn registration_with_mismatched_sender_fails() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
     let challenge = api::create_challenge(&env, canister_id)?;
-    let result = api::register(
+    let result = api::compat::register(
         &env,
         canister_id,
         principal_2(),
@@ -119,7 +119,7 @@ fn should_not_register_non_recovery_device_as_protected() -> Result<(), CallErro
     device1.protection = DeviceProtection::Protected;
 
     let challenge = api::create_challenge(&env, canister_id)?;
-    let result = api::register(
+    let result = api::compat::register(
         &env,
         canister_id,
         principal_1(),
@@ -146,7 +146,7 @@ fn should_not_allow_wrong_captcha() -> Result<(), CallError> {
     let canister_id = install_ii_canister(&env, II_WASM.clone());
 
     let challenge = api::create_challenge(&env, canister_id)?;
-    let result = api::register(
+    let result = api::compat::register(
         &env,
         canister_id,
         principal_1(),
@@ -174,7 +174,7 @@ fn should_not_allow_expired_captcha() -> Result<(), CallError> {
 
     // required because register does not check captcha expiry
     api::create_challenge(&env, canister_id)?;
-    let result = api::register(
+    let result = api::compat::register(
         &env,
         canister_id,
         principal_1(),
@@ -227,7 +227,7 @@ fn should_rate_limit_register_calls() -> Result<(), CallError> {
         flows::register_anchor(&env, canister_id);
     }
     let challenge = api::create_challenge(&env, canister_id)?;
-    let result = api::register(
+    let result = api::compat::register(
         &env,
         canister_id,
         principal_1(),
@@ -251,7 +251,7 @@ fn should_rate_limit_register_calls() -> Result<(), CallError> {
 
     env.advance_time(Duration::from_secs(1));
 
-    let result = api::register(
+    let result = api::compat::register(
         &env,
         canister_id,
         principal_1(),

--- a/src/internet_identity/tests/integration/anchor_management/registration/temp_keys.rs
+++ b/src/internet_identity/tests/integration/anchor_management/registration/temp_keys.rs
@@ -108,14 +108,15 @@ fn should_not_allow_temp_key_to_equal_device_key() -> Result<(), CallError> {
     let device = device_data_1();
 
     let challenge = api::create_challenge(&env, canister_id).unwrap();
-    let response = api::register(
+    api::check_challenge(
         &env,
         canister_id,
         device.principal(),
-        &device,
         &challenge_solution(challenge),
-        Some(device.principal()),
-    );
+    )
+    .unwrap();
+
+    let response = api::register(&env, canister_id, device.principal(), &device, &None);
 
     expect_user_error_with_message(
         response,
@@ -177,15 +178,8 @@ fn register_with_temp_key(
     device: &DeviceData,
 ) -> AnchorNumber {
     let challenge = api::create_challenge(env, canister_id).unwrap();
-    let response = api::register(
-        env,
-        canister_id,
-        temp_key,
-        device,
-        &challenge_solution(challenge),
-        Some(temp_key),
-    )
-    .unwrap();
+    api::check_challenge(env, canister_id, temp_key, &challenge_solution(challenge)).unwrap();
+    let response = api::register(env, canister_id, temp_key, device, &None).unwrap();
 
     let RegisterResponse::Registered { user_number } = response else {
         panic!("expected RegisterResponse::Registered");

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -273,7 +273,7 @@ fn metrics_inflight_challenges() -> Result<(), CallError> {
     assert_eq!(challenge_count, 2f64);
 
     // solving a challenge removes it from the inflight pool
-    api::register(
+    api::compat::register(
         &env,
         canister_id,
         principal_1(),

--- a/src/internet_identity/tests/integration/upgrade.rs
+++ b/src/internet_identity/tests/integration/upgrade.rs
@@ -152,7 +152,7 @@ fn ii_upgrade_should_allow_same_user_range() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
 
-    let stats = api::compat::stats(&env, canister_id)?;
+    let stats = api::stats(&env, canister_id)?;
 
     let result = upgrade_ii_canister_with_arg(
         &env,

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -55,6 +55,18 @@ pub enum Purpose {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum ChallengeCheckResult {
+    #[serde(rename = "success")]
+    Success,
+    #[serde(rename = "bad_challenge")]
+    BadChallenge,
+    #[serde(rename = "invalid_caller")]
+    InvalidCaller,
+    #[serde(rename = "rate_limit_exceeded")]
+    RateLimitExcceeded,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
 pub enum RegisterResponse {
     #[serde(rename = "registered")]
     Registered { user_number: AnchorNumber },


### PR DESCRIPTION
This PR adds a new canister call to submit captcha solutions. The caller principal will automatically be entitled to call register _without_ having to submit another captcha solution for 10 minutes (which is the default front-end session duration).

This mechanism replaces the previous temp_key mechanism where the temp_key could be submitted alongside the captcha solution on register.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
