### PR TITLE
Infer authenticator aliases

### DIFF
--- a/demos/using-dev-build/specs/auth.e2e.ts
+++ b/demos/using-dev-build/specs/auth.e2e.ts
@@ -7,13 +7,6 @@ describe("authentication", () => {
     // Click on "Create an Internet Identity Anchor"
     await browser.$("#registerButton").click();
 
-    // Set the name of the device and submit
-    const registerAlias = await browser.$("#pickAliasInput");
-    await registerAlias.waitForExist();
-    await registerAlias.setValue("My Device");
-
-    await browser.$('button[type="submit"]').click();
-
     // Construct Identity (no-op)
     const constructIdentity = await browser.$(
       '[data-action="construct-identity"]'

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,15 @@
         "lit-html": "^2.7.2",
         "process": "^0.11.10",
         "qr-creator": "^1.0.0",
-        "stream-browserify": "^3.0.0"
+        "stream-browserify": "^3.0.0",
+        "ua-parser-js": "^1.0.35"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "~5",
         "@trust/webcrypto": "^0.9.2",
         "@types/jest": "~29",
         "@types/selenium-standalone": "^7.0.1",
+        "@types/ua-parser-js": "^0.7.36",
         "@typescript-eslint/eslint-plugin": "5.45.1",
         "@typescript-eslint/parser": "5.45.1",
         "@wdio/globals": "^8.6.9",
@@ -1981,6 +1983,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+    },
+    "node_modules/@types/ua-parser-js": {
+      "version": "0.7.36",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
+      "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==",
+      "dev": true
     },
     "node_modules/@types/which": {
       "version": "2.0.2",
@@ -8945,7 +8953,6 @@
       "version": "1.0.35",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
       "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11076,6 +11083,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
       "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+    },
+    "@types/ua-parser-js": {
+      "version": "0.7.36",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
+      "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==",
+      "dev": true
     },
     "@types/which": {
       "version": "2.0.2",
@@ -16279,8 +16292,7 @@
     "ua-parser-js": {
       "version": "1.0.35",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
-      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
-      "dev": true
+      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA=="
     },
     "unbzip2-stream": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@trust/webcrypto": "^0.9.2",
     "@types/jest": "~29",
     "@types/selenium-standalone": "^7.0.1",
+    "@types/ua-parser-js": "^0.7.36",
     "@typescript-eslint/eslint-plugin": "5.45.1",
     "@typescript-eslint/parser": "5.45.1",
     "@wdio/globals": "^8.6.9",
@@ -58,7 +59,8 @@
     "lit-html": "^2.7.2",
     "process": "^0.11.10",
     "qr-creator": "^1.0.0",
-    "stream-browserify": "^3.0.0"
+    "stream-browserify": "^3.0.0",
+    "ua-parser-js": "^1.0.35"
   },
   "engines": {
     "npm": ">=9.0.0 <10.0.0",

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -67,7 +67,10 @@ export const authenticatorsSection = ({
         </div>
         ${
           warnFewDevices
-            ? html`<p class="warning-message t-paragraph t-lead">
+            ? html`<p
+                style="max-width: 30rem;"
+                class="warning-message t-paragraph t-lead"
+              >
                 Add a Passkey or recovery method to make your Internet Identity
                 more secure.
               </p>`

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -127,14 +127,6 @@ export const inferAlias = async ({
   }
 
   const os = uaParser.getOS().name;
-  authenticatorType satisfies undefined | "platform";
-  if (nonNullish(os) && os.startsWith("Android")) {
-    // For Android devices we simply show the device name/model (android is assumed)
-    const device = uaParser.getDevice();
-    if (nonNullish(device) && nonNullish(device.model)) {
-      return device.model;
-    }
-  }
 
   // As a last resort, we try to show something like "Chrome on Linux" or just "Chrome" or just "Linux"
   const browser = uaParser.getBrowser().name;

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -1,12 +1,13 @@
-import { promptDeviceAlias } from "$src/components/alias";
 import {
   apiResultToLoginFlowResult,
   cancel,
   LoginFlowResult,
 } from "$src/utils/flowResult";
-import { Connection } from "$src/utils/iiConnection";
+import { Connection, IIWebAuthnIdentity } from "$src/utils/iiConnection";
 import { setAnchorUsed } from "$src/utils/userNumber";
 import { unknownToString } from "$src/utils/utils";
+import { nonNullish } from "@dfinity/utils";
+import type { UAParser } from "ua-parser-js";
 import { promptCaptcha } from "./captcha";
 import { displayUserNumber } from "./finish";
 import { savePasskey } from "./passkey";
@@ -18,10 +19,8 @@ export const register = async ({
   connection: Connection;
 }): Promise<LoginFlowResult> => {
   try {
-    const alias = await promptDeviceAlias({ title: "Register this device" });
-    if (alias === null) {
-      return cancel;
-    }
+    // Kick-off fetching "ua-parser-js";
+    const uaParser = loadUAParser();
 
     // Kick-off the challenge request early, so that we might already
     // have a captcha to show once we get to the CAPTCHA screen
@@ -30,6 +29,12 @@ export const register = async ({
     if (identity === "canceled") {
       return cancel;
     }
+
+    const alias = await inferAlias({
+      authenticatorType: identity.getAuthenticatorAttachment(),
+      userAgent: navigator.userAgent,
+      uaParser,
+    });
 
     const captchaResult = await promptCaptcha({
       connection,
@@ -55,5 +60,103 @@ export const register = async ({
       message: "An error occurred during Internet Identity creation.",
       detail: unknownToString(e, "unknown error"),
     };
+  }
+};
+
+type AuthenticatorType = ReturnType<
+  IIWebAuthnIdentity["getAuthenticatorAttachment"]
+>;
+type PreloadedUAParser = ReturnType<typeof loadUAParser>;
+
+// Logic for inferring a passkey alias based on the authenticator type & user agent
+export const inferAlias = async ({
+  authenticatorType,
+  userAgent,
+  uaParser: uaParser_,
+}: {
+  authenticatorType: AuthenticatorType;
+  userAgent: typeof navigator.userAgent;
+  uaParser: PreloadedUAParser;
+}): Promise<string> => {
+  const UNNAMED = "Unnamed Passkey";
+  const FIDO = "FIDO Passkey";
+  const ICLOUD = "iCloud Passkey";
+
+  // If the authenticator is cross platform, then it's FIDO
+  if (authenticatorType === "cross-platform") {
+    return FIDO;
+  }
+
+  // Otherwise, make sure the UA parser module is loaded, because
+  // everything from here will use UA heuristics
+  const UAParser = await uaParser_;
+  if (UAParser === undefined) {
+    return UNNAMED;
+  }
+  const uaParser = new UAParser(userAgent);
+
+  if (
+    authenticatorType === "platform" &&
+    uaParser.getEngine().name === "WebKit"
+  ) {
+    // Safari, including Chrome, FireFox etc on iOS/iPadOs
+    const version = uaParser.getBrowser().version;
+
+    if (nonNullish(version) && Number(version) >= 16.2) {
+      // Safari 16.2 enforce usage of iCloud passkeys
+      return ICLOUD;
+    } else {
+      // If the Safari version is older, then we just give the device (since
+      // each apple device like iPhone, iPad, etc has its own OS, there is no
+      // need to duplicate the info with the OS)
+      const device = uaParser.getDevice();
+      if (nonNullish(device) && nonNullish(device.model)) {
+        return device.model;
+      }
+    }
+  }
+
+  if (
+    authenticatorType !== "platform" &&
+    uaParser.getEngine().name === "Gecko" &&
+    uaParser.getOS().name === "Mac OS"
+  ) {
+    // FireFox on Mac OS does not support TouchID, so if it's not a "platform" authenticator it's some sort
+    // of FIDO device, even if no authenticator type was provided
+    return FIDO;
+  }
+
+  const os = uaParser.getOS().name;
+  authenticatorType satisfies undefined | "platform";
+  if (nonNullish(os) && os.startsWith("Android")) {
+    // For Android devices we simply show the device name/model (android is assumed)
+    const device = uaParser.getDevice();
+    if (nonNullish(device) && nonNullish(device.model)) {
+      return device.model;
+    }
+  }
+
+  // As a last resort, we try to show something like "Chrome on Linux" or just "Chrome" or just "Linux"
+  const browser = uaParser.getBrowser().name;
+  const browserOn = [
+    ...(nonNullish(browser) ? [browser] : []),
+    ...(nonNullish(os) ? [os] : []),
+  ];
+  authenticatorType satisfies undefined | "platform";
+  if (browserOn.length !== 0) {
+    return browserOn.join(" on ");
+  }
+
+  // If all else fails, the device is unnamed
+  return UNNAMED;
+};
+
+// Dynamically load the user agent parser module
+export const loadUAParser = async (): Promise<typeof UAParser | undefined> => {
+  try {
+    return (await import("ua-parser-js")).default;
+  } catch (e) {
+    console.error(e);
+    return undefined;
   }
 };

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -621,7 +621,7 @@ a:hover,
 .l-container {
   position: relative;
   font-size: 1.6rem;
-  min-width: 30rem;
+  min-width: 40rem;
   max-width: 40rem;
   /* centers the container and adds a bit of space to make sure the footer does not stick to it */
   margin: 0 auto 2rem;

--- a/src/frontend/src/test-e2e/constants.ts
+++ b/src/frontend/src/test-e2e/constants.ts
@@ -13,6 +13,5 @@ export const REPLICA_URL = "https://icp-api.io";
 export const II_URL =
   process.env.II_URL ?? "https://identity.internetcomputer.org";
 
-export const DEVICE_NAME1 = "Virtual WebAuthn device";
-export const DEVICE_NAME2 = "Other WebAuthn device";
+export const DEVICE_NAME1 = "FIDO Passkey";
 export const RECOVERY_PHRASE_NAME = "Recovery Phrase";

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -14,7 +14,6 @@ export const FLOWS = {
   ): Promise<string> {
     const registerView = new RegisterView(browser);
     await registerView.waitForDisplay();
-    await registerView.enterAlias(deviceName);
     await registerView.create();
     await registerView.waitForRegisterConfirm();
     await registerView.confirmRegisterConfirm();

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -59,16 +59,11 @@ export class RenameView extends View {
 export class RegisterView extends View {
   async waitForDisplay(): Promise<void> {
     await this.browser
-      .$("#pickAliasInput")
+      .$('[data-action="construct-identity"')
       .waitForDisplayed({ timeout: 10_000 });
   }
 
-  async enterAlias(alias: string): Promise<void> {
-    await this.browser.$("#pickAliasInput").setValue(alias);
-  }
-
   async create(): Promise<void> {
-    await this.browser.$("#pickAliasSubmit").click();
     await this.browser.$('[data-action="construct-identity"').click();
   }
 
@@ -219,6 +214,13 @@ export class MainView extends View {
       .waitForDisplayed({ timeout: 10_000 });
   }
 
+  async waitForDeviceCount(deviceName: string, count: number): Promise<void> {
+    const elems = await this.browser.$$(`//li[@data-device="${deviceName}"]`);
+    if (elems.length !== count) {
+      throw Error("Bad number of elements");
+    }
+  }
+
   async waitForDeviceDisplay(deviceName: string): Promise<void> {
     await this.browser
       .$(`//li[@data-device="${deviceName}"]`)
@@ -362,22 +364,6 @@ export class MainView extends View {
     await this.browser
       .$("button[data-action='remove']")
       .waitForDisplayed({ reverse: true });
-  }
-}
-
-export class AddDeviceAliasView extends View {
-  async waitForDisplay(): Promise<void> {
-    await this.browser
-      .$("#pickAliasSubmit")
-      .waitForDisplayed({ timeout: 3_000 });
-  }
-
-  async addAdditionalDevice(alias: string): Promise<void> {
-    await this.browser.$("#pickAliasInput").setValue(alias);
-  }
-
-  async continue(): Promise<void> {
-    await this.browser.$("#pickAliasSubmit").click();
   }
 }
 


### PR DESCRIPTION
This introduces heuristics to give default aliases to authenticators. The alias prompt is removed from the flows (the user will have to explicitly rename the device if the alias is not ok).

The UAParser module is lazily loaded to make sure existing users don't incur the cost of an increased bundle size.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
