### PR TITLE
Remove references to jest custom sequencer

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,6 @@
     "src/**/*.test.ts",
     "src/frontend/src/test-e2e/*.ts",
     "src/frontend/generated/*",
-    "src/frontend/jest-custom-sequencer.ts",
     "vite.config.ts",
     "vite.plugins.ts"
   ]

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -1,8 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src", "./*.ts"],
-  "exclude": [
-    "src/frontend/generated/*",
-    "src/frontend/jest-custom-sequencer.ts"
-  ]
+  "exclude": [ "src/frontend/generated/*" ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,6 @@
   "exclude": [
     "src/**/*.test.ts",
     "src/frontend/src/test-e2e/*.ts",
-    "src/frontend/generated/*",
-    "src/frontend/jest-custom-sequencer.ts"
+    "src/frontend/generated/*"
   ]
 }


### PR DESCRIPTION
This removes a couple of stray references to the new gone jest custom sequencer.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ecd4ee0f0/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
