### PR TITLE
Import dapps list in main bundle

### DIFF
--- a/src/frontend/src/flows/dappsExplorer/dapps.json
+++ b/src/frontend/src/flows/dappsExplorer/dapps.json
@@ -1,284 +1,199 @@
 [
   {
-    "id": "dscvr",
     "name": "DSCVR",
     "oneLiner": "Web3 alternative to Reddit with user governed Portals",
     "link": "https://dscvr.one/",
-    "derivationOrigin": "https://h5aet-waaaa-aaaab-qaamq-cai.raw.ic0.app",
-    "description": "DSCVR is an end-to-end decentralized Web3 social media platform that allows communities to form into groups called Portals. These Portals can be NFT gated, airdrop fungible and non-fungible tokens to their members and much more. DSCVR also allows for tipping posts in a growing number of cryptos, supporting ckBTC, a Bitcoin twin living on the Internet Computer.",
     "logo": "/img/showcase/dscvr_logo.webp"
   },
   {
-    "id": "distrikt",
     "name": "Distrikt",
     "oneLiner": "100% on-chain microblogging social media platform",
     "link": "https://az5sd-cqaaa-aaaae-aaarq-cai.ic0.app",
-    "description": "Distrikt is a completely decentralized, community-owned Web3 social media platform. Users of the platform will soon be able vote on upgrades, and no user data will ever be mined or sold. Create your account, secured by Internet Identity today.",
     "logo": "/img/showcase/distrikt_logo.webp"
   },
   {
-    "id": "kontribute",
     "name": "Kontribute",
     "oneLiner": "Web3 storytelling",
     "link": "https://kontribute.app",
-    "derivationOrigins": "https://3ezq7-iqaaa-aaaal-aaacq-cai.raw.ic0.app",
-    "description": "Kontribute is a web3 creators platform that brings story writing and digital art collectibles together. Features include: decentralized story storage, likes, tipping, polls, NFT marketplace and NFT minting.",
     "logo": "/img/showcase/kontribute_logo.webp"
   },
   {
-    "id": "kinic",
     "name": "Kinic",
     "oneLiner": "The world's first web3 search engine",
     "link": "https://74iy7-xqaaa-aaaaf-qagra-cai.ic0.app",
-    "description": "The world’s first Web3 search engine",
     "logo": "/img/showcase/kinic_logo.webp"
   },
   {
-    "id": "openchat",
     "name": "OpenChat",
     "oneLiner": "Decentralized alternative to WhatsApp",
     "link": "https://oc.app/",
-    "derivationOrigin": "https://6hsbt-vqaaa-aaaaf-aaafq-cai.ic0.app",
-    "description": "What if you could own a piece of WhatsApp and vote on what features get added? OpenChat is a fully decentralized real-time messaging service that is indistinguishable from Web2 chat apps, while living 100% on the blockchain. This allows users to send crypto to each other - including Bitcoin - and soon to own a part of OpenChat through CHAT tokens.",
     "logo": "/img/showcase/openchat_logo.webp"
   },
   {
-    "id": "juno",
     "name": "Juno",
     "link": "https://juno.build",
     "oneLiner": "Build Web3 Apps Like It's Web2",
-    "description": "Juno is an open-source platform that combines the power of Web3 with the ease and simplicity of Web2 development, enabling programmers to build decentralized apps faster and easier than ever before.",
     "logo": "/img/showcase/juno_logo.webp"
   },
   {
-    "id": "uniswapfrontendontheic",
     "name": "Uniswap Front End on the IC",
     "link": "https://uniswap-on-ic.xyz",
-    "description": "Uniswap's frontend hosted on the Internet Computer with canister-based wallet integration. Thanks to the Internet Computer, traditional DeFi solutions can now be completely decentralized, having their frontend hosted on ICP. There is no longer a need to include centralized cloud providers in a decentralized application.",
     "oneLiner": "Front-End On-Chain",
     "logo": "/img/showcase/uniswapfrontendontheic_logo.webp"
   },
   {
-    "id": "seers",
     "name": "Seers",
     "link": "https://seers.social/",
-    "derivationOrigin": "https://oulla-fyaaa-aaaag-qa6fa-cai.ic0.app",
-    "description": "What if there was decentralized Twitter that included prediction markets? Seers is Web3 social media platform hosted 100% on-chain combining social media features with prediction markets.",
     "logo": "/img/showcase/seers_logo.webp"
   },
   {
-    "id": "taggr",
     "name": "Taggr",
     "link": "https://6qfxa-ryaaa-aaaai-qbhsq-cai.ic0.app",
-    "description": "Fully on-chain and fully autonomous SocialFi network. A simple way to publish content on a public compute infrastructure. No Ponzinomics - TAGGR has a sustainable tokenomics model that rewards quality posts and removes incentive to spam.",
     "logo": "/img/showcase/taggr_logo.webp"
   },
   {
-    "id": "funded",
     "name": "Funded",
     "link": "https://funded.app",
-    "description": "Web3 crowdfunding! Thanks to ICP's low transaction fees and advanced smart contract technology, you can participate in crowdfunding with ICP, BTC and ETH without worrying about losing money on gas fees.",
     "logo": "/img/showcase/funded_logo.webp"
   },
   {
-    "id": "contentfly",
     "name": "Content Fly",
     "link": "https://contentfly.app/",
-    "derivationOrigin": "https://main.contentfly.app",
-    "description": "Content Fly is a Web3 Job Management Tool & Marketplace. It allows content buyers & creators to work together with the security of an escrow payment and DAO based dispute resolution. IP is protected and transferred as an NFT.",
     "logo": "/img/showcase/contentfly_logo.webp"
   },
   {
-    "id": "icdex",
     "name": "ICDex",
     "link": "https://avjzx-pyaaa-aaaaj-aadmq-cai.raw.ic0.app/ICDex",
-    "derivationOrigin": "https://avjzx-pyaaa-aaaaj-aadmq-cai.raw.ic0.app",
-    "description": "ICDex is flagship product by ICLighthouse, an orderbook based DEX that runs 100% on-chain. The world's first orderbook DEX - made possible by advanced ICP smart contracts",
     "logo": "/img/showcase/icdex_logo.webp"
   },
   {
-    "id": "unfoldvr",
     "name": "UnfoldVR",
     "oneLiner": "Decentralizing asset Creation and Discovery for the Metaverse",
     "link": "https://jmorc-qiaaa-aaaam-aaeda-cai.ic0.app",
-    "description": "UnfoldVR empowers creators to author 3D NFTs using easy-to-use tools both on the Web and in Virtual Reality.",
     "logo": "/img/showcase/unfoldvr_logo.webp"
   },
   {
-    "id": "yumi",
     "name": "Yumi",
     "oneLiner": "Yumi is an ultra-fast, low-cost, and 100% decentralized NFT marketplace on ICP.",
     "link": "https://tppkg-ziaaa-aaaal-qatrq-cai.raw.ic0.app",
-    "description": "Yumi is a high-speed, low-cost, and fully decentralized NFT marketplace built on the Internet Computer. All digital collectibles available on Yumi are hosted fully on-chain. The minting of NFTs is completely free for creators (no gas fees).",
     "logo": "/img/showcase/yumi_logo.webp"
   },
   {
-    "id": "canlista",
     "name": "Canlista",
     "oneLiner": "Internet Computer Canister Registry",
     "link": "https://k7gat-daaaa-aaaae-qaahq-cai.ic0.app",
-    "description": "The Internet Computer community canister registry. Find, publish and extend applications and services built on the Internet Computer. Log in with Internet Identity. ",
     "logo": "/img/showcase/canlista_logo.webp"
   },
   {
-    "id": "missionispossible",
     "name": "Mission Is Possible",
     "link": "https://to3ja-iyaaa-aaaai-qapsq-cai.raw.ic0.app",
-    "description": "Mission is Possible - 3rd place winner of the DSCVR Hackathon Season 2 - is a PVP third person shooter hosted on the Internet Computer blockchain. The John Wick inspired game is built using the Unity 3D Game Engine, and hosted on the IC enabling decentralized login with Internet Identity. ",
     "oneLiner": "3rd Place DSCVR Hackathon",
     "logo": "/img/showcase/missionispossible_logo.webp"
   },
   {
-    "id": "catalyze",
     "name": "Catalyze",
     "link": "https://aqs24-xaaaa-aaaal-qbbea-cai.ic0.app",
-    "description": "Catalyze is a decentralized social and community-building platform designed to host engaged and thriving Web3 communities. With a unique and customized engagement economy, Catalyze communities and their members will be rewarded for their participation and contribution. Main features include: direct communication, event & task management, integrated Web3 wallets, NFT Gating, NFT airdrop & sales management.",
     "oneLiner": "Web3 social media platform for communities",
     "logo": "/img/showcase/catalyze_logo.webp"
   },
   {
-    "id": "icme",
     "name": "ICME",
     "link": "https://sygsn-caaaa-aaaaf-qaahq-cai.raw.ic0.app",
-    "description": "ICME is a no-code tool that makes it easy for anyone to build and deploy beautiful websites on the Internet Computer. Launch your blog or business's website on the Internet Computer today.",
     "logo": "/img/showcase/icme_logo.webp"
   },
   {
-    "id": "sagatarot",
     "name": "Saga Tarot",
     "link": "https://5nl7c-zqaaa-aaaah-qaa7a-cai.raw.ic0.app/",
-    "derivationOrigin": "https://l2jyf-nqaaa-aaaah-qadha-cai.raw.ic0.app",
-    "description": "Have your fortune told on the Internet Computer. Saga Tarot gives you a tarot reading in one click. The user-friendly dapp is built completely on the Internet Computer, accessible from any browser. What will the future hold for you?",
     "logo": "/img/showcase/sagatarot_logo.webp"
   },
   {
-    "id": "icdrive",
     "name": "IC Drive",
     "link": "https://rglue-kyaaa-aaaah-qakca-cai.ic0.app",
-    "description": "A decentralized private file storage dapp built on the Internet Computer. Store and securely share any type from anywhere in the world with this decentralized version of Box, or Google Drive. ",
     "logo": "/img/showcase/icdrive_logo.webp"
   },
   {
-    "id": "crowdgovorg",
     "name": "CrowdGov.org",
     "oneLiner": "The simplified, one stop shop for IC Governance.",
     "link": "https://crowdgov.org",
-    "description": "The crowdgov.org website is dedicated to simplified governance for the internet computer. You will find information about how to participate in governance and how to maximize voting rewards. A variety of research tools are provided to help you learn more about NNS ecosystem participants and the current state of decentralization.",
     "logo": "/img/showcase/crowdgovorg_logo.webp"
   },
   {
-    "id": "nnsfront-enddapp",
     "name": "NNS Front-End Dapp",
     "oneLiner": "Dapp for Staking Neurons + Voting On-Chain",
     "link": "https://nns.ic0.app",
-    "description": "The NNS front-end dapp allows anyone to interact with the Internet Computer's Network Nervous System with a user-friendly UI. Served completely end-to-end through blockchain, this dapp allows you to manage ICP, stake neurons, participate in voting, and earn governance rewards.",
     "logo": "/img/showcase/nnsfront-enddapp_logo.webp"
   },
   {
-    "id": "tipjar",
     "name": "Tipjar",
     "link": "https://tipjar.rocks",
-    "derivationOrigin": "https://k25co-pqaaa-aaaab-aaakq-cai.ic0.app",
-    "description": "A tool to donate cycles to canisters as well as keep them monitored.",
     "logo": "/img/showcase/tipjar_logo.webp"
   },
   {
-    "id": "aedile",
     "name": "Aedile",
     "link": "https://aedile.io",
-    "derivationOrigin": "https://vqdn4-miaaa-aaaaf-qaawa-cai.ic0.app",
-    "description": "Build and fund, 100% on chain aedile is the first open and decentralized service offering individuals, teams, and communities, an alternative to their favorite management tools.",
     "logo": "/img/showcase/aedile_logo.webp"
   },
   {
-    "id": "riseofthemagni",
     "name": "Rise of the Magni",
     "link": "https://riseofthemagni.com/",
-    "description": "Rise of the Magni, built by Toniq Labs, winner of the DSCVR hackathon for games on the Internet Computer. Buy, earn, and trade collectibles, compete in tactical battles online to earn in-game tokens, and venture through story mode to experience one of the first games built on the Internet Computer.",
     "logo": "/img/showcase/riseofthemagni_logo.webp"
   },
   {
-    "id": "nuance",
     "name": "Nuance",
     "link": "https://exwqn-uaaaa-aaaaf-qaeaa-cai.ic0.app/",
-    "description": "Nuance is a Web3.0 blogging platform that is hosted on-chain end-to-end on the Internet Computer. Developed by Aikin Dapps, the alpha of the world's first blogging platform to be hosted entirely on a blockchain has now launched. Nuance aims to bring NFTs into the world of editorial content ownership.",
     "logo": "/img/showcase/nuance_logo.webp"
   },
   {
-    "id": "modclub",
     "name": "MODCLUB",
     "link": "https://ljyte-qiaaa-aaaah-qaiva-cai.raw.ic0.app",
-    "description": "MODCLUB is a decentralized moderation tool based hosted fully on-chain. Built on the Internet Computer, MODCLUB rewards users for effectively moderating content. Currently in beta stages of their solution, users will be rewarded in tokens for moderating their favorite communities.",
     "logo": "/img/showcase/modclub_logo.webp"
   },
   {
-    "id": "nftanvil",
     "name": "NFTAnvil",
     "link": "https://nftanvil.com",
-    "description": "NFTAnvil is a wallet, mint & marketplace in the Anvil ecosystem. It's built from scratch and has an alternative & genuine approach to NFTs. It uses Anvil's auto-scaling multi-canister token architecture.",
     "logo": "/img/showcase/nftanvil_logo.webp"
   },
   {
-    "id": "icpswap",
     "name": "ICPSwap",
     "link": "https://icpswap.com",
-    "derivationOrigin": "https://app.icpswap.com",
-    "description": "ICPSwap is DEX built completely end-to-end on-chain. By building the ability for anyone to swap tokens through ICPSwap leveraging the Internet Computer blockchain as the high-speed, scalable, low-cost infrastructure makes ICPSwap a first-to-market in the growing Internet Computer DeFi ecosystem.",
     "logo": "/img/showcase/icpswap_logo.webp"
   },
   {
-    "id": "dmail",
     "name": "Dmail",
     "oneLiner": "Web3 Decentralized Email Client",
     "link": "https://dmail.ai/",
-    "derivationOrigin": "https://evyc3-ziaaa-aaaak-aam5a-cai.ic0.app",
-    "description": "Dmail is the Web3 replacement for e-mail. Hosted completely on-chain and built on the Internet Computer, this dapp enables users to send and receive blockchain-backed, encrypted messages. In addition, Dmail addresses are owned by users as NFT assets - there is a natively built marketplace. Dmail was the winner of the 2021 Warpspeed ICP Hackathon in China, and saw an immediate round of funding netting a $10M valuation. ",
     "logo": "/img/showcase/dmail_logo.webp"
   },
   {
-    "id": "dsocial",
     "name": "DSocial",
     "link": "https://DSocial.app",
-    "derivationOrigin": "https://dwqte-viaaa-aaaai-qaufq-cai.ic0.app",
-    "description": "DSocial is a decentralized version of YouTube -- enabling content creators to be fairly rewarded for their work, and engagement. This Web3 media platform is hosted end-to-end on the Internet Computer interoperating with Arweave for decentralized video content.",
     "logo": "/img/showcase/dsocial_logo.webp"
   },
   {
-    "id": "icnaming",
     "name": "ICNaming",
     "link": "https://app-testnet.icnaming.com/",
-    "description": "ICNaming is a testnet that is enabling the Internet Computer ecosystem to register domain names on the Internet Computer Name Service. Similar to the Ethereum Name Servce (ENS), ICNaming aims to offer a decentralized name service for users to pseudonomize their wallet addresses on ICP, as well as domain names, and canister smart contract IDs. ",
     "logo": "/img/showcase/icnaming_logo.webp"
   },
   {
-    "id": "stoicwallet",
     "name": "Stoic Wallet",
     "link": "https://www.stoicwallet.com/",
-    "description": "Stoic Wallet by Toniq Labs allows anyone to create a digital wallet, authenticating users through a variety of methods, one of those being Internet Identity. Create accounts, keep an address book, and more. ",
     "logo": "/img/showcase/stoicwallet_logo.webp"
   },
   {
-    "id": "departurelabs",
     "name": "Departure Labs",
     "link": "https://uhmvd-qqaaa-aaaam-aavna-cai.ic0.app",
-    "description": "Departure Labs is exploring on-chain media, web native NFTs, and developing productized open internet services for developers and consumers. Departure Labs is currently developing a non-fungible token standard that leverages the unique properties of the Internet Computer and enables builders to create entire experiences from a single contract.\n",
     "logo": "/img/showcase/departurelabs_logo.webp"
   },
   {
-    "id": "factland",
     "name": "Factland DAO",
     "oneLiner": "A Web3 community building decentralized trust in the age of misinformation",
     "link": "https://factland.org",
-    "derivationOrigin": "https://demo.factland.org",
-    "description": "Factland is a Web3 DAO with a mission to slow the spread of misinformation online. Factland makes it easy for anyone to flag untrustworthy claims and have them promptly adjudicated by a decentralized community of fact checkers rewarded in crypto.",
     "logo": "/img/showcase/factland_logo.png"
   },
   {
-    "id": "hot-or-not",
     "name": "Hot or Not",
     "oneLiner": "Web3's answer to TikTok with speculation on short video content",
     "link": "https://hotornot.wtf",
-    "description": "Hot or Not is a decentralized short-video social media (like TikTok) which integrates prediction markets for content. In addition to creating and sharing short videos on the platform, the users can also speculate on the short videos uploaded by other users on the platform. The users can vote whether a video would be 'Hot' or 'Not' and stake blockchain tokens to substantiate their vote. The results are declared every hour and the winners are rewarded with 2x tokens. With Decentralized governance and content moderation, Hot or Not would put the users at the center of the ecosystem",
     "logo": "/img/showcase/hot_or_not_logo.webp"
   }
 ]

--- a/src/frontend/src/flows/dappsExplorer/dapps.ts
+++ b/src/frontend/src/flows/dappsExplorer/dapps.ts
@@ -1,12 +1,10 @@
-import { toast } from "$src/components/toast";
 import { BASE_URL } from "$src/environment";
-import { isNullish } from "@dfinity/utils";
 
 // The list of dapps. This is derived from https://github.com/dfinity/portal:
 // * Only dapps using II are used
 // * All relevant logos are copied to II's assets
 // * Some logos are converted to webp
-import type dappsJson from "./dapps.json";
+import dappsJson from "./dapps.json";
 
 // Infer the type of an array's elements
 type ElementOf<Arr> = Arr extends readonly (infer ElementOf)[]
@@ -15,27 +13,9 @@ type ElementOf<Arr> = Arr extends readonly (infer ElementOf)[]
 
 export type DappDescription = ElementOf<typeof dappsJson>;
 
-// Dynamically load the dapps list
-const loadDapps = async (): Promise<DappDescription[] | undefined> => {
-  try {
-    return (await import("./dapps.json")).default;
-  } catch (e) {
-    console.error(e);
-    return undefined;
-  }
-};
-
 // The list of dapps we showcase
-export const getDapps = async (): Promise<DappDescription[]> => {
-  // Load the dapps list
-  const dapps = await loadDapps();
-  if (isNullish(dapps)) {
-    toast.error("Could not load dapps list");
-    console.error("Could not load dapps module");
-    return [];
-  }
-
-  return dapps.map((dapp) => ({
+export const getDapps = (): DappDescription[] => {
+  return dappsJson.map((dapp) => ({
     ...dapp,
     /* fix up logo path (inherited from dfinity/portal) to match our assets */
     logo: dapp.logo.replace("/img/showcase/", BASE_URL + "icons/"),

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -97,7 +97,7 @@ export const authnTemplateManage = ({
 
 /* the II authentication flow */
 export const authFlowManage = async (connection: Connection, i18n: I18n) => {
-  const dapps = shuffleArray(await getDapps());
+  const dapps = shuffleArray(getDapps());
   const identityBackground = loadIdentityBackground();
   // Go through the login flow, potentially creating an anchor.
   const {
@@ -261,7 +261,7 @@ export const renderManage = async ({
 
 export const displayManagePage = renderPage(displayManageTemplate);
 
-export const displayManage = async (
+export const displayManage = (
   userNumber: bigint,
   connection: AuthenticatedConnection,
   devices_: DeviceData[],
@@ -269,7 +269,7 @@ export const displayManage = async (
 ): Promise<void | AuthenticatedConnection> => {
   // Fetch the dapps used in the teaser & explorer
   // (dapps are suffled to encourage discovery of new dapps)
-  const dapps = shuffleArray(await getDapps());
+  const dapps = shuffleArray(getDapps());
   return new Promise((resolve) => {
     const devices = devicesFromDeviceDatas({
       devices: devices_,

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -117,7 +117,7 @@ const authnCnfg = {
   onSubmit: (anchor: bigint) => console.log("Submitting anchor", anchor),
 };
 
-const dapps = await getDapps();
+const dapps = getDapps();
 
 const authzTemplates = authnTemplateAuthorize({
   origin: "https://nowhere.com",


### PR DESCRIPTION
This bundles the dapps in the script loaded on page load to avoid extra fetching (and extra latency if the first page to load needs information about the dapps).

The dapps list is also cleaned up to only include what we actually need.

Before:
dist/dapps.js.gz                            15.19kb / gzip: 5.30kb
dist/index.js.gz                            574.37kb / gzip: 189.43kb

After:
dist/index.js.gz                            578.50kb / gzip: 190.90kb

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
