### PR TITLE
Use HTML autofocus attribute

### DIFF
--- a/src/frontend/src/components/anchorPicker.test.ts
+++ b/src/frontend/src/components/anchorPicker.test.ts
@@ -1,24 +1,19 @@
 import { render } from "lit-html";
 import { mkAnchorPicker } from "./anchorPicker";
 
-const commonProps = {
-  button: "go",
-  recoverAnchor: () => {},
-  register: () => {},
-  addDevice: () => {},
-};
-
 test("first anchor is focused", async () => {
   const picker = mkAnchorPicker({
     savedAnchors: [BigInt(10000), BigInt(9990042)],
     pick: () => {},
     moreOptions: () => {},
-    ...commonProps,
+    focus: true,
   });
   render(picker.template, document.body);
-  // Tick once, otherwise element isn't focused yet
-  await tick();
-  const elem = document.activeElement as HTMLElement;
+  // jsdom does not follow the HTML spec for 'autofocus':
+  //    https://github.com/jsdom/jsdom/issues/3041
+  // so instead of checking for the element to be focused, we just check that
+  // the attribute is present and trust the HTML spec.
+  const elem = document.querySelector("[autofocus]") as HTMLElement;
   expect(elem.dataset.anchorId).toBe("10000");
 });
 
@@ -30,7 +25,7 @@ test("pick saved anchor", async () => {
       picked = anchor;
     },
     moreOptions: () => {},
-    ...commonProps,
+    focus: true,
   });
   render(picker.template, document.body);
   // Tick once, otherwise element isn't focused yet

--- a/src/frontend/src/components/anchorPicker.ts
+++ b/src/frontend/src/components/anchorPicker.ts
@@ -1,4 +1,3 @@
-import { autofocus } from "$src/utils/lit-html";
 import { NonEmptyArray } from "$src/utils/utils";
 import { html, TemplateResult } from "lit-html";
 import { arrowRight } from "./icons";
@@ -48,7 +47,7 @@ const anchorItem = (props: {
 }): TemplateResult => html`
   <li class="c-list__item c-list__item--vip c-list__item--icon icon-trigger">
     <button
-      ${props.focus ? autofocus : undefined}
+      ?autofocus=${props.focus}
       data-anchor-id=${props.anchor}
       class="c-list__parcel c-list__parcel--select"
       @click="${() => props.pick(props.anchor)}"

--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -7,7 +7,7 @@ import {
   IIWebAuthnIdentity,
   RegisterResult,
 } from "$src/utils/iiConnection";
-import { autofocus, mount, renderPage, withRef } from "$src/utils/lit-html";
+import { mount, renderPage, withRef } from "$src/utils/lit-html";
 import { Chan } from "$src/utils/utils";
 import { ECDSAKeyIdentity } from "@dfinity/identity";
 import { html, TemplateResult } from "lit-html";
@@ -211,7 +211,7 @@ export const promptCaptchaTemplate = <T>({
         <label>
           <strong class="t-strong">${copy.instructions}</strong>
           <input
-            ${focus ? autofocus : undefined}
+            ?autofocus=${focus}
             ${ref(input)}
             id="captchaInput"
             class="c-input ${asyncReplace(hasError)}"

--- a/src/frontend/src/utils/lit-html.ts
+++ b/src/frontend/src/utils/lit-html.ts
@@ -61,15 +61,6 @@ export const mount = (callback: (elem: Element) => void): DirectiveResult =>
     }
   });
 
-/* A lit-html directive that focuses the element when the element is added
- * to the DOM.
- */
-export const autofocus = mount((elem: Element) => {
-  if (elem instanceof HTMLElement) {
-    elem.focus();
-  }
-});
-
 /* A wrapper for lit-html's render, rendering a page to the "pageContent" element */
 export function renderPage<
   T extends (props: Parameters<T>[0]) => TemplateResult


### PR DESCRIPTION
This replaces our custom `autofocus` lit directive with the simple, more standard
[`autofocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus) HTML attribute. When set to true, this attribute will ensure the element it is attached to is focused when inserted in the DOM. If several elements have the attribute set, only the first element will be focused.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
