### PR TITLE
Disable asset inlining

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,6 +38,7 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
       alias: aliasConfig,
     },
     build: {
+      assetsInlineLimit: 0,
       outDir: "../../dist",
       emptyOutDir: true,
       rollupOptions: {


### PR DESCRIPTION
This ensures vite doesn't inline any assets. Inlining assets (like small fonts) causes CSP issues.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
