### PR TITLE
Deploy issuer & test app canisters on release

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -633,11 +633,12 @@ jobs:
         run: |
           dfx stop
 
-  # This deploys the production build to mainnet, to a canister that we use for release testing.
+  # This deploys the production build to mainnet (to a canister that we use for release testing) alongside
+  # some other canisters useful for testing & playing with II.
   deploy:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/release-')
-    needs: [docker-build-internet_identity_production, docker-build-archive]
+    needs: [docker-build-internet_identity_production, docker-build-archive, test-app-build, vc-issuer-build]
     steps:
       - uses: actions/checkout@v3
 
@@ -672,6 +673,36 @@ jobs:
             --argument "(opt record {archive_config = record { module_hash = blob \"$sha\"; entries_buffer_limit = 10000:nat64; entries_fetch_limit = 1000:nat16; polling_interval_ns = 60000000000:nat64}; canister_creation_cycles_cost = opt (1000000000000:nat64); })" \
             --wasm internet_identity_production.wasm.gz \
             fgte5-ciaaa-aaaad-aaatq-cai
+
+      - name: 'Download test app wasm'
+        uses: actions/download-artifact@v3
+        with:
+          name: test_app.wasm
+          path: .
+
+      - name: "Deploy test app"
+        run: |
+          wallet="cvthj-wyaaa-aaaad-aaaaq-cai"
+          dfx canister --network ic --wallet "$wallet" install --mode upgrade \
+            --wasm ./test_app.wasm \
+            vt36r-2qaaa-aaaad-aad5a-cai
+
+      - name: 'Download VC issuer wasm'
+        uses: actions/download-artifact@v3
+        with:
+          name: vc_issuer.wasm.gz
+          path: .
+
+      - name: "Deploy Issuer"
+        run: |
+          wallet="cvthj-wyaaa-aaaad-aaaaq-cai"
+          dfx canister --network ic --wallet "$wallet" install --mode upgrade \
+            --wasm vc_issuer.wasm.gz \
+            v2yvn-myaaa-aaaad-aad4q-cai
+          ./demos/vc_issuer/provision \
+            --ii-canister-id fgte5-ciaaa-aaaad-aaatq-cai \
+            --dfx-network ic \
+            --issuer-canister v2yvn-myaaa-aaaad-aad4q-cai
 
       - name: "Deploy archive"
         run: scripts/deploy-archive --wasm archive.wasm.gz --canister-id fgte5-ciaaa-aaaad-aaatq-cai --network ic

--- a/demos/vc_issuer/provision
+++ b/demos/vc_issuer/provision
@@ -2,22 +2,92 @@
 
 set -euo pipefail
 
-# Provision the issuer canister
-# The issuer canister needs some info to operate correctly. This
-# reads data from the local replica & canisters to ensure the issuer
-# is provisioned correctly.
+#########
+# USAGE #
+#########
 
-echo "Provisioning issuer canister" >&2
+function title() {
+    echo "Provisioning issuer canister" >&2
+}
 
-# At the time of writing dfx outputs incorrect JSON with dfx ping (commas between object 
+function usage() {
+    cat >&2 << EOF
+
+Usage:
+  $0 [--ii-canister-id CANISTER_ID] [--dfx-network NETWORK]
+
+Options:
+  --ii-canister-id CANISTER_ID  The canister ID to use as IDP, defaults to the local internet_identity canister
+  --dfx-network NETWORK         The network to use (typically "local" or "ic"), defaults to "local"
+  --issuer-canister CANISTER    The canister to configure (name or canister ID), defaults to "issuer"
+EOF
+}
+
+function help() {
+    cat >&2 << EOF
+
+The issuer canister needs some information to operate correctly. This reads data
+from the replica to ensure the issuer is provisioned correctly.
+EOF
+}
+
+II_CANISTER_ID=
+DFX_NETWORK=
+
+while [[ $# -gt 0  ]]
+do
+    case "$1" in
+        -h|--help)
+            title
+            usage
+            help
+            exit 0
+            ;;
+        --ii-canister-id)
+            II_CANISTER_ID="${2:?missing value for '--ii-canister-id'}"
+            shift; # shift past --ii-canister-id & value
+            shift;
+            ;;
+        --dfx-network)
+            DFX_NETWORK="${2:?missing value for '--dfx-network'}"
+            shift; # shift past --dfx-network & value
+            shift;
+            ;;
+        --issuer-canister)
+            ISSUER_CANISTER="${2:?missing value for '--issuer-canister'}"
+            shift; # shift past --issuer-canister & value
+            shift;
+            ;;
+        *)
+            echo "ERROR: unknown argument $1"
+            usage
+            echo
+            echo "Use '$0 --help' for more information"
+            exit 1
+            ;;
+    esac
+done
+
+
+DFX_NETWORK="${DFX_NETWORK:-local}"
+II_CANISTER_ID="${II_CANISTER_ID:-$(dfx canister id internet_identity)}"
+ISSUER_CANISTER="${ISSUER_CANISTER:-issuer}"
+
+echo "Using DFX network: $DFX_NETWORK" >&2
+
+# At the time of writing dfx outputs incorrect JSON with dfx ping (commas between object
 # entries are missing).
 # In order to read the root key we grab the array from the '"root_key": [...]' bit, the brackets
-# to match what candid expects ({}) and replace the commas between array entries to match
-# what candid expects (semicolon).
-rootkey_did=$(dfx ping  | sed -n 's/.*"root_key": \[\(.*\)\].*/{\1}/p' | sed 's/,/;/g')
+# to match what candid expects ({}), replace the commas between array entries to match
+# what candid expects (semicolon) and annotate the numbers with their type (otherwise dfx assumes 'nat'
+# instead of 'nat8').
+rootkey_did=$(dfx ping "$DFX_NETWORK" \
+    | sed -n 's/.*"root_key": \[\(.*\)\].*/{\1}/p' \
+    | sed 's/\([0-9][0-9]*\)/\1:nat8/g' \
+    | sed 's/,/;/g')
 
 echo "Parsed rootkey: ${rootkey_did:0:20}..." >&2
 
-ii_canister_id="$(dfx canister id internet_identity)"
+echo "Using II canister: $II_CANISTER_ID" >&2
 
-dfx canister call issuer configure '(record { idp_canister_ids = vec{ principal "'"$ii_canister_id"'" }; ic_root_key_der = vec '"$rootkey_did"' })'
+dfx canister call --network "$DFX_NETWORK" "$ISSUER_CANISTER" configure '(record { idp_canister_ids = vec{ principal "'"$II_CANISTER_ID"'" }; ic_root_key_der = vec '"$rootkey_did"' })'


### PR DESCRIPTION
This adds automated deploys of the issuer & of the test app upon new II releases. The issuer and test app can then be used to test the latest II changes.

NOTE: the provisioning script for the issuer was updated to allow running against a mainnet deploy.
NOTE: the test app & issuer canisters don't (yet?) have logic to point to e.g. the test II on mainnet (the URL has to be set manually).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
