### PR TITLE
Add second credential type to issuer

### DIFF
--- a/demos/vc_issuer/vc_issuer.did
+++ b/demos/vc_issuer/vc_issuer.did
@@ -35,6 +35,7 @@ type IssueCredentialError = variant {
     signature_not_found : text;
     unknown_subject : text;
     invalid_id_alias : text;
+    invalid_credential_spec : text;
 };
 type IssuedCredentialData = record { vc_jws : text };
 type PrepareCredentialRequest = record {
@@ -53,11 +54,8 @@ type SignedIdAlias = record {
 };
 service : {
     add_employee : (principal) -> (text);
+    add_graduate : (principal) -> (text);
     get_credential : (GetCredentialRequest) -> (GetCredentialResponse) query;
-    prepare_credential : (PrepareCredentialRequest) -> (
-    PrepareCredentialResponse,
-    );
-    vc_consent_message : (Icrc21VcConsentMessageRequest) -> (
-    Icrc21ConsentMessageResponse,
-    );
+    prepare_credential : (PrepareCredentialRequest) -> (PrepareCredentialResponse);
+    vc_consent_message : (Icrc21VcConsentMessageRequest) -> (Icrc21ConsentMessageResponse);
 }

--- a/src/frontend/generated/vc_issuer_idl.js
+++ b/src/frontend/generated/vc_issuer_idl.js
@@ -18,6 +18,7 @@ export const idlFactory = ({ IDL }) => {
   const IssueCredentialError = IDL.Variant({
     'unauthorized_subject' : IDL.Text,
     'internal' : IDL.Text,
+    'invalid_credential_spec' : IDL.Text,
     'signature_not_found' : IDL.Text,
     'unknown_subject' : IDL.Text,
     'invalid_id_alias' : IDL.Text,
@@ -62,6 +63,7 @@ export const idlFactory = ({ IDL }) => {
   });
   return IDL.Service({
     'add_employee' : IDL.Func([IDL.Principal], [IDL.Text], []),
+    'add_graduate' : IDL.Func([IDL.Principal], [IDL.Text], []),
     'get_credential' : IDL.Func(
         [GetCredentialRequest],
         [GetCredentialResponse],

--- a/src/frontend/generated/vc_issuer_types.d.ts
+++ b/src/frontend/generated/vc_issuer_types.d.ts
@@ -35,6 +35,7 @@ export interface Icrc21VcConsentMessageRequest {
 }
 export type IssueCredentialError = { 'unauthorized_subject' : string } |
   { 'internal' : string } |
+  { 'invalid_credential_spec' : string } |
   { 'signature_not_found' : string } |
   { 'unknown_subject' : string } |
   { 'invalid_id_alias' : string };
@@ -55,6 +56,7 @@ export interface SignedIdAlias {
 }
 export interface _SERVICE {
   'add_employee' : ActorMethod<[Principal], string>,
+  'add_graduate' : ActorMethod<[Principal], string>,
   'get_credential' : ActorMethod<[GetCredentialRequest], GetCredentialResponse>,
   'prepare_credential' : ActorMethod<
     [PrepareCredentialRequest],

--- a/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
@@ -98,6 +98,8 @@ pub mod issuer {
         SignatureNotFound(String),
         #[serde(rename = "internal")]
         Internal(String),
+        #[serde(rename = "unsupported_credential_spec")]
+        UnsupportedCredentialSpec(String),
     }
 
     #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
This PR adds a second type of credential to the issuer.

It also refactors the issuer to:
* validate the credential spec more accurately
  * reject additional parameters
  * check the value of the supplied parameters
  * reject with a specific error on unsupported credential spec
* make the code more generic to be reusable among the different credential specs


<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

