### PR TITLE
Add API to request principal link credentials for attribute sharing 

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -150,6 +150,14 @@ export const idlFactory = ({ IDL }) => {
     'no_such_delegation' : IDL.Null,
     'signed_delegation' : SignedDelegation,
   });
+  const GetIdAliasResponse = IDL.Variant({
+    'ok' : IDL.Record({
+      'rp_id_alias_credential' : IDL.Text,
+      'issuer_id_alias_credential' : IDL.Text,
+    }),
+    'authentication_failed' : IDL.Text,
+    'no_such_credentials' : IDL.Text,
+  });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
     'url' : IDL.Text,
@@ -189,6 +197,10 @@ export const idlFactory = ({ IDL }) => {
   });
   const IdentityInfoResponse = IDL.Variant({ 'ok' : IdentityInfo });
   const UserKey = PublicKey;
+  const PrepareIdAliasResponse = IDL.Variant({
+    'ok' : IDL.Null,
+    'authentication_failed' : IDL.Text,
+  });
   const ChallengeResult = IDL.Record({
     'key' : ChallengeKey,
     'chars' : IDL.Text,
@@ -282,6 +294,11 @@ export const idlFactory = ({ IDL }) => {
         [GetDelegationResponse],
         ['query'],
       ),
+    'get_id_alias' : IDL.Func(
+        [UserNumber, FrontendHostname, FrontendHostname],
+        [IDL.Opt(GetIdAliasResponse)],
+        ['query'],
+      ),
     'get_principal' : IDL.Func(
         [UserNumber, FrontendHostname],
         [IDL.Principal],
@@ -299,6 +316,11 @@ export const idlFactory = ({ IDL }) => {
     'prepare_delegation' : IDL.Func(
         [UserNumber, FrontendHostname, SessionKey, IDL.Opt(IDL.Nat64)],
         [UserKey, Timestamp],
+        [],
+      ),
+    'prepare_id_alias' : IDL.Func(
+        [UserNumber, FrontendHostname, FrontendHostname],
+        [IDL.Opt(PrepareIdAliasResponse)],
         [],
       ),
     'register' : IDL.Func(

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -125,6 +125,14 @@ export interface DomainOngoingActiveAnchorStats {
 export type FrontendHostname = string;
 export type GetDelegationResponse = { 'no_such_delegation' : null } |
   { 'signed_delegation' : SignedDelegation };
+export type GetIdAliasResponse = {
+    'ok' : {
+      'rp_id_alias_credential' : string,
+      'issuer_id_alias_credential' : string,
+    }
+  } |
+  { 'authentication_failed' : string } |
+  { 'no_such_credentials' : string };
 export type HeaderField = [string, string];
 export interface HttpRequest {
   'url' : string,
@@ -183,6 +191,8 @@ export interface OngoingActiveAnchorStats {
   'monthly_active_anchors' : Array<ActiveAnchorCounter>,
   'daily_active_anchors' : ActiveAnchorCounter,
 }
+export type PrepareIdAliasResponse = { 'ok' : null } |
+  { 'authentication_failed' : string };
 export type PublicKey = Uint8Array | number[];
 export interface PublicKeyAuthn { 'pubkey' : PublicKey }
 export type Purpose = { 'authentication' : null } |
@@ -246,6 +256,10 @@ export interface _SERVICE {
     [UserNumber, FrontendHostname, SessionKey, Timestamp],
     GetDelegationResponse
   >,
+  'get_id_alias' : ActorMethod<
+    [UserNumber, FrontendHostname, FrontendHostname],
+    [] | [GetIdAliasResponse]
+  >,
   'get_principal' : ActorMethod<[UserNumber, FrontendHostname], Principal>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'http_request_update' : ActorMethod<[HttpRequest], HttpResponse>,
@@ -255,6 +269,10 @@ export interface _SERVICE {
   'prepare_delegation' : ActorMethod<
     [UserNumber, FrontendHostname, SessionKey, [] | [bigint]],
     [UserKey, Timestamp]
+  >,
+  'prepare_id_alias' : ActorMethod<
+    [UserNumber, FrontendHostname, FrontendHostname],
+    [] | [PrepareIdAliasResponse]
   >,
   'register' : ActorMethod<
     [DeviceData, ChallengeResult, [] | [Principal]],

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -413,6 +413,23 @@ type AuthnMethodAddResponse = variant {
     invalid_metadata: text;
 };
 
+type PreparePrincipalLinkResponse = variant {
+    ok;
+    authentication_failed: text;
+};
+
+type GetPrincipalLinkResponse = variant {
+    ok: record {
+        // Verifiable credential intended for the RP linking P_new <-> P_rp
+        rp_link_credential: text;
+        // Verifiable credential intended for the issuer linking P_new <-> P_issuer
+        issuer_link_credential: text;
+    };
+    authentication_failed: text;
+    // The signature is not ready. Maybe retry by calling `prepare_principal_link`
+    no_such_credentials: text;
+};
+
 service : (opt InternetIdentityInit) -> {
     init_salt: () -> ();
     create_challenge : () -> (Challenge);
@@ -464,4 +481,8 @@ service : (opt InternetIdentityInit) -> {
     // Adds a new authentication method to the identity.
     // Requires authentication.
     authn_method_add: (IdentityNumber, AuthnMethodData) -> (opt AuthnMethodAddResponse);
+
+    // Attribute sharing MVP
+    prepare_principal_link : (UserNumber, relying_party: FrontendHostname, issuer: FrontendHostname) -> (opt PreparePrincipalLinkResponse);
+    get_principal_link: (UserNumber, relying_party: FrontendHostname, issuer: FrontendHostname) -> (opt GetPrincipalLinkResponse) query;
 }

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -413,20 +413,22 @@ type AuthnMethodAddResponse = variant {
     invalid_metadata: text;
 };
 
-type PreparePrincipalLinkResponse = variant {
+type PrepareIdAliasResponse = variant {
     ok;
     authentication_failed: text;
 };
 
-type GetPrincipalLinkResponse = variant {
+type GetIdAliasResponse = variant {
     ok: record {
-        // Verifiable credential intended for the RP linking P_new <-> P_rp
-        rp_link_credential: text;
-        // Verifiable credential intended for the issuer linking P_new <-> P_issuer
-        issuer_link_credential: text;
+        // Verifiable credential that provides an alias for the relying party identity.
+        // The alias identity is identitcal to the alias provided to the issuer (see below).
+        rp_id_alias_credential: text;
+        // Verifiable credential that provides an alias for the issuer identity.
+        // The alias identity is identitcal to the alias provided to the relying party (see above).
+        issuer_id_alias_credential: text;
     };
     authentication_failed: text;
-    // The signature is not ready. Maybe retry by calling `prepare_principal_link`
+    // The credentials are not ready. Maybe retry by calling `prepare_id_alias`.
     no_such_credentials: text;
 };
 
@@ -483,6 +485,21 @@ service : (opt InternetIdentityInit) -> {
     authn_method_add: (IdentityNumber, AuthnMethodData) -> (opt AuthnMethodAddResponse);
 
     // Attribute sharing MVP
-    prepare_principal_link : (UserNumber, relying_party: FrontendHostname, issuer: FrontendHostname) -> (opt PreparePrincipalLinkResponse);
-    get_principal_link: (UserNumber, relying_party: FrontendHostname, issuer: FrontendHostname) -> (opt GetPrincipalLinkResponse) query;
+    //
+    // Note: the responses of attribute sharing MVP API calls are `opt` for compatibility reasons
+    // with future variant extensions.
+    // A client decoding a response as `null` indicates outdated type information
+    // and should be treated as an error.
+
+    // Prepares verifiable credentials that provide a common alias to the issuer and the relying party.
+    // The alias credentials are issued by Internet Identity.
+    // This call is used in the attribute sharing flow where the common identity alias is used to issue
+    // a verifiable credential that is understood in both the relying party and the issuer context.
+    // This call can be called multiple times. Only the latest credentials are returned by `get_id_alias`.
+    // Requires authentication.
+    prepare_id_alias : (UserNumber, relying_party: FrontendHostname, issuer: FrontendHostname) -> (opt PrepareIdAliasResponse);
+
+    // Returns the verifiable credentials that were prepared by `prepare_id_alias`, if any.
+    // Requires authentication.
+    get_id_alias: (UserNumber, relying_party: FrontendHostname, issuer: FrontendHostname) -> (opt GetIdAliasResponse) query;
 }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -10,7 +10,7 @@ use ic_certified_map::AsHashTree;
 use internet_identity_interface::archive::types::{BufferedEntry, Operation};
 use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
 use internet_identity_interface::internet_identity::types::attribute_sharing_mvp::{
-    GetPrincipalLinkResponse, PreparePrincipalLinkResponse,
+    GetIdAliasResponse, PrepareIdAliasResponse,
 };
 use internet_identity_interface::internet_identity::types::*;
 use serde_bytes::ByteBuf;
@@ -550,22 +550,22 @@ mod attribute_sharing_mvp {
 
     #[update]
     #[candid_method]
-    fn prepare_principal_link(
+    fn prepare_id_alias(
         _identity_number: IdentityNumber,
         _relying_party: FrontendHostname,
         _issuer: FrontendHostname,
-    ) -> Option<PreparePrincipalLinkResponse> {
-        todo!("implement prepare_principal_link")
+    ) -> Option<PrepareIdAliasResponse> {
+        todo!("implement prepare_id_alias")
     }
 
     #[query]
     #[candid_method(query)]
-    fn get_principal_link(
+    fn get_id_alias(
         _identity_number: IdentityNumber,
         _relying_party: FrontendHostname,
         _issuer: FrontendHostname,
-    ) -> Option<GetPrincipalLinkResponse> {
-        todo!("implement get_principal_link")
+    ) -> Option<GetIdAliasResponse> {
+        todo!("implement get_id_alias")
     }
 }
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -9,6 +9,9 @@ use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use ic_certified_map::AsHashTree;
 use internet_identity_interface::archive::types::{BufferedEntry, Operation};
 use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
+use internet_identity_interface::internet_identity::types::attribute_sharing_mvp::{
+    GetPrincipalLinkResponse, PreparePrincipalLinkResponse,
+};
 use internet_identity_interface::internet_identity::types::*;
 use serde_bytes::ByteBuf;
 use storage::{Salt, Storage};
@@ -538,6 +541,31 @@ mod v2_api {
             Err(err) => err,
         };
         Some(result)
+    }
+}
+
+/// API for the attribute sharing mvp
+mod attribute_sharing_mvp {
+    use super::*;
+
+    #[update]
+    #[candid_method]
+    fn prepare_principal_link(
+        _identity_number: IdentityNumber,
+        _relying_party: FrontendHostname,
+        _issuer: FrontendHostname,
+    ) -> Option<PreparePrincipalLinkResponse> {
+        todo!("implement prepare_principal_link")
+    }
+
+    #[query]
+    #[candid_method(query)]
+    fn get_principal_link(
+        _identity_number: IdentityNumber,
+        _relying_party: FrontendHostname,
+        _issuer: FrontendHostname,
+    ) -> Option<GetPrincipalLinkResponse> {
+        todo!("implement get_principal_link")
     }
 }
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -15,6 +15,8 @@ pub type DeviceVerificationCode = String;
 pub type FailedAttemptsCounter = u8;
 
 mod api_v2;
+pub mod attribute_sharing_mvp;
+
 // re-export v2 types without the ::v2 prefix, so that this crate can be restructured once v1 is removed
 // without breaking clients
 pub use api_v2::*;

--- a/src/internet_identity_interface/src/internet_identity/types/attribute_sharing_mvp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/attribute_sharing_mvp.rs
@@ -1,0 +1,25 @@
+use candid::{CandidType, Deserialize};
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum PreparePrincipalLinkResponse {
+    #[serde(rename = "ok")]
+    Ok,
+    #[serde(rename = "authentication_failed")]
+    AuthenticationFailed(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct PrincipalLinkCredentials {
+    pub rp_link_credential: String,
+    pub issuer_link_credential: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum GetPrincipalLinkResponse {
+    #[serde(rename = "ok")]
+    Ok(PrincipalLinkCredentials),
+    #[serde(rename = "authentication_failed")]
+    AuthenticationFailed(String),
+    #[serde(rename = "no_such_credentials")]
+    NoSuchCredentials(String),
+}

--- a/src/internet_identity_interface/src/internet_identity/types/attribute_sharing_mvp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/attribute_sharing_mvp.rs
@@ -1,7 +1,7 @@
 use candid::{CandidType, Deserialize};
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub enum PreparePrincipalLinkResponse {
+pub enum PrepareIdAliasResponse {
     #[serde(rename = "ok")]
     Ok,
     #[serde(rename = "authentication_failed")]
@@ -9,15 +9,15 @@ pub enum PreparePrincipalLinkResponse {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub struct PrincipalLinkCredentials {
-    pub rp_link_credential: String,
-    pub issuer_link_credential: String,
+pub struct IdAliasCredentials {
+    pub rp_id_alias_credential: String,
+    pub issuer_id_alias_credential: String,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub enum GetPrincipalLinkResponse {
+pub enum GetIdAliasResponse {
     #[serde(rename = "ok")]
-    Ok(PrincipalLinkCredentials),
+    Ok(IdAliasCredentials),
     #[serde(rename = "authentication_failed")]
     AuthenticationFailed(String),
     #[serde(rename = "no_such_credentials")]


### PR DESCRIPTION
This PR adds the stubs for getting the principal link credentials (signed using canister signatures).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
