### PR TITLE
Simplify storage initialization

### DIFF
--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -223,15 +223,8 @@ pub fn init_from_stable_memory() {
     STATE.with(|s| {
         s.last_upgrade_timestamp.set(time());
     });
-    let maybe_new_storage = Storage::from_memory(DefaultMemoryImpl::default());
-    match maybe_new_storage {
-        Some(new_storage) => {
-            storage_replace(new_storage);
-        }
-        None => {
-            storage_borrow_mut(|storage| storage.flush());
-        }
-    }
+    let storage = Storage::from_memory(DefaultMemoryImpl::default());
+    storage_replace(storage);
 }
 
 pub fn save_persistent_state() {

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -47,7 +47,7 @@ fn should_recover_header_from_memory_v8() {
     memory.grow(1);
     memory.write(0, &hex::decode("494943080500000040e2010000000000f1fb090000000000000843434343434343434343434343434343434343434343434343434343434343430002000000000000000000000000000000000000000000000000").unwrap());
 
-    let storage = Storage::from_memory(memory).unwrap();
+    let storage = Storage::from_memory(memory);
     assert_eq!(storage.assigned_anchor_number_range(), (123456, 654321));
     assert_eq!(storage.salt().unwrap(), &[67u8; 32]);
     assert_eq!(storage.anchor_count(), 5);


### PR DESCRIPTION
This PR removes duplication in the initialization of new and existing `Storage` structs. It also removes the unnecessary handling of empty stable memories in `post_upgrade`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

