### PR TITLE
Typecheck frontend on CI

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -13,6 +13,8 @@ jobs:
           token: ${{ secrets.GIX_BOT_PAT }}
       - uses: ./.github/actions/setup-node
       - run: npm ci
+      - name: Run tsc
+        run: npm run check
       - name: Run ESLint
         run: npm run lint
       - name: Check formatting

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "host": "II_FETCH_ROOT_KEY=1 vite --host",
     "showcase": "II_FETCH_ROOT_KEY=1 vite --mode showcase",
     "build": "tsc --noEmit && vite build",
+    "check": "tsc --project ./tsconfig.all.json --noEmit",
     "watch": "tsc --project ./tsconfig.all.json --noEmit --watch",
     "opts": "NODE_OPTIONS='--loader ts-node/esm --experimental-specifier-resolution=node' \"$@\"",
     "generate": "npm run generate:types && npm run generate:js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["node", "@wdio/globals/types", "vite/client", "vitest/globals"],
+    "types": ["node", "vite/client", "vitest/globals"],
     "paths": {
       "$generated": ["./src/frontend/generated"],
       "$generated/*": ["./src/frontend/generated/*"],


### PR DESCRIPTION
This ensures all ts files are type checked on CI, by copying the `watch` config to a new `check` script.

One type error is fixed by removing an unnecessary wdio type inclusion.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
