### PR TITLE
Bump nodejs16 based GitHub actions

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -79,10 +79,10 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build ${{ matrix.name }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
@@ -115,10 +115,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Archive Canister
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
@@ -703,7 +703,7 @@ jobs:
           path: .
 
       - name: 'Get GHA job IDs'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: pipeline-jobs
         with:
           script: |
@@ -719,7 +719,7 @@ jobs:
               });
 
       - name: 'Get latest release'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: latest-release-tag
         with:
           result-encoding: string
@@ -731,7 +731,7 @@ jobs:
       # listing contributions since).
       # https://github.com/github/feedback/discussions/5975
       - name: 'Generate CHANGELOG'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: changelog
         with:
           result-encoding: string

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -58,7 +58,7 @@ jobs:
       # to match the deploy URL: https://dfinity.github.io/internet-identity/
       - run: npm run build:showcase -- --base '/internet-identity/'
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v4
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
The previous versions have been deprecated. Some of the actions have already been bumped in #2276. This PR changes the rest.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/89b97c647/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

