### PR TITLE
Run tests with clean IndexedDB

### DIFF
--- a/src/frontend/src/components/authenticateBox.test.ts
+++ b/src/frontend/src/components/authenticateBox.test.ts
@@ -1,7 +1,13 @@
 import { I18n } from "$src/utils/i18n";
+import { IDBFactory } from "fake-indexeddb";
 import { html, render } from "lit-html";
 import { vi } from "vitest";
 import { authnTemplates } from "./authenticateBox";
+
+beforeEach(() => {
+  // Create a fresh IDB before each test
+  global.indexedDB = new IDBFactory();
+});
 
 test("anchors are forwarded", async () => {
   const addDevice: (anchor?: bigint) => void = vi.fn();

--- a/src/frontend/src/flows/pin/idb.ts
+++ b/src/frontend/src/flows/pin/idb.ts
@@ -11,10 +11,8 @@ export {
 /* IndexedDB-specific storage for browser identities
  * (indexed by user number) */
 
-export const idbIdentitiesStore = createStore(
-  "browser-identities",
-  "identities"
-);
+export const idbIdentitiesStore = () =>
+  createStore("browser-identities", "identities");
 
 export const idbStorePinIdentityMaterial = async ({
   userNumber,
@@ -23,7 +21,7 @@ export const idbStorePinIdentityMaterial = async ({
   userNumber: bigint;
   pinIdentityMaterial: PinIdentityMaterial;
 }): Promise<void> => {
-  await set(userNumber.toString(), pinIdentityMaterial, idbIdentitiesStore);
+  await set(userNumber.toString(), pinIdentityMaterial, idbIdentitiesStore());
 };
 
 export const idbRetrievePinIdentityMaterial = async ({
@@ -31,7 +29,7 @@ export const idbRetrievePinIdentityMaterial = async ({
 }: {
   userNumber: bigint;
 }): Promise<PinIdentityMaterial | undefined> => {
-  const retrieved = await get(userNumber.toString(), idbIdentitiesStore);
+  const retrieved = await get(userNumber.toString(), idbIdentitiesStore());
 
   if (retrieved === undefined) {
     return undefined;

--- a/src/frontend/test-setup.ts
+++ b/src/frontend/test-setup.ts
@@ -1,4 +1,3 @@
-import indexeddb from "fake-indexeddb";
 import { TextEncoder } from "util";
 import { vi } from "vitest";
 
@@ -51,4 +50,3 @@ global.crypto = require("crypto").webcrypto;
 // eslint-disable-next-line
 global.CryptoKey = require("crypto").webcrypto.CryptoKey;
 global.TextEncoder = TextEncoder;
-global.indexedDB = indexeddb;


### PR DESCRIPTION
This updates our test setup to use a fresh IndexedDB before each test. This ensures that data from one test doesn't pollute other tests.

The `createStore` calls a turned into function to ensure `idb-keyval` doesn't try to access the global `indexeddb` object upon module import, but only once the stores are actually needed.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
