### PR TITLE
Provide verify function externally to usePin flow

### DIFF
--- a/src/frontend/src/flows/pin/usePin.ts
+++ b/src/frontend/src/flows/pin/usePin.ts
@@ -1,23 +1,25 @@
 import { mainWindow } from "$src/components/mainWindow";
-import { pinInput } from "$src/components/pinInput";
+import { pinInput, PinResult } from "$src/components/pinInput";
 import { I18n } from "$src/i18n";
 import { mount, renderPage } from "$src/utils/lit-html";
-import { TemplateResult, html } from "lit-html";
+import { html, TemplateResult } from "lit-html";
 
 import copyJson from "./usePin.json";
 
 /* Prompt the user to input their PIN for use */
 
-const usePinTemplate = ({
+const usePinTemplate = <T>({
   i18n,
   cancel,
+  verify,
   onContinue,
   onUsePasskey,
   scrollToTop = false,
 }: {
   i18n: I18n;
   cancel: () => void;
-  onContinue: (pin: string) => void;
+  verify: (pin: string) => Promise<PinResult<T>>;
+  onContinue: (result: T) => void;
   onUsePasskey: () => void;
   /* put the page into view */
   scrollToTop?: boolean;
@@ -25,9 +27,7 @@ const usePinTemplate = ({
   const copy = i18n.i18n(copyJson);
   const pinInput_ = pinInput({
     onSubmit: onContinue,
-    verify: (pin) =>
-      // XXX: here we don't do any verification, but ideally the identity reconstruction should happen here
-      ({ ok: true, value: pin }),
+    verify: verify,
     secret: true,
   });
   const slot = html`
@@ -57,14 +57,19 @@ const usePinTemplate = ({
 };
 
 export const usePinPage = renderPage(usePinTemplate);
-export const usePin = (): Promise<
-  { kind: "pin"; pin: string } | { kind: "canceled" } | { kind: "passkey" }
+export const usePin = <T>({
+  verifyPin,
+}: {
+  verifyPin: (pin: string) => Promise<PinResult<T>>;
+}): Promise<
+  { kind: "pin"; result: T } | { kind: "canceled" } | { kind: "passkey" }
 > => {
   return new Promise((resolve) =>
-    usePinPage({
+    renderPage(usePinTemplate<T>)({
       i18n: new I18n(),
       onUsePasskey: () => resolve({ kind: "passkey" }),
-      onContinue: (pin: string) => resolve({ kind: "pin", pin }),
+      verify: verifyPin,
+      onContinue: (result: T) => resolve({ kind: "pin", result }),
       cancel: () => resolve({ kind: "canceled" }),
       scrollToTop: true,
     })

--- a/src/frontend/src/flows/pin/usePin.ts
+++ b/src/frontend/src/flows/pin/usePin.ts
@@ -2,7 +2,8 @@ import { mainWindow } from "$src/components/mainWindow";
 import { pinInput, PinResult } from "$src/components/pinInput";
 import { I18n } from "$src/i18n";
 import { mount, renderPage } from "$src/utils/lit-html";
-import { html, TemplateResult } from "lit-html";
+import type { TemplateResult } from "lit-html";
+import { html } from "lit-html";
 
 import copyJson from "./usePin.json";
 
@@ -27,7 +28,7 @@ const usePinTemplate = <T>({
   const copy = i18n.i18n(copyJson);
   const pinInput_ = pinInput({
     onSubmit: onContinue,
-    verify: verify,
+    verify,
     secret: true,
   });
   const slot = html`

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -354,7 +354,7 @@ export const iiPages: Record<string, () => void> = {
     }),
   usePin: () =>
     usePinPage({
-      verify: async (pin: string) => {
+      verify: (pin: string) => {
         toast.info(`submitted pin: '${pin}'`);
         if (pin !== "123456") {
           toast.info("correct pin is '123456'");

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -354,9 +354,22 @@ export const iiPages: Record<string, () => void> = {
     }),
   usePin: () =>
     usePinPage({
+      verify: async (pin: string) => {
+        toast.info(`submitted pin: '${pin}'`);
+        if (pin !== "123456") {
+          toast.info("correct pin is '123456'");
+          return Promise.resolve({ ok: false, error: "Invalid PIN" });
+        }
+        return Promise.resolve({
+          ok: true,
+          value: pin,
+        });
+      },
       i18n,
       onContinue: (pin) =>
-        toast.info(html`PIN: <strong class="t-strong">${pin}</strong>`),
+        toast.success(
+          html`Success, PIN: <strong class="t-strong">${pin}</strong>`
+        ),
       onUsePasskey: () => toast.info("Requested to use passkey"),
       cancel: () => toast.info("Canceled"),
     }),


### PR DESCRIPTION
This PR expands the usePin function to take a PIN verification function as an argument. This will later be used to immediately check whether the identity can be decrypted using the provided PIN.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/13b968e07/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


