### PR TITLE
Fix class typos

### DIFF
--- a/src/frontend/src/flows/recovery/displaySeedPhrase.ts
+++ b/src/frontend/src/flows/recovery/displaySeedPhrase.ts
@@ -66,7 +66,7 @@ const displaySeedPhraseTemplate = ({
           <ol
             data-role="recovery-words"
             translate="no"
-            class="c-list c-list--recovery"
+            class="c-list--recovery"
           >
             <li
               class="c-list--recovery-word c-list--recovery-word--important"

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -592,7 +592,7 @@ const i18nExample = () => {
       }
     </style>
     <section class="i18n-example">
-      <article class="l-statck c-card c-card--highlight">
+      <article class="l-stack c-card c-card--highlight">
         <h2 class="t-title t-tile--main">${copy.title}</h2>
         <p class="t-lead">${copy.paragraph}</p>
         <div class="c-button-group">


### PR DESCRIPTION
This fixes a couple of typos spotted in CSS classnames:

* The `c-list` class isn't actually defined
* The `l-statck` class should be `l-stack`

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a72ace8cf/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
