### PR TITLE
Introduce API v2 identity_authn_info method 

### DIFF
--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -1,6 +1,8 @@
 use candid::Principal;
 use ic_cdk::api::management_canister::main::CanisterId;
-use ic_test_state_machine_client::{call_candid, call_candid_as, CallError, StateMachine};
+use ic_test_state_machine_client::{
+    call_candid, call_candid_as, query_candid, CallError, StateMachine,
+};
 use internet_identity_interface::internet_identity::types::*;
 use std::collections::HashMap;
 
@@ -27,6 +29,14 @@ pub fn identity_register(
         (authn_method, challenge_attempt, temp_key),
     )
     .map(|(x,)| x)
+}
+
+pub fn identity_authn_info(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    identity_number: IdentityNumber,
+) -> Result<Result<IdentityAuthnInfo, ()>, CallError> {
+    query_candid(env, canister_id, "identity_authn_info", (identity_number,)).map(|(x,)| x)
 }
 
 pub fn identity_info(

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -216,6 +216,10 @@ export const idlFactory = ({ IDL }) => {
     'streaming_strategy' : IDL.Opt(StreamingStrategy),
     'status_code' : IDL.Nat16,
   });
+  const IdentityAuthnInfo = IDL.Record({
+    'authn_methods' : IDL.Vec(AuthnMethod),
+    'recovery_authn_methods' : IDL.Vec(AuthnMethod),
+  });
   const AuthnMethodRegistrationInfo = IDL.Record({
     'expiration' : Timestamp,
     'authn_method' : IDL.Opt(AuthnMethodData),
@@ -324,6 +328,11 @@ export const idlFactory = ({ IDL }) => {
       ),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'http_request_update' : IDL.Func([HttpRequest], [HttpResponse], []),
+    'identity_authn_info' : IDL.Func(
+        [IdentityNumber],
+        [IDL.Variant({ 'Ok' : IdentityAuthnInfo, 'Err' : IDL.Null })],
+        ['query'],
+      ),
     'identity_info' : IDL.Func(
         [IdentityNumber],
         [IDL.Variant({ 'Ok' : IdentityInfo, 'Err' : IDL.Null })],

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -130,6 +130,10 @@ export interface IdentityAnchorInfo {
   'devices' : Array<DeviceWithUsage>,
   'device_registration' : [] | [DeviceRegistrationInfo],
 }
+export interface IdentityAuthnInfo {
+  'authn_methods' : Array<AuthnMethod>,
+  'recovery_authn_methods' : Array<AuthnMethod>,
+}
 export interface IdentityInfo {
   'authn_methods' : Array<AuthnMethodData>,
   'metadata' : MetadataMapV2,
@@ -271,6 +275,11 @@ export interface _SERVICE {
   'get_principal' : ActorMethod<[UserNumber, FrontendHostname], Principal>,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
   'http_request_update' : ActorMethod<[HttpRequest], HttpResponse>,
+  'identity_authn_info' : ActorMethod<
+    [IdentityNumber],
+    { 'Ok' : IdentityAuthnInfo } |
+      { 'Err' : null }
+  >,
   'identity_info' : ActorMethod<
     [IdentityNumber],
     { 'Ok' : IdentityInfo } |

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -363,6 +363,11 @@ type AuthnMethodRegistrationInfo = record {
     expiration: Timestamp;
 };
 
+type IdentityAuthnInfo = record {
+    authn_methods: vec AuthnMethod;
+    recovery_authn_methods: vec AuthnMethod;
+};
+
 type IdentityInfo = record {
     authn_methods: vec AuthnMethodData;
     authn_method_registration: opt AuthnMethodRegistrationInfo;
@@ -482,6 +487,10 @@ service : (opt InternetIdentityInit) -> {
     // A valid captcha solution to a previously generated captcha (using create_captcha) must be provided.
     // The sender needs to match the supplied authn_method.
     identity_register: (AuthnMethodData, CaptchaResult, opt principal) -> (variant {Ok: IdentityNumber; Err: IdentityRegisterError;});
+
+    // Returns information about the authentication methods of the identity with the given number.
+    // Only returns the minimal information required for authentication without exposing any metadata such as aliases.
+    identity_authn_info: (IdentityNumber) -> (variant {Ok: IdentityAuthnInfo; Err;}) query;
 
     // Returns information about the identity with the given number.
     // Requires authentication.

--- a/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
@@ -66,3 +66,35 @@ fn should_require_authentication_to_remove_authn_method() -> Result<(), CallErro
     );
     Ok(())
 }
+
+/// Verifies that the even last authn_method can be removed.
+/// This behaviour should be changed because it makes anchors unusable, see GIX-745.
+#[test]
+fn should_remove_last_authn_method() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let authn_method = sample_pubkey_authn_method(1);
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
+
+    let identity_info =
+        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?
+            .expect("identity info failed");
+
+    assert_eq!(identity_info.authn_methods.len(), 1);
+
+    api_v2::authn_method_remove(
+        &env,
+        canister_id,
+        authn_method.principal(),
+        identity_number,
+        &authn_method.public_key(),
+    )?
+    .expect("authn method remove failed");
+
+    let identity_authn_info = api_v2::identity_authn_info(&env, canister_id, identity_number)?
+        .expect("identity_authn_info failed");
+
+    assert_eq!(identity_authn_info.authn_methods.len(), 0);
+    assert_eq!(identity_authn_info.recovery_authn_methods.len(), 0);
+    Ok(())
+}

--- a/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
@@ -1,0 +1,36 @@
+use crate::v2_api::authn_method_test_helpers::{
+    create_identity_with_authn_methods, sample_authn_methods,
+};
+use canister_tests::api::internet_identity::api_v2;
+use canister_tests::framework::{env, install_ii_canister, II_WASM};
+use ic_test_state_machine_client::CallError;
+use internet_identity_interface::internet_identity::types::Purpose;
+
+#[test]
+fn should_get_identity_authn_info() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let authn_methods = sample_authn_methods();
+    let identity_number = create_identity_with_authn_methods(&env, canister_id, &authn_methods);
+
+    let identity_authn_info = api_v2::identity_authn_info(&env, canister_id, identity_number)?
+        .expect("identity_authn_info failed");
+
+    assert_eq!(
+        identity_authn_info.authn_methods,
+        authn_methods
+            .iter()
+            .filter(|x| x.purpose == Purpose::Authentication)
+            .map(|x| x.authn_method.clone())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        identity_authn_info.recovery_authn_methods,
+        authn_methods
+            .iter()
+            .filter(|x| x.purpose == Purpose::Recovery)
+            .map(|x| x.authn_method.clone())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}

--- a/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{env, install_ii_canister, II_WASM};
 use ic_test_state_machine_client::CallError;
-use internet_identity_interface::internet_identity::types::Purpose;
+use internet_identity_interface::internet_identity::types::AuthnMethodPurpose;
 
 #[test]
 fn should_get_identity_authn_info() -> Result<(), CallError> {
@@ -20,7 +20,7 @@ fn should_get_identity_authn_info() -> Result<(), CallError> {
         identity_authn_info.authn_methods,
         authn_methods
             .iter()
-            .filter(|x| x.purpose == Purpose::Authentication)
+            .filter(|x| x.purpose == AuthnMethodPurpose::Authentication)
             .map(|x| x.authn_method.clone())
             .collect::<Vec<_>>()
     );
@@ -28,7 +28,7 @@ fn should_get_identity_authn_info() -> Result<(), CallError> {
         identity_authn_info.recovery_authn_methods,
         authn_methods
             .iter()
-            .filter(|x| x.purpose == Purpose::Recovery)
+            .filter(|x| x.purpose == AuthnMethodPurpose::Recovery)
             .map(|x| x.authn_method.clone())
             .collect::<Vec<_>>()
     );

--- a/src/internet_identity/tests/integration/v2_api/mod.rs
+++ b/src/internet_identity/tests/integration/v2_api/mod.rs
@@ -1,6 +1,7 @@
 mod authn_method_add;
 mod authn_method_remove;
 pub mod authn_method_test_helpers;
+mod identity_authn_info;
 mod identity_info;
 mod identity_metadata;
 mod identity_register;

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -63,6 +63,12 @@ pub struct AuthnMethodRegistration {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct IdentityAuthnInfo {
+    pub authn_methods: Vec<AuthnMethod>,
+    pub recovery_authn_methods: Vec<AuthnMethod>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct IdentityInfo {
     pub authn_methods: Vec<AuthnMethodData>,
     pub authn_method_registration: Option<AuthnMethodRegistration>,


### PR DESCRIPTION
This PR introduces the `identity_authn_info` query call to retrieve
the necessary information for authentication.

It also adds test to check that last device can be removed (was not possible before due to the lack of options to query the number of authn_methods without authentication).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

