### PR TITLE
Bump github-script in deploy-rc

### DIFF
--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: "Download build for Release Candidate"
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             // Find all artifacts for the production build, and filter for non-expired main artifacts


### PR DESCRIPTION
The previous version (v5) might be using a Node version incompatible with the runners.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ae7642aa1/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
