### PR TITLE
Remove googlefonts from CSP

### DIFF
--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -434,9 +434,9 @@ img-src 'self' data:;\
 script-src 'sha256-[a-zA-Z0-9/=+]+' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https:;\
 base-uri 'none';\
 form-action 'none';\
-style-src 'self' 'unsafe-inline' https://fonts\\.googleapis\\.com;\
-style-src-elem 'self' 'unsafe-inline' https://fonts\\.googleapis\\.com;\
-font-src 'self' https://fonts\\.gstatic\\.com;\
+style-src 'self' 'unsafe-inline';\
+style-src-elem 'self' 'unsafe-inline';\
+font-src 'self';\
 upgrade-insecure-requests;\
 frame-ancestors 'none';$"
     )

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -401,9 +401,9 @@ pub fn content_security_policy_meta() -> String {
          script-src '{hash}' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https:;\
          base-uri 'none';\
          form-action 'none';\
-         style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;\
-         style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com;\
-         font-src 'self' https://fonts.gstatic.com;"
+         style-src 'self' 'unsafe-inline';\
+         style-src-elem 'self' 'unsafe-inline';\
+         font-src 'self';"
     );
     #[cfg(not(feature = "insecure_requests"))]
     let csp = format!("{csp}upgrade-insecure-requests;");


### PR DESCRIPTION
We don't pull in any fonts from Google Fonts anymore, so the CSP section is not relevant anymore.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
