### PR TITLE
Add loader when fetching delegation

### DIFF
--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -4,6 +4,7 @@ import {
 } from "$src/components/authenticateBox";
 import { displayError } from "$src/components/displayError";
 import { caretDownIcon } from "$src/components/icons";
+import { withLoader } from "$src/components/loader";
 import { showMessage } from "$src/components/message";
 import { showSpinner } from "$src/components/spinner";
 import { getDapps } from "$src/flows/dappsExplorer/dapps";
@@ -206,12 +207,14 @@ const authenticate = async (
   const derivationOrigin =
     authContext.authRequest.derivationOrigin ?? authContext.requestOrigin;
 
-  const result = await fetchDelegation({
-    connection: authSuccess.connection,
-    derivationOrigin,
-    publicKey: authContext.authRequest.sessionPublicKey,
-    maxTimeToLive: authContext.authRequest.maxTimeToLive,
-  });
+  const result = await withLoader(() =>
+    fetchDelegation({
+      connection: authSuccess.connection,
+      derivationOrigin,
+      publicKey: authContext.authRequest.sessionPublicKey,
+      maxTimeToLive: authContext.authRequest.maxTimeToLive,
+    })
+  );
 
   if ("error" in result) {
     return {


### PR DESCRIPTION
A recent refactor of the postMessage interface left out a loader during a slow operation (fetching the delegation). This re-introduces a loader.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
