### PR TITLE
Push back RC deploy

### DIFF
--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -4,9 +4,9 @@ name: Deploy Release Candidate
 on:
   schedule:
     # Run every Tuesday:
-    #   summer: 5pm Zurich time
-    #   winter: 6pm Zurich time
-    - cron:  '0 16 * * 2'
+    #   summer: 7pm Zurich time
+    #   winter: 8pm Zurich time
+    - cron:  '0 18 * * 2'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This changes the release candidate automated deploy to happen after the end of the (Zurich) work day, to ensure all changes for the day are in. This is still early enough for e.g. the US to have a look during the US day.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
