### PR TITLE
Remove spacing on info screens

### DIFF
--- a/src/frontend/src/components/infoScreen.ts
+++ b/src/frontend/src/components/infoScreen.ts
@@ -71,7 +71,7 @@ export const infoScreenTemplate = ({
         ${cancelText}
       </button>
     </div>
-    <section style="margin-top: 7em;" class="c-marketing-block">
+    <section class="c-marketing-block">
       ${entries.map((entry) => renderEntry(entry))}
     </section>
   `;

--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -51,7 +51,7 @@ const savePasskeyTemplate = ({
     >
       ${copy.cancel}
     </button>
-    <section style="margin-top: 7em;" class="c-marketing-block">
+    <section class="c-marketing-block">
       <aside class="l-stack">
         <h3 class="t-title">${copy.what_is_passkey}</h3>
         <ul class="c-list c-list--bulleted">


### PR DESCRIPTION
We introduced arbitrary spacing on some screens, before we had the stepper, for the page to be less cramped. We now have the stepper and can remove the spacing.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4e0bd2586/desktop/addPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4e0bd2586/desktop/addPhraseWarning.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4e0bd2586/desktop/savePasskey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4e0bd2586/mobile/addPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4e0bd2586/mobile/addPhraseWarning.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4e0bd2586/mobile/savePasskey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
