### PR TITLE
Add issuer id alias verification

### DIFF
--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -3022,7 +3022,28 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sha2 0.10.8",
+ "vc_util",
  "vc_util_br",
+]
+
+[[package]]
+name = "vc_util"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "canister_sig_util",
+ "ic-cdk",
+ "ic-certified-map",
+ "ic-crypto-standalone-sig-verifier",
+ "ic-types",
+ "identity_core",
+ "identity_credential",
+ "identity_jose",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
 ]
 
 [[package]]

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 # local dependencies
 canister_sig_util = { path = "../../src/canister_sig_util" }
 internet_identity_interface = { path = "../../src/internet_identity_interface" }
-vc_util_br = { path = "../../src/vc_util_br" }
+vc_util = { path = "../../src/vc_util" }
 # ic dependencies
 candid = "0.9"
 ic-cdk = "0.10"
@@ -38,3 +38,4 @@ assert_matches = "1.5.0"
 ic-test-state-machine-client = "3"
 canister_tests = { path = "../../src/canister_tests" }
 lazy_static = "1.4"
+vc_util_br = { path = "../../src/vc_util_br" }


### PR DESCRIPTION
This PR adds the check to verify the id alias
with respect to the configured root key and
idp canister ids.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/38bce356c/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
