### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -749,7 +749,9 @@ jobs:
       - uses: actions/github-script@v6
         id: pipeline-jobs
         with:
-          script: return github.paginate("GET /repos/dfinity/internet-identity/actions/runs/${{ github.run_id }}/jobs");
+          script: |
+            return (await github.paginate("GET /repos/dfinity/internet-identity/actions/runs/${{ github.run_id }}/jobs"))
+              .map(job => {id: job.id, job.name, job.steps, job.html_url});
 
       - uses: actions/github-script@v6
         id: latest-release-tag

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -710,7 +710,7 @@ jobs:
   # This ... releases
   release:
     runs-on: ubuntu-latest
-    # if: startsWith(github.ref, 'refs/tags/release-')
+    if: startsWith(github.ref, 'refs/tags/release-')
     needs: [docker-build-internet_identity_production, docker-build-archive]
 
     steps:
@@ -809,7 +809,6 @@ jobs:
           workflow_jobs: ${{ steps.pipeline-jobs.outputs.result }}
 
       - name: Publish release
-        if: startsWith(github.ref, 'refs/tags/release-')
         run: |
           ./scripts/release \
             --tag ${{ github.ref }} \

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -710,7 +710,7 @@ jobs:
   # This ... releases
   release:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/release-')
+    # if: startsWith(github.ref, 'refs/tags/release-')
     needs: [docker-build-internet_identity_production, docker-build-archive]
 
     steps:
@@ -801,6 +801,7 @@ jobs:
           workflow_jobs: ${{ steps.pipeline-jobs.outputs.result }}
 
       - name: Publish release
+        if: startsWith(github.ref, 'refs/tags/release-')
         run: |
           ./scripts/release \
             --tag ${{ github.ref }} \

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -227,7 +227,7 @@ jobs:
             exit 1
           fi
 
-  vc-issuer-build:
+  vc_demo_issuer-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -290,7 +290,7 @@ jobs:
 
   vc-issuer-test:
     runs-on: ubuntu-latest
-    needs: [docker-build-ii, vc-issuer-build]
+    needs: [docker-build-ii, vc_demo_issuer-build]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -470,7 +470,7 @@ jobs:
 
   selenium:
     runs-on: ubuntu-latest
-    needs: [docker-build-ii, test-app-build, vc-issuer-build]
+    needs: [docker-build-ii, test-app-build, vc_demo_issuer-build]
     strategy:
       matrix:
         device: [ 'desktop', 'mobile' ]
@@ -637,7 +637,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/release-')
-    needs: [docker-build-internet_identity_production, docker-build-archive, test-app-build, vc-issuer-build]
+    needs: [docker-build-internet_identity_production, docker-build-archive, test-app-build, vc_demo_issuer-build]
     steps:
       - uses: actions/checkout@v3
 
@@ -752,7 +752,13 @@ jobs:
           script: |
             return (await github.paginate("GET /repos/dfinity/internet-identity/actions/runs/${{ github.run_id }}/jobs"))
               .map(job => {
-                return {id: job.id, name: job.name, steps: job.steps, html_url: job.html_url}
+                return {
+                  id: job.id,
+                  name: job.name,
+                  steps: job.steps.map(step => {
+                    return {name: step.name, number: step.number}
+                  },
+                  html_url: job.html_url}
               });
 
       - uses: actions/github-script@v6

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -757,7 +757,7 @@ jobs:
                   name: job.name,
                   steps: job.steps.map(step => {
                     return {name: step.name, number: step.number}
-                  },
+                  }),
                   html_url: job.html_url}
               });
 

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -751,7 +751,9 @@ jobs:
         with:
           script: |
             return (await github.paginate("GET /repos/dfinity/internet-identity/actions/runs/${{ github.run_id }}/jobs"))
-              .map(job => {id: job.id, job.name, job.steps, job.html_url});
+              .map(job => {
+                return {id: job.id, name: job.name, steps: job.steps, html_url: job.html_url}
+              });
 
       - uses: actions/github-script@v6
         id: latest-release-tag


### PR DESCRIPTION
Filter out irrelevant information from workflow jobs data, so that `INPUT_WORKFLOW_JOBS` is not too long.



