### PR TITLE
Use correct node version in clean build

### DIFF
--- a/.github/actions/check-build/action.yml
+++ b/.github/actions/check-build/action.yml
@@ -12,6 +12,7 @@ runs:
   using: "composite"
   steps:
     - uses: ./.github/actions/bootstrap
+    - uses: ./.github/actions/setup-node
 
     # run the build
     - run: npm ci

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -850,7 +850,6 @@ jobs:
 
 
   verify-clean-build-hash:
-    if: false # We skip these builds because recent GHA runner changes made the native ubuntu builds non-reproducible
     needs: ['clean-build', 'docker-build-internet_identity_production']
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -53,7 +53,6 @@ jobs:
 
   # Perform the clean build (non-docker), using the release as checkout
   clean-build:
-    if: false # We skip these builds because recent GHA runner changes made the native ubuntu builds non-reproducible
     runs-on: ${{ matrix.os }}
     needs: latest-release
     strategy:

--- a/scripts/build
+++ b/scripts/build
@@ -95,6 +95,22 @@ then
     exit 1
 fi
 
+# Check for exact node version
+if [[ "$(node --version)" !=  "v$(cat .node-version)" ]]
+then
+    echo; echo
+    echo "!!!WARNING!!!: could not find node with exact expected version: v$(cat .node-version)"
+    # On CI we abort
+    if [ -n "${CI:-}" ]
+    then
+        exit 1
+    fi
+    # If the node version doesn't match 100% the build might still succeed though is less likely
+    # to be reproducible. For developer convenience we still try to go through.
+    echo "This might cause build or reproducibility issues."
+    echo; echo
+fi
+
 # Builds a single canister
 # build_canister CANISTER EXTRA_BUILD_ARGS...
 # CANISTER: possible values: [internet_identity, archive]


### PR DESCRIPTION
The clean build was using whatever node version was in the environment. This updates the `check-build` action to use the `setup-node` action, so that it uses the expected node version.

A version check is added to the build script. On CI, this aborts the build. Not on CI, this issues a warning.

The clean build reproducibility checks are also re-enabled. The reproducibility issues were caused by differences in the compressed assets. It looks like node statically links zlib, and it looks like the zlib version from the GHA environment's node differs from the one in our docker setup (set through `.node-version`).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
