### PR TITLE
Add more toast variations

### DIFF
--- a/src/frontend/src/components/toast.ts
+++ b/src/frontend/src/components/toast.ts
@@ -3,12 +3,12 @@ import { Chan } from "$src/utils/utils";
 import { html, render, TemplateResult } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { repeat } from "lit-html/directives/repeat.js";
-import { closeIcon, warningIcon } from "./icons";
+import { checkmarkIcon, closeIcon, settingsIcon, warningIcon } from "./icons";
 
 // A toast element containing a message, and the (static) list of all toasts. The `Toast` element
 // must be an object because we (lit) use object-references in `repeat` to figure out which DOM elements
 // to replace.
-type Toast = { message: TemplateElement };
+type Toast = { message: TemplateElement; level: "error" | "info" | "success" };
 const toastStore: Toast[] = []; // the "toasts" singleton
 
 /**
@@ -17,7 +17,15 @@ const toastStore: Toast[] = []; // the "toasts" singleton
  */
 export const toast = {
   error: (message: Toast["message"]): void => {
-    toastStore.push({ message });
+    toastStore.push({ message, level: "error" });
+    renderToasts();
+  },
+  info: (message: Toast["message"]): void => {
+    toastStore.push({ message, level: "info" });
+    renderToasts();
+  },
+  success: (message: Toast["message"]): void => {
+    toastStore.push({ message, level: "success" });
     renderToasts();
   },
 };
@@ -47,6 +55,17 @@ const toastTemplate = (toast: Toast): TemplateResult => {
     renderToasts();
   };
 
+  const levelClass = {
+    error: "c-toast-body--error",
+    info: "c-toast-body--info",
+    success: "c-toast-body--success",
+  }[toast.level];
+  const levelIcon = {
+    error: warningIcon,
+    info: settingsIcon,
+    success: checkmarkIcon,
+  }[toast.level];
+
   return html` <div
     role="alert"
     class="c-toast ${asyncReplace(
@@ -56,11 +75,11 @@ const toastTemplate = (toast: Toast): TemplateResult => {
       closing.map((closing) => (closing ? () => removeToast() : undefined))
     )}
   >
-    <div class="c-irregularity c-irregularity--error c-irregularity--closable">
-      <div class="c-irregularity__icon">${warningIcon}</div>
-      <p class="c-irregularity__message">${toast.message}</p>
+    <div class="c-toast-body ${levelClass}">
+      <div class="c-toast-body__icon">${levelIcon}</div>
+      <p class="c-toast-body__message">${toast.message}</p>
       <button
-        class="c-irregularity__close"
+        class="c-toast-body__close"
         aria-label="Close"
         @click="${() => closeToast()}"
       >

--- a/src/frontend/src/styleguide.ts
+++ b/src/frontend/src/styleguide.ts
@@ -490,8 +490,7 @@ export const styleguide = html`
         <h2 class="t-title">Toast</h2>
         <p class="t-lead">
           Toasts are messages of varying length and importance that appear at
-          the bottom or the top of the screen. They typically use the
-          Irregularity component.
+          the bottom or the top of the screen.
         </p>
         <section class="demo" aria-label="Toast Elements Demo">
           <button

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -117,6 +117,7 @@
   --vc-brand-purple-light: #890eed;
   --vc-brand-blue: #29abe2;
   --vc-brand-blue--dark: #1f6ef4;
+  --vc-brand-green--light: hsl(89 76% 86%);
   --vc-brand-green: #79d11c;
   --vc-brand-alt: rgba(215, 205, 235, 1);
   --vc-grey: grey;
@@ -277,8 +278,8 @@
 
   --rs-marketing-block-stack: calc(var(--vs-stack) * 5);
 
-  --rs-irregularity-stack: calc(var(--vs-stack) * 0.5);
-  --rs-toast-stack: var(--rs-irregularity-stack);
+  --rs-toast-body-stack: calc(var(--vs-stack) * 0.5);
+  --rs-toast-stack: var(--rs-toast-body-stack);
 
   --rs-button-bezel: calc(var(--vs-bezel) * 1.5);
   --rs-button-stack: var(--vs-stack);
@@ -1020,82 +1021,6 @@ by all browsers (FF is missing) */
 }
 
 /**
- *  irregularity component
- */
-.c-irregularity {
-  display: flex;
-  align-items: stretch;
-  gap: calc(var(--rs-card-bezel-x) * 0.25);
-
-  --state-color: var(--rc-errorLight);
-  --state-onColor: var(--rc-error);
-
-  position: relative;
-  padding: calc(var(--rs-card-bezel) * 0.35) calc(var(--rs-card-bezel-x) * 0.35);
-  border: var(--rs-line) solid var(--rc-line);
-  background-color: var(--state-color);
-  border-radius: var(--rs-card-border-radius);
-  overflow: hidden;
-  box-shadow: 0 0 0 1px var(--state-onColor);
-}
-
-.c-irregularity + .c-irregularity {
-  margin-top: var(--rs-irregularity-stack);
-}
-
-.c-irregularity__icon {
-  position: relative;
-  flex: 0 0 4.5rem;
-  background: var(--state-onColor);
-  margin: calc(var(--rs-card-bezel) * -0.25) calc(var(--rs-card-bezel-x) * 0.1)
-    calc(var(--rs-card-bezel) * -0.25) calc(var(--rs-card-bezel) * -0.4);
-  border-radius: var(--rs-card-border-radius);
-}
-
-.c-irregularity__icon svg {
-  display: block;
-  width: 70%;
-  height: 70%;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-.c-irregularity__icon svg [fill] {
-  fill: #fff;
-}
-
-.c-irregularity__message {
-  flex: 1 1 auto;
-  font-size: 0.8em;
-  line-height: 1.2;
-}
-
-.c-irregularity__close {
-  --scale: 1;
-  position: relative;
-  background: #fff;
-  border-radius: 50%;
-  flex: 0 0 1.5rem;
-  height: 1.5rem;
-  cursor: pointer;
-  transition: 200ms transform cubic-bezier(0.4, 0, 0.2, 1);
-  transform: scale(var(--scale));
-}
-
-.c-irregularity__close svg {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 100%;
-  transform: translate(-50%, -50%) scale(0.6);
-}
-
-.c-irregularity__close:hover {
-  --scale: 1.3;
-}
-
-/**
  *  toast component
  */
 
@@ -1146,6 +1071,95 @@ by all browsers (FF is missing) */
     opacity: 0;
     transform: translateY(100%);
   }
+}
+
+/**
+ *  toast-body component
+ */
+.c-toast-body {
+  display: flex;
+  align-items: stretch;
+  gap: calc(var(--rs-card-bezel-x) * 0.25);
+
+  position: relative;
+  padding: calc(var(--rs-card-bezel) * 0.35) calc(var(--rs-card-bezel-x) * 0.35);
+  border: var(--rs-line) solid var(--rc-line);
+  background-color: var(--state-color);
+  border-radius: var(--rs-card-border-radius);
+  overflow: hidden;
+  box-shadow: 0 0 0 1px var(--state-onColor);
+}
+
+.c-toast-body + .c-toast-body {
+  margin-top: var(--rs-toast-body-stack);
+}
+
+.c-toast-body__icon {
+  position: relative;
+  flex: 0 0 4.5rem;
+  background: var(--state-onColor);
+  margin: calc(var(--rs-card-bezel) * -0.25) calc(var(--rs-card-bezel-x) * 0.1)
+    calc(var(--rs-card-bezel) * -0.25) calc(var(--rs-card-bezel) * -0.4);
+  border-radius: var(--rs-card-border-radius);
+}
+
+.c-toast-body__icon svg {
+  display: block;
+  width: 70%;
+  height: 70%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+.c-toast-body__icon svg [fill] {
+  fill: #fff;
+}
+
+.c-toast-body__message {
+  flex: 1 1 auto;
+  font-size: 0.8em;
+  line-height: 1.2;
+}
+
+.c-toast-body__close {
+  --scale: 1;
+  position: relative;
+  background: #fff;
+  border-radius: 50%;
+  flex: 0 0 1.5rem;
+  height: 1.5rem;
+  cursor: pointer;
+  transition: 200ms transform cubic-bezier(0.4, 0, 0.2, 1);
+  transform: scale(var(--scale));
+}
+
+.c-toast-body__close svg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  transform: translate(-50%, -50%) scale(0.6);
+}
+
+.c-toast-body__close:hover {
+  --scale: 1.3;
+}
+
+/** The various body types */
+.c-toast-body--info {
+  --state-color: var(--vc-brand-blue);
+  --state-onColor: var(--vc-brand-blue--dark);
+}
+
+.c-toast-body--success {
+  --state-color: var(--vc-brand-green--light);
+  --state-onColor: var(--vc-brand-green);
+}
+
+.c-toast-body--error {
+  --state-color: var(--rc-errorLight);
+  --state-onColor: var(--rc-error);
 }
 
 /**

--- a/src/showcase/src/components.ts
+++ b/src/showcase/src/components.ts
@@ -1,5 +1,6 @@
 import { mkAnchorPicker } from "$src/components/anchorPicker";
 import { pinInput } from "$src/components/pinInput";
+import { toast } from "$src/components/toast";
 import { badChallenge, promptCaptchaPage } from "$src/flows/register/captcha";
 import { mount, withRef } from "$src/utils/lit-html";
 import { Chan, NonEmptyArray, asNonEmptyArray } from "$src/utils/utils";
@@ -15,7 +16,36 @@ export const componentsPage = () => {
 };
 
 const components = (): TemplateResult => {
-  return html`${choosePin()} ${pickAnchor()}${completeCaptcha()}`;
+  return html`${mkToast()} ${choosePin()} ${pickAnchor()}${completeCaptcha()}`;
+};
+
+const mkToast = (): TemplateResult => {
+  const toastMessage = html`This is a
+    <strong class="t-strong">new</strong> message`;
+
+  return html`<div class="c-card" style="max-width: 30em; margin: 40px auto;">
+    <h2 class="t-title t-title--sub">Toasts</h2>
+    <div class="c-button-group">
+      <button
+        @click=${() => toast.info(toastMessage)}
+        class="c-button c-input--stack"
+      >
+        info
+      </button>
+      <button
+        @click=${() => toast.success(toastMessage)}
+        class="c-button c-input--stack"
+      >
+        success
+      </button>
+      <button
+        @click=${() => toast.error(toastMessage)}
+        class="c-button c-input--stack"
+      >
+        error
+      </button>
+    </div>
+  </div>`;
 };
 
 const choosePin = (): TemplateResult => {


### PR DESCRIPTION
This restructures the toast styling implementation and adds some toast variations.

In particular, the "irregularity" classes are renamed to "toast-body" to be more accurate, and slightly modified to accomodate more toast variations.

Said variations are added (for "info" and "success" toasts), and toasts are now added to the showcase components page.

The design of "info" and "success" is not pretty, but these are currently only used in the showcase.


https://github.com/dfinity/internet-identity/assets/6930756/c524880f-8941-4db7-bf6a-e9c65d65c62d



<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
