### PR TITLE
Add support for different status codes to asset lib

### DIFF
--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -55,12 +55,13 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
         },
         probably_an_asset => match certified_asset(probably_an_asset, req.certificate_version) {
             Some(CertifiedAsset {
+                status_code,
                 mut headers,
                 content,
             }) => {
                 headers.append(&mut security_headers());
                 HttpResponse {
-                    status_code: 200,
+                    status_code,
                     headers,
                     body: ByteBuf::from(content),
                     upgrade: None,


### PR DESCRIPTION
This PR adds support for per-asset status codes in the asset lib, which is necessary to support certified redirects. We will make use of that in the test_app in an upcoming PR.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dd662977e/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

