### PR TITLE
Clean up test-app authentication

### DIFF
--- a/demos/test-app/package.json
+++ b/demos/test-app/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@dfinity/agent": "*",
-    "@dfinity/auth-client": "*",
     "@dfinity/candid": "*",
     "@dfinity/identity": "*",
     "@dfinity/principal": "*",

--- a/demos/test-app/src/index.html
+++ b/demos/test-app/src/index.html
@@ -54,7 +54,6 @@
           />
         </div>
         <button data-action="authenticate" id="signinBtn">Sign In</button>
-        <button id="signoutBtn">Sign Out</button>
         <h3>/.well-known/ii-alternative-origins</h3>
         <div id="alternativeOrigins"></div>
         <h3>Principal:</h3>

--- a/demos/test-app/src/index.tsx
+++ b/demos/test-app/src/index.tsx
@@ -3,7 +3,6 @@ import { VcFlowRequestWire } from "@dfinity/internet-identity-vc-api";
 import type { Identity, SignIdentity } from "@dfinity/agent";
 import { Actor, HttpAgent } from "@dfinity/agent";
 import {
-  Delegation,
   DelegationChain,
   DelegationIdentity,
   Ed25519KeyIdentity,
@@ -15,7 +14,7 @@ import ReactDOM from "react-dom/client";
 
 import { decodeJwt } from "jose";
 
-import { authWithII } from "./auth";
+import { authWithII, extractDelegation } from "./auth";
 
 import "./main.css";
 
@@ -177,16 +176,7 @@ window.addEventListener("message", (event) => {
     return;
   }
 
-  const delegations = event.data.delegations.map((signedDelegation: any) => {
-    return {
-      delegation: new Delegation(
-        signedDelegation.delegation.pubkey,
-        signedDelegation.delegation.expiration,
-        signedDelegation.delegation.targets
-      ),
-      signature: signedDelegation.signature.buffer,
-    };
-  });
+  const delegations = event.data.delegations.map(extractDelegation);
   const delegationChain = DelegationChain.fromDelegations(
     delegations,
     event.data.userPublicKey.buffer

--- a/demos/test-app/src/index.tsx
+++ b/demos/test-app/src/index.tsx
@@ -2,7 +2,6 @@ import { VcFlowRequestWire } from "@dfinity/internet-identity-vc-api";
 
 import type { Identity, SignIdentity } from "@dfinity/agent";
 import { Actor, HttpAgent } from "@dfinity/agent";
-import { AuthClient } from "@dfinity/auth-client";
 import {
   Delegation,
   DelegationChain,
@@ -16,10 +15,11 @@ import ReactDOM from "react-dom/client";
 
 import { decodeJwt } from "jose";
 
+import { authWithII } from "./auth";
+
 import "./main.css";
 
 const signInBtn = document.getElementById("signinBtn") as HTMLButtonElement;
-const signOutBtn = document.getElementById("signoutBtn") as HTMLButtonElement;
 const whoamiBtn = document.getElementById("whoamiBtn") as HTMLButtonElement;
 const updateAlternativeOriginsBtn = document.getElementById(
   "updateNewAlternativeOrigins"
@@ -67,9 +67,19 @@ const derivationOriginEl = document.getElementById(
   "derivationOrigin"
 ) as HTMLInputElement;
 
-let authClient: AuthClient;
 let iiProtocolTestWindow: Window | undefined;
-let localIdentity: SignIdentity;
+
+// The identity set by the authentication
+let delegationIdentity: DelegationIdentity | undefined = undefined;
+
+// The local, ephemeral key-pair
+let localIdentity_: SignIdentity | undefined = undefined;
+function getLocalIdentity(): SignIdentity {
+  if (localIdentity_ === undefined) {
+    localIdentity_ = Ed25519KeyIdentity.generate();
+  }
+  return localIdentity_;
+}
 
 const idlFactory = ({ IDL }: { IDL: any }) => {
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
@@ -129,7 +139,13 @@ const updateAlternativeOriginsView = async () => {
   alternativeOriginsEl.innerText = await response.text();
 };
 
-function addMessageElement(message: unknown, received: boolean) {
+function addMessageElement({
+  message,
+  ty,
+}: {
+  message: unknown;
+  ty: "received" | "sent";
+}) {
   const messageContainer = document.createElement("div");
   messageContainer.classList.add("postMessage");
   const messageTitle = document.createElement("div");
@@ -138,7 +154,7 @@ function addMessageElement(message: unknown, received: boolean) {
   messageContent.innerText = JSON.stringify(message, (_, v) =>
     typeof v === "bigint" ? v.toString() : v
   );
-  if (received) {
+  if (ty === "received") {
     messageTitle.innerText = "Message Received";
     messageContainer.classList.add("received");
   } else {
@@ -151,30 +167,33 @@ function addMessageElement(message: unknown, received: boolean) {
 }
 
 window.addEventListener("message", (event) => {
-  if (event.source === iiProtocolTestWindow) {
-    addMessageElement(event.data, true);
-    if (event?.data?.kind === "authorize-client-success") {
-      const delegations = event.data.delegations.map(
-        (signedDelegation: any) => {
-          return {
-            delegation: new Delegation(
-              signedDelegation.delegation.pubkey,
-              signedDelegation.delegation.expiration,
-              signedDelegation.delegation.targets
-            ),
-            signature: signedDelegation.signature.buffer,
-          };
-        }
-      );
-      const delegationChain = DelegationChain.fromDelegations(
-        delegations,
-        event.data.userPublicKey.buffer
-      );
-      updateDelegationView(
-        DelegationIdentity.fromDelegation(localIdentity, delegationChain)
-      );
-    }
+  if (!event.source || event.source !== iiProtocolTestWindow) {
+    return;
   }
+
+  addMessageElement({ message: event.data, ty: "received" });
+
+  if (event?.data?.kind !== "authorize-client-success") {
+    return;
+  }
+
+  const delegations = event.data.delegations.map((signedDelegation: any) => {
+    return {
+      delegation: new Delegation(
+        signedDelegation.delegation.pubkey,
+        signedDelegation.delegation.expiration,
+        signedDelegation.delegation.targets
+      ),
+      signature: signedDelegation.signature.buffer,
+    };
+  });
+  const delegationChain = DelegationChain.fromDelegations(
+    delegations,
+    event.data.userPublicKey.buffer
+  );
+  updateDelegationView(
+    DelegationIdentity.fromDelegation(getLocalIdentity(), delegationChain)
+  );
 });
 
 const readCanisterId = (): string => {
@@ -183,31 +202,28 @@ const readCanisterId = (): string => {
 };
 
 const init = async () => {
-  authClient = await AuthClient.create();
-  updateDelegationView(authClient.getIdentity());
   await updateAlternativeOriginsView();
   signInBtn.onclick = async () => {
-    let derivationOrigin =
+    const maxTimeToLive_ = BigInt(maxTimeToLiveEl.value);
+    // The default max TTL setin the @dfinity/auth-client library
+    const authClientDefaultMaxTTL =
+      /* hours */ BigInt(8) * /* nanoseconds */ BigInt(3_600_000_000_000);
+    const maxTimeToLive =
+      maxTimeToLive_ > BigInt(0) ? maxTimeToLive_ : authClientDefaultMaxTTL;
+    const derivationOrigin =
       derivationOriginEl.value !== "" ? derivationOriginEl.value : undefined;
-    if (BigInt(maxTimeToLiveEl.value) > BigInt(0)) {
-      authClient.login({
-        identityProvider: iiUrlEl.value,
-        maxTimeToLive: BigInt(maxTimeToLiveEl.value),
-        derivationOrigin,
-        onSuccess: () => updateDelegationView(authClient.getIdentity()),
-      });
-    } else {
-      authClient.login({
-        identityProvider: iiUrlEl.value,
-        derivationOrigin,
-        onSuccess: () => updateDelegationView(authClient.getIdentity()),
-      });
-    }
-  };
 
-  signOutBtn.onclick = async () => {
-    await authClient.logout();
-    updateDelegationView(authClient.getIdentity());
+    try {
+      delegationIdentity = await authWithII({
+        url: iiUrlEl.value,
+        maxTimeToLive,
+        derivationOrigin,
+        sessionIdentity: getLocalIdentity(),
+      });
+      updateDelegationView(delegationIdentity);
+    } catch (e) {
+      showError(JSON.stringify(e));
+    }
   };
 
   openIiWindowBtn.onclick = () => {
@@ -231,7 +247,7 @@ const init = async () => {
       return;
     }
     const invalidData = "some invalid data";
-    addMessageElement(invalidData, false);
+    addMessageElement({ message: invalidData, ty: "sent" });
     iiProtocolTestWindow.postMessage(invalidData, iiUrlEl.value);
   };
 
@@ -241,7 +257,7 @@ const init = async () => {
       return;
     }
     const incompleteMessage = { kind: "authorize-client" };
-    addMessageElement(incompleteMessage, false);
+    addMessageElement({ message: incompleteMessage, ty: "sent" });
     iiProtocolTestWindow.postMessage(incompleteMessage, iiUrlEl.value);
   };
 
@@ -250,7 +266,6 @@ const init = async () => {
       alert("Open II tab first");
       return;
     }
-    localIdentity = Ed25519KeyIdentity.generate();
     let derivationOrigin =
       derivationOriginEl.value !== "" ? derivationOriginEl.value : undefined;
     let maxTimeToLive =
@@ -259,11 +274,13 @@ const init = async () => {
         : undefined;
     const validMessage = {
       kind: "authorize-client",
-      sessionPublicKey: new Uint8Array(localIdentity.getPublicKey().toDer()),
+      sessionPublicKey: new Uint8Array(
+        getLocalIdentity().getPublicKey().toDer()
+      ),
       derivationOrigin,
       maxTimeToLive,
     };
-    addMessageElement(validMessage, false);
+    addMessageElement({ message: validMessage, ty: "sent" });
     iiProtocolTestWindow.postMessage(validMessage, iiUrlEl.value);
   };
 
@@ -273,7 +290,7 @@ const init = async () => {
       return;
     }
     let message = JSON.parse(customMessageEl.value);
-    addMessageElement(message, false);
+    addMessageElement({ message, ty: "sent" });
     iiProtocolTestWindow.postMessage(message, iiUrlEl.value);
   };
 
@@ -310,12 +327,11 @@ const init = async () => {
 init();
 
 whoamiBtn.addEventListener("click", async () => {
-  const identity = await authClient.getIdentity();
   const canisterId = Principal.fromText(readCanisterId());
   const actor = Actor.createActor(idlFactory, {
     agent: new HttpAgent({
       host: hostUrlEl.value,
-      identity,
+      identity: delegationIdentity,
     }),
     canisterId,
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
       "name": "@dfinity/internet-identity-test-app",
       "dependencies": {
         "@dfinity/agent": "*",
-        "@dfinity/auth-client": "*",
         "@dfinity/candid": "*",
         "@dfinity/identity": "*",
         "@dfinity/principal": "*",

--- a/src/frontend/src/test-e2e/alternativeOrigin/endpointFormat.test.ts
+++ b/src/frontend/src/test-e2e/alternativeOrigin/endpointFormat.test.ts
@@ -33,7 +33,7 @@ test("Should not issue delegation when /.well-known/ii-alternative-origins has t
       "certified"
     );
     await niceDemoAppView.setDerivationOrigin(TEST_APP_CANONICAL_URL);
-    expect(await niceDemoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await niceDemoAppView.getPrincipal()).toBe("");
     await niceDemoAppView.signin();
 
     const authenticatorId3 = await switchToPopup(browser);
@@ -71,7 +71,7 @@ test("Should not follow redirect returned by /.well-known/ii-alternative-origins
       "redirect"
     );
     await niceDemoAppView.setDerivationOrigin(TEST_APP_CANONICAL_URL);
-    expect(await niceDemoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await niceDemoAppView.getPrincipal()).toBe("");
     await niceDemoAppView.signin();
 
     const authenticatorId3 = await switchToPopup(browser);
@@ -109,7 +109,7 @@ test("Should fetch /.well-known/ii-alternative-origins using the non-raw url", a
       "certified"
     );
     await niceDemoAppView.setDerivationOrigin(TEST_APP_CANONICAL_URL_RAW);
-    expect(await niceDemoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await niceDemoAppView.getPrincipal()).toBe("");
     await niceDemoAppView.signin();
 
     const authenticatorId2 = await switchToPopup(browser);

--- a/src/frontend/src/test-e2e/alternativeOrigin/ingressFormat.test.ts
+++ b/src/frontend/src/test-e2e/alternativeOrigin/ingressFormat.test.ts
@@ -29,7 +29,7 @@ test("Should not issue delegation when derivationOrigin is missing from /.well-k
     await niceDemoAppView.waitForDisplay();
     await niceDemoAppView.resetAlternativeOrigins();
     await niceDemoAppView.setDerivationOrigin(TEST_APP_CANONICAL_URL);
-    expect(await niceDemoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await niceDemoAppView.getPrincipal()).toBe("");
     await niceDemoAppView.signin();
 
     const authenticatorId3 = await switchToPopup(browser);
@@ -66,7 +66,7 @@ test("Should not issue delegation when derivationOrigin is malformed", async () 
     await niceDemoAppView.setDerivationOrigin(
       "https://some-random-disallowed-url.com"
     );
-    expect(await niceDemoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await niceDemoAppView.getPrincipal()).toBe("");
     await niceDemoAppView.signin();
 
     const authenticatorId3 = await switchToPopup(browser);

--- a/src/frontend/src/test-e2e/delegationTtl.test.ts
+++ b/src/frontend/src/test-e2e/delegationTtl.test.ts
@@ -15,7 +15,7 @@ test("Delegation maxTimeToLive: 1 min", async () => {
     const demoAppView = new DemoAppView(browser);
     await demoAppView.open(TEST_APP_NICE_URL, II_URL);
     await demoAppView.waitForDisplay();
-    expect(await demoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await demoAppView.getPrincipal()).toBe("");
     await demoAppView.setMaxTimeToLive(BigInt(60_000_000_000));
     await demoAppView.signin();
     await switchToPopup(browser);
@@ -34,13 +34,13 @@ test("Delegation maxTimeToLive: 1 day", async () => {
     const demoAppView = new DemoAppView(browser);
     await demoAppView.open(TEST_APP_NICE_URL, II_URL);
     await demoAppView.waitForDisplay();
-    expect(await demoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await demoAppView.getPrincipal()).toBe("");
     await demoAppView.setMaxTimeToLive(BigInt(86400_000_000_000));
     await demoAppView.signin();
     await switchToPopup(browser);
     await FLOWS.registerNewIdentityAuthenticateView(browser);
     await waitToClose(browser);
-    expect(await demoAppView.getPrincipal()).not.toBe("2vxsx-fae");
+    expect(await demoAppView.getPrincipal()).not.toBe("");
     const exp = await browser.$("#expiration").getText();
     expect(Number(exp) / 86400_000_000_000).toBeCloseTo(1);
   });
@@ -52,7 +52,7 @@ test("Delegation maxTimeToLive: 2 months", async () => {
     const demoAppView = new DemoAppView(browser);
     await demoAppView.open(TEST_APP_NICE_URL, II_URL);
     await demoAppView.waitForDisplay();
-    expect(await demoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await demoAppView.getPrincipal()).toBe("");
     await demoAppView.setMaxTimeToLive(BigInt(5_184_000_000_000_000)); // 60 days
     await demoAppView.signin();
     await switchToPopup(browser);

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -1,4 +1,3 @@
-import { Principal } from "@dfinity/principal";
 import {
   APPLE_USER_AGENT,
   DEVICE_NAME1,
@@ -131,9 +130,7 @@ test("Log into client application using PIN registration flow", async () => {
     const demoAppView = new DemoAppView(browser);
     await demoAppView.open(TEST_APP_NICE_URL, II_URL);
     await demoAppView.waitForDisplay();
-    expect(await demoAppView.getPrincipal()).toBe(
-      Principal.anonymous().toText()
-    );
+    expect(await demoAppView.getPrincipal()).toBe("");
     await demoAppView.signin();
     await switchToPopup(browser);
     await FLOWS.registerPinNewIdentityAuthenticateView(pin, browser);
@@ -157,9 +154,7 @@ test("Register with PIN then log into client application", async () => {
     const demoAppView = new DemoAppView(browser);
     await demoAppView.open(TEST_APP_NICE_URL, II_URL);
     await demoAppView.waitForDisplay();
-    expect(await demoAppView.getPrincipal()).toBe(
-      Principal.anonymous().toText()
-    );
+    expect(await demoAppView.getPrincipal()).toBe("");
     await demoAppView.signin();
 
     await switchToPopup(browser);

--- a/src/frontend/src/test-e2e/principals.test.ts
+++ b/src/frontend/src/test-e2e/principals.test.ts
@@ -29,7 +29,7 @@ test("Should issue the same principal to nice url and canonical url", async () =
     await canonicalDemoAppView.open(TEST_APP_CANONICAL_URL, II_URL);
     await canonicalDemoAppView.waitForDisplay();
     await canonicalDemoAppView.setDerivationOrigin(TEST_APP_CANONICAL_URL);
-    expect(await canonicalDemoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await canonicalDemoAppView.getPrincipal()).toBe("");
     await canonicalDemoAppView.signin();
 
     const authenticatorId2 = await switchToPopup(browser);
@@ -53,7 +53,7 @@ test("Should issue the same principal to nice url and canonical url", async () =
       "certified"
     );
     await niceDemoAppView.setDerivationOrigin(TEST_APP_CANONICAL_URL);
-    expect(await niceDemoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await niceDemoAppView.getPrincipal()).toBe("");
     await niceDemoAppView.signin();
 
     const authenticatorId3 = await switchToPopup(browser);

--- a/src/frontend/src/test-e2e/register.test.ts
+++ b/src/frontend/src/test-e2e/register.test.ts
@@ -49,7 +49,7 @@ test("Log into client application, after registration", async () => {
     const demoAppView = new DemoAppView(browser);
     await demoAppView.open(TEST_APP_NICE_URL, II_URL);
     await demoAppView.waitForDisplay();
-    expect(await demoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await demoAppView.getPrincipal()).toBe("");
     await demoAppView.signin();
     await switchToPopup(browser);
     await FLOWS.registerNewIdentityAuthenticateView(browser);
@@ -75,7 +75,7 @@ test("Register first then log into client application", async () => {
     const demoAppView = new DemoAppView(browser);
     await demoAppView.open(TEST_APP_NICE_URL, II_URL);
     await demoAppView.waitForDisplay();
-    expect(await demoAppView.getPrincipal()).toBe("2vxsx-fae");
+    expect(await demoAppView.getPrincipal()).toBe("");
     await demoAppView.signin();
 
     const authenticatorId2 = await switchToPopup(browser);

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -735,7 +735,7 @@ export class VcTestAppView extends View {
         return false;
       }
 
-      if (principal === Principal.anonymous().toText()) {
+      if (principal === "") {
         return false;
       }
 
@@ -778,7 +778,6 @@ export class DemoAppView extends View {
   }
 
   async waitForDisplay(): Promise<void> {
-    await this.browser.$("#principal").waitForDisplayed({ timeout: 10_000 });
     // wait for the slowest element to appear
     await this.browser.waitUntil(
       async () =>
@@ -803,14 +802,11 @@ export class DemoAppView extends View {
     await waitToClose(this.browser);
     // wait for the demo app to update the principal
     await this.browser.waitUntil(
-      async () => (await this.getPrincipal()) !== Principal.anonymous().toText()
+      async () => (await this.getPrincipal()) !== ""
     );
     return this.getPrincipal();
   }
 
-  async signout(): Promise<void> {
-    await this.browser.$("#signoutBtn").click();
-  }
   async setMaxTimeToLive(mttl: bigint): Promise<void> {
     await fillText(this.browser, "maxTimeToLive", String(mttl));
   }


### PR DESCRIPTION
This removes the dependency on auth-client for greater flexibility in tests, removes an unused button (signout) from the test app, and makes makes the message-display function a bit more robuest/clear.

This will allow us to be more flexible when testing out new APIs, since we now fully control the authentication flow in the test.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->







<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b755fc87f/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->






