### PR TITLE
License should also be mentionned in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@dfinity/internet-identity",
       "version": "0.1.0",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@dfinity/agent": "0.15.5",
         "@dfinity/candid": "0.15.5",


### PR DESCRIPTION
Follow-up of https://github.com/dfinity/internet-identity/pull/1776. I should have run "npm i" in previous PR.
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
