### PR TITLE
Update support links

### DIFF
--- a/src/frontend/src/flows/dappsExplorer/index.ts
+++ b/src/frontend/src/flows/dappsExplorer/index.ts
@@ -41,7 +41,7 @@ const dappsExplorerTemplate = ({
     <p class="t-paragraph t-centered">
       ${copy.add_your_dapp}
       <a
-        href="https://github.com/dfinity/portal#showcase-submission-guidelines"
+        href="https://identitysupport.dfinity.org/hc/en-us/articles/16195954040724"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -89,8 +89,7 @@ const init = async () => {
   // The canister should already be handling this with a 301 when serving "/faq", this is just a safety
   // measure.
   if (window.location.pathname === "/faq") {
-    const faqUrl =
-      "https://support.dfinity.org/hc/en-us/sections/8730568843412-Internet-Identity";
+    const faqUrl = "https://identitysupport.dfinity.org/hc/en-us";
     window.location.replace(faqUrl);
   }
 

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -43,8 +43,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
             status_code: 301,
             headers: vec![(
                 "location".to_string(),
-                "https://support.dfinity.org/hc/en-us/sections/8730568843412-Internet-Identity"
-                    .to_string(),
+                "https://identitysupport.dfinity.org/hc/en-us".to_string(),
             )],
             body: ByteBuf::new(),
             // Redirects are not allowed as query because certification V1 does not cover headers.


### PR DESCRIPTION
Support has some new links. We now link (or rather, redirect) the old `/faq` endpoint to the identity support landing, and update the dapps explorer submission link to point to the new dapps submission support page: https://identitysupport.dfinity.org/hc/en-us/articles/16195954040724

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
