### PR TITLE
Move LABEL_SIG constant  to a crate, so that it can be re-used.

### DIFF
--- a/src/canister_sig_util/src/lib.rs
+++ b/src/canister_sig_util/src/lib.rs
@@ -41,7 +41,7 @@ pub fn get_canister_sig_pk_der(canister_id: Principal, seed: &[u8]) -> Vec<u8> {
 }
 
 /// Verifies the structure given public key in DER-format, and returns raw bytes of the key.
-fn extract_raw_root_pk_from_der(pk_der: &[u8]) -> Result<Vec<u8>, String> {
+pub fn extract_raw_root_pk_from_der(pk_der: &[u8]) -> Result<Vec<u8>, String> {
     let expected_length = IC_ROOT_PK_DER_PREFIX.len() + IC_ROOT_PK_LENGTH;
     if pk_der.len() != expected_length {
         return Err(String::from("invalid root pk length"));

--- a/src/canister_sig_util/src/signature_map.rs
+++ b/src/canister_sig_util/src/signature_map.rs
@@ -3,6 +3,7 @@ use ic_certified_map::{leaf_hash, AsHashTree, Hash, HashTree, RbTree};
 use std::borrow::Cow;
 use std::collections::BinaryHeap;
 
+pub const LABEL_SIG: &[u8] = b"sig";
 #[derive(Default)]
 struct Unit;
 

--- a/src/internet_identity/src/delegation.rs
+++ b/src/internet_identity/src/delegation.rs
@@ -1,10 +1,10 @@
 use crate::assets::CertifiedAssets;
 use crate::ii_domain::IIDomain;
 use crate::state::persistent_state_mut;
-use crate::{hash, state, update_root_hash, DAY_NS, LABEL_SIG, MINUTE_NS};
+use crate::{hash, state, update_root_hash, DAY_NS, MINUTE_NS};
 use candid::Principal;
 use canister_sig_util::get_canister_sig_pk_der;
-use canister_sig_util::signature_map::SignatureMap;
+use canister_sig_util::signature_map::{SignatureMap, LABEL_SIG};
 use ic_cdk::api::{data_certificate, time};
 use ic_cdk::{id, trap};
 use ic_certified_map::{Hash, HashTree};

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -1,8 +1,9 @@
 use crate::assets::{ContentType, EXACT_MATCH_TERMINATOR, IC_CERTIFICATE_EXPRESSION};
 use crate::http::metrics::metrics;
-use crate::{assets, state, LABEL_SIG};
+use crate::{assets, state};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
+use canister_sig_util::signature_map::LABEL_SIG;
 use ic_cdk::api::data_certificate;
 use ic_cdk::trap;
 use ic_certified_map::HashTree;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -4,6 +4,7 @@ use crate::assets::init_assets;
 use crate::ii_domain::IIDomain;
 use crate::storage::anchor::Anchor;
 use candid::{candid_method, Principal};
+use canister_sig_util::signature_map::LABEL_SIG;
 use ic_cdk::api::{caller, set_certified_data, trap};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use internet_identity_interface::archive::types::{BufferedEntry, Operation};
@@ -33,8 +34,6 @@ const fn secs_to_nanos(secs: u64) -> u64 {
 const MINUTE_NS: u64 = secs_to_nanos(60);
 const HOUR_NS: u64 = 60 * MINUTE_NS;
 const DAY_NS: u64 = 24 * HOUR_NS;
-
-const LABEL_SIG: &[u8] = b"sig";
 
 // Note: concatenating const &str is a hassle in rust. It seemed easiest to just repeat.
 const IC0_APP_DOMAIN: &str = "identity.ic0.app";


### PR DESCRIPTION
Move `LABEL_SIG`-constant to `canister_sig_util`, so that it can be used elsewhere.
Also, make `canister_sig_util::extract_raw_root_pk_from_der` public (it was overlooked previously).
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
