### PR TITLE
Clean up card warning CSS

### DIFF
--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -954,17 +954,24 @@ by all browsers (FF is missing) */
   position: relative;
   border: none;
   /* The before/after are used for the effects & background so we push
-   * them back with arbitrarily large neg. z-index */
+   * them back with a negative z-index. This prevents them going behind
+   * the rest of the page. */
   isolation: isolate;
   border-radius: var(--rs-card-border-radius);
 }
 
 .c-card--warning::before,
-.c-card--modal::before {
+.c-card--modal::before,
+.c-card--warning::after,
+.c-card--modal::after {
   position: absolute;
   content: "";
-  z-index: -10;
+  z-index: -1;
   inset: 0;
+}
+
+.c-card--warning::before,
+.c-card--modal::before {
   background-image: linear-gradient(170deg, var(--rg-brand));
   filter: blur(30px);
   opacity: 0.75;
@@ -973,10 +980,6 @@ by all browsers (FF is missing) */
 
 .c-card--warning::after,
 .c-card--modal::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: -9;
   background: var(--rc-background);
   border-radius: var(--rs-card-border-radius);
   box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.4);


### PR DESCRIPTION
This cleans up the card warning CSS class furth by clarifying what is used to actually style the card vs. set up for being able to style the pseudo elements, and simplifies the `z-index` values.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
