### PR TITLE
Add IDB storage operations for browser IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@dfinity/utils": "^0.0.20",
         "bip39": "^3.0.4",
         "buffer": "^6.0.3",
+        "idb-keyval": "^6.2.1",
         "lit-html": "^2.7.2",
         "process": "^0.11.10",
         "qr-creator": "^1.0.0",
@@ -5790,6 +5791,11 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -16169,6 +16175,11 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
       "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
       "dev": true
+    },
+    "idb-keyval": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@dfinity/utils": "^0.0.20",
     "bip39": "^3.0.4",
     "buffer": "^6.0.3",
+    "idb-keyval": "^6.2.1",
     "lit-html": "^2.7.2",
     "process": "^0.11.10",
     "qr-creator": "^1.0.0",

--- a/src/frontend/src/flows/pin/idb.ts
+++ b/src/frontend/src/flows/pin/idb.ts
@@ -1,0 +1,49 @@
+import { toast } from "$src/components/toast";
+import { PinIdentityMaterial } from "$src/crypto/pinIdentity";
+import { createStore, get, set } from "idb-keyval";
+
+export {
+  PinIdentityMaterial,
+  constructPinIdentity,
+  reconstructPinIdentity,
+} from "$src/crypto/pinIdentity";
+
+/* IndexedDB-specific storage for browser identities
+ * (indexed by user number) */
+
+export const idbIdentitiesStore = createStore(
+  "browser-identities",
+  "identities"
+);
+
+export const idbStorePinIdentityMaterial = async ({
+  userNumber,
+  pinIdentityMaterial,
+}: {
+  userNumber: bigint;
+  pinIdentityMaterial: PinIdentityMaterial;
+}): Promise<void> => {
+  await set(userNumber.toString(), pinIdentityMaterial, idbIdentitiesStore);
+};
+
+export const idbRetrievePinIdentityMaterial = async ({
+  userNumber,
+}: {
+  userNumber: bigint;
+}): Promise<PinIdentityMaterial | undefined> => {
+  const retrieved = await get(userNumber.toString(), idbIdentitiesStore);
+
+  if (retrieved === undefined) {
+    return undefined;
+  }
+  const result = PinIdentityMaterial.safeParse(retrieved);
+  if (!result.success) {
+    const message =
+      `Unexpected error: malformed browser identity for identity ${userNumber}: ` +
+      result.error;
+    console.error(message);
+    toast.error(message);
+    throw new Error(message);
+  }
+  return result.data;
+};


### PR DESCRIPTION
This adds an implementation for storing/retrieving browser identities (for PIN authentication).

There are no tests associated, as jsdom unfortunately does not have an `indexeddb` object (AFAICT).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/660dfd61d/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/660dfd61d/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
