### PR TITLE
Refactor canister_sig_util.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,13 +267,8 @@ name = "canister_sig_util"
 version = "0.1.0"
 dependencies = [
  "candid",
- "canister_tests",
- "hex",
  "ic-cdk",
  "ic-certified-map",
- "ic-test-state-machine-client",
- "identity_jose",
- "lazy_static",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -1279,6 +1274,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sha2 0.10.7",
+ "vc_util",
 ]
 
 [[package]]
@@ -2430,6 +2426,24 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "vc_util"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "canister_tests",
+ "hex",
+ "ic-cdk",
+ "ic-certified-map",
+ "ic-test-state-machine-client",
+ "identity_jose",
+ "lazy_static",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.7",
+]
 
 [[package]]
 name = "version_check"

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ COPY src/internet_identity_interface/Cargo.toml src/internet_identity_interface/
 COPY src/archive/Cargo.toml src/archive/Cargo.toml
 COPY src/canister_tests/Cargo.toml src/canister_tests/Cargo.toml
 COPY src/canister_sig_util/Cargo.toml src/canister_sig_util/Cargo.toml
+COPY src/vc_util/Cargo.toml src/vc_util/Cargo.toml
 ENV CARGO_TARGET_DIR=/cargo_target
 COPY ./scripts/build ./scripts/build
 RUN mkdir -p src/internet_identity/src \
@@ -60,6 +61,8 @@ RUN mkdir -p src/internet_identity/src \
     && touch src/canister_tests/src/lib.rs \
     && mkdir -p src/canister_sig_util/src \
     && touch src/canister_sig_util/src/lib.rs \
+    && mkdir -p src/vc_util/src \
+    && touch src/vc_util/src/lib.rs \
     && ./scripts/build --only-dependencies --internet-identity --archive \
     && rm -rf src
 

--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -30,15 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "autocfg"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,12 +69,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-
-[[package]]
 name = "binread"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,31 +92,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -182,14 +146,10 @@ dependencies = [
  "byteorder",
  "candid_derive",
  "codespan-reporting",
- "convert_case",
  "crc32fast",
  "data-encoding",
  "hex",
- "lalrpop",
- "lalrpop-util",
  "leb128",
- "logos",
  "num-bigint",
  "num-traits",
  "num_enum",
@@ -219,10 +179,8 @@ name = "canister_sig_util"
 version = "0.1.0"
 dependencies = [
  "candid",
- "hex",
  "ic-cdk",
  "ic-certified-map",
- "identity_jose",
  "serde",
  "serde_bytes",
  "sha2 0.10.7",
@@ -298,7 +256,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -318,15 +276,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,12 +292,6 @@ checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -441,12 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,27 +402,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -528,40 +444,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "errno"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "ff"
@@ -584,12 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
 name = "flate2"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,12 +478,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -681,12 +555,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -941,26 +809,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,38 +828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "diff",
- "ena",
- "is-terminal",
- "itertools",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax 0.7.5",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,60 +844,6 @@ name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
-
-[[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg 1.1.0",
- "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "logos"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c000ca4d908ff18ac99b93a062cb8958d331c3220719c52e77cb19cc6ac5d2c1"
-dependencies = [
- "logos-derive",
-]
-
-[[package]]
-name = "logos-codegen"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc487311295e0002e452025d6b580b77bb17286de87b57138f3b5db711cded68"
-dependencies = [
- "beef",
- "fnv",
- "proc-macro2",
- "quote",
- "regex-syntax 0.6.29",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
-dependencies = [
- "logos-codegen",
-]
 
 [[package]]
 name = "memchr"
@@ -1108,12 +870,6 @@ dependencies = [
  "data-encoding",
  "data-encoding-macro",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "num-bigint"
@@ -1189,29 +945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.3.5",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,31 +957,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
-name = "petgraph"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,12 +965,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty"
@@ -1443,35 +1145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,7 +1153,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1491,14 +1164,8 @@ checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1517,19 +1184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
-dependencies = [
- "bitflags 2.4.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,12 +1194,6 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -1657,18 +1305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "smallvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
-
-[[package]]
 name = "spki"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,19 +1325,6 @@ dependencies = [
  "libc",
  "psm",
  "winapi",
-]
-
-[[package]]
-name = "string_cache"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
-dependencies = [
- "new_debug_unreachable",
- "once_cell",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
 ]
 
 [[package]]
@@ -1752,17 +1375,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]
@@ -1820,15 +1432,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
 dependencies = [
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -1909,12 +1512,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +1544,21 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "sha2 0.10.7",
+ "vc_util",
+]
+
+[[package]]
+name = "vc_util"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "hex",
+ "ic-cdk",
+ "ic-certified-map",
+ "identity_jose",
+ "serde",
+ "serde_bytes",
  "sha2 0.10.7",
 ]
 
@@ -1992,72 +1604,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -10,13 +10,14 @@ edition = "2021"
 # local dependencies
 canister_sig_util = { path = "../../src/canister_sig_util" }
 internet_identity_interface = { path = "../../src/internet_identity_interface" }
+vc_util = { path = "../../src/vc_util" }
 # ic dependencies
 candid = "0.9"
 ic-cdk = "0.10"
 ic-cdk-macros = "0.7"
 ic-certified-map = "0.4"
 # vc dependencies
-identity_core = {git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false}
+identity_core = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false}
 identity_credential = {git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false, features = ["credential"]}
 identity_jose = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false, features = ["iccs"]}
 # identity_core = {path = "../../../identity.rs/identity_core", default-features = false}
@@ -33,6 +34,5 @@ sha2 = "^0.10" # set bound to match ic-certified-map bound
 
 [dev-dependencies]
 ic-test-state-machine-client = "3"
-candid = { version = "0.9", features = ["parser"] }
 canister_tests = { path = "../../src/canister_tests" }
 lazy_static = "1.4"

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -1,8 +1,5 @@
 use candid::{candid_method, Principal};
-use canister_sig_util::{
-    der_encoded_canister_sig_pk, did_for_principal, hash_bytes, vc_jwt_to_jws, vc_signing_input,
-    vc_signing_input_hash, CanisterSig,
-};
+use canister_sig_util::{canister_sig_pk_der, hash_bytes, CanisterSig};
 use ic_cdk_macros::{query, update};
 use ic_certified_map::Hash;
 use identity_core::common::Url;
@@ -21,6 +18,7 @@ use std::cell::RefCell;
 use canister_sig_util::signature_map::{SignatureMap, LABEL_SIG};
 use ic_cdk::api::{data_certificate, set_certified_data, time};
 use ic_cdk::trap;
+use vc_util::{did_for_principal, vc_jwt_to_jws, vc_signing_input, vc_signing_input_hash};
 
 const MINUTE_NS: u64 = 60 * 1_000_000_000;
 const CERTIFICATE_VALIDITY_PERIOD_NS: u64 = 5 * MINUTE_NS;
@@ -41,7 +39,7 @@ async fn prepare_credential(req: PrepareCredentialRequest) -> PrepareCredentialR
     let subject_principal = req.signed_id_alias.id_alias;
     let seed = calculate_seed(&subject_principal);
     let canister_id = ic_cdk::id();
-    let canister_sig_pk_der = der_encoded_canister_sig_pk(canister_id, &seed);
+    let canister_sig_pk_der = canister_sig_pk_der(canister_id, &seed);
     let credential = new_credential(subject_principal);
     let credential_jwt = credential
         .serialize_jwt()
@@ -77,7 +75,7 @@ fn get_credential(req: GetCredentialRequest) -> GetCredentialResponse {
     let subject_principal = req.signed_id_alias.id_alias;
     let seed = calculate_seed(&subject_principal);
     let canister_id = ic_cdk::id();
-    let canister_sig_pk_der = der_encoded_canister_sig_pk(canister_id, &seed);
+    let canister_sig_pk_der = canister_sig_pk_der(canister_id, &seed);
     let signing_input = vc_signing_input(&req.vc_jwt, &canister_sig_pk_der, canister_id);
     let msg_hash = vc_signing_input_hash(&signing_input);
     let maybe_sig = SIGNATURES.with(|sigs| {

--- a/src/canister_sig_util/Cargo.toml
+++ b/src/canister_sig_util/Cargo.toml
@@ -10,19 +10,10 @@ candid = "0.9"
 ic-cdk = "0.10"
 ic-certified-map = "0.4"
 
-# vc dependencies
-identity_jose = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false, features = ["iccs"]}
-# identity_jose = { path = "../../../identity.rs/identity_jose", default-features = false, features = ["iccs"]}
-
 # other dependencies
-hex = "0.4"
 serde = { version = "1", features = ["rc"] }
 serde_bytes = "0.11"
 sha2 = "^0.10" # set bound to match ic-certified-map bound
 
 [dev-dependencies]
-ic-test-state-machine-client = "3"
-candid = { version = "0.9", features = ["parser"] }
-canister_tests = { path = "../../src/canister_tests" }
-lazy_static = "1.4"
 rand = { version ="0.8.5" }

--- a/src/canister_sig_util/src/lib.rs
+++ b/src/canister_sig_util/src/lib.rs
@@ -1,15 +1,10 @@
 use candid::Principal;
 use ic_certified_map::{Hash, HashTree};
-use identity_jose::jwk::{Jwk, JwkParams, JwkParamsOct, JwkType};
-use identity_jose::jws::{CompactJwsEncoder, JwsAlgorithm, JwsHeader};
-use identity_jose::jwu::encode_b64;
 use serde::Serialize;
 use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
-use std::ops::{Add, DerefMut};
 
 pub mod signature_map;
-pub use identity_jose::jws::verify_credential_jws;
 
 #[derive(Serialize)]
 pub struct CanisterSig<'a> {
@@ -23,36 +18,7 @@ pub fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
     hasher.finalize().into()
 }
 
-pub fn vc_signing_input(
-    credential_jwt: &str,
-    canister_sig_pk_der: &[u8],
-    canister_id: Principal,
-) -> Vec<u8> {
-    let encoder = jws_encoder(credential_jwt, canister_sig_pk_der, canister_id);
-    encoder.signing_input().to_vec()
-}
-
-pub fn vc_jwt_to_jws(
-    credential_jwt: &str,
-    canister_sig_pk_der: &[u8],
-    sig: &[u8],
-    canister_id: Principal,
-) -> String {
-    let encoder = jws_encoder(credential_jwt, canister_sig_pk_der, canister_id);
-    encoder.into_jws(sig)
-}
-
-pub fn vc_signing_input_hash(signing_input: &[u8]) -> Hash {
-    let sep = b"iccs_verifiable_credential";
-    let mut hasher = Sha256::new();
-    let buf = [sep.len() as u8];
-    hasher.update(buf);
-    hasher.update(sep);
-    hasher.update(signing_input);
-    hasher.finalize().into()
-}
-
-pub fn der_encoded_canister_sig_pk(canister_id: Principal, seed: &[u8]) -> Vec<u8> {
+pub fn canister_sig_pk_der(canister_id: Principal, seed: &[u8]) -> Vec<u8> {
     let mut bitstring: Vec<u8> = vec![];
     bitstring.push(canister_id.as_ref().len() as u8);
     bitstring.extend(canister_id.as_ref());
@@ -73,40 +39,4 @@ pub fn der_encoded_canister_sig_pk(canister_id: Principal, seed: &[u8]) -> Vec<u
     der.push(0x00);
     der.extend(bitstring);
     der
-}
-
-pub fn did_for_principal(principal: Principal) -> String {
-    let prefix = String::from("did:icp:");
-    prefix.add(&principal.to_string())
-}
-
-// Per https://datatracker.ietf.org/doc/html/rfc7518#section-6.4,
-// JwkParamsOct are for symmetric keys or another key whose value is a single octet sequence.
-fn canister_sig_pk_jwk(canister_sig_pk_der: &[u8]) -> Jwk {
-    let mut cspk_jwk = Jwk::new(JwkType::Oct);
-    cspk_jwk.set_alg("IcCs");
-    cspk_jwk
-        .set_params(JwkParams::Oct(JwkParamsOct {
-            k: encode_b64(canister_sig_pk_der),
-        }))
-        .expect("internal: failed setting JwkParams");
-    cspk_jwk
-}
-
-fn jws_encoder<'a>(
-    credential_jwt: &'a str,
-    canister_sig_pk_der: &[u8],
-    canister_id: Principal,
-) -> CompactJwsEncoder<'a> {
-    let mut header: JwsHeader = JwsHeader::new();
-    header.set_alg(JwsAlgorithm::IcCs);
-    let kid = did_for_principal(canister_id);
-    header.set_kid(kid);
-    header
-        .deref_mut()
-        .set_jwk(canister_sig_pk_jwk(canister_sig_pk_der));
-
-    let encoder: CompactJwsEncoder = CompactJwsEncoder::new(credential_jwt.as_ref(), &header)
-        .expect("internal error: JWS encoder failed");
-    encoder
 }

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 canister_sig_util = { path = "../../src/canister_sig_util" }
 internet_identity_interface = { path = "../internet_identity_interface" }
+vc_util = { path = "../../src/vc_util" }
+
 
 hex = "0.4"
 include_dir = "0.7"

--- a/src/internet_identity/src/vc_mvp.rs
+++ b/src/internet_identity/src/vc_mvp.rs
@@ -2,10 +2,7 @@ use crate::assets::CertifiedAssets;
 use crate::delegation::check_frontend_length;
 use crate::{delegation, hash, state, update_root_hash, LABEL_SIG, MINUTE_NS};
 use candid::Principal;
-use canister_sig_util::{
-    der_encoded_canister_sig_pk, did_for_principal, vc_jwt_to_jws, vc_signing_input,
-    vc_signing_input_hash,
-};
+use canister_sig_util::canister_sig_pk_der;
 use ic_cdk::api::{data_certificate, time};
 use ic_cdk::trap;
 use ic_certified_map::{Hash, HashTree};
@@ -23,6 +20,7 @@ use internet_identity_interface::internet_identity::types::{
 use serde::Serialize;
 use serde_bytes::ByteBuf;
 use serde_json::json;
+use vc_util::{did_for_principal, vc_jwt_to_jws, vc_signing_input, vc_signing_input_hash};
 
 // The expiration used for signatures
 #[allow(clippy::identity_op)]
@@ -46,7 +44,7 @@ pub async fn prepare_id_alias(
     let id_alias_principal = get_id_alias_principal(identity_number, &dapps);
     let seed = calculate_id_alias_seed(identity_number, &dapps);
     let canister_id = ic_cdk::id();
-    let canister_sig_pk_der = der_encoded_canister_sig_pk(canister_id, &seed);
+    let canister_sig_pk_der = canister_sig_pk_der(canister_id, &seed);
 
     let rp_tuple = AliasTuple {
         id_alias: id_alias_principal,
@@ -100,7 +98,7 @@ pub fn get_id_alias(
         let id_rp = delegation::get_principal(identity_number, dapps.relying_party.clone());
         let id_issuer = delegation::get_principal(identity_number, dapps.issuer.clone());
         let canister_id = ic_cdk::id();
-        let canister_sig_pk_der = der_encoded_canister_sig_pk(canister_id, &seed);
+        let canister_sig_pk_der = canister_sig_pk_der(canister_id, &seed);
 
         let signing_input = vc_signing_input(rp_id_alias_jwt, &canister_sig_pk_der, canister_id);
         let msg_hash = vc_signing_input_hash(&signing_input);

--- a/src/vc_util/Cargo.toml
+++ b/src/vc_util/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "vc_util"
+description = "Utils for verifiable credentials on the IC"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# ic dependencies
+candid = "0.9"
+ic-cdk = "0.10"
+ic-certified-map = "0.4"
+
+# vc dependencies
+identity_jose = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false, features = ["iccs"]}
+# identity_jose = { path = "../../../identity.rs/identity_jose", default-features = false, features = ["iccs"]}
+
+# other dependencies
+hex = "0.4"
+serde = { version = "1", features = ["rc"] }
+serde_bytes = "0.11"
+sha2 = "^0.10" # set bound to match ic-certified-map bound
+
+[dev-dependencies]
+ic-test-state-machine-client = "3"
+candid = { version = "0.9", features = ["parser"] }
+canister_tests = { path = "../../src/canister_tests" }
+lazy_static = "1.4"
+rand = { version ="0.8.5" }

--- a/src/vc_util/src/lib.rs
+++ b/src/vc_util/src/lib.rs
@@ -1,0 +1,74 @@
+use candid::Principal;
+use ic_certified_map::Hash;
+use identity_jose::jwk::{Jwk, JwkParams, JwkParamsOct, JwkType};
+use identity_jose::jws::{CompactJwsEncoder, JwsAlgorithm, JwsHeader};
+use identity_jose::jwu::encode_b64;
+use sha2::{Digest, Sha256};
+use std::ops::{Add, DerefMut};
+
+pub use identity_jose::jws::verify_credential_jws;
+
+pub fn vc_signing_input(
+    credential_jwt: &str,
+    canister_sig_pk_der: &[u8],
+    canister_id: Principal,
+) -> Vec<u8> {
+    let encoder = jws_encoder(credential_jwt, canister_sig_pk_der, canister_id);
+    encoder.signing_input().to_vec()
+}
+
+pub fn vc_jwt_to_jws(
+    credential_jwt: &str,
+    canister_sig_pk_der: &[u8],
+    sig: &[u8],
+    canister_id: Principal,
+) -> String {
+    let encoder = jws_encoder(credential_jwt, canister_sig_pk_der, canister_id);
+    encoder.into_jws(sig)
+}
+
+pub fn vc_signing_input_hash(signing_input: &[u8]) -> Hash {
+    let sep = b"iccs_verifiable_credential";
+    let mut hasher = Sha256::new();
+    let buf = [sep.len() as u8];
+    hasher.update(buf);
+    hasher.update(sep);
+    hasher.update(signing_input);
+    hasher.finalize().into()
+}
+
+pub fn did_for_principal(principal: Principal) -> String {
+    let prefix = String::from("did:icp:");
+    prefix.add(&principal.to_string())
+}
+
+// Per https://datatracker.ietf.org/doc/html/rfc7518#section-6.4,
+// JwkParamsOct are for symmetric keys or another key whose value is a single octet sequence.
+fn canister_sig_pk_jwk(canister_sig_pk_der: &[u8]) -> Jwk {
+    let mut cspk_jwk = Jwk::new(JwkType::Oct);
+    cspk_jwk.set_alg("IcCs");
+    cspk_jwk
+        .set_params(JwkParams::Oct(JwkParamsOct {
+            k: encode_b64(canister_sig_pk_der),
+        }))
+        .expect("internal: failed setting JwkParams");
+    cspk_jwk
+}
+
+fn jws_encoder<'a>(
+    credential_jwt: &'a str,
+    canister_sig_pk_der: &[u8],
+    canister_id: Principal,
+) -> CompactJwsEncoder<'a> {
+    let mut header: JwsHeader = JwsHeader::new();
+    header.set_alg(JwsAlgorithm::IcCs);
+    let kid = did_for_principal(canister_id);
+    header.set_kid(kid);
+    header
+        .deref_mut()
+        .set_jwk(canister_sig_pk_jwk(canister_sig_pk_der));
+
+    let encoder: CompactJwsEncoder = CompactJwsEncoder::new(credential_jwt.as_ref(), &header)
+        .expect("internal error: JWS encoder failed");
+    encoder
+}


### PR DESCRIPTION
Move VC-related utils from `canister_sig_util` to newly created `vc_util`.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ca6086dc6/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

