### PR TITLE
Wait for principals to not be anonymous after sign-in

### DIFF
--- a/src/frontend/src/test-e2e/alternativeOrigin/endpointFormat.test.ts
+++ b/src/frontend/src/test-e2e/alternativeOrigin/endpointFormat.test.ts
@@ -6,7 +6,6 @@ import {
   originToRelyingPartyId,
   runInBrowser,
   switchToPopup,
-  waitToClose,
 } from "../util";
 import { AuthenticateView, DemoAppView, ErrorView } from "../views";
 
@@ -147,8 +146,6 @@ test("Should fetch /.well-known/ii-alternative-origins using the non-raw url", a
     const authenticateView = new AuthenticateView(browser);
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
-    await waitToClose(browser);
-
-    expect(await niceDemoAppView.getPrincipal()).not.toBe("2vxsx-fae");
+    await niceDemoAppView.waitForAuthenticated();
   });
 }, 300_000);

--- a/src/frontend/src/test-e2e/delegationTtl.test.ts
+++ b/src/frontend/src/test-e2e/delegationTtl.test.ts
@@ -20,9 +20,8 @@ test("Delegation maxTimeToLive: 1 min", async () => {
     await demoAppView.signin();
     await switchToPopup(browser);
     await FLOWS.registerNewIdentityAuthenticateView(DEVICE_NAME1, browser);
-    await waitToClose(browser);
-    await demoAppView.waitForDisplay();
-    expect(await demoAppView.getPrincipal()).not.toBe("2vxsx-fae");
+    await demoAppView.waitForAuthenticated();
+
     const exp = await browser.$("#expiration").getText();
     // compare only up to one decimal place for the 1min test
     expect(Number(exp) / 60_000_000_000).toBeCloseTo(1, 0);
@@ -58,8 +57,7 @@ test("Delegation maxTimeToLive: 2 months", async () => {
     await demoAppView.signin();
     await switchToPopup(browser);
     await FLOWS.registerNewIdentityAuthenticateView(DEVICE_NAME1, browser);
-    await waitToClose(browser);
-    expect(await demoAppView.getPrincipal()).not.toBe("2vxsx-fae");
+    await demoAppView.waitForAuthenticated();
     const exp = await browser.$("#expiration").getText();
     // NB: Max out at 30 days
     expect(Number(exp) / 2_592_000_000_000_000).toBeCloseTo(1);

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -7,12 +7,7 @@ import {
   TEST_APP_NICE_URL,
 } from "./constants";
 import { FLOWS } from "./flows";
-import {
-  addVirtualAuthenticator,
-  runInBrowser,
-  switchToPopup,
-  waitToClose,
-} from "./util";
+import { addVirtualAuthenticator, runInBrowser, switchToPopup } from "./util";
 import {
   AuthenticateView,
   DemoAppView,
@@ -142,11 +137,8 @@ test("Log into client application using PIN registration flow", async () => {
     await demoAppView.signin();
     await switchToPopup(browser);
     await FLOWS.registerPinNewIdentityAuthenticateView(pin, browser);
-    await waitToClose(browser);
-    await demoAppView.waitForDisplay();
-    const principal = await demoAppView.getPrincipal();
-    expect(principal).not.toBe(Principal.anonymous().toText());
 
+    const principal = await demoAppView.waitForAuthenticated();
     expect(await demoAppView.whoami(REPLICA_URL, TEST_APP_CANISTER_ID)).toBe(
       principal
     );
@@ -175,10 +167,6 @@ test("Register with PIN then log into client application", async () => {
     await switchToPopup(browser);
 
     await FLOWS.loginPinAuthenticateView(userNumber, pin, browser);
-    await waitToClose(browser);
-
-    await demoAppView.waitForDisplay();
-    const principal = await demoAppView.getPrincipal();
-    expect(principal).not.toBe(Principal.anonymous().toText());
+    await demoAppView.waitForAuthenticated();
   }, APPLE_USER_AGENT);
 }, 300_000);

--- a/src/frontend/src/test-e2e/principals.test.ts
+++ b/src/frontend/src/test-e2e/principals.test.ts
@@ -51,7 +51,9 @@ test("Should issue the same principal to nice url and canonical url", async () =
     await authenticateView.pickAnchor(userNumber);
     await waitToClose(browser);
 
-    const principal1 = await canonicalDemoAppView.getPrincipal();
+    const principal1 = await canonicalDemoAppView.getPrincipal({
+      waitForNonAnonymous: true,
+    });
 
     const niceDemoAppView = new DemoAppView(browser);
     await niceDemoAppView.open(TEST_APP_NICE_URL, II_URL);
@@ -78,7 +80,9 @@ test("Should issue the same principal to nice url and canonical url", async () =
     await authenticateView.pickAnchor(userNumber);
     await waitToClose(browser);
 
-    const principal2 = await niceDemoAppView.getPrincipal();
+    const principal2 = await niceDemoAppView.getPrincipal({
+      waitForNonAnonymous: true,
+    });
     expect(principal1).toEqual(principal2);
   });
 }, 300_000);
@@ -118,7 +122,9 @@ test("Should issue the same principal to dapps on legacy & official domains", as
       await authenticateView.pickAnchor(userNumber);
       await waitToClose(browser);
 
-      return await canonicalDemoAppView.getPrincipal();
+      return await canonicalDemoAppView.getPrincipal({
+        waitForNonAnonymous: true,
+      });
     };
 
     // Compare that principals issues for ic0.app & icp0.io are the same

--- a/src/frontend/src/test-e2e/principals.test.ts
+++ b/src/frontend/src/test-e2e/principals.test.ts
@@ -6,7 +6,6 @@ import {
   originToRelyingPartyId,
   runInBrowser,
   switchToPopup,
-  waitToClose,
 } from "./util";
 import { AuthenticateView, DemoAppView } from "./views";
 
@@ -49,11 +48,8 @@ test("Should issue the same principal to nice url and canonical url", async () =
     let authenticateView = new AuthenticateView(browser);
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
-    await waitToClose(browser);
 
-    const principal1 = await canonicalDemoAppView.getPrincipal({
-      waitForNonAnonymous: true,
-    });
+    const principal1 = await canonicalDemoAppView.waitForAuthenticated();
 
     const niceDemoAppView = new DemoAppView(browser);
     await niceDemoAppView.open(TEST_APP_NICE_URL, II_URL);
@@ -78,11 +74,8 @@ test("Should issue the same principal to nice url and canonical url", async () =
     authenticateView = new AuthenticateView(browser);
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
-    await waitToClose(browser);
 
-    const principal2 = await niceDemoAppView.getPrincipal({
-      waitForNonAnonymous: true,
-    });
+    const principal2 = await niceDemoAppView.waitForAuthenticated();
     expect(principal1).toEqual(principal2);
   });
 }, 300_000);
@@ -120,11 +113,8 @@ test("Should issue the same principal to dapps on legacy & official domains", as
       let authenticateView = new AuthenticateView(browser);
       await authenticateView.waitForDisplay();
       await authenticateView.pickAnchor(userNumber);
-      await waitToClose(browser);
 
-      return await canonicalDemoAppView.getPrincipal({
-        waitForNonAnonymous: true,
-      });
+      return canonicalDemoAppView.waitForAuthenticated();
     };
 
     // Compare that principals issues for ic0.app & icp0.io are the same

--- a/src/frontend/src/test-e2e/register.test.ts
+++ b/src/frontend/src/test-e2e/register.test.ts
@@ -6,7 +6,6 @@ import {
   originToRelyingPartyId,
   runInBrowser,
   switchToPopup,
-  waitToClose,
 } from "./util";
 import { AuthenticateView, DemoAppView, MainView } from "./views";
 
@@ -67,11 +66,7 @@ test("Log into client application, after registration", async () => {
     await demoAppView.signin();
     await switchToPopup(browser);
     await FLOWS.registerNewIdentityAuthenticateView(DEVICE_NAME1, browser);
-    await waitToClose(browser);
-    await demoAppView.waitForDisplay();
-    const principal = await demoAppView.getPrincipal();
-    expect(principal).not.toBe("2vxsx-fae");
-
+    const principal = await demoAppView.waitForAuthenticated();
     expect(await demoAppView.whoami(REPLICA_URL, TEST_APP_CANISTER_ID)).toBe(
       principal
     );
@@ -113,11 +108,7 @@ test("Register first then log into client application", async () => {
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
     await FLOWS.skipRecoveryNag(browser);
-    await waitToClose(browser);
-    await demoAppView.waitForDisplay();
-    const principal = await demoAppView.getPrincipal();
-    expect(principal).not.toBe("2vxsx-fae");
-
+    const principal = await demoAppView.waitForAuthenticated();
     expect(await demoAppView.whoami(REPLICA_URL, TEST_APP_CANISTER_ID)).toBe(
       principal
     );

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -598,7 +598,13 @@ export class DemoAppView extends View {
     );
   }
 
-  async getPrincipal(): Promise<string> {
+  async getPrincipal(opts?: { waitForNonAnonymous: boolean }): Promise<string> {
+    if (opts?.waitForNonAnonymous) {
+      await this.browser.waitUntil(
+        async () =>
+          (await this.browser.$("#principal").getText()) !== "2vxsx-fae"
+      );
+    }
     return await this.browser.$("#principal").getText();
   }
 


### PR DESCRIPTION
The switch to non-dockerized selenium tests exposed some flakyness in the way principals are collected from the test app after sign-in.

This PR introduces a new method on the `DemoAppView` to properly wait for authentication to finish, including a check that the principal has been updated.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8f857a0ad/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

