### PR TITLE
Update readme with local URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Use the Internet Identity canister in your local dfx project by adding the follo
 ```
 To deploy, run `dfx deploy`.
 
-To access Internet Identity use one of the following URLs:
+To access Internet Identity or configure it for your dapp, use one of the following URLs:
 * Chrome, Firefox: `http://<canister_id>.localhost:4943`
 * Safari: `http://localhost:4943?canisterId=<canister_id>`
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Use the Internet Identity canister in your local dfx project by adding the follo
   }
 }
 ```
+To deploy, run `dfx deploy`.
+
+To access Internet Identity use one of the following URLs:
+* Chrome, Firefox: `http://<canister_id>.localhost:4943`
+* Safari: `http://localhost:4943?canisterId=<canister_id>`
 
 ### Architecture Overview
 

--- a/demos/using-dev-build/README.md
+++ b/demos/using-dev-build/README.md
@@ -129,8 +129,8 @@ You might get different canister IDs (and that's totally fine). If the `webapp` 
 ![](./webapp.png)
 
 _If you actually use the webapp, make sure that the "Internet Identity URL" field points to one of these URLS_:
-* Chrome and FirefoxSafari `http://<canister ID of the internet_identity canister>.localhost:4943/`.
-* Safari `http://localhost:4943/?canisterId=<canister ID of the internet_identity canister>`.
+* Chrome, Firefox: `http://<canister ID of the internet_identity canister>.localhost:4943/`.
+* Safari: `http://localhost:4943/?canisterId=<canister ID of the internet_identity canister>`.
 
 ## Helpers
 

--- a/demos/using-dev-build/README.md
+++ b/demos/using-dev-build/README.md
@@ -129,8 +129,9 @@ You might get different canister IDs (and that's totally fine). If the `webapp` 
 ![](./webapp.png)
 
 _If you actually use the webapp, make sure that the "Internet Identity URL" field points to one of these URLS_:
-* Chrome, Firefox: `http://<canister ID of the internet_identity canister>.localhost:4943/`.
-* Safari: `http://localhost:4943/?canisterId=<canister ID of the internet_identity canister>`.
+
+- Chrome, Firefox: `http://<canister ID of the internet_identity canister>.localhost:4943/`.
+- Safari: `http://localhost:4943/?canisterId=<canister ID of the internet_identity canister>`.
 
 ## Helpers
 

--- a/demos/using-dev-build/README.md
+++ b/demos/using-dev-build/README.md
@@ -128,7 +128,9 @@ You might get different canister IDs (and that's totally fine). If the `webapp` 
 
 ![](./webapp.png)
 
-_If you actually use the webapp, make sure that the "Internet Identity URL" field points to `http://localhost:4943/?canisterId=<canister ID of the internet_identity canister>`._
+_If you actually use the webapp, make sure that the "Internet Identity URL" field points to one of these URLS_:
+* Chrome and FirefoxSafari `http://<canister ID of the internet_identity canister>.localhost:4943/`.
+* Safari `http://localhost:4943/?canisterId=<canister ID of the internet_identity canister>`.
 
 ## Helpers
 


### PR DESCRIPTION
The recent refactoring with multiple JS bundles has lead to II breaking in Chrome, when the canister id is supplied as an URL parameter.
There is no easy or nice solution, so for now we just advise developers to use a different URL scheme when using anything but Safari.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

