### PR TITLE
Make max number of inflight captchas configurable

### DIFF
--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -164,7 +164,6 @@ pub fn install_ii_canister_with_arg(
 
 pub fn arg_with_wasm_hash(wasm: Vec<u8>) -> Option<InternetIdentityInit> {
     Some(InternetIdentityInit {
-        assigned_user_number_range: None,
         archive_config: Some(ArchiveConfig {
             module_hash: archive_wasm_hash(&wasm),
             entries_buffer_limit: 10_000,
@@ -172,18 +171,14 @@ pub fn arg_with_wasm_hash(wasm: Vec<u8>) -> Option<InternetIdentityInit> {
             entries_fetch_limit: 10,
         }),
         canister_creation_cycles_cost: Some(0),
-        register_rate_limit: None,
-        max_num_latest_delegation_origins: None,
+        ..InternetIdentityInit::default()
     })
 }
 
 pub fn arg_with_rate_limit(rate_limit: RateLimitConfig) -> Option<InternetIdentityInit> {
     Some(InternetIdentityInit {
-        assigned_user_number_range: None,
-        archive_config: None,
-        canister_creation_cycles_cost: None,
         register_rate_limit: Some(rate_limit),
-        max_num_latest_delegation_origins: None,
+        ..InternetIdentityInit::default()
     })
 }
 
@@ -192,10 +187,7 @@ pub fn arg_with_anchor_range(
 ) -> Option<InternetIdentityInit> {
     Some(InternetIdentityInit {
         assigned_user_number_range: Some(anchor_range),
-        archive_config: None,
-        canister_creation_cycles_cost: None,
-        register_rate_limit: None,
-        max_num_latest_delegation_origins: None,
+        ..InternetIdentityInit::default()
     })
 }
 

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -13,6 +13,7 @@ export const idlFactory = ({ IDL }) => {
   const InternetIdentityInit = IDL.Record({
     'max_num_latest_delegation_origins' : IDL.Opt(IDL.Nat64),
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
+    'max_inflight_captchas' : IDL.Opt(IDL.Nat64),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
     'register_rate_limit' : IDL.Opt(RateLimitConfig),
@@ -310,6 +311,7 @@ export const init = ({ IDL }) => {
   const InternetIdentityInit = IDL.Record({
     'max_num_latest_delegation_origins' : IDL.Opt(IDL.Nat64),
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
+    'max_inflight_captchas' : IDL.Opt(IDL.Nat64),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
     'register_rate_limit' : IDL.Opt(RateLimitConfig),

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -126,6 +126,7 @@ export type IdentityNumber = bigint;
 export interface InternetIdentityInit {
   'max_num_latest_delegation_origins' : [] | [bigint],
   'assigned_user_number_range' : [] | [[bigint, bigint]],
+  'max_inflight_captchas' : [] | [bigint],
   'archive_config' : [] | [ArchiveConfig],
   'canister_creation_cycles_cost' : [] | [bigint],
   'register_rate_limit' : [] | [RateLimitConfig],

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -230,6 +230,9 @@ type InternetIdentityInit = record {
     // Maximum number of latest delegation origins to track.
     // Default: 1000
     max_num_latest_delegation_origins : opt nat64;
+    // Maximum number of inflight captchas.
+    // Default: 500
+    max_inflight_captchas: opt nat64;
 };
 
 type ChallengeKey = text;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -379,6 +379,11 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
                 persistent_state.max_num_latest_delegation_origins = Some(limit);
             })
         }
+        if let Some(limit) = arg.max_inflight_captchas {
+            state::persistent_state_mut(|persistent_state| {
+                persistent_state.max_inflight_captchas = Some(limit);
+            })
+        }
     }
 }
 

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -24,6 +24,9 @@ mod temp_keys;
 // Default value for max number of delegation origins to store in the list of latest used delegation origins
 const MAX_NUM_DELEGATION_ORIGINS: u64 = 1000;
 
+// Default value for max number of inflight captchas.
+pub const MAX_INFLIGHT_CAPTCHAS: u64 = 500;
+
 thread_local! {
     static STATE: State = State::default();
     static ASSETS: RefCell<CertifiedAssets> = RefCell::new(CertifiedAssets::default());
@@ -92,6 +95,8 @@ pub struct PersistentState {
     pub latest_delegation_origins: Option<HashMap<FrontendHostname, Timestamp>>,
     // Maximum number of latest delegation origins to store
     pub max_num_latest_delegation_origins: Option<u64>,
+    // Maximum number of inflight captchas
+    pub max_inflight_captchas: Option<u64>,
 }
 
 impl Default for PersistentState {
@@ -105,6 +110,7 @@ impl Default for PersistentState {
             active_authn_method_stats: None,
             latest_delegation_origins: None,
             max_num_latest_delegation_origins: Some(MAX_NUM_DELEGATION_ORIGINS),
+            max_inflight_captchas: Some(MAX_INFLIGHT_CAPTCHAS),
         }
     }
 }

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -349,7 +349,7 @@ fn should_overwrite_persistent_state_with_next_anchor() {
 fn should_read_previously_stored_persistent_state() {
     const NUM_ANCHORS: u64 = 3;
     const EXPECTED_ADDRESS: u64 = RESERVED_HEADER_BYTES + NUM_ANCHORS * 4096;
-    const PERSISTENT_STATE_BYTES: &str = "4949505368010000000000004449444c116c03949d879d0701f7f5cbfb0778eed5f3af090a6b04dee7beb6080291a5fcf10a7fd1d3dab70b05c8bbeff50d066c01c2adc9be0c036c04c3f9fca002788beea8c5047881cfaef40a0487eb979d0d7a6d7b6c02d6a9bbae0a78c2adc9be0c036c02aaac8d930407c2adc9be0c036c03c7e8ccee037884fbf0820968cfd6ffea0f086d096c04c7e8ccee0378f2f099840704938da78c0a78d6a9bbae0a786e0b6c028bc3e2f9040cbbd492d8090f6c0297beb4cb080d8b858cea090d6e0e6c02fcdde6ea0178f9a6ebf703786c0297beb4cb08108b858cea090e6d0e0100032700000000000000010a00000000006000b0010100005847f80d0000001027000000000000206363636363636363636363636363636363636363636363636363636363636363e8038002e1df0200000001000163000000000000006dbb0e000000000001420000000000000030f1c520000000002c00000000000000d133b45001000000";
+    let persistent_state_bytes = candid::encode_one(&sample_persistent_state()).unwrap();
     let memory = VectorMemory::default();
     // allocate space for the writes
     memory.grow(3);
@@ -363,10 +363,12 @@ fn should_read_previously_stored_persistent_state() {
             .expect("Failed writing anchor");
     }
 
+    memory.write(EXPECTED_ADDRESS, b"IIPS".as_ref());
     memory.write(
-        EXPECTED_ADDRESS,
-        &hex::decode(PERSISTENT_STATE_BYTES).unwrap(),
+        EXPECTED_ADDRESS + 4,
+        &(persistent_state_bytes.len() as u64).to_le_bytes(),
     );
+    memory.write(EXPECTED_ADDRESS + 12, &persistent_state_bytes);
 
     assert_eq!(
         storage

--- a/src/internet_identity/tests/integration/anchor_management/registration/mod.rs
+++ b/src/internet_identity/tests/integration/anchor_management/registration/mod.rs
@@ -194,9 +194,13 @@ fn should_not_allow_expired_captcha() -> Result<(), CallError> {
 #[test]
 fn should_limit_captcha_creation() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let init_arg = InternetIdentityInit {
+        max_inflight_captchas: Some(3),
+        ..Default::default()
+    };
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(init_arg));
 
-    for _ in 0..500 {
+    for _ in 0..3 {
         api::create_challenge(&env, canister_id)?;
     }
     let result = api::create_challenge(&env, canister_id);

--- a/src/internet_identity/tests/integration/archive_integration.rs
+++ b/src/internet_identity/tests/integration/archive_integration.rs
@@ -40,7 +40,6 @@ mod deployment_tests {
             &env,
             II_WASM.clone(),
             Some(InternetIdentityInit {
-                assigned_user_number_range: None,
                 archive_config: Some(ArchiveConfig {
                     module_hash: archive_wasm_hash(&ARCHIVE_WASM),
                     entries_buffer_limit: 0,
@@ -48,8 +47,7 @@ mod deployment_tests {
                     entries_fetch_limit: 0,
                 }),
                 canister_creation_cycles_cost: Some(100_000_000_000), // current cost in application subnets
-                register_rate_limit: None,
-                max_num_latest_delegation_origins: None,
+                ..InternetIdentityInit::default()
             }),
         );
         env.add_cycles(ii_canister, 150_000_000_000);
@@ -174,16 +172,13 @@ mod deployment_tests {
             ii_canister,
             II_WASM.clone(),
             Some(InternetIdentityInit {
-                assigned_user_number_range: None,
                 archive_config: Some(ArchiveConfig {
                     module_hash: archive_wasm_hash(&ARCHIVE_WASM),
                     entries_buffer_limit: 10,
                     polling_interval_ns: 5_000,
                     entries_fetch_limit: 10,
                 }),
-                canister_creation_cycles_cost: None, // current cost in application subnets
-                register_rate_limit: None,
-                max_num_latest_delegation_origins: None,
+                ..InternetIdentityInit::default()
             }),
         )
         .unwrap();
@@ -650,7 +645,6 @@ mod pull_entries_tests {
         let env = env();
 
         let init_arg = InternetIdentityInit {
-            assigned_user_number_range: None,
             archive_config: Some(ArchiveConfig {
                 module_hash: archive_wasm_hash(&ARCHIVE_WASM),
                 entries_buffer_limit: 20_000,
@@ -658,8 +652,7 @@ mod pull_entries_tests {
                 entries_fetch_limit: 10,
             }),
             canister_creation_cycles_cost: Some(0),
-            register_rate_limit: None,
-            max_num_latest_delegation_origins: None,
+            ..InternetIdentityInit::default()
         };
 
         let ii_canister = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(init_arg));

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -194,6 +194,7 @@ pub struct InternetIdentityInit {
     pub canister_creation_cycles_cost: Option<u64>,
     pub register_rate_limit: Option<RateLimitConfig>,
     pub max_num_latest_delegation_origins: Option<u64>,
+    pub max_inflight_captchas: Option<u64>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
This PR fixes a long standing issue with a very long running integration test that maxes out a non configurable limit.
It is fixed by making the limit configurabel. This is done in preparation for the API v2 registration endpoint that would also have duplicated the long running test aggravating the issue further. Fixing this issue cuts down rust integration test time by about 90 seconds.

In addition, the storage tests for the persistent state are made more robust so that they no longer break on persistent state changes.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
