### PR TITLE
Remove redundant values in SignedIdAlias

### DIFF
--- a/demos/vc_issuer/vc_issuer.did
+++ b/demos/vc_issuer/vc_issuer.did
@@ -63,8 +63,6 @@ type GetCredentialResponse = variant {
 
 type SignedIdAlias = record {
     credential_jws : text;
-    id_alias : principal;
-    id_dapp : principal;
 };
 type IssuedCredentialData = record { vc_jws : text };
 type IssueCredentialError = variant {

--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -61,8 +61,6 @@ type PrepareCredentialResponse = variant {
 type PreparedCredentialData = record { prepared_context : opt blob };
 type SignedIdAlias = record {
     credential_jws : text;
-    id_alias : principal;
-    id_dapp : principal;
 };
 service : {
     get_credential : (GetCredentialRequest) -> (GetCredentialResponse) query;
@@ -96,8 +94,6 @@ type PrepareCredentialRequest = record {
 
 type SignedIdAlias = record {
     credential_jws : text;
-    id_alias : principal;
-    id_dapp : principal;
 };
 
 type PrepareCredentialRequest = record {
@@ -113,9 +109,9 @@ type PrepareCredentialResponse = variant {
 type PreparedCredentialData = record { prepared_context : opt blob };
 ```
 
-Specifically, the issuer checks via `prepared_id_alias.credential_jws` that user identified via `id_dapp` on the issuer
-side can be identified using `id_alias` for the purpose of attribute sharing, and that the credential
-described by `credential_spec` does apply to the user.  When these checks are successful, the issuer
+Specifically, the issuer checks via `prepared_id_alias.credential_jws` that user identified by its `sub` claim on the
+issuer side has a valid `has_id_alias` principal for the purpose of attribute sharing, and that the credential
+described by `credential_spec` does apply to the `caller`.  When these checks are successful, the issuer
 prepares and returns a context in `PreparedCredentialData.prepared_context` (if any).  The returned prepared context is then
 passed back to the issuer in a subsequent `get_credential`-call (see below).
 This call must be authenticated, i.e. the sender must match the principal for which the credential is requested.

--- a/src/vc_util/src/issuer_api.rs
+++ b/src/vc_util/src/issuer_api.rs
@@ -1,15 +1,12 @@
-use candid::{CandidType, Deserialize, Principal};
+use candid::{CandidType, Deserialize};
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
 /// API to be implemented by an issuer of verifiable credentials.
 /// (cf. https://github.com/dfinity/internet-identity/blob/main/docs/vc-spec.md)
-
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct SignedIdAlias {
-    pub id_alias: Principal,
-    pub id_dapp: Principal,
     pub credential_jws: String,
 }
 


### PR DESCRIPTION
The `SignedIdAlias` contained the plain `id_dapp` and `id_alias` values next to the signed JWS. This is redundant and a potential footgun as one might be inclined to use those values _without_ checking the JWS.

This PR removes the values and changes the code and doc accordingly.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8e95dc098/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

