### PR TITLE
Allow pin registration for Apple devices

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/addFIDODevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addFIDODevice.ts
@@ -1,7 +1,7 @@
 import { DeviceData } from "$generated/internet_identity_types";
 import { displayError } from "$src/components/displayError";
 import { withLoader } from "$src/components/loader";
-import { inferAlias, loadUAParser } from "$src/flows/register";
+import { inferPasskeyAlias, loadUAParser } from "$src/flows/register";
 import { authenticatorAttachmentToKeyType } from "$src/utils/authenticatorAttachment";
 import {
   AuthenticatedConnection,
@@ -59,7 +59,7 @@ export const addFIDODevice = async (
     return;
   }
 
-  const deviceName = await inferAlias({
+  const deviceName = await inferPasskeyAlias({
     authenticatorType: newDevice.getAuthenticatorAttachment(),
     userAgent: navigator.userAgent,
     uaParser,

--- a/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -5,7 +5,7 @@ import {
 } from "$generated/internet_identity_types";
 import { displayError } from "$src/components/displayError";
 import { withLoader } from "$src/components/loader";
-import { inferAlias, loadUAParser } from "$src/flows/register";
+import { inferPasskeyAlias, loadUAParser } from "$src/flows/register";
 import { authenticatorAttachmentToKeyType } from "$src/utils/authenticatorAttachment";
 import { Connection, creationOptions } from "$src/utils/iiConnection";
 import { setAnchorUsed } from "$src/utils/userNumber";
@@ -56,7 +56,7 @@ export const registerTentativeDevice = async (
     return window.location.reload() as never;
   }
 
-  const alias = await inferAlias({
+  const alias = await inferPasskeyAlias({
     authenticatorType: result.getAuthenticatorAttachment(),
     userAgent: navigator.userAgent,
     uaParser,

--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -98,8 +98,12 @@ const savePasskeyTemplate = ({
 
 export const savePasskeyPage = renderPage(savePasskeyTemplate);
 
-// Prompt the user to create a WebAuthn identity
-export const savePasskey = (): Promise<IIWebAuthnIdentity | "canceled"> => {
+// Prompt the user to create a WebAuthn identity or a PIN identity (if allowed)
+export const savePasskeyOrPin = ({
+  pinAllowed,
+}: {
+  pinAllowed: boolean;
+}): Promise<IIWebAuthnIdentity | "pin" | "canceled"> => {
   return new Promise((resolve) =>
     savePasskeyPage({
       i18n: new I18n(),
@@ -113,6 +117,7 @@ export const savePasskey = (): Promise<IIWebAuthnIdentity | "canceled"> => {
           toast.error(errorMessage(e));
         }
       },
+      constructPin: pinAllowed ? () => resolve("pin") : undefined,
     })
   );
 };

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -5,6 +5,19 @@ import { registerFlow, RegisterFlowOpts } from "$src/flows/register";
 import { html, render, TemplateResult } from "lit-html";
 import { dummyChallenge, i18n, manageTemplates } from "./showcase";
 
+const registerSuccessToastTemplate = (result: unknown) => html`
+  Identity successfully created!<br />
+  <p class="l-stack">
+    <strong class="t-strong">${prettyResult(result)}</strong>
+  </p>
+  <button
+    class="l-stack c-button c-button--secondary"
+    @click=${() => window.location.reload()}
+  >
+    reload
+  </button>
+`;
+
 export const flowsPage = () => {
   document.title = "Flows";
   const container = document.getElementById("pageContent") as HTMLElement;
@@ -29,6 +42,12 @@ const registerFlowOpts: RegisterFlowOpts<null> = {
     };
   },
   registrationAllowed: true,
+  storePinIdentity: () => {
+    toast.info("PIN identity was stored");
+    return Promise.resolve();
+  },
+  pinAllowed: () => Promise.resolve(false),
+  uaParser: Promise.resolve(undefined),
 } as const;
 
 export const iiFlows: Record<string, () => void> = {
@@ -105,19 +124,14 @@ export const iiFlows: Record<string, () => void> = {
   },
   register: async () => {
     const result = await registerFlow<null>(registerFlowOpts);
-
-    toast.success(html`
-      Identity successfully created!<br />
-      <p class="l-stack">
-        <strong class="t-strong">${prettyResult(result)}</strong>
-      </p>
-      <button
-        class="l-stack c-button c-button--secondary"
-        @click=${() => window.location.reload()}
-      >
-        reload
-      </button>
-    `);
+    toast.success(registerSuccessToastTemplate(result));
+  },
+  registerWithPin: async () => {
+    const result = await registerFlow<null>({
+      ...registerFlowOpts,
+      pinAllowed: () => Promise.resolve(true),
+    });
+    toast.success(registerSuccessToastTemplate(result));
   },
 };
 

--- a/src/showcase/src/pages/flows/[flow].astro
+++ b/src/showcase/src/pages/flows/[flow].astro
@@ -2,7 +2,7 @@
 import Layout from "../../layouts/Layout.astro";
 import "$src/styles/main.css";
 
-export const iiFlowNames = ["loginManage", "register"];
+export const iiFlowNames = ["loginManage", "register", "registerWithPin"];
 export function getStaticPaths() {
   return iiFlowNames.map((flow) => ({ params: { flow } }));
 }


### PR DESCRIPTION
This PR enables registration of PIN protected browser keys when signing up for II. The feature is enabled on Apple devices only, because it is meant as a workaround for the forced Apple iCloud integration.

When adding a device later, the PIN protected browser key is not allowed, even on Apple devices.

The feature is still very basic. In particular, still missing are:
- the temporary key info screen
- updates to the management page to correctly list temporary keys separate from passkeys
- warnings on the management screen

Almost all of the code is taken from the `nm-set-pin` branch by @nmattia.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
