### PR TITLE
Clarify filetype error

### DIFF
--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -260,7 +260,11 @@ fn collect_assets_from_dir(dir: &Dir) -> Vec<(String, Vec<u8>, ContentEncoding, 
             "svg" => (file_bytes, ContentEncoding::Identity, ContentType::SVG),
             "webp" => (file_bytes, ContentEncoding::Identity, ContentType::WEBP),
             "woff2.gz" => (file_bytes, ContentEncoding::GZip, ContentType::WOFF2),
-            _ => panic!("Unknown asset type: {}", asset.path().display()),
+            ext => panic!(
+                "Unknown asset type '{}' for asset '{}'",
+                ext,
+                asset.path().display()
+            ),
         };
 
         assets.push((file_to_asset_path(asset), content, encoding, content_type));


### PR DESCRIPTION
This clarifies the error message in case on unknown asset type. The previous error showed the asset basename, suggesting this had been used as the extension.

The new error message clarifies what was assumed to be the filetype/extension, and also clarifies word (string) boundaries to avoid subtle space/invisible char issues.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
