### PR TITLE
Make chromedriver log to stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ dist/
 dist-showcase/
 .env
 lib
-wdio.log
 
 # Cargo build output
 target/

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -69,10 +69,6 @@ export async function runInBrowser(
     hostname: "127.0.0.1",
     port: 4444,
     path: "/wd/hub",
-    logLevel: "info",
-    // outputDir pipes all webdriver log output into ./wdio.log
-    // stdout only contains errors on test failures
-    outputDir: "./",
   });
 
   // setup test suite


### PR DESCRIPTION
This PR removes the file based log collection of chromedriver for the following reasons:
* Most of the logs _still_ go to stdout, even with the `outputDir` set. The log files only contain a few lines (which are also okay to appear in stdout): ``` Starting ChromeDriver 119.0.6045.105 (38c72552c5e15ba9b3117c0967a0fd105072d7c6-refs/branch-heads/6045@{#1103}) on port 55890 Remote connections are allowed by an allowlist (0.0.0.0). Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe. ChromeDriver was started successfully. ```
* wdio now creates a logfile per test, because chrome driver is started new for each test. This results in an awful lot of tiny files that are hard to match to the actual tests, because the filename only contains an opaque session id.

I think having all the e2e test infrastructure output in stdout makes analyzing test failures easier. Note that the `test-failures` folder is still created as previously, that contains the HTML file, screenshot and browser console logs of the test at the point of failure.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
