### PR TITLE
Clean up storage constants and remove 32GB limitation

### DIFF
--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -5,7 +5,7 @@ use crate::activity_stats::ActivityStats;
 use crate::archive::{ArchiveData, ArchiveState, ArchiveStatusCache};
 use crate::state::temp_keys::TempKeys;
 use crate::storage::anchor::Anchor;
-use crate::storage::DEFAULT_RANGE_SIZE;
+use crate::storage::MAX_ENTRIES;
 use crate::{random_salt, Storage};
 use asset_util::CertifiedAssets;
 use candid::{CandidType, Deserialize};
@@ -212,7 +212,7 @@ pub fn init_new() {
     let storage = Storage::new(
         (
             FIRST_ANCHOR_NUMBER,
-            FIRST_ANCHOR_NUMBER.saturating_add(DEFAULT_RANGE_SIZE),
+            FIRST_ANCHOR_NUMBER.saturating_add(MAX_ENTRIES),
         ),
         memory,
     );

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -3,7 +3,7 @@ use crate::activity_stats::{ActivityStats, CompletedActivityStats, OngoingActivi
 use crate::archive::{ArchiveData, ArchiveState};
 use crate::state::PersistentState;
 use crate::storage::anchor::{Anchor, Device};
-use crate::storage::{Header, PersistentStateError, StorageError};
+use crate::storage::{Header, PersistentStateError, StorageError, MAX_ENTRIES};
 use crate::Storage;
 use candid::Principal;
 use ic_stable_structures::{Memory, VectorMemory};
@@ -13,7 +13,7 @@ use internet_identity_interface::internet_identity::types::{
 use serde_bytes::ByteBuf;
 use std::rc::Rc;
 
-const HEADER_SIZE: usize = 66;
+const HEADER_SIZE: usize = 58;
 
 #[test]
 fn should_match_actual_header_size() {
@@ -22,10 +22,11 @@ fn should_match_actual_header_size() {
 }
 
 #[test]
-fn should_report_max_number_of_entries_for_32gb() {
-    let memory = VectorMemory::default();
-    let storage = Storage::new((1, 2), memory);
-    assert_eq!(storage.max_entries(), 8_388_576);
+fn should_report_max_number_of_entries_for_256gb() {
+    // The maximum number of entries that could be supported by the canister without making any changes
+    // is constant. This test now exists to make sure any dev is aware of the limit if making changes
+    // to the underlying constants.
+    assert_eq!(MAX_ENTRIES, 67_106_816);
 }
 
 #[test]
@@ -38,7 +39,7 @@ fn should_serialize_header_v8() {
     assert_eq!(storage.version(), 8);
     let mut buf = vec![0; HEADER_SIZE];
     memory.read(0, &mut buf);
-    assert_eq!(buf, hex::decode("494943080000000001000000000000000200000000000000001005050505050505050505050505050505050505050505050505050505050505050000020000000000").unwrap());
+    assert_eq!(buf, hex::decode("49494308000000000100000000000000020000000000000000100505050505050505050505050505050505050505050505050505050505050505").unwrap());
 }
 
 #[test]

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -197,7 +197,7 @@ fn metrics_should_list_default_user_range() -> Result<(), CallError> {
     let (min_user_number, _) = parse_metric(&metrics, "internet_identity_min_user_number");
     let (max_user_number, _) = parse_metric(&metrics, "internet_identity_max_user_number");
     assert_eq!(min_user_number, 10_000f64);
-    assert_eq!(max_user_number, 8_398_575f64);
+    assert_eq!(max_user_number, 67_116_815f64);
     Ok(())
 }
 


### PR DESCRIPTION
This removes outdated constants in the `storage` module and removes an obsolete element from the II stable memory header. The 32GB memory limit is dropped as well. Due to limitations of the memory manager (to manage at most 256GB given the bucket size used) we still maintain a reserve of ~144GB stable memory that cannot be used for identities.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
