### PR TITLE
Change issuer API to camel case

### DIFF
--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -275,7 +275,7 @@ async fn vc_consent_message(req: Icrc21VcConsentMessageRequest) -> Icrc21Consent
 }
 
 fn verify_credential_spec(spec: &CredentialSpec) -> Result<SupportedCredentialType, String> {
-    match spec.credential_name.as_str() {
+    match spec.credential_type.as_str() {
         "VerifiedEmployee" => {
             verify_single_argument(
                 spec,
@@ -309,7 +309,7 @@ fn verify_single_argument(
     ) -> Result<(), String> {
         Err(format!(
             "Missing argument '{}' for credential {}",
-            expected_argument, spec.credential_name
+            expected_argument, spec.credential_type
         ))
     }
 
@@ -334,7 +334,7 @@ fn verify_single_argument(
     if !unexpected_arguments.is_empty() {
         return Err(format!(
             "Unexpected arguments for credential {}: {:?}",
-            spec.credential_name, unexpected_arguments
+            spec.credential_type, unexpected_arguments
         ));
     }
     Ok(())

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -179,7 +179,7 @@ fn should_return_vc_consent_message() {
         );
         let consent_message_request = Icrc21VcConsentMessageRequest {
             credential_spec: CredentialSpec {
-                credential_name: "VerifiedEmployee".to_string(),
+                credential_type: "VerifiedEmployee".to_string(),
                 arguments: Some(args),
             },
             preferences: Icrc21ConsentPreferences {
@@ -205,7 +205,7 @@ fn should_fail_vc_consent_message_if_not_supported() {
 
     let consent_message_request = Icrc21VcConsentMessageRequest {
         credential_spec: CredentialSpec {
-            credential_name: "VerifiedAdult".to_string(),
+            credential_type: "VerifiedAdult".to_string(),
             arguments: None,
         },
         preferences: Icrc21ConsentPreferences {
@@ -230,7 +230,7 @@ fn should_fail_vc_consent_message_if_missing_arguments() {
 
     let consent_message_request = Icrc21VcConsentMessageRequest {
         credential_spec: CredentialSpec {
-            credential_name: "VerifiedEmployee".to_string(),
+            credential_type: "VerifiedEmployee".to_string(),
             arguments: None,
         },
         preferences: Icrc21ConsentPreferences {
@@ -258,7 +258,7 @@ fn should_fail_vc_consent_message_if_missing_required_argument() {
 
     let consent_message_request = Icrc21VcConsentMessageRequest {
         credential_spec: CredentialSpec {
-            credential_name: "VerifiedEmployee".to_string(),
+            credential_type: "VerifiedEmployee".to_string(),
             arguments: None,
         },
         preferences: Icrc21ConsentPreferences {
@@ -283,7 +283,7 @@ fn employee_credential_spec() -> CredentialSpec {
         ArgumentValue::String("DFINITY Foundation".to_string()),
     );
     CredentialSpec {
-        credential_name: "VerifiedEmployee".to_string(),
+        credential_type: "VerifiedEmployee".to_string(),
         arguments: Some(args),
     }
 }
@@ -295,7 +295,7 @@ fn degree_credential_spec() -> CredentialSpec {
         ArgumentValue::String("DFINITY College of Engineering".to_string()),
     );
     CredentialSpec {
-        credential_name: "UniversityDegreeCredential".to_string(),
+        credential_type: "UniversityDegreeCredential".to_string(),
         arguments: Some(args),
     }
 }
@@ -629,7 +629,7 @@ fn validate_vc_claims(
         vc.get("type"),
         Some(Value::Array(vec![
             Value::String("VerifiableCredential".to_string()),
-            Value::String(credential_spec.credential_name.clone())
+            Value::String(credential_spec.credential_type.clone())
         ]))
         .as_ref()
     );

--- a/demos/vc_issuer/vc_issuer.did
+++ b/demos/vc_issuer/vc_issuer.did
@@ -5,7 +5,7 @@
 
 /// Specification of a requested credential.
 type CredentialSpec = record {
-    credential_name : text;
+    credential_type : text;
     /// arguments are optional, and specific to the credential_name
     arguments : opt vec record { text; ArgumentValue };
 };

--- a/demos/vc_issuer/vc_issuer.did
+++ b/demos/vc_issuer/vc_issuer.did
@@ -9,20 +9,20 @@ type CredentialSpec = record {
     /// arguments are optional, and specific to the credential_name
     arguments : opt vec record { text; ArgumentValue };
 };
-type ArgumentValue = variant { "int" : int32; string : text };
+type ArgumentValue = variant { "Int" : int32; String : text };
 
 /// Messages for ICRC-21 consent message, cf.
 /// https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md
 type Icrc21ConsentInfo = record { consent_message : text; language : text };
 type Icrc21ConsentMessageResponse = variant {
-    ok : Icrc21ConsentInfo;
-    err : Icrc21Error;
+    Ok : Icrc21ConsentInfo;
+    Err : Icrc21Error;
 };
 type Icrc21ConsentPreferences = record { language : text };
 type Icrc21Error = variant {
-    generic_error : Icrc21ErrorInfo;
-    unsupported_canister_call : Icrc21ErrorInfo;
-    consent_message_unavailable : Icrc21ErrorInfo;
+    GenericError : Icrc21ErrorInfo;
+    UnsupportedCanisterCall : Icrc21ErrorInfo;
+    ConsentMessageUnavailable : Icrc21ErrorInfo;
 };
 type Icrc21ErrorInfo = record { description : text; error_code : nat64 };
 type Icrc21VcConsentMessageRequest = record {
@@ -44,8 +44,8 @@ type PrepareCredentialRequest = record {
     credential_spec : CredentialSpec;
 };
 type PrepareCredentialResponse = variant {
-    ok : PreparedCredentialData;
-    err : IssueCredentialError;
+    Ok : PreparedCredentialData;
+    Err : IssueCredentialError;
 };
 type PreparedCredentialData = record { prepared_context : opt vec nat8 };
 
@@ -56,8 +56,8 @@ type GetCredentialRequest = record {
     prepared_context : opt vec nat8;
 };
 type GetCredentialResponse = variant {
-    ok : IssuedCredentialData;
-    err : IssueCredentialError;
+    Ok : IssuedCredentialData;
+    Err : IssueCredentialError;
 };
 
 type SignedIdAlias = record {
@@ -66,18 +66,18 @@ type SignedIdAlias = record {
 type IssuedCredentialData = record { vc_jws : text };
 type IssueCredentialError = variant {
     /// The caller is not known to the issuer.  Caller should register first with the issuer before retrying.
-    unknown_subject : text;
+    UnknownSubject : text;
     /// The caller is not authorized to obtain the requested credential.  Caller requested a credential
     /// for a different principal, or the issuer does not have sufficient knowledge about the caller
     /// to issue the requested credential.
-    unauthorized_subject : text;
+    UnauthorizedSubject : text;
     /// The id_alias credential provided by the identity provider is invalid.
-    invalid_id_alias : text;
+    InvalidIdAlias : text;
     /// The issuer does not issue credentials described in the credential spec.
-    unsupported_credential_spec : text;
+    UnsupportedCredentialSpec : text;
     /// Internal errors, indicate malfunctioning of the issuer.
-    signature_not_found : text;
-    internal : text;
+    SignatureNotFound : text;
+    Internal : text;
 };
 
 /// Configuration specific to this issuer.

--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -11,7 +11,7 @@ The Candid interface is as follows, and the subsequent sections describe the
 services and the corresponding messages in more detail.
 
 ```candid
-type ArgumentValue = variant { "int" : int32; string : text };
+type ArgumentValue = variant { "Int" : int32; String : text };
 type CredentialSpec = record {
     arguments : opt vec record { text; ArgumentValue };
     credential_name : text;
@@ -22,8 +22,8 @@ type GetCredentialRequest = record {
     credential_spec : CredentialSpec;
 };
 type GetCredentialResponse = variant {
-    ok : IssuedCredentialData;
-    err : IssueCredentialError;
+    Ok : IssuedCredentialData;
+    Err : IssueCredentialError;
 };
 type Icrc21ConsentInfo = record { consent_message : text; language : text };
 type Icrc21VcConsentMessageRequest = record {
@@ -31,15 +31,14 @@ type Icrc21VcConsentMessageRequest = record {
     credential_spec : CredentialSpec;
 };
 type Icrc21ConsentMessageResponse = variant {
-    ok : Icrc21ConsentInfo;
-    err : Icrc21Error;
+    Ok : Icrc21ConsentInfo;
+    Err : Icrc21Error;
 };
 type Icrc21ConsentPreferences = record { language : text };
 type Icrc21Error = variant {
     GenericError : Icrc21ErrorInfo;
-    MalformedCall : Icrc21ErrorInfo;
-    NotSupported : Icrc21ErrorInfo;
-    Forbidden : Icrc21ErrorInfo;
+    UnsupportedCanisterCall : Icrc21ErrorInfo;
+    ConsentMessageUnavailable : Icrc21ErrorInfo;
 };
 type Icrc21ErrorInfo = record { description : text; error_code : nat64 };
 type IssueCredentialError = variant {
@@ -55,8 +54,8 @@ type PrepareCredentialRequest = record {
     credential_spec : CredentialSpec;
 };
 type PrepareCredentialResponse = variant {
-    ok : PreparedCredentialData;
-    err : IssueCredentialError;
+    Ok : PreparedCredentialData;
+    Err : IssueCredentialError;
 };
 type PreparedCredentialData = record { prepared_context : opt blob };
 type SignedIdAlias = record {
@@ -140,8 +139,8 @@ type GetCredentialRequest = record {
     credential_spec : CredentialSpec;
 };
 type GetCredentialResponse = variant {
-    ok : IssuedCredentialData;
-    err : IssueCredentialError;
+    Ok : IssuedCredentialData;
+    Err : IssueCredentialError;
 };
 type IssuedCredentialData = record { vc_jws : text };
 

--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -14,7 +14,7 @@ services and the corresponding messages in more detail.
 type ArgumentValue = variant { "Int" : int32; String : text };
 type CredentialSpec = record {
     arguments : opt vec record { text; ArgumentValue };
-    credential_name : text;
+    credential_type : text;
 };
 type GetCredentialRequest = record {
     signed_id_alias : SignedIdAlias;

--- a/src/vc_util/src/issuer_api.rs
+++ b/src/vc_util/src/issuer_api.rs
@@ -72,7 +72,7 @@ impl Display for ArgumentValue {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct CredentialSpec {
-    pub credential_name: String,
+    pub credential_type: String,
     pub arguments: Option<HashMap<String, ArgumentValue>>,
 }
 

--- a/src/vc_util/src/issuer_api.rs
+++ b/src/vc_util/src/issuer_api.rs
@@ -18,25 +18,17 @@ pub struct PrepareCredentialRequest {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum PrepareCredentialResponse {
-    #[serde(rename = "ok")]
     Ok(PreparedCredentialData),
-    #[serde(rename = "err")]
     Err(IssueCredentialError),
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum IssueCredentialError {
-    #[serde(rename = "unknown_subject")]
     UnknownSubject(String),
-    #[serde(rename = "unauthorized_subject")]
     UnauthorizedSubject(String),
-    #[serde(rename = "invalid_id_alias")]
     InvalidIdAlias(String),
-    #[serde(rename = "signature_not_found")]
     SignatureNotFound(String),
-    #[serde(rename = "internal")]
     Internal(String),
-    #[serde(rename = "unsupported_credential_spec")]
     UnsupportedCredentialSpec(String),
 }
 
@@ -49,9 +41,7 @@ pub struct GetCredentialRequest {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum GetCredentialResponse {
-    #[serde(rename = "ok")]
     Ok(IssuedCredentialData),
-    #[serde(rename = "err")]
     Err(IssueCredentialError),
 }
 
@@ -67,9 +57,7 @@ pub struct IssuedCredentialData {
 
 #[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
 pub enum ArgumentValue {
-    #[serde(rename = "string")]
     String(String),
-    #[serde(rename = "int")]
     Int(i32),
 }
 
@@ -93,9 +81,7 @@ pub struct ManifestRequest {}
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum ManifestResponse {
-    #[serde(rename = "ok")]
     Ok(ManifestData),
-    #[serde(rename = "err")]
     Err(String),
 }
 
@@ -121,11 +107,8 @@ pub struct Icrc21ErrorInfo {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum Icrc21Error {
-    #[serde(rename = "unsupported_canister_call")]
     UnsupportedCanisterCall(Icrc21ErrorInfo),
-    #[serde(rename = "consent_message_unavailable")]
     ConsentMessageUnavailable(Icrc21ErrorInfo),
-    #[serde(rename = "generic_error")]
     GenericError(Icrc21ErrorInfo),
 }
 
@@ -137,9 +120,7 @@ pub struct Icrc21ConsentInfo {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum Icrc21ConsentMessageResponse {
-    #[serde(rename = "ok")]
     Ok(Icrc21ConsentInfo),
-    #[serde(rename = "err")]
     Err(Icrc21Error),
 }
 


### PR DESCRIPTION
Newer standards, such as ICRC-1,2,3 as well as the HTTP gateway spec all use came case for candid variants. To be consistent with this new development, we will do the same for the issuer API.

The rename from `credential_name` -> `credential_type` is bundled in as well, to reduce the number of breaking changes.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2b50b6051/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


