### PR TITLE
Split encoding metrics into its own submodule

### DIFF
--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -1,17 +1,16 @@
-use crate::archive::ArchiveState;
 use crate::assets::{ContentType, EXACT_MATCH_TERMINATOR, IC_CERTIFICATE_EXPRESSION};
-use crate::{assets, state, IC0_APP_DOMAIN, INTERNETCOMPUTER_ORG_DOMAIN, LABEL_SIG};
+use crate::http::metrics::metrics;
+use crate::{assets, state, LABEL_SIG};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
-use ic_cdk::api::stable::stable64_size;
-use ic_cdk::api::{data_certificate, time};
+use ic_cdk::api::data_certificate;
 use ic_cdk::trap;
 use ic_certified_map::HashTree;
-use ic_metrics_encoder::MetricsEncoder;
 use internet_identity_interface::http_gateway::{HeaderField, HttpRequest, HttpResponse};
 use serde::Serialize;
 use serde_bytes::ByteBuf;
-use std::time::Duration;
+
+mod metrics;
 
 pub const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
 pub const IC_CERTIFICATE_EXPRESSION_HEADER: &str = "IC-CertificateExpression";
@@ -52,36 +51,32 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
             upgrade: Some(true),
             streaming_strategy: None,
         },
-        "/metrics" => {
-            let mut writer = MetricsEncoder::new(vec![], time() as i64 / 1_000_000);
-            match encode_metrics(&mut writer) {
-                Ok(()) => {
-                    let body = writer.into_inner();
-                    let mut headers = vec![
-                        (
-                            "Content-Type".to_string(),
-                            "text/plain; version=0.0.4".to_string(),
-                        ),
-                        ("Content-Length".to_string(), body.len().to_string()),
-                    ];
-                    headers.append(&mut security_headers());
-                    HttpResponse {
-                        status_code: 200,
-                        headers,
-                        body: ByteBuf::from(body),
-                        upgrade: None,
-                        streaming_strategy: None,
-                    }
-                }
-                Err(err) => HttpResponse {
-                    status_code: 500,
-                    headers: security_headers(),
-                    body: ByteBuf::from(format!("Failed to encode metrics: {err}")),
+        "/metrics" => match metrics() {
+            Ok(body) => {
+                let mut headers = vec![
+                    (
+                        "Content-Type".to_string(),
+                        "text/plain; version=0.0.4".to_string(),
+                    ),
+                    ("Content-Length".to_string(), body.len().to_string()),
+                ];
+                headers.append(&mut security_headers());
+                HttpResponse {
+                    status_code: 200,
+                    headers,
+                    body: ByteBuf::from(body),
                     upgrade: None,
                     streaming_strategy: None,
-                },
+                }
             }
-        }
+            Err(err) => HttpResponse {
+                status_code: 500,
+                headers: security_headers(),
+                body: ByteBuf::from(format!("Failed to encode metrics: {err}")),
+                upgrade: None,
+                streaming_strategy: None,
+            },
+        },
         probably_an_asset => {
             state::assets(
                 |certified_assets| match certified_assets.assets.get(probably_an_asset) {
@@ -114,183 +109,6 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
             )
         }
     }
-}
-
-fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
-    state::storage_borrow(|storage| {
-        w.encode_gauge(
-            "internet_identity_user_count",
-            storage.anchor_count() as f64,
-            "Number of users registered in this canister.",
-        )?;
-        let (lo, hi) = storage.assigned_anchor_number_range();
-        w.encode_gauge(
-            "internet_identity_min_user_number",
-            lo as f64,
-            "The lowest Identity Anchor served by this canister.",
-        )?;
-        w.encode_gauge(
-            "internet_identity_max_user_number",
-            (hi - 1) as f64,
-            "The highest Identity Anchor that can be served by this canister.",
-        )
-    })?;
-    state::signature_map(|sigs| {
-        w.encode_gauge(
-            "internet_identity_signature_count",
-            sigs.len() as f64,
-            "Number of active signatures issued by this canister.",
-        )
-    })?;
-    w.encode_gauge(
-        "internet_identity_stable_memory_pages",
-        stable64_size() as f64,
-        "Number of stable memory pages used by this canister.",
-    )?;
-    w.encode_gauge(
-        "internet_identity_temp_keys_count",
-        state::with_temp_keys(|temp_keys| temp_keys.num_temp_keys()) as f64,
-        "Number of temporary keys.",
-    )?;
-    w.encode_gauge(
-        "internet_identity_last_upgrade_timestamp",
-        state::last_upgrade_timestamp() as f64,
-        "The most recent IC time (in nanos) when this canister was successfully upgraded.",
-    )?;
-    state::inflight_challenges(|inflight_challenges| {
-        w.encode_gauge(
-            "internet_identity_inflight_challenges",
-            inflight_challenges.len() as f64,
-            "The number of inflight CAPTCHA challenges",
-        )
-    })?;
-    state::tentative_device_registrations(|tentative_device_registrations| {
-        w.encode_gauge(
-            "internet_identity_users_in_registration_mode",
-            tentative_device_registrations.len() as f64,
-            "The number of users in registration mode",
-        )
-    })?;
-    state::usage_metrics(|usage_metrics| {
-        w.encode_gauge(
-            "internet_identity_delegation_counter",
-            usage_metrics.delegation_counter as f64,
-            "The number of delegations created since last upgrade",
-        )?;
-        w.encode_gauge(
-            "internet_identity_anchor_operations_counter",
-            usage_metrics.anchor_operation_counter as f64,
-            "The number of anchor operations since last upgrade",
-        )
-    })?;
-    if let ArchiveState::Created { ref data, config } = state::archive_state() {
-        w.encode_gauge(
-            "internet_identity_archive_sequence_number",
-            data.sequence_number as f64,
-            "The number of entries written to the archive.",
-        )?;
-        w.encode_gauge(
-            "internet_identity_buffered_archive_entries",
-            data.entries_buffer.len() as f64,
-            "The number of buffered archive entries.",
-        )?;
-        w.encode_gauge(
-            "internet_identity_archive_config_entries_buffer_limit",
-            config.entries_buffer_limit as f64,
-            "Max number of buffered archive entries.",
-        )?;
-        w.encode_gauge(
-            "internet_identity_archive_config_fetch_limit",
-            config.entries_fetch_limit as f64,
-            "Max number of entries fetched by the archive per call.",
-        )?;
-        w.encode_gauge(
-            "internet_identity_archive_config_polling_interval_seconds",
-            Duration::from_nanos(config.polling_interval_ns).as_secs() as f64,
-            "Polling interval of the archive to fetch new entries from II.",
-        )?;
-    }
-    state::persistent_state(|persistent_state| {
-        if let Some(ref register_rate_limit_config) = persistent_state.registration_rate_limit {
-            w.encode_gauge(
-                "internet_identity_register_rate_limit_max_tokens",
-                register_rate_limit_config.max_tokens as f64,
-                "The maximum number of `register` calls that are allowed in any time window.",
-            )?;
-            w.encode_gauge(
-                "internet_identity_register_rate_limit_time_per_tokens_seconds",
-                Duration::from_nanos(register_rate_limit_config.time_per_token_ns).as_secs() as f64,
-                "Min number of seconds between two register calls to not exceed the rate limit (sustained).",
-            )?;
-        }
-        if let Some(ref stats) = persistent_state.active_anchor_stats {
-            if let Some(ref daily_active_anchor_stats) = stats.completed.daily_events {
-                w.encode_gauge(
-                "internet_identity_daily_active_anchors",
-                daily_active_anchor_stats.counter as f64,
-                "The number of unique active anchors in the last completed 24h collection window.",
-            )?;
-                w.encode_gauge(
-                "internet_identity_daily_active_anchors_start_timestamp_seconds",
-                Duration::from_nanos(daily_active_anchor_stats.start_timestamp).as_secs() as f64,
-                "Timestamp of the last completed 24h collection window for unique active anchors.",
-            )?;
-            }
-            if let Some(ref monthly_active_anchor_stats) = stats.completed.monthly_events {
-                w.encode_gauge(
-                "internet_identity_monthly_active_anchors",
-                monthly_active_anchor_stats.counter as f64,
-                "The number of unique active anchors in the last completed 30-day collection window.",
-            )?;
-                w.encode_gauge(
-                "internet_identity_monthly_active_anchors_start_timestamp_seconds",
-                Duration::from_nanos(monthly_active_anchor_stats.start_timestamp).as_secs() as f64,
-                "Timestamp of the last completed 30-day collection window for unique active anchors.",
-            )?;
-            }
-        };
-        if let Some(ref stats) = persistent_state.domain_active_anchor_stats {
-            const BOTH_DOMAINS: &str = "both_ii_domains";
-            if let Some(ref daily_stats) = stats.completed.daily_events {
-                w.gauge_vec("internet_identity_daily_active_anchors_by_domain", "The number of unique active anchors in the last completed 24h collection window aggregated by II domains used.")
-                    .unwrap()
-                    .value(&[("domain", IC0_APP_DOMAIN)], daily_stats.ic0_app_counter as f64)
-                    .unwrap()
-                    .value(&[("domain", INTERNETCOMPUTER_ORG_DOMAIN)], daily_stats.internetcomputer_org_counter as f64)
-                    .unwrap()
-                    .value(&[("domain", BOTH_DOMAINS)], daily_stats.both_ii_domains_counter as f64)?;
-            }
-            if let Some(ref daily_stats) = stats.completed.monthly_events {
-                w.gauge_vec("internet_identity_monthly_active_anchors_by_domain", "The number of unique active anchors in the last completed 30-day collection window aggregated by II domains used.")
-                    .unwrap()
-                    .value(&[("domain", IC0_APP_DOMAIN)], daily_stats.ic0_app_counter as f64)
-                    .unwrap()
-                    .value(&[("domain", INTERNETCOMPUTER_ORG_DOMAIN)], daily_stats.internetcomputer_org_counter as f64)
-                    .unwrap()
-                    .value(&[("domain", BOTH_DOMAINS )], daily_stats.both_ii_domains_counter as f64)?;
-            }
-        };
-        if let Some(delegation_origins_limit) = persistent_state.max_num_latest_delegation_origins {
-            w.encode_gauge(
-                "internet_identity_max_num_latest_delegation_origins",
-                delegation_origins_limit as f64,
-                "The maximum number of latest delegation origins that were used with II bound devices.",
-            )?;
-        }
-
-        Ok::<(), std::io::Error>(())
-    })?;
-    state::registration_rate_limit(|rate_limit_opt| {
-        if let Some(ref rate_limit_state) = rate_limit_opt {
-            w.encode_gauge(
-                "internet_identity_register_rate_limit_current_tokens",
-                rate_limit_state.tokens as f64,
-                "The number of `register` calls that are still allowed in the current time window.",
-            )?;
-        }
-        Ok::<(), std::io::Error>(())
-    })?;
-    Ok(())
 }
 
 /// List of recommended security headers as per https://owasp.org/www-project-secure-headers/

--- a/src/internet_identity/src/http/metrics.rs
+++ b/src/internet_identity/src/http/metrics.rs
@@ -1,0 +1,191 @@
+use crate::archive::ArchiveState;
+use crate::{state, IC0_APP_DOMAIN, INTERNETCOMPUTER_ORG_DOMAIN};
+use ic_cdk::api::stable::stable64_size;
+use ic_cdk::api::time;
+use ic_metrics_encoder::MetricsEncoder;
+use std::time::Duration;
+
+/// Collects the various metrics exposed by the Internet Identity canister.
+/// Returns a ascii-encoded string of the metrics in the Prometheus exposition format.
+pub fn metrics() -> Result<Vec<u8>, std::io::Error> {
+    let mut writer = MetricsEncoder::new(vec![], time() as i64 / 1_000_000);
+    encode_metrics(&mut writer)?;
+    Ok(writer.into_inner())
+}
+
+fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
+    state::storage_borrow(|storage| {
+        w.encode_gauge(
+            "internet_identity_user_count",
+            storage.anchor_count() as f64,
+            "Number of users registered in this canister.",
+        )?;
+        let (lo, hi) = storage.assigned_anchor_number_range();
+        w.encode_gauge(
+            "internet_identity_min_user_number",
+            lo as f64,
+            "The lowest Identity Anchor served by this canister.",
+        )?;
+        w.encode_gauge(
+            "internet_identity_max_user_number",
+            (hi - 1) as f64,
+            "The highest Identity Anchor that can be served by this canister.",
+        )
+    })?;
+    state::signature_map(|sigs| {
+        w.encode_gauge(
+            "internet_identity_signature_count",
+            sigs.len() as f64,
+            "Number of active signatures issued by this canister.",
+        )
+    })?;
+    w.encode_gauge(
+        "internet_identity_stable_memory_pages",
+        stable64_size() as f64,
+        "Number of stable memory pages used by this canister.",
+    )?;
+    w.encode_gauge(
+        "internet_identity_temp_keys_count",
+        state::with_temp_keys(|temp_keys| temp_keys.num_temp_keys()) as f64,
+        "Number of temporary keys.",
+    )?;
+    w.encode_gauge(
+        "internet_identity_last_upgrade_timestamp",
+        state::last_upgrade_timestamp() as f64,
+        "The most recent IC time (in nanos) when this canister was successfully upgraded.",
+    )?;
+    state::inflight_challenges(|inflight_challenges| {
+        w.encode_gauge(
+            "internet_identity_inflight_challenges",
+            inflight_challenges.len() as f64,
+            "The number of inflight CAPTCHA challenges",
+        )
+    })?;
+    state::tentative_device_registrations(|tentative_device_registrations| {
+        w.encode_gauge(
+            "internet_identity_users_in_registration_mode",
+            tentative_device_registrations.len() as f64,
+            "The number of users in registration mode",
+        )
+    })?;
+    state::usage_metrics(|usage_metrics| {
+        w.encode_gauge(
+            "internet_identity_delegation_counter",
+            usage_metrics.delegation_counter as f64,
+            "The number of delegations created since last upgrade",
+        )?;
+        w.encode_gauge(
+            "internet_identity_anchor_operations_counter",
+            usage_metrics.anchor_operation_counter as f64,
+            "The number of anchor operations since last upgrade",
+        )
+    })?;
+    if let ArchiveState::Created { ref data, config } = state::archive_state() {
+        w.encode_gauge(
+            "internet_identity_archive_sequence_number",
+            data.sequence_number as f64,
+            "The number of entries written to the archive.",
+        )?;
+        w.encode_gauge(
+            "internet_identity_buffered_archive_entries",
+            data.entries_buffer.len() as f64,
+            "The number of buffered archive entries.",
+        )?;
+        w.encode_gauge(
+            "internet_identity_archive_config_entries_buffer_limit",
+            config.entries_buffer_limit as f64,
+            "Max number of buffered archive entries.",
+        )?;
+        w.encode_gauge(
+            "internet_identity_archive_config_fetch_limit",
+            config.entries_fetch_limit as f64,
+            "Max number of entries fetched by the archive per call.",
+        )?;
+        w.encode_gauge(
+            "internet_identity_archive_config_polling_interval_seconds",
+            Duration::from_nanos(config.polling_interval_ns).as_secs() as f64,
+            "Polling interval of the archive to fetch new entries from II.",
+        )?;
+    }
+    state::persistent_state(|persistent_state| {
+        if let Some(ref register_rate_limit_config) = persistent_state.registration_rate_limit {
+            w.encode_gauge(
+                "internet_identity_register_rate_limit_max_tokens",
+                register_rate_limit_config.max_tokens as f64,
+                "The maximum number of `register` calls that are allowed in any time window.",
+            )?;
+            w.encode_gauge(
+                "internet_identity_register_rate_limit_time_per_tokens_seconds",
+                Duration::from_nanos(register_rate_limit_config.time_per_token_ns).as_secs() as f64,
+                "Min number of seconds between two register calls to not exceed the rate limit (sustained).",
+            )?;
+        }
+        if let Some(ref stats) = persistent_state.active_anchor_stats {
+            if let Some(ref daily_active_anchor_stats) = stats.completed.daily_events {
+                w.encode_gauge(
+                    "internet_identity_daily_active_anchors",
+                    daily_active_anchor_stats.counter as f64,
+                    "The number of unique active anchors in the last completed 24h collection window.",
+                )?;
+                w.encode_gauge(
+                    "internet_identity_daily_active_anchors_start_timestamp_seconds",
+                    Duration::from_nanos(daily_active_anchor_stats.start_timestamp).as_secs() as f64,
+                    "Timestamp of the last completed 24h collection window for unique active anchors.",
+                )?;
+            }
+            if let Some(ref monthly_active_anchor_stats) = stats.completed.monthly_events {
+                w.encode_gauge(
+                    "internet_identity_monthly_active_anchors",
+                    monthly_active_anchor_stats.counter as f64,
+                    "The number of unique active anchors in the last completed 30-day collection window.",
+                )?;
+                w.encode_gauge(
+                    "internet_identity_monthly_active_anchors_start_timestamp_seconds",
+                    Duration::from_nanos(monthly_active_anchor_stats.start_timestamp).as_secs() as f64,
+                    "Timestamp of the last completed 30-day collection window for unique active anchors.",
+                )?;
+            }
+        };
+        if let Some(ref stats) = persistent_state.domain_active_anchor_stats {
+            const BOTH_DOMAINS: &str = "both_ii_domains";
+            if let Some(ref daily_stats) = stats.completed.daily_events {
+                w.gauge_vec("internet_identity_daily_active_anchors_by_domain", "The number of unique active anchors in the last completed 24h collection window aggregated by II domains used.")
+                    .unwrap()
+                    .value(&[("domain", IC0_APP_DOMAIN)], daily_stats.ic0_app_counter as f64)
+                    .unwrap()
+                    .value(&[("domain", INTERNETCOMPUTER_ORG_DOMAIN)], daily_stats.internetcomputer_org_counter as f64)
+                    .unwrap()
+                    .value(&[("domain", BOTH_DOMAINS)], daily_stats.both_ii_domains_counter as f64)?;
+            }
+            if let Some(ref daily_stats) = stats.completed.monthly_events {
+                w.gauge_vec("internet_identity_monthly_active_anchors_by_domain", "The number of unique active anchors in the last completed 30-day collection window aggregated by II domains used.")
+                    .unwrap()
+                    .value(&[("domain", IC0_APP_DOMAIN)], daily_stats.ic0_app_counter as f64)
+                    .unwrap()
+                    .value(&[("domain", INTERNETCOMPUTER_ORG_DOMAIN)], daily_stats.internetcomputer_org_counter as f64)
+                    .unwrap()
+                    .value(&[("domain", BOTH_DOMAINS )], daily_stats.both_ii_domains_counter as f64)?;
+            }
+        };
+        if let Some(delegation_origins_limit) = persistent_state.max_num_latest_delegation_origins {
+            w.encode_gauge(
+                "internet_identity_max_num_latest_delegation_origins",
+                delegation_origins_limit as f64,
+                "The maximum number of latest delegation origins that were used with II bound devices.",
+            )?;
+        }
+
+        Ok::<(), std::io::Error>(())
+    })?;
+    state::registration_rate_limit(|rate_limit_opt| {
+        if let Some(ref rate_limit_state) = rate_limit_opt {
+            w.encode_gauge(
+                "internet_identity_register_rate_limit_current_tokens",
+                rate_limit_state.tokens as f64,
+                "The number of `register` calls that are still allowed in the current time window.",
+            )?;
+        }
+        Ok::<(), std::io::Error>(())
+    })?;
+    Ok(())
+}


### PR DESCRIPTION
The metrics encoding code is getting more complex
as more metrics are added. With the new authentication methods stats being added, it makes sense to first clean up the code a bit.

This is the first step of more refactoring that moves the `encode_metrics` function unchanged and introduces a wrapper around it so that the caller does not need to know about the `MetricsEncoder`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
