### PR TITLE
Bump actions/checkout v3 -> v4

### DIFF
--- a/.github/actions/file-size/README.md
+++ b/.github/actions/file-size/README.md
@@ -8,7 +8,7 @@ A GitHub Action for recording file sizes in git notes.
   record-readme-size:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/file-size
         with:
           file: README.md

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -17,7 +17,7 @@ jobs:
   docker-build-base:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # We use buildx and its GitHub Actions caching support `type=gha`. For
       # more information, see
@@ -65,7 +65,7 @@ jobs:
             II_INSECURE_REQUESTS: 1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Infer version
         id: version
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-ii
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Infer version
         id: version
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-base
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v2
@@ -205,7 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-internet_identity_production
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Download wasm'
         uses: actions/download-artifact@v4
         with:
@@ -230,7 +230,7 @@ jobs:
   vc_demo_issuer-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: |
@@ -258,7 +258,7 @@ jobs:
   test-app-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: |
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [docker-build-ii, vc_demo_issuer-build]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: |
@@ -340,7 +340,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Attempt to restore the pre-built test binaries from cache.
       # The test binaries are only dependent on rust code, because the front-end code is bundled in the `wasm` file
@@ -410,7 +410,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         partition: ['1/3', '2/3', '3/3']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download nextest
         run: |
@@ -487,7 +487,7 @@ jobs:
       artifact_suffix: ${{ contains(matrix.domain, 'internetcomputer') && 'current' || 'legacy' }}-${{ matrix.device }}-${{ matrix.shard }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
 
       # npm ci is a slow operation that mostly involves downloading packages, so we run
@@ -597,7 +597,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-ii
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: |
           sudo apt-get update
@@ -658,7 +658,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/release-')
     needs: [docker-build-internet_identity_production, docker-build-archive, test-app-build, vc_demo_issuer-build]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-dfx
 
@@ -733,7 +733,7 @@ jobs:
     needs: [docker-build-internet_identity_production, docker-build-archive, vc_demo_issuer-build]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Download test build'
         uses: actions/download-artifact@v4
@@ -890,7 +890,7 @@ jobs:
   cached-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         id: cache
         with:
@@ -930,7 +930,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [docker-build-ii, cached-build]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Download docker build'
         uses: actions/download-artifact@v4
         with:
@@ -965,7 +965,7 @@ jobs:
         # XXX: GHA fails if we return the matrix object directly, so we have to pretend it's JSON
         os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-22.04", "ubuntu-20.04", "macos-11", "macos-12" ]') || fromJson('[ "ubuntu-22.04" ]') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/check-build
       - run: mv internet_identity.wasm.gz internet_identity_clean_build_${{ matrix.os }}.wasm.gz
       - name: 'Upload clean build'
@@ -1020,7 +1020,7 @@ jobs:
   interface-compatibility:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # we need the history for the tags, but we don't need the files (except for the GitHub workflows / actions)
           # --> sparse checkout of only the needed things

--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -17,7 +17,7 @@ jobs:
       testnet_app_canister_id: jlfvx-nqaaa-aaaad-aab7a-cai
       wallet_canister_id: cvthj-wyaaa-aaaad-aaaaq-cai
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Download build for Release Candidate"
         uses: actions/github-script@v6

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -7,7 +7,7 @@ jobs:
   frontend-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # set a PAT so that add-and-commit can trigger CI runs
           token: ${{ secrets.GIX_BOT_PAT }}
@@ -50,7 +50,7 @@ jobs:
   showcase:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
       - run: npm ci
 

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         os: [ ubuntu-22.04, ubuntu-20.04, macos-11, macos-12 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "refs/tags/${{ needs.latest-release.outputs.ref }}"
 
@@ -86,7 +86,7 @@ jobs:
       matrix:
         os: [ ubuntu-22.04, ubuntu-20.04, macos-11, macos-12 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "refs/tags/${{ needs.latest-release.outputs.ref }}"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
   cargo-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # set a PAT so that add-and-commit can trigger
           # CI runs
@@ -38,7 +38,7 @@ jobs:
   cargo-clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/bootstrap
 
       - name: Create dummy assets
@@ -71,7 +71,7 @@ jobs:
   check-lockfile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/bootstrap
 
         # fails if lockfile is out of date

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -23,9 +23,9 @@ jobs:
       # Make sure that one failing test does not cancel all other matrix jobs
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ matrix.ref == 'head' }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ matrix.ref == 'base' }}
         with:
           ref: ${{ github.event.pull_request.base.sha }}
@@ -90,7 +90,7 @@ jobs:
           echo "dumpster_path=objs/$branch_alias" >> "$GITHUB_OUTPUT"
         id: sys
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         # Checks out 'image-dumpster', a single-commit branch used to keep objects (screenshots).
         # We store the images in a branch (as opposed to e.g. artifacts) so that GitHub will serve
         # them (on rawgithubusercontent), meaning we can display them on PRs.

--- a/.github/workflows/update-dapps.yml
+++ b/.github/workflows/update-dapps.yml
@@ -11,7 +11,7 @@ jobs:
   dapps-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
       - run: npm ci
 

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -11,7 +11,7 @@ jobs:
   didc-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
         # First, check didc releases (on the candid repo) for a new version.
       - name: Check new didc version

--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -11,7 +11,7 @@ jobs:
   node-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
         # First, check node's releases for a new version.
       - name: Check new node version

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -11,7 +11,7 @@ jobs:
   rust-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
         # First, check rust GitHub releases for a new version. We assume that the
         # latest version's tag name is the version.

--- a/.github/workflows/update-state-machine.yml
+++ b/.github/workflows/update-state-machine.yml
@@ -10,7 +10,7 @@ jobs:
   ic-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
         # First, check if there is a newer version and update the file referencing the version
       - name: Check new ic version


### PR DESCRIPTION
This bumps the checkout action to the latest version. The previous version (v3) ran on node 16 which is now deprecated on GHA.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
<img width="911" alt="Screenshot 2024-01-26 at 13 25 50" src="https://github.com/dfinity/internet-identity/assets/6930756/261823a1-d276-4905-9277-26388db27a70">


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

