### PR TITLE
Package vc_util_js

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup nodejs'
-description: Setup nodejs
+description: Setup nodejs and other frontend tools used in the frontend build
 runs:
   using: "composite"
   steps:
@@ -7,6 +7,10 @@ runs:
       shell: bash
       id: read-node-version
       run: echo "version=$(cat .node-version)" >> "$GITHUB_OUTPUT"
+
+    - name: Install wasm-pack
+      shell: bash
+      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
     - uses: actions/setup-node@v4
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,6 +3684,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "vc_util_js"
+version = "1.0.0"
+dependencies = [
+ "candid",
+ "canister_sig_util",
+ "vc_util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ members = [
     "src/canister_tests",
     "src/internet_identity_interface",
     "src/archive",
-    "src/vc_util"
+    "src/vc_util",
+    "src/vc_util_js"
 ]
 resolver = "2"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ COPY ./scripts/bootstrap ./scripts/bootstrap
 COPY ./rust-toolchain.toml ./rust-toolchain.toml
 
 RUN ./scripts/bootstrap
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+RUN wasm-pack --version
 
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependecies, we pretend that our project is a simple, empty
@@ -49,6 +51,7 @@ COPY src/archive/Cargo.toml src/archive/Cargo.toml
 COPY src/canister_tests/Cargo.toml src/canister_tests/Cargo.toml
 COPY src/canister_sig_util/Cargo.toml src/canister_sig_util/Cargo.toml
 COPY src/vc_util/Cargo.toml src/vc_util/Cargo.toml
+COPY src/vc_util_js/Cargo.toml src/vc_util_js/Cargo.toml
 COPY src/asset_util/Cargo.toml src/asset_util/Cargo.toml
 ENV CARGO_TARGET_DIR=/cargo_target
 COPY ./scripts/build ./scripts/build
@@ -64,6 +67,8 @@ RUN mkdir -p src/internet_identity/src \
     && touch src/canister_sig_util/src/lib.rs \
     && mkdir -p src/vc_util/src \
     && touch src/vc_util/src/lib.rs \
+    && mkdir -p src/vc_util_js/src \
+    && touch src/vc_util_js/src/lib.rs \
     && mkdir -p src/asset_util/src \
     && touch src/asset_util/src/lib.rs \
     && ./scripts/build --only-dependencies --internet-identity --archive \

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "src/vc-api",
         "demos/test-app",
         "demos/vc_issuer",
-        "src/vite-plugins"
+        "src/vite-plugins",
+        "src/vc_util_js"
       ],
       "dependencies": {
         "@dfinity/agent": "^0.19.2",
@@ -75,11 +76,13 @@
       "devDependencies": {
         "@dfinity/internet-identity-vc-api": "*",
         "@dfinity/internet-identity-vite-plugins": "*",
+        "@dfinity/vc_util_js": "*",
         "@types/react": "^18.2.38",
         "@types/react-dom": "^18.2.17",
         "@vitejs/plugin-react": "^4.2.0",
         "typescript": "5.2.2",
-        "vite": "^4.5.2"
+        "vite": "^4.5.2",
+        "vite-plugin-wasm": "^3.3.0"
       }
     },
     "demos/vc_issuer": {
@@ -853,6 +856,10 @@
         "@dfinity/candid": "^0.19.1",
         "@dfinity/principal": "^0.19.1"
       }
+    },
+    "node_modules/@dfinity/vc_util_js": {
+      "resolved": "src/vc_util_js",
+      "link": true
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
@@ -12613,6 +12620,15 @@
         "vite": ">=2.0.0"
       }
     },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.3.0.tgz",
+      "integrity": "sha512-tVhz6w+W9MVsOCHzxo6SSMSswCeIw4HTrXEi6qL3IRzATl83jl09JVO1djBqPSwfjgnpVHNLYcaMbaDX5WB/pg==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/darwin-x64": {
       "version": "0.18.20",
       "cpu": [
@@ -13755,6 +13771,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "src/vc_util_js": {
+      "name": "@dfinity/vc_util_js",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "devDependencies": {
+        "@dfinity/internet-identity-vite-plugins": "*",
+        "@types/react": "^18.2.38",
+        "@types/react-dom": "^18.2.17",
+        "@vitejs/plugin-react": "^4.2.0",
+        "typescript": "5.2.2",
+        "vite": "^4.5.2"
       }
     },
     "src/vc-api": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "src/vc-api",
     "demos/test-app",
     "demos/vc_issuer",
-    "src/vite-plugins"
+    "src/vite-plugins",
+    "src/vc_util_js"
   ]
 }

--- a/src/vc_util_js/Cargo.toml
+++ b/src/vc_util_js/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vc_util_js"
+description = "JavaScript Wasm wrapper around vc_util"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+candid.workspace = true
+canister_sig_util.workspace = true
+vc_util.workspace = true
+wasm-bindgen = "0.2"

--- a/src/vc_util_js/README.md
+++ b/src/vc_util_js/README.md
@@ -1,0 +1,55 @@
+# vc-util-web
+
+JS/TS Wrapper for the [`vc_util` Rust crate](../vc_util).
+
+
+> [!WARNING]
+> There are some caveats to using this library:
+> 1. This library only supports verifying a specific kind of credentials (age).
+> 1. **Verifying signatures in the front-end is generally unsafe!** Malicious users could modify the front-end code and bypass the signature verification. This library is intended for use in demos, prototypes, backends and other situations where the code either cannot be tampered with _or_ the tampering does not pose a security risk.
+> 1. This library is in alpha version. This means that the API may change at any time.
+> 1. The resulting wasm module is _heavy_, around 1MB gzipped. Do not use this library if you are concerned about the size of your bundle.
+
+
+## Prerequisites
+
+- [rust](https://www.rust-lang.org)
+- [wasm-pack](https://github.com/rustwasm/wasm-pack)
+
+## Building
+
+Run the following command
+```bash
+$ npm run build
+```
+## Usage Example
+
+```js
+import vcUtil, {validateVerifiedAdultPresentation} from "@dfinity/vc-util-web";
+export var ROOT_PUBLIC_KEY_RAW = new Uint8Array([
+    0x81, 0x4c, 0x0e, 0x6e, 0xc7, 0x1f, 0xab, 0x58, 0x3b, 0x08, 0xbd, 0x81, 0x37, 0x3c, 0x25, 0x5c, 0x3c,
+    0x37, 0x1b, 0x2e, 0x84, 0x86, 0x3c, 0x98, 0xa4, 0xf1, 0xe0, 0x8b, 0x74, 0x23, 0x5d, 0x14, 0xfb, 0x5d,
+    0x9c, 0x0c, 0xd5, 0x46, 0xd9, 0x68, 0x5f, 0x91, 0x3a, 0x0c, 0x0b, 0x2c, 0xc5, 0x34, 0x15, 0x83, 0xbf,
+    0x4b, 0x43, 0x92, 0xe4, 0x67, 0xdb, 0x96, 0xd6, 0x5b, 0x9b, 0xb4, 0xcb, 0x71, 0x71, 0x12, 0xf8, 0x47,
+    0x2e, 0x0d, 0x5a, 0x4d, 0x14, 0x50, 0x5f, 0xfd, 0x74, 0x84, 0xb0, 0x12, 0x91, 0x09, 0x1c, 0x5f, 0x87,
+    0xb9, 0x88, 0x83, 0x46, 0x3f, 0x98, 0x09, 0x1a, 0x0b, 0xaa, 0xae]);
+
+async function verifyAdultVp(vpJwt : string, vcSubjectPrincipal: Principal, issuerOrigin: string,
+                             iiCanisterId: Principal, issuerCanisterId: Principal) {
+    await vcUtil();
+    const currentTimeNs = new Date().getTime().valueOf();
+    var encoder = new TextEncoder();
+    try {
+        validateVerifiedAdultPresentation(encoder.encode(vpJwt),
+            vcSubjectPrincipal.toUint8Array(),
+            iiCanisterId.toUint8Array(),
+            encoder.encode(issuerOrigin),
+            issuerCanisterId.toUint8Array(),
+            ROOT_PUBLIC_KEY_RAW,
+            BigInt(currentTimeNs))
+        console.log('--- Adult VP verified successfully')
+    } catch (error) {
+        console.error('--- Adult VP verification failed', error)
+    }
+}
+```

--- a/src/vc_util_js/package.json
+++ b/src/vc_util_js/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@dfinity/vc_util_js",
+  "type": "module",
+  "private": true,
+  "license": "SEE LICENSE IN LICENSE.md",
+  "exports": {
+    "./vc_util_js": "dist/vc_util_js.js",
+    "./package.json": "package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "vc_util_js": [
+        "dist/vc_util_js.d.ts"
+      ]
+    }
+  },
+  "scripts": {
+    "build": "wasm-pack build --out-dir dist --release --scope dfinity && rm dist/package.json",
+    "postinstall": "npm run build"
+  },
+  "devDependencies": {
+    "@dfinity/internet-identity-vite-plugins": "*",
+    "@types/react": "^18.2.38",
+    "@types/react-dom": "^18.2.17",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "5.2.2",
+    "vite": "^4.5.2"
+  }
+}

--- a/src/vc_util_js/src/lib.rs
+++ b/src/vc_util_js/src/lib.rs
@@ -1,0 +1,31 @@
+use candid::Principal;
+use vc_util::VcFlowSigners;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(js_name = validateVerifiedAdultPresentation)]
+pub fn validate_verified_adult_presentation(
+    vp_jwt: &[u8],
+    vc_subject_principal: &[u8],
+    ii_canister_id: &[u8],
+    issuer_origin: &[u8],
+    issuer_canister_id: &[u8],
+    root_pk_raw: &[u8],
+    current_time_ns: u64,
+) -> Result<(), String> {
+    let vp_jwt = String::from_utf8(vp_jwt.to_vec()).expect("wrong vp_jwt");
+    let effective_vc_subject = Principal::from_slice(vc_subject_principal);
+    let vc_flow_signers: VcFlowSigners = VcFlowSigners {
+        ii_canister_id: Principal::from_slice(ii_canister_id),
+        ii_origin: vc_util::II_ISSUER_URL.to_string(),
+        issuer_canister_id: Principal::from_slice(issuer_canister_id),
+        issuer_origin: String::from_utf8(issuer_origin.to_vec()).expect("wrong issuer origin"),
+    };
+    vc_util::custom::validate_verified_adult_presentation(
+        &vp_jwt,
+        effective_vc_subject,
+        &vc_flow_signers,
+        root_pk_raw,
+        current_time_ns as u128,
+    )
+    .map_err(|e| format!("{:?}", e))
+}


### PR DESCRIPTION
This adds a new npm workspace, `src/vc_util_js`, which can be used to verify credentials.

See README.md for caveats.

NOTE: we do not pin the version of wasm-pack for simplicity (the wasm is not currently used, and should not be used in the production build anyway "ever").

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
