### PR TITLE
Support JPG assets

### DIFF
--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -91,6 +91,7 @@ pub enum ContentType {
     OCTETSTREAM,
     PNG,
     SVG,
+    JPG,
     WOFF2,
 }
 
@@ -258,6 +259,7 @@ fn collect_assets_from_dir(dir: &Dir) -> Vec<(String, Vec<u8>, ContentEncoding, 
             "js.gz" => (file_bytes, ContentEncoding::GZip, ContentType::JS),
             "png" => (file_bytes, ContentEncoding::Identity, ContentType::PNG),
             "svg" => (file_bytes, ContentEncoding::Identity, ContentType::SVG),
+            "jpg" | "jpeg" => (file_bytes, ContentEncoding::Identity, ContentType::JPG),
             "webp" => (file_bytes, ContentEncoding::Identity, ContentType::WEBP),
             "woff2" => (file_bytes, ContentEncoding::Identity, ContentType::WOFF2),
             "woff2.gz" => (file_bytes, ContentEncoding::GZip, ContentType::WOFF2),

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -28,6 +28,7 @@ impl ContentType {
             ContentType::OCTETSTREAM => "application/octet-stream".to_string(),
             ContentType::PNG => "image/png".to_string(),
             ContentType::SVG => "image/svg+xml".to_string(),
+            ContentType::JPG => "image/jpeg".to_string(),
             ContentType::WOFF2 => "application/font-woff2".to_string(),
         }
     }


### PR DESCRIPTION
The dapps list now contains logos in jpg format.
This PR adds support for jpg images so that they can be included.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
