### PR TITLE
Remove unnecessary npm commands from build script

### DIFF
--- a/demos/vc_issuer/build.sh
+++ b/demos/vc_issuer/build.sh
@@ -5,8 +5,6 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
-npm ci
-npm run build
 cargo build --release --target wasm32-unknown-unknown --manifest-path ./Cargo.toml -j1
 ic-wasm "target/wasm32-unknown-unknown/release/vc_issuer.wasm" -o "./vc_issuer.wasm" shrink
 ic-wasm vc_issuer.wasm -o vc_issuer.wasm metadata candid:service -f vc_issuer.did -v public


### PR DESCRIPTION
The issuer has no front-end thus `npm` does not need to be involved when building the canister.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
