### PR TITLE
Remove support for storage v7

### DIFF
--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -10,7 +10,7 @@ internet_identity_interface.workspace = true
 hex.workspace = true
 include_dir.workspace = true
 lazy_static.workspace = true
-serde = { version = "1", features = ["rc"] }
+serde.workspace = true
 serde_bytes.workspace = true
 serde_cbor.workspace = true
 serde_json = { version = "1.0", default-features = false, features = ["std"] }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -21,7 +21,6 @@ use internet_identity_interface::internet_identity::types::vc_mvp::{
 use internet_identity_interface::internet_identity::types::*;
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
-use std::ops::Deref;
 use storage::{Salt, Storage};
 
 mod activity_stats;
@@ -409,24 +408,6 @@ fn post_upgrade(maybe_arg: Option<InternetIdentityInit>) {
     update_root_hash();
     // load the persistent state after initializing storage, otherwise the memory address to load it from cannot be calculated
     state::load_persistent_state();
-
-    // Migrate the archive entries buffer if necessary.
-    state::storage_borrow_mut(|storage| {
-        if storage.version() == 7 {
-            // We need to update the storage layout to version 8.
-            let entries = match state::archive_state() {
-                // If the archive has been created, we need to migrate the entries to the archive buffer.
-                // The buffer in persistent state is not modified yet. It will be cleaned up when it
-                // is moved into its own stable memory.
-                ArchiveState::Created { data, .. } => data.entries_buffer.deref().clone(),
-                // If not, we migrate using the empty buffer.
-                ArchiveState::NotConfigured
-                | ArchiveState::Configured { .. }
-                | ArchiveState::CreationInProgress { .. } => vec![],
-            };
-            storage.migrate_to_stable_memory_archive_buffer(entries);
-        }
-    });
 
     apply_install_arg(maybe_arg);
 }

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -11,7 +11,6 @@ use internet_identity_interface::internet_identity::types::{
     ArchiveConfig, DeviceProtection, KeyType, Purpose,
 };
 use serde_bytes::ByteBuf;
-use std::rc::Rc;
 
 const HEADER_SIZE: usize = 58;
 
@@ -40,19 +39,6 @@ fn should_serialize_header_v8() {
     let mut buf = vec![0; HEADER_SIZE];
     memory.read(0, &mut buf);
     assert_eq!(buf, hex::decode("49494308000000000100000000000000020000000000000000100505050505050505050505050505050505050505050505050505050505050505").unwrap());
-}
-
-#[test]
-fn should_recover_header_from_memory_v7() {
-    let memory = VectorMemory::default();
-    memory.grow(1);
-    memory.write(0, &hex::decode("494943070500000040e2010000000000f1fb090000000000000843434343434343434343434343434343434343434343434343434343434343430002000000000000000000000000000000000000000000000000").unwrap());
-
-    let storage = Storage::from_memory(memory).unwrap();
-    assert_eq!(storage.assigned_anchor_number_range(), (123456, 654321));
-    assert_eq!(storage.salt().unwrap(), &[67u8; 32]);
-    assert_eq!(storage.anchor_count(), 5);
-    assert_eq!(storage.version(), 7);
 }
 
 #[test]
@@ -164,7 +150,6 @@ fn sample_persistent_state() -> PersistentState {
             data: ArchiveData {
                 sequence_number: 39,
                 archive_canister: Principal::from_text("2h5ob-7aaaa-aaaad-aacya-cai").unwrap(),
-                entries_buffer: Rc::new(vec![]),
             },
             config: ArchiveConfig {
                 module_hash: [99u8; 32],


### PR DESCRIPTION
This PR removes II support for storage `v7`.
The previous release automatically migrates II to `v8`, so the code to handle `v7` can now be removed.
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
