### PR TITLE
Fix screenshot workflow on empty description

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -317,7 +317,7 @@ jobs:
               repo: context.repo.repo,
             })
 
-            let [ before, rest ] = pr.data.body.split(REPORT_START);
+            let [ before, rest ] = (pr.data.body ?? "").split(REPORT_START);
             rest = rest ?? "";
             let [ _outdated, after ] = rest.split(REPORT_STOP);
             after = after ?? "";


### PR DESCRIPTION
The screenshot workflow made the assumption that all PRs had a body; in practice this may not be the case. PRs created without a description will have a `null` body.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
