### PR TITLE
Add dev server logs

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -482,6 +482,10 @@ jobs:
       # Make sure that one failing test does not cancel all other matrix jobs
       fail-fast: false
 
+    env:
+      # Suffix used for tagging artifacts
+      artifact_suffix: ${{ contains(matrix.domain, 'internetcomputer') && 'current' || 'legacy' }}-${{ matrix.device }}-${{ matrix.shard }}
+
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
@@ -536,7 +540,7 @@ jobs:
       - name: Run dev server
         id: dev-server-start
         run: |
-          TLS_DEV_SERVER=1 NO_HOT_RELOAD=1 npm run dev&
+          TLS_DEV_SERVER=1 NO_HOT_RELOAD=1 npm run dev | tee -a > dev-server-logs.txt &
           dev_server_pid=$!
           echo "dev_server_pid=$dev_server_pid" >> "$GITHUB_OUTPUT"
 
@@ -556,11 +560,19 @@ jobs:
         if: ${{ always() }}
         run: kill ${{ steps.dev-server-start.outputs.dev_server_pid }}
 
+      - name: Archive dev server logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-server-logs-${{ env.artifact_suffix }}
+          path: dev-server-logs.txt
+          if-no-files-found: ignore
+
       - name: Archive test failures
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-failures-${{ matrix.device }}-${{ matrix.shard }}
+          name: e2e-test-failures-${{ env.artifact_suffix }}
           path: test-failures/*
           if-no-files-found: ignore
 

--- a/src/vite-plugins/src/index.ts
+++ b/src/vite-plugins/src/index.ts
@@ -1,5 +1,4 @@
 import { isNullish, nonNullish } from "@dfinity/utils";
-import { execSync } from "child_process";
 import { minify } from "html-minifier-terser";
 import httpProxy from "http-proxy";
 import { extname } from "path";
@@ -136,6 +135,7 @@ export const replicaForwardPlugin = ({
         const canisterId = readCanisterId({
           canisterName: matchingRule.canisterName,
         });
+        console.log("Host matches forward rule", host);
         return forwardToReplica({ canisterId });
       }
 
@@ -155,6 +155,7 @@ export const replicaForwardPlugin = ({
         ) /* fast check for principal-ish */
       ) {
         // Assume the principal-ish thing is a canister ID
+        console.log("Domain matches list to forward", domain);
         return forwardToReplica({ canisterId: subdomain });
       }
 
@@ -162,10 +163,8 @@ export const replicaForwardPlugin = ({
       // and if found forward to that
       if (nonNullish(subdomain) && domain === "localhost") {
         try {
-          const canisterId = execSync(`dfx canister id ${subdomain}`)
-            .toString()
-            .trim();
-          console.log("Forwarding to", canisterId);
+          const canisterId = readCanisterId({ canisterName: subdomain });
+          console.log("Subdomain is a canister", subdomain, canisterId);
           return forwardToReplica({ canisterId });
         } catch {}
       }


### PR DESCRIPTION
This saves the dev server logs as artifacts and cleans up the dev server canister look up & logs a bit.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
