### PR TITLE
Remove e2e type workaround

### DIFF
--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -39,12 +39,10 @@ export async function runInBrowser(
     // Disables permission prompt for clipboard, needed for tests using the clipboard (without this,
     // the browser window prompts the user to allow or block clipboard access).
     // https://stackoverflow.com/questions/53669639/enable-clipboard-in-automated-tests-with-protractor-and-webdriver
-    // XXX: the "any" cast is needed because our webdriverio version only expects numbers, strings
-    // or bools: https://github.com/webdriverio/webdriverio/issues/9924
     prefs: {
       "profile.content_settings.exceptions.clipboard": {
         "*": { last_modified: Date.now(), setting: 1 },
-      } as any,
+      },
     },
   };
 


### PR DESCRIPTION
This removes an `any` cast that was necessary to make TypeScript happy, but which isn't necessary due to updated type definitions in WebDriverIO: https://github.com/webdriverio/webdriverio/issues/9924

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
