### PR TITLE
Add HTTP response certification v2

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -129,6 +129,8 @@ function build_canister() {
             -o "./$canister.wasm" \
             shrink
         ic-wasm "$canister.wasm" -o "$canister.wasm" metadata candid:service -f "$SRC_DIR/$canister.did" -v public
+        # indicate support for certificate version 1 and 2 in the canister metadata
+        ic-wasm "$canister.wasm" -o "$canister.wasm" metadata supported_certificate_versions -d "1,2" -v public
         gzip --no-name --force "$canister.wasm"
     fi
 }

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -451,6 +451,7 @@ pub fn get_metrics(env: &StateMachine, canister_id: CanisterId) -> String {
             url: "/metrics".to_string(),
             headers: vec![],
             body: ByteBuf::new(),
+            certificate_version: None,
         },
     )
     .expect("HTTP request to /metrics failed");

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -156,6 +156,7 @@ export const idlFactory = ({ IDL }) => {
     'method' : IDL.Text,
     'body' : IDL.Vec(IDL.Nat8),
     'headers' : IDL.Vec(HeaderField),
+    'certificate_version' : IDL.Opt(IDL.Nat16),
   });
   const Token = IDL.Record({});
   const StreamingCallbackHttpResponse = IDL.Record({

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -131,6 +131,7 @@ export interface HttpRequest {
   'method' : string,
   'body' : Uint8Array | number[],
   'headers' : Array<HeaderField>,
+  'certificate_version' : [] | [number],
 }
 export interface HttpResponse {
   'body' : Uint8Array | number[],

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -17,6 +17,7 @@ type HttpRequest = record {
     url: text;
     headers: vec HeaderField;
     body: blob;
+    certificate_version: opt nat16;
 };
 
 type HttpResponse = record {

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -4,6 +4,7 @@
 
 use crate::hash::{hash_of_map, Value};
 use crate::http::{security_headers, IC_CERTIFICATE_EXPRESSION_HEADER};
+use crate::nested_tree::NestedTree;
 use crate::{http, state};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
@@ -12,7 +13,6 @@ use ic_certified_map::{
     fork, fork_hash, labeled, labeled_hash, AsHashTree, Hash, HashTree, RbTree,
 };
 use include_dir::{include_dir, Dir, File};
-use internet_identity::nested_tree::NestedTree;
 use internet_identity_interface::http_gateway::HeaderField;
 use lazy_static::lazy_static;
 use sha2::Digest;

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -2,34 +2,70 @@
 //
 // This file describes which assets are used and how (content, content type and content encoding).
 
+use crate::hash::{hash_of_map, Value};
+use crate::http::{security_headers, IC_CERTIFICATE_EXPRESSION_HEADER};
 use crate::{http, state};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use ic_cdk::api;
-use ic_certified_map::{AsHashTree, Hash, HashTree, RbTree};
+use ic_certified_map::{
+    fork, fork_hash, labeled, labeled_hash, AsHashTree, Hash, HashTree, RbTree,
+};
 use include_dir::{include_dir, Dir, File};
+use internet_identity::nested_tree::NestedTree;
 use internet_identity_interface::http_gateway::HeaderField;
 use lazy_static::lazy_static;
 use sha2::Digest;
 use std::collections::HashMap;
 
-const LABEL_ASSETS: &[u8] = b"http_assets";
+const LABEL_ASSETS_V1: &[u8] = b"http_assets";
+const LABEL_ASSETS_V2: &[u8] = b"http_expr";
+pub const IC_CERTIFICATE_EXPRESSION: &str =
+    "default_certification(ValidationArgs{certification:Certification{no_request_certification: Empty{},\
+    response_certification:ResponseCertification{response_header_exclusions:ResponseHeaderList{headers:[]}}}})";
 
 #[derive(Debug, Default, Clone)]
 pub struct CertifiedAssets {
     pub assets: HashMap<String, (Vec<HeaderField>, Vec<u8>)>,
     pub certification_v1: RbTree<String, Hash>,
+    pub certification_v2: NestedTree<Vec<u8>, Vec<u8>>,
 }
 
 impl CertifiedAssets {
     /// Returns the root_hash of the asset certification tree.
     pub fn root_hash(&self) -> Hash {
-        ic_certified_map::labeled_hash(LABEL_ASSETS, &self.certification_v1.root_hash())
+        fork_hash(
+            // NB: Labels added in lexicographic order.
+            &labeled_hash(LABEL_ASSETS_V1, &self.certification_v1.root_hash()),
+            &labeled_hash(LABEL_ASSETS_V2, &self.certification_v2.root_hash()),
+        )
     }
 
-    pub fn witness(&self, path: &str) -> HashTree {
+    pub fn witness_v1(&self, path: &str) -> HashTree {
         let witness = self.certification_v1.witness(path.as_bytes());
-        ic_certified_map::labeled(LABEL_ASSETS, witness)
+        fork(
+            labeled(LABEL_ASSETS_V1, witness),
+            HashTree::Pruned(labeled_hash(
+                LABEL_ASSETS_V2,
+                &self.certification_v2.root_hash(),
+            )),
+        )
+    }
+
+    pub fn witness_v2(&self, path: &str) -> HashTree {
+        let mut path: Vec<String> = path.split('/').map(str::to_string).collect();
+        path.remove(0); // remove leading empty string due to absolute path
+        path.push("<$>".to_string());
+        let path_bytes: Vec<Vec<u8>> = path.iter().map(String::as_bytes).map(Vec::from).collect();
+        let witness = self.certification_v2.witness(&path_bytes);
+
+        fork(
+            HashTree::Pruned(labeled_hash(
+                LABEL_ASSETS_V1,
+                &self.certification_v1.root_hash(),
+            )),
+            labeled(LABEL_ASSETS_V2, witness),
+        )
     }
 }
 
@@ -82,15 +118,17 @@ lazy_static! {
         let hash = BASE64.encode(hash);
         format!("sha256-{hash}")
     };
+
+     pub static ref EXPR_HASH: Hash = sha2::Sha256::digest(IC_CERTIFICATE_EXPRESSION).into();
 }
 
 // used both in init and post_upgrade
 pub fn init_assets() {
     state::assets_mut(|certified_assets| {
         for (path, content, content_encoding, content_type) in get_static_assets() {
-            certified_assets
-                .certification_v1
-                .insert(path.clone(), sha2::Sha256::digest(&content).into());
+            let body_hash = sha2::Sha256::digest(&content).into();
+            add_certification_v1(certified_assets, &path, body_hash);
+
             let mut headers = match content_encoding {
                 ContentEncoding::Identity => vec![],
                 ContentEncoding::GZip => {
@@ -101,9 +139,61 @@ pub fn init_assets() {
                 "Content-Type".to_string(),
                 content_type.to_mime_type_string(),
             ));
+
+            add_certification_v2(
+                certified_assets,
+                &path,
+                &security_headers()
+                    .iter()
+                    .chain(headers.iter())
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                body_hash,
+            );
+
             certified_assets.assets.insert(path, (headers, content));
         }
     });
+}
+
+fn add_certification_v1(certified_assets: &mut CertifiedAssets, path: &str, body_hash: Hash) {
+    certified_assets
+        .certification_v1
+        .insert(path.to_string(), body_hash)
+}
+
+fn add_certification_v2(
+    certified_assets: &mut CertifiedAssets,
+    path: &str,
+    headers: &[HeaderField],
+    body_hash: Hash,
+) {
+    let mut segments: Vec<Vec<u8>> = path.split('/').map(str::as_bytes).map(Vec::from).collect();
+    segments.remove(0); // remove leading empty string due to absolute path
+    segments.push("<$>".as_bytes().to_vec());
+    segments.push(Vec::from(EXPR_HASH.as_slice()));
+    segments.push(vec![]);
+    segments.push(Vec::from(response_hash(headers, &body_hash)));
+
+    certified_assets.certification_v2.insert(&segments, vec![])
+}
+
+fn response_hash(headers: &[HeaderField], body_hash: &Hash) -> Hash {
+    let mut response_metadata = HashMap::from_iter(
+        headers
+            .iter()
+            .map(|(header, value)| (header.to_ascii_lowercase(), Value::String(value)))
+            .collect::<Vec<_>>(),
+    );
+    response_metadata.insert(
+        IC_CERTIFICATE_EXPRESSION_HEADER.to_ascii_lowercase(),
+        Value::String(IC_CERTIFICATE_EXPRESSION),
+    );
+    response_metadata.insert(":ic-cert-status".to_string(), Value::U64(200));
+    let mut response_metadata_hash: Vec<u8> = hash_of_map(response_metadata).into();
+    response_metadata_hash.extend_from_slice(body_hash);
+    let response_hash: Hash = sha2::Sha256::digest(&response_metadata_hash).into();
+    response_hash
 }
 
 static ASSET_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../dist");

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -52,8 +52,10 @@ impl CertifiedAssets {
         )
     }
 
-    pub fn witness_v2(&self, path: &str) -> HashTree {
-        let mut path: Vec<String> = path.split('/').map(str::to_string).collect();
+    pub fn witness_v2(&self, absolute_path: &str) -> HashTree {
+        assert!(absolute_path.starts_with("/"));
+
+        let mut path: Vec<String> = absolute_path.split('/').map(str::to_string).collect();
         path.remove(0); // remove leading empty string due to absolute path
         path.push("<$>".to_string());
         let path_bytes: Vec<Vec<u8>> = path.iter().map(String::as_bytes).map(Vec::from).collect();
@@ -164,11 +166,17 @@ fn add_certification_v1(certified_assets: &mut CertifiedAssets, path: &str, body
 
 fn add_certification_v2(
     certified_assets: &mut CertifiedAssets,
-    path: &str,
+    absolute_path: &str,
     headers: &[HeaderField],
     body_hash: Hash,
 ) {
-    let mut segments: Vec<Vec<u8>> = path.split('/').map(str::as_bytes).map(Vec::from).collect();
+    assert!(absolute_path.starts_with("/"));
+
+    let mut segments: Vec<Vec<u8>> = absolute_path
+        .split('/')
+        .map(str::as_bytes)
+        .map(Vec::from)
+        .collect();
     segments.remove(0); // remove leading empty string due to absolute path
     segments.push("<$>".as_bytes().to_vec());
     segments.push(Vec::from(EXPR_HASH.as_slice()));

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -55,7 +55,7 @@ impl CertifiedAssets {
     }
 
     pub fn witness_v2(&self, absolute_path: &str) -> HashTree {
-        assert!(absolute_path.starts_with("/"));
+        assert!(absolute_path.starts_with('/'));
 
         let mut path: Vec<String> = absolute_path.split('/').map(str::to_string).collect();
         path.remove(0); // remove leading empty string due to absolute path
@@ -172,7 +172,7 @@ fn add_certification_v2(
     headers: &[HeaderField],
     body_hash: Hash,
 ) {
-    assert!(absolute_path.starts_with("/"));
+    assert!(absolute_path.starts_with('/'));
 
     let mut segments: Vec<Vec<u8>> = absolute_path
         .split('/')

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -442,19 +442,21 @@ fn asset_certificate_headers_v1(asset_name: &str) -> Vec<(String, String)> {
     })
 }
 
-fn asset_certificate_headers_v2(asset_name: &str) -> Vec<(String, String)> {
+fn asset_certificate_headers_v2(absolute_path: &str) -> Vec<(String, String)> {
+    assert!(absolute_path.starts_with("/"));
+
     let certificate = data_certificate().unwrap_or_else(|| {
         trap("data certificate is only available in query calls");
     });
 
-    let mut path: Vec<String> = asset_name.split('/').map(str::to_string).collect();
+    let mut path: Vec<String> = absolute_path.split('/').map(str::to_string).collect();
     // replace the first empty split segment (due to absolute path) with "http_expr"
     *path.get_mut(0).unwrap() = "http_expr".to_string();
     path.push("<$>".to_string());
 
     state::assets_and_signatures(|assets, sigs| {
         let tree = ic_certified_map::fork(
-            assets.witness_v2(asset_name),
+            assets.witness_v2(absolute_path),
             HashTree::Pruned(ic_certified_map::labeled_hash(LABEL_SIG, &sigs.root_hash())),
         );
 

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -1,5 +1,5 @@
 use crate::archive::ArchiveState;
-use crate::assets::{ContentType, IC_CERTIFICATE_EXPRESSION};
+use crate::assets::{ContentType, EXACT_MATCH_TERMINATOR, IC_CERTIFICATE_EXPRESSION};
 use crate::{assets, state, IC0_APP_DOMAIN, INTERNETCOMPUTER_ORG_DOMAIN, LABEL_SIG};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 pub const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
 pub const IC_CERTIFICATE_EXPRESSION_HEADER: &str = "IC-CertificateExpression";
+const LABEL_HTTP_EXPR: &str = "http_expr";
 
 impl ContentType {
     pub fn to_mime_type_string(self) -> String {
@@ -451,8 +452,8 @@ fn asset_certificate_headers_v2(absolute_path: &str) -> Vec<(String, String)> {
 
     let mut path: Vec<String> = absolute_path.split('/').map(str::to_string).collect();
     // replace the first empty split segment (due to absolute path) with "http_expr"
-    *path.get_mut(0).unwrap() = "http_expr".to_string();
-    path.push("<$>".to_string());
+    *path.get_mut(0).unwrap() = LABEL_HTTP_EXPR.to_string();
+    path.push(EXACT_MATCH_TERMINATOR.to_string());
 
     state::assets_and_signatures(|assets, sigs| {
         let tree = ic_certified_map::fork(

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -1,5 +1,5 @@
 use crate::archive::ArchiveState;
-use crate::assets::ContentType;
+use crate::assets::{ContentType, IC_CERTIFICATE_EXPRESSION};
 use crate::{assets, state, IC0_APP_DOMAIN, INTERNETCOMPUTER_ORG_DOMAIN, LABEL_SIG};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
@@ -12,6 +12,9 @@ use internet_identity_interface::http_gateway::{HeaderField, HttpRequest, HttpRe
 use serde::Serialize;
 use serde_bytes::ByteBuf;
 use std::time::Duration;
+
+pub const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
+pub const IC_CERTIFICATE_EXPRESSION_HEADER: &str = "IC-CertificateExpression";
 
 impl ContentType {
     pub fn to_mime_type_string(self) -> String {
@@ -80,13 +83,16 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
             }
         }
         probably_an_asset => {
-            let certificate_header = make_asset_certificate_header(probably_an_asset);
-            let mut headers = security_headers();
-            headers.push(certificate_header);
-
             state::assets(
                 |certified_assets| match certified_assets.assets.get(probably_an_asset) {
                     Some((asset_headers, data)) => {
+                        let mut headers = security_headers();
+                        let mut certificate_headers = match req.certificate_version {
+                            None | Some(1) => asset_certificate_headers_v1(probably_an_asset),
+                            Some(2) => asset_certificate_headers_v2(probably_an_asset),
+                            _ => trap("Unsupported certificate version."),
+                        };
+                        headers.append(&mut certificate_headers);
                         headers.append(&mut asset_headers.clone());
 
                         HttpResponse {
@@ -99,7 +105,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                     }
                     None => HttpResponse {
                         status_code: 404,
-                        headers,
+                        headers: security_headers(),
                         body: ByteBuf::from(format!("Asset {probably_an_asset} not found.")),
                         upgrade: None,
                         streaming_strategy: None,
@@ -290,7 +296,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
 /// List of recommended security headers as per https://owasp.org/www-project-secure-headers/
 /// These headers enable browser security features (like limit access to platform apis and set
 /// iFrame policies, etc.).
-fn security_headers() -> Vec<HeaderField> {
+pub fn security_headers() -> Vec<HeaderField> {
     vec![
         ("X-Frame-Options".to_string(), "DENY".to_string()),
         ("X-Content-Type-Options".to_string(), "nosniff".to_string()),
@@ -412,26 +418,70 @@ pub fn content_security_policy_meta() -> String {
     csp
 }
 
-fn make_asset_certificate_header(asset_name: &str) -> (String, String) {
+fn asset_certificate_headers_v1(asset_name: &str) -> Vec<(String, String)> {
     let certificate = data_certificate().unwrap_or_else(|| {
         trap("data certificate is only available in query calls");
     });
     state::assets_and_signatures(|assets, sigs| {
         let tree = ic_certified_map::fork(
-            assets.witness(asset_name),
+            assets.witness_v1(asset_name),
             HashTree::Pruned(ic_certified_map::labeled_hash(LABEL_SIG, &sigs.root_hash())),
         );
         let mut serializer = serde_cbor::ser::Serializer::new(vec![]);
         serializer.self_describe().unwrap();
         tree.serialize(&mut serializer)
             .unwrap_or_else(|e| trap(&format!("failed to serialize a hash tree: {e}")));
-        (
-            "IC-Certificate".to_string(),
+        vec![(
+            IC_CERTIFICATE_HEADER.to_string(),
             format!(
                 "certificate=:{}:, tree=:{}:",
                 BASE64.encode(&certificate),
                 BASE64.encode(serializer.into_inner())
             ),
-        )
+        )]
+    })
+}
+
+fn asset_certificate_headers_v2(asset_name: &str) -> Vec<(String, String)> {
+    let certificate = data_certificate().unwrap_or_else(|| {
+        trap("data certificate is only available in query calls");
+    });
+
+    let mut path: Vec<String> = asset_name.split('/').map(str::to_string).collect();
+    // replace the first empty split segment (due to absolute path) with "http_expr"
+    *path.get_mut(0).unwrap() = "http_expr".to_string();
+    path.push("<$>".to_string());
+
+    state::assets_and_signatures(|assets, sigs| {
+        let tree = ic_certified_map::fork(
+            assets.witness_v2(asset_name),
+            HashTree::Pruned(ic_certified_map::labeled_hash(LABEL_SIG, &sigs.root_hash())),
+        );
+
+        let mut tree_serializer = serde_cbor::ser::Serializer::new(vec![]);
+        tree_serializer.self_describe().unwrap();
+        tree.serialize(&mut tree_serializer)
+            .unwrap_or_else(|e| trap(&format!("failed to serialize a hash tree: {e}")));
+
+        let mut expr_path_serializer = serde_cbor::ser::Serializer::new(vec![]);
+        expr_path_serializer.self_describe().unwrap();
+        path.serialize(&mut expr_path_serializer)
+            .unwrap_or_else(|e| trap(&format!("failed to serialize a expr_path: {e}")));
+
+        vec![
+            (
+                IC_CERTIFICATE_HEADER.to_string(),
+                format!(
+                    "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
+                    BASE64.encode(&certificate),
+                    BASE64.encode(tree_serializer.into_inner()),
+                    BASE64.encode(expr_path_serializer.into_inner())
+                ),
+            ),
+            (
+                IC_CERTIFICATE_EXPRESSION_HEADER.to_string(),
+                IC_CERTIFICATE_EXPRESSION.to_string(),
+            ),
+        ]
     })
 }

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -444,7 +444,7 @@ fn asset_certificate_headers_v1(asset_name: &str) -> Vec<(String, String)> {
 }
 
 fn asset_certificate_headers_v2(absolute_path: &str) -> Vec<(String, String)> {
-    assert!(absolute_path.starts_with("/"));
+    assert!(absolute_path.starts_with('/'));
 
     let certificate = data_certificate().unwrap_or_else(|| {
         trap("data certificate is only available in query calls");

--- a/src/internet_identity/src/lib.rs
+++ b/src/internet_identity/src/lib.rs
@@ -1,6 +1,9 @@
 //! Various APIs for managing internet identities.
 pub mod signature_map;
 
+/// Infrastructure to help building nested certification trees.
+pub mod nested_tree;
+
 /// A small module that makes get_random work on wasm32-unknown-unknown.
 /// The dependency on get_random comes from the captcha library.
 #[cfg(all(

--- a/src/internet_identity/src/lib.rs
+++ b/src/internet_identity/src/lib.rs
@@ -1,9 +1,6 @@
 //! Various APIs for managing internet identities.
 pub mod signature_map;
 
-/// Infrastructure to help building nested certification trees.
-pub mod nested_tree;
-
 /// A small module that makes get_random work on wasm32-unknown-unknown.
 /// The dependency on get_random comes from the captcha library.
 #[cfg(all(

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -19,6 +19,8 @@ mod assets;
 mod delegation;
 mod hash;
 mod http;
+/// Infrastructure to help building nested certification trees.
+mod nested_tree;
 mod state;
 mod storage;
 

--- a/src/internet_identity/src/nested_tree.rs
+++ b/src/internet_identity/src/nested_tree.rs
@@ -1,5 +1,6 @@
 //! This module has been copied from https://github.com/dfinity/sdk/blob/master/src/canisters/frontend/ic-certified-assets/src/asset_certification/tree.rs
-//! XXX: Replace with library, once the trust team has extracted a reusable certification library.
+//! (commit d6a3cb89dc3bfb2c07500e1fc781667e3b0cda5a).
+//! TODO: Replace with library, once the trust team has extracted a reusable certification library.
 #![allow(dead_code)] // we don't need all the features provided here
 
 use ic_certified_map::{AsHashTree, HashTree, RbTree};

--- a/src/internet_identity/src/nested_tree.rs
+++ b/src/internet_identity/src/nested_tree.rs
@@ -1,5 +1,6 @@
 //! This module has been copied from https://github.com/dfinity/sdk/blob/master/src/canisters/frontend/ic-certified-assets/src/asset_certification/tree.rs
 //! XXX: Replace with library, once the trust team has extracted a reusable certification library.
+#![allow(dead_code)] // we don't need all the features provided here
 
 use ic_certified_map::{AsHashTree, HashTree, RbTree};
 
@@ -37,7 +38,6 @@ impl<K: NestedTreeKeyRequirements, V: NestedTreeValueRequirements> AsHashTree fo
 }
 
 impl<K: NestedTreeKeyRequirements, V: NestedTreeValueRequirements> NestedTree<K, V> {
-    #[allow(dead_code)]
     pub fn get(&self, path: &[K]) -> Option<&V> {
         if let Some(key) = path.get(0) {
             match self {

--- a/src/internet_identity/src/nested_tree.rs
+++ b/src/internet_identity/src/nested_tree.rs
@@ -1,0 +1,203 @@
+//! This module has been copied from https://github.com/dfinity/sdk/blob/master/src/canisters/frontend/ic-certified-assets/src/asset_certification/tree.rs
+//! XXX: Replace with library, once the trust team has extracted a reusable certification library.
+
+use ic_certified_map::{AsHashTree, HashTree, RbTree};
+
+pub trait NestedTreeKeyRequirements: Clone + AsRef<[u8]> + 'static {}
+pub trait NestedTreeValueRequirements: AsHashTree + 'static {}
+impl<T> NestedTreeKeyRequirements for T where T: Clone + AsRef<[u8]> + 'static {}
+impl<T> NestedTreeValueRequirements for T where T: AsHashTree + 'static {}
+
+#[derive(Debug, Clone)]
+pub enum NestedTree<K: NestedTreeKeyRequirements, V: NestedTreeValueRequirements> {
+    Leaf(V),
+    Nested(RbTree<K, NestedTree<K, V>>),
+}
+
+impl<K: NestedTreeKeyRequirements, V: NestedTreeValueRequirements> Default for NestedTree<K, V> {
+    fn default() -> Self {
+        NestedTree::Nested(RbTree::<K, NestedTree<K, V>>::new())
+    }
+}
+
+impl<K: NestedTreeKeyRequirements, V: NestedTreeValueRequirements> AsHashTree for NestedTree<K, V> {
+    fn root_hash(&self) -> ic_certified_map::Hash {
+        match self {
+            NestedTree::Leaf(a) => a.root_hash(),
+            NestedTree::Nested(tree) => tree.root_hash(),
+        }
+    }
+
+    fn as_hash_tree(&self) -> HashTree<'_> {
+        match self {
+            NestedTree::Leaf(a) => a.as_hash_tree(),
+            NestedTree::Nested(tree) => tree.as_hash_tree(),
+        }
+    }
+}
+
+impl<K: NestedTreeKeyRequirements, V: NestedTreeValueRequirements> NestedTree<K, V> {
+    #[allow(dead_code)]
+    pub fn get(&self, path: &[K]) -> Option<&V> {
+        if let Some(key) = path.get(0) {
+            match self {
+                NestedTree::Leaf(_) => None,
+                NestedTree::Nested(tree) => tree
+                    .get(key.as_ref())
+                    .and_then(|child| child.get(&path[1..])),
+            }
+        } else {
+            match self {
+                NestedTree::Leaf(value) => Some(value),
+                NestedTree::Nested(_) => None,
+            }
+        }
+    }
+
+    /// Returns true if there is a leaf at the specified path
+    pub fn contains_leaf(&self, path: &[K]) -> bool {
+        if let Some(key) = path.get(0) {
+            match self {
+                NestedTree::Leaf(_) => false,
+                NestedTree::Nested(tree) => tree
+                    .get(key.as_ref())
+                    .map(|child| child.contains_leaf(&path[1..]))
+                    .unwrap_or(false),
+            }
+        } else {
+            matches!(self, NestedTree::Leaf(_))
+        }
+    }
+
+    /// Returns true if there is a leaf or a subtree at the specified path
+    pub fn contains_path(&self, path: &[K]) -> bool {
+        if let Some(key) = path.get(0) {
+            match self {
+                NestedTree::Leaf(_) => false,
+                NestedTree::Nested(tree) => tree
+                    .get(key.as_ref())
+                    .map(|child| child.contains_path(&path[1..]))
+                    .unwrap_or(false),
+            }
+        } else {
+            true
+        }
+    }
+
+    pub fn insert(&mut self, path: &[K], value: V) {
+        if let Some(key) = path.get(0) {
+            match self {
+                NestedTree::Leaf(_) => {
+                    *self = NestedTree::default();
+                    self.insert(path, value);
+                }
+                NestedTree::Nested(tree) => {
+                    if tree.get(key.as_ref()).is_some() {
+                        tree.modify(key.as_ref(), |child| child.insert(&path[1..], value));
+                    } else {
+                        tree.insert(key.clone(), NestedTree::default());
+                        self.insert(path, value);
+                    }
+                }
+            }
+        } else {
+            *self = NestedTree::Leaf(value);
+        }
+    }
+
+    pub fn delete(&mut self, path: &[K]) {
+        if let Some(key) = path.get(0) {
+            match self {
+                NestedTree::Leaf(_) => {}
+                NestedTree::Nested(tree) => {
+                    tree.modify(key.as_ref(), |child| child.delete(&path[1..]));
+                }
+            }
+        } else {
+            *self = NestedTree::default();
+        }
+    }
+
+    pub fn witness(&self, path: &[K]) -> HashTree {
+        if let Some(key) = path.get(0) {
+            match self {
+                NestedTree::Leaf(value) => value.as_hash_tree(),
+                NestedTree::Nested(tree) => {
+                    tree.nested_witness(key.as_ref(), |tree| tree.witness(&path[1..]))
+                }
+            }
+        } else {
+            self.as_hash_tree()
+        }
+    }
+}
+
+pub fn merge_hash_trees<'a>(lhs: HashTree<'a>, rhs: HashTree<'a>) -> HashTree<'a> {
+    use HashTree::{Empty, Fork, Labeled, Leaf, Pruned};
+
+    match (lhs, rhs) {
+        (Pruned(l), Pruned(r)) => {
+            if l != r {
+                panic!("merge_hash_trees: inconsistent hashes");
+            }
+            Pruned(l)
+        }
+        (Pruned(_), r) => r,
+        (l, Pruned(_)) => l,
+        (Fork(l), Fork(r)) => Fork(Box::new((
+            merge_hash_trees(l.0, r.0),
+            merge_hash_trees(l.1, r.1),
+        ))),
+        (Labeled(l_label, l), Labeled(r_label, r)) => {
+            if l_label != r_label {
+                panic!("merge_hash_trees: inconsistent hash tree labels");
+            }
+            Labeled(l_label, Box::new(merge_hash_trees(*l, *r)))
+        }
+        (Empty, Empty) => Empty,
+        (Leaf(l), Leaf(r)) => {
+            if l != r {
+                panic!("merge_hash_trees: inconsistent leaves");
+            }
+            Leaf(l)
+        }
+        (_l, _r) => {
+            panic!("merge_hash_trees: inconsistent tree structure");
+        }
+    }
+}
+
+#[test]
+fn nested_tree_operation() {
+    let mut tree: NestedTree<&str, Vec<u8>> = NestedTree::default();
+    // insertion
+    tree.insert(&["one", "two"], vec![2]);
+    tree.insert(&["one", "three"], vec![3]);
+    assert_eq!(tree.get(&["one", "two"]), Some(&vec![2]));
+    assert_eq!(tree.get(&["one", "two", "three"]), None);
+    assert_eq!(tree.get(&["one"]), None);
+    assert!(tree.contains_leaf(&["one", "two"]));
+    assert!(tree.contains_path(&["one"]));
+    assert!(!tree.contains_leaf(&["one", "two", "three"]));
+    assert!(!tree.contains_path(&["one", "two", "three"]));
+    assert!(!tree.contains_leaf(&["one"]));
+
+    // deleting non-existent key doesn't do anything
+    tree.delete(&["one", "two", "three"]);
+    assert_eq!(tree.get(&["one", "two"]), Some(&vec![2]));
+    assert!(tree.contains_leaf(&["one", "two"]));
+
+    // deleting existing key works
+    tree.delete(&["one", "three"]);
+    assert_eq!(tree.get(&["one", "two"]), Some(&vec![2]));
+    assert_eq!(tree.get(&["one", "three"]), None);
+    assert!(tree.contains_leaf(&["one", "two"]));
+    assert!(!tree.contains_leaf(&["one", "three"]));
+
+    // deleting subtree works
+    tree.delete(&["one"]);
+    assert_eq!(tree.get(&["one", "two"]), None);
+    assert_eq!(tree.get(&["one"]), None);
+    assert!(!tree.contains_leaf(&["one", "two"]));
+    assert!(!tree.contains_leaf(&["one"]));
+}

--- a/src/internet_identity_interface/src/http_gateway.rs
+++ b/src/internet_identity_interface/src/http_gateway.rs
@@ -26,6 +26,7 @@ pub struct HttpRequest {
     pub url: String,
     pub headers: Vec<(String, String)>,
     pub body: ByteBuf,
+    pub certificate_version: Option<u16>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]


### PR DESCRIPTION
This PR adds certification v2 support for assets served by II.
See specification here: https://github.com/dfinity/interface-spec/blob/master/spec/http-gateway-protocol-spec.md#the-http-gateway-protocol-specification

This PR contains only contains the minimal required features of v2
certification.
In particular, we do not yet take advantage of:
* fast redirects
* wildcard certification for certified 404 pages
* certification opt-out for dynamic data (i.e. /metrics)

The certification v1 support is maintained.
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
