### PR TITLE
Change rust build to use the --locked flag

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -117,6 +117,7 @@ function build_canister() {
         --manifest-path "$SRC_DIR/Cargo.toml"
         --target "$TARGET"
         --release
+        --locked
         -j1
         )
     # XXX: for bash > 4.4, empty arrays are considered unset, so do some substitution


### PR DESCRIPTION
This change makes builds fail if the `Cargo.lock` file is outdated, which prevents future PRs such as #1972.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
