### PR TITLE
Fix flakyness in e2e tests

### DIFF
--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -66,6 +66,7 @@ export const FLOWS = {
     await mainView.addRecovery();
 
     const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
+    await recoveryMethodSelectorView.waitForSeedPhrase();
     const seedPhrase = await recoveryMethodSelectorView.getSeedPhrase();
     await recoveryMethodSelectorView.acknowledgeCheckbox();
     await recoveryMethodSelectorView.seedPhraseContinue();

--- a/src/frontend/src/test-e2e/recovery/protected/reset.test.ts
+++ b/src/frontend/src/test-e2e/recovery/protected/reset.test.ts
@@ -21,7 +21,6 @@ test("Reset protected recovery phrase", async () => {
     // Ensure the settings dropdown is in view
     await browser.execute("window.scrollTo(0, document.body.scrollHeight)");
     await mainView.reset(RECOVERY_PHRASE_NAME);
-    await browser.acceptAlert();
 
     const recoveryView = new RecoverView(browser);
     await recoveryView.waitForSeedInputDisplay();
@@ -50,7 +49,6 @@ test("Reset protected recovery phrase, confirm with empty seed phrase", async ()
     // Ensure the settings dropdown is in view
     await browser.execute("window.scrollTo(0, document.body.scrollHeight)");
     await mainView.reset(RECOVERY_PHRASE_NAME);
-    await browser.acceptAlert();
 
     const recoveryView = new RecoverView(browser);
     await recoveryView.waitForSeedInputDisplay();

--- a/src/frontend/src/test-e2e/recovery/reset.test.ts
+++ b/src/frontend/src/test-e2e/recovery/reset.test.ts
@@ -19,7 +19,7 @@ test("Reset recovery phrase", async () => {
     // Ensure the settings dropdown is in view
     await browser.execute("window.scrollTo(0, document.body.scrollHeight)");
     await mainView.reset(RECOVERY_PHRASE_NAME);
-    await browser.acceptAlert();
+
     const _seedPhrase = await FLOWS.readSeedPhrase(browser);
     await mainView.waitForDisplay();
   });
@@ -44,7 +44,7 @@ test("Recover access, after reset", async () => {
     // Ensure the settings dropdown is in view
     await browser.execute("window.scrollTo(0, document.body.scrollHeight)");
     await mainView.reset(RECOVERY_PHRASE_NAME);
-    await browser.acceptAlert();
+
     const seedPhrase = await FLOWS.readSeedPhrase(browser);
     await mainView.waitForDisplay();
 
@@ -85,7 +85,7 @@ test("Canceling reset keeps old phrase", async () => {
     // Ensure the settings dropdown is in view
     await browser.execute("window.scrollTo(0, document.body.scrollHeight)");
     await mainView.reset(RECOVERY_PHRASE_NAME);
-    await browser.acceptAlert();
+
     // Instead of reading the new seed phrase, cancel the flow
     await browser.$(`button[data-action='cancel']`).click();
     await mainView.waitForDisplay();
@@ -137,7 +137,7 @@ test("Reset unprotected recovery phrase, when authenticated with phrase", async 
     // Ensure the settings dropdown is in view
     await browser.execute("window.scrollTo(0, document.body.scrollHeight)");
     await mainView.reset(RECOVERY_PHRASE_NAME);
-    await browser.acceptAlert();
+
     const _seedPhrase = await FLOWS.readSeedPhrase(browser);
     await mainView.waitForDisplay();
   });

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -328,6 +328,8 @@ export class MainView extends View {
     await this.browser
       .$(`button[data-device="${deviceName}"][data-action='reset']`)
       .click();
+    await this.browser.waitUntil(this.browser.isAlertOpen);
+    await this.browser.acceptAlert();
   }
 
   async removeNotDisplayed(deviceName: string): Promise<void> {


### PR DESCRIPTION
This PR fixes flakyness with regards to accepting
alerts related to recovery by explicitly waiting for the
alert to be open.
The alert is now part of the reset action in order to prevent
new tests from reintroducing the flakyness again.

In addition, this PR adds a missing `waitForSeedPhrase` call when
creating a new recovery phrase.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
