### PR TITLE
Continue with another device copy changes

### DIFF
--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -333,10 +333,12 @@ const page = (slot: TemplateResult) => {
 // Register this device as a new device with the anchor
 const asNewDevice = async (connection: Connection, userNumber?: bigint) => {
   // Prompt the user for an anchor (only used if we don't know the anchor already)
-  const askUserNumber = async () => {
+  const askUserNumber = async (userNumber?: bigint) => {
     const result = await promptUserNumber({
-      title: "Add a Trusted Device",
-      message: "What’s your Internet Identity?",
+      title: "Continue with another device",
+      message:
+        "Is this your first time connecting to Internet Identity on this device? In the next steps, you will add this device as an Internet Identity passkey. Do you wish to continue?",
+      userNumber,
     });
     if (result === "canceled") {
       // TODO L2-309: do this without reload
@@ -346,8 +348,5 @@ const asNewDevice = async (connection: Connection, userNumber?: bigint) => {
     return result;
   };
 
-  return registerTentativeDevice(
-    userNumber ?? (await askUserNumber()),
-    connection
-  );
+  return registerTentativeDevice(await askUserNumber(userNumber), connection);
 };

--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -14,7 +14,7 @@ const deviceRegistrationDisabledInfoTemplate = ({
 }) => {
   const pageContentSlot = html` <article>
     <hgroup>
-      <h1 class="t-title t-title--main">Continue with another device</h1>
+      <h1 class="t-title t-title--main">Add this device as a passkey</h1>
       <p class="t-lead">
         If this is your first time connecting to Internet Identity on this
         device, follow these steps to continue:
@@ -22,10 +22,8 @@ const deviceRegistrationDisabledInfoTemplate = ({
     </hgroup>
     <ol class="c-list c-list--numbered l-stack">
       <li>
-        Connect to
-        <strong class="t-strong">${LEGACY_II_URL_NO_PROTOCOL}</strong> on your
-        other device using Internet Identity
-        <strong class="t-strong">${userNumber}</strong>
+        Connect to ${LEGACY_II_URL_NO_PROTOCOL} on a recognized device using
+        Internet Identity ${userNumber}
       </li>
       <li>
         Once you are connected, select “<strong class="t-string"
@@ -33,14 +31,16 @@ const deviceRegistrationDisabledInfoTemplate = ({
         >”
       </li>
     </ol>
-    <p class="t-paragraph t-strong">Then, press Retry below.</p>
+    <p class="t-paragraph">
+      Then, press <strong class="t-strong">Refresh</strong> below.
+    </p>
     <div class="l-stack">
       <button
         id="deviceRegModeDisabledRetry"
         class="c-button"
         @click=${() => retry()}
       >
-        Retry
+        Refresh
       </button>
       <button
         id="deviceRegModeDisabledCancel"


### PR DESCRIPTION
Copy changes for the happy path when pressing the
"continue with another device" button on the landing page.

Includes a change to always prompt the anchor pickor with additional text.

The error message has not been changed, since it is used in multiple places and would first need to be split.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/545c41348/desktop/deviceRegistrationDisabledInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/545c41348/mobile/deviceRegistrationDisabledInfo.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
