### PR TITLE
Auto reload CAPTCHA on incorrect input

### DIFF
--- a/src/frontend/src/flows/register/captcha.json
+++ b/src/frontend/src/flows/register/captcha.json
@@ -7,6 +7,6 @@
     "generating": "Generating...",
     "verifying": "Verifying...",
     "next": "Next",
-    "incorrect": "The value you entered is incorrect. Click \"retry\" to generate a new value."
+    "incorrect": "Try one more time."
   }
 }

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1402,9 +1402,12 @@ by all browsers (FF is missing) */
   cursor: pointer;
 }
 
+/** An error state for an input
+ * We leave the text color as default to show the text is still
+ * interactable
+ */
 .c-input.has-error,
 .c-input.has-error:focus {
-  color: var(--rc-error);
   box-shadow: inset 0 0 0 calc(var(--rs-line) * 2) var(--rc-error);
   border-image: none;
 }


### PR DESCRIPTION
This changes the CAPTCHA flow to fetch a new challenge automatically if the user provides incorrect input.

The copy is slightly modified to be shorter and more understandable. The text input is also changed to stay black on error, to show that the input content is still interactable/modifiable.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
