### PR TITLE
Show loader when fetching recoveries

### DIFF
--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -1,3 +1,4 @@
+import { withLoader } from "$src/components/loader";
 import { mainWindow } from "$src/components/mainWindow";
 import { I18n } from "$src/i18n";
 import { mount, renderPage } from "$src/utils/lit-html";
@@ -98,7 +99,10 @@ export const recoveryWizard = async (
 ): Promise<void> => {
   // Here, if the user doesn't have any recovery device, we prompt them to add
   // one.
-  if ((await connection.lookupRecovery(userNumber)).length === 0) {
+  const recoveries = await withLoader(() =>
+    connection.lookupRecovery(userNumber)
+  );
+  if (recoveries.length === 0) {
     const doAdd = await addPhrase();
     if (doAdd !== "skip") {
       doAdd satisfies "ok";


### PR DESCRIPTION
This ensures the `recoveryWizard` displays a loader when fetching the list of recovery methods. Otherwise, it's not clear that the app is waiting for canister data.

Before:


https://github.com/dfinity/internet-identity/assets/6930756/75386a62-de7d-4b8d-ae47-073d12cd15e0

After:


https://github.com/dfinity/internet-identity/assets/6930756/875d0013-385a-4302-bbe1-50f1a75494ba


<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
