### PR TITLE
Remove dependency of vc_issuer on vc_util_br

### DIFF
--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -3023,7 +3023,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "vc_util",
- "vc_util_br",
 ]
 
 [[package]]
@@ -3033,25 +3032,6 @@ dependencies = [
  "candid",
  "canister_sig_util",
  "ic-cdk",
- "ic-certified-map",
- "ic-crypto-standalone-sig-verifier",
- "ic-types",
- "identity_core",
- "identity_credential",
- "identity_jose",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "serde_json",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "vc_util_br"
-version = "0.1.0"
-dependencies = [
- "candid",
- "canister_sig_util",
  "ic-certified-map",
  "ic-crypto-standalone-sig-verifier",
  "ic-types",

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -38,4 +38,3 @@ assert_matches = "1.5.0"
 ic-test-state-machine-client = "3"
 canister_tests = { path = "../../src/canister_tests" }
 lazy_static = "1.4"
-vc_util_br = { path = "../../src/vc_util_br" }


### PR DESCRIPTION
`vc_util` has now all functionality needed by `vc_issuer`, so there is no need to depend on `vc_util_br`. (the remaining functionality in `vc_util_br` not yet in `vc_util` is related to presentations, which are not really relevant for the issuer)
<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/0a6d54bed/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
