### PR TITLE
Typecheck vite config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@types/html-minifier-terser": "^7.0.0",
+        "@types/http-proxy": "^1.17.14",
         "@types/selenium-standalone": "^7.0.1",
         "@types/ua-parser-js": "^0.7.36",
         "@typescript-eslint/eslint-plugin": "6.7.5",
@@ -1778,6 +1779,15 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
       "integrity": "sha512-V46MYLFp08Wf2mmaBhvgjStM3tPa+2GAdy/iqoX+noX1//zje2x4XmrIU0cAwyClATsTmahbtoQ2EwP7I5WSiA==",
       "dev": true
+    },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.14",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
+      "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -16197,6 +16207,15 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
       "integrity": "sha512-V46MYLFp08Wf2mmaBhvgjStM3tPa+2GAdy/iqoX+noX1//zje2x4XmrIU0cAwyClATsTmahbtoQ2EwP7I5WSiA==",
       "dev": true
+    },
+    "@types/http-proxy": {
+      "version": "1.17.14",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
+      "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -31,15 +31,18 @@
   },
   "devDependencies": {
     "@types/html-minifier-terser": "^7.0.0",
+    "@types/http-proxy": "^1.17.14",
     "@types/selenium-standalone": "^7.0.1",
     "@types/ua-parser-js": "^0.7.36",
     "@typescript-eslint/eslint-plugin": "6.7.5",
     "@typescript-eslint/parser": "6.7.5",
+    "@vitejs/plugin-basic-ssl": "^1.0.1",
     "@wdio/globals": "^8.6.9",
     "astro": "^2.4.1",
     "eslint": "8.51.0",
     "fake-indexeddb": "^4.0.2",
     "html-minifier-terser": "^7.2.0",
+    "http-proxy": "^1.18.1",
     "prettier": "2.8.0",
     "prettier-plugin-organize-imports": "^3.2.2",
     "ts-loader": "9.4.1",
@@ -47,9 +50,7 @@
     "typescript": "5.2.2",
     "vite": "^4.2.1",
     "vite-plugin-compression": "^0.5.1",
-    "@vitejs/plugin-basic-ssl": "^1.0.1",
     "vitest": "^0.31.0",
-    "http-proxy": "^1.18.1",
     "webdriverio": "^8.21.0"
   },
   "dependencies": {

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src"],
+  "include": ["src", "./*.ts"],
   "exclude": [
     "src/frontend/generated/*",
     "src/frontend/jest-custom-sequencer.ts"


### PR DESCRIPTION
This ensures the vite (vitest, plugins, etc) config is typechecked, and installs the http-proxy package type definitions.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
