### PR TITLE
Update using dev build README.md to correctly point to gzipped wasm

### DIFF
--- a/demos/using-dev-build/README.md
+++ b/demos/using-dev-build/README.md
@@ -48,7 +48,7 @@ This section explains how to add Internet Identity to your (local) project. Add 
 "internet_identity": {
   "type": "custom",
   "candid": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did",
-  "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm",
+  "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz",
   "remote": {
     "id": {
       "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
the current releases end in `gz`, if we're not providing the correct file ending `dfx` fails
```sh
❯ dfx deploy
Deploying all canisters.
Creating canisters...
Creating canister internet_identity...
internet_identity canister created with canister id: avqkn-guaaa-aaaaa-qaaea-cai
Building canisters...
Error: Failed while trying to deploy canisters.
Caused by: Failed while trying to deploy canisters.
  Failed to build all canisters.
    Failed while trying to build all canisters.
      Failed to download https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm to /Users/moritz/projects/ii_integration/.dfx/local/canisters/internet_identity/download-internet_identity_dev.wasm.
        Failed to download from url: https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.
          Not found: https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm
```