### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -591,6 +591,12 @@ jobs:
           name: internet_identity_production.wasm.gz
           path: .
 
+      - name: 'Download wasm.gz'
+        uses: actions/download-artifact@v3
+        with:
+          name: archive.wasm.gz
+          path: .
+
       - name: Prepare release
         uses: ./.github/actions/release
         id: prepare-release


### PR DESCRIPTION
This PR adds the missing archive.wasm.gz file back to the list of files that need to be downloaded.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
