### PR TITLE
Make stepper on registration finish step dependent on the auth flow

### DIFF
--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -13,26 +13,27 @@ import {
   withRef,
 } from "$src/utils/lit-html";
 import { OmitParams } from "$src/utils/utils";
-import { html } from "lit-html";
+import { TemplateResult, html } from "lit-html";
 import { Ref, createRef, ref } from "lit-html/directives/ref.js";
-import { registerStepper } from "./stepper";
 
 export const displayUserNumberTemplate = ({
   onContinue,
   userNumber,
   identityBackground,
+  stepper,
   scrollToTop = false,
 }: {
   onContinue: () => void;
   userNumber: bigint;
   identityBackground: IdentityBackground;
+  stepper: TemplateResult;
   /* put the page into view */
   scrollToTop?: boolean;
 }) => {
   const userNumberCopy: Ref<HTMLButtonElement> = createRef();
   const displayUserNumberSlot = html`
 
-  ${registerStepper({ current: "finish" })}
+  ${stepper}
 <hgroup
 
       ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}
@@ -124,15 +125,18 @@ export const displayUserNumberWarmup = (): OmitParams<
 export const displayUserNumber = ({
   userNumber,
   identityBackground,
+  stepper,
 }: {
   userNumber: bigint;
   identityBackground: IdentityBackground;
+  stepper: TemplateResult;
 }): Promise<void> => {
   return new Promise((resolve) =>
     displayUserNumberPage({
       onContinue: () => resolve(),
       userNumber,
       identityBackground,
+      stepper,
       scrollToTop: true,
     })
   );

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -147,6 +147,7 @@ export const iiPages: Record<string, () => void> = {
       identityBackground,
       userNumber,
       onContinue: () => console.log("done"),
+      stepper: registerStepper({ current: "finish" }),
     }),
   compatibilityNotice: () => compatibilityNotice("This is the reason."),
   promptDeviceAlias: () =>


### PR DESCRIPTION
This PR extracts the stepper on the finish page and adjusts it to show the appropriate steps depending on whether a passkey or a pin protected storage key was registered.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
