### PR TITLE
Introduce rust workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,32 @@ resolver = "2"
 debug = false # stripped by ic-wasm anyway
 lto = true
 opt-level = 'z'
+
+
+[workspace.dependencies]
+# local dependencies
+canister_sig_util = { path = "src/canister_sig_util" }
+canister_tests = { path = "src/canister_tests" }
+internet_identity_interface = { path = "src/internet_identity_interface" }
+vc_util = { path = "src/vc_util" }
+
+# ic dependencies
+candid = "0.9"
+ic-cdk = "0.10"
+ic-cdk-macros = "0.7"
+ic-certification = "1.3"
+ic-metrics-encoder = "1"
+ic-response-verification = "1.3"
+ic-stable-structures = "0.5"
+ic-test-state-machine-client = "3"
+
+# other dependencies
+assert_matches = "1.5.0"
+base64 = "0.21"
+hex = "0.4"
+lazy_static = "1.4"
+regex = "1.9"
+serde = "1"
+serde_bytes = "0.11"
+serde_cbor = "0.11"
+sha2 = "0.10"

--- a/src/archive/Cargo.toml
+++ b/src/archive/Cargo.toml
@@ -8,21 +8,21 @@ edition = "2021"
 
 [dependencies]
 # local dependencies
-internet_identity_interface = { path = "../internet_identity_interface" }
+internet_identity_interface.workspace = true
 # ic dependencies
-candid = "0.9"
-ic-cdk = "0.10"
+candid.workspace = true
+ic-cdk.workspace = true
+ic-cdk-macros.workspace = true
 ic-cdk-timers = "0.4"
-ic-cdk-macros = "0.7"
-ic-metrics-encoder = "1"
-ic-stable-structures = "0.5"
+ic-metrics-encoder.workspace = true
+ic-stable-structures.workspace = true
 # other
-serde = "1"
-serde_bytes = "0.11"
+serde.workspace = true
+serde_bytes.workspace = true
 
 [dev-dependencies]
 candid = { version = "0.9", features = ["parser"] }
-canister_tests = { path = "../canister_tests" }
-hex = "0.4"
-ic-test-state-machine-client = "3"
-regex = "1.9"
+canister_tests.workspace = true
+hex.workspace = true
+ic-test-state-machine-client.workspace = true
+regex.workspace = true

--- a/src/canister_sig_util/Cargo.toml
+++ b/src/canister_sig_util/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 
 [dependencies]
 # ic dependencies
-candid = "0.9"
-ic-certification = "1.3"
+candid.workspace = true
+ic-certification.workspace = true
 
 # other dependencies
-lazy_static = "1.4"
-sha2 = "^0.10" # set bound to match ic-certified-map bound
+lazy_static.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches.workspace = true
 rand = { version ="0.8.5" }

--- a/src/canister_tests/Cargo.toml
+++ b/src/canister_tests/Cargo.toml
@@ -4,22 +4,22 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-base64 = "0.21"
+base64.workspace = true
 flate2 = "1.0"
-hex = "0.4"
-ic-test-state-machine-client = "3"
-lazy_static = "1.4"
-regex = "1.9"
-serde = "1"
-serde_cbor = "0.11"
-serde_bytes = "0.11"
-sha2 = "0.10"
+hex.workspace = true
+ic-test-state-machine-client.workspace = true
+lazy_static.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_cbor.workspace = true
+serde_bytes.workspace = true
+sha2.workspace = true
 
-internet_identity_interface = { path = "../internet_identity_interface" }
-vc_util = { path = "../vc_util"}
+internet_identity_interface.workspace = true
+vc_util.workspace = true
 identity_jose = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false, features = ["iccs"]}
 
 # All IC deps
-candid = "0.9"
-ic-cdk = "0.10"
+candid.workspace = true
+ic-cdk.workspace = true
 ic-representation-independent-hash = "1.0"

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -4,20 +4,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-internet_identity_interface = { path = "../internet_identity_interface" }
+internet_identity_interface.workspace = true
 
-hex = "0.4"
+hex.workspace = true
 include_dir = "0.7"
-lazy_static = "1.4"
+lazy_static.workspace = true
 serde = { version = "1", features = ["rc"] }
-serde_bytes = "0.11"
-serde_cbor = "0.11"
+serde_bytes.workspace = true
+serde_cbor.workspace = true
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
-sha2 = "^0.10" # set bound to match ic-certified-map bound
+sha2.workspace = true
 
 # Captcha deps
 lodepng = "*"
-base64 = "*"
+base64.workspace = true
 
 rand = { version ="*", default-features = false }
 
@@ -26,16 +26,16 @@ rand_chacha = { version = "*", default-features = false }
 captcha = { git = "https://github.com/nmattia/captcha", rev = "9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391" }
 
 # All IC deps
-candid = "0.9"
-ic-cdk = "0.10"
-ic-cdk-macros = "0.7"
-ic-certification = "1.3"
-ic-metrics-encoder = "1"
-ic-stable-structures = "0.5"
+candid.workspace = true
+ic-cdk.workspace = true
+ic-cdk-macros.workspace = true
+ic-certification.workspace = true
+ic-metrics-encoder.workspace = true
+ic-stable-structures.workspace = true
 
 # VC deps
-canister_sig_util = { path = "../canister_sig_util" }
-vc_util = { path = "../vc_util" }
+canister_sig_util.workspace = true
+vc_util.workspace = true
 identity_core = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test" }
 identity_credential = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false, features = ["credential"]}
 identity_jose = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false, features = ["iccs"]}
@@ -45,12 +45,12 @@ identity_jose = { git = "https://github.com/frederikrothenberger/identity.rs.git
 getrandom = { version = "0.2", features = ["custom"] }
 
 [dev-dependencies]
-ic-test-state-machine-client = "3"
+ic-test-state-machine-client.workspace = true
 candid = { version = "0.9", features = ["parser"] }
-canister_tests = { path = "../canister_tests" }
+canister_tests.workspace = true
 hex-literal = "0.4"
-regex = "1.9"
-ic-response-verification = "1.3"
+regex.workspace = true
+ic-response-verification.workspace = true
 
 
 [features]

--- a/src/internet_identity_interface/Cargo.toml
+++ b/src/internet_identity_interface/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_bytes = "0.11"
-candid = "0.9"
-serde = "1"
-ic-cdk = "0.10"
+serde_bytes.workspace = true
+candid.workspace = true
+serde.workspace = true
+ic-cdk.workspace = true

--- a/src/vc_util/Cargo.toml
+++ b/src/vc_util/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 
 [dependencies]
 # ic dependencies
-candid = "0.9"
-ic-cdk = "0.10"
-ic-certification = "1.3"
+candid.workspace = true
+ic-cdk.workspace = true
+ic-certification.workspace = true
 ic-crypto-standalone-sig-verifier = { git = "https://github.com/dfinity/ic", rev = "bf9bc00b032a18d2dbcfcfcfb7a76a562f350c9e" }
 ic-types = { git = "https://github.com/dfinity/ic", rev = "bf9bc00b032a18d2dbcfcfcfb7a76a562f350c9e" }
-canister_sig_util = { path = "../canister_sig_util" }
+canister_sig_util.workspace = true
 
 # vc dependencies
 identity_core = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false }
@@ -19,11 +19,11 @@ identity_credential = { git = "https://github.com/frederikrothenberger/identity.
 identity_jose = { git = "https://github.com/frederikrothenberger/identity.rs.git", branch = "frederik/wasm-test", default-features = false, features = ["iccs"]}
 
 # other dependencies
-serde = { version = "1", features = ["rc"] }
-serde_bytes = "0.11"
-serde_cbor = "0.11"
+serde.workspace = true
+serde_bytes.workspace = true
+serde_cbor.workspace = true
 serde_json = "1"
-sha2 = "^0.10" # set bound to match ic-certified-map bound
+sha2.workspace = true
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches.workspace = true


### PR DESCRIPTION
Using workspace dependencies makes it easier to manage common dependencies. This change is made in preparation for rust dependency upgrades of the ic dependencies.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
