### PR TITLE
Add better PIN component for device verification

### DIFF
--- a/src/frontend/src/components/pinInput.test.ts
+++ b/src/frontend/src/components/pinInput.test.ts
@@ -1,0 +1,215 @@
+import { render } from "lit-html";
+import { pinInput } from "./pinInput";
+
+// A pin input where the verification step is successful and returns the pin
+const pinInputId = (opts: { onSubmit: (pin: string) => void }) =>
+  pinInput({
+    ...opts,
+    verify: (pin: string) => ({ ok: true, value: pin }),
+  });
+
+// Dispatch an "InputEvent"-ish event that works in jsdom
+function dispatchInput(elem: HTMLInputElement, text: string) {
+  elem.value = text;
+  elem.dispatchEvent(new Event("input"));
+}
+
+// Dispatch an "ClipboardEvent"-ish event that works in jsdom
+function dispatchPaste(elem: HTMLInputElement, text: string) {
+  const event: any = new Event("paste", { bubbles: true, cancelable: true });
+  event.clipboardData = {
+    getData() {
+      return text;
+    },
+  };
+  elem.dispatchEvent(event);
+}
+
+// Get all inputs on the page
+function getAllInputs(): HTMLInputElement[] {
+  return Array.from(document.body.querySelectorAll("input"));
+}
+
+// A noop that makes eslint happy
+export const noop = () => {
+  /* */
+};
+
+describe("pin input", () => {
+  // Ensure the DOM is clean before running the tests
+  beforeEach(() => {
+    document.getElementsByTagName("html")[0].innerHTML = "";
+  });
+
+  test("writing to all chars triggers onSubmit", () => {
+    const onSubmit: (pin: string) => void = vi.fn();
+    const pinInput_ = pinInputId({
+      onSubmit,
+    });
+
+    render(pinInput_.template, document.body);
+
+    for (const input of getAllInputs()) {
+      dispatchInput(input, "a");
+    }
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      Array(pinInput_.pinLength).fill("a").join("")
+    );
+  });
+
+  test("writing to all chars triggers autosubmit only once", () => {
+    const onSubmit: (pin: string) => void = vi.fn();
+
+    render(pinInputId({ onSubmit }).template, document.body);
+
+    const inputs = getAllInputs();
+
+    for (const input of inputs) {
+      dispatchInput(input, "a");
+    }
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    dispatchInput(inputs[0], "a"); // after an extra dispatch, the submit should still only have been called once
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  test("writing to all chars removes focus", () => {
+    render(pinInputId({ onSubmit: noop }).template, document.body);
+
+    for (const input of getAllInputs()) {
+      dispatchInput(input, "a");
+    }
+
+    const noneHasFocus = getAllInputs().every(
+      (input) => input !== document.activeElement
+    );
+
+    expect(noneHasFocus).toBeTruthy();
+  });
+
+  test("input moves focus to next", () => {
+    render(
+      pinInputId({
+        onSubmit: () => {},
+      }).template,
+      document.body
+    );
+
+    const [first, second] = getAllInputs();
+
+    first.focus();
+
+    expect(first).toBe(document.activeElement);
+    expect(second).not.toBe(document.activeElement);
+
+    dispatchInput(first, "a");
+
+    expect(first).not.toBe(document.activeElement);
+    expect(second).toBe(document.activeElement);
+  });
+
+  test("deleting keeps focus", () => {
+    render(
+      pinInputId({
+        onSubmit: noop,
+      }).template,
+      document.body
+    );
+    const input = getAllInputs()[2];
+    dispatchInput(input, "a");
+    input.focus();
+    dispatchInput(input, "");
+
+    expect(input).toBe(document.activeElement);
+  });
+
+  test("pasting triggers onSubmit", () => {
+    const onSubmit: (pin: string) => void = vi.fn();
+    const pinInput_ = pinInputId({ onSubmit });
+
+    render(pinInput_.template, document.body);
+    const pin = Array(pinInput_.pinLength).fill("a").join("");
+    dispatchPaste(getAllInputs()[0], pin);
+
+    expect(onSubmit).toHaveBeenCalledWith(pin);
+  });
+
+  test("pasting all removes focus", () => {
+    const pinInput_ = pinInputId({
+      onSubmit: noop,
+    });
+    render(pinInput_.template, document.body);
+    const pin = Array(pinInput_.pinLength).fill("a").join("");
+    dispatchPaste(getAllInputs()[0], pin);
+
+    // Check that no input is focused
+    const noneHasFocus = getAllInputs().every(
+      (input) => input !== document.activeElement
+    );
+    expect(noneHasFocus).toBeTruthy();
+  });
+
+  test("pasting moves focus", () => {
+    render(pinInputId({ onSubmit: noop }).template, document.body);
+    const inputs = getAllInputs();
+    // dispatch a paste that sits somewhere in the middle (not dispatched in the first input, and not long enough
+    // to reach the last input)
+    const content = "123";
+    dispatchPaste(inputs[2], content);
+
+    // Focus should have moved (3 = length of "123")
+    expect(inputs[2 + content.length - 1]).toBe(document.activeElement);
+  });
+
+  test("calling .submit() does submit", () => {
+    const onSubmit: (pin: string) => void = vi.fn();
+    const pinInput_ = pinInputId({ onSubmit });
+
+    render(pinInput_.template, document.body);
+
+    for (const input of getAllInputs()) {
+      // we don't call dispatchInput on purpose to not trigger an auto submit
+      input.value = "a";
+    }
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    pinInput_.submit();
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  test("calling .submit() triggers error if not full", () => {
+    const pinInput_ = pinInputId({
+      onSubmit: noop,
+    });
+
+    render(pinInput_.template, document.body);
+
+    const someInputs = getAllInputs();
+    someInputs.shift();
+    someInputs.shift();
+
+    for (const input of someInputs) {
+      dispatchInput(input, "a");
+    }
+
+    expect(pinInput_.hasError.latest).not.toBe(true);
+    pinInput_.submit();
+    expect(pinInput_.hasError.latest).toBe(true);
+  });
+
+  test("input removes error state", () => {
+    const pinInput_ = pinInputId({
+      onSubmit: noop,
+    });
+
+    render(pinInput_.template, document.body);
+
+    // Submit on empty, to trigger error
+    pinInput_.submit();
+
+    expect(pinInput_.hasError.latest).toBe(true);
+    dispatchInput(getAllInputs()[0], "a");
+    expect(pinInput_.hasError.latest).not.toBe(true);
+  });
+});

--- a/src/frontend/src/components/pinInput.ts
+++ b/src/frontend/src/components/pinInput.ts
@@ -1,0 +1,259 @@
+import { toast } from "$src/components/toast";
+import { withRef } from "$src/utils/lit-html";
+import { Chan, withInputElement, zip } from "$src/utils/utils";
+import { isNullish, nonNullish } from "@dfinity/utils";
+import { TemplateResult, html } from "lit-html";
+import { asyncReplace } from "lit-html/directives/async-replace.js";
+import { Ref, createRef, ref } from "lit-html/directives/ref.js";
+
+type Result<T> = { ok: true; value: T } | { ok: false; error: string };
+
+// A Pin Input component
+export const pinInput = <T>({
+  pinLength = 6,
+  onSubmit: onSubmit_,
+  verify,
+}: {
+  pinLength?: number;
+  onSubmit: (
+    result: T
+  ) => void /* Called when all inputs have been set or when .submit() is called */;
+  verify: (
+    pin: string
+  ) => Promise<Result<T>> | Result<T> /* Used to verify & transform the pin */;
+}): {
+  template: TemplateResult;
+  submit: () => void;
+  hasError: Chan<boolean>;
+  pinLength: number;
+} => {
+  // The root <ul> which lists the inputs
+  const listRoot: Ref<HTMLUListElement> = createRef();
+
+  // A currently displayed error, if any
+  const currentError = new Chan<string | undefined>(undefined);
+  const hasError = currentError.map((e) => nonNullish(e));
+
+  // Called on submission, either autosubmit (when filled) or when '.submit()' is called
+  const onSubmit: (pin: string) => void = async (pin: string) => {
+    const result_ = verify(pin);
+    // Only await if necessary
+    const result = result_ instanceof Promise ? await result_ : result_;
+    if (!result.ok) {
+      currentError.send(result.error);
+      return;
+    }
+
+    onSubmit_(result.value);
+  };
+
+  // We autosubmit only once
+  let didAutosubmit = false;
+  const autosubmit = (pin: string) => {
+    if (didAutosubmit) {
+      return;
+    }
+
+    didAutosubmit = true;
+    onSubmit(pin);
+  };
+
+  const errorMessage = currentError.map((currentError) =>
+    nonNullish(currentError)
+      ? html`<p class="t-centered t-error c-input--stack">${currentError}</p>`
+      : undefined
+  );
+  const notFilledError = `Please fill in all ${pinLength} inputs`;
+
+  const withInputs = <T>(f: (inputs: HTMLInputElement[]) => T): T | undefined =>
+    withRef(listRoot, (ul) => {
+      const inputs = ul.querySelectorAll("input");
+      if (isNullish(inputs)) {
+        // Unexpected error
+        toast.error("Could not find any inputs");
+        return;
+      }
+
+      return f(Array.from(inputs));
+    });
+
+  const onInput_ = (event: InputEvent, element: HTMLInputElement) =>
+    withInputs((inputs) => {
+      currentError.send(undefined);
+      onInput({ element, event, inputs, onFilled: autosubmit });
+    });
+  const onPaste_ = (event: ClipboardEvent, element: HTMLInputElement) =>
+    withInputs((inputs) => {
+      currentError.send(undefined);
+      onPaste({ event, element, inputs, onFilled: onSubmit });
+    });
+
+  // A function that can be called to trigger submission. If some digits are missing, then
+  // we show and error message.
+  const submit = () =>
+    withInputs((inputs) =>
+      submitIfFilled({
+        inputs,
+        onSubmit,
+        onMissing: () => currentError.send(notFilledError),
+      })
+    );
+
+  const template = html`
+    <div class="t-centered">
+      <ul
+        ${ref(listRoot)}
+        class="c-list--pin"
+        data-haserror=${asyncReplace(hasError)}
+      >
+        ${Array.from(
+          { length: pinLength },
+          (_, _ix) => html`
+            <li class="c-list--pin-char c-input--anchor">
+              <label class="c-input--anchor__wrap">
+                <input
+                  autocomplete="off"
+                  type="tel"
+                  size="1"
+                  maxlength="1"
+                  class="c-input c-input--pin c-input--pin__error"
+                  @input=${(e: InputEvent) => withInputElement(e, onInput_)}
+                  @paste=${(e: ClipboardEvent) => withInputElement(e, onPaste_)}
+                  @focus=${(e: Event) =>
+                    /* on focus, select the input so that the content is effectively replaced */ withInputElement(
+                      e,
+                      (_, elem) => elem.select()
+                    )}
+                />
+              </label>
+            </li>
+          `
+        )}
+      </ul>
+      ${asyncReplace(errorMessage)}
+    </div>
+  `;
+
+  return { template, submit, hasError, pinLength };
+};
+
+/* Callback used when an input is being set */
+const onInput = ({
+  element,
+  event,
+  inputs,
+  onFilled,
+}: {
+  element: HTMLInputElement;
+  event: InputEvent;
+  inputs: HTMLInputElement[];
+  onFilled: (pin: string) => void;
+}) => {
+  // First, if the input is empty (i.e. the "input" was to delete the content OR the browser prevented inserting an extra char due to maxlength=1) then we do nothing
+  // XXX: we don't test this because mocking the event data is really hard in jsdom
+  if (event.data === "") {
+    return;
+  }
+
+  // If the content was just deleted, then we just stay here
+  if (isNullish(element.value) || element.value === "") {
+    return;
+  }
+
+  // Only keep the last character (for instance if user focused & appended)
+  // element.value = element.value.slice(-1);
+
+  // Move focus to the next input, if any
+  focusNextOrBlur(element);
+
+  // Check if we should submit the content
+  submitIfFilled({ inputs, onSubmit: onFilled });
+};
+
+/* Callback used when the user pastes */
+const onPaste = ({
+  event,
+  inputs,
+  element,
+  onFilled,
+}: {
+  event: ClipboardEvent;
+  element: HTMLInputElement;
+  inputs: HTMLInputElement[];
+  onFilled: (pin: string) => void;
+}) => {
+  // If no actual data was pasted, do nothing
+  if (event.clipboardData === null) {
+    return;
+  }
+
+  // Get a hold of all input elements that may be pasted into (this + everything afterwards)
+  //  pasted ━┓
+  // [] [] [] [] [] []
+  //          ┗━━╋━━┛
+  //          interesting
+  const nextInputs = inputs.slice(inputs.indexOf(element));
+  if (isNullish(nextInputs)) {
+    toast.error("Could not find any input to paste into");
+    return;
+  }
+
+  // Create an array of pairs of inputs + the char/digit to be pasted in that input
+  const toBePasted = zip(
+    nextInputs,
+    event.clipboardData.getData("text").trim().split("")
+  );
+  if (toBePasted.length === 0) {
+    return;
+  }
+
+  // Actually set the value (for reasons unclear, preventDefault() is not necessary here as tested on
+  // Chrome, Safari)
+  for (const [input, char] of toBePasted) {
+    input.value = char;
+  }
+
+  if (toBePasted.length < nextInputs.length) {
+    // If all inputs have NOT been filled, then focus on the one after the last paste/fill
+    nextInputs[toBePasted.length - 1].focus();
+  } else {
+    // otherwise, drop focus entirely
+    element.blur();
+  }
+
+  // Check if we should submit the content
+  submitIfFilled({ inputs, onSubmit: onFilled });
+};
+
+// Calls 'onSubmit', only if all inputs have a value. Otherwise, 'onMissing' is called.
+const submitIfFilled = ({
+  inputs,
+  onSubmit,
+  onMissing = () => {},
+}: {
+  inputs: HTMLInputElement[];
+  onSubmit: (pin: string) => void;
+  onMissing?: () => void;
+}) => {
+  const values = inputs.map((x) => x.value);
+
+  if (values.every((value) => value !== "")) {
+    onSubmit(values.join(""));
+  } else {
+    onMissing?.();
+  }
+};
+
+// Focus the next input in the list, if any
+const focusNextOrBlur = (element: HTMLInputElement) => {
+  // Go up until we find a list item, then to the next sibling, and finally back down until we find an input
+  const next = element
+    .closest("li")
+    ?.nextElementSibling?.querySelector("input");
+
+  if (nonNullish(next)) {
+    next.focus();
+  } else {
+    element.blur();
+  }
+};

--- a/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/verifyTentativeDevice.ts
@@ -2,13 +2,13 @@ import { VerifyTentativeDeviceResponse } from "$generated/internet_identity_type
 import { displayError } from "$src/components/displayError";
 import { withLoader } from "$src/components/loader";
 import { mainWindow } from "$src/components/mainWindow";
+import { pinInput } from "$src/components/pinInput";
 import { AsyncCountdown } from "$src/utils/countdown";
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
-import { renderPage, withRef } from "$src/utils/lit-html";
-import { Chan, unknownToString } from "$src/utils/utils";
-import { html } from "lit-html";
+import { renderPage } from "$src/utils/lit-html";
+import { unknownToString } from "$src/utils/utils";
+import { TemplateResult, html } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
-import { createRef, ref } from "lit-html/directives/ref.js";
 
 // The type that we return, pretty much the result of the canister
 // except that all retries have been exhausted
@@ -17,9 +17,11 @@ type VerifyResult =
   | { too_many_attempts: null };
 
 // A helper type for the page verification function where a retry may be possible/requested
-type VerifyResultOrRetry = VerifyResult | { retry: null };
+type VerifyResultOrRetry =
+  | { retry: false; value: VerifyResult }
+  | { retry: true };
 
-const verifyTentativeDeviceTemplate = ({
+const verifyTentativeDeviceTemplate = <T>({
   alias,
   remaining,
   verify,
@@ -29,42 +31,25 @@ const verifyTentativeDeviceTemplate = ({
   alias: string;
   remaining: AsyncIterable<string>;
   cancel: () => void;
-  verify: (value: string) => Promise<VerifyResultOrRetry>;
-  doContinue: (result: VerifyResult) => void;
+  verify: (
+    value: string
+  ) => Promise<{ retry: false; value: T } | { retry: true }>;
+  doContinue: (result: T) => void;
 }) => {
-  // The error shown on failed verification
-  const showRetryPrompt = new Chan<boolean>(false);
-  const retryPromptHidden = showRetryPrompt.map((showRetry) =>
-    showRetry ? "" : "is-hidden"
-  );
-
-  // The error shown on bad input (e.g. "")
-  const badInput = new Chan<"ok" | "bad">("ok");
-  const hasError = badInput.map((e) => (e === "bad" ? "has-error" : ""));
-
-  const pinInput = createRef<HTMLInputElement>();
-
-  // When submitting, we either give visual feedback on bad input (e.g. "") or we
-  // use the provided verification function to decide whether to retry or contine by forwarding
-  // the result.
-  const submit = () => {
-    void withRef(pinInput, async (pin) => {
-      const value = pin.value;
-      if (value === "") {
-        badInput.send("bad");
-      } else {
-        showRetryPrompt.send(false);
-        badInput.send("ok");
-
-        const result = await verify(value);
-        if ("retry" in result) {
-          showRetryPrompt.send(true);
-        } else {
-          doContinue(result);
-        }
+  const pinInput_ = pinInput({
+    verify: async (pin: string) => {
+      const result = await verify(pin);
+      if (result.retry) {
+        return {
+          ok: false,
+          error: "The entered verification code was invalid. Please try again.",
+        };
       }
-    });
-  };
+
+      return { ok: true, value: result.value };
+    },
+    onSubmit: doContinue,
+  });
 
   const pageContentSlot = html`<h1 class="t-title t-title--main">
       Do you want to create this Passkey for your Internet Identity?
@@ -78,31 +63,23 @@ const verifyTentativeDeviceTemplate = ({
       the <strong class="t-strong">Verification Code</strong> displayed on your
       other window:
     </p>
-    <label class="l-stack" aria-label="Verification Code">
-      <p class="t-paragraph ${asyncReplace(retryPromptHidden)}">
-        The entered verification code was invalid. Please try again.
-      </p>
-      <input
-        ${ref(pinInput)}
-        @keypress=${(e: KeyboardEvent) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            submit();
-          }
-        }}
-        id="tentativeDeviceCode"
-        class="c-input c-input--fullwidth c-input--stack ${asyncReplace(
-          hasError
-        )}"
-        placeholder="Verification Code"
-      />
+    <label
+      class="l-stack"
+      data-role="verification-code"
+      aria-label="Verification Code"
+    >
+      <div class="c-input--stack">${pinInput_.template}</div>
     </label>
     <p class="t-paragraph">
       Time remaining: <span class="t-strong">${asyncReplace(remaining)}</span>
     </p>
 
     <div class="l-stack">
-      <button @click=${() => submit()} id="verifyDevice" class="c-button">
+      <button
+        @click=${() => pinInput_.submit()}
+        id="verifyDevice"
+        class="c-button"
+      >
         Verify Passkey
       </button>
       <button @click=${() => cancel()} class="c-button c-button--secondary">
@@ -117,9 +94,16 @@ const verifyTentativeDeviceTemplate = ({
   });
 };
 
-export const verifyTentativeDevicePage = renderPage(
-  verifyTentativeDeviceTemplate
-);
+type TemplateProps<T> = Parameters<typeof verifyTentativeDeviceTemplate<T>>[0];
+
+export function verifyTentativeDevicePage<T>(
+  props: TemplateProps<T>,
+  container?: HTMLElement
+): void {
+  return renderPage<(props: TemplateProps<T>) => TemplateResult>(
+    verifyTentativeDeviceTemplate
+  )(props, container);
+}
 
 /**
  * Page to verify the tentative device: the device verification code can be entered and is the checked on the canister.
@@ -139,7 +123,7 @@ export const verifyTentativeDevice = async ({
   const countdown: AsyncCountdown<VerifyResult | "canceled"> =
     AsyncCountdown.fromNanos(endTimestamp);
 
-  verifyTentativeDevicePage({
+  verifyTentativeDevicePage<VerifyResult>({
     alias,
     cancel: async () => {
       await withLoader(() => connection.exitDeviceRegistrationMode());
@@ -156,12 +140,12 @@ export const verifyTentativeDevice = async ({
 
       if ("wrong_code" in result) {
         if (result.wrong_code.retries_left === 0) {
-          return { too_many_attempts: null };
+          return { retry: false, value: { too_many_attempts: null } };
         } else {
-          return { retry: null };
+          return { retry: true };
         }
       } else {
-        return result;
+        return { retry: false, value: result };
       }
     },
     doContinue: (res) => countdown.stop(res),

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -13,7 +13,7 @@ import { DynamicKey } from "$src/utils/i18n";
 import { Connection } from "$src/utils/iiConnection";
 import { renderPage, withRef } from "$src/utils/lit-html";
 import { parseUserNumber } from "$src/utils/userNumber";
-import { Chan } from "$src/utils/utils";
+import { Chan, withInputElement } from "$src/utils/utils";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { wordlists } from "bip39";
 import { TemplateResult, html } from "lit-html";
@@ -230,20 +230,6 @@ export const wordTemplate = ({
         >`,
       }[s])
   );
-
-  // Helper to gain access to the event's target
-  const withElement = <E extends Event>(
-    event: E,
-    f: (event: E, element: HTMLInputElement) => void
-  ): void => {
-    const element = event.currentTarget;
-    if (!(element instanceof HTMLInputElement)) {
-      return;
-    }
-
-    return f(event, element);
-  };
-
   const classes = [...(classes_ ?? []), "c-list--recovery-word"];
 
   return html`<li
@@ -255,7 +241,7 @@ export const wordTemplate = ({
       autofocus
       data-validity-type=${validityType}
       @paste=${(e: ClipboardEvent) =>
-        withElement(e, (event, element) => {
+        withInputElement(e, (event, element) => {
           e.preventDefault();
 
           // Get the text pasted
@@ -311,13 +297,13 @@ export const wordTemplate = ({
       data-state=${asyncReplace(state)}
       @input=${(e: InputEvent) => {
         state.send("pending");
-        withElement(e, (_e, element) => {
+        withInputElement(e, (_e, element) => {
           // Reset validity when typing
           resetValidity({ element });
         });
       }}
       @change=${(e: InputEvent) => {
-        withElement(e, (event, element) => {
+        withInputElement(e, (event, element) => {
           // Check validity when leaving the field
           state.send(reportValidity({ element }));
         });

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -465,6 +465,10 @@ body {
   font-size: 0.8em;
 }
 
+.t-error {
+  color: var(--rc-error);
+}
+
 .t-centered {
   text-align: center;
 }
@@ -1714,6 +1718,42 @@ by all browsers (FF is missing) */
 
 .c-list--numbered {
   list-style-type: decimal;
+}
+
+/**
+ *  Pin Input
+ *
+ */
+
+.c-list--pin {
+  width: 100%;
+  display: inline-flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.c-list--pin-char {
+  display: block;
+  flex-basis: content;
+}
+
+.c-list--pin[data-haserror="true"] .c-input--pin {
+  border-color: red;
+}
+
+.c-input--pin {
+  text-align: center;
+
+  /* Sizing the input
+   *
+   * The 'input' is sized by its width (width here, or size=1 in HTML as fallback) and "height" (line-height), plus padding in both
+   * dimensions.
+   * */
+  font-size: 2em;
+  padding: 0.2em;
+  width: 1.4em;
+
+  font-weight: 600;
 }
 
 /**

--- a/src/frontend/src/test-e2e/addDevice.test.ts
+++ b/src/frontend/src/test-e2e/addDevice.test.ts
@@ -100,7 +100,6 @@ test("Add remote device", async () => {
       const verificationView = new VerifyRemoteDeviceView(browser);
       await verificationView.waitForDisplay();
       await verificationView.enterVerificationCode(code);
-      await verificationView.continue();
 
       // Verify success on Browser 1
 
@@ -179,7 +178,6 @@ test("Add remote device starting on new device", async () => {
       const verificationView = new VerifyRemoteDeviceView(browser);
       await verificationView.waitForDisplay();
       await verificationView.enterVerificationCode(code);
-      await verificationView.continue();
 
       // success page
       const addDeviceSuccessView = new AddDeviceSuccessView(browser);

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -1,3 +1,4 @@
+import { zip } from "$src/utils/utils";
 import { nonNullish } from "@dfinity/utils";
 
 class View {
@@ -397,7 +398,12 @@ export class VerifyRemoteDeviceView extends View {
   }
 
   async enterVerificationCode(code: string): Promise<void> {
-    await this.browser.$("#tentativeDeviceCode").setValue(code);
+    const inputs = await this.browser
+      .$('[data-role="verification-code"]')
+      .$$("input");
+    for (const [input, digit] of zip(inputs, code.split(""))) {
+      await input.setValue(digit);
+    }
   }
 
   async continue(): Promise<void> {

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -20,6 +20,19 @@ export function unknownToString(obj: unknown, def: string): string {
   return def;
 }
 
+// Helper to gain access to the event's target
+export const withInputElement = <E extends Event>(
+  event: E,
+  f: (event: E, element: HTMLInputElement) => void
+): void => {
+  const element = event.currentTarget;
+  if (!(element instanceof HTMLInputElement)) {
+    return;
+  }
+
+  return f(event, element);
+};
+
 /** Try to read unknown data as a record */
 export function unknownToRecord(
   msg: unknown
@@ -329,3 +342,7 @@ export function shuffleArray<T>(array_: T[]): T[] {
 export type OmitParams<T extends (arg: any) => any, A extends string> = (
   a: Omit<Parameters<T>[0], A>
 ) => ReturnType<T>;
+
+// Zip two arrays together
+export const zip = <A, B>(a: A[], b: B[]): [A, B][] =>
+  Array.from(Array(Math.min(b.length, a.length)), (_, i) => [a[i], b[i]]);


### PR DESCRIPTION
This introduces a new components for PIN input (`pinInput`) and updates `verifyTentativeDevice` to use this new component.

The component supports both typing & pasting the PIN. The PIN will be autosubmitting when all inputs are filled, at most once. On subsequent attempts the user will need to submit manually.

See tests & notes in code for the many corner cases & tweaks.


https://github.com/dfinity/internet-identity/assets/6930756/69b3b65d-03c5-4364-a2e2-050004e82882

(note: in the recording, the final attempt with 121212 is a success, but the showcase just doesn't show a message)

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ab931b784/desktop/verifyTentativeDevice.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ab931b784/mobile/verifyTentativeDevice.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
