### PR TITLE
Remove traps from authenticated_anchor_operation

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -907,8 +907,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # we need the history for the tags, but we don't need the files (except for the GitHub workflows / actions)
+          # --> sparse checkout of only the needed things
+          fetch-depth: 0
+          sparse-checkout: |
+            src/internet_identity/internet_identity.did
+            src/internet_identity/breaking_change_exceptions.patch
+            .github
+            .didc-release
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/setup-didc
       - name: "Check canister interface compatibility"
         run: |
+          release="release-2024-01-05"
+          # undo the breaking changes that we _explicitly_ made
+          # remove after the next release
+          # if we accidentally introduced other breaking changes, the patch would no longer apply / fix them
+          # making this job fail.
+          if [ "$(git describe --tags --match="release-[0-9-]*" HEAD --abbrev=0)" == "$release" ]; then
+            echo "Applying breaking change exceptions for release $release"
+            git apply src/internet_identity/breaking_change_exceptions.patch
+          fi
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
           didc check src/internet_identity/internet_identity.did internet_identity_previous.did

--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -61,7 +61,7 @@ pub fn identity_metadata_replace(
     sender: Principal,
     identity_number: IdentityNumber,
     metadata: &HashMap<String, MetadataEntryV2>,
-) -> Result<Result<(), ()>, CallError> {
+) -> Result<Result<(), IdentityMetadataReplaceError>, CallError> {
     call_candid_as(
         env,
         canister_id,

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -259,8 +259,11 @@ export const idlFactory = ({ IDL }) => {
   });
   const IdentityMetadataReplaceError = IDL.Variant({
     'InternalCanisterError' : IDL.Text,
-    'Unauthorized' : IDL.Null,
-    'StorageSpaceExceeded' : IDL.Null,
+    'Unauthorized' : IDL.Principal,
+    'StorageSpaceExceeded' : IDL.Record({
+      'space_required' : IDL.Nat64,
+      'space_available' : IDL.Nat64,
+    }),
   });
   const ChallengeResult = IDL.Record({
     'key' : ChallengeKey,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -162,8 +162,13 @@ export interface IdentityInfo {
 export type IdentityMetadataReplaceError = {
     'InternalCanisterError' : string
   } |
-  { 'Unauthorized' : null } |
-  { 'StorageSpaceExceeded' : null };
+  { 'Unauthorized' : Principal } |
+  {
+    'StorageSpaceExceeded' : {
+      'space_required' : bigint,
+      'space_available' : bigint,
+    }
+  };
 export type IdentityNumber = bigint;
 export type IdentityRegisterError = { 'BadCaptcha' : null } |
   { 'CanisterFull' : null } |

--- a/src/internet_identity/breaking_change_exceptions.patch
+++ b/src/internet_identity/breaking_change_exceptions.patch
@@ -1,0 +1,13 @@
+diff --git a/src/internet_identity/internet_identity.did b/src/internet_identity/internet_identity.did
+index 43c7400b..e724916b 100644
+--- a/src/internet_identity/internet_identity.did
++++ b/src/internet_identity/internet_identity.did
+@@ -554,7 +554,7 @@ service : (opt InternetIdentityInit) -> {
+     // Replaces the authentication method independent metadata map.
+     // The existing metadata map will be overwritten.
+     // Requires authentication.
+-    identity_metadata_replace: (IdentityNumber, MetadataMapV2) -> (variant {Ok; Err: IdentityMetadataReplaceError;});
++    identity_metadata_replace: (IdentityNumber, MetadataMapV2) -> (variant {Ok; Err;});
+ 
+     // Adds a new authentication method to the identity.
+     // Requires authentication.

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -434,6 +434,15 @@ type AuthnMethodSecuritySettingsReplaceError = variant {
     AuthnMethodNotFound;
 };
 
+type IdentityMetadataReplaceError = variant {
+    /// The caller is not authorized to call this method with the given arguments.
+    Unauthorized;
+    /// The supplied metadata including the new metadata exceeds the maximum allowed size.
+    StorageSpaceExceeded;
+    /// Internal canister error. See the error message for details.
+    InternalCanisterError: text;
+};
+
 type PrepareIdAliasRequest = record {
     /// Origin of the issuer in the attribute sharing flow.
     issuer : FrontendHostname;
@@ -545,7 +554,7 @@ service : (opt InternetIdentityInit) -> {
     // Replaces the authentication method independent metadata map.
     // The existing metadata map will be overwritten.
     // Requires authentication.
-    identity_metadata_replace: (IdentityNumber, MetadataMapV2) -> (variant {Ok; Err;});
+    identity_metadata_replace: (IdentityNumber, MetadataMapV2) -> (variant {Ok; Err: IdentityMetadataReplaceError;});
 
     // Adds a new authentication method to the identity.
     // Requires authentication.

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -435,10 +435,10 @@ type AuthnMethodSecuritySettingsReplaceError = variant {
 };
 
 type IdentityMetadataReplaceError = variant {
-    /// The caller is not authorized to call this method with the given arguments.
-    Unauthorized;
-    /// The supplied metadata including the new metadata exceeds the maximum allowed size.
-    StorageSpaceExceeded;
+    /// The principal is not authorized to call this method with the given arguments.
+    Unauthorized: principal;
+    /// The identity including the new metadata exceeds the maximum allowed size.
+    StorageSpaceExceeded: record {space_available: nat64; space_required: nat64};
     /// Internal canister error. See the error message for details.
     InternalCanisterError: text;
 };

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -1,7 +1,7 @@
 use crate::archive::{archive_operation, device_diff};
 use crate::state::RegistrationState::DeviceTentativelyAdded;
 use crate::state::TentativeDeviceRegistration;
-use crate::storage::anchor::{Anchor, Device};
+use crate::storage::anchor::{Anchor, AnchorError, Device};
 use crate::{activity_stats, state};
 use ic_cdk::api::time;
 use ic_cdk::{caller, trap};
@@ -160,10 +160,8 @@ pub fn remove(
 pub fn identity_metadata_replace(
     anchor: &mut Anchor,
     metadata: HashMap<String, MetadataEntry>,
-) -> Operation {
+) -> Result<Operation, AnchorError> {
     let metadata_keys = metadata.keys().cloned().collect();
-    anchor
-        .replace_identity_metadata(metadata)
-        .unwrap_or_else(|err| trap(&format!("failed to write identity metadata: {err}")));
-    Operation::IdentityMetadataReplace { metadata_keys }
+    anchor.replace_identity_metadata(metadata)?;
+    Ok(Operation::IdentityMetadataReplace { metadata_keys })
 }

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -60,12 +60,12 @@ pub struct TentativeRegistrationInfo {
 pub enum TentativeDeviceRegistrationError {
     DeviceRegistrationModeOff,
     AnotherDeviceTentativelyAdded,
-    AnchorOpError(IdentityUpdateError),
+    IdentityUpdateError(IdentityUpdateError),
 }
 
 impl From<IdentityUpdateError> for TentativeDeviceRegistrationError {
     fn from(err: IdentityUpdateError) -> Self {
-        TentativeDeviceRegistrationError::AnchorOpError(err)
+        TentativeDeviceRegistrationError::IdentityUpdateError(err)
     }
 }
 
@@ -108,12 +108,12 @@ pub enum VerifyTentativeDeviceError {
     WrongCode { retries_left: u8 },
     DeviceRegistrationModeOff,
     NoDeviceToVerify,
-    AnchorOpError(IdentityUpdateError),
+    IdentityUpdateError(IdentityUpdateError),
 }
 
 impl From<IdentityUpdateError> for VerifyTentativeDeviceError {
     fn from(err: IdentityUpdateError) -> Self {
-        VerifyTentativeDeviceError::AnchorOpError(err)
+        VerifyTentativeDeviceError::IdentityUpdateError(err)
     }
 }
 

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -2,7 +2,7 @@ use crate::anchor_management::add;
 use crate::state::RegistrationState::{DeviceRegistrationModeActive, DeviceTentativelyAdded};
 use crate::state::TentativeDeviceRegistration;
 use crate::storage::anchor::Anchor;
-use crate::{secs_to_nanos, state};
+use crate::{secs_to_nanos, state, IdentityUpdateError};
 use candid::Principal;
 use ic_cdk::api::time;
 use ic_cdk::{call, trap};
@@ -56,9 +56,17 @@ pub struct TentativeRegistrationInfo {
     pub device_registration_timeout: Timestamp,
 }
 
+#[derive(Debug)]
 pub enum TentativeDeviceRegistrationError {
     DeviceRegistrationModeOff,
     AnotherDeviceTentativelyAdded,
+    AnchorOpError(IdentityUpdateError),
+}
+
+impl From<IdentityUpdateError> for TentativeDeviceRegistrationError {
+    fn from(err: IdentityUpdateError) -> Self {
+        TentativeDeviceRegistrationError::AnchorOpError(err)
+    }
 }
 
 pub async fn add_tentative_device(
@@ -95,11 +103,18 @@ pub async fn add_tentative_device(
     })
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum VerifyTentativeDeviceError {
     WrongCode { retries_left: u8 },
     DeviceRegistrationModeOff,
     NoDeviceToVerify,
+    AnchorOpError(IdentityUpdateError),
+}
+
+impl From<IdentityUpdateError> for VerifyTentativeDeviceError {
+    fn from(err: IdentityUpdateError) -> Self {
+        VerifyTentativeDeviceError::AnchorOpError(err)
+    }
 }
 
 /// Verifies the tentative device using the submitted `user_verification_code` and returns

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -92,7 +92,7 @@ async fn add_tentative_device(
             TentativeDeviceRegistrationError::AnotherDeviceTentativelyAdded => {
                 AddTentativeDeviceResponse::AnotherDeviceTentativelyAdded
             }
-            TentativeDeviceRegistrationError::AnchorOpError(err) => {
+            TentativeDeviceRegistrationError::IdentityUpdateError(err) => {
                 // Legacy API traps instead of returning an error.
                 trap(String::from(err).as_str())
             }
@@ -125,7 +125,7 @@ fn verify_tentative_device(
             VerifyTentativeDeviceError::WrongCode { retries_left } => {
                 VerifyTentativeDeviceResponse::WrongCode { retries_left }
             }
-            VerifyTentativeDeviceError::AnchorOpError(err) => {
+            VerifyTentativeDeviceError::IdentityUpdateError(err) => {
                 // Legacy API traps instead of returning an error.
                 trap(String::from(err).as_str())
             }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -6,6 +6,7 @@ use crate::archive::ArchiveState;
 use crate::assets::init_assets;
 use crate::ii_domain::IIDomain;
 use crate::storage::anchor::Anchor;
+use crate::storage::StorageError;
 use candid::{candid_method, Principal};
 use canister_sig_util::signature_map::LABEL_SIG;
 use ic_cdk::api::{caller, set_certified_data, trap};
@@ -91,6 +92,10 @@ async fn add_tentative_device(
             TentativeDeviceRegistrationError::AnotherDeviceTentativelyAdded => {
                 AddTentativeDeviceResponse::AnotherDeviceTentativelyAdded
             }
+            TentativeDeviceRegistrationError::AnchorOpError(err) => {
+                // Legacy API traps instead of returning an error.
+                trap(String::from(err).as_str())
+            }
         },
     }
 }
@@ -120,6 +125,10 @@ fn verify_tentative_device(
             VerifyTentativeDeviceError::WrongCode { retries_left } => {
                 VerifyTentativeDeviceResponse::WrongCode { retries_left }
             }
+            VerifyTentativeDeviceError::AnchorOpError(err) => {
+                // Legacy API traps instead of returning an error.
+                trap(String::from(err).as_str())
+            }
         },
     }
 }
@@ -144,45 +153,45 @@ fn register(
 #[candid_method]
 fn add(anchor_number: AnchorNumber, device_data: DeviceData) {
     authenticated_anchor_operation(anchor_number, |anchor| {
-        Ok(((), anchor_management::add(anchor, device_data)))
+        Ok::<_, String>(((), anchor_management::add(anchor, device_data)))
     })
-    .unwrap_or_else(|err| err)
+    .unwrap_or_else(|err| trap(err.as_str()))
 }
 
 #[update]
 #[candid_method]
 fn update(anchor_number: AnchorNumber, device_key: DeviceKey, device_data: DeviceData) {
     authenticated_anchor_operation(anchor_number, |anchor| {
-        Ok((
+        Ok::<_, String>((
             (),
             anchor_management::update(anchor, device_key, device_data),
         ))
     })
-    .unwrap_or_else(|err| err)
+    .unwrap_or_else(|err| trap(err.as_str()))
 }
 
 #[update]
 #[candid_method]
 fn replace(anchor_number: AnchorNumber, device_key: DeviceKey, device_data: DeviceData) {
     authenticated_anchor_operation(anchor_number, |anchor| {
-        Ok((
+        Ok::<_, String>((
             (),
             anchor_management::replace(anchor_number, anchor, device_key, device_data),
         ))
     })
-    .unwrap_or_else(|err| err)
+    .unwrap_or_else(|err| trap(err.as_str()))
 }
 
 #[update]
 #[candid_method]
 fn remove(anchor_number: AnchorNumber, device_key: DeviceKey) {
     authenticated_anchor_operation(anchor_number, |anchor| {
-        Ok((
+        Ok::<_, String>((
             (),
             anchor_management::remove(anchor_number, anchor, device_key),
         ))
     })
-    .unwrap_or_else(|err| err)
+    .unwrap_or_else(|err| trap(err.as_str()))
 }
 
 /// Returns all devices of the anchor (authentication and recovery) but no information about device registrations.
@@ -492,6 +501,31 @@ fn authenticate_and_record_activity(anchor_number: AnchorNumber) -> Option<IIDom
     domain
 }
 
+#[derive(Debug)]
+enum IdentityUpdateError {
+    Unauthorized,
+    StorageError(IdentityNumber, StorageError),
+}
+
+impl From<IdentityUpdateError> for String {
+    fn from(err: IdentityUpdateError) -> Self {
+        match err {
+            IdentityUpdateError::Unauthorized => {
+                // This error message is used by the legacy API and should not be changed, even though
+                // it is confusing authentication with authorization.
+                format!("{} could not be authenticated.", caller())
+            }
+            IdentityUpdateError::StorageError(identity_nr, err) => {
+                // This error message is used by the legacy API and should not be changed
+                format!(
+                    "unable to update anchor {} in stable memory: {}",
+                    identity_nr, err
+                )
+            }
+        }
+    }
+}
+
 /// Authenticates the caller (traps if not authenticated) calls the provided function and handles all
 /// the necessary bookkeeping for anchor operations.
 ///
@@ -502,18 +536,20 @@ fn authenticate_and_record_activity(anchor_number: AnchorNumber) -> Option<IIDom
 fn authenticated_anchor_operation<R, E>(
     anchor_number: AnchorNumber,
     op: impl FnOnce(&mut Anchor) -> Result<(R, Operation), E>,
-) -> Result<R, E> {
+) -> Result<R, E>
+where
+    E: From<IdentityUpdateError>,
+{
     let Ok((mut anchor, device_key)) = check_authentication(anchor_number) else {
-        trap(&format!("{} could not be authenticated.", caller()));
+        return Err(E::from(IdentityUpdateError::Unauthorized));
     };
     anchor_management::activity_bookkeeping(&mut anchor, &device_key);
 
     let result = op(&mut anchor);
 
     // write back anchor
-    state::storage_borrow_mut(|storage| storage.write(anchor_number, anchor)).unwrap_or_else(
-        |err| panic!("unable to update anchor {anchor_number} in stable memory: {err}"),
-    );
+    state::storage_borrow_mut(|storage| storage.write(anchor_number, anchor))
+        .map_err(|err| E::from(IdentityUpdateError::StorageError(anchor_number, err)))?;
 
     match result {
         Ok((ret, operation)) => {
@@ -557,6 +593,7 @@ fn check_authentication(anchor_number: AnchorNumber) -> Result<(Anchor, DeviceKe
 /// 4. Add additional features to the API v2, that were not possible with the old API.
 mod v2_api {
     use super::*;
+    use crate::storage::anchor::AnchorError;
 
     #[query]
     #[candid_method(query)]
@@ -728,20 +765,50 @@ mod v2_api {
         Ok(())
     }
 
+    impl From<IdentityUpdateError> for IdentityMetadataReplaceError {
+        fn from(value: IdentityUpdateError) -> Self {
+            let storage_err = match value {
+                IdentityUpdateError::Unauthorized => {
+                    return IdentityMetadataReplaceError::Unauthorized
+                }
+                IdentityUpdateError::StorageError(_, storage_err) => storage_err,
+            };
+
+            match storage_err {
+                StorageError::EntrySizeLimitExceeded(_) => {
+                    IdentityMetadataReplaceError::StorageSpaceExceeded
+                }
+                err => IdentityMetadataReplaceError::InternalCanisterError(err.to_string()),
+            }
+        }
+    }
+
+    impl From<AnchorError> for IdentityMetadataReplaceError {
+        fn from(value: AnchorError) -> Self {
+            match value {
+                AnchorError::CumulativeDataLimitExceeded { .. } => {
+                    IdentityMetadataReplaceError::StorageSpaceExceeded
+                }
+                err => IdentityMetadataReplaceError::InternalCanisterError(err.to_string()),
+            }
+        }
+    }
+
     #[update]
     #[candid_method]
     fn identity_metadata_replace(
         identity_number: IdentityNumber,
         metadata: HashMap<String, MetadataEntryV2>,
-    ) -> Result<(), ()> {
+    ) -> Result<(), IdentityMetadataReplaceError> {
         authenticated_anchor_operation(identity_number, |anchor| {
             let metadata = metadata
                 .into_iter()
                 .map(|(k, v)| (k, MetadataEntry::from(v)))
                 .collect();
-            Ok((
+            Ok::<_, IdentityMetadataReplaceError>((
                 (),
-                anchor_management::identity_metadata_replace(anchor, metadata),
+                anchor_management::identity_metadata_replace(anchor, metadata)
+                    .map_err(IdentityMetadataReplaceError::from)?,
             ))
         })
     }

--- a/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
@@ -68,7 +68,7 @@ fn should_require_authentication_to_replace_identity_metadata() -> Result<(), Ca
     )?;
     assert!(matches!(
         result,
-        Err(IdentityMetadataReplaceError::Unauthorized)
+        Err(IdentityMetadataReplaceError::Unauthorized(_))
     ));
     Ok(())
 }
@@ -101,7 +101,7 @@ fn should_not_write_too_large_identity_metadata_map() -> Result<(), CallError> {
     )?;
     assert!(matches!(
         result,
-        Err(IdentityMetadataReplaceError::StorageSpaceExceeded)
+        Err(IdentityMetadataReplaceError::StorageSpaceExceeded { .. })
     ));
     Ok(())
 }

--- a/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
@@ -3,13 +3,11 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_canister, II_WASM,
-};
+use canister_tests::framework::{env, install_ii_canister, II_WASM};
 use ic_test_state_machine_client::CallError;
-use ic_test_state_machine_client::ErrorCode::CanisterCalledTrap;
-use internet_identity_interface::internet_identity::types::MetadataEntryV2;
-use regex::Regex;
+use internet_identity_interface::internet_identity::types::{
+    IdentityMetadataReplaceError, MetadataEntryV2,
+};
 use std::collections::HashMap;
 
 #[test]
@@ -48,7 +46,7 @@ fn should_write_metadata() -> Result<(), CallError> {
 }
 
 #[test]
-fn should_require_authentication_to_replace_identity_metadata() {
+fn should_require_authentication_to_replace_identity_metadata() -> Result<(), CallError> {
     const METADATA_KEY: &str = "some-key";
 
     let env = env();
@@ -67,12 +65,12 @@ fn should_require_authentication_to_replace_identity_metadata() {
         Principal::anonymous(),
         identity_number,
         &metadata,
-    );
-    expect_user_error_with_message(
+    )?;
+    assert!(matches!(
         result,
-        CanisterCalledTrap,
-        Regex::new("[a-z\\d-]+ could not be authenticated.").unwrap(),
-    );
+        Err(IdentityMetadataReplaceError::Unauthorized)
+    ));
+    Ok(())
 }
 
 #[test]
@@ -100,11 +98,10 @@ fn should_not_write_too_large_identity_metadata_map() -> Result<(), CallError> {
         authn_method.principal(),
         identity_number,
         &metadata,
-    );
-    expect_user_error_with_message(
+    )?;
+    assert!(matches!(
         result,
-        CanisterCalledTrap,
-        Regex::new("failed to write identity metadata: Cumulative size of variable sized fields exceeds limit: length \\d+, limit \\d+\\.").unwrap(),
-    );
+        Err(IdentityMetadataReplaceError::StorageSpaceExceeded)
+    ));
     Ok(())
 }

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -133,3 +133,10 @@ pub enum AuthnMethodConfirmationError {
     RegistrationModeOff,
     NoAuthnMethodToConfirm,
 }
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum IdentityMetadataReplaceError {
+    Unauthorized,
+    StorageSpaceExceeded,
+    InternalCanisterError(String),
+}

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -1,5 +1,5 @@
 use crate::internet_identity::types::{CredentialId, PublicKey, Timestamp};
-use candid::{CandidType, Deserialize};
+use candid::{CandidType, Deserialize, Principal};
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 
@@ -136,7 +136,10 @@ pub enum AuthnMethodConfirmationError {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum IdentityMetadataReplaceError {
-    Unauthorized,
-    StorageSpaceExceeded,
+    Unauthorized(Principal),
+    StorageSpaceExceeded {
+        space_available: u64,
+        space_required: u64,
+    },
     InternalCanisterError(String),
 }


### PR DESCRIPTION
This removes the traps from the authenticated_anchor_operation helper, which allows to add proper errors to `identity_metadata_replace`.

I will do a follow-up PR to move the authentication helpers and error mappers out of the `main.rs` file to keep it focused on the endpoints.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->






<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->





