### PR TITLE
Add warning to PIN info screen

### DIFF
--- a/src/frontend/src/flows/pin/pinInfo.json
+++ b/src/frontend/src/flows/pin/pinInfo.json
@@ -5,6 +5,10 @@
     "create_temporary_key_form_pin": "Create a temporary key from a PIN",
     "set_memorable_pin": "Set a memorable PIN and securely store a temporary key in your browser cache",
 
+    "security_warning": "Security Warning",
+    "are_you_sure": "Are you sure you want to set up a temporary key?",
+    "clear_browser_storage_add_passkey": "Clearing your browser storage will erase this key. Add a passkey if you want to hold assets with this identity.",
+
     "what_is_temporary_key": "What is a temporary key?",
     "unique_key_pair": "A unique private key that is safely stored in your browser cache and protected by two layers of advanced encryption",
     "convenient_secure_replacement": "A convenient and more secure replacement for passwords",

--- a/src/frontend/src/flows/pin/pinInfo.ts
+++ b/src/frontend/src/flows/pin/pinInfo.ts
@@ -1,3 +1,4 @@
+import { warningIcon } from "$src/components/icons";
 import { mainWindow } from "$src/components/mainWindow";
 import { pinStepper } from "$src/flows/pin/stepper";
 import { I18n } from "$src/i18n";
@@ -42,6 +43,24 @@ const pinInfoTemplate = ({
     >
       ${copy.cancel}
     </button>
+    <section class="l-stack--tight">
+      <aside class="c-card c-card--narrow">
+        <span class="c-card__label c-card__label--hasIcon" aria-hidden="true">
+          <i class="c-card__icon c-icon c-icon--error__flipped c-icon--inline"
+            >${warningIcon}</i
+          >
+          <h2>${copy.security_warning}</h2>
+        </span>
+        <div class="t-title t-title--complications">
+          <h2 style="max-width: 30rem;" class="t-title">
+            ${copy.are_you_sure}
+          </h2>
+        </div>
+        <p style="max-width: 30rem;" class="warning-message t-paragraph t-lead">
+          ${copy.clear_browser_storage_add_passkey}
+        </p>
+      </aside>
+    </section>
     <section class="c-marketing-block">
       <aside class="l-stack">
         <h3 class="t-title">${copy.what_is_temporary_key}</h3>


### PR DESCRIPTION
This adds the warning as shown in the figmas to the PIN info screen.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc51b518f/desktop/pinInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc51b518f/mobile/pinInfo.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
