### PR TITLE
Introduce information page for temporary keys

### DIFF
--- a/src/frontend/src/flows/pin/pinInfo.json
+++ b/src/frontend/src/flows/pin/pinInfo.json
@@ -1,0 +1,18 @@
+{
+  "en": {
+    "continue_and_set_pin": "Continue and set pin",
+    "cancel": "Cancel",
+    "create_temporary_key_form_pin": "Create a temporary key from a PIN",
+    "set_memorable_pin": "Set a memorable PIN and securely store a temporary key in your browser cache",
+
+    "what_is_temporary_key": "What is a temporary key?",
+    "unique_key_pair": "A unique private key that is safely stored in your browser cache and protected by two layers of advanced encryption",
+    "convenient_secure_replacement": "A convenient and more secure replacement for passwords",
+    "enables_sign_by_pin": "Enables you to sign into dapps on your devices using a simple PIN",
+
+    "why_temporary": "Why is it temporary?",
+    "clear_browser_storage": "Clearing your browser storage will erase your key",
+    "set_up_recovery": "Set up a recovery phrase after registering to avoid loss",
+    "do_not_store_assets": "Do not store assets on the Internet Identity until you create a passkey or recovery phrase"
+  }
+}

--- a/src/frontend/src/flows/pin/pinInfo.ts
+++ b/src/frontend/src/flows/pin/pinInfo.ts
@@ -1,0 +1,86 @@
+import { mainWindow } from "$src/components/mainWindow";
+import { pinStepper } from "$src/flows/pin/stepper";
+import { I18n } from "$src/i18n";
+import { mount, renderPage } from "$src/utils/lit-html";
+import { TemplateResult, html } from "lit-html";
+
+import copyJson from "./pinInfo.json";
+
+const pinInfoTemplate = ({
+  i18n,
+  onContinue,
+  cancel,
+  scrollToTop = false,
+}: {
+  onContinue: () => void;
+  i18n: I18n;
+  cancel: () => void;
+  /* put the page into view */
+  scrollToTop?: boolean;
+}): TemplateResult => {
+  const copy = i18n.i18n(copyJson);
+
+  const slot = html`
+    ${pinStepper({ current: "set" })}
+    <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
+      <h1 class="t-title t-title--main">
+        ${copy.create_temporary_key_form_pin}
+      </h1>
+      <p class="t-paragraph">${copy.set_memorable_pin}</p>
+    </hgroup>
+    <button
+      @click=${() => onContinue()}
+      data-action="continue-pin"
+      class="c-button"
+    >
+      ${copy.continue_and_set_pin}
+    </button>
+    <button
+      @click=${() => cancel()}
+      data-action="cancel"
+      class="c-button c-button--textOnly"
+    >
+      ${copy.cancel}
+    </button>
+    <section class="c-marketing-block">
+      <aside class="l-stack">
+        <h3 class="t-title">${copy.what_is_temporary_key}</h3>
+        <ul class="c-list c-list--bulleted">
+          <li>${copy.unique_key_pair}</li>
+          <li>${copy.convenient_secure_replacement}</li>
+          <li>${copy.enables_sign_by_pin}</li>
+        </ul>
+      </aside>
+
+      <aside class="l-stack">
+        <h3 class="t-title">${copy.why_temporary}</h3>
+        <ul class="c-list c-list--bulleted">
+          <li>${copy.clear_browser_storage}</li>
+          <li>${copy.set_up_recovery}</li>
+          <li>${copy.do_not_store_assets}</li>
+        </ul>
+      </aside>
+    </section>
+  `;
+
+  return mainWindow({
+    showFooter: false,
+    showLogo: false,
+    slot,
+  });
+};
+
+export const pinInfoPage = renderPage(pinInfoTemplate);
+
+// Show information about the PIN authentication (aka temporary key) and prompt
+// the user to continue (or cancel).
+export const promptPinInfo = (): Promise<"continue" | "canceled"> => {
+  return new Promise((resolve) =>
+    pinInfoPage({
+      i18n: new I18n(),
+      onContinue: () => resolve("continue"),
+      cancel: () => resolve("canceled"),
+      scrollToTop: true,
+    })
+  );
+};

--- a/src/showcase/src/pages/[page].astro
+++ b/src/showcase/src/pages/[page].astro
@@ -28,6 +28,7 @@ export const iiPageNames = [
   "savePasskeyWithPin",
   "promptCaptcha",
   "promptCaptchaReady",
+  "pinInfo",
   "setPin",
   "confirmPin",
   "usePin",

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -32,6 +32,7 @@ import {
   unprotectDeviceInfoPage,
 } from "$src/flows/manage/deviceSettings";
 import { confirmPinPage } from "$src/flows/pin/confirmPin";
+import { pinInfoPage } from "$src/flows/pin/pinInfo";
 import { setPinPage } from "$src/flows/pin/setPin";
 import { usePinPage } from "$src/flows/pin/usePin";
 import {
@@ -338,6 +339,12 @@ export const iiPages: Record<string, () => void> = {
       stepper: registerStepper({ current: "captcha" }),
       onContinue: () => console.log("Done"),
       i18n,
+    }),
+  pinInfo: () =>
+    pinInfoPage({
+      i18n,
+      onContinue: () => console.log("continue"),
+      cancel: () => console.log("cancel"),
     }),
   setPin: () =>
     setPinPage({


### PR DESCRIPTION
This PR introduces the information page for temporary keys to the showcase. It is not yet part of the pin registration flow.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/664463bc0/desktop/pinInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/664463bc0/mobile/pinInfo.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/664463bc0/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
