### PR TITLE
Add inline script loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,6 +2210,7 @@ name = "internet_identity"
 version = "0.1.0"
 dependencies = [
  "asset_util",
+ "base64 0.21.5",
  "candid",
  "candid_parser",
  "canister_sig_util",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,13 +76,11 @@
       "devDependencies": {
         "@dfinity/internet-identity-vc-api": "*",
         "@dfinity/internet-identity-vite-plugins": "*",
-        "@dfinity/vc_util_js": "*",
         "@types/react": "^18.2.38",
         "@types/react-dom": "^18.2.17",
         "@vitejs/plugin-react": "^4.2.0",
         "typescript": "5.2.2",
-        "vite": "^4.5.2",
-        "vite-plugin-wasm": "^3.3.0"
+        "vite": "^4.5.2"
       }
     },
     "demos/vc_issuer": {
@@ -12618,15 +12616,6 @@
       },
       "peerDependencies": {
         "vite": ">=2.0.0"
-      }
-    },
-    "node_modules/vite-plugin-wasm": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.3.0.tgz",
-      "integrity": "sha512-tVhz6w+W9MVsOCHzxo6SSMSswCeIw4HTrXEi6qL3IRzATl83jl09JVO1djBqPSwfjgnpVHNLYcaMbaDX5WB/pg==",
-      "dev": true,
-      "peerDependencies": {
-        "vite": "^2 || ^3 || ^4 || ^5"
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-x64": {

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -15,6 +15,7 @@ serde_bytes.workspace = true
 serde_cbor.workspace = true
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 sha2.workspace = true
+base64.workspace = true
 
 # Captcha deps
 lodepng = "*"

--- a/src/vite-plugins/src/index.ts
+++ b/src/vite-plugins/src/index.ts
@@ -1,6 +1,4 @@
 import { isNullish, nonNullish } from "@dfinity/utils";
-import { createHash } from "crypto";
-import { writeFileSync } from "fs";
 import { minify } from "html-minifier-terser";
 import { extname } from "path";
 import type { Plugin, ViteDevServer } from "vite";
@@ -142,52 +140,23 @@ export const replicaForwardPlugin = ({
   },
 });
 
-/** Update the HTML files to include integrity hashes for script.
- * i.e.: `<script src="foo.js">` becomes `<script integrity="<hash(./foo.js)>" src="foo.js">`.
+/** Update the HTML files to inline script imports.
+ * i.e.: `<script src="foo.js"></script>` becomes `<script>... insert new script node...</script>`.
+ *
+ * This allows us to use the `strict-dynamic` CSP directive.
+ * Otherwise, the directive requires `integrity=...` attributes which (in Chrome) does not easily allow importing
+ * other scripts. https://github.com/WICG/import-maps/issues/174#issuecomment-987678704
  */
-export const integrityPlugin: Plugin = {
+export const inlineScriptsPlugin: Plugin = {
   name: "integrity",
   apply: "build" /* only use during build, not serve */,
 
-  // XXX We use writeBundle as opposed to transformIndexHtml because transformIndexHtml still
-  // includes some variables (VITE_PRELOAD) that will be replaced later (by vite), changing
-  // the effective checksum. By the time writeBundle is called, the bundle has already been
-  // written so we update the files directly on the filesystem.
-  writeBundle(options: any, bundle: any) {
-    // Matches a script tag, grouping all the attributes (re-injected later) and extracting
-    // the 'src' attribute
+  transformIndexHtml(html: string): string {
     const rgx =
-      /<script(?<attrs>(?:\s+[^>]+)*\s+src="?(?<src>[^"]+)"?(?:\s+[^>]+)*)>/g;
-
-    const distDir = options.dir;
-
-    for (const filename in bundle) {
-      // If this is not HTML, skip
-      if (!filename.endsWith(".html")) {
-        continue;
-      }
-
-      // Grab the source, match all the script tags, inject the hash, and write the updated
-      // HTML to the filesystem
-      const html: string = bundle[filename].source;
-      const replaced = html.replace(rgx, (match, attrs, src) => {
-        const subresourcePath = src.slice(1); /* drop leading slash */
-        const item =
-          bundle[subresourcePath]; /* grab the item from the bundle */
-        const content = item.source || item.code;
-        const HASH_ALGO = "sha384" as const;
-        const integrityHash = createHash(HASH_ALGO)
-          .update(content)
-          .digest()
-          .toString("base64"); /* Compute the hash */
-
-        const integrityValue = `${HASH_ALGO}-${integrityHash}`;
-        return `<script integrity="${integrityValue}"${attrs}>`;
-      });
-
-      // Write the new content to disk
-      const filepath = [distDir, filename].join("/");
-      writeFileSync(filepath, replaced);
-    }
+      /<script(?<attrs>(?<beforesrc>\s+[^>]+)*\s+src="?(?<src>[^"]+)"?(?<aftersrc>\s+[^>]+)*)>/g;
+    return html.replace(rgx, (match, _attrs, beforesrc, src, aftersrc) => {
+      const tag = ["script", beforesrc, aftersrc].filter(Boolean).join(" ");
+      return `<${tag}>let s = document.createElement('script');s.type = 'module';s.src = '${src}';document.head.appendChild(s);`;
+    });
   },
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import {
   compression,
   injectCanisterIdPlugin,
-  integrityPlugin,
+  inlineScriptsPlugin,
   minifyHTML,
   replicaForwardPlugin,
 } from "@dfinity/internet-identity-vite-plugins";
@@ -64,7 +64,7 @@ export default defineConfig(({ mode }: UserConfig): UserConfig => {
       },
     },
     plugins: [
-      integrityPlugin,
+      inlineScriptsPlugin,
       [
         ...(mode === "development"
           ? [injectCanisterIdPlugin({ canisterName: "internet_identity" })]


### PR DESCRIPTION
This (re-)adds an inline script loader.

This is a workaround for [SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) not working very well with whitelisted scripts in the CSP. See `inlineScriptsPlugin` for a description of the limitation.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
