### PR TITLE
Refactor temp key warning

### DIFF
--- a/src/frontend/src/components/tempKeysWarning.json
+++ b/src/frontend/src/components/tempKeysWarning.json
@@ -1,0 +1,9 @@
+{
+  "en": {
+    "security_warning": "Security Warning",
+    "you_are_using_temporary_key": "You are using a temporary key. Do not hold any assets with this identity.",
+    "set_up_recovery_and_passkey": "Clearing your browser storage will erase this key. Set up a recovery method to avoid losing access to your identity. Add a passkey to securely hold assets with this identity.",
+    "add_recovery_phrase": "Add Recovery Phrase",
+    "add_new_passkey": "Add new Passkey"
+  }
+}

--- a/src/frontend/src/components/tempKeysWarning.ts
+++ b/src/frontend/src/components/tempKeysWarning.ts
@@ -1,0 +1,49 @@
+import { warnBox } from "$src/components/warnBox";
+import { DynamicKey, I18n } from "$src/i18n";
+import { unreachable } from "$src/utils/utils";
+import { TemplateResult, html } from "lit-html";
+
+import { isNullish } from "@dfinity/utils";
+import copyJson from "./tempKeysWarning.json";
+
+export type TempKeysWarning =
+  | { tag: "add_recovery"; action: () => void }
+  | { tag: "add_passkey"; action: () => void };
+export const tempKeyWarning = ({
+  i18n,
+  tempKeysWarning,
+}: {
+  i18n: I18n;
+  tempKeysWarning?: TempKeysWarning;
+}): TemplateResult => {
+  const copy = i18n.i18n(copyJson);
+
+  const warningButton = (tempKeysWarning?: TempKeysWarning) => {
+    if (isNullish(tempKeysWarning)) {
+      return undefined;
+    }
+    switch (tempKeysWarning.tag) {
+      case "add_recovery":
+        return button(tempKeysWarning.action, copy.add_recovery_phrase);
+      case "add_passkey":
+        return button(tempKeysWarning.action, copy.add_new_passkey);
+      default:
+        unreachable(tempKeysWarning, "unknown temp keys warning tag");
+    }
+  };
+
+  return warnBox({
+    title: copy.you_are_using_temporary_key,
+    headerSlot: html`<h2>${copy.security_warning}</h2>`,
+    message: copy.set_up_recovery_and_passkey,
+    slot: warningButton(tempKeysWarning),
+  });
+};
+
+const button = (action: () => void, buttonText: DynamicKey) => html`<button
+  class="c-button c-button--primary l-stack"
+  @click="${action}"
+  id="addRecovery"
+>
+  <span>${buttonText}</span>
+</button>`;

--- a/src/frontend/src/components/warnBox.ts
+++ b/src/frontend/src/components/warnBox.ts
@@ -1,4 +1,5 @@
 import { TemplateElement } from "$src/utils/lit-html";
+import { nonNullish } from "@dfinity/utils";
 import { html, TemplateResult } from "lit-html";
 import { warningIcon } from "./icons";
 
@@ -9,6 +10,7 @@ import { warningIcon } from "./icons";
 
 interface warnBoxProps {
   title: TemplateElement;
+  headerSlot?: TemplateElement;
   message: TemplateElement;
   slot?: TemplateResult;
   htmlElement?: "div" | "aside";
@@ -17,6 +19,7 @@ interface warnBoxProps {
 
 export const warnBox = ({
   title,
+  headerSlot,
   message,
   slot,
   htmlElement = "aside",
@@ -28,7 +31,10 @@ export const warnBox = ({
   }
   const contents: TemplateResult = html`
     <span class="c-card__label c-card__label--hasIcon" aria-hidden="true">
-      <i class="c-card__icon c-icon c-icon--error__flipped">${warningIcon}</i>
+      <i class="c-card__icon c-icon c-icon--error__flipped c-icon--inline"
+        >${warningIcon}</i
+      >
+      ${nonNullish(headerSlot) ? headerSlot : ""}
     </span>
     <h3 class="t-title c-card__title">${title}</h3>
     <div data-role="warning-message" class="t-paragraph c-card__paragraph">

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -15,17 +15,17 @@ import {
 import { withLoader } from "$src/components/loader";
 import { logoutSection } from "$src/components/logout";
 import { mainWindow } from "$src/components/mainWindow";
+import {
+  TempKeysWarning,
+  tempKeyWarning,
+} from "$src/components/tempKeysWarning";
 import { toast } from "$src/components/toast";
 import { LEGACY_II_URL } from "$src/config";
 import { addDevice } from "$src/flows/addDevice/manage/addDevice";
 import { dappsExplorer } from "$src/flows/dappsExplorer";
 import { KnownDapp, getDapps } from "$src/flows/dappsExplorer/dapps";
 import { dappsHeader, dappsTeaser } from "$src/flows/dappsExplorer/teaser";
-import {
-  TempKeysWarning,
-  tempKeyWarningSection,
-  tempKeysSection,
-} from "$src/flows/manage/tempKeys";
+import { tempKeysSection } from "$src/flows/manage/tempKeys";
 import { addPhrase, recoveryWizard } from "$src/flows/recovery/recoveryWizard";
 import { setupKey, setupPhrase } from "$src/flows/recovery/setupRecovery";
 import { I18n } from "$src/i18n";
@@ -175,7 +175,7 @@ const displayManageTemplate = ({
     </hgroup>
     ${anchorSection({ userNumber, identityBackground })}
     ${nonNullish(tempKeysWarning)
-      ? tempKeyWarningSection({ i18n, tempKeysWarning })
+      ? tempKeyWarning({ i18n, tempKeysWarning })
       : ""}
     <p class="t-paragraph">
       ${dappsTeaser({

--- a/src/frontend/src/flows/manage/tempKeys.json
+++ b/src/frontend/src/flows/manage/tempKeys.json
@@ -1,12 +1,6 @@
 {
   "en": {
     "temporary_key": "Temporary Keys",
-    "key_stored_in_browser": "These keys are stored in browser cache, clearing your browser storage will erase them.",
-
-    "security_warning": "Security Warning",
-    "you_are_using_temporary_key": "You are using a temporary key. Do not hold any assets with this identity.",
-    "set_up_recovery_and_passkey": "Clearing your browser storage will erase this key. Set up a recovery method to avoid losing access to your identity. Add a passkey to securely hold assets with this identity.",
-    "add_recovery_phrase": "Add Recovery Phrase",
-    "add_new_passkey": "Add new Passkey"
+    "key_stored_in_browser": "These keys are stored in browser cache, clearing your browser storage will erase them."
   }
 }

--- a/src/frontend/src/flows/manage/tempKeys.ts
+++ b/src/frontend/src/flows/manage/tempKeys.ts
@@ -1,62 +1,13 @@
-import { cypherIcon, warningIcon } from "$src/components/icons";
+import { cypherIcon } from "$src/components/icons";
 import {
   authenticatorItem,
   dedupLabels,
 } from "$src/flows/manage/authenticatorsSection";
 import { Authenticator } from "$src/flows/manage/types";
 import { I18n } from "$src/i18n";
-import { unreachable } from "$src/utils/utils";
 import { TemplateResult, html } from "lit-html";
 
 import copyJson from "./tempKeys.json";
-
-export type TempKeysWarning =
-  | { tag: "add_recovery"; action: () => void }
-  | { tag: "add_passkey"; action: () => void };
-export const tempKeyWarningSection = ({
-  i18n,
-  tempKeysWarning,
-}: {
-  i18n: I18n;
-  tempKeysWarning: TempKeysWarning;
-}): TemplateResult => {
-  const copy = i18n.i18n(copyJson);
-
-  const warningButtonCopy = (tempKeysWarning: TempKeysWarning) => {
-    switch (tempKeysWarning.tag) {
-      case "add_recovery":
-        return copy.add_recovery_phrase;
-      case "add_passkey":
-        return copy.add_new_passkey;
-      default:
-        unreachable(tempKeysWarning, "unknown temp keys warning tag");
-    }
-  };
-
-  return html`
-    <aside class="c-card c-card--narrow c-card--warning">
-      <span class="c-card__label c-card__label--hasIcon" aria-hidden="true">
-        <i class="c-card__icon c-icon c-icon--error__flipped c-icon--inline"
-          >${warningIcon}</i
-        >
-        <h2>${copy.security_warning}</h2>
-      </span>
-      <div class="t-title t-title--complications">
-        <h2 class="t-title">${copy.you_are_using_temporary_key}</h2>
-      </div>
-      <p class="warning-message t-paragraph t-lead">
-        ${copy.set_up_recovery_and_passkey}
-      </p>
-      <button
-        class="c-button c-button--primary l-stack"
-        @click="${tempKeysWarning.action}"
-        id="addRecovery"
-      >
-        <span>${warningButtonCopy(tempKeysWarning)}</span>
-      </button>
-    </aside>
-  `;
-};
 
 export const tempKeysSection = ({
   authenticators: authenticators_,


### PR DESCRIPTION
This PR extracts the temp key warning as a separate component and makes use of the existing `warnBox` component. This warning will subsequently be used on additional screens.

The next location this warning will be displayed is the finish registration screen that displays the identity number after successful registration.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74fed0ac1/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74fed0ac1/mobile/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
