### PR TITLE
Consistently use camel case variants in APIv2

### DIFF
--- a/allowed_breaking_change.patch
+++ b/allowed_breaking_change.patch
@@ -1,8 +1,8 @@
 diff --git a/src/internet_identity/internet_identity.did b/src/internet_identity/internet_identity.did
-index 09937178..e545e0ba 100644
+index 125d8de0..b5a84b1e 100644
 --- a/src/internet_identity/internet_identity.did
 +++ b/src/internet_identity/internet_identity.did
-@@ -313,16 +313,16 @@ type PublicKeyAuthn = record {
+@@ -320,21 +320,21 @@ type PublicKeyAuthn = record {
  
  // The authentication methods currently supported by II.
  type AuthnMethod = variant {
@@ -22,4 +22,38 @@ index 09937178..e545e0ba 100644
 +    unprotected;
  };
  
+ type AuthnMethodPurpose = variant {
+-    Recovery;
+-    Authentication;
++    recovery;
++    authentication;
+ };
+ 
  type AuthnMethodData = record {
+@@ -348,7 +348,7 @@ type AuthnMethodData = record {
+     // - usage: data taken from key_type and reduced to "recovery_phrase", "browser_storage_key" or absent on migration
+     // Note: for compatibility reasons with the v1 API, the entries above (if present)
+     // must be of the `String` variant. This restriction may be lifted in the future.
+-    metadata: MetadataMapV2;
++    metadata: MetadataMap;
+     last_authentication: opt Timestamp;
+ };
+ 
+@@ -367,7 +367,7 @@ type IdentityInfo = record {
+     authn_methods: vec AuthnMethodData;
+     authn_method_registration: opt AuthnMethodRegistrationInfo;
+     // Authentication method independent metadata
+-    metadata: MetadataMapV2;
++    metadata: MetadataMap;
+ };
+ 
+ type IdentityRegisterError = variant {
+@@ -490,7 +490,7 @@ service : (opt InternetIdentityInit) -> {
+     // Replaces the authentication method independent metadata map.
+     // The existing metadata map will be overwritten.
+     // Requires authentication.
+-    identity_metadata_replace: (IdentityNumber, MetadataMapV2) -> (variant {Ok; Err;});
++    identity_metadata_replace: (IdentityNumber, MetadataMap) -> (variant {Ok; Err;});
+ 
+     // Adds a new authentication method to the identity.
+     // Requires authentication.

--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -50,7 +50,7 @@ pub fn identity_metadata_replace(
     canister_id: CanisterId,
     sender: Principal,
     identity_number: IdentityNumber,
-    metadata: &HashMap<String, MetadataEntry>,
+    metadata: &HashMap<String, MetadataEntryV2>,
 ) -> Result<Result<(), ()>, CallError> {
     call_candid_as(
         env,

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -1,5 +1,6 @@
 export const idlFactory = ({ IDL }) => {
   const MetadataMap = IDL.Rec();
+  const MetadataMapV2 = IDL.Rec();
   const ArchiveConfig = IDL.Record({
     'polling_interval_ns' : IDL.Nat64,
     'entries_buffer_limit' : IDL.Nat64,
@@ -69,6 +70,18 @@ export const idlFactory = ({ IDL }) => {
     }),
   });
   const IdentityNumber = IDL.Nat64;
+  MetadataMapV2.fill(
+    IDL.Vec(
+      IDL.Tuple(
+        IDL.Text,
+        IDL.Variant({
+          'Map' : MetadataMapV2,
+          'String' : IDL.Text,
+          'Bytes' : IDL.Vec(IDL.Nat8),
+        }),
+      )
+    )
+  );
   const AuthnMethodProtection = IDL.Variant({
     'Protected' : IDL.Null,
     'Unprotected' : IDL.Null,
@@ -82,12 +95,16 @@ export const idlFactory = ({ IDL }) => {
     'PubKey' : PublicKeyAuthn,
     'WebAuthn' : WebAuthn,
   });
+  const AuthnMethodPurpose = IDL.Variant({
+    'Recovery' : IDL.Null,
+    'Authentication' : IDL.Null,
+  });
   const AuthnMethodData = IDL.Record({
-    'metadata' : MetadataMap,
+    'metadata' : MetadataMapV2,
     'protection' : AuthnMethodProtection,
     'last_authentication' : IDL.Opt(Timestamp),
     'authn_method' : AuthnMethod,
-    'purpose' : Purpose,
+    'purpose' : AuthnMethodPurpose,
   });
   const AuthnMethodAddError = IDL.Variant({ 'InvalidMetadata' : IDL.Text });
   const ChallengeKey = IDL.Text;
@@ -205,7 +222,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const IdentityInfo = IDL.Record({
     'authn_methods' : IDL.Vec(AuthnMethodData),
-    'metadata' : MetadataMap,
+    'metadata' : MetadataMapV2,
     'authn_method_registration' : IDL.Opt(AuthnMethodRegistrationInfo),
   });
   const ChallengeResult = IDL.Record({
@@ -313,7 +330,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'identity_metadata_replace' : IDL.Func(
-        [IdentityNumber, MetadataMap],
+        [IdentityNumber, MetadataMapV2],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Null })],
         [],
       ),

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -31,14 +31,16 @@ export type AuthnMethod = { 'PubKey' : PublicKeyAuthn } |
   { 'WebAuthn' : WebAuthn };
 export type AuthnMethodAddError = { 'InvalidMetadata' : string };
 export interface AuthnMethodData {
-  'metadata' : MetadataMap,
+  'metadata' : MetadataMapV2,
   'protection' : AuthnMethodProtection,
   'last_authentication' : [] | [Timestamp],
   'authn_method' : AuthnMethod,
-  'purpose' : Purpose,
+  'purpose' : AuthnMethodPurpose,
 }
 export type AuthnMethodProtection = { 'Protected' : null } |
   { 'Unprotected' : null };
+export type AuthnMethodPurpose = { 'Recovery' : null } |
+  { 'Authentication' : null };
 export interface AuthnMethodRegistrationInfo {
   'expiration' : Timestamp,
   'authn_method' : [] | [AuthnMethodData],
@@ -130,7 +132,7 @@ export interface IdentityAnchorInfo {
 }
 export interface IdentityInfo {
   'authn_methods' : Array<AuthnMethodData>,
-  'metadata' : MetadataMap,
+  'metadata' : MetadataMapV2,
   'authn_method_registration' : [] | [AuthnMethodRegistrationInfo],
 }
 export type IdentityNumber = bigint;
@@ -165,6 +167,14 @@ export type MetadataMap = Array<
     { 'map' : MetadataMap } |
       { 'string' : string } |
       { 'bytes' : Uint8Array | number[] },
+  ]
+>;
+export type MetadataMapV2 = Array<
+  [
+    string,
+    { 'Map' : MetadataMapV2 } |
+      { 'String' : string } |
+      { 'Bytes' : Uint8Array | number[] },
   ]
 >;
 export type PrepareIdAliasError = { 'AuthenticationFailed' : string };
@@ -267,7 +277,7 @@ export interface _SERVICE {
       { 'Err' : null }
   >,
   'identity_metadata_replace' : ActorMethod<
-    [IdentityNumber, MetadataMap],
+    [IdentityNumber, MetadataMapV2],
     { 'Ok' : null } |
       { 'Err' : null }
   >,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -295,6 +295,13 @@ type BufferedArchiveEntry = record {
 
 type IdentityNumber = nat64;
 
+// Map with some variants for the value type.
+// Note, due to the Candid mapping this must be a tuple type thus we cannot name the fields `key` and `value`.
+type MetadataMapV2 = vec record {
+    text;
+    variant { Map : MetadataMapV2; String : text; Bytes : vec nat8 };
+};
+
 // Authentication method using WebAuthn signatures
 // See https://www.w3.org/TR/webauthn-2/
 // This is a separate type because WebAuthn requires to also store
@@ -325,18 +332,23 @@ type AuthnMethodProtection = variant {
     Unprotected;
 };
 
+type AuthnMethodPurpose = variant {
+    Recovery;
+    Authentication;
+};
+
 type AuthnMethodData = record {
     authn_method: AuthnMethod;
     protection: AuthnMethodProtection;
-    purpose: Purpose;
+    purpose: AuthnMethodPurpose;
     // contains the following fields of the DeviceWithUsage type:
     // - alias
     // - origin
     // - authenticator_attachment: data taken from key_type and reduced to "platform", "cross_platform" or absent on migration
     // - usage: data taken from key_type and reduced to "recovery_phrase", "browser_storage_key" or absent on migration
     // Note: for compatibility reasons with the v1 API, the entries above (if present)
-    // must be of the `string` variant. This restriction may be lifted in the future.
-    metadata: MetadataMap;
+    // must be of the `String` variant. This restriction may be lifted in the future.
+    metadata: MetadataMapV2;
     last_authentication: opt Timestamp;
 };
 
@@ -355,7 +367,7 @@ type IdentityInfo = record {
     authn_methods: vec AuthnMethodData;
     authn_method_registration: opt AuthnMethodRegistrationInfo;
     // Authentication method independent metadata
-    metadata: MetadataMap;
+    metadata: MetadataMapV2;
 };
 
 type IdentityRegisterError = variant {
@@ -478,7 +490,7 @@ service : (opt InternetIdentityInit) -> {
     // Replaces the authentication method independent metadata map.
     // The existing metadata map will be overwritten.
     // Requires authentication.
-    identity_metadata_replace: (IdentityNumber, MetadataMap) -> (variant {Ok; Err;});
+    identity_metadata_replace: (IdentityNumber, MetadataMapV2) -> (variant {Ok; Err;});
 
     // Adds a new authentication method to the identity.
     // Requires authentication.

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -551,10 +551,14 @@ mod v2_api {
     fn identity_info(identity_number: IdentityNumber) -> Result<IdentityInfo, ()> {
         authenticate_and_record_activity(identity_number);
         let anchor_info = anchor_management::get_anchor_info(identity_number);
+
         let metadata = state::anchor(identity_number)
             .identity_metadata()
             .clone()
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(k, v)| (k, MetadataEntryV2::from(v)))
+            .collect();
 
         let identity_info = IdentityInfo {
             authn_methods: anchor_info
@@ -595,9 +599,13 @@ mod v2_api {
     #[candid_method]
     fn identity_metadata_replace(
         identity_number: IdentityNumber,
-        metadata: HashMap<String, MetadataEntry>,
+        metadata: HashMap<String, MetadataEntryV2>,
     ) -> Result<(), ()> {
         authenticated_anchor_operation(identity_number, |anchor| {
+            let metadata = metadata
+                .into_iter()
+                .map(|(k, v)| (k, MetadataEntry::from(v)))
+                .collect();
             Ok((
                 (),
                 anchor_management::identity_metadata_replace(anchor, metadata),

--- a/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
+++ b/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
@@ -8,7 +8,7 @@ use canister_tests::framework::{
 };
 use ic_test_state_machine_client::CallError;
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, MetadataEntry, Purpose, WebAuthn,
+    AuthnMethod, AuthnMethodData, AuthnMethodPurpose, MetadataEntryV2, WebAuthn,
 };
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
@@ -151,7 +151,7 @@ fn should_only_count_ii_domain_authn_methods() -> Result<(), CallError> {
     let ii_authn_method = AuthnMethodData {
         metadata: HashMap::from([(
             "origin".to_string(),
-            MetadataEntry::String("https://identity.ic0.app".to_string()),
+            MetadataEntryV2::String("https://identity.ic0.app".to_string()),
         )]),
         ..test_authn_method()
     };
@@ -210,7 +210,7 @@ fn should_keep_stats_across_upgrades() -> Result<(), CallError> {
     let authn_method = AuthnMethodData {
         metadata: HashMap::from([(
             "origin".to_string(),
-            MetadataEntry::String("https://identity.ic0.app".to_string()),
+            MetadataEntryV2::String("https://identity.ic0.app".to_string()),
         )]),
         ..test_authn_method()
     };
@@ -247,7 +247,7 @@ fn authn_methods_all_types() -> Vec<(String, AuthnMethodData)> {
     });
     let ii_domain_entry = (
         "origin".to_string(),
-        MetadataEntry::String("https://identity.ic0.app".to_string()),
+        MetadataEntryV2::String("https://identity.ic0.app".to_string()),
     );
     vec![
         (
@@ -269,7 +269,7 @@ fn authn_methods_all_types() -> Vec<(String, AuthnMethodData)> {
             "webauthn_recovery".to_string(),
             AuthnMethodData {
                 authn_method: webauthn_authn_method,
-                purpose: Purpose::Recovery,
+                purpose: AuthnMethodPurpose::Recovery,
                 metadata: HashMap::from([ii_domain_entry.clone()]),
                 ..test_authn_method()
             },
@@ -280,7 +280,7 @@ fn authn_methods_all_types() -> Vec<(String, AuthnMethodData)> {
                 metadata: HashMap::from([
                     (
                         "usage".to_string(),
-                        MetadataEntry::String("recovery_phrase".to_string()),
+                        MetadataEntryV2::String("recovery_phrase".to_string()),
                     ),
                     ii_domain_entry.clone(),
                 ]),
@@ -293,7 +293,7 @@ fn authn_methods_all_types() -> Vec<(String, AuthnMethodData)> {
                 metadata: HashMap::from([
                     (
                         "usage".to_string(),
-                        MetadataEntry::String("browser_storage_key".to_string()),
+                        MetadataEntryV2::String("browser_storage_key".to_string()),
                     ),
                     ii_domain_entry.clone(),
                 ]),

--- a/src/internet_identity/tests/integration/archive_integration.rs
+++ b/src/internet_identity/tests/integration/archive_integration.rs
@@ -476,7 +476,7 @@ mod pull_entries_tests {
 
         let metadata = HashMap::from_iter(vec![(
             METADATA_KEY.to_string(),
-            MetadataEntry::String("some value".to_string()),
+            MetadataEntryV2::String("some value".to_string()),
         )]);
 
         ii_api::api_v2::identity_metadata_replace(

--- a/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
@@ -8,7 +8,7 @@ use canister_tests::framework::{
 };
 use ic_test_state_machine_client::CallError;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
-use internet_identity_interface::internet_identity::types::{AuthnMethodAddError, MetadataEntry};
+use internet_identity_interface::internet_identity::types::{AuthnMethodAddError, MetadataEntryV2};
 use regex::Regex;
 use serde_bytes::ByteBuf;
 
@@ -73,7 +73,7 @@ fn should_report_error_on_failed_conversion() -> Result<(), CallError> {
     let mut authn_method_2 = sample_pubkey_authn_method(2);
     authn_method_2.metadata.insert(
         "usage".to_string(),
-        MetadataEntry::Bytes(ByteBuf::from("invalid")),
+        MetadataEntryV2::Bytes(ByteBuf::from("invalid")),
     );
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);

--- a/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
@@ -2,8 +2,8 @@ use canister_tests::api::internet_identity::api_v2;
 use ic_cdk::api::management_canister::main::CanisterId;
 use ic_test_state_machine_client::StateMachine;
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, AuthnMethodProtection, ChallengeAttempt, IdentityNumber,
-    MetadataEntry, PublicKeyAuthn, Purpose, WebAuthn,
+    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, ChallengeAttempt,
+    IdentityNumber, MetadataEntryV2, PublicKeyAuthn, WebAuthn,
 };
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
@@ -44,7 +44,7 @@ pub fn test_authn_method() -> AuthnMethodData {
         }),
         metadata: Default::default(),
         protection: AuthnMethodProtection::Unprotected,
-        purpose: Purpose::Authentication,
+        purpose: AuthnMethodPurpose::Authentication,
         last_authentication: None,
     }
 }
@@ -120,15 +120,15 @@ pub fn sample_authn_methods() -> Vec<AuthnMethodData> {
         metadata: HashMap::from([
             (
                 "some_key".to_string(),
-                MetadataEntry::String("some data".to_string()),
+                MetadataEntryV2::String("some data".to_string()),
             ),
             (
                 "origin".to_string(),
-                MetadataEntry::String("https://some.origin".to_string()),
+                MetadataEntryV2::String("https://some.origin".to_string()),
             ),
             (
                 "alias".to_string(),
-                MetadataEntry::String("Test Authn Method 1".to_string()),
+                MetadataEntryV2::String("Test Authn Method 1".to_string()),
             ),
         ]),
         ..sample_pubkey_authn_method(0)
@@ -137,7 +137,7 @@ pub fn sample_authn_methods() -> Vec<AuthnMethodData> {
     let authn_method2 = AuthnMethodData {
         metadata: HashMap::from([(
             "different_key".to_string(),
-            MetadataEntry::String("other data".to_string()),
+            MetadataEntryV2::String("other data".to_string()),
         )]),
         ..sample_webauthn_authn_method(1)
     };
@@ -146,24 +146,24 @@ pub fn sample_authn_methods() -> Vec<AuthnMethodData> {
         metadata: HashMap::from([
             (
                 "recovery_metadata_1".to_string(),
-                MetadataEntry::String("recovery data 1".to_string()),
+                MetadataEntryV2::String("recovery data 1".to_string()),
             ),
             (
                 "origin".to_string(),
-                MetadataEntry::String("https://identity.ic0.app".to_string()),
+                MetadataEntryV2::String("https://identity.ic0.app".to_string()),
             ),
             (
                 "usage".to_string(),
-                MetadataEntry::String("recovery_phrase".to_string()),
+                MetadataEntryV2::String("recovery_phrase".to_string()),
             ),
         ]),
-        purpose: Purpose::Recovery,
+        purpose: AuthnMethodPurpose::Recovery,
         ..sample_pubkey_authn_method(2)
     };
 
     let authn_method4 = AuthnMethodData {
         metadata: HashMap::default(),
-        purpose: Purpose::Recovery,
+        purpose: AuthnMethodPurpose::Recovery,
         ..sample_webauthn_authn_method(3)
     };
 
@@ -171,15 +171,15 @@ pub fn sample_authn_methods() -> Vec<AuthnMethodData> {
         metadata: HashMap::from([
             (
                 "origin".to_string(),
-                MetadataEntry::String("https://identity.internetcomputer.org".to_string()),
+                MetadataEntryV2::String("https://identity.internetcomputer.org".to_string()),
             ),
             (
                 "alias".to_string(),
-                MetadataEntry::String("Test Authn Method 5".to_string()),
+                MetadataEntryV2::String("Test Authn Method 5".to_string()),
             ),
             (
                 "usage".to_string(),
-                MetadataEntry::String("browser_storage_key".to_string()),
+                MetadataEntryV2::String("browser_storage_key".to_string()),
             ),
         ]),
         ..sample_webauthn_authn_method(4)

--- a/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
@@ -8,7 +8,7 @@ use canister_tests::framework::{
 };
 use ic_test_state_machine_client::CallError;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
-use internet_identity_interface::internet_identity::types::MetadataEntry;
+use internet_identity_interface::internet_identity::types::MetadataEntryV2;
 use regex::Regex;
 use std::collections::HashMap;
 
@@ -28,7 +28,7 @@ fn should_write_metadata() -> Result<(), CallError> {
 
     let metadata = HashMap::from_iter(vec![(
         METADATA_KEY.to_string(),
-        MetadataEntry::String("some value".to_string()),
+        MetadataEntryV2::String("some value".to_string()),
     )]);
 
     api_v2::identity_metadata_replace(
@@ -58,7 +58,7 @@ fn should_require_authentication_to_replace_identity_metadata() {
 
     let metadata = HashMap::from_iter(vec![(
         METADATA_KEY.to_string(),
-        MetadataEntry::String("some value".to_string()),
+        MetadataEntryV2::String("some value".to_string()),
     )]);
 
     let result = api_v2::identity_metadata_replace(
@@ -91,7 +91,7 @@ fn should_not_write_too_large_identity_metadata_map() -> Result<(), CallError> {
 
     let metadata = HashMap::from_iter(vec![(
         METADATA_KEY.to_string(),
-        MetadataEntry::String("a".repeat(3000)),
+        MetadataEntryV2::String("a".repeat(3000)),
     )]);
 
     let result = api_v2::identity_metadata_replace(

--- a/src/internet_identity/tests/integration/v2_api/identity_register.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_register.rs
@@ -9,7 +9,7 @@ use canister_tests::framework::{
 };
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
 use internet_identity_interface::internet_identity::types::{
-    ChallengeAttempt, IdentityRegisterError, MetadataEntry,
+    ChallengeAttempt, IdentityRegisterError, MetadataEntryV2,
 };
 use regex::Regex;
 use serde_bytes::ByteBuf;
@@ -152,7 +152,7 @@ fn should_fail_on_invalid_metadata() {
     let mut authn_method = test_authn_method();
     authn_method.metadata.insert(
         "usage".to_string(),
-        MetadataEntry::Bytes(ByteBuf::from("invalid")),
+        MetadataEntryV2::Bytes(ByteBuf::from("invalid")),
     );
 
     let challenge = api_v2::captcha_create(&env, canister_id)

--- a/src/internet_identity_interface/src/internet_identity/conversions/test.rs
+++ b/src/internet_identity_interface/src/internet_identity/conversions/test.rs
@@ -70,6 +70,40 @@ fn should_fail_to_convert_to_device_on_bad_metadata_types() {
     }
 }
 
+#[test]
+fn should_convert_authn_method_purpose() {
+    let authn_method_purpose = AuthnMethodPurpose::Authentication;
+    let purpose = Purpose::from(authn_method_purpose.clone());
+    assert_eq!(purpose, Purpose::Authentication);
+    assert_eq!(AuthnMethodPurpose::from(purpose), authn_method_purpose);
+
+    let authn_method_purpose = AuthnMethodPurpose::Recovery;
+    let purpose = Purpose::from(authn_method_purpose.clone());
+    assert_eq!(purpose, Purpose::Recovery);
+    assert_eq!(AuthnMethodPurpose::from(purpose), authn_method_purpose);
+}
+
+#[test]
+fn should_convert_metadata_entry() {
+    let test_string = "some data";
+    let test_bytes = ByteBuf::from(*b"some data");
+
+    let entry_v2 = MetadataEntryV2::String(test_string.to_string());
+    let entry = MetadataEntry::from(entry_v2.clone());
+    assert_eq!(entry, MetadataEntry::String(test_string.to_string()));
+    assert_eq!(MetadataEntryV2::from(entry), entry_v2);
+
+    let entry_v2 = MetadataEntryV2::Bytes(test_bytes.clone());
+    let entry = MetadataEntry::from(entry_v2.clone());
+    assert_eq!(entry, MetadataEntry::Bytes(test_bytes));
+    assert_eq!(MetadataEntryV2::from(entry), entry_v2);
+
+    let entry_v2 = MetadataEntryV2::Map(HashMap::new());
+    let entry = MetadataEntry::from(entry_v2.clone());
+    assert_eq!(entry, MetadataEntry::Map(HashMap::new()));
+    assert_eq!(MetadataEntryV2::from(entry), entry_v2);
+}
+
 fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
     const ORIGIN: &str = "origin";
     const ALIAS: &str = "alias";

--- a/src/internet_identity_interface/src/internet_identity/conversions/test.rs
+++ b/src/internet_identity_interface/src/internet_identity/conversions/test.rs
@@ -1,8 +1,8 @@
 use crate::internet_identity::conversions::AuthnMethodConversionError;
 use crate::internet_identity::types as ii_types;
 use crate::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, AuthnMethodProtection, DeviceProtection, DeviceWithUsage,
-    KeyType, MetadataEntry, PublicKeyAuthn, Purpose, WebAuthn,
+    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, DeviceProtection,
+    DeviceWithUsage, KeyType, MetadataEntry, MetadataEntryV2, PublicKeyAuthn, Purpose, WebAuthn,
 };
 use ii_types::{DeviceData, WebAuthnCredential};
 use serde_bytes::ByteBuf;
@@ -57,7 +57,7 @@ fn should_fail_to_convert_to_device_on_bad_metadata_types() {
         let (_, mut authn_method) = test_conversion_pairs().pop().unwrap();
         authn_method.metadata.insert(
             key.to_string(),
-            MetadataEntry::Bytes(ByteBuf::from([1, 2, 3])),
+            MetadataEntryV2::Bytes(ByteBuf::from([1, 2, 3])),
         );
         assert_eq!(
             DeviceWithUsage::try_from(authn_method).unwrap_err(),
@@ -99,14 +99,14 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
             pubkey: pubkey.clone(),
         }),
         metadata: HashMap::from([
-            (ALIAS.to_string(), MetadataEntry::String(alias.clone())),
-            (ORIGIN.to_string(), MetadataEntry::String(origin.clone())),
+            (ALIAS.to_string(), MetadataEntryV2::String(alias.clone())),
+            (ORIGIN.to_string(), MetadataEntryV2::String(origin.clone())),
             (
                 "some_key".to_string(),
-                MetadataEntry::String("some data".to_string()),
+                MetadataEntryV2::String("some data".to_string()),
             ),
         ]),
-        purpose: Purpose::Recovery,
+        purpose: AuthnMethodPurpose::Recovery,
         protection: AuthnMethodProtection::Protected,
         last_authentication: Some(123456789),
     };
@@ -129,16 +129,16 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
             pubkey: pubkey.clone(),
             credential_id: credential_id.clone(),
         }),
-        purpose: Purpose::Authentication,
+        purpose: AuthnMethodPurpose::Authentication,
         metadata: HashMap::from([
-            (ALIAS.to_string(), MetadataEntry::String(alias.clone())),
+            (ALIAS.to_string(), MetadataEntryV2::String(alias.clone())),
             (
                 AUTHENTICATOR_ATTACHMENT.to_string(),
-                MetadataEntry::String("cross_platform".to_string()),
+                MetadataEntryV2::String("cross_platform".to_string()),
             ),
             (
                 "some_key2".to_string(),
-                MetadataEntry::String("some data".to_string()),
+                MetadataEntryV2::String("some data".to_string()),
             ),
         ]),
         protection: AuthnMethodProtection::Unprotected,
@@ -158,15 +158,15 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
             pubkey,
             credential_id,
         }),
-        purpose: Purpose::Authentication,
+        purpose: AuthnMethodPurpose::Authentication,
         metadata: HashMap::from([
             (
                 AUTHENTICATOR_ATTACHMENT.to_string(),
-                MetadataEntry::String("cross_platform".to_string()),
+                MetadataEntryV2::String("cross_platform".to_string()),
             ),
             (
                 "some_key2".to_string(),
-                MetadataEntry::String("some data".to_string()),
+                MetadataEntryV2::String("some data".to_string()),
             ),
         ]),
         protection: AuthnMethodProtection::Unprotected,
@@ -180,7 +180,7 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
     let mut authn_method_data4 = authn_method_data1.clone();
     authn_method_data4.metadata.insert(
         USAGE.to_string(),
-        MetadataEntry::String("recovery_phrase".to_string()),
+        MetadataEntryV2::String("recovery_phrase".to_string()),
     );
 
     let device5 = DeviceWithUsage {
@@ -190,7 +190,7 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
     let mut authn_method_data5 = authn_method_data1.clone();
     authn_method_data5.metadata.insert(
         USAGE.to_string(),
-        MetadataEntry::String("browser_storage_key".to_string()),
+        MetadataEntryV2::String("browser_storage_key".to_string()),
     );
 
     vec![

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -1,13 +1,27 @@
-use crate::internet_identity::types::{CredentialId, MetadataEntry, PublicKey, Purpose, Timestamp};
+use crate::internet_identity::types::{CredentialId, PublicKey, Timestamp};
 use candid::{CandidType, Deserialize};
+use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 
 pub type IdentityNumber = u64;
+
+#[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
+pub enum MetadataEntryV2 {
+    String(String),
+    Bytes(ByteBuf),
+    Map(HashMap<String, MetadataEntryV2>),
+}
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum AuthnMethodProtection {
     Protected,
     Unprotected,
+}
+
+#[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]
+pub enum AuthnMethodPurpose {
+    Recovery,
+    Authentication,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -35,9 +49,9 @@ pub struct AuthnMethodData {
     // - alias
     // - origin
     // - key_type: reduced to "platform", "cross_platform" on migration
-    pub metadata: HashMap<String, MetadataEntry>,
+    pub metadata: HashMap<String, MetadataEntryV2>,
     pub protection: AuthnMethodProtection,
-    pub purpose: Purpose,
+    pub purpose: AuthnMethodPurpose,
     // last usage timestamp cannot be written and will always be ignored on write
     pub last_authentication: Option<Timestamp>,
 }
@@ -52,7 +66,7 @@ pub struct AuthnMethodRegistration {
 pub struct IdentityInfo {
     pub authn_methods: Vec<AuthnMethodData>,
     pub authn_method_registration: Option<AuthnMethodRegistration>,
-    pub metadata: HashMap<String, MetadataEntry>,
+    pub metadata: HashMap<String, MetadataEntryV2>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
This refactors the API v2 to use camel case in all remaining variants:
* metadata map
* purpose

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

