### PR TITLE
Update ic stable structures dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
  "ic-cdk-macros",
  "ic-cdk-timers",
  "ic-metrics-encoder",
- "ic-stable-structures",
+ "ic-stable-structures 0.6.2",
  "ic-test-state-machine-client",
  "internet_identity_interface",
  "regex",
@@ -1344,7 +1344,7 @@ dependencies = [
  "crc32fast",
  "ic-crypto-sha2",
  "ic-protobuf",
- "ic-stable-structures",
+ "ic-stable-structures 0.5.6",
  "phantom_newtype",
  "prost",
  "serde",
@@ -1918,6 +1918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95dce29e3ceb0e6da3e78b305d95365530f2efd2146ca18590c0ef3aa6038568"
 
 [[package]]
+name = "ic-stable-structures"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774d7d26420c095f2b5f0f71f7b2ff4a5b58b87e0959dccc78b3d513a7db5112"
+dependencies = [
+ "ic_principal",
+]
+
+[[package]]
 name = "ic-sys"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic?rev=e69bcc7b319cbb3ebc22ec55af35287741244db6#e69bcc7b319cbb3ebc22ec55af35287741244db6"
@@ -2216,7 +2225,7 @@ dependencies = [
  "ic-http-certification",
  "ic-metrics-encoder",
  "ic-response-verification",
- "ic-stable-structures",
+ "ic-stable-structures 0.6.2",
  "ic-test-state-machine-client",
  "identity_core",
  "identity_credential",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ ic-http-certification = "2.2"
 ic-metrics-encoder = "1"
 ic-representation-independent-hash = "2.2"
 ic-response-verification = "2.2"
-ic-stable-structures = "0.5"
+ic-stable-structures = "0.6"
 ic-test-state-machine-client = "3"
 
 # other dependencies

--- a/src/archive/src/main.rs
+++ b/src/archive/src/main.rs
@@ -46,8 +46,9 @@ use ic_cdk_macros::{init, post_upgrade, query, update};
 use ic_cdk_timers::set_timer_interval;
 use ic_metrics_encoder::MetricsEncoder;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::storable::Bound;
 use ic_stable_structures::{
-    cell::Cell as StableCell, log::Log, BoundedStorable, DefaultMemoryImpl, Memory as StableMemory,
+    cell::Cell as StableCell, log::Log, DefaultMemoryImpl, Memory as StableMemory,
     RestrictedMemory, StableBTreeMap, Storable,
 };
 use internet_identity_interface::archive::types::*;
@@ -194,6 +195,8 @@ impl Storable for ConfigState {
             candid::decode_one::<ArchiveConfig>(&bytes).expect("failed to decode archive config"),
         )
     }
+
+    const BOUND: Bound = Bound::Unbounded;
 }
 
 /// Index key for the anchor index.
@@ -231,11 +234,11 @@ impl Storable for AnchorIndexKey {
             ),
         }
     }
-}
 
-impl BoundedStorable for AnchorIndexKey {
-    const MAX_SIZE: u32 = std::mem::size_of::<AnchorIndexKey>() as u32;
-    const IS_FIXED_SIZE: bool = true;
+    const BOUND: Bound = Bound::Bounded {
+        is_fixed_size: true,
+        max_size: std::mem::size_of::<AnchorIndexKey>() as u32,
+    };
 }
 
 /// This method is kept for legacy compatibility and easier testability of the archive.


### PR DESCRIPTION
Updating the stable structures allows making use of new features such as unbounded values in BTreeMaps.

Note: we will still retain a dependency on v0.5.6 because it is a dependency of `ic-types` as well. However, given the crate is pretty small, we can live with the duplication.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
