### PR TITLE
Add screens for non-passkey flow

### DIFF
--- a/src/frontend/src/flows/pin/confirmPin.json
+++ b/src/frontend/src/flows/pin/confirmPin.json
@@ -1,0 +1,6 @@
+{
+  "en": {
+    "confirm_pin": "Confirm PIN for Internet Identity on this Device",
+    "cancel": "Cancel"
+  }
+}

--- a/src/frontend/src/flows/pin/confirmPin.ts
+++ b/src/frontend/src/flows/pin/confirmPin.ts
@@ -1,0 +1,85 @@
+import { mainWindow } from "$src/components/mainWindow";
+import { PinResult, pinInput } from "$src/components/pinInput";
+import { I18n } from "$src/i18n";
+import { mount, renderPage } from "$src/utils/lit-html";
+import { TemplateResult, html } from "lit-html";
+import { pinStepper } from "./stepper";
+
+import copyJson from "./confirmPin.json";
+
+/* PIN confirmation (just prompts the user to re-enter their PIN) */
+
+const confirmPinTemplate = ({
+  i18n,
+  cancel,
+  onContinue,
+  expectedPin: expectedPin,
+  focus = false,
+  scrollToTop = false,
+}: {
+  i18n: I18n;
+  cancel: () => void;
+  onContinue: () => void;
+  expectedPin: string;
+  focus?: boolean;
+  /* put the page into view */
+  scrollToTop?: boolean;
+}): TemplateResult => {
+  const copy = i18n.i18n(copyJson);
+  const verify = (pin: string): PinResult<string> => {
+    if (pin === expectedPin) {
+      return { ok: true, value: pin };
+    }
+
+    // XXX: there is currently no way to restart the PIN. We need to figure
+    // out what to do UX-wise first.
+    return { ok: false, error: "PINs don't match" };
+  };
+
+  const pinInput_ = pinInput({
+    onSubmit: (_pin) => onContinue(),
+    verify,
+    secret: true,
+    focus,
+  });
+  const slot = html`
+    ${pinStepper({ current: "confirm" })}
+    <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
+      <h1 class="t-title t-title--main">${copy.confirm_pin}</h1>
+    </hgroup>
+    <div class="l-stack">
+      <div class="c-input--stack">${pinInput_.template}</div>
+    </div>
+    <button
+      @click=${() => cancel()}
+      data-action="cancel"
+      class="c-button c-button--secondary l-stack"
+    >
+      ${copy.cancel}
+    </button>
+  `;
+
+  return mainWindow({
+    showFooter: false,
+    showLogo: false,
+    slot,
+  });
+};
+
+export const confirmPinPage = renderPage(confirmPinTemplate);
+export const confirmPin = ({
+  expectedPin,
+}: {
+  expectedPin: string;
+}): Promise<{ tag: "ok" } | { tag: "canceled" }> => {
+  return new Promise((resolve) =>
+    confirmPinPage({
+      i18n: new I18n(),
+      onContinue: () => resolve({ tag: "ok" }),
+      expectedPin,
+      cancel: () => resolve({ tag: "canceled" }),
+      focus: true,
+      scrollToTop: true,
+    })
+  );
+};

--- a/src/frontend/src/flows/pin/setPin.json
+++ b/src/frontend/src/flows/pin/setPin.json
@@ -1,0 +1,6 @@
+{
+  "en": {
+    "set_pin_for_ii": "Set a PIN for Internet Identity on this Device",
+    "cancel": "Cancel"
+  }
+}

--- a/src/frontend/src/flows/pin/setPin.ts
+++ b/src/frontend/src/flows/pin/setPin.ts
@@ -1,0 +1,88 @@
+import { mainWindow } from "$src/components/mainWindow";
+import { PinResult, pinInput } from "$src/components/pinInput";
+import { I18n } from "$src/i18n";
+import { mount, renderPage } from "$src/utils/lit-html";
+import { isNullish } from "@dfinity/utils";
+import { TemplateResult, html } from "lit-html";
+import { pinStepper } from "./stepper";
+
+import copyJson from "./setPin.json";
+
+/* Prompt the user to create a new PIN */
+
+const setPinTemplate = ({
+  i18n,
+  cancel,
+  onContinue,
+  focus = false,
+  scrollToTop = false,
+}: {
+  i18n: I18n;
+  cancel: () => void;
+  onContinue: (pin: string) => void;
+  /* put the page into view */
+  scrollToTop?: boolean;
+  focus?: boolean;
+}): TemplateResult => {
+  const copy = i18n.i18n(copyJson);
+  const pinInput_ = pinInput({
+    onSubmit: onContinue,
+    verify: (pin) => verifyPin(pin),
+    secret: true,
+    focus,
+  });
+  const slot = html`
+    ${pinStepper({ current: "set" })}
+    <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
+      <h1 class="t-title t-title--main">${copy.set_pin_for_ii}</h1>
+    </hgroup>
+    <div class="l-stack">
+      <div class="c-input--stack">${pinInput_.template}</div>
+    </div>
+    <button
+      @click=${() => cancel()}
+      data-action="cancel"
+      class="c-button c-button--secondary l-stack"
+    >
+      ${copy.cancel}
+    </button>
+  `;
+
+  return mainWindow({
+    showFooter: false,
+    showLogo: false,
+    slot,
+  });
+};
+
+// Ensure the PIN is wellformed
+const verifyPin = (pin: string): PinResult<string> => {
+  if (pin.length < 6) {
+    return { ok: false, error: "PIN is too short, should be 6 digits" };
+  }
+
+  if (pin.length > 6) {
+    return { ok: false, error: "PIN is too long, should be 6 digits" };
+  }
+
+  if (isNullish(pin.match(/^[0-9]+$/))) {
+    return { ok: false, error: "PIN should only contain digits" };
+  }
+
+  return { ok: true, value: pin };
+};
+
+export const setPinPage = renderPage(setPinTemplate);
+export const setPin = (): Promise<
+  { tag: "ok"; pin: string } | { tag: "canceled" }
+> => {
+  return new Promise((resolve) =>
+    setPinPage({
+      i18n: new I18n(),
+      onContinue: (pin: string) => resolve({ tag: "ok", pin }),
+      cancel: () => resolve({ tag: "canceled" }),
+      focus: true,
+      scrollToTop: true,
+    })
+  );
+};

--- a/src/frontend/src/flows/pin/stepper.ts
+++ b/src/frontend/src/flows/pin/stepper.ts
@@ -1,0 +1,35 @@
+import { checkmarkIcon } from "$src/components/icons";
+import { html } from "lit-html";
+
+export const pinStepper = ({
+  current,
+}: {
+  current: "set" | "confirm" | "captcha" | "finish";
+}) => html`
+  <div class="c-progress-container">
+    <ol class="c-progress-stepper">
+      <li class="c-progress-stepper__step" aria-current=${current === "set"}>
+        <span class="c-progress-stepper__label">Set PIN</span>
+      </li>
+      <li
+        class="c-progress-stepper__step"
+        aria-current=${current === "confirm"}
+      >
+        <span class="c-progress-stepper__label">Confirm PIN</span>
+      </li>
+      <li
+        class="c-progress-stepper__step"
+        aria-current=${current === "captcha"}
+      >
+        <span class="c-progress-stepper__label">Complete CAPTCHA</span>
+      </li>
+      <li
+        class="c-progress-stepper__step c-progress-stepper__step--final"
+        aria-current=${current === "finish"}
+      >
+        <i class="c-progress-stepper__icon">${checkmarkIcon}</i>
+        <span class="c-progress-stepper__label">Get Internet Identity</span>
+      </li>
+    </ol>
+  </div>
+`;

--- a/src/frontend/src/flows/pin/usePin.json
+++ b/src/frontend/src/flows/pin/usePin.json
@@ -1,0 +1,7 @@
+{
+  "en": {
+    "enter_pin_for_ii": "Enter PIN for Internet Identity on this Device",
+    "or_use_passkey": "or Continue with Passkey",
+    "cancel": "Cancel"
+  }
+}

--- a/src/frontend/src/flows/pin/usePin.ts
+++ b/src/frontend/src/flows/pin/usePin.ts
@@ -1,0 +1,72 @@
+import { mainWindow } from "$src/components/mainWindow";
+import { pinInput } from "$src/components/pinInput";
+import { I18n } from "$src/i18n";
+import { mount, renderPage } from "$src/utils/lit-html";
+import { TemplateResult, html } from "lit-html";
+
+import copyJson from "./usePin.json";
+
+/* Prompt the user to input their PIN for use */
+
+const usePinTemplate = ({
+  i18n,
+  cancel,
+  onContinue,
+  onUsePasskey,
+  scrollToTop = false,
+}: {
+  i18n: I18n;
+  cancel: () => void;
+  onContinue: (pin: string) => void;
+  onUsePasskey: () => void;
+  /* put the page into view */
+  scrollToTop?: boolean;
+}): TemplateResult => {
+  const copy = i18n.i18n(copyJson);
+  const pinInput_ = pinInput({
+    onSubmit: onContinue,
+    verify: (pin) =>
+      // XXX: here we don't do any verification, but ideally the identity reconstruction should happen here
+      ({ ok: true, value: pin }),
+    secret: true,
+  });
+  const slot = html`
+    <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
+      <h1 class="t-title t-title--main">${copy.enter_pin_for_ii}</h1>
+    </hgroup>
+    <div class="l-stack">
+      <div class="c-input--stack">${pinInput_.template}</div>
+    </div>
+    <button
+      @click=${() => cancel()}
+      data-action="cancel"
+      class="c-button c-button--secondary l-stack"
+    >
+      ${copy.cancel}
+    </button>
+    <button @click=${() => onUsePasskey()} class="c-button c-button--textOnly">
+      ${copy.or_use_passkey}
+    </button>
+  `;
+
+  return mainWindow({
+    showFooter: false,
+    showLogo: false,
+    slot,
+  });
+};
+
+export const usePinPage = renderPage(usePinTemplate);
+export const usePin = (): Promise<
+  { kind: "pin"; pin: string } | { kind: "canceled" } | { kind: "passkey" }
+> => {
+  return new Promise((resolve) =>
+    usePinPage({
+      i18n: new I18n(),
+      onUsePasskey: () => resolve({ kind: "passkey" }),
+      onContinue: (pin: string) => resolve({ kind: "pin", pin }),
+      cancel: () => resolve({ kind: "canceled" }),
+      scrollToTop: true,
+    })
+  );
+};

--- a/src/frontend/src/flows/register/captcha.ts
+++ b/src/frontend/src/flows/register/captcha.ts
@@ -7,7 +7,6 @@ import { Chan } from "$src/utils/utils";
 import { TemplateResult, html } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { Ref, createRef, ref } from "lit-html/directives/ref.js";
-import { registerStepper } from "./stepper";
 
 import { isNullish, nonNullish } from "@dfinity/utils";
 import copyJson from "./captcha.json";
@@ -22,6 +21,7 @@ export const promptCaptchaTemplate = <T>({
   verifyChallengeChars,
   onContinue,
   i18n,
+  stepper,
   focus: focus_,
   scrollToTop = false,
 }: {
@@ -33,6 +33,7 @@ export const promptCaptchaTemplate = <T>({
   }) => Promise<T | typeof badChallenge>;
   onContinue: (result: T) => void;
   i18n: I18n;
+  stepper: TemplateResult;
   focus?: boolean;
   /* put the page into view */
   scrollToTop?: boolean;
@@ -181,7 +182,7 @@ export const promptCaptchaTemplate = <T>({
 
   const promptCaptchaSlot = html`
     <article ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
-      ${registerStepper({ current: "captcha" })}
+      ${stepper}
       <h1 class="t-title t-title--main">${copy.title}</h1>
       <form autocomplete="off" @submit=${asyncReplace(next)} class="l-stack">
         <div
@@ -258,9 +259,11 @@ export function promptCaptchaPage<T>(
 
 export const promptCaptcha = <T>({
   createChallenge,
+  stepper,
   register,
 }: {
   createChallenge: () => Promise<Challenge>;
+  stepper: TemplateResult;
   register: (cr: {
     chars: string;
     challenge: Challenge;
@@ -274,6 +277,7 @@ export const promptCaptcha = <T>({
       cancel: () => resolve(cancel),
       onContinue: resolve,
       i18n,
+      stepper,
       scrollToTop: true,
       focus: true,
     });

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -1,4 +1,5 @@
 import { Challenge } from "$generated/internet_identity_types";
+import { registerStepper } from "$src/flows/register/stepper";
 import { registerDisabled } from "$src/flows/registerDisabled";
 import { LoginFlowCanceled } from "$src/utils/flowResult";
 import {
@@ -70,6 +71,7 @@ export const registerFlow = async <T>({
 
       return result;
     },
+    stepper: registerStepper({ current: "captcha" }),
   });
 
   if ("tag" in result) {

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -1,7 +1,6 @@
 import { authenticateBoxFlow } from "$src/components/authenticateBox";
 import { toast } from "$src/components/toast";
 import { registerFlow, RegisterFlowOpts } from "$src/flows/register";
-import { badChallenge, promptCaptchaPage } from "$src/flows/register/captcha";
 import { html, render, TemplateResult } from "lit-html";
 import { dummyChallenge, i18n, manageTemplates } from "./showcase";
 
@@ -72,23 +71,6 @@ export const iiFlows: Record<string, () => void> = {
       </button>
     `);
   },
-  captcha: () => {
-    promptCaptchaPage({
-      cancel: () => console.log("canceled"),
-      requestChallenge: () =>
-        new Promise((resolve) => setTimeout(resolve, 1000)).then(
-          () => dummyChallenge
-        ),
-      verifyChallengeChars: (cr) =>
-        new Promise((resolve) => setTimeout(resolve, 1000)).then(() =>
-          cr.chars === "8wJ6Q" ? "yes" : badChallenge
-        ),
-      onContinue: () => console.log("Done"),
-      i18n,
-      focus: false,
-    });
-  },
-
   register: async () => {
     const result = await registerFlow<null>(registerFlowOpts);
 

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -44,6 +44,7 @@ import { addPhrasePage } from "$src/flows/recovery/recoveryWizard";
 import { promptCaptchaPage } from "$src/flows/register/captcha";
 import { displayUserNumberPage } from "$src/flows/register/finish";
 import { savePasskeyPage } from "$src/flows/register/passkey";
+import { registerStepper } from "$src/flows/register/stepper";
 import { registerDisabled } from "$src/flows/registerDisabled";
 import { styleguide } from "$src/styleguide";
 import "$src/styles/main.css";
@@ -305,6 +306,7 @@ export const iiPages: Record<string, () => void> = {
         new Promise(() => {
           /* noop */
         }),
+      stepper: registerStepper({ current: "captcha" }),
       onContinue: () => console.log("Done"),
       i18n,
     }),
@@ -317,6 +319,7 @@ export const iiPages: Record<string, () => void> = {
         new Promise(() => {
           /* noop */
         }),
+      stepper: registerStepper({ current: "captcha" }),
       onContinue: () => console.log("Done"),
       i18n,
     }),


### PR DESCRIPTION
This introduces all the screens necessary for the non-passkey (non-webauthn) flow. It includes screens for creating & using a PIN, as well as changes to the CAPTCHA to make the stepper generic (as the passkey & non-passkey flows both use the captcha but use different steppers).

The CAPTCHA is also removed from the flows, since it's not a flow per se.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
