### PR TITLE
Simplify asset collection

### DIFF
--- a/demos/test-app/lib.rs
+++ b/demos/test-app/lib.rs
@@ -1,5 +1,4 @@
 use crate::AlternativeOriginsMode::{CertifiedContent, Redirect};
-use asset_util::DirectoryTraversalMode::IncludeSubdirs;
 use asset_util::{collect_assets, Asset, CertifiedAssets, ContentEncoding, ContentType};
 use candid::{CandidType, Deserialize, Principal};
 use ic_cdk::api;
@@ -171,7 +170,7 @@ fn post_upgrade() {
 
 /// Collect all the assets from the dist folder.
 fn init_assets(alternative_origins: String) {
-    let mut assets = collect_assets(&ASSET_DIR, IncludeSubdirs, Some(fixup_html));
+    let mut assets = collect_assets(&ASSET_DIR, Some(fixup_html));
     assets.push(Asset {
         url_path: ALTERNATIVE_ORIGINS_PATH.to_string(),
         content: alternative_origins.as_bytes().to_vec(),

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -28,10 +28,9 @@ use vc_util::{
 };
 use SupportedCredentialType::{UniversityDegree, VerifiedAdult, VerifiedEmployee};
 
-use asset_util::{collect_assets, CertifiedAssets, DirectoryTraversalMode};
+use asset_util::{collect_assets, CertifiedAssets};
 use ic_cdk::api;
 use ic_cdk_macros::post_upgrade;
-use DirectoryTraversalMode::IncludeSubdirs;
 
 mod consent_message;
 
@@ -577,7 +576,7 @@ static ASSET_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/dist");
 pub fn init_assets() {
     ASSETS.with_borrow_mut(|assets| {
         *assets = CertifiedAssets::certify_assets(
-            collect_assets(&ASSET_DIR, IncludeSubdirs, Some(fixup_html)),
+            collect_assets(&ASSET_DIR, Some(fixup_html)),
             &static_headers(),
         );
     });

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -3,16 +3,13 @@
 // This file describes which assets are used and how (content, content type and content encoding).
 use crate::http::security_headers;
 use crate::state;
-use asset_util::{
-    collect_assets, Asset, CertifiedAssets, ContentEncoding, ContentType, DirectoryTraversalMode,
-};
+use asset_util::{collect_assets, Asset, CertifiedAssets, ContentEncoding, ContentType};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use ic_cdk::api;
 use include_dir::{include_dir, Dir};
 use lazy_static::lazy_static;
 use sha2::Digest;
-use DirectoryTraversalMode::IncludeSubdirs;
 
 // used both in init and post_upgrade
 pub fn init_assets() {
@@ -61,7 +58,7 @@ static ASSET_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../dist");
 
 // Gets the static assets. All static assets are prepared only once (like injecting the canister ID).
 fn get_static_assets() -> Vec<Asset> {
-    let mut assets = collect_assets(&ASSET_DIR, IncludeSubdirs, Some(fixup_html));
+    let mut assets = collect_assets(&ASSET_DIR, Some(fixup_html));
 
     // Required to make II available on the identity.internetcomputer.org domain.
     // See https://internetcomputer.org/docs/current/developer-docs/production/custom-domain/#custom-domains-on-the-boundary-nodes


### PR DESCRIPTION
This simplifies/clarifies the asset collection (used when including assets of a built app) in a few ways:

* The concern of transforming the HTML is moved out of the asset collection recursion and to the top-level (and recursion is limited to a single function)
* The unused traversal (collection) mode option is removed
* The documentation is updated to clarify undefined behavior in some cases

An added benefit of moving the HTML transformer out of the loop is that it would now be straightforward to pass the assets themselves to the transformer (for instance for computing assets of linked assets in subresource integrity).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
