### PR TITLE
Fix PIN pasting

### DIFF
--- a/src/frontend/src/components/pinInput.ts
+++ b/src/frontend/src/components/pinInput.ts
@@ -207,15 +207,16 @@ const onPaste = ({
     return;
   }
 
-  // Actually set the value (for reasons unclear, preventDefault() is not necessary here as tested on
-  // Chrome, Safari)
+  // Set the values manually
   for (const [input, char] of toBePasted) {
     input.value = char;
   }
+  // Prevent actually pasting the value in any of the fields since we just did this manually
+  event.preventDefault();
 
   if (toBePasted.length < nextInputs.length) {
     // If all inputs have NOT been filled, then focus on the one after the last paste/fill
-    nextInputs[toBePasted.length - 1].focus();
+    nextInputs[toBePasted.length].focus();
   } else {
     // otherwise, drop focus entirely
     element.blur();


### PR DESCRIPTION
This prevents the browser from actually pasting anything. Without this, the browser tries to re-paste the entire input on the last element (which ended up being focused).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a6c1ea2f0/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
