### PR TITLE
Add VC support for alternative origins

### DIFF
--- a/demos/test-app/src/index.tsx
+++ b/demos/test-app/src/index.tsx
@@ -360,6 +360,7 @@ let latestOpts:
   | undefined
   | {
       issuerOrigin: string;
+      derivationOrigin?: string;
       credTy: CredType;
       flowId: number;
       win: Window;
@@ -408,6 +409,7 @@ function handleFlowReady(evnt: MessageEvent) {
       },
       credentialSpec: credentialSpecs[opts.credTy],
       credentialSubject: principal,
+      derivationOrigin: opts.derivationOrigin,
     },
   };
 
@@ -458,6 +460,9 @@ const App = () => {
     "http://issuer.localhost:5173"
   );
 
+  // Alternative origin for the RP, if any
+  const [derivationOrigin, setDerivationOrigin] = useState<string>("");
+
   // Continuously incrementing flow IDs used in the JSON RPC messages
   const [nextFlowId, setNextFlowId] = useState(0);
 
@@ -486,6 +491,7 @@ const App = () => {
       flowId,
       credTy,
       issuerOrigin: issuerUrl,
+      derivationOrigin: derivationOrigin !== "" ? derivationOrigin : undefined,
       win: iiWindow,
     };
 
@@ -502,6 +508,15 @@ const App = () => {
           type="text"
           value={issuerUrl}
           onChange={(evt) => setIssuerUrl(evt.target.value)}
+        />
+      </label>
+      <label>
+        Alternative Derivation Origin:
+        <input
+          data-role="derivation-origin-rp"
+          type="text"
+          placeholder="(use default)"
+          onChange={(evt) => setDerivationOrigin(evt.target.value)}
         />
       </label>
 

--- a/src/frontend/src/flows/verifiableCredentials/abortedCredentials.json
+++ b/src/frontend/src/flows/verifiableCredentials/abortedCredentials.json
@@ -9,6 +9,7 @@
     "aborted_bad_principal_rp": "The principal provided by the relying party does not match the data Internet Identity has.",
     "aborted_no_canister_id": "Internet Identity could not find the canister for the issuer.",
     "aborted_bad_canister_id": "Internet Identity could not confirm the canister ID given for the issuer.",
+    "aborted_bad_derivation_origin_rp": "Internet Identity could not confirm the derivation origin for the relying party.",
     "notice": "We will now let the relying party know there was an issue.",
     "you_may_close": "You may now close this page."
   }

--- a/src/frontend/src/flows/verifiableCredentials/abortedCredentials.ts
+++ b/src/frontend/src/flows/verifiableCredentials/abortedCredentials.ts
@@ -15,7 +15,8 @@ export type AbortReason =
   | "issuer_api_error"
   | "bad_principal_rp"
   | "no_canister_id"
-  | "bad_canister_id";
+  | "bad_canister_id"
+  | "bad_derivation_origin_rp";
 
 /* A screen telling the user the flow was aborted and giving information
  * on why it was aborted and what they can do about it. */
@@ -42,7 +43,8 @@ const abortedCredentialsTemplate = ({
 
   const slot = html`
     <hgroup
-      data-page="vc-allow"
+      data-page="vc-aborted"
+      data-abort-reason=${reason}
       ${scrollToTop ? mount(() => window.scrollTo(0, 0)) : undefined}
     >
       <h1 class="t-title t-title--main">${copy.title}</h1>

--- a/src/frontend/src/test-e2e/verifiableCredentials/alternativeOrigins.test.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/alternativeOrigins.test.ts
@@ -102,7 +102,9 @@ test("Cannot issue credential with bad alternative RP derivation origin", async 
 
     expect(result.result).toBe("aborted");
     if (!("reason" in result)) {
-      throw new Error("brwa");
+      throw new Error(
+        "Expected VC result to be aborted, got: " + JSON.stringify(result)
+      );
     }
     expect(result.reason).toBe("bad_derivation_origin_rp");
   });

--- a/src/frontend/src/test-e2e/verifiableCredentials/alternativeOrigins.test.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/alternativeOrigins.test.ts
@@ -1,0 +1,109 @@
+import { runInBrowser } from "$src/test-e2e/util";
+import { DemoAppView } from "$src/test-e2e/views";
+
+import {
+  II_URL,
+  ISSUER_APP_URL,
+  TEST_APP_CANONICAL_URL,
+  TEST_APP_NICE_URL,
+} from "$src/test-e2e/constants";
+
+import {
+  authenticateToRelyingParty,
+  getVCPresentation,
+  getVCPresentation_,
+  register,
+  registerWithIssuer,
+} from "./utils";
+
+test("Can issue credential with alternative RP derivation origin", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    await browser.url(II_URL);
+
+    const authConfig = await register["webauthn"](browser);
+
+    // 1. Add employee
+
+    const { msg: _msg, principal: _principal } = await registerWithIssuer({
+      browser,
+      issuer: ISSUER_APP_URL,
+      authConfig,
+    });
+
+    // 2. Do the flow without alt origins
+
+    const vcTestApp = await authenticateToRelyingParty({
+      browser,
+      issuer: ISSUER_APP_URL,
+      authConfig,
+      relyingParty: TEST_APP_CANONICAL_URL,
+    });
+    const principalRP = await vcTestApp.getPrincipal();
+    const { alias: alias_ } = await getVCPresentation({
+      vcTestApp,
+      browser,
+      authConfig,
+    });
+    const alias = JSON.parse(alias_);
+
+    // 3. Do the flow WITH alt origins
+    const vcTestAppAlt = await authenticateToRelyingParty({
+      browser,
+      issuer: ISSUER_APP_URL,
+      authConfig,
+      relyingParty: TEST_APP_NICE_URL,
+      derivationOrigin: TEST_APP_CANONICAL_URL,
+    });
+    const principalRPAlt = await vcTestAppAlt.getPrincipal();
+    expect(principalRPAlt).toBe(principalRP);
+
+    const { alias: aliasAlt_ } = await getVCPresentation({
+      vcTestApp: vcTestAppAlt,
+      browser,
+      authConfig,
+    });
+
+    const aliasAlt = JSON.parse(aliasAlt_);
+    expect(aliasAlt.sub).toBe(alias.sub);
+  });
+}, 300_000);
+
+test("Cannot issue credential with bad alternative RP derivation origin", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    await browser.url(II_URL);
+
+    const authConfig = await register["webauthn"](browser);
+
+    // 1. Add employee
+
+    const { msg: _msg, principal: _principal } = await registerWithIssuer({
+      browser,
+      issuer: ISSUER_APP_URL,
+      authConfig,
+    });
+
+    // 2. Do the flow WITH alt origins RESET
+
+    const vcTestAppAlt = await authenticateToRelyingParty({
+      browser,
+      issuer: ISSUER_APP_URL,
+      authConfig,
+      relyingParty: TEST_APP_NICE_URL,
+      derivationOrigin: TEST_APP_CANONICAL_URL,
+    });
+
+    await new DemoAppView(browser).resetAlternativeOrigins();
+
+    const result = await getVCPresentation_({
+      vcTestApp: vcTestAppAlt,
+      browser,
+      authConfig,
+    });
+
+    expect(result.result).toBe("aborted");
+    if (!("reason" in result)) {
+      throw new Error("brwa");
+    }
+    expect(result.reason).toBe("bad_derivation_origin_rp");
+  });
+}, 300_000);

--- a/src/frontend/src/test-e2e/verifiableCredentials/index.test.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/index.test.ts
@@ -1,0 +1,111 @@
+import { runInBrowser } from "$src/test-e2e/util";
+
+import {
+  APPLE_USER_AGENT,
+  II_URL,
+  ISSUER_APP_URL,
+  ISSUER_APP_URL_LEGACY,
+  TEST_APP_CANONICAL_URL,
+  TEST_APP_CANONICAL_URL_LEGACY,
+} from "$src/test-e2e/constants";
+
+import {
+  authenticateToRelyingParty,
+  getVCPresentation,
+  register,
+  registerWithIssuer,
+} from "./utils";
+
+test("Can add employee on issuer app", async () => {
+  await runInBrowser(async (browser: WebdriverIO.Browser) => {
+    const authConfig = await register["webauthn"](browser);
+
+    const { msg, principal } = await registerWithIssuer({
+      browser,
+      authConfig,
+      issuer: ISSUER_APP_URL,
+    });
+
+    expect(msg).toContain("Added");
+    expect(msg).toContain(principal);
+  });
+}, 300_000);
+
+const getDomain = (url: string) => url.split(".").slice(1).join(".");
+
+// The different test configs (different URLs, differnet auth methods)
+const testConfigs: Array<{
+  relyingParty: string;
+  issuer: string;
+  authType: "pin" | "webauthn";
+}> = [
+  {
+    relyingParty: TEST_APP_CANONICAL_URL_LEGACY,
+    issuer: ISSUER_APP_URL,
+    authType: "webauthn",
+  },
+  {
+    relyingParty: TEST_APP_CANONICAL_URL,
+    issuer: ISSUER_APP_URL_LEGACY,
+    authType: "webauthn",
+  },
+  {
+    relyingParty: TEST_APP_CANONICAL_URL,
+    issuer: ISSUER_APP_URL,
+    authType: "pin",
+  },
+];
+
+testConfigs.forEach(({ relyingParty, issuer, authType }) => {
+  const testSuffix = `RP: ${getDomain(relyingParty)}, ISS: ${getDomain(
+    issuer
+  )}, auth: ${authType}`;
+
+  test(
+    "Can issue credentials " + testSuffix,
+    async () => {
+      await runInBrowser(
+        async (browser: WebdriverIO.Browser) => {
+          await browser.url(II_URL);
+
+          const authConfig = await register[authType](browser);
+
+          // 1. Add employee
+
+          const { msg: _msg, principal: _principal } = await registerWithIssuer(
+            {
+              browser,
+              issuer,
+              authConfig,
+            }
+          );
+
+          // 2. Auth to RP
+
+          const vcTestApp = await authenticateToRelyingParty({
+            browser,
+            issuer,
+            authConfig,
+            relyingParty,
+          });
+
+          const principalRP = await vcTestApp.getPrincipal();
+
+          // 3. Get VC presentation
+
+          const { alias } = await getVCPresentation({
+            vcTestApp,
+            browser,
+            authConfig,
+          });
+
+          // Perform a basic check on the alias
+          const aliasObj = JSON.parse(alias);
+          expect(aliasObj.sub).toBe(`did:icp:${principalRP}`);
+        },
+        authType === "pin" ? APPLE_USER_AGENT : undefined
+      );
+    },
+    300_000
+  );
+});

--- a/src/frontend/src/test-e2e/verifiableCredentials/utils.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/utils.ts
@@ -16,7 +16,7 @@ import {
   VcTestAppView,
 } from "$src/test-e2e/views";
 
-import { II_URL, TEST_APP_NICE_URL } from "$src/test-e2e/constants";
+import { II_URL } from "$src/test-e2e/constants";
 
 import { nonNullish } from "@dfinity/utils";
 
@@ -78,7 +78,7 @@ export const authenticateToRelyingParty = async ({
     await demoView.setDerivationOrigin(derivationOrigin);
 
     await demoView.updateAlternativeOrigins(
-      `{"alternativeOrigins":["${TEST_APP_NICE_URL}"]}`,
+      `{"alternativeOrigins":["${relyingParty}"]}`,
       "certified"
     );
 

--- a/src/frontend/src/test-e2e/verifiableCredentials/utils.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/utils.ts
@@ -1,47 +1,27 @@
-import { FLOWS } from "./flows";
+import { FLOWS } from "$src/test-e2e/flows";
 import {
   addVirtualAuthenticator,
   addWebAuthnCredential,
   getWebAuthnCredentials,
   originToRelyingPartyId,
-  runInBrowser,
   switchToPopup,
   waitToClose,
-} from "./util";
+} from "$src/test-e2e/util";
 import {
   AuthenticateView,
+  DemoAppView,
   IssuerAppView,
   PinAuthView,
   VcAllowView,
   VcTestAppView,
-} from "./views";
+} from "$src/test-e2e/views";
 
-import {
-  APPLE_USER_AGENT,
-  II_URL,
-  ISSUER_APP_URL,
-  ISSUER_APP_URL_LEGACY,
-  TEST_APP_CANONICAL_URL,
-  TEST_APP_CANONICAL_URL_LEGACY,
-} from "./constants";
+import { II_URL, TEST_APP_NICE_URL } from "$src/test-e2e/constants";
 
-test("Can add employee on issuer app", async () => {
-  await runInBrowser(async (browser: WebdriverIO.Browser) => {
-    const authConfig = await register["webauthn"](browser);
-
-    const { msg, principal } = await registerWithIssuer({
-      browser,
-      authConfig,
-      issuer: ISSUER_APP_URL,
-    });
-
-    expect(msg).toContain("Added");
-    expect(msg).toContain(principal);
-  });
-}, 300_000);
+import { nonNullish } from "@dfinity/utils";
 
 // Open the issuer demo, authenticate and register as an employee
-const registerWithIssuer = async ({
+export const registerWithIssuer = async ({
   browser,
   issuer,
   authConfig: { setupAuth, finalizeAuth, userNumber },
@@ -77,20 +57,33 @@ const registerWithIssuer = async ({
 };
 
 // Open the specified test app on the URL `relyingParty` and authenticate
-const authenticateToRelyingParty = async ({
+export const authenticateToRelyingParty = async ({
   browser,
   authConfig: { setupAuth, finalizeAuth, userNumber },
   issuer,
   relyingParty,
+  derivationOrigin,
 }: {
   browser: WebdriverIO.Browser;
   relyingParty: string;
   issuer: string;
   authConfig: AuthConfig;
+  derivationOrigin?: string;
 }): Promise<VcTestAppView> => {
   const vcTestApp = new VcTestAppView(browser);
   await vcTestApp.open(relyingParty, II_URL, issuer);
 
+  if (nonNullish(derivationOrigin)) {
+    const demoView = new DemoAppView(browser);
+    await demoView.setDerivationOrigin(derivationOrigin);
+
+    await demoView.updateAlternativeOrigins(
+      `{"alternativeOrigins":["${TEST_APP_NICE_URL}"]}`,
+      "certified"
+    );
+
+    await vcTestApp.setAlternativeOrigin(derivationOrigin);
+  }
   await vcTestApp.startSignIn();
 
   await setupAuth(browser);
@@ -107,8 +100,23 @@ const authenticateToRelyingParty = async ({
   return vcTestApp;
 };
 
+export const getVCPresentation = async (args: {
+  vcTestApp: VcTestAppView;
+  browser: WebdriverIO.Browser;
+  authConfig: AuthConfig;
+}): Promise<{ alias: string; credential: string }> => {
+  const result = await getVCPresentation_(args);
+  if (result.result === "aborted") {
+    throw new Error(
+      "Expected successful VC flow, got error: " + JSON.stringify(result)
+    );
+  }
+
+  return result;
+};
+
 // Go through the VC flow and get the presentation
-const getVCPresentation = async ({
+export const getVCPresentation_ = async ({
   vcTestApp,
   browser,
   authConfig: { setupAuth, finalizeAuth, userNumber },
@@ -116,13 +124,20 @@ const getVCPresentation = async ({
   vcTestApp: VcTestAppView;
   browser: WebdriverIO.Browser;
   authConfig: AuthConfig;
-}): Promise<{ alias: string; credential: string }> => {
+}): Promise<
+  | { result: "ok"; alias: string; credential: string }
+  | { result: "aborted"; reason: string }
+> => {
   await vcTestApp.startVcFlow();
 
   await setupAuth(browser);
 
   const vcAllow = new VcAllowView(browser);
-  await vcAllow.waitForDisplay();
+  const ty = await vcAllow.waitForDisplay();
+  if (ty === "aborted") {
+    const reason = await vcAllow.getAbortReason();
+    return { result: "aborted", reason };
+  }
   const userNumber_ = await vcAllow.getUserNumber();
   expect(userNumber_).toBe(userNumber);
   await vcAllow.allow();
@@ -133,7 +148,7 @@ const getVCPresentation = async ({
   const alias = await vcTestApp.getPresentationAlias();
   const credential = await vcTestApp.getPresentationCredential();
 
-  return { alias, credential };
+  return { result: "ok", alias, credential };
 };
 
 // The different ways to register (webauthn, pin).
@@ -144,7 +159,8 @@ type AuthConfig = {
   setupAuth: (browser: WebdriverIO.Browser) => Promise<void>;
   finalizeAuth: (browser: WebdriverIO.Browser) => Promise<void>;
 };
-const register: Record<
+
+export const register: Record<
   "webauthn" | "pin",
   (browser: WebdriverIO.Browser) => Promise<AuthConfig>
 > = {
@@ -190,82 +206,3 @@ const register: Record<
     };
   },
 };
-
-const getDomain = (url: string) => url.split(".").slice(1).join(".");
-
-// The different test configs (different URLs, differnet auth methods)
-const testConfigs: Array<{
-  relyingParty: string;
-  issuer: string;
-  authType: "pin" | "webauthn";
-}> = [
-  {
-    relyingParty: TEST_APP_CANONICAL_URL_LEGACY,
-    issuer: ISSUER_APP_URL,
-    authType: "webauthn",
-  },
-  {
-    relyingParty: TEST_APP_CANONICAL_URL,
-    issuer: ISSUER_APP_URL_LEGACY,
-    authType: "webauthn",
-  },
-  {
-    relyingParty: TEST_APP_CANONICAL_URL,
-    issuer: ISSUER_APP_URL,
-    authType: "pin",
-  },
-];
-
-testConfigs.forEach(({ relyingParty, issuer, authType }) => {
-  const testSuffix = `RP: ${getDomain(relyingParty)}, ISS: ${getDomain(
-    issuer
-  )}, auth: ${authType}`;
-
-  test(
-    "Can issue credentials " + testSuffix,
-    async () => {
-      await runInBrowser(
-        async (browser: WebdriverIO.Browser) => {
-          await browser.url(II_URL);
-
-          const authConfig = await register[authType](browser);
-
-          // 1. Add employee
-
-          const { msg: _msg, principal: _principal } = await registerWithIssuer(
-            {
-              browser,
-              issuer,
-              authConfig,
-            }
-          );
-
-          // 2. Auth to RP
-
-          const vcTestApp = await authenticateToRelyingParty({
-            browser,
-            issuer,
-            authConfig,
-            relyingParty,
-          });
-
-          const principalRP = await vcTestApp.getPrincipal();
-
-          // 3. Get VC presentation
-
-          const { alias } = await getVCPresentation({
-            vcTestApp,
-            browser,
-            authConfig,
-          });
-
-          // Perform a basic check on the alias
-          const aliasObj = JSON.parse(alias);
-          expect(aliasObj.sub).toBe(`did:icp:${principalRP}`);
-        },
-        authType === "pin" ? APPLE_USER_AGENT : undefined
-      );
-    },
-    300_000
-  );
-});

--- a/src/vc-api/src/index.ts
+++ b/src/vc-api/src/index.ts
@@ -74,6 +74,7 @@ export const VcFlowRequest = z.object({
     }),
     credentialSpec: zodCredentialSpec,
     credentialSubject: zodPrincipal,
+    derivationOrigin: z.optional(z.string()),
   }),
 });
 


### PR DESCRIPTION
This updates the frontend verifiable credentials flow to access a new `derivationOrigin` field in the VC request.

The frontend then queries the specified derivation origin and checks the RP is listed as an alternative origin, as in the authentication flow.

If successful, the specified derivation origin is used as the origin for the VC flow.

The Verifiable Credentials e2e tests are moved to their own directory and split between base flow tests, utils, and new alternative origin tests.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->













<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->












