### PR TITLE
Remove canister_ids.json

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -520,10 +520,10 @@ jobs:
           dfx canister --network ic --wallet "$wallet" install --mode upgrade \
             --argument "(opt record {archive_config = record { module_hash = blob \"$sha\"; entries_buffer_limit = 10000:nat64; entries_fetch_limit = 1000:nat16; polling_interval_ns = 60000000000:nat64}; canister_creation_cycles_cost = opt (1000000000000:nat64); })" \
             --wasm internet_identity_production.wasm.gz \
-            internet_identity
+            fgte5-ciaaa-aaaad-aaatq-cai
 
       - name: "Deploy archive"
-        run: scripts/deploy-archive --wasm archive.wasm.gz --canister-id internet_identity --network ic
+        run: scripts/deploy-archive --wasm archive.wasm.gz --canister-id fgte5-ciaaa-aaaad-aaatq-cai --network ic
 
 
   # This ... releases

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,7 +1,0 @@
-{
-  "internet_identity": {
-    "identity": "rdmx6-jaaaa-aaaaa-aaadq-cai",
-    "ic": "fgte5-ciaaa-aaaad-aaatq-cai",
-    "nnsdapp": "qjdve-lqaaa-aaaaa-aaaeq-cai"
-  }
-}


### PR DESCRIPTION
The file was only used to deploy II to the mainnet canister from CI, but got in the way when deploying locally to other canisters. Plus the file contained configuration unrelated to II.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
