### PR TITLE
Remove await when creating test object

### DIFF
--- a/src/frontend/src/test-e2e/register.test.ts
+++ b/src/frontend/src/test-e2e/register.test.ts
@@ -92,7 +92,7 @@ test("Register new identity and add additional device", async () => {
     await browser.pause(10_000);
 
     // success page
-    const addDeviceSuccessView = await new AddDeviceSuccessView(browser);
+    const addDeviceSuccessView = new AddDeviceSuccessView(browser);
     await addDeviceSuccessView.waitForDisplay();
     await addDeviceSuccessView.continue();
 
@@ -130,14 +130,15 @@ test("Register new identity and add additional remote device", async () => {
       await addRemoteDeviceView.selectAlias(DEVICE_NAME2);
       await addRemoteDeviceView.continue();
 
-      const verificationCodeView =
-        await new AddRemoteDeviceVerificationCodeView(browser2);
+      const verificationCodeView = new AddRemoteDeviceVerificationCodeView(
+        browser2
+      );
       await verificationCodeView.waitForDisplay();
       const code = await verificationCodeView.getVerificationCode();
 
       // browser 1 again
       await focusBrowser(browser);
-      const verificationView = await new VerifyRemoteDeviceView(browser);
+      const verificationView = new VerifyRemoteDeviceView(browser);
       await verificationView.waitForDisplay();
       await verificationView.enterVerificationCode(code);
       await verificationView.continue();
@@ -145,7 +146,7 @@ test("Register new identity and add additional remote device", async () => {
       // Verify success on Browser 1
 
       // success page
-      const addDeviceSuccessView = await new AddDeviceSuccessView(browser);
+      const addDeviceSuccessView = new AddDeviceSuccessView(browser);
       await addDeviceSuccessView.waitForDisplay();
       await addDeviceSuccessView.continue();
 
@@ -212,20 +213,21 @@ test("Register new identity and add additional remote device starting on new dev
       // browser 2 again
       await focusBrowser(browser2);
       await notInRegistrationModeView.retry();
-      const verificationCodeView =
-        await new AddRemoteDeviceVerificationCodeView(browser2);
+      const verificationCodeView = new AddRemoteDeviceVerificationCodeView(
+        browser2
+      );
       await verificationCodeView.waitForDisplay();
       const code = await verificationCodeView.getVerificationCode();
 
       // browser 1 again
       await focusBrowser(browser);
-      const verificationView = await new VerifyRemoteDeviceView(browser);
+      const verificationView = new VerifyRemoteDeviceView(browser);
       await verificationView.waitForDisplay();
       await verificationView.enterVerificationCode(code);
       await verificationView.continue();
 
       // success page
-      const addDeviceSuccessView = await new AddDeviceSuccessView(browser);
+      const addDeviceSuccessView = new AddDeviceSuccessView(browser);
       await addDeviceSuccessView.waitForDisplay();
       await addDeviceSuccessView.continue();
     });


### PR DESCRIPTION
# Motivation

`await` seem to be a copy/pasted typo as it is not needed to create a test object.