### PR TITLE
Make Unauthorized and InternalCanisterError errors consistent

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -211,7 +211,8 @@ export const idlFactory = ({ IDL }) => {
     'issuer_id_alias_credential' : SignedIdAlias,
   });
   const GetIdAliasError = IDL.Variant({
-    'Unauthorized' : IDL.Null,
+    'InternalCanisterError' : IDL.Text,
+    'Unauthorized' : IDL.Principal,
     'NoSuchCredentials' : IDL.Text,
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
@@ -286,7 +287,10 @@ export const idlFactory = ({ IDL }) => {
     'issuer_id_alias_jwt' : IDL.Text,
     'canister_sig_pk_der' : PublicKey,
   });
-  const PrepareIdAliasError = IDL.Variant({ 'Unauthorized' : IDL.Null });
+  const PrepareIdAliasError = IDL.Variant({
+    'InternalCanisterError' : IDL.Text,
+    'Unauthorized' : IDL.Principal,
+  });
   const RegisterResponse = IDL.Variant({
     'bad_challenge' : IDL.Null,
     'canister_full' : IDL.Null,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -118,7 +118,8 @@ export interface DeviceWithUsage {
 export type FrontendHostname = string;
 export type GetDelegationResponse = { 'no_such_delegation' : null } |
   { 'signed_delegation' : SignedDelegation };
-export type GetIdAliasError = { 'Unauthorized' : null } |
+export type GetIdAliasError = { 'InternalCanisterError' : string } |
+  { 'Unauthorized' : Principal } |
   { 'NoSuchCredentials' : string };
 export interface GetIdAliasRequest {
   'rp_id_alias_jwt' : string,
@@ -211,7 +212,8 @@ export type MetadataMapV2 = Array<
       { 'Bytes' : Uint8Array | number[] },
   ]
 >;
-export type PrepareIdAliasError = { 'Unauthorized' : null };
+export type PrepareIdAliasError = { 'InternalCanisterError' : string } |
+  { 'Unauthorized' : Principal };
 export interface PrepareIdAliasRequest {
   'issuer' : FrontendHostname,
   'relying_party' : FrontendHostname,

--- a/src/internet_identity/breaking_change_exceptions.patch
+++ b/src/internet_identity/breaking_change_exceptions.patch
@@ -1,8 +1,32 @@
 diff --git a/src/internet_identity/internet_identity.did b/src/internet_identity/internet_identity.did
-index 43c7400b..e724916b 100644
+index 6ef07401..a9883f61 100644
 --- a/src/internet_identity/internet_identity.did
 +++ b/src/internet_identity/internet_identity.did
-@@ -554,7 +554,7 @@ service : (opt InternetIdentityInit) -> {
+@@ -454,9 +454,7 @@ type PrepareIdAliasRequest = record {
+ 
+ type PrepareIdAliasError = variant {
+     /// The principal is not authorized to call this method with the given arguments.
+-    Unauthorized: principal;
+-    /// Internal canister error. See the error message for details.
+-    InternalCanisterError: text;
++    Unauthorized;
+ };
+ 
+ /// The prepared id alias contains two (still unsigned) credentials in JWT format,
+@@ -480,11 +478,9 @@ type GetIdAliasRequest = record {
+ 
+ type GetIdAliasError = variant {
+     /// The principal is not authorized to call this method with the given arguments.
+-    Unauthorized: principal;
++    Unauthorized;
+     /// The credential(s) are not available: may be expired or not prepared yet (call prepare_id_alias to prepare).
+     NoSuchCredentials : text;
+-    /// Internal canister error. See the error message for details.
+-    InternalCanisterError: text;
+ };
+ 
+ /// The signed id alias credentials for each involved party.
+@@ -558,7 +554,7 @@ service : (opt InternetIdentityInit) -> {
      // Replaces the authentication method independent metadata map.
      // The existing metadata map will be overwritten.
      // Requires authentication.

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -453,8 +453,10 @@ type PrepareIdAliasRequest = record {
 };
 
 type PrepareIdAliasError = variant {
-    /// The caller is not authorized to call this method with the given arguments.
-    Unauthorized;
+    /// The principal is not authorized to call this method with the given arguments.
+    Unauthorized: principal;
+    /// Internal canister error. See the error message for details.
+    InternalCanisterError: text;
 };
 
 /// The prepared id alias contains two (still unsigned) credentials in JWT format,
@@ -477,10 +479,12 @@ type GetIdAliasRequest = record {
 };
 
 type GetIdAliasError = variant {
-    /// The caller is not authorized to call this method with the given arguments.
-    Unauthorized;
+    /// The principal is not authorized to call this method with the given arguments.
+    Unauthorized: principal;
     /// The credential(s) are not available: may be expired or not prepared yet (call prepare_id_alias to prepare).
     NoSuchCredentials : text;
+    /// Internal canister error. See the error message for details.
+    InternalCanisterError: text;
 };
 
 /// The signed id alias credentials for each involved party.

--- a/src/internet_identity/src/conversions/api_errors.rs
+++ b/src/internet_identity/src/conversions/api_errors.rs
@@ -1,6 +1,9 @@
-use crate::authz_utils::IdentityUpdateError;
+use crate::authz_utils::{AuthorizationError, IdentityUpdateError};
 use crate::storage::anchor::AnchorError;
 use crate::storage::StorageError;
+use internet_identity_interface::internet_identity::types::vc_mvp::{
+    GetIdAliasError, PrepareIdAliasError,
+};
 use internet_identity_interface::internet_identity::types::IdentityMetadataReplaceError;
 
 impl From<IdentityUpdateError> for IdentityMetadataReplaceError {
@@ -35,6 +38,25 @@ impl From<AnchorError> for IdentityMetadataReplaceError {
                 }
             }
             err => IdentityMetadataReplaceError::InternalCanisterError(err.to_string()),
+        }
+    }
+}
+
+impl From<IdentityUpdateError> for PrepareIdAliasError {
+    fn from(value: IdentityUpdateError) -> Self {
+        match value {
+            IdentityUpdateError::Unauthorized(principal) => {
+                PrepareIdAliasError::Unauthorized(principal)
+            }
+            err => PrepareIdAliasError::InternalCanisterError(err.to_string()),
+        }
+    }
+}
+
+impl From<AuthorizationError> for GetIdAliasError {
+    fn from(value: AuthorizationError) -> Self {
+        match value {
+            AuthorizationError::Unauthorized(principal) => GetIdAliasError::Unauthorized(principal),
         }
     }
 }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -768,8 +768,7 @@ mod attribute_sharing_mvp {
     async fn prepare_id_alias(
         req: PrepareIdAliasRequest,
     ) -> Result<PreparedIdAlias, PrepareIdAliasError> {
-        authenticate_and_record_activity(req.identity_number)
-            .map_err(|_err| PrepareIdAliasError::Unauthorized)?;
+        authenticate_and_record_activity(req.identity_number).map_err(PrepareIdAliasError::from)?;
         let prepared_id_alias = vc_mvp::prepare_id_alias(
             req.identity_number,
             vc_mvp::InvolvedDapps {
@@ -784,9 +783,7 @@ mod attribute_sharing_mvp {
     #[query]
     #[candid_method(query)]
     fn get_id_alias(req: GetIdAliasRequest) -> Result<IdAliasCredentials, GetIdAliasError> {
-        let Ok(_) = check_authentication(req.identity_number) else {
-            return Err(GetIdAliasError::Unauthorized);
-        };
+        check_authentication(req.identity_number).map_err(GetIdAliasError::from)?;
         vc_mvp::get_id_alias(
             req.identity_number,
             vc_mvp::InvolvedDapps {

--- a/src/internet_identity/tests/integration/vc_mvp.rs
+++ b/src/internet_identity/tests/integration/vc_mvp.rs
@@ -622,7 +622,7 @@ fn should_not_prepare_id_alias_for_different_user() -> Result<(), CallError> {
             issuer,
         },
     )?;
-    assert!(matches!(result, Err(PrepareIdAliasError::Unauthorized)));
+    assert!(matches!(result, Err(PrepareIdAliasError::Unauthorized(_))));
     Ok(())
 }
 
@@ -659,7 +659,7 @@ fn should_not_get_id_alias_for_different_user() -> Result<(), CallError> {
         },
     )?;
 
-    assert!(matches!(response, Err(GetIdAliasError::Unauthorized)));
+    assert!(matches!(response, Err(GetIdAliasError::Unauthorized(_))));
     Ok(())
 }
 

--- a/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
@@ -32,7 +32,8 @@ pub struct PreparedIdAlias {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum PrepareIdAliasError {
-    Unauthorized,
+    Unauthorized(Principal),
+    InternalCanisterError(String),
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -57,6 +58,7 @@ pub struct GetIdAliasRequest {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum GetIdAliasError {
-    Unauthorized,
+    Unauthorized(Principal),
     NoSuchCredentials(String),
+    InternalCanisterError(String),
 }


### PR DESCRIPTION
This PR changes the interface for the VC MVP canister calls to propagate the principal of authorization errors and internal errors back to the
 client.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
