### PR TITLE
Don't force captcha focus

### DIFF
--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -43,7 +43,7 @@ export const promptCaptchaTemplate = <T>({
   /* put the page into view */
   scrollToTop?: boolean;
 }) => {
-  const focus = focus_ ?? true;
+  const focus = focus_ ?? false;
   const copy = i18n.i18n(copyJson);
 
   const spinnerImg: TemplateResult = html`
@@ -275,6 +275,7 @@ export const promptCaptcha = ({
     const i18n = new I18n();
     promptCaptchaPage({
       cancel: () => resolve(cancel),
+      focus: true,
       verifyChallengeChars: async ({ chars, challenge }) => {
         const tempIdentity = await ECDSAKeyIdentity.generate({
           extractable: false,

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -247,6 +247,7 @@ export const iiPages: Record<string, () => void> = {
   promptCaptcha: () =>
     promptCaptchaPage({
       cancel: () => console.log("canceled"),
+      focus: true,
       requestChallenge: () =>
         new Promise(() => {
           /* noop */
@@ -261,6 +262,7 @@ export const iiPages: Record<string, () => void> = {
   promptCaptchaReady: () =>
     promptCaptchaPage({
       cancel: () => console.log("canceled"),
+      focus: true,
       requestChallenge: () => Promise.resolve(dummyChallenge),
       verifyChallengeChars: () =>
         new Promise(() => {


### PR DESCRIPTION
The captcha was autofocused in the showcase, which made the page automatically scroll to it. This is now disabled, and the captcha is only focused when shown on an actually page in the webapp.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f343489fb/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f343489fb/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

