### PR TITLE
Add showcase page for components

### DIFF
--- a/src/showcase/src/pages/components.astro
+++ b/src/showcase/src/pages/components.astro
@@ -1,0 +1,10 @@
+---
+import "$src/styles/main.css";
+---
+
+<div id="pageContent"></div>
+<script>
+  import { componentsPage } from "$showcase/showcase";
+
+  componentsPage();
+</script>

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -83,6 +83,12 @@ export const defaultPage = () => {
   render(pageContent, container);
 };
 
+export const componentsPage = () => {
+  document.title = "Components";
+  const container = document.getElementById("pageContent") as HTMLElement;
+  render(components(), container);
+};
+
 // A challenge with a base64 CAPTCHA, apologies for the length
 const dummyChallenge: Challenge = {
   png_base64:


### PR DESCRIPTION
This adds an astro page only for the components. The default showcase page loads _all_ pages from the app in iframes, making it somewhat hard to scroll down all the way to the components.

By having components on a different route (`/components`) they can be browsed more easily.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/50043961c/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
