### PR TITLE
Add basic e2e test for PIN protected key registration

### DIFF
--- a/src/frontend/src/flows/pin/confirmPin.ts
+++ b/src/frontend/src/flows/pin/confirmPin.ts
@@ -47,7 +47,7 @@ const confirmPinTemplate = ({
     <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
       <h1 class="t-title t-title--main">${copy.confirm_pin}</h1>
     </hgroup>
-    <div class="l-stack">
+    <div class="l-stack" data-role="confirm-pin">
       <div class="c-input--stack">${pinInput_.template}</div>
     </div>
     <button

--- a/src/frontend/src/flows/pin/setPin.ts
+++ b/src/frontend/src/flows/pin/setPin.ts
@@ -36,7 +36,7 @@ const setPinTemplate = ({
     <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
       <h1 class="t-title t-title--main">${copy.set_pin_for_ii}</h1>
     </hgroup>
-    <div class="l-stack">
+    <div class="l-stack" data-role="set-pin">
       <div class="c-input--stack">${pinInput_.template}</div>
     </div>
     <button

--- a/src/frontend/src/flows/pin/usePin.ts
+++ b/src/frontend/src/flows/pin/usePin.ts
@@ -35,7 +35,7 @@ const usePinTemplate = <T>({
     <hgroup ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}>
       <h1 class="t-title t-title--main">${copy.enter_pin_for_ii}</h1>
     </hgroup>
-    <div class="l-stack">
+    <div class="l-stack" data-role="pin">
       <div class="c-input--stack">${pinInput_.template}</div>
     </div>
     <button

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -1,6 +1,7 @@
 import {
   AuthenticateView,
   MainView,
+  PinRegistrationView,
   RecoveryMethodSelectorView,
   RegisterView,
   WelcomeView,
@@ -38,6 +39,27 @@ export const FLOWS = {
     await authenticateView.waitForDisplay();
     await authenticateView.register();
     return await FLOWS.register(browser, deviceName);
+  },
+  registerPin: async function (
+    browser: WebdriverIO.Browser,
+    pin: string
+  ): Promise<string> {
+    const registerView = new RegisterView(browser);
+    await registerView.waitForDisplay();
+    await registerView.createPin();
+    const pinRegistrationView = new PinRegistrationView(browser);
+    await pinRegistrationView.waitForPinInfo();
+    await pinRegistrationView.pinInfoContinue();
+    await pinRegistrationView.waitForSetPin();
+    await pinRegistrationView.setPin(pin);
+    await pinRegistrationView.waitForConfirmPin();
+    await pinRegistrationView.confirmPin(pin);
+    await registerView.waitForRegisterConfirm();
+    await registerView.confirmRegisterConfirm();
+    await registerView.waitForIdentity();
+    const userNumber = await registerView.registerGetIdentity();
+    await registerView.registerConfirmIdentity();
+    return userNumber;
   },
   login: async (
     userNumber: string,

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -1,0 +1,38 @@
+import { II_URL } from "./constants";
+import { FLOWS } from "./flows";
+import { runInBrowser } from "./util";
+import { MainView, RegisterView, WelcomeView } from "./views";
+
+// The PIN auth feature is only enabled for Apple specific user agents
+const APPLE_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36";
+
+// Sample user agent for Edge on Windows
+const EDGE_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36 Edg/116.0.1938.81";
+
+test("PIN registration not enabled on non-Apple device", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    await browser.url(II_URL);
+    const welcomeView = new WelcomeView(browser);
+    await welcomeView.waitForDisplay();
+    await welcomeView.register();
+    const registerView = new RegisterView(browser);
+    await registerView.waitForDisplay();
+    await registerView.assertPinRegistrationNotShown();
+  }, EDGE_USER_AGENT);
+}, 300_000);
+
+test("Register new PIN identity", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    const pin = "123456";
+
+    await browser.url(II_URL);
+    const welcomeView = new WelcomeView(browser);
+    await welcomeView.waitForDisplay();
+    await welcomeView.register();
+    await FLOWS.registerPin(browser, pin);
+    const mainView = new MainView(browser);
+    await mainView.waitForDisplay(); // we should be logged in
+  }, APPLE_USER_AGENT);
+}, 300_000);

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -1,4 +1,5 @@
 import { randomString, wrapError } from "$src/utils/utils";
+import { nonNullish } from "@dfinity/utils";
 import { ChromeOptions } from "@wdio/types/build/Capabilities";
 import * as fs from "fs";
 import * as fsasync from "fs/promises";
@@ -25,7 +26,8 @@ export async function runInBrowser(
   test: (
     browser: WebdriverIO.Browser,
     runConfig: RunConfiguration
-  ) => Promise<void>
+  ) => Promise<void>,
+  userAgent?: string
 ): Promise<void> {
   // parse run configuration from environment variables
   const runConfig = parseRunConfiguration();
@@ -34,6 +36,7 @@ export async function runInBrowser(
     args: [
       "--ignore-certificate-errors", // allow self-signed certificates
       "--disable-gpu",
+      ...(nonNullish(userAgent) ? [`--user-agent=${userAgent}`] : []),
     ],
 
     // Disables permission prompt for clipboard, needed for tests using the clipboard (without this,

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -71,6 +71,10 @@ export class RegisterView extends View {
     await this.browser.$('[data-action="construct-identity"').click();
   }
 
+  async createPin(): Promise<void> {
+    await this.browser.$('[data-action="construct-pin-identity"').click();
+  }
+
   // View: Register confirmation
   async waitForRegisterConfirm(): Promise<void> {
     await this.browser
@@ -104,6 +108,50 @@ export class RegisterView extends View {
 
   async registerConfirmIdentity(): Promise<void> {
     await this.browser.$("#displayUserContinue").click();
+  }
+
+  async assertPinRegistrationNotShown(): Promise<void> {
+    await this.browser
+      .$('[data-action="construct-pin-identity"')
+      .waitForDisplayed({ reverse: true });
+  }
+}
+
+export class PinRegistrationView extends View {
+  async waitForPinInfo(): Promise<void> {
+    await this.browser
+      .$('[data-action="continue-pin"]')
+      .waitForDisplayed({ timeout: 10_000 });
+  }
+
+  async pinInfoContinue(): Promise<void> {
+    await this.browser.$('[data-action="continue-pin"').click();
+  }
+  async waitForSetPin(): Promise<void> {
+    await this.browser
+      .$('[data-role="set-pin"]')
+      .waitForDisplayed({ timeout: 10_000 });
+  }
+
+  async setPin(pin: string): Promise<void> {
+    const inputs = await this.browser.$('[data-role="set-pin"]').$$("input");
+    for (const [input, digit] of zip(inputs, pin.split(""))) {
+      await input.setValue(digit);
+    }
+  }
+  async waitForConfirmPin(): Promise<void> {
+    await this.browser
+      .$('[data-role="confirm-pin"]')
+      .waitForDisplayed({ timeout: 10_000 });
+  }
+
+  async confirmPin(pin: string): Promise<void> {
+    const inputs = await this.browser
+      .$('[data-role="confirm-pin"]')
+      .$$("input");
+    for (const [input, digit] of zip(inputs, pin.split(""))) {
+      await input.setValue(digit);
+    }
   }
 }
 


### PR DESCRIPTION
This adds the first basic e2e tests for the PIN registration feature.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7aa99e300/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
