### PR TITLE
Run e2e tests sequentially

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "preview:showcase": "astro preview --root ./src/showcase",
     "screenshots": "npm run opts -- ./src/frontend/screenshots.ts",
     "test": "vitest --config ./vitest.config.ts",
-    "test:e2e": "vitest --mode e2e --config ./vitest.config.ts",
+    "test:e2e": "vitest --mode e2e --config ./vitest.config.ts --threads=false",
     "test:e2e-desktop": "SCREEN=desktop npm run test:e2e",
     "test:e2e-mobile": "SCREEN=mobile npm run test:e2e",
     "lint": "eslint --max-warnings 0 --cache --cache-location node_modules/.cache/eslint 'src/frontend/**/*.ts*' 'src/showcase/**/*.ts'",


### PR DESCRIPTION
This instructs vitest to run all e2e tests sequentially.

Without this, vitest may run several spec files at the same time, which seems to cause issues with the virtual authenticator, leading to flakiness.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
