### PR TITLE
Drop WeakRef handling of Chan listeners

### DIFF
--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -165,13 +165,7 @@ export class Chan<A> implements AsyncIterable<A> {
 
   // A list of other channels to which we forward (`send()`) the values
   // sent to us
-  // We use weak references to the channels so that they do not need to deregister explicitely,
-  // but instead we simply drop them when they're gone.
-  private listeners: WeakRef<{ notify: (a: A) => void }>[] = [];
-
-  // Reference to a parent (whose listeners we've added ourselves to) to prevent garbage collection of parent (necessary if parent itself is a listener, to prevent dropping the listener).
-  // This is a bit of a hack, but much cleaner and way less error prone than deregistering listeners by hand.
-  protected parent?: unknown;
+  private listeners: ((a: A) => void)[] = [];
 
   public latest: A;
 
@@ -190,18 +184,8 @@ export class Chan<A> implements AsyncIterable<A> {
       this.buffer.push(a);
     }
 
-    // Finally, broadcast and prune listeners if they're gone
-    this.listeners = this.listeners.reduce<typeof this.listeners>(
-      (acc, ref) => {
-        const listener = ref.deref();
-        if (nonNullish(listener)) {
-          listener.notify(a);
-          acc.push(ref);
-        }
-        return acc;
-      },
-      []
-    );
+    // Finally, broadcast to all listeners
+    this.listeners.forEach((listener) => listener(a));
 
     // and set as latest
     this.latest = a;
@@ -242,16 +226,12 @@ export class Chan<A> implements AsyncIterable<A> {
   ): Chan<B> {
     const { handleValue, latest } = this.__handleMapOpts(opts);
 
-    // Create a chan that the WeakRef can hang on to, but that automatically
-    // translates As into Bs
-    class MappedChan extends Chan<B> {
-      notify(value: A) {
-        handleValue({ send: (a: B) => this.send(a), value });
-      }
-    }
-    const input = new MappedChan(latest);
-    this.listeners.push(new WeakRef(input));
-    this.parent = input; // keep a ref to prevent parent being garbage collected
+    // Create a chan that automatically maps the value
+    const input = new Chan<B>(latest);
+    this.listeners.push((value: A) =>
+      handleValue({ send: (a: B) => input.send(a), value })
+    );
+
     return input;
   }
 


### PR DESCRIPTION
We used `WeakRef`s to know if a particular `Chan` listener was still alive or not; if not, we'd re-register it automatically.

This caused extra complexity in the code, and the implementation was not correct in all cases. In addition to that, the codebase as it is today does not really benefit from this. For these reasons, the extra logic is now removed.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
