### PR TITLE
Factor out canister_sig_util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "canister_sig_util"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "canister_tests",
+ "ic-cdk",
+ "ic-certified-map",
+ "ic-test-state-machine-client",
+ "identity_jose",
+ "lazy_static",
+ "sha2 0.10.7",
+]
+
+[[package]]
 name = "canister_tests"
 version = "0.1.0"
 dependencies = [
@@ -1221,6 +1235,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.21.3",
  "candid",
+ "canister_sig_util",
  "canister_tests",
  "captcha",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "src/internet_identity",
+    "src/canister_sig_util",
     "src/canister_tests",
     "src/internet_identity_interface",
     "src/archive",

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,8 @@ RUN mkdir -p src/internet_identity/src \
     && touch src/archive/src/lib.rs \
     && mkdir -p src/canister_tests/src \
     && touch src/canister_tests/src/lib.rs \
+    && mkdir -p src/canister_sig_util/src \
+    && touch src/canister_sig_util/src/lib.rs \
     && ./scripts/build --only-dependencies --internet-identity --archive \
     && rm -rf src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ COPY src/internet_identity/Cargo.toml src/internet_identity/Cargo.toml
 COPY src/internet_identity_interface/Cargo.toml src/internet_identity_interface/Cargo.toml
 COPY src/archive/Cargo.toml src/archive/Cargo.toml
 COPY src/canister_tests/Cargo.toml src/canister_tests/Cargo.toml
+COPY src/canister_sig_util/Cargo.toml src/canister_sig_util/Cargo.toml
 ENV CARGO_TARGET_DIR=/cargo_target
 COPY ./scripts/build ./scripts/build
 RUN mkdir -p src/internet_identity/src \

--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -214,6 +214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "canister_sig_util"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "ic-cdk",
+ "ic-certified-map",
+ "identity_jose",
+ "sha2 0.10.7",
+]
+
+[[package]]
 name = "canister_tests"
 version = "0.1.0"
 dependencies = [
@@ -1906,6 +1917,7 @@ name = "vc_issuer"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "canister_sig_util",
  "canister_tests",
  "ic-cdk",
  "ic-cdk-macros",

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 # local dependencies
+canister_sig_util = { path = "../../src/canister_sig_util" }
 internet_identity_interface = { path = "../../src/internet_identity_interface" }
 # ic dependencies
 candid = "0.9"

--- a/src/canister_sig_util/Cargo.toml
+++ b/src/canister_sig_util/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "canister_sig_util"
+description = "Utils for handling canister signatures"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# ic dependencies
+candid = "0.9"
+ic-cdk = "0.10"
+ic-certified-map = "0.4"
+
+# vc dependencies
+identity_jose = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false, features = ["iccs"]}
+# identity_jose = { path = "../../../identity.rs/identity_jose", default-features = false, features = ["iccs"]}
+
+# other dependencies
+sha2 = "^0.10" # set bound to match ic-certified-map bound
+
+[dev-dependencies]
+ic-test-state-machine-client = "3"
+candid = { version = "0.9", features = ["parser"] }
+canister_tests = { path = "../../src/canister_tests" }
+lazy_static = "1.4"

--- a/src/canister_sig_util/src/lib.rs
+++ b/src/canister_sig_util/src/lib.rs
@@ -1,0 +1,101 @@
+use candid::Principal;
+use ic_certified_map::Hash;
+use identity_jose::jwk::{Jwk, JwkParams, JwkParamsOct, JwkType};
+use identity_jose::jws::{CompactJwsEncoder, JwsAlgorithm, JwsHeader};
+use identity_jose::jwu::encode_b64;
+use sha2::{Digest, Sha256};
+use std::ops::{Add, DerefMut};
+
+pub fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_ref());
+    hasher.finalize().into()
+}
+
+pub fn vc_signing_input(
+    credential_jwt: &str,
+    canister_sig_pk_der: &[u8],
+    canister_id: Principal,
+) -> Vec<u8> {
+    let encoder = jws_encoder(credential_jwt, canister_sig_pk_der, canister_id);
+    encoder.signing_input().to_vec()
+}
+
+pub fn vc_jwt_to_jws(
+    credential_jwt: &str,
+    canister_sig_pk_der: &[u8],
+    sig: &[u8],
+    canister_id: Principal,
+) -> String {
+    let encoder = jws_encoder(credential_jwt, canister_sig_pk_der, canister_id);
+    encoder.into_jws(sig)
+}
+
+pub fn vc_signing_input_hash(signing_input: &[u8]) -> Hash {
+    let sep = b"iccs_verifiable_credential";
+    let mut hasher = Sha256::new();
+    let buf = [sep.len() as u8];
+    hasher.update(buf);
+    hasher.update(sep);
+    hasher.update(signing_input);
+    hasher.finalize().into()
+}
+
+pub fn der_encoded_canister_sig_pk(canister_id: Principal, seed: &[u8]) -> Vec<u8> {
+    let mut bitstring: Vec<u8> = vec![];
+    bitstring.push(canister_id.as_ref().len() as u8);
+    bitstring.extend(canister_id.as_ref());
+    bitstring.extend(seed);
+
+    let mut der: Vec<u8> = vec![];
+    // sequence of length 17 + the bit string length
+    der.push(0x30);
+    der.push(17 + bitstring.len() as u8);
+    der.extend(vec![
+        // sequence of length 12 for the OID
+        0x30, 0x0C, // OID 1.3.6.1.4.1.56387.1.2
+        0x06, 0x0A, 0x2B, 0x06, 0x01, 0x04, 0x01, 0x83, 0xB8, 0x43, 0x01, 0x02,
+    ]);
+    // BIT string of given length
+    der.push(0x03);
+    der.push(1 + bitstring.len() as u8);
+    der.push(0x00);
+    der.extend(bitstring);
+    der
+}
+
+pub fn did_for_principal(principal: Principal) -> String {
+    let prefix = String::from("did:icp:");
+    prefix.add(&principal.to_string())
+}
+
+// Per https://datatracker.ietf.org/doc/html/rfc7518#section-6.4,
+// JwkParamsOct are for symmetric keys or another key whose value is a single octet sequence.
+fn canister_sig_pk_jwk(canister_sig_pk_der: &[u8]) -> Jwk {
+    let mut cspk_jwk = Jwk::new(JwkType::Oct);
+    cspk_jwk.set_alg("IcCs");
+    cspk_jwk
+        .set_params(JwkParams::Oct(JwkParamsOct {
+            k: encode_b64(canister_sig_pk_der),
+        }))
+        .expect("internal: failed setting JwkParams");
+    cspk_jwk
+}
+
+fn jws_encoder<'a>(
+    credential_jwt: &'a str,
+    canister_sig_pk_der: &[u8],
+    canister_id: Principal,
+) -> CompactJwsEncoder<'a> {
+    let mut header: JwsHeader = JwsHeader::new();
+    header.set_alg(JwsAlgorithm::IcCs);
+    let kid = did_for_principal(canister_id);
+    header.set_kid(kid);
+    header
+        .deref_mut()
+        .set_jwk(canister_sig_pk_jwk(canister_sig_pk_der));
+
+    let encoder: CompactJwsEncoder = CompactJwsEncoder::new(credential_jwt.as_ref(), &header)
+        .expect("internal error: JWS encoder failed");
+    encoder
+}

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-
+canister_sig_util = { path = "../../src/canister_sig_util" }
 internet_identity_interface = { path = "../internet_identity_interface" }
 
 hex = "0.4"


### PR DESCRIPTION
Factor out crate `canister_sig_util`, which contains utils for creating/verifying verifiable credentials that use canister signatures.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d2b3ac92d/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


