### PR TITLE
Remove useless Result aliases

### DIFF
--- a/demos/vc_issuer/app/generated/vc_issuer_idl.js
+++ b/demos/vc_issuer/app/generated/vc_issuer_idl.js
@@ -23,10 +23,6 @@ export const idlFactory = ({ IDL }) => {
     'UnknownSubject' : IDL.Text,
     'UnsupportedCredentialSpec' : IDL.Text,
   });
-  const GetCredentialResponse = IDL.Variant({
-    'Ok' : IssuedCredentialData,
-    'Err' : IssueCredentialError,
-  });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
     'url' : IDL.Text,
@@ -47,10 +43,6 @@ export const idlFactory = ({ IDL }) => {
   const PreparedCredentialData = IDL.Record({
     'prepared_context' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
-  const PrepareCredentialResponse = IDL.Variant({
-    'Ok' : PreparedCredentialData,
-    'Err' : IssueCredentialError,
-  });
   const Icrc21ConsentPreferences = IDL.Record({ 'language' : IDL.Text });
   const Icrc21VcConsentMessageRequest = IDL.Record({
     'preferences' : Icrc21ConsentPreferences,
@@ -69,10 +61,6 @@ export const idlFactory = ({ IDL }) => {
     'UnsupportedCanisterCall' : Icrc21ErrorInfo,
     'ConsentMessageUnavailable' : Icrc21ErrorInfo,
   });
-  const Icrc21ConsentMessageResponse = IDL.Variant({
-    'Ok' : Icrc21ConsentInfo,
-    'Err' : Icrc21Error,
-  });
   return IDL.Service({
     'add_adult' : IDL.Func([IDL.Principal], [IDL.Text], []),
     'add_employee' : IDL.Func([IDL.Principal], [IDL.Text], []),
@@ -80,18 +68,28 @@ export const idlFactory = ({ IDL }) => {
     'configure' : IDL.Func([IssuerConfig], [], []),
     'get_credential' : IDL.Func(
         [GetCredentialRequest],
-        [GetCredentialResponse],
+        [
+          IDL.Variant({
+            'Ok' : IssuedCredentialData,
+            'Err' : IssueCredentialError,
+          }),
+        ],
         ['query'],
       ),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'prepare_credential' : IDL.Func(
         [PrepareCredentialRequest],
-        [PrepareCredentialResponse],
+        [
+          IDL.Variant({
+            'Ok' : PreparedCredentialData,
+            'Err' : IssueCredentialError,
+          }),
+        ],
         [],
       ),
     'vc_consent_message' : IDL.Func(
         [Icrc21VcConsentMessageRequest],
-        [Icrc21ConsentMessageResponse],
+        [IDL.Variant({ 'Ok' : Icrc21ConsentInfo, 'Err' : Icrc21Error })],
         [],
       ),
   });

--- a/demos/vc_issuer/app/generated/vc_issuer_types.d.ts
+++ b/demos/vc_issuer/app/generated/vc_issuer_types.d.ts
@@ -13,8 +13,6 @@ export interface GetCredentialRequest {
   'prepared_context' : [] | [Uint8Array | number[]],
   'credential_spec' : CredentialSpec,
 }
-export type GetCredentialResponse = { 'Ok' : IssuedCredentialData } |
-  { 'Err' : IssueCredentialError };
 export type HeaderField = [string, string];
 export interface HttpRequest {
   'url' : string,
@@ -32,8 +30,6 @@ export interface Icrc21ConsentInfo {
   'consent_message' : string,
   'language' : string,
 }
-export type Icrc21ConsentMessageResponse = { 'Ok' : Icrc21ConsentInfo } |
-  { 'Err' : Icrc21Error };
 export interface Icrc21ConsentPreferences { 'language' : string }
 export type Icrc21Error = {
     'GenericError' : { 'description' : string, 'error_code' : bigint }
@@ -60,8 +56,6 @@ export interface PrepareCredentialRequest {
   'signed_id_alias' : SignedIdAlias,
   'credential_spec' : CredentialSpec,
 }
-export type PrepareCredentialResponse = { 'Ok' : PreparedCredentialData } |
-  { 'Err' : IssueCredentialError };
 export interface PreparedCredentialData {
   'prepared_context' : [] | [Uint8Array | number[]],
 }
@@ -71,15 +65,21 @@ export interface _SERVICE {
   'add_employee' : ActorMethod<[Principal], string>,
   'add_graduate' : ActorMethod<[Principal], string>,
   'configure' : ActorMethod<[IssuerConfig], undefined>,
-  'get_credential' : ActorMethod<[GetCredentialRequest], GetCredentialResponse>,
+  'get_credential' : ActorMethod<
+    [GetCredentialRequest],
+    { 'Ok' : IssuedCredentialData } |
+      { 'Err' : IssueCredentialError }
+  >,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'prepare_credential' : ActorMethod<
     [PrepareCredentialRequest],
-    PrepareCredentialResponse
+    { 'Ok' : PreparedCredentialData } |
+      { 'Err' : IssueCredentialError }
   >,
   'vc_consent_message' : ActorMethod<
     [Icrc21VcConsentMessageRequest],
-    Icrc21ConsentMessageResponse
+    { 'Ok' : Icrc21ConsentInfo } |
+      { 'Err' : Icrc21Error }
   >,
 }
 export declare const idlFactory: IDL.InterfaceFactory;

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -5,8 +5,8 @@ use candid::{CandidType, Deserialize, Principal};
 use canister_sig_util::{extract_raw_root_pk_from_der, CanisterSigPublicKey};
 use canister_tests::api::http_request;
 use canister_tests::api::internet_identity::vc_mvp as ii_api;
+use canister_tests::flows;
 use canister_tests::framework::{env, get_wasm_path, principal_1, test_principal, time, II_WASM};
-use canister_tests::{flows, match_value};
 use ic_cdk::api::management_canister::provisional::CanisterId;
 use ic_response_verification::types::{Request, Response, VerificationInfo};
 use ic_response_verification::verify_request_response_pair;
@@ -25,9 +25,10 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::{Duration, UNIX_EPOCH};
 use vc_util::issuer_api::{
-    ArgumentValue, CredentialSpec, GetCredentialRequest, GetCredentialResponse,
+    ArgumentValue, CredentialSpec, GetCredentialRequest, Icrc21ConsentInfo,
     Icrc21ConsentPreferences, Icrc21Error, Icrc21VcConsentMessageRequest, IssueCredentialError,
-    PrepareCredentialRequest, PrepareCredentialResponse, SignedIdAlias as SignedIssuerIdAlias,
+    IssuedCredentialData, PrepareCredentialRequest, PreparedCredentialData,
+    SignedIdAlias as SignedIssuerIdAlias,
 };
 use vc_util::{
     did_for_principal, get_verified_id_alias_from_jws, verify_credential_jws_with_canister_id,
@@ -91,7 +92,6 @@ pub fn install_issuer(env: &StateMachine, init: &IssuerInit) -> CanisterId {
 
 mod api {
     use super::*;
-    use vc_util::issuer_api::Icrc21ConsentInfo;
 
     pub fn configure(
         env: &StateMachine,
@@ -146,7 +146,7 @@ mod api {
         canister_id: CanisterId,
         sender: Principal,
         prepare_credential_request: &PrepareCredentialRequest,
-    ) -> Result<PrepareCredentialResponse, CallError> {
+    ) -> Result<Result<PreparedCredentialData, IssueCredentialError>, CallError> {
         call_candid_as(
             env,
             canister_id,
@@ -162,7 +162,7 @@ mod api {
         canister_id: CanisterId,
         sender: Principal,
         get_credential_request: &GetCredentialRequest,
-    ) -> Result<GetCredentialResponse, CallError> {
+    ) -> Result<Result<IssuedCredentialData, IssueCredentialError>, CallError> {
         query_candid_as(
             env,
             canister_id,
@@ -360,7 +360,7 @@ fn should_fail_prepare_credential_for_unauthorized_principal() {
         },
     )
     .expect("API call failed");
-    assert_matches!(response, PrepareCredentialResponse::Err(e) if format!("{:?}", e).contains("unauthorized principal"));
+    assert_matches!(response, Err(e) if format!("{:?}", e).contains("unauthorized principal"));
 }
 
 #[test]
@@ -380,7 +380,7 @@ fn should_fail_prepare_credential_for_wrong_sender() {
     )
     .expect("API call failed");
     assert_matches!(response,
-        PrepareCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(&format!("Caller {} does not match id alias dapp principal {}.", principal_1(), DUMMY_ALIAS_ID_DAPP_PRINCIPAL))
+        Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(&format!("Caller {} does not match id alias dapp principal {}.", principal_1(), DUMMY_ALIAS_ID_DAPP_PRINCIPAL))
     );
 }
 
@@ -393,18 +393,18 @@ fn should_fail_get_credential_for_wrong_sender() {
     api::add_employee(&env, issuer_id, authorized_principal).expect("failed to add employee");
     let unauthorized_principal = test_principal(2);
 
-    match_value!(
-        api::prepare_credential(
-            &env,
-            issuer_id,
-            authorized_principal,
-            &PrepareCredentialRequest {
-                credential_spec: employee_credential_spec(),
-                signed_id_alias: signed_id_alias.clone(),
-            },
-        ),
-        Ok(PrepareCredentialResponse::Ok(prepare_credential_response))
-    );
+    let prepare_credential_response = api::prepare_credential(
+        &env,
+        issuer_id,
+        authorized_principal,
+        &PrepareCredentialRequest {
+            credential_spec: employee_credential_spec(),
+            signed_id_alias: signed_id_alias.clone(),
+        },
+    )
+    .unwrap()
+    .unwrap();
+
     let get_credential_response = api::get_credential(
         &env,
         issuer_id,
@@ -417,7 +417,7 @@ fn should_fail_get_credential_for_wrong_sender() {
     )
     .expect("API call failed");
     assert_matches!(get_credential_response,
-        GetCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(&format!("Caller {} does not match id alias dapp principal {}.", unauthorized_principal, authorized_principal))
+        Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(&format!("Caller {} does not match id alias dapp principal {}.", unauthorized_principal, authorized_principal))
     );
 }
 
@@ -436,7 +436,7 @@ fn should_fail_prepare_credential_for_anonymous_caller() {
     )
     .expect("API call failed");
     assert_matches!(response,
-        PrepareCredentialResponse::Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(&format!("Caller 2vxsx-fae does not match id alias dapp principal {}.", DUMMY_ALIAS_ID_DAPP_PRINCIPAL))
+        Err(IssueCredentialError::UnauthorizedSubject(e)) if e.contains(&format!("Caller 2vxsx-fae does not match id alias dapp principal {}.", DUMMY_ALIAS_ID_DAPP_PRINCIPAL))
     );
 }
 
@@ -460,10 +460,7 @@ fn should_fail_prepare_credential_for_wrong_root_key() {
         },
     )
     .expect("API call failed");
-    assert_matches!(
-        response,
-        PrepareCredentialResponse::Err(IssueCredentialError::InvalidIdAlias(_))
-    );
+    assert_matches!(response, Err(IssueCredentialError::InvalidIdAlias(_)));
 }
 
 #[test]
@@ -486,10 +483,7 @@ fn should_fail_prepare_credential_for_wrong_idp_canister_id() {
         },
     )
     .expect("API call failed");
-    assert_matches!(
-        response,
-        PrepareCredentialResponse::Err(IssueCredentialError::InvalidIdAlias(_))
-    );
+    assert_matches!(response, Err(IssueCredentialError::InvalidIdAlias(_)));
 }
 
 #[test]
@@ -508,7 +502,7 @@ fn should_prepare_employee_credential_for_authorized_principal() {
         },
     )
     .expect("API call failed");
-    assert_matches!(response, PrepareCredentialResponse::Ok(_));
+    assert_matches!(response, Ok(_));
 }
 
 #[test]
@@ -527,7 +521,7 @@ fn should_prepare_degree_credential_for_authorized_principal() {
         },
     )
     .expect("API call failed");
-    assert_matches!(response, PrepareCredentialResponse::Ok(_));
+    assert_matches!(response, Ok(_));
 }
 
 /// Verifies that different credentials are being created including II interactions.
@@ -591,7 +585,7 @@ fn should_issue_credential_e2e() -> Result<(), CallError> {
         degree_credential_spec(),
         adult_credential_spec(),
     ] {
-        let prepare_credential_response = api::prepare_credential(
+        let prepared_credential = api::prepare_credential(
             &env,
             issuer_id,
             id_alias_credentials.issuer_id_alias_credential.id_dapp,
@@ -604,16 +598,8 @@ fn should_issue_credential_e2e() -> Result<(), CallError> {
                         .clone(),
                 },
             },
-        )?;
-        let prepared_credential =
-            if let PrepareCredentialResponse::Ok(data) = prepare_credential_response {
-                data
-            } else {
-                panic!(
-                    "Prepare credential failed: {:?}",
-                    prepare_credential_response
-                );
-            };
+        )?
+        .unwrap();
 
         let get_credential_response = api::get_credential(
             &env,
@@ -630,12 +616,8 @@ fn should_issue_credential_e2e() -> Result<(), CallError> {
                 prepared_context: prepared_credential.prepared_context,
             },
         )?;
-        match_value!(
-            get_credential_response,
-            GetCredentialResponse::Ok(credential_data)
-        );
         let claims = verify_credential_jws_with_canister_id(
-            &credential_data.vc_jws,
+            &get_credential_response.unwrap().vc_jws,
             &issuer_id,
             &root_pk_raw,
             env.time().duration_since(UNIX_EPOCH).unwrap().as_nanos(),

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -402,8 +402,8 @@ fn should_fail_get_credential_for_wrong_sender() {
             signed_id_alias: signed_id_alias.clone(),
         },
     )
-    .unwrap()
-    .unwrap();
+    .expect("API call failed")
+    .expect("failed to prepare credential");
 
     let get_credential_response = api::get_credential(
         &env,
@@ -599,7 +599,7 @@ fn should_issue_credential_e2e() -> Result<(), CallError> {
                 },
             },
         )?
-        .unwrap();
+        .expect("failed to prepare credential");
 
         let get_credential_response = api::get_credential(
             &env,

--- a/demos/vc_issuer/vc_demo_issuer.did
+++ b/demos/vc_issuer/vc_demo_issuer.did
@@ -14,10 +14,6 @@ type ArgumentValue = variant { "Int" : int32; String : text };
 /// Messages for ICRC-21 consent message, cf.
 /// https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md
 type Icrc21ConsentInfo = record { consent_message : text; language : text };
-type Icrc21ConsentMessageResponse = variant {
-    Ok : Icrc21ConsentInfo;
-    Err : Icrc21Error;
-};
 type Icrc21ConsentPreferences = record { language : text };
 type Icrc21Error = variant {
     GenericError : record { description : text; error_code : nat };
@@ -43,10 +39,6 @@ type PrepareCredentialRequest = record {
     signed_id_alias : SignedIdAlias;
     credential_spec : CredentialSpec;
 };
-type PrepareCredentialResponse = variant {
-    Ok : PreparedCredentialData;
-    Err : IssueCredentialError;
-};
 type PreparedCredentialData = record { prepared_context : opt vec nat8 };
 
 /// Messages for `get_credential`.
@@ -54,10 +46,6 @@ type GetCredentialRequest = record {
     signed_id_alias : SignedIdAlias;
     credential_spec : CredentialSpec;
     prepared_context : opt vec nat8;
-};
-type GetCredentialResponse = variant {
-    Ok : IssuedCredentialData;
-    Err : IssueCredentialError;
 };
 
 type SignedIdAlias = record {
@@ -111,9 +99,9 @@ type HttpResponse = record {
 
 service: (opt IssuerConfig) -> {
     /// VC-flow API.
-    vc_consent_message : (Icrc21VcConsentMessageRequest) -> (Icrc21ConsentMessageResponse);
-    prepare_credential : (PrepareCredentialRequest) -> (PrepareCredentialResponse);
-    get_credential : (GetCredentialRequest) -> (GetCredentialResponse) query;
+    vc_consent_message : (Icrc21VcConsentMessageRequest) -> (variant { Ok : Icrc21ConsentInfo; Err : Icrc21Error;});
+    prepare_credential : (PrepareCredentialRequest) -> (variant { Ok : PreparedCredentialData; Err : IssueCredentialError;});
+    get_credential : (GetCredentialRequest) -> (variant { Ok : IssuedCredentialData; Err : IssueCredentialError;}) query;
 
     /// Configure the issuer (e.g. set the root key), used for deployment/testing.
     configure: (IssuerConfig) -> ();

--- a/src/frontend/generated/vc_issuer_idl.js
+++ b/src/frontend/generated/vc_issuer_idl.js
@@ -23,10 +23,6 @@ export const idlFactory = ({ IDL }) => {
     'UnknownSubject' : IDL.Text,
     'UnsupportedCredentialSpec' : IDL.Text,
   });
-  const GetCredentialResponse = IDL.Variant({
-    'Ok' : IssuedCredentialData,
-    'Err' : IssueCredentialError,
-  });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
     'url' : IDL.Text,
@@ -47,10 +43,6 @@ export const idlFactory = ({ IDL }) => {
   const PreparedCredentialData = IDL.Record({
     'prepared_context' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
-  const PrepareCredentialResponse = IDL.Variant({
-    'Ok' : PreparedCredentialData,
-    'Err' : IssueCredentialError,
-  });
   const Icrc21ConsentPreferences = IDL.Record({ 'language' : IDL.Text });
   const Icrc21VcConsentMessageRequest = IDL.Record({
     'preferences' : Icrc21ConsentPreferences,
@@ -69,10 +61,6 @@ export const idlFactory = ({ IDL }) => {
     'UnsupportedCanisterCall' : Icrc21ErrorInfo,
     'ConsentMessageUnavailable' : Icrc21ErrorInfo,
   });
-  const Icrc21ConsentMessageResponse = IDL.Variant({
-    'Ok' : Icrc21ConsentInfo,
-    'Err' : Icrc21Error,
-  });
   return IDL.Service({
     'add_adult' : IDL.Func([IDL.Principal], [IDL.Text], []),
     'add_employee' : IDL.Func([IDL.Principal], [IDL.Text], []),
@@ -80,18 +68,28 @@ export const idlFactory = ({ IDL }) => {
     'configure' : IDL.Func([IssuerConfig], [], []),
     'get_credential' : IDL.Func(
         [GetCredentialRequest],
-        [GetCredentialResponse],
+        [
+          IDL.Variant({
+            'Ok' : IssuedCredentialData,
+            'Err' : IssueCredentialError,
+          }),
+        ],
         ['query'],
       ),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'prepare_credential' : IDL.Func(
         [PrepareCredentialRequest],
-        [PrepareCredentialResponse],
+        [
+          IDL.Variant({
+            'Ok' : PreparedCredentialData,
+            'Err' : IssueCredentialError,
+          }),
+        ],
         [],
       ),
     'vc_consent_message' : IDL.Func(
         [Icrc21VcConsentMessageRequest],
-        [Icrc21ConsentMessageResponse],
+        [IDL.Variant({ 'Ok' : Icrc21ConsentInfo, 'Err' : Icrc21Error })],
         [],
       ),
   });

--- a/src/frontend/generated/vc_issuer_types.d.ts
+++ b/src/frontend/generated/vc_issuer_types.d.ts
@@ -13,8 +13,6 @@ export interface GetCredentialRequest {
   'prepared_context' : [] | [Uint8Array | number[]],
   'credential_spec' : CredentialSpec,
 }
-export type GetCredentialResponse = { 'Ok' : IssuedCredentialData } |
-  { 'Err' : IssueCredentialError };
 export type HeaderField = [string, string];
 export interface HttpRequest {
   'url' : string,
@@ -32,8 +30,6 @@ export interface Icrc21ConsentInfo {
   'consent_message' : string,
   'language' : string,
 }
-export type Icrc21ConsentMessageResponse = { 'Ok' : Icrc21ConsentInfo } |
-  { 'Err' : Icrc21Error };
 export interface Icrc21ConsentPreferences { 'language' : string }
 export type Icrc21Error = {
     'GenericError' : { 'description' : string, 'error_code' : bigint }
@@ -60,8 +56,6 @@ export interface PrepareCredentialRequest {
   'signed_id_alias' : SignedIdAlias,
   'credential_spec' : CredentialSpec,
 }
-export type PrepareCredentialResponse = { 'Ok' : PreparedCredentialData } |
-  { 'Err' : IssueCredentialError };
 export interface PreparedCredentialData {
   'prepared_context' : [] | [Uint8Array | number[]],
 }
@@ -71,15 +65,21 @@ export interface _SERVICE {
   'add_employee' : ActorMethod<[Principal], string>,
   'add_graduate' : ActorMethod<[Principal], string>,
   'configure' : ActorMethod<[IssuerConfig], undefined>,
-  'get_credential' : ActorMethod<[GetCredentialRequest], GetCredentialResponse>,
+  'get_credential' : ActorMethod<
+    [GetCredentialRequest],
+    { 'Ok' : IssuedCredentialData } |
+      { 'Err' : IssueCredentialError }
+  >,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'prepare_credential' : ActorMethod<
     [PrepareCredentialRequest],
-    PrepareCredentialResponse
+    { 'Ok' : PreparedCredentialData } |
+      { 'Err' : IssueCredentialError }
   >,
   'vc_consent_message' : ActorMethod<
     [Icrc21VcConsentMessageRequest],
-    Icrc21ConsentMessageResponse
+    { 'Ok' : Icrc21ConsentInfo } |
+      { 'Err' : Icrc21Error }
   >,
 }
 export declare const idlFactory: IDL.InterfaceFactory;

--- a/src/vc_util/src/issuer_api.rs
+++ b/src/vc_util/src/issuer_api.rs
@@ -18,12 +18,6 @@ pub struct PrepareCredentialRequest {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub enum PrepareCredentialResponse {
-    Ok(PreparedCredentialData),
-    Err(IssueCredentialError),
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum IssueCredentialError {
     UnknownSubject(String),
     UnauthorizedSubject(String),
@@ -38,12 +32,6 @@ pub struct GetCredentialRequest {
     pub signed_id_alias: SignedIdAlias,
     pub credential_spec: CredentialSpec,
     pub prepared_context: Option<ByteBuf>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub enum GetCredentialResponse {
-    Ok(IssuedCredentialData),
-    Err(IssueCredentialError),
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
This PR removes a few types that could be replaced by `std::Result`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

