### PR TITLE
Strip device metadata from lookup

### DIFF
--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -160,6 +160,7 @@ fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
             .map(|mut d| {
                 // Remove non-public fields.
                 d.alias = "".to_string();
+                d.metadata = None;
                 d
             })
             .collect()

--- a/src/internet_identity/tests/integration/anchor_management/device_management.rs
+++ b/src/internet_identity/tests/integration/anchor_management/device_management.rs
@@ -32,16 +32,23 @@ fn should_lookup() -> Result<(), CallError> {
         user_number,
         &recovery_device_data_1(),
     )?;
+    api::add(
+        &env,
+        canister_id,
+        principal_1(),
+        user_number,
+        &large_size_device(),
+    )?;
 
     let mut devices = api::lookup(&env, canister_id, user_number)?;
     devices.sort_by(|a, b| a.pubkey.cmp(&b.pubkey));
 
     let mut anchor_info = api::get_anchor_info(&env, canister_id, principal_1(), user_number)?;
     // clear alias to make it consistent with lookup
-    anchor_info
-        .devices
-        .iter_mut()
-        .for_each(|device| device.alias = "".to_string());
+    anchor_info.devices.iter_mut().for_each(|device| {
+        device.alias = "".to_string();
+        device.metadata = None;
+    });
     anchor_info.devices.sort_by(|a, b| a.pubkey.cmp(&b.pubkey));
 
     assert_eq!(devices, anchor_info.into_device_data());


### PR DESCRIPTION
This PR removes the `metadata` field from the `lookup` endpoint.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
