### PR TITLE
Refactor activity stats infrastructure to be independent of the activity being tracked

### DIFF
--- a/src/internet_identity/src/activity_stats.rs
+++ b/src/internet_identity/src/activity_stats.rs
@@ -1,5 +1,4 @@
-use crate::activity_stats::activity_counter::active_anchor_counter::update_active_anchor_counter;
-use crate::activity_stats::activity_counter::domain_active_anchor_counter::update_ii_domain_counter;
+use crate::activity_stats::activity_counter::domain_active_anchor_counter::DomainActivityContext;
 use crate::activity_stats::activity_counter::ActivityCounter;
 use crate::ii_domain::IIDomain;
 use crate::state;
@@ -12,84 +11,97 @@ pub mod activity_counter;
 mod stats_maintenance;
 
 #[derive(Clone, CandidType, Deserialize, Eq, PartialEq, Debug)]
-pub struct ActiveAnchorStatistics<T> {
-    // Stats for the last completed collection period for daily and monthly active anchors
-    pub completed: CompletedActiveAnchorStats<T>,
-    // ongoing periods for daily and monthly active anchors
-    pub ongoing: OngoingActiveAnchorStats<T>,
+pub struct ActivityStats<T: ActivityCounter> {
+    // Stats for the last completed collection period for daily and monthly activity
+    pub completed: CompletedActivityStats<T>,
+    // ongoing collection periods for daily and monthly activity
+    pub ongoing: OngoingActivityStats<T>,
+}
+
+impl<T: ActivityCounter> ActivityStats<T> {
+    fn new(time: Timestamp) -> Self {
+        Self {
+            completed: CompletedActivityStats {
+                daily_events: None,
+                monthly_events: None,
+            },
+            ongoing: OngoingActivityStats {
+                daily_events: ActivityCounter::new(time),
+                monthly_events: vec![ActivityCounter::new(time)],
+            },
+        }
+    }
+
+    /// Updates all ongoing counters with the given context.
+    /// Also performs maintenance on the stats, e.g. removing old monthly counters.
+    fn update_counters(&mut self, context: &T::CountingContext<'_>) {
+        stats_maintenance::process_stats(self);
+        self.ongoing.daily_events.count_event(context);
+        self.ongoing
+            .monthly_events
+            .iter_mut()
+            .for_each(|counter| counter.count_event(context));
+    }
 }
 
 #[derive(Clone, CandidType, Deserialize, Eq, PartialEq, Debug)]
-pub struct CompletedActiveAnchorStats<T> {
-    pub daily_active_anchors: Option<T>,
-    pub monthly_active_anchors: Option<T>,
+pub struct CompletedActivityStats<T: ActivityCounter> {
+    // Completed daily activity counter.
+    //
+    // For legacy reasons / stable memory compatibility the old name is kept when serializing.
+    // This will be cleaned up when the stats are moved out of the persistent state directly
+    // into the stable memory.
+    #[serde(rename = "daily_active_anchors")]
+    pub daily_events: Option<T>,
+
+    // Completed monthly activity counter.
+    //
+    // For legacy reasons / stable memory compatibility the old name is kept when serializing.
+    // This will be cleaned up when the stats are moved out of the persistent state directly
+    // into the stable memory.
+    #[serde(rename = "monthly_active_anchors")]
+    pub monthly_events: Option<T>,
 }
 
 #[derive(Clone, CandidType, Deserialize, Eq, PartialEq, Debug)]
-pub struct OngoingActiveAnchorStats<T> {
-    // Ongoing active anchor counter for the current 24 h time bucket.
-    pub daily_active_anchors: T,
-    // Monthly active users are collected using 30-day sliding windows.
+pub struct OngoingActivityStats<T: ActivityCounter> {
+    // Ongoing activity counter for the current 24 h time bucket.
+    //
+    // For legacy reasons / stable memory compatibility the old name is kept when serializing.
+    // This will be cleaned up when the stats are moved out of the persistent state directly
+    // into the stable memory.
+    #[serde(rename = "daily_active_anchors")]
+    pub daily_events: T,
+
+    // Monthly activity is collected using 30-day sliding windows.
     // This vec contains up to 30 30-day active windows each offset by one day.
     // The vec is sorted, new collection windows are added at the end.
-    pub monthly_active_anchors: Vec<T>,
+    //
+    // For legacy reasons / stable memory compatibility the old name is kept when serializing.
+    // This will be cleaned up when the stats are moved out of the persistent state directly
+    // into the stable memory.
+    #[serde(rename = "monthly_active_anchors")]
+    pub monthly_events: Vec<T>,
 }
 
 pub fn update_active_anchors_stats(anchor: &Anchor, current_domain: &Option<IIDomain>) {
     let previous_activity_timestamp = anchor.last_activity();
 
     state::persistent_state_mut(|persistent_state| {
-        update_activity_stats(&mut persistent_state.active_anchor_stats, |counter| {
-            update_active_anchor_counter(counter, previous_activity_timestamp)
-        });
+        let stats = persistent_state
+            .active_anchor_stats
+            .get_or_insert_with(|| ActivityStats::new(time()));
+        stats.update_counters(&previous_activity_timestamp);
 
         if let Some(domain) = current_domain {
-            update_activity_stats(
-                &mut persistent_state.domain_active_anchor_stats,
-                |counter| update_ii_domain_counter(counter, anchor, domain),
-            )
+            let context = DomainActivityContext {
+                anchor,
+                current_domain: domain,
+            };
+            let stats = persistent_state
+                .domain_active_anchor_stats
+                .get_or_insert_with(|| ActivityStats::new(time()));
+            stats.update_counters(&context);
         }
     })
-}
-
-fn update_activity_stats<T: ActivityCounter>(
-    stats: &mut Option<ActiveAnchorStatistics<T>>,
-    update: impl Fn(&mut T),
-) {
-    match stats {
-        None => {
-            let mut new_stats = new_active_anchor_statistics(time());
-            update_counters(&mut new_stats, update);
-            *stats = Some(new_stats)
-        }
-        Some(ref mut stats) => {
-            stats_maintenance::process_stats(stats);
-            update_counters(stats, update);
-        }
-    }
-}
-
-fn update_counters<T: ActivityCounter>(
-    stats: &mut ActiveAnchorStatistics<T>,
-    update: impl Fn(&mut T),
-) {
-    update(&mut stats.ongoing.daily_active_anchors);
-    stats
-        .ongoing
-        .monthly_active_anchors
-        .iter_mut()
-        .for_each(update);
-}
-
-fn new_active_anchor_statistics<T: ActivityCounter>(time: Timestamp) -> ActiveAnchorStatistics<T> {
-    ActiveAnchorStatistics {
-        completed: CompletedActiveAnchorStats {
-            daily_active_anchors: None,
-            monthly_active_anchors: None,
-        },
-        ongoing: OngoingActiveAnchorStats {
-            daily_active_anchors: ActivityCounter::new(time),
-            monthly_active_anchors: vec![ActivityCounter::new(time)],
-        },
-    }
 }

--- a/src/internet_identity/src/activity_stats/activity_counter.rs
+++ b/src/internet_identity/src/activity_stats/activity_counter.rs
@@ -16,9 +16,15 @@ pub mod domain_active_anchor_counter;
 ///     - ActiveAnchorCounter: used to track unique active anchors
 ///     - IIDomainCounter: used to track unique active anchors per domain
 pub trait ActivityCounter: Clone {
+    /// Context that is required for the counter to count an event.
+    type CountingContext<'a>;
+
     /// Creates a new counter with the given start timestamp.
     fn new(start_timestamp: Timestamp) -> Self;
 
     /// Returns the start timestamp of the counter.
     fn start_timestamp(&self) -> Timestamp;
+
+    /// Counts an event on the counter.
+    fn count_event(&mut self, context: &Self::CountingContext<'_>);
 }

--- a/src/internet_identity/src/activity_stats/activity_counter/active_anchor_counter.rs
+++ b/src/internet_identity/src/activity_stats/activity_counter/active_anchor_counter.rs
@@ -9,6 +9,8 @@ pub struct ActiveAnchorCounter {
 }
 
 impl ActivityCounter for ActiveAnchorCounter {
+    type CountingContext<'a> = Option<Timestamp>;
+
     fn new(start_timestamp: Timestamp) -> Self {
         Self {
             start_timestamp,
@@ -19,25 +21,22 @@ impl ActivityCounter for ActiveAnchorCounter {
     fn start_timestamp(&self) -> Timestamp {
         self.start_timestamp
     }
-}
 
-/// Increases the counter on a window if the `previous_activity_timestamp` lies before
-/// the `start_timestamp` (i.e. a window where the anchor has not yet had any activity in).
-///
-/// For any given anchor and window the `previous_activity_timestamp` is only absent or before the
-/// `window.start_timestamp` once because:
-/// * `previous_activity_timestamp` of the given anchor is set to `ic_cdk::time()` in this canister call
-/// * `window.start_timestamp` is <= `ic_cdk::time()` for any active window
-pub fn update_active_anchor_counter(
-    counter: &mut ActiveAnchorCounter,
-    previous_activity_timestamp: Option<Timestamp>,
-) {
-    if let Some(timestamp) = previous_activity_timestamp {
-        if counter.start_timestamp > timestamp {
-            counter.counter += 1;
+    /// Increases the counter on a counter if the `previous_activity_timestamp` lies before
+    /// the `start_timestamp` (i.e. a window where the anchor has not yet had any activity in).
+    ///
+    /// For any given anchor and counter the `previous_activity_timestamp` is only absent or before the
+    /// `window.start_timestamp` once because:
+    /// * `previous_activity_timestamp` of the given anchor is set to `ic_cdk::time()` in this canister call
+    /// * `window.start_timestamp` is <= `ic_cdk::time()` for any active counter
+    fn count_event(&mut self, previous_activity_timestamp: &Self::CountingContext<'_>) {
+        if let Some(timestamp) = previous_activity_timestamp {
+            if self.start_timestamp > *timestamp {
+                self.counter += 1;
+            }
+        } else {
+            // increase counter if there is no previous activity
+            self.counter += 1;
         }
-    } else {
-        // increase counter if there is no previous activity
-        counter.counter += 1;
     }
 }

--- a/src/internet_identity/src/activity_stats/stats_maintenance.rs
+++ b/src/internet_identity/src/activity_stats/stats_maintenance.rs
@@ -1,77 +1,76 @@
 use crate::activity_stats::activity_counter::ActivityCounter;
-use crate::activity_stats::ActiveAnchorStatistics;
+use crate::activity_stats::ActivityStats;
 use crate::DAY_NS;
 use ic_cdk::api::time;
 
-/// Updates the active anchor counters if an ongoing collection bucket has completed.
-pub fn process_stats<T: ActivityCounter>(stats: &mut ActiveAnchorStatistics<T>) {
+/// Updates the activity counters if an ongoing collection bucket has completed.
+pub fn process_stats<T: ActivityCounter>(stats: &mut ActivityStats<T>) {
     process_daily_stats(stats);
     process_monthly_stats(stats);
 }
 
-/// If the ongoing daily active users bucket was started 24h ago (or earlier), it replaces the current
-/// completed daily active user counter and a new ongoing 24h counter is created
+/// If the ongoing daily activity bucket was started 24h ago (or earlier), it replaces the current
+/// completed daily activity counter and a new ongoing 24h counter is created
 /// (starting from the end of the now completed counter).
 #[allow(clippy::identity_op)]
-fn process_daily_stats<T: ActivityCounter>(stats: &mut ActiveAnchorStatistics<T>) {
+fn process_daily_stats<T: ActivityCounter>(stats: &mut ActivityStats<T>) {
     let now = time();
-    if stats.ongoing.daily_active_anchors.start_timestamp() + 1 * DAY_NS <= now {
+    if stats.ongoing.daily_events.start_timestamp() + 1 * DAY_NS <= now {
         // there might have been no activity for more than 24h, so the new window will skip the
         // period with no activity and start a new counter for the currently active 24h window
-        let offset = (now - stats.ongoing.daily_active_anchors.start_timestamp()) % DAY_NS;
+        let offset = (now - stats.ongoing.daily_events.start_timestamp()) % DAY_NS;
         let new_start_timestamp = now - offset;
 
-        if stats.ongoing.daily_active_anchors.start_timestamp() + 2 * DAY_NS <= now {
+        if stats.ongoing.daily_events.start_timestamp() + 2 * DAY_NS <= now {
             // there was no activity for more than 24h since the end of the completed window so the
             // last ongoing window is already outdated
             // -> create an empty counter for the last completed window
-            stats.completed.daily_active_anchors =
+            stats.completed.daily_events =
                 Some(ActivityCounter::new(new_start_timestamp - 1 * DAY_NS));
         } else {
-            stats.completed.daily_active_anchors = Some(stats.ongoing.daily_active_anchors.clone());
+            stats.completed.daily_events = Some(stats.ongoing.daily_events.clone());
         }
 
-        stats.ongoing.daily_active_anchors = ActivityCounter::new(new_start_timestamp)
+        stats.ongoing.daily_events = ActivityCounter::new(new_start_timestamp)
     }
 }
 
-/// Monthly active anchor counters are processed as follows:
+/// Monthly activity counters are processed as follows:
 /// * buckets are removed from the ongoing collection vector if they are completed
 /// * the completed monthly counter is replaced by the most recently completed 30-day collection bucket
 ///   or an empty one if the last completed bucket is already outdated
 /// * a new monthly ongoing collection period is added if the most recent one was started more than
 ///   24h ago
 #[allow(clippy::identity_op)]
-fn process_monthly_stats<T: ActivityCounter>(stats: &mut ActiveAnchorStatistics<T>) {
+fn process_monthly_stats<T: ActivityCounter>(stats: &mut ActivityStats<T>) {
     let now = time();
     // Remove all completed 30-day time windows from the ongoing collection vector
-    while let Some(monthly_stats) = stats.ongoing.monthly_active_anchors.first() {
+    while let Some(monthly_stats) = stats.ongoing.monthly_events.first() {
         if monthly_stats.start_timestamp() + 30 * DAY_NS <= now {
-            let counter = stats.ongoing.monthly_active_anchors.remove(0);
-            stats.completed.monthly_active_anchors = Some(counter);
+            let counter = stats.ongoing.monthly_events.remove(0);
+            stats.completed.monthly_events = Some(counter);
         } else {
             break;
         }
     }
 
-    if let Some(ref monthly_stats) = stats.completed.monthly_active_anchors {
+    if let Some(ref monthly_stats) = stats.completed.monthly_events {
         // there was no activity for more than 24h since the end of the completed window so the
         // last ongoing window is already outdated
         // -> create an empty counter for the last completed window
         if monthly_stats.start_timestamp() + 31 * DAY_NS <= now {
             // align empty completed 30-day window to the 24h collection interval
             let offset = (now - monthly_stats.start_timestamp()) % DAY_NS;
-            stats.completed.monthly_active_anchors =
-                Some(ActivityCounter::new(now - 30 * DAY_NS - offset));
+            stats.completed.monthly_events = Some(ActivityCounter::new(now - 30 * DAY_NS - offset));
         }
     }
 
     // Align new window to the currently running 24h interval
-    let start_timestamp = stats.ongoing.daily_active_anchors.start_timestamp();
+    let start_timestamp = stats.ongoing.daily_events.start_timestamp();
     // Note: requires daily stats to be processed before the monthly stats
     assert!(now - start_timestamp < DAY_NS);
 
-    if let Some(monthly_stats) = stats.ongoing.monthly_active_anchors.last() {
+    if let Some(monthly_stats) = stats.ongoing.monthly_events.last() {
         if monthly_stats.start_timestamp() + 1 * DAY_NS <= now {
             // Start a new 30-day time window if the last one starts more than 24h in the past.
             // This will result in at most 30 ongoing collection windows:
@@ -88,16 +87,16 @@ fn process_monthly_stats<T: ActivityCounter>(stats: &mut ActiveAnchorStatistics<
             //           -> for any time t there are at most 3 ongoing collection windows
             stats
                 .ongoing
-                .monthly_active_anchors
+                .monthly_events
                 .push(ActivityCounter::new(start_timestamp));
         }
     } else {
         // there was no activity for so long that there is no ongoing 30-day collection window anymore
-        // -> start collecting again (in sync with the daily active anchor stats)
+        // -> start collecting again (in sync with the daily activity stats)
         // Note: requires daily stats to be processed before the monthly stats
         stats
             .ongoing
-            .monthly_active_anchors
+            .monthly_events
             .push(ActivityCounter::new(start_timestamp));
     }
 }

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -224,7 +224,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             )?;
         }
         if let Some(ref stats) = persistent_state.active_anchor_stats {
-            if let Some(ref daily_active_anchor_stats) = stats.completed.daily_active_anchors {
+            if let Some(ref daily_active_anchor_stats) = stats.completed.daily_events {
                 w.encode_gauge(
                 "internet_identity_daily_active_anchors",
                 daily_active_anchor_stats.counter as f64,
@@ -236,7 +236,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
                 "Timestamp of the last completed 24h collection window for unique active anchors.",
             )?;
             }
-            if let Some(ref monthly_active_anchor_stats) = stats.completed.monthly_active_anchors {
+            if let Some(ref monthly_active_anchor_stats) = stats.completed.monthly_events {
                 w.encode_gauge(
                 "internet_identity_monthly_active_anchors",
                 monthly_active_anchor_stats.counter as f64,
@@ -251,7 +251,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         };
         if let Some(ref stats) = persistent_state.domain_active_anchor_stats {
             const BOTH_DOMAINS: &str = "both_ii_domains";
-            if let Some(ref daily_stats) = stats.completed.daily_active_anchors {
+            if let Some(ref daily_stats) = stats.completed.daily_events {
                 w.gauge_vec("internet_identity_daily_active_anchors_by_domain", "The number of unique active anchors in the last completed 24h collection window aggregated by II domains used.")
                     .unwrap()
                     .value(&[("domain", IC0_APP_DOMAIN)], daily_stats.ic0_app_counter as f64)
@@ -260,7 +260,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
                     .unwrap()
                     .value(&[("domain", BOTH_DOMAINS)], daily_stats.both_ii_domains_counter as f64)?;
             }
-            if let Some(ref daily_stats) = stats.completed.monthly_active_anchors {
+            if let Some(ref daily_stats) = stats.completed.monthly_events {
                 w.gauge_vec("internet_identity_monthly_active_anchors_by_domain", "The number of unique active anchors in the last completed 30-day collection window aggregated by II domains used.")
                     .unwrap()
                     .value(&[("domain", IC0_APP_DOMAIN)], daily_stats.ic0_app_counter as f64)

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -1,6 +1,6 @@
 use crate::activity_stats::activity_counter::active_anchor_counter::ActiveAnchorCounter;
 use crate::activity_stats::activity_counter::domain_active_anchor_counter::DomainActiveAnchorCounter;
-use crate::activity_stats::ActiveAnchorStatistics;
+use crate::activity_stats::ActivityStats;
 use crate::archive::{ArchiveData, ArchiveState, ArchiveStatusCache};
 use crate::assets::CertifiedAssets;
 use crate::state::temp_keys::TempKeys;
@@ -82,9 +82,9 @@ pub struct PersistentState {
     // Configuration for the rate limit on `register`, if any.
     pub registration_rate_limit: Option<RateLimitConfig>,
     // Daily and monthly active anchor statistics
-    pub active_anchor_stats: Option<ActiveAnchorStatistics<ActiveAnchorCounter>>,
+    pub active_anchor_stats: Option<ActivityStats<ActiveAnchorCounter>>,
     // Daily and monthly active anchor statistics (filtered by domain)
-    pub domain_active_anchor_stats: Option<ActiveAnchorStatistics<DomainActiveAnchorCounter>>,
+    pub domain_active_anchor_stats: Option<ActivityStats<DomainActiveAnchorCounter>>,
     // Hashmap of last used delegation origins
     pub latest_delegation_origins: Option<HashMap<FrontendHostname, Timestamp>>,
     // Maximum number of latest delegation origins to store

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -1,7 +1,5 @@
 use crate::activity_stats::activity_counter::active_anchor_counter::ActiveAnchorCounter;
-use crate::activity_stats::{
-    ActiveAnchorStatistics, CompletedActiveAnchorStats, OngoingActiveAnchorStats,
-};
+use crate::activity_stats::{ActivityStats, CompletedActivityStats, OngoingActivityStats};
 use crate::archive::{ArchiveData, ArchiveState};
 use crate::state::PersistentState;
 use crate::storage::anchor::{Anchor, Device, KeyTypeInternal};
@@ -416,20 +414,20 @@ fn sample_persistent_state() -> PersistentState {
         },
         canister_creation_cycles_cost: 12_346_000_000,
         registration_rate_limit: None,
-        active_anchor_stats: Some(ActiveAnchorStatistics {
-            completed: CompletedActiveAnchorStats {
-                daily_active_anchors: Some(ActiveAnchorCounter {
+        active_anchor_stats: Some(ActivityStats {
+            completed: CompletedActivityStats {
+                daily_events: Some(ActiveAnchorCounter {
                     start_timestamp: 965485,
                     counter: 99,
                 }),
-                monthly_active_anchors: None,
+                monthly_events: None,
             },
-            ongoing: OngoingActiveAnchorStats {
-                daily_active_anchors: ActiveAnchorCounter {
+            ongoing: OngoingActivityStats {
+                daily_events: ActiveAnchorCounter {
                     start_timestamp: 5648954321,
                     counter: 44,
                 },
-                monthly_active_anchors: vec![ActiveAnchorCounter {
+                monthly_events: vec![ActiveAnchorCounter {
                     start_timestamp: 549843248,
                     counter: 66,
                 }],


### PR DESCRIPTION
This PR refactors the activity counter infrastructure to no longer bother with the content of the counters. This is important because we want to introduce counters that do no longer count information per anchor but per authentication method.


Changes:
- Move the counting logic into the ActivityCounter trait
- Rename types, fields and comments mentioning anchors or users
- Provide an implementation for ActivityStats to do counting across all counters
  on the object rather than calling an external function

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->





<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d285ba0d6/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->




