### PR TITLE
Read user number from recovery phrase input

### DIFF
--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -187,7 +187,6 @@ export const resetPhrase = async ({
   const opConnection = isProtected(device)
     ? await deviceConnection(
         connection,
-        userNumber,
         "Please input your recovery phrase to reset it."
       )
     : connection;
@@ -286,12 +285,10 @@ const protectDeviceInfo = (): Promise<"ok" | "cancel"> => {
 
 /* Protect the device and re-render the device settings (with the updated device) */
 export const protectDevice = async ({
-  userNumber,
   connection,
   device,
   reload,
 }: {
-  userNumber: bigint;
   connection: AuthenticatedConnection;
   device: DeviceData & RecoveryPhrase;
   reload: () => void;
@@ -311,7 +308,6 @@ export const protectDevice = async ({
   // with the device.
   const newConnection = await deviceConnection(
     connection,
-    userNumber,
     "Please input your recovery phrase to lock it."
   );
 
@@ -367,7 +363,6 @@ const unprotectDeviceInfo = (): Promise<"ok" | "cancel"> => {
 
 /* Unprotect the device and re-render the device settings (with the updated device) */
 export const unprotectDevice = async (
-  userNumber: bigint,
   connection: AuthenticatedConnection,
   device: DeviceData & RecoveryPhrase,
   back: () => void
@@ -383,7 +378,6 @@ export const unprotectDevice = async (
   // NOTE: we do need to be authenticated with the device in order to unprotect it
   const newConnection = await deviceConnection(
     connection,
-    userNumber,
     "Please input your recovery phrase to unlock it."
   );
 
@@ -403,12 +397,10 @@ export const unprotectDevice = async (
 // NOTE: this expects a recovery phrase device
 const deviceConnection = async (
   connection: Connection,
-  userNumber: bigint,
   recoveryPhraseMessage: string
 ): Promise<AuthenticatedConnection | null> => {
   try {
     const loginResult = await recoverWithPhrase({
-      userNumber,
       connection,
       message: recoveryPhraseMessage,
     });

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -374,14 +374,12 @@ export const readRecovery = ({
       const protection: Protection = isProtected(device)
         ? {
             isProtected: true,
-            unprotect: () =>
-              unprotectDevice(userNumber, connection, device, reload),
+            unprotect: () => unprotectDevice(connection, device, reload),
           }
         : {
             isProtected: false,
             protect: () =>
               protectDevice({
-                userNumber,
                 connection,
                 device,
                 reload,

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.test.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.test.ts
@@ -1,0 +1,27 @@
+import { vi } from "vitest";
+import { recoverWithPhrasePage } from "./phrase";
+
+test("user number is set", () => {
+  const f = vi.fn();
+
+  recoverWithPhrasePage(
+    {
+      confirm: () => {
+        /**/
+      },
+      back: () => {
+        /**/
+      },
+      verify: ({ userNumber }) => {
+        f(userNumber);
+        return Promise.resolve({ tag: "err", message: "this is a test" });
+      },
+      message: "",
+    },
+    document.body
+  );
+
+  document.querySelectorAll("input")[0].value = "12345";
+  (document.querySelector('[data-action="next"]') as HTMLButtonElement).click();
+  expect(f).toHaveBeenCalledWith(BigInt(12345));
+});

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -60,7 +60,6 @@ const runRecovery = async (
 
   const res = isRecoveryPhrase(device)
     ? await recoverWithPhrase({
-        userNumber,
         connection,
         message: html`Type your recovery phrase below to access your Internet
           Identity <strong class="t-strong">${userNumber}</strong>`,

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -238,11 +238,13 @@ export const iiPages: Record<string, () => void> = {
 
   recoverWithPhrase: () =>
     recoverWithPhrasePage<
-      { tag: "ok"; words: string },
+      { tag: "ok"; userNumber: bigint; words: string[] },
       { tag: "err"; message: string }
     >({
-      verify: (words: string) => Promise.resolve({ tag: "ok", words }),
-      confirm: ({ words }) => console.log("confirmed: " + words),
+      verify: ({ userNumber, words }) =>
+        Promise.resolve({ tag: "ok", userNumber, words }),
+      confirm: ({ userNumber, words }) =>
+        console.log("confirmed: ", userNumber, words),
       back: () => console.log("remove"),
       message: "Something cool will happen if you type your anchor",
     }),


### PR DESCRIPTION
This changes the recovery phrase screens to not require the userNumber to be known before the user types their phrase. Instead, the number is read from the input.

This is part of the ongoing work for simplifying the recovery flow. By not requiring the user number to be known, we'll be able to skip the user number prompt step.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
