### PR TITLE
Move temp keys section above passkeys section in manage view

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -192,14 +192,14 @@ const displayManageTemplate = ({
         },
       })}
     </p>
+    ${pinAuthenticators.length > 0
+      ? tempKeysSection({ authenticators: pinAuthenticators, i18n })
+      : ""}
     ${authenticatorsSection({
       authenticators,
       onAddDevice,
       warnFewDevices,
     })}
-    ${pinAuthenticators.length > 0
-      ? tempKeysSection({ authenticators: pinAuthenticators, i18n })
-      : ""}
     ${recoveryMethodsSection({ recoveries, addRecoveryPhrase, addRecoveryKey })}
     ${logoutSection()}
   </section>`;


### PR DESCRIPTION
According to the figmans, the temp keys need to be shown first.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9f2facd7e/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
