### PR TITLE
Change AuthenticationFailed to Unauthorized

### DIFF
--- a/allowed_breaking_change.patch
+++ b/allowed_breaking_change.patch
@@ -1,5 +1,5 @@
 diff --git a/src/internet_identity/internet_identity.did b/src/internet_identity/internet_identity.did
-index 125d8de0..b5a84b1e 100644
+index ae4fc77f..b5a84b1e 100644
 --- a/src/internet_identity/internet_identity.did
 +++ b/src/internet_identity/internet_identity.did
 @@ -320,21 +320,21 @@ type PublicKeyAuthn = record {
@@ -48,6 +48,28 @@ index 125d8de0..b5a84b1e 100644
  };
  
  type IdentityRegisterError = variant {
+@@ -393,8 +393,8 @@ type PrepareIdAliasRequest = record {
+ };
+ 
+ type PrepareIdAliasError = variant {
+-    /// The caller is not authorized to call this method with the given arguments.
+-    Unauthorized;
++    /// Caller authentication failed.
++    AuthenticationFailed : text;
+ };
+ 
+ /// The prepared id alias contains two (still unsigned) credentials in JWT format,
+@@ -417,8 +417,8 @@ type GetIdAliasRequest = record {
+ };
+ 
+ type GetIdAliasError = variant {
+-    /// The caller is not authorized to call this method with the given arguments.
+-    Unauthorized;
++    /// Caller authentication failed.
++    AuthenticationFailed : text;
+     /// The credential(s) are not available: may be expired or not prepared yet (call prepare_id_alias to prepare).
+     NoSuchCredentials : text;
+ };
 @@ -490,7 +490,7 @@ service : (opt InternetIdentityInit) -> {
      // Replaces the authentication method independent metadata map.
      // The existing metadata map will be overwritten.

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -183,8 +183,8 @@ export const idlFactory = ({ IDL }) => {
     'issuer_id_alias_credential' : SignedIdAlias,
   });
   const GetIdAliasError = IDL.Variant({
+    'Unauthorized' : IDL.Null,
     'NoSuchCredentials' : IDL.Text,
-    'AuthenticationFailed' : IDL.Text,
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
@@ -246,9 +246,7 @@ export const idlFactory = ({ IDL }) => {
     'issuer_id_alias_jwt' : IDL.Text,
     'canister_sig_pk_der' : PublicKey,
   });
-  const PrepareIdAliasError = IDL.Variant({
-    'AuthenticationFailed' : IDL.Text,
-  });
+  const PrepareIdAliasError = IDL.Variant({ 'Unauthorized' : IDL.Null });
   const RegisterResponse = IDL.Variant({
     'bad_challenge' : IDL.Null,
     'canister_full' : IDL.Null,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -98,8 +98,8 @@ export interface DeviceWithUsage {
 export type FrontendHostname = string;
 export type GetDelegationResponse = { 'no_such_delegation' : null } |
   { 'signed_delegation' : SignedDelegation };
-export type GetIdAliasError = { 'NoSuchCredentials' : string } |
-  { 'AuthenticationFailed' : string };
+export type GetIdAliasError = { 'Unauthorized' : null } |
+  { 'NoSuchCredentials' : string };
 export interface GetIdAliasRequest {
   'rp_id_alias_jwt' : string,
   'issuer' : FrontendHostname,
@@ -177,7 +177,7 @@ export type MetadataMapV2 = Array<
       { 'Bytes' : Uint8Array | number[] },
   ]
 >;
-export type PrepareIdAliasError = { 'AuthenticationFailed' : string };
+export type PrepareIdAliasError = { 'Unauthorized' : null };
 export interface PrepareIdAliasRequest {
   'issuer' : FrontendHostname,
   'relying_party' : FrontendHostname,

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -622,7 +622,7 @@ export class AuthenticatedConnection extends Connection {
     }
 
     const err = result.Err;
-    if ("AuthenticationFailed" in err) {
+    if ("Unauthorized" in err) {
       return { error: "authentication_failed" };
     }
 
@@ -677,7 +677,7 @@ export class AuthenticatedConnection extends Connection {
       console.error(["No credentials", err.NoSuchCredentials].join(": "));
       return { error: "internal_error" };
     }
-    if ("AuthenticationFailed" in err) {
+    if ("Unauthorized" in err) {
       return { error: "authentication_failed" };
     }
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -393,8 +393,8 @@ type PrepareIdAliasRequest = record {
 };
 
 type PrepareIdAliasError = variant {
-    /// Caller authentication failed.
-    AuthenticationFailed : text;
+    /// The caller is not authorized to call this method with the given arguments.
+    Unauthorized;
 };
 
 /// The prepared id alias contains two (still unsigned) credentials in JWT format,
@@ -417,8 +417,8 @@ type GetIdAliasRequest = record {
 };
 
 type GetIdAliasError = variant {
-    /// Caller authentication failed.
-    AuthenticationFailed : text;
+    /// The caller is not authorized to call this method with the given arguments.
+    Unauthorized;
     /// The credential(s) are not available: may be expired or not prepared yet (call prepare_id_alias to prepare).
     NoSuchCredentials : text;
 };

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -641,10 +641,7 @@ mod attribute_sharing_mvp {
     #[candid_method(query)]
     fn get_id_alias(req: GetIdAliasRequest) -> Result<IdAliasCredentials, GetIdAliasError> {
         let Ok(_) = check_authentication(req.identity_number) else {
-            return Err(GetIdAliasError::AuthenticationFailed(format!(
-                "{} could not be authenticated.",
-                caller()
-            )));
+            return Err(GetIdAliasError::Unauthorized);
         };
         vc_mvp::get_id_alias(
             req.identity_number,

--- a/src/internet_identity/tests/integration/vc_mvp.rs
+++ b/src/internet_identity/tests/integration/vc_mvp.rs
@@ -659,10 +659,7 @@ fn should_not_get_id_alias_for_different_user() -> Result<(), CallError> {
         },
     )?;
 
-    assert!(matches!(
-        response,
-        Err(GetIdAliasError::AuthenticationFailed(_))
-    ));
+    assert!(matches!(response, Err(GetIdAliasError::Unauthorized)));
     Ok(())
 }
 

--- a/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
@@ -32,7 +32,7 @@ pub struct PreparedIdAlias {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum PrepareIdAliasError {
-    AuthenticationFailed(String),
+    Unauthorized,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -57,6 +57,6 @@ pub struct GetIdAliasRequest {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum GetIdAliasError {
-    AuthenticationFailed(String),
+    Unauthorized,
     NoSuchCredentials(String),
 }


### PR DESCRIPTION
The `AuthenticationFailed` was misleading, since the issue is not with authentication (i.e. the `caller` is known), but with authorization (i.e. the `caller` is not allowed to do the specific action).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
