### PR TITLE
Remove c-card__content

### DIFF
--- a/src/frontend/src/components/warnBox.ts
+++ b/src/frontend/src/components/warnBox.ts
@@ -27,16 +27,14 @@ export const warnBox = ({
     cssClasses.push(...additionalClasses);
   }
   const contents: TemplateResult = html`
-    <div class="c-card__content">
-      <span class="c-card__label c-card__label--hasIcon" aria-hidden="true">
-        <i class="c-card__icon c-icon c-icon--error__flipped">${warningIcon}</i>
-      </span>
-      <h3 class="t-title c-card__title">${title}</h3>
-      <div data-role="warning-message" class="t-paragraph c-card__paragraph">
-        ${message}
-      </div>
-      ${slot}
+    <span class="c-card__label c-card__label--hasIcon" aria-hidden="true">
+      <i class="c-card__icon c-icon c-icon--error__flipped">${warningIcon}</i>
+    </span>
+    <h3 class="t-title c-card__title">${title}</h3>
+    <div data-role="warning-message" class="t-paragraph c-card__paragraph">
+      ${message}
     </div>
+    ${slot}
   `;
 
   return html`${htmlElement === "aside"

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -47,7 +47,6 @@ export const authenticatorsSection = ({
 
   return html`
     <aside class=${wrapClasses.join(" ")}>
-      <div class="c-card__content">
       ${
         warnFewDevices
           ? html`
@@ -105,7 +104,6 @@ export const authenticatorsSection = ({
           </div>
 
         </div>
-      </div>
     </aside>`;
 };
 

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -937,17 +937,6 @@ by all browsers (FF is missing) */
   fill: var(--rc-onButton);
 }
 
-.c-card__content {
-  position: relative;
-  z-index: var(--z-foreground);
-  /* The card content is insed the c-card, so is padded. But since it
-   * should fit the card itself (and contain all the card' contents) we
-   * enlarge it to counteract the effect of the card's content.
-   */
-  margin: calc(-1 * var(--rs-card-bezel)) calc(-1 * var(--rs-card-bezel-x));
-  padding: var(--rs-card-bezel) var(--rs-card-bezel-x);
-}
-
 .c-card__title {
   /*
     approximation: to make sure the title
@@ -964,6 +953,9 @@ by all browsers (FF is missing) */
 .c-card--modal {
   position: relative;
   border: none;
+  /* The before/after are used for the effects & background so we push
+   * them back with arbitrarily large neg. z-index */
+  isolation: isolate;
   border-radius: var(--rs-card-border-radius);
 }
 
@@ -971,7 +963,7 @@ by all browsers (FF is missing) */
 .c-card--modal::before {
   position: absolute;
   content: "";
-  z-index: 0;
+  z-index: -10;
   inset: 0;
   background-image: linear-gradient(170deg, var(--rg-brand));
   filter: blur(30px);
@@ -984,7 +976,7 @@ by all browsers (FF is missing) */
   content: "";
   position: absolute;
   inset: 0;
-  z-index: var(--z-background);
+  z-index: -9;
   background: var(--rc-background);
   border-radius: var(--rs-card-border-radius);
   box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.4);


### PR DESCRIPTION
The `c-card__content` class was a workaround for pushing forward content inside cards where the z-index had to be adapted to display `::after` behind the content. The workaround itself then led to more marging workarounds.

Instead the wrapping cards now use `isolation: isolate` to create a new stacking context and allow the `::before` and `::after` to simply use arbitrarily large neg. z-indexs.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
