### PR TITLE
Add derivation_origin-API to the demo issuer

### DIFF
--- a/demos/vc_issuer/app/generated/vc_issuer_idl.js
+++ b/demos/vc_issuer/app/generated/vc_issuer_idl.js
@@ -1,7 +1,14 @@
 export const idlFactory = ({ IDL }) => {
   const IssuerConfig = IDL.Record({
+    'derivation_origin' : IDL.Text,
     'idp_canister_ids' : IDL.Vec(IDL.Principal),
     'ic_root_key_der' : IDL.Vec(IDL.Nat8),
+    'frontend_hostname' : IDL.Text,
+  });
+  const DerivationOriginData = IDL.Record({ 'origin' : IDL.Text });
+  const DerivationOriginError = IDL.Variant({
+    'Internal' : IDL.Text,
+    'UnsupportedOrigin' : IDL.Text,
   });
   const SignedIdAlias = IDL.Record({ 'credential_jws' : IDL.Text });
   const ArgumentValue = IDL.Variant({ 'Int' : IDL.Int32, 'String' : IDL.Text });
@@ -66,6 +73,16 @@ export const idlFactory = ({ IDL }) => {
     'add_employee' : IDL.Func([IDL.Principal], [IDL.Text], []),
     'add_graduate' : IDL.Func([IDL.Principal], [IDL.Text], []),
     'configure' : IDL.Func([IssuerConfig], [], []),
+    'derivation_origin' : IDL.Func(
+        [IDL.Text],
+        [
+          IDL.Variant({
+            'Ok' : DerivationOriginData,
+            'Err' : DerivationOriginError,
+          }),
+        ],
+        [],
+      ),
     'get_credential' : IDL.Func(
         [GetCredentialRequest],
         [
@@ -96,8 +113,10 @@ export const idlFactory = ({ IDL }) => {
 };
 export const init = ({ IDL }) => {
   const IssuerConfig = IDL.Record({
+    'derivation_origin' : IDL.Text,
     'idp_canister_ids' : IDL.Vec(IDL.Principal),
     'ic_root_key_der' : IDL.Vec(IDL.Nat8),
+    'frontend_hostname' : IDL.Text,
   });
   return [IDL.Opt(IssuerConfig)];
 };

--- a/demos/vc_issuer/app/generated/vc_issuer_idl.js
+++ b/demos/vc_issuer/app/generated/vc_issuer_idl.js
@@ -5,6 +5,9 @@ export const idlFactory = ({ IDL }) => {
     'ic_root_key_der' : IDL.Vec(IDL.Nat8),
     'frontend_hostname' : IDL.Text,
   });
+  const DerivationOriginRequest = IDL.Record({
+    'frontend_hostname' : IDL.Text,
+  });
   const DerivationOriginData = IDL.Record({ 'origin' : IDL.Text });
   const DerivationOriginError = IDL.Variant({
     'Internal' : IDL.Text,
@@ -74,7 +77,7 @@ export const idlFactory = ({ IDL }) => {
     'add_graduate' : IDL.Func([IDL.Principal], [IDL.Text], []),
     'configure' : IDL.Func([IssuerConfig], [], []),
     'derivation_origin' : IDL.Func(
-        [IDL.Text],
+        [DerivationOriginRequest],
         [
           IDL.Variant({
             'Ok' : DerivationOriginData,

--- a/demos/vc_issuer/app/generated/vc_issuer_types.d.ts
+++ b/demos/vc_issuer/app/generated/vc_issuer_types.d.ts
@@ -8,6 +8,9 @@ export interface CredentialSpec {
   'arguments' : [] | [Array<[string, ArgumentValue]>],
   'credential_type' : string,
 }
+export interface DerivationOriginData { 'origin' : string }
+export type DerivationOriginError = { 'Internal' : string } |
+  { 'UnsupportedOrigin' : string };
 export interface GetCredentialRequest {
   'signed_id_alias' : SignedIdAlias,
   'prepared_context' : [] | [Uint8Array | number[]],
@@ -49,8 +52,10 @@ export type IssueCredentialError = { 'Internal' : string } |
   { 'UnsupportedCredentialSpec' : string };
 export interface IssuedCredentialData { 'vc_jws' : string }
 export interface IssuerConfig {
+  'derivation_origin' : string,
   'idp_canister_ids' : Array<Principal>,
   'ic_root_key_der' : Uint8Array | number[],
+  'frontend_hostname' : string,
 }
 export interface PrepareCredentialRequest {
   'signed_id_alias' : SignedIdAlias,
@@ -65,6 +70,11 @@ export interface _SERVICE {
   'add_employee' : ActorMethod<[Principal], string>,
   'add_graduate' : ActorMethod<[Principal], string>,
   'configure' : ActorMethod<[IssuerConfig], undefined>,
+  'derivation_origin' : ActorMethod<
+    [string],
+    { 'Ok' : DerivationOriginData } |
+      { 'Err' : DerivationOriginError }
+  >,
   'get_credential' : ActorMethod<
     [GetCredentialRequest],
     { 'Ok' : IssuedCredentialData } |

--- a/demos/vc_issuer/app/generated/vc_issuer_types.d.ts
+++ b/demos/vc_issuer/app/generated/vc_issuer_types.d.ts
@@ -11,6 +11,7 @@ export interface CredentialSpec {
 export interface DerivationOriginData { 'origin' : string }
 export type DerivationOriginError = { 'Internal' : string } |
   { 'UnsupportedOrigin' : string };
+export interface DerivationOriginRequest { 'frontend_hostname' : string }
 export interface GetCredentialRequest {
   'signed_id_alias' : SignedIdAlias,
   'prepared_context' : [] | [Uint8Array | number[]],
@@ -71,7 +72,7 @@ export interface _SERVICE {
   'add_graduate' : ActorMethod<[Principal], string>,
   'configure' : ActorMethod<[IssuerConfig], undefined>,
   'derivation_origin' : ActorMethod<
-    [string],
+    [DerivationOriginRequest],
     { 'Ok' : DerivationOriginData } |
       { 'Err' : DerivationOriginError }
   >,

--- a/demos/vc_issuer/provision
+++ b/demos/vc_issuer/provision
@@ -17,9 +17,11 @@ Usage:
   $0 [--ii-canister-id CANISTER_ID] [--dfx-network NETWORK]
 
 Options:
-  --ii-canister-id CANISTER_ID  The canister ID to use as IDP, defaults to the local internet_identity canister
-  --dfx-network NETWORK         The network to use (typically "local" or "ic"), defaults to "local"
-  --issuer-canister CANISTER    The canister to configure (name or canister ID), defaults to "issuer"
+  --ii-canister-id CANISTER_ID    The canister ID to use as IDP, defaults to the local internet_identity canister
+  --dfx-network NETWORK           The network to use (typically "local" or "ic"), defaults to "local"
+  --issuer-canister CANISTER      The canister to configure (name or canister ID), defaults to "issuer"
+  --issuer-derivation-origin URL  The issuer's derivation origin, defaults to <issuer-canister-id>.ic0.app
+  --issuer-frontend-hostname URL  The issuer's frontend hostname, defaults to issuer's derivation origin
 EOF
 }
 
@@ -58,6 +60,16 @@ do
             shift; # shift past --issuer-canister & value
             shift;
             ;;
+        --issuer-derivation-origin)
+            DERIVATION_ORIGIN="${2:?missing value for '--issuer-canister'}"
+            shift; # shift past --issuer-canister & value
+            shift;
+            ;;
+        --issuer-frontend-hostname)
+            FRONTEND_HOSTNAME="${2:?missing value for '--issuer-canister'}"
+            shift; # shift past --issuer-canister & value
+            shift;
+            ;;
         *)
             echo "ERROR: unknown argument $1"
             usage
@@ -72,6 +84,10 @@ done
 DFX_NETWORK="${DFX_NETWORK:-local}"
 II_CANISTER_ID="${II_CANISTER_ID:-$(dfx canister id internet_identity)}"
 ISSUER_CANISTER="${ISSUER_CANISTER:-issuer}"
+ISSUER_CANISTER_ID=$(dfx canister id $ISSUER_CANISTER)
+DEFAULT_DERIVATION_ORIGIN="https://$ISSUER_CANISTER_ID.ic0.app"
+ISSUER_DERIVATION_ORIGIN="${ISSUER_DERIVATION_ORIGIN:-$DEFAULT_DERIVATION_ORIGIN}"
+ISSUER_FRONTEND_HOSTNAME="${ISSUER_FRONTEND_HOSTNAME:-$ISSUER_DERIVATION_ORIGIN}"
 
 echo "Using DFX network: $DFX_NETWORK" >&2
 
@@ -89,5 +105,8 @@ rootkey_did=$(dfx ping "$DFX_NETWORK" \
 echo "Parsed rootkey: ${rootkey_did:0:20}..." >&2
 
 echo "Using II canister: $II_CANISTER_ID" >&2
+echo "Using issuer derivation origin: $ISSUER_DERIVATION_ORIGIN" >&2
+echo "Using issuer frontend_hostname: $ISSUER_FRONTEND_HOSTNAME" >&2
 
-dfx canister call --network "$DFX_NETWORK" "$ISSUER_CANISTER" configure '(record { idp_canister_ids = vec{ principal "'"$II_CANISTER_ID"'" }; ic_root_key_der = vec '"$rootkey_did"' })'
+dfx canister call --network "$DFX_NETWORK" "$ISSUER_CANISTER" configure \
+    '(record { idp_canister_ids = vec{ principal "'"$II_CANISTER_ID"'" }; ic_root_key_der = vec '"$rootkey_did"'; derivation_origin = "'"$ISSUER_DERIVATION_ORIGIN"'"; frontend_hostname = "'"$ISSUER_FRONTEND_HOSTNAME"'"})'

--- a/demos/vc_issuer/provision
+++ b/demos/vc_issuer/provision
@@ -61,12 +61,12 @@ do
             shift;
             ;;
         --issuer-derivation-origin)
-            DERIVATION_ORIGIN="${2:?missing value for '--issuer-canister'}"
+            DERIVATION_ORIGIN="${2:?missing value for '--issuer-derivation-origin'}"
             shift; # shift past --issuer-canister & value
             shift;
             ;;
         --issuer-frontend-hostname)
-            FRONTEND_HOSTNAME="${2:?missing value for '--issuer-canister'}"
+            FRONTEND_HOSTNAME="${2:?missing value for '--issuer-frontend-hostname'}"
             shift; # shift past --issuer-canister & value
             shift;
             ;;

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -15,9 +15,9 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use vc_util::issuer_api::{
     ArgumentValue, CredentialSpec, DerivationOriginData, DerivationOriginError,
-    GetCredentialRequest, Icrc21ConsentInfo, Icrc21Error, Icrc21VcConsentMessageRequest,
-    IssueCredentialError, IssuedCredentialData, PrepareCredentialRequest, PreparedCredentialData,
-    SignedIdAlias,
+    DerivationOriginRequest, GetCredentialRequest, Icrc21ConsentInfo, Icrc21Error,
+    Icrc21VcConsentMessageRequest, IssueCredentialError, IssuedCredentialData,
+    PrepareCredentialRequest, PreparedCredentialData, SignedIdAlias,
 };
 use vc_util::{
     build_credential_jwt, did_for_principal, get_verified_id_alias_from_jws, vc_jwt_to_jws,
@@ -78,7 +78,7 @@ struct IssuerConfig {
     idp_canister_ids: Vec<Principal>,
     /// The derivation origin to be used by the issuer.
     derivation_origin: String,
-    /// Frontend hostname be used by the issuer.
+    /// Frontend hostname to be used by the issuer.
     frontend_hostname: String,
 }
 
@@ -296,9 +296,9 @@ async fn vc_consent_message(
 #[update]
 #[candid_method]
 async fn derivation_origin(
-    hostname: String,
+    req: DerivationOriginRequest,
 ) -> Result<DerivationOriginData, DerivationOriginError> {
-    get_derivation_origin(&hostname)
+    get_derivation_origin(&req.frontend_hostname)
 }
 
 fn get_derivation_origin(hostname: &str) -> Result<DerivationOriginData, DerivationOriginError> {

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -14,9 +14,10 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use vc_util::issuer_api::{
-    ArgumentValue, CredentialSpec, GetCredentialRequest, Icrc21ConsentInfo, Icrc21Error,
-    Icrc21VcConsentMessageRequest, IssueCredentialError, IssuedCredentialData,
-    PrepareCredentialRequest, PreparedCredentialData, SignedIdAlias,
+    ArgumentValue, CredentialSpec, DerivationOriginData, DerivationOriginError,
+    GetCredentialRequest, Icrc21ConsentInfo, Icrc21Error, Icrc21VcConsentMessageRequest,
+    IssueCredentialError, IssuedCredentialData, PrepareCredentialRequest, PreparedCredentialData,
+    SignedIdAlias,
 };
 use vc_util::{
     build_credential_jwt, did_for_principal, get_verified_id_alias_from_jws, vc_jwt_to_jws,
@@ -75,6 +76,10 @@ struct IssuerConfig {
     ic_root_key_raw: Vec<u8>,
     /// List of canister ids that are allowed to provide id alias credentials.
     idp_canister_ids: Vec<Principal>,
+    /// The derivation origin to be used by the issuer.
+    derivation_origin: String,
+    /// Frontend hostname be used by the issuer.
+    frontend_hostname: String,
 }
 
 impl Storable for IssuerConfig {
@@ -89,10 +94,13 @@ impl Storable for IssuerConfig {
 
 impl Default for IssuerConfig {
     fn default() -> Self {
+        let derivation_origin = format!("https://{}.ic0.app", ic_cdk::id().to_text());
         Self {
             ic_root_key_raw: extract_raw_root_pk_from_der(IC_ROOT_PK_DER)
                 .expect("failed to extract raw root pk from der"),
             idp_canister_ids: vec![Principal::from_text(PROD_II_CANISTER_ID).unwrap()],
+            derivation_origin: derivation_origin.clone(),
+            frontend_hostname: derivation_origin, // by default, use DERIVATION_ORIGIN as frontend-hostname
         }
     }
 }
@@ -103,6 +111,8 @@ impl From<IssuerInit> for IssuerConfig {
             ic_root_key_raw: extract_raw_root_pk_from_der(&init.ic_root_key_der)
                 .expect("failed to extract raw root pk from der"),
             idp_canister_ids: init.idp_canister_ids,
+            derivation_origin: init.derivation_origin,
+            frontend_hostname: init.frontend_hostname,
         }
     }
 }
@@ -113,6 +123,10 @@ struct IssuerInit {
     ic_root_key_der: Vec<u8>,
     /// List of canister ids that are allowed to provide id alias credentials.
     idp_canister_ids: Vec<Principal>,
+    /// The derivation origin to be used by the issuer.
+    derivation_origin: String,
+    /// Frontend hostname be used by the issuer.
+    frontend_hostname: String,
 }
 
 #[init]
@@ -277,6 +291,29 @@ async fn vc_consent_message(
         &req.credential_spec,
         &SupportedLanguage::from(req.preferences),
     )
+}
+
+#[update]
+#[candid_method]
+async fn derivation_origin(
+    hostname: String,
+) -> Result<DerivationOriginData, DerivationOriginError> {
+    get_derivation_origin(&hostname)
+}
+
+fn get_derivation_origin(hostname: &str) -> Result<DerivationOriginData, DerivationOriginError> {
+    CONFIG.with_borrow(|config| {
+        let config = config.get();
+        if hostname == config.frontend_hostname {
+            return Ok(DerivationOriginData {
+                origin: config.derivation_origin.clone(),
+            });
+        } else {
+            return Err(DerivationOriginError::UnsupportedOrigin(
+                hostname.to_string(),
+            ));
+        }
+    })
 }
 
 fn verify_credential_spec(spec: &CredentialSpec) -> Result<SupportedCredentialType, String> {

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -305,13 +305,13 @@ fn get_derivation_origin(hostname: &str) -> Result<DerivationOriginData, Derivat
     CONFIG.with_borrow(|config| {
         let config = config.get();
         if hostname == config.frontend_hostname {
-            return Ok(DerivationOriginData {
+            Ok(DerivationOriginData {
                 origin: config.derivation_origin.clone(),
-            });
+            })
         } else {
-            return Err(DerivationOriginError::UnsupportedOrigin(
+            Err(DerivationOriginError::UnsupportedOrigin(
                 hostname.to_string(),
-            ));
+            ))
         }
     })
 }

--- a/demos/vc_issuer/vc_demo_issuer.did
+++ b/demos/vc_issuer/vc_demo_issuer.did
@@ -69,6 +69,9 @@ type IssueCredentialError = variant {
 };
 
 /// Messages for `derivation_origin`.
+type DerivationOriginRequest = record {
+    frontend_hostname : text;
+};
 type DerivationOriginData = record { origin : text };
 type DerivationOriginError = variant {
   Internal : text;
@@ -113,7 +116,7 @@ service: (opt IssuerConfig) -> {
     vc_consent_message : (Icrc21VcConsentMessageRequest) -> (variant { Ok : Icrc21ConsentInfo; Err : Icrc21Error;});
     prepare_credential : (PrepareCredentialRequest) -> (variant { Ok : PreparedCredentialData; Err : IssueCredentialError;});
     get_credential : (GetCredentialRequest) -> (variant { Ok : IssuedCredentialData; Err : IssueCredentialError;}) query;
-    derivation_origin : (text) -> (variant {Ok: DerivationOriginData; Err: DerivationOriginError});
+    derivation_origin : (DerivationOriginRequest) -> (variant {Ok: DerivationOriginData; Err: DerivationOriginError});
 
     /// Configure the issuer (e.g. set the root key), used for deployment/testing.
     configure: (IssuerConfig) -> ();

--- a/demos/vc_issuer/vc_demo_issuer.did
+++ b/demos/vc_issuer/vc_demo_issuer.did
@@ -68,12 +68,23 @@ type IssueCredentialError = variant {
     Internal : text;
 };
 
+/// Messages for `derivation_origin`.
+type DerivationOriginData = record { origin : text };
+type DerivationOriginError = variant {
+  Internal : text;
+  UnsupportedOrigin : text;
+};
+
 /// Configuration specific to this issuer.
 type IssuerConfig = record {
     /// Root of trust for checking canister signatures.
     ic_root_key_der : blob;
     /// List of canister ids that are allowed to provide id alias credentials.
     idp_canister_ids : vec principal;
+    /// The derivation origin to be used by the issuer.
+    derivation_origin : text;
+    /// Frontend hostname be used by the issuer.
+    frontend_hostname : text;
 };
 
 /// Options related to HTTP handling
@@ -102,6 +113,7 @@ service: (opt IssuerConfig) -> {
     vc_consent_message : (Icrc21VcConsentMessageRequest) -> (variant { Ok : Icrc21ConsentInfo; Err : Icrc21Error;});
     prepare_credential : (PrepareCredentialRequest) -> (variant { Ok : PreparedCredentialData; Err : IssueCredentialError;});
     get_credential : (GetCredentialRequest) -> (variant { Ok : IssuedCredentialData; Err : IssueCredentialError;}) query;
+    derivation_origin : (text) -> (variant {Ok: DerivationOriginData; Err: DerivationOriginError});
 
     /// Configure the issuer (e.g. set the root key), used for deployment/testing.
     configure: (IssuerConfig) -> ();
@@ -111,7 +123,6 @@ service: (opt IssuerConfig) -> {
     add_employee : (principal) -> (text);
     add_graduate : (principal) -> (text);
     add_adult : (principal) -> (text);
-
 
     /// Serve the app
     http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/src/frontend/generated/vc_issuer_idl.js
+++ b/src/frontend/generated/vc_issuer_idl.js
@@ -1,7 +1,14 @@
 export const idlFactory = ({ IDL }) => {
   const IssuerConfig = IDL.Record({
+    'derivation_origin' : IDL.Text,
     'idp_canister_ids' : IDL.Vec(IDL.Principal),
     'ic_root_key_der' : IDL.Vec(IDL.Nat8),
+    'frontend_hostname' : IDL.Text,
+  });
+  const DerivationOriginData = IDL.Record({ 'origin' : IDL.Text });
+  const DerivationOriginError = IDL.Variant({
+    'Internal' : IDL.Text,
+    'UnsupportedOrigin' : IDL.Text,
   });
   const SignedIdAlias = IDL.Record({ 'credential_jws' : IDL.Text });
   const ArgumentValue = IDL.Variant({ 'Int' : IDL.Int32, 'String' : IDL.Text });
@@ -66,6 +73,16 @@ export const idlFactory = ({ IDL }) => {
     'add_employee' : IDL.Func([IDL.Principal], [IDL.Text], []),
     'add_graduate' : IDL.Func([IDL.Principal], [IDL.Text], []),
     'configure' : IDL.Func([IssuerConfig], [], []),
+    'derivation_origin' : IDL.Func(
+        [IDL.Text],
+        [
+          IDL.Variant({
+            'Ok' : DerivationOriginData,
+            'Err' : DerivationOriginError,
+          }),
+        ],
+        [],
+      ),
     'get_credential' : IDL.Func(
         [GetCredentialRequest],
         [
@@ -96,8 +113,10 @@ export const idlFactory = ({ IDL }) => {
 };
 export const init = ({ IDL }) => {
   const IssuerConfig = IDL.Record({
+    'derivation_origin' : IDL.Text,
     'idp_canister_ids' : IDL.Vec(IDL.Principal),
     'ic_root_key_der' : IDL.Vec(IDL.Nat8),
+    'frontend_hostname' : IDL.Text,
   });
   return [IDL.Opt(IssuerConfig)];
 };

--- a/src/frontend/generated/vc_issuer_idl.js
+++ b/src/frontend/generated/vc_issuer_idl.js
@@ -5,6 +5,9 @@ export const idlFactory = ({ IDL }) => {
     'ic_root_key_der' : IDL.Vec(IDL.Nat8),
     'frontend_hostname' : IDL.Text,
   });
+  const DerivationOriginRequest = IDL.Record({
+    'frontend_hostname' : IDL.Text,
+  });
   const DerivationOriginData = IDL.Record({ 'origin' : IDL.Text });
   const DerivationOriginError = IDL.Variant({
     'Internal' : IDL.Text,
@@ -74,7 +77,7 @@ export const idlFactory = ({ IDL }) => {
     'add_graduate' : IDL.Func([IDL.Principal], [IDL.Text], []),
     'configure' : IDL.Func([IssuerConfig], [], []),
     'derivation_origin' : IDL.Func(
-        [IDL.Text],
+        [DerivationOriginRequest],
         [
           IDL.Variant({
             'Ok' : DerivationOriginData,

--- a/src/vc_util/src/issuer_api.rs
+++ b/src/vc_util/src/issuer_api.rs
@@ -140,6 +140,11 @@ pub struct Icrc21ConsentInfo {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct DerivationOriginRequest {
+    pub frontend_hostname: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct DerivationOriginData {
     pub origin: String,
 }

--- a/src/vc_util/src/issuer_api.rs
+++ b/src/vc_util/src/issuer_api.rs
@@ -139,6 +139,17 @@ pub struct Icrc21ConsentInfo {
     pub language: String,
 }
 
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct DerivationOriginData {
+    pub origin: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum DerivationOriginError {
+    UnsupportedOrigin(String),
+    Internal(String),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Add `derivation_origin`-method to the demo issuer. Also, adapt issuer's initialisation to enable custom configuration for testing.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


