### PR TITLE
Prune expired signatures in VC code

### DIFF
--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -433,7 +433,10 @@ fn static_headers() -> Vec<(String, String)> {
 fn main() {}
 
 fn add_signature(sigs: &mut SignatureMap, msg_hash: Hash, seed: Hash) {
-    let signature_expires_at = time().saturating_add(CERTIFICATE_VALIDITY_PERIOD_NS);
+    const MAX_SIGS_TO_PRUNE: usize = 50;
+    let now = time();
+    sigs.prune_expired(now, MAX_SIGS_TO_PRUNE);
+    let signature_expires_at = now.saturating_add(CERTIFICATE_VALIDITY_PERIOD_NS);
     sigs.put(hash_bytes(seed), msg_hash, signature_expires_at);
 }
 

--- a/src/canister_sig_util/src/signature_map/test.rs
+++ b/src/canister_sig_util/src/signature_map/test.rs
@@ -42,7 +42,7 @@ fn test_signature_expiration() {
     map.put(&seed(2), message(1), 15);
     map.put(&seed(2), message(2), 25);
 
-    assert_eq!(2, map.prune_expired(/*time now*/ 19 /*max_to_prune*/));
+    assert_eq!(2, map.prune_expired(/*time now*/ 19));
     assert!(map.witness(&seed(1), message(1)).is_none());
     assert!(map.witness(&seed(2), message(1)).is_none());
 
@@ -54,16 +54,16 @@ fn test_signature_expiration() {
 fn test_signature_expiration_limit() {
     let mut map = SignatureMap::default();
 
-    for i in 0..10 {
-        map.put(&seed(i), message(i), 10 * i);
+    for i in 0..100 {
+        map.put(&seed(i), message(i), 10 + i);
     }
 
-    assert_eq!(5, map.prune_expired(/*time now*/ 100 /*max_to_prune*/));
+    assert_eq!(50, map.prune_expired(/*time now*/ 100));
 
-    for i in 0..5 {
+    for i in 0..50 {
         assert!(map.witness(&seed(i), message(i)).is_none());
     }
-    for i in 5..10 {
+    for i in 50..100 {
         assert!(map.witness(&seed(i), message(i)).is_some());
     }
 }


### PR DESCRIPTION
So far, signatures are not pruned in the vc issuer nor when adding new signatures for the vc flow. This will eventually lead to memory exhaustion (and might be expensive on cycles).
This PR fixes that by refactoring the library such that prune is called when adding new signatures.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


