### PR TITLE
Pre-fill anchors in VC flow

### DIFF
--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -1,5 +1,6 @@
 // Types and functions related to the window post message interface used by
 // applications that want to authenticate the user using Internet Identity
+import { setKnownPrincipal } from "$src/storage";
 import { LoginData } from "$src/utils/flowResult";
 import { unknownToRecord } from "$src/utils/utils";
 import { Signature } from "@dfinity/agent";
@@ -178,6 +179,15 @@ export async function authenticationProtocol({
   }
 
   const [userKey, parsed_signed_delegation] = result;
+
+  const userPublicKey = Uint8Array.from(userKey);
+  const principal = Principal.selfAuthenticating(userPublicKey);
+
+  await setKnownPrincipal({
+    userNumber: authSuccess.userNumber,
+    origin: authContext.requestOrigin,
+    principal,
+  });
 
   window.opener.postMessage(
     {

--- a/src/frontend/src/flows/verifiableCredentials/index.ts
+++ b/src/frontend/src/flows/verifiableCredentials/index.ts
@@ -8,6 +8,7 @@ import { withLoader } from "$src/components/loader";
 import { showMessage } from "$src/components/message";
 import { showSpinner } from "$src/components/spinner";
 import { fetchDelegation } from "$src/flows/authorize/fetchDelegation";
+import { getAnchorByPrincipal } from "$src/storage";
 import { AuthenticatedConnection, Connection } from "$src/utils/iiConnection";
 import {
   Delegation,
@@ -98,12 +99,17 @@ const verifyCredentials = async ({
     return abortedCredentials({ reason: "auth_failed_issuer" });
   }
 
+  const userNumber_ = await getAnchorByPrincipal({
+    origin: rpOrigin,
+    principal: givenP_RP,
+  });
+
   // Ask user to confirm the verification of credentials
   const allowed = await allowCredentials({
     relyingOrigin: rpOrigin,
     providerOrigin: issuerOrigin,
     consentMessage: consentInfo.consent_message,
-    userNumber: undefined,
+    userNumber: userNumber_,
   });
   if (allowed.tag === "canceled") {
     return "aborted";

--- a/src/frontend/src/test-e2e/verifiableCredentials.test.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials.test.ts
@@ -125,7 +125,8 @@ const getDomain = (url: string) => url.split(".").slice(1).join(".");
 
             const vcAllow = new VcAllowView(browser);
             await vcAllow.waitForDisplay();
-            await vcAllow.typeUserNumber(userNumber);
+            const userNumber_ = await vcAllow.getUserNumber();
+            expect(userNumber_).toBe(userNumber);
             await vcAllow.allow();
             await waitToClose(browser);
 

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -579,6 +579,10 @@ export class VcAllowView extends View {
     await this.browser.$('[data-action="allow"]').click();
   }
 
+  async getUserNumber(): Promise<string> {
+    return await this.browser.$('[data-role="anchor-input"]').getValue();
+  }
+
   async typeUserNumber(userNumber: string): Promise<void> {
     await this.browser.$('[data-role="anchor-input"]').waitForDisplayed();
     await this.browser.$('[data-role="anchor-input"]').setValue(userNumber);


### PR DESCRIPTION
This updates the storage to store (a digest of) principals of visited dapps. This allows the VC flow to know (in the general, best case scenario) which anchor (identity number) the user is intending to use.

The storage migration includes three things:

* Anchors are not written directly as `{ 10000:  <data> }` anymore but are nested as `{ anchors: { 10000: <data> } }` to allow for a new top-level field `hasher` which is global to all anchors.
* Said new field `hasher` is introduced
* Anchors themselves now have a new field, `knownPrincipalDigests`.

See storage module documentation for more information on the digests.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/09f93a061/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/09f93a061/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/09f93a061/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/09f93a061/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/09f93a061/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


