### PR TITLE
fix typo in dapps class

### DIFF
--- a/src/frontend/src/flows/dappsExplorer/dapps.ts
+++ b/src/frontend/src/flows/dappsExplorer/dapps.ts
@@ -44,7 +44,7 @@ export class KnownDapp {
   }
 
   public get website(): string | undefined {
-    return this.descr.oneLiner;
+    return this.descr.website;
   }
 }
 


### PR DESCRIPTION
This fixes a typo, that returned the dapps one liner instead of the website
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
