### PR TITLE
Use cdk println! macro in vc_utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,6 +3457,7 @@ dependencies = [
  "assert_matches",
  "candid",
  "canister_sig_util",
+ "ic-cdk",
  "ic-certified-map",
  "ic-crypto-standalone-sig-verifier",
  "ic-types",

--- a/src/vc_util/Cargo.toml
+++ b/src/vc_util/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 # ic dependencies
 candid = "0.9"
+ic-cdk = "0.10"
 ic-certified-map = "0.4"
 ic-crypto-standalone-sig-verifier = { git = "https://github.com/dfinity/ic", rev = "bf9bc00b032a18d2dbcfcfcfb7a76a562f350c9e" }
 ic-types = { git = "https://github.com/dfinity/ic", rev = "bf9bc00b032a18d2dbcfcfcfb7a76a562f350c9e" }

--- a/src/vc_util/src/lib.rs
+++ b/src/vc_util/src/lib.rs
@@ -39,7 +39,7 @@ pub enum CredentialVerificationError {
 }
 
 /// Returns the effective bytes that will be signed when computing a canister signature for
-/// the given JWT-credential, verfiable via the specified public key.
+/// the given JWT-credential, verifiable via the specified public key.
 pub fn vc_signing_input(
     credential_jwt: &str,
     canister_sig_pk: &CanisterSigPublicKey,
@@ -178,14 +178,16 @@ fn validate_claim<T: std::cmp::PartialEq<S> + std::fmt::Display, S: std::fmt::Di
         if expected == actual {
             Ok(())
         } else {
-            println!(
+            ic_cdk::println!(
                 "inconsistent claim [{}] in id_alias VC::  expected: {}, actual: {}",
-                label, expected, actual
+                label,
+                expected,
+                actual
             );
             Err(inconsistent_jwt_claims("inconsistent claim in id_alias VC"))
         }
     } else {
-        println!("missing claim [{}] in id_alias VC", label);
+        ic_cdk::println!("missing claim [{}] in id_alias VC", label);
         Err(inconsistent_jwt_claims("missing claim in id_alias VC"))
     }
 }


### PR DESCRIPTION
This PR changes the `println!` macro usages
to `ic_cdk::println!` macros so that they also
work when the library is used inside a canister.

Includes a drive-by typo fix.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a7ee2cbcc/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
