### PR TITLE
Add sha256 file for dev build

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -774,7 +774,7 @@ jobs:
       - name: Create sha for dfx pull
         run: |
           shasum -a 256 \
-            ./internet_identity_dev.wasm.gz \
+            ./internet_identity_dev.wasm.gz > \
             ./internet_identity_dev.wasm.gz.sha256
 
       - name: Publish release

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -774,7 +774,7 @@ jobs:
       - name: Create sha for dfx pull
         run: |
           shasum -a 256 \
-            ./internet_identity_dev.wasm.gz | cut -d ' ' -f1 > \
+            ./internet_identity_dev.wasm.gz \
             ./internet_identity_dev.wasm.gz.sha256
 
       - name: Publish release

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -770,6 +770,13 @@ jobs:
       - name: Release notes
         run: cat ${{ steps.prepare-release.outputs.notes-file }}
 
+      # Create a sha file for dfx pull, referenced by the metadata set in the build
+      - name: Create sha for dfx pull
+        run: |
+          shasum -a 256 \
+            ./internet_identity_dev.wasm.gz | cut -d ' ' -f1 > \
+            ./internet_identity_dev.wasm.gz.sha256
+
       - name: Publish release
         if: startsWith(github.ref, 'refs/tags/release-')
         run: |
@@ -779,6 +786,7 @@ jobs:
             -- \
             internet_identity_production.wasm.gz \
             internet_identity_dev.wasm.gz \
+            internet_identity_dev.wasm.gz.sha256 \
             internet_identity_test.wasm.gz \
             src/internet_identity/internet_identity.did \
             archive.wasm.gz \

--- a/scripts/build
+++ b/scripts/build
@@ -168,11 +168,13 @@ function build_canister() {
           then
               asset_name="internet_identity_dev.wasm.gz"
               wasm_url="https://github.com/dfinity/internet-identity/releases/download/$release/$asset_name"
+              wasm_hash_url="https://github.com/dfinity/internet-identity/releases/download/$release/$asset_name.sha256"
               init_guide="Use '(null)' for sensible defaults. See the candid interface for more details."
               metadata_json=$(echo '{}' | jq -cMr \
                   --arg wasm_url "$wasm_url" \
+                  --arg wasm_hash_url "$wasm_hash_url" \
                   --arg init_guide "$init_guide" \
-                  '. | .pullable = { wasm_url: $wasm_url, dependencies: [], init_guide: $init_guide} ')
+                  '. | .pullable = { wasm_url: $wasm_url, wasm_hash_url: $wasm_hash_url, dependencies: [], init_guide: $init_guide} ')
               ic-wasm "$canister.wasm" -o "$canister.wasm" metadata dfx -d "$metadata_json" -v public
           fi
 

--- a/scripts/build
+++ b/scripts/build
@@ -158,9 +158,8 @@ function build_canister() {
           # Write metadata for dfx.
           # The metadata includes a link to the release, which only exists if this is a release build.
           # In case of a release build, the version looks like this: <commit>,<release>,<dirty>
-          # We do not include a checksum file URL because the II canister is very small and would not
-          # benefit much from skipping a canister download in case of existing canister with same
-          # checksum.
+          # We include (the URL of) a checksum file URL so that dfx clients can check the hash
+          # of the build (for caching & integrity checking)
           IFS=,
           read -r -a version_parts <<< "$II_VERSION"
           release="${version_parts[1]}"

--- a/scripts/build
+++ b/scripts/build
@@ -158,7 +158,7 @@ function build_canister() {
           # Write metadata for dfx.
           # The metadata includes a link to the release, which only exists if this is a release build.
           # In case of a release build, the version looks like this: <commit>,<release>,<dirty>
-          # We include (the URL of) a checksum file URL so that dfx clients can check the hash
+          # We include the URL of a checksum file so that dfx clients can check the hash
           # of the build (for caching & integrity checking)
           IFS=,
           read -r -a version_parts <<< "$II_VERSION"


### PR DESCRIPTION
This adds a new release asset, `internet_identity_dev.wasm.gz.sha256`. This assets is linked to from the `dfx pull`-related metadata so that `dfx` can check the shasum of the downloaded dev-flavored Wasm.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->




<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->



