### PR TITLE
Focus CAPTCHA input on retry

### DIFF
--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -153,10 +153,11 @@ export const promptCaptchaTemplate = <T>({
         challenge,
       });
       if (res === badChallenge) {
-        // on a bad challenge, show some error, clear the input
+        // on a bad challenge, show some error, clear the input & focus
         // and retry
         state.send({ status: "bad" });
         input.value = "";
+        input.focus();
         void doRetry();
       } else {
         onContinue(res);


### PR DESCRIPTION
The CAPTCHA input loses focus when the user clicks the "Verify"/"Next" button.

This re-focuses the input in case the user has to retry, to simplify the flow & draw attention back to the input.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
