### PR TITLE
Highlight passkey warning only on 0 passkeys

### DIFF
--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -33,16 +33,16 @@ export const dedupLabels = (
 export const authenticatorsSection = ({
   authenticators: authenticators_,
   onAddDevice,
-  warnFewDevices,
+  warnNoPasskeys,
 }: {
   authenticators: Authenticator[];
   onAddDevice: () => void;
-  warnFewDevices: boolean;
+  warnNoPasskeys: boolean;
 }): TemplateResult => {
-  const wrapClasses = ["l-stack"];
+  const wrapClasses = ["l-stack", "c-card", "c-card--narrow"];
 
-  if (warnFewDevices) {
-    wrapClasses.push("c-card", "c-card--narrow", "c-card--warning");
+  if (warnNoPasskeys) {
+    wrapClasses.push("c-card--warning");
   }
 
   const authenticators = dedupLabels(authenticators_);
@@ -50,7 +50,7 @@ export const authenticatorsSection = ({
   return html`
     <aside class=${wrapClasses.join(" ")}>
       ${
-        warnFewDevices
+        warnNoPasskeys
           ? html`
               <span
                 class="c-card__label c-card__label--hasIcon"
@@ -76,15 +76,18 @@ export const authenticatorsSection = ({
           </span>
         </div>
         ${
-          warnFewDevices
+          warnNoPasskeys
             ? html`<p
                 style="max-width: 30rem;"
                 class="warning-message t-paragraph t-lead"
               >
-                Add a Passkey or recovery method to make your Internet Identity
-                more secure.
+                Set up a passkey and securely sign into dapps by unlocking your
+                device.
               </p>`
-            : undefined
+            : html`<p style="max-width: 30rem;" class="t-paragraph t-lead">
+                Use passkeys to hold assets and securely sign into dapps by
+                unlocking your device.
+              </p>`
         }
 
         <div class="c-action-list">

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -39,11 +39,12 @@ export const authenticatorsSection = ({
   onAddDevice: () => void;
   warnNoPasskeys: boolean;
 }): TemplateResult => {
-  const wrapClasses = ["l-stack", "c-card", "c-card--narrow"];
-
-  if (warnNoPasskeys) {
-    wrapClasses.push("c-card--warning");
-  }
+  const wrapClasses = [
+    "l-stack",
+    "c-card",
+    "c-card--narrow",
+    ...(warnNoPasskeys ? ["c-card--warning"] : []),
+  ];
 
   const authenticators = dedupLabels(authenticators_);
 
@@ -63,7 +64,7 @@ export const authenticatorsSection = ({
                 <h2>Security warning</h2>
               </span>
             `
-          : undefined
+          : ""
       }
         <div class="t-title t-title--complications">
           <h2 class="t-title">Passkeys</h2>

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -75,21 +75,15 @@ export const authenticatorsSection = ({
             </span>
           </span>
         </div>
-        ${
+        <p
+          style="max-width: 30rem;"
+          class="${warnNoPasskeys ? "warning-message" : ""} t-paragraph t-lead"
+        >${
           warnNoPasskeys
-            ? html`<p
-                style="max-width: 30rem;"
-                class="warning-message t-paragraph t-lead"
-              >
-                Set up a passkey and securely sign into dapps by unlocking your
-                device.
-              </p>`
-            : html`<p style="max-width: 30rem;" class="t-paragraph t-lead">
-                Use passkeys to hold assets and securely sign into dapps by
-                unlocking your device.
-              </p>`
+            ? "Set up a passkey and securely sign into dapps by unlocking your device."
+            : "Use passkeys to hold assets and securely sign into dapps by unlocking your device."
         }
-
+        </p>
         <div class="c-action-list">
           <ul>
           ${authenticators.map((authenticator, index) =>

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -167,11 +167,8 @@ const displayManageTemplate = ({
   identityBackground: IdentityBackground;
   tempKeysWarning?: TempKeysWarning;
 }): TemplateResult => {
-  // Nudge the user to add a device iff there is one or fewer authenticators and no recoveries
-  const warnFewDevices =
-    authenticators.length <= 1 &&
-    isNullish(recoveries.recoveryPhrase) &&
-    isNullish(recoveries.recoveryKey);
+  // Nudge the user to add a passkey if there is none
+  const warnNoPasskeys = authenticators.length === 0;
   const i18n = new I18n();
 
   const pageContentSlot = html` <section data-role="identity-management">
@@ -195,7 +192,7 @@ const displayManageTemplate = ({
     ${authenticatorsSection({
       authenticators,
       onAddDevice,
-      warnFewDevices,
+      warnNoPasskeys,
     })}
     ${pinAuthenticators.length > 0
       ? tempKeysSection({ authenticators: pinAuthenticators, i18n })

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -462,13 +462,7 @@ export const iiPages: Record<string, () => void> = {
       identityBackground,
       userNumber,
       devices: {
-        authenticators: [
-          {
-            alias: "Some Passkey",
-            rename: () => console.log("rename"),
-            remove: () => console.log("remove"),
-          },
-        ],
+        authenticators: [],
         recoveries: {},
         pinAuthenticators: [
           {


### PR DESCRIPTION
This changes the warning highlight around passkeys to only appear if the number of passkeys is zero. Also, there is now a text shown for passkeys in the non-warning state.

Together with #1888 this shifts the warning box highlight on an identity with just a single passkey from the passkey box to the recovery box.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d08416d30/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d08416d30/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d08416d30/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d08416d30/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d08416d30/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d08416d30/mobile/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


