### PR TITLE
Add Support for PIN Identity to AuthBox

### DIFF
--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -1,4 +1,11 @@
+import { withLoader } from "$src/components/loader";
+import {
+  PinIdentityMaterial,
+  reconstructPinIdentity,
+} from "$src/crypto/pinIdentity";
 import { registerTentativeDevice } from "$src/flows/addDevice/welcomeView/registerTentativeDevice";
+import { idbRetrievePinIdentityMaterial } from "$src/flows/pin/idb";
+import { usePin } from "$src/flows/pin/usePin";
 import { useRecovery } from "$src/flows/recovery/useRecovery";
 import { getRegisterFlowOpts, registerFlow } from "$src/flows/register";
 import { I18n } from "$src/i18n";
@@ -30,7 +37,6 @@ import {
   secureIcon,
   signInIcon,
 } from "./icons";
-import { withLoader } from "./loader";
 import { mainWindow } from "./mainWindow";
 import { promptUserNumber } from "./promptUserNumber";
 
@@ -66,9 +72,12 @@ export const authenticateBox = async ({
       i18n,
       templates,
       addDevice: (userNumber) => asNewDevice(connection, userNumber),
-      login: (userNumber) => login({ connection, userNumber }),
+      loginPasskey: (userNumber) => loginPasskey({ connection, userNumber }),
+      loginPinIdentityMaterial: (opts) =>
+        loginPinIdentityMaterial({ ...opts, connection }),
       recover: () => useRecovery(connection),
       registerFlowOpts: getRegisterFlowOpts({ connection }),
+      retrievePinIdentityMaterial: idbRetrievePinIdentityMaterial,
     });
 
   // Retry until user has successfully authenticated
@@ -84,19 +93,37 @@ export const authenticateBox = async ({
 
 /** Authentication box component which authenticates a user
  * to II or to another dapp */
-export const authenticateBoxFlow = async <T>({
+export const authenticateBoxFlow = async <T, I>({
   i18n,
   templates,
   addDevice,
-  login,
+  loginPasskey,
+  loginPinIdentityMaterial,
   recover,
   registerFlowOpts,
+  retrievePinIdentityMaterial,
 }: {
   i18n: I18n;
   templates: AuthnTemplates;
   addDevice: (userNumber?: bigint) => Promise<{ alias: string }>;
-  login: (userNumber: bigint) => Promise<LoginFlowSuccess<T> | LoginFlowError>;
+  loginPasskey: (
+    userNumber: bigint
+  ) => Promise<LoginFlowSuccess<T> | LoginFlowError>;
+  loginPinIdentityMaterial: ({
+    userNumber,
+    pin,
+    pinIdentityMaterial,
+  }: {
+    userNumber: bigint;
+    pin: string;
+    pinIdentityMaterial: I;
+  }) => Promise<LoginFlowResult<T> | { tag: "err"; message: string }>;
   recover: () => Promise<LoginFlowResult<T>>;
+  retrievePinIdentityMaterial: ({
+    userNumber,
+  }: {
+    userNumber: bigint;
+  }) => Promise<I | undefined>;
   registerFlowOpts: Parameters<typeof registerFlow<T>>[0];
 }): Promise<LoginFlowResult<T> & { newAnchor: boolean }> => {
   const pages = authnScreens(i18n, { ...templates });
@@ -120,14 +147,62 @@ export const authenticateBoxFlow = async <T>({
     };
   };
 
+  const doLogin = async ({
+    userNumber,
+  }: {
+    userNumber: bigint;
+  }): Promise<LoginFlowResult<T> & { newAnchor: boolean }> => {
+    const pinIdentityMaterial = await retrievePinIdentityMaterial({
+      userNumber,
+    });
+
+    if (pinIdentityMaterial === undefined) {
+      // this user number does not have a browser storage identity
+      const result = await withLoader(() => loginPasskey(userNumber));
+      return { newAnchor: false, ...result };
+    }
+
+    // Otherwise, attempt login with PIN
+    const result = await usePin({
+      verifyPin: async (pin) => {
+        const result = await loginPinIdentityMaterial({
+          userNumber,
+          pin,
+          pinIdentityMaterial,
+        });
+        if (result.tag === "err") {
+          return { ok: false, error: result.message };
+        }
+        return { ok: true, value: result };
+      },
+    });
+
+    if (result.kind === "canceled") {
+      return {
+        newAnchor: false,
+        tag: "canceled",
+      } as const;
+    }
+
+    if (result.kind === "passkey") {
+      // User still decided to use a passkey
+      const result = await withLoader(() => loginPasskey(userNumber));
+      return { newAnchor: false, ...result };
+    }
+
+    result satisfies { kind: "pin" };
+    const { result: pinResult } = result;
+
+    return { newAnchor: false, ...pinResult };
+  };
+
   // Prompt for an identity number
   const doPrompt = async (): Promise<
     LoginFlowResult<T> & { newAnchor: boolean }
   > => {
     const result = await pages.useExisting();
     if (result.tag === "submit") {
-      const result2 = await withLoader(() => login(result.userNumber));
-      return { newAnchor: false, ...result2 };
+      return doLogin({ userNumber: result.userNumber });
     }
 
     if (result.tag === "add_device") {
@@ -159,8 +234,7 @@ export const authenticateBoxFlow = async <T>({
     const result = await pages.pick({ anchors });
 
     if (result.tag === "pick") {
-      const result1 = await withLoader(() => login(result.userNumber));
-      return { newAnchor: false, ...result1 };
+      return doLogin({ userNumber: result.userNumber });
     }
 
     result satisfies { tag: "more_options" };
@@ -437,7 +511,7 @@ const page = (slot: TemplateResult) => {
   render(template, container);
 };
 
-const login = ({
+const loginPasskey = ({
   connection,
   userNumber,
 }: {
@@ -447,6 +521,36 @@ const login = ({
   handleLogin({
     login: () => connection.login(userNumber),
   });
+
+const loginPinIdentityMaterial = ({
+  connection,
+  userNumber,
+  pin,
+  pinIdentityMaterial,
+}: {
+  connection: Connection;
+  userNumber: bigint;
+  pin: string;
+  pinIdentityMaterial: PinIdentityMaterial;
+}): Promise<LoginFlowResult | { tag: "err"; message: string }> => {
+  return withLoader(async () => {
+    try {
+      const identity = await reconstructPinIdentity({
+        pin,
+        pinIdentityMaterial,
+      });
+      return handleLogin({
+        login: () => connection.fromIdentity(userNumber, identity),
+      });
+    } catch {
+      // We handle all exceptions as wrong PIN because there is no nice way to check for that particular failure.
+      // The best we could do is check that the error is a DOMException and that the name is "OperationError". However,
+      // the "OperationError" names is still marked as experimental, so we should not rely on that.
+      // See https://developer.mozilla.org/en-US/docs/Web/API/DOMException
+      return { tag: "err", message: "Invalid PIN" };
+    }
+  });
+};
 
 // Register this device as a new device with the anchor
 const asNewDevice = async (

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -216,9 +216,11 @@ export const resetPhrase = async ({
   if ("ok" in res) {
     // If the user was authenticated with the phrase, then replace the connection
     // to use the new phrase to void logging them out
-    const nextConnection = sameDevice
-      ? await connection.fromIdentity(userNumber, res.ok)
-      : undefined;
+    let nextConnection = undefined;
+    if (sameDevice) {
+      nextConnection = (await connection.fromIdentity(userNumber, res.ok))
+        .connection;
+    }
     return reload(nextConnection);
   } else if ("error" in res) {
     await displayError({

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -286,17 +286,22 @@ export class Connection {
   fromIdentity = async (
     userNumber: bigint,
     identity: SignIdentity
-  ): Promise<AuthenticatedConnection> => {
+  ): Promise<LoginSuccess> => {
     const delegationIdentity = await this.requestFEDelegation(identity);
     const actor = await this.createActor(delegationIdentity);
 
-    return new AuthenticatedConnection(
+    const connection = new AuthenticatedConnection(
       this.canisterId,
       identity,
       delegationIdentity,
       userNumber,
       actor
     );
+    return {
+      kind: "loginSuccess",
+      userNumber,
+      connection,
+    };
   };
 
   fromSeedPhrase = async (

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -1,4 +1,5 @@
 import { authenticateBoxFlow } from "$src/components/authenticateBox";
+import { withLoader } from "$src/components/loader";
 import { toast } from "$src/components/toast";
 import { registerFlow, RegisterFlowOpts } from "$src/flows/register";
 import { html, render, TemplateResult } from "lit-html";
@@ -32,15 +33,34 @@ const registerFlowOpts: RegisterFlowOpts<null> = {
 
 export const iiFlows: Record<string, () => void> = {
   loginManage: async () => {
-    const result = await authenticateBoxFlow<null>({
+    const result = await authenticateBoxFlow<null, "identity">({
       i18n,
       templates: manageTemplates,
       addDevice: () => {
         toast.info(html`Added device`);
         return Promise.resolve({ alias: "My Device" });
       },
-      login: async () => {
+      loginPasskey: async () => {
         await new Promise((resolve) => setTimeout(resolve, 2000));
+        toast.info(html`Logged in`);
+        return Promise.resolve({
+          tag: "ok",
+          userNumber: BigInt(1234),
+          connection: null,
+        });
+      },
+      loginPinIdentityMaterial: async ({ pin }) => {
+        toast.info(html`Valid PIN is '123456'`);
+        await withLoader(
+          () => new Promise((resolve) => setTimeout(resolve, 2000))
+        );
+        if (pin !== "123456") {
+          return Promise.resolve({
+            tag: "err",
+            title: "Invalid PIN",
+            message: "Invalid PIN",
+          });
+        }
         toast.info(html`Logged in`);
         return Promise.resolve({
           tag: "ok",
@@ -55,6 +75,18 @@ export const iiFlows: Record<string, () => void> = {
           userNumber: BigInt(1234),
           connection: null,
         });
+      },
+      retrievePinIdentityMaterial: ({ userNumber }) => {
+        toast.info(
+          html`Looking up identity for ${userNumber} (pretending only 10000 has
+          pin identity)`
+        );
+
+        if (userNumber !== BigInt(10000)) {
+          return Promise.resolve(undefined);
+        }
+
+        return Promise.resolve("identity");
       },
       registerFlowOpts,
     });


### PR DESCRIPTION
This PR adds support for pin identities to the authentication box. The feature won't become active yet, as users cannot register pin identities.

The flow/functionality however can be tested using the showcase flow.

Basically all of the code is taken from the `nm-set-pin` branch by @nmattia.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
