### PR TITLE
Use HeaderField where applicable

### DIFF
--- a/demos/test-app/lib.rs
+++ b/demos/test-app/lib.rs
@@ -60,7 +60,7 @@ pub type HeaderField = (String, String);
 pub struct HttpRequest {
     pub method: String,
     pub url: String,
-    pub headers: Vec<(String, String)>,
+    pub headers: Vec<HeaderField>,
     pub body: ByteBuf,
     pub certificate_version: Option<u16>,
 }
@@ -142,7 +142,7 @@ fn not_found_response(path: &str) -> HttpResponse {
     }
 }
 
-fn static_headers() -> Vec<(String, String)> {
+fn static_headers() -> Vec<HeaderField> {
     vec![("Access-Control-Allow-Origin".to_string(), "*".to_string())]
 }
 

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -399,7 +399,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
     }
 }
 
-fn static_headers() -> Vec<(String, String)> {
+fn static_headers() -> Vec<HeaderField> {
     vec![("Access-Control-Allow-Origin".to_string(), "*".to_string())]
 }
 

--- a/src/asset_util/src/lib.rs
+++ b/src/asset_util/src/lib.rs
@@ -268,7 +268,7 @@ impl CertifiedAssets {
         &self,
         absolute_path: &str,
         sigs_tree: Option<HashTree>,
-    ) -> Vec<(String, String)> {
+    ) -> Vec<HeaderField> {
         let certificate = data_certificate().unwrap_or_else(|| {
             trap("data certificate is only available in query calls");
         });

--- a/src/internet_identity_interface/src/http_gateway.rs
+++ b/src/internet_identity_interface/src/http_gateway.rs
@@ -29,7 +29,7 @@ pub struct StreamingCallbackHttpResponse {
 pub struct HttpRequest {
     pub method: String,
     pub url: String,
-    pub headers: Vec<(String, String)>,
+    pub headers: Vec<HeaderField>,
     pub body: ByteBuf,
     pub certificate_version: Option<u16>,
 }


### PR DESCRIPTION
A couple of signatures were using `(String, String)` instead of the more appropriate type alias `HeaderField = (String, String)`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
