### PR TITLE
Look up replica port in dev server

### DIFF
--- a/src/vite-plugins/src/index.ts
+++ b/src/vite-plugins/src/index.ts
@@ -3,7 +3,7 @@ import { minify } from "html-minifier-terser";
 import { extname } from "path";
 import type { Plugin, ViteDevServer } from "vite";
 import viteCompression from "vite-plugin-compression";
-import { forwardToReplica, readCanisterId } from "./utils.js";
+import { forwardToReplica, readCanisterId, readReplicaPort } from "./utils.js";
 
 export * from "./utils.js";
 
@@ -56,16 +56,15 @@ export const minifyHTML = (): Plugin => ({
  *                     to forward requests to a specific canister
  */
 export const replicaForwardPlugin = ({
-  replicaOrigin,
   forwardDomains /* note: will match exactly on <canister>.<domain> */,
   forwardRules,
 }: {
-  replicaOrigin: string;
   forwardDomains?: string[];
   forwardRules: Array<{ canisterName: string; hosts: string[] }>;
 }) => ({
   name: "replica-forward",
   configureServer(server: ViteDevServer) {
+    const replicaOrigin = `127.0.0.1:${readReplicaPort()}`;
     server.middlewares.use((req, res, next) => {
       if (
         /* Deny requests to raw URLs, e.g. <canisterId>.raw.ic0.app to make sure that II always uses certified assets

--- a/src/vite-plugins/src/utils.ts
+++ b/src/vite-plugins/src/utils.ts
@@ -5,6 +5,14 @@ import type { IncomingMessage, ServerResponse } from "http";
 import { request } from "undici";
 
 /**
+ * Read the replica port from dfx's local state
+ */
+export const readReplicaPort = (): string => {
+  const stdout = execSync("dfx info webserver-port");
+  return stdout.toString().trim();
+};
+
+/**
  * Read a canister ID from dfx's local state
  */
 export const readCanisterId = ({


### PR DESCRIPTION
This ensures the correct replica port is used even if the user uses a different port than the default `4943` port.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
