### PR TITLE
Allow loading font from canister

### DIFF
--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -436,7 +436,7 @@ base-uri 'none';\
 form-action 'none';\
 style-src 'self' 'unsafe-inline' https://fonts\\.googleapis\\.com;\
 style-src-elem 'self' 'unsafe-inline' https://fonts\\.googleapis\\.com;\
-font-src https://fonts\\.gstatic\\.com;\
+font-src 'self' https://fonts\\.gstatic\\.com;\
 upgrade-insecure-requests;\
 frame-ancestors 'none';$"
     )

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -28,6 +28,7 @@ pub enum ContentType {
     OCTETSTREAM,
     PNG,
     SVG,
+    WOFF2,
 }
 
 // The <script> tag that loads the 'index.js'
@@ -125,6 +126,7 @@ fn collect_assets_from_dir(dir: &Dir) -> Vec<(String, Vec<u8>, ContentEncoding, 
             "png" => (file_bytes, ContentEncoding::Identity, ContentType::PNG),
             "svg" => (file_bytes, ContentEncoding::Identity, ContentType::SVG),
             "webp" => (file_bytes, ContentEncoding::Identity, ContentType::WEBP),
+            "woff2.gz" => (file_bytes, ContentEncoding::GZip, ContentType::WOFF2),
             _ => panic!("Unknown asset type: {}", asset.path().display()),
         };
 
@@ -171,8 +173,8 @@ fn file_to_asset_path(asset: &File) -> String {
             .chars()
             .take(file_path.len() - ".html".len())
             .collect()
-    } else if file_path.ends_with(".js.gz") {
-        // drop .gz for .js.gz files (i.e. maps **/<foo>.js.gz to **/<foo>.js)
+    } else if file_path.ends_with(".gz") {
+        // drop .gz for .foo.gz files (i.e. maps **/<foo>.js.gz to **/<foo>.js)
         file_path = file_path
             .chars()
             .take(file_path.len() - ".gz".len())

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -25,6 +25,7 @@ impl ContentType {
             ContentType::OCTETSTREAM => "application/octet-stream".to_string(),
             ContentType::PNG => "image/png".to_string(),
             ContentType::SVG => "image/svg+xml".to_string(),
+            ContentType::WOFF2 => "application/font-woff2".to_string(),
         }
     }
 }
@@ -402,7 +403,7 @@ pub fn content_security_policy_meta() -> String {
          form-action 'none';\
          style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;\
          style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com;\
-         font-src https://fonts.gstatic.com;"
+         font-src 'self' https://fonts.gstatic.com;"
     );
     #[cfg(not(feature = "insecure_requests"))]
     let csp = format!("{csp}upgrade-insecure-requests;");


### PR DESCRIPTION
This changes the asset handler to add support for `woff2` files and generalizes gzip support for all file formats, not just `.js`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
