### PR TITLE
Bump agent-js to 0.19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@dfinity/agent": "^0.19.1",
-        "@dfinity/candid": "^0.19.1",
-        "@dfinity/identity": "^0.19.1",
-        "@dfinity/principal": "^0.19.1",
+        "@dfinity/agent": "^0.19.2",
+        "@dfinity/candid": "^0.19.2",
+        "@dfinity/identity": "^0.19.2",
+        "@dfinity/principal": "^0.19.2",
         "@dfinity/utils": "^0.0.20",
         "bip39": "^3.0.4",
         "buffer": "^6.0.3",
@@ -673,9 +673,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.1.tgz",
-      "integrity": "sha512-xKIOUDR72bPFP7/q441Mtr4+Vw/S9ddgtI37NeI3YovjWfFwkJ+89cbDaTxxgIYA0GRIUEdOHGxfDfmcO3RoKA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.2.tgz",
+      "integrity": "sha512-KLRWEjeU9SyyaS7IBVJ9ZUcufxufr55e/kRIyClK157+0pkTG9a8xKjUIMx3QzKvLsqqzXL238nWwdoP6jAD8g==",
       "dependencies": {
         "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
@@ -683,37 +683,37 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^0.19.1",
-        "@dfinity/principal": "^0.19.1"
+        "@dfinity/candid": "^0.19.2",
+        "@dfinity/principal": "^0.19.2"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.1.tgz",
-      "integrity": "sha512-CAe2OQgr8ehoyRE+qJ5mHqYl7+61n6Ed7vsAE6gofTjCk5JmWERNGxMpQLJmO+zljkiEAIWvdc+DZAvybgjyuw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.2.tgz",
+      "integrity": "sha512-X2hCqNMhnnmwtnOc0WnymOZYx3qphjEMuSYbBr7tMIkV7Hwt9BmXXlLnQTxUytTPxf+3he0GcS3KzsSQ9CK8ew==",
       "peerDependencies": {
-        "@dfinity/principal": "^0.19.1"
+        "@dfinity/principal": "^0.19.2"
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.1.tgz",
-      "integrity": "sha512-qTlO7uWCZkrgjCgdvfS6HSrXSAnfkJGRLSrwoFnVkneXX1qgjGC/L805c+yx3K9kLzIAoED3NQG6MIXIfFuVIg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.2.tgz",
+      "integrity": "sha512-0EwZd8lVfXzHLl5flRysRbjV181b2Xh9loV7QUrt5fE+lP5hgF4f+odFB1YajHQaSyCY1t+v7DA6R9+ICZK9AQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.1",
         "borc": "^2.1.1",
         "tweetnacl": "^1.0.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^0.19.1",
-        "@dfinity/principal": "^0.19.1",
+        "@dfinity/agent": "^0.19.2",
+        "@dfinity/principal": "^0.19.2",
         "@peculiar/webcrypto": "^1.4.0"
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.1.tgz",
-      "integrity": "sha512-UB5Fvh7PvQ35cS/+bHcyH/nPSBjyp/O4/J97t4L/oRWhobvMIsnxeH1uV6GUqNi7v/UHwtmhoMpjd23SIOX8kQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.2.tgz",
+      "integrity": "sha512-vsKN6BKya70bQUsjgKRDlR2lOpv/XpUkCMIiji6rjMtKHIuWEB5Eu3JqZsOuBmWo3A3TT/K/osT9VPm0k4qdYQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.1"
       }
@@ -12462,9 +12462,9 @@
       }
     },
     "@dfinity/agent": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.1.tgz",
-      "integrity": "sha512-xKIOUDR72bPFP7/q441Mtr4+Vw/S9ddgtI37NeI3YovjWfFwkJ+89cbDaTxxgIYA0GRIUEdOHGxfDfmcO3RoKA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.19.2.tgz",
+      "integrity": "sha512-KLRWEjeU9SyyaS7IBVJ9ZUcufxufr55e/kRIyClK157+0pkTG9a8xKjUIMx3QzKvLsqqzXL238nWwdoP6jAD8g==",
       "requires": {
         "@noble/hashes": "^1.3.1",
         "base64-arraybuffer": "^0.2.0",
@@ -12473,15 +12473,15 @@
       }
     },
     "@dfinity/candid": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.1.tgz",
-      "integrity": "sha512-CAe2OQgr8ehoyRE+qJ5mHqYl7+61n6Ed7vsAE6gofTjCk5JmWERNGxMpQLJmO+zljkiEAIWvdc+DZAvybgjyuw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-0.19.2.tgz",
+      "integrity": "sha512-X2hCqNMhnnmwtnOc0WnymOZYx3qphjEMuSYbBr7tMIkV7Hwt9BmXXlLnQTxUytTPxf+3he0GcS3KzsSQ9CK8ew==",
       "requires": {}
     },
     "@dfinity/identity": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.1.tgz",
-      "integrity": "sha512-qTlO7uWCZkrgjCgdvfS6HSrXSAnfkJGRLSrwoFnVkneXX1qgjGC/L805c+yx3K9kLzIAoED3NQG6MIXIfFuVIg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-0.19.2.tgz",
+      "integrity": "sha512-0EwZd8lVfXzHLl5flRysRbjV181b2Xh9loV7QUrt5fE+lP5hgF4f+odFB1YajHQaSyCY1t+v7DA6R9+ICZK9AQ==",
       "requires": {
         "@noble/hashes": "^1.3.1",
         "borc": "^2.1.1",
@@ -12489,9 +12489,9 @@
       }
     },
     "@dfinity/principal": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.1.tgz",
-      "integrity": "sha512-UB5Fvh7PvQ35cS/+bHcyH/nPSBjyp/O4/J97t4L/oRWhobvMIsnxeH1uV6GUqNi7v/UHwtmhoMpjd23SIOX8kQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-0.19.2.tgz",
+      "integrity": "sha512-vsKN6BKya70bQUsjgKRDlR2lOpv/XpUkCMIiji6rjMtKHIuWEB5Eu3JqZsOuBmWo3A3TT/K/osT9VPm0k4qdYQ==",
       "requires": {
         "@noble/hashes": "^1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "webdriverio": "^8.6.9"
   },
   "dependencies": {
-    "@dfinity/agent": "^0.19.1",
-    "@dfinity/candid": "^0.19.1",
-    "@dfinity/identity": "^0.19.1",
-    "@dfinity/principal": "^0.19.1",
+    "@dfinity/agent": "^0.19.2",
+    "@dfinity/candid": "^0.19.2",
+    "@dfinity/identity": "^0.19.2",
+    "@dfinity/principal": "^0.19.2",
     "@dfinity/utils": "^0.0.20",
     "bip39": "^3.0.4",
     "buffer": "^6.0.3",


### PR DESCRIPTION
This updates to agent-js 0.19.2 which fixes some issues with their 0.19.1 release.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
