### PR TITLE
Rename 'event' to 'evnt'

### DIFF
--- a/src/frontend/src/components/pinInput.test.ts
+++ b/src/frontend/src/components/pinInput.test.ts
@@ -16,13 +16,13 @@ function dispatchInput(elem: HTMLInputElement, text: string) {
 
 // Dispatch an "ClipboardEvent"-ish event that works in jsdom
 function dispatchPaste(elem: HTMLInputElement, text: string) {
-  const event: any = new Event("paste", { bubbles: true, cancelable: true });
-  event.clipboardData = {
+  const evnt: any = new Event("paste", { bubbles: true, cancelable: true });
+  evnt.clipboardData = {
     getData() {
       return text;
     },
   };
-  elem.dispatchEvent(event);
+  elem.dispatchEvent(evnt);
 }
 
 // Get all inputs on the page

--- a/src/frontend/src/components/pinInput.ts
+++ b/src/frontend/src/components/pinInput.ts
@@ -77,19 +77,19 @@ export const pinInput = <T>({
       return f(Array.from(inputs));
     });
 
-  const onInput_ = (event: InputEvent, element: HTMLInputElement) =>
+  const onInput_ = (evnt: InputEvent, element: HTMLInputElement) =>
     withInputs((inputs) => {
       currentError.send(undefined);
-      onInput({ element, event, inputs, onFilled: autosubmit });
+      onInput({ element, evnt, inputs, onFilled: autosubmit });
     });
-  const onPaste_ = (event: ClipboardEvent, element: HTMLInputElement) =>
+  const onPaste_ = (evnt: ClipboardEvent, element: HTMLInputElement) =>
     withInputs((inputs) => {
       currentError.send(undefined);
-      onPaste({ event, element, inputs, onFilled: onSubmit });
+      onPaste({ evnt, element, inputs, onFilled: onSubmit });
     });
-  const onKeydown_ = (event: KeyboardEvent, element: HTMLInputElement) => {
+  const onKeydown_ = (evnt: KeyboardEvent, element: HTMLInputElement) => {
     currentError.send(undefined);
-    onKeydown({ event, element });
+    onKeydown({ evnt, element });
   };
 
   // A function that can be called to trigger submission. If some digits are missing, then
@@ -146,18 +146,18 @@ export const pinInput = <T>({
 /* Callback used when an input is being set */
 const onInput = ({
   element,
-  event,
+  evnt,
   inputs,
   onFilled,
 }: {
   element: HTMLInputElement;
-  event: InputEvent;
+  evnt: InputEvent;
   inputs: HTMLInputElement[];
   onFilled: (pin: string) => void;
 }) => {
   // First, if the input is empty (i.e. the "input" was to delete the content OR the browser prevented inserting an extra char due to maxlength=1) then we do nothing
   // XXX: we don't test this because mocking the event data is really hard in jsdom
-  if (event.data === "") {
+  if (evnt.data === "") {
     return;
   }
 
@@ -178,18 +178,18 @@ const onInput = ({
 
 /* Callback used when the user pastes */
 const onPaste = ({
-  event,
+  evnt,
   inputs,
   element,
   onFilled,
 }: {
-  event: ClipboardEvent;
+  evnt: ClipboardEvent;
   element: HTMLInputElement;
   inputs: HTMLInputElement[];
   onFilled: (pin: string) => void;
 }) => {
   // If no actual data was pasted, do nothing
-  if (event.clipboardData === null) {
+  if (evnt.clipboardData === null) {
     return;
   }
 
@@ -207,7 +207,7 @@ const onPaste = ({
   // Create an array of pairs of inputs + the char/digit to be pasted in that input
   const toBePasted = zip(
     nextInputs,
-    event.clipboardData.getData("text").trim().split("")
+    evnt.clipboardData.getData("text").trim().split("")
   );
   if (toBePasted.length === 0) {
     return;
@@ -218,7 +218,7 @@ const onPaste = ({
     input.value = char;
   }
   // Prevent actually pasting the value in any of the fields since we just did this manually
-  event.preventDefault();
+  evnt.preventDefault();
 
   if (toBePasted.length < nextInputs.length) {
     // If all inputs have NOT been filled, then focus on the one after the last paste/fill
@@ -234,20 +234,20 @@ const onPaste = ({
 
 /* Callback used to handle pressing backspace on an empty input */
 const onKeydown = ({
-  event,
+  evnt,
   element,
 }: {
-  event: KeyboardEvent;
+  evnt: KeyboardEvent;
   element: HTMLInputElement;
 }) => {
   // If the input is empty, then move to the previous input
-  if (event.code === "Backspace" && element.value === "") {
+  if (evnt.code === "Backspace" && element.value === "") {
     const didMove = clearPrevious(element);
 
     if (didMove) {
       // If a previous input was found, then we prevent the default backspace behavior. Otherwise
       // we let the browser e.g. ring the bell
-      event.preventDefault();
+      evnt.preventDefault();
     }
   }
 };

--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -190,11 +190,11 @@ export async function authenticationProtocol({
  */
 const waitForAuthRequest = (): Promise<AuthContext> =>
   new Promise<AuthContext>((resolve) => {
-    const eventHandler = (event: MessageEvent) => {
-      const message: unknown = event.data; // Drop assumptions about event.data (an 'any')
+    const evntHandler = (evnt: MessageEvent) => {
+      const message: unknown = evnt.data; // Drop assumptions about evnt.data (an 'any')
       const authRequest = asAuthRequest(message);
       if (typeof authRequest !== "string") {
-        window.removeEventListener("message", eventHandler);
+        window.removeEventListener("message", evntHandler);
         console.log(
           `Handling authorize-client request ${JSON.stringify(
             authRequest,
@@ -203,7 +203,7 @@ const waitForAuthRequest = (): Promise<AuthContext> =>
         );
         resolve({
           authRequest,
-          requestOrigin: event.origin,
+          requestOrigin: evnt.origin,
         });
       } else {
         console.warn(
@@ -214,5 +214,5 @@ const waitForAuthRequest = (): Promise<AuthContext> =>
     };
 
     // Set up an event listener for receiving messages from the client.
-    window.addEventListener("message", eventHandler);
+    window.addEventListener("message", evntHandler);
   });

--- a/src/frontend/src/flows/recovery/recoverWith/phrase.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/phrase.ts
@@ -240,15 +240,15 @@ export const wordTemplate = ({
     <input
       autofocus
       data-validity-type=${validityType}
-      @paste=${(e: ClipboardEvent) =>
-        withInputElement(e, (event, element) => {
-          e.preventDefault();
+      @paste=${(evnt: ClipboardEvent) =>
+        withInputElement(evnt, (_, element) => {
+          evnt.preventDefault();
 
           // Get the text pasted
-          if (event.clipboardData === null) {
+          if (evnt.clipboardData === null) {
             return;
           }
-          const text = event.clipboardData.getData("text");
+          const text = evnt.clipboardData.getData("text");
 
           // Split the text into words, dropping (leading) white spaces, empty strings (from e.g. double spaces), etc
           const [word = undefined, ...rest] = text
@@ -303,7 +303,7 @@ export const wordTemplate = ({
         });
       }}
       @change=${(e: InputEvent) => {
-        withInputElement(e, (event, element) => {
+        withInputElement(e, (_, element) => {
           // Check validity when leaving the field
           state.send(reportValidity({ element }));
         });

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -22,15 +22,15 @@ export function unknownToString(obj: unknown, def: string): string {
 
 // Helper to gain access to the event's target
 export const withInputElement = <E extends Event>(
-  event: E,
-  f: (event: E, element: HTMLInputElement) => void
+  evnt: E,
+  f: (evnt: E, element: HTMLInputElement) => void
 ): void => {
-  const element = event.currentTarget;
+  const element = evnt.currentTarget;
   if (!(element instanceof HTMLInputElement)) {
     return;
   }
 
-  return f(event, element);
+  return f(evnt, element);
 };
 
 /** Try to read unknown data as a record */


### PR DESCRIPTION
This renames all occurrences of `event` to `evnt`. The word `event` shouldn't be used in JS code because it is a reserved keyword.

https://www.w3schools.com/js/js_reserved.asp
https://github.com/dfinity/internet-identity/pull/1816#discussion_r1304208748

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
