### PR TITLE
Move authorization helpers and error conversions to their own module

### DIFF
--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -1,8 +1,9 @@
 use crate::anchor_management::add;
+use crate::authz_utils::IdentityUpdateError;
 use crate::state::RegistrationState::{DeviceRegistrationModeActive, DeviceTentativelyAdded};
 use crate::state::TentativeDeviceRegistration;
 use crate::storage::anchor::Anchor;
-use crate::{secs_to_nanos, state, IdentityUpdateError};
+use crate::{secs_to_nanos, state};
 use candid::Principal;
 use ic_cdk::api::time;
 use ic_cdk::{call, trap};

--- a/src/internet_identity/src/authz_utils.rs
+++ b/src/internet_identity/src/authz_utils.rs
@@ -1,0 +1,107 @@
+use crate::anchor_management::post_operation_bookkeeping;
+use crate::ii_domain::IIDomain;
+use crate::storage::anchor::Anchor;
+use crate::storage::StorageError;
+use crate::{anchor_management, state};
+use candid::Principal;
+use ic_cdk::{caller, trap};
+use internet_identity_interface::archive::types::Operation;
+use internet_identity_interface::internet_identity::types::{
+    AnchorNumber, DeviceKey, IdentityNumber,
+};
+
+#[derive(Debug)]
+pub enum IdentityUpdateError {
+    Unauthorized(Principal),
+    StorageError(IdentityNumber, StorageError),
+}
+
+/// Authenticates the caller (traps if not authenticated) calls the provided function and handles all
+/// the necessary bookkeeping for anchor operations.
+///
+/// * anchor_number: indicates the anchor to be provided op should be called on
+/// * op: Function that modifies an anchor and returns a [Result] indicating
+///       success or failure which determines whether additional bookkeeping (on success) is required.
+///       On success, the function must also return an [Operation] which is used for archiving purposes.
+pub fn authenticated_anchor_operation<R, E>(
+    anchor_number: AnchorNumber,
+    op: impl FnOnce(&mut Anchor) -> Result<(R, Operation), E>,
+) -> Result<R, E>
+where
+    E: From<IdentityUpdateError>,
+{
+    let Ok((mut anchor, device_key)) = check_authentication(anchor_number) else {
+        return Err(E::from(IdentityUpdateError::Unauthorized(caller())));
+    };
+    anchor_management::activity_bookkeeping(&mut anchor, &device_key);
+
+    let result = op(&mut anchor);
+
+    // write back anchor
+    state::storage_borrow_mut(|storage| storage.write(anchor_number, anchor))
+        .map_err(|err| E::from(IdentityUpdateError::StorageError(anchor_number, err)))?;
+
+    match result {
+        Ok((ret, operation)) => {
+            post_operation_bookkeeping(anchor_number, operation);
+            Ok(ret)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Checks if the caller is authenticated against the anchor provided and returns a reference to the device used.
+/// Returns an error if the caller cannot be authenticated.
+pub fn check_authentication(anchor_number: AnchorNumber) -> Result<(Anchor, DeviceKey), ()> {
+    let anchor = state::anchor(anchor_number);
+    let caller = caller();
+
+    for device in anchor.devices() {
+        if caller == Principal::self_authenticating(&device.pubkey)
+            || state::with_temp_keys_mut(|temp_keys| {
+                temp_keys
+                    .check_temp_key(&caller, &device.pubkey, anchor_number)
+                    .is_ok()
+            })
+        {
+            return Ok((anchor.clone(), device.pubkey.clone()));
+        }
+    }
+    Err(())
+}
+
+/// Authenticates the caller (traps if not authenticated) and updates the device used to authenticate
+/// reflecting the current activity. Also updates the aggregated stats on daily and monthly active users.
+///
+/// Note: this function reads / writes the anchor from / to stable memory. It is intended to be used by functions that
+/// do not further modify the anchor.
+pub fn authenticate_and_record_activity(anchor_number: AnchorNumber) -> Option<IIDomain> {
+    let Ok((mut anchor, device_key)) = check_authentication(anchor_number) else {
+        trap(&format!("{} could not be authenticated.", caller()));
+    };
+    let domain = anchor.device(&device_key).unwrap().ii_domain();
+    anchor_management::activity_bookkeeping(&mut anchor, &device_key);
+    state::storage_borrow_mut(|storage| storage.write(anchor_number, anchor)).unwrap_or_else(
+        |err| panic!("last_usage_timestamp update: unable to update anchor {anchor_number}: {err}"),
+    );
+    domain
+}
+
+impl From<IdentityUpdateError> for String {
+    fn from(err: IdentityUpdateError) -> Self {
+        match err {
+            IdentityUpdateError::Unauthorized(principal) => {
+                // This error message is used by the legacy API and should not be changed, even though
+                // it is confusing authentication with authorization.
+                format!("{} could not be authenticated.", principal)
+            }
+            IdentityUpdateError::StorageError(identity_nr, err) => {
+                // This error message is used by the legacy API and should not be changed
+                format!(
+                    "unable to update anchor {} in stable memory: {}",
+                    identity_nr, err
+                )
+            }
+        }
+    }
+}

--- a/src/internet_identity/src/conversions.rs
+++ b/src/internet_identity/src/conversions.rs
@@ -1,0 +1,4 @@
+//! A module to provide type conversions between internal and external types.
+
+/// Type conversion for internal error types to exposed API errors.
+mod api_errors;

--- a/src/internet_identity/src/conversions/api_errors.rs
+++ b/src/internet_identity/src/conversions/api_errors.rs
@@ -1,0 +1,40 @@
+use crate::authz_utils::IdentityUpdateError;
+use crate::storage::anchor::AnchorError;
+use crate::storage::StorageError;
+use internet_identity_interface::internet_identity::types::IdentityMetadataReplaceError;
+
+impl From<IdentityUpdateError> for IdentityMetadataReplaceError {
+    fn from(value: IdentityUpdateError) -> Self {
+        let storage_err = match value {
+            IdentityUpdateError::Unauthorized(principal) => {
+                return IdentityMetadataReplaceError::Unauthorized(principal)
+            }
+            IdentityUpdateError::StorageError(_, storage_err) => storage_err,
+        };
+
+        match storage_err {
+            StorageError::EntrySizeLimitExceeded {
+                space_available,
+                space_required,
+            } => IdentityMetadataReplaceError::StorageSpaceExceeded {
+                space_available,
+                space_required,
+            },
+            err => IdentityMetadataReplaceError::InternalCanisterError(err.to_string()),
+        }
+    }
+}
+
+impl From<AnchorError> for IdentityMetadataReplaceError {
+    fn from(value: AnchorError) -> Self {
+        match value {
+            AnchorError::CumulativeDataLimitExceeded { limit, length } => {
+                IdentityMetadataReplaceError::StorageSpaceExceeded {
+                    space_available: limit as u64,
+                    space_required: length as u64,
+                }
+            }
+            err => IdentityMetadataReplaceError::InternalCanisterError(err.to_string()),
+        }
+    }
+}


### PR DESCRIPTION
This PR only moves code around:
* authorization helpers to `authz_utils`
  * in a subsequent PR, this module will be refactored to no longer confuse authentication with authorization
* error mapper to `conversions::api_errors`

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
