### PR TITLE
Fix issuer not being uploaded as release artifact

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -818,7 +818,8 @@ jobs:
             internet_identity_dev.wasm.gz \
             internet_identity_test.wasm.gz \
             src/internet_identity/internet_identity.did \
-            archive.wasm.gz
+            archive.wasm.gz \
+            vc_demo_issuer.wasm.gz
         env:
           # populated by GitHub Actions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow


### PR DESCRIPTION
So far the issuer is correctly added to the release notes but not actually uploaded to the release page. This PR fixes that.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
