### PR TITLE
Improve candid interface tests

### DIFF
--- a/src/archive/archive.did
+++ b/src/archive/archive.did
@@ -162,6 +162,7 @@ type HttpRequest = record {
     url: text;
     headers: vec HeaderField;
     body: blob;
+    certificate_version: opt nat16;
 };
 
 type HttpResponse = record {

--- a/src/archive/src/main.rs
+++ b/src/archive/src/main.rs
@@ -513,6 +513,7 @@ fn set_highest_archived_sequence_number(sequence_number: u64) {
 
 #[init]
 #[post_upgrade]
+#[candid_method(init)]
 fn initialize(arg: ArchiveInit) {
     write_config(ArchiveConfig {
         ii_canister: arg.ii_canister,
@@ -689,7 +690,7 @@ candid::export_service!();
 #[cfg(test)]
 mod test {
     use crate::__export_service;
-    use candid::utils::{service_compatible, CandidSource};
+    use candid::utils::{service_equal, CandidSource};
     use std::path::Path;
 
     /// Checks candid interface type equality by making sure that the service in the did file is
@@ -697,16 +698,15 @@ mod test {
     #[test]
     fn check_candid_interface_compatibility() {
         let canister_interface = __export_service();
-        service_compatible(
+        service_equal(
             CandidSource::Text(&canister_interface),
             CandidSource::File(Path::new("archive.did")),
         )
-        .unwrap_or_else(|e| panic!("the canister code is incompatible to the did file: {:?}", e));
-
-        service_compatible(
-            CandidSource::File(Path::new("archive.did")),
-            CandidSource::Text(&canister_interface),
-        )
-        .unwrap_or_else(|e| panic!("the did file is incompatible to the canister code: {:?}", e));
+        .unwrap_or_else(|e| {
+            panic!(
+                "the canister code interface is not equal to the did file: {:?}",
+                e
+            )
+        });
     }
 }

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -187,7 +187,7 @@ export const idlFactory = ({ IDL }) => {
   const IdentityInfo = IDL.Record({
     'authn_methods' : IDL.Vec(AuthnMethodData),
     'metadata' : MetadataMap,
-    'authn_data_registration' : IDL.Opt(AuthnMethodRegistrationInfo),
+    'authn_method_registration' : IDL.Opt(AuthnMethodRegistrationInfo),
   });
   const IdentityInfoResponse = IDL.Variant({ 'ok' : IdentityInfo });
   const IdentityMetadataReplaceResponse = IDL.Variant({ 'ok' : IDL.Null });

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -147,7 +147,7 @@ export interface IdentityAnchorInfo {
 export interface IdentityInfo {
   'authn_methods' : Array<AuthnMethodData>,
   'metadata' : MetadataMap,
-  'authn_data_registration' : [] | [AuthnMethodRegistrationInfo],
+  'authn_method_registration' : [] | [AuthnMethodRegistrationInfo],
 }
 export type IdentityInfoResponse = { 'ok' : IdentityInfo };
 export type IdentityMetadataReplaceResponse = { 'ok' : null };

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -404,7 +404,7 @@ type AuthnMethodRegistrationInfo = record {
 
 type IdentityInfo = record {
     authn_methods: vec AuthnMethodData;
-    authn_data_registration: opt AuthnMethodRegistrationInfo;
+    authn_method_registration: opt AuthnMethodRegistrationInfo;
     // Authentication method independent metadata
     metadata: MetadataMap;
 };

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -334,6 +334,7 @@ fn acknowledge_entries(sequence_number: u64) {
 }
 
 #[init]
+#[candid_method(init)]
 fn init(maybe_arg: Option<InternetIdentityInit>) {
     init_assets();
     state::init_new();
@@ -563,7 +564,7 @@ candid::export_service!();
 #[cfg(test)]
 mod test {
     use crate::__export_service;
-    use candid::utils::{service_compatible, CandidSource};
+    use candid::utils::{service_equal, CandidSource};
     use std::path::Path;
 
     /// Checks candid interface type equality by making sure that the service in the did file is
@@ -571,16 +572,15 @@ mod test {
     #[test]
     fn check_candid_interface_compatibility() {
         let canister_interface = __export_service();
-        service_compatible(
+        service_equal(
             CandidSource::Text(&canister_interface),
             CandidSource::File(Path::new("internet_identity.did")),
         )
-        .unwrap_or_else(|e| panic!("the canister code is incompatible to the did file: {:?}", e));
-
-        service_compatible(
-            CandidSource::File(Path::new("internet_identity.did")),
-            CandidSource::Text(&canister_interface),
-        )
-        .unwrap_or_else(|e| panic!("the did file is incompatible to the canister code: {:?}", e));
+        .unwrap_or_else(|e| {
+            panic!(
+                "the canister code interface is not equal to the did file: {:?}",
+                e
+            )
+        });
     }
 }


### PR DESCRIPTION
This PR replaces the existing subtype based candid interface tests with the simpler and more accurate `candid_equal` check.

The previuos method did not pick up type inequalities hidden by `opt` (which allows mismatched types, they will just be coerced to `null`). The `candid_equal` check was introduced with candid 0.9.

Using the new way of testing, uncovered two bugs in the candid files which this PR also fixes.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4fcac904f/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
