### PR TITLE
Remove outdated compatibility test API

### DIFF
--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -308,29 +308,4 @@ pub fn acknowledge_entries(
 }
 
 /// A "compatibility" module for the previous version of II to handle API changes.
-pub mod compat {
-    use super::*;
-    use candid::{CandidType, Deserialize};
-    use internet_identity_interface::internet_identity::types::{
-        ActiveAnchorCounter, ActiveAnchorStatistics, AnchorNumber, ArchiveInfo,
-        DomainActiveAnchorCounter,
-    };
-
-    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-    pub struct InternetIdentityStats {
-        pub assigned_user_number_range: (AnchorNumber, AnchorNumber),
-        pub users_registered: u64,
-        pub archive_info: ArchiveInfo,
-        pub canister_creation_cycles_cost: u64,
-        pub storage_layout_version: u8,
-        pub active_anchor_stats: Option<ActiveAnchorStatistics<ActiveAnchorCounter>>,
-        pub domain_active_anchor_stats: Option<ActiveAnchorStatistics<DomainActiveAnchorCounter>>,
-    }
-
-    pub fn stats(
-        env: &StateMachine,
-        canister_id: CanisterId,
-    ) -> Result<InternetIdentityStats, CallError> {
-        query_candid(env, canister_id, "stats", ()).map(|(x,)| x)
-    }
-}
+pub mod compat {}

--- a/src/internet_identity/tests/integration/upgrade.rs
+++ b/src/internet_identity/tests/integration/upgrade.rs
@@ -152,7 +152,7 @@ fn ii_upgrade_should_allow_same_user_range() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
 
-    let stats = api::compat::stats(&env, canister_id)?;
+    let stats = api::stats(&env, canister_id)?;
 
     let result = upgrade_ii_canister_with_arg(
         &env,

--- a/src/internet_identity/tests/integration/upgrade.rs
+++ b/src/internet_identity/tests/integration/upgrade.rs
@@ -146,25 +146,6 @@ fn should_not_allow_user_range_exceeding_capacity() {
     );
 }
 
-/// Test to verify that the same anchor range is allowed on upgrade.
-#[test]
-fn ii_upgrade_should_allow_same_user_range() -> Result<(), CallError> {
-    let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
-
-    let stats = api::stats(&env, canister_id)?;
-
-    let result = upgrade_ii_canister_with_arg(
-        &env,
-        canister_id,
-        II_WASM.clone(),
-        arg_with_anchor_range(stats.assigned_user_number_range),
-    );
-
-    assert!(result.is_ok());
-    Ok(())
-}
-
 /// Tests simple upgrade and downgrade.
 #[test]
 fn ii_canister_can_be_upgraded_and_rolled_back() {


### PR DESCRIPTION
It was previously required for a change to the stats endpoint. Given that the change is now also contained in the previous release, these types are no longer needed.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

