### PR TITLE
Remove anchor from dev build readme

### DIFF
--- a/demos/using-dev-build/README.md
+++ b/demos/using-dev-build/README.md
@@ -27,7 +27,7 @@ $ dfx deploy --no-wallet
 At this point, the replica (for all practical matters, a local version of the Internet Computer) is running and three canisters have been deployed:
 
 - `internet_identity`: The development version of Internet Identity (downloaded from the [latest release](https://github.com/dfinity/internet-identity/releases/latest), see [`dfx.json`](./dfx.json)).
-- `webapp`: A tiny webapp that calls out to the `internet_identity` canister for identity (anchor) creation and authentication, and that then calls the `whoami` canister (see below) to show that the identity is valid. You'll find the source of the webapp in [`index.html`](./webapp/index.html) and [`index.ts`](./webapp/index.ts).
+- `webapp`: A tiny webapp that calls out to the `internet_identity` canister for authentication, and that then calls the `whoami` canister (see below) to show that the identity is valid. You'll find the source of the webapp in [`index.html`](./webapp/index.html) and [`index.ts`](./webapp/index.ts).
 - `whoami`: A simple canister that checks that calls are authenticated, and that returns the "principal of the caller". The implementation is terribly simple:
   ```motoko
   actor {


### PR DESCRIPTION
This aligns the using dev build readme to the recent anchor removal UI change.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
