### PR TITLE
Fix captcha expiry not being checked in register

### DIFF
--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -71,9 +71,9 @@ pub async fn create_challenge() -> Challenge {
 /// Remove challenges older than CAPTCHA_CHALLENGE_LIFETIME from the inflight challenges map
 fn prune_expired_challenges(inflight_challenges: &mut HashMap<ChallengeKey, ChallengeInfo>) {
     // 5 mins
-    const CAPTCHA_CHALLENGE_LIFETIME: u64 = secs_to_nanos(300);
+    const CAPTCHA_CHALLENGE_LIFETIME_NS: u64 = secs_to_nanos(300);
 
-    inflight_challenges.retain(|_, v| v.created > time() - CAPTCHA_CHALLENGE_LIFETIME);
+    inflight_challenges.retain(|_, v| v.created > time() - CAPTCHA_CHALLENGE_LIFETIME_NS);
 }
 
 // Get a random number generator based on 'raw_rand'

--- a/src/internet_identity/tests/integration/anchor_management/registration/mod.rs
+++ b/src/internet_identity/tests/integration/anchor_management/registration/mod.rs
@@ -163,7 +163,6 @@ fn should_not_allow_wrong_captcha() -> Result<(), CallError> {
 }
 
 /// Tests that there is a time limit for captchas.
-/// Currently only checked by create_challenge, see L2-766.
 #[test]
 fn should_not_allow_expired_captcha() -> Result<(), CallError> {
     let env = env();
@@ -172,8 +171,6 @@ fn should_not_allow_expired_captcha() -> Result<(), CallError> {
     let challenge = api::create_challenge(&env, canister_id)?;
     env.advance_time(Duration::from_secs(301)); // one second longer than captcha validity
 
-    // required because register does not check captcha expiry
-    api::create_challenge(&env, canister_id)?;
     let result = api::register(
         &env,
         canister_id,


### PR DESCRIPTION
Fixes a long standing bug related to captcha expiry. This bug is fixed now, because the API v2 call `identity_register` would be affected as well.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fa3f78490/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

