### PR TITLE
Remove trailing whitespace

### DIFF
--- a/.github/actions/release/README.md
+++ b/.github/actions/release/README.md
@@ -8,7 +8,7 @@ To try the action locally, run the following:
 
 ``` bash
 $ # first, you need a GitHub Access token: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
-$ # Make sure the command is prefixed with a space so that bash does not store in in its 
+$ # Make sure the command is prefixed with a space so that bash does not store in in its
 $ # history file.
 $  export GITHUB_TOKEN="..."
 $ # The list of files for which we compute the sha256

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -320,7 +320,7 @@ jobs:
           # a relatively small price to pay to make sure PRs are always tested against the latest release.
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_test.wasm.gz -o internet_identity_previous.wasm.gz
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/archive.wasm.gz -o archive_previous.wasm.gz
-          
+
           # We are using --partition hash instead of count, because it makes sure that the tests partition is stable across runs
           # even if tests are added or removed. The tradeoff is that the balancing might be slightly worse, but we have enough
           # tests that it should not be a big issue.

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -2282,7 +2282,7 @@ a.c-action-list__item {
 }
 
 .c-progress-stepper__icon path {
-  /* 
+  /*
     this is a bit of a hack, the check-mark should not be a filled path
     but a stroke.
   */

--- a/src/internet_identity/tests/integration/active_anchor_stats/mod.rs
+++ b/src/internet_identity/tests/integration/active_anchor_stats/mod.rs
@@ -1,6 +1,6 @@
 //! Module for active anchor statistics
 
-/// Tests for the general (domain independent) active anchor statistics  
+/// Tests for the general (domain independent) active anchor statistics
 mod all_domains;
 
 /// Tests for the active anchor statistics that are specific to the II domains.


### PR DESCRIPTION
It was probably left there by mistake, and no one reclaimed it.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
