### PR TITLE
Introduce API v2 authn_method_replace

### DIFF
--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -89,6 +89,24 @@ pub fn authn_method_add(
     .map(|(x,)| x)
 }
 
+pub fn authn_method_replace(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    sender: Principal,
+    identity_number: IdentityNumber,
+    public_key: &PublicKey,
+    authn_method: &AuthnMethodData,
+) -> Result<Result<(), AuthnMethodReplaceError>, CallError> {
+    call_candid_as(
+        env,
+        canister_id,
+        sender,
+        "authn_method_replace",
+        (identity_number, public_key, authn_method),
+    )
+    .map(|(x,)| x)
+}
+
 pub fn authn_method_metadata_replace(
     env: &StateMachine,
     canister_id: CanisterId,

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -111,6 +111,10 @@ export const idlFactory = ({ IDL }) => {
     'AuthnMethodNotFound' : IDL.Null,
     'InvalidMetadata' : IDL.Text,
   });
+  const AuthnMethodReplaceError = IDL.Variant({
+    'AuthnMethodNotFound' : IDL.Null,
+    'InvalidMetadata' : IDL.Text,
+  });
   const ChallengeKey = IDL.Text;
   const Challenge = IDL.Record({
     'png_base64' : IDL.Text,
@@ -319,6 +323,11 @@ export const idlFactory = ({ IDL }) => {
     'authn_method_remove' : IDL.Func(
         [IdentityNumber, PublicKey],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Null })],
+        [],
+      ),
+    'authn_method_replace' : IDL.Func(
+        [IdentityNumber, PublicKey, AuthnMethodData],
+        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : AuthnMethodReplaceError })],
         [],
       ),
     'captcha_create' : IDL.Func(

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -47,6 +47,8 @@ export interface AuthnMethodRegistrationInfo {
   'expiration' : Timestamp,
   'authn_method' : [] | [AuthnMethodData],
 }
+export type AuthnMethodReplaceError = { 'AuthnMethodNotFound' : null } |
+  { 'InvalidMetadata' : string };
 export interface BufferedArchiveEntry {
   'sequence_number' : bigint,
   'entry' : Uint8Array | number[],
@@ -273,6 +275,11 @@ export interface _SERVICE {
     [IdentityNumber, PublicKey],
     { 'Ok' : null } |
       { 'Err' : null }
+  >,
+  'authn_method_replace' : ActorMethod<
+    [IdentityNumber, PublicKey, AuthnMethodData],
+    { 'Ok' : null } |
+      { 'Err' : AuthnMethodReplaceError }
   >,
   'captcha_create' : ActorMethod<[], { 'Ok' : Challenge } | { 'Err' : null }>,
   'create_challenge' : ActorMethod<[], Challenge>,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -413,6 +413,12 @@ type AuthnMethodAddError = variant {
     InvalidMetadata: text;
 };
 
+type AuthnMethodReplaceError = variant {
+    InvalidMetadata: text;
+    // No authentication method found with the given public key.
+    AuthnMethodNotFound;
+};
+
 type AuthnMethodMetadataReplaceError = variant {
     InvalidMetadata: text;
     /// No authentication method found with the given public key.
@@ -535,6 +541,11 @@ service : (opt InternetIdentityInit) -> {
     // Adds a new authentication method to the identity.
     // Requires authentication.
     authn_method_add: (IdentityNumber, AuthnMethodData) -> (variant {Ok; Err: AuthnMethodAddError;});
+
+    // Atomically replaces the authentication method matching the supplied public key with the new authentication method
+    // provided.
+    // Requires authentication.
+    authn_method_replace: (IdentityNumber, PublicKey, AuthnMethodData) -> (variant {Ok; Err: AuthnMethodReplaceError;});
 
     // Replaces the authentication method metadata map.
     // The existing metadata map will be overwritten.

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -633,6 +633,20 @@ mod v2_api {
 
     #[update]
     #[candid_method]
+    fn authn_method_replace(
+        identity_number: IdentityNumber,
+        authn_method_pk: PublicKey,
+        new_authn_method: AuthnMethodData,
+    ) -> Result<(), AuthnMethodReplaceError> {
+        let new_device = DeviceWithUsage::try_from(new_authn_method)
+            .map(DeviceData::from)
+            .map_err(|err| AuthnMethodReplaceError::InvalidMetadata(err.to_string()))?;
+        replace(identity_number, authn_method_pk, new_device);
+        Ok(())
+    }
+
+    #[update]
+    #[candid_method]
     fn authn_method_metadata_replace(
         identity_number: IdentityNumber,
         authn_method_pk: PublicKey,

--- a/src/internet_identity/tests/integration/v2_api/authn_method_replace.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_replace.rs
@@ -1,0 +1,114 @@
+use crate::v2_api::authn_method_test_helpers::{
+    assert_eq_ignoring_last_authentication, create_identity_with_authn_method,
+    sample_pubkey_authn_method, sample_webauthn_authn_method,
+};
+use candid::Principal;
+use canister_tests::api::internet_identity::api_v2;
+use canister_tests::framework::{
+    env, expect_user_error_with_message, install_ii_canister, II_WASM,
+};
+use ic_test_state_machine_client::CallError;
+use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
+use internet_identity_interface::internet_identity::types::{
+    AuthnMethodData, AuthnMethodReplaceError, MetadataEntryV2,
+};
+use regex::Regex;
+use serde_bytes::ByteBuf;
+use std::collections::HashMap;
+
+#[test]
+fn should_replace_authn_method() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let authn_method_1 = sample_pubkey_authn_method(1);
+    let authn_method_2 = sample_webauthn_authn_method(2);
+
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
+    api_v2::authn_method_replace(
+        &env,
+        canister_id,
+        authn_method_1.principal(),
+        identity_number,
+        &authn_method_1.public_key(),
+        &authn_method_2,
+    )?
+    .expect("authn method add failed");
+
+    let identity_info = api_v2::identity_info(
+        &env,
+        canister_id,
+        authn_method_2.principal(),
+        identity_number,
+    )?
+    .expect("identity info failed");
+
+    assert_eq_ignoring_last_authentication(&identity_info.authn_methods, &[authn_method_2]);
+
+    Ok(())
+}
+
+#[test]
+fn should_require_authentication_to_replace_authn_method() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let authn_method_1 = sample_pubkey_authn_method(1);
+    let authn_method_2 = sample_pubkey_authn_method(2);
+
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
+    let result = api_v2::authn_method_replace(
+        &env,
+        canister_id,
+        Principal::anonymous(),
+        identity_number,
+        &authn_method_1.public_key(),
+        &authn_method_2,
+    );
+
+    expect_user_error_with_message(
+        result,
+        CanisterCalledTrap,
+        Regex::new("[a-z\\d-]+ could not be authenticated.").unwrap(),
+    );
+
+    let identity_info = api_v2::identity_info(
+        &env,
+        canister_id,
+        authn_method_1.principal(),
+        identity_number,
+    )?
+    .expect("identity info failed");
+    assert_eq_ignoring_last_authentication(&identity_info.authn_methods, &[authn_method_1]);
+
+    Ok(())
+}
+
+#[test]
+fn should_validate_metadata_of_new_authn_method() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let authn_method_1 = sample_pubkey_authn_method(1);
+    let authn_method_2 = AuthnMethodData {
+        metadata: HashMap::from([(
+            "alias".to_string(),
+            MetadataEntryV2::Bytes(ByteBuf::from(*b"some value")),
+        )]),
+        ..sample_webauthn_authn_method(2)
+    };
+
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method_1);
+    let result = api_v2::authn_method_replace(
+        &env,
+        canister_id,
+        authn_method_1.principal(),
+        identity_number,
+        &authn_method_1.public_key(),
+        &authn_method_2,
+    )?;
+
+    assert!(matches!(
+        result,
+        Err(AuthnMethodReplaceError::InvalidMetadata(_))
+    ));
+
+    Ok(())
+}

--- a/src/internet_identity/tests/integration/v2_api/mod.rs
+++ b/src/internet_identity/tests/integration/v2_api/mod.rs
@@ -1,6 +1,7 @@
 mod authn_method_add;
 mod authn_method_metadata;
 mod authn_method_remove;
+mod authn_method_replace;
 pub mod authn_method_test_helpers;
 mod identity_authn_info;
 mod identity_info;

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -88,10 +88,17 @@ pub enum AuthnMethodAddError {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum AuthnMethodReplaceError {
+    InvalidMetadata(String),
+    AuthnMethodNotFound,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum AuthnMethodMetadataReplaceError {
     InvalidMetadata(String),
     AuthnMethodNotFound,
 }
+
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct RegistrationModeInfo {
     pub expiration: Timestamp,


### PR DESCRIPTION
This PR adds the `authn_method_replace` method as a replacement for the
legacy API `replace` method.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
