### PR TITLE
Send Slack notification on RC deploy fail

### DIFF
--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -84,3 +84,12 @@ jobs:
             Internet Identity release candidate
             RC link: https://${{ env.ii_canister_id }}.ic0.app
             test app: https://${{ env.testnet_app_canister_id }}.ic0.app
+
+        # Since the this is a scheduled job, a failure won't be shown on any
+        # PR status. To notify the team, we send a message to our Slack channel on failure.
+      - name: Notify Slack on failure
+        uses: ./.github/actions/slack
+        if: ${{ failure() }}
+        with:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MESSAGE: "RC deployment failed"


### PR DESCRIPTION
This updates the RC deployment to notify the team if the deployment failed. This is similar to what we do for other scheduled jobs (node updated, rust update, etc).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
