### PR TITLE
Clean up compatibility notice

### DIFF
--- a/src/frontend/src/flows/compatibilityNotice.ts
+++ b/src/frontend/src/flows/compatibilityNotice.ts
@@ -1,26 +1,31 @@
-import { compatibilityChart } from "$src/components/compatibilityChart";
 import { mainWindow } from "$src/components/mainWindow";
 import { warnBox } from "$src/components/warnBox";
 import { html, render } from "lit-html";
 
 // Taken from: https://caniuse.com/?search=PublicKeyCredential
-const pageContent = (reason: string) => html`
-  <h1 class="t-title t-title--main" id="compatibilityNotice">
-    Internet Identity does not support your browser
-  </h1>
-  ${warnBox({
-    title: "Reason",
-    message: reason,
+const pageContent = () =>
+  warnBox({
+    title: "Browser Not Supported",
+    message: html`
+      <p class="t-paragraph">
+        Internet Identity is not supported by your browser.
+      </p>
+      <p class="t-paragraph">
+        This device does not offer
+        <a href="https://webauthn.io" rel="noopener noreferrer" class="t-link"
+          >WebAuthn</a
+        >
+        authentication. Please make sure you have biometrics (fingerprint /
+        Touch ID / Face ID) enabled and try again.
+      </p>
+    `,
     additionalClasses: ["l-stack"],
-  })}
-  <div class="l-stack">${compatibilityChart}</div>
-`;
-
-export const compatibilityNotice = (reason: string): void => {
+  });
+export const compatibilityNotice = (): void => {
   const container = document.getElementById("pageContent") as HTMLElement;
   render(
     mainWindow({
-      slot: pageContent(reason),
+      slot: pageContent(),
       showLogo: false,
     }),
     container

--- a/src/frontend/src/flows/compatibilityNotice.ts
+++ b/src/frontend/src/flows/compatibilityNotice.ts
@@ -12,8 +12,11 @@ const pageContent = () =>
       </p>
       <p class="t-paragraph">
         This device does not offer
-        <a href="https://webauthn.io" rel="noopener noreferrer" class="t-link"
-          >WebAuthn</a
+        <a
+          href="https://fidoalliance.org/passkeys/"
+          rel="noopener noreferrer"
+          class="t-link"
+          >Passkeys</a
         >
         authentication. Please make sure you have biometrics (fingerprint /
         Touch ID / Face ID) enabled and try again.

--- a/src/frontend/src/spa.ts
+++ b/src/frontend/src/spa.ts
@@ -4,7 +4,7 @@ import { displayError } from "./components/displayError";
 import { anyFeatures, features } from "./features";
 import { compatibilityNotice } from "./flows/compatibilityNotice";
 import "./styles/main.css";
-import { checkRequiredFeatures } from "./utils/featureDetection";
+import { supportsWebAuthn } from "./utils/featureDetection";
 import { Connection } from "./utils/iiConnection";
 import { version } from "./version";
 
@@ -77,9 +77,7 @@ const preloadLoaderImage = () => {
 };
 
 // Create a single page app with canister connection
-export const createSpa = async (
-  app: (connection: Connection) => Promise<never>
-) => {
+export const createSpa = (app: (connection: Connection) => Promise<never>) => {
   try {
     printDevMessage();
   } catch (e) {
@@ -93,9 +91,8 @@ export const createSpa = async (
   // https://github.com/dfinity/internet-identity#build-features
   showWarningIfNecessary();
 
-  const okOrReason = await checkRequiredFeatures();
-  if (okOrReason !== true) {
-    return compatibilityNotice(okOrReason);
+  if (!supportsWebAuthn()) {
+    return compatibilityNotice();
   }
 
   // Prepare the actor/connection to talk to the canister

--- a/src/frontend/src/utils/featureDetection.ts
+++ b/src/frontend/src/utils/featureDetection.ts
@@ -1,23 +1,13 @@
 import { features } from "$src/features";
 import { isNullish } from "@dfinity/utils";
-import { wrapError } from "./utils";
 
-export const checkRequiredFeatures = async (): Promise<true | string> => {
+export const supportsWebAuthn = (): boolean => {
   if (features.DUMMY_AUTH) {
     // do not check for webauthn compatibility if DUMMY_AUTH is enabled
     return true;
   }
-  if (isNullish(window.PublicKeyCredential))
-    return "window.PublicKeyCredential is not defined";
-  // For mobile devices we want to make sure we can use platform authenticators
-  if (!navigator.userAgent.match(/(iPhone|iPod|iPad|Android)/)) return true;
-  try {
-    return (await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable())
-      ? true
-      : "This device does not offer WebAuthn authentication. Please make sure you have biometrics (fingerprint / Touch ID / Face ID) enabled and try again.";
-  } catch (error) {
-    return `An error occurred when checking for compatibility: ${wrapError(
-      error
-    )}`;
-  }
+
+  if (isNullish(window.PublicKeyCredential)) return false;
+
+  return true;
 };

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -161,7 +161,7 @@ export const iiPages: Record<string, () => void> = {
       stepper: registerStepper({ current: "finish" }),
       marketingIntroSlot: tempKeyWarningBox({ i18n: new I18n("en") }),
     }),
-  compatibilityNotice: () => compatibilityNotice("This is the reason."),
+  compatibilityNotice: () => compatibilityNotice(),
   promptDeviceAlias: () =>
     promptDeviceAliasPage({
       title: "Register this device",


### PR DESCRIPTION
This updates the compatibility notice to make it more correct and more informative.

In particular, it now only ensures that `window.PublicKeyCredential` exists, which is enough for ensuring webauthn support in most cases. For the other cases, we simply show an error later on during usage.

The compatibility page is also cleaned up a bit to make sure all the text ("Your browser doesn't support II...") is inside the error box, and clarifies the cause of the error (no webauthn support).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d95b4ca21/desktop/compatibilityNotice.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d95b4ca21/mobile/compatibilityNotice.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



