### PR TITLE
Clean up release job

### DIFF
--- a/.github/actions/release/run.sh
+++ b/.github/actions/release/run.sh
@@ -49,7 +49,9 @@ do
     if [ -z "$filename" ]; then continue; fi
     >&2 echo working on asset "$filename"
 
-    # Find out the Job ID
+    # For each asset, find the ID of the job that created the asset and find the step that
+    # printed the asset's checksum (will be linked in the notes)
+    #
     # XXX: Unfortunately GitHub actions doesn't give us a way to find out the Job ID explicitely.
     # Instead, we find the job name that includes "$filename" without the .wasm or .wasm.gz extension and assume that's the Job ID.
     # This works because our jobs contain the filename without extension

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -716,46 +716,47 @@ jobs:
         run: scripts/deploy-archive --wasm archive.wasm.gz --canister-id fgte5-ciaaa-aaaad-aaatq-cai --network ic
 
 
-  # This ... releases
+  # This prepares all the files necessary for a release (all flavors of Wasm, release notes).
+  # On release tags, a new release is created and the assets are uploaded.
   release:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/release-')
     needs: [docker-build-internet_identity_production, docker-build-archive]
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: 'Download wasm.gz'
+      - name: 'Download test build'
         uses: actions/download-artifact@v4
         with:
           name: internet_identity_test.wasm.gz
           path: .
 
-      - name: 'Download wasm.gz'
+      - name: 'Download dev build'
         uses: actions/download-artifact@v4
         with:
           name: internet_identity_dev.wasm.gz
           path: .
 
-      - name: 'Download wasm.gz'
+      - name: 'Download production build'
         uses: actions/download-artifact@v4
         with:
           name: internet_identity_production.wasm.gz
           path: .
 
-      - name: 'Download wasm.gz'
+      - name: 'Download archive'
         uses: actions/download-artifact@v4
         with:
           name: archive.wasm.gz
           path: .
 
-      - name: 'Download wasm.gz'
+      - name: 'Download issuer'
         uses: actions/download-artifact@v4
         with:
           name: vc_demo_issuer.wasm.gz
           path: .
 
-      - uses: actions/github-script@v6
+      - name: 'Get GHA job IDs'
+        uses: actions/github-script@v6
         id: pipeline-jobs
         with:
           script: |
@@ -770,7 +771,8 @@ jobs:
                   html_url: job.html_url}
               });
 
-      - uses: actions/github-script@v6
+      - name: 'Get latest release'
+        uses: actions/github-script@v6
         id: latest-release-tag
         with:
           result-encoding: string
@@ -781,7 +783,8 @@ jobs:
       # it on its own, GitHub is really bad at figuring which tag to use as the previous tag (for
       # listing contributions since).
       # https://github.com/github/feedback/discussions/5975
-      - uses: actions/github-script@v6
+      - name: 'Generate CHANGELOG'
+        uses: actions/github-script@v6
         id: changelog
         with:
           result-encoding: string
@@ -817,7 +820,11 @@ jobs:
           changelog: ${{ steps.changelog.outputs.result }}
           workflow_jobs: ${{ steps.pipeline-jobs.outputs.result }}
 
+      - name: Release notes
+        run: cat ${{ steps.prepare-release.outputs.notes-file }}
+
       - name: Publish release
+        if: startsWith(github.ref, 'refs/tags/release-')
         run: |
           ./scripts/release \
             --tag ${{ github.ref }} \


### PR DESCRIPTION
This updates the release job in the canister-tests workflow:
* The release notes are built on every CI run instead on only on release (though they are _uploaded_ only on release)
* The release steps are all given names for legibility
* A new step is added that simply prints the notes
* Some comments are updated to clarify what's happening in the note generation

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5cf5199d8/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
