### PR TITLE
Show Passkey alias when renaming

### DIFF
--- a/src/frontend/src/components/alias/index.ts
+++ b/src/frontend/src/components/alias/index.ts
@@ -3,6 +3,7 @@ import { I18n } from "$src/i18n";
 import { renderPage, withRef } from "$src/utils/lit-html";
 import { validateAlias } from "$src/utils/validateAlias";
 import { html, TemplateResult } from "lit-html";
+import { ifDefined } from "lit-html/directives/if-defined.js";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
 
 import copyJson from "./index.json";
@@ -13,6 +14,7 @@ export const promptDeviceAliasTemplate = (props: {
   title: string;
   message?: string | TemplateResult;
   cancelText?: string;
+  value?: string;
   continue: (alias: string) => void;
   cancel: () => void;
   i18n: I18n;
@@ -56,6 +58,7 @@ export const promptDeviceAliasTemplate = (props: {
           e.currentTarget.setCustomValidity(message);
         }}
         placeholder=${copy.placeholder}
+        value=${ifDefined(props.value)}
         aria-label="device name"
         type="text"
         required
@@ -91,10 +94,12 @@ export const promptDeviceAliasPage = renderPage(promptDeviceAliasTemplate);
 export const promptDeviceAlias = ({
   title,
   message,
+  value,
   cancelText,
 }: {
   title: string;
   message?: string | TemplateResult;
+  value?: string;
   cancelText?: string;
 }): Promise<string | null> =>
   new Promise((resolve) => {
@@ -102,6 +107,7 @@ export const promptDeviceAlias = ({
     promptDeviceAliasPage({
       title,
       message,
+      value,
       cancelText,
       cancel: () => resolve(null),
       continue: resolve,

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -35,6 +35,7 @@ export const renameDevice = async ({
   const alias = await promptDeviceAlias({
     title: "Passkey Nickname",
     message: "Choose a nickname for this Passkey",
+    value: device.alias,
   });
   if (alias === null) {
     reload();


### PR DESCRIPTION
This ensures the current Passkey's alias is shown and set as a default when the user renames their Passkey. This gives the user context about which Passkey they're renaming, and improves the flow (since renaming is often just slightly tweaking the current alias).


https://user-images.githubusercontent.com/6930756/236777144-3a96ea2d-7f3a-40d4-898a-b93d8b161cf8.mov



<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
