### PR TITLE
Refactor utils for VC-validation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,10 +280,14 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ic-cdk",
+ "ic-certification 0.24.1",
  "ic-certified-map",
+ "ic-verify-bls-signature",
+ "lazy_static",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "sha2 0.10.7",
 ]
 
@@ -489,6 +493,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1349,6 +1366,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "serial_test",
  "sha2 0.10.7",
  "vc_util",
 ]
@@ -2212,6 +2230,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,9 +2594,11 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "candid",
+ "canister_sig_util",
  "canister_tests",
  "hex",
  "ic-cdk",
+ "ic-certification 0.24.1",
  "ic-certified-map",
  "ic-test-state-machine-client",
  "identity_core",
@@ -2563,6 +2608,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_json",
  "sha2 0.10.7",
 ]

--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -197,9 +197,13 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "ic-cdk",
+ "ic-certification",
  "ic-certified-map",
+ "ic-verify-bls-signature",
+ "lazy_static",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "sha2 0.10.7",
 ]
 
@@ -371,6 +375,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -568,6 +585,83 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -937,6 +1031,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg 1.1.0",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1146,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1179,18 @@ name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -1242,6 +1387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1454,12 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -1394,6 +1554,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1611,21 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "spki"
@@ -1656,6 +1856,7 @@ dependencies = [
  "hex",
  "ic-cdk",
  "ic-cdk-macros",
+ "ic-certification",
  "ic-certified-map",
  "ic-test-state-machine-client",
  "identity_core",
@@ -1667,6 +1868,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "serial_test",
  "sha2 0.10.7",
  "vc_util",
 ]
@@ -1676,14 +1878,17 @@ name = "vc_util"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "canister_sig_util",
  "hex",
  "ic-cdk",
+ "ic-certification",
  "ic-certified-map",
  "identity_core",
  "identity_credential",
  "identity_jose",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_json",
  "sha2 0.10.7",
 ]
@@ -1730,6 +1935,63 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -15,6 +15,7 @@ vc_util = { path = "../../src/vc_util" }
 candid = "0.9"
 ic-cdk = "0.10"
 ic-cdk-macros = "0.7"
+ic-certification = "0.24.1"
 ic-certified-map = "0.4"
 # vc dependencies
 identity_core = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false}
@@ -30,6 +31,7 @@ serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_cbor = "0.11"
 serde_json = "1"
+serial_test = "2"
 sha2 = "^0.10" # set bound to match ic-certified-map bound
 
 [dev-dependencies]

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -1,7 +1,7 @@
 use candid::{candid_method, Principal};
-use canister_sig_util::{canister_sig_pk_der, hash_bytes, CanisterSig};
+use canister_sig_util::{canister_sig_pk_der, hash_bytes};
 use ic_cdk_macros::{query, update};
-use ic_certified_map::Hash;
+use ic_certified_map::{Hash, HashTree};
 use identity_core::common::Url;
 use identity_core::convert::FromJson;
 use identity_credential::credential::{Credential, CredentialBuilder, Subject};
@@ -123,7 +123,13 @@ fn get_signature(sigs: &SignatureMap, seed: Hash, msg_hash: Hash) -> Option<Vec<
         ));
     }
     let tree = ic_certified_map::labeled(LABEL_SIG, witness);
-    let sig = CanisterSig {
+    #[derive(Serialize)]
+    struct Sig<'a> {
+        certificate: ByteBuf,
+        tree: HashTree<'a>,
+    }
+
+    let sig = Sig {
         certificate: ByteBuf::from(certificate),
         tree,
     };

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -1,13 +1,13 @@
 //! Tests related to issue_credential canister call.
 
 use candid::Principal;
+use canister_sig_util::set_ic_root_public_key_for_testing;
 use canister_tests::api::internet_identity::vc_mvp as ii_api;
 use canister_tests::flows;
 use canister_tests::framework::{env, get_wasm_path, principal_1, II_WASM};
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use ic_test_state_machine_client::call_candid_as;
 use ic_test_state_machine_client::{query_candid_as, CallError, StateMachine};
-use identity_jose::jws::set_ic_root_public_key_for_testing;
 use internet_identity_interface::internet_identity::types::vc_mvp::issuer::{
     CredentialSpec, GetCredentialRequest, GetCredentialResponse, Icrc21ConsentMessageRequest,
     Icrc21ConsentMessageResponse, Icrc21ConsentPreferences, PrepareCredentialRequest,
@@ -18,6 +18,7 @@ use internet_identity_interface::internet_identity::types::vc_mvp::{
 };
 use internet_identity_interface::internet_identity::types::FrontendHostname;
 use lazy_static::lazy_static;
+use serial_test::serial;
 use std::path::PathBuf;
 use vc_util::verify_credential_jws;
 
@@ -117,6 +118,7 @@ fn should_return_consent_message() -> Result<(), CallError> {
 
 /// Verifies that a credential is being created including II interactions.
 #[test]
+#[serial]
 fn should_issue_credential_e2e() -> Result<(), CallError> {
     let env = env();
     let issuer_id = install_canister(&env, VC_ISSUER_WASM.clone());

--- a/src/canister_sig_util/Cargo.toml
+++ b/src/canister_sig_util/Cargo.toml
@@ -8,11 +8,15 @@ edition = "2021"
 # ic dependencies
 candid = "0.9"
 ic-cdk = "0.10"
+ic-certification = "0.24.1"
 ic-certified-map = "0.4"
+ic-verify-bls-signature = "0.2"
 
 # other dependencies
+lazy_static = "1.4"
 serde = { version = "1", features = ["rc"] }
 serde_bytes = "0.11"
+serde_cbor = "0.11"
 sha2 = "^0.10" # set bound to match ic-certified-map bound
 
 [dev-dependencies]

--- a/src/canister_sig_util/src/lib.rs
+++ b/src/canister_sig_util/src/lib.rs
@@ -1,15 +1,112 @@
 use candid::Principal;
-use ic_certified_map::{Hash, HashTree};
-use serde::Serialize;
+use ic_certification::{Certificate, Delegation, HashTree, LookupResult};
+use ic_certified_map::Hash;
+use ic_verify_bls_signature::verify_bls_signature;
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
+use std::sync::RwLock;
 
 pub mod signature_map;
 
-#[derive(Serialize)]
-pub struct CanisterSig<'a> {
+pub const IC_STATE_ROOT_DOMAIN_SEPARATOR: &[u8; 14] = b"\x0Dic-state-root";
+pub const IC_ROOT_KEY_DER_PREFIX: &[u8; 37] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x01\x02\x01\x06\x0c\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x02\x01\x03\x61\x00";
+pub const IC_ROOT_KEY_DER: &[u8; 133] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x01\x02\x01\x06\x0c\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x02\x01\x03\x61\x00\x81\x4c\x0e\x6e\xc7\x1f\xab\x58\x3b\x08\xbd\x81\x37\x3c\x25\x5c\x3c\x37\x1b\x2e\x84\x86\x3c\x98\xa4\xf1\xe0\x8b\x74\x23\x5d\x14\xfb\x5d\x9c\x0c\xd5\x46\xd9\x68\x5f\x91\x3a\x0c\x0b\x2c\xc5\x34\x15\x83\xbf\x4b\x43\x92\xe4\x67\xdb\x96\xd6\x5b\x9b\xb4\xcb\x71\x71\x12\xf8\x47\x2e\x0d\x5a\x4d\x14\x50\x5f\xfd\x74\x84\xb0\x12\x91\x09\x1c\x5f\x87\xb9\x88\x83\x46\x3f\x98\x09\x1a\x0b\xaa\xae";
+pub const IC_ROOT_KEY_LENGTH: usize = 96;
+
+pub const CANISTER_KEY_DER_PREFIX_LENGTH: usize = 19;
+// Canister signatures' public key OID is 1.3.6.1.4.1.56387.1.2,
+// cf. https://internetcomputer.org/docs/current/references/ic-interface-spec#canister-signatures
+pub const CANISTER_KEY_DER_OID: &[u8; 14] =
+    b"\x30\x0C\x06\x0A\x2B\x06\x01\x04\x01\x83\xB8\x43\x01\x02";
+
+lazy_static! {
+    static ref IC_ROOT_PUBLIC_KEY: RwLock<Vec<u8>> = RwLock::new(
+        extract_ic_root_key_from_der(IC_ROOT_KEY_DER).expect("Failed decoding IC root key.")
+    );
+}
+
+fn extract_ic_root_key_from_der(buf: &[u8]) -> Result<Vec<u8>, CanisterSigVerificationError> {
+    let expected_length = IC_ROOT_KEY_DER_PREFIX.len() + IC_ROOT_KEY_LENGTH;
+    if buf.len() != expected_length {
+        return Err(CanisterSigVerificationError::Unknown(String::from(
+            "invalid root pk length",
+        )));
+    }
+
+    let prefix = &buf[0..IC_ROOT_KEY_DER_PREFIX.len()];
+    if prefix[..] != IC_ROOT_KEY_DER_PREFIX[..] {
+        return Err(CanisterSigVerificationError::Unknown(String::from(
+            "invalid root pk prefix",
+        )));
+    }
+
+    let key = &buf[IC_ROOT_KEY_DER_PREFIX.len()..];
+    Ok(key.to_vec())
+}
+
+pub fn set_ic_root_public_key_for_testing(pk_der: Vec<u8>) {
+    let mut root_pk = IC_ROOT_PUBLIC_KEY.write().unwrap();
+    *root_pk = extract_ic_root_key_from_der(&pk_der).expect("Failed decoding IC root key.");
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CanisterSig {
     pub certificate: ByteBuf,
-    pub tree: HashTree<'a>,
+    pub tree: HashTree,
+}
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CanisterSigPublicKey {
+    pub signing_canister_id: Principal,
+    #[serde(with = "serde_bytes")]
+    pub seed: Vec<u8>,
+}
+
+fn key_decoding_err(err_msg: &str) -> CanisterSigVerificationError {
+    CanisterSigVerificationError::InvalidPublicKey(String::from(err_msg))
+}
+
+impl TryFrom<&[u8]> for CanisterSigPublicKey {
+    type Error = CanisterSigVerificationError;
+
+    fn try_from(der_pubkey_bytes: &[u8]) -> Result<Self, Self::Error> {
+        // TODO: check the entire DER-structure.
+        let oid_part = &der_pubkey_bytes[2..(CANISTER_KEY_DER_OID.len() + 2)];
+        if oid_part[..] != CANISTER_KEY_DER_OID[..] {
+            return Err(key_decoding_err("invalid OID of canister key"));
+        }
+        let bitstring_offset: usize = CANISTER_KEY_DER_PREFIX_LENGTH;
+        let canister_id_len: usize = if der_pubkey_bytes.len() > bitstring_offset {
+            usize::from(der_pubkey_bytes[bitstring_offset])
+        } else {
+            return Err(key_decoding_err("canister key shorter than DER prefix"));
+        };
+        if der_pubkey_bytes.len() < (bitstring_offset + 1 + canister_id_len) {
+            return Err(key_decoding_err("canister key too short"));
+        }
+        let canister_id_raw =
+            &der_pubkey_bytes[(bitstring_offset + 1)..(bitstring_offset + 1 + canister_id_len)];
+        let seed = &der_pubkey_bytes[bitstring_offset + canister_id_len + 1..];
+
+        let canister_id = Principal::try_from_slice(canister_id_raw)
+            .map_err(|e| key_decoding_err(&format!("invalid canister id in canister pk: {}", e)))?;
+        Ok(CanisterSigPublicKey {
+            signing_canister_id: canister_id,
+            seed: seed.to_vec(),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum CanisterSigVerificationError {
+    InvalidPublicKey(String),
+    InvalidRootPublicKey,
+    InvalidBlsSignature,
+    InvalidDelegation,
+    CertificateNotAuthorized,
+    Unknown(String),
 }
 
 pub fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
@@ -39,4 +136,68 @@ pub fn canister_sig_pk_der(canister_id: Principal, seed: &[u8]) -> Vec<u8> {
     der.push(0x00);
     der.extend(bitstring);
     der
+}
+
+pub fn verify_root_signature(
+    ic_certificate: &Certificate,
+    signing_canister_id: Principal,
+) -> Result<(), CanisterSigVerificationError> {
+    let signing_pk = validate_delegation(&ic_certificate.delegation, signing_canister_id)?;
+    let root_hash = ic_certificate.tree.digest();
+    let mut msg = vec![];
+    msg.extend_from_slice(IC_STATE_ROOT_DOMAIN_SEPARATOR);
+    msg.extend_from_slice(&root_hash);
+    if verify_bls_signature(&ic_certificate.signature, &msg, &signing_pk).is_err() {
+        return Err(CanisterSigVerificationError::InvalidBlsSignature);
+    }
+    Ok(())
+}
+
+fn validate_delegation(
+    delegation: &Option<Delegation>,
+    signing_canister_id: Principal,
+) -> Result<Vec<u8>, CanisterSigVerificationError> {
+    match delegation {
+        None => {
+            let root_pk = IC_ROOT_PUBLIC_KEY.read().map_err(|_| {
+                CanisterSigVerificationError::Unknown(String::from(
+                    "Internal error accessing IC root public key",
+                ))
+            })?;
+            Ok(root_pk.to_owned())
+        }
+        Some(delegation) => {
+            let cert: Certificate = serde_cbor::from_slice(&delegation.certificate).unwrap();
+            let _ = verify_root_signature(&cert, signing_canister_id);
+            let canister_range_path = [
+                b"subnet",
+                delegation.subnet_id.as_slice(),
+                b"canister_ranges",
+            ];
+            let LookupResult::Found(canister_range) = cert.tree.lookup_path(&canister_range_path)
+            else {
+                return Err(CanisterSigVerificationError::InvalidDelegation);
+            };
+            let ranges: Vec<(Principal, Principal)> =
+                serde_cbor::from_slice(canister_range).unwrap();
+            if !principal_is_within_ranges(&signing_canister_id, &ranges[..]) {
+                return Err(CanisterSigVerificationError::CertificateNotAuthorized);
+            }
+
+            let public_key_path = [b"subnet", delegation.subnet_id.as_slice(), b"public_key"];
+            let LookupResult::Found(pk) = cert.tree.lookup_path(&public_key_path) else {
+                return Err(CanisterSigVerificationError::InvalidDelegation);
+            };
+            Ok(pk.to_vec())
+        }
+    }
+}
+
+// Checks if a principal is contained within a list of principal ranges
+// A range is a tuple: (low: Principal, high: Principal), as described here: https://docs.dfinity.systems/spec/public/#state-tree-subnet
+// Taken from https://github.com/dfinity/agent-rs/blob/60f7a0db21688ca423dee0bb150e142a03e925c6/ic-agent/src/agent/mod.rs#L784
+fn principal_is_within_ranges(principal: &Principal, ranges: &[(Principal, Principal)]) -> bool {
+    ranges
+        .iter()
+        .any(|r| principal >= &r.0 && principal <= &r.1)
 }

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -56,6 +56,7 @@ canister_tests = { path = "../canister_tests" }
 hex-literal = "0.4"
 regex = "1.9"
 ic-response-verification = "1.0"
+serial_test = "2"
 
 
 [features]

--- a/src/internet_identity/tests/integration/vc_mvp.rs
+++ b/src/internet_identity/tests/integration/vc_mvp.rs
@@ -1,15 +1,17 @@
 //! Tests related to prepare_id_alias and get_id_alias canister calls.
+use canister_sig_util::set_ic_root_public_key_for_testing;
 use canister_tests::api::internet_identity as api;
 use canister_tests::flows;
 use canister_tests::framework::*;
 use ic_test_state_machine_client::CallError;
 use identity_jose::jwk::JwkType;
-use identity_jose::jws::{set_ic_root_public_key_for_testing, Decoder};
+use identity_jose::jws::Decoder;
 use identity_jose::jwu::encode_b64;
 use internet_identity_interface::internet_identity::types::vc_mvp::{
     GetIdAliasRequest, GetIdAliasResponse, PrepareIdAliasRequest, PrepareIdAliasResponse,
 };
 use internet_identity_interface::internet_identity::types::FrontendHostname;
+use serial_test::serial;
 use std::ops::Deref;
 use vc_util::verify_credential_jws;
 
@@ -28,6 +30,7 @@ fn verify_canister_sig_pk(credential_jws: &str, canister_sig_pk_der: &[u8]) {
 
 // Verifies that a valid id_alias is created.
 #[test]
+#[serial]
 fn should_get_valid_id_alias() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
@@ -117,6 +120,7 @@ fn should_get_valid_id_alias() -> Result<(), CallError> {
 }
 
 #[test]
+#[serial]
 fn should_get_different_id_alias_for_different_users() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
@@ -220,9 +224,36 @@ fn should_get_different_id_alias_for_different_users() -> Result<(), CallError> 
         id_alias_credentials_2.issuer_id_alias_credential.id_alias
     );
 
+    set_ic_root_public_key_for_testing(env.root_key());
+    verify_credential_jws(
+        &id_alias_credentials_1.rp_id_alias_credential.credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
+    verify_credential_jws(
+        &id_alias_credentials_1
+            .issuer_id_alias_credential
+            .credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
+    verify_credential_jws(
+        &id_alias_credentials_2.rp_id_alias_credential.credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
+    verify_credential_jws(
+        &id_alias_credentials_2
+            .issuer_id_alias_credential
+            .credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
     Ok(())
 }
+
 #[test]
+#[serial]
 fn should_get_different_id_alias_for_different_relying_parties() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
@@ -329,10 +360,37 @@ fn should_get_different_id_alias_for_different_relying_parties() -> Result<(), C
         id_alias_credentials_2.issuer_id_alias_credential.id_alias
     );
 
+    set_ic_root_public_key_for_testing(env.root_key());
+    verify_credential_jws(
+        &id_alias_credentials_1.rp_id_alias_credential.credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
+    verify_credential_jws(
+        &id_alias_credentials_1
+            .issuer_id_alias_credential
+            .credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
+    verify_credential_jws(
+        &id_alias_credentials_2.rp_id_alias_credential.credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
+    verify_credential_jws(
+        &id_alias_credentials_2
+            .issuer_id_alias_credential
+            .credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
+
     Ok(())
 }
 
 #[test]
+#[serial]
 fn should_get_different_id_alias_for_different_issuers() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
@@ -438,6 +496,32 @@ fn should_get_different_id_alias_for_different_issuers() -> Result<(), CallError
         id_alias_credentials_1.issuer_id_alias_credential.id_alias,
         id_alias_credentials_2.issuer_id_alias_credential.id_alias
     );
+
+    set_ic_root_public_key_for_testing(env.root_key());
+    verify_credential_jws(
+        &id_alias_credentials_1.rp_id_alias_credential.credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
+    verify_credential_jws(
+        &id_alias_credentials_1
+            .issuer_id_alias_credential
+            .credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
+    verify_credential_jws(
+        &id_alias_credentials_2.rp_id_alias_credential.credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
+    verify_credential_jws(
+        &id_alias_credentials_2
+            .issuer_id_alias_credential
+            .credential_jws,
+        canister_id,
+    )
+    .expect("external verification failed");
 
     Ok(())
 }

--- a/src/vc_util/Cargo.toml
+++ b/src/vc_util/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2021"
 # ic dependencies
 candid = "0.9"
 ic-cdk = "0.10"
+ic-certification = "0.24.1"
 ic-certified-map = "0.4"
+canister_sig_util = { path = "../canister_sig_util" }
 
 # vc dependencies
 identity_core = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false }
@@ -21,6 +23,7 @@ identity_jose = { git = "https://github.com/frederikrothenberger/identity.rs.git
 hex = "0.4"
 serde = { version = "1", features = ["rc"] }
 serde_bytes = "0.11"
+serde_cbor = "0.11"
 serde_json = "1"
 sha2 = "^0.10" # set bound to match ic-certified-map bound
 

--- a/src/vc_util/src/lib.rs
+++ b/src/vc_util/src/lib.rs
@@ -100,14 +100,14 @@ pub fn verify_credential_jws(
     let jws = decoder
         .decode_compact_serialization(credential_jws.as_ref(), None)
         .map_err(|e| key_decoding_err(&format!("credential JWS parsing error: {}", e)))?;
-    let canister_sig: CanisterSig = serde_cbor::from_slice(&jws.decoded_signature())
+    let canister_sig: CanisterSig = serde_cbor::from_slice(jws.decoded_signature())
         .map_err(|e| invalid_signature_err(&format!("signature parsing error: {}", e)))?;
     let ic_certificate: Certificate = serde_cbor::from_slice(canister_sig.certificate.as_ref())
         .map_err(|e| key_decoding_err(&format!("certificate parsing error: {}", e)))?;
     let jws_header = jws
         .protected_header()
         .ok_or(key_decoding_err("missing JWS header"))?;
-    let canister_sig_pk = get_canister_sig_pk(&jws_header)?;
+    let canister_sig_pk = get_canister_sig_pk(jws_header)?;
 
     ///// Check if root hash of the signatures hash tree matches the certified data in the certificate
     let certified_data_path = [


### PR DESCRIPTION
- move `verify_credential_jws` from `identity_jose` to `vc_util`
- move supporting utils from `identity_jose` to `canister_sig_util`

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8e5f411bb/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

