### PR TITLE
Remove CSP meta tag

### DIFF
--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -424,8 +424,8 @@ form-action 'none';\
 style-src 'self' 'unsafe-inline';\
 style-src-elem 'self' 'unsafe-inline';\
 font-src 'self';\
-upgrade-insecure-requests;\
-frame-ancestors 'none';$"
+frame-ancestors 'none';\
+upgrade-insecure-requests;$"
     )
     .unwrap()
     .is_match(csp));

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- CSP directives injected by the canister -->
-    <meta replaceme-with-csp />
     <title>Internet Identity</title>
     <link rel="shortcut icon" href="/favicon.ico" />
     <link rel="stylesheet" href="src/styles/main.css" />

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -5,7 +5,7 @@
 use crate::hash::{hash_of_map, Value};
 use crate::http::{security_headers, IC_CERTIFICATE_EXPRESSION_HEADER};
 use crate::nested_tree::NestedTree;
-use crate::{http, state};
+use crate::state;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use ic_cdk::api;
@@ -97,21 +97,13 @@ pub enum ContentType {
 // The <script> tag that loads the 'index.js'
 const JS_SETUP_SCRIPT: &str = "let s = document.createElement('script');s.type = 'module';s.src = '/index.js';document.head.appendChild(s);";
 
-// Fix up HTML pages, by injecting canister ID, script tag and CSP
+// Fix up HTML pages, by injecting canister ID & script tag
 fn fixup_html(html: &str) -> String {
     let canister_id = api::id();
     let setup_js: String = JS_SETUP_SCRIPT.to_string();
-    let html = html.replace(
+    html.replace(
         r#"<script type="module" crossorigin src="/index.js"></script>"#,
         &format!(r#"<script data-canister-id="{canister_id}" type="module">{setup_js}</script>"#),
-    );
-
-    html.replace(
-        "<meta replaceme-with-csp/>",
-        &format!(
-            r#"<meta http-equiv="Content-Security-Policy" content="{}" />"#,
-            &http::content_security_policy_meta()
-        ),
     )
 }
 

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -180,7 +180,7 @@ pub fn security_headers() -> Vec<HeaderField> {
 /// Full content security policy delivered via HTTP response header.
 ///
 /// This policy also includes the `frame-ancestors` directive in addition to the policies included in the HTML `meta` tag.
-/// We deliver the CSP by header _and_ meta tag because the headers are not yet certified.
+/// We deliver the CSP by header
 fn content_security_policy_header() -> String {
     let meta_policy = content_security_policy_meta();
     format!("{meta_policy}frame-ancestors 'none';")

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -179,15 +179,6 @@ pub fn security_headers() -> Vec<HeaderField> {
 
 /// Full content security policy delivered via HTTP response header.
 ///
-/// This policy also includes the `frame-ancestors` directive in addition to the policies included in the HTML `meta` tag.
-/// We deliver the CSP by header
-fn content_security_policy_header() -> String {
-    let meta_policy = content_security_policy_meta();
-    format!("{meta_policy}frame-ancestors 'none';")
-}
-
-/// Stripped down content security policy for the HTML `meta` tag, where not all directives are supported.
-///
 /// The sha256 hash matches the inline script in index.html. This inline script is a workaround
 /// for Firefox not supporting SRI (recommended here https://csp.withgoogle.com/docs/faq.html#static-content).
 /// This also prevents use of trusted-types. See https://bugzilla.mozilla.org/show_bug.cgi?id=1409200.
@@ -218,7 +209,7 @@ fn content_security_policy_header() -> String {
 ///
 /// upgrade-insecure-requests is omitted when building in dev mode to allow loading II on localhost
 /// with Safari.
-pub fn content_security_policy_meta() -> String {
+pub fn content_security_policy_header() -> String {
     let hash = assets::JS_SETUP_SCRIPT_SRI_HASH.to_string();
     let csp = format!(
         "default-src 'none';\
@@ -229,7 +220,8 @@ pub fn content_security_policy_meta() -> String {
          form-action 'none';\
          style-src 'self' 'unsafe-inline';\
          style-src-elem 'self' 'unsafe-inline';\
-         font-src 'self';"
+         font-src 'self';\
+         frame-ancestors 'none';"
     );
     #[cfg(not(feature = "insecure_requests"))]
     let csp = format!("{csp}upgrade-insecure-requests;");


### PR DESCRIPTION
This removes the `<meta>` tag used for CSP. We originally included the CSP in the HTML because the HTTP headers could not be certified.

HTTP headers are now certified so the `Content-Security-Policy` header _should_ be enough. Additionally, the `<meta>` tag hasn't been replaced correctly for some time leading to an irrelevant HTML tag.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


