### PR TITLE
Preload Identity card background

### DIFF
--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -95,7 +95,7 @@ export const displayUserNumberTemplate = ({
 };
 
 // A non-exported wrapper around HTMLImageElement, to ensure this exact image is loaded
-// (a no other image is passed as an argument to this page)
+// (and no other image is passed as an argument to this page)
 class IdentityBackground {
   public img: HTMLImageElement;
 

--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -9,12 +9,14 @@ import { createRef, ref, Ref } from "lit-html/directives/ref.js";
 export const displayUserNumberTemplate = ({
   onContinue,
   userNumber,
+  identityBackground: identityBackground_,
 }: {
   onContinue: () => void;
   userNumber: bigint;
+  identityBackground?: IdentityBackground;
 }) => {
   const userNumberCopy: Ref<HTMLButtonElement> = createRef();
-
+  const identityBackground = identityBackground_ ?? new IdentityBackground();
   const displayUserNumberSlot = html`<hgroup>
       <h1 class="t-title t-title--main">
         You’ve created an Internet Identity!
@@ -25,7 +27,7 @@ export const displayUserNumberTemplate = ({
     </hgroup>
     <div class="c-input c-input--textarea c-input--readonly c-input--icon c-input--id" >
       <div class="c-input--id__wrap">
-        <img class="c-input--id__art" src="${BASE_URL}image.png" alt="" />
+      ${identityBackground.img}
         <h2 class="c-input--id__caption">Internet Identity:</h2>
         <output class="c-input--id__value" class="t-vip" aria-label="usernumber" id="userNumber" data-usernumber="${userNumber}">${userNumber}</output>
       </div>
@@ -92,10 +94,56 @@ export const displayUserNumberTemplate = ({
   });
 };
 
+// A non-exported wrapper around HTMLImageElement, to ensure this exact image is loaded
+// (a no other image is passed as an argument to this page)
+class IdentityBackground {
+  public img: HTMLImageElement;
+
+  constructor() {
+    const img = new Image();
+    img.src = `${BASE_URL}image.png`; // Setting the src kicks off the fetching
+    img.classList.add("c-input--id__art");
+    img.alt = "";
+    this.img = img;
+  }
+}
+
 export const displayUserNumberPage = renderPage(displayUserNumberTemplate);
 
-export const displayUserNumber = (userNumber: bigint): Promise<void> => {
+// Omit specified functions parameters, for instance OmitParams<..., "foo" | "bar">
+// will transform
+//  f: (a: { foo, bar, baz }) => void
+// into
+//  f: (a: { baz }) => void
+//
+// eslint-disable-next-line
+type OmitParams<T extends (arg: any) => any, A extends string> = (
+  a: Omit<Parameters<T>[0], A>
+) => ReturnType<T>;
+
+// A variant of `displayUserNumber` where the `identityBackground` is preloaded
+export const displayUserNumberWarmup = (): OmitParams<
+  typeof displayUserNumber,
+  "identityBackground"
+> => {
+  const identityBackground = new IdentityBackground();
+  return async (opts) => {
+    await displayUserNumber({ ...opts, identityBackground });
+  };
+};
+
+export const displayUserNumber = ({
+  userNumber,
+  identityBackground,
+}: {
+  userNumber: bigint;
+  identityBackground?: IdentityBackground;
+}): Promise<void> => {
   return new Promise((resolve) =>
-    displayUserNumberPage({ onContinue: () => resolve(), userNumber })
+    displayUserNumberPage({
+      onContinue: () => resolve(),
+      userNumber,
+      identityBackground,
+    })
   );
 };

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -9,7 +9,7 @@ import { unknownToString } from "$src/utils/utils";
 import { nonNullish } from "@dfinity/utils";
 import type { UAParser } from "ua-parser-js";
 import { promptCaptcha } from "./captcha";
-import { displayUserNumber } from "./finish";
+import { displayUserNumberWarmup } from "./finish";
 import { savePasskey } from "./passkey";
 
 /** Registration (anchor creation) flow for new users */
@@ -36,6 +36,7 @@ export const register = async ({
       uaParser,
     });
 
+    const displayUserNumber = displayUserNumberWarmup();
     const captchaResult = await promptCaptcha({
       connection,
       challenge: preloadedChallenge,
@@ -48,8 +49,9 @@ export const register = async ({
     } else {
       const result = apiResultToLoginFlowResult(captchaResult);
       if (result.tag === "ok") {
-        setAnchorUsed(result.userNumber);
-        await displayUserNumber(result.userNumber);
+        const { userNumber } = result;
+        setAnchorUsed(userNumber);
+        await displayUserNumber({ userNumber });
       }
       return result;
     }


### PR DESCRIPTION
The "Internet Identity" card background is an image that must be loaded from the canister, which can take a few seconds. This ensures that when used in the identity creation flow, the browser can already start fetching the image as the user is dealing with the CAPTCHA (optimistically assume the user will succeed, at very little cost if the user does not actually succeed).

Before, with network throttling (2s/request):

https://user-images.githubusercontent.com/6930756/236805453-4826804f-4101-4dd5-8011-2bf60104794f.mov

After, with network throttling (2s/request):


https://user-images.githubusercontent.com/6930756/236805523-b54f7b55-e444-47b7-8000-39898684c4ab.mov



<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
