### PR TITLE
Add release job dependency to vc issuer build

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -720,7 +720,7 @@ jobs:
   # On release tags, a new release is created and the assets are uploaded.
   release:
     runs-on: ubuntu-latest
-    needs: [docker-build-internet_identity_production, docker-build-archive]
+    needs: [docker-build-internet_identity_production, docker-build-archive, vc_demo_issuer-build]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Previously, the release job might run before the vc issuer was finished building. This PR fixes that.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
