### PR TITLE
Bump agent-js to 0.19.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.1.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@dfinity/agent": "0.15.5",
-        "@dfinity/candid": "0.15.5",
-        "@dfinity/identity": "0.15.5",
-        "@dfinity/principal": "0.15.5",
-        "@dfinity/utils": "^0.0.14",
+        "@dfinity/agent": "^0.19.1",
+        "@dfinity/candid": "^0.19.1",
+        "@dfinity/identity": "^0.19.1",
+        "@dfinity/principal": "^0.19.1",
+        "@dfinity/utils": "^0.0.20",
         "bip39": "^3.0.4",
         "buffer": "^6.0.3",
         "lit-html": "^2.7.2",
@@ -654,6 +654,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -665,68 +666,66 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.5.tgz",
-      "integrity": "sha512-Ytn8eo0Gk8QkaCX2X+CS1NYOdCr0ZjanqFyKbR5rY7LGQoVaNzdVHJufzheuTFMhTZs6i/OtaG2BQug4cNIocw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.1.tgz",
+      "integrity": "sha512-xKIOUDR72bPFP7/q441Mtr4+Vw/S9ddgtI37NeI3YovjWfFwkJ+89cbDaTxxgIYA0GRIUEdOHGxfDfmcO3RoKA==",
       "dependencies": {
+        "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
-        "bignumber.js": "^9.0.0",
         "borc": "^2.1.1",
-        "js-sha256": "0.9.0",
-        "simple-cbor": "^0.4.1",
-        "ts-node": "^10.8.2"
+        "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.15.5",
-        "@dfinity/principal": "^0.15.5"
+        "@dfinity/candid": "^0.19.1",
+        "@dfinity/principal": "^0.19.1"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.5.tgz",
-      "integrity": "sha512-SWf70AuFJ+SphvOHPiyCXE2s5b63c8U/UVGIRhnxSR/xi8iiP3tjPL6Cfe+TPsuXQShX8pPJBJhKC9O20cua2Q==",
-      "dependencies": {
-        "ts-node": "^10.8.2"
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.1.tgz",
+      "integrity": "sha512-CAe2OQgr8ehoyRE+qJ5mHqYl7+61n6Ed7vsAE6gofTjCk5JmWERNGxMpQLJmO+zljkiEAIWvdc+DZAvybgjyuw==",
+      "peerDependencies": {
+        "@dfinity/principal": "^0.19.1"
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.15.5.tgz",
-      "integrity": "sha512-Lli8I86y/3AGf3e5yXTQtFNij/1YrGWlgPDxMsmyzBQjkiUh8PLQYPNGbq7uH410gG+vvmBBJy7h/vEl3ECALA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.1.tgz",
+      "integrity": "sha512-qTlO7uWCZkrgjCgdvfS6HSrXSAnfkJGRLSrwoFnVkneXX1qgjGC/L805c+yx3K9kLzIAoED3NQG6MIXIfFuVIg==",
       "dependencies": {
+        "@noble/hashes": "^1.3.1",
         "borc": "^2.1.1",
-        "js-sha256": "^0.9.0",
         "tweetnacl": "^1.0.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.5",
-        "@dfinity/principal": "^0.15.5",
+        "@dfinity/agent": "^0.19.1",
+        "@dfinity/principal": "^0.19.1",
         "@peculiar/webcrypto": "^1.4.0"
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.5.tgz",
-      "integrity": "sha512-K+oIH/zAuZf6JxQAZrPzkkGL+hPn96/CnFzjWNqwHADZjBShr9m1n2Sv/68hKoND5p/uMNVIAV0km39A03Se6g==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.1.tgz",
+      "integrity": "sha512-UB5Fvh7PvQ35cS/+bHcyH/nPSBjyp/O4/J97t4L/oRWhobvMIsnxeH1uV6GUqNi7v/UHwtmhoMpjd23SIOX8kQ==",
       "dependencies": {
-        "js-sha256": "^0.9.0",
-        "ts-node": "^10.8.2"
+        "@noble/hashes": "^1.3.1"
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.14.tgz",
-      "integrity": "sha512-wSZOQHMmIPTW9LRpj6mMo0QKAYOBTkIRuoU6Mhbo3zH/TjszJTTbK1coIvneXHu9/HkdgzG7x4MWwJaUp8ZMZg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.20.tgz",
+      "integrity": "sha512-9mkxDfQ/ppSqkErYhbKc4zXgu6hTUdqUlePh2DatX55nlGlbyuC16HQAjLYOrOw1b+kRoN8Opl8wf/qObumFsQ==",
       "peerDependencies": {
-        "@dfinity/agent": "^0.15.4",
-        "@dfinity/candid": "^0.15.4",
-        "@dfinity/principal": "^0.15.4"
+        "@dfinity/agent": "^0.19.1",
+        "@dfinity/candid": "^0.19.1",
+        "@dfinity/principal": "^0.19.1"
       }
     },
     "node_modules/@emmetio/abbreviation": {
@@ -1283,6 +1282,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1309,7 +1309,8 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.17",
@@ -1326,6 +1327,17 @@
       "resolved": "https://registry.npmjs.org/@ljharb/has-package-exports-patterns/-/has-package-exports-patterns-0.0.2.tgz",
       "integrity": "sha512-4/RWEeXDO6bocPONheFe6gX/oQdP/bEpv0oL4HqjPP5DCenBSt0mHgahppY49N0CpsaqffdwPq+TlX9CYOq2Dw==",
       "dev": true
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1497,22 +1509,26 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
@@ -1695,7 +1711,8 @@
     "node_modules/@types/node": {
       "version": "18.8.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA=="
+      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2509,6 +2526,7 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2551,6 +2569,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2737,7 +2756,8 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3916,7 +3936,8 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -4332,6 +4353,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -6486,11 +6508,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -7034,7 +7051,8 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/markdown-table": {
       "version": "3.0.3",
@@ -10613,6 +10631,7 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10729,6 +10748,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11043,7 +11063,8 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -11902,6 +11923,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -12422,6 +12444,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -12430,6 +12453,7 @@
           "version": "0.3.9",
           "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
           "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
           "requires": {
             "@jridgewell/resolve-uri": "^3.0.3",
             "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -12438,49 +12462,44 @@
       }
     },
     "@dfinity/agent": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.15.5.tgz",
-      "integrity": "sha512-Ytn8eo0Gk8QkaCX2X+CS1NYOdCr0ZjanqFyKbR5rY7LGQoVaNzdVHJufzheuTFMhTZs6i/OtaG2BQug4cNIocw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.1.tgz",
+      "integrity": "sha512-xKIOUDR72bPFP7/q441Mtr4+Vw/S9ddgtI37NeI3YovjWfFwkJ+89cbDaTxxgIYA0GRIUEdOHGxfDfmcO3RoKA==",
       "requires": {
+        "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
-        "bignumber.js": "^9.0.0",
         "borc": "^2.1.1",
-        "js-sha256": "0.9.0",
-        "simple-cbor": "^0.4.1",
-        "ts-node": "^10.8.2"
+        "simple-cbor": "^0.4.1"
       }
     },
     "@dfinity/candid": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.15.5.tgz",
-      "integrity": "sha512-SWf70AuFJ+SphvOHPiyCXE2s5b63c8U/UVGIRhnxSR/xi8iiP3tjPL6Cfe+TPsuXQShX8pPJBJhKC9O20cua2Q==",
-      "requires": {
-        "ts-node": "^10.8.2"
-      }
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.1.tgz",
+      "integrity": "sha512-CAe2OQgr8ehoyRE+qJ5mHqYl7+61n6Ed7vsAE6gofTjCk5JmWERNGxMpQLJmO+zljkiEAIWvdc+DZAvybgjyuw==",
+      "requires": {}
     },
     "@dfinity/identity": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.15.5.tgz",
-      "integrity": "sha512-Lli8I86y/3AGf3e5yXTQtFNij/1YrGWlgPDxMsmyzBQjkiUh8PLQYPNGbq7uH410gG+vvmBBJy7h/vEl3ECALA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.1.tgz",
+      "integrity": "sha512-qTlO7uWCZkrgjCgdvfS6HSrXSAnfkJGRLSrwoFnVkneXX1qgjGC/L805c+yx3K9kLzIAoED3NQG6MIXIfFuVIg==",
       "requires": {
+        "@noble/hashes": "^1.3.1",
         "borc": "^2.1.1",
-        "js-sha256": "^0.9.0",
         "tweetnacl": "^1.0.1"
       }
     },
     "@dfinity/principal": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.15.5.tgz",
-      "integrity": "sha512-K+oIH/zAuZf6JxQAZrPzkkGL+hPn96/CnFzjWNqwHADZjBShr9m1n2Sv/68hKoND5p/uMNVIAV0km39A03Se6g==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.1.tgz",
+      "integrity": "sha512-UB5Fvh7PvQ35cS/+bHcyH/nPSBjyp/O4/J97t4L/oRWhobvMIsnxeH1uV6GUqNi7v/UHwtmhoMpjd23SIOX8kQ==",
       "requires": {
-        "js-sha256": "^0.9.0",
-        "ts-node": "^10.8.2"
+        "@noble/hashes": "^1.3.1"
       }
     },
     "@dfinity/utils": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.14.tgz",
-      "integrity": "sha512-wSZOQHMmIPTW9LRpj6mMo0QKAYOBTkIRuoU6Mhbo3zH/TjszJTTbK1coIvneXHu9/HkdgzG7x4MWwJaUp8ZMZg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-0.0.20.tgz",
+      "integrity": "sha512-9mkxDfQ/ppSqkErYhbKc4zXgu6hTUdqUlePh2DatX55nlGlbyuC16HQAjLYOrOw1b+kRoN8Opl8wf/qObumFsQ==",
       "requires": {}
     },
     "@emmetio/abbreviation": {
@@ -12788,7 +12807,8 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
@@ -12809,7 +12829,8 @@
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.17",
@@ -12826,6 +12847,11 @@
       "resolved": "https://registry.npmjs.org/@ljharb/has-package-exports-patterns/-/has-package-exports-patterns-0.0.2.tgz",
       "integrity": "sha512-4/RWEeXDO6bocPONheFe6gX/oQdP/bEpv0oL4HqjPP5DCenBSt0mHgahppY49N0CpsaqffdwPq+TlX9CYOq2Dw==",
       "dev": true
+    },
+    "@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -12965,22 +12991,26 @@
     "@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
     },
     "@tsconfig/node12": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
     },
     "@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
     },
     "@tsconfig/node16": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.20.1",
@@ -13163,7 +13193,8 @@
     "@types/node": {
       "version": "18.8.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA=="
+      "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -13818,7 +13849,8 @@
     "acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -13850,7 +13882,8 @@
     "acorn-walk": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",
@@ -14008,7 +14041,8 @@
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -14852,7 +14886,8 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-fetch": {
       "version": "3.1.5",
@@ -15164,7 +15199,8 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "diff-sequences": {
       "version": "29.3.1",
@@ -16758,11 +16794,6 @@
         }
       }
     },
-    "js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -17205,7 +17236,8 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "markdown-table": {
       "version": "3.0.3",
@@ -19741,6 +19773,7 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -19815,7 +19848,8 @@
     "typescript": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "1.0.35",
@@ -20026,7 +20060,8 @@
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -20633,7 +20668,8 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -52,11 +52,11 @@
     "webdriverio": "^8.6.9"
   },
   "dependencies": {
-    "@dfinity/agent": "0.15.5",
-    "@dfinity/candid": "0.15.5",
-    "@dfinity/identity": "0.15.5",
-    "@dfinity/principal": "0.15.5",
-    "@dfinity/utils": "^0.0.14",
+    "@dfinity/agent": "^0.19.1",
+    "@dfinity/candid": "^0.19.1",
+    "@dfinity/identity": "^0.19.1",
+    "@dfinity/principal": "^0.19.1",
+    "@dfinity/utils": "^0.0.20",
     "bip39": "^3.0.4",
     "buffer": "^6.0.3",
     "lit-html": "^2.7.2",


### PR DESCRIPTION
Updating agent-js https://github.com/dfinity/agent-js/releases/tag/v0.19.0 solve an issue with last version of Chrome 116.0.5845.110 which sometimes fails (not on all devices) verifying responses using the sha256 library. That's why in agent-js they replaced the library.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/707d808f6/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
