### PR TITLE
Fix paths in auto release bump

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -868,7 +868,7 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
-          add-paths: ./README
+          add-paths: ./README.md
           commit-message: Update release in README
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>


### PR DESCRIPTION
The automated release bump is supposed to create a PR with the updated README.

The path to the README however was incorrect: `s/README/README.md/`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
