### PR TITLE
Introduce helper macro for handling variant results

### DIFF
--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -664,3 +664,17 @@ pub fn test_principal(n: u64) -> Principal {
     bytes.push(0xfe); // internal marker for user test ids
     Principal::from_slice(&bytes[..])
 }
+
+/// Helper macro to make API v2 return types easier to handle.
+/// In particular, API v2 calls all return variants, requiring a match on the result.
+/// This macro allows to write the match in terms of the expected variant, with a fallback
+/// on unexpected variants.
+#[macro_export]
+#[rustfmt::skip] // cargo fmt seems to have a bug with this macro (it indents the panic! way too far)
+macro_rules! cast {
+    ($target: expr, $pat: pat_param) => {
+        let $pat = $target else {
+            panic!("expected {}", stringify!($pat));
+        };
+    };
+}

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -673,15 +673,15 @@ pub fn test_principal(n: u64) -> Principal {
 /// on unexpected variants.
 /// Example:
 /// ```
-/// use canister_tests::assert_matches;
-/// assert_matches!(
+/// use canister_tests::match_value;
+/// match_value!(
 ///     api_v2::identity_info(&env, canister_id, principal, identity_number)?, // value
 ///     Some(IdentityInfoResponse::Ok(identity_info)) // expected pattern, with binding to identity_info
 /// );
 /// ```
 #[macro_export]
 #[rustfmt::skip] // cargo fmt seems to have a bug with this macro (it indents the panic! way too far)
-macro_rules! assert_matches {
+macro_rules! match_value {
     ($target: expr, $pat: pat_param) => {
         let $pat = $target else {
             panic!("expected {}", stringify!($pat));

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -671,7 +671,7 @@ pub fn test_principal(n: u64) -> Principal {
 /// on unexpected variants.
 #[macro_export]
 #[rustfmt::skip] // cargo fmt seems to have a bug with this macro (it indents the panic! way too far)
-macro_rules! cast {
+macro_rules! assert_matches {
     ($target: expr, $pat: pat_param) => {
         let $pat = $target else {
             panic!("expected {}", stringify!($pat));

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -665,10 +665,20 @@ pub fn test_principal(n: u64) -> Principal {
     Principal::from_slice(&bytes[..])
 }
 
-/// Helper macro to make API v2 return types easier to handle.
-/// In particular, API v2 calls all return variants, requiring a match on the result.
+/// Macro to easily match a value against a pattern, and panic if the match fails.
+///
+/// This makes API v2 return types easier to handle.
+/// API v2 calls all return variants, requiring a match on the result.
 /// This macro allows to write the match in terms of the expected variant, with a fallback
 /// on unexpected variants.
+/// Example:
+/// ```
+/// use canister_tests::assert_matches;
+/// assert_matches!(
+///     api_v2::identity_info(&env, canister_id, principal, identity_number)?, // value
+///     Some(IdentityInfoResponse::Ok(identity_info)) // expected pattern, with binding to identity_info
+/// );
+/// ```
 #[macro_export]
 #[rustfmt::skip] // cargo fmt seems to have a bug with this macro (it indents the panic! way too far)
 macro_rules! assert_matches {

--- a/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
@@ -3,7 +3,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::cast;
+use canister_tests::assert_matches;
 use canister_tests::framework::{
     env, expect_user_error_with_message, install_ii_canister, II_WASM,
 };
@@ -25,7 +25,7 @@ fn should_add_authn_method() -> Result<(), CallError> {
     let authn_method_2 = sample_authn_method(2);
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
-    cast!(
+    assert_matches!(
         api_v2::authn_method_add(
             &env,
             canister_id,
@@ -36,7 +36,7 @@ fn should_add_authn_method() -> Result<(), CallError> {
         Some(AuthnMethodAddResponse::Ok)
     );
 
-    cast!(
+    assert_matches!(
         api_v2::identity_info(&env, canister_id, principal, identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );
@@ -85,7 +85,7 @@ fn should_report_error_on_failed_conversion() -> Result<(), CallError> {
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
 
-    cast!(
+    assert_matches!(
         api_v2::authn_method_add(
             &env,
             canister_id,

--- a/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
@@ -3,10 +3,10 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::assert_matches;
 use canister_tests::framework::{
     env, expect_user_error_with_message, install_ii_canister, II_WASM,
 };
+use canister_tests::match_value;
 use ic_test_state_machine_client::CallError;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
 use internet_identity_interface::internet_identity::types::{
@@ -25,7 +25,7 @@ fn should_add_authn_method() -> Result<(), CallError> {
     let authn_method_2 = sample_authn_method(2);
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
-    assert_matches!(
+    match_value!(
         api_v2::authn_method_add(
             &env,
             canister_id,
@@ -36,7 +36,7 @@ fn should_add_authn_method() -> Result<(), CallError> {
         Some(AuthnMethodAddResponse::Ok)
     );
 
-    assert_matches!(
+    match_value!(
         api_v2::identity_info(&env, canister_id, principal, identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );
@@ -85,7 +85,7 @@ fn should_report_error_on_failed_conversion() -> Result<(), CallError> {
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
 
-    assert_matches!(
+    match_value!(
         api_v2::authn_method_add(
             &env,
             canister_id,

--- a/src/internet_identity/tests/integration/v2_api/identity_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_info.rs
@@ -6,7 +6,7 @@ use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
     env, expect_user_error_with_message, install_ii_canister, time, II_WASM,
 };
-use canister_tests::{assert_matches, flows};
+use canister_tests::{flows, match_value};
 use ic_cdk::api::management_canister::main::CanisterId;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
 use ic_test_state_machine_client::{CallError, StateMachine};
@@ -26,7 +26,7 @@ fn should_get_identity_info() -> Result<(), CallError> {
     let devices = sample_devices();
     let identity_number = create_identity_with_devices(&env, canister_id, &devices);
 
-    assert_matches!(
+    match_value!(
         api_v2::identity_info(&env, canister_id, devices[0].principal(), identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );
@@ -80,7 +80,7 @@ fn should_provide_authn_registration() -> Result<(), CallError> {
     api::enter_device_registration_mode(&env, canister_id, device1.principal(), identity_number)?;
     api::add_tentative_device(&env, canister_id, identity_number, &device2)?;
 
-    assert_matches!(
+    match_value!(
         api_v2::identity_info(&env, canister_id, device1.principal(), identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );
@@ -125,7 +125,7 @@ fn create_identity_with_devices(
     let device1 = iter.next().unwrap();
     let identity_number = flows::register_anchor_with_device(env, canister_id, device1);
     for (idx, device) in iter.enumerate() {
-        assert_matches!(
+        match_value!(
             api_v2::authn_method_add(
                 env,
                 canister_id,

--- a/src/internet_identity/tests/integration/v2_api/identity_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_info.rs
@@ -6,7 +6,7 @@ use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
     env, expect_user_error_with_message, install_ii_canister, time, II_WASM,
 };
-use canister_tests::{cast, flows};
+use canister_tests::{assert_matches, flows};
 use ic_cdk::api::management_canister::main::CanisterId;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
 use ic_test_state_machine_client::{CallError, StateMachine};
@@ -26,7 +26,7 @@ fn should_get_identity_info() -> Result<(), CallError> {
     let devices = sample_devices();
     let identity_number = create_identity_with_devices(&env, canister_id, &devices);
 
-    cast!(
+    assert_matches!(
         api_v2::identity_info(&env, canister_id, devices[0].principal(), identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );
@@ -80,7 +80,7 @@ fn should_provide_authn_registration() -> Result<(), CallError> {
     api::enter_device_registration_mode(&env, canister_id, device1.principal(), identity_number)?;
     api::add_tentative_device(&env, canister_id, identity_number, &device2)?;
 
-    cast!(
+    assert_matches!(
         api_v2::identity_info(&env, canister_id, device1.principal(), identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );
@@ -125,7 +125,7 @@ fn create_identity_with_devices(
     let device1 = iter.next().unwrap();
     let identity_number = flows::register_anchor_with_device(env, canister_id, device1);
     for (idx, device) in iter.enumerate() {
-        cast!(
+        assert_matches!(
             api_v2::authn_method_add(
                 env,
                 canister_id,

--- a/src/internet_identity/tests/integration/v2_api/identity_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_info.rs
@@ -3,10 +3,10 @@
 use candid::Principal;
 use canister_tests::api::internet_identity as api;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::flows;
 use canister_tests::framework::{
     env, expect_user_error_with_message, install_ii_canister, time, II_WASM,
 };
+use canister_tests::{cast, flows};
 use ic_cdk::api::management_canister::main::CanisterId;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
 use ic_test_state_machine_client::{CallError, StateMachine};
@@ -26,10 +26,10 @@ fn should_get_identity_info() -> Result<(), CallError> {
     let devices = sample_devices();
     let identity_number = create_identity_with_devices(&env, canister_id, &devices);
 
-    let Some(IdentityInfoResponse::Ok(identity_info)) =
-        api_v2::identity_info(&env, canister_id, devices[0].principal(), identity_number)? else {
-        panic!("Expected identity info to be returned");
-    };
+    cast!(
+        api_v2::identity_info(&env, canister_id, devices[0].principal(), identity_number)?,
+        Some(IdentityInfoResponse::Ok(identity_info))
+    );
 
     assert_eq_ignoring_last_authentication(&identity_info.authn_methods, &devices);
     assert_eq!(identity_info.authn_method_registration, None);
@@ -80,10 +80,10 @@ fn should_provide_authn_registration() -> Result<(), CallError> {
     api::enter_device_registration_mode(&env, canister_id, device1.principal(), identity_number)?;
     api::add_tentative_device(&env, canister_id, identity_number, &device2)?;
 
-    let Some(IdentityInfoResponse::Ok(identity_info)) =
-        api_v2::identity_info(&env, canister_id, device1.principal(), identity_number)? else {
-        panic!("Expected identity info to be returned");
-    };
+    cast!(
+        api_v2::identity_info(&env, canister_id, device1.principal(), identity_number)?,
+        Some(IdentityInfoResponse::Ok(identity_info))
+    );
 
     assert_eq!(
         identity_info.authn_method_registration,
@@ -125,16 +125,17 @@ fn create_identity_with_devices(
     let device1 = iter.next().unwrap();
     let identity_number = flows::register_anchor_with_device(env, canister_id, device1);
     for (idx, device) in iter.enumerate() {
-        let response = api_v2::authn_method_add(
-            env,
-            canister_id,
-            device1.principal(),
-            identity_number,
-            &AuthnMethodData::from(device.clone()),
-        )
-        .unwrap_or_else(|_| panic!("could not add device {}", idx))
-        .unwrap();
-        assert!(matches!(response, AuthnMethodAddResponse::Ok));
+        cast!(
+            api_v2::authn_method_add(
+                env,
+                canister_id,
+                device1.principal(),
+                identity_number,
+                &AuthnMethodData::from(device.clone()),
+            )
+            .unwrap_or_else(|_| panic!("could not add device {}", idx)),
+            Some(AuthnMethodAddResponse::Ok)
+        );
     }
     identity_number
 }

--- a/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
@@ -3,10 +3,10 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::assert_matches;
 use canister_tests::framework::{
     env, expect_user_error_with_message, install_ii_canister, II_WASM,
 };
+use canister_tests::match_value;
 use ic_test_state_machine_client::CallError;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
 use internet_identity_interface::internet_identity::types::{IdentityInfoResponse, MetadataEntry};
@@ -22,7 +22,7 @@ fn should_write_metadata() -> Result<(), CallError> {
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
-    assert_matches!(
+    match_value!(
         api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );
@@ -41,7 +41,7 @@ fn should_write_metadata() -> Result<(), CallError> {
         &metadata,
     )?;
 
-    assert_matches!(
+    match_value!(
         api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );
@@ -86,7 +86,7 @@ fn should_not_write_too_large_identity_metadata_map() -> Result<(), CallError> {
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
-    assert_matches!(
+    match_value!(
         api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );

--- a/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
@@ -3,7 +3,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::cast;
+use canister_tests::assert_matches;
 use canister_tests::framework::{
     env, expect_user_error_with_message, install_ii_canister, II_WASM,
 };
@@ -22,7 +22,7 @@ fn should_write_metadata() -> Result<(), CallError> {
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
-    cast!(
+    assert_matches!(
         api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );
@@ -41,7 +41,7 @@ fn should_write_metadata() -> Result<(), CallError> {
         &metadata,
     )?;
 
-    cast!(
+    assert_matches!(
         api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );
@@ -86,7 +86,7 @@ fn should_not_write_too_large_identity_metadata_map() -> Result<(), CallError> {
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
-    cast!(
+    assert_matches!(
         api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?,
         Some(IdentityInfoResponse::Ok(identity_info))
     );

--- a/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
@@ -3,6 +3,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
+use canister_tests::cast;
 use canister_tests::framework::{
     env, expect_user_error_with_message, install_ii_canister, II_WASM,
 };
@@ -21,10 +22,10 @@ fn should_write_metadata() -> Result<(), CallError> {
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
-    let Some(IdentityInfoResponse::Ok(identity_info)) =
-        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)? else {
-        panic!("Expected identity info to be returned");
-    };
+    cast!(
+        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?,
+        Some(IdentityInfoResponse::Ok(identity_info))
+    );
     assert!(identity_info.metadata.is_empty());
 
     let metadata = HashMap::from_iter(vec![(
@@ -40,10 +41,10 @@ fn should_write_metadata() -> Result<(), CallError> {
         &metadata,
     )?;
 
-    let Some(IdentityInfoResponse::Ok(identity_info)) =
-        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)? else {
-        panic!("Expected identity info to be returned");
-    };
+    cast!(
+        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?,
+        Some(IdentityInfoResponse::Ok(identity_info))
+    );
     assert_eq!(identity_info.metadata, metadata);
     Ok(())
 }
@@ -85,10 +86,10 @@ fn should_not_write_too_large_identity_metadata_map() -> Result<(), CallError> {
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
-    let Some(IdentityInfoResponse::Ok(identity_info)) =
-        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)? else {
-        panic!("Expected identity info to be returned");
-    };
+    cast!(
+        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?,
+        Some(IdentityInfoResponse::Ok(identity_info))
+    );
     assert!(identity_info.metadata.is_empty());
 
     let metadata = HashMap::from_iter(vec![(


### PR DESCRIPTION
This PR introduces a macro `match_value!` which allows casting an enum to a specific value (checked at runtime). This is useful especially for handling API v2 call results as they are all `opt varinat`.

The due to the way our formatter behaves, this macro does not actually lead to less lines, but much shorter ones.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ca3fe3ef5/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



