### PR TITLE
Extract temporary key template and copy

### DIFF
--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -15,7 +15,9 @@ const MAX_AUTHENTICATORS = 8;
 export type DedupAuthenticator = Authenticator & { dupCount?: number };
 
 // Deduplicate devices with same (duplicated) aliases
-const dedupLabels = (authenticators: Authenticator[]): DedupAuthenticator[] => {
+export const dedupLabels = (
+  authenticators: Authenticator[]
+): DedupAuthenticator[] => {
   return authenticators.reduce<Authenticator[]>((acc, authenticator) => {
     const _authenticator: DedupAuthenticator = { ...authenticator };
     const sameName = acc.filter((a) => a.alias === _authenticator.alias);
@@ -107,32 +109,6 @@ export const authenticatorsSection = ({
 
         </div>
     </aside>`;
-};
-
-export const tempKeysSection = ({
-  authenticators: authenticators_,
-}: {
-  authenticators: Authenticator[];
-}): TemplateResult => {
-  const authenticators = dedupLabels(authenticators_);
-
-  return html` <aside class="l-stack c-card c-card--narrow">
-    <div class="t-title t-title--complications">
-      <h2 class="t-title">Temporary Keys</h2>
-    </div>
-
-    <p style="max-width: 30rem;" class="t-paragraph t-lead">
-      These keys are stored in browser cache, clearing your browser storage will
-      erase them.
-    </p>
-    <div class="c-action-list">
-      <ul>
-        ${authenticators.map((authenticator, index) =>
-          authenticatorItem({ authenticator, index })
-        )}
-      </ul>
-    </div>
-  </aside>`;
 };
 
 export const authenticatorItem = ({

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -22,6 +22,7 @@ import { addDevice } from "$src/flows/addDevice/manage/addDevice";
 import { dappsExplorer } from "$src/flows/dappsExplorer";
 import { KnownDapp, getDapps } from "$src/flows/dappsExplorer/dapps";
 import { dappsHeader, dappsTeaser } from "$src/flows/dappsExplorer/teaser";
+import { tempKeysSection } from "$src/flows/manage/tempKeys";
 import { addPhrase, recoveryWizard } from "$src/flows/recovery/recoveryWizard";
 import { setupKey, setupPhrase } from "$src/flows/recovery/setupRecovery";
 import { I18n } from "$src/i18n";
@@ -36,10 +37,7 @@ import {
 import { OmitParams, shuffleArray, unreachable } from "$src/utils/utils";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { TemplateResult, html } from "lit-html";
-import {
-  authenticatorsSection,
-  tempKeysSection,
-} from "./authenticatorsSection";
+import { authenticatorsSection } from "./authenticatorsSection";
 import {
   deleteDevice,
   protectDevice,
@@ -189,7 +187,7 @@ const displayManageTemplate = ({
       warnFewDevices,
     })}
     ${pinAuthenticators.length > 0
-      ? tempKeysSection({ authenticators: pinAuthenticators })
+      ? tempKeysSection({ authenticators: pinAuthenticators, i18n: new I18n() })
       : ""}
     ${recoveryMethodsSection({ recoveries, addRecoveryPhrase, addRecoveryKey })}
     ${logoutSection()}

--- a/src/frontend/src/flows/manage/tempKeys.json
+++ b/src/frontend/src/flows/manage/tempKeys.json
@@ -1,0 +1,6 @@
+{
+  "en": {
+    "temporary_key": "Temporary Keys",
+    "key_stored_in_browser": "These keys are stored in browser cache, clearing your browser storage will erase them."
+  }
+}

--- a/src/frontend/src/flows/manage/tempKeys.ts
+++ b/src/frontend/src/flows/manage/tempKeys.ts
@@ -1,0 +1,37 @@
+import {
+  authenticatorItem,
+  dedupLabels,
+} from "$src/flows/manage/authenticatorsSection";
+import { Authenticator } from "$src/flows/manage/types";
+import { TemplateResult, html } from "lit-html";
+
+import { I18n } from "$src/i18n";
+import copyJson from "./tempKeys.json";
+
+export const tempKeysSection = ({
+  authenticators: authenticators_,
+  i18n,
+}: {
+  authenticators: Authenticator[];
+  i18n: I18n;
+}): TemplateResult => {
+  const authenticators = dedupLabels(authenticators_);
+  const copy = i18n.i18n(copyJson);
+
+  return html` <aside class="l-stack c-card c-card--narrow">
+    <div class="t-title t-title--complications">
+      <h2 class="t-title">${copy.temporary_key}</h2>
+    </div>
+
+    <p style="max-width: 30rem;" class="t-paragraph t-lead">
+      ${copy.key_stored_in_browser}
+    </p>
+    <div class="c-action-list">
+      <ul>
+        ${authenticators.map((authenticator, index) =>
+          authenticatorItem({ authenticator, index })
+        )}
+      </ul>
+    </div>
+  </aside>`;
+};


### PR DESCRIPTION
Additional warnings, etc. need to be added.
Extracting copy and separating everything related to temp keys into its own file makes it easier to modify later.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
