### PR TITLE
Apply pending changes to Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "canister_sig_util"
+version = "0.1.0"
+dependencies = [
+ "ic-certified-map",
+ "rand",
+ "sha2",
+]
+
+[[package]]
 name = "canister_tests"
 version = "0.1.0"
 dependencies = [
@@ -815,6 +824,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.21.2",
  "candid",
+ "canister_sig_util",
  "canister_tests",
  "captcha",
  "getrandom",


### PR DESCRIPTION
The PR #1961 updated the `Cargo.toml` but not the `Cargo.lock`. This PR updates the `Cargo.lock` file accordingly.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
