### PR TITLE
Disable spellcheck when not necessary

### DIFF
--- a/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/confirmSeedPhrase.ts
@@ -217,6 +217,7 @@ export const wordTemplate = ({
     <input
       type="text"
       autocapitalize="none"
+      spellcheck="false"
       class="c-recoveryInput"
       ${ref(word.elem)}
       data-expected=${word.word}

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -266,6 +266,7 @@ export const wordTemplate = ({
         })}
       type="text"
       autocapitalize="none"
+      spellcheck="false"
       class="c-recoveryInput"
       ${ref(wordRef)}
       data-role="recovery-word-input"

--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -216,6 +216,7 @@ export const promptCaptchaTemplate = <T>({
             id="captchaInput"
             class="c-input ${asyncReplace(hasError)}"
             autocapitalize="none"
+            spellcheck="false"
           />
           <strong class="c-input__message">${asyncReplace(errorText)}</strong>
         </label>


### PR DESCRIPTION
This disables browser spellchecking on captcha + recovery words.

The CAPTCHA definitely doesn't spellchecking, and the recovery words anyway get validated against the BIP39 word checklist so don't need the red browser squiggly/dashed underline.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
