### PR TITLE
Allow toast message overflow

### DIFF
--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1131,6 +1131,9 @@ by all browsers (FF is missing) */
 }
 
 .c-toast-body__message {
+  /* Ensures the content doesn't grow out of the toast or push other items */
+  overflow-x: auto;
+
   flex: 1 1 auto;
   font-size: 0.8em;
   line-height: 1.2;

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -609,6 +609,9 @@ export const iiPages: Record<string, () => void> = {
     toast.error(
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec varius tellus id massa lobortis, et luctus nulla consequat. Phasellus lacinia velit non quam placerat imperdiet. In elementum orci sit amet malesuada eleifend. Vestibulum ultricies fringilla lorem sit amet laoreet. Suspendisse aliquet tincidunt risus, sed pellentesque purus porttitor nec."
     );
+    toast.error(
+      "Loremipsumdolorsitamet,consecteturadipiscingelit.Donecvariustellusidmassalobortis,etluctusnullaconsequat.Phaselluslaciniavelitnonquamplaceratimperdiet.Inelementumorcisitametmalesuadaeleifend.Vestibulumultriciesfringillaloremsitametlaoreet.Suspendissealiquettinciduntrisus,sedpellentesquepurusporttitornec."
+    );
   },
   dappsExplorer: () => {
     dappsExplorerPage({ dapps, i18n, back: () => console.log("back") });


### PR DESCRIPTION
This adds a scrollbar to toast messages in case they are too long. Before this, content too long would push the close button out of the toast.

---

Before:

<img width="512" alt="Screenshot 2023-10-16 at 15 54 13" src="https://github.com/dfinity/internet-identity/assets/6930756/b0ed353c-9ea3-4fec-bb1f-c30368f5e629">

After:

<img width="512" alt="Screenshot 2023-10-16 at 15 54 21" src="https://github.com/dfinity/internet-identity/assets/6930756/64a336f7-5611-44dc-ae52-c4a5ca2a21de">

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7a14f4b8a/desktop/toasts.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7a14f4b8a/mobile/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7a14f4b8a/mobile/toasts.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

