### PR TITLE
Add CI step to check Cargo.lock

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,4 +54,6 @@ jobs:
       - uses: ./.github/actions/bootstrap
 
       - name: Cargo Lockfile Check
+      # fails if lockfile is out of date
+      # https://users.rust-lang.org/t/check-if-the-cargo-lock-is-up-to-date-without-building-anything/91048/5
         run: cargo update --workspace --locked

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,3 +46,12 @@ jobs:
         run: |
           cargo clippy -- -D clippy::all -D warnings -A clippy::manual_range_contains
           cargo clippy --tests --benches -- -D clippy::all -D warnings -A clippy::manual_range_contains
+
+  check-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bootstrap
+
+      - name: Cargo Lockfile Check
+        run: cargo update --workspace --locked

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,6 @@ jobs:
       - uses: ./.github/actions/bootstrap
 
       - name: Cargo Lockfile Check
-      # fails if lockfile is out of date
-      # https://users.rust-lang.org/t/check-if-the-cargo-lock-is-up-to-date-without-building-anything/91048/5
+        # fails if lockfile is out of date
+        # https://users.rust-lang.org/t/check-if-the-cargo-lock-is-up-to-date-without-building-anything/91048/5
         run: cargo update --workspace --locked


### PR DESCRIPTION
This PR adds a small job to check whether the Cargo.lock is up to date.

Test failure: https://github.com/dfinity/internet-identity/actions/runs/6623474516/job/17990608224

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

