### PR TITLE
Bump npm ci timeout

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -541,7 +541,7 @@ jobs:
       # Check the return code of npm ci
       - name: Check on npm ci
         # make sure we don't wait too long if for some unlikely reason the npm status file doesn't get created
-        timeout-minutes: 1
+        timeout-minutes: 5
         run: |
           until [ -f ~/npm-ci-status ]; do sleep 1; done
           exit $(cat ~/npm-ci-status)


### PR DESCRIPTION
This bumps the npm ci timeout from 1mn to 5mn. 1mn might have been a bit optimistic.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
