### PR TITLE
Speed up and improve canister tests

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -34,8 +34,10 @@ runs:
     # NOTE: we include the output of uname to ensure binary compatibility (e.g. same glibc)
     - uses: actions/cache@v3
       with:
-        path: ~/.cargo/bin
-        key: cargo-bin-${{ steps.platform.outputs.platform-id }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-3
+        path: |
+          ~/.cargo/bin/ic-wasm
+          ~/.rustup
+        key: cargo-bin-${{ steps.platform.outputs.platform-id }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-4
 
     - name: Bootstrap
       shell: bash

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -1,5 +1,5 @@
 # This describes all the tests we run on the canister code (various builds,
-# integration tests, selenium tests). The canister code is built in docker and the
+# integration tests, e2e tests). The canister code is built in docker and the
 # wasm is then reused by subsequent build steps. We build various flavors of
 # the code, see `docker-build-...` for more info.
 name: Canister tests
@@ -49,7 +49,7 @@ jobs:
           # See job: docker-build-internet_identity_production
 
           # No captcha and fetching the root key, used in (our) tests, backend and
-          # selenium.
+          # e2e.
           - name: internet_identity_test.wasm.gz
             II_FETCH_ROOT_KEY: 1
             II_DUMMY_CAPTCHA: 1
@@ -404,7 +404,7 @@ jobs:
 
   canister-tests-run:
     runs-on: ${{ matrix.os }}
-    needs: [canister-tests-build, docker-build-ii, docker-build-archive]
+    needs: [canister-tests-build, cached-build, docker-build-archive]
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
@@ -436,7 +436,7 @@ jobs:
       - name: 'Download II wasm'
         uses: actions/download-artifact@v4
         with:
-          name: internet_identity_test.wasm.gz
+          name: internet_identity_test_cached.wasm.gz
           path: .
 
       - name: 'Download archive wasm'
@@ -462,12 +462,12 @@ jobs:
           RUST_BACKTRACE: 1
 
   ######################
-  # The selenium tests #
+  # The end-to-end tests #
   ######################
 
-  selenium:
+  e2e:
     runs-on: ubuntu-latest
-    needs: [docker-build-ii, test-app-build, vc_demo_issuer-build]
+    needs: [cached-build, test-app-build, vc_demo_issuer-build]
     strategy:
       matrix:
         device: [ 'desktop', 'mobile' ]
@@ -478,7 +478,7 @@ jobs:
         # based on the shard assigned to it)
         # The jest parameter is actually 1/N, 2/N etc but we use a artifact-friendly
         # version here (with underscore).
-        shard: [ '1_5', '2_5', '3_5', '4_5', '5_5' ]
+        shard: [ '1_6', '2_6', '3_6', '4_6', '5_6', '6_6' ]
       # Make sure that one failing test does not cancel all other matrix jobs
       fail-fast: false
 
@@ -490,6 +490,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
 
+      # npm ci is a slow operation that mostly involves downloading packages, so we run
+      # it in the background while we set up the replica
+      - name: Kickstart npm ci
+        run: '{ npm ci --no-audit --no-fund; echo "$?" > ~/npm-ci-status; } &'
+
       - uses: ./.github/actions/setup-dfx
 
       # Helps with debugging
@@ -500,17 +505,13 @@ jobs:
           echo node --version
           node --version
 
-      # Setup npm and run fast tests early
-      - run: npm ci
-      - run: npm test
-
       - name: 'Run dfx'
         run: dfx start --background --artificial-delay 0
 
       - name: 'Download II wasm'
         uses: actions/download-artifact@v4
         with:
-          name: internet_identity_test.wasm.gz
+          name: internet_identity_test_cached.wasm.gz
           path: .
 
       - name: 'Download test app wasm'
@@ -537,6 +538,14 @@ jobs:
       - name: Provision issuer canister
         run: ./demos/vc_issuer/provision
 
+      # Check the return code of npm ci
+      - name: Check on npm ci
+        # make sure we don't wait too long if for some unlikely reason the npm status file doesn't get created
+        timeout-minutes: 1
+        run: |
+          until [ -f ~/npm-ci-status ]; do sleep 1; done
+          exit $(cat ~/npm-ci-status)
+
       - name: Run dev server
         id: dev-server-start
         run: |
@@ -544,6 +553,7 @@ jobs:
           dev_server_pid=$!
           echo "dev_server_pid=$dev_server_pid" >> "$GITHUB_OUTPUT"
 
+      # run unit tests & e2e tests
       # NOTE: we run chrome in headless mode because that's the only thing that works in GHA
       # NOTE: the last bit (tr) replaces 1_N with 1/N
       - run: |
@@ -576,12 +586,12 @@ jobs:
           path: test-failures/*
           if-no-files-found: ignore
 
-  # Aggregate all selenium matrix jobs, used in branch protection
-  selenium-all:
+  # Aggregate all e2e matrix jobs, used in branch protection
+  e2e-all:
     runs-on: ubuntu-latest
-    needs: selenium
+    needs: e2e
     steps:
-      - run: echo selenium ok
+      - run: echo e2e ok
 
   using-dev-build:
     runs-on: ubuntu-latest
@@ -840,6 +850,76 @@ jobs:
           # populated by GitHub Actions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # A native, fast cached build. We use the produced test assets to run the canister & e2e tests.
+  # The asset's checksum is compared against that of the (slower) docker build.
+  cached-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: ${{ runner.os }}-cached-build-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock', '.node-version', 'package-lock.json') }}
+
+      - uses: ./.github/actions/bootstrap
+      - uses: ./.github/actions/setup-node
+
+      # run the build
+      # NOTE: npm ci is only ~2s slower than an offline install (npm i --offline), so we use npm ci to have
+      # a Clean Install
+      - run: npm ci --no-audit --no-fund
+
+      - name: Build test flavor
+        env:
+          II_FETCH_ROOT_KEY: 1
+          II_DUMMY_CAPTCHA: 1
+          II_DUMMY_AUTH: 0
+          II_INSECURE_REQUESTS: 0
+        run: ./scripts/build
+
+      - run: mv internet_identity.wasm.gz internet_identity_test.wasm.gz
+      - name: 'Upload test build'
+        uses: actions/upload-artifact@v4
+        with:
+          # name is the name used to display and retrieve the artifact
+          name: internet_identity_test_cached.wasm.gz
+          # path is the name used as the file to upload and the name of the
+          # file when downloaded
+          path: internet_identity_test.wasm.gz
+
+  # Make sure that the asset we're testing is the same as that produced by the (slower) docker builds
+  cached-build-check:
+    runs-on: ubuntu-22.04
+    needs: [docker-build-ii, cached-build]
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Download docker build'
+        uses: actions/download-artifact@v4
+        with:
+          name: internet_identity_test.wasm.gz
+          path: .
+      - run: mv internet_identity_test.wasm.gz docker.wasm.gz
+      - name: 'Download native cached build'
+        uses: actions/download-artifact@v4
+        with:
+          name: internet_identity_test_cached.wasm.gz
+          path: .
+      - run: mv internet_identity_test.wasm.gz native.wasm.gz
+      - run: |
+          native_sha256=$(shasum -a 256 ./native.wasm.gz | cut -d ' ' -f1)
+          docker_sha256=$(shasum -a 256 ./docker.wasm.gz | cut -d ' ' -f1)
+          echo "shas: native '$native_sha256', docker '$docker_sha256'"
+          if [ "$native_sha256" == "$docker_sha256" ]
+          then
+            echo output sha256 matches expected
+          else
+            echo "sha mismatch"
+            exit 1
+          fi
 
   clean-build:
     runs-on: ${{ matrix.os }}

--- a/demos/test-app/package.json
+++ b/demos/test-app/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@dfinity/internet-identity-vc-api": "*",
     "@dfinity/internet-identity-vite-plugins": "*",
-    "@types/node": "^20.10.1",
     "@types/react": "^18.2.38",
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       ],
       "dependencies": {
         "@dfinity/agent": "^0.19.2",
-        "@dfinity/auth-client": "*",
+        "@dfinity/auth-client": "^0.19.2",
         "@dfinity/candid": "^0.19.2",
         "@dfinity/identity": "^0.19.2",
         "@dfinity/internet-identity-vc-api": "*",
@@ -36,6 +36,7 @@
       "devDependencies": {
         "@dfinity/internet-identity-vite-plugins": "*",
         "@types/dompurify": "^3.0.5",
+        "@types/node": "*",
         "@types/ua-parser-js": "^0.7.36",
         "@typescript-eslint/eslint-plugin": "6.7.5",
         "@typescript-eslint/parser": "6.7.5",
@@ -75,20 +76,11 @@
       "devDependencies": {
         "@dfinity/internet-identity-vc-api": "*",
         "@dfinity/internet-identity-vite-plugins": "*",
-        "@types/node": "^20.10.1",
         "@types/react": "^18.2.38",
         "@types/react-dom": "^18.2.17",
         "@vitejs/plugin-react": "^4.2.0",
         "typescript": "5.2.2",
         "vite": "^4.5.2"
-      }
-    },
-    "demos/test-app/node_modules/@types/node": {
-      "version": "20.11.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "demos/vc_issuer": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
+    "@types/node": "*",
     "@types/ua-parser-js": "^0.7.36",
     "@typescript-eslint/eslint-plugin": "6.7.5",
     "@typescript-eslint/parser": "6.7.5",
@@ -57,11 +58,12 @@
   },
   "dependencies": {
     "@dfinity/agent": "^0.19.2",
-    "@dfinity/auth-client": "*",
+    "@dfinity/auth-client": "^0.19.2",
     "@dfinity/candid": "^0.19.2",
     "@dfinity/identity": "^0.19.2",
-    "@dfinity/internet-identity-vc-api": "*",
     "@dfinity/principal": "^0.19.2",
+
+    "@dfinity/internet-identity-vc-api": "*",
     "@dfinity/utils": "^0.0.20",
     "bip39": "^3.0.4",
     "buffer": "^6.0.3",

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -28,3 +28,8 @@ then
     echo "installing ic-wasm 0.3.5"
     run cargo install ic-wasm --version 0.3.5
 fi
+
+# make sure the packages are actually installed (rustup waits for the first invoke to lazyload)
+cargo --version
+cargo clippy --version
+cargo fmt --version


### PR DESCRIPTION
This includes a couple of fixes that clarify the canister tests (in particular end-to-end tests) and that shorten CI runs in most cases (both for frontend & backend development). A typical CI run should now be ~5mn shorter (7mn now vs 12mn before):

* The 'selenium' tests are renamed to 'e2e' (since selenium isn't being used anymore)
* A new native build job, `cached-build:`, is added and used by the canister & e2e tests in lieu of the slower docker builds. The docker builds are still used to check the output of the native cached build.
* Some npm packages are removed/deduplicated
* Some `npm ci` steps are run in the background
* The `npm test` step is removed, since unit tests are currently run as part of the sharded e2e tests
* A new shard is added to the e2e tests to balance the recently added slow verifiable credential tests
* Rustup executables are eagerly loaded (mostly to clarify timings)

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

