### PR TITLE
Provide proper error for identity_info method

### DIFF
--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -44,7 +44,7 @@ pub fn identity_info(
     canister_id: CanisterId,
     sender: Principal,
     identity_number: IdentityNumber,
-) -> Result<Result<IdentityInfo, ()>, CallError> {
+) -> Result<Result<IdentityInfo, IdentityInfoError>, CallError> {
     call_candid_as(
         env,
         canister_id,

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -258,6 +258,10 @@ export const idlFactory = ({ IDL }) => {
     'metadata' : MetadataMapV2,
     'authn_method_registration' : IDL.Opt(AuthnMethodRegistrationInfo),
   });
+  const IdentityInfoError = IDL.Variant({
+    'InternalCanisterError' : IDL.Text,
+    'Unauthorized' : IDL.Principal,
+  });
   const IdentityMetadataReplaceError = IDL.Variant({
     'InternalCanisterError' : IDL.Text,
     'Unauthorized' : IDL.Principal,
@@ -433,7 +437,7 @@ export const idlFactory = ({ IDL }) => {
       ),
     'identity_info' : IDL.Func(
         [IdentityNumber],
-        [IDL.Variant({ 'Ok' : IdentityInfo, 'Err' : IDL.Null })],
+        [IDL.Variant({ 'Ok' : IdentityInfo, 'Err' : IdentityInfoError })],
         [],
       ),
     'identity_metadata_replace' : IDL.Func(

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -160,6 +160,8 @@ export interface IdentityInfo {
   'metadata' : MetadataMapV2,
   'authn_method_registration' : [] | [AuthnMethodRegistrationInfo],
 }
+export type IdentityInfoError = { 'InternalCanisterError' : string } |
+  { 'Unauthorized' : Principal };
 export type IdentityMetadataReplaceError = {
     'InternalCanisterError' : string
   } |
@@ -350,7 +352,7 @@ export interface _SERVICE {
   'identity_info' : ActorMethod<
     [IdentityNumber],
     { 'Ok' : IdentityInfo } |
-      { 'Err' : null }
+      { 'Err' : IdentityInfoError }
   >,
   'identity_metadata_replace' : ActorMethod<
     [IdentityNumber, MetadataMapV2],

--- a/src/internet_identity/breaking_change_exceptions.patch
+++ b/src/internet_identity/breaking_change_exceptions.patch
@@ -1,8 +1,8 @@
 diff --git a/src/internet_identity/internet_identity.did b/src/internet_identity/internet_identity.did
-index 6ef07401..a9883f61 100644
+index dd464712..266039e1 100644
 --- a/src/internet_identity/internet_identity.did
 +++ b/src/internet_identity/internet_identity.did
-@@ -454,9 +454,7 @@ type PrepareIdAliasRequest = record {
+@@ -463,9 +463,7 @@ type PrepareIdAliasRequest = record {
  
  type PrepareIdAliasError = variant {
      /// The principal is not authorized to call this method with the given arguments.
@@ -13,7 +13,7 @@ index 6ef07401..a9883f61 100644
  };
  
  /// The prepared id alias contains two (still unsigned) credentials in JWT format,
-@@ -480,11 +478,9 @@ type GetIdAliasRequest = record {
+@@ -489,11 +487,9 @@ type GetIdAliasRequest = record {
  
  type GetIdAliasError = variant {
      /// The principal is not authorized to call this method with the given arguments.
@@ -26,7 +26,13 @@ index 6ef07401..a9883f61 100644
  };
  
  /// The signed id alias credentials for each involved party.
-@@ -558,7 +554,7 @@ service : (opt InternetIdentityInit) -> {
+@@ -562,12 +558,12 @@ service : (opt InternetIdentityInit) -> {
+ 
+     // Returns information about the identity with the given number.
+     // Requires authentication.
+-    identity_info: (IdentityNumber) -> (variant {Ok: IdentityInfo; Err: IdentityInfoError;});
++    identity_info: (IdentityNumber) -> (variant {Ok: IdentityInfo; Err;});
+ 
      // Replaces the authentication method independent metadata map.
      // The existing metadata map will be overwritten.
      // Requires authentication.

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -404,6 +404,15 @@ type IdentityInfo = record {
     metadata: MetadataMapV2;
 };
 
+type IdentityInfoError = variant {
+    /// The principal is not authorized to call this method with the given arguments.
+    Unauthorized: principal;
+    /// Internal canister error. See the error message for details.
+    InternalCanisterError: text;
+};
+
+
+
 type IdentityRegisterError = variant {
     // No more registrations are possible in this instance of the II service canister.
     CanisterFull;
@@ -553,7 +562,7 @@ service : (opt InternetIdentityInit) -> {
 
     // Returns information about the identity with the given number.
     // Requires authentication.
-    identity_info: (IdentityNumber) -> (variant {Ok: IdentityInfo; Err;});
+    identity_info: (IdentityNumber) -> (variant {Ok: IdentityInfo; Err: IdentityInfoError;});
 
     // Replaces the authentication method independent metadata map.
     // The existing metadata map will be overwritten.

--- a/src/internet_identity/src/conversions/api_errors.rs
+++ b/src/internet_identity/src/conversions/api_errors.rs
@@ -4,7 +4,9 @@ use crate::storage::StorageError;
 use internet_identity_interface::internet_identity::types::vc_mvp::{
     GetIdAliasError, PrepareIdAliasError,
 };
-use internet_identity_interface::internet_identity::types::IdentityMetadataReplaceError;
+use internet_identity_interface::internet_identity::types::{
+    IdentityInfoError, IdentityMetadataReplaceError,
+};
 
 impl From<IdentityUpdateError> for IdentityMetadataReplaceError {
     fn from(value: IdentityUpdateError) -> Self {
@@ -49,6 +51,17 @@ impl From<IdentityUpdateError> for PrepareIdAliasError {
                 PrepareIdAliasError::Unauthorized(principal)
             }
             err => PrepareIdAliasError::InternalCanisterError(err.to_string()),
+        }
+    }
+}
+
+impl From<IdentityUpdateError> for IdentityInfoError {
+    fn from(value: IdentityUpdateError) -> Self {
+        match value {
+            IdentityUpdateError::Unauthorized(principal) => {
+                IdentityInfoError::Unauthorized(principal)
+            }
+            err => IdentityInfoError::InternalCanisterError(err.to_string()),
         }
     }
 }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -563,9 +563,8 @@ mod v2_api {
 
     #[update]
     #[candid_method]
-    fn identity_info(identity_number: IdentityNumber) -> Result<IdentityInfo, ()> {
-        authenticate_and_record_activity(identity_number)
-            .unwrap_or_else(|err| trap(&format!("{err}")));
+    fn identity_info(identity_number: IdentityNumber) -> Result<IdentityInfo, IdentityInfoError> {
+        authenticate_and_record_activity(identity_number).map_err(IdentityInfoError::from)?;
         let anchor_info = anchor_management::get_anchor_info(identity_number);
 
         let metadata = state::anchor(identity_number)

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -81,6 +81,12 @@ pub struct IdentityInfo {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum IdentityInfoError {
+    Unauthorized(Principal),
+    InternalCanisterError(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum IdentityRegisterError {
     CanisterFull,
     BadCaptcha,


### PR DESCRIPTION
This PR relays the error back to the client consistent with the errors used in other new API calls.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/e248cb482/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
