### PR TITLE
Move asset certification header code to asset_util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,8 @@ dependencies = [
  "include_dir",
  "internet_identity_interface",
  "lazy_static",
+ "serde",
+ "serde_cbor",
  "sha2 0.10.8",
 ]
 

--- a/src/asset_util/Cargo.toml
+++ b/src/asset_util/Cargo.toml
@@ -16,4 +16,6 @@ ic-representation-independent-hash.workspace = true
 include_dir = "0.7"
 internet_identity_interface.workspace = true
 lazy_static.workspace = true
+serde.workspace = true
+serde_cbor.workspace = true
 sha2.workspace = true


### PR DESCRIPTION
This moves code from `http.rs` into the new `asset_util` crate.

This PR is step **2** of 4:
1. move code from `assets.rs` to the crate
2. move certification header code from `http.rs` to the crate
3. refactor the crate a bit to make the public interface nicer
4. use the crate in the other canisters

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
