### PR TITLE
Install dependencies in dapps update

### DIFF
--- a/.github/workflows/update-dapps.yml
+++ b/.github/workflows/update-dapps.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
+      - run: npm ci
 
       # Run the update
       - name: Check new dapps file


### PR DESCRIPTION
The formatter needs to be installed first before it can be run in the dapps update workflow. Fixes oversight in #1895.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
