### PR TITLE
Add issuer configuration endpoint

### DIFF
--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -107,6 +107,16 @@ fn init(init_arg: Option<IssuerInit>) {
         // nothing to do
         return;
     };
+    apply_config(init);
+}
+
+#[update]
+#[candid_method]
+fn configure(config: IssuerInit) {
+    apply_config(config);
+}
+
+fn apply_config(init: IssuerInit) {
     CONFIG
         .with_borrow_mut(|config_cell| config_cell.set(IssuerConfig::from(init)))
         .expect("failed to apply issuer config");

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -9,7 +9,7 @@ use canister_tests::framework::{
 };
 use canister_tests::{flows, match_value};
 use ic_cdk::api::management_canister::provisional::CanisterId;
-use ic_test_state_machine_client::call_candid_as;
+use ic_test_state_machine_client::{call_candid, call_candid_as};
 use ic_test_state_machine_client::{query_candid_as, CallError, StateMachine};
 use internet_identity_interface::internet_identity::types::vc_mvp::issuer::{
     ArgumentValue, CredentialSpec, GetCredentialRequest, GetCredentialResponse,
@@ -88,6 +88,14 @@ pub fn install_issuer(env: &StateMachine, init: &IssuerInit) -> CanisterId {
 
 mod api {
     use super::*;
+
+    pub fn configure(
+        env: &StateMachine,
+        canister_id: CanisterId,
+        config: &IssuerInit,
+    ) -> Result<(), CallError> {
+        call_candid(env, canister_id, "configure", (config,))
+    }
 
     pub fn vc_consent_message(
         env: &StateMachine,
@@ -624,4 +632,11 @@ fn should_issue_credential_e2e() -> Result<(), CallError> {
     }
 
     Ok(())
+}
+
+#[test]
+fn should_configure() {
+    let env = env();
+    let issuer_id = install_canister(&env, VC_ISSUER_WASM.clone());
+    api::configure(&env, issuer_id, &DUMMY_ISSUER_INIT).expect("API call failed");
 }

--- a/demos/vc_issuer/vc_issuer.did
+++ b/demos/vc_issuer/vc_issuer.did
@@ -57,6 +57,7 @@ type IssuerConfig = record {
     idp_canister_ids : vec principal;
 };
 service: (opt IssuerConfig) -> {
+    configure: (IssuerConfig) -> ();
     add_employee : (principal) -> (text);
     add_graduate : (principal) -> (text);
     get_credential : (GetCredentialRequest) -> (GetCredentialResponse) query;

--- a/src/frontend/generated/vc_issuer_idl.js
+++ b/src/frontend/generated/vc_issuer_idl.js
@@ -68,6 +68,7 @@ export const idlFactory = ({ IDL }) => {
   return IDL.Service({
     'add_employee' : IDL.Func([IDL.Principal], [IDL.Text], []),
     'add_graduate' : IDL.Func([IDL.Principal], [IDL.Text], []),
+    'configure' : IDL.Func([IssuerConfig], [], []),
     'get_credential' : IDL.Func(
         [GetCredentialRequest],
         [GetCredentialResponse],

--- a/src/frontend/generated/vc_issuer_types.d.ts
+++ b/src/frontend/generated/vc_issuer_types.d.ts
@@ -61,6 +61,7 @@ export interface SignedIdAlias {
 export interface _SERVICE {
   'add_employee' : ActorMethod<[Principal], string>,
   'add_graduate' : ActorMethod<[Principal], string>,
+  'configure' : ActorMethod<[IssuerConfig], undefined>,
   'get_credential' : ActorMethod<[GetCredentialRequest], GetCredentialResponse>,
   'prepare_credential' : ActorMethod<
     [PrepareCredentialRequest],


### PR DESCRIPTION
This PR adds the `configure` canister call to the issuer, which
allows setting the root key and idp canister ids after deployment.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
