### PR TITLE
Randomize id alias for attribute exchange

### DIFF
--- a/src/internet_identity/src/anchor_management/registration.rs
+++ b/src/internet_identity/src/anchor_management/registration.rs
@@ -1,11 +1,10 @@
 use crate::anchor_management::{activity_bookkeeping, post_operation_bookkeeping};
 use crate::state::{ChallengeInfo, MAX_INFLIGHT_CAPTCHAS};
 use crate::storage::anchor::Device;
-use crate::storage::Salt;
-use crate::{secs_to_nanos, state};
+use crate::{random_salt, secs_to_nanos, state};
 use candid::Principal;
 use ic_cdk::api::time;
-use ic_cdk::{call, caller, trap};
+use ic_cdk::{caller, trap};
 use internet_identity_interface::archive::types::{DeviceDataWithoutAlias, Operation};
 use internet_identity_interface::internet_identity::types::*;
 use rand_core::{RngCore, SeedableRng};
@@ -78,17 +77,7 @@ fn prune_expired_challenges(inflight_challenges: &mut HashMap<ChallengeKey, Chal
 
 // Get a random number generator based on 'raw_rand'
 async fn make_rng() -> rand_chacha::ChaCha20Rng {
-    let raw_rand: Vec<u8> = match call(Principal::management_canister(), "raw_rand", ()).await {
-        Ok((res,)) => res,
-        Err((_, err)) => trap(&format!("failed to get seed: {err}")),
-    };
-    let seed: Salt = raw_rand[..].try_into().unwrap_or_else(|_| {
-        trap(&format!(
-            "when creating seed from raw_rand output, expected raw randomness to be of length 32, got {}",
-            raw_rand.len()
-        ));
-    });
-
+    let seed = random_salt().await;
     rand_chacha::ChaCha20Rng::from_seed(seed)
 }
 

--- a/src/internet_identity/src/vc_mvp.rs
+++ b/src/internet_identity/src/vc_mvp.rs
@@ -1,6 +1,8 @@
 use crate::delegation::check_frontend_length;
-use crate::{delegation, hash, state, update_root_hash, LABEL_SIG, MINUTE_NS};
+use crate::{delegation, hash, random_salt, state, update_root_hash, LABEL_SIG, MINUTE_NS};
+use asset_util::CertifiedAssets;
 use candid::Principal;
+use canister_sig_util::signature_map::SignatureMap;
 use canister_sig_util::CanisterSigPublicKey;
 use ic_cdk::api::{data_certificate, time};
 use ic_cdk::trap;
@@ -8,28 +10,24 @@ use ic_certification::{fork, labeled, pruned, Hash, HashTree};
 use identity_core::common::{Timestamp, Url};
 use identity_core::convert::FromJson;
 use identity_credential::credential::{Credential, CredentialBuilder, Subject};
-
-use asset_util::CertifiedAssets;
-use canister_sig_util::signature_map::SignatureMap;
+use identity_jose::jws::{CompactJwsEncoder, Decoder};
 use internet_identity_interface::internet_identity::types::vc_mvp::{
     GetIdAliasResponse, IdAliasCredentials, PreparedIdAlias, SignedIdAlias,
 };
-use internet_identity_interface::internet_identity::types::{
-    AnchorNumber, FrontendHostname, IdentityNumber,
-};
+use internet_identity_interface::internet_identity::types::{FrontendHostname, IdentityNumber};
 use serde::Serialize;
 use serde_bytes::ByteBuf;
 use serde_json::json;
 use vc_util::{
-    did_for_principal, vc_jwt_to_jws, vc_signing_input, vc_signing_input_hash, AliasTuple,
-    II_CREDENTIAL_URL_PREFIX, II_ISSUER_URL,
+    did_for_principal, get_canister_sig_pk_raw, vc_signing_input, vc_signing_input_hash,
+    AliasTuple, II_CREDENTIAL_URL_PREFIX, II_ISSUER_URL,
 };
 
 // The expiration used for signatures.
 #[allow(clippy::identity_op)]
 const SIGNATURE_EXPIRATION_PERIOD_NS: u64 = 1 * MINUTE_NS;
 
-// The expiration of id_alias verfiable credentials.
+// The expiration of id_alias verifiable credentials.
 const ID_ALIAS_VC_EXPIRATION_PERIOD_NS: u64 = 15 * MINUTE_NS;
 pub struct InvolvedDapps {
     pub(crate) relying_party: FrontendHostname,
@@ -44,7 +42,7 @@ pub async fn prepare_id_alias(
     check_frontend_length(&dapps.relying_party);
     check_frontend_length(&dapps.issuer);
 
-    let seed = calculate_id_alias_seed(identity_number, &dapps);
+    let seed = random_salt().await;
     let canister_sig_pk = CanisterSigPublicKey::new(ic_cdk::id(), seed.to_vec());
     let id_alias_principal = Principal::self_authenticating(canister_sig_pk.to_der());
 
@@ -57,33 +55,21 @@ pub async fn prepare_id_alias(
         id_dapp: delegation::get_principal(identity_number, dapps.issuer.clone()),
     };
 
-    let rp_id_alias_jwt = prepare_id_alias_jwt(&rp_tuple);
-    let issuer_id_alias_jwt = prepare_id_alias_jwt(&issuer_tuple);
-
+    let rp_signing_input = vc_signing_input(&prepare_id_alias_jwt(&rp_tuple), &canister_sig_pk)
+        .expect("failed getting signing_input");
+    let issuer_signing_input =
+        vc_signing_input(&prepare_id_alias_jwt(&issuer_tuple), &canister_sig_pk)
+            .expect("failed getting signing_input");
     state::signature_map_mut(|sigs| {
-        add_signature(
-            sigs,
-            vc_jwt_signing_input_hash(&rp_id_alias_jwt, &canister_sig_pk),
-            seed,
-        );
-        add_signature(
-            sigs,
-            vc_jwt_signing_input_hash(&issuer_id_alias_jwt, &canister_sig_pk),
-            seed,
-        );
+        add_signature(sigs, vc_signing_input_hash(&rp_signing_input), seed);
+        add_signature(sigs, vc_signing_input_hash(&issuer_signing_input), seed);
     });
     update_root_hash();
     PreparedIdAlias {
         canister_sig_pk_der: ByteBuf::from(canister_sig_pk.to_der()),
-        rp_id_alias_jwt,
-        issuer_id_alias_jwt,
+        rp_id_alias_jwt: String::from_utf8(rp_signing_input).unwrap(),
+        issuer_id_alias_jwt: String::from_utf8(issuer_signing_input).unwrap(),
     }
-}
-
-fn vc_jwt_signing_input_hash(credential_jwt: &str, canister_sig_pk: &CanisterSigPublicKey) -> Hash {
-    let signing_input =
-        vc_signing_input(credential_jwt, canister_sig_pk).expect("failed getting signing_input");
-    vc_signing_input_hash(&signing_input)
 }
 
 pub fn get_id_alias(
@@ -96,28 +82,34 @@ pub fn get_id_alias(
     check_frontend_length(&dapps.issuer);
 
     state::assets_and_signatures(|cert_assets, sigs| {
-        let seed = calculate_id_alias_seed(identity_number, &dapps);
-        let canister_sig_pk = CanisterSigPublicKey::new(ic_cdk::id(), seed.to_vec());
+        let canister_sig_pk = match canister_sig_pk_from_signing_input(rp_id_alias_jwt) {
+            Ok(pk) => pk,
+            Err(err) => return GetIdAliasResponse::NoSuchCredentials(err),
+        };
+
         let id_alias_principal = Principal::self_authenticating(canister_sig_pk.to_der());
         let id_rp = delegation::get_principal(identity_number, dapps.relying_party.clone());
         let id_issuer = delegation::get_principal(identity_number, dapps.issuer.clone());
 
-        let signing_input = vc_signing_input(rp_id_alias_jwt, &canister_sig_pk)
-            .expect("failed getting signing_input");
-        let msg_hash = vc_signing_input_hash(&signing_input);
-        let Some(rp_sig) = get_signature(cert_assets, sigs, seed, msg_hash) else {
+        let rp_alias_msg_hash = vc_signing_input_hash(rp_id_alias_jwt.as_bytes());
+        let Some(rp_sig) =
+            get_signature(cert_assets, sigs, &canister_sig_pk.seed, rp_alias_msg_hash)
+        else {
             return GetIdAliasResponse::NoSuchCredentials("rp_sig not found".to_string());
         };
-        let rp_jws = vc_jwt_to_jws(rp_id_alias_jwt, &canister_sig_pk, &rp_sig)
-            .expect("failed constructing JWS");
+        let rp_jws =
+            add_sig_to_signing_input(rp_id_alias_jwt, &rp_sig).expect("failed constructing JWS");
 
-        let signing_input = vc_signing_input(issuer_id_alias_jwt, &canister_sig_pk)
-            .expect("failed getting signing_input");
-        let msg_hash = vc_signing_input_hash(&signing_input);
-        let Some(issuer_sig) = get_signature(cert_assets, sigs, seed, msg_hash) else {
+        let issuer_id_alias_msg_hash = vc_signing_input_hash(issuer_id_alias_jwt.as_bytes());
+        let Some(issuer_sig) = get_signature(
+            cert_assets,
+            sigs,
+            &canister_sig_pk.seed,
+            issuer_id_alias_msg_hash,
+        ) else {
             return GetIdAliasResponse::NoSuchCredentials("issuer_sig not found".to_string());
         };
-        let issuer_jws = vc_jwt_to_jws(issuer_id_alias_jwt, &canister_sig_pk, &issuer_sig)
+        let issuer_jws = add_sig_to_signing_input(issuer_id_alias_jwt, &issuer_sig)
             .expect("failed constructing JWS");
 
         GetIdAliasResponse::Ok(IdAliasCredentials {
@@ -135,10 +127,42 @@ pub fn get_id_alias(
     })
 }
 
+/// Parses the canister signature public key from the given signing_input.
+fn canister_sig_pk_from_signing_input(signing_input: &str) -> Result<CanisterSigPublicKey, String> {
+    let decoder = Decoder::new();
+    let bytes_with_separators = [signing_input.as_bytes(), &[b'.']].concat();
+    let parsed_signing_input = decoder
+        .decode_compact_serialization(&bytes_with_separators, None)
+        .map_err(|e| format!("internal: failed parsing signing_input: {:?}", e))?;
+    let header = parsed_signing_input
+        .protected_header()
+        .expect("internal: failed getting protected header");
+    let canister_sig_pk_raw = get_canister_sig_pk_raw(header)
+        .map_err(|e| format!("internal: failed getting canister_sig_pk_raw: {:?}", e))?;
+    CanisterSigPublicKey::try_from_raw(&canister_sig_pk_raw)
+        .map_err(|e| format!("internal: failed parsing canister_sig_pk: {}", e))
+}
+
+/// Constructs and returns a JWS (a signed JWT) from the given components.
+fn add_sig_to_signing_input(signing_input: &str, sig: &[u8]) -> Result<String, String> {
+    let decoder = Decoder::new();
+    let bytes_with_separators = [signing_input.as_bytes(), &[b'.']].concat();
+    let parsed_signing_input = decoder
+        .decode_compact_serialization(&bytes_with_separators, None)
+        .unwrap();
+    let header = parsed_signing_input
+        .protected_header()
+        .expect("internal: failed getting protected header");
+
+    let encoder: CompactJwsEncoder = CompactJwsEncoder::new(parsed_signing_input.claims(), header)
+        .map_err(|e| format!("internal: failed creating JWS encoder: {:?}", e))?;
+    Ok(encoder.into_jws(sig))
+}
+
 fn get_signature(
     cert_assets: &CertifiedAssets,
     sigs: &SignatureMap,
-    seed: Hash,
+    seed: impl AsRef<[u8]>,
     msg_hash: Hash,
 ) -> Option<Vec<u8>> {
     let certificate = data_certificate().unwrap_or_else(|| {
@@ -178,27 +202,6 @@ fn get_signature(
 fn add_signature(sigs: &mut SignatureMap, msg_hash: Hash, seed: Hash) {
     let expires_at = time().saturating_add(SIGNATURE_EXPIRATION_PERIOD_NS);
     sigs.put(hash::hash_bytes(seed), msg_hash, expires_at);
-}
-
-fn calculate_id_alias_seed(identity_number: AnchorNumber, dapps: &InvolvedDapps) -> Hash {
-    let salt = state::salt();
-
-    let mut blob: Vec<u8> = vec![];
-    blob.push(salt.len() as u8);
-    blob.extend_from_slice(&salt);
-
-    let identity_number_str = identity_number.to_string();
-    let identity_number_blob = identity_number_str.bytes();
-    blob.push(identity_number_blob.len() as u8);
-    blob.extend(identity_number_blob);
-
-    blob.push(dapps.relying_party.bytes().len() as u8);
-    blob.extend(dapps.relying_party.bytes());
-
-    blob.push(dapps.issuer.bytes().len() as u8);
-    blob.extend(dapps.issuer.bytes());
-
-    hash::hash_bytes(blob)
 }
 
 fn id_alias_credential(alias_tuple: &AliasTuple) -> Credential {

--- a/src/internet_identity/tests/integration/vc_mvp.rs
+++ b/src/internet_identity/tests/integration/vc_mvp.rs
@@ -581,6 +581,149 @@ fn should_get_different_id_alias_for_different_issuers() -> Result<(), CallError
 }
 
 #[test]
+fn should_get_different_id_alias_for_different_flows() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let identity_number = flows::register_anchor(&env, canister_id);
+    let relying_party = FrontendHostname::from("https://some-dapp.com");
+    let issuer = FrontendHostname::from("https://some-issuer-1.com");
+    let prepare_id_alias_req = PrepareIdAliasRequest {
+        identity_number,
+        relying_party: relying_party.clone(),
+        issuer: issuer.clone(),
+    };
+
+    let (get_id_alias_req_1, canister_sig_pk_1) = {
+        let prepare_response = api::vc_mvp::prepare_id_alias(
+            &env,
+            canister_id,
+            principal_1(),
+            prepare_id_alias_req.clone(),
+        )?
+        .expect("Got 'None' from prepare_id_alias");
+        if let PrepareIdAliasResponse::Ok(prepared_id_alias_1) = prepare_response {
+            (
+                GetIdAliasRequest {
+                    identity_number,
+                    relying_party: relying_party.clone(),
+                    issuer: issuer.clone(),
+                    rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
+                    issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
+                },
+                CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
+                    .expect("failed parsing canister sig pk"),
+            )
+        } else {
+            panic!("prepare id_alias failed")
+        }
+    };
+
+    let (get_id_alias_req_2, canister_sig_pk_2) = {
+        let prepare_response =
+            api::vc_mvp::prepare_id_alias(&env, canister_id, principal_1(), prepare_id_alias_req)?
+                .expect("Got 'None' from prepare_id_alias");
+        if let PrepareIdAliasResponse::Ok(prepared_id_alias_2) = prepare_response {
+            (
+                GetIdAliasRequest {
+                    identity_number,
+                    relying_party,
+                    issuer,
+                    rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
+                    issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
+                },
+                CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
+                    .expect("failed parsing canister sig pk"),
+            )
+        } else {
+            panic!("prepare id_alias failed")
+        }
+    };
+
+    let id_alias_credentials_1 =
+        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_1)?
+            .expect("Got 'None' from get_id_alias")
+        {
+            GetIdAliasResponse::Ok(credentials) => credentials,
+            GetIdAliasResponse::NoSuchCredentials(err) => {
+                panic!("{}", format!("failed to get id_alias credentials: {}", err))
+            }
+            GetIdAliasResponse::AuthenticationFailed(err) => {
+                panic!("{}", format!("failed authentication: {}", err))
+            }
+        };
+
+    let id_alias_credentials_2 =
+        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_2)?
+            .expect("Got 'None' from get_id_alias")
+        {
+            GetIdAliasResponse::Ok(credentials) => credentials,
+            GetIdAliasResponse::NoSuchCredentials(err) => {
+                panic!("{}", format!("failed to get id_alias credentials: {}", err))
+            }
+            GetIdAliasResponse::AuthenticationFailed(err) => {
+                panic!("{}", format!("failed authentication: {}", err))
+            }
+        };
+
+    assert_eq!(
+        id_alias_credentials_1.rp_id_alias_credential.id_alias,
+        id_alias_credentials_1.issuer_id_alias_credential.id_alias
+    );
+
+    assert_eq!(
+        id_alias_credentials_2.rp_id_alias_credential.id_alias,
+        id_alias_credentials_2.issuer_id_alias_credential.id_alias
+    );
+
+    assert_ne!(
+        id_alias_credentials_1.rp_id_alias_credential.id_alias,
+        id_alias_credentials_2.rp_id_alias_credential.id_alias
+    );
+
+    assert_ne!(
+        id_alias_credentials_1.issuer_id_alias_credential.id_alias,
+        id_alias_credentials_2.issuer_id_alias_credential.id_alias
+    );
+
+    let root_pk_raw =
+        extract_raw_root_pk_from_der(&env.root_key()).expect("Failed decoding IC root key.");
+    verify_credential_jws_with_canister_id(
+        &id_alias_credentials_1.rp_id_alias_credential.credential_jws,
+        &canister_sig_pk_1.canister_id,
+        &root_pk_raw,
+        time(&env) as u128,
+    )
+    .expect("external verification failed");
+    verify_credential_jws_with_canister_id(
+        &id_alias_credentials_1
+            .issuer_id_alias_credential
+            .credential_jws,
+        &canister_sig_pk_1.canister_id,
+        &root_pk_raw,
+        time(&env) as u128,
+    )
+    .expect("external verification failed");
+    verify_credential_jws_with_canister_id(
+        &id_alias_credentials_2.rp_id_alias_credential.credential_jws,
+        &canister_sig_pk_2.canister_id,
+        &root_pk_raw,
+        time(&env) as u128,
+    )
+    .expect("external verification failed");
+    verify_credential_jws_with_canister_id(
+        &id_alias_credentials_2
+            .issuer_id_alias_credential
+            .credential_jws,
+        &canister_sig_pk_2.canister_id,
+        &root_pk_raw,
+        time(&env) as u128,
+    )
+    .expect("external verification failed");
+
+    Ok(())
+}
+
+#[test]
 #[should_panic(expected = "could not be authenticated")]
 fn should_not_prepare_id_alias_for_different_user() {
     let env = env();

--- a/src/vc_util/src/lib.rs
+++ b/src/vc_util/src/lib.rs
@@ -403,8 +403,10 @@ fn inconsistent_jwt_claims(custom_message: &'static str) -> JwtValidationError {
     ))
 }
 
-// Extracts and returns raw canister sig public key (without DER-prefix) from the given header.
-fn get_canister_sig_pk_raw(jws_header: &JwsHeader) -> Result<Vec<u8>, SignatureVerificationError> {
+/// Extracts and returns raw canister sig public key (without DER-prefix) from the given header.
+pub fn get_canister_sig_pk_raw(
+    jws_header: &JwsHeader,
+) -> Result<Vec<u8>, SignatureVerificationError> {
     let jwk = jws_header
         .deref()
         .jwk()


### PR DESCRIPTION
This PR introduces randomized id aliases. In order to achieve this, the context handed out by `prepare_id_alias` has to be changed to already include the JWS header so that the `get_id_alias` call knows about the random seed.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
