### PR TITLE
Add markdown support for consent message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,11 @@
         "@dfinity/utils": "^0.0.20",
         "bip39": "^3.0.4",
         "buffer": "^6.0.3",
+        "dompurify": "^3.0.6",
         "idb-keyval": "^6.2.1",
         "jose": "^5.1.3",
         "lit-html": "^2.7.2",
+        "marked": "^11.0.0",
         "process": "^0.11.10",
         "qr-creator": "^1.0.0",
         "stream-browserify": "^3.0.0",
@@ -26,6 +28,7 @@
         "zod": "^3.22.3"
       },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "@types/html-minifier-terser": "^7.0.0",
         "@types/http-proxy": "^1.17.14",
         "@types/selenium-standalone": "^7.0.1",
@@ -1727,6 +1730,15 @@
       "dev": true,
       "dependencies": {
         "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -5922,6 +5934,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -8986,6 +9003,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.0.0.tgz",
+      "integrity": "sha512-2GsW34uXaFEGTQ/+3rCnNC6vUYTAgFuDLGl70v/aWinA5mIJtTrrFAmfbLOfVvgPyxXuDVL9He/7reCK+6j3Sw==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/marky": {
@@ -16020,6 +16048,15 @@
         "@types/ms": "*"
       }
     },
+    "@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
     "@types/eslint": {
       "version": "8.4.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -19266,6 +19303,11 @@
         "webidl-conversions": "^7.0.0"
       }
     },
+    "dompurify": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
+    },
     "dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -21571,6 +21613,11 @@
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
       "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
       "dev": true
+    },
+    "marked": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.0.0.tgz",
+      "integrity": "sha512-2GsW34uXaFEGTQ/+3rCnNC6vUYTAgFuDLGl70v/aWinA5mIJtTrrFAmfbLOfVvgPyxXuDVL9He/7reCK+6j3Sw=="
     },
     "marky": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "format-check": "prettier --check src/showcase src/frontend tsconfig.json .eslintrc.json vite.config.ts vite.plugins.ts vitest.config.ts demos"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "@types/html-minifier-terser": "^7.0.0",
     "@types/http-proxy": "^1.17.14",
     "@types/selenium-standalone": "^7.0.1",
@@ -63,9 +64,11 @@
     "@dfinity/utils": "^0.0.20",
     "bip39": "^3.0.4",
     "buffer": "^6.0.3",
+    "dompurify": "^3.0.6",
     "idb-keyval": "^6.2.1",
     "jose": "^5.1.3",
     "lit-html": "^2.7.2",
+    "marked": "^11.0.0",
     "process": "^0.11.10",
     "qr-creator": "^1.0.0",
     "stream-browserify": "^3.0.0",

--- a/src/frontend/src/flows/verifiableCredentials/allowCredentials.ts
+++ b/src/frontend/src/flows/verifiableCredentials/allowCredentials.ts
@@ -1,6 +1,7 @@
 import { mkAnchorInput } from "$src/components/anchorInput";
 import { mainWindow } from "$src/components/mainWindow";
 import { I18n } from "$src/i18n";
+import { markdownToHTML } from "$src/utils/html";
 import { mount, renderPage, TemplateElement } from "$src/utils/lit-html";
 import { Chan } from "$src/utils/utils";
 import { html, TemplateResult } from "lit-html";
@@ -8,7 +9,6 @@ import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { unsafeHTML } from "lit-html/directives/unsafe-html.js";
 
 import DOMPurify from "dompurify";
-import { parse as parseMarked } from "marked";
 
 import copyJson from "./allowCredentials.json";
 
@@ -45,7 +45,7 @@ const allowCredentialsTemplate = ({
 
   // Kickstart markdown parsing & sanitizing; once done, replace the consent message
   void (async () => {
-    const parsed = await parseMarked(consentMessage_);
+    const parsed = await markdownToHTML(consentMessage_);
     const sanitized = await DOMPurify.sanitize(parsed);
     consentMessage.send(unsafeHTML(sanitized));
   })();

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -2780,6 +2780,13 @@ input[type="checkbox"] {
   font-family: monospace;
 }
 
+/* The styling for the markdown-rendered elements of the message
+ * (very minimalistic styling) */
+.c-consent-message h1 {
+  font-size: 1.2em;
+  margin-bottom: 0.5em;
+}
+
 /*
   Marquee
 

--- a/src/frontend/src/utils/html.ts
+++ b/src/frontend/src/utils/html.ts
@@ -1,0 +1,109 @@
+// Copied verbatim (modulo linting comment, formatting & eager importing) from NNS dapp
+// https://github.com/dfinity/nns-dapp/blob/4619857a316be5b47a950c6b8461ffcaa1a3dde3/frontend/src/lib/utils/html.utils.ts#L94
+//
+
+import { isNullish } from "@dfinity/utils";
+import type { marked as markedTypes, Renderer } from "marked";
+import { marked } from "marked";
+
+type Marked = typeof markedTypes;
+
+export const targetBlankLinkRenderer = (
+  href: string | null | undefined,
+  title: string | null | undefined,
+  text: string
+): string =>
+  `<a${
+    href === null || href === undefined
+      ? ""
+      : ` target="_blank" rel="noopener noreferrer" href="${href}"`
+  }${title === null || title === undefined ? "" : ` title="${title}"`}>${
+    text.length === 0 ? href ?? title : text
+  }</a>`;
+
+/**
+ * Based on https://github.com/markedjs/marked/blob/master/src/Renderer.js#L186
+ * @returns <a> tag to image
+ */
+export const imageToLinkRenderer = (
+  src: string | null | undefined,
+  title: string | null | undefined,
+  alt: string
+): string => {
+  if (src === undefined || src === null || src?.length === 0) {
+    return alt;
+  }
+  const fileExtention = src.includes(".")
+    ? (src.split(".").pop() as string)
+    : "";
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-type
+  const typeProp =
+    fileExtention === "" ? undefined : ` type="image/${fileExtention}"`;
+  const titleDefined = title !== undefined && title !== null;
+  const titleProp = titleDefined ? ` title="${title}"` : undefined;
+  const text = alt === "" ? (titleDefined ? title : src) : alt;
+
+  return `<a href="${src}" target="_blank" rel="noopener noreferrer"${
+    typeProp ?? ""
+  }${titleProp ?? ""}>${text}</a>`;
+};
+
+const escapeHtml = (html: string): string =>
+  html.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+const escapeSvgs = (html: string): string =>
+  html.replace(/<svg[^>]*>[\s\S]*?<\/svg>/gi, escapeHtml);
+
+/**
+ * Escape <img> tags or convert them to links
+ */
+const transformImg = (img: string): string => {
+  const src = img.match(/src="([^"]+)"/)?.[1];
+  // eslint-disable-next-line
+  const alt = img.match(/alt="([^"]+)"/)?.[1] || "img";
+  const title = img.match(/title="([^"]+)"/)?.[1];
+  const shouldEscape = isNullish(src) || src.startsWith("data:image");
+  const imageHtml = shouldEscape
+    ? escapeHtml(img)
+    : imageToLinkRenderer(src, title, alt);
+
+  return imageHtml;
+};
+
+/** Avoid <img> tags; instead, apply the same logic as for markdown images by either escaping them or converting them to links. */
+export const htmlRenderer = (html: string): string =>
+  /<img\s+[^>]*>/gi.test(html) ? transformImg(html) : html;
+
+/**
+ * Marked.js renderer for proposal summary.
+ * Customized renderers
+ * - targetBlankLinkRenderer
+ * - imageToLinkRenderer
+ * - htmlRenderer
+ *
+ * @param marked
+ */
+const proposalSummaryRenderer = (marked: Marked): Renderer => {
+  const renderer = new marked.Renderer();
+
+  renderer.link = targetBlankLinkRenderer;
+  renderer.image = imageToLinkRenderer;
+  renderer.html = htmlRenderer;
+
+  return renderer;
+};
+
+/**
+ * Uses markedjs.
+ * Escape or transform to links some raw HTML tags (img, svg)
+ * @see {@link https://github.com/markedjs/marked}
+ */
+export const markdownToHTML = async (text: string): Promise<string> => {
+  // Replace the SVG elements in the HTML with their escaped versions to improve security.
+  // It's not possible to do it with html renderer because the svg consists of multiple tags.
+  // One edge case is not covered: if the svg is inside the <code> tag, it will be rendered as with &lt; & &gt; instead of "<" & ">"
+  const escapedText = escapeSvgs(text);
+
+  return await marked(escapedText, {
+    renderer: proposalSummaryRenderer(marked),
+  });
+};


### PR DESCRIPTION
This adds support for rendering consent messages as markdown.

We use [`marked`](https://www.npmjs.com/package/marked) for rendering the markdown to HTML, and then sanitize the HTML with [`DOMPurify`](https://www.npmjs.com/package/dompurify). The consent message is rendered async and the original message (raw markdown) is shown until the markdown was rendered (in practice, instantaneous).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a36531493/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a36531493/mobile/allowCredentials.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


