### PR TITLE
Don't use index as 404 for showcase

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -171,9 +171,6 @@ jobs:
       # Build the showcase with a special base URL (used in links and esp. routing)
       # to match the deploy URL: https://dfinity.github.io/internet-identity/
       - run: npm run build:showcase -- --base '/internet-identity/'
-      # the showcase needs the same index.html served on all routes; on GH pages we just show a fake 404 page
-      # that is actually the index.
-      - run: cp dist-showcase/index.html dist-showcase/404.html
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload Pages artifact


### PR DESCRIPTION
The previous showcase build (pre-Astro) needed the index served on 404, since there was actually only a single page built which took care of the routing.

Now that we have one page built per actual page, we don't need this workaround, and instead can serve the actual 404 on missing pages.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
