### PR TITLE
Fix issue with SVG conversion in dapp update

### DIFF
--- a/scripts/update-dapps
+++ b/scripts/update-dapps
@@ -132,7 +132,7 @@ function update() {
             echo "converting '$old' -> '$new'"
             # if the file is a huge SVG (surprising, but why not)
             # then convert it to a raster webp (with transparency)
-            convert -background none -size 256x256 "$old" "$new"
+            convert -background none -resize 256x256 "$old" "$new"
             dapps_json_tmp=$(mktemp)
             jq <"$DAPPS_JSON" \
                 --arg old "$(basename "$old")" --arg new "$(basename "$new")" \


### PR DESCRIPTION
SVGs with a smaller size than 256*256 were resized in a way that just put the original image in the top-left corner. This PR fixes this and resizes the icons to appropriately fill the space.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
