### PR TITLE
Don't show dialog on device rename

### DIFF
--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -27,11 +27,6 @@ export const renameDevice = async ({
   device: DeviceData;
   reload: () => void;
 }) => {
-  const confirmed = confirm("Choose a nickname for this passkey.");
-  if (!confirmed) {
-    return;
-  }
-
   const alias = await promptDeviceAlias({
     title: "Passkey Nickname",
     message: "Choose a nickname for this Passkey",

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -239,8 +239,6 @@ export class MainView extends View {
     await this.browser
       .$(`button[data-device="${deviceName}"][data-action='rename']`)
       .click();
-    await this.browser.waitUntil(this.browser.isAlertOpen);
-    await this.browser.acceptAlert();
 
     const renameView = new RenameView(this.browser);
     await renameView.waitForDisplay();


### PR DESCRIPTION
This removes the prompt when the user decides to rename a device. The prompt was simply confusing.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
