### PR TITLE
Focus identity field on recovery

### DIFF
--- a/src/frontend/src/flows/recovery/confirmSeedPhrase.test.ts
+++ b/src/frontend/src/flows/recovery/confirmSeedPhrase.test.ts
@@ -7,7 +7,7 @@ const i18n = new I18n("en");
 
 test("word changes state", async () => {
   const template = wordTemplate({
-    word: { check: true, elem: createRef(), word: "hello", shouldFocus: true },
+    word: { check: true, elem: createRef(), word: "hello" },
     update: () => {
       /* */
     },

--- a/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
@@ -14,7 +14,7 @@ import copyJson from "./confirmSeedPhrase.json";
 // A list of words, where "check" indicates if the user needs to double check (re-input) a word
 type Word = { word: string } & (
   | { check: false }
-  | { check: true; elem: Ref<HTMLInputElement>; shouldFocus: boolean }
+  | { check: true; elem: Ref<HTMLInputElement> }
 );
 
 // A list of indices nicely spread over the 24 BIP39 words (anchor is separate)
@@ -47,19 +47,11 @@ const confirmSeedPhraseTemplate = ({
     if (word.check) {
       const elem: Ref<HTMLInputElement> = createRef();
       // NOTE: typescript can't follow if word is deconstructed with {...word}
-      return { word: word.word, check: word.check, elem, shouldFocus: false };
+      return { word: word.word, check: word.check, elem };
     } else {
       return { word: word.word, check: word.check };
     }
   });
-
-  // Focus the first word (that needs to be checked)
-  for (const word of words) {
-    if (word.check) {
-      word.shouldFocus = true;
-      break;
-    }
-  }
 
   // if the identity number has been re-input correctly
   const identityInputState = new Chan<"pending" | "wrong" | "correct">(
@@ -227,7 +219,6 @@ export const wordTemplate = ({
       class="c-recoveryInput"
       ${ref(word.elem)}
       data-expected=${word.word}
-      ?autofocus=${word.shouldFocus}
       data-state=${asyncReplace(state)}
       @input=${() => {
         /* On input, immediately show word as correct when correct, but don't show if a

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -215,7 +215,6 @@ export const wordTemplate = ({
   >
     ${asyncReplace(icon)}
     <input
-      ?autofocus=${i === 0 /* autofocus the first word */}
       @paste=${(e: ClipboardEvent) =>
         withElement(e, (event, element) => {
           e.preventDefault();


### PR DESCRIPTION
Previously, the identity number was just another word in the recoery word grid, so in order to focus it we just focused the first word (during recovery & new phrase confirmation).

Now that the identity is a different field, it is that new field that should be focused; not the first BIP39 word.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
