### PR TITLE
Add e2e tests for login without prefilled user number

### DIFF
--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -83,6 +83,19 @@ export const FLOWS = {
     await authenticateView.register();
     return await FLOWS.registerPin(browser, pin);
   },
+  loginWelcomeView: async (
+    userNumber: string,
+    deviceName: string,
+    browser: WebdriverIO.Browser
+  ): Promise<void> => {
+    const welcomeView = new WelcomeView(browser);
+    await welcomeView.waitForDisplay();
+    await welcomeView.login(userNumber);
+    // This flow assumes no recovery phrase, so we explicitly skip the recovery nag here
+    await FLOWS.skipRecoveryNag(browser);
+    const mainView = new MainView(browser);
+    await mainView.waitForDeviceDisplay(deviceName);
+  },
   loginAuthenticateView: async (
     userNumber: string,
     deviceName: string,
@@ -104,6 +117,20 @@ export const FLOWS = {
     const authenticateView = new AuthenticateView(browser);
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
+    const pinAuthView = new PinAuthView(browser);
+    await pinAuthView.waitForDisplay();
+    await pinAuthView.enterPin(pin);
+    // This flow assumes no recovery phrase, so we explicitly skip the recovery nag here
+    await FLOWS.skipRecoveryNag(browser);
+  },
+  loginPinWelcomeView: async (
+    userNumber: string,
+    pin: string,
+    browser: WebdriverIO.Browser
+  ): Promise<void> => {
+    const welcomeView = new WelcomeView(browser);
+    await welcomeView.waitForDisplay();
+    await welcomeView.login(userNumber);
     const pinAuthView = new PinAuthView(browser);
     await pinAuthView.waitForDisplay();
     await pinAuthView.enterPin(pin);

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -59,6 +59,25 @@ test("Register and Log in with PIN identity", async () => {
   }, APPLE_USER_AGENT);
 }, 300_000);
 
+test("Register with PIN and login without prefilled identity number", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    const pin = "123456";
+    await browser.url(II_URL);
+    const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
+
+    const mainView = new MainView(browser);
+    await mainView.waitForTempKeyDisplay(DEFAULT_PIN_DEVICE_NAME);
+
+    // clear local storage, so that the identity number is not prefilled
+    await browser.execute("localStorage.clear()");
+
+    // load the II page again
+    await browser.url(II_URL);
+    await FLOWS.loginPinWelcomeView(userNumber, pin, browser);
+    await mainView.waitForTempKeyDisplay(DEFAULT_PIN_DEVICE_NAME);
+  }, APPLE_USER_AGENT);
+}, 300_000);
+
 test("Register and log in with PIN identity, retry on wrong PIN", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";

--- a/src/frontend/src/test-e2e/register.test.ts
+++ b/src/frontend/src/test-e2e/register.test.ts
@@ -41,6 +41,26 @@ test("Register new identity and login with it", async () => {
   });
 }, 300_000);
 
+test("Register new identity and login without prefilled identity number", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    await browser.url(II_URL);
+    await addVirtualAuthenticator(browser);
+    const userNumber = await FLOWS.registerNewIdentityWelcomeView(
+      DEVICE_NAME1,
+      browser
+    );
+    const mainView = new MainView(browser);
+    await mainView.waitForDeviceDisplay(DEVICE_NAME1);
+
+    // clear local storage, so that the identity number is not prefilled
+    await browser.execute("localStorage.clear()");
+
+    // load the II page again
+    await browser.url(II_URL);
+    await FLOWS.loginWelcomeView(userNumber, DEVICE_NAME1, browser);
+  });
+}, 300_000);
+
 test("Log into client application, after registration", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -13,13 +13,16 @@ export class WelcomeView extends View {
   }
 
   async typeUserNumber(userNumber: string): Promise<void> {
+    await this.browser.$('[data-role="anchor-input"]').waitForDisplayed();
     await this.browser.$('[data-role="anchor-input"]').setValue(userNumber);
   }
 
-  async login(): Promise<void> {
+  async login(userNumber: string): Promise<void> {
     await this.browser.$("#loginButton").waitForDisplayed();
     await this.browser.$("#loginButton").scrollIntoView();
     await this.browser.$("#loginButton").click();
+    await this.typeUserNumber(userNumber);
+    await this.browser.$('[data-action="continue"').click();
   }
 
   async register(): Promise<void> {


### PR DESCRIPTION
Due to the change in #1929 the login flow with unknown user number was no longer tested. This  reintroduces these tests for both webAuthn and PIN login.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

