### PR TITLE
Add build archive dependencies in deps docker stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN mkdir -p src/internet_identity/src \
     && touch src/archive/src/lib.rs \
     && mkdir -p src/canister_tests/src \
     && touch src/canister_tests/src/lib.rs \
-    && ./scripts/build --only-dependencies \
+    && ./scripts/build --only-dependencies --internet-identity --archive \
     && rm -rf src
 
 FROM deps as build_internet_identity


### PR DESCRIPTION
This explicitly adds the archive to the list of canister dependencies to be built, so that the docker caching also caches archive dependencies. This will speed up CI because it reduces the build time of the archive docker build.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
