### PR TITLE
Clean up auth postMessage interface

### DIFF
--- a/src/frontend/src/flows/authorize/fetchDelegation.ts
+++ b/src/frontend/src/flows/authorize/fetchDelegation.ts
@@ -6,7 +6,16 @@ import { toast } from "$src/components/toast";
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
 import { unknownToString } from "$src/utils/utils";
 import { Signature } from "@dfinity/agent";
-import { Delegation } from "./postMessageInterface";
+import { Principal } from "@dfinity/principal";
+
+export interface Delegation {
+  delegation: {
+    pubkey: Uint8Array;
+    expiration: bigint;
+    targets?: Principal[];
+  };
+  signature: Signature;
+}
 
 /**
  * Prepares and fetches a delegation valid for the authenticated user and the derivation.


### PR DESCRIPTION
This simplifies the postMessage interface for
the authorization flow by separating concerns (actual auth code moved out of the postMessage interface) and by removing the clumsy manual parsing (and replacing it with zod).

Except for the parsing, code was only moved around and functionality left unchanged (or made to look like the newer VC code).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a8805ecad/mobile/manageNew.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
