### PR TITLE
Typecheck tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "host": "II_FETCH_ROOT_KEY=1 vite --host",
     "showcase": "II_FETCH_ROOT_KEY=1 vite --mode showcase",
     "build": "tsc --noEmit && vite build",
-    "watch": "tsc --noEmit --watch",
+    "watch": "tsc --project ./tsconfig.all.json --noEmit --watch",
     "opts": "NODE_OPTIONS='--loader ts-node/esm --experimental-specifier-resolution=node' \"$@\"",
     "generate": "npm run generate:types && npm run generate:js",
     "generate:types": "didc bind ./src/internet_identity/internet_identity.did -t ts > src/frontend/generated/internet_identity_types.d.ts",

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": [
+    "src/frontend/generated/*",
+    "src/frontend/jest-custom-sequencer.ts"
+  ]
+}


### PR DESCRIPTION
This ensures tsc (for instance with `npm run watch`) also runs on tests.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
