### PR TITLE
Do not clear localstorage on logout

### DIFF
--- a/src/frontend/src/components/logout.ts
+++ b/src/frontend/src/components/logout.ts
@@ -15,7 +15,6 @@ export const logoutSection = (
 </div>`;
 
 const logout = () => {
-  localStorage.clear();
   clearHash();
   window.location.reload();
 };

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -94,9 +94,8 @@ export const deleteDevice = async ({
   });
 
   if (sameDevice) {
-    // clear anchor and reload the page.
+    // reload the page.
     // do not call "reload", otherwise the management page will try to reload the list of devices which will cause an error
-    localStorage.clear();
     location.reload();
     return;
   } else {

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -88,11 +88,9 @@ export const FLOWS = {
     deviceName: string,
     browser: WebdriverIO.Browser
   ): Promise<void> => {
-    const welcomeView = new WelcomeView(browser);
-    await welcomeView.waitForDisplay();
-    await welcomeView.login();
-    await welcomeView.typeUserNumber(userNumber);
-    await browser.$("button[data-action='continue']").click();
+    const authenticateView = new AuthenticateView(browser);
+    await authenticateView.waitForDisplay();
+    await authenticateView.pickAnchor(userNumber);
     // This flow assumes no recovery phrase, so we explicitly skip the recovery nag here
     await FLOWS.skipRecoveryNag(browser);
     const mainView = new MainView(browser);
@@ -101,21 +99,16 @@ export const FLOWS = {
   loginPin: async (
     userNumber: string,
     pin: string,
-    deviceName: string,
     browser: WebdriverIO.Browser
   ): Promise<void> => {
-    const welcomeView = new WelcomeView(browser);
-    await welcomeView.waitForDisplay();
-    await welcomeView.login();
-    await welcomeView.typeUserNumber(userNumber);
-    await browser.$("button[data-action='continue']").click();
+    const authenticateView = new AuthenticateView(browser);
+    await authenticateView.waitForDisplay();
+    await authenticateView.pickAnchor(userNumber);
     const pinAuthView = new PinAuthView(browser);
     await pinAuthView.waitForDisplay();
     await pinAuthView.enterPin(pin);
     // This flow assumes no recovery phrase, so we explicitly skip the recovery nag here
     await FLOWS.skipRecoveryNag(browser);
-    const mainView = new MainView(browser);
-    await mainView.waitForTempKeyDisplay(deviceName);
   },
   addRecoveryMechanismSeedPhrase: async (
     browser: WebdriverIO.Browser
@@ -172,8 +165,8 @@ export const FLOWS = {
     browser: WebdriverIO.Browser,
     recoveryPhrase: string
   ): Promise<void> => {
-    const welcomeView = new WelcomeView(browser);
-    await welcomeView.recover();
+    const authenticateView = new AuthenticateView(browser);
+    await authenticateView.recover();
     const recoveryView = new RecoverView(browser);
     await recoveryView.waitForSeedInputDisplay();
     await recoveryView.enterSeedPhrase(recoveryPhrase);

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -54,7 +54,8 @@ test("Register and Log in with PIN identity", async () => {
     await mainView.waitForDisplay(); // we should be logged in
     await mainView.waitForTempKeyDisplay(DEFAULT_PIN_DEVICE_NAME);
     await mainView.logout();
-    await FLOWS.loginPin(userNumber, pin, DEFAULT_PIN_DEVICE_NAME, browser);
+    await FLOWS.loginPin(userNumber, pin, browser);
+    await mainView.waitForTempKeyDisplay(DEFAULT_PIN_DEVICE_NAME);
   }, APPLE_USER_AGENT);
 }, 300_000);
 
@@ -69,11 +70,10 @@ test("Register and log in with PIN identity, retry on wrong PIN", async () => {
     await mainView.waitForDisplay(); // we should be logged in
     await mainView.logout();
 
-    const welcomeView = new WelcomeView(browser);
-    await welcomeView.waitForDisplay();
-    await welcomeView.login();
-    await welcomeView.typeUserNumber(userNumber);
-    await browser.$("button[data-action='continue']").click();
+    const authenticateView = new AuthenticateView(browser);
+    await authenticateView.waitForDisplay();
+    await authenticateView.pickAnchor(userNumber);
+
     const pinAuthView = new PinAuthView(browser);
     await pinAuthView.waitForDisplay();
     await pinAuthView.enterPin(wrongPin);
@@ -155,15 +155,7 @@ test("Register with PIN then log into client application", async () => {
 
     await switchToPopup(browser);
 
-    const authenticateView = new AuthenticateView(browser);
-    await authenticateView.waitForDisplay();
-    await authenticateView.pickAnchor(userNumber);
-
-    const pinAuthView = new PinAuthView(browser);
-    await pinAuthView.waitForDisplay();
-    await pinAuthView.enterPin(pin);
-
-    await FLOWS.skipRecoveryNag(browser);
+    await FLOWS.loginPin(userNumber, pin, browser);
     await waitToClose(browser);
 
     await demoAppView.waitForDisplay();

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -32,16 +32,6 @@ export class WelcomeView extends View {
     await this.browser.$("#loginButton").click();
     await this.browser.$("#addNewDeviceButton").click();
   }
-
-  async recover(): Promise<void> {
-    await this.browser.$("#loginButton").waitForDisplayed();
-    await this.browser.$("#loginButton").scrollIntoView();
-    await this.browser.$("#loginButton").click();
-    await this.browser.$("#recoverButton").waitForDisplayed();
-    await this.browser.$("#recoverButton").scrollIntoView();
-    await this.browser.$("#recoverButton").click();
-    await this.browser.$('[data-action="recover-with-phrase"]').click();
-  }
 }
 
 export class RenameView extends View {
@@ -536,6 +526,17 @@ export class AuthenticateView extends View {
 
   async switchToAnchorInput(): Promise<void> {
     await this.browser.$('[data-role="anchor-input"]').click();
+  }
+
+  async recover(): Promise<void> {
+    await await this.browser.$('[data-role="more-options"]').click();
+    await this.browser.$("#recoverButton").waitForDisplayed();
+    await this.browser.$("#recoverButton").scrollIntoView();
+    await this.browser.$("#recoverButton").click();
+    await this.browser
+      .$('[data-action="recover-with-phrase"]')
+      .waitForDisplayed();
+    await this.browser.$('[data-action="recover-with-phrase"]').click();
   }
 }
 


### PR DESCRIPTION
Deleting identity numbers on logout is unexpected and destructive. A change was requested to no longer do that.

Instead, we should give users a different way of managing the numbers shown on the landing page (to be solved as a separate PR).

Note: 3 lines were changed in the production code. The rest is adapting the e2e tests to use the pick identity flow instead of entering it new.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
