### PR TITLE
Refactor AuthnMethodData to group security relevant, modifiable fields

### DIFF
--- a/allowed_breaking_change.patch
+++ b/allowed_breaking_change.patch
@@ -1,5 +1,5 @@
 diff --git a/src/internet_identity/internet_identity.did b/src/internet_identity/internet_identity.did
-index ae4fc77f..b5a84b1e 100644
+index c1bf6d34..60bd6b90 100644
 --- a/src/internet_identity/internet_identity.did
 +++ b/src/internet_identity/internet_identity.did
 @@ -320,21 +320,21 @@ type PublicKeyAuthn = record {
@@ -29,8 +29,18 @@ index ae4fc77f..b5a84b1e 100644
 +    authentication;
  };
  
+ type AuthnMethodSecuritySettings = record {
+@@ -344,7 +344,8 @@ type AuthnMethodSecuritySettings = record {
+ 
  type AuthnMethodData = record {
-@@ -348,7 +348,7 @@ type AuthnMethodData = record {
+     authn_method: AuthnMethod;
+-    security_settings: AuthnMethodSecuritySettings;
++    protection: AuthnMethodProtection;
++    purpose: AuthnMethodPurpose;
+     // contains the following fields of the DeviceWithUsage type:
+     // - alias
+     // - origin
+@@ -352,7 +353,7 @@ type AuthnMethodData = record {
      // - usage: data taken from key_type and reduced to "recovery_phrase", "browser_storage_key" or absent on migration
      // Note: for compatibility reasons with the v1 API, the entries above (if present)
      // must be of the `String` variant. This restriction may be lifted in the future.
@@ -39,16 +49,7 @@ index ae4fc77f..b5a84b1e 100644
      last_authentication: opt Timestamp;
  };
  
-@@ -367,7 +367,7 @@ type IdentityInfo = record {
-     authn_methods: vec AuthnMethodData;
-     authn_method_registration: opt AuthnMethodRegistrationInfo;
-     // Authentication method independent metadata
--    metadata: MetadataMapV2;
-+    metadata: MetadataMap;
- };
- 
- type IdentityRegisterError = variant {
-@@ -393,8 +393,8 @@ type PrepareIdAliasRequest = record {
+@@ -433,8 +434,8 @@ type PrepareIdAliasRequest = record {
  };
  
  type PrepareIdAliasError = variant {
@@ -59,7 +60,7 @@ index ae4fc77f..b5a84b1e 100644
  };
  
  /// The prepared id alias contains two (still unsigned) credentials in JWT format,
-@@ -417,8 +417,8 @@ type GetIdAliasRequest = record {
+@@ -457,8 +458,8 @@ type GetIdAliasRequest = record {
  };
  
  type GetIdAliasError = variant {
@@ -70,7 +71,7 @@ index ae4fc77f..b5a84b1e 100644
      /// The credential(s) are not available: may be expired or not prepared yet (call prepare_id_alias to prepare).
      NoSuchCredentials : text;
  };
-@@ -490,7 +490,7 @@ service : (opt InternetIdentityInit) -> {
+@@ -534,7 +535,7 @@ service : (opt InternetIdentityInit) -> {
      // Replaces the authentication method independent metadata map.
      // The existing metadata map will be overwritten.
      // Requires authentication.

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -70,6 +70,18 @@ export const idlFactory = ({ IDL }) => {
     }),
   });
   const IdentityNumber = IDL.Nat64;
+  const AuthnMethodProtection = IDL.Variant({
+    'Protected' : IDL.Null,
+    'Unprotected' : IDL.Null,
+  });
+  const AuthnMethodPurpose = IDL.Variant({
+    'Recovery' : IDL.Null,
+    'Authentication' : IDL.Null,
+  });
+  const AuthnMethodSecuritySettings = IDL.Record({
+    'protection' : AuthnMethodProtection,
+    'purpose' : AuthnMethodPurpose,
+  });
   MetadataMapV2.fill(
     IDL.Vec(
       IDL.Tuple(
@@ -82,10 +94,6 @@ export const idlFactory = ({ IDL }) => {
       )
     )
   );
-  const AuthnMethodProtection = IDL.Variant({
-    'Protected' : IDL.Null,
-    'Unprotected' : IDL.Null,
-  });
   const PublicKeyAuthn = IDL.Record({ 'pubkey' : PublicKey });
   const WebAuthn = IDL.Record({
     'pubkey' : PublicKey,
@@ -95,16 +103,11 @@ export const idlFactory = ({ IDL }) => {
     'PubKey' : PublicKeyAuthn,
     'WebAuthn' : WebAuthn,
   });
-  const AuthnMethodPurpose = IDL.Variant({
-    'Recovery' : IDL.Null,
-    'Authentication' : IDL.Null,
-  });
   const AuthnMethodData = IDL.Record({
+    'security_settings' : AuthnMethodSecuritySettings,
     'metadata' : MetadataMapV2,
-    'protection' : AuthnMethodProtection,
     'last_authentication' : IDL.Opt(Timestamp),
     'authn_method' : AuthnMethod,
-    'purpose' : AuthnMethodPurpose,
   });
   const AuthnMethodAddError = IDL.Variant({ 'InvalidMetadata' : IDL.Text });
   const AuthnMethodMetadataReplaceError = IDL.Variant({

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -46,6 +46,8 @@ export interface AuthnMethodRegistrationInfo {
   'expiration' : Timestamp,
   'authn_method' : [] | [AuthnMethodData],
 }
+export type AuthnMethodReplaceError = { 'AuthnMethodNotFound' : null } |
+  { 'InvalidMetadata' : string };
 export interface AuthnMethodSecuritySettings {
   'protection' : AuthnMethodProtection,
   'purpose' : AuthnMethodPurpose,
@@ -276,6 +278,11 @@ export interface _SERVICE {
     [IdentityNumber, PublicKey],
     { 'Ok' : null } |
       { 'Err' : null }
+  >,
+  'authn_method_replace' : ActorMethod<
+    [IdentityNumber, PublicKey, AuthnMethodData],
+    { 'Ok' : null } |
+      { 'Err' : AuthnMethodReplaceError }
   >,
   'captcha_create' : ActorMethod<[], { 'Ok' : Challenge } | { 'Err' : null }>,
   'create_challenge' : ActorMethod<[], Challenge>,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -31,11 +31,10 @@ export type AuthnMethod = { 'PubKey' : PublicKeyAuthn } |
   { 'WebAuthn' : WebAuthn };
 export type AuthnMethodAddError = { 'InvalidMetadata' : string };
 export interface AuthnMethodData {
+  'security_settings' : AuthnMethodSecuritySettings,
   'metadata' : MetadataMapV2,
-  'protection' : AuthnMethodProtection,
   'last_authentication' : [] | [Timestamp],
   'authn_method' : AuthnMethod,
-  'purpose' : AuthnMethodPurpose,
 }
 export type AuthnMethodMetadataReplaceError = { 'AuthnMethodNotFound' : null } |
   { 'InvalidMetadata' : string };
@@ -46,6 +45,10 @@ export type AuthnMethodPurpose = { 'Recovery' : null } |
 export interface AuthnMethodRegistrationInfo {
   'expiration' : Timestamp,
   'authn_method' : [] | [AuthnMethodData],
+}
+export interface AuthnMethodSecuritySettings {
+  'protection' : AuthnMethodProtection,
+  'purpose' : AuthnMethodPurpose,
 }
 export interface BufferedArchiveEntry {
   'sequence_number' : bigint,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -337,10 +337,14 @@ type AuthnMethodPurpose = variant {
     Authentication;
 };
 
-type AuthnMethodData = record {
-    authn_method: AuthnMethod;
+type AuthnMethodSecuritySettings = record {
     protection: AuthnMethodProtection;
     purpose: AuthnMethodPurpose;
+};
+
+type AuthnMethodData = record {
+    authn_method: AuthnMethod;
+    security_settings: AuthnMethodSecuritySettings;
     // contains the following fields of the DeviceWithUsage type:
     // - alias
     // - origin

--- a/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
+++ b/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
@@ -8,11 +8,13 @@ use canister_tests::framework::{
 };
 use ic_test_state_machine_client::CallError;
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, AuthnMethodPurpose, MetadataEntryV2, WebAuthn,
+    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose,
+    AuthnMethodSecuritySettings, MetadataEntryV2, WebAuthn,
 };
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 use std::time::Duration;
+use AuthnMethodProtection::Unprotected;
 
 const DAY_SECONDS: u64 = 24 * 60 * 60;
 const MONTH_SECONDS: u64 = 30 * DAY_SECONDS;
@@ -269,7 +271,10 @@ fn authn_methods_all_types() -> Vec<(String, AuthnMethodData)> {
             "webauthn_recovery".to_string(),
             AuthnMethodData {
                 authn_method: webauthn_authn_method,
-                purpose: AuthnMethodPurpose::Recovery,
+                security_settings: AuthnMethodSecuritySettings {
+                    purpose: AuthnMethodPurpose::Recovery,
+                    protection: Unprotected,
+                },
                 metadata: HashMap::from([ii_domain_entry.clone()]),
                 ..test_authn_method()
             },

--- a/src/internet_identity/tests/integration/v2_api/authn_method_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_metadata.rs
@@ -9,7 +9,8 @@ use canister_tests::framework::{
 use ic_test_state_machine_client::CallError;
 use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethodData, AuthnMethodMetadataReplaceError, AuthnMethodPurpose, MetadataEntryV2,
+    AuthnMethodData, AuthnMethodMetadataReplaceError, AuthnMethodProtection, AuthnMethodPurpose,
+    AuthnMethodSecuritySettings, MetadataEntryV2,
 };
 use regex::Regex;
 use serde_bytes::ByteBuf;
@@ -82,7 +83,10 @@ fn should_replace_authn_method_metadata() -> Result<(), CallError> {
                 MetadataEntryV2::String("recovery_phrase".to_string()),
             ),
         ]),
-        purpose: AuthnMethodPurpose::Recovery,
+        security_settings: AuthnMethodSecuritySettings {
+            purpose: AuthnMethodPurpose::Recovery,
+            protection: AuthnMethodProtection::Unprotected,
+        },
         ..sample_pubkey_authn_method(0)
     };
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);

--- a/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
@@ -2,8 +2,9 @@ use canister_tests::api::internet_identity::api_v2;
 use ic_cdk::api::management_canister::main::CanisterId;
 use ic_test_state_machine_client::StateMachine;
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, ChallengeAttempt,
-    IdentityNumber, MetadataEntryV2, PublicKeyAuthn, WebAuthn,
+    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose,
+    AuthnMethodSecuritySettings, ChallengeAttempt, IdentityNumber, MetadataEntryV2, PublicKeyAuthn,
+    WebAuthn,
 };
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
@@ -43,8 +44,10 @@ pub fn test_authn_method() -> AuthnMethodData {
             pubkey: ByteBuf::from(vec![0; 32]),
         }),
         metadata: Default::default(),
-        protection: AuthnMethodProtection::Unprotected,
-        purpose: AuthnMethodPurpose::Authentication,
+        security_settings: AuthnMethodSecuritySettings {
+            protection: AuthnMethodProtection::Unprotected,
+            purpose: AuthnMethodPurpose::Authentication,
+        },
         last_authentication: None,
     }
 }
@@ -157,13 +160,19 @@ pub fn sample_authn_methods() -> Vec<AuthnMethodData> {
                 MetadataEntryV2::String("recovery_phrase".to_string()),
             ),
         ]),
-        purpose: AuthnMethodPurpose::Recovery,
+        security_settings: AuthnMethodSecuritySettings {
+            protection: AuthnMethodProtection::Protected,
+            purpose: AuthnMethodPurpose::Recovery,
+        },
         ..sample_pubkey_authn_method(2)
     };
 
     let authn_method4 = AuthnMethodData {
         metadata: HashMap::default(),
-        purpose: AuthnMethodPurpose::Recovery,
+        security_settings: AuthnMethodSecuritySettings {
+            protection: AuthnMethodProtection::Unprotected,
+            purpose: AuthnMethodPurpose::Recovery,
+        },
         ..sample_webauthn_authn_method(3)
     };
 

--- a/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
@@ -20,7 +20,7 @@ fn should_get_identity_authn_info() -> Result<(), CallError> {
         identity_authn_info.authn_methods,
         authn_methods
             .iter()
-            .filter(|x| x.purpose == AuthnMethodPurpose::Authentication)
+            .filter(|x| x.security_settings.purpose == AuthnMethodPurpose::Authentication)
             .map(|x| x.authn_method.clone())
             .collect::<Vec<_>>()
     );
@@ -28,7 +28,7 @@ fn should_get_identity_authn_info() -> Result<(), CallError> {
         identity_authn_info.recovery_authn_methods,
         authn_methods
             .iter()
-            .filter(|x| x.purpose == AuthnMethodPurpose::Recovery)
+            .filter(|x| x.security_settings.purpose == AuthnMethodPurpose::Recovery)
             .map(|x| x.authn_method.clone())
             .collect::<Vec<_>>()
     );

--- a/src/internet_identity_interface/src/internet_identity/conversions.rs
+++ b/src/internet_identity_interface/src/internet_identity/conversions.rs
@@ -176,8 +176,10 @@ impl From<DeviceWithUsage> for AuthnMethodData {
                 .into_iter()
                 .map(|(key, value)| (key, MetadataEntryV2::from(value)))
                 .collect(),
-            protection: AuthnMethodProtection::from(device_data.protection),
-            purpose: AuthnMethodPurpose::from(device_data.purpose),
+            security_settings: AuthnMethodSecuritySettings {
+                protection: AuthnMethodProtection::from(device_data.protection),
+                purpose: AuthnMethodPurpose::from(device_data.purpose),
+            },
             last_authentication: device_data.last_usage,
         }
     }
@@ -290,9 +292,9 @@ impl TryFrom<AuthnMethodData> for DeviceWithUsage {
             pubkey,
             alias,
             credential_id,
-            purpose: Purpose::from(data.purpose),
+            purpose: Purpose::from(data.security_settings.purpose),
             key_type,
-            protection: DeviceProtection::from(data.protection),
+            protection: DeviceProtection::from(data.security_settings.protection),
             origin,
             last_usage: data.last_authentication,
             metadata: Some(

--- a/src/internet_identity_interface/src/internet_identity/conversions/test.rs
+++ b/src/internet_identity_interface/src/internet_identity/conversions/test.rs
@@ -1,8 +1,9 @@
 use crate::internet_identity::conversions::AuthnMethodConversionError;
 use crate::internet_identity::types as ii_types;
 use crate::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, DeviceProtection,
-    DeviceWithUsage, KeyType, MetadataEntry, MetadataEntryV2, PublicKeyAuthn, Purpose, WebAuthn,
+    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose,
+    AuthnMethodSecuritySettings, DeviceProtection, DeviceWithUsage, KeyType, MetadataEntry,
+    MetadataEntryV2, PublicKeyAuthn, Purpose, WebAuthn,
 };
 use ii_types::{DeviceData, WebAuthnCredential};
 use serde_bytes::ByteBuf;
@@ -140,8 +141,10 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
                 MetadataEntryV2::String("some data".to_string()),
             ),
         ]),
-        purpose: AuthnMethodPurpose::Recovery,
-        protection: AuthnMethodProtection::Protected,
+        security_settings: AuthnMethodSecuritySettings {
+            protection: AuthnMethodProtection::Protected,
+            purpose: AuthnMethodPurpose::Recovery,
+        },
         last_authentication: Some(123456789),
     };
     let device2 = DeviceWithUsage {
@@ -163,7 +166,6 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
             pubkey: pubkey.clone(),
             credential_id: credential_id.clone(),
         }),
-        purpose: AuthnMethodPurpose::Authentication,
         metadata: HashMap::from([
             (ALIAS.to_string(), MetadataEntryV2::String(alias.clone())),
             (
@@ -175,7 +177,10 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
                 MetadataEntryV2::String("some data".to_string()),
             ),
         ]),
-        protection: AuthnMethodProtection::Unprotected,
+        security_settings: AuthnMethodSecuritySettings {
+            protection: AuthnMethodProtection::Unprotected,
+            purpose: AuthnMethodPurpose::Authentication,
+        },
         last_authentication: None,
     };
 
@@ -192,7 +197,6 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
             pubkey,
             credential_id,
         }),
-        purpose: AuthnMethodPurpose::Authentication,
         metadata: HashMap::from([
             (
                 AUTHENTICATOR_ATTACHMENT.to_string(),
@@ -203,7 +207,10 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
                 MetadataEntryV2::String("some data".to_string()),
             ),
         ]),
-        protection: AuthnMethodProtection::Unprotected,
+        security_settings: AuthnMethodSecuritySettings {
+            purpose: AuthnMethodPurpose::Authentication,
+            protection: AuthnMethodProtection::Unprotected,
+        },
         last_authentication: None,
     };
 

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -43,15 +43,20 @@ pub enum AuthnMethod {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct AuthnMethodSecuritySettings {
+    pub protection: AuthnMethodProtection,
+    pub purpose: AuthnMethodPurpose,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct AuthnMethodData {
     pub authn_method: AuthnMethod,
+    pub security_settings: AuthnMethodSecuritySettings,
     // contains now the following fields
     // - alias
     // - origin
     // - key_type: reduced to "platform", "cross_platform" on migration
     pub metadata: HashMap<String, MetadataEntryV2>,
-    pub protection: AuthnMethodProtection,
-    pub purpose: AuthnMethodPurpose,
     // last usage timestamp cannot be written and will always be ignored on write
     pub last_authentication: Option<Timestamp>,
 }


### PR DESCRIPTION
This PR refactors `AuthnMethodData` to group together security relevant,
modifiable fields. It allows to later introduce a method to update
these fields specifically which will require additional security
measures compared to modifying the `metadata`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

