### PR TITLE
Add sig-verifier-js basic workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,6 +3261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sig_verifier_js"
+version = "1.0.0"
+dependencies = [
+ "ic-crypto-standalone-sig-verifier",
+ "ic-types",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ members = [
     "src/internet_identity_interface",
     "src/archive",
     "src/vc_util",
-    "src/vc_util_js"
+    "src/vc_util_js",
+    "src/sig-verifier-js"
 ]
 resolver = "2"
 
@@ -37,6 +38,8 @@ ic-representation-independent-hash = "2.2"
 ic-response-verification = "2.2"
 ic-stable-structures = "0.6"
 ic-test-state-machine-client = "3"
+ic-crypto-standalone-sig-verifier = { git = "https://github.com/dfinity/ic", rev = "e69bcc7b319cbb3ebc22ec55af35287741244db6" }
+ic-types = { git = "https://github.com/dfinity/ic", rev = "e69bcc7b319cbb3ebc22ec55af35287741244db6" }
 
 # other dependencies
 assert_matches = "1.5.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ COPY src/canister_tests/Cargo.toml src/canister_tests/Cargo.toml
 COPY src/canister_sig_util/Cargo.toml src/canister_sig_util/Cargo.toml
 COPY src/vc_util/Cargo.toml src/vc_util/Cargo.toml
 COPY src/vc_util_js/Cargo.toml src/vc_util_js/Cargo.toml
+COPY src/sig-verifier-js/Cargo.toml src/sig-verifier-js/Cargo.toml
 COPY src/asset_util/Cargo.toml src/asset_util/Cargo.toml
 ENV CARGO_TARGET_DIR=/cargo_target
 COPY ./scripts/build ./scripts/build
@@ -69,6 +70,8 @@ RUN mkdir -p src/internet_identity/src \
     && touch src/vc_util/src/lib.rs \
     && mkdir -p src/vc_util_js/src \
     && touch src/vc_util_js/src/lib.rs \
+    && mkdir -p src/sig-verifier-js/src \
+    && touch src/sig-verifier-js/src/lib.rs \
     && mkdir -p src/asset_util/src \
     && touch src/asset_util/src/lib.rs \
     && ./scripts/build --only-dependencies --internet-identity --archive \

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "demos/test-app",
         "demos/vc_issuer",
         "src/vite-plugins",
-        "src/vc_util_js"
+        "src/vc_util_js",
+        "src/sig-verifier-js"
       ],
       "dependencies": {
         "@dfinity/agent": "^0.19.2",
@@ -913,6 +914,10 @@
       "dependencies": {
         "@noble/hashes": "^1.3.1"
       }
+    },
+    "node_modules/@dfinity/sig-verifier-js": {
+      "resolved": "src/sig-verifier-js",
+      "link": true
     },
     "node_modules/@dfinity/utils": {
       "version": "0.0.20",
@@ -13654,6 +13659,15 @@
         "vite": ">=2.0.0"
       }
     },
+    "node_modules/vite-plugin-wasm": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.3.0.tgz",
+      "integrity": "sha512-tVhz6w+W9MVsOCHzxo6SSMSswCeIw4HTrXEi6qL3IRzATl83jl09JVO1djBqPSwfjgnpVHNLYcaMbaDX5WB/pg==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": "^2 || ^3 || ^4 || ^5"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
@@ -15206,6 +15220,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "src/sig-verifier-js": {
+      "name": "@dfinity/sig-verifier-js",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "devDependencies": {
+        "@dfinity/internet-identity-vite-plugins": "*",
+        "@types/react": "^18.2.38",
+        "@types/react-dom": "^18.2.17",
+        "@vitejs/plugin-react": "^4.2.0",
+        "typescript": "5.2.2",
+        "vite": "^4.5.2",
+        "vite-plugin-wasm": "^3.3.0",
+        "vitest": "^0.34.0"
       }
     },
     "src/vc_util_js": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "lint": "npm run lint:eslint && npm run lint:lit",
     "lint:eslint": "eslint --max-warnings 0 --cache --cache-location node_modules/.cache/eslint 'src/frontend/**/*.ts*' 'src/showcase/**/*.ts'",
     "lint:lit": "lit-analyzer -- --rules.no-incompatible-type-binding off --rules.no-invalid-directive-binding off --rules.no-noncallable-event-binding off ./src/showcase ./src/frontend",
-    "format": "prettier --write src/showcase src/frontend src/vc-api src/vite-plugins tsconfig.json tsconfig.all.json .eslintrc.json vite.config.ts vitest.config.ts demos",
-    "format-check": "prettier --check src/showcase src/frontend src/vc-api src/vite-plugins tsconfig.json tsconfig.all.json .eslintrc.json vite.config.ts vitest.config.ts demos"
+    "format": "prettier --write src/showcase src/frontend src/vc-api src/sig-verifier-js src/vite-plugins tsconfig.json tsconfig.all.json .eslintrc.json vite.config.ts vitest.config.ts demos",
+    "format-check": "prettier --check src/showcase src/frontend src/vc-api src/sig-verifier-js src/vite-plugins tsconfig.json tsconfig.all.json .eslintrc.json vite.config.ts vitest.config.ts demos"
   },
   "devDependencies": {
     "@astrojs/check": "^0.5.3",
@@ -84,6 +84,7 @@
     "demos/test-app",
     "demos/vc_issuer",
     "src/vite-plugins",
-    "src/vc_util_js"
+    "src/vc_util_js",
+    "src/sig-verifier-js"
   ]
 }

--- a/src/sig-verifier-js/Cargo.toml
+++ b/src/sig-verifier-js/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sig_verifier_js"
+description = "JavaScript Wasm wrapper for verifying signatures"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+ic-crypto-standalone-sig-verifier.workspace = true
+ic-types.workspace = true
+wasm-bindgen = "0.2"

--- a/src/sig-verifier-js/README.md
+++ b/src/sig-verifier-js/README.md
@@ -1,0 +1,15 @@
+# sig-verifier-js
+
+JS/TS Wrapper for verifying canister signatures.
+
+> [!WARNING]
+> This library is under development and is untested. This library should not be used.
+
+## Build
+
+From the root of the repository:
+
+```
+$ npm run --workspace ./src/sig-verifier-js build
+$ npm run --workspace ./src/sig-verifier-js test
+```

--- a/src/sig-verifier-js/package.json
+++ b/src/sig-verifier-js/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@dfinity/sig-verifier-js",
+  "type": "module",
+  "private": true,
+  "license": "SEE LICENSE IN LICENSE.md",
+  "exports": {
+    "./sig_verifier_js": "./dist/sig_verifier_js.js",
+    "./sig_verifier_js_bg": "./dist/sig_verifier_js_bg.js",
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "sig_verifier_js": [
+        "dist/sig_verifier_js.d.ts"
+      ]
+    }
+  },
+  "scripts": {
+    "build": "wasm-pack build --out-dir dist --release --scope dfinity && rm dist/package.json",
+    "test": "vitest --config ./vitest.config.ts"
+  },
+  "devDependencies": {
+    "@dfinity/internet-identity-vite-plugins": "*",
+    "@types/react": "^18.2.38",
+    "@types/react-dom": "^18.2.17",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "5.2.2",
+    "vite": "^4.5.2",
+    "vite-plugin-wasm": "^3.3.0",
+    "vitest": "^0.34.0"
+  }
+}

--- a/src/sig-verifier-js/src/lib.rs
+++ b/src/sig-verifier-js/src/lib.rs
@@ -1,0 +1,80 @@
+use ic_crypto_standalone_sig_verifier as ic_sig_ver;
+use ic_crypto_standalone_sig_verifier::KeyBytesContentType;
+use ic_types::crypto::threshold_sig::IcRootOfTrust;
+use wasm_bindgen::prelude::wasm_bindgen;
+use KeyBytesContentType::IcCanisterSignatureAlgPublicKeyDer;
+
+/// Verifies a basic (i.e. not a canister signature) IC supported signature.
+/// Supported signature schemes: https://internetcomputer.org/docs/current/references/ic-interface-spec/#signatures
+///
+/// Throws an error if the signature verification fails.
+#[wasm_bindgen(js_name = verifyBasicSignature)]
+pub fn verify_basic_sig_by_public_key(
+    msg: &[u8],
+    signature: &[u8],
+    public_key: &[u8],
+) -> Result<(), String> {
+    let (public_key, _) =
+        ic_sig_ver::user_public_key_from_bytes(public_key).map_err(|e| e.to_string())?;
+    ic_sig_ver::verify_basic_sig_by_public_key(
+        public_key.algorithm_id,
+        msg,
+        signature,
+        &public_key.key,
+    )
+    .map_err(|e| e.to_string())
+}
+
+/// Verifies an IC canister signature.
+/// More details: https://internetcomputer.org/docs/current/references/ic-interface-spec/#canister-signatures
+///
+/// Throws an error if the signature verification fails.
+#[wasm_bindgen(js_name = verifyCanisterSignature)]
+pub fn verify_canister_sig(
+    message: &[u8],
+    signature: &[u8],
+    public_key: &[u8],
+    ic_root_public_key: &[u8],
+) -> Result<(), String> {
+    let root_of_trust = root_public_key_from_bytes(ic_root_public_key)?;
+    ic_sig_ver::verify_canister_sig(message, signature, public_key, root_of_trust)
+        .map_err(|e| e.to_string())
+}
+
+/// Verifies any IC supported signature.
+/// Supported signature schemes: https://internetcomputer.org/docs/current/references/ic-interface-spec/#signatures
+///
+/// Throws an error if the signature verification fails.
+#[wasm_bindgen(js_name = verifyIcSignature)]
+pub fn verify_ic_signature(
+    message: &[u8],
+    signature: &[u8],
+    public_key: &[u8],
+    ic_root_public_key: &[u8],
+) -> Result<(), String> {
+    let (public_key, content_type) =
+        ic_sig_ver::user_public_key_from_bytes(public_key).map_err(|e| e.to_string())?;
+    let result = match content_type {
+        IcCanisterSignatureAlgPublicKeyDer => {
+            let root_of_trust = root_public_key_from_bytes(ic_root_public_key)?;
+            ic_sig_ver::verify_canister_sig(message, signature, &public_key.key, root_of_trust)
+        }
+        _ => ic_sig_ver::verify_basic_sig_by_public_key(
+            public_key.algorithm_id,
+            message,
+            signature,
+            &public_key.key,
+        ),
+    };
+    result.map_err(|e| e.to_string())
+}
+
+fn root_public_key_from_bytes(ic_root_public_key: &[u8]) -> Result<IcRootOfTrust, String> {
+    let root_key_bytes: [u8; 96] = ic_root_public_key.try_into().map_err(|_| {
+        format!(
+            "Invalid length of ic root public key: expected 96 bytes, got {}",
+            ic_root_public_key.len()
+        )
+    })?;
+    Ok(IcRootOfTrust::from(root_key_bytes))
+}

--- a/src/sig-verifier-js/tests.ts
+++ b/src/sig-verifier-js/tests.ts
@@ -1,0 +1,18 @@
+import { verifyIcSignature } from "@dfinity/sig-verifier-js/sig_verifier_js";
+
+// This just checks that the Wasm can be successfully loaded.
+test("Wasm can be loaded", async () => {
+  try {
+    await verifyIcSignature(
+      Uint8Array.from([1, 2, 3, 5]),
+      Uint8Array.from([1, 2, 3, 5]),
+      Uint8Array.from([1, 2, 3, 5]),
+      Uint8Array.from([1, 2, 3, 5])
+    );
+  } catch (e) {
+    // Expect an error string generated from the Wasm module
+    expect(e.toString()).toContain(
+      "Error in DER encoding: Bad length field in boolean block: 2"
+    );
+  }
+});

--- a/src/sig-verifier-js/vitest.config.ts
+++ b/src/sig-verifier-js/vitest.config.ts
@@ -1,0 +1,15 @@
+import { UserConfig } from "vite";
+import wasm from "vite-plugin-wasm";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig(
+  ({ mode }: UserConfig): UserConfig => ({
+    plugins: [wasm()],
+    test: {
+      environment: "node",
+      include: "./tests.ts",
+      globals: true /* globals like 'test' and 'describe' */,
+      watch: false,
+    },
+  })
+);

--- a/src/vc_util/Cargo.toml
+++ b/src/vc_util/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 # ic dependencies
 candid.workspace = true
 ic-certification.workspace = true
-ic-crypto-standalone-sig-verifier = { git = "https://github.com/dfinity/ic", rev = "e69bcc7b319cbb3ebc22ec55af35287741244db6" }
-ic-types = { git = "https://github.com/dfinity/ic", rev = "e69bcc7b319cbb3ebc22ec55af35287741244db6" }
+ic-crypto-standalone-sig-verifier.workspace = true
+ic-types.workspace = true
 canister_sig_util.workspace = true
 
 # vc dependencies


### PR DESCRIPTION
This adds a new npm package/workspace, wrapping the signature verification crate.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

