### PR TITLE
Remove dependency of `vc_util` on `ic_cdk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,7 +3479,6 @@ dependencies = [
  "assert_matches",
  "candid",
  "canister_sig_util",
- "ic-cdk",
  "ic-certification 1.3.0",
  "ic-crypto-standalone-sig-verifier",
  "ic-types",

--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -3174,7 +3174,6 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "canister_sig_util",
- "ic-cdk",
  "ic-certification 1.3.0",
  "ic-crypto-standalone-sig-verifier",
  "ic-types",

--- a/src/vc_util/Cargo.toml
+++ b/src/vc_util/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 # ic dependencies
 candid.workspace = true
-ic-cdk.workspace = true
 ic-certification.workspace = true
 ic-crypto-standalone-sig-verifier = { git = "https://github.com/dfinity/ic", rev = "bf9bc00b032a18d2dbcfcfcfb7a76a562f350c9e" }
 ic-types = { git = "https://github.com/dfinity/ic", rev = "bf9bc00b032a18d2dbcfcfcfb7a76a562f350c9e" }

--- a/src/vc_util/src/lib.rs
+++ b/src/vc_util/src/lib.rs
@@ -329,9 +329,7 @@ fn validate_claim<T: PartialEq<S> + std::fmt::Display, S: std::fmt::Display>(
         } else {
             println!(
                 "inconsistent claim [{}] in VC::  expected: {}, actual: {}",
-                label,
-                expected,
-                actual
+                label, expected, actual
             );
             Err(inconsistent_jwt_claims("inconsistent claim in VC"))
         }

--- a/src/vc_util/src/lib.rs
+++ b/src/vc_util/src/lib.rs
@@ -327,7 +327,7 @@ fn validate_claim<T: PartialEq<S> + std::fmt::Display, S: std::fmt::Display>(
         if expected == actual {
             Ok(())
         } else {
-            ic_cdk::println!(
+            println!(
                 "inconsistent claim [{}] in VC::  expected: {}, actual: {}",
                 label,
                 expected,
@@ -336,7 +336,7 @@ fn validate_claim<T: PartialEq<S> + std::fmt::Display, S: std::fmt::Display>(
             Err(inconsistent_jwt_claims("inconsistent claim in VC"))
         }
     } else {
-        ic_cdk::println!("missing claim [{}] in VC", label);
+        println!("missing claim [{}] in VC", label);
         Err(inconsistent_jwt_claims("missing claim in VC"))
     }
 }


### PR DESCRIPTION
The dependency on `ic_cdk` implies that `vc_util` cannot be compiled into WASM that would work in a browser context (where ic0-API is not available).  As `vc_util` was using `ic_cdk` only for printing debug info, there is no reason to really keep this dependency.
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
