### PR TITLE
Fix workflow step name

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -847,7 +847,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/check-build
       - run: mv internet_identity.wasm.gz internet_identity_clean_build_${{ matrix.os }}.wasm.gz
-      - name: 'Upload ${{ matrix.name }}'
+      - name: 'Upload clean build'
         uses: actions/upload-artifact@v4
         with:
           # name is the name used to display and retrieve the artifact


### PR DESCRIPTION
This fixes the clean build upload step name, which was referencing a non-existing matrix element.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5e307f3a/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
