### PR TITLE
Disable autocapitalization on phrase input

### DIFF
--- a/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
@@ -224,6 +224,7 @@ export const wordTemplate = ({
     ${asyncReplace(icon)}
     <input
       type="text"
+      autocapitalize="none"
       class="c-recoveryInput"
       ${ref(word.elem)}
       data-expected=${word.word}

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -266,6 +266,7 @@ export const wordTemplate = ({
           next.dispatchEvent(newEvent);
         })}
       type="text"
+      autocapitalize="none"
       class="c-recoveryInput"
       ${ref(wordRef)}
       data-role="recovery-word-input"


### PR DESCRIPTION
This sets `autocapitalize=none` on recovery word inputs to avoid mobile virtual keyboards autocapitalizing the BIP39 words.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
