### PR TITLE
Don't update dapps without logo

### DIFF
--- a/scripts/update-dapps
+++ b/scripts/update-dapps
@@ -80,10 +80,11 @@ function update() {
         | jq \
             --arg portal_logo_prefix "$portal_logo_prefix" \
         '[ .[]
-            | select(.usesInternetIdentity == true)
-            | select(.name != "Internet Identity")
-            | .logo |= sub("^/" + $portal_logo_prefix + "/"; "")
-            | with_entries(
+            | select(.usesInternetIdentity == true) # ensure the dapp actually uses II
+            | select(.name != "Internet Identity") # skip II itself
+            | select(.logo != null) # only use dapps with logo
+            | .logo |= sub("^/" + $portal_logo_prefix + "/"; "") # swap the logo for our prefix
+            | with_entries( # drop entries we do not care about to reduce size
                 select(
                     [.key]
                     | inside(["name", "website", "oneLiner", "logo", "authOrigins"])


### PR DESCRIPTION
This updates the dapps update script to skip dapps that do not have a logo. If the dapp doesn't have a logo, then we don't have much to display.

This also adds some comments to the jq filter used to parse the dapps list for clarity.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
