### PR TITLE
Use credentials instead of devices to authenticate

### DIFF
--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -67,8 +67,25 @@ const init = (
     ) as HTMLButtonElement | null;
     if (buttonContinue !== null) {
       buttonContinue.onclick = async () => {
+        const { pubkey, credential_id } = device;
+
+        // This is a sanity check to give a more precise error message in case the
+        // inferred recovery device does not have webauthn credentials
+        if (credential_id.length === 0) {
+          await displayError({
+            title: "No credentials found",
+            message:
+              "There were no credentials associated with the recovery device",
+            primaryButton: "Try again",
+          });
+          return deviceRecoveryPage(userNumber, connection, device).then(
+            (res) => resolve(res)
+          );
+        }
         const result = apiResultToLoginFlowResult(
-          await connection.fromWebauthnDevices(userNumber, [device])
+          await connection.fromWebauthnCredentials(userNumber, [
+            { credential_id: credential_id[0], pubkey },
+          ])
         );
 
         switch (result.tag) {


### PR DESCRIPTION
This replaces `fromWebauthnDevices` with `fromWebauthnCredentials`, which is more correct. The reason is that all devices may not have credentials. Previously, trying to build an (sign) identity with a device without credential was an error implicitly ignored.

This is part of the work for simplifying the recovery flow, and is also necessary in order to fully deprecate the `lookup` endpoint.

The error handling in `recoverWith/device.ts` will be replaced very soon to reflect the new planned recovery flow.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
