### PR TITLE
Fix bug in archive fetch interval metric

### DIFF
--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -197,9 +197,9 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             "Max number of entries fetched by the archive per call.",
         )?;
         w.encode_gauge(
-            "internet_identity_archive_config_polling_interval",
-            config.entries_fetch_limit as f64,
-            "Polling interval (in ns) of the archive.",
+            "internet_identity_archive_config_polling_interval_seconds",
+            Duration::from_nanos(config.polling_interval_ns).as_secs() as f64,
+            "Polling interval of the archive to fetch new entries from II.",
         )?;
     }
     state::persistent_state(|persistent_state| {

--- a/src/internet_identity/tests/integration/archive_integration.rs
+++ b/src/internet_identity/tests/integration/archive_integration.rs
@@ -595,8 +595,8 @@ mod pull_entries_tests {
             assigned_user_number_range: None,
             archive_config: Some(ArchiveConfig {
                 module_hash: archive_wasm_hash(&ARCHIVE_WASM),
-                entries_buffer_limit: 10_000,
-                polling_interval_ns: Duration::from_secs(1).as_nanos() as u64,
+                entries_buffer_limit: 20_000,
+                polling_interval_ns: Duration::from_secs(3).as_nanos() as u64,
                 entries_fetch_limit: 10,
             }),
             canister_creation_cycles_cost: Some(0),
@@ -611,7 +611,7 @@ mod pull_entries_tests {
         assert_metric(
             &get_metrics(&env, ii_canister),
             "internet_identity_archive_config_entries_buffer_limit",
-            10_000f64,
+            20_000f64,
         );
         assert_metric(
             &get_metrics(&env, ii_canister),
@@ -620,8 +620,8 @@ mod pull_entries_tests {
         );
         assert_metric(
             &get_metrics(&env, ii_canister),
-            "internet_identity_archive_config_polling_interval",
-            10f64,
+            "internet_identity_archive_config_polling_interval_seconds",
+            3f64,
         );
         Ok(())
     }


### PR DESCRIPTION
This PR fixes a bug that caused II to expose the wrong data as the `internet_identity_archive_config_polling_interval` metric.

Also, the metric is adjusted to give the interval in seconds as is recommended for time durations for prometheus. Additionally, the test is changed to use different values at are more easily distinguished to avoid similar bugs in the future.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
