### PR TITLE
Wrap dapp descriptions in KnownDapp

### DIFF
--- a/src/frontend/src/flows/dappsExplorer/dapps.ts
+++ b/src/frontend/src/flows/dappsExplorer/dapps.ts
@@ -1,3 +1,4 @@
+import { BASE_URL } from "$src/environment";
 import { features } from "$src/features";
 
 // The list of dapps. This is derived from https://github.com/dfinity/portal:
@@ -13,20 +14,56 @@ type ElementOf<Arr> = Arr extends readonly (infer ElementOf)[]
 
 export type DappDescription = ElementOf<typeof dappsJson>;
 
+// A 'known dapp", i.e. a dapp description with the logo fixed up and convenience methods
+export class KnownDapp {
+  constructor(public descr: DappDescription) {}
+
+  // It's a known dapp if the origin matches
+  // * the website
+  // * any (some) of the authOrigins
+  hasOrigin(orig: string): boolean {
+    return (
+      orig === new URL(this.descr.website).origin ||
+      (this.descr.authOrigins ?? []).some(
+        (authOrigin) => orig === new URL(authOrigin).origin
+      )
+    );
+  }
+
+  // Path to use for logo files
+  public get logoSrc(): string {
+    return BASE_URL + "icons/" + this.descr.logo;
+  }
+
+  public get name(): string {
+    return this.descr.name;
+  }
+
+  public get oneLiner(): string | undefined {
+    return this.descr.oneLiner;
+  }
+
+  public get website(): string | undefined {
+    return this.descr.oneLiner;
+  }
+}
+
 // The list of dapps we showcase
-export const getDapps = (): DappDescription[] => {
-  const dapps = [...dappsJson];
+export const getDapps = (): KnownDapp[] => {
+  const dapps = [...dappsJson].map((dapp) => new KnownDapp(dapp));
 
   // XXX: Piggy back on the DUMMY_CAPTCHA feature to assume this is a test build
   // and add test data
   if (features.DUMMY_CAPTCHA) {
     // The dapp used in tests
-    const nnsDappLogo = dapps.find((dapp) => dapp.name === "NNS Dapp");
-    dapps.push({
-      name: "Test Dapp",
-      website: "https://nice-name.com",
-      logo: nnsDappLogo?.logo ?? "no-such-logo",
-    });
+    const nnsDappLogo = dapps.find((dapp) => dapp.descr.name === "NNS Dapp");
+    dapps.push(
+      new KnownDapp({
+        name: "Test Dapp",
+        website: "https://nice-name.com",
+        logo: nnsDappLogo?.descr.logo ?? "no-such-logo",
+      })
+    );
   }
 
   return dapps;

--- a/src/frontend/src/flows/dappsExplorer/index.ts
+++ b/src/frontend/src/flows/dappsExplorer/index.ts
@@ -1,11 +1,10 @@
 import { closeIcon, externalLinkIcon } from "$src/components/icons";
 import { mainWindow } from "$src/components/mainWindow";
-import { BASE_URL } from "$src/environment";
 import { I18n } from "$src/i18n";
 import { mount, renderPage } from "$src/utils/lit-html";
 import { html, TemplateResult } from "lit-html";
 
-import { DappDescription } from "./dapps";
+import { KnownDapp } from "./dapps";
 
 import { nonNullish } from "@dfinity/utils";
 import copyJson from "./copy.json";
@@ -17,7 +16,7 @@ const dappsExplorerTemplate = ({
   back,
   scrollToTop = false,
 }: {
-  dapps: DappDescription[];
+  dapps: KnownDapp[];
   i18n: I18n;
   back: () => void;
   /* put the page into view */
@@ -64,10 +63,10 @@ export const dappsExplorerPage = renderPage(dappsExplorerTemplate);
 /* Template for a single dapp */
 const dappTemplate = ({
   website,
-  logo,
+  logoSrc,
   name,
   oneLiner,
-}: DappDescription): TemplateResult => {
+}: KnownDapp): TemplateResult => {
   return html`
     <a
       href=${website}
@@ -76,7 +75,7 @@ const dappTemplate = ({
       rel="noopener noreferrer"
     >
       <div class="c-action-list__icon" aria-hidden="true">
-        <img src=${BASE_URL + "icons/" + logo} alt=${name} loading="lazy" />
+        <img src=${logoSrc} alt=${name} loading="lazy" />
       </div>
       <div class="c-action-list__label c-action-list__label--stacked">
         <h3 class="t-title t-title--list">${name}</h3>
@@ -95,7 +94,7 @@ const dappTemplate = ({
 export const dappsExplorer = ({
   dapps,
 }: {
-  dapps: DappDescription[];
+  dapps: KnownDapp[];
 }): Promise<void> => {
   const i18n = new I18n();
   return new Promise((resolve) =>

--- a/src/frontend/src/flows/dappsExplorer/teaser.ts
+++ b/src/frontend/src/flows/dappsExplorer/teaser.ts
@@ -1,13 +1,12 @@
-import { BASE_URL } from "$src/environment";
 import { DynamicKey } from "$src/i18n";
 import { html, TemplateResult } from "lit-html";
-import { DappDescription } from "./dapps";
+import { KnownDapp } from "./dapps";
 
 export const dappsHeader = ({
   dapps,
   clickable,
 }: {
-  dapps: DappDescription[];
+  dapps: KnownDapp[];
   clickable: boolean;
 }): TemplateResult => html`
   <figure
@@ -25,7 +24,7 @@ export const dappsTeaser = ({
   click,
   copy: { dapps_explorer, sign_into_dapps },
 }: {
-  dapps: DappDescription[];
+  dapps: KnownDapp[];
   click: () => void;
   copy: { dapps_explorer: DynamicKey; sign_into_dapps: DynamicKey };
 }): TemplateResult => {
@@ -44,7 +43,7 @@ export const dappsTeaser = ({
   </article>`;
 };
 
-const marqueeList = (dapps: DappDescription[]): TemplateResult => {
+const marqueeList = (dapps: KnownDapp[]): TemplateResult => {
   const itemsPerRow = 5;
   const totalRows = 4;
 
@@ -75,12 +74,8 @@ const marqueeList = (dapps: DappDescription[]): TemplateResult => {
         // images start appearing before they're loaded. This then
         // shows an empty space where the image suddenly pops seconds
         // later.
-        ({ logo, name }) => html`<div class="c-marquee__item">
-          <img
-            src=${BASE_URL + "icons/" + logo}
-            alt="${name}"
-            class="c-marquee__image"
-          />
+        ({ logoSrc, name }) => html`<div class="c-marquee__item">
+          <img src=${logoSrc} alt="${name}" class="c-marquee__image" />
         </div>`
       );
 

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -20,7 +20,7 @@ import { toast } from "$src/components/toast";
 import { LEGACY_II_URL } from "$src/config";
 import { addDevice } from "$src/flows/addDevice/manage/addDevice";
 import { dappsExplorer } from "$src/flows/dappsExplorer";
-import { DappDescription, getDapps } from "$src/flows/dappsExplorer/dapps";
+import { getDapps, KnownDapp } from "$src/flows/dappsExplorer/dapps";
 import { dappsHeader, dappsTeaser } from "$src/flows/dappsExplorer/teaser";
 import { recoveryWizard } from "$src/flows/recovery/recoveryWizard";
 import { setupKey, setupPhrase } from "$src/flows/recovery/setupRecovery";
@@ -51,7 +51,7 @@ import { Devices, Protection, RecoveryKey, RecoveryPhrase } from "./types";
 export const authnTemplateManage = ({
   dapps,
 }: {
-  dapps: DappDescription[];
+  dapps: KnownDapp[];
 }): AuthnTemplates => {
   const wrap = ({
     title,
@@ -151,7 +151,7 @@ const displayManageTemplate = ({
   onAddDevice: () => void;
   addRecoveryPhrase: () => void;
   addRecoveryKey: () => void;
-  dapps: DappDescription[];
+  dapps: KnownDapp[];
   exploreDapps: () => void;
   identityBackground: IdentityBackground;
 }): TemplateResult => {


### PR DESCRIPTION
This adds a type wrapper (class), `KnownDapp`, that ensures that the logo field of `DappDescription` is used correctly.

This ensures the path to actual logo files (`"<BASE_URL>/icons/<logo>"`) has to be set only once.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
