### PR TITLE
Add specs and APIs for attribute sharing

### DIFF
--- a/.ic-commit
+++ b/.ic-commit
@@ -1,3 +1,3 @@
 # the commit used to pull the state machine executable
 # see rust canister tests for more info
-dc09a9c339a6250e1d4a6b851903b995270dff96
+7d40c09f4a0609f3d00322172c1336759f8f6be1

--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -116,13 +116,13 @@ type PreparedCredentialData = record { prepared_context : opt blob };
 Specifically, the issuer checks via `prepared_id_alias.credential_jws` that user identified via `id_dapp` on the issuer
 side can be identified using `id_alias` for the purpose of attribute sharing, and that the credential
 described by `credential_spec` does apply to the user.  When these checks are successful, the issuer
-prepares and returns a context in `PreparedCredentialData.prepared_context` (if any).  The returned prepared context is then 
+prepares and returns a context in `PreparedCredentialData.prepared_context` (if any).  The returned prepared context is then
 passed back to the issuer in a subsequent `get_credential`-call (see below).
 This call must be authenticated (i.e. it is not available for the anonymous sender).
 
-**NOTE:** 
+**NOTE:**
 The value of `prepared_context` is basically used to transfer information between `prepare_credential`
-and `get_credential` steps, and it is totally up to the issuer to decide on the content of 
+and `get_credential` steps, and it is totally up to the issuer to decide on the content of
 that field.  That is, the issuer creates `prepared_context`, and is the only entity that
 consumes it.
 
@@ -158,14 +158,14 @@ This call must be authenticated (i.e. it is not available for the anonymous send
 Upon successful checks, issuer returns the signed credential in JWS-format.
 
 
-##  Identity Provider API 
+##  Identity Provider API
 
-This section describes the _Window Post Message_-interface implemented by the identity provider (Internet Idenity).
+This section describes the [_`window.postMessage()`_](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage)-interface implemented by the identity provider (Internet Identity).
 This interface is used by a Relying Party during attribute sharing flow (cf. [flow description](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/attribute-sharing.md))
 
 ### 1: Load II in a new window
 
-The II window needs to be opened with the subpath `/vc-flow`.
+The II window needs to be opened with the URL path `/vc-flow`.
 
 After opening the II window, II will load and notify `window.opener` with the following JSON-RPC notification:
 
@@ -179,7 +179,6 @@ After opening the II window, II will load and notify `window.opener` with the fo
 ### 2: Request a VC
 
 After receiving the notification that II is ready, the relying party can request a VC by sending the following JSON-RPC request:
- 
 * Method: `request_credential`
 * Params:
   * `issuer`: An issuer that the relying party trusts. It has the following properties:
@@ -262,7 +261,7 @@ After receiving the notification that II is ready, the relying party can request
 
 After the user has successfully completed the flow, Internet Identity will respond with the following JSON-RPC response:
 
-  * `verifiablePresentation`: The JWT based verifiable presentation containing two credentials: 
+  * `verifiablePresentation`: The JWT based verifiable presentation containing two credentials:
     1. A verifiable credential issued by Internet Identity that relates the requested `credentialSubject` to another alias principal.
     2. A verifiable credential issued by the requested issuer to the alias principal.
 

--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -4,8 +4,8 @@
 ## Issuer API
 
 This section describes the (Candid) interface to be implemented by an issuer of verifiable credentials on the IC.
-This interface is used by the II-canister during attribute sharing flow (cf. [flow description](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/attribute-sharing.md))
-An example implementation of the interface is given in [demos/vc_issuer](../demos/vc_issuer).
+This interface is used by the II-canister during attribute sharing flow (cf. [flow description](https://github.com/dfinity/wg-identity-authentication/blob/d2664795afe9cea40386804bdb1259a47e34540d/topics/attribute-sharing.md))
+An example implementation of the interface is given in [demos/vc_issuer](https://github.com/dfinity/internet-identity/tree/vc-mvp/demos/vc_issuer).
 
 The Candid interface is as follows, and the subsequent sections describe the
 services and the corresponding messages in more detail.
@@ -22,8 +22,8 @@ type GetCredentialRequest = record {
     credential_spec : CredentialSpec;
 };
 type GetCredentialResponse = variant {
-    Ok : IssuedCredentialData;
-    Err : IssueCredentialError
+    ok : IssuedCredentialData;
+    err : IssueCredentialError;
 };
 type Icrc21ConsentInfo = record { consent_message : text; language : text };
 type Icrc21VcConsentMessageRequest = record {
@@ -31,8 +31,8 @@ type Icrc21VcConsentMessageRequest = record {
     credential_spec : CredentialSpec;
 };
 type Icrc21ConsentMessageResponse = variant {
-    Ok : Icrc21ConsentInfo;
-    Err : Icrc21Error;
+    ok : Icrc21ConsentInfo;
+    err : Icrc21Error;
 };
 type Icrc21ConsentPreferences = record { language : text };
 type Icrc21Error = variant {
@@ -55,8 +55,8 @@ type PrepareCredentialRequest = record {
     credential_spec : CredentialSpec;
 };
 type PrepareCredentialResponse = variant {
-    Ok : PreparedCredentialData;
-    Err : IssueCredentialError;
+    ok : PreparedCredentialData;
+    err : IssueCredentialError;
 };
 type PreparedCredentialData = record { prepared_context : opt blob };
 type SignedIdAlias = record {
@@ -75,7 +75,6 @@ service : {
 
 In the attribute sharing flow a user must approve the issuance of a verifiable
 credential by an issuer, and this happens by approving a human-readable consent message from the issuer.
-See [ICRC-21](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md) for more detail.
 
 Identity provider uses a VC-extension of  [ICRC-21](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md), and requests the consent message via `Icrc21VcConsentMessageRequest`,
 Upon successful response idenity provider displays the consent message from `Icrc21ConsentInfo` to the user.
@@ -107,8 +106,8 @@ type PrepareCredentialRequest = record {
 };
 
 type PrepareCredentialResponse = variant {
-    Ok : PreparedCredentialData;
-    Err : IssueCredentialError;
+    ok : PreparedCredentialData;
+    err : IssueCredentialError;
 };
 
 type PreparedCredentialData = record { prepared_context : opt blob };
@@ -143,8 +142,8 @@ type GetCredentialRequest = record {
     credential_spec : CredentialSpec;
 };
 type GetCredentialResponse = variant {
-    Ok : IssuedCredentialData;
-    Err : IssueCredentialError;
+    ok : IssuedCredentialData;
+    err : IssueCredentialError;
 };
 type IssuedCredentialData = record { vc_jws : text };
 
@@ -265,7 +264,10 @@ After the user has successfully completed the flow, Internet Identity will respo
 
   * `verifiablePresentation`: The JWT based verifiable presentation containing two credentials: 
     1. A verifiable credential issued by Internet Identity that relates the requested `credentialSubject` to another alias principal.
-    2. A verifiable credential issued by on of the requested issuers issued to the alias principal.
+    2. A verifiable credential issued by the requested issuer to the alias principal.
+
+**NOTE:** the order of the credentials in the presentation should match the list above,
+i.e. the credential that relates the subject to alias principal should come first.
 
 ##### Example
 

--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -1,0 +1,313 @@
+# II Verifiable Credential Spec (MVP)
+
+
+## Issuer API
+
+This section describes the (Candid) interface to be implemented by an issuer of verifiable credentials on the IC.
+This interface is used by the II-canister during attribute sharing flow (cf. [flow description](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/attribute-sharing.md))
+An example implementation of the interface is given in [demos/vc_issuer](../demos/vc_issuer).
+
+The Candid interface is as follows, and the subsequent sections describe the
+services and the corresponding messages in more detail.
+
+```candid
+type ArgumentValue = variant { "int" : int32; string : text };
+type CredentialSpec = record {
+    arguments : opt vec record { text; ArgumentValue };
+    credential_name : text;
+};
+type GetCredentialRequest = record {
+    signed_id_alias : SignedIdAlias;
+    prepared_context : opt blob;
+    credential_spec : CredentialSpec;
+};
+type GetCredentialResponse = variant {
+    Ok : IssuedCredentialData;
+    Err : IssueCredentialError
+};
+type Icrc21ConsentInfo = record { consent_message : text; language : text };
+type Icrc21VcConsentMessageRequest = record {
+    preferences : Icrc21ConsentPreferences;
+    credential_spec : CredentialSpec;
+};
+type Icrc21ConsentMessageResponse = variant {
+    Ok : Icrc21ConsentInfo;
+    Err : Icrc21Error;
+};
+type Icrc21ConsentPreferences = record { language : text };
+type Icrc21Error = variant {
+    GenericError : Icrc21ErrorInfo;
+    MalformedCall : Icrc21ErrorInfo;
+    NotSupported : Icrc21ErrorInfo;
+    Forbidden : Icrc21ErrorInfo;
+};
+type Icrc21ErrorInfo = record { description : text; error_code : nat64 };
+type IssueCredentialError = variant {
+    Internal : text;
+    SignatureNotFound : text;
+    InvalidIdAlias : text;
+    UnauthorizedSubject : text;
+    UnknownSubject : text;
+};
+type IssuedCredentialData = record { vc_jws : text };
+type PrepareCredentialRequest = record {
+    signed_id_alias : SignedIdAlias;
+    credential_spec : CredentialSpec;
+};
+type PrepareCredentialResponse = variant {
+    Ok : PreparedCredentialData;
+    Err : IssueCredentialError;
+};
+type PreparedCredentialData = record { prepared_context : opt blob };
+type SignedIdAlias = record {
+    credential_jws : text;
+    id_alias : principal;
+    id_dapp : principal;
+};
+service : {
+    get_credential : (GetCredentialRequest) -> (GetCredentialResponse) query;
+    prepare_credential : (PrepareCredentialRequest) -> (PrepareCredentialResponse);
+    vc_consent_message : (Icrc21VcConsentMessageRequest) -> (Icrc21ConsentMessageResponse);
+}
+```
+
+### 1: Consent Message
+
+In the attribute sharing flow a user must approve the issuance of a verifiable
+credential by an issuer, and this happens by approving a human-readable consent message from the issuer.
+See [ICRC-21](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md) for more detail.
+
+Identity provider uses a VC-extension of  [ICRC-21](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md), and requests the consent message via `Icrc21VcConsentMessageRequest`,
+Upon successful response idenity provider displays the consent message from `Icrc21ConsentInfo` to the user.
+
+### 2: Prepare Credential
+
+Preparation of a credential involves checking the validity of the request,
+and upon success, preparation of the actual credential requested by the user.
+
+```candid
+service : {
+  prepare_credential : (PrepareCredentialRequest) -> (PrepareCredentialResponse);
+};
+
+type PrepareCredentialRequest = record {
+    signed_id_alias : SignedIdAlias;
+    credential_spec : CredentialSpec;
+};
+
+type SignedIdAlias = record {
+    credential_jws : text;
+    id_alias : principal;
+    id_dapp : principal;
+};
+
+type PrepareCredentialRequest = record {
+    signed_id_alias : SignedIdAlias;
+    credential_spec : CredentialSpec;
+};
+
+type PrepareCredentialResponse = variant {
+    Ok : PreparedCredentialData;
+    Err : IssueCredentialError;
+};
+
+type PreparedCredentialData = record { prepared_context : opt blob };
+```
+
+Specifically, the issuer checks via `prepared_id_alias.credential_jws` that user identified via `id_dapp` on the issuer
+side can be identified using `id_alias` for the purpose of attribute sharing, and that the credential
+described by `credential_spec` does apply to the user.  When these checks are successful, the issuer
+prepares and returns a context in `PreparedCredentialData.prepared_context` (if any).  The returned prepared context is then 
+passed back to the issuer in a subsequent `get_credential`-call (see below).
+This call must be authenticated (i.e. it is not available for the anonymous sender).
+
+**NOTE:** 
+The value of `prepared_context` is basically used to transfer information between `prepare_credential`
+and `get_credential` steps, and it is totally up to the issuer to decide on the content of 
+that field.  That is, the issuer creates `prepared_context`, and is the only entity that
+consumes it.
+
+
+### 3: Get Credential
+
+`get_credential`-service issues the actual credential requested by the user.
+
+```candid
+service : {
+  get_credential : (GetCredentialRequest) -> (GetCredentialResponse) query;
+};
+
+type GetCredentialRequest = record {
+    signed_id_alias : SignedIdAlias;
+    prepared_context : opt blob;
+    credential_spec : CredentialSpec;
+};
+type GetCredentialResponse = variant {
+    Ok : IssuedCredentialData;
+    Err : IssueCredentialError;
+};
+type IssuedCredentialData = record { vc_jws : text };
+
+```
+
+`GetCredentialRequest` should contain the same parameters as `PrepareCredentialRequest`, plus the
+`prepared_context`-value  returned by `prepare_credential`, if any.
+The issuer performs the same checks as during the `prepare_credential`-call,
+plus verify that `prepared_context` is consistent with the other parameters.
+This call must be authenticated (i.e. it is not available for the anonymous sender).
+
+Upon successful checks, issuer returns the signed credential in JWS-format.
+
+
+##  Identity Provider API 
+
+This section describes the _Window Post Message_-interface implemented by the identity provider (Internet Idenity).
+This interface is used by a Relying Party during attribute sharing flow (cf. [flow description](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/attribute-sharing.md))
+
+### 1: Load II in a new window
+
+The II window needs to be opened with the subpath `/vc-flow`.
+
+After opening the II window, II will load and notify `window.opener` with the following JSON-RPC notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "vc-flow-ready"
+}
+```
+
+### 2: Request a VC
+
+After receiving the notification that II is ready, the relying party can request a VC by sending the following JSON-RPC request:
+ 
+* Method: `request_credential`
+* Params:
+  * `issuer`: An issuer that the relying party trusts. It has the following properties:
+    * `origin`: The origin of the issuer.
+    * `canisterId`: (optional) The canister id of the issuer, if applicable/known.
+  * `credentialSpec`: The spec of the credential that the relying party wants to request from the issuer.
+    * `credentialName`: The name of the requested credential.
+    * `arguments`: (optional) A map with arguments specific to the requested credentials. It maps string keys to values that must be either strings or integers.
+  * `credentialSubject`: The subject of the credential as known to the relying party. Internet Identity will use this principal to ensure that the flow is completed using the matching identity.
+
+#### Examples
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "request_credential",
+  "params": {
+    "issuer": {
+        "origin": "https://employment-info.com",
+        "canisterId": "rwlgt-iiaaa-aaaaa-aaaaa-cai"
+    },
+    "credentialSpec": {
+        "credentialName": "VerifiedEmployee",
+        "arguments": {
+          "employerName": "XYZ Ltd."
+        }
+    },
+    "credentialSubject": "2mdal-aedsb-hlpnv-qu3zl-ae6on-72bt5-fwha5-xzs74-5dkaz-dfywi-aqe"
+  }
+}
+```
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "request_credential",
+  "params": {
+    "issuer": {
+        "origin": "https://kyc-star.com",
+        "canisterId": "rdmx6-jaaaa-aaaaa-aaadq-cai"
+    },
+    "credentialSpec": {
+        "credentialName": "VerifiedAdult",
+        "arguments": {
+            "minAge": 21
+        }
+    },
+    "credentialSubject": "s33qc-ctnp5-ubyz4-kubqo-p2tem-he4ls-6j23j-hwwba-37zbl-t2lv3-pae"
+  }
+}
+```
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "request_credential",
+  "params": {
+    "issuer": {
+        "origin": "https://kyc-resident-info.org"
+    },
+    "credentialSpec": {
+        "credentialName": "VerifiedResident",
+        "arguments": {
+            "countryName": "Panama",
+            "countryAlpha2": "PA"
+        }
+    },
+    "credentialSubject": "cpehq-54hef-odjjt-bockl-3ldtg-jqle4-ysi5r-6bfah-v6lsa-xprdv-pqe"
+  }
+}
+```
+
+### 3: Get a Response
+
+
+#### Receive a Verifiable Presentation
+
+After the user has successfully completed the flow, Internet Identity will respond with the following JSON-RPC response:
+
+  * `verifiablePresentation`: The JWT based verifiable presentation containing two credentials: 
+    1. A verifiable credential issued by Internet Identity that relates the requested `credentialSubject` to another alias principal.
+    2. A verifiable credential issued by on of the requested issuers issued to the alias principal.
+
+##### Example
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "verifiablePresentation": "eyJQ..."
+  }
+}
+```
+
+An example of such a verifiable presentation can be found [here](https://www.w3.org/TR/vc-data-model/#example-jwt-payload-of-a-jwt-based-verifiable-presentation-non-normative).
+
+#### Receive an Error Message
+
+If the flow failed for any reason, Internet Identity returns an error.
+For privacy protection, the error does not give any details on the root cause of the failure.
+(This may change in the future, as some failures can be reported to the relying
+party without impacting user's privacy.)
+
+##### Example
+
+``` json
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "error": {
+        "version": "1",
+        "code": "UNKNOWN"
+    }
+}
+```
+
+
+#### Interaction Model
+
+Given the interactive nature of the flow, the relying party should not expect to receive a response immediately. Instead, the relying party should wait for one of the following events:
+* II sends a JSON-RPC response as described above.
+* II sends a JSON-RPC error response.
+* The user closes the II window. This should be treated as an error.
+
+The relying party may also close the II window after some timeout. The user should then be notified by the relying party that the flow failed.
+

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -8,6 +8,7 @@ pub type PublicKey = ByteBuf;
 pub type DeviceKey = PublicKey;
 pub type UserKey = PublicKey;
 pub type SessionKey = PublicKey;
+pub type CanisterSigPublicKeyDer = PublicKey;
 pub type FrontendHostname = String;
 pub type Timestamp = u64; // in nanos since epoch
 pub type Signature = ByteBuf;
@@ -15,6 +16,8 @@ pub type DeviceVerificationCode = String;
 pub type FailedAttemptsCounter = u8;
 
 mod api_v2;
+mod vc_mvp;
+
 // re-export v2 types without the ::v2 prefix, so that this crate can be restructured once v1 is removed
 // without breaking clients
 pub use api_v2::*;

--- a/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
@@ -1,0 +1,71 @@
+use crate::internet_identity::types::{CanisterSigPublicKeyDer, FrontendHostname, IdentityNumber};
+use candid::{CandidType, Deserialize, Principal};
+
+
+/// Types for requesting ID-alias credentials, used for attribute sharing feature.
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct SignedIdAlias {
+    pub id_alias: Principal,
+    pub id_dapp: Principal,
+    pub credential_jws: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct PrepareIdAliasRequest {
+    #[serde(rename = "identity_number")]
+    pub identity_number: IdentityNumber,
+    #[serde(rename = "relying_party")]
+    pub relying_party: FrontendHostname,
+    #[serde(rename = "issuer")]
+    pub issuer: FrontendHostname,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct PreparedIdAlias {
+    #[serde(rename = "canister_sig_pk_der")]
+    pub canister_sig_pk_der: CanisterSigPublicKeyDer,
+    #[serde(rename = "rp_id_alias_jwt")]
+    pub rp_id_alias_jwt: String,
+    #[serde(rename = "issuer_id_alias_jwt")]
+    pub issuer_id_alias_jwt: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum PrepareIdAliasResponse {
+    #[serde(rename = "ok")]
+    Ok(PreparedIdAlias),
+    #[serde(rename = "authentication_failed")]
+    AuthenticationFailed(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct IdAliasCredentials {
+    pub rp_id_alias_credential: SignedIdAlias,
+    pub issuer_id_alias_credential: SignedIdAlias,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct GetIdAliasRequest {
+    #[serde(rename = "identity_number")]
+    pub identity_number: IdentityNumber,
+    #[serde(rename = "relying_party")]
+    pub relying_party: FrontendHostname,
+    #[serde(rename = "issuer")]
+    pub issuer: FrontendHostname,
+    #[serde(rename = "rp_id_alias_jwt")]
+    pub rp_id_alias_jwt: String,
+    #[serde(rename = "issuer_id_alias_jwt")]
+    pub issuer_id_alias_jwt: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum GetIdAliasResponse {
+    #[serde(rename = "ok")]
+    Ok(IdAliasCredentials),
+    #[serde(rename = "authentication_failed")]
+    AuthenticationFailed(String),
+    #[serde(rename = "no_such_credentials")]
+    NoSuchCredentials(String),
+}
+

--- a/src/vc_util/src/issuer_api.rs
+++ b/src/vc_util/src/issuer_api.rs
@@ -1,0 +1,161 @@
+use candid::{CandidType, Deserialize, Principal};
+use serde_bytes::ByteBuf;
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+
+/// API to be implemented by an issuer of verifiable credentials.
+/// (cf. https://github.com/dfinity/internet-identity/blob/vc-mvp/docs/vc-spec.md)
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct SignedIdAlias {
+    pub id_alias: Principal,
+    pub id_dapp: Principal,
+    pub credential_jws: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct PrepareCredentialRequest {
+    pub signed_id_alias: SignedIdAlias,
+    pub credential_spec: CredentialSpec,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum PrepareCredentialResponse {
+    #[serde(rename = "ok")]
+    Ok(PreparedCredentialData),
+    #[serde(rename = "err")]
+    Err(IssueCredentialError),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum IssueCredentialError {
+    #[serde(rename = "unknown_subject")]
+    UnknownSubject(String),
+    #[serde(rename = "unauthorized_subject")]
+    UnauthorizedSubject(String),
+    #[serde(rename = "invalid_id_alias")]
+    InvalidIdAlias(String),
+    #[serde(rename = "signature_not_found")]
+    SignatureNotFound(String),
+    #[serde(rename = "internal")]
+    Internal(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct GetCredentialRequest {
+    pub signed_id_alias: SignedIdAlias,
+    pub credential_spec: CredentialSpec,
+    pub prepared_context: Option<ByteBuf>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum GetCredentialResponse {
+    #[serde(rename = "ok")]
+    Ok(IssuedCredentialData),
+    #[serde(rename = "err")]
+    Err(IssueCredentialError),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct PreparedCredentialData {
+    pub prepared_context: Option<ByteBuf>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct IssuedCredentialData {
+    pub vc_jws: String,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
+pub enum ArgumentValue {
+    #[serde(rename = "string")]
+    String(String),
+    #[serde(rename = "int")]
+    Int(i32),
+}
+
+impl Display for ArgumentValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            ArgumentValue::String(s) => write!(f, "'{}'", s),
+            ArgumentValue::Int(i) => write!(f, "{}", i),
+        }
+    }
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct CredentialSpec {
+    pub credential_name: String,
+    pub arguments: Option<HashMap<String, ArgumentValue>>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct ManifestRequest {}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum ManifestResponse {
+    #[serde(rename = "ok")]
+    Ok(ManifestData),
+    #[serde(rename = "err")]
+    Err(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct ManifestData {}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct Icrc21VcConsentMessageRequest {
+    pub credential_spec: CredentialSpec,
+    pub preferences: Icrc21ConsentPreferences,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct Icrc21ConsentPreferences {
+    pub language: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct Icrc21ErrorInfo {
+    pub error_code: u64,
+    pub description: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum Icrc21Error {
+    #[serde(rename = "forbidden")]
+    Forbidden(Icrc21ErrorInfo),
+    #[serde(rename = "malformed_call")]
+    MalformedCall(Icrc21ErrorInfo),
+    #[serde(rename = "not_supported")]
+    NotSupported(Icrc21ErrorInfo),
+    #[serde(rename = "generic_error")]
+    GenericError(Icrc21ErrorInfo),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct Icrc21ConsentInfo {
+    pub consent_message: String,
+    pub language: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum Icrc21ConsentMessageResponse {
+    #[serde(rename = "ok")]
+    Ok(Icrc21ConsentInfo),
+    #[serde(rename = "err")]
+    Err(Icrc21Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn should_display_argument_values() {
+        assert_eq!("42", format!("{}", ArgumentValue::Int(42)));
+        assert_eq!("0", format!("{}", ArgumentValue::Int(0)));
+        assert_eq!("-7", format!("{}", ArgumentValue::Int(-7)));
+        assert_eq!("''", format!("{}", ArgumentValue::String("".to_string())));
+        assert_eq!("'some string'", format!("{}", ArgumentValue::String("some string".to_string())));
+    }
+}

--- a/src/vc_util/src/issuer_api.rs
+++ b/src/vc_util/src/issuer_api.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
 /// API to be implemented by an issuer of verifiable credentials.
-/// (cf. https://github.com/dfinity/internet-identity/blob/vc-mvp/docs/vc-spec.md)
+/// (cf. https://github.com/dfinity/internet-identity/blob/main/docs/vc-spec.md)
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct SignedIdAlias {
@@ -149,7 +149,7 @@ pub enum Icrc21ConsentMessageResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn should_display_argument_values() {
         assert_eq!("42", format!("{}", ArgumentValue::Int(42)));

--- a/src/vc_util/src/lib.rs
+++ b/src/vc_util/src/lib.rs
@@ -18,6 +18,8 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::ops::{Add, Deref, DerefMut};
 
+pub mod issuer_api;
+
 pub const II_CREDENTIAL_URL_PREFIX: &str =
     "https://internetcomputer.org/credential/internet-identity/";
 pub const II_ISSUER_URL: &str = "https://internetcomputer.org/issuers/internet-identity";


### PR DESCRIPTION
Add specs and APIs for attribute sharing (verifiable credentials) feature: 
- specs for issuers and for identity providers (II)
- API types for issuers
- API types for II



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/424247265/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



