### PR TITLE
Add header slot to warn box

### DIFF
--- a/src/frontend/src/components/warnBox.ts
+++ b/src/frontend/src/components/warnBox.ts
@@ -9,6 +9,7 @@ import { warningIcon } from "./icons";
 
 interface warnBoxProps {
   title: TemplateElement;
+  headerSlot?: TemplateElement;
   message: TemplateElement;
   slot?: TemplateResult;
   htmlElement?: "div" | "aside";
@@ -17,6 +18,7 @@ interface warnBoxProps {
 
 export const warnBox = ({
   title,
+  headerSlot,
   message,
   slot,
   htmlElement = "aside",
@@ -28,7 +30,10 @@ export const warnBox = ({
   }
   const contents: TemplateResult = html`
     <span class="c-card__label c-card__label--hasIcon" aria-hidden="true">
-      <i class="c-card__icon c-icon c-icon--error__flipped">${warningIcon}</i>
+      <i class="c-card__icon c-icon c-icon--error__flipped c-icon--inline"
+        >${warningIcon}</i
+      >
+      ${headerSlot}
     </span>
     <h3 class="t-title c-card__title">${title}</h3>
     <div data-role="warning-message" class="t-paragraph c-card__paragraph">


### PR DESCRIPTION
Extends the `warnBox` helper with a slot to add some template next to the exclamation mark icon.

The PR will make the helper usable in more contexts relate to the non-passkey auth feature.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
