### PR TITLE
Add anchor number to Anchor type

### DIFF
--- a/src/internet_identity/src/authz_utils.rs
+++ b/src/internet_identity/src/authz_utils.rs
@@ -78,7 +78,7 @@ where
     let result = op(&mut anchor);
 
     // write back anchor
-    state::storage_borrow_mut(|storage| storage.write(anchor_number, anchor))
+    state::storage_borrow_mut(|storage| storage.write(anchor))
         .map_err(|err| E::from(IdentityUpdateError::StorageError(anchor_number, err)))?;
 
     match result {
@@ -126,7 +126,7 @@ pub fn check_authz_and_record_activity(
         check_authorization(anchor_number).map_err(IdentityUpdateError::from)?;
     let maybe_domain = anchor.device(&device_key).unwrap().ii_domain();
     anchor_management::activity_bookkeeping(&mut anchor, &device_key);
-    state::storage_borrow_mut(|storage| storage.write(anchor_number, anchor))
+    state::storage_borrow_mut(|storage| storage.write(anchor))
         .map_err(|err| IdentityUpdateError::StorageError(anchor_number, err))?;
     Ok(maybe_domain)
 }

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -14,8 +14,9 @@ mod tests;
 /// The anchor has limited visibility for the constructor to make sure it is loaded from storage.
 /// The devices can only be modified by the exposed functions which keeps invariant checking local
 /// to this module.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Anchor {
+    anchor_number: AnchorNumber,
     devices: Vec<Device>,
     metadata: Option<HashMap<String, MetadataEntry>>,
 }
@@ -107,9 +108,10 @@ impl From<Anchor> for StorableAnchor {
     }
 }
 
-impl From<StorableAnchor> for Anchor {
-    fn from(storable_anchor: StorableAnchor) -> Self {
+impl From<(AnchorNumber, StorableAnchor)> for Anchor {
+    fn from((anchor_number, storable_anchor): (AnchorNumber, StorableAnchor)) -> Self {
         Anchor {
+            anchor_number,
             devices: storable_anchor.devices,
             metadata: storable_anchor.metadata,
         }
@@ -119,11 +121,16 @@ impl From<StorableAnchor> for Anchor {
 impl Anchor {
     /// Creation of new anchors is restricted in order to make sure that the device checks are
     /// not accidentally bypassed.
-    pub(super) fn new() -> Anchor {
+    pub(super) fn new(anchor_number: AnchorNumber) -> Anchor {
         Self {
+            anchor_number,
             devices: vec![],
             metadata: None,
         }
+    }
+
+    pub fn anchor_number(&self) -> AnchorNumber {
+        self.anchor_number
     }
 
     pub fn add_device(&mut self, device: Device) -> Result<(), AnchorError> {

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -60,13 +60,13 @@ fn should_recover_header_from_memory_v7() {
 
 fn add_test_anchor_data<M: Memory + Clone>(storage: &mut Storage<M>, number_of_anchors: usize) {
     for _ in 0..number_of_anchors {
-        let (anchor_number, mut anchor) = storage
+        let mut anchor = storage
             .allocate_anchor()
             .expect("Failure allocating an anchor.");
         anchor
-            .add_device(sample_unique_device(anchor_number as usize))
+            .add_device(sample_unique_device(anchor.anchor_number() as usize))
             .expect("Failure adding a device");
-        storage.write(anchor_number, anchor.clone()).unwrap();
+        storage.write(anchor.clone()).unwrap();
     }
 }
 
@@ -93,10 +93,11 @@ fn should_allocate_new_bucket_after_2048_anchors_v7() {
 fn should_read_previous_write() {
     let memory = VectorMemory::default();
     let mut storage = Storage::new((12345, 678910), memory);
-    let (anchor_number, mut anchor) = storage.allocate_anchor().unwrap();
+    let mut anchor = storage.allocate_anchor().unwrap();
+    let anchor_number = anchor.anchor_number();
 
     anchor.add_device(sample_device()).unwrap();
-    storage.write(anchor_number, anchor.clone()).unwrap();
+    storage.write(anchor.clone()).unwrap();
 
     let read_anchor = storage.read(anchor_number).unwrap();
     assert_eq!(anchor, read_anchor);
@@ -106,20 +107,20 @@ fn should_read_previous_write() {
 fn should_serialize_first_record() {
     let memory = VectorMemory::default();
     let mut storage = Storage::new((123, 456), memory.clone());
-    let (anchor_number, mut anchor) = storage.allocate_anchor().unwrap();
-    assert_eq!(anchor_number, 123u64);
+    let mut anchor = storage.allocate_anchor().unwrap();
+    assert_eq!(anchor.anchor_number(), 123u64);
 
     anchor.add_device(sample_device()).unwrap();
     let expected_length = candid::encode_one(StorableAnchor::from(anchor.clone()))
         .unwrap()
         .len();
 
-    storage.write(anchor_number, anchor.clone()).unwrap();
+    storage.write(anchor.clone()).unwrap();
 
     let mut buf = vec![0u8; expected_length];
     memory.read(RESERVED_HEADER_BYTES + LENGTH_OFFSET, &mut buf);
     let decoded_from_memory: StorableAnchor = candid::decode_one(&buf).unwrap();
-    assert_eq!(Anchor::from(decoded_from_memory), anchor);
+    assert_eq!(Anchor::from((123u64, decoded_from_memory)), anchor);
 }
 
 #[test]
@@ -130,15 +131,15 @@ fn should_serialize_subsequent_record_to_expected_memory_location() {
     for _ in 0..100 {
         storage.allocate_anchor().unwrap();
     }
-    let (anchor_number, mut anchor) = storage.allocate_anchor().unwrap();
-    assert_eq!(anchor_number, 223u64);
+    let mut anchor = storage.allocate_anchor().unwrap();
+    assert_eq!(anchor.anchor_number(), 223u64);
 
     anchor.add_device(sample_device()).unwrap();
     let expected_length = candid::encode_one(StorableAnchor::from(anchor.clone()))
         .unwrap()
         .len();
 
-    storage.write(anchor_number, anchor.clone()).unwrap();
+    storage.write(anchor.clone()).unwrap();
 
     let mut buf = vec![0u8; expected_length];
     memory.read(
@@ -146,17 +147,7 @@ fn should_serialize_subsequent_record_to_expected_memory_location() {
         &mut buf,
     );
     let decoded_from_memory: StorableAnchor = candid::decode_one(&buf).unwrap();
-    assert_eq!(Anchor::from(decoded_from_memory), anchor);
-}
-
-#[test]
-fn should_not_write_using_anchor_number_outside_allocated_range() {
-    let memory = VectorMemory::default();
-    let mut storage = Storage::new((123, 456), memory);
-    let (_, anchor) = storage.allocate_anchor().unwrap();
-
-    let result = storage.write(222, anchor);
-    assert!(matches!(result, Err(StorageError::BadAnchorNumber(_))))
+    assert_eq!(Anchor::from((223u64, decoded_from_memory)), anchor);
 }
 
 #[test]
@@ -164,13 +155,13 @@ fn should_deserialize_first_record() {
     let memory = VectorMemory::default();
     memory.grow(3);
     let mut storage = Storage::new((123, 456), memory.clone());
-    let (anchor_number, mut anchor) = storage
+    let mut anchor = storage
         .allocate_anchor()
         .expect("Failed to allocate an anchor");
     storage
-        .write(anchor_number, anchor.clone())
+        .write(anchor.clone())
         .expect("Failed to write anchor");
-    assert_eq!(anchor_number, 123u64);
+    assert_eq!(anchor.anchor_number(), 123u64);
 
     anchor.add_device(sample_device()).unwrap();
     let buf = candid::encode_one(StorableAnchor::from(anchor.clone())).unwrap();
@@ -188,15 +179,13 @@ fn should_deserialize_subsequent_record_at_expected_memory_location() {
     memory.grow(9); // grow memory to accommodate a write to record 100
     let mut storage = Storage::new((123, 456), memory.clone());
     for _ in 0..100 {
-        let (anchor_number, anchor) = storage
+        let anchor = storage
             .allocate_anchor()
             .expect("Failed to allocate an anchor");
-        storage
-            .write(anchor_number, anchor)
-            .expect("Failed to write anchor");
+        storage.write(anchor).expect("Failed to write anchor");
     }
-    let (anchor_number, mut anchor) = storage.allocate_anchor().unwrap();
-    assert_eq!(anchor_number, 223u64);
+    let mut anchor = storage.allocate_anchor().unwrap();
+    assert_eq!(anchor.anchor_number(), 223u64);
 
     anchor.add_device(sample_device()).unwrap();
     let buf = candid::encode_one(StorableAnchor::from(anchor.clone())).unwrap();
@@ -339,8 +328,8 @@ fn should_overwrite_persistent_state_with_next_anchor() {
     memory.read(EXPECTED_ADDRESS, &mut buf);
     assert_eq!(buf, PERSISTENT_STATE_MAGIC);
 
-    let (anchor_number, anchor) = storage.allocate_anchor().unwrap();
-    storage.write(anchor_number, anchor).unwrap();
+    let anchor = storage.allocate_anchor().unwrap();
+    storage.write(anchor).unwrap();
 
     let mut buf = vec![0u8; 4];
     memory.read(EXPECTED_ADDRESS, &mut buf);
@@ -362,10 +351,8 @@ fn should_read_previously_stored_persistent_state() {
     // Create storage, and add anchors (so that MemoryManager allocates a memory block for anchors).
     let mut storage = Storage::new((1, 100), memory.clone());
     for _ in 0..NUM_ANCHORS {
-        let (anchor_number, anchor) = storage.allocate_anchor().expect("Failed allocating anchor");
-        storage
-            .write(anchor_number, anchor)
-            .expect("Failed writing anchor");
+        let anchor = storage.allocate_anchor().expect("Failed allocating anchor");
+        storage.write(anchor).expect("Failed writing anchor");
     }
 
     memory.write(EXPECTED_ADDRESS, b"IIPS".as_ref());


### PR DESCRIPTION
This refactoring includes the anchor number in the `Anchor` business logic struct, making it impossible to mix up different anchors in storage.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
