### PR TITLE
Don't show recovery warning on anchor creation

### DIFF
--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -98,7 +98,12 @@ export const authFlowAuthorize = async (
           i18n,
         })
       );
-      await recoveryWizard(authSuccess.userNumber, authSuccess.connection);
+
+      // Here, if the user is returning & doesn't have any recovery device, we prompt them to add
+      // one. The exact flow depends on the device they use.
+      if (!authSuccess.newAnchor) {
+        await recoveryWizard(authSuccess.userNumber, authSuccess.connection);
+      }
       return authSuccess;
     },
     onInvalidOrigin: (result) =>

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -83,12 +83,17 @@ export const authnTemplateManage = (): AuthnTemplates => {
 /* the II authentication flow */
 export const authFlowManage = async (connection: Connection, i18n: I18n) => {
   // Go through the login flow, potentially creating an anchor.
-  const { userNumber, connection: authenticatedConnection } =
-    await authenticateBox(connection, i18n, authnTemplateManage());
+  const {
+    userNumber,
+    connection: authenticatedConnection,
+    newAnchor,
+  } = await authenticateBox(connection, i18n, authnTemplateManage());
 
-  // Here, if the user doesn't have any recovery device, we prompt them to add
+  // Here, if the user is returning & doesn't have any recovery device, we prompt them to add
   // one. The exact flow depends on the device they use.
-  await recoveryWizard(userNumber, authenticatedConnection);
+  if (!newAnchor) {
+    await recoveryWizard(userNumber, authenticatedConnection);
+  }
   // From here on, the user is authenticated to II.
   void renderManage(userNumber, authenticatedConnection);
 };

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -21,12 +21,6 @@ export const FLOWS = {
     await registerView.waitForIdentity();
     const userNumber = await registerView.registerGetIdentity();
     await registerView.registerConfirmIdentity();
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
-    const singleDeviceWarningView = new SingleDeviceWarningView(browser);
-    await singleDeviceWarningView.waitForDisplay();
-    await singleDeviceWarningView.remindLater();
     return userNumber;
   },
   registerNewIdentityWelcomeView: async (


### PR DESCRIPTION
This changes the anchor creation/registration flow to _not_ show a warning in case of single device, no recovery, etc; but instead only shows those warning for returning users.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
