### PR TITLE
Always preload identity background

### DIFF
--- a/src/frontend/src/components/identityCard.ts
+++ b/src/frontend/src/components/identityCard.ts
@@ -1,0 +1,47 @@
+import { BASE_URL } from "$src/environment";
+import { html, TemplateResult } from "lit-html";
+
+export const identityCard = ({
+  userNumber,
+  identityBackground,
+}: {
+  userNumber: bigint;
+  identityBackground: IdentityBackground;
+}): TemplateResult => {
+  return html` <div class="c-input--id__wrap">
+    <img src=${identityBackground.img.src} class="c-input--id__art" />
+    <h2 class="c-input--id__caption">Internet Identity:</h2>
+    <output
+      class="c-input--id__value"
+      class="t-vip"
+      aria-label="usernumber"
+      id="userNumber"
+      data-usernumber="${userNumber}"
+      >${userNumber}</output
+    >
+  </div>`;
+};
+
+// A wrapper around HTMLImageElement, to ensure this exact image is loaded
+// (and no other image is passed as an argument to this page by mistake)
+export class IdentityBackground {
+  // The image element created in order for the browser to load the image. Only the src attribute is used.
+  public img: HTMLImageElement;
+
+  // Only the src attribute is used so the same Element can be shared across Templates
+  public static singleton?: IdentityBackground;
+  public static getSingleton(): IdentityBackground {
+    IdentityBackground.singleton ??= new IdentityBackground();
+    return IdentityBackground.singleton;
+  }
+
+  constructor() {
+    const img = new Image();
+    img.src = `${BASE_URL}image.png`; // Setting the src kicks off the fetching
+    this.img = img;
+  }
+}
+
+// Start loading the card background; should ideally be called a couple seconds
+// before rendering the template
+export const loadIdentityBackground = IdentityBackground.getSingleton;

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -5,7 +5,7 @@ import { anyFeatures, features } from "./features";
 import { registerTentativeDevice } from "./flows/addDevice/welcomeView/registerTentativeDevice";
 import { authFlowAuthorize } from "./flows/authorize";
 import { compatibilityNotice } from "./flows/compatibilityNotice";
-import { authFlowManage, renderManage } from "./flows/manage";
+import { authFlowManage, renderManageWarmup } from "./flows/manage";
 import { I18n } from "./i18n";
 import "./styles/main.css";
 import { getAddDeviceAnchor } from "./utils/addDeviceLink";
@@ -116,13 +116,18 @@ const init = async () => {
     // Display a success page once device added (above registerTentativeDevice **never** returns if it fails)
     await addDeviceSuccess({ deviceAlias });
 
+    const renderManage = renderManageWarmup();
+
     // If user "Click" continue in success page, proceed with authentication
     const result = await authenticate(connection, userNumber);
     const loginData = await handleLoginFlowResult(result);
 
     // User have successfully signed-in we can jump to manage page
     if (nonNullish(loginData)) {
-      return await renderManage(userNumber, loginData.connection);
+      return await renderManage({
+        userNumber,
+        connection: loginData.connection,
+      });
     }
   }
 

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -326,3 +326,14 @@ export function shuffleArray<T>(array_: T[]): T[] {
   }
   return array;
 }
+
+// Omit specified functions parameters, for instance OmitParams<..., "foo" | "bar">
+// will transform
+//  f: (a: { foo, bar, baz }) => void
+// into
+//  f: (a: { baz }) => void
+//
+// eslint-disable-next-line
+export type OmitParams<T extends (arg: any) => any, A extends string> = (
+  a: Omit<Parameters<T>[0], A>
+) => ReturnType<T>;

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -11,6 +11,7 @@ import { promptDeviceAliasPage } from "$src/components/alias";
 import { mkAnchorPicker } from "$src/components/anchorPicker";
 import { authnPages } from "$src/components/authenticateBox";
 import { displayError } from "$src/components/displayError";
+import { loadIdentityBackground } from "$src/components/identityCard";
 import { withLoader } from "$src/components/loader";
 import { showMessage, showMessagePage } from "$src/components/message";
 import { promptUserNumber } from "$src/components/promptUserNumber";
@@ -50,6 +51,8 @@ import { asNonEmptyArray, Chan, NonEmptyArray } from "$src/utils/utils";
 import { html, render, TemplateResult } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
+
+const identityBackground = loadIdentityBackground();
 
 // A "dummy" connection which actually is just undefined, hoping pages won't call it
 const dummyConnection = undefined as unknown as AuthenticatedConnection;
@@ -137,6 +140,7 @@ const manage = authnPages(i18n, { ...authnCnfg, ...manageTemplates });
 const iiPages: Record<string, () => void> = {
   displayUserNumber: () =>
     displayUserNumberPage({
+      identityBackground,
       userNumber,
       onContinue: () => console.log("done"),
     }),
@@ -256,6 +260,7 @@ const iiPages: Record<string, () => void> = {
     ),
   displayManage: () => {
     displayManagePage({
+      identityBackground,
       userNumber,
       devices: {
         authenticators: [
@@ -301,6 +306,7 @@ const iiPages: Record<string, () => void> = {
   },
   displayManageSingle: () => {
     displayManagePage({
+      identityBackground,
       userNumber,
       devices: {
         authenticators: [


### PR DESCRIPTION
This extracts the "Internet Identity" card component and ensures the background image is always preloaded:

* The `identityBackground` parameter is not optional anymore
* The new component is used in the management page as well
* The helpers & component are moved out of `finish.ts` to be shared

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
