### PR TITLE
Fix misleading error message on anchor size check

### DIFF
--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -558,7 +558,7 @@ impl fmt::Display for AnchorError {
             ),
             AnchorError::CumulativeDataLimitExceeded { length, limit } => write!(
                 f,
-                "Cumulative size of variable sized fields exceeds limit: length {length}, limit {limit}. Either use shorter aliases or remove an existing device."
+                "Cumulative size of variable sized fields exceeds limit: length {length}, limit {limit}."
             ),
             AnchorError::InvalidDeviceProtection { key_type } => write!(
                 f,

--- a/src/internet_identity/tests/integration/anchor_management/device_management.rs
+++ b/src/internet_identity/tests/integration/anchor_management/device_management.rs
@@ -204,10 +204,13 @@ fn should_respect_total_size_limit() -> Result<(), CallError> {
     );
 
     expect_user_error_with_message(
-            result,
-            CanisterCalledTrap,
-            Regex::new("Cumulative size of variable sized fields exceeds limit: length \\d+, limit \\d+\\. Either use shorter aliases or remove an existing device\\.").unwrap(),
-        );
+        result,
+        CanisterCalledTrap,
+        Regex::new(
+            "Cumulative size of variable sized fields exceeds limit: length \\d+, limit \\d+\\.",
+        )
+        .unwrap(),
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Since introducing the device metadata map, only pointing to aliases to recover space is misleading. Since this is a technical error the solution hint is simply removed.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
