### PR TITLE
Replace jose with custom Base64UrlEncode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "buffer": "^6.0.3",
         "dompurify": "^3.0.6",
         "idb-keyval": "^6.2.1",
-        "jose": "^5.1.3",
         "lit-html": "^2.7.2",
         "marked": "^11.0.0",
         "process": "^0.11.10",
@@ -8414,14 +8413,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jose": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.3.tgz",
-      "integrity": "sha512-GPExOkcMsCLBTi1YetY2LmkoY559fss0+0KVa6kOfb2YFe84nAM7Nm/XzuZozah4iHgmBGrCOHL5/cy670SBRw==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -21131,11 +21122,6 @@
           }
         }
       }
-    },
-    "jose": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.3.tgz",
-      "integrity": "sha512-GPExOkcMsCLBTi1YetY2LmkoY559fss0+0KVa6kOfb2YFe84nAM7Nm/XzuZozah4iHgmBGrCOHL5/cy670SBRw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "buffer": "^6.0.3",
     "dompurify": "^3.0.6",
     "idb-keyval": "^6.2.1",
-    "jose": "^5.1.3",
     "lit-html": "^2.7.2",
     "marked": "^11.0.0",
     "process": "^0.11.10",


### PR DESCRIPTION
This drops the `jose` dependency in the main II codebase to instead use the browser's `btoa` base64 support with a few tweaks to URL encode in a JWT-friendly way.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
