### PR TITLE
Scroll to top of onboarding steps

### DIFF
--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -8,7 +8,7 @@ import {
   IIWebAuthnIdentity,
   RegisterResult,
 } from "$src/utils/iiConnection";
-import { autofocus, renderPage, withRef } from "$src/utils/lit-html";
+import { autofocus, mount, renderPage, withRef } from "$src/utils/lit-html";
 import { Chan } from "$src/utils/utils";
 import { ECDSAKeyIdentity } from "@dfinity/identity";
 import { html, TemplateResult } from "lit-html";
@@ -29,6 +29,7 @@ export const promptCaptchaTemplate = <T>({
   onContinue,
   i18n,
   focus: focus_,
+  scrollToTop = false,
 }: {
   cancel: () => void;
   requestChallenge: () => Promise<Challenge>;
@@ -39,6 +40,8 @@ export const promptCaptchaTemplate = <T>({
   onContinue: (result: T) => void;
   i18n: I18n;
   focus?: boolean;
+  /* put the page into view */
+  scrollToTop?: boolean;
 }) => {
   const focus = focus_ ?? true;
   const copy = i18n.i18n(copyJson);
@@ -144,7 +147,7 @@ export const promptCaptchaTemplate = <T>({
   void doRetry();
 
   const promptCaptchaSlot = html`
-    <article>
+    <article ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
       <h1 class="t-title t-title--main">${copy.title}</h1>
       <form autocomplete="off" @submit=${asyncReplace(next)} class="l-stack">
         <div class="c-input c-input--icon">
@@ -255,6 +258,7 @@ export const promptCaptcha = ({
 
       onContinue: resolve,
       i18n,
+      scrollToTop: true,
     });
   });
 };

--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -6,7 +6,12 @@ import {
 } from "$src/components/identityCard";
 import { mainWindow } from "$src/components/mainWindow";
 import { toast } from "$src/components/toast";
-import { renderPage, TemplateElement, withRef } from "$src/utils/lit-html";
+import {
+  mount,
+  renderPage,
+  TemplateElement,
+  withRef,
+} from "$src/utils/lit-html";
 import { OmitParams } from "$src/utils/utils";
 import { html } from "lit-html";
 import { createRef, ref, Ref } from "lit-html/directives/ref.js";
@@ -15,13 +20,19 @@ export const displayUserNumberTemplate = ({
   onContinue,
   userNumber,
   identityBackground,
+  scrollToTop = false,
 }: {
   onContinue: () => void;
   userNumber: bigint;
   identityBackground: IdentityBackground;
+  /* put the page into view */
+  scrollToTop?: boolean;
 }) => {
   const userNumberCopy: Ref<HTMLButtonElement> = createRef();
-  const displayUserNumberSlot = html`<hgroup>
+  const displayUserNumberSlot = html`<hgroup
+
+      ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}
+  >
       <h1 class="t-title t-title--main">
         You’ve created an Internet Identity!
       </h1>
@@ -124,6 +135,7 @@ export const displayUserNumber = ({
       onContinue: () => resolve(),
       userNumber,
       identityBackground,
+      scrollToTop: true,
     })
   );
 };

--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -17,19 +17,19 @@ const savePasskeyTemplate = ({
   construct,
   i18n,
   cancel,
-  scrollTo = false,
+  scrollToTop = false,
 }: {
   construct: () => void;
   i18n: I18n;
   cancel: () => void;
-  /* put the CTA into view */
-  scrollTo?: boolean;
+  /* put the page into view */
+  scrollToTop?: boolean;
 }): TemplateResult => {
   const copy = i18n.i18n(copyJson);
   const slot = html`
     <hgroup
       style="margin-top: 7em;"
-      ${scrollTo ? mount((e) => e.scrollIntoView()) : undefined}
+      ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}
     >
       <h1 class="t-title t-title--main">${copy.save_passkey}</h1>
       <p class="t-paragraph">
@@ -88,7 +88,7 @@ export const savePasskey = (): Promise<IIWebAuthnIdentity | "canceled"> => {
     savePasskeyPage({
       i18n: new I18n(),
       cancel: () => resolve("canceled"),
-      scrollTo: true,
+      scrollToTop: true,
       construct: async () => {
         try {
           const identity = await withLoader(() => constructIdentity({}));


### PR DESCRIPTION
This instructs the steps of the onboarding flow to always reset the scroll to the top, to ensure the title, explanation or CTA are always in view.

We've tried a couple of HTML & CSS fixes but nothing seems to work as reliably as this.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
