### PR TITLE
Add temp key warning to registration success screen

### DIFF
--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -21,12 +21,14 @@ export const displayUserNumberTemplate = ({
   userNumber,
   identityBackground,
   stepper,
+  slot,
   scrollToTop = false,
 }: {
   onContinue: () => void;
   userNumber: bigint;
   identityBackground: IdentityBackground;
   stepper: TemplateResult;
+  slot?: TemplateResult;
   /* put the page into view */
   scrollToTop?: boolean;
 }) => {
@@ -84,6 +86,7 @@ export const displayUserNumberTemplate = ({
         I saved it, continue
       </button>
     <section class="c-marketing-block">
+      ${slot}
       <aside class="l-stack">
         <h3 class="t-title">This number is your Internet Identity</h3>
         <p class="t-paragraph">With your Internet Identity and your passkey, you will be able to create and securely connect to Internet Computer dapps</p>
@@ -126,10 +129,12 @@ export const displayUserNumber = ({
   userNumber,
   identityBackground,
   stepper,
+  slot,
 }: {
   userNumber: bigint;
   identityBackground: IdentityBackground;
   stepper: TemplateResult;
+  slot?: TemplateResult;
 }): Promise<void> => {
   return new Promise((resolve) =>
     displayUserNumberPage({
@@ -137,6 +142,7 @@ export const displayUserNumber = ({
       userNumber,
       identityBackground,
       stepper,
+      slot,
       scrollToTop: true,
     })
   );

--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -21,14 +21,14 @@ export const displayUserNumberTemplate = ({
   userNumber,
   identityBackground,
   stepper,
-  slot,
+  marketingIntroSlot,
   scrollToTop = false,
 }: {
   onContinue: () => void;
   userNumber: bigint;
   identityBackground: IdentityBackground;
   stepper: TemplateResult;
-  slot?: TemplateResult;
+  marketingIntroSlot?: TemplateResult;
   /* put the page into view */
   scrollToTop?: boolean;
 }) => {
@@ -86,7 +86,7 @@ export const displayUserNumberTemplate = ({
         I saved it, continue
       </button>
     <section class="c-marketing-block">
-      ${slot}
+      ${marketingIntroSlot}
       <aside class="l-stack">
         <h3 class="t-title">This number is your Internet Identity</h3>
         <p class="t-paragraph">With your Internet Identity and your passkey, you will be able to create and securely connect to Internet Computer dapps</p>
@@ -129,12 +129,12 @@ export const displayUserNumber = ({
   userNumber,
   identityBackground,
   stepper,
-  slot,
+  marketingIntroSlot,
 }: {
   userNumber: bigint;
   identityBackground: IdentityBackground;
   stepper: TemplateResult;
-  slot?: TemplateResult;
+  marketingIntroSlot?: TemplateResult;
 }): Promise<void> => {
   return new Promise((resolve) =>
     displayUserNumberPage({
@@ -142,7 +142,7 @@ export const displayUserNumber = ({
       userNumber,
       identityBackground,
       stepper,
-      slot,
+      marketingIntroSlot,
       scrollToTop: true,
     })
   );

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -8,11 +8,13 @@ import {
   PinIdentityMaterial,
   constructPinIdentity,
 } from "$src/crypto/pinIdentity";
+import { tempKeyWarningBox } from "$src/flows/manage/tempKeys";
 import { idbStorePinIdentityMaterial } from "$src/flows/pin/idb";
 import { setPinFlow } from "$src/flows/pin/setPin";
 import { pinStepper } from "$src/flows/pin/stepper";
 import { registerStepper } from "$src/flows/register/stepper";
 import { registerDisabled } from "$src/flows/registerDisabled";
+import { I18n } from "$src/i18n";
 import { authenticatorAttachmentToKeyType } from "$src/utils/authenticatorAttachment";
 import { LoginFlowCanceled } from "$src/utils/flowResult";
 import {
@@ -98,6 +100,7 @@ export const registerFlow = async <T>({
         keyType: { browser_storage_key: null },
         finalizeIdentity: (userNumber: bigint) =>
           storePinIdentity({ userNumber, pinIdentityMaterial }),
+        finishSlot: tempKeyWarningBox({ i18n: new I18n() }),
       };
     } else {
       const identity = savePasskeyResult;
@@ -131,6 +134,7 @@ export const registerFlow = async <T>({
     credentialId,
     keyType,
     finalizeIdentity,
+    finishSlot,
   }: {
     identity: SignIdentity;
     alias: string;
@@ -139,6 +143,7 @@ export const registerFlow = async <T>({
     credentialId?: CredentialId;
     keyType: KeyType;
     finalizeIdentity?: (userNumber: bigint) => Promise<void>;
+    finishSlot?: TemplateResult;
   } = result_;
 
   const result = await promptCaptcha({
@@ -173,6 +178,7 @@ export const registerFlow = async <T>({
     await displayUserNumber({
       userNumber,
       stepper: finishStepper,
+      slot: finishSlot,
     });
   }
   return result;

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -178,7 +178,7 @@ export const registerFlow = async <T>({
     await displayUserNumber({
       userNumber,
       stepper: finishStepper,
-      slot: finishSlot,
+      marketingIntroSlot: finishSlot,
     });
   }
   return result;

--- a/src/showcase/src/pages/[page].astro
+++ b/src/showcase/src/pages/[page].astro
@@ -3,6 +3,7 @@ import Layout from "../layouts/Layout.astro";
 import "$src/styles/main.css";
 export const iiPageNames = [
   "displayUserNumber",
+  "displayUserNumberTempKey",
   "compatibilityNotice",
   "promptDeviceAlias",
   "authorizeNew",

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -31,6 +31,7 @@ import {
   resetPhraseInfoPage,
   unprotectDeviceInfoPage,
 } from "$src/flows/manage/deviceSettings";
+import { tempKeyWarningBox } from "$src/flows/manage/tempKeys";
 import { confirmPinPage } from "$src/flows/pin/confirmPin";
 import { pinInfoPage } from "$src/flows/pin/pinInfo";
 import { setPinPage } from "$src/flows/pin/setPin";
@@ -148,6 +149,14 @@ export const iiPages: Record<string, () => void> = {
       userNumber,
       onContinue: () => console.log("done"),
       stepper: registerStepper({ current: "finish" }),
+    }),
+  displayUserNumberTempKey: () =>
+    displayUserNumberPage({
+      identityBackground,
+      userNumber,
+      onContinue: () => console.log("done"),
+      stepper: registerStepper({ current: "finish" }),
+      slot: tempKeyWarningBox({ i18n: new I18n("en") }),
     }),
   compatibilityNotice: () => compatibilityNotice("This is the reason."),
   promptDeviceAlias: () =>

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -156,7 +156,7 @@ export const iiPages: Record<string, () => void> = {
       userNumber,
       onContinue: () => console.log("done"),
       stepper: registerStepper({ current: "finish" }),
-      slot: tempKeyWarningBox({ i18n: new I18n("en") }),
+      marketingIntroSlot: tempKeyWarningBox({ i18n: new I18n("en") }),
     }),
   compatibilityNotice: () => compatibilityNotice("This is the reason."),
   promptDeviceAlias: () =>


### PR DESCRIPTION
This adds the temp key warning also to the registration success page.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/25c7706cf/desktop/displayUserNumberTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/25c7706cf/mobile/displayUserNumberTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

