### PR TITLE
Retain key_type information in AuthnMethodData

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -80,6 +80,7 @@ type DeviceData = record {
     // Note: some fields above will be moved to the metadata map in the future.
     // All field names of `DeviceData` (such as 'alias', 'origin, etc.) are
     // reserved and cannot be written.
+    // In addition, the keys "usage" and "authenticator_attachment" are reserved as well.
     metadata: opt MetadataMap;
 };
 
@@ -382,7 +383,8 @@ type AuthnMethodData = record {
     // contains the following fields of the DeviceWithUsage type:
     // - alias
     // - origin
-    // - key_type: reduced to "platform", "cross_platform" on migration
+    // - authenticator_attachment: data taken from key_type and reduced to "platform", "cross_platform" or absent on migration
+    // - usage: data taken from key_type and reduced to "recovery_phrase", "browser_storage_key" or absent on migration
     // Note: for compatibility reasons with the v1 API, the entries above (if present)
     // must be of the `string` variant. This restriction may be lifted in the future.
     metadata: MetadataMap;

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -447,7 +447,7 @@ fn check_anchor_invariants(
 ///  NOTE: while in the future we may lift this restriction, for now we do ensure that
 ///  protected devices are limited to recovery phrases, which the webapp expects.
 fn check_device_invariants(device: &Device) -> Result<(), AnchorError> {
-    const RESERVED_KEYS: [&str; 9] = [
+    const RESERVED_KEYS: &[&str] = &[
         "pubkey",
         "alias",
         "credential_id",
@@ -457,11 +457,13 @@ fn check_device_invariants(device: &Device) -> Result<(), AnchorError> {
         "origin",
         "last_usage_timestamp",
         "metadata",
+        "usage",
+        "authenticator_attachment",
     ];
 
     if let Some(metadata) = &device.metadata {
         for key in RESERVED_KEYS {
-            if metadata.contains_key(key) {
+            if metadata.contains_key(*key) {
                 return Err(AnchorError::ReservedMetadataKey {
                     key: key.to_string(),
                 });

--- a/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
@@ -77,7 +77,7 @@ fn should_report_error_on_failed_conversion() -> Result<(), CallError> {
     let principal = authn_method_1.principal();
     let mut authn_method_2 = sample_authn_method(2);
     authn_method_2.metadata.insert(
-        "key_type".to_string(),
+        "usage".to_string(),
         MetadataEntry::Bytes(ByteBuf::from("invalid")),
     );
 

--- a/src/internet_identity_interface/src/internet_identity/conversions/test.rs
+++ b/src/internet_identity_interface/src/internet_identity/conversions/test.rs
@@ -51,7 +51,7 @@ fn should_convert_device_data_to_authn_method_data() {
 
 #[test]
 fn should_fail_to_convert_to_device_on_bad_metadata_types() {
-    const KEYS: &[&str] = &["alias", "origin", "key_type"];
+    const KEYS: &[&str] = &["alias", "origin", "usage", "authenticator_attachment"];
 
     for key in KEYS {
         let (_, mut authn_method) = test_conversion_pairs().pop().unwrap();
@@ -71,6 +71,11 @@ fn should_fail_to_convert_to_device_on_bad_metadata_types() {
 }
 
 fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
+    const ORIGIN: &str = "origin";
+    const ALIAS: &str = "alias";
+    const AUTHENTICATOR_ATTACHMENT: &str = "authenticator_attachment";
+    const USAGE: &str = "usage";
+
     let pubkey = ByteBuf::from([123; 32]);
     let alias = "test device".to_string();
     let origin = "https://some.origin.com".to_string();
@@ -94,8 +99,8 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
             pubkey: pubkey.clone(),
         }),
         metadata: HashMap::from([
-            ("alias".to_string(), MetadataEntry::String(alias.clone())),
-            ("origin".to_string(), MetadataEntry::String(origin)),
+            (ALIAS.to_string(), MetadataEntry::String(alias.clone())),
+            (ORIGIN.to_string(), MetadataEntry::String(origin.clone())),
             (
                 "some_key".to_string(),
                 MetadataEntry::String("some data".to_string()),
@@ -126,9 +131,9 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
         }),
         purpose: Purpose::Authentication,
         metadata: HashMap::from([
-            ("alias".to_string(), MetadataEntry::String(alias)),
+            (ALIAS.to_string(), MetadataEntry::String(alias.clone())),
             (
-                "key_type".to_string(),
+                AUTHENTICATOR_ATTACHMENT.to_string(),
                 MetadataEntry::String("cross_platform".to_string()),
             ),
             (
@@ -156,7 +161,7 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
         purpose: Purpose::Authentication,
         metadata: HashMap::from([
             (
-                "key_type".to_string(),
+                AUTHENTICATOR_ATTACHMENT.to_string(),
                 MetadataEntry::String("cross_platform".to_string()),
             ),
             (
@@ -168,9 +173,30 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
         last_authentication: None,
     };
 
+    let device4 = DeviceWithUsage {
+        key_type: KeyType::SeedPhrase,
+        ..device1.clone()
+    };
+    let authn_method_data4 = AuthnMethodData {
+        metadata: HashMap::from([
+            (ALIAS.to_string(), MetadataEntry::String(alias)),
+            (ORIGIN.to_string(), MetadataEntry::String(origin)),
+            (
+                USAGE.to_string(),
+                MetadataEntry::String("recovery_phrase".to_string()),
+            ),
+            (
+                "some_key".to_string(),
+                MetadataEntry::String("some data".to_string()),
+            ),
+        ]),
+        ..authn_method_data1.clone()
+    };
+
     vec![
         (device1, authn_method_data1),
         (device2, authn_method_data2),
         (device3, authn_method_data3),
+        (device4, authn_method_data4),
     ]
 }


### PR DESCRIPTION
This PR changes the AuthnMethodData usedin the API v2 to retain all information that is present in the key_type field of DeviceData.

The reason is that this is useful for stats purposes as well as for the front-end to handle certain authn methods differently.

The tests for the type conversion are expanded to
cover more cases.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/efa93650f/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
