### PR TITLE
Turn off autocapitalization on CAPTCHA

### DIFF
--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -214,6 +214,7 @@ export const promptCaptchaTemplate = <T>({
             ${ref(input)}
             id="captchaInput"
             class="c-input ${asyncReplace(hasError)}"
+            autocapitalize="none"
           />
           <strong class="c-input__message">${asyncReplace(errorText)}</strong>
         </label>


### PR DESCRIPTION
This ensures virtual keyboards (iOS, Android, etc) don't try to capitalize the first letter of the CAPTCHA.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

https://github.com/dfinity/internet-identity/assets/6930756/0d1ed18e-e39c-4cfe-b9ae-87c8f6a37be1

