### PR TITLE
Reuse usePinPage

### DIFF
--- a/src/frontend/src/flows/pin/usePin.ts
+++ b/src/frontend/src/flows/pin/usePin.ts
@@ -57,7 +57,11 @@ const usePinTemplate = <T>({
   });
 };
 
-export const usePinPage = renderPage(usePinTemplate);
+export const usePinPage = <T>(
+  props: Parameters<typeof usePinTemplate<T>>[0],
+  container?: HTMLElement
+) => renderPage(usePinTemplate<T>)(props, container);
+
 export const usePin = <T>({
   verifyPin,
 }: {
@@ -66,7 +70,7 @@ export const usePin = <T>({
   { kind: "pin"; result: T } | { kind: "canceled" } | { kind: "passkey" }
 > => {
   return new Promise((resolve) =>
-    renderPage(usePinTemplate<T>)({
+    usePinPage<T>({
       i18n: new I18n(),
       onUsePasskey: () => resolve({ kind: "passkey" }),
       verify: verifyPin,


### PR DESCRIPTION
This makes `usePinPage` generic so that it can actually be used in `usePin` instead of redefining the page.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/438445d64/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
