### PR TITLE
Remove openssl install step in canister tests CI job

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -337,12 +337,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Required by the ic-test-state-machine
-      - name: Install openssl (macos)
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: |
-          brew install openssl@3
-
       - name: Download nextest
         run: |
           set -euo pipefail


### PR DESCRIPTION
The macos runners no longer require installation of `openssl`, because the component is now preinstalled. This shaves of some CI time and makes it more consistent, as the installation process was dependent on network speed (sometimes it would hang for up to 1 minute).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
