### PR TITLE
Allow renaming devices

### DIFF
--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -1,5 +1,5 @@
 import { warningIcon } from "$src/components/icons";
-import { isNullish } from "@dfinity/utils";
+import { isNullish, nonNullish } from "@dfinity/utils";
 import { html, TemplateResult } from "lit-html";
 import { settingsDropdown } from "./settingsDropdown";
 import { Authenticator } from "./types";
@@ -99,12 +99,20 @@ export const authenticatorsSection = ({
 };
 
 export const authenticatorItem = ({
-  authenticator: { alias, dupCount, warn, remove },
+  authenticator: { alias, dupCount, warn, remove, rename },
   index,
 }: {
   authenticator: DedupAuthenticator;
   index: number;
 }) => {
+  const settings = [
+    { action: "rename", caption: "Rename", fn: () => rename() },
+  ];
+
+  if (nonNullish(remove)) {
+    settings.push({ action: "remove", caption: "Remove", fn: () => remove() });
+  }
+
   return html`
     <li class="c-action-list__item" data-device=${alias}>
       ${isNullish(warn) ? undefined : itemWarning({ warn })}
@@ -114,15 +122,11 @@ export const authenticatorItem = ({
           ? html`<i class="t-muted">&nbsp;(${dupCount})</i>`
           : undefined}
       </div>
-      ${isNullish(remove)
-        ? undefined
-        : settingsDropdown({
-            alias,
-            id: `authenticator-${index}`,
-            settings: [
-              { action: "remove", caption: "Remove", fn: () => remove() },
-            ],
-          })}
+      ${settingsDropdown({
+        alias,
+        id: `authenticator-${index}`,
+        settings,
+      })}
     </li>
   `;
 };

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -1,4 +1,5 @@
 import { DeviceData } from "$generated/internet_identity_types";
+import { promptDeviceAlias } from "$src/components/alias";
 import { displayError } from "$src/components/displayError";
 import { withLoader } from "$src/components/loader";
 import { recoverWithPhrase } from "$src/flows/recovery/recoverWith/phrase";
@@ -16,6 +17,38 @@ import {
 import { unknownToString, unreachable } from "$src/utils/utils";
 import { DerEncodedPublicKey } from "@dfinity/agent";
 
+/* Rename the device and return */
+export const renameDevice = async ({
+  connection,
+  device,
+  reload,
+}: {
+  connection: AuthenticatedConnection;
+  device: DeviceData;
+  reload: () => void;
+}) => {
+  const confirmed = confirm("Choose a nickname for this passkey.");
+  if (!confirmed) {
+    return;
+  }
+
+  const alias = await promptDeviceAlias({
+    title: "Passkey Nickname",
+    message: "Choose a nickname for this Passkey",
+  });
+  if (alias === null) {
+    reload();
+    return;
+  }
+
+  device.alias = alias;
+
+  await withLoader(async () => {
+    await connection.update(device);
+  });
+  reload();
+  return;
+};
 /* Remove the device and return */
 export const deleteDevice = async ({
   connection,

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -35,6 +35,7 @@ import { authenticatorsSection } from "./authenticatorsSection";
 import {
   deleteDevice,
   protectDevice,
+  renameDevice,
   resetPhrase,
   unprotectDevice,
 } from "./deviceSettings";
@@ -392,6 +393,7 @@ export const devicesFromDeviceDatas = ({
       acc.authenticators.push({
         alias: device.alias,
         warn: domainWarning(device),
+        rename: () => renameDevice({ connection, device, reload }),
         remove: hasSingleDevice
           ? undefined
           : () => deleteDevice({ connection, device, reload }),

--- a/src/frontend/src/flows/manage/types.ts
+++ b/src/frontend/src/flows/manage/types.ts
@@ -3,6 +3,7 @@ import { TemplateResult } from "lit-html";
 // A simple authenticator (non-recovery device)
 export type Authenticator = {
   alias: string;
+  rename: () => void;
   remove?: () => void;
   warn?: TemplateResult;
 };

--- a/src/frontend/src/test-e2e/misc.test.ts
+++ b/src/frontend/src/test-e2e/misc.test.ts
@@ -8,7 +8,7 @@ import {
   switchToPopup,
   waitToClose,
 } from "./util";
-import { AuthenticateView, DemoAppView } from "./views";
+import { AuthenticateView, DemoAppView, MainView } from "./views";
 
 import {
   DEVICE_NAME1,
@@ -201,5 +201,19 @@ test("Should issue the same principal to dapps on legacy & official domains", as
     const principal2 = await authenticate(TEST_APP_CANONICAL_URL_LEGACY);
 
     expect(principal1).toEqual(principal2);
+  });
+}, 300_000);
+
+test("Device can be renamed", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    await addVirtualAuthenticator(browser);
+    await browser.url(II_URL);
+    await FLOWS.registerNewIdentityWelcomeView(DEVICE_NAME1, browser);
+    const mainView = new MainView(browser);
+    await mainView.waitForDeviceDisplay(DEVICE_NAME1);
+    const newName = DEVICE_NAME1 + "-new";
+    await mainView.rename(DEVICE_NAME1, newName);
+    await mainView.waitForDisplay();
+    await mainView.waitForDeviceDisplay(newName);
   });
 }, 300_000);

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -40,6 +40,22 @@ export class WelcomeView extends View {
   }
 }
 
+export class RenameView extends View {
+  async waitForDisplay(): Promise<void> {
+    await this.browser
+      .$("#pickAliasInput")
+      .waitForDisplayed({ timeout: 10_000 });
+  }
+
+  async enterAlias(alias: string): Promise<void> {
+    await this.browser.$("#pickAliasInput").setValue(alias);
+  }
+
+  async submit(): Promise<void> {
+    await this.browser.$("#pickAliasSubmit").click();
+  }
+}
+
 export class RegisterView extends View {
   async waitForDisplay(): Promise<void> {
     await this.browser
@@ -229,6 +245,30 @@ export class MainView extends View {
 
   async addRecovery(): Promise<void> {
     await this.browser.$('[data-action="add-recovery-phrase"]').click();
+  }
+
+  async rename(deviceName: string, newName: string): Promise<void> {
+    // Ensure the settings dropdown is in view
+    await this.browser.execute(
+      "window.scrollTo(0, document.body.scrollHeight)"
+    );
+    // Ensure the dropdown is open by hovering/clicking (clicking is needed for mobile)
+    await this.browser
+      .$(`button.c-dropdown__trigger[data-device="${deviceName}"]`)
+      .click();
+    await this.browser
+      .$(`button[data-device="${deviceName}"][data-action='rename']`)
+      .waitForClickable();
+    await this.browser
+      .$(`button[data-device="${deviceName}"][data-action='rename']`)
+      .click();
+    await this.browser.waitUntil(this.browser.isAlertOpen);
+    await this.browser.acceptAlert();
+
+    const renameView = new RenameView(this.browser);
+    await renameView.waitForDisplay();
+    await renameView.enterAlias(newName);
+    await renameView.submit();
   }
 
   async protect(deviceName: string, seedPhrase: string): Promise<void> {

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -262,14 +262,17 @@ const iiPages: Record<string, () => void> = {
           {
             alias: "Chrome on iPhone",
             remove: () => console.log("remove"),
+            rename: () => console.log("rename"),
           },
           {
             alias: "Yubikey Blue",
             remove: () => console.log("remove"),
+            rename: () => console.log("rename"),
           },
           {
             alias: "Yubikey Blue",
             remove: () => console.log("remove"),
+            rename: () => console.log("rename"),
             warn: html`Something is rotten in the state of Device`,
           },
         ],
@@ -303,6 +306,7 @@ const iiPages: Record<string, () => void> = {
         authenticators: [
           {
             alias: "Chrome on iPhone",
+            rename: () => console.log("rename"),
           },
         ],
         recoveries: {},


### PR DESCRIPTION
This adds an option in the management page for renaming authenticator devices.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
