### PR TITLE
Refactor asset state

### DIFF
--- a/src/internet_identity/src/delegation.rs
+++ b/src/internet_identity/src/delegation.rs
@@ -1,10 +1,10 @@
 use crate::active_anchor_stats::IIDomain;
-use crate::state::{persistent_state_mut, AssetHashes};
-use crate::{hash, state, update_root_hash, DAY_NS, LABEL_ASSETS, LABEL_SIG, MINUTE_NS};
+use crate::assets::CertifiedAssets;
+use crate::state::persistent_state_mut;
+use crate::{hash, state, update_root_hash, DAY_NS, LABEL_SIG, MINUTE_NS};
 use candid::Principal;
 use ic_cdk::api::{data_certificate, time};
 use ic_cdk::{id, trap};
-use ic_certified_map::AsHashTree;
 use ic_certified_map::{Hash, HashTree};
 use internet_identity::signature_map::SignatureMap;
 use internet_identity_interface::internet_identity::types::*;
@@ -127,7 +127,7 @@ pub fn get_delegation(
 ) -> GetDelegationResponse {
     check_frontend_length(&frontend);
 
-    state::asset_hashes_and_sigs(|asset_hashes, sigs| {
+    state::assets_and_signatures(|asset_hashes, sigs| {
         match get_signature(
             asset_hashes,
             sigs,
@@ -217,7 +217,7 @@ fn delegation_signature_msg_hash(d: &Delegation) -> Hash {
 }
 
 fn get_signature(
-    asset_hashes: &AssetHashes,
+    assets: &CertifiedAssets,
     sigs: &SignatureMap,
     pk: PublicKey,
     seed: Hash,
@@ -244,10 +244,7 @@ fn get_signature(
     }
 
     let tree = ic_certified_map::fork(
-        HashTree::Pruned(ic_certified_map::labeled_hash(
-            LABEL_ASSETS,
-            &asset_hashes.root_hash(),
-        )),
+        HashTree::Pruned(assets.root_hash()),
         ic_certified_map::labeled(LABEL_SIG, witness),
     );
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -6,7 +6,6 @@ use crate::storage::anchor::Anchor;
 use candid::{candid_method, Principal};
 use ic_cdk::api::{caller, set_certified_data, trap};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
-use ic_certified_map::AsHashTree;
 use internet_identity_interface::archive::types::{BufferedEntry, Operation};
 use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
 use internet_identity_interface::internet_identity::types::*;
@@ -31,7 +30,6 @@ const MINUTE_NS: u64 = secs_to_nanos(60);
 const HOUR_NS: u64 = 60 * MINUTE_NS;
 const DAY_NS: u64 = 24 * HOUR_NS;
 
-const LABEL_ASSETS: &[u8] = b"http_assets";
 const LABEL_SIG: &[u8] = b"sig";
 
 // Note: concatenating const &str is a hassle in rust. It seemed easiest to just repeat.
@@ -414,10 +412,10 @@ fn save_persistent_state() {
 
 fn update_root_hash() {
     use ic_certified_map::{fork_hash, labeled_hash};
-    state::asset_hashes_and_sigs(|asset_hashes, sigs| {
+    state::assets_and_signatures(|assets, sigs| {
         let prefixed_root_hash = fork_hash(
-            // NB: Labels added in lexicographic order
-            &labeled_hash(LABEL_ASSETS, &asset_hashes.root_hash()),
+            &assets.root_hash(),
+            // NB: sigs have to be added last due to lexical ordering of labels
             &labeled_hash(LABEL_SIG, &sigs.root_hash()),
         );
         set_certified_data(&prefixed_root_hash[..]);


### PR DESCRIPTION
This PR refactors how assets are kept in the `state` module. It creates a clearer separation between assets and the rest of the state and it allows to extend the asset state with v2 certification without breaking clients that rely on the certification (i.e. signed delegations).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
