### PR TITLE
Remove dfx metadata infrastructure from release build check

### DIFF
--- a/.github/actions/check-build/action.yml
+++ b/.github/actions/check-build/action.yml
@@ -5,12 +5,8 @@ inputs:
   # in the release build check workflow. The reason is that this workflow runs off the latest main commit but checks out
   # this action as it was at the time of the most recent release. This means that any changes to the action's inputs will
   # not be reflected in the release build check workflow.
-  # See compatibility parameter below for an example of why it was bad to introduce that in the first place.
   sha256:
     description: The expected sha256 of the final production Wasm module
-    required: false
-  dfx-metadata:
-    description: Unused, kept for backwards compatibility. Remove once release-2023-08-28 is no longer the latest release.
     required: false
 runs:
   using: "composite"

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -3,7 +3,6 @@
 #
 # We use this regular check to be notified early if our builds are not reproducible
 # over time (due to e.g. changing or missing dependencies).
-# TODO: remove all dfx metadata related actions once release-2023-08-28 is no longer the latest release.
 name: Release Build Check
 
 on:
@@ -33,15 +32,11 @@ jobs:
             exit 1
           fi
           curl --silent -SL "https://github.com/dfinity/internet-identity/releases/download/$latest_release_ref/internet_identity_production.wasm.gz" -o internet_identity_production.wasm.gz
-          curl --silent -SL "https://github.com/dfinity/internet-identity/releases/download/$latest_release_ref/internet_identity_dev.wasm.gz" -o internet_identity_dev.wasm.gz
           latest_prod_release_sha256=$(shasum -a 256 ./internet_identity_production.wasm.gz | cut -d ' ' -f1)
-          latest_dev_release_sha256=$(shasum -a 256 ./internet_identity_dev.wasm.gz | cut -d ' ' -f1)
           echo latest release is "$latest_release_ref"
           echo latest prod release sha256 is "$latest_prod_release_sha256"
-          echo latest dev release sha256 is "$latest_dev_release_sha256"
           echo "ref=$latest_release_ref" >> "$GITHUB_OUTPUT"
           echo "prod_sha256=$latest_prod_release_sha256" >> "$GITHUB_OUTPUT"
-          echo "dev_sha256=$latest_dev_release_sha256" >> "$GITHUB_OUTPUT"
         id: release
 
   # Then perform the build, using the release as checkout
@@ -56,18 +51,10 @@ jobs:
         with:
           ref: "refs/tags/${{ needs.latest-release.outputs.ref }}"
 
-      - name: "Create dfx metadata"
-        id: dfx-metadata
-        run: |
-          dfx_metadata_json="$(./scripts/dfx-metadata --asset-name internet_identity_dev.wasm.gz --wasm-hash ${{ needs.latest-release.outputs.dev_sha256 }})"
-          echo "using dfx metadata $dfx_metadata_json"
-          echo "metadata=$dfx_metadata_json" >> "$GITHUB_OUTPUT"
-
       - uses: ./.github/actions/check-build
         with:
           # we check that ubuntu builds match the latest release build
           sha256: ${{ startsWith(matrix.os, 'ubuntu') && needs.latest-release.outputs.prod_sha256 || '' }}
-          dfx-metadata: ${{ steps.dfx-metadata.outputs.metadata }}
 
         # Since the release build check is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.


### PR DESCRIPTION
This PR removes the dfx metadata functionality from the release build check. This restores the property that the release build check workflow is independent of the internals of the check action.

The release build check action now again only requires the hash to check.

CI test run: https://github.com/dfinity/internet-identity/actions/runs/6145672199

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d725138fe/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
