### PR TITLE
Fix dapps explorer submission link

### DIFF
--- a/src/frontend/src/flows/dappsExplorer/index.ts
+++ b/src/frontend/src/flows/dappsExplorer/index.ts
@@ -36,7 +36,7 @@ const dappsExplorerTemplate = ({
     <p class="t-paragraph t-centered">
       ${copy.add_your_dapp}
       <a
-        href="https://github.com/dfinity/internet-identity/issues/new"
+        href="https://github.com/dfinity/portal#showcase-submission-guidelines"
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
This takes the user to the [portal showcase submission guidelines](https://github.com/dfinity/portal#showcase-submission-guidelines) instead of the II GitHub repo, since we source the dapps from the portal.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
