### PR TITLE
Change PIN registration stepper to 3 steps

### DIFF
--- a/src/frontend/src/flows/pin/confirmPin.ts
+++ b/src/frontend/src/flows/pin/confirmPin.ts
@@ -43,7 +43,7 @@ const confirmPinTemplate = ({
     focus,
   });
   const slot = html`
-    ${pinStepper({ current: "confirm" })}
+    ${pinStepper({ current: "set_pin" })}
     <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
       <h1 class="t-title t-title--main">${copy.confirm_pin}</h1>
     </hgroup>

--- a/src/frontend/src/flows/pin/pinInfo.ts
+++ b/src/frontend/src/flows/pin/pinInfo.ts
@@ -21,7 +21,7 @@ const pinInfoTemplate = ({
   const copy = i18n.i18n(copyJson);
 
   const slot = html`
-    ${pinStepper({ current: "set" })}
+    ${pinStepper({ current: "set_pin" })}
     <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
       <h1 class="t-title t-title--main">
         ${copy.create_temporary_key_form_pin}

--- a/src/frontend/src/flows/pin/setPin.ts
+++ b/src/frontend/src/flows/pin/setPin.ts
@@ -32,7 +32,7 @@ const setPinTemplate = ({
     focus,
   });
   const slot = html`
-    ${pinStepper({ current: "set" })}
+    ${pinStepper({ current: "set_pin" })}
     <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
       <h1 class="t-title t-title--main">${copy.set_pin_for_ii}</h1>
     </hgroup>

--- a/src/frontend/src/flows/pin/stepper.ts
+++ b/src/frontend/src/flows/pin/stepper.ts
@@ -4,18 +4,15 @@ import { html } from "lit-html";
 export const pinStepper = ({
   current,
 }: {
-  current: "set" | "confirm" | "captcha" | "finish";
+  current: "set_pin" | "captcha" | "finish";
 }) => html`
   <div class="c-progress-container">
     <ol class="c-progress-stepper">
-      <li class="c-progress-stepper__step" aria-current=${current === "set"}>
-        <span class="c-progress-stepper__label">Set PIN</span>
-      </li>
       <li
         class="c-progress-stepper__step"
-        aria-current=${current === "confirm"}
+        aria-current=${current === "set_pin"}
       >
-        <span class="c-progress-stepper__label">Confirm PIN</span>
+        <span class="c-progress-stepper__label">Set PIN</span>
       </li>
       <li
         class="c-progress-stepper__step"


### PR DESCRIPTION
It also renames the first step from "set" to "set_pin" because `set` is a reserved keyword in js.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fb1360923/desktop/confirmPin.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fb1360923/desktop/pinInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fb1360923/desktop/setPin.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fb1360923/mobile/confirmPin.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fb1360923/mobile/pinInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fb1360923/mobile/setPin.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
