### PR TITLE
Move test helper to make it useable in other tests

### DIFF
--- a/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
@@ -1,19 +1,16 @@
 use crate::v2_api::authn_method_test_helpers::{
-    eq_ignoring_last_authentication, test_authn_method,
+    create_identity_with_authn_method, eq_ignoring_last_authentication, test_authn_method,
 };
 use candid::Principal;
-use canister_tests::api::internet_identity as api;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
     env, expect_user_error_with_message, install_ii_canister, II_WASM,
 };
-use ic_cdk::api::management_canister::main::CanisterId;
+use ic_test_state_machine_client::CallError;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
-use ic_test_state_machine_client::{CallError, StateMachine};
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethod, AuthnMethodAddResponse, AuthnMethodData, ChallengeAttempt, DeviceData,
-    DeviceWithUsage, IdentityInfoResponse, IdentityNumber, MetadataEntry, PublicKeyAuthn,
-    RegisterResponse,
+    AuthnMethod, AuthnMethodAddResponse, AuthnMethodData, IdentityInfoResponse, MetadataEntry,
+    PublicKeyAuthn,
 };
 use regex::Regex;
 use serde_bytes::ByteBuf;
@@ -26,7 +23,7 @@ fn should_add_authn_method() -> Result<(), CallError> {
     let principal = authn_method_1.principal();
     let authn_method_2 = sample_authn_method(2);
 
-    let identity_number = create_identity_with_authn_method(&env, canister_id, authn_method_1);
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
     let result = api_v2::authn_method_add(
         &env,
         canister_id,
@@ -54,8 +51,7 @@ fn should_require_authentication_for_identity_info() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
     let authn_method = sample_authn_method(1);
-    let identity_number =
-        create_identity_with_authn_method(&env, canister_id, authn_method.clone());
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
     let result = api_v2::authn_method_add(
         &env,
@@ -85,7 +81,7 @@ fn should_report_error_on_failed_conversion() -> Result<(), CallError> {
         MetadataEntry::Bytes(ByteBuf::from("invalid")),
     );
 
-    let identity_number = create_identity_with_authn_method(&env, canister_id, authn_method_1);
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
     let result = api_v2::authn_method_add(
         &env,
         canister_id,
@@ -107,21 +103,4 @@ fn sample_authn_method(i: u8) -> AuthnMethodData {
         }),
         ..test_authn_method()
     }
-}
-
-fn create_identity_with_authn_method(
-    env: &StateMachine,
-    canister_id: CanisterId,
-    authn_method: AuthnMethodData,
-) -> IdentityNumber {
-    let challenge = api::create_challenge(env, canister_id).unwrap();
-    let device = DeviceData::from(DeviceWithUsage::try_from(authn_method).unwrap());
-    let challenge_attempt = ChallengeAttempt {
-        chars: "a".to_string(),
-        key: challenge.challenge_key,
-    };
-    let RegisterResponse::Registered { user_number} = api::register(env, canister_id, device.principal(), &device, &challenge_attempt, None).unwrap() else {
-        panic!("Expected device to be registered");
-    };
-    user_number
 }

--- a/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
@@ -1,5 +1,9 @@
+use canister_tests::api::internet_identity as api;
+use ic_cdk::api::management_canister::main::CanisterId;
+use ic_test_state_machine_client::StateMachine;
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, AuthnMethodProtection, PublicKeyAuthn, Purpose,
+    AuthnMethod, AuthnMethodData, AuthnMethodProtection, ChallengeAttempt, DeviceData,
+    DeviceWithUsage, IdentityNumber, PublicKeyAuthn, Purpose, RegisterResponse,
 };
 use serde_bytes::ByteBuf;
 
@@ -25,4 +29,21 @@ pub fn test_authn_method() -> AuthnMethodData {
         purpose: Purpose::Authentication,
         last_authentication: None,
     }
+}
+
+pub fn create_identity_with_authn_method(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    authn_method: &AuthnMethodData,
+) -> IdentityNumber {
+    let challenge = api::create_challenge(env, canister_id).unwrap();
+    let device = DeviceData::from(DeviceWithUsage::try_from(authn_method.clone()).unwrap());
+    let challenge_attempt = ChallengeAttempt {
+        chars: "a".to_string(),
+        key: challenge.challenge_key,
+    };
+    let RegisterResponse::Registered { user_number} = api::register(env, canister_id, device.principal(), &device, &challenge_attempt, None).unwrap() else {
+        panic!("Expected device to be registered");
+    };
+    user_number
 }


### PR DESCRIPTION
Creating new identities based off authn_methods will be requiered in almost all v2 API integration tests. This PR moves it into a helper file where it can be used from any other test.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/317c3bf90/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
