### PR TITLE
II interface v2

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1,8 +1,6 @@
-type UserNumber = nat64;
+type IdentityNumber = nat64;
 type PublicKey = blob;
 type CredentialId = blob;
-type DeviceKey = PublicKey;
-type UserKey = PublicKey;
 type SessionKey = PublicKey;
 type FrontendHostname = text;
 type Timestamp = nat64;
@@ -41,22 +39,10 @@ type StreamingStrategy = variant {
     };
 };
 
-type Purpose = variant {
-    recovery;
-    authentication;
-};
-
-type KeyType = variant {
-    unknown;
-    platform;
-    cross_platform;
-    seed_phrase;
-};
-
-// This describes whether a device is "protected" or not.
-// When protected, a device can only be updated or removed if the
-// user is authenticated with that very device.
-type DeviceProtection = variant {
+// This describes whether a key is "protected" or not.
+// When protected, a key can only be updated or removed if the
+// user is authenticated with that very key.
+type KeyProtection = variant {
     protected;
     unprotected;
 };
@@ -66,35 +52,6 @@ type Challenge = record {
     challenge_key: ChallengeKey;
 };
 
-type DeviceData = record {
-    pubkey : DeviceKey;
-    alias : text;
-    credential_id : opt CredentialId;
-    purpose: Purpose;
-    key_type: KeyType;
-    protection: DeviceProtection;
-    origin: opt text;
-    // Metadata map for additional device information.
-    //
-    // Note: some fields above will be moved to the metadata map in the future.
-    // All field names of `DeviceData` (such as 'alias', 'origin, etc.) are
-    // reserved and cannot be written.
-    metadata: opt MetadataMap;
-};
-
-// The same as `DeviceData` but with the `last_usage` field.
-// This field cannot be written, hence the separate type.
-type DeviceWithUsage = record {
-    pubkey : DeviceKey;
-    alias : text;
-    credential_id : opt CredentialId;
-    purpose: Purpose;
-    key_type: KeyType;
-    protection: DeviceProtection;
-    origin: opt text;
-    last_usage: opt Timestamp;
-    metadata: opt MetadataMap;
-};
 
 // Map with some variants for the value type.
 // Note, due to the Candid mapping this must be a tuple type thus we cannot name the fields `key` and `value`.
@@ -104,9 +61,9 @@ type MetadataMap = vec record {
 };
 
 type RegisterResponse = variant {
-    // A new user was successfully registered.
+    // A new identity was successfully registered.
     registered: record {
-        user_number: UserNumber;
+        identity_number: IdentityNumber;
     };
     // No more registrations are possible in this instance of the II service canister.
     canister_full;
@@ -114,7 +71,7 @@ type RegisterResponse = variant {
     bad_challenge;
 };
 
-type AddTentativeDeviceResponse = variant {
+type AddTentativeKeyResponse = variant {
     // The device was tentatively added.
     added_tentatively: record {
         verification_code: text;
@@ -127,7 +84,7 @@ type AddTentativeDeviceResponse = variant {
     another_device_tentatively_added;
 };
 
-type VerifyTentativeDeviceResponse = variant {
+type VerifyTentativeKeyResponse = variant {
     // The device was successfully verified.
     verified;
     // Wrong verification code entered. Retry with correct code.
@@ -292,35 +249,17 @@ type ChallengeResult = record {
     chars : text;
 };
 
-// Extra information about registration status for new devices
-type DeviceRegistrationInfo = record {
+    // Extra information about registration status for new devices
+type KeyRegistrationInfo = record {
     // If present, the user has tentatively added a new device. This
     // new device needs to be verified (see relevant endpoint) before
     // 'expiration'.
-    tentative_device : opt DeviceData;
-    // The timestamp at which the anchor will turn off registration mode
+    tentative_key : opt KeyRecord;
+    // The timestamp at which the registration mode will expire for this identity
     // (and the tentative device will be forgotten, if any, and if not verified)
     expiration: Timestamp;
 };
 
-// Information about the anchor
-type IdentityAnchorInfo = record {
-    // All devices that can authenticate to this anchor
-    devices : vec DeviceWithUsage;
-    // Device registration status used when adding devices, see DeviceRegistrationInfo
-    device_registration: opt DeviceRegistrationInfo;
-};
-
-type AnchorCredentials = record {
-    credentials : vec WebAuthnCredential;
-    recovery_credentials : vec WebAuthnCredential;
-    recovery_phrases: vec PublicKey;
-};
-
-type WebAuthnCredential = record {
-    credential_id : CredentialId;
-    pubkey: PublicKey;
-};
 
 type DeployArchiveResult = variant {
     // The archive was deployed successfully and the supplied wasm module has been installed. The principal of the archive
@@ -333,42 +272,112 @@ type DeployArchiveResult = variant {
 };
 
 type BufferedArchiveEntry = record {
-    anchor_number: UserNumber;
+    anchor_number: IdentityNumber;
     timestamp: Timestamp;
     sequence_number: nat64;
     entry: blob;
 };
 
+// This is a placeholder result that will be replaced by the real result type
+// once we introduce actual errors. This is possible, because the result is
+// always used in an opt position.
+type result = variant {
+    ok;
+};
+
+type WebAuthnDirectSigMode = variant {
+    mandatory;
+    optional;
+};
+
+type key = variant {
+    webauthn_key: record {
+        credential_id: CredentialId;
+        pubkey: PublicKey;
+        // whether sensitive actions require a direct signature
+        direct_signature: WebAuthnDirectSigMode;
+    };
+    generic_key: record {
+        pubkey: PublicKey;
+    };
+};
+
+type KeyRecord = record {
+    key: key;
+    // contains now the following fields
+    // - alias
+    // - key_type: platform,
+    // - origin
+    // - key_type: reduced to "platform", "cross_platform" on migration
+    metadata: MetadataMap;
+    protection: KeyProtection;
+    // If a timestamp is present on write, the write will be rejected if it does
+    // not match the canister side timestamp. This can be used to detect stale
+    // writes.
+    last_usage: opt Timestamp;
+};
+
+// Information about the identity
+type IdentityInfo = record {
+    // All keys that can authenticate to this identity
+    keys : vec KeyRecord;
+    // All keys that can recover this identity
+    recovery_keys: vec KeyRecord;
+    // Key registration status used when adding devices, see KeyRegistrationInfo
+    key_registration: opt KeyRegistrationInfo;
+};
+
+// Public information about the keys attached to the identity
+type IdentityKeys = record {
+    keys : vec key;
+    recovery_keys : vec key;
+};
+
+type KeySettings = record {
+    protection: KeyProtection;
+    direct_signature: WebAuthnDirectSigMode;
+}
 
 service : (opt InternetIdentityInit) -> {
+    // registration flow
+    create_captcha : () -> (opt variant { ok:Challenge});
+    register_identity : (KeyRecord, ChallengeResult, opt principal) -> (opt RegisterResponse);
+
+    // key management
+    add_key : (IdentityNumber, KeyRecord, webauthn_sig: opt blob) -> (opt result);
+    add_recovery_key : (IdentityNumber, KeyRecord, webauthn_sig: opt blob) -> (opt result);
+    // opt timestamp to detect stale writes, if desired
+    update_key_metadata : (IdentityNumber, PublicKey, MetadataMap, opt Timestamp) -> (opt result);
+    // Atomically replace a key record matching the public key with a new one.
+    replace_key : (IdentityNumber, PublicKey, KeyRecord, webauthn_sig: opt blob) -> (opt result);
+    remove_key : (IdentityNumber, PublicKey, webauthn_sig: opt blob) -> (opt result);
+    update_key_settings : (IdentityNumber, PublicKey, KeySettings, webauthn_sig: opt blob) -> (opt result);
+
+    // information about the identity
+    // public
+    identity_keys : (IdentityNumber) -> (opt variant { ok: IdentityKeys }) query;
+    // requires authentication
+    identity_info : (IdentityNumber) -> (opt variant { ok: IdentityInfo });
+
+    // remote key registration
+    enter_key_registration_mode : (IdentityNumber) -> (opt variant { ok: Timestamp });
+    exit_key_registration_mode : (IdentityNumber) -> (opt result);
+    add_tentative_key : (IdentityNumber, key, MetadataMap) -> (opt variant { ok: AddTentativeKeyResponse });
+    verify_tentative_key : (IdentityNumber, verification_code: text, webauthn_sig: opt blob) -> (opt variant { ok: VerifyTentativeKeyResponse });
+
+    // delegation related endpoints
+    // no changes
+    get_principal : (IdentityNumber, FrontendHostname) -> (principal) query;
+    prepare_delegation : (IdentityNumber, FrontendHostname, SessionKey, maxTimeToLive: opt nat64) -> (PublicKey, Timestamp);
+    get_delegation: (IdentityNumber, FrontendHostname, SessionKey, Timestamp) -> (GetDelegationResponse) query;
+
+    // technical endpoints, no changes
     init_salt: () -> ();
-    create_challenge : () -> (Challenge);
-    register : (DeviceData, ChallengeResult, opt principal) -> (RegisterResponse);
-    add : (UserNumber, DeviceData) -> ();
-    update : (UserNumber, DeviceKey, DeviceData) -> ();
-    // Atomically replace device matching the device key with the new device data
-    replace : (UserNumber, DeviceKey, DeviceData) -> ();
-    remove : (UserNumber, DeviceKey) -> ();
-    // Returns all devices of the user (authentication and recovery) but no information about device registrations.
-    // Note: Clears out the 'alias' fields on the devices. Use 'get_anchor_info' to obtain the full information.
-    // Deprecated: Use 'get_anchor_credentials' instead.
-    lookup : (UserNumber) -> (vec DeviceData) query;
-    get_anchor_credentials : (UserNumber) -> (AnchorCredentials) query;
-    get_anchor_info : (UserNumber) -> (IdentityAnchorInfo);
-    get_principal : (UserNumber, FrontendHostname) -> (principal) query;
-    stats : () -> (InternetIdentityStats) query;
-
-    enter_device_registration_mode : (UserNumber) -> (Timestamp);
-    exit_device_registration_mode : (UserNumber) -> ();
-    add_tentative_device : (UserNumber, DeviceData) -> (AddTentativeDeviceResponse);
-    verify_tentative_device : (UserNumber, verification_code: text) -> (VerifyTentativeDeviceResponse);
-
-    prepare_delegation : (UserNumber, FrontendHostname, SessionKey, maxTimeToLive : opt nat64) -> (UserKey, Timestamp);
-    get_delegation: (UserNumber, FrontendHostname, SessionKey, Timestamp) -> (GetDelegationResponse) query;
-
+    stats: () -> (InternetIdentityStats) query;
     http_request: (request: HttpRequest) -> (HttpResponse) query;
     http_request_update: (request: HttpRequest) -> (HttpResponse);
 
+    // archive related endpoints, no changes
     deploy_archive: (wasm: blob) -> (DeployArchiveResult);
     /// Returns a batch of entries _sorted by sequence number_ to be archived.
     /// This is an update call because the archive information _must_ be certified.

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -39,10 +39,10 @@ type StreamingStrategy = variant {
     };
 };
 
-// This describes whether a key is "protected" or not.
-// When protected, a key can only be updated or removed if the
-// user is authenticated with that very key.
-type KeyProtection = variant {
+// This describes whether an auth method is "protected" or not.
+// When protected, an auth method can only be updated or removed if the
+// user is authenticated with that very auth method.
+type AuthProtection = variant {
     protected;
     unprotected;
 };
@@ -71,21 +71,21 @@ type RegisterResponse = variant {
     bad_challenge;
 };
 
-type AddTentativeKeyResponse = variant {
-    // The device was tentatively added.
+type AddTentativeAuthResponse = variant {
+    // The auth method was tentatively added.
     added_tentatively: record {
         verification_code: text;
         // Expiration date, in nanos since the epoch
         device_registration_timeout: Timestamp;
     };
-    // Device registration mode is off, either due to timeout or because it was never enabled.
-    device_registration_mode_off;
-    // There is another device already added tentatively
-    another_device_tentatively_added;
+    // Authentication method registration mode is off, either due to timeout or because it was never enabled.
+    auth_registration_mode_off;
+    // There is another auth method already added tentatively
+    another_auth_tentatively_added;
 };
 
-type VerifyTentativeKeyResponse = variant {
-    // The device was successfully verified.
+type VerifyTentativeAuthResponse = variant {
+    // The auth method was successfully verified.
     verified;
     // Wrong verification code entered. Retry with correct code.
     wrong_code: record {
@@ -249,14 +249,14 @@ type ChallengeResult = record {
     chars : text;
 };
 
-    // Extra information about registration status for new devices
-type KeyRegistrationInfo = record {
-    // If present, the user has tentatively added a new device. This
-    // new device needs to be verified (see relevant endpoint) before
+// Extra information about registration status for new auth methods
+type AuthRegistrationInfo = record {
+    // If present, the user has tentatively added a new auth method. This
+    // new auth method needs to be verified (see relevant endpoint) before
     // 'expiration'.
-    tentative_key : opt KeyRecord;
+    tentative_auth : opt AuthRecord;
     // The timestamp at which the registration mode will expire for this identity
-    // (and the tentative device will be forgotten, if any, and if not verified)
+    // (and the tentative auth method will be forgotten, if any, and if not verified)
     expiration: Timestamp;
 };
 
@@ -290,7 +290,8 @@ type WebAuthnDirectSigMode = variant {
     optional;
 };
 
-type key = variant {
+// Authentication method
+type Auth = variant {
     webauthn_key: record {
         credential_id: CredentialId;
         pubkey: PublicKey;
@@ -302,14 +303,14 @@ type key = variant {
     };
 };
 
-type KeyRecord = record {
-    key: key;
+type AuthRecord = record {
+    auth: Auth;
     // contains now the following fields
     // - alias
     // - origin
     // - key_type: reduced to "platform", "cross_platform" on migration
     metadata: MetadataMap;
-    protection: KeyProtection;
+    protection: AuthProtection;
     // If a timestamp is present on write, the write will be rejected if it does
     // not match the canister side timestamp. This can be used to detect stale
     // writes.
@@ -318,51 +319,53 @@ type KeyRecord = record {
 
 // Information about the identity
 type IdentityInfo = record {
-    // All keys that can authenticate to this identity
-    keys : vec KeyRecord;
-    // All keys that can recover this identity
-    recovery_keys: vec KeyRecord;
-    // Key registration status used when adding devices, see KeyRegistrationInfo
-    key_registration: opt KeyRegistrationInfo;
+    // All auth methods that can authenticate to this identity
+    auth_records: vec AuthRecord;
+    // All auth methods that can recover this identity
+    recovery_records: vec AuthRecord;
+    // Auth registration status used when adding devices, see AuthRegistrationInfo
+    auth_registration: opt AuthRegistrationInfo;
 };
 
 // Public information about the keys attached to the identity
-type IdentityKeys = record {
-    keys : vec key;
-    recovery_keys : vec key;
+type IdentityAuthInfo = record {
+    auth : vec Auth;
+    recovery : vec Auth;
 };
 
-type KeySettings = record {
-    protection: KeyProtection;
+type AuthSettings = record {
+    protection: AuthProtection;
     direct_signature: WebAuthnDirectSigMode;
 }
 
 service : (opt InternetIdentityInit) -> {
     // registration flow
     create_captcha : () -> (opt variant { ok:Challenge});
-    register_identity : (KeyRecord, ChallengeResult, opt principal) -> (opt RegisterResponse);
+    register_identity : (AuthRecord, ChallengeResult, opt principal) -> (opt RegisterResponse);
 
-    // key management
-    add_key : (IdentityNumber, KeyRecord, webauthn_sig: opt blob) -> (opt result);
-    add_recovery_key : (IdentityNumber, KeyRecord, webauthn_sig: opt blob) -> (opt result);
+    // auth management
+    add_auth : (IdentityNumber, AuthRecord, webauthn_sig: opt blob) -> (opt result);
+    add_recovery : (IdentityNumber, AuthRecord, webauthn_sig: opt blob) -> (opt result);
     // opt timestamp to detect stale writes, if desired
-    update_key_metadata : (IdentityNumber, PublicKey, MetadataMap, opt Timestamp) -> (opt result);
-    // Atomically replace a key record matching the public key with a new one.
-    replace_key : (IdentityNumber, PublicKey, KeyRecord, webauthn_sig: opt blob) -> (opt result);
-    remove_key : (IdentityNumber, PublicKey, webauthn_sig: opt blob) -> (opt result);
-    update_key_settings : (IdentityNumber, PublicKey, KeySettings, webauthn_sig: opt blob) -> (opt result);
+    update_auth_metadata : (IdentityNumber, PublicKey, MetadataMap, opt Timestamp) -> (opt result);
+    // Atomically replace a auth record matching the public key with a new one.
+    replace_auth : (IdentityNumber, PublicKey, AuthRecord, webauthn_sig: opt blob) -> (opt result);
+    remove_auth : (IdentityNumber, PublicKey, webauthn_sig: opt blob) -> (opt result);
+    update_auth_settings : (IdentityNumber, PublicKey, AuthSettings, webauthn_sig: opt blob) -> (opt result);
 
     // information about the identity
     // public
-    identity_keys : (IdentityNumber) -> (opt variant { ok: IdentityKeys }) query;
+    identity_auth_info : (IdentityNumber) -> (opt variant { ok: IdentityAuthInfo }) query;
     // requires authentication
     identity_info : (IdentityNumber) -> (opt variant { ok: IdentityInfo });
 
-    // remote key registration
-    enter_key_registration_mode : (IdentityNumber) -> (opt variant { ok: Timestamp });
-    exit_key_registration_mode : (IdentityNumber) -> (opt result);
-    add_tentative_key : (IdentityNumber, key, MetadataMap) -> (opt variant { ok: AddTentativeKeyResponse });
-    verify_tentative_key : (IdentityNumber, verification_code: text, webauthn_sig: opt blob) -> (opt variant { ok: VerifyTentativeKeyResponse });
+    // remote auth registration
+    enter_auth_registration_mode : (IdentityNumber) -> (opt variant { ok: Timestamp });
+    exit_auth_registration_mode : (IdentityNumber) -> (opt result);
+    add_tentative_auth : (IdentityNumber, Auth, MetadataMap) -> (opt variant { ok: AddTentativeAuthResponse
+    });
+    verify_tentative_auth : (IdentityNumber, verification_code: text, webauthn_sig: opt blob) -> (opt variant { ok: VerifyTentativeAuthResponse
+    });
 
     // delegation related endpoints
     // no changes

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -306,7 +306,6 @@ type KeyRecord = record {
     key: key;
     // contains now the following fields
     // - alias
-    // - key_type: platform,
     // - origin
     // - key_type: reduced to "platform", "cross_platform" on migration
     metadata: MetadataMap;


### PR DESCRIPTION
Strawman PR to discuss a possible v2 II interface. The interface introduces the following changes:
* remove any mention of anchor. The new API is based around "identity". (I decided against "user", as a user could have many identities.)
* remove the concept of "device" (the new API is based around keys)
* by doing the above two renames, all methods now have a new name that does not clash with the v1 api (except for `create_challenge` which has been renamed to `create_captcha`). This avoids having to introduce a `_v2` suffix (or similar).
* all changed methods now return `opt variant`, which allows to properly return errors (and also extend the types later without breaking clients)
* `update` is now clearly scoped to only allow changing metadata
* the `last_usage` timestamp can now be provided on write. The write will be rejected if the timestamp does not match the canister side value. This can be used to prevent writes of stale data.
* Some redundant type aliases have been removed.
* No changes have been made to the endpoints related to delegations as well as the non user-facing the technical ones (i.e. stats and archive related endpoints).

The Plan is to gradually introduce the new API alongside the old one in an experimental state. Once we are happy with the new interface, we can stabilize the API and deprecate (and later remove) the current one.

This work is motivated by repeatedly bumping into limitations with the current API, the latest two examples being the inability to introduce proper errors and the need to introduce additional WebAuthnSignatures (which causes problems on the current `update` call as it mixes sensitive and non-sensitive data changes).

This PR is _not_ intended to be merged, but rather to form agreement on the new API, so that we can then introduce it gradually as needed in separate PRs.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
