### PR TITLE
Extract e2e test flow for recovery nag skipping

### DIFF
--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -92,12 +92,8 @@ export const FLOWS = {
     await welcomeView.login();
     await welcomeView.typeUserNumber(userNumber);
     await browser.$("button[data-action='continue']").click();
-    // NOTE: depending on the browser, we issue different warnings. On Safari,
-    // the warning comes before the recovery method selector. Since we only
-    // test on Chrome we always expect the recovery selector first.
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
+    // NOTE: handle recovery nag because there is no recovery phrase
+    await FLOWS.skipRecoveryNag(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(deviceName);
   },
@@ -116,9 +112,7 @@ export const FLOWS = {
     await pinAuthView.waitForDisplay();
     await pinAuthView.enterPin(pin);
     // NOTE: handle recovery nag because there is no recovery phrase
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
+    await FLOWS.skipRecoveryNag(browser);
     const mainView = new MainView(browser);
     await mainView.waitForTempKeyDisplay(deviceName);
   },
@@ -167,5 +161,10 @@ export const FLOWS = {
     const addDeviceSuccessView = new AddDeviceSuccessView(browser);
     await addDeviceSuccessView.waitForDisplay();
     await addDeviceSuccessView.continue();
+  },
+  skipRecoveryNag: async (browser: WebdriverIO.Browser): Promise<void> => {
+    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
+    await recoveryMethodSelectorView.waitForDisplay();
+    await recoveryMethodSelectorView.skipRecovery();
   },
 };

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -18,7 +18,6 @@ import {
   DemoAppView,
   MainView,
   PinAuthView,
-  RecoveryMethodSelectorView,
   RegisterView,
   WelcomeView,
 } from "./views";
@@ -82,9 +81,7 @@ test("Register and log in with PIN identity, retry on wrong PIN", async () => {
     await pinAuthView.enterPin(pin);
 
     // NOTE: handle recovery nag because there is no recovery phrase
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
+    await FLOWS.skipRecoveryNag(browser);
     const mainView2 = new MainView(browser);
     await mainView2.waitForDisplay(); // we should be logged in
   }, APPLE_USER_AGENT);
@@ -166,9 +163,7 @@ test("Register with PIN then log into client application", async () => {
     await pinAuthView.waitForDisplay();
     await pinAuthView.enterPin(pin);
 
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
+    await FLOWS.skipRecoveryNag(browser);
     await waitToClose(browser);
 
     await demoAppView.waitForDisplay();

--- a/src/frontend/src/test-e2e/register.test.ts
+++ b/src/frontend/src/test-e2e/register.test.ts
@@ -8,13 +8,7 @@ import {
   switchToPopup,
   waitToClose,
 } from "./util";
-import {
-  AuthenticateView,
-  DemoAppView,
-  MainView,
-  RecoveryMethodSelectorView,
-  WelcomeView,
-} from "./views";
+import { AuthenticateView, DemoAppView, MainView, WelcomeView } from "./views";
 
 // Read canister ids from the corresponding dfx files.
 // This assumes that they have been successfully dfx-deployed
@@ -102,9 +96,7 @@ test("Register first then log into client application", async () => {
     const authenticateView = new AuthenticateView(browser);
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
+    await FLOWS.skipRecoveryNag(browser);
     await waitToClose(browser);
     await demoAppView.waitForDisplay();
     const principal = await demoAppView.getPrincipal();


### PR DESCRIPTION
This PR extracts a flow for recovery nag skipping in the e2e tests, thus simplifying the code.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
