### PR TITLE
Extend test_app to use certified redirects and actual invalid certificates

### DIFF
--- a/demos/test-app/lib.rs
+++ b/demos/test-app/lib.rs
@@ -12,6 +12,7 @@ use AlternativeOriginsMode::UncertifiedContent;
 const ALTERNATIVE_ORIGINS_PATH: &str = "/.well-known/ii-alternative-origins";
 const EVIL_ALTERNATIVE_ORIGINS_PATH: &str = "/.well-known/evil-alternative-origins";
 const EMPTY_ALTERNATIVE_ORIGINS: &str = r#"{"alternativeOrigins":[]}"#;
+const OUTDATED_INVALID_CERTIFICATE_HEADER: &str = ":2dn3omR0cmVlgwGDAYMBgwJIY2FuaXN0ZXKDAYMBggRYIF7eYW50QXA1hAANBQ4J616Ekjch0ihDxnNGwvlxxIKDgwGCBFggH4wduBeihx+gd8Oe2KvzyQxp/PEe6ustjHJNlVhLbmaDAkqAAAAAABAAAwEBgwGDAYMCTmNlcnRpZmllZF9kYXRhggNYIIA3JGAjACCVyCTmsRmhhlZDI5oDZZkhGVMbpCIFTEejggRYIIMJ950nCB4emD2uvICtY5WfLhcOzb2BaqH4EvUGTX2xggRYIFfnBG3quMbImRDu81QLZKq0ADXD75bQIoPHA2y4JRQVggRYIETEKmiZ1Lflrx8sIiDUOqBdb7X+mJ5+kEturndxJYzeggRYINPKhi8ZGTDLJJGHdaSlL3lxf8JFGiBHe3FVp4y/myCvggRYIIZ883QyMwhObp/SFU8xtXu8w8xGgwEWfkJYAWqC9dNSgwGCBFgg49iYnFVeAADyzEwGNNe…Bcfct/T4ZWVYbJe/P3gUbLOS8n9uDAklodHRwX2V4cHKDAYMBgwGCBFgggaSHI9J56LbuKjb58O8AWYlQNqTWZBxB58L7Y6u9j2ODAksud2VsbC1rbm93boMBggRYIJY8druSGXKdr/LHH3Kr/F+Vo9VwgluKJZS6HxkTrIeUgwJWaWktYWx0ZXJuYXRpdmUtb3JpZ2luc4MCQzwkPoMCWCBiB64Pds+kxrd7O3KKhS3TAcooPTqycnGLKWuiy3dP6IMCQIMCWCCaryvDtyyZdDWHqiLmkc63lZuPrBF2Tt6ULsG0LUkWcIIDQIIEWCAYA1f5ooQFb7bDDkKE0QhYJLkfsn2j1GCIGJvp8r8ucYIEWCB28Uo/B0pARPP3FnDUBj83i4NpGPehI4IGGI2I2iOQhg==:, expr_path=:2dn3hGlodHRwX2V4cHJrLndlbGwta25vd252aWktYWx0ZXJuYXRpdmUtb3JpZ2luc2M8JD4=:, version=2";
 
 thread_local! {
     static ASSETS: RefCell<CertifiedAssets> = RefCell::new(CertifiedAssets::default());
@@ -29,18 +30,29 @@ fn whoami() -> Principal {
 /// * mode: enum that allows changing the behaviour of the asset. See [AlternativeOriginsMode].
 #[update]
 fn update_alternative_origins(alternative_origins: String, mode: AlternativeOriginsMode) {
+    ASSETS
+        .with_borrow_mut(|assets| {
+            let asset = Asset {
+                url_path: ALTERNATIVE_ORIGINS_PATH.to_string(),
+                content: alternative_origins.as_bytes().to_vec(),
+                encoding: ContentEncoding::Identity,
+                content_type: ContentType::JSON,
+            };
+            match &mode {
+                CertifiedContent | UncertifiedContent => {
+                    assets.certify_asset(asset, &static_headers())
+                }
+                Redirect { location } => assets.certify_redirect(
+                    ALTERNATIVE_ORIGINS_PATH,
+                    location.as_str(),
+                    &static_headers(),
+                ).expect("Failed to certify alternative origins redirect"),
+            }
+        });
+
     ALTERNATIVE_ORIGINS_MODE.with(|m| {
         m.replace(mode);
     });
-    ASSETS
-        .with_borrow_mut(|assets| {
-            assets.update_asset_content(
-                ALTERNATIVE_ORIGINS_PATH,
-                alternative_origins.as_bytes().to_vec(),
-                &static_headers()
-            )
-        })
-        .expect("Failed to update alternative origins");
     update_root_hash()
 }
 
@@ -80,43 +92,44 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
 
     match path {
         ALTERNATIVE_ORIGINS_PATH => ALTERNATIVE_ORIGINS_MODE.with_borrow(|mode| {
-            let mut certified_response = certified_ok_response(path, req.certificate_version)
+            let mut certified_response = certified_response(path, req.certificate_version)
                 .expect("/.well-known/ii-alternative-origins must be certified");
             match mode {
-                CertifiedContent => {
-                    // don't tamper with the certified response
-                }
                 UncertifiedContent => {
-                    // drop the IC-Certificate and IC-Certificate-Expr headers
-                    certified_response.headers.retain(|(header_name, _)| {
-                        !header_name.to_lowercase().starts_with("ic-certificate")
-                    });
-                }
-                Redirect { location } => {
-                    // Add a Location header and modify status code to 302 to indicate redirect
-                    // Keep the content and certification headers as then the response remains valid
-                    // under certification v1.
-                    certified_response
+                    certified_response.headers = certified_response
                         .headers
-                        .push(("Location".to_string(), location.clone()));
-                    certified_response.status_code = 302;
+                        .into_iter()
+                        .map(|(header_name, header_value)| {
+                            // Modify the IC-Certificate header to make certification invalid
+                            // Note: we cannot simply drop the header because then the local replica (dfx 0.15 and later)
+                            // will skip the certification check altogether.
+                            if header_name == "IC-Certificate" {
+                                (header_name, OUTDATED_INVALID_CERTIFICATE_HEADER.to_string())
+                            } else {
+                                (header_name, header_value)
+                            }
+                        })
+                        .collect::<_>()
+                }
+                Redirect { .. } | CertifiedContent => {
+                    // don't tamper with the certified response
                 }
             }
             certified_response
         }),
-        path => certified_ok_response(path, req.certificate_version)
+        path => certified_response(path, req.certificate_version)
             .unwrap_or_else(|| not_found_response(path)),
     }
 }
 
-fn certified_ok_response(url: &str, max_certificate_version: Option<u16>) -> Option<HttpResponse> {
+fn certified_response(url: &str, max_certificate_version: Option<u16>) -> Option<HttpResponse> {
     let maybe_asset =
-        ASSETS.with_borrow(|assets| assets.certified_asset(url, max_certificate_version, None));
+        ASSETS.with_borrow(|assets| assets.get_certified_asset(url, max_certificate_version, None));
     maybe_asset.map(|asset| {
         let mut headers = asset.headers;
         headers.extend(static_headers());
         HttpResponse {
-            status_code: 200,
+            status_code: asset.status_code,
             headers,
             body: ByteBuf::from(asset.content),
         }

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -415,7 +415,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
     let sigs_root_hash =
         SIGNATURES.with_borrow(|sigs| pruned(labeled_hash(LABEL_SIG, &sigs.root_hash())));
     let maybe_asset = ASSETS.with_borrow(|assets| {
-        assets.certified_asset(path, req.certificate_version, Some(sigs_root_hash))
+        assets.get_certified_asset(path, req.certificate_version, Some(sigs_root_hash))
     });
 
     let mut headers = static_headers();

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -199,7 +199,7 @@ pub fn content_security_policy_header() -> String {
 
 fn certified_asset(asset_name: &str, certificate_version: Option<u16>) -> Option<CertifiedAsset> {
     state::assets_and_signatures(|assets, sigs| {
-        assets.certified_asset(
+        assets.get_certified_asset(
             asset_name,
             certificate_version,
             Some(pruned(labeled_hash(LABEL_SIG, &sigs.root_hash()))),


### PR DESCRIPTION
This PR changes the test_app to certify redirects properly and to use an actually invalid certificate header rather than simply dropping them in the "uncertified" configuration.

To make this possible, the asset_util crate is refactored a bit:
* allow clients to (re-)certify individual assets (just extracts the loop body of `certify_assets`)
* allow clients to specify certified redirects
* the `certified_asset` method is renamed to `get_certified_asset` to make it more distinct from `certify_asset`

This PR is a preparation for the switch to DFX 0.15.3.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5e1eb355a/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
