### PR TITLE
Show pin protected keys in a separate list on the management page

### DIFF
--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -109,6 +109,32 @@ export const authenticatorsSection = ({
     </aside>`;
 };
 
+export const tempKeysSection = ({
+  authenticators: authenticators_,
+}: {
+  authenticators: Authenticator[];
+}): TemplateResult => {
+  const authenticators = dedupLabels(authenticators_);
+
+  return html` <aside class="l-stack c-card c-card--narrow">
+    <div class="t-title t-title--complications">
+      <h2 class="t-title">Temporary Keys</h2>
+    </div>
+
+    <p style="max-width: 30rem;" class="t-paragraph t-lead">
+      These keys are stored in browser cache, clearing your browser storage will
+      erase them.
+    </p>
+    <div class="c-action-list">
+      <ul>
+        ${authenticators.map((authenticator, index) =>
+          authenticatorItem({ authenticator, index })
+        )}
+      </ul>
+    </div>
+  </aside>`;
+};
+
 export const authenticatorItem = ({
   authenticator: { alias, dupCount, warn, remove, rename },
   index,

--- a/src/frontend/src/flows/manage/types.ts
+++ b/src/frontend/src/flows/manage/types.ts
@@ -29,4 +29,5 @@ export type Devices = {
     recoveryKey?: RecoveryKey;
     recoveryPhrase?: RecoveryPhrase;
   };
+  pinAuthenticators: Authenticator[];
 };

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -324,7 +324,7 @@ export const inferPinAlias = async ({
   userAgent: typeof navigator.userAgent;
   uaParser: PreloadedUAParser;
 }): Promise<string> => {
-  const UNNAMED = "Temporary Key";
+  const UNNAMED = "Unnamed Temporary Key";
 
   // Otherwise, make sure the UA parser module is loaded, because
   // everything from here will use UA heuristics
@@ -341,8 +341,7 @@ export const inferPinAlias = async ({
     ...(nonNullish(os) ? [os] : []),
   ];
   if (browserOn.length !== 0) {
-    // XXX: remove temp key prefix, once temp keys are correctly separated in their own lists
-    return UNNAMED + ": " + browserOn.join(" on ");
+    return browserOn.join(" on ");
   }
 
   // If all else fails, the device is unnamed

--- a/src/showcase/src/pages/[page].astro
+++ b/src/showcase/src/pages/[page].astro
@@ -33,6 +33,7 @@ export const iiPageNames = [
   "usePin",
   "displayManage",
   "displayManageSingle",
+  "displayManageTempKey",
   "pollForTentativeDevicePage",
   "deviceRegistrationDisabledInfo",
   "showVerificationCode",

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -403,6 +403,7 @@ export const iiPages: Record<string, () => void> = {
             reset: () => Promise.resolve(),
           },
         },
+        pinAuthenticators: [],
       },
       onAddDevice: () => {
         console.log("add device requested");
@@ -431,6 +432,43 @@ export const iiPages: Record<string, () => void> = {
           },
         ],
         recoveries: {},
+        pinAuthenticators: [],
+      },
+      onAddDevice: () => {
+        console.log("add device requested");
+      },
+      addRecoveryPhrase: () => {
+        console.log("add recovery phrase");
+      },
+      addRecoveryKey: () => {
+        console.log("add recovery key");
+      },
+      dapps,
+      exploreDapps: () => {
+        console.log("explore dapps");
+      },
+    });
+  },
+  displayManageTempKey: () => {
+    displayManagePage({
+      identityBackground,
+      userNumber,
+      devices: {
+        authenticators: [
+          {
+            alias: "Some Passkey",
+            rename: () => console.log("rename"),
+            remove: () => console.log("remove"),
+          },
+        ],
+        recoveries: {},
+        pinAuthenticators: [
+          {
+            alias: "Chrome on iPhone",
+            rename: () => console.log("rename"),
+            remove: () => console.log("remove"),
+          },
+        ],
       },
       onAddDevice: () => {
         console.log("add device requested");


### PR DESCRIPTION
This allows users to distinguish between the temporary keys and passkeys when visiting the management page.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc5b3bdcd/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc5b3bdcd/mobile/displayManageTempKey.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc5b3bdcd/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
