### PR TITLE
Add crypto operations for browser-storage key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "process": "^0.11.10",
         "qr-creator": "^1.0.0",
         "stream-browserify": "^3.0.0",
-        "ua-parser-js": "^1.0.35"
+        "ua-parser-js": "^1.0.35",
+        "zod": "^3.22.2"
       },
       "devDependencies": {
         "@types/html-minifier-terser": "^7.0.0",
@@ -11829,10 +11830,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
-      "dev": true,
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -20438,10 +20438,9 @@
       }
     },
     "zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
-      "dev": true
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
+      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg=="
     },
     "zwitch": {
       "version": "2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "ua-parser-js": "^1.0.35"
       },
       "devDependencies": {
-        "@trust/webcrypto": "^0.9.2",
         "@types/html-minifier-terser": "^7.0.0",
         "@types/selenium-standalone": "^7.0.1",
         "@types/ua-parser-js": "^0.7.36",
@@ -1475,37 +1474,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@trust/keyto": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-0.3.7.tgz",
-      "integrity": "sha512-t5kWWCTkPgg24JWVuCTPMx7l13F7YHdxBeJkT1vmoHjROgiOIEAN8eeY+iRmP1Hwsx+S7U55HyuqSsECr08a8A==",
-      "dev": true,
-      "dependencies": {
-        "asn1.js": "^5.0.1",
-        "base64url": "^3.0.1",
-        "elliptic": "^6.4.1"
-      }
-    },
-    "node_modules/@trust/webcrypto": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@trust/webcrypto/-/webcrypto-0.9.2.tgz",
-      "integrity": "sha512-5iMAVcGYKhqLJGjefB1nzuQSqUJTru0nG4CytpBT/GGp1Piz/MVnj2jORdYf4JBYzggCIa8WZUr2rchP2Ngn/w==",
-      "dev": true,
-      "dependencies": {
-        "@trust/keyto": "^0.3.4",
-        "base64url": "^3.0.0",
-        "elliptic": "^6.4.0",
-        "node-rsa": "^0.4.0",
-        "text-encoding": "^0.6.1"
-      }
-    },
-    "node_modules/@trust/webcrypto/node_modules/text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "deprecated": "no longer maintained",
-      "dev": true
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -2825,18 +2793,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "dev": true,
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/asn1js": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
@@ -3110,15 +3066,6 @@
         }
       ]
     },
-    "node_modules/base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -3200,12 +3147,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
       "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
-      "dev": true
-    },
-    "node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
     },
     "node_modules/borc": {
@@ -3303,12 +3244,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
     },
     "node_modules/browserslist": {
       "version": "4.21.3",
@@ -4459,21 +4394,6 @@
       "integrity": "sha512-GMCxR3p2HQvIw47A599crTKYZprqihoBL4lDSAUmr7IYekXFK5t/WgEBrGJDCa2HWIZFQEkGuMqPCi05ceYqPQ==",
       "dev": true
     },
-    "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dev": true,
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
     "node_modules/emmet": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.4.tgz",
@@ -5612,16 +5532,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hast-util-from-parse5": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
@@ -5749,17 +5659,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/hosted-git-info": {
@@ -7971,18 +7870,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -8149,21 +8036,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
-      "dev": true
-    },
-    "node_modules/node-rsa": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.4.2.tgz",
-      "integrity": "sha1-1jkXKewWqDDtWjgEKzFX0tXXJTA=",
-      "dev": true,
-      "dependencies": {
-        "asn1": "0.2.3"
-      }
-    },
-    "node_modules/node-rsa/node_modules/asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -9838,7 +9710,9 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/sass-formatter": {
       "version": "0.7.6",
@@ -12956,38 +12830,6 @@
       "optional": true,
       "peer": true
     },
-    "@trust/keyto": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-0.3.7.tgz",
-      "integrity": "sha512-t5kWWCTkPgg24JWVuCTPMx7l13F7YHdxBeJkT1vmoHjROgiOIEAN8eeY+iRmP1Hwsx+S7U55HyuqSsECr08a8A==",
-      "dev": true,
-      "requires": {
-        "asn1.js": "^5.0.1",
-        "base64url": "^3.0.1",
-        "elliptic": "^6.4.1"
-      }
-    },
-    "@trust/webcrypto": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@trust/webcrypto/-/webcrypto-0.9.2.tgz",
-      "integrity": "sha512-5iMAVcGYKhqLJGjefB1nzuQSqUJTru0nG4CytpBT/GGp1Piz/MVnj2jORdYf4JBYzggCIa8WZUr2rchP2Ngn/w==",
-      "dev": true,
-      "requires": {
-        "@trust/keyto": "^0.3.4",
-        "base64url": "^3.0.0",
-        "elliptic": "^6.4.0",
-        "node-rsa": "^0.4.0",
-        "text-encoding": "^0.6.1"
-      },
-      "dependencies": {
-        "text-encoding": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-          "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-          "dev": true
-        }
-      }
-    },
     "@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -14102,18 +13944,6 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
-    "asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "asn1js": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
@@ -14302,12 +14132,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
-    "base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
-      "dev": true
-    },
     "big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -14370,12 +14194,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
       "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
-      "dev": true
-    },
-    "bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
     },
     "borc": {
@@ -14446,12 +14264,6 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
-    },
-    "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
     },
     "browserslist": {
       "version": "4.21.3",
@@ -15281,21 +15093,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.249.tgz",
       "integrity": "sha512-GMCxR3p2HQvIw47A599crTKYZprqihoBL4lDSAUmr7IYekXFK5t/WgEBrGJDCa2HWIZFQEkGuMqPCi05ceYqPQ==",
       "dev": true
-    },
-    "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "emmet": {
       "version": "2.4.4",
@@ -16170,16 +15967,6 @@
         "safe-buffer": "^5.2.0"
       }
     },
-    "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "hast-util-from-parse5": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
@@ -16281,17 +16068,6 @@
         "hast-util-parse-selector": "^3.0.0",
         "property-information": "^6.0.0",
         "space-separated-tokens": "^2.0.0"
-      }
-    },
-    "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
-      "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -17825,18 +17601,6 @@
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true
     },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
-    },
-    "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -17970,23 +17734,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
-    },
-    "node-rsa": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.4.2.tgz",
-      "integrity": "sha1-1jkXKewWqDDtWjgEKzFX0tXXJTA=",
-      "dev": true,
-      "requires": {
-        "asn1": "0.2.3"
-      },
-      "dependencies": {
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true
-        }
-      }
     },
     "normalize-package-data": {
       "version": "3.0.3",
@@ -19172,7 +18919,9 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "sass-formatter": {
       "version": "0.7.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "format-check": "prettier --check src/showcase src/frontend tsconfig.json .eslintrc.json vite.config.ts vite.plugins.ts vitest.config.ts demos"
   },
   "devDependencies": {
-    "@trust/webcrypto": "^0.9.2",
     "@types/html-minifier-terser": "^7.0.0",
     "@types/selenium-standalone": "^7.0.1",
     "@types/ua-parser-js": "^0.7.36",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "process": "^0.11.10",
     "qr-creator": "^1.0.0",
     "stream-browserify": "^3.0.0",
-    "ua-parser-js": "^1.0.35"
+    "ua-parser-js": "^1.0.35",
+    "zod": "^3.22.2"
   },
   "engines": {
     "npm": ">=9.0.0 <10.0.0",

--- a/src/frontend/src/crypto/pinIdentity.test.ts
+++ b/src/frontend/src/crypto/pinIdentity.test.ts
@@ -1,0 +1,20 @@
+import { constructPinIdentity, reconstructPinIdentity } from "./pinIdentity";
+
+describe("pin identity", () => {
+  test("identity can be reconstructed", async () => {
+    const { identity, pinIdentityMaterial } = await constructPinIdentity({
+      pin: "123456",
+    });
+    const reconstructed = await reconstructPinIdentity({
+      pin: "123456",
+      pinIdentityMaterial,
+    });
+
+    expect(reconstructed.getPrincipal().toText()).toBe(
+      identity.getPrincipal().toText()
+    );
+    expect(new Uint8Array(reconstructed.getPublicKey().toDer())).toStrictEqual(
+      new Uint8Array(identity.getPublicKey().toDer())
+    );
+  });
+});

--- a/src/frontend/src/crypto/pinIdentity.ts
+++ b/src/frontend/src/crypto/pinIdentity.ts
@@ -2,7 +2,7 @@ import { SignIdentity } from "@dfinity/agent";
 import { ECDSAKeyIdentity } from "@dfinity/identity";
 import { z } from "zod";
 
-/** This modules defines the crypto operations for the browser storage Identity.
+/** This module defines the crypto operations for the browser storage Identity.
  *
  * The identity is an ECDSA keypair. The keypair is meant to be indirectly stored in browser storage (IndexedDB).
  * Before being stored, the keypair in encrypted twice (symmetrically).
@@ -51,7 +51,7 @@ export const constructPinIdentity = async ({
   const browserIv = window.crypto.getRandomValues(new Uint8Array(96));
   const pinIv = window.crypto.getRandomValues(new Uint8Array(96));
   const pinSalt = window.crypto.getRandomValues(new Uint8Array(96));
-  const pinPbkdfIters: number = 10000;
+  const pinPbkdfIters: number = 100000;
   const keypairNamedCurve: NistEc = "P-256";
 
   const keypair = await generateKeyPair({ namedCurve: keypairNamedCurve });

--- a/src/frontend/src/crypto/pinIdentity.ts
+++ b/src/frontend/src/crypto/pinIdentity.ts
@@ -1,0 +1,215 @@
+import { SignIdentity } from "@dfinity/agent";
+import { ECDSAKeyIdentity } from "@dfinity/identity";
+import { z } from "zod";
+
+/** This modules defines the crypto operations for the browser storage Identity.
+ *
+ * The identity is an ECDSA keypair. The keypair is meant to be indirectly stored in browser storage (IndexedDB).
+ * Before being stored, the keypair in encrypted twice (symmetrically).
+ *
+ * The first encryption round uses an AES-GCM key, which may be stored (unencrypted _but_ unextractable) in the
+ * browser.
+ * The second encryption round uses an AES-GCM key, derived (PBKDF2) from a user-defined PIN.
+ *
+ * All the data necessary to recreated & retrieve the keys (salt, initialization vectors, iterations) may also
+ * be stored in the browser.
+ *
+ * The following terms are used:
+ *  * construct/reconstruct: how to originally construct and later re-construct the identity keypair
+ *  * generate: originally generate either an AES key or ECDSA keypair
+ *  * derive: derive a key from e.g. the PIN
+ */
+
+export const PinIdentityMaterial = z.object({
+  /* The ECDSA keypair */
+  publicKey: z.instanceof(CryptoKey),
+  encryptedPrivateKey: z.instanceof(ArrayBuffer),
+  /* any of the NIST approved curves
+   * https://developer.mozilla.org/en-US/docs/Web/API/EcKeyGenParams#instance_properties */
+  namedCurve: z.enum(["P-256", "P-384", "P-521"]),
+
+  /* The first round of encryption with browser key */
+  browserIv: z.instanceof(Uint8Array),
+  browserKey: z.instanceof(CryptoKey),
+
+  /* The second round of encryption with PIN key */
+  pinIv: z.instanceof(Uint8Array),
+  pinSalt: z.instanceof(Uint8Array),
+  pinPbkdfIters: z.number(),
+});
+export type NistEc = PinIdentityMaterial["namedCurve"];
+export type PinIdentityMaterial = z.infer<typeof PinIdentityMaterial>;
+
+export const constructPinIdentity = async ({
+  pin,
+}: {
+  pin: string;
+}): Promise<{
+  identity: SignIdentity;
+  pinIdentityMaterial: PinIdentityMaterial;
+}> => {
+  const browserIv = window.crypto.getRandomValues(new Uint8Array(96));
+  const pinIv = window.crypto.getRandomValues(new Uint8Array(96));
+  const pinSalt = window.crypto.getRandomValues(new Uint8Array(96));
+  const pinPbkdfIters: number = 10000;
+  const keypairNamedCurve: NistEc = "P-256";
+
+  const keypair = await generateKeyPair({ namedCurve: keypairNamedCurve });
+  const secretKey = keypair.getKeyPair().privateKey;
+
+  const browserKey = await generateBrowserKey();
+  const encryptedOnce = await crypto.subtle.wrapKey(
+    "pkcs8" /* the export format */,
+    secretKey /* the key to wrap */,
+    browserKey /* the wrapping key */,
+    { name: "AES-GCM", iv: browserIv }
+  );
+
+  const pinKey = await derivePinKey({
+    pin,
+    salt: pinSalt,
+    iterations: pinPbkdfIters,
+  });
+  const encryptedTwice = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: pinIv },
+    pinKey,
+    encryptedOnce
+  );
+
+  return {
+    identity: keypair,
+    pinIdentityMaterial: {
+      publicKey: keypair.getKeyPair().publicKey,
+      encryptedPrivateKey: encryptedTwice,
+      namedCurve: keypairNamedCurve,
+
+      browserIv,
+      browserKey,
+
+      pinIv,
+      pinSalt,
+      pinPbkdfIters,
+    },
+  };
+};
+
+export const reconstructPinIdentity = async ({
+  pin,
+  pinIdentityMaterial: {
+    encryptedPrivateKey: encryptedTwice,
+    publicKey,
+    namedCurve,
+
+    browserIv,
+    browserKey,
+
+    pinIv,
+    pinSalt,
+    pinPbkdfIters,
+  },
+}: {
+  pin: string;
+  pinIdentityMaterial: PinIdentityMaterial;
+}): Promise<SignIdentity> => {
+  const pinKey = await derivePinKey({
+    pin,
+    salt: pinSalt,
+    iterations: pinPbkdfIters,
+  });
+  const encryptedOnce = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: pinIv },
+    pinKey,
+    encryptedTwice
+  );
+
+  const secretKey = await crypto.subtle.unwrapKey(
+    "pkcs8" /* the export format */,
+    encryptedOnce,
+    browserKey,
+    { name: "AES-GCM", iv: browserIv } /* the encryption algo */,
+    { name: "ECDSA", namedCurve },
+    false /* non-extractable */,
+    ["sign"] /* key usages */
+  );
+
+  return ECDSAKeyIdentity.fromKeyPair({ privateKey: secretKey, publicKey });
+};
+
+/** PIN identity key pair */
+
+// Generates a new ECDSA key pair
+export const generateKeyPair = async ({
+  namedCurve,
+}: {
+  namedCurve: NistEc;
+}): Promise<ECDSAKeyIdentity> => {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "ECDSA",
+      namedCurve,
+    },
+    true /* extractable for storage */,
+    ["sign"] /* The only usage of the actual keypair is to sign requests */
+  );
+
+  return ECDSAKeyIdentity.fromKeyPair(keyPair);
+};
+
+/** Encryption keys */
+
+const AesKeyGenParams = { name: "AES-GCM", length: 256 } as const;
+
+/* PIN key */
+
+export const derivePinKey = async ({
+  pin,
+  salt,
+  iterations,
+}: {
+  pin: string;
+  salt: ArrayBuffer;
+  iterations: number;
+}): Promise<CryptoKey> => {
+  const enc = new TextEncoder();
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/deriveKey#pbkdf2_2
+  const passwordKeyMaterial = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(pin),
+    "PBKDF2",
+    false /* non extractable */,
+    ["deriveKey"] /* this material is only used to derive the PIN key */
+  );
+
+  const encryptionKey = await crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations,
+      hash: "SHA-256",
+    },
+    passwordKeyMaterial,
+    AesKeyGenParams,
+    true,
+    [
+      "encrypt",
+      "decrypt",
+    ] /* The password-derived key is used to encrypt/decrypt the keypair (2nd encryption round )*/
+  );
+
+  return encryptionKey;
+};
+
+/* Browser key */
+
+export const generateBrowserKey = async (): Promise<CryptoKey> => {
+  const key = await crypto.subtle.generateKey(
+    AesKeyGenParams,
+    false /* non extractable */,
+    [
+      "wrapKey",
+      "unwrapKey",
+    ] /* key is used to wrap (and unwrap) the identity secret key */
+  );
+  return key;
+};

--- a/src/frontend/test-setup.ts
+++ b/src/frontend/test-setup.ts
@@ -1,4 +1,3 @@
-import crypto from "@trust/webcrypto";
 import { TextEncoder } from "util";
 import { vi } from "vitest";
 
@@ -46,7 +45,8 @@ declare global {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-global.crypto.subtle = crypto.subtle;
+// eslint-disable-next-line
+global.crypto = require("crypto").webcrypto;
+// eslint-disable-next-line
+global.CryptoKey = require("crypto").webcrypto.CryptoKey;
 global.TextEncoder = TextEncoder;


### PR DESCRIPTION
This introduces the cryptographic operations for storing an II keypair in browser storage.

The keypair is encrypted twice (once with a generated key, once with a key derived from a user PIN, see module) before being stored in IndexedDB.

The test-setup's crypto module is updated. The previous crypto module did not support `CryptoKey`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

