### PR TITLE
Fix loader in flow showcase

### DIFF
--- a/src/showcase/src/pages/flows/[flow].astro
+++ b/src/showcase/src/pages/flows/[flow].astro
@@ -8,11 +8,11 @@ export function getStaticPaths() {
 }
 
 const { flow } = Astro.params;
-console.log(flow);
 ---
 
 <Layout>
   <main id="pageContent" aria-live="polite" data-flow-name={flow}></main>
+  <div id="loaderContainer"></div>
   <script>
     import { iiFlows } from "$showcase/flows";
 


### PR DESCRIPTION
When showcasing flows with a loader, lit would crash because it's expecting a `#loaderContainer` element which didn't exist. This copies the element from the main `index.html`.

Also cleans up a console.log.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
