### PR TITLE
Clean up test app

### DIFF
--- a/demos/test-app/lib.rs
+++ b/demos/test-app/lib.rs
@@ -219,7 +219,7 @@ lazy_static! {
         // the string we are replacing here is inserted by vite during the front-end build
         let index_html = index_html.replace(
             r#"<script type="module" crossorigin src="/index.js"></script>"#,
-            &format!(r#"<script>var canisterId = '{canister_id}';</script><script type="module" crossorigin src="/index.js"></script>"#).to_string()
+            &format!(r#"<script data-canister-id="{canister_id}" type="module" crossorigin src="/index.js"></script>"#).to_string()
         );
         index_html
     };

--- a/demos/test-app/package.json
+++ b/demos/test-app/package.json
@@ -11,12 +11,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "dev": "vite",
-    "lint:fix": "npm run lint -- --fix",
-    "make:docs/reference": "",
-    "publish:release": "",
-    "test:coverage": "",
-    "test": ""
+    "dev": "vite"
   },
   "devDependencies": {
     "vite": "^4.3.9"

--- a/demos/test-app/src/index.html
+++ b/demos/test-app/src/index.html
@@ -58,11 +58,6 @@
         >Replica URL:
       </label>
       <input type="text" id="hostUrl" value="https://ic0.app/" />
-      <br />
-      <label for="canisterId" style="display: inline-block; width: 120px"
-        >Canister ID:
-      </label>
-      <input type="text" id="canisterId" />
     </div>
     <div>
       <button id="whoamiBtn">Who Am I?</button>

--- a/demos/test-app/src/main.js
+++ b/demos/test-app/src/main.js
@@ -28,7 +28,6 @@ const alternativeOriginsEl = document.getElementById("alternativeOrigins");
 const newAlternativeOriginsEl = document.getElementById(
   "newAlternativeOrigins"
 );
-const canisterIdEl = document.getElementById("canisterId");
 const principalEl = document.getElementById("principal");
 const delegationEl = document.getElementById("delegation");
 const expirationEl = document.getElementById("expiration");
@@ -142,11 +141,14 @@ window.addEventListener("message", (event) => {
   }
 });
 
+const readCanisterId = () => {
+  return document.querySelector("[data-canister-id]").dataset.canisterId;
+};
+
 const init = async () => {
   authClient = await AuthClient.create();
   updateDelegationView(authClient.getIdentity());
   await updateAlternativeOriginsView();
-  canisterIdEl.value = canisterId;
   signInBtn.onclick = async () => {
     let derivationOrigin =
       derivationOriginEl.value !== "" ? derivationOriginEl.value : undefined;
@@ -239,7 +241,7 @@ const init = async () => {
   };
 
   updateAlternativeOriginsBtn.onclick = async () => {
-    const canisterId = Principal.fromText(canisterIdEl.value);
+    const canisterId = Principal.fromText(readCanisterId());
     const httpAgent = new HttpAgent({ host: hostUrlEl.value });
     await httpAgent.fetchRootKey();
     const actor = Actor.createActor(idlFactory, {
@@ -265,7 +267,7 @@ init();
 
 whoamiBtn.addEventListener("click", async () => {
   const identity = await authClient.getIdentity();
-  const canisterId = Principal.fromText(canisterIdEl.value);
+  const canisterId = Principal.fromText(readCanisterId());
   const actor = Actor.createActor(idlFactory, {
     agent: new HttpAgent({
       host: hostUrlEl.value,

--- a/src/frontend/src/test-e2e/addDevice.test.ts
+++ b/src/frontend/src/test-e2e/addDevice.test.ts
@@ -28,11 +28,7 @@ test("Add device", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const firstAuthenticator = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    const userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
-
+    const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     // We're removing the first authenticator here, because unfortunately we
@@ -56,10 +52,7 @@ test("Add remote device", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     await mainView.addAdditionalDevice();
@@ -118,10 +111,7 @@ test("Add remote device starting on new device", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    const userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
 

--- a/src/frontend/src/test-e2e/alternativeOrigin/ingressFormat.test.ts
+++ b/src/frontend/src/test-e2e/alternativeOrigin/ingressFormat.test.ts
@@ -10,10 +10,7 @@ import {
 import { DemoAppView, ErrorView } from "../views";
 
 import {
-  DEVICE_NAME1,
   II_URL,
-  REPLICA_URL,
-  TEST_APP_CANISTER_ID,
   TEST_APP_CANONICAL_URL,
   TEST_APP_NICE_URL,
 } from "../constants";
@@ -22,10 +19,7 @@ test("Should not issue delegation when derivationOrigin is missing from /.well-k
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const authenticatorId1 = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     await FLOWS.addRecoveryMechanismSeedPhrase(browser);
     const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
     expect(credentials).toHaveLength(1);
@@ -33,10 +27,7 @@ test("Should not issue delegation when derivationOrigin is missing from /.well-k
     const niceDemoAppView = new DemoAppView(browser);
     await niceDemoAppView.open(TEST_APP_NICE_URL, II_URL);
     await niceDemoAppView.waitForDisplay();
-    await niceDemoAppView.resetAlternativeOrigins(
-      REPLICA_URL,
-      TEST_APP_CANISTER_ID
-    );
+    await niceDemoAppView.resetAlternativeOrigins();
     await niceDemoAppView.setDerivationOrigin(TEST_APP_CANONICAL_URL);
     expect(await niceDemoAppView.getPrincipal()).toBe("2vxsx-fae");
     await niceDemoAppView.signin();
@@ -51,10 +42,10 @@ test("Should not issue delegation when derivationOrigin is missing from /.well-k
     const errorView = new ErrorView(browser);
     await errorView.waitForDisplay();
     expect(await errorView.getErrorMessage()).toEqual(
-      `"${TEST_APP_CANONICAL_URL}" is not a valid derivation origin for "https://nice-name.com"`
+      `"${TEST_APP_CANONICAL_URL}" is not a valid derivation origin for "${TEST_APP_NICE_URL}"`
     );
     expect(await errorView.getErrorDetail()).toEqual(
-      '"https://nice-name.com" is not listed in the list of allowed alternative origins. Allowed alternative origins:'
+      `"${TEST_APP_NICE_URL}" is not listed in the list of allowed alternative origins. Allowed alternative origins:`
     );
   });
 }, 300_000);
@@ -63,7 +54,7 @@ test("Should not issue delegation when derivationOrigin is malformed", async () 
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const authenticatorId1 = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    await FLOWS.registerNewIdentityWelcomeView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityWelcomeView(browser);
     await FLOWS.addRecoveryMechanismSeedPhrase(browser);
     const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
     expect(credentials).toHaveLength(1);
@@ -71,10 +62,7 @@ test("Should not issue delegation when derivationOrigin is malformed", async () 
     const niceDemoAppView = new DemoAppView(browser);
     await niceDemoAppView.open(TEST_APP_NICE_URL, II_URL);
     await niceDemoAppView.waitForDisplay();
-    await niceDemoAppView.resetAlternativeOrigins(
-      REPLICA_URL,
-      TEST_APP_CANISTER_ID
-    );
+    await niceDemoAppView.resetAlternativeOrigins();
     await niceDemoAppView.setDerivationOrigin(
       "https://some-random-disallowed-url.com"
     );
@@ -91,7 +79,7 @@ test("Should not issue delegation when derivationOrigin is malformed", async () 
     const errorView = new ErrorView(browser);
     await errorView.waitForDisplay();
     expect(await errorView.getErrorMessage()).toEqual(
-      '"https://some-random-disallowed-url.com" is not a valid derivation origin for "https://nice-name.com"'
+      `"https://some-random-disallowed-url.com" is not a valid derivation origin for "${TEST_APP_NICE_URL}"`
     );
     expect(await errorView.getErrorDetail()).toEqual(
       "derivationOrigin does not match regex /^https:\\/\\/([\\w-]+)(?:\\.raw)?\\.(?:ic0\\.app|icp0\\.io)$/"

--- a/src/frontend/src/test-e2e/authData.test.ts
+++ b/src/frontend/src/test-e2e/authData.test.ts
@@ -2,7 +2,7 @@ import { FLOWS } from "./flows";
 import { addVirtualAuthenticator, runInBrowser, switchToPopup } from "./util";
 import { DemoAppView } from "./views";
 
-import { DEVICE_NAME1, II_URL, TEST_APP_NICE_URL } from "./constants";
+import { II_URL, TEST_APP_NICE_URL } from "./constants";
 
 test("Authorize ready message should be sent immediately", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
@@ -29,7 +29,7 @@ test("Should allow valid message", async () => {
     await demoAppView.sendValidMessage(); // message 2: authorize-client
 
     await switchToPopup(browser);
-    await FLOWS.registerNewIdentityAuthenticateView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityAuthenticateView(browser);
     await browser
       .$("[data-role=notify-auth-success]")
       .waitForDisplayed({ timeout: 15_000 });
@@ -61,7 +61,7 @@ test("Should ignore invalid data and allow second valid message", async () => {
     await demoAppView.sendValidMessage(); // message 3
 
     await switchToPopup(browser);
-    await FLOWS.registerNewIdentityAuthenticateView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityAuthenticateView(browser);
     await browser
       .$("[data-role=notify-auth-success]")
       .waitForDisplayed({ timeout: 15_000 });

--- a/src/frontend/src/test-e2e/constants.ts
+++ b/src/frontend/src/test-e2e/constants.ts
@@ -5,11 +5,12 @@ export const test_app_canister_ids = JSON.parse(
   readFileSync("./demos/test-app/.dfx/local/canister_ids.json", "utf-8")
 );
 
-export const TEST_APP_CANISTER_ID = test_app_canister_ids.test_app.local;
+const TEST_APP_CANISTER_ID = test_app_canister_ids.test_app.local;
+
 export const TEST_APP_CANONICAL_URL = `https://${TEST_APP_CANISTER_ID}.icp0.io`;
+export const TEST_APP_CANONICAL_URL_RAW = `https://${TEST_APP_CANISTER_ID}.raw.icp0.io`;
 export const TEST_APP_CANONICAL_URL_LEGACY = `https://${TEST_APP_CANISTER_ID}.ic0.app`;
 export const TEST_APP_NICE_URL = "https://nice-name.com";
-export const REPLICA_URL = "https://icp-api.io";
 export const II_URL =
   process.env.II_URL ?? "https://identity.internetcomputer.org";
 

--- a/src/frontend/src/test-e2e/delegationTtl.test.ts
+++ b/src/frontend/src/test-e2e/delegationTtl.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./util";
 import { DemoAppView } from "./views";
 
-import { DEVICE_NAME1, II_URL, TEST_APP_NICE_URL } from "./constants";
+import { II_URL, TEST_APP_NICE_URL } from "./constants";
 
 test("Delegation maxTimeToLive: 1 min", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
@@ -19,7 +19,7 @@ test("Delegation maxTimeToLive: 1 min", async () => {
     await demoAppView.setMaxTimeToLive(BigInt(60_000_000_000));
     await demoAppView.signin();
     await switchToPopup(browser);
-    await FLOWS.registerNewIdentityAuthenticateView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityAuthenticateView(browser);
     await demoAppView.waitForAuthenticated();
 
     const exp = await browser.$("#expiration").getText();
@@ -38,7 +38,7 @@ test("Delegation maxTimeToLive: 1 day", async () => {
     await demoAppView.setMaxTimeToLive(BigInt(86400_000_000_000));
     await demoAppView.signin();
     await switchToPopup(browser);
-    await FLOWS.registerNewIdentityAuthenticateView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityAuthenticateView(browser);
     await waitToClose(browser);
     expect(await demoAppView.getPrincipal()).not.toBe("2vxsx-fae");
     const exp = await browser.$("#expiration").getText();
@@ -56,7 +56,7 @@ test("Delegation maxTimeToLive: 2 months", async () => {
     await demoAppView.setMaxTimeToLive(BigInt(5_184_000_000_000_000)); // 60 days
     await demoAppView.signin();
     await switchToPopup(browser);
-    await FLOWS.registerNewIdentityAuthenticateView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityAuthenticateView(browser);
     await demoAppView.waitForAuthenticated();
     const exp = await browser.$("#expiration").getText();
     // NB: Max out at 30 days

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -24,7 +24,6 @@ export const FLOWS = {
     return userNumber;
   },
   registerNewIdentityWelcomeView: async (
-    deviceName: string,
     browser: WebdriverIO.Browser
   ): Promise<string> => {
     const welcomeView = new WelcomeView(browser);
@@ -33,7 +32,6 @@ export const FLOWS = {
     return await FLOWS.register(browser);
   },
   registerNewIdentityAuthenticateView: async (
-    deviceName: string,
     browser: WebdriverIO.Browser
   ): Promise<string> => {
     const authenticateView = new AuthenticateView(browser);

--- a/src/frontend/src/test-e2e/misc.test.ts
+++ b/src/frontend/src/test-e2e/misc.test.ts
@@ -8,7 +8,7 @@ test("Device can be renamed", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    await FLOWS.registerNewIdentityWelcomeView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     const newName = DEVICE_NAME1 + "-new";

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -1,11 +1,5 @@
 import { Principal } from "@dfinity/principal";
-import {
-  DEVICE_NAME1,
-  II_URL,
-  REPLICA_URL,
-  TEST_APP_CANISTER_ID,
-  TEST_APP_NICE_URL,
-} from "./constants";
+import { DEVICE_NAME1, II_URL, TEST_APP_NICE_URL } from "./constants";
 import { FLOWS } from "./flows";
 import {
   addVirtualAuthenticator,
@@ -144,9 +138,7 @@ test("Log into client application using PIN registration flow", async () => {
     await FLOWS.registerPinNewIdentityAuthenticateView(pin, browser);
 
     const principal = await demoAppView.waitForAuthenticated();
-    expect(await demoAppView.whoami(REPLICA_URL, TEST_APP_CANISTER_ID)).toBe(
-      principal
-    );
+    expect(await demoAppView.whoami()).toBe(principal);
 
     // default value
     const exp = await browser.$("#expiration").getText();

--- a/src/frontend/src/test-e2e/principals.test.ts
+++ b/src/frontend/src/test-e2e/principals.test.ts
@@ -10,10 +10,7 @@ import {
 import { AuthenticateView, DemoAppView } from "./views";
 
 import {
-  DEVICE_NAME1,
   II_URL,
-  REPLICA_URL,
-  TEST_APP_CANISTER_ID,
   TEST_APP_CANONICAL_URL,
   TEST_APP_CANONICAL_URL_LEGACY,
   TEST_APP_NICE_URL,
@@ -23,10 +20,7 @@ test("Should issue the same principal to nice url and canonical url", async () =
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const authenticatorId1 = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    const userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     await FLOWS.addRecoveryMechanismSeedPhrase(browser);
     const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
     expect(credentials).toHaveLength(1);
@@ -55,8 +49,6 @@ test("Should issue the same principal to nice url and canonical url", async () =
     await niceDemoAppView.open(TEST_APP_NICE_URL, II_URL);
     await niceDemoAppView.waitForDisplay();
     await niceDemoAppView.updateAlternativeOrigins(
-      REPLICA_URL,
-      TEST_APP_CANISTER_ID,
       `{"alternativeOrigins":["${TEST_APP_NICE_URL}"]}`,
       "certified"
     );
@@ -85,10 +77,7 @@ test("Should issue the same principal to dapps on legacy & official domains", as
     // create a new anchor
     const registrationAuthenticator = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    const userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     await FLOWS.addRecoveryMechanismSeedPhrase(browser); // avoids being prompted later during authz
     const credentials = await getWebAuthnCredentials(
       browser,

--- a/src/frontend/src/test-e2e/recovery/index.test.ts
+++ b/src/frontend/src/test-e2e/recovery/index.test.ts
@@ -8,10 +8,7 @@ test("Recover with phrase", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     const seedPhrase = await FLOWS.addRecoveryMechanismSeedPhrase(browser);

--- a/src/frontend/src/test-e2e/recovery/protected/index.test.ts
+++ b/src/frontend/src/test-e2e/recovery/protected/index.test.ts
@@ -8,7 +8,7 @@ test("Make recovery protected", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    await FLOWS.registerNewIdentityWelcomeView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     const seedPhrase = await FLOWS.addRecoveryMechanismSeedPhrase(browser);
@@ -23,7 +23,7 @@ test("Make recovery unprotected", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    await FLOWS.registerNewIdentityWelcomeView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     const seedPhrase = await FLOWS.addRecoveryMechanismSeedPhrase(browser);

--- a/src/frontend/src/test-e2e/recovery/protected/reset.test.ts
+++ b/src/frontend/src/test-e2e/recovery/protected/reset.test.ts
@@ -8,7 +8,7 @@ test("Reset protected recovery phrase", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    await FLOWS.registerNewIdentityWelcomeView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     const seedPhrase = await FLOWS.addRecoveryMechanismSeedPhrase(browser);
@@ -37,7 +37,7 @@ test("Reset protected recovery phrase, confirm with incorrect seed phrase", asyn
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    await FLOWS.registerNewIdentityWelcomeView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     const seedPhrase = await FLOWS.addRecoveryMechanismSeedPhrase(browser);

--- a/src/frontend/src/test-e2e/recovery/reset.test.ts
+++ b/src/frontend/src/test-e2e/recovery/reset.test.ts
@@ -8,7 +8,7 @@ test("Reset recovery phrase", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    await FLOWS.registerNewIdentityWelcomeView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     await FLOWS.addRecoveryMechanismSeedPhrase(browser);
@@ -29,10 +29,7 @@ test("Recover access, after reset", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
 
@@ -61,10 +58,7 @@ test("Canceling reset keeps old phrase", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
 
@@ -94,10 +88,7 @@ test("Reset unprotected recovery phrase, when authenticated with phrase", async 
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
-    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const _userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     const seedPhrase = await FLOWS.addRecoveryMechanismSeedPhrase(browser);

--- a/src/frontend/src/test-e2e/register.test.ts
+++ b/src/frontend/src/test-e2e/register.test.ts
@@ -12,23 +12,13 @@ import { AuthenticateView, DemoAppView, MainView } from "./views";
 
 // Read canister ids from the corresponding dfx files.
 // This assumes that they have been successfully dfx-deployed
-import { readFileSync } from "fs";
-import { DEVICE_NAME1, II_URL, REPLICA_URL } from "./constants";
-export const test_app_canister_ids = JSON.parse(
-  readFileSync("./demos/test-app/.dfx/local/canister_ids.json", "utf-8")
-);
-
-const TEST_APP_CANISTER_ID = test_app_canister_ids.test_app.local;
-const TEST_APP_NICE_URL = "https://nice-name.com";
+import { DEVICE_NAME1, II_URL, TEST_APP_NICE_URL } from "./constants";
 
 test("Register new identity and login with it", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await browser.url(II_URL);
     await addVirtualAuthenticator(browser);
-    const userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
     await mainView.logout();
@@ -40,10 +30,7 @@ test("Register new identity and login without prefilled identity number", async 
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await browser.url(II_URL);
     await addVirtualAuthenticator(browser);
-    const userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(DEVICE_NAME1);
 
@@ -65,11 +52,9 @@ test("Log into client application, after registration", async () => {
     expect(await demoAppView.getPrincipal()).toBe("2vxsx-fae");
     await demoAppView.signin();
     await switchToPopup(browser);
-    await FLOWS.registerNewIdentityAuthenticateView(DEVICE_NAME1, browser);
+    await FLOWS.registerNewIdentityAuthenticateView(browser);
     const principal = await demoAppView.waitForAuthenticated();
-    expect(await demoAppView.whoami(REPLICA_URL, TEST_APP_CANISTER_ID)).toBe(
-      principal
-    );
+    expect(await demoAppView.whoami()).toBe(principal);
 
     // default value
     const exp = await browser.$("#expiration").getText();
@@ -82,10 +67,7 @@ test("Register first then log into client application", async () => {
     const authenticatorId1 = await addVirtualAuthenticator(browser);
 
     await browser.url(II_URL);
-    const userNumber = await FLOWS.registerNewIdentityWelcomeView(
-      DEVICE_NAME1,
-      browser
-    );
+    const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
 
     const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
     expect(credentials).toHaveLength(1);
@@ -109,9 +91,7 @@ test("Register first then log into client application", async () => {
     await authenticateView.pickAnchor(userNumber);
     await FLOWS.skipRecoveryNag(browser);
     const principal = await demoAppView.waitForAuthenticated();
-    expect(await demoAppView.whoami(REPLICA_URL, TEST_APP_CANISTER_ID)).toBe(
-      principal
-    );
+    expect(await demoAppView.whoami()).toBe(principal);
 
     // default value
     const exp = await browser.$("#expiration").getText();

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -569,6 +569,13 @@ export class AboutView extends View {
 }
 
 export class DemoAppView extends View {
+  replicaUrl: string;
+
+  public constructor(browser: WebdriverIO.Browser) {
+    super(browser);
+    this.replicaUrl = "https://icp-api.io";
+  }
+
   async open(demoAppUrl: string, iiUrl: string): Promise<void> {
     await this.browser.url(demoAppUrl);
     await fillText(this.browser, "iiUrl", iiUrl);
@@ -616,9 +623,8 @@ export class DemoAppView extends View {
     await fillText(this.browser, "derivationOrigin", derivationOrigin);
   }
 
-  async whoami(replicaUrl: string, testCanister: string): Promise<string> {
-    await fillText(this.browser, "hostUrl", replicaUrl);
-    await fillText(this.browser, "canisterId", testCanister);
+  async whoami(): Promise<string> {
+    await fillText(this.browser, "hostUrl", this.replicaUrl);
     await this.browser.$("#whoamiBtn").click();
     const whoamiResponseElem = await this.browser.$("#whoamiResponse");
     await whoamiResponseElem.waitUntil(
@@ -634,13 +640,10 @@ export class DemoAppView extends View {
   }
 
   async updateAlternativeOrigins(
-    replicaUrl: string,
-    testCanister: string,
     alternativeOrigins: string,
     mode: "certified" | "uncertified" | "redirect"
   ): Promise<string> {
-    await fillText(this.browser, "hostUrl", replicaUrl);
-    await fillText(this.browser, "canisterId", testCanister);
+    await fillText(this.browser, "hostUrl", this.replicaUrl);
     await fillText(this.browser, "newAlternativeOrigins", alternativeOrigins);
     await this.browser.$(`#${mode}`).click();
     await this.browser.$("#updateNewAlternativeOrigins").click();
@@ -657,13 +660,8 @@ export class DemoAppView extends View {
     return await alternativeOriginsElem.getText();
   }
 
-  resetAlternativeOrigins(
-    replicaUrl: string,
-    testCanister: string
-  ): Promise<string> {
+  resetAlternativeOrigins(): Promise<string> {
     return this.updateAlternativeOrigins(
-      replicaUrl,
-      testCanister,
       '{"alternativeOrigins":[]}',
       "certified"
     );

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "./*.ts"],
+  "include": ["src", "./*.ts", "demos/test-app"],
   "exclude": [ "src/frontend/generated/*" ]
 }


### PR DESCRIPTION
This cleans up the test app used by the e2e tests:

* Unused arguments are removed
* Canister ID is injected in the app and not threaded as argument
* Constant values are pulled in from constants.ts and not copied
* REPLICA_URL is inlined
* Constant for `https://nice-name.com` is used instead of mixing with literal string
* Old config is removed from the test app's package.json
* The test app dir is added to the tsconfig

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
