### PR TITLE
Increase the number of jobs fetched when generating release notes

### DIFF
--- a/.github/actions/release/run.sh
+++ b/.github/actions/release/run.sh
@@ -67,7 +67,10 @@ do
         html_url="https://example.com"
         step="step"
     else
-        job_id=$(curl --silent "https://api.github.com/repos/dfinity/internet-identity/actions/runs/$GITHUB_RUN_ID/jobs" \
+        # We have so many jobs in our CI run that we need to explicitly increase the number of jobs per page in order to
+        # not run into errors due to pagination (default is 30 jobs per page).
+        # See https://docs.github.com/en/rest/actions/workflow-jobs?apiVersion=2022-11-28#list-jobs-for-a-workflow-run
+        job_id=$(curl --silent "https://api.github.com/repos/dfinity/internet-identity/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100" \
             | jq -cMr \
             --arg search_string "${filename%%.*}" \
             '.jobs[] | select(.name | contains($search_string)) | .id')


### PR DESCRIPTION
The release script currently only works due to fortunate ordering. Reordering the jobs might push some to the second page causing the release script to no longer find the `job_id`.

Increasing the number of jobs fetched to 100 gives us enough leeway to not run into the issue again immediately (we are currently at 36 jobs). We should anyway try to stay well below 100 jobs per pipeline.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
