### PR TITLE
Rename authn method registration types and methods

### DIFF
--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -160,7 +160,7 @@ pub fn authn_method_remove(
     .map(|(x,)| x)
 }
 
-pub fn tentative_authn_method_registration_mode_enter(
+pub fn authn_method_registration_mode_enter(
     env: &StateMachine,
     canister_id: CanisterId,
     sender: Principal,
@@ -170,13 +170,13 @@ pub fn tentative_authn_method_registration_mode_enter(
         env,
         canister_id,
         sender,
-        "tentative_authn_method_registration_mode_enter",
+        "authn_method_registration_mode_enter",
         (identity_number,),
     )
     .map(|(x,)| x)
 }
 
-pub fn tentative_authn_method_registration_mode_exit(
+pub fn authn_method_registration_mode_exit(
     env: &StateMachine,
     canister_id: CanisterId,
     sender: Principal,
@@ -186,40 +186,40 @@ pub fn tentative_authn_method_registration_mode_exit(
         env,
         canister_id,
         sender,
-        "tentative_authn_method_registration_mode_exit",
+        "authn_method_registration_mode_exit",
         (identity_number,),
     )
     .map(|(x,)| x)
 }
 
-pub fn tentative_authn_method_add(
+pub fn authn_method_register(
     env: &StateMachine,
     canister_id: CanisterId,
     identity_number: IdentityNumber,
     authn_method: &AuthnMethodData,
-) -> Result<Result<TentativeAuthnMethodAddInfo, TentativeAuthnMethodAddError>, CallError> {
+) -> Result<Result<AuthnMethodConfirmationCode, AuthnMethodRegisterError>, CallError> {
     call_candid(
         env,
         canister_id,
-        "tentative_authn_method_add",
+        "authn_method_register",
         (identity_number, authn_method),
     )
     .map(|(x,)| x)
 }
 
-pub fn tentative_authn_method_verify(
+pub fn authn_method_confirm(
     env: &StateMachine,
     canister_id: CanisterId,
     sender: Principal,
     identity_number: IdentityNumber,
-    verification_code: &str,
-) -> Result<Result<(), TentativeAuthnMethodVerificationError>, CallError> {
+    confirmation_code: &str,
+) -> Result<Result<(), AuthnMethodConfirmationError>, CallError> {
     call_candid_as(
         env,
         canister_id,
         sender,
-        "tentative_authn_method_verify",
-        (identity_number, verification_code),
+        "authn_method_confirm",
+        (identity_number, confirmation_code),
     )
     .map(|(x,)| x)
 }

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -30,6 +30,13 @@ export interface ArchiveInfo {
 export type AuthnMethod = { 'PubKey' : PublicKeyAuthn } |
   { 'WebAuthn' : WebAuthn };
 export type AuthnMethodAddError = { 'InvalidMetadata' : string };
+export interface AuthnMethodConfirmationCode {
+  'confirmation_code' : string,
+  'expiration' : Timestamp,
+}
+export type AuthnMethodConfirmationError = { 'RegistrationModeOff' : null } |
+  { 'NoAuthnMethodToConfirm' : null } |
+  { 'WrongCode' : { 'retries_left' : number } };
 export interface AuthnMethodData {
   'security_settings' : AuthnMethodSecuritySettings,
   'metadata' : MetadataMapV2,
@@ -42,6 +49,9 @@ export type AuthnMethodProtection = { 'Protected' : null } |
   { 'Unprotected' : null };
 export type AuthnMethodPurpose = { 'Recovery' : null } |
   { 'Authentication' : null };
+export type AuthnMethodRegisterError = { 'RegistrationModeOff' : null } |
+  { 'RegistrationAlreadyInProgress' : null } |
+  { 'InvalidMetadata' : string };
 export interface AuthnMethodRegistrationInfo {
   'expiration' : Timestamp,
   'authn_method' : [] | [AuthnMethodData],
@@ -230,18 +240,6 @@ export interface StreamingCallbackHttpResponse {
 export type StreamingStrategy = {
     'Callback' : { 'token' : Token, 'callback' : [Principal, string] }
   };
-export type TentativeAuthnMethodAddError = { 'RegistrationModeOff' : null } |
-  { 'VerificationAlreadyInProgress' : null } |
-  { 'InvalidMetadata' : string };
-export interface TentativeAuthnMethodAddInfo {
-  'expiration' : Timestamp,
-  'verification_code' : string,
-}
-export type TentativeAuthnMethodVerificationError = {
-    'NoAuthnMethodToVerify' : null
-  } |
-  { 'RegistrationModeOff' : null } |
-  { 'WrongCode' : { 'retries_left' : number } };
 export type Timestamp = bigint;
 export type Token = {};
 export type UserKey = PublicKey;
@@ -272,10 +270,30 @@ export interface _SERVICE {
     { 'Ok' : null } |
       { 'Err' : AuthnMethodAddError }
   >,
+  'authn_method_confirm' : ActorMethod<
+    [IdentityNumber, string],
+    { 'Ok' : null } |
+      { 'Err' : AuthnMethodConfirmationError }
+  >,
   'authn_method_metadata_replace' : ActorMethod<
     [IdentityNumber, PublicKey, MetadataMapV2],
     { 'Ok' : null } |
       { 'Err' : AuthnMethodMetadataReplaceError }
+  >,
+  'authn_method_register' : ActorMethod<
+    [IdentityNumber, AuthnMethodData],
+    { 'Ok' : AuthnMethodConfirmationCode } |
+      { 'Err' : AuthnMethodRegisterError }
+  >,
+  'authn_method_registration_mode_enter' : ActorMethod<
+    [IdentityNumber],
+    { 'Ok' : { 'expiration' : Timestamp } } |
+      { 'Err' : null }
+  >,
+  'authn_method_registration_mode_exit' : ActorMethod<
+    [IdentityNumber],
+    { 'Ok' : null } |
+      { 'Err' : null }
   >,
   'authn_method_remove' : ActorMethod<
     [IdentityNumber, PublicKey],
@@ -350,26 +368,6 @@ export interface _SERVICE {
   'remove' : ActorMethod<[UserNumber, DeviceKey], undefined>,
   'replace' : ActorMethod<[UserNumber, DeviceKey, DeviceData], undefined>,
   'stats' : ActorMethod<[], InternetIdentityStats>,
-  'tentative_authn_method_add' : ActorMethod<
-    [IdentityNumber, AuthnMethodData],
-    { 'Ok' : TentativeAuthnMethodAddInfo } |
-      { 'Err' : TentativeAuthnMethodAddError }
-  >,
-  'tentative_authn_method_registration_mode_enter' : ActorMethod<
-    [IdentityNumber],
-    { 'Ok' : { 'expiration' : Timestamp } } |
-      { 'Err' : null }
-  >,
-  'tentative_authn_method_registration_mode_exit' : ActorMethod<
-    [IdentityNumber],
-    { 'Ok' : null } |
-      { 'Err' : null }
-  >,
-  'tentative_authn_method_verify' : ActorMethod<
-    [IdentityNumber, string],
-    { 'Ok' : null } |
-      { 'Err' : TentativeAuthnMethodVerificationError }
-  >,
   'update' : ActorMethod<[UserNumber, DeviceKey, DeviceData], undefined>,
   'verify_tentative_device' : ActorMethod<
     [UserNumber, string],

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -367,29 +367,29 @@ type AuthnMethodRegistrationInfo = record {
     expiration: Timestamp;
 };
 
-type TentativeAuthnMethodAddInfo = record {
-    verification_code: text;
+type AuthnMethodConfirmationCode = record {
+    confirmation_code: text;
     expiration: Timestamp;
 };
 
-type TentativeAuthnMethodAddError = variant {
+type AuthnMethodRegisterError = variant {
     // Authentication method registration mode is off, either due to timeout or because it was never enabled.
     RegistrationModeOff;
-    // There is another authentication method already added tentatively that needs to be verified first.
-    VerificationAlreadyInProgress;
+    // There is another authentication method already registered that needs to be confirmed first.
+    RegistrationAlreadyInProgress;
     // The metadata of the provided authentication method contains invalid entries.
     InvalidMetadata: text;
 };
 
-type TentativeAuthnMethodVerificationError = variant {
-    // Wrong verification code entered. Retry with correct code.
+type AuthnMethodConfirmationError = variant {
+    // Wrong confirmation code entered. Retry with correct code.
     WrongCode: record {
         retries_left: nat8
     };
     // Authentication method registration mode is off, either due to timeout or because it was never enabled.
     RegistrationModeOff;
-    // There is no tentative authentication method to be verified.
-    NoAuthnMethodToVerify;
+    // There is no registered authentication method to be confirmed.
+    NoAuthnMethodToConfirm;
 };
 
 type IdentityAuthnInfo = record {
@@ -571,25 +571,25 @@ service : (opt InternetIdentityInit) -> {
     authn_method_remove: (IdentityNumber, PublicKey) -> (variant {Ok; Err;});
 
     // Enters the authentication method registration mode for the identity.
-    // In this mode, a new authentication method can be added tentatively, which then needs to be
-    // verified before it can be used for authentication on this identity.
+    // In this mode, a new authentication method can be registered, which then needs to be
+    // confirmed before it can be used for authentication on this identity.
     // The registration mode is automatically exited after the returned expiration timestamp.
     // Requires authentication.
-    tentative_authn_method_registration_mode_enter : (IdentityNumber) -> (variant {Ok: record { expiration: Timestamp; }; Err;});
+    authn_method_registration_mode_enter : (IdentityNumber) -> (variant {Ok: record { expiration: Timestamp; }; Err;});
 
     // Exits the authentication method registration mode for the identity.
     // Requires authentication.
-    tentative_authn_method_registration_mode_exit : (IdentityNumber) -> (variant {Ok; Err;});
+    authn_method_registration_mode_exit : (IdentityNumber) -> (variant {Ok; Err;});
 
-    // Tentatively adds a new authentication method to the identity.
-    // This authentication method needs to be verified before it can be used for authentication on this identity.
-    tentative_authn_method_add: (IdentityNumber, AuthnMethodData) -> (variant {Ok: TentativeAuthnMethodAddInfo; Err: TentativeAuthnMethodAddError;});
+    // Registers a new authentication method to the identity.
+    // This authentication method needs to be confirmed before it can be used for authentication on this identity.
+    authn_method_register: (IdentityNumber, AuthnMethodData) -> (variant {Ok: AuthnMethodConfirmationCode; Err: AuthnMethodRegisterError;});
 
-    // Verifies a previously added tentative authentication method.
-    // On successful verification, the tentative authentication method is permanently added to the identity and can
+    // Confirms a previously registered authentication method.
+    // On successful confirmation, the authentication method is permanently added to the identity and can
     // subsequently be used for authentication for that identity.
     // Requires authentication.
-    tentative_authn_method_verify: (IdentityNumber, verification_code: text) -> (variant {Ok; Err: TentativeAuthnMethodVerificationError;});
+    authn_method_confirm: (IdentityNumber, confirmation_code: text) -> (variant {Ok; Err: AuthnMethodConfirmationError;});
 
     // Attribute Sharing MVP API
     // The methods below are used to generate ID-alias credentials during attribute sharing flow.

--- a/src/internet_identity/tests/integration/v2_api/mod.rs
+++ b/src/internet_identity/tests/integration/v2_api/mod.rs
@@ -1,5 +1,6 @@
 mod authn_method_add;
 mod authn_method_metadata;
+mod authn_method_registration;
 mod authn_method_remove;
 mod authn_method_replace;
 mod authn_method_security_settings;
@@ -8,4 +9,3 @@ mod identity_authn_info;
 mod identity_info;
 mod identity_metadata;
 mod identity_register;
-mod tentative_authn_method;

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -115,21 +115,21 @@ pub struct RegistrationModeInfo {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub struct TentativeAuthnMethodAddInfo {
-    pub verification_code: String,
+pub struct AuthnMethodConfirmationCode {
+    pub confirmation_code: String,
     pub expiration: Timestamp,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub enum TentativeAuthnMethodAddError {
+pub enum AuthnMethodRegisterError {
     RegistrationModeOff,
-    VerificationAlreadyInProgress,
+    RegistrationAlreadyInProgress,
     InvalidMetadata(String),
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub enum TentativeAuthnMethodVerificationError {
+pub enum AuthnMethodConfirmationError {
     WrongCode { retries_left: u8 },
     RegistrationModeOff,
-    NoAuthnMethodToVerify,
+    NoAuthnMethodToConfirm,
 }


### PR DESCRIPTION
This PR renames the authn method registration related methods and types to
* remove the word tentative
* change add / verify to register / confirm

This makes the API v2 align with the decision taken here: https://github.com/dfinity/internet-identity/pull/1581#issuecomment-1547819194

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5958b9193/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
