### PR TITLE
Use get_anchor_credentials for checking recovery

### DIFF
--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -188,7 +188,6 @@ export const resetPhrase = async ({
     ? await deviceConnection(
         connection,
         userNumber,
-        device,
         "Please input your recovery phrase to reset it."
       )
     : connection;
@@ -313,7 +312,6 @@ export const protectDevice = async ({
   const newConnection = await deviceConnection(
     connection,
     userNumber,
-    device,
     "Please input your recovery phrase to lock it."
   );
 
@@ -386,7 +384,6 @@ export const unprotectDevice = async (
   const newConnection = await deviceConnection(
     connection,
     userNumber,
-    device,
     "Please input your recovery phrase to unlock it."
   );
 
@@ -407,14 +404,12 @@ export const unprotectDevice = async (
 const deviceConnection = async (
   connection: Connection,
   userNumber: bigint,
-  device: DeviceData & RecoveryPhrase,
   recoveryPhraseMessage: string
 ): Promise<AuthenticatedConnection | null> => {
   try {
     const loginResult = await recoverWithPhrase({
       userNumber,
       connection,
-      device,
       message: recoveryPhraseMessage,
     });
     switch (loginResult.tag) {

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -16,7 +16,6 @@ import { apiResultToLoginFlowResult } from "$src/utils/flowResult";
 import { DynamicKey } from "$src/utils/i18n";
 import { Connection } from "$src/utils/iiConnection";
 import { renderPage, withRef } from "$src/utils/lit-html";
-import { RecoveryDevice } from "$src/utils/recoveryDevice";
 import { Chan } from "$src/utils/utils";
 import { isNullish } from "@dfinity/utils";
 import { wordlists } from "bip39";
@@ -302,12 +301,10 @@ export const recoverWithPhrasePage = <
 export const recoverWithPhrase = ({
   userNumber,
   connection,
-  device,
   message,
 }: {
   userNumber: bigint;
   connection: Connection;
-  device: RecoveryDevice;
   message: TemplateResult | string;
 }): Promise<LoginFlowSuccess | LoginFlowCanceled> => {
   return new Promise((resolve) => {
@@ -317,7 +314,7 @@ export const recoverWithPhrase = ({
         const mnemonic = dropLeadingUserNumber(phrase);
         const result = await withLoader(async () =>
           apiResultToLoginFlowResult(
-            await connection.fromSeedPhrase(userNumber, mnemonic, device)
+            await connection.fromSeedPhrase(userNumber, mnemonic)
           )
         );
         return result;

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -62,7 +62,6 @@ const runRecovery = async (
     ? await recoverWithPhrase({
         userNumber,
         connection,
-        device,
         message: html`Type your recovery phrase below to access your Internet
           Identity <strong class="t-strong">${userNumber}</strong>`,
       })

--- a/src/frontend/src/utils/flowResult.ts
+++ b/src/frontend/src/utils/flowResult.ts
@@ -83,6 +83,13 @@ export const apiResultToLoginFlowResult = (
           "Failed to register with Internet Identity, because the CAPTCHA challenge wasn't successful",
       };
     }
+    case "noSeedPhrase": {
+      return {
+        tag: "err",
+        title: "No Recovery Phrase",
+        message: "No recovery found for this Identity.",
+      };
+    }
     case "seedPhraseFail": {
       return {
         tag: "err",


### PR DESCRIPTION
This changes `fromSeedPhrase` to use the "new" `get_anchor_credentials` API endpoint to retrieve a list of known recovery phrase public keys.

Previously we required the caller to provide a `device` which had to be looked up before.

This is preparation work for simplifying the recovery flow, where we won't even be asking the user for their identity number prior to prompting them with the recovery phrase input.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
