### PR TITLE
Test that known dapp logo loaded

### DIFF
--- a/src/frontend/src/test-e2e/misc.test.ts
+++ b/src/frontend/src/test-e2e/misc.test.ts
@@ -26,6 +26,20 @@ test("Should show dapp logo for known dapp", async () => {
     await niceDemoAppView.signin();
 
     await switchToPopup(browser);
+    // Ensure element exists
     await browser.$('[data-role="known-dapp-image"]').waitForExist();
+
+    // Ensure image loaded succesfully
+    await browser.waitUntil(
+      () =>
+        browser.execute(function () {
+          const img = document.querySelector(
+            '[data-role="known-dapp-image"]'
+          ) as HTMLImageElement;
+          // Simplest solution to check whether image actually did load
+          return img.naturalHeight !== 0;
+        }),
+      { timeoutMsg: "image wasn't loaded" }
+    );
   });
 }, 300_000);


### PR DESCRIPTION
This ensures that logos for known dapps are actually loaded (previously, we only tested that the `img` tag was present). This flow is not easy to test or check manually, so this should help catch more issues.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
