### PR TITLE
Transfer CAPTCHA to dfinity org

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "captcha"
 version = "0.0.9"
-source = "git+https://github.com/nmattia/captcha?rev=9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391#9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391"
+source = "git+https://github.com/dfinity/captcha?rev=9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391#9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391"
 dependencies = [
  "base64 0.13.1",
  "hound",

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -24,7 +24,7 @@ rand = { version ="*", default-features = false }
 
 rand_core = { version = "*", default-features = false }
 rand_chacha = { version = "*", default-features = false }
-captcha = { git = "https://github.com/nmattia/captcha", rev = "9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391" }
+captcha = { git = "https://github.com/dfinity/captcha", rev = "9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391" }
 
 # All IC deps
 candid.workspace = true


### PR DESCRIPTION
This transfers my personal fork of `daniel-e/captcha` (the CAPTCHA lib powering out CAPTCHA) to the dfinity org.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
