### PR TITLE
Add CanisterSigPublicKey, simplify vc_util API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,7 +2060,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sha2 0.10.8",
- "vc_util",
+ "vc_util_br",
 ]
 
 [[package]]
@@ -3456,7 +3456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
-name = "vc_util"
+name = "vc_util_br"
 version = "0.1.0"
 dependencies = [
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "src/canister_tests",
     "src/internet_identity_interface",
     "src/archive",
+    "src/vc_util_br"
 ]
 resolver = "2"
 

--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -3015,11 +3015,11 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sha2 0.10.8",
- "vc_util",
+ "vc_util_br",
 ]
 
 [[package]]
-name = "vc_util"
+name = "vc_util_br"
 version = "0.1.0"
 dependencies = [
  "candid",

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 # local dependencies
 canister_sig_util = { path = "../../src/canister_sig_util" }
 internet_identity_interface = { path = "../../src/internet_identity_interface" }
-vc_util = { path = "../../src/vc_util_br" }
+vc_util_br = { path = "../../src/vc_util_br" }
 # ic dependencies
 candid = "0.9"
 ic-cdk = "0.10"

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -1,5 +1,5 @@
 use candid::{candid_method, Principal};
-use canister_sig_util::get_canister_sig_pk_der;
+use canister_sig_util::CanisterSigPublicKey;
 use ic_cdk_macros::{query, update};
 use ic_certified_map::{Hash, HashTree};
 use identity_core::common::Url;
@@ -17,11 +17,11 @@ use serde_json::json;
 use std::cell::RefCell;
 
 use canister_sig_util::signature_map::{SignatureMap, LABEL_SIG};
-use ic_cdk::api::{data_certificate, set_certified_data, time};
+use ic_cdk::api::{caller as cdk_caller, data_certificate, set_certified_data, time};
 use ic_cdk::trap;
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
-use vc_util::{did_for_principal, vc_jwt_to_jws, vc_signing_input, vc_signing_input_hash};
+use vc_util_br::{did_for_principal, vc_jwt_to_jws, vc_signing_input, vc_signing_input_hash};
 
 const MINUTE_NS: u64 = 60 * 1_000_000_000;
 const CERTIFICATE_VALIDITY_PERIOD_NS: u64 = 5 * MINUTE_NS;
@@ -34,21 +34,36 @@ thread_local! {
 #[cfg(target_arch = "wasm32")]
 use ic_cdk::println;
 
+fn check_caller_not_anonymous() -> Result<Principal, String> {
+    let caller = cdk_caller();
+    // The anonymous principal is not allowed to request credentials.
+    if caller == Principal::anonymous() {
+        return Err("Anonymous principal not allowed to request credentials.".to_string());
+    }
+    Ok(caller)
+}
+
 #[update]
 #[candid_method]
 async fn prepare_credential(req: PrepareCredentialRequest) -> PrepareCredentialResponse {
+    let _caller = match check_caller_not_anonymous() {
+        Ok(caller) => caller,
+        Err(e) => {
+            return PrepareCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e))
+        }
+    };
     if let Err(err) = verify_prepare_credential_request(&req) {
         return PrepareCredentialResponse::Err(err);
     }
     let subject_principal = req.signed_id_alias.id_alias;
     let seed = calculate_seed(&subject_principal);
     let canister_id = ic_cdk::id();
-    let canister_sig_pk_der = get_canister_sig_pk_der(canister_id, &seed);
+    let canister_sig_pk = CanisterSigPublicKey::new(canister_id, seed.to_vec());
     let credential = new_credential_dfinity_employment(subject_principal);
     let credential_jwt = credential
         .serialize_jwt()
         .expect("internal: JWT serialization failure");
-    let signing_input = vc_signing_input(&credential_jwt, &canister_sig_pk_der, canister_id);
+    let signing_input = vc_signing_input(&credential_jwt, &canister_sig_pk);
     let msg_hash = vc_signing_input_hash(&signing_input);
 
     SIGNATURES.with(|sigs| {
@@ -73,13 +88,17 @@ fn update_root_hash() {
 #[query]
 #[candid_method(query)]
 fn get_credential(req: GetCredentialRequest) -> GetCredentialResponse {
+    let _caller = match check_caller_not_anonymous() {
+        Ok(caller) => caller,
+        Err(e) => return GetCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)),
+    };
     if let Err(err) = verify_get_credential_request(&req) {
         return GetCredentialResponse::Err(err);
     }
     let subject_principal = req.signed_id_alias.id_alias;
     let seed = calculate_seed(&subject_principal);
     let canister_id = ic_cdk::id();
-    let canister_sig_pk_der = get_canister_sig_pk_der(canister_id, &seed);
+    let canister_sig_pk = CanisterSigPublicKey::new(canister_id, seed.to_vec());
     let prepared_context = match req.prepared_context {
         Some(context) => context,
         None => return GetCredentialResponse::Err(internal_error("missing prepared_context")),
@@ -88,7 +107,7 @@ fn get_credential(req: GetCredentialRequest) -> GetCredentialResponse {
         Ok(s) => s,
         Err(_) => return GetCredentialResponse::Err(internal_error("invalid prepared_context")),
     };
-    let signing_input = vc_signing_input(&credential_jwt, &canister_sig_pk_der, canister_id);
+    let signing_input = vc_signing_input(&credential_jwt, &canister_sig_pk);
     let msg_hash = vc_signing_input_hash(&signing_input);
     let maybe_sig = SIGNATURES.with(|sigs| {
         let sigs = sigs.borrow();
@@ -101,7 +120,7 @@ fn get_credential(req: GetCredentialRequest) -> GetCredentialResponse {
             "signature not prepared or expired",
         )));
     };
-    let vc_jws = vc_jwt_to_jws(&credential_jwt, &canister_sig_pk_der, &sig, canister_id);
+    let vc_jws = vc_jwt_to_jws(&credential_jwt, &canister_sig_pk, &sig);
     GetCredentialResponse::Ok(IssuedCredentialData { vc_jws })
 }
 

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -22,7 +22,7 @@ use internet_identity_interface::internet_identity::types::FrontendHostname;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use vc_util::{
+use vc_util_br::{
     create_verifiable_presentation_jwt, verify_id_alias_credential_jws, AliasTuple,
     PresentationParams,
 };
@@ -255,6 +255,28 @@ fn should_fail_prepare_credential_for_unauthorized_principal() {
     )
     .expect("API call failed");
     assert_matches!(response, PrepareCredentialResponse::Err(e) if format!("{:?}", e).contains("unauthorized principal"));
+}
+
+#[test]
+fn should_fail_prepare_credential_for_anonymous_caller() {
+    let env = env();
+    let issuer_id = install_canister(&env, VC_ISSUER_WASM.clone());
+    let signed_id_alias = SignedIdAlias {
+        id_alias: principal_1(),
+        id_dapp: principal_2(),
+        credential_jws: "dummy jws".to_string(),
+    };
+    let response = api::prepare_credential(
+        &env,
+        issuer_id,
+        Principal::anonymous(),
+        &PrepareCredentialRequest {
+            credential_spec: employee_credential_spec(),
+            signed_id_alias,
+        },
+    )
+    .expect("API call failed");
+    assert_matches!(response, PrepareCredentialResponse::Err(e) if format!("{:?}", e).contains("Anonymous principal not allowed"));
 }
 
 #[test]

--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -119,6 +119,7 @@ side can be identified using `id_alias` for the purpose of attribute sharing, an
 described by `credential_spec` does apply to the user.  When these checks are successful, the issuer
 prepares and returns a context in `PreparedCredentialData.prepared_context` (if any).  The returned prepared context is then 
 passed back to the issuer in a subsequent `get_credential`-call (see below).
+This call must be authenticated (i.e. it is not available for the anonymous sender).
 
 **NOTE:** 
 The value of `prepared_context` is basically used to transfer information between `prepare_credential`
@@ -153,6 +154,7 @@ type IssuedCredentialData = record { vc_jws : text };
 `prepared_context`-value  returned by `prepare_credential`, if any.
 The issuer performs the same checks as during the `prepare_credential`-call,
 plus verify that `prepared_context` is consistent with the other parameters.
+This call must be authenticated (i.e. it is not available for the anonymous sender).
 
 Upon successful checks, issuer returns the signed credential in JWS-format.
 

--- a/src/canister_sig_util/src/lib.rs
+++ b/src/canister_sig_util/src/lib.rs
@@ -19,6 +19,50 @@ lazy_static! {
         extract_raw_root_pk_from_der(IC_ROOT_PK_DER).expect("Failed decoding IC root key.");
 }
 
+/// A public key of canister signatures,
+/// see https://internetcomputer.org/docs/current/references/ic-interface-spec#canister-signatures
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct CanisterSigPublicKey {
+    pub canister_id: Principal,
+    pub seed: Vec<u8>,
+}
+
+impl TryFrom<&[u8]> for CanisterSigPublicKey {
+    type Error = String;
+
+    fn try_from(pk_der: &[u8]) -> Result<Self, Self::Error> {
+        let pk_raw = extract_raw_canister_sig_pk_from_der(pk_der)?;
+        let canister_id_len: usize = if pk_raw.len() > 0 {
+            usize::from(pk_der[0])
+        } else {
+            return Err("empty raw canister sig pk".to_string());
+        };
+        if pk_raw.len() < (1 + canister_id_len) {
+            return Err("canister sig pk too short".to_string());
+        }
+        let canister_id_raw = &pk_der[1..(1 + canister_id_len)];
+        let seed = &pk_der[canister_id_len + 1..];
+        let canister_id = Principal::try_from_slice(canister_id_raw)
+            .map_err(|e| format!("invalid canister id in canister sig pk: {}", e))?;
+        Ok(CanisterSigPublicKey {
+            canister_id: canister_id,
+            seed: seed.to_vec(),
+        })
+    }
+}
+
+impl CanisterSigPublicKey {
+    /// Constructs a new canister signatures public key.
+    pub fn new(canister_id: Principal, seed: Vec<u8>) -> Self {
+        CanisterSigPublicKey { canister_id, seed }
+    }
+
+    /// Returns a byte vector with DER-encoding of this key.
+    pub fn to_der(&self) -> Vec<u8> {
+        get_canister_sig_pk_der(self.canister_id, &self.seed)
+    }
+}
+
 /// Returns (DER-encoded) public key of the canister signatures for the given canister_id and seed.
 /// (cf. https://internetcomputer.org/docs/current/references/ic-interface-spec#canister-signatures))
 pub fn get_canister_sig_pk_der(canister_id: Principal, seed: &[u8]) -> Vec<u8> {

--- a/src/canister_sig_util/src/lib.rs
+++ b/src/canister_sig_util/src/lib.rs
@@ -32,7 +32,7 @@ impl TryFrom<&[u8]> for CanisterSigPublicKey {
 
     fn try_from(pk_der: &[u8]) -> Result<Self, Self::Error> {
         let pk_raw = extract_raw_canister_sig_pk_from_der(pk_der)?;
-        let canister_id_len: usize = if pk_raw.len() > 0 {
+        let canister_id_len: usize = if !pk_raw.is_empty() {
             usize::from(pk_der[0])
         } else {
             return Err("empty raw canister sig pk".to_string());
@@ -45,7 +45,7 @@ impl TryFrom<&[u8]> for CanisterSigPublicKey {
         let canister_id = Principal::try_from_slice(canister_id_raw)
             .map_err(|e| format!("invalid canister id in canister sig pk: {}", e))?;
         Ok(CanisterSigPublicKey {
-            canister_id: canister_id,
+            canister_id,
             seed: seed.to_vec(),
         })
     }

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 canister_sig_util = { path = "../canister_sig_util" }
 internet_identity_interface = { path = "../internet_identity_interface" }
-vc_util = { path = "../vc_util_br" }
+vc_util_br = { path = "../vc_util_br" }
 
 
 hex = "0.4"

--- a/src/internet_identity/tests/integration/vc_mvp.rs
+++ b/src/internet_identity/tests/integration/vc_mvp.rs
@@ -12,7 +12,7 @@ use internet_identity_interface::internet_identity::types::vc_mvp::{
 };
 use internet_identity_interface::internet_identity::types::FrontendHostname;
 use std::ops::Deref;
-use vc_util::verify_credential_jws;
+use vc_util_br::verify_credential_jws;
 
 fn verify_canister_sig_pk(credential_jws: &str, canister_sig_pk_der: &[u8]) {
     let decoder: Decoder = Decoder::new();

--- a/src/vc_util_br/Cargo.toml
+++ b/src/vc_util_br/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vc_util"
+name = "vc_util_br"
 description = "Utils for verifiable credentials on the IC"
 version = "0.1.0"
 edition = "2021"


### PR DESCRIPTION
Introduce `CanisterSigPublicKey` to `canister_sig_util`, and use it to simplify `vc_util`-API.
Also, add checking for anonymous caller in VC issuer calls.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/76a11966a/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

