### PR TITLE
Factor out get_signature and add it to canister_sig_util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,9 +334,14 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "candid",
+ "hex",
+ "ic-cdk",
  "ic-certification 1.3.0",
  "lazy_static",
  "rand",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
  "sha2 0.10.8",
 ]
 

--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -307,8 +307,13 @@ name = "canister_sig_util"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "hex",
+ "ic-cdk",
  "ic-certification 1.3.0",
  "lazy_static",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
  "sha2 0.10.8",
 ]
 

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -1,18 +1,18 @@
 use crate::consent_message::{get_vc_consent_message, SupportedLanguage};
 use candid::{candid_method, CandidType, Deserialize, Principal};
 use canister_sig_util::signature_map::{SignatureMap, LABEL_SIG};
-use canister_sig_util::{extract_raw_root_pk_from_der, CanisterSigPublicKey, IC_ROOT_PK_DER};
-use ic_cdk::api::{caller, data_certificate, set_certified_data, time};
-use ic_cdk::trap;
+use canister_sig_util::{
+    extract_raw_root_pk_from_der, get_signature_as_cbor, CanisterSigPublicKey, IC_ROOT_PK_DER,
+};
+use ic_cdk::api::{caller, set_certified_data, time};
 use ic_cdk_macros::{init, query, update};
-use ic_certification::{fork, fork_hash, labeled, labeled_hash, pruned, Hash, HashTree};
+use ic_certification::{fork_hash, labeled_hash, pruned, Hash};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::{DefaultMemoryImpl, RestrictedMemory, StableCell, Storable};
 use identity_core::common::{Timestamp, Url};
 use identity_core::convert::FromJson;
 use identity_credential::credential::{Credential, CredentialBuilder, Subject};
 use include_dir::{include_dir, Dir};
-use serde::Serialize;
 use serde_bytes::ByteBuf;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -264,17 +264,25 @@ fn get_credential(req: GetCredentialRequest) -> GetCredentialResponse {
     };
     let signing_input =
         vc_signing_input(&credential_jwt, &canister_sig_pk).expect("failed getting signing_input");
-    let msg_hash = vc_signing_input_hash(&signing_input);
-    let maybe_sig = SIGNATURES.with(|sigs| {
-        let sigs = sigs.borrow();
-        get_signature(&sigs, seed, msg_hash)
+    let message_hash = vc_signing_input_hash(&signing_input);
+    let sig_result = SIGNATURES.with(|sigs| {
+        let sig_map = sigs.borrow();
+        let certified_assets_root_hash = ASSETS.with_borrow(|assets| assets.root_hash());
+        get_signature_as_cbor(
+            &sig_map,
+            &seed,
+            message_hash,
+            Some(certified_assets_root_hash),
+        )
     });
-    let sig = if let Some(sig) = maybe_sig {
-        sig
-    } else {
-        return GetCredentialResponse::Err(IssueCredentialError::SignatureNotFound(String::from(
-            "signature not prepared or expired",
-        )));
+    let sig = match sig_result {
+        Ok(sig) => sig,
+        Err(e) => {
+            return GetCredentialResponse::Err(IssueCredentialError::SignatureNotFound(format!(
+                "signature not prepared or expired: {}",
+                e
+            )));
+        }
     };
     let vc_jws =
         vc_jwt_to_jws(&credential_jwt, &canister_sig_pk, &sig).expect("failed constructing JWS");
@@ -427,40 +435,6 @@ fn main() {}
 fn add_signature(sigs: &mut SignatureMap, msg_hash: Hash, seed: Hash) {
     let signature_expires_at = time().saturating_add(CERTIFICATE_VALIDITY_PERIOD_NS);
     sigs.put(hash_bytes(seed), msg_hash, signature_expires_at);
-}
-
-fn get_signature(sigs: &SignatureMap, seed: Hash, msg_hash: Hash) -> Option<Vec<u8>> {
-    let certificate = data_certificate().unwrap_or_else(|| {
-        trap("data certificate is only available in query calls");
-    });
-    let asset_root_hash = ASSETS.with_borrow(|assets| assets.root_hash());
-    let witness = sigs.witness(hash_bytes(seed), msg_hash)?;
-
-    let witness_hash = witness.digest();
-    let root_hash = sigs.root_hash();
-    if witness_hash != root_hash {
-        trap(&format!(
-            "internal error: signature map computed an invalid hash tree, witness hash is {}, root hash is {}",
-            hex::encode(witness_hash),
-            hex::encode(root_hash)
-        ));
-    }
-    let tree = fork(pruned(asset_root_hash), labeled(LABEL_SIG, witness));
-    #[derive(Serialize)]
-    struct Sig {
-        certificate: ByteBuf,
-        tree: HashTree,
-    }
-
-    let sig = Sig {
-        certificate: ByteBuf::from(certificate),
-        tree,
-    };
-
-    let mut cbor = serde_cbor::ser::Serializer::new(Vec::new());
-    cbor.self_describe().unwrap();
-    sig.serialize(&mut cbor).unwrap();
-    Some(cbor.into_inner())
 }
 
 fn calculate_seed(principal: &Principal) -> Hash {

--- a/src/canister_sig_util/Cargo.toml
+++ b/src/canister_sig_util/Cargo.toml
@@ -7,10 +7,15 @@ edition = "2021"
 [dependencies]
 # ic dependencies
 candid.workspace = true
+ic-cdk.workspace = true
 ic-certification.workspace = true
 
 # other dependencies
+hex.workspace = true
 lazy_static.workspace = true
+serde = { version = "1", features = ["derive"] }
+serde_bytes.workspace = true
+serde_cbor.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]

--- a/src/canister_sig_util/src/lib.rs
+++ b/src/canister_sig_util/src/lib.rs
@@ -1,5 +1,11 @@
 use candid::Principal;
+use ic_cdk::api::data_certificate;
+use ic_certification::{fork, labeled, pruned, Hash, HashTree};
 use lazy_static::lazy_static;
+use serde::Serialize;
+use serde_bytes::ByteBuf;
+use sha2::{Digest, Sha256};
+use signature_map::{SignatureMap, LABEL_SIG};
 
 pub mod signature_map;
 
@@ -123,6 +129,63 @@ pub fn extract_raw_canister_sig_pk_from_der(pk_der: &[u8]) -> Result<Vec<u8>, St
         return Err(String::from("canister sig pk too short"));
     }
     Ok(pk_der[(bitstring_offset)..].to_vec())
+}
+
+pub fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_ref());
+    hasher.finalize().into()
+}
+
+#[derive(Serialize)]
+struct CanisterSig {
+    certificate: ByteBuf,
+    tree: HashTree,
+}
+
+/// Returns canister signature for the specified `seed` and `message_hash` by retrieving
+/// the witness from `sig_map`.  If the canister uses
+/// [certified_data](https://internetcomputer.org/docs/current/references/ic-interface-spec/#system-api-certified-data)
+/// to manage certified assets, the caller should provide also the root hash of the assets subtree
+/// (cf. `asset_util`-crate).
+/// The returned value (if found) is a CBOR-serialised `CanisterSig`.
+pub fn get_signature_as_cbor(
+    sig_map: &SignatureMap,
+    seed: &[u8],
+    message_hash: Hash,
+    maybe_certified_assets_root_hash: Option<Hash>,
+) -> Result<Vec<u8>, String> {
+    let certificate = data_certificate()
+        .ok_or("data certificate is only available in query calls".to_string())?;
+    let witness = sig_map
+        .witness(hash_bytes(seed), message_hash)
+        .ok_or("missing witness".to_string())?;
+
+    let witness_hash = witness.digest();
+    let root_hash = sig_map.root_hash();
+    if witness_hash != root_hash {
+        return Err(format!(
+            "internal error: signature map computed an invalid hash tree, witness hash is {}, root hash is {}",
+            hex::encode(witness_hash),
+            hex::encode(root_hash)
+        ));
+    }
+
+    let sigs_tree = labeled(LABEL_SIG, witness);
+    let tree = match maybe_certified_assets_root_hash {
+        Some(certified_assets_root_hash) => fork(pruned(certified_assets_root_hash), sigs_tree),
+        None => sigs_tree,
+    };
+
+    let sig = CanisterSig {
+        certificate: ByteBuf::from(certificate),
+        tree,
+    };
+
+    let mut cbor = serde_cbor::ser::Serializer::new(Vec::new());
+    cbor.self_describe().unwrap();
+    sig.serialize(&mut cbor).unwrap();
+    Ok(cbor.into_inner())
 }
 
 #[cfg(test)]

--- a/src/internet_identity/src/delegation.rs
+++ b/src/internet_identity/src/delegation.rs
@@ -1,15 +1,13 @@
 use crate::ii_domain::IIDomain;
 use crate::state::persistent_state_mut;
 use crate::{hash, state, update_root_hash, DAY_NS, MINUTE_NS};
-use asset_util::CertifiedAssets;
 use candid::Principal;
-use canister_sig_util::signature_map::{SignatureMap, LABEL_SIG};
-use canister_sig_util::CanisterSigPublicKey;
-use ic_cdk::api::{data_certificate, time};
+use canister_sig_util::signature_map::SignatureMap;
+use canister_sig_util::{get_signature_as_cbor, CanisterSigPublicKey};
+use ic_cdk::api::time;
 use ic_cdk::{id, trap};
-use ic_certification::{fork, labeled, pruned, Hash, HashTree};
+use ic_certification::Hash;
 use internet_identity_interface::internet_identity::types::*;
-use serde::Serialize;
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -128,15 +126,19 @@ pub fn get_delegation(
 ) -> GetDelegationResponse {
     check_frontend_length(&frontend);
 
-    state::assets_and_signatures(|asset_hashes, sigs| {
-        match get_signature(
-            asset_hashes,
-            sigs,
-            session_key.clone(),
-            calculate_seed(anchor_number, &frontend),
+    state::assets_and_signatures(|certified_assets, sigs| {
+        let message_hash = delegation_signature_msg_hash(&Delegation {
+            pubkey: session_key.clone(),
             expiration,
+            targets: None,
+        });
+        match get_signature_as_cbor(
+            sigs,
+            &calculate_seed(anchor_number, &frontend),
+            message_hash,
+            Some(certified_assets.root_hash()),
         ) {
-            Some(signature) => GetDelegationResponse::SignedDelegation(SignedDelegation {
+            Ok(signature) => GetDelegationResponse::SignedDelegation(SignedDelegation {
                 delegation: Delegation {
                     pubkey: session_key,
                     expiration,
@@ -144,7 +146,7 @@ pub fn get_delegation(
                 },
                 signature: ByteBuf::from(signature),
             }),
-            None => GetDelegationResponse::NoSuchDelegation,
+            Err(_) => GetDelegationResponse::NoSuchDelegation,
         }
     })
 }
@@ -195,52 +197,6 @@ fn delegation_signature_msg_hash(d: &Delegation) -> Hash {
     }
     let map_hash = hash::hash_of_map(m);
     hash::hash_with_domain(b"ic-request-auth-delegation", &map_hash)
-}
-
-fn get_signature(
-    assets: &CertifiedAssets,
-    sigs: &SignatureMap,
-    pk: PublicKey,
-    seed: Hash,
-    expiration: Timestamp,
-) -> Option<Vec<u8>> {
-    let certificate = data_certificate().unwrap_or_else(|| {
-        trap("data certificate is only available in query calls");
-    });
-    let msg_hash = delegation_signature_msg_hash(&Delegation {
-        pubkey: pk,
-        expiration,
-        targets: None,
-    });
-    let witness = sigs.witness(hash::hash_bytes(seed), msg_hash)?;
-
-    let witness_hash = witness.digest();
-    let root_hash = sigs.root_hash();
-    if witness_hash != root_hash {
-        trap(&format!(
-            "internal error: signature map computed an invalid hash tree, witness hash is {}, root hash is {}",
-            hex::encode(witness_hash),
-            hex::encode(root_hash)
-        ));
-    }
-
-    let tree = fork(pruned(assets.root_hash()), labeled(LABEL_SIG, witness));
-
-    #[derive(Serialize)]
-    struct Sig {
-        certificate: ByteBuf,
-        tree: HashTree,
-    }
-
-    let sig = Sig {
-        certificate: ByteBuf::from(certificate),
-        tree,
-    };
-
-    let mut cbor = serde_cbor::ser::Serializer::new(Vec::new());
-    cbor.self_describe().unwrap();
-    sig.serialize(&mut cbor).unwrap();
-    Some(cbor.into_inner())
 }
 
 fn add_signature(sigs: &mut SignatureMap, pk: PublicKey, seed: Hash, expiration: Timestamp) {

--- a/src/internet_identity/src/vc_mvp.rs
+++ b/src/internet_identity/src/vc_mvp.rs
@@ -110,7 +110,7 @@ pub fn get_id_alias(
         let issuer_id_alias_msg_hash = vc_signing_input_hash(issuer_id_alias_jwt.as_bytes());
         let issuer_sig = match get_signature_as_cbor(
             sigs,
-            &seed,
+            seed,
             issuer_id_alias_msg_hash,
             Some(cert_assets.root_hash()),
         ) {


### PR DESCRIPTION
Factor out `get_signature`, which is used in canisters that create canister signatures, and add the corresponding functionality to `canister_sig_util`-crate (as function `get_signature_as_cbor`).

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a62fd4830/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

