### PR TITLE
Always autosubmit when PIN input is filled

### DIFF
--- a/src/frontend/src/components/pinInput.test.ts
+++ b/src/frontend/src/components/pinInput.test.ts
@@ -58,7 +58,7 @@ describe("pin input", () => {
     );
   });
 
-  test("writing to all chars triggers autosubmit only once", () => {
+  test("writing to all chars triggers submit on every dispatch", () => {
     const onSubmit: (pin: string) => void = vi.fn();
 
     render(pinInputId({ onSubmit }).template, document.body);
@@ -70,8 +70,8 @@ describe("pin input", () => {
     }
 
     expect(onSubmit).toHaveBeenCalledOnce();
-    dispatchInput(inputs[0], "a"); // after an extra dispatch, the submit should still only have been called once
-    expect(onSubmit).toHaveBeenCalledOnce();
+    dispatchInput(inputs[0], "a"); // after an extra dispatch the value should be submitted again
+    expect(onSubmit).toHaveBeenCalledTimes(2);
   });
 
   test("writing to all chars removes focus", () => {

--- a/src/frontend/src/components/pinInput.ts
+++ b/src/frontend/src/components/pinInput.ts
@@ -56,17 +56,6 @@ export const pinInput = <T>({
     onSubmit_(result.value);
   };
 
-  // We autosubmit only once
-  let didAutosubmit = false;
-  const autosubmit = (pin: string) => {
-    if (didAutosubmit) {
-      return;
-    }
-
-    didAutosubmit = true;
-    onSubmit(pin);
-  };
-
   const errorMessage = currentError.map((currentError) =>
     nonNullish(currentError)
       ? html`<p class="t-centered t-error c-input--stack">${currentError}</p>`
@@ -89,7 +78,7 @@ export const pinInput = <T>({
   const onInput_ = (evnt: InputEvent, element: HTMLInputElement) =>
     withInputs((inputs) => {
       currentError.send(undefined);
-      onInput({ element, evnt, inputs, onFilled: autosubmit });
+      onInput({ element, evnt, inputs, onFilled: onSubmit });
     });
   const onPaste_ = (evnt: ClipboardEvent, element: HTMLInputElement) =>
     withInputs((inputs) => {


### PR DESCRIPTION
On error, there is no way currently to change the input and resubmit because there is no submit button and the autosubmit only submits once.

After quick check-back with Artem it was decided that the autosubmit should submit whenever the input is filled.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

