### PR TITLE
Remove a flag remaining from migration to MemoryManager.

### DIFF
--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -174,7 +174,6 @@ pub fn arg_with_wasm_hash(wasm: Vec<u8>) -> Option<InternetIdentityInit> {
         canister_creation_cycles_cost: Some(0),
         register_rate_limit: None,
         max_num_latest_delegation_origins: None,
-        migrate_storage_to_memory_manager: None,
     })
 }
 
@@ -185,7 +184,6 @@ pub fn arg_with_rate_limit(rate_limit: RateLimitConfig) -> Option<InternetIdenti
         canister_creation_cycles_cost: None,
         register_rate_limit: Some(rate_limit),
         max_num_latest_delegation_origins: None,
-        migrate_storage_to_memory_manager: None,
     })
 }
 
@@ -198,7 +196,6 @@ pub fn arg_with_anchor_range(
         canister_creation_cycles_cost: None,
         register_rate_limit: None,
         max_num_latest_delegation_origins: None,
-        migrate_storage_to_memory_manager: None,
     })
 }
 

--- a/src/internet_identity/tests/integration/anchor_management/device_management.rs
+++ b/src/internet_identity/tests/integration/anchor_management/device_management.rs
@@ -161,14 +161,7 @@ fn should_not_add_device_for_different_user() {
 #[test]
 fn should_add_additional_device_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister_with_arg(
-        &env,
-        II_WASM_PREVIOUS.clone(),
-        Some(InternetIdentityInit {
-            migrate_storage_to_memory_manager: Some(true),
-            ..Default::default()
-        }),
-    );
+    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
     let user_number = flows::register_anchor(&env, canister_id);
 
     upgrade_ii_canister(&env, canister_id, II_WASM.clone());
@@ -670,14 +663,7 @@ fn should_not_remove_protected_with_different_device() {
 #[test]
 fn should_remove_device_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister_with_arg(
-        &env,
-        II_WASM_PREVIOUS.clone(),
-        Some(InternetIdentityInit {
-            migrate_storage_to_memory_manager: Some(true),
-            ..Default::default()
-        }),
-    );
+    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(

--- a/src/internet_identity/tests/integration/archive_integration.rs
+++ b/src/internet_identity/tests/integration/archive_integration.rs
@@ -50,7 +50,6 @@ mod deployment_tests {
                 canister_creation_cycles_cost: Some(100_000_000_000), // current cost in application subnets
                 register_rate_limit: None,
                 max_num_latest_delegation_origins: None,
-                migrate_storage_to_memory_manager: None,
             }),
         );
         env.add_cycles(ii_canister, 150_000_000_000);
@@ -185,7 +184,6 @@ mod deployment_tests {
                 canister_creation_cycles_cost: None, // current cost in application subnets
                 register_rate_limit: None,
                 max_num_latest_delegation_origins: None,
-                migrate_storage_to_memory_manager: None,
             }),
         )
         .unwrap();
@@ -602,7 +600,6 @@ mod pull_entries_tests {
             canister_creation_cycles_cost: Some(0),
             register_rate_limit: None,
             max_num_latest_delegation_origins: None,
-            migrate_storage_to_memory_manager: None,
         };
 
         let ii_canister = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(init_arg));

--- a/src/internet_identity/tests/integration/delegation.rs
+++ b/src/internet_identity/tests/integration/delegation.rs
@@ -6,9 +6,7 @@ use canister_tests::flows;
 use canister_tests::framework::*;
 use ic_test_state_machine_client::CallError;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
-use internet_identity_interface::internet_identity::types::{
-    GetDelegationResponse, InternetIdentityInit,
-};
+use internet_identity_interface::internet_identity::types::GetDelegationResponse;
 use regex::Regex;
 use serde_bytes::ByteBuf;
 use std::ops::Add;
@@ -240,14 +238,7 @@ fn should_get_multiple_valid_delegations() -> Result<(), CallError> {
 #[test]
 fn should_get_valid_delegation_for_old_anchor_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister_with_arg(
-        &env,
-        II_WASM_PREVIOUS.clone(),
-        Some(InternetIdentityInit {
-            migrate_storage_to_memory_manager: Some(true),
-            ..Default::default()
-        }),
-    );
+    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com";
     let pub_session_key = ByteBuf::from("session public key");

--- a/src/internet_identity/tests/integration/rollback.rs
+++ b/src/internet_identity/tests/integration/rollback.rs
@@ -5,27 +5,14 @@ use candid::Principal;
 use canister_tests::api::internet_identity as api;
 use canister_tests::flows;
 use canister_tests::framework::*;
-use ic_cdk::api::management_canister::main::CanisterId;
-use ic_test_state_machine_client::{CallError, StateMachine};
-use internet_identity_interface::internet_identity::types::InternetIdentityInit;
+use ic_test_state_machine_client::CallError;
 use serde_bytes::ByteBuf;
-
-fn install_previous_ii_canister_with_memory_manager(env: &StateMachine) -> CanisterId {
-    install_ii_canister_with_arg(
-        env,
-        II_WASM_PREVIOUS.clone(),
-        Some(InternetIdentityInit {
-            migrate_storage_to_memory_manager: Some(true),
-            ..Default::default()
-        }),
-    )
-}
 
 /// Tests simple upgrade and downgrade.
 #[test]
 fn ii_canister_can_be_upgraded_and_rolled_back() {
     let env = env();
-    let canister_id = install_previous_ii_canister_with_memory_manager(&env);
+    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
     upgrade_ii_canister(&env, canister_id, II_WASM.clone());
     api::health_check(&env, canister_id);
     upgrade_ii_canister(&env, canister_id, II_WASM_PREVIOUS.clone());
@@ -36,7 +23,7 @@ fn ii_canister_can_be_upgraded_and_rolled_back() {
 #[test]
 fn upgrade_and_rollback_keeps_anchor_intact() {
     let env = env();
-    let canister_id = install_previous_ii_canister_with_memory_manager(&env);
+    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
     let user_number = flows::register_anchor(&env, canister_id);
     let mut devices_before = api::get_anchor_info(&env, canister_id, principal_1(), user_number)
         .unwrap()
@@ -63,7 +50,7 @@ fn should_keep_new_anchor_across_rollback() -> Result<(), CallError> {
     let env = env();
 
     // start with the previous release
-    let canister_id = install_previous_ii_canister_with_memory_manager(&env);
+    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
     api::init_salt(&env, canister_id)?;
 
     // use the new version to register an anchor

--- a/src/internet_identity/tests/integration/stable_memory/test_setup_helpers.rs
+++ b/src/internet_identity/tests/integration/stable_memory/test_setup_helpers.rs
@@ -7,10 +7,8 @@ pub(crate) fn prepare_persistent_state_v7(anchor_count: usize) {
     let env = env();
     const FIRST_ANCHOR_NUMBER: AnchorNumber = 1000;
     const RANGE_SIZE: u64 = 5000;
-    let arg = InternetIdentityInit {
-        migrate_storage_to_memory_manager: Some(true),
-        ..arg_with_anchor_range((FIRST_ANCHOR_NUMBER, FIRST_ANCHOR_NUMBER + RANGE_SIZE)).unwrap()
-    };
+    let arg =
+        arg_with_anchor_range((FIRST_ANCHOR_NUMBER, FIRST_ANCHOR_NUMBER + RANGE_SIZE)).unwrap();
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(arg));
     let stats = api::stats(&env, canister_id).expect("Failed getting stats.");
     assert_eq!(7, stats.storage_layout_version);

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -192,7 +192,6 @@ pub struct InternetIdentityInit {
     pub canister_creation_cycles_cost: Option<u64>,
     pub register_rate_limit: Option<RateLimitConfig>,
     pub max_num_latest_delegation_origins: Option<u64>,
-    pub migrate_storage_to_memory_manager: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
The migration to `MemoryManager` (storage v7) is completed, so the flag `InternetIdentityInit.migrate_storage_to_memory_manager` is now obsolete hence can be removed.