### PR TITLE
Simplify canister ID injection & SRI

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -14,10 +14,5 @@
   <body>
     <main id="pageContent" aria-live="polite"></main>
     <div id="loaderContainer"></div>
-
-    <!-- this is replaced by the backend before serving -->
-    <!-- XXX: DO NOT CHANGE! or if you do, change the bit that matches on this
-      exact string in the canister code-->
-    <script id="setupJs"></script>
   </body>
 </html>

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -28,7 +28,9 @@ globalThis.Buffer = Buffer;
  */
 const readCanisterId = (): string => {
   // The backend uses a known element ID so that we can pick up the value from here
-  const setupJs = document.querySelector("#setupJs") as HTMLElement | null;
+  const setupJs = document.querySelector(
+    "[data-canister-id]"
+  ) as HTMLElement | null;
   if (isNullish(setupJs) || isNullish(setupJs.dataset.canisterId)) {
     void displayError({
       title: "Canister ID not set",

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -95,16 +95,17 @@ pub enum ContentType {
 }
 
 // The <script> tag that loads the 'index.js'
-const JS_SETUP_SCRIPT: &str = "let s = document.createElement('script');s.type = 'module';s.src = 'index.js';document.head.appendChild(s);";
+const JS_SETUP_SCRIPT: &str = "let s = document.createElement('script');s.type = 'module';s.src = '/index.js';document.head.appendChild(s);";
 
 // Fix up HTML pages, by injecting canister ID, script tag and CSP
 fn fixup_html(html: &str) -> String {
     let canister_id = api::id();
     let setup_js: String = JS_SETUP_SCRIPT.to_string();
     let html = html.replace(
-        r#"<script id="setupJs"></script>"#,
-        &format!(r#"<script data-canister-id="{canister_id}" id="setupJs">{setup_js}</script>"#),
+        r#"<script type="module" crossorigin src="/index.js"></script>"#,
+        &format!(r#"<script data-canister-id="{canister_id}" type="module">{setup_js}</script>"#),
     );
+
     html.replace(
         "<meta replaceme-with-csp/>",
         &format!(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,6 @@ import {
   compression,
   injectCanisterIdPlugin,
   minifyHTML,
-  stripInjectJsScript,
 } from "./vite.plugins";
 
 export const aliasConfig: AliasOptions = {
@@ -58,11 +57,7 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
     },
     plugins: [
       [...(mode === "development" ? [injectCanisterIdPlugin()] : [])],
-      [
-        ...(mode === "production"
-          ? [stripInjectJsScript(), minifyHTML(), compression()]
-          : []),
-      ],
+      [...(mode === "production" ? [minifyHTML(), compression()] : [])],
     ],
     optimizeDeps: {
       esbuildOptions: {


### PR DESCRIPTION
This updates the transforming that we do of HTML files. This transforming handles injecting the canister ID & figuring out the correct SRI directive.

Instead of having a custom `#setupJs` element in `index.html` that we used to replace, we now directly use the `<script>` tag generated by vitejs during the build. This means we do not need to strip the vitejs script tag anymore (i.e. no need for the strip plugin).

Moreover, the `src` of the canister-injected tag is fixed to point to the same absolute path as vite (was `index.js`, is now `/index.js`).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47c8b4d7d/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

