### PR TITLE
Improve confirm pin flow on pin mismatch

### DIFF
--- a/src/frontend/src/flows/pin/confirmPin.json
+++ b/src/frontend/src/flows/pin/confirmPin.json
@@ -1,6 +1,7 @@
 {
   "en": {
     "confirm_pin": "Confirm PIN for Internet Identity on this Device",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "retry": "Retry"
   }
 }

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -359,6 +359,7 @@ export const iiPages: Record<string, () => void> = {
       onContinue: () => console.log("PIN confirmed"),
       expectedPin: "123456",
       cancel: () => console.log("cancel"),
+      retry: () => console.log("retry"),
     }),
   usePin: () =>
     usePinPage({


### PR DESCRIPTION
Previously, if the pin on the confirmation page did not match the previous input the only option was to cancel and start over. This is a very bad user experience.

The behaviour is replaced with a mechanism that replaces the cancel button with a retry button that sends the user to the previous page.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
