### PR TITLE
Don't mandate color support in the verify script

### DIFF
--- a/scripts/verify-hash
+++ b/scripts/verify-hash
@@ -9,9 +9,15 @@ cd "$SCRIPTS_DIR/.."
 
 declare expected_ii_hash=
 declare expected_archive_hash=
-GREEN=$(tput setaf 2)
-RED=$(tput setaf 1)
-NC=$(tput sgr0)
+
+# Check that colors are supported (i.e. that we are running in a terminal)
+# I.e. github actions does not support colors
+if [ -n "$TERM" ]
+then
+    GREEN=$(tput setaf 2)
+    RED=$(tput setaf 1)
+    NC=$(tput sgr0)
+fi
 
 print_red() {
     echo "${RED}$*${NC}"


### PR DESCRIPTION
Github actions does not support colors / tput so this PR gates it behind a check.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
