### PR TITLE
Highlight recovery box on no recoveries

### DIFF
--- a/src/frontend/src/flows/manage/recoveryMethodsSection.json
+++ b/src/frontend/src/flows/manage/recoveryMethodsSection.json
@@ -1,5 +1,6 @@
 {
   "en": {
+    "security_warning": "Security Warning",
     "recovery_phrase_enabled": "You enabled a recovery phrase.",
     "recovery_key_enabled": "You enabled a recovery device."
   }

--- a/src/frontend/src/flows/manage/recoveryMethodsSection.ts
+++ b/src/frontend/src/flows/manage/recoveryMethodsSection.ts
@@ -26,8 +26,31 @@ export const recoveryMethodsSection = ({
   addRecoveryPhrase: () => void;
   addRecoveryKey: () => void;
 }): TemplateResult => {
+  const i18n = new I18n();
+
+  const copy = i18n.i18n(copyJson);
+  const wrapClasses = ["l-stack"];
+  const warnNoRecovery = isNullish(recoveryPhrase) && isNullish(recoveryKey);
+
+  if (warnNoRecovery) {
+    wrapClasses.push("c-card", "c-card--narrow", "c-card--warning");
+  }
   return html`
-    <aside class="l-stack">
+    <aside class=${wrapClasses.join(" ")}>
+      ${warnNoRecovery
+        ? html`
+            <span
+              class="c-card__label c-card__label--hasIcon"
+              aria-hidden="true"
+            >
+              <i
+                class="c-card__icon c-icon c-icon--error__flipped c-icon--inline"
+                >${warningIcon}</i
+              >
+              <h2>${copy.security_warning}</h2>
+            </span>
+          `
+        : undefined}
       <div class="t-title">
         <h2>Recovery Methods</h2>
       </div>
@@ -35,10 +58,10 @@ export const recoveryMethodsSection = ({
         <ul>
           ${isNullish(recoveryPhrase)
             ? missingRecovery({ recovery: "phrase", addRecoveryPhrase })
-            : recoveryPhraseItem({ recoveryPhrase, i18n: new I18n() })}
+            : recoveryPhraseItem({ recoveryPhrase, i18n: i18n })}
           ${isNullish(recoveryKey)
             ? missingRecovery({ recovery: "key", addRecoveryKey })
-            : recoveryKeyItem({ recoveryKey, i18n: new I18n() })}
+            : recoveryKeyItem({ recoveryKey, i18n: i18n })}
         </ul>
       </div>
     </aside>

--- a/src/frontend/src/flows/manage/recoveryMethodsSection.ts
+++ b/src/frontend/src/flows/manage/recoveryMethodsSection.ts
@@ -29,12 +29,12 @@ export const recoveryMethodsSection = ({
   const i18n = new I18n();
 
   const copy = i18n.i18n(copyJson);
-  const wrapClasses = ["l-stack"];
   const warnNoRecovery = isNullish(recoveryPhrase) && isNullish(recoveryKey);
+  const wrapClasses = [
+    "l-stack",
+    ...(warnNoRecovery ? ["c-card", "c-card--narrow", "c-card--warning"] : []),
+  ];
 
-  if (warnNoRecovery) {
-    wrapClasses.push("c-card", "c-card--narrow", "c-card--warning");
-  }
   return html`
     <aside class=${wrapClasses.join(" ")}>
       ${warnNoRecovery
@@ -50,7 +50,7 @@ export const recoveryMethodsSection = ({
               <h2>${copy.security_warning}</h2>
             </span>
           `
-        : undefined}
+        : ""}
       <div class="t-title">
         <h2>Recovery Methods</h2>
       </div>
@@ -58,10 +58,10 @@ export const recoveryMethodsSection = ({
         <ul>
           ${isNullish(recoveryPhrase)
             ? missingRecovery({ recovery: "phrase", addRecoveryPhrase })
-            : recoveryPhraseItem({ recoveryPhrase, i18n: i18n })}
+            : recoveryPhraseItem({ recoveryPhrase, i18n })}
           ${isNullish(recoveryKey)
             ? missingRecovery({ recovery: "key", addRecoveryKey })
-            : recoveryKeyItem({ recoveryKey, i18n: i18n })}
+            : recoveryKeyItem({ recoveryKey, i18n })}
         </ul>
       </div>
     </aside>


### PR DESCRIPTION
If there are no recovery methods, the recovery section is now highlighted with a warning.

The code for the warning highlight box has been copied from the `authenticatorsSection`.
The warning box wrapper should be extracted as a common helper function in the future.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d76e1db7a/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d76e1db7a/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d76e1db7a/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d76e1db7a/mobile/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

