### PR TITLE
Add TempKey Security Warning to Management Screen

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -22,7 +22,11 @@ import { addDevice } from "$src/flows/addDevice/manage/addDevice";
 import { dappsExplorer } from "$src/flows/dappsExplorer";
 import { KnownDapp, getDapps } from "$src/flows/dappsExplorer/dapps";
 import { dappsHeader, dappsTeaser } from "$src/flows/dappsExplorer/teaser";
-import { tempKeysSection } from "$src/flows/manage/tempKeys";
+import {
+  TempKeysWarning,
+  tempKeyWarningSection,
+  tempKeysSection,
+} from "$src/flows/manage/tempKeys";
 import { addPhrase, recoveryWizard } from "$src/flows/recovery/recoveryWizard";
 import { setupKey, setupPhrase } from "$src/flows/recovery/setupRecovery";
 import { I18n } from "$src/i18n";
@@ -35,6 +39,7 @@ import {
   isRecoveryPhrase,
 } from "$src/utils/recoveryDevice";
 import { OmitParams, shuffleArray, unreachable } from "$src/utils/utils";
+import { Principal } from "@dfinity/principal";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { TemplateResult, html } from "lit-html";
 import { authenticatorsSection } from "./authenticatorsSection";
@@ -150,6 +155,7 @@ const displayManageTemplate = ({
   dapps,
   exploreDapps,
   identityBackground,
+  tempKeysWarning,
 }: {
   userNumber: bigint;
   devices: Devices;
@@ -159,18 +165,23 @@ const displayManageTemplate = ({
   dapps: KnownDapp[];
   exploreDapps: () => void;
   identityBackground: IdentityBackground;
+  tempKeysWarning?: TempKeysWarning;
 }): TemplateResult => {
   // Nudge the user to add a device iff there is one or fewer authenticators and no recoveries
   const warnFewDevices =
     authenticators.length <= 1 &&
     isNullish(recoveries.recoveryPhrase) &&
     isNullish(recoveries.recoveryKey);
+  const i18n = new I18n();
 
   const pageContentSlot = html` <section data-role="identity-management">
     <hgroup>
       <h1 class="t-title t-title--main">Manage your<br />Internet Identity</h1>
     </hgroup>
     ${anchorSection({ userNumber, identityBackground })}
+    ${nonNullish(tempKeysWarning)
+      ? tempKeyWarningSection({ i18n, tempKeysWarning })
+      : ""}
     <p class="t-paragraph">
       ${dappsTeaser({
         dapps,
@@ -187,7 +198,7 @@ const displayManageTemplate = ({
       warnFewDevices,
     })}
     ${pinAuthenticators.length > 0
-      ? tempKeysSection({ authenticators: pinAuthenticators, i18n: new I18n() })
+      ? tempKeysSection({ authenticators: pinAuthenticators, i18n })
       : ""}
     ${recoveryMethodsSection({ recoveries, addRecoveryPhrase, addRecoveryKey })}
     ${logoutSection()}
@@ -271,6 +282,20 @@ export const renderManage = async ({
 
 export const displayManagePage = renderPage(displayManageTemplate);
 
+function isPinAuthenticated(
+  devices_: DeviceData[],
+  connection: AuthenticatedConnection
+): boolean {
+  const principal = connection.identity.getPrincipal();
+  const currentDevice = devices_.find((device) => {
+    const principal1 = Principal.selfAuthenticating(
+      new Uint8Array(device.pubkey)
+    );
+    return principal1.compareTo(principal) === "eq";
+  });
+  return !!(currentDevice && "browser_storage_key" in currentDevice.key_type);
+}
+
 export const displayManage = (
   userNumber: bigint,
   connection: AuthenticatedConnection,
@@ -297,24 +322,53 @@ export const displayManage = (
         "More than one recovery keys are registered, which is unexpected. Only one will be shown."
       );
     }
+
+    const onAddDevice = async () => {
+      await addDevice({ userNumber, connection });
+      resolve();
+    };
+    const addRecoveryPhrase = async () => {
+      const doAdd = await addPhrase({ intent: "userInitiated" });
+      if (doAdd === "cancel") {
+        resolve();
+        return;
+      }
+      doAdd satisfies "ok";
+      await setupPhrase(userNumber, connection);
+      resolve();
+    };
+
+    // Function to figure out what temp keys warning should be shown, if any.
+    const determineTempKeysWarning = (): TempKeysWarning | undefined => {
+      if (!isPinAuthenticated(devices_, connection)) {
+        // Don't show the warning, if the user is not authenticated using a PIN
+        // protected browser storage key
+        return undefined;
+      }
+      // First priority, nudge to add a recovery phrase
+      if (devices.recoveries.recoveryPhrase === undefined) {
+        return {
+          tag: "add_recovery",
+          action: addRecoveryPhrase,
+        };
+      }
+      // Second priority, nudge to add a passkey
+      if (devices.authenticators.length === 0) {
+        return {
+          tag: "add_passkey",
+          action: onAddDevice,
+        };
+      }
+      // If both, recovery phrase and passkey are present, don't show a warning
+      return undefined;
+    };
+
     const display = () =>
       displayManagePage({
         userNumber,
         devices,
-        onAddDevice: async () => {
-          await addDevice({ userNumber, connection });
-          resolve();
-        },
-        addRecoveryPhrase: async () => {
-          const doAdd = await addPhrase({ intent: "userInitiated" });
-          if (doAdd === "cancel") {
-            resolve();
-            return;
-          }
-          doAdd satisfies "ok";
-          await setupPhrase(userNumber, connection);
-          resolve();
-        },
+        onAddDevice,
+        addRecoveryPhrase,
         addRecoveryKey: async () => {
           const confirmed = confirm(
             "Add a Recovery Device\n\nUse a FIDO Security Key, like a YubiKey, as an additional recovery method."
@@ -335,6 +389,7 @@ export const displayManage = (
           display();
         },
         identityBackground,
+        tempKeysWarning: determineTempKeysWarning(),
       });
 
     display();

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -286,14 +286,16 @@ function isPinAuthenticated(
   devices_: DeviceData[],
   connection: AuthenticatedConnection
 ): boolean {
-  const principal = connection.identity.getPrincipal();
-  const currentDevice = devices_.find((device) => {
-    const principal1 = Principal.selfAuthenticating(
-      new Uint8Array(device.pubkey)
+  const connectionPrincipal = connection.identity.getPrincipal();
+  const currentDevice = devices_.find(({ pubkey }) => {
+    const devicePrincipal = Principal.selfAuthenticating(
+      new Uint8Array(pubkey)
     );
-    return principal1.compareTo(principal) === "eq";
+    return devicePrincipal.toText() === connectionPrincipal.toText();
   });
-  return !!(currentDevice && "browser_storage_key" in currentDevice.key_type);
+  return (
+    nonNullish(currentDevice) && "browser_storage_key" in currentDevice.key_type
+  );
 }
 
 export const displayManage = (

--- a/src/frontend/src/flows/manage/tempKeys.json
+++ b/src/frontend/src/flows/manage/tempKeys.json
@@ -1,6 +1,12 @@
 {
   "en": {
     "temporary_key": "Temporary Keys",
-    "key_stored_in_browser": "These keys are stored in browser cache, clearing your browser storage will erase them."
+    "key_stored_in_browser": "These keys are stored in browser cache, clearing your browser storage will erase them.",
+
+    "security_warning": "Security Warning",
+    "you_are_using_temporary_key": "You are using a temporary key. Do not hold any assets with this identity.",
+    "set_up_recovery_and_passkey": "Clearing your browser storage will erase this key. Set up a recovery method to avoid losing access to your identity. Add a passkey to securely hold assets with this identity.",
+    "add_recovery_phrase": "Add Recovery Phrase",
+    "add_new_passkey": "Add new Passkey"
   }
 }

--- a/src/frontend/src/flows/manage/tempKeys.ts
+++ b/src/frontend/src/flows/manage/tempKeys.ts
@@ -39,7 +39,7 @@ export const tempKeyWarningSection = ({
           <button
             class="c-button c-button--primary"
             @click="${btnAction.action}"
-            id="addRecovery"
+            id="addPasskey"
           >
             <span>${copy.add_new_passkey}</span>
           </button>

--- a/src/frontend/src/flows/manage/tempKeys.ts
+++ b/src/frontend/src/flows/manage/tempKeys.ts
@@ -22,14 +22,14 @@ export const tempKeyWarningSection = ({
 }): TemplateResult => {
   const copy = i18n.i18n(copyJson);
 
-  const warningButtonCopy = (btnAction: TempKeysWarning) => {
-    switch (btnAction.tag) {
+  const warningButtonCopy = (tempKeysWarning: TempKeysWarning) => {
+    switch (tempKeysWarning.tag) {
       case "add_recovery":
         return copy.add_recovery_phrase;
       case "add_passkey":
         return copy.add_new_passkey;
       default:
-        unreachable(btnAction, "unknown temp keys warning action");
+        unreachable(tempKeysWarning, "unknown temp keys warning tag");
     }
   };
 

--- a/src/frontend/src/flows/manage/tempKeys.ts
+++ b/src/frontend/src/flows/manage/tempKeys.ts
@@ -27,7 +27,7 @@ export const tempKeyWarningSection = ({
       case "add_recovery":
         return html`
           <button
-            class="c-button c-button--primary c-tooltip c-tooltip--onDisabled c-tooltip--left"
+            class="c-button c-button--primary"
             @click="${btnAction.action}"
             id="addRecovery"
           >
@@ -37,7 +37,7 @@ export const tempKeyWarningSection = ({
       case "add_passkey":
         return html`
           <button
-            class="c-button c-button--primary c-tooltip c-tooltip--onDisabled c-tooltip--left"
+            class="c-button c-button--primary"
             @click="${btnAction.action}"
             id="addRecovery"
           >

--- a/src/frontend/src/flows/manage/tempKeys.ts
+++ b/src/frontend/src/flows/manage/tempKeys.ts
@@ -22,28 +22,12 @@ export const tempKeyWarningSection = ({
 }): TemplateResult => {
   const copy = i18n.i18n(copyJson);
 
-  const warningButtonTemplate = (btnAction: TempKeysWarning) => {
+  const warningButtonCopy = (btnAction: TempKeysWarning) => {
     switch (btnAction.tag) {
       case "add_recovery":
-        return html`
-          <button
-            class="c-button c-button--primary"
-            @click="${btnAction.action}"
-            id="addRecovery"
-          >
-            <span>${copy.add_recovery_phrase}</span>
-          </button>
-        `;
+        return copy.add_recovery_phrase;
       case "add_passkey":
-        return html`
-          <button
-            class="c-button c-button--primary"
-            @click="${btnAction.action}"
-            id="addPasskey"
-          >
-            <span>${copy.add_new_passkey}</span>
-          </button>
-        `;
+        return copy.add_new_passkey;
       default:
         unreachable(btnAction, "unknown temp keys warning action");
     }
@@ -65,7 +49,13 @@ export const tempKeyWarningSection = ({
       <p style="max-width: 30rem;" class="warning-message t-paragraph t-lead">
         ${copy.set_up_recovery_and_passkey}
       </p>
-      ${warningButtonTemplate(tempKeysWarning)}
+      <button
+        class="c-button c-button--primary"
+        @click="${tempKeysWarning.action}"
+        id="addRecovery"
+      >
+        <span>${warningButtonCopy(tempKeysWarning)}</span>
+      </button>
     </aside>
   `;
 };

--- a/src/frontend/src/flows/manage/tempKeys.ts
+++ b/src/frontend/src/flows/manage/tempKeys.ts
@@ -1,12 +1,74 @@
+import { warningIcon } from "$src/components/icons";
 import {
   authenticatorItem,
   dedupLabels,
 } from "$src/flows/manage/authenticatorsSection";
 import { Authenticator } from "$src/flows/manage/types";
+import { I18n } from "$src/i18n";
+import { unreachable } from "$src/utils/utils";
 import { TemplateResult, html } from "lit-html";
 
-import { I18n } from "$src/i18n";
 import copyJson from "./tempKeys.json";
+
+export type TempKeysWarning =
+  | { tag: "add_recovery"; action: () => void }
+  | { tag: "add_passkey"; action: () => void };
+export const tempKeyWarningSection = ({
+  i18n,
+  tempKeysWarning,
+}: {
+  i18n: I18n;
+  tempKeysWarning: TempKeysWarning;
+}): TemplateResult => {
+  const copy = i18n.i18n(copyJson);
+
+  const warningButtonTemplate = (btnAction: TempKeysWarning) => {
+    switch (btnAction.tag) {
+      case "add_recovery":
+        return html`
+          <button
+            class="c-button c-button--primary c-tooltip c-tooltip--onDisabled c-tooltip--left"
+            @click="${btnAction.action}"
+            id="addRecovery"
+          >
+            <span>${copy.add_recovery_phrase}</span>
+          </button>
+        `;
+      case "add_passkey":
+        return html`
+          <button
+            class="c-button c-button--primary c-tooltip c-tooltip--onDisabled c-tooltip--left"
+            @click="${btnAction.action}"
+            id="addRecovery"
+          >
+            <span>${copy.add_new_passkey}</span>
+          </button>
+        `;
+      default:
+        unreachable(btnAction, "unknown temp keys warning action");
+    }
+  };
+
+  return html`
+    <aside class="c-card c-card--narrow c-card--warning">
+      <span class="c-card__label c-card__label--hasIcon" aria-hidden="true">
+        <i class="c-card__icon c-icon c-icon--error__flipped c-icon--inline"
+          >${warningIcon}</i
+        >
+        <h2>${copy.security_warning}</h2>
+      </span>
+      <div class="t-title t-title--complications">
+        <h2 style="max-width: 30rem;" class="t-title">
+          ${copy.you_are_using_temporary_key}
+        </h2>
+      </div>
+      <p style="max-width: 30rem;" class="warning-message t-paragraph t-lead">
+        ${copy.set_up_recovery_and_passkey}
+      </p>
+      ${warningButtonTemplate(tempKeysWarning)}
+    </aside>
+  `;
+};
 
 export const tempKeysSection = ({
   authenticators: authenticators_,

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -490,6 +490,10 @@ export const iiPages: Record<string, () => void> = {
       exploreDapps: () => {
         console.log("explore dapps");
       },
+      tempKeysWarning: {
+        tag: "add_recovery",
+        action: () => console.log("add recovery phrase"),
+      },
     });
   },
   pollForTentativeDevicePage: () =>


### PR DESCRIPTION
This PR adds a security warning to the management page if you have signed in using a PIN protected browser key, if there is no recovery phrase and/or passkey.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5526eaabf/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5526eaabf/mobile/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5526eaabf/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



