### PR TITLE
Support multiple char replacements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,8 +227,7 @@ dependencies = [
 [[package]]
 name = "captcha"
 version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db21780337b425f968a2c3efa842eeaa4fe53d2bcb1eb27d2877460a862fb0ab"
+source = "git+https://github.com/nmattia/captcha?rev=9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391#9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391"
 dependencies = [
  "base64 0.13.1",
  "hound",

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -23,7 +23,7 @@ rand = { version ="*", default-features = false }
 
 rand_core = { version = "*", default-features = false }
 rand_chacha = { version = "*", default-features = false }
-captcha = "0.0.9"
+captcha = { git = "https://github.com/nmattia/captcha", rev = "9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391" }
 
 # All IC deps
 candid = "0.8"

--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -203,6 +203,8 @@ fn check_challenge(res: ChallengeAttempt) -> Result<(), ()> {
             // Apply all replacements
             *CHAR_REPLACEMENTS
                 .iter()
+                // For each key, see if the char matches any of the values (replaced chars) and if
+                // so replace with the key itself (replacement char)
                 .find_map(|(k, v)| if v.contains(&c) { Some(k) } else { None })
                 .unwrap_or(&c)
         })

--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -124,7 +124,7 @@ fn create_captcha<T: RngCore>(rng: T) -> (Base64, String) {
 }
 
 lazy_static! {
-    /// Problematic characters that are easily mixed up by humans to the "normalized" replacement.
+    /// Problematic characters that are easily mixed up by humans to "normalized" replacement.
     /// I.e. the captcha will only contain a "replaced" character (values below in map) if the
     /// character also appears as a "replacement" (keys below in map). All occurrences of
     /// "replaced" characters in the user's challenge result will be replaced with the


### PR DESCRIPTION
This adds support for mapping multiple chars to one char in the CAPTCHA (e.g. `1`, `I`, `l` etc can all map to `i`).

This is done by reworking the `CHAR_REPLACEMENTS` map to read the "replacement" chars from its keys and "replaced" chars from its values (now an array).

Additionally, this extracts the font creation/parsing to a (lazy) static value, so that the font doesn't have to be recreated every time.

---

NOTE: had to perform some changes [upstream](https://github.com/nmattia/captcha/tree/nm-fonts), will try to get those merged

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
