### PR TITLE
Do not clear localstorage on logout

### DIFF
--- a/src/frontend/src/components/logout.ts
+++ b/src/frontend/src/components/logout.ts
@@ -15,7 +15,6 @@ export const logoutSection = (
 </div>`;
 
 const logout = () => {
-  localStorage.clear();
   clearHash();
   window.location.reload();
 };

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -94,9 +94,8 @@ export const deleteDevice = async ({
   });
 
   if (sameDevice) {
-    // clear anchor and reload the page.
+    // reload the page.
     // do not call "reload", otherwise the management page will try to reload the list of devices which will cause an error
-    localStorage.clear();
     location.reload();
     return;
   } else {

--- a/src/frontend/src/test-e2e/addDevice.test.ts
+++ b/src/frontend/src/test-e2e/addDevice.test.ts
@@ -52,7 +52,7 @@ test("Add device", async () => {
     await mainView.waitForDeviceCount(DEVICE_NAME1, 2);
 
     await mainView.logout();
-    await FLOWS.login(userNumber, DEVICE_NAME1, browser);
+    await FLOWS.loginPick(userNumber, DEVICE_NAME1, browser);
   });
 }, 300_000);
 

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -7,6 +7,7 @@ import {
   PinRegistrationView,
   RecoveryMethodSelectorView,
   RegisterView,
+  WelcomeBackView,
   WelcomeView,
 } from "./views";
 
@@ -92,6 +93,19 @@ export const FLOWS = {
     await welcomeView.login();
     await welcomeView.typeUserNumber(userNumber);
     await browser.$("button[data-action='continue']").click();
+    // NOTE: handle recovery nag because there is no recovery phrase
+    await FLOWS.skipRecoveryNag(browser);
+    const mainView = new MainView(browser);
+    await mainView.waitForDeviceDisplay(deviceName);
+  },
+  loginPick: async (
+    userNumber: string,
+    deviceName: string,
+    browser: WebdriverIO.Browser
+  ): Promise<void> => {
+    const welcomeView = new WelcomeBackView(browser);
+    await welcomeView.waitForDisplay();
+    await welcomeView.login(userNumber);
     // NOTE: handle recovery nag because there is no recovery phrase
     await FLOWS.skipRecoveryNag(browser);
     const mainView = new MainView(browser);

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -122,9 +122,7 @@ export const FLOWS = {
     await welcomeView.login();
     await welcomeView.typeUserNumber(userNumber);
     await browser.$("button[data-action='continue']").click();
-    const pinAuthView = new PinAuthView(browser);
-    await pinAuthView.waitForDisplay();
-    await pinAuthView.enterPin(pin);
+    await FLOWS.enterPin(browser, pin);
     // NOTE: handle recovery nag because there is no recovery phrase
     await FLOWS.skipRecoveryNag(browser);
     const mainView = new MainView(browser);
@@ -180,5 +178,13 @@ export const FLOWS = {
     const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
     await recoveryMethodSelectorView.waitForDisplay();
     await recoveryMethodSelectorView.skipRecovery();
+  },
+  enterPin: async (
+    browser: WebdriverIO.Browser,
+    pin: string
+  ): Promise<void> => {
+    const pinAuthView = new PinAuthView(browser);
+    await pinAuthView.waitForDisplay();
+    await pinAuthView.enterPin(pin);
   },
 };

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -92,12 +92,8 @@ export const FLOWS = {
     await welcomeView.login();
     await welcomeView.typeUserNumber(userNumber);
     await browser.$("button[data-action='continue']").click();
-    // NOTE: depending on the browser, we issue different warnings. On Safari,
-    // the warning comes before the recovery method selector. Since we only
-    // test on Chrome we always expect the recovery selector first.
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
+    // NOTE: handle recovery nag because there is no recovery phrase
+    await FLOWS.skipRecoveryNag(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(deviceName);
   },
@@ -116,9 +112,7 @@ export const FLOWS = {
     await pinAuthView.waitForDisplay();
     await pinAuthView.enterPin(pin);
     // NOTE: handle recovery nag because there is no recovery phrase
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
+    await FLOWS.skipRecoveryNag(browser);
     const mainView = new MainView(browser);
     await mainView.waitForTempKeyDisplay(deviceName);
   },
@@ -167,5 +161,10 @@ export const FLOWS = {
     const addDeviceSuccessView = new AddDeviceSuccessView(browser);
     await addDeviceSuccessView.waitForDisplay();
     await addDeviceSuccessView.continue();
+  },
+  skipRecoveryNag: async (browser: WebdriverIO.Browser): Promise<void> => {
+    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
+    await recoveryMethodSelectorView.waitForDisplay();
+    await recoveryMethodSelectorView.skipRecovery();
   },
 };

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -18,7 +18,6 @@ import {
   DemoAppView,
   MainView,
   PinAuthView,
-  RecoveryMethodSelectorView,
   RegisterView,
   WelcomeView,
 } from "./views";
@@ -82,9 +81,7 @@ test("Register and log in with PIN identity, retry on wrong PIN", async () => {
     await pinAuthView.enterPin(pin);
 
     // NOTE: handle recovery nag because there is no recovery phrase
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
+    await FLOWS.skipRecoveryNag(browser);
     const mainView2 = new MainView(browser);
     await mainView2.waitForDisplay(); // we should be logged in
   }, APPLE_USER_AGENT);
@@ -166,9 +163,7 @@ test("Register with PIN then log into client application", async () => {
     await pinAuthView.waitForDisplay();
     await pinAuthView.enterPin(pin);
 
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
+    await FLOWS.skipRecoveryNag(browser);
     await waitToClose(browser);
 
     await demoAppView.waitForDisplay();

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -106,7 +106,7 @@ test("Should not prompt for PIN after deleting temp key", async () => {
     await browser.acceptAlert();
 
     // login now happens using the WebAuthn flow
-    await FLOWS.login(userNumber, DEVICE_NAME1, browser);
+    await FLOWS.loginPick(userNumber, DEVICE_NAME1, browser);
   }, APPLE_USER_AGENT);
 }, 300_000);
 

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -158,11 +158,7 @@ test("Register with PIN then log into client application", async () => {
     const authenticateView = new AuthenticateView(browser);
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
-
-    const pinAuthView = new PinAuthView(browser);
-    await pinAuthView.waitForDisplay();
-    await pinAuthView.enterPin(pin);
-
+    await FLOWS.enterPin(browser, pin);
     await FLOWS.skipRecoveryNag(browser);
     await waitToClose(browser);
 

--- a/src/frontend/src/test-e2e/register.test.ts
+++ b/src/frontend/src/test-e2e/register.test.ts
@@ -8,13 +8,7 @@ import {
   switchToPopup,
   waitToClose,
 } from "./util";
-import {
-  AuthenticateView,
-  DemoAppView,
-  MainView,
-  RecoveryMethodSelectorView,
-  WelcomeView,
-} from "./views";
+import { AuthenticateView, DemoAppView, MainView, WelcomeView } from "./views";
 
 // Read canister ids from the corresponding dfx files.
 // This assumes that they have been successfully dfx-deployed
@@ -102,9 +96,7 @@ test("Register first then log into client application", async () => {
     const authenticateView = new AuthenticateView(browser);
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
+    await FLOWS.skipRecoveryNag(browser);
     await waitToClose(browser);
     await demoAppView.waitForDisplay();
     const principal = await demoAppView.getPrincipal();

--- a/src/frontend/src/test-e2e/register.test.ts
+++ b/src/frontend/src/test-e2e/register.test.ts
@@ -37,7 +37,7 @@ test("Register new identity and login with it", async () => {
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     await mainView.logout();
-    await FLOWS.login(userNumber, DEVICE_NAME1, browser);
+    await FLOWS.loginPick(userNumber, DEVICE_NAME1, browser);
   });
 }, 300_000);
 

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -542,16 +542,12 @@ export class AuthenticateView extends View {
 export class WelcomeBackView extends View {
   async waitForDisplay(): Promise<void> {
     await this.browser
-      .$("#loginDifferent")
+      .$('[data-page="authorize-pick"]')
       .waitForDisplayed({ timeout: 15_000 });
   }
 
-  async getIdentityAnchor(): Promise<string> {
-    return await this.browser.$("[data-usernumber]").getText();
-  }
-
-  async login(): Promise<void> {
-    await this.browser.$("#login").click();
+  async login(userNumber: string): Promise<void> {
+    await this.browser.$(`[data-anchor-id]="${userNumber}"`).click();
   }
 }
 


### PR DESCRIPTION
Deleting identity numbers on logout is unexpected and destructive. A change was requested to no longer do that.

Instead, we should give users a different way of managing the numbers shown on the landing page (to be solved as a separate PR).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dda451a1b/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

