### PR TITLE
Use consistent casing for issuer DID-interface.

### DIFF
--- a/demos/vc_issuer/vc_issuer.did
+++ b/demos/vc_issuer/vc_issuer.did
@@ -1,12 +1,12 @@
 type CredentialSpec = record { info : text };
 type GetCredentialRequest = record {
     signed_id_alias : SignedIdAlias;
-    prepared_context : opt blob;
+    prepared_context : opt vec nat8;
     credential_spec : CredentialSpec;
 };
 type GetCredentialResponse = variant {
-    Ok : IssuedCredentialData;
-    Err : IssueCredentialError;
+    ok : IssuedCredentialData;
+    err : IssueCredentialError;
 };
 type Icrc21ConsentInfo = record { consent_message : text; language : text };
 type Icrc21ConsentMessageRequest = record {
@@ -15,23 +15,23 @@ type Icrc21ConsentMessageRequest = record {
     preferences : Icrc21ConsentPreferences;
 };
 type Icrc21ConsentMessageResponse = variant {
-    Ok : Icrc21ConsentInfo;
-    Err : Icrc21Error;
+    ok : Icrc21ConsentInfo;
+    err : Icrc21Error;
 };
 type Icrc21ConsentPreferences = record { language : text };
 type Icrc21Error = variant {
-    GenericError : Icrc21ErrorInfo;
-    MalformedCall : Icrc21ErrorInfo;
-    NotSupported : Icrc21ErrorInfo;
-    Forbidden : Icrc21ErrorInfo;
+    generic_error : Icrc21ErrorInfo;
+    forbidden : Icrc21ErrorInfo;
+    not_supported : Icrc21ErrorInfo;
+    malformed_call : Icrc21ErrorInfo;
 };
 type Icrc21ErrorInfo = record { description : text; error_code : nat64 };
 type IssueCredentialError = variant {
-    Internal : text;
-    SignatureNotFound : text;
-    InvalidIdAlias : text;
-    UnauthorizedSubject : text;
-    UnknownSubject : text;
+    unauthorized_subject : text;
+    internal : text;
+    signature_not_found : text;
+    unknown_subject : text;
+    invalid_id_alias : text;
 };
 type IssuedCredentialData = record { vc_jws : text };
 type PrepareCredentialRequest = record {
@@ -39,10 +39,10 @@ type PrepareCredentialRequest = record {
     credential_spec : CredentialSpec;
 };
 type PrepareCredentialResponse = variant {
-    Ok : PreparedCredentialData;
-    Err : IssueCredentialError;
+    ok : PreparedCredentialData;
+    err : IssueCredentialError;
 };
-type PreparedCredentialData = record { prepared_context : opt blob };
+type PreparedCredentialData = record { prepared_context : opt vec nat8 };
 type SignedIdAlias = record {
     credential_jws : text;
     id_alias : principal;

--- a/src/frontend/generated/vc_issuer_idl.js
+++ b/src/frontend/generated/vc_issuer_idl.js
@@ -14,14 +14,14 @@ export const idlFactory = ({ IDL }) => {
     'error_code' : IDL.Nat64,
   });
   const Icrc21Error = IDL.Variant({
-    'GenericError' : Icrc21ErrorInfo,
-    'MalformedCall' : Icrc21ErrorInfo,
-    'NotSupported' : Icrc21ErrorInfo,
-    'Forbidden' : Icrc21ErrorInfo,
+    'generic_error' : Icrc21ErrorInfo,
+    'forbidden' : Icrc21ErrorInfo,
+    'not_supported' : Icrc21ErrorInfo,
+    'malformed_call' : Icrc21ErrorInfo,
   });
   const Icrc21ConsentMessageResponse = IDL.Variant({
-    'Ok' : Icrc21ConsentInfo,
-    'Err' : Icrc21Error,
+    'ok' : Icrc21ConsentInfo,
+    'err' : Icrc21Error,
   });
   const SignedIdAlias = IDL.Record({
     'credential_jws' : IDL.Text,
@@ -36,15 +36,15 @@ export const idlFactory = ({ IDL }) => {
   });
   const IssuedCredentialData = IDL.Record({ 'vc_jws' : IDL.Text });
   const IssueCredentialError = IDL.Variant({
-    'Internal' : IDL.Text,
-    'SignatureNotFound' : IDL.Text,
-    'InvalidIdAlias' : IDL.Text,
-    'UnauthorizedSubject' : IDL.Text,
-    'UnknownSubject' : IDL.Text,
+    'unauthorized_subject' : IDL.Text,
+    'internal' : IDL.Text,
+    'signature_not_found' : IDL.Text,
+    'unknown_subject' : IDL.Text,
+    'invalid_id_alias' : IDL.Text,
   });
   const GetCredentialResponse = IDL.Variant({
-    'Ok' : IssuedCredentialData,
-    'Err' : IssueCredentialError,
+    'ok' : IssuedCredentialData,
+    'err' : IssueCredentialError,
   });
   const PrepareCredentialRequest = IDL.Record({
     'signed_id_alias' : SignedIdAlias,
@@ -54,8 +54,8 @@ export const idlFactory = ({ IDL }) => {
     'prepared_context' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
   const PrepareCredentialResponse = IDL.Variant({
-    'Ok' : PreparedCredentialData,
-    'Err' : IssueCredentialError,
+    'ok' : PreparedCredentialData,
+    'err' : IssueCredentialError,
   });
   return IDL.Service({
     'add_employee' : IDL.Func([IDL.Principal], [IDL.Text], []),

--- a/src/frontend/generated/vc_issuer_types.d.ts
+++ b/src/frontend/generated/vc_issuer_types.d.ts
@@ -7,8 +7,8 @@ export interface GetCredentialRequest {
   'prepared_context' : [] | [Uint8Array | number[]],
   'credential_spec' : CredentialSpec,
 }
-export type GetCredentialResponse = { 'Ok' : IssuedCredentialData } |
-  { 'Err' : IssueCredentialError };
+export type GetCredentialResponse = { 'ok' : IssuedCredentialData } |
+  { 'err' : IssueCredentialError };
 export interface Icrc21ConsentInfo {
   'consent_message' : string,
   'language' : string,
@@ -18,29 +18,29 @@ export interface Icrc21ConsentMessageRequest {
   'method' : string,
   'preferences' : Icrc21ConsentPreferences,
 }
-export type Icrc21ConsentMessageResponse = { 'Ok' : Icrc21ConsentInfo } |
-  { 'Err' : Icrc21Error };
+export type Icrc21ConsentMessageResponse = { 'ok' : Icrc21ConsentInfo } |
+  { 'err' : Icrc21Error };
 export interface Icrc21ConsentPreferences { 'language' : string }
-export type Icrc21Error = { 'GenericError' : Icrc21ErrorInfo } |
-  { 'MalformedCall' : Icrc21ErrorInfo } |
-  { 'NotSupported' : Icrc21ErrorInfo } |
-  { 'Forbidden' : Icrc21ErrorInfo };
+export type Icrc21Error = { 'generic_error' : Icrc21ErrorInfo } |
+  { 'forbidden' : Icrc21ErrorInfo } |
+  { 'not_supported' : Icrc21ErrorInfo } |
+  { 'malformed_call' : Icrc21ErrorInfo };
 export interface Icrc21ErrorInfo {
   'description' : string,
   'error_code' : bigint,
 }
-export type IssueCredentialError = { 'Internal' : string } |
-  { 'SignatureNotFound' : string } |
-  { 'InvalidIdAlias' : string } |
-  { 'UnauthorizedSubject' : string } |
-  { 'UnknownSubject' : string };
+export type IssueCredentialError = { 'unauthorized_subject' : string } |
+  { 'internal' : string } |
+  { 'signature_not_found' : string } |
+  { 'unknown_subject' : string } |
+  { 'invalid_id_alias' : string };
 export interface IssuedCredentialData { 'vc_jws' : string }
 export interface PrepareCredentialRequest {
   'signed_id_alias' : SignedIdAlias,
   'credential_spec' : CredentialSpec,
 }
-export type PrepareCredentialResponse = { 'Ok' : PreparedCredentialData } |
-  { 'Err' : IssueCredentialError };
+export type PrepareCredentialResponse = { 'ok' : PreparedCredentialData } |
+  { 'err' : IssueCredentialError };
 export interface PreparedCredentialData {
   'prepared_context' : [] | [Uint8Array | number[]],
 }

--- a/src/frontend/src/flows/verifiableCredentials/vcIssuer.ts
+++ b/src/frontend/src/flows/verifiableCredentials/vcIssuer.ts
@@ -52,7 +52,7 @@ export class VcIssuer {
       return { error: "wops" };
     }
 
-    return result.Ok;
+    return result.ok;
   };
 
   getCredential = async ({
@@ -78,6 +78,6 @@ export class VcIssuer {
       return { error: "wops" };
     }
 
-    return result.Ok;
+    return result.ok;
   };
 }

--- a/src/frontend/src/flows/verifiableCredentials/vcIssuer.ts
+++ b/src/frontend/src/flows/verifiableCredentials/vcIssuer.ts
@@ -47,12 +47,12 @@ export class VcIssuer {
     });
 
     // TODO: proper error handling
-    if ("Err" in result) {
+    if ("err" in result) {
       console.error("wops");
       return { error: "wops" };
     }
 
-    return result.ok;
+    return result.Ok;
   };
 
   getCredential = async ({
@@ -73,11 +73,11 @@ export class VcIssuer {
     });
 
     // TODO: proper error handling
-    if ("Err" in result) {
+    if ("err" in result) {
       console.error("wops");
       return { error: "wops" };
     }
 
-    return result.ok;
+    return result.Ok;
   };
 }

--- a/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
@@ -78,16 +78,23 @@ pub mod issuer {
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
     pub enum PrepareCredentialResponse {
+        #[serde(rename = "ok")]
         Ok(PreparedCredentialData),
+        #[serde(rename = "err")]
         Err(IssueCredentialError),
     }
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
     pub enum IssueCredentialError {
+        #[serde(rename = "unknown_subject")]
         UnknownSubject(String),
+        #[serde(rename = "unauthorized_subject")]
         UnauthorizedSubject(String),
+        #[serde(rename = "invalid_id_alias")]
         InvalidIdAlias(String),
+        #[serde(rename = "signature_not_found")]
         SignatureNotFound(String),
+        #[serde(rename = "internal")]
         Internal(String),
     }
 
@@ -100,7 +107,9 @@ pub mod issuer {
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
     pub enum GetCredentialResponse {
+        #[serde(rename = "ok")]
         Ok(IssuedCredentialData),
+        #[serde(rename = "err")]
         Err(IssueCredentialError),
     }
 
@@ -124,7 +133,9 @@ pub mod issuer {
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
     pub enum ManifestResponse {
+        #[serde(rename = "ok")]
         Ok(ManifestData),
+        #[serde(rename = "err")]
         Err(String),
     }
 
@@ -151,9 +162,13 @@ pub mod issuer {
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
     pub enum Icrc21Error {
+        #[serde(rename = "forbidden")]
         Forbidden(Icrc21ErrorInfo),
+        #[serde(rename = "malformed_call")]
         MalformedCall(Icrc21ErrorInfo),
+        #[serde(rename = "not_supported")]
         NotSupported(Icrc21ErrorInfo),
+        #[serde(rename = "generic_error")]
         GenericError(Icrc21ErrorInfo),
     }
 
@@ -165,7 +180,9 @@ pub mod issuer {
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
     pub enum Icrc21ConsentMessageResponse {
+        #[serde(rename = "ok")]
         Ok(Icrc21ConsentInfo),
+        #[serde(rename = "err")]
         Err(Icrc21Error),
     }
 }


### PR DESCRIPTION
Issuer's Candid interface used `CamelCase` for enums/variants, which was inconsistent with the II Candid interface. 
This PR changes to `lower_case` for issuer's interface.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

