### PR TITLE
Fix wrong link in add device instructions

### DIFF
--- a/src/frontend/src/config.ts
+++ b/src/frontend/src/config.ts
@@ -6,10 +6,7 @@ export const OFFICIAL_II_URL_NO_PROTOCOL = "identity.internetcomputer.org";
 // The URL where the official, production II is served
 export const OFFICIAL_II_URL = "https://" + OFFICIAL_II_URL_NO_PROTOCOL;
 
-// The legacy II URL, without protocol
-export const LEGACY_II_URL_NO_PROTOCOL = "identity.ic0.app";
-
 // The legacy production II URL
-export const LEGACY_II_URL = "https://" + LEGACY_II_URL_NO_PROTOCOL;
+export const LEGACY_II_URL = "https://identity.ic0.app";
 
 export const PORTAL_II_URL = "https://internetcomputer.org/internet-identity";

--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -74,7 +74,7 @@ export const deviceRegistrationDisabledInfo = (
   return new Promise((resolve) =>
     deviceRegistrationDisabledInfoPage({
       userNumber,
-      iiUrl: window.origin,
+      origin: window.origin,
       cancel: () => resolve("canceled"),
       retry: () => resolve("retry"),
     })

--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -1,5 +1,4 @@
 import { mainWindow } from "$src/components/mainWindow";
-import { LEGACY_II_URL_NO_PROTOCOL } from "$src/config";
 import { renderPage } from "$src/utils/lit-html";
 import { html } from "lit-html";
 
@@ -22,8 +21,8 @@ const deviceRegistrationDisabledInfoTemplate = ({
     </hgroup>
     <ol class="c-list c-list--numbered l-stack">
       <li>
-        Connect to ${LEGACY_II_URL_NO_PROTOCOL} on a recognized device using
-        Internet Identity ${userNumber}
+        Connect to ${window.origin} on a recognized device using Internet
+        Identity ${userNumber}
       </li>
       <li>
         Once you are connected, select “<strong class="t-string"

--- a/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled.ts
@@ -4,10 +4,12 @@ import { html } from "lit-html";
 
 const deviceRegistrationDisabledInfoTemplate = ({
   userNumber,
+  origin,
   cancel,
   retry,
 }: {
   userNumber: bigint;
+  origin: string;
   cancel: () => void;
   retry: () => void;
 }) => {
@@ -21,8 +23,8 @@ const deviceRegistrationDisabledInfoTemplate = ({
     </hgroup>
     <ol class="c-list c-list--numbered l-stack">
       <li>
-        Connect to ${window.origin} on a recognized device using Internet
-        Identity ${userNumber}
+        Connect to ${origin} on a recognized device using Internet Identity
+        ${userNumber}
       </li>
       <li>
         Once you are connected, select “<strong class="t-string"
@@ -72,6 +74,7 @@ export const deviceRegistrationDisabledInfo = (
   return new Promise((resolve) =>
     deviceRegistrationDisabledInfoPage({
       userNumber,
+      iiUrl: window.origin,
       cancel: () => resolve("canceled"),
       retry: () => resolve("retry"),
     })

--- a/src/showcase/src/constants.ts
+++ b/src/showcase/src/constants.ts
@@ -4,6 +4,8 @@ import { getDapps } from "$src/flows/dappsExplorer/dapps";
 
 export const dapps = getDapps();
 
+export const iiLegacyOrigin = "https://identity.ic0.app";
+
 const recoveryPhraseText =
   "10050 mandate vague same suspect eight pet gentle repeat maple actor about legal sword text food print material churn perfect sword blossom sleep vintage blouse";
 

--- a/src/showcase/src/pages/deviceRegistrationDisabledInfo.astro
+++ b/src/showcase/src/pages/deviceRegistrationDisabledInfo.astro
@@ -5,13 +5,14 @@ import Screen from "../layouts/Screen.astro";
 <Screen title="Device Registration Disabled Info" pageName="deviceRegistrationDisabledInfo">
   <script>
     import { toast } from "$src/components/toast";
-    import { userNumber } from "../constants";
+    import { userNumber, iiLegacyOrigin } from "../constants";
     import { deviceRegistrationDisabledInfoPage } from "$src/flows/addDevice/welcomeView/deviceRegistrationModeDisabled";
 
     deviceRegistrationDisabledInfoPage({
       userNumber,
+      iiUrl: iiLegacyOrigin,
       retry: () => toast.info("retry"),
-      cancel: () => toast.info("canceled"),
+      cancel: () => toast.info("canceled")
     });
   </script>
 </Screen>

--- a/src/showcase/src/showcase.ts
+++ b/src/showcase/src/showcase.ts
@@ -520,6 +520,7 @@ export const iiPages: Record<string, () => void> = {
   deviceRegistrationDisabledInfo: () =>
     deviceRegistrationDisabledInfoPage({
       userNumber,
+      origin: "https://identity.ic0.app",
       retry: () => console.log("retry"),
       cancel: () => console.log("canceled"),
     }),


### PR DESCRIPTION
The link on the add tentative device disabled page was always pointing to `identity.ic0.app`. This PR fixes it to point to the same origin instead. This way it is also correct for dev setups, etc.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f2884d4c4/desktop/deviceRegistrationDisabledInfo.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f2884d4c4/mobile/deviceRegistrationDisabledInfo.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

