### PR TITLE
Switch to cargo feature resolver 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "src/internet_identity_interface",
     "src/archive",
 ]
+resolver = "2"
 
 [profile.release]
 debug = false # stripped by ic-wasm anyway


### PR DESCRIPTION
This PR switches the workspace to the new feature resolver v2. It makes cleverer choices about the features to be included with different builds.
In practice this reduces the size of the prod wasm by ~20kb and speeds up the build by a few seconds.
See more information here: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/133dbec67/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
