### PR TITLE
Update vc_issuer API.

### DIFF
--- a/demos/vc_issuer/vc_issuer.did
+++ b/demos/vc_issuer/vc_issuer.did
@@ -1,24 +1,42 @@
-type ConsentData = record { consent_message : text; language : text };
-type ConsentMessageRequest = record { preferences : ConsentPreferences };
+type ConsentErrorInfo = record { description : text; error_code : nat64 };
+type ConsentInfo = record { consent_message : text; language : text };
+type ConsentMessageRequest = record {
+    arg : vec nat8;
+    method : text;
+    preferences : ConsentPreferences;
+};
+type ConsentMessageResponse = variant {
+    MalformedCall : ConsentErrorInfo;
+    Valid : ConsentInfo;
+    Forbidden : ConsentErrorInfo;
+};
 type ConsentPreferences = record { language : text };
-type CredentialData = record { vc_jwt : text };
 type CredentialSpec = record { info : text };
-type IssueCredentialRequest = record {
+type GetCredentialRequest = record {
+    signed_id_alias : SignedIdAlias;
+    vc_jwt : text;
+    credential_spec : CredentialSpec;
+};
+type GetCredentialResponse = variant { Ok : IssuedCredentialData; Err : text };
+type IssuedCredentialData = record { vc_jws : text };
+type PrepareCredentialRequest = record {
     signed_id_alias : SignedIdAlias;
     credential_spec : CredentialSpec;
 };
-type IssueCredentialResponse = variant { Ok : CredentialData; Err : text };
-type ManifestData = record { consent_info : ConsentData };
-type ManifestRequest = record {
-    consent_message_request : ConsentMessageRequest;
+type PrepareCredentialResponse = variant {
+    Ok : PreparedCredentialData;
+    Err : text;
 };
-type ManifestResponse = variant { Ok : ManifestData; Err : text };
+type PreparedCredentialData = record { vc_jwt : text };
 type SignedIdAlias = record {
-    signature : vec nat8;
+    credential_jws : text;
     id_alias : principal;
     id_dapp : principal;
 };
 service : {
-    get_manifest : (ManifestRequest) -> (ManifestResponse);
-    issue_credential : (IssueCredentialRequest) -> (IssueCredentialResponse);
+    consent_message : (ConsentMessageRequest) -> (ConsentMessageResponse);
+    get_credential : (GetCredentialRequest) -> (GetCredentialResponse) query;
+    prepare_credential : (PrepareCredentialRequest) -> (
+    PrepareCredentialResponse,
+    );
 }

--- a/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
@@ -68,38 +68,41 @@ pub enum GetIdAliasResponse {
 
 pub mod issuer {
     use super::*;
+    use serde_bytes::ByteBuf;
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-    pub struct IssueCredentialRequest {
+    pub struct PrepareCredentialRequest {
         pub signed_id_alias: SignedIdAlias,
         pub credential_spec: CredentialSpec,
     }
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-    pub enum IssueCredentialResponse {
-        Ok(CredentialData),
+    pub enum PrepareCredentialResponse {
+        Ok(PreparedCredentialData),
         Err(String),
     }
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-    pub struct CredentialData {
+    pub struct GetCredentialRequest {
+        pub signed_id_alias: SignedIdAlias,
+        pub credential_spec: CredentialSpec,
         pub vc_jwt: String,
     }
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-    pub struct ManifestRequest {
-        pub consent_message_request: ConsentMessageRequest,
-    }
-
-    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-    pub struct ManifestData {
-        pub consent_info: ConsentData,
-    }
-
-    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-    pub enum ManifestResponse {
-        Ok(ManifestData),
+    pub enum GetCredentialResponse {
+        Ok(IssuedCredentialData),
         Err(String),
+    }
+
+    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+    pub struct PreparedCredentialData {
+        pub vc_jwt: String,
+    }
+
+    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+    pub struct IssuedCredentialData {
+        pub vc_jws: String,
     }
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -108,18 +111,46 @@ pub mod issuer {
     }
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+    pub struct ManifestRequest {}
+
+    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+    pub enum ManifestResponse {
+        Ok(ManifestData),
+        Err(String),
+    }
+
+    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+    pub struct ManifestData {}
+
+    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+    pub struct ConsentMessageRequest {
+        pub method: String,
+        pub arg: ByteBuf,
+        pub preferences: ConsentPreferences,
+    }
+
+    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
     pub struct ConsentPreferences {
         pub language: String,
     }
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-    pub struct ConsentMessageRequest {
-        pub preferences: ConsentPreferences,
+    #[serde(rename = "error_info")]
+    pub struct ConsentErrorInfo {
+        pub error_code: u64,
+        pub description: String,
     }
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-    pub struct ConsentData {
+    pub struct ConsentInfo {
         pub consent_message: String,
         pub language: String,
+    }
+
+    #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+    pub enum ConsentMessageResponse {
+        Valid(ConsentInfo),
+        Forbidden(ConsentErrorInfo),
+        MalformedCall(ConsentErrorInfo),
     }
 }


### PR DESCRIPTION
Update VC-issuer API: 

- make VC issuance a 2-step process, to enable canister signatures as an option for VCs 
- decouple manifest requests and consent message requests
- update consent message API, to comply with [ICRC-21](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/consent-msg.md)-draft
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
