### PR TITLE
Remove references to docker-test-env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,3 @@ Dockerfile
 scripts/
 !scripts/build
 !scripts/bootstrap
-
-# docker build doesn't depend on the docker-compose setup
-docker-test-env/

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,7 @@ lib
 # Cargo build output
 target/
 
-# selenium docker environment files
-docker-test-env/dfx-docker/canisters/
+# End-to-end test artifacts
 test-failures/
 
 # built canisters

--- a/demos/test-app/README.md
+++ b/demos/test-app/README.md
@@ -23,7 +23,7 @@ This app is used by the Internet Identity Selenium tests. It contains additional
 
 ## Development
 
-Note: These steps are intended to do development on the test-app. To simply run selenium tests against the test-app follow [these instructions](../../docker-test-env/README.md) instead.
+Note: These steps are intended to do development on the test-app. To simply run selenium tests against the test-app follow [these instructions](../../HACKING.md) instead.
 
 1. Ensure all dependencies are installed: `npm ci`
 2. Run the local replica `dfx start --clean`


### PR DESCRIPTION
There were a couple leftover references to the docker compose setup. They've be removed or updated to point to new instructions.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
