### PR TITLE
Wait for alert being open before accepting it

### DIFF
--- a/src/frontend/src/test-e2e/recovery.test.ts
+++ b/src/frontend/src/test-e2e/recovery.test.ts
@@ -218,6 +218,8 @@ test("Reset protected recovery phrase", async () => {
 
     await mainView.waitForDisplay();
     await mainView.reset(RECOVERY_PHRASE_NAME);
+
+    await browser.waitUntil(browser.isAlertOpen);
     await browser.acceptAlert();
 
     const recoveryView = new RecoverView(browser);
@@ -245,6 +247,7 @@ test("Reset protected recovery phrase, confirm with empty seed phrase", async ()
     await mainView.waitForDisplay();
     await mainView.reset(RECOVERY_PHRASE_NAME);
 
+    await browser.waitUntil(browser.isAlertOpen);
     await browser.acceptAlert();
 
     const recoveryView = new RecoverView(browser);


### PR DESCRIPTION
# Motivation

Test are currently flaky. They work locally but often fails in the CI. By comparing the test I noticed that the two that fails are not awaiting for the alert to be open before clicking it on the contrary of the other tests that do await.
