### PR TITLE
Publish VC demo issuer

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -243,6 +243,7 @@ jobs:
         working-directory: demos/vc_issuer
         run: ./build.sh
       - run: sha256sum vc_issuer.wasm.gz
+        working-directory: demos/vc_issuer
       - name: 'Upload VC issuer'
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -242,6 +242,7 @@ jobs:
       - name: "Build VC issuer canister"
         working-directory: demos/vc_issuer
         run: ./build.sh
+      - run: sha256sum vc_issuer.wasm.gz
       - name: 'Upload VC issuer'
         uses: actions/upload-artifact@v3
         with:
@@ -693,6 +694,12 @@ jobs:
           name: archive.wasm.gz
           path: .
 
+      - name: 'Download wasm.gz'
+        uses: actions/download-artifact@v3
+        with:
+          name: vc_issuer.wasm.gz
+          path: .
+
       - uses: actions/github-script@v6
         id: pipeline-jobs
         with:
@@ -740,6 +747,7 @@ jobs:
             internet_identity_dev.wasm.gz
             internet_identity_test.wasm.gz
             archive.wasm.gz
+            vc_issuer.wasm.gz
           production_asset: internet_identity_production.wasm.gz
           changelog: ${{ steps.changelog.outputs.result }}
           workflow_jobs: ${{ steps.pipeline-jobs.outputs.result }}


### PR DESCRIPTION
This PR adds the VC demo issuer to the releases page. Publishing the demo issuer is useful to pull it into dev setups and example projects.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/51c349c07/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

