### PR TITLE
Add ability to issue "VerifiedEmployee" verifiable certificates.

### DIFF
--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -1061,9 +1061,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "lock_api"
@@ -1131,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -1266,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]

--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -47,6 +47,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "autocfg"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,6 +1879,7 @@ dependencies = [
 name = "vc_issuer"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "candid",
  "canister_sig_util 0.1.0",
  "canister_tests",

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -35,6 +35,7 @@ serial_test = "2"
 sha2 = "^0.10" # set bound to match ic-certified-map bound
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 ic-test-state-machine-client = "3"
 canister_tests = { path = "../../src/canister_tests" }
 lazy_static = "1.4"

--- a/demos/vc_issuer/vc_issuer.did
+++ b/demos/vc_issuer/vc_issuer.did
@@ -49,6 +49,7 @@ type SignedIdAlias = record {
     id_dapp : principal;
 };
 service : {
+    add_employee : (principal) -> (text);
     consent_message : (Icrc21ConsentMessageRequest) -> (
     Icrc21ConsentMessageResponse,
     );

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 sha2 = "^0.10" # set bound to match ic-certified-map bound
 
 # Captcha deps
-lodepng = "3.7.2"
+lodepng = "*"
 base64 = "*"
 
 rand = { version ="*", default-features = false }

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 sha2 = "^0.10" # set bound to match ic-certified-map bound
 
 # Captcha deps
-lodepng = "*"
+lodepng = "3.7.2"
 base64 = "*"
 
 rand = { version ="*", default-features = false }


### PR DESCRIPTION
Add to the example VC-issuer ability to issue certificates for employment.
Also, add `add_employee`-API to enable adding "authorised employee" principals (for testing purposes).


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c673c0da5/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


