### PR TITLE
Fix being prompted for PIN input after temporary key is removed

### DIFF
--- a/src/frontend/src/crypto/pinIdentity.ts
+++ b/src/frontend/src/crypto/pinIdentity.ts
@@ -1,4 +1,4 @@
-import { SignIdentity } from "@dfinity/agent";
+import { DerEncodedPublicKey, SignIdentity } from "@dfinity/agent";
 import { ECDSAKeyIdentity } from "@dfinity/identity";
 import { z } from "zod";
 
@@ -235,4 +235,13 @@ export const generateBrowserKey = async (): Promise<CryptoKey> => {
     ] /* key is used to wrap (and unwrap) the identity secret key */
   );
   return key;
+};
+
+export const pinIdentityToDerPubkey = async (
+  pinIdentity: PinIdentityMaterial
+): Promise<DerEncodedPublicKey> => {
+  return (await crypto.subtle.exportKey(
+    "spki",
+    pinIdentity.publicKey
+  )) as DerEncodedPublicKey;
 };

--- a/src/frontend/src/test-e2e/addDevice.test.ts
+++ b/src/frontend/src/test-e2e/addDevice.test.ts
@@ -44,19 +44,7 @@ test("Add device", async () => {
     // leads to flaky tests otherwise.
     await removeVirtualAuthenticator(browser, firstAuthenticator);
     await addVirtualAuthenticator(browser);
-    await mainView.addAdditionalDevice();
-
-    const addRemoteDeviceInstructionsView = new AddRemoteDeviceInstructionsView(
-      browser
-    );
-    await addRemoteDeviceInstructionsView.addFIDODevice();
-
-    await browser.pause(10_000);
-
-    // success page
-    const addDeviceSuccessView = new AddDeviceSuccessView(browser);
-    await addDeviceSuccessView.waitForDisplay();
-    await addDeviceSuccessView.continue();
+    await FLOWS.addFidoDevice(browser);
 
     // home
     await mainView.waitForDisplay();

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -1,4 +1,6 @@
 import {
+  AddDeviceSuccessView,
+  AddRemoteDeviceInstructionsView,
   AuthenticateView,
   MainView,
   PinAuthView,
@@ -140,5 +142,21 @@ export const FLOWS = {
     await recoveryMethodSelectorView.seedPhraseFill();
 
     return seedPhrase;
+  },
+  addFidoDevice: async (browser: WebdriverIO.Browser): Promise<void> => {
+    const mainView = new MainView(browser);
+    await mainView.waitForDisplay();
+    await mainView.addAdditionalDevice();
+    const addRemoteDeviceInstructionsView = new AddRemoteDeviceInstructionsView(
+      browser
+    );
+    await addRemoteDeviceInstructionsView.addFIDODevice();
+
+    await browser.pause(10_000);
+
+    // success page
+    const addDeviceSuccessView = new AddDeviceSuccessView(browser);
+    await addDeviceSuccessView.waitForDisplay();
+    await addDeviceSuccessView.continue();
   },
 };

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -1,6 +1,6 @@
-import { II_URL } from "./constants";
+import { DEVICE_NAME1, II_URL } from "./constants";
 import { FLOWS } from "./flows";
-import { runInBrowser } from "./util";
+import { addVirtualAuthenticator, runInBrowser } from "./util";
 import { MainView, RegisterView, WelcomeView } from "./views";
 
 // The PIN auth feature is only enabled for Apple specific user agents
@@ -36,5 +36,28 @@ test("Register and Log in with PIN identity", async () => {
     await mainView.waitForTempKeyDisplay(DEFAULT_PIN_DEVICE_NAME);
     await mainView.logout();
     await FLOWS.loginPin(userNumber, pin, DEFAULT_PIN_DEVICE_NAME, browser);
+  }, APPLE_USER_AGENT);
+}, 300_000);
+
+test("Should not prompt for PIN after deleting temp key", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    const pin = "123456";
+    await addVirtualAuthenticator(browser);
+
+    await browser.url(II_URL);
+    const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
+    const mainView = new MainView(browser);
+    await mainView.waitForDisplay(); // we should be logged in
+    await mainView.waitForTempKeyDisplay(DEFAULT_PIN_DEVICE_NAME);
+    await FLOWS.addFidoDevice(browser);
+
+    await mainView.waitForDisplay();
+    await mainView.remove(DEFAULT_PIN_DEVICE_NAME);
+    await browser.waitUntil(() => browser.isAlertOpen());
+    // this is equivalent to logout as we are deleting the device that was used for authentication
+    await browser.acceptAlert();
+
+    // login now happens using the WebAuthn flow
+    await FLOWS.login(userNumber, DEVICE_NAME1, browser);
   }, APPLE_USER_AGENT);
 }, 300_000);

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -307,6 +307,11 @@ export class MainView extends View {
     await renameView.submit();
   }
 
+  async remove(deviceName: string): Promise<void> {
+    await this.openDeviceActions({ deviceName });
+    await this.deviceAction({ deviceName, action: "remove" }).click();
+  }
+
   async protect(deviceName: string, seedPhrase: string): Promise<void> {
     await this.openDeviceActions({ deviceName });
     await this.deviceAction({ deviceName, action: "protect" }).click();


### PR DESCRIPTION
When deleting the temporary key from the identity, the key remains in browser storage. This leads to the awkward situation of the browser still prompting for the PIN even if subsequent authentication will fail.

This PR introduces a check, that the browser will only use the PIN protected key if the public key is still present on the identity.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/458c38501/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

