### PR TITLE
Save Identity number early

### DIFF
--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -43,8 +43,8 @@ export const register = async ({
     } else {
       const result = apiResultToLoginFlowResult(captchaResult);
       if (result.tag === "ok") {
-        await displayUserNumber(result.userNumber);
         setAnchorUsed(result.userNumber);
+        await displayUserNumber(result.userNumber);
       }
       return result;
     }


### PR DESCRIPTION
This ensures the Internet Identity number is saved to local storage by the time the user sees the success screen. Otherwise the number may not be offered in the number picker if the user stops the flow immediately upon success (without visiting the management page).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
