### PR TITLE
Showcase fixes

### DIFF
--- a/src/showcase/src/pages/[page].astro
+++ b/src/showcase/src/pages/[page].astro
@@ -25,6 +25,7 @@ export const iiPageNames = [
   "recoverWithDevice",
   "forgotNumber",
   "savePasskey",
+  "savePasskeyWithPin",
   "promptCaptcha",
   "promptCaptchaReady",
   "setPin",
@@ -61,6 +62,7 @@ const { page } = Astro.params;
 
 <Layout>
   <main id="pageContent" aria-live="polite" data-page-name={page}></main>
+  <div id="loaderContainer"></div>
   <script>
     import { iiPages } from "$showcase/showcase";
 


### PR DESCRIPTION
This PR fixes two small issues with the showcase:
* add the missing page `savePasskeyWithPin`
* add the loader conatainer to make the loader showcase work again

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cbc3fd4d2/desktop/savePasskeyWithPin.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cbc3fd4d2/mobile/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cbc3fd4d2/mobile/savePasskeyWithPin.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
