### PR TITLE
Improve recovery phrase input UX

### DIFF
--- a/src/frontend/src/flows/recovery/displaySeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/displaySeedPhrase.ts
@@ -61,23 +61,19 @@ const displaySeedPhraseTemplate = ({
           ${operation === "create" ? copy.header : copy.header_reset}
         </p>
       </hgroup>
-      <div class="c-input--anchor l-stack">
-        <label class="c-input--anchor__wrap" aria-label="Identity Anchor">
-          <div
-            class="c-input c-input--vip c-input--readonly c-input--centered c-input--spacious"
-          >
-            ${userNumberWord}
-          </div>
-        </label>
-      </div>
-
       <div class="l-stack">
-        <output class="c-input c-input--recovery"
-          ><ol
+        <output class="c-input c-input--recovery">
+          <ol
             data-role="recovery-words"
             translate="no"
             class="c-list c-list--recovery"
           >
+            <li
+              class="c-list--recovery-word c-list--recovery-word--important"
+              style="--index: '#';"
+            >
+              ${userNumberWord}
+            </li>
             ${recoveryWords.map(
               (word, i) =>
                 html`<li

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -215,6 +215,8 @@
   --rc-positive: var(--vc-brand-green);
   --rc-onPositive: var(--rc-dark);
 
+  --rc-input-placeholder: var(--vc-grey);
+
   --rc-input: var(--rc-light);
   --rc-onInput: var(--rc-dark);
 
@@ -1393,7 +1395,7 @@ by all browsers (FF is missing) */
 }
 
 .c-input::placeholder {
-  color: var(--vc-grey);
+  color: var(--rc-input-placeholder);
 }
 
 .c-button-group {
@@ -1707,7 +1709,6 @@ by all browsers (FF is missing) */
   font-size: 0.7em;
   font-weight: bold;
   font-family: monospace;
-  text-align: center;
 }
 
 @media screen and (max-width: 512px) {
@@ -1840,6 +1841,11 @@ by all browsers (FF is missing) */
   color: transparent;
 }
 
+.c-list--recovery-word--important {
+  display: block;
+  margin: 0.5rem auto;
+}
+
 .c-recoveryInput {
   display: block;
 
@@ -1852,6 +1858,10 @@ by all browsers (FF is missing) */
 
   /* fixes layout-shifts in safari when input is empty */
   position: absolute;
+}
+
+.c-recoveryInput::placeholder {
+  color: var(--rc-input-placeholder);
 }
 
 .c-list__item--vip {

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -630,16 +630,9 @@ export class RecoverView extends View {
 
   async enterSeedPhrase(seedPhrase: string): Promise<void> {
     const words = seedPhrase.split(" ").filter(Boolean);
-    // eslint-disable-next-line
-    const userNumberWord = words.shift()!;
-    const userNumberInput = await this.browser.$(
-      'input[data-role="anchor-input"]'
-    );
-    await userNumberInput.setValue(userNumberWord);
 
-    const inputs = await this.browser.$$(
-      'input[data-role="recovery-word-input"]'
-    );
+    // Assume the only inputs on this screen are the phrase inputs
+    const inputs = await this.browser.$$("input");
     for (let i = 0; i < words.length; i++) {
       await inputs[i].setValue(words[i]);
     }


### PR DESCRIPTION

This changes the recovery phrase screens (creation, confirmation & actual recovery). The previous screens had some UX issues. In particular:

* The previous screens displayed the identity number separately. Because the style was different from the other words, and because the placeholder was very visible, some users failed to understand the field was an input.
* The previous screens made use of icons for feedback on bad input, but did not always show an error message, and did not allow the user to view the error message once it had disappeared. We now use the browser's validity API everywhere, and re-show the validity message when the error icon is clicked.
* All error messages for recovery word input are clarified.



https://github.com/dfinity/internet-identity/assets/6930756/62bf9c2e-8dfe-44de-842c-55b9bc1b9d70


https://github.com/dfinity/internet-identity/assets/6930756/0b494e0e-cd7b-4c9b-8de7-a50d869f9476


https://github.com/dfinity/internet-identity/assets/6930756/0515a23d-663c-49b1-b1d3-7f824e10696a


<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5db42d39/desktop/confirmSeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5db42d39/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5db42d39/desktop/recoverWithPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5db42d39/mobile/confirmSeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5db42d39/mobile/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5db42d39/mobile/recoverWithPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
