### PR TITLE
Fix typo in hash verification script

### DIFF
--- a/scripts/verify-hash
+++ b/scripts/verify-hash
@@ -108,7 +108,7 @@ fi
 
 if [ -n "$expected_archive_hash" ]
 then
-  ./scripts/docker-build.sh --archive
+  ./scripts/docker-build --archive
   archive_sha256="$(shasum -a 256 ./archive.wasm.gz | cut -d ' ' -f1)"
   if [ "$archive_sha256" == "$expected_archive_hash" ]
   then


### PR DESCRIPTION
This fixes a small issue with the hash verification script when verifying the archive.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/1c7d5f83f/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/1c7d5f83f/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
