### PR TITLE
Fix README release update sed command

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -859,7 +859,7 @@ jobs:
           NEW_RELEASE_TAG: ${{ github.ref_name }}
         run: |
           echo "II release: $PREVIOUS_RELEASE_TAG -> $NEW_RELEASE_TAG"
-          sed -i "s/$PREVIOUS_RELEASE_TAG/$NEW_RELEASE_TAG/g" ./README.md
+          sed -i "s|$PREVIOUS_RELEASE_TAG|$NEW_RELEASE_TAG|g" ./README.md
           cat ./README.md
 
       - name: Create Pull Request


### PR DESCRIPTION
This changes the `sed` command to use `|` separators instead of `/`, since `/` often occurs and branch (and hence: ref) names.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
