### PR TITLE
Introduce new key type variant for browser storage keys

### DIFF
--- a/src/internet_identity/src/archive.rs
+++ b/src/internet_identity/src/archive.rs
@@ -403,7 +403,7 @@ pub fn device_diff(old: &Device, new: &Device) -> DeviceDataUpdate {
         key_type: if old.key_type == new.key_type {
             None
         } else {
-            Some(new.key_type.clone())
+            Some(KeyType::from(new.key_type.clone()))
         },
         protection: if old.protection == new.protection {
             None

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -2,7 +2,7 @@ use crate::active_anchor_stats::IIDomain;
 use crate::anchor_management::{post_operation_bookkeeping, tentative_device_registration};
 use crate::archive::ArchiveState;
 use crate::assets::init_assets;
-use crate::storage::anchor::Anchor;
+use crate::storage::anchor::{Anchor, KeyTypeInternal};
 use candid::{candid_method, Principal};
 use ic_cdk::api::{caller, set_certified_data, trap};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
@@ -175,7 +175,7 @@ fn get_anchor_credentials(anchor_number: AnchorNumber) -> AnchorCredentials {
             recovery_phrases: vec![],
         },
         |mut credentials, device| {
-            if device.key_type == KeyType::SeedPhrase {
+            if device.key_type == KeyTypeInternal::SeedPhrase {
                 credentials.recovery_phrases.push(device.pubkey);
             } else if let Some(credential_id) = device.credential_id {
                 let credential = WebAuthnCredential {

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -26,7 +26,7 @@ impl Device {
         self.alias = device_data.alias;
         self.credential_id = device_data.credential_id;
         self.purpose = device_data.purpose;
-        self.key_type = device_data.key_type;
+        self.key_type = KeyTypeInternal::from(device_data.key_type);
         self.protection = device_data.protection;
         self.origin = device_data.origin;
         self.metadata = device_data.metadata;
@@ -40,7 +40,7 @@ impl From<DeviceData> for Device {
             alias: device_data.alias,
             credential_id: device_data.credential_id,
             purpose: device_data.purpose,
-            key_type: device_data.key_type,
+            key_type: KeyTypeInternal::from(device_data.key_type),
             protection: device_data.protection,
             origin: device_data.origin,
             last_usage_timestamp: None,
@@ -56,7 +56,7 @@ impl From<Device> for DeviceData {
             alias: device.alias,
             credential_id: device.credential_id,
             purpose: device.purpose,
-            key_type: device.key_type,
+            key_type: KeyType::from(device.key_type),
             protection: device.protection,
             origin: device.origin,
             metadata: device.metadata,
@@ -71,7 +71,7 @@ impl From<Device> for DeviceWithUsage {
             alias: device.alias,
             credential_id: device.credential_id,
             purpose: device.purpose,
-            key_type: device.key_type,
+            key_type: KeyType::from(device.key_type),
             protection: device.protection,
             origin: device.origin,
             last_usage: device.last_usage_timestamp,
@@ -86,7 +86,7 @@ impl From<Device> for DeviceDataWithoutAlias {
             pubkey: device_data.pubkey,
             credential_id: device_data.credential_id,
             purpose: device_data.purpose,
-            key_type: device_data.key_type,
+            key_type: KeyType::from(device_data.key_type),
             protection: device_data.protection,
             origin: device_data.origin,
             metadata_keys: device_data
@@ -310,11 +310,54 @@ pub struct Device {
     pub alias: String,
     pub credential_id: Option<CredentialId>,
     pub purpose: Purpose,
-    pub key_type: KeyType,
+    pub key_type: KeyTypeInternal,
     pub protection: DeviceProtection,
     pub origin: Option<String>,
     pub last_usage_timestamp: Option<Timestamp>,
     pub metadata: Option<HashMap<String, MetadataEntry>>,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
+pub enum KeyTypeInternal {
+    #[serde(rename = "unknown")]
+    Unknown,
+    #[serde(rename = "platform")]
+    Platform,
+    #[serde(rename = "cross_platform")]
+    CrossPlatform,
+    #[serde(rename = "seed_phrase")]
+    SeedPhrase,
+    #[serde(rename = "browser_storage_key")]
+    BrowserStorageKey,
+}
+
+impl From<KeyTypeInternal> for KeyType {
+    fn from(key_type_internal: KeyTypeInternal) -> Self {
+        match key_type_internal {
+            KeyTypeInternal::Unknown => KeyType::Unknown,
+            KeyTypeInternal::Platform => KeyType::Platform,
+            KeyTypeInternal::CrossPlatform => KeyType::CrossPlatform,
+            KeyTypeInternal::SeedPhrase => KeyType::SeedPhrase,
+            // This key type cannot be written through the API, so the only way to see it here, is
+            // if we roll back to this version after having upgraded to a version that allowed the
+            // browser_storage_key variant to be written.
+            // In that case, this is the best we can do. At worst, this well lead to data loss of the
+            // key type value (if the device is subsequently written again) which is only used for
+            // statistics. The identity itself remains fully functional, including the affected key.
+            KeyTypeInternal::BrowserStorageKey => KeyType::Unknown,
+        }
+    }
+}
+
+impl From<KeyType> for KeyTypeInternal {
+    fn from(key_type: KeyType) -> Self {
+        match key_type {
+            KeyType::Unknown => KeyTypeInternal::Unknown,
+            KeyType::Platform => KeyTypeInternal::Platform,
+            KeyType::CrossPlatform => KeyTypeInternal::CrossPlatform,
+            KeyType::SeedPhrase => KeyTypeInternal::SeedPhrase,
+        }
+    }
 }
 
 impl Device {
@@ -428,7 +471,7 @@ fn check_anchor_invariants(
     // check that there is only a single recovery phrase
     if devices
         .iter()
-        .filter(|device| device.key_type == KeyType::SeedPhrase)
+        .filter(|device| device.key_type == KeyTypeInternal::SeedPhrase)
         .count()
         > 1
     {
@@ -471,13 +514,15 @@ fn check_device_invariants(device: &Device) -> Result<(), AnchorError> {
 
     check_device_limits(device)?;
 
-    if device.key_type == KeyType::SeedPhrase && device.credential_id.is_some() {
+    if device.key_type == KeyTypeInternal::SeedPhrase && device.credential_id.is_some() {
         return Err(AnchorError::RecoveryPhraseCredentialIdMismatch);
     }
 
-    if device.protection == DeviceProtection::Protected && device.key_type != KeyType::SeedPhrase {
+    if device.protection == DeviceProtection::Protected
+        && device.key_type != KeyTypeInternal::SeedPhrase
+    {
         return Err(AnchorError::InvalidDeviceProtection {
-            key_type: device.key_type.clone(),
+            key_type: KeyType::from(device.key_type.clone()),
         });
     }
     Ok(())

--- a/src/internet_identity/src/storage/anchor/tests.rs
+++ b/src/internet_identity/src/storage/anchor/tests.rs
@@ -1,4 +1,4 @@
-use crate::storage::anchor::{Anchor, AnchorError, Device};
+use crate::storage::anchor::{Anchor, AnchorError, Device, KeyTypeInternal};
 use candid::Principal;
 use internet_identity_interface::internet_identity::types::{
     DeviceData, DeviceProtection, KeyType, MetadataEntry, Purpose, Timestamp,
@@ -122,7 +122,7 @@ fn should_enforce_cumulative_device_limit() {
         alias: "a".repeat(64),
         credential_id: Some(ByteBuf::from([0; 100])),
         purpose: Purpose::Recovery,
-        key_type: KeyType::Unknown,
+        key_type: KeyTypeInternal::Unknown,
         protection: DeviceProtection::Unprotected,
         origin: None,
         last_usage_timestamp: None,
@@ -202,7 +202,7 @@ fn should_allow_protection_only_on_recovery_phrases() {
         alias: "".to_string(),
         credential_id: None,
         purpose: Purpose::Recovery,
-        key_type: KeyType::Unknown,
+        key_type: KeyTypeInternal::Unknown,
         protection: DeviceProtection::Protected,
         origin: None,
         last_usage_timestamp: None,
@@ -366,7 +366,7 @@ fn should_not_allow_modification_of_device_key() {
 fn should_not_allow_to_add_recovery_phrase_with_credential_id() {
     let mut anchor = Anchor::new();
     let device = Device {
-        key_type: KeyType::SeedPhrase,
+        key_type: KeyTypeInternal::SeedPhrase,
         credential_id: Some(ByteBuf::from(vec![1, 2, 3])),
         ..sample_device()
     };
@@ -383,7 +383,7 @@ fn should_not_allow_to_add_recovery_phrase_with_credential_id() {
 fn should_not_allow_to_modify_recovery_phrase_to_add_credential_id() {
     let mut anchor = Anchor::new();
     let mut device = Device {
-        key_type: KeyType::SeedPhrase,
+        key_type: KeyTypeInternal::SeedPhrase,
         credential_id: None,
         ..sample_device()
     };
@@ -483,7 +483,7 @@ fn sample_device() -> Device {
         alias: "Test alias".to_string(),
         credential_id: Some(ByteBuf::from("credential id of some sample device")),
         purpose: Purpose::Authentication,
-        key_type: KeyType::Platform,
+        key_type: KeyTypeInternal::Platform,
         protection: DeviceProtection::Unprotected,
         origin: Some("https://fooo.bar".to_string()),
         last_usage_timestamp: Some(465789),
@@ -497,7 +497,7 @@ fn device(n: u8) -> Device {
         alias: format!("test alias {n}"),
         credential_id: Some(ByteBuf::from([n; 64])),
         purpose: Purpose::Authentication,
-        key_type: KeyType::Platform,
+        key_type: KeyTypeInternal::Platform,
         protection: DeviceProtection::Unprotected,
         origin: Some(format!("https://foo{n}.bar")),
         last_usage_timestamp: Some(n as u64),
@@ -512,7 +512,7 @@ fn large_device(n: u8) -> Device {
         alias: "alias12chars".to_string(),
         credential_id: Some(ByteBuf::from(vec![n; 200])),
         purpose: Purpose::Authentication,
-        key_type: KeyType::Unknown,
+        key_type: KeyTypeInternal::Unknown,
         protection: DeviceProtection::Unprotected,
         origin: Some("https://rdmx6-jaaaa-aaaaa-aaadq-cai.foobar.icp0.io".to_string()),
         last_usage_timestamp: Some(12345679),
@@ -529,7 +529,7 @@ fn recovery_phrase(n: u8, protection: DeviceProtection) -> Device {
         alias: format!("recovery phrase {n}"),
         credential_id: None,
         purpose: Purpose::Recovery,
-        key_type: KeyType::SeedPhrase,
+        key_type: KeyTypeInternal::SeedPhrase,
         protection,
         origin: None,
         last_usage_timestamp: None,

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -1,13 +1,13 @@
 use crate::archive::{ArchiveData, ArchiveState};
 use crate::state::PersistentState;
-use crate::storage::anchor::{Anchor, Device};
+use crate::storage::anchor::{Anchor, Device, KeyTypeInternal};
 use crate::storage::{Header, PersistentStateError, StorageError};
 use crate::Storage;
 use candid::Principal;
 use ic_stable_structures::{Memory, VectorMemory};
 use internet_identity_interface::internet_identity::types::{
     ActiveAnchorCounter, ActiveAnchorStatistics, ArchiveConfig, CompletedActiveAnchorStats,
-    DeviceProtection, KeyType, OngoingActiveAnchorStats, Purpose,
+    DeviceProtection, OngoingActiveAnchorStats, Purpose,
 };
 use serde_bytes::ByteBuf;
 use std::rc::Rc;
@@ -388,7 +388,7 @@ fn sample_device() -> Device {
         alias: "my test device".to_string(),
         credential_id: Some(ByteBuf::from("this is the credential id")),
         purpose: Purpose::Authentication,
-        key_type: KeyType::Unknown,
+        key_type: KeyTypeInternal::Unknown,
         protection: DeviceProtection::Unprotected,
         origin: None,
         last_usage_timestamp: Some(1234),


### PR DESCRIPTION
The new key type variant is introduced as a preparation for the browser storage keys authentication mechanism.

The variant cannot be written, it is just introduced so that the upcoming release can be used as a rollback version to the release that allows writing the new variant.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bf6debd56/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bf6debd56/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
