### PR TITLE
Don't duplicate BASE_URL in dapp logo

### DIFF
--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -5,7 +5,6 @@ import {
 import { displayError } from "$src/components/displayError";
 import { caretDownIcon, spinner } from "$src/components/icons";
 import { showMessage } from "$src/components/message";
-import { BASE_URL } from "$src/environment";
 import { getDapps } from "$src/flows/dappsExplorer/dapps";
 import { recoveryWizard } from "$src/flows/recovery/recoveryWizard";
 import { I18n } from "$src/i18n";
@@ -68,9 +67,7 @@ export const authnTemplateAuthorize = ({
     name: string;
     logo: string;
   }) => html`
-    <img data-role="known-dapp-image" class="c-dapp-logo" src=${
-      BASE_URL + logo
-    }></img>
+    <img data-role="known-dapp-image" class="c-dapp-logo" src=${logo}></img>
     <div class="l-stack">
       ${h1(
         html`${copy.first_time_title_1}<br />${copy.first_time_title_join}

--- a/src/frontend/src/flows/dappsExplorer/dapps.ts
+++ b/src/frontend/src/flows/dappsExplorer/dapps.ts
@@ -29,7 +29,7 @@ export const getDapps = (): DappDescription[] => {
     dapps.push({
       name: "Test Dapp",
       link: "https://nice-name.com",
-      logo: "icons/nnsfront-enddapp_logo.webp",
+      logo: BASE_URL + "icons/nnsfront-enddapp_logo.webp",
     });
   }
 


### PR DESCRIPTION
This fixes an issue where the BASE_URL is prepended twice to the dapp logo URL. The BASE_URL is already included in the `dapps.ts` module, which loads the dapps.

This issue turns `/foo.png` into `//foo.png`, which browsers then interpret as `https://foo.png` instead of `https://<this website>/foo.png`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
