### PR TITLE
Catch prepareDelegation errors

### DIFF
--- a/src/frontend/src/flows/authorize/fetchDelegation.ts
+++ b/src/frontend/src/flows/authorize/fetchDelegation.ts
@@ -18,7 +18,7 @@ export const fetchDelegation = async (
   userNumber: bigint,
   connection: AuthenticatedConnection,
   authContext: AuthContext
-): Promise<[PublicKey, Delegation]> => {
+): Promise<[PublicKey, Delegation] | { error: unknown }> => {
   const sessionKey = Array.from(authContext.authRequest.sessionPublicKey);
 
   // at this point, derivationOrigin is either validated or undefined
@@ -36,11 +36,17 @@ export const fetchDelegation = async (
     derivationOrigin = `https://${subdomain}.ic0.app`;
   }
 
-  const [userKey, timestamp] = await connection.prepareDelegation(
+  const result = await connection.prepareDelegation(
     derivationOrigin,
     sessionKey,
     authContext.authRequest.maxTimeToLive
   );
+
+  if ("error" in result) {
+    return result;
+  }
+
+  const [userKey, timestamp] = result;
 
   const signed_delegation = await retryGetDelegation(
     connection,

--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -154,11 +154,24 @@ export async function authenticationProtocol({
 
   onProgress("fetching delegation");
 
-  const [userKey, parsed_signed_delegation] = await fetchDelegation(
+  const result = await fetchDelegation(
     authSuccess.userNumber,
     authSuccess.connection,
     authContext
   );
+
+  if ("error" in result) {
+    window.opener.postMessage(
+      {
+        kind: "authorize-client-failure",
+        text: "Unexpected error",
+      },
+      authContext.requestOrigin
+    );
+    return "failure";
+  }
+
+  const [userKey, parsed_signed_delegation] = result;
 
   window.opener.postMessage(
     {

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -549,17 +549,22 @@ export class AuthenticatedConnection extends Connection {
     hostname: FrontendHostname,
     sessionKey: SessionKey,
     maxTimeToLive?: bigint
-  ): Promise<[PublicKey, bigint]> => {
-    console.log(
-      `prepare_delegation(user: ${this.userNumber}, hostname: ${hostname}, session_key: ${sessionKey})`
-    );
-    const actor = await this.getActor();
-    return await actor.prepare_delegation(
-      this.userNumber,
-      hostname,
-      sessionKey,
-      nonNullish(maxTimeToLive) ? [maxTimeToLive] : []
-    );
+  ): Promise<[PublicKey, bigint] | { error: unknown }> => {
+    try {
+      console.log(
+        `prepare_delegation(user: ${this.userNumber}, hostname: ${hostname}, session_key: ${sessionKey})`
+      );
+      const actor = await this.getActor();
+      return await actor.prepare_delegation(
+        this.userNumber,
+        hostname,
+        sessionKey,
+        nonNullish(maxTimeToLive) ? [maxTimeToLive] : []
+      );
+    } catch (e: unknown) {
+      console.error(e);
+      return { error: e };
+    }
   };
 
   getDelegation = async (


### PR DESCRIPTION
This ensures canister errors when preparing the delegation are caught and an error message is shown to the user.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
