### PR TITLE
Fix dapps update job not creating a PR

### DIFF
--- a/.github/workflows/update-dapps.yml
+++ b/.github/workflows/update-dapps.yml
@@ -19,8 +19,8 @@ jobs:
         run: ./scripts/update-dapps
 
       # If the dapps changed, create a PR.
+      # This action creates a PR only if there are changes.
       - name: Create Pull Request
-        if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GIX_BOT_PAT }}


### PR DESCRIPTION
The PR action of the dapps update workflow skipped on a variable that was never set, thus never actually updating the dapps file.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
