### PR TITLE
Bump nodejs16 actions

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -32,7 +32,7 @@ runs:
     # NOTE: here we make sure to only cache ic-wasm and _not_ e.g. the cargo target, since in some cases
     # (clean builds) we build from scratch
     # NOTE: we include the output of uname to ensure binary compatibility (e.g. same glibc)
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/ic-wasm

--- a/.github/actions/setup-dfx/action.yml
+++ b/.github/actions/setup-dfx/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           /usr/local/bin/dfx

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -8,6 +8,6 @@ runs:
       id: read-node-version
       run: echo "version=$(cat .node-version)" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ steps.read-node-version.outputs.version }}

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -231,7 +231,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -259,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -290,7 +290,7 @@ jobs:
     needs: [docker-build-ii, vc_demo_issuer-build]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -346,7 +346,7 @@ jobs:
       # The test binaries are only dependent on rust code, because the front-end code is bundled in the `wasm` file
       # that is loaded by the test binaries.
       # If the binary can be restored from cache, we skip the build step, including even setting up the toolchain etc.
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-test-archive
         with:
           path: /tmp/test-archive
@@ -355,7 +355,7 @@ jobs:
       - uses: ./.github/actions/bootstrap
         if: steps.cache-test-archive.outputs.cache-hit != 'true'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         if: steps.cache-test-archive.outputs.cache-hit != 'true'
         with:
           path: |
@@ -891,7 +891,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache
         with:
           path: |


### PR DESCRIPTION
We have a few actions still using the (now deprecated) nodejs16 runtime. This bumps those actions (setup-node v3 -> v4, cache v3 -> v4) to all use the nodejs20 runtime.

This is unrelated to the node version set up by setup-node, which we use in our builds. The changes in this PR only impact the nodejs environment used by the JS-based actions.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
