### PR TITLE
Upgrade IC related dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 name = "archive"
 version = "0.1.0"
 dependencies = [
- "candid",
+ "candid 0.9.1",
  "canister_tests",
  "hex",
  "ic-cdk",
@@ -172,23 +172,53 @@ dependencies = [
  "anyhow",
  "binread",
  "byteorder",
- "candid_derive",
+ "candid_derive 0.5.0",
  "codespan-reporting",
  "crc32fast",
  "data-encoding",
  "hex",
- "lalrpop",
- "lalrpop-util",
+ "lalrpop 0.19.12",
+ "lalrpop-util 0.19.12",
  "leb128",
- "logos",
+ "logos 0.12.1",
  "num-bigint",
  "num-traits",
- "num_enum",
+ "num_enum 0.5.11",
  "paste",
- "pretty",
+ "pretty 0.10.0",
  "serde",
  "serde_bytes",
  "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "candid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df671c37a9c6168db0334f2b289dd4e02dea1bbefe1fb22c5d43b12d865aacd"
+dependencies = [
+ "anyhow",
+ "binread",
+ "byteorder",
+ "candid_derive 0.6.2",
+ "codespan-reporting",
+ "crc32fast",
+ "data-encoding",
+ "hex",
+ "lalrpop 0.20.0",
+ "lalrpop-util 0.20.0",
+ "leb128",
+ "logos 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "num_enum 0.6.1",
+ "paste",
+ "pretty 0.12.1",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "stacker",
  "thiserror",
 ]
 
@@ -205,11 +235,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "candid_derive"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810b3bd60244f282090652ffc7c30a9d23892e72dfe443e46ee55569044f7dd5"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "canister_tests"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.2",
- "candid",
+ "candid 0.9.1",
  "flate2",
  "hex",
  "ic-cdk",
@@ -613,11 +655,11 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1faa7b42964694fb38d7f62172e0d8261381e39ce85b4d6b519929f7cad9b4fb"
+checksum = "08d4c0b932bf454d5d60e61e13c3c944972fcfd74dc82b9ed5c8b0a75979cf50"
 dependencies = [
- "candid",
+ "candid 0.9.1",
  "ic-cdk-macros",
  "ic0",
  "serde",
@@ -626,11 +668,11 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.6.10"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf50458685a0fc6b0e414cdba487610aeb199ac94db52d9fd76270565debee7"
+checksum = "b4587624e64b8db56224033ee74e5c246d39be15375d03d3df7c117d49d18487"
 dependencies = [
- "candid",
+ "candid 0.9.1",
  "proc-macro2",
  "quote",
  "serde",
@@ -640,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-timers"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06623d548784bdca42f487373d1165a5d106fbef2730e3aeface08a469aa1caf"
+checksum = "198e55e4d9e069903fbea1dceae6fd28f7e0b38d5a4e1026ed2c772e1d55f5e0"
 dependencies = [
  "futures",
  "ic-cdk",
@@ -664,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certified-map"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6adc65afeffc619a7cd19553c66c79820908c12f42191af90cfb39e2e93c4431"
+checksum = "197524aecec47db0b6c0c9f8821aad47272c2bd762c7a0ffe9715eaca0364061"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -696,7 +738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "736044d69c526fa8a2a5e54d3debd878bbd4ec10c259fd21d9e6804aef67687b"
 dependencies = [
  "base64 0.13.1",
- "candid",
+ "candid 0.8.4",
  "flate2",
  "http",
  "ic-certification",
@@ -717,22 +759,21 @@ checksum = "b4e026318236de13568edafd85534ad29910908bf08cdcf177d4403fd4a5f6c4"
 
 [[package]]
 name = "ic-test-state-machine-client"
-version = "2.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb2db930617e7384a9ce26a2b6ebd1b7eb01da1513336cd82637e0c2119b3ea"
+checksum = "0cadf6ac4a193a8a45287da67c6c385f118d9266f46d6d98e40fbbd469d3822e"
 dependencies = [
- "candid",
+ "candid 0.9.1",
  "ciborium",
- "ic-cdk",
  "serde",
  "serde_bytes",
 ]
 
 [[package]]
 name = "ic0"
-version = "0.18.10"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187fa0cecf46628330b7a390a1a65fb0637ea00d3a1121aa847ecbebc0f3ff79"
+checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
 
 [[package]]
 name = "image"
@@ -782,7 +823,7 @@ name = "internet_identity"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.2",
- "candid",
+ "candid 0.9.1",
  "canister_tests",
  "captcha",
  "getrandom",
@@ -813,7 +854,7 @@ dependencies = [
 name = "internet_identity_interface"
 version = "0.1.0"
 dependencies = [
- "candid",
+ "candid 0.9.1",
  "ic-cdk",
  "serde",
  "serde_bytes",
@@ -869,10 +910,33 @@ dependencies = [
  "ena",
  "is-terminal",
  "itertools",
- "lalrpop-util",
+ "lalrpop-util 0.19.12",
  "petgraph",
  "regex",
  "regex-syntax 0.6.29",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "diff",
+ "ena",
+ "is-terminal",
+ "itertools",
+ "lalrpop-util 0.20.0",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax 0.7.2",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -884,6 +948,15 @@ name = "lalrpop-util"
 version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 dependencies = [
  "regex",
 ]
@@ -947,7 +1020,30 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
 dependencies = [
- "logos-derive",
+ "logos-derive 0.12.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
+dependencies = [
+ "logos-derive 0.13.0",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.6.29",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -962,6 +1058,15 @@ dependencies = [
  "quote",
  "regex-syntax 0.6.29",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
+dependencies = [
+ "logos-codegen",
 ]
 
 [[package]]
@@ -1056,7 +1161,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
+dependencies = [
+ "num_enum_derive 0.6.1",
 ]
 
 [[package]]
@@ -1069,6 +1183,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1126,6 +1252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1305,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563c9d701c3a31dfffaaf9ce23507ba09cbe0b9125ba176d15e629b0235e9acc"
+dependencies = [
+ "arrayvec",
+ "typed-arena",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1332,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1423,6 +1575,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1705,12 @@ name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/src/archive/Cargo.toml
+++ b/src/archive/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 # local dependencies
 internet_identity_interface = { path = "../internet_identity_interface" }
 # ic dependencies
-candid = { version = "0.9", features = ["parser"] }
+candid = "0.9"
 ic-cdk = "0.10"
 ic-cdk-timers = "0.4"
 ic-cdk-macros = "0.7"
@@ -21,6 +21,7 @@ serde = "1"
 serde_bytes = "0.11"
 
 [dev-dependencies]
+candid = { version = "0.9", features = ["parser"] }
 canister_tests = { path = "../canister_tests" }
 hex = "0.4"
 ic-test-state-machine-client = "3"

--- a/src/archive/Cargo.toml
+++ b/src/archive/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2021"
 # local dependencies
 internet_identity_interface = { path = "../internet_identity_interface" }
 # ic dependencies
-candid = "0.8"
-ic-cdk = "0.8"
-ic-cdk-timers = "0.2"
-ic-cdk-macros = "0.6"
+candid = { version = "0.9", features = ["parser"] }
+ic-cdk = "0.10"
+ic-cdk-timers = "0.4"
+ic-cdk-macros = "0.7"
 ic-metrics-encoder = "1"
 ic-stable-structures = "0.5"
 # other
@@ -23,5 +23,5 @@ serde_bytes = "0.11"
 [dev-dependencies]
 canister_tests = { path = "../canister_tests" }
 hex = "0.4"
-ic-test-state-machine-client = "2"
+ic-test-state-machine-client = "3"
 regex = "1.5"

--- a/src/canister_tests/Cargo.toml
+++ b/src/canister_tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 base64 = "0.21"
 flate2 = "1.0"
 hex = "0.4.3"
-ic-test-state-machine-client = "2"
+ic-test-state-machine-client = "3"
 lazy_static = "1.4"
 regex = "1.5"
 serde = "1"
@@ -18,6 +18,6 @@ sha2 = "0.10"
 internet_identity_interface = { path = "../internet_identity_interface" }
 
 # All IC deps
-candid = "0.8"
-ic-cdk = "0.8"
+candid = "0.9"
+ic-cdk = "0.10"
 ic-representation-independent-hash = "0.3"

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -16,7 +16,7 @@ pub fn health_check(env: &StateMachine, canister_id: CanisterId) {
     let user_number: types::AnchorNumber = 0;
     // XXX: we use "IDLValue" because we're just checking that the canister is sending
     // valid data, but we don't care about the actual data.
-    let _: (candid::parser::value::IDLValue,) =
+    let _: (candid::types::value::IDLValue,) =
         call_candid(env, canister_id, "lookup", (user_number,)).unwrap();
 }
 

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -26,10 +26,10 @@ rand_chacha = { version = "*", default-features = false }
 captcha = { git = "https://github.com/nmattia/captcha", rev = "9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391" }
 
 # All IC deps
-candid = "0.8"
-ic-cdk = "0.8"
-ic-cdk-macros = "0.6"
-ic-certified-map = "0.3"
+candid = { version = "0.9", features = ["parser"] }
+ic-cdk = "0.10"
+ic-cdk-macros = "0.7"
+ic-certified-map = "0.4"
 ic-metrics-encoder = "1"
 ic-stable-structures = "0.5"
 
@@ -37,7 +37,7 @@ ic-stable-structures = "0.5"
 getrandom = { version = "0.2", features = ["custom"] }
 
 [dev-dependencies]
-ic-test-state-machine-client = "2"
+ic-test-state-machine-client = "3"
 canister_tests = { path = "../canister_tests" }
 hex-literal = "0.4"
 regex = "1.5"

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -26,7 +26,7 @@ rand_chacha = { version = "*", default-features = false }
 captcha = { git = "https://github.com/nmattia/captcha", rev = "9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391" }
 
 # All IC deps
-candid = { version = "0.9", features = ["parser"] }
+candid = "0.9"
 ic-cdk = "0.10"
 ic-cdk-macros = "0.7"
 ic-certified-map = "0.4"
@@ -38,6 +38,7 @@ getrandom = { version = "0.2", features = ["custom"] }
 
 [dev-dependencies]
 ic-test-state-machine-client = "3"
+candid = { version = "0.9", features = ["parser"] }
 canister_tests = { path = "../canister_tests" }
 hex-literal = "0.4"
 regex = "1.5"

--- a/src/internet_identity_interface/Cargo.toml
+++ b/src/internet_identity_interface/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 serde_bytes = "0.11"
-candid = "0.8"
+candid = "0.9"
 serde = "1"
-ic-cdk = "0.8"
+ic-cdk = "0.10"

--- a/src/internet_identity_interface/src/http_gateway.rs
+++ b/src/internet_identity_interface/src/http_gateway.rs
@@ -1,7 +1,7 @@
 //! Types as defined by the HTTP gateway spec.
 //! See https://internetcomputer.org/docs/current/references/ic-interface-spec/#http-gateway-interface
 
-use candid::{CandidType, Deserialize, Func};
+use candid::{define_function, CandidType, Deserialize};
 use serde_bytes::ByteBuf;
 
 pub type HeaderField = (String, String);
@@ -9,9 +9,14 @@ pub type HeaderField = (String, String);
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct Token {}
 
+define_function!(pub StreamingCallbackFunction : (Token) -> (StreamingCallbackHttpResponse) query);
+
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub enum StreamingStrategy {
-    Callback { callback: Func, token: Token },
+    Callback {
+        callback: StreamingCallbackFunction,
+        token: Token,
+    },
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]


### PR DESCRIPTION
In the candid update in  particular finally allows more flexibility on extending candid variants and brings a performance improvement.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


