### PR TITLE
Remove unnecessary argument in test

### DIFF
--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -237,14 +237,12 @@ pub fn exit_device_registration_mode(
 pub fn add_tentative_device(
     env: &StateMachine,
     canister_id: CanisterId,
-    sender: Principal,
     anchor_number: types::AnchorNumber,
     device_data: &types::DeviceData,
 ) -> Result<types::AddTentativeDeviceResponse, CallError> {
-    call_candid_as(
+    call_candid(
         env,
         canister_id,
-        sender,
         "add_tentative_device",
         (anchor_number, device_data),
     )

--- a/src/internet_identity/tests/integration/anchor_management/last_usage_timestamp.rs
+++ b/src/internet_identity/tests/integration/anchor_management/last_usage_timestamp.rs
@@ -280,18 +280,14 @@ fn should_update_last_usage_on_tentative_device_registration() -> Result<(), Cal
     let anchor_info = api::get_anchor_info(&env, canister_id, principal_2(), user_number)?;
     assert_device_last_used(&anchor_info, &device_data_1().pubkey, expected_timestamp);
 
-    let verification_code = match api::add_tentative_device(
-        &env,
-        canister_id,
-        principal_recovery_1(),
-        user_number,
-        &recovery_device_data_1(),
-    )? {
-        AddTentativeDeviceResponse::AddedTentatively {
-            verification_code, ..
-        } => verification_code,
-        _ => panic!("unexpected response"),
-    };
+    let verification_code =
+        match api::add_tentative_device(&env, canister_id, user_number, &recovery_device_data_1())?
+        {
+            AddTentativeDeviceResponse::AddedTentatively {
+                verification_code, ..
+            } => verification_code,
+            _ => panic!("unexpected response"),
+        };
 
     env.advance_time(Duration::from_secs(1));
     let expected_timestamp = time(&env);

--- a/src/internet_identity/tests/integration/anchor_management/remote_device_registration.rs
+++ b/src/internet_identity/tests/integration/anchor_management/remote_device_registration.rs
@@ -63,13 +63,7 @@ fn can_register_remote_device() -> Result<(), CallError> {
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
-    let add_response = api::add_tentative_device(
-        &env,
-        canister_id,
-        principal_2(),
-        user_number,
-        &device_data_2(),
-    )?;
+    let add_response = api::add_tentative_device(&env, canister_id, user_number, &device_data_2())?;
     let verification_code = match add_response {
         AddTentativeDeviceResponse::AddedTentatively {
             verification_code, ..
@@ -99,13 +93,7 @@ fn can_verify_remote_device_after_failed_attempt() -> Result<(), CallError> {
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
-    let add_response = api::add_tentative_device(
-        &env,
-        canister_id,
-        principal_2(),
-        user_number,
-        &device_data_2(),
-    )?;
+    let add_response = api::add_tentative_device(&env, canister_id, user_number, &device_data_2())?;
     let verification_code = match add_response {
         AddTentativeDeviceResponse::AddedTentatively {
             verification_code, ..
@@ -149,7 +137,7 @@ fn anchor_info_should_return_tentative_device() -> Result<(), CallError> {
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
     let new_device = device_data_2();
-    api::add_tentative_device(&env, canister_id, principal_2(), user_number, &new_device)?;
+    api::add_tentative_device(&env, canister_id, user_number, &new_device)?;
     let anchor_info = api::get_anchor_info(&env, canister_id, principal_1(), user_number)?;
 
     assert!(matches!(
@@ -171,13 +159,7 @@ fn reject_tentative_device_if_not_in_registration_mode() -> Result<(), CallError
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
     api::exit_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
-    let result = api::add_tentative_device(
-        &env,
-        canister_id,
-        principal_2(),
-        user_number,
-        &device_data_2(),
-    )?;
+    let result = api::add_tentative_device(&env, canister_id, user_number, &device_data_2())?;
 
     assert!(matches!(
         result,
@@ -196,13 +178,7 @@ fn reject_tentative_device_if_registration_mode_is_expired() -> Result<(), CallE
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
     env.advance_time(REGISTRATION_MODE_EXPIRATION + Duration::from_secs(1));
-    let result = api::add_tentative_device(
-        &env,
-        canister_id,
-        principal_2(),
-        user_number,
-        &device_data_2(),
-    )?;
+    let result = api::add_tentative_device(&env, canister_id, user_number, &device_data_2())?;
 
     assert!(matches!(
         result,
@@ -239,13 +215,7 @@ fn reject_verification_with_wrong_code() -> Result<(), CallError> {
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
-    api::add_tentative_device(
-        &env,
-        canister_id,
-        principal_2(),
-        user_number,
-        &device_data_2(),
-    )?;
+    api::add_tentative_device(&env, canister_id, user_number, &device_data_2())?;
     for expected_retries in (0..MAX_RETRIES).rev() {
         assert!(matches!(
             api::verify_tentative_device(

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -332,13 +332,7 @@ fn metrics_device_registration_mode() -> Result<(), CallError> {
     // long after expiry (we don't want this test to break, if we change the registration mode expiration)
     env.advance_time(Duration::from_secs(365 * 24 * 60 * 60));
     // make an update call related to tentative devices so that registration mode expiry gets checked
-    api::add_tentative_device(
-        &env,
-        canister_id,
-        principal_2(),
-        user_number_2,
-        &device_data_2(),
-    )?;
+    api::add_tentative_device(&env, canister_id, user_number_2, &device_data_2())?;
 
     let metrics = get_metrics(&env, canister_id);
     let (challenge_count, _) =


### PR DESCRIPTION
This PR removes the `sender` argument from the integration test API, since the call is always made anonymously anyway.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
