### PR TITLE
Fix temp keys clashing on equal public keys

### DIFF
--- a/src/internet_identity/src/state/temp_keys.rs
+++ b/src/internet_identity/src/state/temp_keys.rs
@@ -9,9 +9,10 @@ const TEMP_KEY_EXPIRATION_NS: u64 = 10 * MINUTE_NS;
 
 #[derive(Default, Debug)]
 pub struct TempKeys {
-    /// A map of "temporary keys" attached to devices (and a specific anchor). A temporary key can be used in lieu
-    /// of the device but has a short expiration time. These keys are used as a workaround for WebAuthn
-    /// needing two users interactions: one for "create" and one for "sign". So instead we only "create"
+    /// A map of "temporary keys" attached to specific anchor and device combination.
+    /// A temporary key can be used in lieu of the device but has a short expiration time.
+    /// These keys are used as a workaround for WebAuthn needing two users interactions:
+    /// one for "create" and one for "sign". So instead we only "create"
     /// and instead authenticate the user with a temporary key for their first visit.
     ///
     /// Note: we link the temporary keys to a device so that we can make sure the temporary key is dropped
@@ -25,7 +26,7 @@ pub struct TempKeys {
     ///
     /// Since temp keys can only be added during registration, the the max number of temp keys is
     /// bounded by the registration rate limit.
-    temp_keys: HashMap<DeviceKey, TempKey>,
+    temp_keys: HashMap<(AnchorNumber, DeviceKey), TempKey>,
 
     /// Deque to efficiently prune expired temp keys
     expirations: VecDeque<TempKeyExpiration>,
@@ -40,27 +41,22 @@ impl TempKeys {
     ) {
         let tmp_key = TempKey {
             principal: temp_key,
-            anchor,
             expiration: time() + TEMP_KEY_EXPIRATION_NS,
         };
 
         self.expirations.push_back(TempKeyExpiration {
             device_key: device_key.clone(),
             expiration: tmp_key.expiration,
+            anchor,
         });
-        self.temp_keys.insert(device_key.clone(), tmp_key);
+        self.temp_keys.insert((anchor, device_key.clone()), tmp_key);
     }
 
     /// Removes the temporary key for the given device if it exists and is linked to the provided anchor.
     pub fn remove_temp_key(&mut self, anchor: AnchorNumber, device_key: &DeviceKey) {
         // we can skip the removal from expirations because there it will be removed
         // during amortized clean-up operations
-        if let Some(temp_key) = self.temp_keys.get(device_key) {
-            if temp_key.anchor == anchor {
-                // Only remove temp key if the anchor matches
-                self.temp_keys.remove(device_key);
-            }
-        }
+        self.temp_keys.remove(&(anchor, device_key.clone()));
     }
 
     /// Checks that the temporary key is valid for the given device and anchor.
@@ -74,13 +70,10 @@ impl TempKeys {
     ) -> Result<(), ()> {
         self.prune_expired_keys();
 
-        let Some(temp_key) = self.temp_keys.get(device_key) else {
+        let Some(temp_key) = self.temp_keys.get(&(anchor, device_key.clone())) else {
             return Err(());
         };
         if temp_key.expiration < time() {
-            return Err(());
-        }
-        if temp_key.anchor != anchor {
             return Err(());
         }
         if &temp_key.principal != caller {
@@ -104,7 +97,8 @@ impl TempKeys {
             if expiration.expiration > now {
                 break;
             }
-            self.temp_keys.remove(&expiration.device_key);
+            self.temp_keys
+                .remove(&(expiration.anchor, expiration.device_key.clone()));
             self.expirations.pop_front();
         }
     }
@@ -118,8 +112,6 @@ impl TempKeys {
 pub struct TempKey {
     /// The temp key principal
     principal: Principal,
-    /// The anchor the temporary key is linked to
-    anchor: AnchorNumber,
     /// The expiration timestamp of the temp key
     expiration: Timestamp,
 }
@@ -130,4 +122,6 @@ pub struct TempKeyExpiration {
     pub device_key: DeviceKey,
     /// The expiration timestamp of the temp key
     pub expiration: Timestamp,
+    /// The anchor the temporary key is linked to
+    anchor: AnchorNumber,
 }

--- a/src/internet_identity/src/state/temp_keys.rs
+++ b/src/internet_identity/src/state/temp_keys.rs
@@ -45,9 +45,8 @@ impl TempKeys {
         };
 
         self.expirations.push_back(TempKeyExpiration {
-            device_key: device_key.clone(),
+            key: (anchor, device_key.clone()),
             expiration: tmp_key.expiration,
-            anchor,
         });
         self.temp_keys.insert((anchor, device_key.clone()), tmp_key);
     }
@@ -97,8 +96,7 @@ impl TempKeys {
             if expiration.expiration > now {
                 break;
             }
-            self.temp_keys
-                .remove(&(expiration.anchor, expiration.device_key.clone()));
+            self.temp_keys.remove(&expiration.key);
             self.expirations.pop_front();
         }
     }
@@ -118,10 +116,8 @@ pub struct TempKey {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TempKeyExpiration {
-    /// The device key the temp key is linked to
-    pub device_key: DeviceKey,
+    /// Key with which to find the temp key in the `temp_keys` map
+    pub key: (AnchorNumber, DeviceKey),
     /// The expiration timestamp of the temp key
     pub expiration: Timestamp,
-    /// The anchor the temporary key is linked to
-    anchor: AnchorNumber,
 }


### PR DESCRIPTION
This PR fixes a bug that surfaced in the context of the dev build where the dummy auth public key is static for all anchors: The temp keys were kept by device public key only, which lead to subsequent registrations evicting the temp key of the previous dummy auth device.
Additionally, expirations are only cleaned up lazily and also were only checking the device public key. This lead to the behaviour where a newly registered temp key was not considered valid, because it matched the expiration of a previous registration.

None of the issues above are observed in production, because WebAuthn generates new public keys for each registration, even if the same hardware is used.

The fix moves the anchor into the temp key identifier, making it different for different anchors. This addresses both of the issues outlined above.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

