### PR TITLE
Push newAnchor into LoginData

### DIFF
--- a/src/frontend/src/utils/flowResult.ts
+++ b/src/frontend/src/utils/flowResult.ts
@@ -2,19 +2,19 @@ import { DynamicKey } from "$src/utils/i18n";
 import { ApiResult, AuthenticatedConnection } from "./iiConnection";
 import { webAuthnErrorCopy } from "./webAuthnErrorUtils";
 
-export type LoginFlowResult<T = AuthenticatedConnection> =
-  | LoginFlowSuccess<T>
+export type LoginFlowResult<T = AuthenticatedConnection, E = object> =
+  | LoginFlowSuccess<T, E>
   | LoginFlowError
   | LoginFlowCanceled;
 
-export type LoginFlowSuccess<T = AuthenticatedConnection> = {
+export type LoginFlowSuccess<T = AuthenticatedConnection, E = object> = {
   tag: "ok";
-} & LoginData<T>;
+} & LoginData<T, E>;
 
-export type LoginData<T = AuthenticatedConnection> = {
+export type LoginData<T = AuthenticatedConnection, E = object> = {
   userNumber: bigint;
   connection: T;
-};
+} & E;
 
 export type LoginFlowError = {
   tag: "err";


### PR DESCRIPTION
The authentication flow returns whether the user authenticated with a new or existing anchor. This data is used to tailor subsequent flows to new vs returning users.

Originally this information was added to all return types (success & error alike) for simplicity, although it only ever makes sense to return it upon successful authentication (until now we just defaulted to "not a new anchor" upon failures).

As we start passing more data through the flow (like whether the user used PIN or not) this shortcut became a bit problematic, so these changes push the `newAnchor` information deeper into the success state.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

