### PR TITLE
Add option to run dev server using TLS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/ua-parser-js": "^0.7.36",
         "@typescript-eslint/eslint-plugin": "6.7.5",
         "@typescript-eslint/parser": "6.7.5",
+        "@vitejs/plugin-basic-ssl": "^1.0.1",
         "@wdio/globals": "^8.6.9",
         "astro": "^2.4.1",
         "eslint": "8.51.0",
@@ -2051,6 +2052,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.0.1.tgz",
+      "integrity": "sha512-pcub+YbFtFhaGRTo1832FQHQSHvMrlb43974e2eS8EKleR3p1cDdkJFPci1UhwkEf1J9Bz+wKBSzqpKp7nNj2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.6.0"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -13462,6 +13475,13 @@
         "@typescript-eslint/types": "6.7.5",
         "eslint-visitor-keys": "^3.4.1"
       }
+    },
+    "@vitejs/plugin-basic-ssl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.0.1.tgz",
+      "integrity": "sha512-pcub+YbFtFhaGRTo1832FQHQSHvMrlb43974e2eS8EKleR3p1cDdkJFPci1UhwkEf1J9Bz+wKBSzqpKp7nNj2A==",
+      "dev": true,
+      "requires": {}
     },
     "@vitest/expect": {
       "version": "0.31.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/ua-parser-js": "^0.7.36",
     "@typescript-eslint/eslint-plugin": "6.7.5",
     "@typescript-eslint/parser": "6.7.5",
+    "@vitejs/plugin-basic-ssl": "^1.0.1",
     "@wdio/globals": "^8.6.9",
     "astro": "^2.4.1",
     "eslint": "8.51.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import basicSsl from "@vitejs/plugin-basic-ssl";
 import { resolve } from "path";
 import { AliasOptions, defineConfig, UserConfig } from "vite";
 import {
@@ -58,6 +59,7 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
     plugins: [
       [...(mode === "development" ? [injectCanisterIdPlugin()] : [])],
       [...(mode === "production" ? [minifyHTML(), compression()] : [])],
+      [...(process.env.TLS_DEV_SERVER === "1" ? [basicSsl()] : [])],
     ],
     optimizeDeps: {
       esbuildOptions: {
@@ -67,6 +69,7 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
       },
     },
     server: {
+      https: process.env.TLS_DEV_SERVER === "1",
       proxy: {
         "/api": "http://127.0.0.1:4943",
       },


### PR DESCRIPTION
This PR introduces the env variable `TLS_DEV_SERVER` that can be set to `1` to enable the dev server serving content using tls.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
