### PR TITLE
Don't panic in vc_util

### DIFF
--- a/src/vc_util/src/lib.rs
+++ b/src/vc_util/src/lib.rs
@@ -372,9 +372,15 @@ fn validate_claims_match_spec(
     let subject = Subject::from_json_value(credential_subject.clone()).map_err(|_| {
         inconsistent_jwt_claims("missing credentialSubject in VerifiedAdult JWT vc")
     })?;
-    for (key, value) in spec.arguments.as_ref().unwrap_or(&HashMap::new()).iter() {
-        if *value != subject.properties[key] {
-            return Err(inconsistent_jwt_claims("wrong VerifiedAdult vc"));
+    if let Some(arguments) = spec.arguments.as_ref() {
+        for (key, value) in arguments.iter() {
+            if let Some(v) = subject.properties.get(key) {
+                if value != v {
+                    return Err(inconsistent_jwt_claims("wrong VerifiedAdult vc"));
+                }
+            } else {
+                return Err(inconsistent_jwt_claims("Missing key in subject properties"));
+            }
         }
     }
     Ok(())

--- a/src/vc_util/src/lib.rs
+++ b/src/vc_util/src/lib.rs
@@ -18,7 +18,6 @@ use identity_jose::jwt::JwtClaims;
 use identity_jose::jwu::{decode_b64, encode_b64};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
 use std::ops::{Add, Deref, DerefMut};
 
 pub mod custom;


### PR DESCRIPTION
This ensures that the vc_util lib does not panic because of missing keys (keys specified in the cred spec argument but not in the subject properties).

This also updates the behavior when no arguments are supplied; before this the iteration was implicitly skipped by creating an empty hash map and iterating over it. Now we explicitly skip the check.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

