### PR TITLE
Add a narrow variant for the stepper

### DIFF
--- a/src/frontend/src/flows/recovery/stepper.ts
+++ b/src/frontend/src/flows/recovery/stepper.ts
@@ -7,7 +7,7 @@ export const phraseStepper = ({
   current: "store" | "confirm";
 }) => html`
   <div class="c-progress-container">
-    <ol class="c-progress-stepper">
+    <ol class="c-progress-stepper c-progress-stepper--narrow">
       <li class="c-progress-stepper__step" aria-current=${current === "store"}>
         <span class="c-progress-stepper__label">Store Phrase</span>
       </li>

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -2295,6 +2295,11 @@ a.c-action-list__item {
   text-align: center;
 }
 
+.c-progress-stepper--narrow {
+  padding-left: 10%;
+  padding-right: 10%;
+}
+
 .c-progress-stepper__step {
   counter-increment: progress-step;
   display: flex;


### PR DESCRIPTION
<img width="655" alt="Screenshot 2023-07-12 at 15 21 31" src="https://github.com/dfinity/internet-identity/assets/608386/5cfc5caf-9943-4126-8c0e-b907b0bdc821">

Adds a space to the right and the left of the stepper, that can be used when there are only a few steps.
<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/38ed289f8/desktop/confirmSeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/38ed289f8/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/38ed289f8/mobile/confirmSeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/38ed289f8/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
