### PR TITLE
Add API v2 test helpers

### DIFF
--- a/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
@@ -1,5 +1,5 @@
 use crate::v2_api::authn_method_test_helpers::{
-    create_identity_with_authn_method, eq_ignoring_last_authentication, sample_authn_method,
+    create_identity_with_authn_method, eq_ignoring_last_authentication, sample_pubkey_authn_method,
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
@@ -16,9 +16,9 @@ use serde_bytes::ByteBuf;
 fn should_add_authn_method() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
-    let authn_method_1 = sample_authn_method(1);
+    let authn_method_1 = sample_pubkey_authn_method(1);
     let principal = authn_method_1.principal();
-    let authn_method_2 = sample_authn_method(2);
+    let authn_method_2 = sample_pubkey_authn_method(2);
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
 
@@ -45,7 +45,7 @@ fn should_add_authn_method() -> Result<(), CallError> {
 fn should_require_authentication_to_add_authn_method() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
-    let authn_method = sample_authn_method(1);
+    let authn_method = sample_pubkey_authn_method(1);
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
     let result = api_v2::authn_method_add(
@@ -68,9 +68,9 @@ fn should_require_authentication_to_add_authn_method() -> Result<(), CallError> 
 fn should_report_error_on_failed_conversion() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
-    let authn_method_1 = sample_authn_method(1);
+    let authn_method_1 = sample_pubkey_authn_method(1);
     let principal = authn_method_1.principal();
-    let mut authn_method_2 = sample_authn_method(2);
+    let mut authn_method_2 = sample_pubkey_authn_method(2);
     authn_method_2.metadata.insert(
         "usage".to_string(),
         MetadataEntry::Bytes(ByteBuf::from("invalid")),

--- a/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
@@ -1,5 +1,5 @@
 use crate::v2_api::authn_method_test_helpers::{
-    create_identity_with_authn_method, sample_authn_method,
+    create_identity_with_authn_method, sample_pubkey_authn_method,
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
@@ -14,9 +14,9 @@ use regex::Regex;
 fn should_remove_authn_method() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
-    let authn_method_1 = sample_authn_method(1);
+    let authn_method_1 = sample_pubkey_authn_method(1);
     let principal = authn_method_1.principal();
-    let authn_method_2 = sample_authn_method(2);
+    let authn_method_2 = sample_pubkey_authn_method(2);
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
     api_v2::authn_method_add(
@@ -48,7 +48,7 @@ fn should_remove_authn_method() -> Result<(), CallError> {
 fn should_require_authentication_to_remove_authn_method() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
-    let authn_method = sample_authn_method(1);
+    let authn_method = sample_pubkey_authn_method(1);
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 

--- a/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
@@ -3,9 +3,10 @@ use ic_cdk::api::management_canister::main::CanisterId;
 use ic_test_state_machine_client::StateMachine;
 use internet_identity_interface::internet_identity::types::{
     AuthnMethod, AuthnMethodData, AuthnMethodProtection, ChallengeAttempt, IdentityNumber,
-    PublicKeyAuthn, Purpose,
+    MetadataEntry, PublicKeyAuthn, Purpose, WebAuthn,
 };
 use serde_bytes::ByteBuf;
+use std::collections::HashMap;
 
 pub fn eq_ignoring_last_authentication(a: &AuthnMethodData, b: &AuthnMethodData) -> bool {
     let a = AuthnMethodData {
@@ -17,6 +18,23 @@ pub fn eq_ignoring_last_authentication(a: &AuthnMethodData, b: &AuthnMethodData)
         ..b.clone()
     };
     a == b
+}
+
+pub fn assert_eq_ignoring_last_authentication(
+    authn_methods1: &[AuthnMethodData],
+    authn_methods2: &[AuthnMethodData],
+) {
+    authn_methods1
+        .iter()
+        .zip(authn_methods2.iter())
+        .for_each(|(a, b)| {
+            assert!(
+                eq_ignoring_last_authentication(a, b),
+                "authn methods are not equal: {:?} != {:?}",
+                a,
+                b
+            )
+        });
 }
 
 pub fn test_authn_method() -> AuthnMethodData {
@@ -56,11 +74,122 @@ pub fn create_identity_with_authn_method(
     .expect("identity_register failed")
 }
 
-pub fn sample_authn_method(i: u8) -> AuthnMethodData {
+pub fn create_identity_with_authn_methods(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    authn_methods: &[AuthnMethodData],
+) -> IdentityNumber {
+    let first_authn_method = authn_methods.first().expect("authn_methods is empty");
+    let identity_number = create_identity_with_authn_method(env, canister_id, first_authn_method);
+
+    for authn_method in authn_methods.iter().skip(1) {
+        api_v2::authn_method_add(
+            env,
+            canister_id,
+            first_authn_method.principal(),
+            identity_number,
+            authn_method,
+        )
+        .expect("API call failed")
+        .expect("authn_method_add failed");
+    }
+    identity_number
+}
+
+pub fn sample_pubkey_authn_method(i: u8) -> AuthnMethodData {
     AuthnMethodData {
         authn_method: AuthnMethod::PubKey(PublicKeyAuthn {
             pubkey: ByteBuf::from(vec![i; 32]),
         }),
         ..test_authn_method()
     }
+}
+
+pub fn sample_webauthn_authn_method(i: u8) -> AuthnMethodData {
+    AuthnMethodData {
+        authn_method: AuthnMethod::WebAuthn(WebAuthn {
+            pubkey: ByteBuf::from(vec![i; 32]),
+            credential_id: ByteBuf::from(vec![i * 2; 32]),
+        }),
+        ..test_authn_method()
+    }
+}
+
+pub fn sample_authn_methods() -> Vec<AuthnMethodData> {
+    let authn_method1 = AuthnMethodData {
+        metadata: HashMap::from([
+            (
+                "some_key".to_string(),
+                MetadataEntry::String("some data".to_string()),
+            ),
+            (
+                "origin".to_string(),
+                MetadataEntry::String("https://some.origin".to_string()),
+            ),
+            (
+                "alias".to_string(),
+                MetadataEntry::String("Test Authn Method 1".to_string()),
+            ),
+        ]),
+        ..sample_pubkey_authn_method(0)
+    };
+
+    let authn_method2 = AuthnMethodData {
+        metadata: HashMap::from([(
+            "different_key".to_string(),
+            MetadataEntry::String("other data".to_string()),
+        )]),
+        ..sample_webauthn_authn_method(1)
+    };
+
+    let authn_method3 = AuthnMethodData {
+        metadata: HashMap::from([
+            (
+                "recovery_metadata_1".to_string(),
+                MetadataEntry::String("recovery data 1".to_string()),
+            ),
+            (
+                "origin".to_string(),
+                MetadataEntry::String("https://identity.ic0.app".to_string()),
+            ),
+            (
+                "usage".to_string(),
+                MetadataEntry::String("recovery_phrase".to_string()),
+            ),
+        ]),
+        purpose: Purpose::Recovery,
+        ..sample_pubkey_authn_method(2)
+    };
+
+    let authn_method4 = AuthnMethodData {
+        metadata: HashMap::default(),
+        purpose: Purpose::Recovery,
+        ..sample_webauthn_authn_method(3)
+    };
+
+    let authn_method5 = AuthnMethodData {
+        metadata: HashMap::from([
+            (
+                "origin".to_string(),
+                MetadataEntry::String("https://identity.internetcomputer.org".to_string()),
+            ),
+            (
+                "alias".to_string(),
+                MetadataEntry::String("Test Authn Method 5".to_string()),
+            ),
+            (
+                "usage".to_string(),
+                MetadataEntry::String("browser_storage_key".to_string()),
+            ),
+        ]),
+        ..sample_webauthn_authn_method(4)
+    };
+
+    vec![
+        authn_method1,
+        authn_method2,
+        authn_method3,
+        authn_method4,
+        authn_method5,
+    ]
 }

--- a/src/internet_identity/tests/integration/v2_api/identity_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_info.rs
@@ -1,18 +1,19 @@
 //! Tests that `get_identity_info` returns the correct information.
 
+use crate::v2_api::authn_method_test_helpers::{
+    assert_eq_ignoring_last_authentication, create_identity_with_authn_method,
+    create_identity_with_authn_methods, sample_authn_methods,
+};
 use candid::Principal;
 use canister_tests::api::internet_identity as api;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::flows;
 use canister_tests::framework::{
     env, expect_user_error_with_message, install_ii_canister, time, II_WASM,
 };
-use ic_cdk::api::management_canister::main::CanisterId;
+use ic_test_state_machine_client::CallError;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
-use ic_test_state_machine_client::{CallError, StateMachine};
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethodData, AuthnMethodRegistration, DeviceData, IdentityNumber, KeyType, MetadataEntry,
-    Purpose,
+    AuthnMethodData, AuthnMethodRegistration, DeviceData, DeviceWithUsage, MetadataEntry,
 };
 use regex::Regex;
 use serde_bytes::ByteBuf;
@@ -23,14 +24,18 @@ use std::time::Duration;
 fn should_get_identity_info() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
-    let devices = sample_devices();
-    let identity_number = create_identity_with_devices(&env, canister_id, &devices);
+    let authn_methods = sample_authn_methods();
+    let identity_number = create_identity_with_authn_methods(&env, canister_id, &authn_methods);
 
-    let identity_info =
-        api_v2::identity_info(&env, canister_id, devices[0].principal(), identity_number)?
-            .expect("identity info failed");
+    let identity_info = api_v2::identity_info(
+        &env,
+        canister_id,
+        authn_methods[0].principal(),
+        identity_number,
+    )?
+    .expect("identity info failed");
 
-    assert_eq_ignoring_last_authentication(&identity_info.authn_methods, &devices);
+    assert_eq_ignoring_last_authentication(&identity_info.authn_methods, &authn_methods);
     assert_eq!(identity_info.authn_method_registration, None);
 
     // check that the last authentication timestamp is set correctly
@@ -47,8 +52,8 @@ fn should_get_identity_info() -> Result<(), CallError> {
 fn should_require_authentication_for_identity_info() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
-    let devices = sample_devices();
-    let identity_number = create_identity_with_devices(&env, canister_id, &devices);
+    let authn_methods = sample_authn_methods();
+    let identity_number = create_identity_with_authn_methods(&env, canister_id, &authn_methods);
 
     let result = api_v2::identity_info(&env, canister_id, Principal::anonymous(), identity_number);
 
@@ -65,23 +70,32 @@ fn should_provide_authn_registration() -> Result<(), CallError> {
     const AUTHN_METHOD_REGISTRATION_TIMEOUT: u64 = Duration::from_secs(900).as_nanos() as u64; // 15 minutes
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
-    let device1 = sample_devices().remove(0);
-    let identity_number = flows::register_anchor_with_device(&env, canister_id, &device1);
+    let authn_method1 = sample_authn_methods().remove(0);
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method1);
     let device2 = DeviceData {
         pubkey: ByteBuf::from([55; 32]),
         metadata: Some(HashMap::from([(
             "recovery_metadata_1".to_string(),
             MetadataEntry::String("recovery data 1".to_string()),
         )])),
-        ..device1.clone()
+        ..DeviceData::from(DeviceWithUsage::try_from(authn_method1.clone()).unwrap())
     };
 
-    api::enter_device_registration_mode(&env, canister_id, device1.principal(), identity_number)?;
+    api::enter_device_registration_mode(
+        &env,
+        canister_id,
+        authn_method1.principal(),
+        identity_number,
+    )?;
     api::add_tentative_device(&env, canister_id, identity_number, &device2)?;
 
-    let identity_info =
-        api_v2::identity_info(&env, canister_id, device1.principal(), identity_number)?
-            .expect("identity info failed");
+    let identity_info = api_v2::identity_info(
+        &env,
+        canister_id,
+        authn_method1.principal(),
+        identity_number,
+    )?
+    .expect("identity info failed");
 
     assert_eq!(
         identity_info.authn_method_registration,
@@ -91,87 +105,4 @@ fn should_provide_authn_registration() -> Result<(), CallError> {
         })
     );
     Ok(())
-}
-
-fn assert_eq_ignoring_last_authentication(
-    authn_methods: &[AuthnMethodData],
-    devices: &[DeviceData],
-) {
-    assert_eq!(
-        authn_methods
-            .iter()
-            .cloned()
-            .map(|mut pass| {
-                pass.last_authentication = None;
-                pass
-            })
-            .collect::<Vec<_>>(),
-        devices
-            .iter()
-            .cloned()
-            .map(AuthnMethodData::from)
-            .collect::<Vec<_>>()
-    );
-}
-
-fn create_identity_with_devices(
-    env: &StateMachine,
-    canister_id: CanisterId,
-    devices: &[DeviceData],
-) -> IdentityNumber {
-    let mut iter = devices.iter();
-    let device1 = iter.next().unwrap();
-    let identity_number = flows::register_anchor_with_device(env, canister_id, device1);
-    for (idx, device) in iter.enumerate() {
-        api_v2::authn_method_add(
-            env,
-            canister_id,
-            device1.principal(),
-            identity_number,
-            &AuthnMethodData::from(device.clone()),
-        )
-        .unwrap_or_else(|_| panic!("could not add device {}", idx))
-        .expect("authn method add failed");
-    }
-    identity_number
-}
-
-fn sample_devices() -> Vec<DeviceData> {
-    let device1 = DeviceData {
-        metadata: Some(HashMap::from([(
-            "some_key".to_string(),
-            MetadataEntry::String("some data".to_string()),
-        )])),
-        origin: Some("https://some.origin".to_string()),
-        ..DeviceData::auth_test_device()
-    };
-
-    let device2 = DeviceData {
-        pubkey: ByteBuf::from([1; 32]),
-        credential_id: Some(ByteBuf::from([12; 32])),
-        metadata: Some(HashMap::from([(
-            "different_key".to_string(),
-            MetadataEntry::String("other data".to_string()),
-        )])),
-        ..DeviceData::auth_test_device()
-    };
-    let device3 = DeviceData {
-        pubkey: ByteBuf::from([2; 32]),
-        purpose: Purpose::Recovery,
-        key_type: KeyType::SeedPhrase,
-        metadata: Some(HashMap::from([(
-            "recovery_metadata_1".to_string(),
-            MetadataEntry::String("recovery data 1".to_string()),
-        )])),
-        ..DeviceData::auth_test_device()
-    };
-    let device4 = DeviceData {
-        pubkey: ByteBuf::from([3; 32]),
-        purpose: Purpose::Recovery,
-        credential_id: Some(ByteBuf::from("credential id 1")),
-        key_type: KeyType::CrossPlatform,
-        ..DeviceData::auth_test_device()
-    };
-
-    vec![device1, device2, device3, device4]
 }


### PR DESCRIPTION
This PR adds more useful API v2 test helpers in preparation for more APIv2 methods.

In addition, the `authn_method_add` test is refactored to make use of those new helpers.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
