### PR TITLE
Fix race condition in devserver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1450,14 +1450,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/http-proxy": {
-      "version": "1.17.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "dev": true,
@@ -5897,11 +5889,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "dev": true,
@@ -6154,25 +6141,6 @@
       "version": "3.2.7",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -6956,19 +6924,6 @@
       "version": "4.1.1",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -10819,7 +10774,9 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -13828,10 +13785,9 @@
       "devDependencies": {
         "@dfinity/utils": "^0.0.20",
         "@types/html-minifier-terser": "^7.0.0",
-        "@types/http-proxy": "^1.17.14",
         "html-minifier-terser": "^7.2.0",
-        "http-proxy": "^1.18.1",
         "typescript": "*",
+        "undici": "*",
         "vite": "^4.2.1",
         "vite-plugin-compression": "^0.5.1"
       }

--- a/src/vite-plugins/package.json
+++ b/src/vite-plugins/package.json
@@ -23,11 +23,10 @@
   "devDependencies": {
     "typescript": "*",
     "vite": "^4.2.1",
+    "undici": "*",
     "vite-plugin-compression": "^0.5.1",
     "@dfinity/utils": "^0.0.20",
     "@types/html-minifier-terser": "^7.0.0",
-    "html-minifier-terser": "^7.2.0",
-    "http-proxy": "^1.18.1",
-    "@types/http-proxy": "^1.17.14"
+    "html-minifier-terser": "^7.2.0"
   }
 }

--- a/src/vite-plugins/src/utils.ts
+++ b/src/vite-plugins/src/utils.ts
@@ -1,6 +1,8 @@
 /* Utils used both in the FE code & the FE config */
 
 import { execSync } from "child_process";
+import type { IncomingMessage, ServerResponse } from "http";
+import { request } from "undici";
 
 /**
  * Read a canister ID from dfx's local state
@@ -33,4 +35,78 @@ export const getReplicaHost = (): string => {
       `Could not get replica port '${command}', is the replica running? ${e}`
     );
   }
+};
+
+// Forward a request (IncomingMessage) to a canister `canisterId` installed on a replica listening at `replicaOrigin`.
+export const forwardToReplica = async ({
+  canisterId,
+  res,
+  req,
+  replicaOrigin,
+}: {
+  canisterId: string;
+  res: ServerResponse;
+  req: IncomingMessage;
+  replicaOrigin: string;
+}) => {
+  console.log(
+    `forwarding ${req.method} https://${req.headers.host}${req.url} to canister ${canisterId} ${replicaOrigin}`
+  );
+
+  // Start by crafting the new request with the original request's headers
+  const reqHeaders: string[] = [];
+  for (const k in req.headers) {
+    if (k.match(/host/i)) {
+      // Skip the host header, we add it manually later
+      continue;
+    }
+
+    reqHeaders.push(k);
+    reqHeaders.push(homogenizeHeaderValue(req.headers[k]));
+  }
+
+  // Set the host in a way that icx-proxy knows how to proxy to the right canister
+  reqHeaders.push(`host`);
+  reqHeaders.push(`${canisterId}.localhost`);
+
+  // XXX: we use undici (used also by Vite) instead of node fetch because node fetch does
+  // not support setting a 'host' header
+  const proxyResp = await request(`http://${replicaOrigin}${req.url}`, {
+    method: req.method as any /* undici doesn't trust 'string' */,
+    headers: reqHeaders,
+    body: req,
+  });
+
+  // Read the status code & headers from the response
+  res.statusCode = proxyResp.statusCode;
+
+  const respHeaders = proxyResp.headers;
+  for (const k in respHeaders) {
+    res.setHeader(k, homogenizeHeaderValue(respHeaders[k]));
+  }
+
+  // Add a 'x-ic-canister-id' header like the BNs do
+  res.setHeader("x-ic-canister-id", canisterId);
+
+  // Ensure the browser accepts the response
+  res.setHeader("access-control-allow-origin", "*");
+  res.setHeader("access-control-expose-headers", "*");
+  res.setHeader("access-control-allow-headers", "*");
+
+  res.end(new Uint8Array(await proxyResp.body.arrayBuffer()));
+};
+
+// Convert a header value to a string
+const homogenizeHeaderValue = (
+  header: string | string[] | undefined
+): string => {
+  if (header === undefined) {
+    return "";
+  }
+
+  if (typeof header === "string") {
+    return header;
+  }
+
+  return header.join("; ");
 };


### PR DESCRIPTION
The devserver handles proxying requests to canisters. The previous implementation used a single `http-proxy` Proxy object, where the handlers were rewritten for each new async request.

The caused issues with concurrent request, where a new request might set up new handlers for an in-flight request.

This drops the dependency on `http-proxy` and instead proxies the request using `undici` (existing transivite dep through Vite).

The forwarding code is also moved to the utils module.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
