### PR TITLE
Enable vc_issuer tests on CI

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -227,6 +227,30 @@ jobs:
             exit 1
           fi
 
+  vc-issuer-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            demos/vc_issuer/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('demos/vc_issuer/Cargo.lock', 'rust-toolchain.toml') }}
+      - uses: ./.github/actions/bootstrap
+      - name: "Build VC issuer canister"
+        working-directory: demos/vc_issuer
+        run: ./build.sh
+      - name: 'Upload VC issuer'
+        uses: actions/upload-artifact@v3
+        with:
+          # name is the name used to display and retrieve the artifact
+          name: vc_issuer.wasm.gz
+          # path is the name used as the file to upload and the name of the
+          # downloaded file
+          path: ./demos/vc_issuer/vc_issuer.wasm.gz
+
   test-app-build:
     runs-on: ubuntu-latest
     steps:
@@ -251,6 +275,48 @@ jobs:
           # path is the name used as the file to upload and the name of the
           # downloaded file
           path: ./demos/test-app/test_app.wasm
+
+  #####################################
+  # The Rust vc issuer canister tests #
+  #####################################
+
+  vc-issuer-test:
+    runs-on: ubuntu-latest
+    needs: [docker-build-ii, vc-issuer-build]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            demos/vc_issuer/target
+          key: ${{ runner.os }}-cargo-vc-tests-${{ hashFiles('demos/vc_issuer/Cargo.lock', 'rust-toolchain.toml') }}
+      - uses: ./.github/actions/bootstrap
+      - name: 'Download VC issuer wasm'
+        uses: actions/download-artifact@v3
+        with:
+          name: vc_issuer.wasm.gz
+          path: demos/vc_issuer
+      - name: 'Download II wasm'
+        uses: actions/download-artifact@v3
+        with:
+          name: internet_identity_test.wasm.gz
+          path: .
+      - run: mv internet_identity_test.wasm.gz internet_identity.wasm.gz
+      - name: Download ic-test-state-machine binary
+        run: |
+          uname_sys=$(uname -s | tr '[:upper:]' '[:lower:]')
+          echo "uname_sys: $uname_sys"
+          commit_sha=$(sed <.ic-commit 's/#.*$//' | sed '/^$/d')
+          echo "commit sha: $commit_sha"
+          curl -sLO "https://download.dfinity.systems/ic/$commit_sha/binaries/x86_64-$uname_sys/ic-test-state-machine.gz"
+          gzip -d ic-test-state-machine.gz
+          chmod a+x ic-test-state-machine
+          ./ic-test-state-machine --version
+      - name: "Run VC issuer canister tests"
+        working-directory: demos/vc_issuer
+        run: cargo test
 
   ###########################
   # The Rust canister tests #
@@ -392,7 +458,7 @@ jobs:
 
   selenium:
     runs-on: ubuntu-latest
-    needs: [docker-build-ii, test-app-build]
+    needs: [docker-build-ii, test-app-build, vc-issuer-build]
     strategy:
       matrix:
         device: [ 'desktop', 'mobile' ]
@@ -436,6 +502,12 @@ jobs:
           name: test_app.wasm
           path: demos/test-app
 
+      - name: 'Download VC issuer wasm'
+        uses: actions/download-artifact@v3
+        with:
+          name: vc_issuer.wasm.gz
+          path: demos/vc_issuer
+
       - name: Deploy Internet Identity
         run: |
           dfx canister create --all
@@ -446,6 +518,12 @@ jobs:
         run: |
           dfx canister create --all
           dfx canister install test_app --wasm test_app.wasm
+
+      - name: Deploy VC issuer
+        working-directory: demos/vc_issuer
+        run: |
+          dfx canister create issuer
+          dfx canister install issuer --wasm vc_issuer.wasm.gz
 
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
The code in `demo/vc_issuer` has tests, but so far these were not run on CI, this PR changes that.
(this is basically a copy of the config from `vc_mvp`-branch)
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
