### PR TITLE
Clean up toast corners

### DIFF
--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -111,6 +111,7 @@
   --vc-brand-orange: #f15a24;
   --vc-brand-yellow: #fbb03b;
   --vc-brand-pink: #ed1e79;
+  --vc-brand-pink--light: rgba(251, 172, 202, 1);
   --vc-brand-pink--transparent: rgba(237, 30, 121, 0.4);
   --vc-brand-purple: #4b19d6;
   --vc-brand-purple-light: #890eed;
@@ -202,7 +203,7 @@
   --rc-onButton: var(--rc-text-interaction-inverted);
   --rc-onButton--disabled: var(--rc-light-transparent);
 
-  --rc-errorLight: var(--vc-brand-pink--transparent);
+  --rc-errorLight: var(--vc-brand-pink--light);
   --rc-error: var(--vc-brand-pink);
   --rc-error-strong: var(--vc-red);
   --rc-onError: var(--vc-snow);
@@ -1103,7 +1104,6 @@ by all browsers (FF is missing) */
 
 .c-toast {
   position: relative;
-  background: var(--rc-background);
   animation: appearFromBottom 200ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 


### PR DESCRIPTION
This removes the background color on the basic toast elements, which were protruding from the pink overlay of the "irregularity". A new pink value color is added to achieve the same overall color as before (which was made from a darker pink with low opacity on the white-ish background).

before/after

<img width="399" alt="Screenshot 2023-06-22 at 21 32 11" src="https://github.com/dfinity/internet-identity/assets/6930756/b2342402-e328-4695-af22-ef23b6c6f823">
<img width="399" alt="Screenshot 2023-06-22 at 21 32 02" src="https://github.com/dfinity/internet-identity/assets/6930756/62970c2e-e1f8-4f1d-9c57-3a1866c2d118">


<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c34b02a90/desktop/toasts.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c34b02a90/mobile/toasts.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
