### PR TITLE
Remove unnecessary nullish check

### DIFF
--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -211,9 +211,7 @@ export class Chan<A> implements AsyncIterable<A> {
   // consumes the values: if you need to read the value from different
   // places use `.values()` instead.
   protected async *recv(): AsyncIterable<A> {
-    if (nonNullish(this.latest)) {
-      yield this.latest;
-    }
+    yield this.latest;
 
     // Forever loop, yielding entire buffers and then blocking
     // on `snd` (which prevents hot looping)


### PR DESCRIPTION
At some point, `latest` was potentially `undefined` so we checked before `yield`ing it. Some time after that, the value was made mandatory, but the check was never removed.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
