### PR TITLE
Clarify authentication flows

### DIFF
--- a/src/frontend/src/components/authenticateBox.test.ts
+++ b/src/frontend/src/components/authenticateBox.test.ts
@@ -7,10 +7,6 @@ test("anchors are forwarded", async () => {
   const addDevice: (anchor?: bigint) => void = vi.fn();
   const recover: (anchor?: bigint) => void = vi.fn();
   const pages = authnTemplates(new I18n("en"), {
-    register: () => {},
-    onSubmit: () => {},
-    addDevice,
-    recover,
     firstTime: {
       slot: html``,
       useExistingText: "",
@@ -24,7 +20,12 @@ test("anchors are forwarded", async () => {
     },
   });
 
-  const useExisting = pages.useExisting();
+  const useExisting = pages.useExisting({
+    register: () => {},
+    onSubmit: () => {},
+    addDevice,
+    recover,
+  });
   render(useExisting, document.body);
   const addDeviceButton = document.querySelector(
     "#addNewDeviceButton"

--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -36,7 +36,7 @@ import { promptUserNumber } from "./promptUserNumber";
 
 import copyJson from "./authenticateBox.json";
 
-/** Template used for rendering specific authentication screens. See `authnPages` below
+/** Template used for rendering specific authentication screens. See `authnScreens` below
  * for meaning of "firstTime", "useExisting" and "pick". */
 export type AuthnTemplates = {
   firstTime: {
@@ -66,10 +66,7 @@ export const authenticateBox = async ({
       i18n,
       templates,
       addDevice: (userNumber) => asNewDevice(connection, userNumber),
-      login: (userNumber) =>
-        handleLogin({
-          login: () => connection.login(userNumber),
-        }),
+      login: (userNumber) => login({ connection, userNumber }),
       recover: () => useRecovery(connection),
       registerFlowOpts: getRegisterFlowOpts({ connection }),
     });
@@ -87,7 +84,7 @@ export const authenticateBox = async ({
 
 /** Authentication box component which authenticates a user
  * to II or to another dapp */
-export const authenticateBoxFlow = <T>({
+export const authenticateBoxFlow = async <T>({
   i18n,
   templates,
   addDevice,
@@ -101,54 +98,84 @@ export const authenticateBoxFlow = <T>({
   login: (userNumber: bigint) => Promise<LoginFlowSuccess<T> | LoginFlowError>;
   recover: () => Promise<LoginFlowResult<T>>;
   registerFlowOpts: Parameters<typeof registerFlow<T>>[0];
-}): Promise<LoginFlowResult<T> & { newAnchor: boolean }> =>
-  new Promise((resolve) => {
-    const pages = authnPages(i18n, {
-      ...templates,
-      addDevice: (userNumber) => addDevice(userNumber),
-      onSubmit: async (userNumber) => {
-        const result = await withLoader(() => login(userNumber));
-        resolve({
-          newAnchor: false,
-          ...result,
-        });
-      },
-      register: async () => {
-        const result = await registerFlow<T>(registerFlowOpts);
+}): Promise<LoginFlowResult<T> & { newAnchor: boolean }> => {
+  const pages = authnScreens(i18n, { ...templates });
 
-        if (result === "canceled") {
-          resolve({
-            newAnchor: true,
-            tag: "canceled",
-          });
-          return;
-        }
+  // The registration flow for a new identity
+  const doRegister = async (): Promise<
+    LoginFlowResult<T> & { newAnchor: boolean }
+  > => {
+    const result2 = await registerFlow<T>(registerFlowOpts);
 
-        resolve({
-          newAnchor: true,
-          ...apiResultToLoginFlowResult<T>(result),
-        });
-      },
-      recover: async (_userNumber) => {
-        resolve({
-          newAnchor: false,
-          ...(await recover()),
-        });
-      },
-    });
-
-    // If there _are_ some anchors, then we show the "pick" screen, otherwise
-    // we assume a new user and show the "firstTime" screen.
-    const anchors = getAnchors();
-    if (isNonEmptyArray(anchors)) {
-      pages.pick({
-        anchors: anchors,
-        moreOptions: () => pages.useExisting(),
-      });
-    } else {
-      pages.firstTime({ useExisting: () => pages.useExisting() });
+    if (result2 === "canceled") {
+      return {
+        newAnchor: true,
+        tag: "canceled",
+      } as const;
     }
-  });
+
+    return {
+      newAnchor: true,
+      ...apiResultToLoginFlowResult<T>(result2),
+    };
+  };
+
+  // Prompt for an identity number
+  const doPrompt = async (): Promise<
+    LoginFlowResult<T> & { newAnchor: boolean }
+  > => {
+    const result = await pages.useExisting();
+    if (result.tag === "submit") {
+      const result2 = await withLoader(() => login(result.userNumber));
+      return { newAnchor: false, ...result2 };
+    }
+
+    if (result.tag === "add_device") {
+      const _ = await addDevice(result.userNumber);
+      // XXX: we don't currently do anything with the result from adding a device and
+      // we let the flow hang.
+      const hang = await new Promise<never>((_) => {
+        /* hang forever */
+      });
+      return hang;
+    }
+
+    if (result.tag === "register") {
+      return await doRegister();
+    }
+
+    result satisfies { tag: "recover" };
+    const result2 = await recover();
+    return {
+      newAnchor: false,
+      ...result2,
+    };
+  };
+
+  // If there _are_ some anchors, then we show the "pick" screen, otherwise
+  // we assume a new user and show the "firstTime" screen.
+  const anchors = getAnchors();
+  if (isNonEmptyArray(anchors)) {
+    const result = await pages.pick({ anchors });
+
+    if (result.tag === "pick") {
+      const result1 = await withLoader(() => login(result.userNumber));
+      return { newAnchor: false, ...result1 };
+    }
+
+    result satisfies { tag: "more_options" };
+    return await doPrompt();
+  } else {
+    const result = await pages.firstTime();
+
+    if (result.tag === "register") {
+      return await doRegister();
+    }
+
+    result satisfies { tag: "use_existing" };
+    return await doPrompt();
+  }
+};
 
 export const handleLoginFlowResult = async <T>(
   result: LoginFlowResult<T>
@@ -174,15 +201,7 @@ export const handleLoginFlowResult = async <T>(
 };
 
 /** The templates for the authentication pages */
-export const authnTemplates = (
-  i18n: I18n,
-  props: {
-    register: () => void;
-    onSubmit: (anchor: bigint) => void;
-    addDevice: (anchor?: bigint) => void;
-    recover: (anchor?: bigint) => void;
-  } & AuthnTemplates
-) => {
+export const authnTemplates = (i18n: I18n, props: AuthnTemplates) => {
   const copy = i18n.i18n(copyJson);
 
   const marketingBlocks = [
@@ -219,12 +238,15 @@ export const authnTemplates = (
   ];
 
   return {
-    firstTime: (firstTimeProps: { useExisting: () => void }) => {
+    firstTime: (firstTimeProps: {
+      useExisting: () => void;
+      register: () => void;
+    }) => {
       return html`${props.firstTime.slot}
         <div class="l-stack">
           <button
             type="button"
-            @click=${() => props.register()}
+            @click=${() => firstTimeProps.register()}
             id="registerButton"
             class="c-button"
           >
@@ -254,8 +276,15 @@ export const authnTemplates = (
           )}
         </div> `;
     },
-    useExisting: () => {
-      const anchorInput = mkAnchorInput({ onSubmit: props.onSubmit });
+    useExisting: (useExistingProps: {
+      register: () => void;
+      onSubmit: (userNumber: bigint) => void;
+      recover: (userNumber?: bigint) => void;
+      addDevice: (userNumber?: bigint) => void;
+    }) => {
+      const anchorInput = mkAnchorInput({
+        onSubmit: useExistingProps.onSubmit,
+      });
       const withUserNumber = (f: (arg: bigint | undefined) => void) => {
         const value = withRef(
           anchorInput.userNumberInput,
@@ -278,7 +307,9 @@ export const authnTemplates = (
         </div>
         <button
           @click=${() =>
-            withUserNumber((userNumber) => props.addDevice(userNumber))}
+            withUserNumber((userNumber) =>
+              useExistingProps.addDevice(userNumber)
+            )}
           id="addNewDeviceButton"
           class="c-button c-button--textOnly"
         >
@@ -287,14 +318,16 @@ export const authnTemplates = (
 
         <ul class="c-link-group">
           <li>
-            <button @click=${() => props.register()} class="t-link">
+            <button @click=${() => useExistingProps.register()} class="t-link">
               Create New
             </button>
           </li>
           <li>
             <a
               @click="${() =>
-                withUserNumber((userNumber) => props.recover(userNumber))}"
+                withUserNumber((userNumber) =>
+                  useExistingProps.recover(userNumber)
+                )}"
               id="recoverButton"
               class="t-link"
               >Lost Access?</a
@@ -304,13 +337,14 @@ export const authnTemplates = (
     },
     pick: (pickProps: {
       anchors: NonEmptyArray<bigint>;
+      onSubmit: (userNumber: bigint) => void;
       moreOptions: () => void;
     }) => {
       return html`
         ${props.pick.slot}
         ${mkAnchorPicker({
           savedAnchors: pickProps.anchors,
-          pick: props.onSubmit,
+          pick: pickProps.onSubmit,
           moreOptions: pickProps.moreOptions,
         }).template}
       `;
@@ -318,27 +352,59 @@ export const authnTemplates = (
   };
 };
 
+export const authnPages = (i18n: I18n, props: AuthnTemplates) => {
+  const templates = authnTemplates(i18n, props);
+
+  return {
+    firstTime: (opts: Parameters<typeof templates.firstTime>[0]) =>
+      page(templates.firstTime(opts)),
+    useExisting: (opts: Parameters<typeof templates.useExisting>[0]) =>
+      page(templates.useExisting(opts)),
+    pick: (opts: Parameters<typeof templates.pick>[0]) =>
+      page(templates.pick(opts)),
+  };
+};
+
 /** The authentication pages, namely "firstTime" (for new users), "useExisting" (for users who
  * don't have saved anchors or who wish to use non-saved anchors) and "pick" (for users
  * picking a saved anchor) */
-export const authnPages = (
-  i18n: I18n,
-  props: {
-    register: () => void;
-    onSubmit: (anchor: bigint) => void;
-    addDevice: (anchor?: bigint) => void;
-    recover: (anchor?: bigint) => void;
-  } & AuthnTemplates
-) => {
-  const tpls = authnTemplates(i18n, props);
+export const authnScreens = (i18n: I18n, props: AuthnTemplates) => {
+  const pages = authnPages(i18n, props);
   return {
-    firstTime: (firstTimeProps: { useExisting: () => void }) =>
-      page(tpls.firstTime(firstTimeProps)),
-    useExisting: () => page(tpls.useExisting()),
-    pick: (pickProps: {
-      anchors: NonEmptyArray<bigint>;
-      moreOptions: () => void;
-    }) => page(tpls.pick(pickProps)),
+    firstTime: () =>
+      new Promise<{ tag: "use_existing" } | { tag: "register" }>((resolve) =>
+        pages.firstTime({
+          useExisting: () => resolve({ tag: "use_existing" }),
+          register: () => resolve({ tag: "register" }),
+        })
+      ),
+    useExisting: () =>
+      new Promise<
+        | { tag: "register" }
+        | { tag: "submit"; userNumber: bigint }
+        | { tag: "add_device"; userNumber?: bigint }
+        | { tag: "recover"; userNumber?: bigint }
+      >((resolve) =>
+        pages.useExisting({
+          register: () => resolve({ tag: "register" }),
+          onSubmit: (userNumber: bigint) =>
+            resolve({ tag: "submit", userNumber }),
+          addDevice: (userNumber?: bigint) =>
+            resolve({ tag: "add_device", userNumber }),
+          recover: (userNumber?: bigint) =>
+            resolve({ tag: "recover", userNumber }),
+        })
+      ),
+    pick: (pickProps: { anchors: NonEmptyArray<bigint> }) =>
+      new Promise<
+        { tag: "more_options" } | { tag: "pick"; userNumber: bigint }
+      >((resolve) =>
+        pages.pick({
+          ...pickProps,
+          onSubmit: (userNumber) => resolve({ tag: "pick", userNumber }),
+          moreOptions: () => resolve({ tag: "more_options" }),
+        })
+      ),
   };
 };
 
@@ -370,6 +436,17 @@ const page = (slot: TemplateResult) => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(template, container);
 };
+
+const login = ({
+  connection,
+  userNumber,
+}: {
+  connection: Connection;
+  userNumber: bigint;
+}) =>
+  handleLogin({
+    login: () => connection.login(userNumber),
+  });
 
 // Register this device as a new device with the anchor
 const asNewDevice = async (

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -124,7 +124,10 @@ const authzTemplatesKnown = authnTemplateAuthorize({
 
 const authz = authnPages(i18n, { ...authnCnfg, ...authzTemplates });
 const authzAlt = authnPages(i18n, { ...authnCnfg, ...authzTemplatesAlt });
-const authzKnown = authnPages(i18n, { ...authnCnfg, ...authzTemplatesKnown });
+const authzKnown = authnPages(i18n, {
+  ...authnCnfg,
+  ...authzTemplatesKnown,
+});
 const authzKnownAlt = authnPages(i18n, {
   ...authnCnfg,
   ...authzTemplatesKnownAlt,
@@ -152,37 +155,86 @@ export const iiPages: Record<string, () => void> = {
   // Authorize screens
 
   authorizeNew: () =>
-    authz.firstTime({ useExisting: () => console.log("Use existing") }),
+    authz.firstTime({
+      useExisting: () => toast.info(html`Asked for existing`),
+      register: () => toast.info(html`Asked for registration`),
+    }),
   authorizeNewKnown: () =>
-    authzKnown.firstTime({ useExisting: () => console.log("Use existing") }),
+    authzKnown.firstTime({
+      useExisting: () => console.log("Use existing"),
+      register: () => toast.info(html`Asked for registration`),
+    }),
   authorizeNewAlt: () =>
-    authzAlt.firstTime({ useExisting: () => console.log("Use existing") }),
+    authzAlt.firstTime({
+      useExisting: () => console.log("Use existing"),
+      register: () => toast.info(html`Asked for registration`),
+    }),
   authorizeNewKnownAlt: () =>
-    authzKnownAlt.firstTime({ useExisting: () => console.log("Use existing") }),
-  authorizeUseExisting: () => authz.useExisting(),
-  authorizeUseExistingKnown: () => authzKnown.useExisting(),
-  authorizeUseExistingKnownAlt: () => authzKnownAlt.useExisting(),
+    authzKnownAlt.firstTime({
+      useExisting: () => console.log("Use existing"),
+      register: () => toast.info(html`Asked for registration`),
+    }),
+  authorizeUseExisting: () =>
+    authz.useExisting({
+      recover: () => toast.info(html`Asked for recovery`),
+      onSubmit: (userNumber) =>
+        toast.info(html`User number submitted: ${userNumber.toString()}`),
+      addDevice: () => toast.info(html`Asked for adding device`),
+      register: () => toast.info(html`Asked for registration`),
+    }),
+  authorizeUseExistingKnown: () =>
+    authzKnown.useExisting({
+      recover: () => toast.info(html`Asked for recovery`),
+      onSubmit: (userNumber) =>
+        toast.info(html`User number submitted: ${userNumber.toString()}`),
+      addDevice: () => toast.info(html`Asked for adding device`),
+      register: () => toast.info(html`Asked for registration`),
+    }),
+  authorizeUseExistingKnownAlt: () =>
+    authzKnownAlt.useExisting({
+      recover: () => toast.info(html`Asked for recovery`),
+      onSubmit: (userNumber) =>
+        toast.info(html`User number submitted: ${userNumber.toString()}`),
+      addDevice: () => toast.info(html`Asked for adding device`),
+      register: () => toast.info(html`Asked for registration`),
+    }),
   authorizePick: () =>
     authz.pick({
       anchors: [BigInt(10000), BigInt(243099)],
-      moreOptions: () => console.log("More options requested"),
+      moreOptions: () => toast.info(html`Asked for more options`),
+      onSubmit: (userNumber) =>
+        toast.info(html`User number submitted: ${userNumber.toString()}`),
     }),
   authorizePickMany: () =>
     authz.pick({
       anchors: [...Array(10).keys()].map((x) =>
         BigInt(10000 + 129 * x * x)
       ) as NonEmptyArray<bigint>,
-      moreOptions: () => console.log("More options requested"),
+      moreOptions: () => toast.info(html`Asked for more options`),
+      onSubmit: (userNumber) =>
+        toast.info(html`User number submitted: ${userNumber.toString()}`),
     }),
 
   // Manage Auth screens
   manageNew: () =>
-    manage.firstTime({ useExisting: () => console.log("Use existing") }),
-  manageUseExisting: () => manage.useExisting(),
+    manage.firstTime({
+      useExisting: () => toast.info(html`Asked for existing`),
+      register: () => toast.info(html`Asked for registration`),
+    }),
+  manageUseExisting: () =>
+    manage.useExisting({
+      register: () => toast.info(html`Asked for registration`),
+      recover: () => toast.info(html`Asked for recovery`),
+      onSubmit: (userNumber) =>
+        toast.info(html`User number submitted: ${userNumber.toString()}`),
+      addDevice: () => toast.info(html`Asked for adding device`),
+    }),
   managePick: () =>
     manage.pick({
       anchors: [BigInt(10000), BigInt(243099)],
-      moreOptions: () => console.log("More options requested"),
+      moreOptions: () => toast.info(html`Asked for more options`),
+      onSubmit: (userNumber) =>
+        toast.info(html`User number submitted: ${userNumber.toString()}`),
     }),
 
   protectDeviceInfo: () =>
@@ -437,7 +489,10 @@ export const iiPages: Record<string, () => void> = {
     }),
   promptUserNumber: () => promptUserNumber({ title: "hello" }),
   banner: () => {
-    manage.firstTime({ useExisting: () => console.log("Use existing") });
+    manage.firstTime({
+      useExisting: () => toast.info(html`Asked for existing`),
+      register: () => toast.info(html`Asked for registration`),
+    });
     showWarning(html`This is a test page, be very careful!`);
   },
   registerDisabled: () => registerDisabled(),


### PR DESCRIPTION
This cleans up the authentication flows (the `authenticateBox`) by making the logic & types clearer.

In particular, the flows are now split into `authnTemplates`, `authnPages` & `authnScreens` which align better with the `page` vs `template` convention of other screens.

An unhandled corner case is also clarified (flow hanging after adding a new device).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a2fefc34d/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a2fefc34d/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
