### PR TITLE
Make origin remapping consistent

### DIFF
--- a/src/frontend/src/flows/authorize/fetchDelegation.ts
+++ b/src/frontend/src/flows/authorize/fetchDelegation.ts
@@ -6,7 +6,6 @@ import { toast } from "$src/components/toast";
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
 import { unknownToString } from "$src/utils/utils";
 import { Signature } from "@dfinity/agent";
-import { nonNullish } from "@dfinity/utils";
 import { Delegation } from "./postMessageInterface";
 
 /**
@@ -28,16 +27,6 @@ export const fetchDelegation = async ({
   publicKey: Uint8Array;
   maxTimeToLive?: bigint;
 }): Promise<[PublicKey, Delegation] | { error: unknown }> => {
-  // In order to give dapps a stable principal regardless whether they use the legacy (ic0.app) or the new domain (icp0.io)
-  // we map back the derivation origin to the ic0.app domain.
-  const ORIGIN_MAPPING_REGEX =
-    /^https:\/\/(?<subdomain>[\w-]+(?:\.raw)?)\.icp0\.io$/;
-  const match = derivationOrigin.match(ORIGIN_MAPPING_REGEX);
-  const subdomain = match?.groups?.subdomain;
-  if (nonNullish(subdomain)) {
-    derivationOrigin = `https://${subdomain}.ic0.app`;
-  }
-
   const result = await connection.prepareDelegation(
     derivationOrigin,
     publicKey,


### PR DESCRIPTION
When the "new" domains (icp0.io & internetcomputer.org) were introduced, a workaround was implemented in II to ensure that dapps would see the same principals regardless on whether they are using CANISTER.ic0.app or CANISTER.icp0.io.

This workaround was implemented for fetching the derivation, but actually needs to be applied to all operations deriving a principal from an identity number/origin pair.

This change makes sure that all calls perform the remapping, including `get_principal` (which will be used in Verifiable Credentials).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
