### PR TITLE
Rename canister_sig_util to canister_sig_util_br.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,23 @@ dependencies = [
 [[package]]
 name = "canister_sig_util"
 version = "0.1.0"
+source = "git+https://github.com/dfinity/internet-identity.git?branch=vc-mvp-2#b14456729909534027a5007e2b3a0e28f27b237f"
+dependencies = [
+ "candid 0.9.7",
+ "ic-cdk",
+ "ic-certification 0.24.1",
+ "ic-certified-map",
+ "ic-verify-bls-signature",
+ "lazy_static",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "sha2 0.10.7",
+]
+
+[[package]]
+name = "canister_sig_util_br"
+version = "0.1.0"
 dependencies = [
  "candid 0.9.7",
  "hex",
@@ -426,23 +443,6 @@ dependencies = [
  "ic-verify-bls-signature",
  "lazy_static",
  "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "sha2 0.10.7",
-]
-
-[[package]]
-name = "canister_sig_util"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/internet-identity.git?branch=vc-mvp-2#b14456729909534027a5007e2b3a0e28f27b237f"
-dependencies = [
- "candid 0.9.7",
- "ic-cdk",
- "ic-certification 0.24.1",
- "ic-certified-map",
- "ic-verify-bls-signature",
- "lazy_static",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -1983,7 +1983,7 @@ version = "0.7.0-alpha.6"
 source = "git+https://github.com/frederikrothenberger/identity.rs.git?branch=frederik/wasm-test#83e24f17f3d65b070a90a95515824ebae0c47180"
 dependencies = [
  "candid 0.9.7",
- "canister_sig_util 0.1.0 (git+https://github.com/dfinity/internet-identity.git?branch=vc-mvp-2)",
+ "canister_sig_util",
  "hex",
  "ic-certification 0.24.1",
  "ic-certified-map",
@@ -2081,7 +2081,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.21.4",
  "candid 0.9.7",
- "canister_sig_util 0.1.0",
+ "canister_sig_util_br",
  "canister_tests",
  "captcha",
  "getrandom",
@@ -3682,7 +3682,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "candid 0.9.7",
- "canister_sig_util 0.1.0",
+ "canister_sig_util_br",
  "canister_tests",
  "hex",
  "ic-cbor",

--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -200,11 +200,11 @@ dependencies = [
 [[package]]
 name = "canister_sig_util"
 version = "0.1.0"
+source = "git+https://github.com/dfinity/internet-identity.git?branch=vc-mvp-2#b14456729909534027a5007e2b3a0e28f27b237f"
 dependencies = [
  "candid",
- "hex",
  "ic-cdk",
- "ic-certification 1.2.0",
+ "ic-certification 0.24.1",
  "ic-certified-map",
  "ic-verify-bls-signature",
  "lazy_static",
@@ -215,13 +215,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "canister_sig_util"
+name = "canister_sig_util_br"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/internet-identity.git?branch=vc-mvp-2#b14456729909534027a5007e2b3a0e28f27b237f"
 dependencies = [
  "candid",
+ "hex",
  "ic-cdk",
- "ic-certification 0.24.1",
+ "ic-certification 1.2.0",
  "ic-certified-map",
  "ic-verify-bls-signature",
  "lazy_static",
@@ -942,7 +942,7 @@ version = "0.7.0-alpha.6"
 source = "git+https://github.com/frederikrothenberger/identity.rs.git?branch=frederik/wasm-test#83e24f17f3d65b070a90a95515824ebae0c47180"
 dependencies = [
  "candid",
- "canister_sig_util 0.1.0 (git+https://github.com/dfinity/internet-identity.git?branch=vc-mvp-2)",
+ "canister_sig_util",
  "hex",
  "ic-certification 0.24.1",
  "ic-certified-map",
@@ -1881,7 +1881,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "candid",
- "canister_sig_util 0.1.0",
+ "canister_sig_util_br",
  "canister_tests",
  "hex",
  "ic-cdk",
@@ -1908,7 +1908,7 @@ name = "vc_util"
 version = "0.1.0"
 dependencies = [
  "candid",
- "canister_sig_util 0.1.0",
+ "canister_sig_util_br",
  "hex",
  "ic-cdk",
  "ic-certification 1.2.0",

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 # local dependencies
-canister_sig_util = { path = "../../src/canister_sig_util_br" }
+canister_sig_util_br = { path = "../../src/canister_sig_util_br" }
 internet_identity_interface = { path = "../../src/internet_identity_interface" }
 vc_util = { path = "../../src/vc_util_br" }
 # ic dependencies

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -1,5 +1,5 @@
 use candid::{candid_method, Principal};
-use canister_sig_util::{canister_sig_pk_der, hash_bytes};
+use canister_sig_util_br::{canister_sig_pk_der, hash_bytes};
 use ic_cdk_macros::{query, update};
 use ic_certified_map::{Hash, HashTree};
 use identity_core::common::Url;
@@ -15,7 +15,7 @@ use serde_bytes::ByteBuf;
 use serde_json::json;
 use std::cell::RefCell;
 
-use canister_sig_util::signature_map::{SignatureMap, LABEL_SIG};
+use canister_sig_util_br::signature_map::{SignatureMap, LABEL_SIG};
 use ic_cdk::api::{data_certificate, set_certified_data, time};
 use ic_cdk::trap;
 use std::collections::HashSet;

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -2,7 +2,7 @@
 
 use assert_matches::assert_matches;
 use candid::Principal;
-use canister_sig_util::set_ic_root_public_key_for_testing;
+use canister_sig_util_br::set_ic_root_public_key_for_testing;
 use canister_tests::api::internet_identity::vc_mvp as ii_api;
 use canister_tests::flows;
 use canister_tests::framework::{env, get_wasm_path, principal_1, principal_2, II_WASM};

--- a/src/canister_sig_util_br/Cargo.toml
+++ b/src/canister_sig_util_br/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "canister_sig_util"
-description = "Utils for handling canister signatures"
+name = "canister_sig_util_br"
+description = "Utils for handling canister signatures (branch version)"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-canister_sig_util = { path = "../canister_sig_util_br" }
+canister_sig_util_br = { path = "../canister_sig_util_br" }
 internet_identity_interface = { path = "../internet_identity_interface" }
 vc_util = { path = "../vc_util_br" }
 

--- a/src/internet_identity/src/vc_mvp.rs
+++ b/src/internet_identity/src/vc_mvp.rs
@@ -2,7 +2,7 @@ use crate::assets::CertifiedAssets;
 use crate::delegation::check_frontend_length;
 use crate::{delegation, hash, state, update_root_hash, LABEL_SIG, MINUTE_NS};
 use candid::Principal;
-use canister_sig_util::canister_sig_pk_der;
+use canister_sig_util_br::canister_sig_pk_der;
 use ic_cdk::api::{data_certificate, time};
 use ic_cdk::trap;
 use ic_certified_map::{Hash, HashTree};

--- a/src/internet_identity/tests/integration/vc_mvp.rs
+++ b/src/internet_identity/tests/integration/vc_mvp.rs
@@ -1,5 +1,5 @@
 //! Tests related to prepare_id_alias and get_id_alias canister calls.
-use canister_sig_util::set_ic_root_public_key_for_testing;
+use canister_sig_util_br::set_ic_root_public_key_for_testing;
 use canister_tests::api::internet_identity as api;
 use canister_tests::flows;
 use canister_tests::framework::*;

--- a/src/vc_util_br/Cargo.toml
+++ b/src/vc_util_br/Cargo.toml
@@ -10,7 +10,7 @@ candid = "0.9"
 ic-cdk = "0.10"
 ic-certification = { version = "1.2.0", features = ["serde", "serde_bytes"] }
 ic-certified-map = "0.4"
-canister_sig_util = { path = "../canister_sig_util_br" }
+canister_sig_util_br = { path = "../canister_sig_util_br" }
 
 # vc dependencies
 identity_core = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false }

--- a/src/vc_util_br/src/lib.rs
+++ b/src/vc_util_br/src/lib.rs
@@ -1,5 +1,5 @@
 use candid::Principal;
-use canister_sig_util::{verify_root_signature, CanisterSig, CanisterSigPublicKey};
+use canister_sig_util_br::{verify_root_signature, CanisterSig, CanisterSigPublicKey};
 use ic_certification::{Certificate, LookupResult};
 use ic_certified_map::Hash;
 use identity_core::common::Url;
@@ -401,7 +401,7 @@ fn get_canister_sig_pk(
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use canister_sig_util::{
+    use canister_sig_util_br::{
         set_ic_root_public_key_for_testing, CanisterSigVerificationError, IC_ROOT_KEY_DER_PREFIX,
     };
     use ic_cbor::CertificateToCbor;


### PR DESCRIPTION
Rename `canister_sig_util` to `canister_sig_util_br` to avoid collisions with main during the step-wise transition of the branch to main.