### PR TITLE
Simplify vc_util API.

### DIFF
--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -20,7 +20,7 @@ use internet_identity_interface::internet_identity::types::FrontendHostname;
 use lazy_static::lazy_static;
 use serial_test::serial;
 use std::path::PathBuf;
-use vc_util::verify_credential_jws;
+use vc_util::{verify_id_alias_credential_jws, AliasTuple};
 
 lazy_static! {
     /** The gzipped Wasm module for the current VC_ISSUER build, i.e. the one we're testing */
@@ -163,11 +163,14 @@ fn should_issue_credential_e2e() -> Result<(), CallError> {
             }
         };
     set_ic_root_public_key_for_testing(env.root_key());
-    verify_credential_jws(
+    verify_id_alias_credential_jws(
         &id_alias_credentials
             .issuer_id_alias_credential
             .credential_jws,
-        ii_id,
+        &AliasTuple {
+            id_alias: id_alias_credentials.issuer_id_alias_credential.id_alias,
+            id_dapp: id_alias_credentials.issuer_id_alias_credential.id_dapp,
+        },
     )
     .expect("Invalid ID alias");
 

--- a/src/internet_identity/tests/integration/vc_mvp.rs
+++ b/src/internet_identity/tests/integration/vc_mvp.rs
@@ -98,11 +98,8 @@ fn should_get_valid_id_alias() -> Result<(), CallError> {
         &id_alias_credentials.rp_id_alias_credential,
         &env.root_key(),
     );
-    verify_credential_jws(
-        &id_alias_credentials.rp_id_alias_credential.credential_jws,
-        canister_id,
-    )
-    .expect("external verification failed");
+    verify_credential_jws(&id_alias_credentials.rp_id_alias_credential.credential_jws)
+        .expect("external verification failed");
     verify_id_alias_credential(
         &env,
         prepared_id_alias.canister_sig_pk.clone(),
@@ -113,7 +110,6 @@ fn should_get_valid_id_alias() -> Result<(), CallError> {
         &id_alias_credentials
             .issuer_id_alias_credential
             .credential_jws,
-        canister_id,
     )
     .expect("external verification failed");
     Ok(())
@@ -225,28 +221,20 @@ fn should_get_different_id_alias_for_different_users() -> Result<(), CallError> 
     );
 
     set_ic_root_public_key_for_testing(env.root_key());
-    verify_credential_jws(
-        &id_alias_credentials_1.rp_id_alias_credential.credential_jws,
-        canister_id,
-    )
-    .expect("external verification failed");
+    verify_credential_jws(&id_alias_credentials_1.rp_id_alias_credential.credential_jws)
+        .expect("external verification failed");
     verify_credential_jws(
         &id_alias_credentials_1
             .issuer_id_alias_credential
             .credential_jws,
-        canister_id,
     )
     .expect("external verification failed");
-    verify_credential_jws(
-        &id_alias_credentials_2.rp_id_alias_credential.credential_jws,
-        canister_id,
-    )
-    .expect("external verification failed");
+    verify_credential_jws(&id_alias_credentials_2.rp_id_alias_credential.credential_jws)
+        .expect("external verification failed");
     verify_credential_jws(
         &id_alias_credentials_2
             .issuer_id_alias_credential
             .credential_jws,
-        canister_id,
     )
     .expect("external verification failed");
     Ok(())
@@ -361,28 +349,20 @@ fn should_get_different_id_alias_for_different_relying_parties() -> Result<(), C
     );
 
     set_ic_root_public_key_for_testing(env.root_key());
-    verify_credential_jws(
-        &id_alias_credentials_1.rp_id_alias_credential.credential_jws,
-        canister_id,
-    )
-    .expect("external verification failed");
+    verify_credential_jws(&id_alias_credentials_1.rp_id_alias_credential.credential_jws)
+        .expect("external verification failed");
     verify_credential_jws(
         &id_alias_credentials_1
             .issuer_id_alias_credential
             .credential_jws,
-        canister_id,
     )
     .expect("external verification failed");
-    verify_credential_jws(
-        &id_alias_credentials_2.rp_id_alias_credential.credential_jws,
-        canister_id,
-    )
-    .expect("external verification failed");
+    verify_credential_jws(&id_alias_credentials_2.rp_id_alias_credential.credential_jws)
+        .expect("external verification failed");
     verify_credential_jws(
         &id_alias_credentials_2
             .issuer_id_alias_credential
             .credential_jws,
-        canister_id,
     )
     .expect("external verification failed");
 
@@ -498,28 +478,20 @@ fn should_get_different_id_alias_for_different_issuers() -> Result<(), CallError
     );
 
     set_ic_root_public_key_for_testing(env.root_key());
-    verify_credential_jws(
-        &id_alias_credentials_1.rp_id_alias_credential.credential_jws,
-        canister_id,
-    )
-    .expect("external verification failed");
+    verify_credential_jws(&id_alias_credentials_1.rp_id_alias_credential.credential_jws)
+        .expect("external verification failed");
     verify_credential_jws(
         &id_alias_credentials_1
             .issuer_id_alias_credential
             .credential_jws,
-        canister_id,
     )
     .expect("external verification failed");
-    verify_credential_jws(
-        &id_alias_credentials_2.rp_id_alias_credential.credential_jws,
-        canister_id,
-    )
-    .expect("external verification failed");
+    verify_credential_jws(&id_alias_credentials_2.rp_id_alias_credential.credential_jws)
+        .expect("external verification failed");
     verify_credential_jws(
         &id_alias_credentials_2
             .issuer_id_alias_credential
             .credential_jws,
-        canister_id,
     )
     .expect("external verification failed");
 

--- a/src/vc_util/src/lib.rs
+++ b/src/vc_util/src/lib.rs
@@ -74,10 +74,10 @@ pub fn verify_id_alias_credential_jws(
     credential_jws: &str,
     alias_tuple: &AliasTuple,
 ) -> Result<(), CredentialVerificationError> {
-    let claims = verify_credential_jws(credential_jws)
-        .map_err(|e| CredentialVerificationError::InvalidJws(e))?;
+    let claims =
+        verify_credential_jws(credential_jws).map_err(CredentialVerificationError::InvalidJws)?;
     validate_id_alias_claims(claims, alias_tuple)
-        .map_err(|e| CredentialVerificationError::InvalidClaims(e))
+        .map_err(CredentialVerificationError::InvalidClaims)
 }
 
 /// Validates that the given claims are consistent with id_alias-credential


### PR DESCRIPTION
- remove redundant argument `signing_canister_id` (it is available via canister public key in the JWK)
- add `verify_id_alias_credential_jws` that check both cryptographic integrity of a credential and semantic validity of the claims.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2efd73e71/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

