### PR TITLE
Improve canister network setup

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -508,22 +508,14 @@ jobs:
           name: vc_issuer.wasm.gz
           path: demos/vc_issuer
 
-      - name: Deploy Internet Identity
+      - name: Create Canisters
+        run: dfx canister create --all
+
+      - name: Deploy canisters
         run: |
-          dfx canister create --all
           dfx canister install internet_identity --wasm internet_identity_test.wasm.gz
-
-      - name: Deploy test app
-        working-directory: demos/test-app
-        run: |
-          dfx canister create --all
-          dfx canister install test_app --wasm test_app.wasm
-
-      - name: Deploy VC issuer
-        working-directory: demos/vc_issuer
-        run: |
-          dfx canister create issuer
-          dfx canister install issuer --wasm vc_issuer.wasm.gz
+          dfx canister install test_app --wasm demos/test-app/test_app.wasm
+          dfx canister install issuer --wasm demos/vc_issuer/vc_issuer.wasm.gz
 
       - run: npm ci
       - run: npm test
@@ -533,7 +525,14 @@ jobs:
           TLS_DEV_SERVER=1 NO_HOT_RELOAD=1 npm run dev&
           dev_server_pid=$!
           echo "dev_server_pid=$dev_server_pid" >> "$GITHUB_OUTPUT"
-      - run: "II_URL=${{ matrix.domain }} SCREEN=${{ matrix.device }} npm run test:e2e -- --shard=$(tr <<<'${{ matrix.shard }}' -s _ /)" # replace 1_N with 1/N
+
+      # NOTE: we run chrome in headless mode because that's the only thing that works in GHA
+      # NOTE: the last bit (tr) replaces 1_N with 1/N
+      - run: |
+          II_URL=${{ matrix.domain }} \
+            SCREEN=${{ matrix.device }} \
+            II_E2E_CHROME_OPTS="--headless" \
+            npm run test:e2e -- --shard=$(tr <<<'${{ matrix.shard }}' -s _ /)
 
       - name: Stop dfx
         if: ${{ always() }}

--- a/HACKING.md
+++ b/HACKING.md
@@ -20,7 +20,7 @@ The build requires the following dependencies:
 
 ## Running Locally
 
-To run the internet_identity canisters, proceed as follows after cloning the repository
+To run the Internet Identity canister, proceed as follows after cloning the repository
 
 ```bash
 npm ci
@@ -30,16 +30,22 @@ dfx start [--clean] [--background]
 In a different terminal, run the following command to install the Internet Identity canister:
 
 ```bash
-II_FETCH_ROOT_KEY=1 dfx deploy --no-wallet
+dfx deploy internet_identity --no-wallet
 ```
+
+> [!NOTE]\
+> By default, a dummy (fixed) CAPTCHA is used. If you want to use the real (random) CAPTCHA, set
+> `II_DUMMY_CAPTCHA` to `0`:\
+> `II_DUMMY_CAPTCHA=0 dfx deploy internet_identity --no-wallet`
+
 
 Then the canister can be used as
 
 ```bash
-$ dfx canister call internet_identity init_salt
-()
-$ echo $?
-0
+$ dfx canister call internet_identity stats
+(
+  record { ... }
+)
 ```
 
 See `dfx canister call --help` and [the documentation](https://sdk.dfinity.org/docs/developers-guide/cli-reference/dfx-canister.html#_examples) for more information.
@@ -57,7 +63,7 @@ The fastest workflow to get the development environment running is to deploy onc
 ```bash
 npm ci
 dfx start [--clean] [--background]
-II_FETCH_ROOT_KEY=1 dfx deploy --no-wallet
+dfx deploy internet_identity --no-wallet
 ```
 
 To serve the frontend locally (recommended during development), run
@@ -67,24 +73,7 @@ the following:
 npm run dev
 ```
 
-Then open `http://localhost:5173` in your browser. The page is reloaded whenever you save changes to files. To ensure your changes pass our formatting and linter checks, run the following command:
-
-```bash
-npm run format && npm run lint
-```
-
-Finally, to test workflows like authentication from a client application, you start the Selenium test app:
-
-```bash
-cd demos/selenium-test-app
-npm ci
-npm run dev
-```
-
-Then open `http://localhost:8081` in your browser.
-
-Make sure that the "Identity Provider" is set to "http://localhost:5173" if you
-serve the Internet Identity frontend locally.
+Then open `http://localhost:5173` in your browser. The page is reloaded whenever you save changes to files.
 
 **NOTE on testing on LAN:**
 
@@ -105,28 +94,21 @@ into the following issues:
 
 We have a set of Selenium tests that run through the various flows. To set up a local deployment follow these steps:
 1. Start a local replica with `dfx start`
-2. Deploy the [`Test` flavour](https://github.com/dfinity/internet-identity/tree/main#flavors) of II by running: `II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=1 dfx deploy internet_identity`
-3. Deploy the test app by running `dfx deploy` from the `demos/test-app` directory
-4. Start the vite dev server with TLS enabled: `TLS_DEV_SERVER=1 npm run dev`
+1. Deploy II and the other test canisters with `dfx deploy --no-wallet`
+1. Start the vite dev server with TLS enabled: `TLS_DEV_SERVER=1 npm run dev`
 
 To watch the tests run in the browser remove the `headless` option from `src/frontend/src/test-e2e/util.ts`.
 
-```bash
 The tests can be executed by running:
 
 ```bash
 npm run test:e2e
 ```
 
-Or with a specific screen size e.g.:
-```bash
-npm run test:e2e-desktop
-```
-
 We autoformat our code using `prettier`. Running `npm run format` formats all files in the frontend.
 If you open a PR that isn't formatted according to `prettier`, CI will automatically add a formatting commit to your PR.
 
-We use `eslint` to check the frontend code. You can run it with `npm run lint`, or set up your editor to do it for you.
+We use `eslint` to check the frontend code. You can run it with `npm run lint`.
 
 
 ### Building the backend

--- a/dfx.json
+++ b/dfx.json
@@ -4,8 +4,20 @@
       "type": "custom",
       "candid": "src/internet_identity/internet_identity.did",
       "wasm": "internet_identity.wasm.gz",
-      "build": "scripts/build",
+      "build": "bash -c 'II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=${II_DUMMY_CAPTCHA:-1} scripts/build'",
       "shrink" : false
+    },
+    "test_app": {
+      "type": "custom",
+      "candid": "demos/test-app/test_app.did",
+      "wasm": "demos/test-app/test_app.wasm",
+      "build": "demos/test-app/build.sh"
+    },
+    "issuer": {
+      "type": "custom",
+      "candid": "demos/vc_issuer/vc_issuer.did",
+      "wasm": "demos/vc_issuer/vc_issuer.wasm.gz",
+      "build": "demos/vc_issuer/build.sh"
     }
   },
   "defaults": {

--- a/src/frontend/src/test-e2e/addDevice.test.ts
+++ b/src/frontend/src/test-e2e/addDevice.test.ts
@@ -21,7 +21,7 @@ import {
 import { readFileSync } from "fs";
 import { DEVICE_NAME1, II_URL } from "./constants";
 export const test_app_canister_ids = JSON.parse(
-  readFileSync("./demos/test-app/.dfx/local/canister_ids.json", "utf-8")
+  readFileSync(".dfx/local/canister_ids.json", "utf-8")
 );
 
 test("Add device", async () => {

--- a/src/frontend/src/test-e2e/constants.ts
+++ b/src/frontend/src/test-e2e/constants.ts
@@ -2,7 +2,7 @@
 // This assumes that they have been successfully dfx-deployed
 import { readFileSync } from "fs";
 export const test_app_canister_ids = JSON.parse(
-  readFileSync("./demos/test-app/.dfx/local/canister_ids.json", "utf-8")
+  readFileSync(".dfx/local/canister_ids.json", "utf-8")
 );
 
 const TEST_APP_CANISTER_ID = test_app_canister_ids.test_app.local;

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -32,17 +32,22 @@ export async function runInBrowser(
   // parse run configuration from environment variables
   const runConfig = parseRunConfiguration();
 
+  // Read potential extra chrome opts from the env
+  const extraChromeOptions = (process.env["II_E2E_CHROME_OPTS"] ?? "")
+    .split(",")
+    .filter(Boolean);
+
   const chromeOptions: ChromeOptions = {
     args: [
       "--ignore-certificate-errors", // allow self-signed certificates
       "--disable-gpu",
       "--disable-dev-shm-usage", // disable /dev/shm usage because chrome is prone to crashing otherwise
-      "--headless",
       // Map all hosts to localhost:5173 (which is the vite dev server) in the context of DNS resolution.
       // The dev server will then terminate TLS and either forward the request to the local replica or serve
       // assets directly.
       "--host-resolver-rules=MAP * localhost:5173",
       ...(nonNullish(userAgent) ? [`--user-agent=${userAgent}`] : []),
+      ...extraChromeOptions,
     ],
 
     // Disables permission prompt for clipboard, needed for tests using the clipboard (without this,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,12 +30,10 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
     II_VERSION: `${process.env.II_VERSION ?? ""}`,
   };
 
-  const testAppCanisterId = existsSync(
-    "demos/test-app/.dfx/local/canister_ids.json"
-  )
+  const testAppCanisterId = existsSync(".dfx/local/canister_ids.json")
     ? readCanisterId({
         canisterName: "test_app",
-        canisterIdsJsonFile: "demos/test-app/.dfx/local/canister_ids.json",
+        canisterIdsJsonFile: ".dfx/local/canister_ids.json",
       })
     : undefined;
 


### PR DESCRIPTION
This improves the way we spin up canisters in a couple of ways:

* The `dfx.json` file is made actually useful by creating & deploying all the test canisters
* By default II is deployed (through dfx.json) using the test options (fetching the root key & using the dummy captcha). Note: as far as I can tell the `dfx.json` isn't used to deploy anything to mainnet.
* The chrome options default to something useful locally (no headless)
* The HACKING instructions are updated & simplified

This creates a more sane setup where all canisters are deployed in `.dfx`, with simpler commands.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
