### PR TITLE
Recognize know dapps by authOrigins

### DIFF
--- a/scripts/update-dapps
+++ b/scripts/update-dapps
@@ -86,7 +86,7 @@ function update() {
             | with_entries(
                 select(
                     [.key]
-                    | inside(["name", "website", "oneLiner", "logo"])
+                    | inside(["name", "website", "oneLiner", "logo", "authOrigins"])
                 )
             )
         ]' \

--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -166,7 +166,15 @@ export const authFlowAuthorize = async (
           derivationOrigin: authContext.authRequest.derivationOrigin,
           i18n,
           knownDapp: getDapps().find(
-            (dapp) => new URL(dapp.website).origin === authContext.requestOrigin
+            // It's a known dapp if, for any known dapp, the request origin matches
+            // * the website
+            // * any (some) of the authOrigins
+            (dapp) =>
+              authContext.requestOrigin === new URL(dapp.website).origin ||
+              (dapp.authOrigins ?? []).some(
+                (authOrigin) =>
+                  authContext.requestOrigin === new URL(authOrigin).origin
+              )
           ),
         })
       );

--- a/src/frontend/src/flows/dappsExplorer/dapps.json
+++ b/src/frontend/src/flows/dappsExplorer/dapps.json
@@ -8,7 +8,11 @@
   {
     "name": "distrikt",
     "oneLiner": "Censorship-resistant fully on-chain social media platform",
-    "website": "https://az5sd-cqaaa-aaaae-aaarq-cai.ic0.app/",
+    "website": "https://distrikt.app",
+    "authOrigins": [
+      "https://distrikt.app",
+      "https://az5sd-cqaaa-aaaae-aaarq-cai.ic0.app/"
+    ],
     "logo": "distrikt_logo.webp"
   },
   {
@@ -21,6 +25,7 @@
     "name": "Juno",
     "oneLiner": "Build Web3 Apps Like It's Web2",
     "website": "https://juno.build",
+    "authOrigins": ["https://console.juno.build"],
     "logo": "juno_logo.svg"
   },
   {
@@ -48,7 +53,11 @@
   },
   {
     "name": "TAGGR",
-    "website": "https://6qfxa-ryaaa-aaaai-qbhsq-cai.ic0.app/#/",
+    "website": "https://taggr.link",
+    "authOrigins": [
+      "https://taggr.link",
+      "https://6qfxa-ryaaa-aaaai-qbhsq-cai.ic0.app"
+    ],
     "logo": "taggr_logo.webp",
     "oneLiner": "Blending forums and blogs - controlled by a DAO"
   },


### PR DESCRIPTION
This extends the matching logic for known dapps to take into account the newly added field `authOrigins` from the portal's showcase.

https://github.com/dfinity/portal/pull/1533

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
