### PR TITLE
Move identityBackground

### DIFF
--- a/src/showcase/src/backgrounds.ts
+++ b/src/showcase/src/backgrounds.ts
@@ -1,0 +1,3 @@
+import { loadIdentityBackground } from "$src/components/identityCard";
+
+export const identityBackground = loadIdentityBackground();

--- a/src/showcase/src/constants.ts
+++ b/src/showcase/src/constants.ts
@@ -1,5 +1,4 @@
 import { Challenge, DeviceData } from "$generated/internet_identity_types";
-import { loadIdentityBackground } from "$src/components/identityCard";
 import { getDapps } from "$src/flows/dappsExplorer/dapps";
 
 export const dapps = getDapps();
@@ -24,8 +23,6 @@ export const chromeDevice: DeviceData = {
   origin: [],
   metadata: [],
 };
-
-export const identityBackground = loadIdentityBackground();
 
 export const dummyChallenge: Challenge = {
   png_base64:

--- a/src/showcase/src/pages/displayManage.astro
+++ b/src/showcase/src/pages/displayManage.astro
@@ -5,9 +5,11 @@ import Screen from "../layouts/Screen.astro";
 <Screen title="Display Manage" pageName="displayManage">
   <script>
     import { toast } from "$src/components/toast";
-    import { userNumber, identityBackground } from "../constants";
+    import { userNumber } from "../constants";
+    import { identityBackground } from "../backgrounds";
     import { dapps } from "../constants";
     import { displayManagePage } from "$src/flows/manage";
+    import { html } from "lit-html";
 
     displayManagePage({
       identityBackground,
@@ -28,7 +30,7 @@ import Screen from "../layouts/Screen.astro";
             alias: "Yubikey Blue",
             remove: () => toast.info("remove"),
             rename: () => toast.info("rename"),
-            warn: "Something is rotten in the state of Device",
+            warn: html`Something is rotten in the state of Device`,
           },
         ],
         recoveries: {

--- a/src/showcase/src/pages/displayManageSingle.astro
+++ b/src/showcase/src/pages/displayManageSingle.astro
@@ -5,7 +5,8 @@ import Screen from "../layouts/Screen.astro";
 <Screen title="Display Manage Single" pageName="displayManageSingle">
   <script>
     import { toast } from "$src/components/toast";
-    import { userNumber, identityBackground } from "../constants";
+    import { userNumber } from "../constants";
+    import { identityBackground } from "../backgrounds";
     import { dapps } from "../constants";
     import { displayManagePage } from "$src/flows/manage";
 

--- a/src/showcase/src/pages/displayManageTempKey.astro
+++ b/src/showcase/src/pages/displayManageTempKey.astro
@@ -5,7 +5,8 @@ import Screen from "../layouts/Screen.astro";
 <Screen title="Display Manage Temp Key" pageName="displayManageTempKey">
   <script>
     import { toast } from "$src/components/toast";
-    import { userNumber, identityBackground } from "../constants";
+    import { identityBackground } from "../backgrounds";
+    import { userNumber } from "../constants";
     import { dapps } from "../constants";
     import { displayManagePage } from "$src/flows/manage";
 

--- a/src/showcase/src/pages/displayUserNumber.astro
+++ b/src/showcase/src/pages/displayUserNumber.astro
@@ -5,7 +5,8 @@ import Screen from "../layouts/Screen.astro";
 <Screen title="Display User Number" pageName="displayUserNumber">
   <script>
     import { toast } from "$src/components/toast";
-    import { identityBackground, userNumber } from "../constants";
+    import { identityBackground } from "../backgrounds";
+    import { userNumber } from "../constants";
     import { displayUserNumberPage } from "$src/flows/register/finish";
     import { registerStepper } from "$src/flows/register/stepper";
 

--- a/src/showcase/src/pages/displayUserNumberTempKey.astro
+++ b/src/showcase/src/pages/displayUserNumberTempKey.astro
@@ -5,7 +5,8 @@ import Screen from "../layouts/Screen.astro";
 <Screen title="Display User Number Temp Key" pageName="displayUserNumberTempKey">
   <script>
     import { toast } from "$src/components/toast";
-    import { identityBackground, userNumber } from "../constants";
+    import { identityBackground } from "../backgrounds";
+    import { userNumber } from "../constants";
     import { i18n } from "../i18n";
     import { displayUserNumberPage } from "$src/flows/register/finish";
     import { registerStepper } from "$src/flows/register/stepper";


### PR DESCRIPTION
Final motivation is to remove the `iiPages` from `showcase.ts` to the `index.astro` by reading the page files.

I found that I would need to import a constant in the server side, but there was an error because the constans.ts file was also importing the `identityBackground` which doesn't work in the server.

Therefore, I move the `identityBackground` to a new file `backgrounds.ts`.
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
