### PR TITLE
Refactor II VC API

### DIFF
--- a/src/canister_tests/src/api/internet_identity/vc_mvp.rs
+++ b/src/canister_tests/src/api/internet_identity/vc_mvp.rs
@@ -2,7 +2,8 @@ use candid::Principal;
 use ic_cdk::api::management_canister::main::CanisterId;
 use ic_test_state_machine_client::{call_candid_as, query_candid_as, CallError, StateMachine};
 use internet_identity_interface::internet_identity::types::vc_mvp::{
-    GetIdAliasRequest, GetIdAliasResponse, PrepareIdAliasRequest, PrepareIdAliasResponse,
+    GetIdAliasError, GetIdAliasRequest, IdAliasCredentials, PrepareIdAliasError,
+    PrepareIdAliasRequest, PreparedIdAlias,
 };
 
 pub fn prepare_id_alias(
@@ -10,7 +11,7 @@ pub fn prepare_id_alias(
     canister_id: CanisterId,
     sender: Principal,
     prepare_id_alias_req: PrepareIdAliasRequest,
-) -> Result<Option<PrepareIdAliasResponse>, CallError> {
+) -> Result<Result<PreparedIdAlias, PrepareIdAliasError>, CallError> {
     call_candid_as(
         env,
         canister_id,
@@ -26,7 +27,7 @@ pub fn get_id_alias(
     canister_id: CanisterId,
     sender: Principal,
     get_id_alias_req: GetIdAliasRequest,
-) -> Result<Option<GetIdAliasResponse>, CallError> {
+) -> Result<Result<IdAliasCredentials, GetIdAliasError>, CallError> {
     query_candid_as(
         env,
         canister_id,

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -170,10 +170,9 @@ export const idlFactory = ({ IDL }) => {
     'rp_id_alias_credential' : SignedIdAlias,
     'issuer_id_alias_credential' : SignedIdAlias,
   });
-  const GetIdAliasResponse = IDL.Variant({
-    'ok' : IdAliasCredentials,
-    'authentication_failed' : IDL.Text,
-    'no_such_credentials' : IDL.Text,
+  const GetIdAliasError = IDL.Variant({
+    'NoSuchCredentials' : IDL.Text,
+    'AuthenticationFailed' : IDL.Text,
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
@@ -238,9 +237,8 @@ export const idlFactory = ({ IDL }) => {
     'issuer_id_alias_jwt' : IDL.Text,
     'canister_sig_pk_der' : PublicKey,
   });
-  const PrepareIdAliasResponse = IDL.Variant({
-    'ok' : PreparedIdAlias,
-    'authentication_failed' : IDL.Text,
+  const PrepareIdAliasError = IDL.Variant({
+    'AuthenticationFailed' : IDL.Text,
   });
   const RegisterResponse = IDL.Variant({
     'bad_challenge' : IDL.Null,
@@ -303,7 +301,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'get_id_alias' : IDL.Func(
         [GetIdAliasRequest],
-        [IDL.Opt(GetIdAliasResponse)],
+        [IDL.Variant({ 'Ok' : IdAliasCredentials, 'Err' : GetIdAliasError })],
         ['query'],
       ),
     'get_principal' : IDL.Func(
@@ -337,7 +335,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'prepare_id_alias' : IDL.Func(
         [PrepareIdAliasRequest],
-        [IDL.Opt(PrepareIdAliasResponse)],
+        [IDL.Variant({ 'Ok' : PreparedIdAlias, 'Err' : PrepareIdAliasError })],
         [],
       ),
     'register' : IDL.Func(

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -99,6 +99,8 @@ export interface DeviceWithUsage {
 export type FrontendHostname = string;
 export type GetDelegationResponse = { 'no_such_delegation' : null } |
   { 'signed_delegation' : SignedDelegation };
+export type GetIdAliasError = { 'NoSuchCredentials' : string } |
+  { 'AuthenticationFailed' : string };
 export interface GetIdAliasRequest {
   'rp_id_alias_jwt' : string,
   'issuer' : FrontendHostname,
@@ -106,9 +108,6 @@ export interface GetIdAliasRequest {
   'relying_party' : FrontendHostname,
   'identity_number' : IdentityNumber,
 }
-export type GetIdAliasResponse = { 'ok' : IdAliasCredentials } |
-  { 'authentication_failed' : string } |
-  { 'no_such_credentials' : string };
 export type HeaderField = [string, string];
 export interface HttpRequest {
   'url' : string,
@@ -174,13 +173,12 @@ export type MetadataMap = Array<
       { 'bytes' : Uint8Array | number[] },
   ]
 >;
+export type PrepareIdAliasError = { 'AuthenticationFailed' : string };
 export interface PrepareIdAliasRequest {
   'issuer' : FrontendHostname,
   'relying_party' : FrontendHostname,
   'identity_number' : IdentityNumber,
 }
-export type PrepareIdAliasResponse = { 'ok' : PreparedIdAlias } |
-  { 'authentication_failed' : string };
 export interface PreparedIdAlias {
   'rp_id_alias_jwt' : string,
   'issuer_id_alias_jwt' : string,
@@ -259,7 +257,11 @@ export interface _SERVICE {
     [UserNumber, FrontendHostname, SessionKey, Timestamp],
     GetDelegationResponse
   >,
-  'get_id_alias' : ActorMethod<[GetIdAliasRequest], [] | [GetIdAliasResponse]>,
+  'get_id_alias' : ActorMethod<
+    [GetIdAliasRequest],
+    { 'Ok' : IdAliasCredentials } |
+      { 'Err' : GetIdAliasError }
+  >,
   'get_principal' : ActorMethod<[UserNumber, FrontendHostname], Principal>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'http_request_update' : ActorMethod<[HttpRequest], HttpResponse>,
@@ -280,7 +282,8 @@ export interface _SERVICE {
   >,
   'prepare_id_alias' : ActorMethod<
     [PrepareIdAliasRequest],
-    [] | [PrepareIdAliasResponse]
+    { 'Ok' : PreparedIdAlias } |
+      { 'Err' : PrepareIdAliasError }
   >,
   'register' : ActorMethod<
     [DeviceData, ChallengeResult, [] | [Principal]],

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -399,11 +399,9 @@ type PrepareIdAliasRequest = record {
     identity_number : IdentityNumber;
 };
 
-type PrepareIdAliasResponse = variant {
-    /// Credentials prepared successfully, can be retrieved via `get_id_alias`
-    ok : PreparedIdAlias;
+type PrepareIdAliasError = variant {
     /// Caller authentication failed.
-    authentication_failed : text;
+    AuthenticationFailed : text;
 };
 
 /// The prepared id alias contains two (still unsigned) credentials in JWT format,
@@ -425,13 +423,11 @@ type GetIdAliasRequest = record {
     identity_number : IdentityNumber;
 };
 
-type GetIdAliasResponse = variant {
-    /// The signed id alias credentials
-    ok : IdAliasCredentials;
+type GetIdAliasError = variant {
     /// Caller authentication failed.
-    authentication_failed : text;
+    AuthenticationFailed : text;
     /// The credential(s) are not available: may be expired or not prepared yet (call prepare_id_alias to prepare).
-    no_such_credentials : text;
+    NoSuchCredentials : text;
 };
 
 /// The signed id alias credentials for each involved party.
@@ -519,6 +515,6 @@ service : (opt InternetIdentityInit) -> {
 
     // Attribute Sharing MVP API
     // The methods below are used to generate ID-alias credentials during attribute sharing flow.
-    prepare_id_alias : (PrepareIdAliasRequest) -> (opt PrepareIdAliasResponse);
-    get_id_alias : (GetIdAliasRequest) -> (opt GetIdAliasResponse) query;
+    prepare_id_alias : (PrepareIdAliasRequest) -> (variant {Ok: PreparedIdAlias; Err: PrepareIdAliasError;});
+    get_id_alias : (GetIdAliasRequest) -> (variant {Ok: IdAliasCredentials; Err: GetIdAliasError;}) query;
 }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -11,7 +11,8 @@ use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use internet_identity_interface::archive::types::{BufferedEntry, Operation};
 use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
 use internet_identity_interface::internet_identity::types::vc_mvp::{
-    GetIdAliasRequest, GetIdAliasResponse, PrepareIdAliasRequest, PrepareIdAliasResponse,
+    GetIdAliasError, GetIdAliasRequest, IdAliasCredentials, PrepareIdAliasError,
+    PrepareIdAliasRequest, PreparedIdAlias,
 };
 use internet_identity_interface::internet_identity::types::*;
 use serde_bytes::ByteBuf;
@@ -622,7 +623,9 @@ mod attribute_sharing_mvp {
 
     #[update]
     #[candid_method]
-    async fn prepare_id_alias(req: PrepareIdAliasRequest) -> Option<PrepareIdAliasResponse> {
+    async fn prepare_id_alias(
+        req: PrepareIdAliasRequest,
+    ) -> Result<PreparedIdAlias, PrepareIdAliasError> {
         let _maybe_ii_domain = authenticate_and_record_activity(req.identity_number);
         let prepared_id_alias = vc_mvp::prepare_id_alias(
             req.identity_number,
@@ -632,19 +635,19 @@ mod attribute_sharing_mvp {
             },
         )
         .await;
-        Some(PrepareIdAliasResponse::Ok(prepared_id_alias))
+        Ok(prepared_id_alias)
     }
 
     #[query]
     #[candid_method(query)]
-    fn get_id_alias(req: GetIdAliasRequest) -> Option<GetIdAliasResponse> {
+    fn get_id_alias(req: GetIdAliasRequest) -> Result<IdAliasCredentials, GetIdAliasError> {
         let Ok(_) = check_authentication(req.identity_number) else {
-            return Some(GetIdAliasResponse::AuthenticationFailed(format!(
+            return Err(GetIdAliasError::AuthenticationFailed(format!(
                 "{} could not be authenticated.",
                 caller()
             )));
         };
-        let response = vc_mvp::get_id_alias(
+        vc_mvp::get_id_alias(
             req.identity_number,
             vc_mvp::InvolvedDapps {
                 relying_party: req.relying_party,
@@ -652,8 +655,7 @@ mod attribute_sharing_mvp {
             },
             &req.rp_id_alias_jwt,
             &req.issuer_id_alias_jwt,
-        );
-        Some(response)
+        )
     }
 }
 

--- a/src/internet_identity/tests/integration/vc_mvp.rs
+++ b/src/internet_identity/tests/integration/vc_mvp.rs
@@ -1,14 +1,14 @@
 //! Tests related to prepare_id_alias and get_id_alias canister calls.
 use canister_sig_util::{extract_raw_root_pk_from_der, CanisterSigPublicKey};
 use canister_tests::api::internet_identity as api;
+use canister_tests::flows;
 use canister_tests::framework::*;
-use canister_tests::{flows, match_value};
 use ic_test_state_machine_client::CallError;
 use identity_jose::jwk::JwkType;
 use identity_jose::jws::Decoder;
 use identity_jose::jwu::encode_b64;
 use internet_identity_interface::internet_identity::types::vc_mvp::{
-    GetIdAliasRequest, GetIdAliasResponse, PrepareIdAliasRequest, PrepareIdAliasResponse,
+    GetIdAliasError, GetIdAliasRequest, PrepareIdAliasRequest,
 };
 use internet_identity_interface::internet_identity::types::FrontendHostname;
 use std::ops::Deref;
@@ -41,15 +41,9 @@ fn should_get_valid_id_alias() -> Result<(), CallError> {
         issuer: issuer.clone(),
     };
 
-    let prepare_response =
+    let prepared_id_alias =
         api::vc_mvp::prepare_id_alias(&env, canister_id, principal_1(), prepare_id_alias_req)?
-            .expect("Got 'None' from prepare_id_alias");
-
-    let prepared_id_alias = if let PrepareIdAliasResponse::Ok(prepared) = prepare_response {
-        prepared
-    } else {
-        panic!("prepare id_alias failed")
-    };
+            .expect("prepare id_alias failed");
 
     let get_id_alias_req = GetIdAliasRequest {
         identity_number,
@@ -59,17 +53,8 @@ fn should_get_valid_id_alias() -> Result<(), CallError> {
         issuer_id_alias_jwt: prepared_id_alias.issuer_id_alias_jwt,
     };
     let id_alias_credentials =
-        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req)?
-            .expect("Got 'None' from get_id_alias")
-        {
-            GetIdAliasResponse::Ok(credentials) => credentials,
-            GetIdAliasResponse::NoSuchCredentials(err) => {
-                panic!("{}", format!("failed to get id_alias credentials: {}", err))
-            }
-            GetIdAliasResponse::AuthenticationFailed(err) => {
-                panic!("{}", format!("failed authentication: {}", err))
-            }
-        };
+        api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req)?
+            .expect("failed to get id_alias credentials");
 
     assert_eq!(
         id_alias_credentials.rp_id_alias_credential.id_alias,
@@ -145,80 +130,54 @@ fn should_get_different_id_alias_for_different_users() -> Result<(), CallError> 
     };
 
     let (get_id_alias_req_1, canister_sig_pk_1) = {
-        let prepare_response = api::vc_mvp::prepare_id_alias(
+        let prepared_id_alias_1 = api::vc_mvp::prepare_id_alias(
             &env,
             canister_id,
             principal_1(),
             prepare_id_alias_req_1,
         )?
         .expect("Got 'None' from prepare_id_alias");
-        if let PrepareIdAliasResponse::Ok(prepared_id_alias_1) = prepare_response {
-            (
-                GetIdAliasRequest {
-                    identity_number: identity_number_1,
-                    relying_party: relying_party.clone(),
-                    issuer: issuer.clone(),
-                    rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
-                    issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
-                },
-                CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
-                    .expect("failed parsing canister sig pk"),
-            )
-        } else {
-            panic!("prepare id_alias failed")
-        }
+        (
+            GetIdAliasRequest {
+                identity_number: identity_number_1,
+                relying_party: relying_party.clone(),
+                issuer: issuer.clone(),
+                rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
+                issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
+            },
+            CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
+                .expect("failed parsing canister sig pk"),
+        )
     };
 
     let (get_id_alias_req_2, canister_sig_pk_2) = {
-        let prepare_response = api::vc_mvp::prepare_id_alias(
+        let prepared_id_alias_2 = api::vc_mvp::prepare_id_alias(
             &env,
             canister_id,
             principal_1(),
             prepare_id_alias_req_2,
         )?
-        .expect("Got 'None' from prepare_id_alias");
-        if let PrepareIdAliasResponse::Ok(prepared_id_alias_2) = prepare_response {
-            (
-                GetIdAliasRequest {
-                    identity_number: identity_number_2,
-                    relying_party,
-                    issuer,
-                    rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
-                    issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
-                },
-                CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
-                    .expect("failed parsing canister sig pk"),
-            )
-        } else {
-            panic!("prepare id_alias failed")
-        }
+        .expect("prepare id_alias failed");
+        (
+            GetIdAliasRequest {
+                identity_number: identity_number_2,
+                relying_party,
+                issuer,
+                rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
+                issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
+            },
+            CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
+                .expect("failed parsing canister sig pk"),
+        )
     };
 
     let id_alias_credentials_1 =
-        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_1)?
-            .expect("Got 'None' from get_id_alias")
-        {
-            GetIdAliasResponse::Ok(credentials) => credentials,
-            GetIdAliasResponse::NoSuchCredentials(err) => {
-                panic!("{}", format!("failed to get id_alias credentials: {}", err))
-            }
-            GetIdAliasResponse::AuthenticationFailed(err) => {
-                panic!("{}", format!("failed authentication: {}", err))
-            }
-        };
+        api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_1)?
+            .expect("failed to get id_alias credentials");
 
     let id_alias_credentials_2 =
-        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_2)?
-            .expect("Got 'None' from get_id_alias")
-        {
-            GetIdAliasResponse::Ok(credentials) => credentials,
-            GetIdAliasResponse::NoSuchCredentials(err) => {
-                panic!("{}", format!("failed to get id_alias credentials: {}", err))
-            }
-            GetIdAliasResponse::AuthenticationFailed(err) => {
-                panic!("{}", format!("failed authentication: {}", err))
-            }
-        };
+        api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_2)?
+            .expect("failed to get id_alias credentials");
 
     assert_eq!(
         id_alias_credentials_1.rp_id_alias_credential.id_alias,
@@ -294,80 +253,54 @@ fn should_get_different_id_alias_for_different_relying_parties() -> Result<(), C
     };
 
     let (get_id_alias_req_1, canister_sig_pk_1) = {
-        let prepare_response = api::vc_mvp::prepare_id_alias(
+        let prepared_id_alias_1 = api::vc_mvp::prepare_id_alias(
             &env,
             canister_id,
             principal_1(),
             prepare_id_alias_req_1,
         )?
         .expect("Got 'None' from prepare_id_alias");
-        if let PrepareIdAliasResponse::Ok(prepared_id_alias_1) = prepare_response {
-            (
-                GetIdAliasRequest {
-                    identity_number,
-                    relying_party: relying_party_1,
-                    issuer: issuer.clone(),
-                    rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
-                    issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
-                },
-                CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
-                    .expect("failed parsing canister sig pk"),
-            )
-        } else {
-            panic!("prepare id_alias failed")
-        }
+        (
+            GetIdAliasRequest {
+                identity_number,
+                relying_party: relying_party_1,
+                issuer: issuer.clone(),
+                rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
+                issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
+            },
+            CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
+                .expect("failed parsing canister sig pk"),
+        )
     };
 
     let (get_id_alias_req_2, canister_sig_pk_2) = {
-        let prepare_response = api::vc_mvp::prepare_id_alias(
+        let prepared_id_alias_2 = api::vc_mvp::prepare_id_alias(
             &env,
             canister_id,
             principal_1(),
             prepare_id_alias_req_2,
         )?
         .expect("Got 'None' from prepare_id_alias");
-        if let PrepareIdAliasResponse::Ok(prepared_id_alias_2) = prepare_response {
-            (
-                GetIdAliasRequest {
-                    identity_number,
-                    relying_party: relying_party_2,
-                    issuer,
-                    rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
-                    issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
-                },
-                CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
-                    .expect("failed parsing canister sig pk"),
-            )
-        } else {
-            panic!("prepare id_alias failed")
-        }
+        (
+            GetIdAliasRequest {
+                identity_number,
+                relying_party: relying_party_2,
+                issuer,
+                rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
+                issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
+            },
+            CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
+                .expect("failed parsing canister sig pk"),
+        )
     };
 
     let id_alias_credentials_1 =
-        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_1)?
-            .expect("Got 'None' from get_id_alias")
-        {
-            GetIdAliasResponse::Ok(credentials) => credentials,
-            GetIdAliasResponse::NoSuchCredentials(err) => {
-                panic!("{}", format!("failed to get id_alias credentials: {}", err))
-            }
-            GetIdAliasResponse::AuthenticationFailed(err) => {
-                panic!("{}", format!("failed authentication: {}", err))
-            }
-        };
+        api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_1)?
+            .expect("failed to get id_alias credentials");
 
     let id_alias_credentials_2 =
-        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_2)?
-            .expect("Got 'None' from get_id_alias")
-        {
-            GetIdAliasResponse::Ok(credentials) => credentials,
-            GetIdAliasResponse::NoSuchCredentials(err) => {
-                panic!("{}", format!("failed to get id_alias credentials: {}", err))
-            }
-            GetIdAliasResponse::AuthenticationFailed(err) => {
-                panic!("{}", format!("failed authentication: {}", err))
-            }
-        };
+        api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_2)?
+            .expect("failed to get id_alias credentials");
 
     assert_eq!(
         id_alias_credentials_1.rp_id_alias_credential.id_alias,
@@ -447,80 +380,54 @@ fn should_get_different_id_alias_for_different_issuers() -> Result<(), CallError
     };
 
     let (get_id_alias_req_1, canister_sig_pk_1) = {
-        let prepare_response = api::vc_mvp::prepare_id_alias(
+        let prepared_id_alias_1 = api::vc_mvp::prepare_id_alias(
             &env,
             canister_id,
             principal_1(),
             prepare_id_alias_req_1,
         )?
         .expect("Got 'None' from prepare_id_alias");
-        if let PrepareIdAliasResponse::Ok(prepared_id_alias_1) = prepare_response {
-            (
-                GetIdAliasRequest {
-                    identity_number,
-                    relying_party: relying_party.clone(),
-                    issuer: issuer_1,
-                    rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
-                    issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
-                },
-                CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
-                    .expect("failed parsing canister sig pk"),
-            )
-        } else {
-            panic!("prepare id_alias failed")
-        }
+        (
+            GetIdAliasRequest {
+                identity_number,
+                relying_party: relying_party.clone(),
+                issuer: issuer_1,
+                rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
+                issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
+            },
+            CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
+                .expect("failed parsing canister sig pk"),
+        )
     };
 
     let (get_id_alias_req_2, canister_sig_pk_2) = {
-        let prepare_response = api::vc_mvp::prepare_id_alias(
+        let prepared_id_alias_2 = api::vc_mvp::prepare_id_alias(
             &env,
             canister_id,
             principal_1(),
             prepare_id_alias_req_2,
         )?
         .expect("Got 'None' from prepare_id_alias");
-        if let PrepareIdAliasResponse::Ok(prepared_id_alias_2) = prepare_response {
-            (
-                GetIdAliasRequest {
-                    identity_number,
-                    relying_party,
-                    issuer: issuer_2,
-                    rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
-                    issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
-                },
-                CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
-                    .expect("failed parsing canister sig pk"),
-            )
-        } else {
-            panic!("prepare id_alias failed")
-        }
+        (
+            GetIdAliasRequest {
+                identity_number,
+                relying_party,
+                issuer: issuer_2,
+                rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
+                issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
+            },
+            CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
+                .expect("failed parsing canister sig pk"),
+        )
     };
 
     let id_alias_credentials_1 =
-        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_1)?
-            .expect("Got 'None' from get_id_alias")
-        {
-            GetIdAliasResponse::Ok(credentials) => credentials,
-            GetIdAliasResponse::NoSuchCredentials(err) => {
-                panic!("{}", format!("failed to get id_alias credentials: {}", err))
-            }
-            GetIdAliasResponse::AuthenticationFailed(err) => {
-                panic!("{}", format!("failed authentication: {}", err))
-            }
-        };
+        api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_1)?
+            .expect("failed to get id_alias credentials");
 
     let id_alias_credentials_2 =
-        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_2)?
-            .expect("Got 'None' from get_id_alias")
-        {
-            GetIdAliasResponse::Ok(credentials) => credentials,
-            GetIdAliasResponse::NoSuchCredentials(err) => {
-                panic!("{}", format!("failed to get id_alias credentials: {}", err))
-            }
-            GetIdAliasResponse::AuthenticationFailed(err) => {
-                panic!("{}", format!("failed authentication: {}", err))
-            }
-        };
+        api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_2)?
+            .expect("failed to get id_alias credentials");
 
     assert_eq!(
         id_alias_credentials_1.rp_id_alias_credential.id_alias,
@@ -594,76 +501,50 @@ fn should_get_different_id_alias_for_different_flows() -> Result<(), CallError> 
     };
 
     let (get_id_alias_req_1, canister_sig_pk_1) = {
-        let prepare_response = api::vc_mvp::prepare_id_alias(
+        let prepared_id_alias_1 = api::vc_mvp::prepare_id_alias(
             &env,
             canister_id,
             principal_1(),
             prepare_id_alias_req.clone(),
         )?
         .expect("Got 'None' from prepare_id_alias");
-        if let PrepareIdAliasResponse::Ok(prepared_id_alias_1) = prepare_response {
-            (
-                GetIdAliasRequest {
-                    identity_number,
-                    relying_party: relying_party.clone(),
-                    issuer: issuer.clone(),
-                    rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
-                    issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
-                },
-                CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
-                    .expect("failed parsing canister sig pk"),
-            )
-        } else {
-            panic!("prepare id_alias failed")
-        }
+        (
+            GetIdAliasRequest {
+                identity_number,
+                relying_party: relying_party.clone(),
+                issuer: issuer.clone(),
+                rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
+                issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
+            },
+            CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
+                .expect("failed parsing canister sig pk"),
+        )
     };
 
     let (get_id_alias_req_2, canister_sig_pk_2) = {
-        let prepare_response =
+        let prepared_id_alias_2 =
             api::vc_mvp::prepare_id_alias(&env, canister_id, principal_1(), prepare_id_alias_req)?
                 .expect("Got 'None' from prepare_id_alias");
-        if let PrepareIdAliasResponse::Ok(prepared_id_alias_2) = prepare_response {
-            (
-                GetIdAliasRequest {
-                    identity_number,
-                    relying_party,
-                    issuer,
-                    rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
-                    issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
-                },
-                CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
-                    .expect("failed parsing canister sig pk"),
-            )
-        } else {
-            panic!("prepare id_alias failed")
-        }
+        (
+            GetIdAliasRequest {
+                identity_number,
+                relying_party,
+                issuer,
+                rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
+                issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
+            },
+            CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
+                .expect("failed parsing canister sig pk"),
+        )
     };
 
     let id_alias_credentials_1 =
-        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_1)?
-            .expect("Got 'None' from get_id_alias")
-        {
-            GetIdAliasResponse::Ok(credentials) => credentials,
-            GetIdAliasResponse::NoSuchCredentials(err) => {
-                panic!("{}", format!("failed to get id_alias credentials: {}", err))
-            }
-            GetIdAliasResponse::AuthenticationFailed(err) => {
-                panic!("{}", format!("failed authentication: {}", err))
-            }
-        };
+        api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_1)?
+            .expect("failed to get id_alias credentials");
 
     let id_alias_credentials_2 =
-        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_2)?
-            .expect("Got 'None' from get_id_alias")
-        {
-            GetIdAliasResponse::Ok(credentials) => credentials,
-            GetIdAliasResponse::NoSuchCredentials(err) => {
-                panic!("{}", format!("failed to get id_alias credentials: {}", err))
-            }
-            GetIdAliasResponse::AuthenticationFailed(err) => {
-                panic!("{}", format!("failed authentication: {}", err))
-            }
-        };
+        api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req_2)?
+            .expect("failed to get id_alias credentials");
 
     assert_eq!(
         id_alias_credentials_1.rp_id_alias_credential.id_alias,
@@ -753,7 +634,7 @@ fn should_not_get_id_alias_for_different_user() -> Result<(), CallError> {
     let relying_party = FrontendHostname::from("https://some-dapp.com");
     let issuer = FrontendHostname::from("https://some-issuer.com");
 
-    let prepare_response = api::vc_mvp::prepare_id_alias(
+    api::vc_mvp::prepare_id_alias(
         &env,
         canister_id,
         principal_1(),
@@ -763,13 +644,7 @@ fn should_not_get_id_alias_for_different_user() -> Result<(), CallError> {
             issuer: issuer.clone(),
         },
     )?
-    .expect("Got 'None' from prepare_id_alias");
-
-    let _canister_sig_key = if let PrepareIdAliasResponse::Ok(key) = prepare_response {
-        key
-    } else {
-        panic!("prepare id_alias failed")
-    };
+    .expect("prepare id_alias failed");
 
     let response = api::vc_mvp::get_id_alias(
         &env,
@@ -782,14 +657,13 @@ fn should_not_get_id_alias_for_different_user() -> Result<(), CallError> {
             rp_id_alias_jwt: "dummy_jwt".to_string(),
             issuer_id_alias_jwt: "another_dummy_jwt".to_string(),
         },
-    )?
-    .expect("Got 'None' from get_id_alias");
+    )?;
 
-    if let GetIdAliasResponse::AuthenticationFailed(_err) = response {
-        Ok(())
-    } else {
-        panic!("Expected a failed authentication, got {:?}", response);
-    }
+    assert!(matches!(
+        response,
+        Err(GetIdAliasError::AuthenticationFailed(_))
+    ));
+    Ok(())
 }
 
 #[test]
@@ -812,14 +686,13 @@ fn should_not_get_id_alias_if_not_prepared() -> Result<(), CallError> {
             rp_id_alias_jwt: "dummy jwt".to_string(),
             issuer_id_alias_jwt: "another dummy jwt".to_string(),
         },
-    )?
-    .expect("Got 'None' from get_id_alias");
+    )?;
 
-    if let GetIdAliasResponse::NoSuchCredentials(_err) = response {
-        Ok(())
-    } else {
-        panic!("Expected that credentials not found, got {:?}", response);
-    }
+    assert!(matches!(
+        response,
+        Err(GetIdAliasError::NoSuchCredentials(_))
+    ));
+    Ok(())
 }
 
 /// Verifies that there is a graceful failure if II gets upgraded between prepare_id_alias
@@ -837,20 +710,13 @@ fn should_not_get_prepared_id_alias_after_ii_upgrade() -> Result<(), CallError> 
         issuer: issuer.clone(),
     };
 
-    let prepare_response = api::vc_mvp::prepare_id_alias(
+    let prepared_id_alias = api::vc_mvp::prepare_id_alias(
         &env,
         canister_id,
         principal_1(),
         prepare_id_alias_req.clone(),
     )?
-    .expect("Got 'None' from prepare_id_alias");
-
-    let prepared_id_alias = if let PrepareIdAliasResponse::Ok(prepared_id_alias) = prepare_response
-    {
-        prepared_id_alias
-    } else {
-        panic!("prepare id_alias failed")
-    };
+    .expect("prepare id_alias failed");
 
     // upgrade, even with the same WASM clears non-stable memory
     upgrade_ii_canister(&env, canister_id, II_WASM.clone());
@@ -862,11 +728,10 @@ fn should_not_get_prepared_id_alias_after_ii_upgrade() -> Result<(), CallError> 
         rp_id_alias_jwt: prepared_id_alias.rp_id_alias_jwt,
         issuer_id_alias_jwt: prepared_id_alias.issuer_id_alias_jwt,
     };
-    let response = api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req)?
-        .expect("Got 'None' from get_id_alias");
+    let response = api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req)?;
     assert!(matches!(
         response,
-        GetIdAliasResponse::NoSuchCredentials(_err)
+        Err(GetIdAliasError::NoSuchCredentials(_))
     ));
     Ok(())
 }
@@ -885,19 +750,14 @@ fn should_not_validate_id_alias_with_wrong_canister_key() {
         issuer: issuer.clone(),
     };
 
-    let prepare_response = api::vc_mvp::prepare_id_alias(
+    let prepared_id_alias = api::vc_mvp::prepare_id_alias(
         &env,
         canister_id,
         principal_1(),
         prepare_id_alias_req.clone(),
     )
     .expect("Result of prepare_id_alias is not Ok")
-    .expect("Got 'None' from prepare_id_alias");
-
-    match_value!(
-        prepare_response,
-        PrepareIdAliasResponse::Ok(prepared_id_alias)
-    );
+    .expect("prepare_id_alias failed");
 
     let get_id_alias_req = GetIdAliasRequest {
         identity_number,
@@ -908,18 +768,9 @@ fn should_not_validate_id_alias_with_wrong_canister_key() {
     };
 
     let id_alias_credentials =
-        match api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req)
+        api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req)
             .expect("Result of get_id_alias is not Ok")
-            .expect("Got 'None' from get_id_alias")
-        {
-            GetIdAliasResponse::Ok(credentials) => credentials,
-            GetIdAliasResponse::NoSuchCredentials(err) => {
-                panic!("{}", format!("failed to get id_alias credentials: {}", err))
-            }
-            GetIdAliasResponse::AuthenticationFailed(err) => {
-                panic!("{}", format!("failed authentication: {}", err))
-            }
-        };
+            .expect("get_id_alias failed");
 
     assert_eq!(
         id_alias_credentials.rp_id_alias_credential.id_alias,

--- a/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
@@ -31,10 +31,7 @@ pub struct PreparedIdAlias {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub enum PrepareIdAliasResponse {
-    #[serde(rename = "ok")]
-    Ok(PreparedIdAlias),
-    #[serde(rename = "authentication_failed")]
+pub enum PrepareIdAliasError {
     AuthenticationFailed(String),
 }
 
@@ -59,11 +56,7 @@ pub struct GetIdAliasRequest {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub enum GetIdAliasResponse {
-    #[serde(rename = "ok")]
-    Ok(IdAliasCredentials),
-    #[serde(rename = "authentication_failed")]
+pub enum GetIdAliasError {
     AuthenticationFailed(String),
-    #[serde(rename = "no_such_credentials")]
     NoSuchCredentials(String),
 }


### PR DESCRIPTION
This PR refactors the II VC API:
* get rid of `opt`
* restructure errors to be aligned with Rusts `Result` type
* CamelCase error variants

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
