### PR TITLE
Add jq to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     apt -yq update && \
     apt -yqq install --no-install-recommends curl ca-certificates \
-        build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake
+        build-essential pkg-config libssl-dev llvm-dev liblmdb-dev clang cmake jq
 
 # Install node
 RUN curl --fail -sSf https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash


### PR DESCRIPTION
This ensures that the release builds can build the JSON metadata.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
