### PR TITLE
Simplify and generalize fetchDelegation

### DIFF
--- a/src/frontend/src/flows/authorize/fetchDelegation.ts
+++ b/src/frontend/src/flows/authorize/fetchDelegation.ts
@@ -19,7 +19,7 @@ import { Delegation } from "./postMessageInterface";
  */
 export const fetchDelegation = async ({
   connection,
-  derivationOrigin: derivationOrigin_,
+  derivationOrigin,
   publicKey,
   maxTimeToLive,
 }: {
@@ -28,9 +28,6 @@ export const fetchDelegation = async ({
   publicKey: Uint8Array;
   maxTimeToLive?: bigint;
 }): Promise<[PublicKey, Delegation] | { error: unknown }> => {
-  // at this point, derivationOrigin is either validated or undefined
-  let derivationOrigin = derivationOrigin_;
-
   // In order to give dapps a stable principal regardless whether they use the legacy (ic0.app) or the new domain (icp0.io)
   // we map back the derivation origin to the ic0.app domain.
   const ORIGIN_MAPPING_REGEX =

--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -155,6 +155,7 @@ export async function authenticationProtocol({
 
   onProgress("fetching delegation");
 
+  // at this point, derivationOrigin is either validated or undefined
   const derivationOrigin =
     authContext.authRequest.derivationOrigin ?? authContext.requestOrigin;
 

--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -2,6 +2,7 @@
 // applications that want to authenticate the user using Internet Identity
 import { LoginData } from "$src/utils/flowResult";
 import { unknownToRecord } from "$src/utils/utils";
+import { Signature } from "@dfinity/agent";
 import { Principal } from "@dfinity/principal";
 import { isNullish } from "@dfinity/utils";
 import { fetchDelegation } from "./fetchDelegation";
@@ -13,7 +14,7 @@ export interface Delegation {
     expiration: bigint;
     targets?: Principal[];
   };
-  signature: Uint8Array;
+  signature: Signature;
 }
 
 /**
@@ -154,11 +155,15 @@ export async function authenticationProtocol({
 
   onProgress("fetching delegation");
 
-  const result = await fetchDelegation(
-    authSuccess.userNumber,
-    authSuccess.connection,
-    authContext
-  );
+  const derivationOrigin =
+    authContext.authRequest.derivationOrigin ?? authContext.requestOrigin;
+
+  const result = await fetchDelegation({
+    connection: authSuccess.connection,
+    derivationOrigin,
+    publicKey: authContext.authRequest.sessionPublicKey,
+    maxTimeToLive: authContext.authRequest.maxTimeToLive,
+  });
 
   if ("error" in result) {
     window.opener.postMessage(


### PR DESCRIPTION
This updates `fetchDelegation` to make the implementation a bit simpler and to generalize it beyond the postMessage flow:

* Unused parameter `userNumber` is dropped
* Everything related to postMessage (AuthContext) is generalized into actual derivation, ttl, publicKey, etc
* The return type is typed a bit more strongly (although has to be coerced)

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

