### PR TITLE
Package json license and private

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "description": "",
   "keywords": [],
+  "private": true,
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {
     "dev": "II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=1 vite",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "description": "",
   "keywords": [],
+  "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {
     "dev": "II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=1 vite",
     "host": "II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=1 vite --host",


### PR DESCRIPTION
# Motivation

Add flags to package.json for better definition.

## Private

`"private": true`

source: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#private

> If you set "private": true in your package.json, then npm will refuse to publish it.

## License

`"license": "SEE LICENSE IN LICENSE.md",`

source: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license

> If you are using a license that hasn't been assigned an SPDX identifier, or if you are using a custom license, use a string value like this one...


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ca0039b9b/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
