### PR TITLE
Add an example failure to RP-flow spec.

### DIFF
--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -183,7 +183,7 @@ After receiving the notification that II is ready, the relying party can request
     * `credentialId`: The ID of the credential that the relying party wants to request from the issuer.
   * `credentialSubject`: The subject of the credential as known to the relying party. Internet Identity will use this principal to ensure that the flow is completed using the matching identity.
 
-#### Example
+_Example_
 
 ```json
 {
@@ -200,16 +200,18 @@ After receiving the notification that II is ready, the relying party can request
 }
 ```
 
-### 3: Receive Verifiable Presentation
+### 3: Get a Response
+
+
+#### Receive a Verifiable Presentation
 
 After the user has successfully completed the flow, Internet Identity will respond with the following JSON-RPC response:
 
-* Result:
   * `verifiablePresentation`: The JWT based verifiable presentation containing two credentials: 
     1. A verifiable credential issued by Internet Identity that relates the requested `credentialSubject` to another alias principal.
     2. A verifiable credential issued by on of the requested issuers issued to the alias principal.
 
-#### Example
+_Example_
 
 ```json
 {
@@ -222,6 +224,27 @@ After the user has successfully completed the flow, Internet Identity will respo
 ```
 
 An example of such a verifiable presentation can be found [here](https://www.w3.org/TR/vc-data-model/#example-jwt-payload-of-a-jwt-based-verifiable-presentation-non-normative).
+
+#### Receive an Error Message
+
+If the flow failed for any reason, Internet Identity returns an error.
+For privacy protection, the error does not give any details on the root cause of the failure.
+(This may change in the future, as some failures can be reported to the relying
+party without impacting user's privacy.)
+
+_Example_
+
+``` json
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "error": {
+        "version": "1",
+        "errorType": "UNKNOWN"
+    }
+}
+```
+
 
 #### Interaction Model
 


### PR DESCRIPTION
Add an example failure to the specification of interaction between relying party and identity provider.