### PR TITLE
Fix selenium tests for paste

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -488,6 +488,13 @@ jobs:
           path: test-failures/*
           if-no-files-found: ignore
 
+  # Aggregate all selenium matrix jobs, used in branch protection
+  selenium-all:
+    runs-on: ubuntu-latest
+    needs: selenium
+    steps:
+      - run: echo selenium ok
+
   using-dev-build:
     runs-on: ubuntu-latest
     needs: docker-build-ii

--- a/src/frontend/src/components/pinInput.test.ts
+++ b/src/frontend/src/components/pinInput.test.ts
@@ -159,7 +159,7 @@ describe("pin input", () => {
     dispatchPaste(inputs[2], content);
 
     // Focus should have moved (3 = length of "123")
-    expect(inputs[2 + content.length - 1]).toBe(document.activeElement);
+    expect(inputs[2 + content.length]).toBe(document.activeElement);
   });
 
   test("calling .submit() does submit", () => {


### PR DESCRIPTION
This fixes a paste test for the PIN input component, and introduces a aggregating job for all selenium tests that can be used to gate for branch protection.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
