### PR TITLE
Fix test_app asset update

### DIFF
--- a/demos/test-app/lib.rs
+++ b/demos/test-app/lib.rs
@@ -37,9 +37,11 @@ fn update_alternative_origins(alternative_origins: String, mode: AlternativeOrig
             assets.update_asset_content(
                 ALTERNATIVE_ORIGINS_PATH,
                 alternative_origins.as_bytes().to_vec(),
+                &static_headers()
             )
         })
         .expect("Failed to update alternative origins");
+    update_root_hash()
 }
 
 pub type HeaderField = (String, String);

--- a/src/asset_util/src/lib.rs
+++ b/src/asset_util/src/lib.rs
@@ -173,6 +173,7 @@ impl CertifiedAssets {
         &mut self,
         url_path: &str,
         new_content: Vec<u8>,
+        shared_headers: &[HeaderField],
     ) -> Result<(), String> {
         let Some((headers, _)) = self.assets.get(url_path) else {
             return Err(format!("Asset {} not found.", url_path));
@@ -180,7 +181,15 @@ impl CertifiedAssets {
         let headers = headers.clone();
         let body_hash = sha2::Sha256::digest(&new_content).into();
         self.add_certification_v1(url_path, body_hash);
-        self.add_certification_v2(url_path, &headers, body_hash);
+        self.add_certification_v2(
+            url_path,
+            &shared_headers
+                .iter()
+                .chain(headers.iter())
+                .cloned()
+                .collect::<Vec<_>>(),
+            body_hash,
+        );
         self.assets
             .insert(url_path.to_string(), (headers, new_content));
         Ok(())
@@ -217,6 +226,8 @@ impl CertifiedAssets {
             .collect();
         segments.remove(0); // remove leading empty string due to absolute path
         segments.push(EXACT_MATCH_TERMINATOR.as_bytes().to_vec());
+        // delete the old certification subtree for the given path, if any
+        self.certification_v2.delete(&segments);
         segments.push(Vec::from(EXPR_HASH.as_slice()));
         segments.push(vec![]);
         segments.push(Vec::from(response_hash(headers, &body_hash)));


### PR DESCRIPTION
This PR updates the asset_util crate to also take shared headers into account and remove outdated subtrees from
the certification on asset updates.
In addition, a missing certified data update was added in the test app code.

These changes are made in preparation for the upgrade to dfx 0.15.3 that now checks asset certification (and thus surfaced this bug in the test_app).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
