### PR TITLE
Make device settings testing robust

### DIFF
--- a/src/frontend/src/flows/manage/settingsDropdown.ts
+++ b/src/frontend/src/flows/manage/settingsDropdown.ts
@@ -38,6 +38,7 @@ export const settingsDropdown = ({
       aria-expanded=${asyncReplace(ariaExpanded)}
       aria-controls="dropdown-${id}"
       aria-label="Open settings"
+      data-action="open-settings"
       data-device=${alias}
       @click=${() => toggle()}
     >

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -227,16 +227,8 @@ export class MainView extends View {
     await this.browser.execute(
       "window.scrollTo(0, document.body.scrollHeight)"
     );
-    // Open the dropdown by clicking on the trigger button
-    await this.browser
-      .$(`button.c-dropdown__trigger[data-device="${deviceName}"]`)
-      .click();
-    await this.browser
-      .$(`button[data-device="${deviceName}"][data-action='rename']`)
-      .waitForClickable();
-    await this.browser
-      .$(`button[data-device="${deviceName}"][data-action='rename']`)
-      .click();
+    await this.openDeviceActions({ deviceName });
+    await this.deviceAction({ deviceName, action: "rename" }).click();
 
     const renameView = new RenameView(this.browser);
     await renameView.waitForDisplay();
@@ -249,17 +241,9 @@ export class MainView extends View {
     await this.browser.execute(
       "window.scrollTo(0, document.body.scrollHeight)"
     );
-    // Open the dropdown by clicking on the trigger button
-    await this.browser
-      .$(`button.c-dropdown__trigger[data-device="${deviceName}"]`)
-      .click();
-    await this.browser
-      .$(`button[data-device="${deviceName}"][data-action='protect']`)
-      .waitForClickable();
-    await this.browser
-      .$(`button[data-device="${deviceName}"][data-action='protect']`)
-      .click();
-    await this.browser.waitUntil(this.browser.isAlertOpen);
+    await this.openDeviceActions({ deviceName });
+    await this.deviceAction({ deviceName, action: "protect" }).click();
+    await this.browser.waitUntil(() => this.browser.isAlertOpen());
     await this.browser.acceptAlert();
 
     const recoveryView = new RecoverView(this.browser);
@@ -279,17 +263,9 @@ export class MainView extends View {
     await this.browser.execute(
       "window.scrollTo(0, document.body.scrollHeight)"
     );
-    // Open the dropdown by clicking on the trigger button
-    await this.browser
-      .$(`button.c-dropdown__trigger[data-device="${deviceName}"]`)
-      .click();
-    await this.browser
-      .$(`button[data-device="${deviceName}"][data-action='unprotect']`)
-      .waitForClickable();
-    await this.browser
-      .$(`button[data-device="${deviceName}"][data-action='unprotect']`)
-      .click();
-    await this.browser.waitUntil(this.browser.isAlertOpen);
+    await this.openDeviceActions({ deviceName });
+    await this.deviceAction({ deviceName, action: "unprotect" }).click();
+    await this.browser.waitUntil(() => this.browser.isAlertOpen());
     await this.browser.acceptAlert();
 
     const recoveryView = new RecoverView(this.browser);
@@ -304,39 +280,52 @@ export class MainView extends View {
       .waitForDisplayed({ timeout: 10_000, reverse: true });
   }
 
-  async remove(deviceName: string): Promise<void> {
-    // Open the dropdown by clicking on the trigger button
-    await this.browser
-      .$(`button.c-dropdown__trigger[data-device="${deviceName}"]`)
-      .click();
-    await this.browser
-      .$(`button[data-device="${deviceName}"][data-action='remove']`)
-      .waitForClickable();
-    await this.browser
-      .$(`button[data-device="${deviceName}"][data-action='remove']`)
-      .click();
-  }
-
   async reset(deviceName: string): Promise<void> {
-    // Open the dropdown by clicking on the trigger button
-    await this.browser
-      .$(`button.c-dropdown__trigger[data-device="${deviceName}"]`)
-      .click();
-    await this.browser
-      .$(`button[data-device="${deviceName}"][data-action='reset']`)
-      .waitForClickable();
-    await this.browser
-      .$(`button[data-device="${deviceName}"][data-action='reset']`)
-      .click();
-    await this.browser.waitUntil(this.browser.isAlertOpen);
+    await this.openDeviceActions({ deviceName });
+    await this.deviceAction({ deviceName, action: "reset" }).click();
+    await this.browser.waitUntil(() => this.browser.isAlertOpen());
     await this.browser.acceptAlert();
   }
 
   async removeNotDisplayed(deviceName: string): Promise<void> {
-    await this.browser.$(`button[data-device="${deviceName}"]`).click();
-    await this.browser
-      .$("button[data-action='remove']")
-      .waitForDisplayed({ reverse: true });
+    await this.openDeviceActions({ deviceName });
+    await this.deviceAction({ deviceName, action: "remove" }).waitForDisplayed({
+      reverse: true,
+    });
+  }
+
+  // Open the device settings/actions dropdown
+  async openDeviceActions({
+    deviceName,
+  }: {
+    deviceName: string;
+  }): Promise<void> {
+    // Grab the trigger (button) and figure out the id of the element it opens
+    const dropdownTrigger = await this.browser.$(
+      `[data-action="open-settings"][data-device="${deviceName}"]`
+    );
+    const dropdownId = await dropdownTrigger.getAttribute("aria-controls");
+    await dropdownTrigger.click();
+
+    // The menu element has an animation, so we wait until all animations are finished so
+    // that we can reliably click on its elements
+    await this.browser.waitUntil(
+      () =>
+        this.browser.execute(
+          (dropdownId) =>
+            document.getElementById(dropdownId)?.getAnimations().length === 0,
+          dropdownId
+        ),
+      { timeoutMsg: "Animation didn't end" }
+    );
+  }
+
+  // Get a device action element from the device settings menu (menu must be opened
+  // separately)
+  deviceAction({ deviceName, action }: { deviceName: string; action: string }) {
+    return this.browser.$(
+      `[data-action="${action}"][data-device="${deviceName}"]`
+    );
   }
 }
 


### PR DESCRIPTION
This improves the test code for the device settings dropdown. In particular:

* Tests now wait until the dropdown animation is finished before trying to click any of its elements. Not waiting caused flakiness, esp. in mobile testing.
* When waiting for alerts to be open, the callback is now specified fully (`() => this.browser.isAlertOpen()`) to avoid any scoping issues.
* Unused test helpers related to the settings dropdown are removed.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
