### PR TITLE
Simplify canister ID lookup

### DIFF
--- a/src/frontend/src/test-e2e/addDevice.test.ts
+++ b/src/frontend/src/test-e2e/addDevice.test.ts
@@ -18,11 +18,7 @@ import {
 
 // Read canister ids from the corresponding dfx files.
 // This assumes that they have been successfully dfx-deployed
-import { readFileSync } from "fs";
 import { DEVICE_NAME1, II_URL } from "./constants";
-export const test_app_canister_ids = JSON.parse(
-  readFileSync(".dfx/local/canister_ids.json", "utf-8")
-);
 
 test("Add device", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {

--- a/src/frontend/src/test-e2e/constants.ts
+++ b/src/frontend/src/test-e2e/constants.ts
@@ -1,15 +1,12 @@
-// Read canister ids from the corresponding dfx files.
-// This assumes that they have been successfully dfx-deployed
-import { readFileSync } from "fs";
-export const test_app_canister_ids = JSON.parse(
-  readFileSync(".dfx/local/canister_ids.json", "utf-8")
-);
+import { readCanisterId } from "../../../../utils";
 
-const TEST_APP_CANISTER_ID = test_app_canister_ids.test_app.local;
+// XXX: this is not exactly a constant (since it might change on every node eval) but in
+// practice is very stable, and is much easier to use as "constants" then as a lookup function.
+const testAppCanisterId = readCanisterId({ canisterName: "test_app" });
 
-export const TEST_APP_CANONICAL_URL = `https://${TEST_APP_CANISTER_ID}.icp0.io`;
-export const TEST_APP_CANONICAL_URL_RAW = `https://${TEST_APP_CANISTER_ID}.raw.icp0.io`;
-export const TEST_APP_CANONICAL_URL_LEGACY = `https://${TEST_APP_CANISTER_ID}.ic0.app`;
+export const TEST_APP_CANONICAL_URL = `https://${testAppCanisterId}.icp0.io`;
+export const TEST_APP_CANONICAL_URL_RAW = `https://${testAppCanisterId}.raw.icp0.io`;
+export const TEST_APP_CANONICAL_URL_LEGACY = `https://${testAppCanisterId}.ic0.app`;
 export const TEST_APP_NICE_URL = "https://nice-name.com";
 export const II_URL =
   process.env.II_URL ?? "https://identity.internetcomputer.org";

--- a/src/frontend/src/test-e2e/constants.ts
+++ b/src/frontend/src/test-e2e/constants.ts
@@ -1,7 +1,7 @@
 import { readCanisterId } from "../../../../utils";
 
 // XXX: this is not exactly a constant (since it might change on every node eval) but in
-// practice is very stable, and is much easier to use as "constants" then as a lookup function.
+// practice is very stable, and is much easier to use as "constants" than as a lookup function.
 const testAppCanisterId = readCanisterId({ canisterName: "test_app" });
 
 export const TEST_APP_CANONICAL_URL = `https://${testAppCanisterId}.icp0.io`;

--- a/utils.ts
+++ b/utils.ts
@@ -15,6 +15,6 @@ export const readCanisterId = ({
     const stdout = execSync(command);
     return stdout.toString().trim();
   } catch (e) {
-    throw Error(`Could not get canister ID with command '${command}': ${e}`);
+    throw Error(`Could not get canister ID for '${canisterName}' with command '${command}', was the canister deployed? ${e}`);
   }
 };

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,20 @@
+/* Utils used both in the FE code & the FE config */
+
+import { execSync } from "child_process";
+
+/**
+ * Read a canister ID from dfx's local state
+ */
+export const readCanisterId = ({
+  canisterName,
+}: {
+  canisterName: string;
+}): string => {
+  const command = `dfx canister id ${canisterName}`;
+  try {
+    const stdout = execSync(command);
+    return stdout.toString().trim();
+  } catch (e) {
+    throw Error(`Could not get canister ID with command '${command}': ${e}`);
+  }
+};

--- a/vite.plugins.ts
+++ b/vite.plugins.ts
@@ -63,7 +63,7 @@ export const minifyHTML = (): {
  */
 export const replicaForwardPlugin = ({
   replicaOrigin,
-  forwardDomains /* note: only exact match, i.e. not 'raw'*/,
+  forwardDomains /* note: will match exactly on <canister>.<domain> */,
   forwardRules,
 }: {
   replicaOrigin: string;
@@ -128,7 +128,7 @@ export const replicaForwardPlugin = ({
       const domain = domain_.join(".");
 
       if (
-        forwardDomains !== undefined &&
+        !isNullish(forwardDomains) &&
         forwardDomains.includes(domain) &&
         /([a-z0-9])+(-[a-z0-9]+)+/.test(
           subdomain

--- a/vite.plugins.ts
+++ b/vite.plugins.ts
@@ -1,39 +1,10 @@
-import { assertNonNullish, isNullish } from "@dfinity/utils";
-import { readFileSync } from "fs";
+import { isNullish } from "@dfinity/utils";
 import { minify } from "html-minifier-terser";
 import httpProxy from "http-proxy";
 import { extname } from "path";
 import { Plugin, ViteDevServer } from "vite";
 import viteCompression from "vite-plugin-compression";
-
-/**
- * Read a canister ID from dfx's local state
- */
-export const readCanisterId = ({
-  canisterName,
-  canisterIdsJsonFile,
-}: {
-  canisterName: string;
-  canisterIdsJsonFile: string;
-}): string => {
-  try {
-    const canisterIds: Record<string, { local: string }> = JSON.parse(
-      readFileSync(canisterIdsJsonFile, "utf-8")
-    );
-    const canisterId = canisterIds[canisterName]?.local;
-    assertNonNullish(
-      canisterId,
-      `Could not get canister ID from ${canisterIdsJsonFile}`
-    );
-    console.log(
-      `Read canister ID '${canisterId} for canister with name '${canisterName}'`
-    );
-
-    return canisterId;
-  } catch (e) {
-    throw Error(`Could not get canister ID from ${canisterIdsJsonFile}: ${e}`);
-  }
-};
+import { readCanisterId } from "./utils";
 
 /**
  * Inject the II canister ID as a <script /> tag in index.html for local development. Will process
@@ -46,12 +17,12 @@ export const injectCanisterIdPlugin = (): {
   name: "html-transform",
   transformIndexHtml(html): string {
     const rgx = /<script type="module" src="(?<src>[^"]+)"><\/script>/;
+    const canisterId = readCanisterId({
+      canisterName: "internet_identity",
+    });
 
     return html.replace(rgx, (_match, src) => {
-      return `<script data-canister-id="${readCanisterId({
-        canisterName: "internet_identity",
-        canisterIdsJsonFile: "./.dfx/local/canister_ids.json",
-      })}" type="module" src="${src}"></script>`;
+      return `<script data-canister-id="${canisterId}" type="module" src="${src}"></script>`;
     });
   },
 });
@@ -92,10 +63,12 @@ export const minifyHTML = (): {
  */
 export const replicaForwardPlugin = ({
   replicaOrigin,
+  forwardDomains /* note: only exact match, i.e. not 'raw'*/,
   forwardRules,
 }: {
   replicaOrigin: string;
-  forwardRules: Array<{ canisterId: string; hosts: string[] }>;
+  forwardDomains?: string[];
+  forwardRules: Array<{ canisterName: string; hosts: string[] }>;
 }) => ({
   name: "replica-forward",
   configureServer(server: ViteDevServer) {
@@ -123,26 +96,49 @@ export const replicaForwardPlugin = ({
         return next();
       }
 
+      // forward to the specified canister (served by the replica)
+      const forwardToReplica = ({ canisterId }: { canisterId: string }) => {
+        console.log(
+          `forwarding ${req.method} https://${req.headers.host}${req.url} to canister ${canisterId}`
+        );
+        req.headers["host"] = `${canisterId}.localhost`;
+        proxy.web(req, res, {
+          target: `http://${replicaOrigin}`,
+        });
+
+        proxy.on("error", (err: Error) => {
+          res.statusCode = 500;
+          res.end("Replica forwarding failed: " + err.message);
+        });
+      };
+
       const matchingRule = forwardRules.find((rule) =>
         rule.hosts.includes(host)
       );
-      if (isNullish(matchingRule)) {
-        // default handling
-        return next();
+
+      if (!isNullish(matchingRule)) {
+        const canisterId = readCanisterId({
+          canisterName: matchingRule.canisterName,
+        });
+        return forwardToReplica({ canisterId });
       }
 
-      console.log(
-        `forwarding ${req.method} https://${req.headers.host}${req.url} to canister ${matchingRule.canisterId}`
-      );
-      req.headers["host"] = `${matchingRule.canisterId}.localhost`;
-      proxy.web(req, res, {
-        target: `http://${replicaOrigin}`,
-      });
+      // split the subdomain & domain by splitting on the first dot
+      const [subdomain, ...domain_] = host.split(".");
+      const domain = domain_.join(".");
 
-      proxy.on("error", (err: Error) => {
-        res.statusCode = 500;
-        res.end("Replica forwarding failed: " + err.message);
-      });
+      if (
+        forwardDomains !== undefined &&
+        forwardDomains.includes(domain) &&
+        /([a-z0-9])+(-[a-z0-9]+)+/.test(
+          subdomain
+        ) /* fast check for principal-ish */
+      ) {
+        // Assume the principal-ish thing is a canister ID
+        return forwardToReplica({ canisterId: subdomain });
+      }
+
+      return next();
     });
   },
 });


### PR DESCRIPTION
This simplifies the way canister IDs are looked up, both for static config & dynamically in the devserver.

In general, canister IDs are not looked up from the canister_ids.json anymore, but instead `dfx canister id <CANISTER_NAME>` is used (so that we don't rely on dfx internals).

The dynamic replica-forwarding is changed to avoid having to specify canister IDs; instead domains can be specified which are treated as `<canister ID>.<domain>` and forwarded to the appropriate canister.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/154e22769/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

