### PR TITLE
Fix broken color opt-out for CI

### DIFF
--- a/scripts/verify-hash
+++ b/scripts/verify-hash
@@ -10,9 +10,13 @@ cd "$SCRIPTS_DIR/.."
 declare expected_ii_hash=
 declare expected_archive_hash=
 
+GREEN=
+RED=
+NC=
+
 # Check that colors are supported (i.e. that we are running in a terminal)
 # I.e. github actions does not support colors
-if [ -n "$TERM" ]
+if [ -n "$TERM" ] && [ "$TERM" != "dumb" ]
 then
     GREEN=$(tput setaf 2)
     RED=$(tput setaf 1)


### PR DESCRIPTION
The verify-hash script with the changes from the  previous PR #1834 still fails on CI. This PR fixes it properly.

Link to proper test run: https://github.com/dfinity/internet-identity/actions/runs/6037492902/job/16381870849#step:3:1762

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
