### PR TITLE
Return information about authentication method

### DIFF
--- a/demos/test-app/src/auth.ts
+++ b/demos/test-app/src/auth.ts
@@ -19,6 +19,7 @@ interface AuthResponseSuccess {
     signature: Uint8Array;
   }[];
   userPublicKey: Uint8Array;
+  authnMethod: "pin" | "passkey" | "recovery";
 }
 
 // Perform a sign in to II using parameters set in this app
@@ -32,7 +33,7 @@ export const authWithII = async ({
   maxTimeToLive?: bigint;
   derivationOrigin?: string;
   sessionIdentity: SignIdentity;
-}): Promise<DelegationIdentity> => {
+}): Promise<{ identity: DelegationIdentity; authnMethod: string }> => {
   // Figure out the II URL to use
   const iiUrl = new URL(url_);
   iiUrl.hash = "#authorize";
@@ -85,10 +86,12 @@ export const authWithII = async ({
     throw new Error("Bad reply: " + JSON.stringify(message));
   }
 
-  return identityFromResponse({
+  const identity = identityFromResponse({
     response: message as AuthResponseSuccess,
     sessionIdentity,
   });
+
+  return { identity, authnMethod: message.authnMethod };
 };
 
 // Read delegations the delegations from the response

--- a/demos/test-app/src/index.html
+++ b/demos/test-app/src/index.html
@@ -58,6 +58,8 @@
         <div id="alternativeOrigins"></div>
         <h3>Principal:</h3>
         <div data-role="principal" id="principal"></div>
+        <h3>Authentication Method:</h3>
+        <div data-role="authn-method"></div>
         <h3>Delegation:</h3>
         <pre id="delegation"></pre>
         <h3>Expiry (ns from now):</h3>

--- a/demos/test-app/src/index.tsx
+++ b/demos/test-app/src/index.tsx
@@ -56,6 +56,9 @@ const newAlternativeOriginsEl = document.getElementById(
   "newAlternativeOrigins"
 ) as HTMLInputElement;
 const principalEl = document.getElementById("principal") as HTMLDivElement;
+const authnMethodEl = document.querySelector(
+  '[data-role="authn-method"]'
+) as HTMLDivElement;
 const delegationEl = document.getElementById("delegation") as HTMLPreElement;
 const expirationEl = document.getElementById("expiration") as HTMLDivElement;
 const iiUrlEl = document.getElementById("iiUrl") as HTMLInputElement;
@@ -109,8 +112,19 @@ const idlFactory = ({ IDL }: { IDL: any }) => {
   });
 };
 
-const updateDelegationView = (identity: Identity) => {
+const updateDelegationView = ({
+  authnMethod,
+  identity,
+}: {
+  authnMethod?: string;
+  identity: Identity;
+}) => {
   principalEl.innerText = identity.getPrincipal().toText();
+
+  if (authnMethod !== undefined) {
+    authnMethodEl.innerText = authnMethod;
+  }
+
   if (identity instanceof DelegationIdentity) {
     delegationEl.innerText = JSON.stringify(
       identity.getDelegation().toJSON(),
@@ -181,9 +195,12 @@ window.addEventListener("message", (event) => {
     delegations,
     event.data.userPublicKey.buffer
   );
-  updateDelegationView(
-    DelegationIdentity.fromDelegation(getLocalIdentity(), delegationChain)
-  );
+  updateDelegationView({
+    identity: DelegationIdentity.fromDelegation(
+      getLocalIdentity(),
+      delegationChain
+    ),
+  });
 });
 
 const readCanisterId = (): string => {
@@ -204,13 +221,17 @@ const init = async () => {
       derivationOriginEl.value !== "" ? derivationOriginEl.value : undefined;
 
     try {
-      delegationIdentity = await authWithII({
+      const result = await authWithII({
         url: iiUrlEl.value,
         maxTimeToLive,
         derivationOrigin,
         sessionIdentity: getLocalIdentity(),
       });
-      updateDelegationView(delegationIdentity);
+      delegationIdentity = result.identity;
+      updateDelegationView({
+        identity: delegationIdentity,
+        authnMethod: result.authnMethod,
+      });
     } catch (e) {
       showError(JSON.stringify(e));
     }

--- a/docs/ii-spec.md
+++ b/docs/ii-spec.md
@@ -177,9 +177,10 @@ This section describes the Internet Identity Service from the point of view of a
             signature: Uint8Array;
           }];
           userPublicKey: Uint8Array;
+          authnMethod: "passkey";
         }
 
-    where the `userPublicKey` is the user's Identity on the given frontend and `delegations` corresponds to the CBOR-encoded delegation chain as used for [*authentication on the IC*](https://internetcomputer.org/docs/current/references/ic-interface-spec#authentication).
+    where the `userPublicKey` is the user's Identity on the given frontend and `delegations` corresponds to the CBOR-encoded delegation chain as used for [*authentication on the IC*](https://internetcomputer.org/docs/current/references/ic-interface-spec#authentication) and `authnMethod` is the method used by the user to authenticate (`passkey` for webauthn, `pin` for temporary key/PIN identity, and `recovery` for recovery phrase or recovery device).
 
 9.  It could also receive a failure message of the following type
 

--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -156,7 +156,12 @@ const authenticate = async (
   connection: Connection,
   authContext: AuthContext
 ): Promise<
-  | { kind: "success"; delegations: Delegation[]; userPublicKey: Uint8Array }
+  | {
+      kind: "success";
+      delegations: Delegation[];
+      userPublicKey: Uint8Array;
+      authnMethod: "pin" | "passkey" | "recovery";
+    }
   | { kind: "failure"; text: string }
 > => {
   const i18n = new I18n();
@@ -238,6 +243,7 @@ const authenticate = async (
     kind: "success",
     delegations: [parsed_signed_delegation],
     userPublicKey: Uint8Array.from(userKey),
+    authnMethod: authSuccess.authnMethod,
   };
 };
 /** Run the authentication flow, including postMessage protocol, offering to authenticate

--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -53,6 +53,7 @@ export type AuthResponse =
       kind: "authorize-client-success";
       delegations: Delegation[];
       userPublicKey: Uint8Array;
+      authnMethod: "pin" | "passkey" | "recovery";
     };
 
 /**
@@ -67,7 +68,12 @@ export async function authenticationProtocol({
     authRequest: AuthRequest;
     requestOrigin: string;
   }) => Promise<
-    | { kind: "success"; delegations: Delegation[]; userPublicKey: Uint8Array }
+    | {
+        kind: "success";
+        delegations: Delegation[];
+        userPublicKey: Uint8Array;
+        authnMethod: "pin" | "passkey" | "recovery";
+      }
     | { kind: "failure"; text: string }
   >;
   /* Progress update messages to let the user know what's happening. */
@@ -109,6 +115,7 @@ export async function authenticationProtocol({
       kind: "authorize-client-success",
       delegations: result.delegations,
       userPublicKey: result.userPublicKey,
+      authnMethod: result.authnMethod,
     } satisfies AuthResponse,
     authContext.requestOrigin
   );

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -155,11 +155,13 @@ test("Register with PIN then log into client application", async () => {
     await demoAppView.open(TEST_APP_NICE_URL, II_URL);
     await demoAppView.waitForDisplay();
     expect(await demoAppView.getPrincipal()).toBe("");
+    expect(await demoAppView.getAuthnMethod()).toBe("");
     await demoAppView.signin();
 
     await switchToPopup(browser);
 
     await FLOWS.loginPinAuthenticateView(userNumber, pin, browser);
     await demoAppView.waitForAuthenticated();
+    expect(await demoAppView.getAuthnMethod()).toBe("pin");
   }, APPLE_USER_AGENT);
 }, 300_000);

--- a/src/frontend/src/test-e2e/register.test.ts
+++ b/src/frontend/src/test-e2e/register.test.ts
@@ -50,11 +50,14 @@ test("Log into client application, after registration", async () => {
     await demoAppView.open(TEST_APP_NICE_URL, II_URL);
     await demoAppView.waitForDisplay();
     expect(await demoAppView.getPrincipal()).toBe("");
+    expect(await demoAppView.getAuthnMethod()).toBe("");
     await demoAppView.signin();
     await switchToPopup(browser);
     await FLOWS.registerNewIdentityAuthenticateView(browser);
     const principal = await demoAppView.waitForAuthenticated();
     expect(await demoAppView.whoami()).toBe(principal);
+    // The default authn method is passkey
+    expect(await demoAppView.getAuthnMethod()).toBe("passkey");
 
     // default value
     const exp = await browser.$("#expiration").getText();

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -790,6 +790,10 @@ export class DemoAppView extends View {
     return await this.browser.$("#principal").getText();
   }
 
+  async getAuthnMethod(): Promise<string> {
+    return await this.browser.$('[data-role="authn-method"]').getText();
+  }
+
   async signin(): Promise<void> {
     await this.browser.$("#signinBtn").click();
   }


### PR DESCRIPTION
This adds a new field `authnMethod` to the auth API response. This field informs the authenticating dapp of which authentication method the user uesd: `passkey`, `pin` or `recovery`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8cbe411a3/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
