### PR TITLE
Extract e2e test flow for recovery with seed phrase

### DIFF
--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -5,6 +5,7 @@ import {
   MainView,
   PinAuthView,
   PinRegistrationView,
+  RecoverView,
   RecoveryMethodSelectorView,
   RegisterView,
   WelcomeView,
@@ -166,5 +167,17 @@ export const FLOWS = {
     const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
     await recoveryMethodSelectorView.waitForDisplay();
     await recoveryMethodSelectorView.skipRecovery();
+  },
+  recoverUsingSeedPhrase: async (
+    browser: WebdriverIO.Browser,
+    recoveryPhrase: string
+  ): Promise<void> => {
+    const welcomeView = new WelcomeView(browser);
+    await welcomeView.recover();
+    const recoveryView = new RecoverView(browser);
+    await recoveryView.waitForSeedInputDisplay();
+    await recoveryView.enterSeedPhrase(recoveryPhrase);
+    await recoveryView.enterSeedPhraseContinue();
+    await recoveryView.skipDeviceEnrollment();
   },
 };

--- a/src/frontend/src/test-e2e/recovery/index.test.ts
+++ b/src/frontend/src/test-e2e/recovery/index.test.ts
@@ -1,6 +1,6 @@
 import { FLOWS } from "../flows";
 import { addVirtualAuthenticator, runInBrowser } from "../util";
-import { MainView, RecoverView, WelcomeView } from "../views";
+import { MainView } from "../views";
 
 import { DEVICE_NAME1, II_URL } from "../constants";
 
@@ -18,13 +18,7 @@ test("Recover with phrase", async () => {
     await mainView.waitForDisplay();
     await mainView.logout();
 
-    const welcomeView = new WelcomeView(browser);
-    await welcomeView.recover();
-    const recoveryView = new RecoverView(browser);
-    await recoveryView.waitForSeedInputDisplay();
-    await recoveryView.enterSeedPhrase(seedPhrase);
-    await recoveryView.enterSeedPhraseContinue();
-    await recoveryView.skipDeviceEnrollment();
+    await FLOWS.recoverUsingSeedPhrase(browser, seedPhrase);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
   });
 }, 300_000);

--- a/src/frontend/src/test-e2e/recovery/reset.test.ts
+++ b/src/frontend/src/test-e2e/recovery/reset.test.ts
@@ -1,6 +1,6 @@
 import { FLOWS } from "../flows";
 import { addVirtualAuthenticator, runInBrowser } from "../util";
-import { MainView, RecoverView, WelcomeView } from "../views";
+import { MainView } from "../views";
 
 import { DEVICE_NAME1, II_URL, RECOVERY_PHRASE_NAME } from "../constants";
 
@@ -52,13 +52,7 @@ test("Recover access, after reset", async () => {
     await mainView.logout();
 
     // Recover with new phrase
-    const welcomeView = new WelcomeView(browser);
-    await welcomeView.recover();
-    const recoveryView = new RecoverView(browser);
-    await recoveryView.waitForSeedInputDisplay();
-    await recoveryView.enterSeedPhrase(seedPhrase);
-    await recoveryView.enterSeedPhraseContinue();
-    await recoveryView.skipDeviceEnrollment();
+    await FLOWS.recoverUsingSeedPhrase(browser, seedPhrase);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
   });
 }, 300_000);
@@ -91,13 +85,7 @@ test("Canceling reset keeps old phrase", async () => {
     await mainView.logout();
 
     // Recover with old phrase
-    const welcomeView = new WelcomeView(browser);
-    await welcomeView.recover();
-    const recoveryView = new RecoverView(browser);
-    await recoveryView.waitForSeedInputDisplay();
-    await recoveryView.enterSeedPhrase(seedPhrase);
-    await recoveryView.enterSeedPhraseContinue();
-    await recoveryView.skipDeviceEnrollment();
+    await FLOWS.recoverUsingSeedPhrase(browser, seedPhrase);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
   });
 }, 300_000);
@@ -116,13 +104,7 @@ test("Reset unprotected recovery phrase, when authenticated with phrase", async 
     await mainView.waitForDisplay();
     await mainView.logout();
 
-    const welcomeView = new WelcomeView(browser);
-    await welcomeView.recover();
-    const recoveryView = new RecoverView(browser);
-    await recoveryView.waitForSeedInputDisplay();
-    await recoveryView.enterSeedPhrase(seedPhrase);
-    await recoveryView.enterSeedPhraseContinue();
-    await recoveryView.skipDeviceEnrollment();
+    await FLOWS.recoverUsingSeedPhrase(browser, seedPhrase);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
 
     // Ensure the settings dropdown is in view


### PR DESCRIPTION
This extracts the common recovery phrase flow for the e2e tests. This refactoring is done in preparation to changes to that flow (so it requires change in only one place).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/147224145/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

