### PR TITLE
Fix mobile viewport in showcase

### DIFF
--- a/src/showcase/src/layouts/Layout.astro
+++ b/src/showcase/src/layouts/Layout.astro
@@ -1,0 +1,16 @@
+---
+import "$src/styles/main.css";
+---
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Showcase - Internet Identity</title>
+    <link rel="shortcut icon" href="/favicon.ico" />
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/src/showcase/src/pages/[page].astro
+++ b/src/showcase/src/pages/[page].astro
@@ -1,4 +1,5 @@
 ---
+import Layout from "../layouts/Layout.astro";
 import "$src/styles/main.css";
 import { iiPages } from "$showcase/showcase";
 
@@ -9,13 +10,15 @@ export function getStaticPaths() {
 const { page } = Astro.params;
 ---
 
-<div id="pageContent" data-page-name={page}></div>
-<script>
-  import { iiPages } from "$showcase/showcase";
+<Layout>
+  <main id="pageContent" aria-live="polite" data-page-name={page}></main>
+  <script>
+    import { iiPages } from "$showcase/showcase";
 
-  const page = (document.querySelector("[data-page-name]") as HTMLDivElement)
-    .dataset?.pageName as string;
+    const page = (document.querySelector("[data-page-name]") as HTMLElement)
+      .dataset?.pageName as string;
 
-  const f = iiPages[page];
-  f();
-</script>
+    const f = iiPages[page];
+    f();
+  </script>
+</Layout>

--- a/src/showcase/src/pages/index.astro
+++ b/src/showcase/src/pages/index.astro
@@ -1,10 +1,13 @@
 ---
+import Layout from "../layouts/Layout.astro";
 import "$src/styles/main.css";
 ---
 
-<div id="pageContent"></div>
-<script>
-  import { defaultPage } from "$showcase/showcase";
+<Layout>
+  <main id="pageContent" aria-live="polite"></main>
+  <script>
+    import { defaultPage } from "$showcase/showcase";
 
-  defaultPage();
-</script>
+    defaultPage();
+  </script>
+</Layout>


### PR DESCRIPTION
The viewport settings were different in the showcase than in the actual app, causing discrepancies between the screens as shown in the showcase vs in the actual app.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/eee5e8248/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
