### PR TITLE
Introduce Pin variation of the create passkey screen

### DIFF
--- a/src/frontend/src/flows/register/passkey.json
+++ b/src/frontend/src/flows/register/passkey.json
@@ -3,6 +3,7 @@
     "select": "Select",
     "cancel": "Cancel",
     "save_passkey": "Create Passkey",
+    "without_passkey": "Continue without Passkey",
     "and_complete_prompts": "and complete the prompts that pop-up on your device",
 
     "what_is_passkey": "What is a passkey?",

--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -10,7 +10,8 @@ import {
   isWebAuthnCancel,
   webAuthnErrorCopy,
 } from "$src/utils/webAuthnErrorUtils";
-import { html, nothing, TemplateResult } from "lit-html";
+import { nonNullish } from "@dfinity/utils";
+import { html, TemplateResult } from "lit-html";
 import { registerStepper } from "./stepper";
 
 import copyJson from "./passkey.json";
@@ -32,17 +33,16 @@ const savePasskeyTemplate = ({
   scrollToTop?: boolean;
 }): TemplateResult => {
   const copy = i18n.i18n(copyJson);
-  const constructPinButton = constructPin
-    ? html`
-        <button
-          @click=${() => constructPasskey()}
-          data-action="construct-pin-identity"
-          class="c-button c-button--secondary"
-        >
-          ${copy.without_passkey}
-        </button>
-      `
-    : nothing;
+  const createPinButton = (constructPin: () => void) => html`
+    <button
+      @click=${() => constructPin()}
+      data-action="construct-pin-identity"
+      class="c-button c-button--secondary"
+    >
+      ${copy.without_passkey}
+    </button>
+  `;
+
   const slot = html`
     ${registerStepper({ current: "create" })}
     <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
@@ -60,7 +60,7 @@ const savePasskeyTemplate = ({
     >
       ${copy.save_passkey}
     </button>
-    ${constructPinButton}
+    ${nonNullish(constructPin) ? createPinButton(constructPin) : ""}
     <button
       @click=${() => cancel()}
       data-action="cancel"

--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -10,7 +10,7 @@ import {
   isWebAuthnCancel,
   webAuthnErrorCopy,
 } from "$src/utils/webAuthnErrorUtils";
-import { html, TemplateResult } from "lit-html";
+import { html, nothing, TemplateResult } from "lit-html";
 import { registerStepper } from "./stepper";
 
 import copyJson from "./passkey.json";
@@ -18,18 +18,31 @@ import copyJson from "./passkey.json";
 /* Anchor construction component (for creating WebAuthn credentials) */
 
 const savePasskeyTemplate = ({
-  construct,
+  constructPasskey,
+  constructPin,
   i18n,
   cancel,
   scrollToTop = false,
 }: {
-  construct: () => void;
+  constructPasskey: () => void;
+  constructPin?: () => void;
   i18n: I18n;
   cancel: () => void;
   /* put the page into view */
   scrollToTop?: boolean;
 }): TemplateResult => {
   const copy = i18n.i18n(copyJson);
+  const constructPinButton = constructPin
+    ? html`
+        <button
+          @click=${() => constructPasskey()}
+          data-action="construct-pin-identity"
+          class="c-button c-button--secondary"
+        >
+          ${copy.without_passkey}
+        </button>
+      `
+    : nothing;
   const slot = html`
     ${registerStepper({ current: "create" })}
     <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
@@ -41,16 +54,17 @@ const savePasskeyTemplate = ({
       </p>
     </hgroup>
     <button
-      @click=${() => construct()}
+      @click=${() => constructPasskey()}
       data-action="construct-identity"
       class="c-button"
     >
       ${copy.save_passkey}
     </button>
+    ${constructPinButton}
     <button
       @click=${() => cancel()}
       data-action="cancel"
-      class="c-button c-button--secondary"
+      class="c-button c-button--textOnly"
     >
       ${copy.cancel}
     </button>
@@ -91,7 +105,7 @@ export const savePasskey = (): Promise<IIWebAuthnIdentity | "canceled"> => {
       i18n: new I18n(),
       cancel: () => resolve("canceled"),
       scrollToTop: true,
-      construct: async () => {
+      constructPasskey: async () => {
         try {
           const identity = await withLoader(() => constructIdentity({}));
           resolve(identity);

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -303,11 +303,11 @@ export const iiPages: Record<string, () => void> = {
       cancel: () => console.log("cancel"),
       constructPasskey: () =>
         new Promise((_) => {
-          console.log("Identity Construction");
+          console.log("Passkey Construction");
         }),
       constructPin: () =>
         new Promise((_) => {
-          console.log("Identity Construction");
+          console.log("Pin Identity Construction");
         }),
     }),
   promptCaptcha: () =>

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -292,7 +292,20 @@ export const iiPages: Record<string, () => void> = {
     savePasskeyPage({
       i18n,
       cancel: () => console.log("cancel"),
-      construct: () =>
+      constructPasskey: () =>
+        new Promise((_) => {
+          console.log("Identity Construction");
+        }),
+    }),
+  savePasskeyWithPin: () =>
+    savePasskeyPage({
+      i18n,
+      cancel: () => console.log("cancel"),
+      constructPasskey: () =>
+        new Promise((_) => {
+          console.log("Identity Construction");
+        }),
+      constructPin: () =>
         new Promise((_) => {
           console.log("Identity Construction");
         }),


### PR DESCRIPTION
This PR adds the option to have a `Continue without Passkey` button on the "Create Passkey" screen.

The new screen variant is added to the showcase.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/88d0d27ea/desktop/savePasskeyWithPin.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/88d0d27ea/mobile/savePasskeyWithPin.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/88d0d27ea/desktop/savePasskey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/88d0d27ea/mobile/savePasskey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

