### PR TITLE
Add second consent message language and make message more descriptive

### DIFF
--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -2709,6 +2709,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strfmt"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8348af2d9fc3258c8733b8d9d8db2e56f54b2363a4b5b81585c7875ed65e65"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,6 +3029,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sha2 0.10.8",
+ "strfmt",
  "vc_util",
 ]
 

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -29,6 +29,7 @@ serde_bytes = "0.11"
 serde_cbor = "0.11"
 serde_json = "1"
 sha2 = "^0.10" # set bound to match ic-certified-map bound
+strfmt = "0.2"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -30,9 +30,9 @@ serde_cbor = "0.11"
 serde_json = "1"
 sha2 = "^0.10" # set bound to match ic-certified-map bound
 strfmt = "0.2"
+lazy_static = "1.4"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 ic-test-state-machine-client = "3"
 canister_tests = { path = "../../src/canister_tests" }
-lazy_static = "1.4"

--- a/demos/vc_issuer/src/consent_message.rs
+++ b/demos/vc_issuer/src/consent_message.rs
@@ -1,10 +1,13 @@
 //! This module contains the various consent messages that is displayed to the user when they are asked to consent to the issuance of a credential.
 
-use std::collections::HashMap;
 use crate::SupportedCredentialType;
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use strfmt::strfmt;
-use vc_util::issuer_api::{Icrc21ConsentInfo, Icrc21ConsentMessageResponse, Icrc21ConsentPreferences, Icrc21Error, Icrc21ErrorInfo};
+use vc_util::issuer_api::{
+    Icrc21ConsentInfo, Icrc21ConsentMessageResponse, Icrc21ConsentPreferences, Icrc21Error,
+    Icrc21ErrorInfo,
+};
 use SupportedCredentialType::{UniversityDegreeCredential, VerifiedEmployee};
 use SupportedLanguage::{English, German};
 
@@ -65,33 +68,45 @@ pub fn get_vc_consent_message(
 }
 
 fn employment_consent_msg_eng(employer: &str) -> Result<String, Icrc21ErrorInfo> {
-    strfmt(EMPLOYMENT_VC_DESCRIPTION_EN, &HashMap::from([("employer".to_string(), employer)]))
-        .map_err(|e| Icrc21ErrorInfo {
-            error_code: 0,
-            description: e.to_string(),
-        })
+    strfmt(
+        EMPLOYMENT_VC_DESCRIPTION_EN,
+        &HashMap::from([("employer".to_string(), employer)]),
+    )
+    .map_err(|e| Icrc21ErrorInfo {
+        error_code: 0,
+        description: e.to_string(),
+    })
 }
 
 fn employment_consent_msg_de(employer: &str) -> Result<String, Icrc21ErrorInfo> {
-    strfmt(EMPLOYMENT_VC_DESCRIPTION_DE, &HashMap::from([("employer".to_string(), employer)]))
-        .map_err(|e| Icrc21ErrorInfo {
-            error_code: 0,
-            description: e.to_string(),
-        })
+    strfmt(
+        EMPLOYMENT_VC_DESCRIPTION_DE,
+        &HashMap::from([("employer".to_string(), employer)]),
+    )
+    .map_err(|e| Icrc21ErrorInfo {
+        error_code: 0,
+        description: e.to_string(),
+    })
 }
 
 fn degree_consent_msg_eng(institute: &str) -> Result<String, Icrc21ErrorInfo> {
-    strfmt(DEGREE_VC_DESCRIPTION_EN, &HashMap::from([("institute".to_string(), institute)]))
-        .map_err(|e| Icrc21ErrorInfo {
-            error_code: 0,
-            description: e.to_string(),
-        })
+    strfmt(
+        DEGREE_VC_DESCRIPTION_EN,
+        &HashMap::from([("institute".to_string(), institute)]),
+    )
+    .map_err(|e| Icrc21ErrorInfo {
+        error_code: 0,
+        description: e.to_string(),
+    })
 }
 
 fn degree_consent_msg_de(institute: &str) -> Result<String, Icrc21ErrorInfo> {
-    strfmt(DEGREE_VC_DESCRIPTION_DE, &HashMap::from([("institute".to_string(), institute)]))
-        .map_err(|e| Icrc21ErrorInfo {
-            error_code: 0,
-            description: e.to_string(),
-        })
+    strfmt(
+        DEGREE_VC_DESCRIPTION_DE,
+        &HashMap::from([("institute".to_string(), institute)]),
+    )
+    .map_err(|e| Icrc21ErrorInfo {
+        error_code: 0,
+        description: e.to_string(),
+    })
 }

--- a/demos/vc_issuer/src/consent_message.rs
+++ b/demos/vc_issuer/src/consent_message.rs
@@ -11,20 +11,20 @@ use SupportedLanguage::{English, German};
 const EMPLOYMENT_VC_DESCRIPTION_EN: &str = r###"# DFINITY Foundation Employment Credential
 
 Credential that states that the holder is employed by the DFINITY Foundation at the time of issuance."###;
-const DEGREE_VC_DESCRIPTION_EN: &str = r###"# Bachelor of Engineering, DFINITY College of Engineering
-
-Credential that states that the holder has a degree in engineering from the DFINITY College of Engineering."###;
-const VALIDITY_INFO_EN: &str = "The credential is valid for 15 minutes.";
-const ANONYMITY_DISCLAIMER_EN: &str = "This credential does **not** contain any additional personal information. It is issued to an ephemeral identity that is created for the sole purpose of issuing this credential.";
-
 const EMPLOYMENT_VC_DESCRIPTION_DE: &str = r###"# Beschäftigungsausweis DFINITY Stiftung
 
 Ausweis, der bestätigt, dass der Besitzer oder die Besitzerin zum Zeitpunkt der Austellung bei der DFINITY Stiftung beschäftigt ist."###;
+const DEGREE_VC_DESCRIPTION_EN: &str = r###"# Bachelor of Engineering, DFINITY College of Engineering
+
+Credential that states that the holder has a degree in engineering from the DFINITY College of Engineering."###;
 const DEGREE_VC_DESCRIPTION_DE: &str = r###"# Bachelor of Engineering, DFINITY Hochschule für Ingenieurwissenschaften
 
 Ausweis, der bestätigt, dass der Besitzer oder die Besitzerin einen Bachelorabschluss in einer Ingenieurwissenschaft der DFINITY Hochschule für Ingenieurwissenschaften besitzt."###;
 
+const VALIDITY_INFO_EN: &str = "The credential is valid for 15 minutes.";
 const VALIDITY_INFO_DE: &str = "Dieser Ausweis ist gültig für 15 Minuten.";
+
+const ANONYMITY_DISCLAIMER_EN: &str = "This credential does **not** contain any additional personal information. It is issued to an ephemeral identity that is created for the sole purpose of issuing this credential.";
 const ANONYMITY_DISCLAIMER_DE: &str =
     "Dieser Ausweis enthält **keine** zusätzlichen persönlichen Daten. Er wird auf eine kurzlebige Identität lautend ausgestellt, die für den alleinigen Verwendungszweck der Austellung dieses Ausweises erzeugt wird.";
 

--- a/demos/vc_issuer/src/consent_message.rs
+++ b/demos/vc_issuer/src/consent_message.rs
@@ -1,0 +1,107 @@
+//! This module contains the various consent messages that is displayed to the user when they are asked to consent to the issuance of a credential.
+
+use crate::SupportedCredentialType;
+use std::fmt::{Display, Formatter};
+use vc_util::issuer_api::{
+    Icrc21ConsentInfo, Icrc21ConsentMessageResponse, Icrc21ConsentPreferences,
+};
+use SupportedCredentialType::{UniversityDegreeCredential, VerifiedEmployee};
+use SupportedLanguage::{English, German};
+
+const EMPLOYMENT_VC_DESCRIPTION_ENG: &str = r###"# DFINITY Foundation Employment Credential
+
+Credential that states that the holder is employed by the DFINITY Foundation at the time of issuance."###;
+const DEGREE_VC_DESCRIPTION_ENG: &str = r###"# Bachelor of Engineering, DFINITY College of Engineering
+
+Credential that states that the holder has a degree in engineering from the DFINITY College of Engineering."###;
+const VALIDITY_INFO_ENG: &str = "The credential is valid for 15 minutes.";
+const ANONYMITY_DISCLAIMER_ENG: &str = "This credential does **not** contain any additional personal information. It is issued to an ephemeral identity that is created for the sole purpose of issuing this credential.";
+
+const EMPLOYMENT_VC_DESCRIPTION_DE: &str = r###"# Beschäftigungsausweis DFINITY Stiftung
+
+Ausweis, der bestätigt, dass der Besitzer oder die Besitzerin zum Zeitpunkt der Austellung bei der DFINITY Stiftung beschäftigt ist."###;
+const DEGREE_VC_DESCRIPTION_DE: &str = r###"# Bachelor of Engineering, DFINITY Hochschule für Ingenieurwissenschaften
+
+Ausweis, der bestätigt, dass der Besitzer oder die Besitzerin einen Bachelorabschluss in einer Ingenieurwissenschaft der DFINITY Hochschule für Ingenieurwissenschaften besitzt."###;
+
+const VALIDITY_INFO_DE: &str = "Dieser Ausweis ist gültig für 15 Minuten.";
+const ANONYMITY_DISCLAIMER_DE: &str =
+    "Dieser Ausweis enthält **keine** zusätzlichen persönlichen Daten. Er wird auf eine kurzlebige Identität lautend ausgestellt, die für den alleinigen Verwendungszweck der Austellung dieses Ausweises erzeugt wird.";
+
+pub enum SupportedLanguage {
+    English,
+    German,
+}
+
+impl From<Icrc21ConsentPreferences> for SupportedLanguage {
+    fn from(value: Icrc21ConsentPreferences) -> Self {
+        match &value.language.to_lowercase()[..2] {
+            "de" => German,
+            _ => English, // english is also the fallback
+        }
+    }
+}
+
+impl Display for SupportedLanguage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            English => write!(f, "en"),
+            German => write!(f, "de"),
+        }
+    }
+}
+
+pub fn get_vc_consent_message(
+    credential_type: &SupportedCredentialType,
+    language: &SupportedLanguage,
+) -> Icrc21ConsentMessageResponse {
+    let message = match (credential_type, language) {
+        (VerifiedEmployee(_), English) => employment_consent_msg_eng(),
+        (VerifiedEmployee(_), German) => employment_consent_msg_de(),
+        (UniversityDegreeCredential(_), English) => degree_consent_msg_eng(),
+        (UniversityDegreeCredential(_), German) => degree_consent_msg_de(),
+    };
+    Icrc21ConsentMessageResponse::Ok(Icrc21ConsentInfo {
+        consent_message: message,
+        language: format!("{}", language),
+    })
+}
+
+fn employment_consent_msg_eng() -> String {
+    format_message(
+        EMPLOYMENT_VC_DESCRIPTION_ENG,
+        VALIDITY_INFO_ENG,
+        ANONYMITY_DISCLAIMER_ENG,
+    )
+}
+
+fn employment_consent_msg_de() -> String {
+    format_message(
+        EMPLOYMENT_VC_DESCRIPTION_DE,
+        VALIDITY_INFO_DE,
+        ANONYMITY_DISCLAIMER_DE,
+    )
+}
+
+fn degree_consent_msg_eng() -> String {
+    format_message(
+        DEGREE_VC_DESCRIPTION_ENG,
+        VALIDITY_INFO_ENG,
+        ANONYMITY_DISCLAIMER_ENG,
+    )
+}
+
+fn degree_consent_msg_de() -> String {
+    format_message(
+        DEGREE_VC_DESCRIPTION_DE,
+        VALIDITY_INFO_DE,
+        ANONYMITY_DISCLAIMER_DE,
+    )
+}
+
+fn format_message(description: &str, validity_info: &str, anonymity_disclaimer: &str) -> String {
+    format!(
+        "{} {}\n\n{}",
+        description, validity_info, anonymity_disclaimer
+    )
+}

--- a/demos/vc_issuer/src/consent_message.rs
+++ b/demos/vc_issuer/src/consent_message.rs
@@ -8,14 +8,14 @@ use vc_util::issuer_api::{
 use SupportedCredentialType::{UniversityDegreeCredential, VerifiedEmployee};
 use SupportedLanguage::{English, German};
 
-const EMPLOYMENT_VC_DESCRIPTION_ENG: &str = r###"# DFINITY Foundation Employment Credential
+const EMPLOYMENT_VC_DESCRIPTION_EN: &str = r###"# DFINITY Foundation Employment Credential
 
 Credential that states that the holder is employed by the DFINITY Foundation at the time of issuance."###;
-const DEGREE_VC_DESCRIPTION_ENG: &str = r###"# Bachelor of Engineering, DFINITY College of Engineering
+const DEGREE_VC_DESCRIPTION_EN: &str = r###"# Bachelor of Engineering, DFINITY College of Engineering
 
 Credential that states that the holder has a degree in engineering from the DFINITY College of Engineering."###;
-const VALIDITY_INFO_ENG: &str = "The credential is valid for 15 minutes.";
-const ANONYMITY_DISCLAIMER_ENG: &str = "This credential does **not** contain any additional personal information. It is issued to an ephemeral identity that is created for the sole purpose of issuing this credential.";
+const VALIDITY_INFO_EN: &str = "The credential is valid for 15 minutes.";
+const ANONYMITY_DISCLAIMER_EN: &str = "This credential does **not** contain any additional personal information. It is issued to an ephemeral identity that is created for the sole purpose of issuing this credential.";
 
 const EMPLOYMENT_VC_DESCRIPTION_DE: &str = r###"# Beschäftigungsausweis DFINITY Stiftung
 
@@ -69,9 +69,9 @@ pub fn get_vc_consent_message(
 
 fn employment_consent_msg_eng() -> String {
     format_message(
-        EMPLOYMENT_VC_DESCRIPTION_ENG,
-        VALIDITY_INFO_ENG,
-        ANONYMITY_DISCLAIMER_ENG,
+        EMPLOYMENT_VC_DESCRIPTION_EN,
+        VALIDITY_INFO_EN,
+        ANONYMITY_DISCLAIMER_EN,
     )
 }
 
@@ -85,9 +85,9 @@ fn employment_consent_msg_de() -> String {
 
 fn degree_consent_msg_eng() -> String {
     format_message(
-        DEGREE_VC_DESCRIPTION_ENG,
-        VALIDITY_INFO_ENG,
-        ANONYMITY_DISCLAIMER_ENG,
+        DEGREE_VC_DESCRIPTION_EN,
+        VALIDITY_INFO_EN,
+        ANONYMITY_DISCLAIMER_EN,
     )
 }
 

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -1,3 +1,4 @@
+use crate::consent_message::{get_vc_consent_message, SupportedLanguage};
 use candid::{candid_method, CandidType, Deserialize, Principal};
 use canister_sig_util::signature_map::{SignatureMap, LABEL_SIG};
 use canister_sig_util::{extract_raw_root_pk_from_der, CanisterSigPublicKey, IC_ROOT_PK_DER};
@@ -16,9 +17,9 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use vc_util::issuer_api::{
-    ArgumentValue, CredentialSpec, GetCredentialRequest, GetCredentialResponse, Icrc21ConsentInfo,
+    ArgumentValue, CredentialSpec, GetCredentialRequest, GetCredentialResponse,
     Icrc21ConsentMessageResponse, Icrc21Error, Icrc21ErrorInfo, Icrc21VcConsentMessageRequest,
     IssueCredentialError, IssuedCredentialData, PrepareCredentialRequest,
     PrepareCredentialResponse, PreparedCredentialData, SignedIdAlias,
@@ -28,6 +29,8 @@ use vc_util::{
     vc_signing_input_hash, AliasTuple,
 };
 use SupportedCredentialType::{UniversityDegreeCredential, VerifiedEmployee};
+
+mod consent_message;
 
 /// We use restricted memory in order to ensure the separation between non-managed config memory (first page)
 /// and the managed memory for potential other data of the canister.
@@ -171,11 +174,6 @@ async fn prepare_credential(req: PrepareCredentialRequest) -> PrepareCredentialR
         Ok(alias_tuple) => alias_tuple,
         Err(err) => return PrepareCredentialResponse::Err(err),
     };
-    if let Err(err) = verify_credential_spec(&req.credential_spec) {
-        return PrepareCredentialResponse::Err(IssueCredentialError::UnsupportedCredentialSpec(
-            err,
-        ));
-    }
     let credential_type = match verify_credential_spec(&req.credential_spec) {
         Ok(credential_type) => credential_type,
         Err(err) => {
@@ -262,16 +260,18 @@ fn get_credential(req: GetCredentialRequest) -> GetCredentialResponse {
 #[update]
 #[candid_method]
 async fn vc_consent_message(req: Icrc21VcConsentMessageRequest) -> Icrc21ConsentMessageResponse {
-    if let Err(err) = verify_credential_spec(&req.credential_spec) {
-        return Icrc21ConsentMessageResponse::Err(Icrc21Error::NotSupported(Icrc21ErrorInfo {
-            description: err,
-            error_code: 0,
-        }));
-    }
-    Icrc21ConsentMessageResponse::Ok(Icrc21ConsentInfo {
-        consent_message: get_vc_consent_message(&req),
-        language: "en-US".to_string(),
-    })
+    let credential_type = match verify_credential_spec(&req.credential_spec) {
+        Ok(credential_type) => credential_type,
+        Err(err) => {
+            return Icrc21ConsentMessageResponse::Err(Icrc21Error::UnsupportedCanisterCall(
+                Icrc21ErrorInfo {
+                    error_code: 0,
+                    description: err,
+                },
+            ));
+        }
+    };
+    get_vc_consent_message(&credential_type, &SupportedLanguage::from(req.preferences))
 }
 
 fn verify_credential_spec(spec: &CredentialSpec) -> Result<SupportedCredentialType, String> {
@@ -338,23 +338,6 @@ fn verify_single_argument(
         ));
     }
     Ok(())
-}
-
-fn get_vc_consent_message(req: &Icrc21VcConsentMessageRequest) -> String {
-    format!(
-        "Issue credential '{}' with arguments:{}",
-        req.credential_spec.credential_name,
-        arguments_as_string(&req.credential_spec.arguments)
-    )
-}
-fn arguments_as_string(maybe_args: &Option<HashMap<String, ArgumentValue>>) -> String {
-    let mut arg_str = String::new();
-    let empty_args = HashMap::new();
-    let args = maybe_args.as_ref().unwrap_or(&empty_args);
-    for (key, value) in args {
-        arg_str.push_str(&format!("\n\t{}: {}", key, value));
-    }
-    arg_str
 }
 
 #[update]
@@ -482,13 +465,19 @@ fn prepare_credential_payload(
             EMPLOYEES.with_borrow(|employees| {
                 verify_authorized_principal(credential_type, alias_tuple, employees)
             })?;
-            Ok(dfinity_employment_credential(alias_tuple.id_alias, employer_name.as_str()))
+            Ok(dfinity_employment_credential(
+                alias_tuple.id_alias,
+                employer_name.as_str(),
+            ))
         }
         UniversityDegreeCredential(institution_name) => {
             GRADUATES.with_borrow(|graduates| {
                 verify_authorized_principal(credential_type, alias_tuple, graduates)
             })?;
-            Ok(bachelor_degree_credential(alias_tuple.id_alias, institution_name.as_str()))
+            Ok(bachelor_degree_credential(
+                alias_tuple.id_alias,
+                institution_name.as_str(),
+            ))
         }
     }
 }

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -28,7 +28,7 @@ use vc_util::{
     did_for_principal, get_verified_id_alias_from_jws, vc_jwt_to_jws, vc_signing_input,
     vc_signing_input_hash, AliasTuple,
 };
-use SupportedCredentialType::{UniversityDegreeCredential, VerifiedEmployee};
+use SupportedCredentialType::{UniversityDegree, VerifiedEmployee};
 
 mod consent_message;
 
@@ -48,7 +48,7 @@ const VC_INSTITUTION_NAME: &str = "DFINITY College of Engineering";
 #[derive(Debug)]
 enum SupportedCredentialType {
     VerifiedEmployee(String),
-    UniversityDegreeCredential(String),
+    UniversityDegree(String),
 }
 
 thread_local! {
@@ -290,7 +290,7 @@ fn verify_credential_spec(spec: &CredentialSpec) -> Result<SupportedCredentialTy
                 "institutionName",
                 ArgumentValue::String(VC_INSTITUTION_NAME.to_string()),
             )?;
-            Ok(UniversityDegreeCredential(VC_INSTITUTION_NAME.to_string()))
+            Ok(UniversityDegree(VC_INSTITUTION_NAME.to_string()))
         }
         other => Err(format!("Credential {} is not supported", other)),
     }
@@ -470,7 +470,7 @@ fn prepare_credential_payload(
                 employer_name.as_str(),
             ))
         }
-        UniversityDegreeCredential(institution_name) => {
+        UniversityDegree(institution_name) => {
             GRADUATES.with_borrow(|graduates| {
                 verify_authorized_principal(credential_type, alias_tuple, graduates)
             })?;

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -191,13 +191,12 @@ fn should_return_vc_consent_message() {
             api::vc_consent_message(&env, canister_id, principal_1(), &consent_message_request)
                 .expect("API call failed")
                 .expect("Got 'None' from vc_consent_message");
-        assert_matches!(response, Icrc21ConsentMessageResponse::Ok(_));
-        if let Icrc21ConsentMessageResponse::Ok(info) = response {
-            assert_eq!(info.language, actual_language);
-            assert!(info
-                .consent_message
-                .starts_with(consent_message_snippet));
-        }
+
+        match_value!(response, Icrc21ConsentMessageResponse::Ok(info));
+        assert_eq!(info.language, actual_language);
+        assert!(info
+            .consent_message
+            .starts_with(consent_message_snippet));
     }
 }
 

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -365,7 +365,9 @@ fn should_fail_get_credential_for_wrong_sender() {
         },
     )
     .expect("API call failed");
-    assert_matches!(get_credential_response, GetCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains("Caller sl5og-mycaa-aaaaa-aaaap-4 does not match id alias dapp principal nugva-s7c6v-4yszt-koycv-5b623-an7q6-ha2nz-kz6rs-hawgl-nznbe-rqe."));
+    assert_matches!(get_credential_response,
+        GetCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(format!("Caller {} does not match id alias dapp principal {}.", unauthorized_principal, authorized_principal))
+    );
 }
 
 #[test]
@@ -382,7 +384,9 @@ fn should_fail_prepare_credential_for_anonymous_caller() {
         },
     )
     .expect("API call failed");
-    assert_matches!(response, PrepareCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains("Caller 2vxsx-fae does not match id alias dapp principal nugva-s7c6v-4yszt-koycv-5b623-an7q6-ha2nz-kz6rs-hawgl-nznbe-rqe."));
+    assert_matches!(response,
+        PrepareCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(format!("Caller 2vxsx-fae does not match id alias dapp principal {}.", DUMMY_ALIAS_ID_DAPP_PRINCIPAL))
+    );
 }
 
 #[test]

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -333,7 +333,9 @@ fn should_fail_prepare_credential_for_wrong_sender() {
         },
     )
     .expect("API call failed");
-    assert_matches!(response, PrepareCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains("Caller 6epth-hmqup-wz4mv-svl2m-mhcbb-24skq-tbdhq-2txct-2qugv-xuzva-eqe does not match id alias dapp principal nugva-s7c6v-4yszt-koycv-5b623-an7q6-ha2nz-kz6rs-hawgl-nznbe-rqe."));
+    assert_matches!(response,
+        PrepareCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(&format!("Caller {} does not match id alias dapp principal {}.", principal_1(), DUMMY_ALIAS_ID_DAPP_PRINCIPAL))
+    );
 }
 
 #[test]

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -165,7 +165,7 @@ mod api {
 fn should_return_vc_consent_message() {
     let test_cases = [
         ("en-US", "en", "# DFINITY Foundation Employment Credential"),
-        ("de-DE", "de", "# Beschäftigungsausweis DFINITY Stiftung"),
+        ("de-DE", "de", "# Beschäftigungsausweis DFINITY Foundation"),
         ("ja-JP", "en", "# DFINITY Foundation Employment Credential"), // test fallback language
     ];
     let env = env();

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -166,7 +166,7 @@ fn should_return_vc_consent_message() {
     let test_cases = [
         ("en-US", "en", "# DFINITY Foundation Employment Credential"),
         ("de-DE", "de", "# Beschäftigungsausweis DFINITY Stiftung"),
-        ("ja_JP", "en", "# DFINITY Foundation Employment Credential"), // test fallback language
+        ("ja-JP", "en", "# DFINITY Foundation Employment Credential"), // test fallback language
     ];
     let env = env();
     let canister_id = install_canister(&env, VC_ISSUER_WASM.clone());

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -194,9 +194,7 @@ fn should_return_vc_consent_message() {
 
         match_value!(response, Icrc21ConsentMessageResponse::Ok(info));
         assert_eq!(info.language, actual_language);
-        assert!(info
-            .consent_message
-            .starts_with(consent_message_snippet));
+        assert!(info.consent_message.starts_with(consent_message_snippet));
     }
 }
 
@@ -244,7 +242,10 @@ fn should_fail_vc_consent_message_if_missing_arguments() {
         api::vc_consent_message(&env, canister_id, principal_1(), &consent_message_request)
             .expect("API call failed")
             .expect("Got 'None' from vc_consent_message");
-    assert_matches!(response,Icrc21ConsentMessageResponse::Err(Icrc21Error::UnsupportedCanisterCall(_)));
+    assert_matches!(
+        response,
+        Icrc21ConsentMessageResponse::Err(Icrc21Error::UnsupportedCanisterCall(_))
+    );
 }
 
 #[test]
@@ -269,7 +270,10 @@ fn should_fail_vc_consent_message_if_missing_required_argument() {
         api::vc_consent_message(&env, canister_id, principal_1(), &consent_message_request)
             .expect("API call failed")
             .expect("Got 'None' from vc_consent_message");
-    assert_matches!(response,Icrc21ConsentMessageResponse::Err(Icrc21Error::UnsupportedCanisterCall(_)));
+    assert_matches!(
+        response,
+        Icrc21ConsentMessageResponse::Err(Icrc21Error::UnsupportedCanisterCall(_))
+    );
 }
 
 fn employee_credential_spec() -> CredentialSpec {

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -366,7 +366,7 @@ fn should_fail_get_credential_for_wrong_sender() {
     )
     .expect("API call failed");
     assert_matches!(get_credential_response,
-        GetCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(format!("Caller {} does not match id alias dapp principal {}.", unauthorized_principal, authorized_principal))
+        GetCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(&format!("Caller {} does not match id alias dapp principal {}.", unauthorized_principal, authorized_principal))
     );
 }
 
@@ -385,7 +385,7 @@ fn should_fail_prepare_credential_for_anonymous_caller() {
     )
     .expect("API call failed");
     assert_matches!(response,
-        PrepareCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(format!("Caller 2vxsx-fae does not match id alias dapp principal {}.", DUMMY_ALIAS_ID_DAPP_PRINCIPAL))
+        PrepareCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(&format!("Caller 2vxsx-fae does not match id alias dapp principal {}.", DUMMY_ALIAS_ID_DAPP_PRINCIPAL))
     );
 }
 

--- a/demos/vc_issuer/vc_issuer.did
+++ b/demos/vc_issuer/vc_issuer.did
@@ -15,14 +15,14 @@ type ArgumentValue = variant { "int" : int32; string : text };
 /// https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md
 type Icrc21ConsentInfo = record { consent_message : text; language : text };
 type Icrc21ConsentMessageResponse = variant {
-    Ok : Icrc21ConsentInfo;
-    Err : Icrc21Error;
+    ok : Icrc21ConsentInfo;
+    err : Icrc21Error;
 };
 type Icrc21ConsentPreferences = record { language : text };
 type Icrc21Error = variant {
-    GenericError : Icrc21ErrorInfo;
-    UnsupportedCanisterCall : Icrc21ErrorInfo;
-    ConsentMessageUnavailable : Icrc21ErrorInfo;
+    generic_error : Icrc21ErrorInfo;
+    unsupported_canister_call : Icrc21ErrorInfo;
+    consent_message_unavailable : Icrc21ErrorInfo;
 };
 type Icrc21ErrorInfo = record { description : text; error_code : nat64 };
 type Icrc21VcConsentMessageRequest = record {

--- a/demos/vc_issuer/vc_issuer.did
+++ b/demos/vc_issuer/vc_issuer.did
@@ -15,15 +15,14 @@ type ArgumentValue = variant { "int" : int32; string : text };
 /// https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md
 type Icrc21ConsentInfo = record { consent_message : text; language : text };
 type Icrc21ConsentMessageResponse = variant {
-    ok : Icrc21ConsentInfo;
-    err : Icrc21Error;
+    Ok : Icrc21ConsentInfo;
+    Err : Icrc21Error;
 };
 type Icrc21ConsentPreferences = record { language : text };
 type Icrc21Error = variant {
-    generic_error : Icrc21ErrorInfo;
-    forbidden : Icrc21ErrorInfo;
-    not_supported : Icrc21ErrorInfo;
-    malformed_call : Icrc21ErrorInfo;
+    GenericError : Icrc21ErrorInfo;
+    UnsupportedCanisterCall : Icrc21ErrorInfo;
+    ConsentMessageUnavailable : Icrc21ErrorInfo;
 };
 type Icrc21ErrorInfo = record { description : text; error_code : nat64 };
 type Icrc21VcConsentMessageRequest = record {

--- a/src/vc_util/src/issuer_api.rs
+++ b/src/vc_util/src/issuer_api.rs
@@ -121,8 +121,11 @@ pub struct Icrc21ErrorInfo {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum Icrc21Error {
+    #[serde(rename = "unsupported_canister_call")]
     UnsupportedCanisterCall(Icrc21ErrorInfo),
+    #[serde(rename = "consent_message_unavailable")]
     ConsentMessageUnavailable(Icrc21ErrorInfo),
+    #[serde(rename = "generic_error")]
     GenericError(Icrc21ErrorInfo),
 }
 
@@ -134,7 +137,9 @@ pub struct Icrc21ConsentInfo {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum Icrc21ConsentMessageResponse {
+    #[serde(rename = "ok")]
     Ok(Icrc21ConsentInfo),
+    #[serde(rename = "err")]
     Err(Icrc21Error),
 }
 

--- a/src/vc_util/src/issuer_api.rs
+++ b/src/vc_util/src/issuer_api.rs
@@ -121,13 +121,8 @@ pub struct Icrc21ErrorInfo {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum Icrc21Error {
-    #[serde(rename = "forbidden")]
-    Forbidden(Icrc21ErrorInfo),
-    #[serde(rename = "malformed_call")]
-    MalformedCall(Icrc21ErrorInfo),
-    #[serde(rename = "not_supported")]
-    NotSupported(Icrc21ErrorInfo),
-    #[serde(rename = "generic_error")]
+    UnsupportedCanisterCall(Icrc21ErrorInfo),
+    ConsentMessageUnavailable(Icrc21ErrorInfo),
     GenericError(Icrc21ErrorInfo),
 }
 
@@ -139,9 +134,7 @@ pub struct Icrc21ConsentInfo {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum Icrc21ConsentMessageResponse {
-    #[serde(rename = "ok")]
     Ok(Icrc21ConsentInfo),
-    #[serde(rename = "err")]
     Err(Icrc21Error),
 }
 


### PR DESCRIPTION
This PR improves the consent messages to be available in 2 languages. The message is improved to be more human readable and is now formatted as markdown.

Additionally, the ICRC21 types were updated to reflect the recent spec changes. Adjusting to the actual types with came case will be done in a separate PR because the issuer API needs adjustment too.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->










<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->









