### PR TITLE
Catch error in get_delegation

### DIFF
--- a/src/frontend/src/flows/authorize/fetchDelegation.ts
+++ b/src/frontend/src/flows/authorize/fetchDelegation.ts
@@ -2,7 +2,9 @@ import {
   PublicKey,
   SignedDelegation,
 } from "$generated/internet_identity_types";
+import { toast } from "$src/components/toast";
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
+import { unknownToString } from "$src/utils/utils";
 import { nonNullish } from "@dfinity/utils";
 import { AuthContext, Delegation } from "./postMessageInterface";
 
@@ -84,9 +86,19 @@ const retryGetDelegation = async (
       setInterval(resolve, 1000 * i);
     });
     const res = await connection.getDelegation(hostname, sessionKey, timestamp);
-    if ("signed_delegation" in res) {
-      return res.signed_delegation;
+    if ("no_such_delegation" in res) {
+      continue;
     }
+
+    if ("error" in res) {
+      toast.error(
+        "Error while fetching delegation: " +
+          unknownToString(res.error, "unknown error")
+      );
+      continue;
+    }
+
+    return res.signed_delegation;
   }
   throw new Error(
     `Failed to retrieve a delegation after ${maxRetries} retries.`

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -571,17 +571,22 @@ export class AuthenticatedConnection extends Connection {
     hostname: FrontendHostname,
     sessionKey: SessionKey,
     timestamp: Timestamp
-  ): Promise<GetDelegationResponse> => {
-    console.log(
-      `get_delegation(user: ${this.userNumber}, hostname: ${hostname}, session_key: ${sessionKey}, timestamp: ${timestamp})`
-    );
-    const actor = await this.getActor();
-    return await actor.get_delegation(
-      this.userNumber,
-      hostname,
-      sessionKey,
-      timestamp
-    );
+  ): Promise<GetDelegationResponse | { error: unknown }> => {
+    try {
+      console.log(
+        `get_delegation(user: ${this.userNumber}, hostname: ${hostname}, session_key: ${sessionKey}, timestamp: ${timestamp})`
+      );
+      const actor = await this.getActor();
+      return await actor.get_delegation(
+        this.userNumber,
+        hostname,
+        sessionKey,
+        timestamp
+      );
+    } catch (e: unknown) {
+      console.error(e);
+      return { error: e };
+    }
   };
 }
 


### PR DESCRIPTION
This ensures errors (e.g. network failure, 500s, etc) are caught within `getDelegation` and returned to the caller.

In this case, we show a toast error and retry.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
