### PR TITLE
Increase number of e2e test shards

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -482,7 +482,7 @@ jobs:
         # based on the shard assigned to it)
         # The jest parameter is actually 1/N, 2/N etc but we use a artifact-friendly
         # version here (with underscore).
-        shard: [ '1_4', '2_4', '3_4', '4_4' ]
+        shard: [ '1_5', '2_5', '3_5', '4_5', '5_5' ]
       # Make sure that one failing test does not cancel all other matrix jobs
       fail-fast: false
 


### PR DESCRIPTION
This bumps the number of shards (4 -> 5) because new tests (VC) have made the test run a bit too long.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
