### PR TITLE
Downgrade rust to 1.73.0

### DIFF
--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -52,7 +52,7 @@ const VC_EMPLOYER_NAME: &str = "DFINITY Foundation";
 const VC_INSTITUTION_NAME: &str = "DFINITY College of Engineering";
 
 #[derive(Debug)]
-enum SupportedCredentialType {
+pub enum SupportedCredentialType {
     VerifiedEmployee(String),
     UniversityDegree(String),
     VerifiedAdult(u16),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.73.0"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
We're hitting reproducibility issues on 1.74.0, either due to rust itself or the way it is provisioned (GHA, rustup, etc).

Downgrading to 1.73.0 makes the issue disappear. This unblocks us while a better solution is found.

The vc_issuer is updated to compile on 1.73.0.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
