### PR TITLE
Refactor readCanisterId to allow reading the test_app id as well

### DIFF
--- a/vite.plugins.ts
+++ b/vite.plugins.ts
@@ -7,10 +7,13 @@ import viteCompression from "vite-plugin-compression";
 /**
  * Read a canister ID from dfx's local state
  */
-export const readCanisterId = (
-  canisterName: string,
-  canisterIdsJsonFile: string
-): string => {
+export const readCanisterId = ({
+  canisterName,
+  canisterIdsJsonFile,
+}: {
+  canisterName: string;
+  canisterIdsJsonFile: string;
+}): string => {
   try {
     const canisterIds: Record<string, { local: string }> = JSON.parse(
       readFileSync(canisterIdsJsonFile, "utf-8")
@@ -43,10 +46,10 @@ export const injectCanisterIdPlugin = (): {
     const rgx = /<script type="module" src="(?<src>[^"]+)"><\/script>/;
 
     return html.replace(rgx, (_match, src) => {
-      return `<script data-canister-id="${readCanisterId(
-        "internet_identity",
-        "./.dfx/local/canister_ids.json"
-      )}" type="module" src="${src}"></script>`;
+      return `<script data-canister-id="${readCanisterId({
+        canisterName: "internet_identity",
+        canisterIdsJsonFile: "./.dfx/local/canister_ids.json",
+      })}" type="module" src="${src}"></script>`;
     });
   },
 });


### PR DESCRIPTION
This PR is in preparation for the migration of the selnium tests out of docker. After the migration, vite needs to know about the test_app canister id too. This refactoring allows using the existing helper for that.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/1972b24ad/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

