### PR TITLE
Fix content encoding for woff2

### DIFF
--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -259,7 +259,7 @@ fn collect_assets_from_dir(dir: &Dir) -> Vec<(String, Vec<u8>, ContentEncoding, 
             "png" => (file_bytes, ContentEncoding::Identity, ContentType::PNG),
             "svg" => (file_bytes, ContentEncoding::Identity, ContentType::SVG),
             "webp" => (file_bytes, ContentEncoding::Identity, ContentType::WEBP),
-            "woff2" => (file_bytes, ContentEncoding::GZip, ContentType::WOFF2),
+            "woff2" => (file_bytes, ContentEncoding::Identity, ContentType::WOFF2),
             "woff2.gz" => (file_bytes, ContentEncoding::GZip, ContentType::WOFF2),
             ext => panic!(
                 "Unknown asset type '{}' for asset '{}'",


### PR DESCRIPTION
Due to a copy/paste error, the non-gzipped woff2 assets were served as gzipped assets.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
