### PR TITLE
Add metadata section "icp:public git_commit_id" to canister wasms

### DIFF
--- a/.github/actions/check-build/action.yml
+++ b/.github/actions/check-build/action.yml
@@ -12,6 +12,8 @@ runs:
     # run the build
     - run: npm ci
       shell: bash
+    - run: echo "${GITHUB_REF}" > git_commit_id.txt
+      shell: bash
     - run: ./scripts/build
       shell: bash
 

--- a/scripts/build
+++ b/scripts/build
@@ -131,6 +131,14 @@ function build_canister() {
         ic-wasm "$canister.wasm" -o "$canister.wasm" metadata candid:service -f "$SRC_DIR/$canister.did" -v public
         # indicate support for certificate version 1 and 2 in the canister metadata
         ic-wasm "$canister.wasm" -o "$canister.wasm" metadata supported_certificate_versions -d "1,2" -v public
+        # add git_commit_id, but only if this build is happening on CI
+        if [[ ! -e git_commit_id.txt ]]
+        then
+            # If there is no git_commit_id.txt file, assume we are not in CI.
+            # We add a rudimentary "icp:public git_commit_id" section that contains all zeros.
+            echo "0000000000000000000000000000000000000000" > git_commit_id.txt
+        fi
+        ic-wasm "$canister.wasm" -o "$canister.wasm" metadata git_commit_id -f "git_commit_id.txt" -v public
         gzip --no-name --force "$canister.wasm"
     fi
 }


### PR DESCRIPTION
This PR is a suggestion for adding a metadata section that marks the git_commit_id of this II canister build.

Intended usage:

On locally built canisters:
```
dfx canister metadata $IIC_CANISTER_ID git_commit_id
0000000000000000000000000000000000000000
```

On canisters built via CI:
```
dfx canister metadata $IIC_CANISTER_ID git_commit_id
# Outputs an actual git commit SHA that allows distinguishing canister versions via CLI
```

Inspired by https://sourcegraph.com/github.com/dfinity/ic/-/blob/bazel/canisters.bzl?L120