### PR TITLE
Add API v2 identity_register method

### DIFF
--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -1,11 +1,33 @@
 use candid::Principal;
 use ic_cdk::api::management_canister::main::CanisterId;
-use ic_test_state_machine_client::{call_candid_as, CallError, StateMachine};
-use internet_identity_interface::internet_identity::types::{
-    AuthnMethodAddResponse, AuthnMethodData, AuthnMethodRemoveResponse, IdentityInfoResponse,
-    IdentityMetadataReplaceResponse, IdentityNumber, MetadataEntry, PublicKey,
-};
+use ic_test_state_machine_client::{call_candid, call_candid_as, CallError, StateMachine};
+use internet_identity_interface::internet_identity::types::*;
 use std::collections::HashMap;
+
+pub fn captcha_create(
+    env: &StateMachine,
+    canister_id: CanisterId,
+) -> Result<Option<CaptchaCreateResponse>, CallError> {
+    call_candid(env, canister_id, "captcha_create", ()).map(|(x,)| x)
+}
+
+pub fn identity_register(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    sender: Principal,
+    authn_method: &AuthnMethodData,
+    challenge_attempt: &ChallengeAttempt,
+    temp_key: Option<Principal>,
+) -> Result<Option<IdentityRegisterResponse>, CallError> {
+    call_candid_as(
+        env,
+        canister_id,
+        sender,
+        "identity_register",
+        (authn_method, challenge_attempt, temp_key),
+    )
+    .map(|(x,)| x)
+}
 
 pub fn identity_info(
     env: &StateMachine,

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -99,6 +99,7 @@ export const idlFactory = ({ IDL }) => {
     'png_base64' : IDL.Text,
     'challenge_key' : ChallengeKey,
   });
+  const CaptchaCreateResponse = IDL.Variant({ 'ok' : Challenge });
   const DeployArchiveResult = IDL.Variant({
     'creation_in_progress' : IDL.Null,
     'success' : IDL.Principal,
@@ -215,6 +216,16 @@ export const idlFactory = ({ IDL }) => {
   });
   const IdentityInfoResponse = IDL.Variant({ 'ok' : IdentityInfo });
   const IdentityMetadataReplaceResponse = IDL.Variant({ 'ok' : IDL.Null });
+  const ChallengeResult = IDL.Record({
+    'key' : ChallengeKey,
+    'chars' : IDL.Text,
+  });
+  const IdentityRegisterResponse = IDL.Variant({
+    'ok' : IdentityNumber,
+    'invalid_metadata' : IDL.Text,
+    'bad_challenge' : IDL.Null,
+    'canister_full' : IDL.Null,
+  });
   const UserKey = PublicKey;
   const PrepareIdAliasRequest = IDL.Record({
     'issuer' : FrontendHostname,
@@ -229,10 +240,6 @@ export const idlFactory = ({ IDL }) => {
   const PrepareIdAliasResponse = IDL.Variant({
     'ok' : PreparedIdAlias,
     'authentication_failed' : IDL.Text,
-  });
-  const ChallengeResult = IDL.Record({
-    'key' : ChallengeKey,
-    'chars' : IDL.Text,
   });
   const RegisterResponse = IDL.Variant({
     'bad_challenge' : IDL.Null,
@@ -276,6 +283,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Opt(AuthnMethodRemoveResponse)],
         [],
       ),
+    'captcha_create' : IDL.Func([], [IDL.Opt(CaptchaCreateResponse)], []),
     'create_challenge' : IDL.Func([], [Challenge], []),
     'deploy_archive' : IDL.Func([IDL.Vec(IDL.Nat8)], [DeployArchiveResult], []),
     'enter_device_registration_mode' : IDL.Func([UserNumber], [Timestamp], []),
@@ -312,6 +320,11 @@ export const idlFactory = ({ IDL }) => {
     'identity_metadata_replace' : IDL.Func(
         [IdentityNumber, MetadataMap],
         [IDL.Opt(IdentityMetadataReplaceResponse)],
+        [],
+      ),
+    'identity_register' : IDL.Func(
+        [AuthnMethodData, ChallengeResult, IDL.Opt(IDL.Principal)],
+        [IDL.Opt(IdentityRegisterResponse)],
         [],
       ),
     'init_salt' : IDL.Func([], [], []),

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -220,10 +220,11 @@ export const idlFactory = ({ IDL }) => {
     'key' : ChallengeKey,
     'chars' : IDL.Text,
   });
+  const CaptchaResult = ChallengeResult;
   const IdentityRegisterResponse = IDL.Variant({
     'ok' : IdentityNumber,
     'invalid_metadata' : IDL.Text,
-    'bad_challenge' : IDL.Null,
+    'bad_captcha' : IDL.Null,
     'canister_full' : IDL.Null,
   });
   const UserKey = PublicKey;
@@ -323,7 +324,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'identity_register' : IDL.Func(
-        [AuthnMethodData, ChallengeResult, IDL.Opt(IDL.Principal)],
+        [AuthnMethodData, CaptchaResult, IDL.Opt(IDL.Principal)],
         [IDL.Opt(IdentityRegisterResponse)],
         [],
       ),

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -52,6 +52,7 @@ export interface BufferedArchiveEntry {
   'timestamp' : Timestamp,
 }
 export type CaptchaCreateResponse = { 'ok' : Challenge };
+export type CaptchaResult = ChallengeResult;
 export interface Challenge {
   'png_base64' : string,
   'challenge_key' : ChallengeKey,
@@ -141,7 +142,7 @@ export type IdentityMetadataReplaceResponse = { 'ok' : null };
 export type IdentityNumber = bigint;
 export type IdentityRegisterResponse = { 'ok' : IdentityNumber } |
   { 'invalid_metadata' : string } |
-  { 'bad_challenge' : null } |
+  { 'bad_captcha' : null } |
   { 'canister_full' : null };
 export interface InternetIdentityInit {
   'max_num_latest_delegation_origins' : [] | [bigint],
@@ -268,7 +269,7 @@ export interface _SERVICE {
     [] | [IdentityMetadataReplaceResponse]
   >,
   'identity_register' : ActorMethod<
-    [AuthnMethodData, ChallengeResult, [] | [Principal]],
+    [AuthnMethodData, CaptchaResult, [] | [Principal]],
     [] | [IdentityRegisterResponse]
   >,
   'init_salt' : ActorMethod<[], undefined>,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -51,6 +51,7 @@ export interface BufferedArchiveEntry {
   'anchor_number' : UserNumber,
   'timestamp' : Timestamp,
 }
+export type CaptchaCreateResponse = { 'ok' : Challenge };
 export interface Challenge {
   'png_base64' : string,
   'challenge_key' : ChallengeKey,
@@ -138,6 +139,10 @@ export interface IdentityInfo {
 export type IdentityInfoResponse = { 'ok' : IdentityInfo };
 export type IdentityMetadataReplaceResponse = { 'ok' : null };
 export type IdentityNumber = bigint;
+export type IdentityRegisterResponse = { 'ok' : IdentityNumber } |
+  { 'invalid_metadata' : string } |
+  { 'bad_challenge' : null } |
+  { 'canister_full' : null };
 export interface InternetIdentityInit {
   'max_num_latest_delegation_origins' : [] | [bigint],
   'assigned_user_number_range' : [] | [[bigint, bigint]],
@@ -241,6 +246,7 @@ export interface _SERVICE {
     [IdentityNumber, PublicKey],
     [] | [AuthnMethodRemoveResponse]
   >,
+  'captcha_create' : ActorMethod<[], [] | [CaptchaCreateResponse]>,
   'create_challenge' : ActorMethod<[], Challenge>,
   'deploy_archive' : ActorMethod<[Uint8Array | number[]], DeployArchiveResult>,
   'enter_device_registration_mode' : ActorMethod<[UserNumber], Timestamp>,
@@ -260,6 +266,10 @@ export interface _SERVICE {
   'identity_metadata_replace' : ActorMethod<
     [IdentityNumber, MetadataMap],
     [] | [IdentityMetadataReplaceResponse]
+  >,
+  'identity_register' : ActorMethod<
+    [AuthnMethodData, ChallengeResult, [] | [Principal]],
+    [] | [IdentityRegisterResponse]
   >,
   'init_salt' : ActorMethod<[], undefined>,
   'lookup' : ActorMethod<[UserNumber], Array<DeviceData>>,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -357,6 +357,21 @@ type IdentityInfo = record {
     metadata: MetadataMap;
 };
 
+type CaptchaCreateResponse = variant {
+    ok: Challenge;
+};
+
+type IdentityRegisterResponse = variant {
+    // Registration successful.
+    ok: IdentityNumber;
+    // No more registrations are possible in this instance of the II service canister.
+    canister_full;
+    // The challenge was not successful.
+    bad_challenge;
+    // The metadata of the provided authentication method contains invalid entries.
+    invalid_metadata: text;
+};
+
 type IdentityInfoResponse = variant {
     ok: IdentityInfo;
 };
@@ -473,6 +488,16 @@ service : (opt InternetIdentityInit) -> {
     // with future variant extensions.
     // A client decoding a response as `null` indicates outdated type information
     // and should be treated as an error.
+
+
+    // Creates a new captcha. The solution needs to be submitted using the
+    // `identity_register` call.
+    captcha_create: () -> (opt CaptchaCreateResponse);
+
+    // Registers a new identity with the given authn_method.
+    // A valid captcha solution to a previously generated captcha (using create_captcha) must be provided.
+    // The sender needs to match the supplied authn_method.
+    identity_register: (AuthnMethodData, ChallengeResult, opt principal) -> (opt IdentityRegisterResponse);
 
     // Returns information about the identity with the given number.
     // Requires authentication.

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -241,6 +241,7 @@ type ChallengeResult = record {
     key : ChallengeKey;
     chars : text;
 };
+type CaptchaResult = ChallengeResult;
 
 // Extra information about registration status for new devices
 type DeviceRegistrationInfo = record {
@@ -366,8 +367,8 @@ type IdentityRegisterResponse = variant {
     ok: IdentityNumber;
     // No more registrations are possible in this instance of the II service canister.
     canister_full;
-    // The challenge was not successful.
-    bad_challenge;
+    // The captcha check was not successful.
+    bad_captcha;
     // The metadata of the provided authentication method contains invalid entries.
     invalid_metadata: text;
 };
@@ -497,7 +498,7 @@ service : (opt InternetIdentityInit) -> {
     // Registers a new identity with the given authn_method.
     // A valid captcha solution to a previously generated captcha (using create_captcha) must be provided.
     // The sender needs to match the supplied authn_method.
-    identity_register: (AuthnMethodData, ChallengeResult, opt principal) -> (opt IdentityRegisterResponse);
+    identity_register: (AuthnMethodData, CaptchaResult, opt principal) -> (opt IdentityRegisterResponse);
 
     // Returns information about the identity with the given number.
     // Requires authentication.

--- a/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
@@ -1,9 +1,10 @@
-use canister_tests::api::internet_identity as api;
+use canister_tests::api::internet_identity::api_v2;
+use canister_tests::match_value;
 use ic_cdk::api::management_canister::main::CanisterId;
 use ic_test_state_machine_client::StateMachine;
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, AuthnMethodProtection, ChallengeAttempt, DeviceData,
-    DeviceWithUsage, IdentityNumber, PublicKeyAuthn, Purpose, RegisterResponse,
+    AuthnMethod, AuthnMethodData, AuthnMethodProtection, CaptchaCreateResponse, ChallengeAttempt,
+    IdentityNumber, IdentityRegisterResponse, PublicKeyAuthn, Purpose,
 };
 use serde_bytes::ByteBuf;
 
@@ -36,23 +37,26 @@ pub fn create_identity_with_authn_method(
     canister_id: CanisterId,
     authn_method: &AuthnMethodData,
 ) -> IdentityNumber {
-    let challenge = api::create_challenge(env, canister_id).unwrap();
-    let device = DeviceData::from(DeviceWithUsage::try_from(authn_method.clone()).unwrap());
+    match_value!(
+        api_v2::captcha_create(env, canister_id).unwrap(),
+        Some(CaptchaCreateResponse::Ok(challenge))
+    );
+
     let challenge_attempt = ChallengeAttempt {
         chars: "a".to_string(),
         key: challenge.challenge_key,
     };
-    let RegisterResponse::Registered { user_number } = api::register(
-        env,
-        canister_id,
-        device.principal(),
-        &device,
-        &challenge_attempt,
-        None,
-    )
-    .unwrap() else {
-        panic!("Expected device to be registered");
-    };
+    match_value!(
+        api_v2::identity_register(
+            env,
+            canister_id,
+            authn_method.principal(),
+            authn_method,
+            &challenge_attempt,
+            None,
+        ),
+        Ok(Some(IdentityRegisterResponse::Ok(user_number)))
+    );
     user_number
 }
 

--- a/src/internet_identity/tests/integration/v2_api/identity_register.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_register.rs
@@ -1,0 +1,185 @@
+use crate::v2_api::authn_method_test_helpers::{
+    create_identity_with_authn_method, test_authn_method,
+};
+use candid::Principal;
+use canister_tests::api::internet_identity::api_v2;
+use canister_tests::framework::{
+    arg_with_anchor_range, env, expect_user_error_with_message, install_ii_canister,
+    install_ii_canister_with_arg, II_WASM,
+};
+use canister_tests::match_value;
+use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
+use internet_identity_interface::internet_identity::types::{
+    CaptchaCreateResponse, ChallengeAttempt, IdentityRegisterResponse, MetadataEntry,
+};
+use regex::Regex;
+use serde_bytes::ByteBuf;
+use std::time::Duration;
+
+#[test]
+fn should_register_new_identity() {
+    let env = env();
+    let canister_id =
+        install_ii_canister_with_arg(&env, II_WASM.clone(), arg_with_anchor_range((42, 44)));
+    let authn_method = test_authn_method();
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
+
+    assert_eq!(identity_number, 42);
+}
+
+#[test]
+fn should_register_multiple_identities() {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let authn_method = test_authn_method();
+    let identity_number_1 = create_identity_with_authn_method(&env, canister_id, &authn_method);
+    let identity_number_2 = create_identity_with_authn_method(&env, canister_id, &authn_method);
+
+    assert_ne!(identity_number_1, identity_number_2);
+}
+
+#[test]
+fn should_not_exceed_configured_identity_range() {
+    let env = env();
+    let canister_id =
+        install_ii_canister_with_arg(&env, II_WASM.clone(), arg_with_anchor_range((42, 44)));
+
+    let authn_method = test_authn_method();
+    create_identity_with_authn_method(&env, canister_id, &authn_method);
+    create_identity_with_authn_method(&env, canister_id, &authn_method);
+
+    match_value!(
+        api_v2::captcha_create(&env, canister_id).unwrap(),
+        Some(CaptchaCreateResponse::Ok(challenge))
+    );
+
+    match_value!(
+        api_v2::identity_register(
+            &env,
+            canister_id,
+            authn_method.principal(),
+            &authn_method,
+            &ChallengeAttempt {
+                chars: "a".to_string(),
+                key: challenge.challenge_key,
+            },
+            None,
+        ),
+        Ok(Some(IdentityRegisterResponse::CanisterFull))
+    );
+}
+
+#[test]
+fn should_verify_sender_matches_authn_method() {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+
+    match_value!(
+        api_v2::captcha_create(&env, canister_id).unwrap(),
+        Some(CaptchaCreateResponse::Ok(challenge))
+    );
+
+    let result = api_v2::identity_register(
+        &env,
+        canister_id,
+        Principal::anonymous(),
+        &test_authn_method(),
+        &ChallengeAttempt {
+            chars: "a".to_string(),
+            key: challenge.challenge_key,
+        },
+        None,
+    );
+    expect_user_error_with_message(
+        result,
+        CanisterCalledTrap,
+        Regex::new("[a-z\\d-]+ could not be authenticated against").unwrap(),
+    );
+}
+
+#[test]
+fn should_not_allow_wrong_captcha() {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let authn_method = test_authn_method();
+
+    match_value!(
+        api_v2::captcha_create(&env, canister_id).unwrap(),
+        Some(CaptchaCreateResponse::Ok(challenge))
+    );
+
+    match_value!(
+        api_v2::identity_register(
+            &env,
+            canister_id,
+            authn_method.principal(),
+            &authn_method,
+            &ChallengeAttempt {
+                chars: "wrong solution".to_string(),
+                key: challenge.challenge_key,
+            },
+            None,
+        ),
+        Ok(Some(IdentityRegisterResponse::BadChallenge))
+    );
+}
+
+#[test]
+fn should_not_allow_expired_captcha() {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let authn_method = test_authn_method();
+
+    match_value!(
+        api_v2::captcha_create(&env, canister_id).unwrap(),
+        Some(CaptchaCreateResponse::Ok(challenge))
+    );
+
+    env.advance_time(Duration::from_secs(301)); // one second longer than captcha validity
+
+    match_value!(
+        api_v2::identity_register(
+            &env,
+            canister_id,
+            authn_method.principal(),
+            &authn_method,
+            &ChallengeAttempt {
+                chars: "wrong solution".to_string(),
+                key: challenge.challenge_key,
+            },
+            None,
+        ),
+        Ok(Some(IdentityRegisterResponse::BadChallenge))
+    );
+}
+
+#[test]
+fn should_fail_on_invalid_metadata() {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let mut authn_method = test_authn_method();
+    authn_method.metadata.insert(
+        "usage".to_string(),
+        MetadataEntry::Bytes(ByteBuf::from("invalid")),
+    );
+
+    match_value!(
+        api_v2::captcha_create(&env, canister_id).unwrap(),
+        Some(CaptchaCreateResponse::Ok(challenge))
+    );
+
+    match_value!(
+        api_v2::identity_register(
+            &env,
+            canister_id,
+            authn_method.principal(),
+            &authn_method,
+            &ChallengeAttempt {
+                chars: "a".to_string(),
+                key: challenge.challenge_key,
+            },
+            None,
+        ),
+        Ok(Some(IdentityRegisterResponse::InvalidMetadata(_)))
+    );
+}

--- a/src/internet_identity/tests/integration/v2_api/identity_register.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_register.rs
@@ -120,7 +120,7 @@ fn should_not_allow_wrong_captcha() {
             },
             None,
         ),
-        Ok(Some(IdentityRegisterResponse::BadChallenge))
+        Ok(Some(IdentityRegisterResponse::BadCaptcha))
     );
 }
 
@@ -149,7 +149,7 @@ fn should_not_allow_expired_captcha() {
             },
             None,
         ),
-        Ok(Some(IdentityRegisterResponse::BadChallenge))
+        Ok(Some(IdentityRegisterResponse::BadCaptcha))
     );
 }
 

--- a/src/internet_identity/tests/integration/v2_api/mod.rs
+++ b/src/internet_identity/tests/integration/v2_api/mod.rs
@@ -3,3 +3,4 @@ mod authn_method_remove;
 pub mod authn_method_test_helpers;
 mod identity_info;
 mod identity_metadata;
+mod identity_register;

--- a/src/internet_identity_interface/src/internet_identity/conversions.rs
+++ b/src/internet_identity_interface/src/internet_identity/conversions.rs
@@ -250,3 +250,15 @@ impl TryFrom<AuthnMethodData> for DeviceWithUsage {
         })
     }
 }
+
+impl From<RegisterResponse> for IdentityRegisterResponse {
+    fn from(register_response: RegisterResponse) -> Self {
+        match register_response {
+            RegisterResponse::Registered { user_number } => {
+                IdentityRegisterResponse::Ok(user_number)
+            }
+            RegisterResponse::CanisterFull => IdentityRegisterResponse::CanisterFull,
+            RegisterResponse::BadChallenge => IdentityRegisterResponse::BadChallenge,
+        }
+    }
+}

--- a/src/internet_identity_interface/src/internet_identity/conversions.rs
+++ b/src/internet_identity_interface/src/internet_identity/conversions.rs
@@ -258,7 +258,7 @@ impl From<RegisterResponse> for IdentityRegisterResponse {
                 IdentityRegisterResponse::Ok(user_number)
             }
             RegisterResponse::CanisterFull => IdentityRegisterResponse::CanisterFull,
-            RegisterResponse::BadChallenge => IdentityRegisterResponse::BadChallenge,
+            RegisterResponse::BadChallenge => IdentityRegisterResponse::BadCaptcha,
         }
     }
 }

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -104,7 +104,7 @@ pub enum MetadataEntry {
     Map(HashMap<String, MetadataEntry>),
 }
 
-#[derive(Clone, Debug, CandidType, Deserialize)]
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct Challenge {
     pub png_base64: String,
     pub challenge_key: ChallengeKey,

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -1,4 +1,6 @@
-use crate::internet_identity::types::{CredentialId, MetadataEntry, PublicKey, Purpose, Timestamp};
+use crate::internet_identity::types::{
+    Challenge, CredentialId, MetadataEntry, PublicKey, Purpose, Timestamp,
+};
 use candid::{CandidType, Deserialize};
 use std::collections::HashMap;
 
@@ -57,6 +59,24 @@ pub struct IdentityInfo {
     pub authn_methods: Vec<AuthnMethodData>,
     pub authn_method_registration: Option<AuthnMethodRegistration>,
     pub metadata: HashMap<String, MetadataEntry>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum CaptchaCreateResponse {
+    #[serde(rename = "ok")]
+    Ok(Challenge),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum IdentityRegisterResponse {
+    #[serde(rename = "ok")]
+    Ok(IdentityNumber),
+    #[serde(rename = "canister_full")]
+    CanisterFull,
+    #[serde(rename = "bad_challenge")]
+    BadChallenge,
+    #[serde(rename = "invalid_metadata")]
+    InvalidMetadata(String),
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -73,8 +73,8 @@ pub enum IdentityRegisterResponse {
     Ok(IdentityNumber),
     #[serde(rename = "canister_full")]
     CanisterFull,
-    #[serde(rename = "bad_challenge")]
-    BadChallenge,
+    #[serde(rename = "bad_captcha")]
+    BadCaptcha,
     #[serde(rename = "invalid_metadata")]
     InvalidMetadata(String),
 }


### PR DESCRIPTION
This PR adds the API v2 `captcha_create` and `identity_register` methods to II. It also removes the calls to the legacy API from the API v2 integration tests.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->





<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7d92ddd55/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7d92ddd55/mobile/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->




