### PR TITLE
Showcase registration flow

### DIFF
--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -1,60 +1,124 @@
+import { Challenge } from "$generated/internet_identity_types";
 import {
+  LoginFlowCanceled,
+  LoginFlowResult,
   apiResultToLoginFlowResult,
   cancel,
-  LoginFlowResult,
 } from "$src/utils/flowResult";
-import { Connection, IIWebAuthnIdentity } from "$src/utils/iiConnection";
+import {
+  AuthenticatedConnection,
+  Connection,
+  IIWebAuthnIdentity,
+  RegisterResult,
+} from "$src/utils/iiConnection";
 import { setAnchorUsed } from "$src/utils/userNumber";
 import { unknownToString } from "$src/utils/utils";
+import { ECDSAKeyIdentity } from "@dfinity/identity";
 import { nonNullish } from "@dfinity/utils";
 import type { UAParser } from "ua-parser-js";
-import { promptCaptcha } from "./captcha";
+import { badChallenge, precomputeFirst, promptCaptcha } from "./captcha";
 import { displayUserNumberWarmup } from "./finish";
 import { savePasskey } from "./passkey";
 
 /** Registration (anchor creation) flow for new users */
+export const registerFlow = async <T>({
+  createChallenge: createChallenge_,
+  register,
+}: {
+  createChallenge: () => Promise<Challenge>;
+  register: (opts: {
+    alias: string;
+    identity: IIWebAuthnIdentity;
+    challengeResult: { chars: string; challenge: Challenge };
+  }) => Promise<RegisterResult<T>>;
+}): Promise<RegisterResult<T> | LoginFlowCanceled> => {
+  // Kick-off fetching "ua-parser-js";
+  const uaParser = loadUAParser();
+
+  // Kick-off the challenge request early, so that we might already
+  // have a captcha to show once we get to the CAPTCHA screen
+  const createChallenge = precomputeFirst(() => createChallenge_());
+
+  const identity = await savePasskey();
+  if (identity === "canceled") {
+    return cancel;
+  }
+
+  const alias = await inferAlias({
+    authenticatorType: identity.getAuthenticatorAttachment(),
+    userAgent: navigator.userAgent,
+    uaParser,
+  });
+
+  const displayUserNumber = displayUserNumberWarmup();
+
+  const result = await promptCaptcha({
+    createChallenge,
+    register: async ({ chars, challenge }) => {
+      const result = await register({
+        identity,
+        alias,
+        challengeResult: { chars, challenge },
+      });
+
+      if (result.kind === "badChallenge") {
+        return badChallenge;
+      }
+
+      return result;
+    },
+  });
+
+  if ("tag" in result) {
+    result.tag satisfies "canceled";
+    return result;
+  }
+
+  if (result.kind === "loginSuccess") {
+    const userNumber = result.userNumber;
+    setAnchorUsed(userNumber);
+    await displayUserNumber({ userNumber });
+  }
+  return result;
+};
+
+/** Concrete implementation of the registration flow */
 export const register = async ({
   connection,
 }: {
   connection: Connection;
 }): Promise<LoginFlowResult> => {
   try {
-    // Kick-off fetching "ua-parser-js";
-    const uaParser = loadUAParser();
+    const result = await registerFlow<AuthenticatedConnection>({
+      createChallenge: () => connection.createChallenge(),
+      register: async ({
+        identity,
+        alias,
+        challengeResult: {
+          chars,
+          challenge: { challenge_key: key },
+        },
+      }) => {
+        const tempIdentity = await ECDSAKeyIdentity.generate({
+          extractable: false,
+        });
+        const result = await connection.register({
+          identity,
+          tempIdentity,
+          alias,
+          challengeResult: { chars, key },
+        });
 
-    // Kick-off the challenge request early, so that we might already
-    // have a captcha to show once we get to the CAPTCHA screen
-    const preloadedChallenge = connection.createChallenge();
-    const identity = await savePasskey();
-    if (identity === "canceled") {
-      return cancel;
-    }
-
-    const alias = await inferAlias({
-      authenticatorType: identity.getAuthenticatorAttachment(),
-      userAgent: navigator.userAgent,
-      uaParser,
+        return result;
+      },
     });
 
-    const displayUserNumber = displayUserNumberWarmup();
-    const captchaResult = await promptCaptcha({
-      connection,
-      challenge: preloadedChallenge,
-      identity,
-      alias,
-    });
-
-    if ("tag" in captchaResult) {
-      return captchaResult;
-    } else {
-      const result = apiResultToLoginFlowResult(captchaResult);
-      if (result.tag === "ok") {
-        const { userNumber } = result;
-        setAnchorUsed(userNumber);
-        await displayUserNumber({ userNumber });
-      }
+    if ("tag" in result) {
+      result satisfies { tag: "canceled" };
       return result;
     }
+
+    return apiResultToLoginFlowResult(result);
   } catch (e) {
     return {
       tag: "err",

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -83,17 +83,17 @@ export type LoginResult =
   | NoSeedPhrase
   | SeedPhraseFail
   | CancelOrTimeout;
-export type RegisterResult =
-  | LoginSuccess
+export type RegisterResult<T = AuthenticatedConnection> =
+  | LoginSuccess<T>
   | AuthFail
   | ApiError
   | RegisterNoSpace
   | BadChallenge
   | CancelOrTimeout;
 
-type LoginSuccess = {
+type LoginSuccess<T = AuthenticatedConnection> = {
   kind: "loginSuccess";
-  connection: AuthenticatedConnection;
+  connection: T;
   userNumber: bigint;
 };
 


### PR DESCRIPTION
This refactors the `register` function to be able to showcase the registration flow without needing to spin up a canister.

A type parameter had to be added to `RegisterResult` to allow "mocking" the result without creating an actual canister connection.

The flow part is extracted from `register`, which is now a wrapper around this new `registerFlow`; `register` now only deals with canister/concrete implementation details whereas `registerFlow` only focuses on the user interaction.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ec875b875/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

