### PR TITLE
Add flows to showcase

### DIFF
--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -1,0 +1,51 @@
+import { badChallenge, promptCaptchaPage } from "$src/flows/register/captcha";
+import { TemplateResult, html, render } from "lit-html";
+import { dummyChallenge, i18n } from "./showcase";
+
+export const flowsPage = () => {
+  document.title = "Flows";
+  const container = document.getElementById("pageContent") as HTMLElement;
+  render(pageContent, container);
+};
+
+export const iiFlows: Record<string, () => void> = {
+  captcha: () => {
+    promptCaptchaPage({
+      cancel: () => console.log("canceled"),
+      requestChallenge: () =>
+        new Promise((resolve) => setTimeout(resolve, 1000)).then(
+          () => dummyChallenge
+        ),
+      verifyChallengeChars: (cr) =>
+        new Promise((resolve) => setTimeout(resolve, 1000)).then(() =>
+          cr.chars === "8wJ6Q" ? "yes" : badChallenge
+        ),
+      onContinue: () => console.log("Done"),
+      i18n,
+      focus: false,
+    });
+  },
+};
+
+const pageContent: TemplateResult = html`
+  <div class="l-wrap">
+    <div class="l-container">
+      <div class="c-card c-card--background">
+        <h1 class="t-title t-title--main">Flows</h1>
+        <div class="l-stack">
+          ${Object.entries(iiFlows).map(([flowName, _]) => {
+            // '/' or '/internet-identity/'
+            const baseUrl = import.meta.env.BASE_URL ?? "/";
+            // '/myFlow' or '/internet-identity/myFlow'
+            const flowLink = baseUrl + "flows/" + flowName;
+            return html`<aside>
+              <a data-page-name=${flowName} href=${flowLink}>
+                <h2>${flowName}</h2>
+              </a>
+            </aside>`;
+          })}
+        </div>
+      </div>
+    </div>
+  </div>
+`;

--- a/src/showcase/src/pages/flows.astro
+++ b/src/showcase/src/pages/flows.astro
@@ -1,0 +1,10 @@
+---
+import "$src/styles/main.css";
+---
+
+<div id="pageContent"></div>
+<script>
+  import { flowsPage } from "$showcase/flows";
+
+  flowsPage();
+</script>

--- a/src/showcase/src/pages/flows/[flow].astro
+++ b/src/showcase/src/pages/flows/[flow].astro
@@ -1,0 +1,25 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import "$src/styles/main.css";
+import { iiFlows } from "$showcase/flows";
+
+export function getStaticPaths() {
+  return Object.keys(iiFlows).map((key) => ({ params: { flow: key } }));
+}
+
+const { flow } = Astro.params;
+console.log(flow);
+---
+
+<Layout>
+  <main id="pageContent" aria-live="polite" data-flow-name={flow}></main>
+  <script>
+    import { iiFlows } from "$showcase/flows";
+
+    const flow = (document.querySelector("[data-flow-name]") as HTMLElement)
+      .dataset?.flowName as string;
+
+    const f = iiFlows[flow];
+    f();
+  </script>
+</Layout>


### PR DESCRIPTION
This introduces a new route to the showcase, `/flows`, for all flows that are not just static pages. Currently includes the captcha flow as an example.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5f8e432d4/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
