### PR TITLE
Add certification version metadata to demo canisters

### DIFF
--- a/demos/test-app/build.sh
+++ b/demos/test-app/build.sh
@@ -10,3 +10,5 @@ npm run build
 cargo build --release --target wasm32-unknown-unknown
 ic-wasm "target/wasm32-unknown-unknown/release/test_app.wasm" -o "./test_app.wasm" shrink
 ic-wasm test_app.wasm -o test_app.wasm metadata candid:service -f test_app.did -v public
+# indicate support for certificate version 1 and 2 in the canister metadata
+ic-wasm test_app.wasm -o test_app.wasm metadata supported_certificate_versions -d "1,2" -v public

--- a/demos/vc_issuer/build.sh
+++ b/demos/vc_issuer/build.sh
@@ -12,5 +12,7 @@ npm run build
 cargo build --release --target wasm32-unknown-unknown --manifest-path ./Cargo.toml -j1
 ic-wasm "target/wasm32-unknown-unknown/release/vc_issuer.wasm" -o "./vc_demo_issuer.wasm" shrink
 ic-wasm vc_demo_issuer.wasm -o vc_demo_issuer.wasm metadata candid:service -f vc_demo_issuer.did -v public
+# indicate support for certificate version 1 and 2 in the canister metadata
+ic-wasm vc_demo_issuer.wasm -o vc_demo_issuer.wasm metadata supported_certificate_versions -d "1,2" -v public
 gzip --no-name --force "vc_demo_issuer.wasm"
 


### PR DESCRIPTION
The metadata is required for certification v2 to work properly.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
