### PR TITLE
Use ports 5173 and 5174 instead of 8080

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -46,8 +46,8 @@ jobs:
           npm run showcase&
           showcase_pid=$!
 
-          # every 100ms, check if localhost:8080 is reachable (i.e. devserver is up)
-          while ! nc -z localhost 8080; do
+          # every 100ms, check if localhost:5174 is reachable (i.e. devserver is up)
+          while ! nc -z localhost 5174; do
             sleep 0.1
           done
           SCREENSHOTS_DIR="./screenshots/${{ matrix.device }}" \

--- a/HACKING.md
+++ b/HACKING.md
@@ -67,7 +67,7 @@ the following:
 npm run dev
 ```
 
-Then open `http://localhost:8080` in your browser. The page is reloaded whenever you save changes to files. To ensure your changes pass our formatting and linter checks, run the following command:
+Then open `http://localhost:5173` in your browser. The page is reloaded whenever you save changes to files. To ensure your changes pass our formatting and linter checks, run the following command:
 
 ```bash
 npm run format && npm run lint
@@ -83,7 +83,7 @@ npm run dev
 
 Then open `http://localhost:8081` in your browser.
 
-Make sure that the "Identity Provider" is set to "http://localhost:8080" if you
+Make sure that the "Identity Provider" is set to "http://localhost:5173" if you
 serve the Internet Identity frontend locally.
 
 **NOTE on testing on LAN:**

--- a/demos/test-app/README.md
+++ b/demos/test-app/README.md
@@ -29,4 +29,4 @@ Note: These steps are intended to do development on the test-app. To simply run 
 2. Run the local replica `dfx start --clean`
 3. Deploy the canister to the local replica `dfx deploy`
 4. Visit the running site at http://localhost:4943?<canister_id>
-   1. alternatively the dev server can be started by running `npm run dev` which can be accessed on http://localhost:8080
+   1. alternatively the dev server can be started by running `npm run dev` which can be accessed on http://localhost:5173

--- a/demos/using-dev-build/README.md
+++ b/demos/using-dev-build/README.md
@@ -134,7 +134,7 @@ _If you actually use the webapp, make sure that the "Internet Identity URL" fiel
 
 Figuring the canister IDs, and using the `canisterId=...` query parameter is all a bit cumbersome. Here are some commands you might like:
 
-- `npm run dev`: Build the app and serve it on `localhost:8080` with hot reload on code changes, ideal for hacking on the webapp.
+- `npm run dev`: Build the app and serve it on `localhost:5173` with hot reload on code changes, ideal for hacking on the webapp.
 - `npm run proxy`: Start a proxy that serves Internet Identity on `localhost:8086` and the webapp on `localhost:8087` for easy access.
 - `npm run test`: Start the proxy and run browser tests against the `internet_identity` canister.
 

--- a/demos/using-dev-build/vite.config.ts
+++ b/demos/using-dev-build/vite.config.ts
@@ -25,7 +25,6 @@ export default defineConfig(
       },
     },
     server: {
-      port: 8080,
       proxy: {
         "/api": "http://127.0.0.1:4943",
       },

--- a/demos/using-dev-build/wdio.conf.ts
+++ b/demos/using-dev-build/wdio.conf.ts
@@ -1,5 +1,5 @@
 export const config: WebdriverIO.Config = {
-  baseUrl: process.env.II_DAPP_URL || "http://localhost:8080",
+  baseUrl: process.env.II_DAPP_URL || "http://localhost:5173",
 
   waitforTimeout: 10_000,
 

--- a/scripts/start-selenium-env
+++ b/scripts/start-selenium-env
@@ -34,7 +34,7 @@ NOTE: This requires docker, docker-compose, a running dfx replica with II and th
 EOF
 
 }
-II_PORT=8080
+II_PORT=5173
 while [[ $# -gt 0  ]]
 do
     case "$1" in

--- a/src/frontend/screenshots.ts
+++ b/src/frontend/screenshots.ts
@@ -6,7 +6,7 @@ import { remote } from "webdriverio";
 import { downloadChrome } from "./download-chrome";
 
 /** This executable takes screenshots of every page in the showcase.
- * This function expects the showcase to be running on 'http://localhost:8080'. Everything
+ * This function expects the showcase to be running on 'http://localhost:5174'. Everything
  * else is automated. */
 async function main() {
   await withChrome(takeShowcaseScreenshots);
@@ -14,7 +14,7 @@ async function main() {
 
 /** Open each showcase page one after the other and screenshot it */
 async function takeShowcaseScreenshots(browser: WebdriverIO.Browser) {
-  await visit(browser, "http://localhost:8080/");
+  await visit(browser, "http://localhost:5174/");
 
   // The landing page has a link for every page. The link tags have `data-page-name`
   // attributes, which we gather as the list of page names.
@@ -40,7 +40,7 @@ async function takeShowcaseScreenshots(browser: WebdriverIO.Browser) {
       continue;
     }
 
-    await visit(browser, `http://localhost:8080/${pageName}`);
+    await visit(browser, `http://localhost:5174/${pageName}`);
 
     // When authenticating with alternative origins, toggle the chasm
     if (pageName === "authorizePickAltOpen") {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,7 +66,6 @@ const defaultConfig = (mode?: string): Omit<UserConfig, "root"> => {
       },
     },
     server: {
-      port: 8080,
       proxy: {
         "/api": "http://127.0.0.1:4943",
       },
@@ -76,7 +75,7 @@ const defaultConfig = (mode?: string): Omit<UserConfig, "root"> => {
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }: UserConfig): UserConfig => {
-  const { build, ...rest } = defaultConfig(mode);
+  const { build, server, ...rest } = defaultConfig(mode);
 
   if (mode === "showcase") {
     return {
@@ -88,6 +87,10 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
         target: "esnext" /* for top-level await in showcase */,
         outDir: "../../dist-showcase",
       },
+      server: {
+        ...server,
+        port: 5174,
+      },
     };
   }
 
@@ -95,5 +98,6 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
     ...rest,
     root: "src/frontend",
     build,
+    server,
   };
 });


### PR DESCRIPTION
# Motivation

Use vitejs default port  `5173` as in NNS-dapp to make easier to switch between projects.

Set `5174` for showcase that way both dev and showcase can run in parallel.