### PR TITLE
Add info screens for device operations

### DIFF
--- a/src/frontend/src/components/infoScreen.ts
+++ b/src/frontend/src/components/infoScreen.ts
@@ -2,6 +2,7 @@ import { infoIconNaked, warningIcon } from "$src/components/icons";
 import { mainWindow } from "$src/components/mainWindow";
 import { DynamicKey } from "$src/i18n";
 import { mount, TemplateElement } from "$src/utils/lit-html";
+import { nonNullish } from "@dfinity/utils";
 import { html, TemplateResult } from "lit-html";
 
 /* An entry in the info screen */
@@ -37,7 +38,7 @@ export const infoScreenTemplate = ({
   cancelText: DynamicKey | string;
   title: DynamicKey | string;
   paragraph: TemplateElement;
-  entries: {
+  entries?: {
     header: TemplateElement;
     content: TemplateElement | TemplateElement[];
   }[];
@@ -71,8 +72,13 @@ export const infoScreenTemplate = ({
         ${cancelText}
       </button>
     </div>
-    <section class="c-marketing-block">
-      ${entries.map((entry) => renderEntry(entry))}
+    ${
+      nonNullish(entries) && entries.length > 0
+        ? html`<section class="c-marketing-block">
+            ${entries.map((entry) => renderEntry(entry))}
+          </section>`
+        : undefined
+    }
     </section>
   `;
 

--- a/src/frontend/src/flows/manage/deviceSettings.json
+++ b/src/frontend/src/flows/manage/deviceSettings.json
@@ -1,0 +1,49 @@
+{
+  "en": {
+    "protect_label": "Security warning",
+    "protect_title": "Lock your recovery phrase",
+    "protect_paragraph": "This will take a few minutes. Make sure no one is watching your screen, and that you have a pen and paper or password manager ready. ",
+    "protect_next": "Lock recovery phrase",
+    "protect_cancel": "Cancel",
+
+    "protect_what_happens_q": "What happens when I lock my recovery phrase?",
+    "protect_what_happens_a": "You will need to input your recovery phrase whenever you want to reset it or unlock it. So if you lose your locked phrase, you will not be able to recover or reset it.",
+
+    "protect_save_q": "How do I save my new recovery phrase?",
+    "protect_save_a_1": "Save in a password manager",
+    "protect_save_a_2": "Store in a safe deposit box",
+    "protect_save_a_3": "Write down and store in multiple secure places",
+
+    "protect_use_q": "When should I use my recovery phrase?",
+    "protect_use_a": "If you lose access to all your devices and have no other method for accessing your Internet Identity",
+
+    "protect_share_q": "Should I share my recovery phrase?",
+    "protect_share_a": "Never! If someone asks for your recovery phrase, they are likely trying to steal access to your accounts",
+
+    "unprotect_label": "Security warning",
+    "unprotect_title": "Unlock your Recovery Phrase",
+    "unprotect_paragraph": "If you unlock your recovery phrase, you will be able to reset your recovery phrase without re-entering the current phrase. Make sure you are in a secure environment. Are you sure you want to proceed?",
+    "unprotect_next": "Unlock",
+    "unprotect_cancel": "Cancel",
+
+    "reset_label": "Security warning",
+    "reset_title": "Reset your recovery phrase",
+    "reset_paragraph": "This will take a few minutes. Make sure no one is watching your screen, and that you have a pen and paper or password manager ready. ",
+    "reset_next": "Reset Recovery Phrase",
+    "reset_cancel": "Cancel",
+
+    "reset_what_happens_q": "What happens when I reset my recovery phrase?",
+    "reset_what_happens_a": "You will be given a new recovery phrase, and your previous recovery phrase is no longer valid",
+
+    "reset_save_q": "How do I save my new recovery phrase?",
+    "reset_save_a_1": "Save in a password manager",
+    "reset_save_a_2": "Store in a safe deposit box",
+    "reset_save_a_3": "Write down and store in multiple secure places",
+
+    "reset_use_q": "When should I use my recovery phrase?",
+    "reset_use_a": "If you lose access to all your devices and have no other method for accessing your Internet Identity",
+
+    "reset_share_q": "Should I share my recovery phrase?",
+    "reset_share_a": "Never! If someone asks for your recovery phrase, they are likely trying to steal access to your accounts"
+  }
+}

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -237,8 +237,8 @@ export class MainView extends View {
   async protect(deviceName: string, seedPhrase: string): Promise<void> {
     await this.openDeviceActions({ deviceName });
     await this.deviceAction({ deviceName, action: "protect" }).click();
-    await this.browser.waitUntil(() => this.browser.isAlertOpen());
-    await this.browser.acceptAlert();
+    await this.browser.$('[data-page="protect-phrase-info"]').waitForExist();
+    await this.browser.$('[data-action="next"]').click();
 
     const recoveryView = new RecoverView(this.browser);
     await recoveryView.waitForSeedInputDisplay();
@@ -255,8 +255,8 @@ export class MainView extends View {
   async unprotect(deviceName: string, seedPhrase: string): Promise<void> {
     await this.openDeviceActions({ deviceName });
     await this.deviceAction({ deviceName, action: "unprotect" }).click();
-    await this.browser.waitUntil(() => this.browser.isAlertOpen());
-    await this.browser.acceptAlert();
+    await this.browser.$('[data-page="unprotect-phrase-info"]').waitForExist();
+    await this.browser.$('[data-action="next"]').click();
 
     const recoveryView = new RecoverView(this.browser);
     await recoveryView.waitForSeedInputDisplay();
@@ -273,8 +273,8 @@ export class MainView extends View {
   async reset(deviceName: string): Promise<void> {
     await this.openDeviceActions({ deviceName });
     await this.deviceAction({ deviceName, action: "reset" }).click();
-    await this.browser.waitUntil(() => this.browser.isAlertOpen());
-    await this.browser.acceptAlert();
+    await this.browser.$('[data-page="reset-phrase-info"]').waitForExist();
+    await this.browser.$('[data-action="next"]').click();
   }
 
   async removeNotDisplayed(deviceName: string): Promise<void> {

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -28,6 +28,11 @@ import { dappsExplorerPage } from "$src/flows/dappsExplorer";
 import { getDapps } from "$src/flows/dappsExplorer/dapps";
 import { authnTemplateManage, displayManagePage } from "$src/flows/manage";
 import {
+  protectDeviceInfoPage,
+  resetPhraseInfoPage,
+  unprotectDeviceInfoPage,
+} from "$src/flows/manage/deviceSettings";
+import {
   checkIndices,
   confirmSeedPhrasePage,
 } from "$src/flows/recovery/confirmSeedPhrase";
@@ -208,6 +213,27 @@ export const iiPages: Record<string, () => void> = {
     manage.pick({
       anchors: [BigInt(10000), BigInt(243099)],
       moreOptions: () => console.log("More options requested"),
+    }),
+
+  protectDeviceInfo: () =>
+    protectDeviceInfoPage({
+      next: () => console.log("next"),
+      cancel: () => console.log("cancel"),
+      i18n,
+    }),
+
+  unprotectDeviceInfo: () =>
+    unprotectDeviceInfoPage({
+      next: () => console.log("next"),
+      cancel: () => console.log("cancel"),
+      i18n,
+    }),
+
+  resetPhraseInfo: () =>
+    resetPhraseInfoPage({
+      next: () => console.log("next"),
+      cancel: () => console.log("cancel"),
+      i18n,
     }),
 
   recoverWithPhrase: () =>


### PR DESCRIPTION
This adds informative screens when resetting, locking & unlocking a phrase.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/84c3e3858/desktop/protectDeviceInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/84c3e3858/desktop/resetPhraseInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/84c3e3858/desktop/unprotectDeviceInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/84c3e3858/mobile/protectDeviceInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/84c3e3858/mobile/resetPhraseInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/84c3e3858/mobile/unprotectDeviceInfo.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
