### PR TITLE
Fix docker-build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,9 +79,7 @@ ARG II_INSECURE_REQUESTS=
 # DFX specific metadata for dfx deps
 ARG DFX_METADATA=
 
-RUN touch src/internet_identity/src/lib.rs
-RUN touch src/internet_identity_interface/src/lib.rs
-RUN touch src/canister_tests/src/lib.rs
+RUN touch src/*/src/lib.rs
 RUN npm ci
 
 RUN ./scripts/build ${DFX_METADATA:+"--dfx-metadata" "$DFX_METADATA"}
@@ -91,9 +89,7 @@ FROM deps as build_archive
 
 COPY . .
 
-RUN touch src/internet_identity_interface/src/lib.rs
-RUN touch src/archive/src/lib.rs
-RUN touch src/canister_tests/src/lib.rs
+RUN touch src/*/src/lib.rs
 
 RUN ./scripts/build --archive
 RUN sha256sum /archive.wasm.gz


### PR DESCRIPTION
The docker build is layered with a dependencies layer to cache already compiled dependencies. To not cache the non-dependency code, the last modified timestamp of the `lib.rs` files has to be updated.

If a new `lib.rs` file is introduced, its timestamp needs to be updated as well. This was overlooked when introducing the `canister_sig_utils` crate.

This PR makes the dockerfile more robust to touch _all_ the relevant `lib.rs` files rather than specific ones.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ba2fd5e0e/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
