### PR TITLE
Fix dead-end in device add flow

### DIFF
--- a/src/frontend/src/test-e2e/addDevice.test.ts
+++ b/src/frontend/src/test-e2e/addDevice.test.ts
@@ -10,6 +10,7 @@ import {
   AddIdentityAnchorView,
   AddRemoteDeviceInstructionsView,
   AddRemoteDeviceVerificationCodeView,
+  AuthenticateView,
   MainView,
   NotInRegistrationModeView,
   VerifyRemoteDeviceView,
@@ -151,6 +152,14 @@ test("Add remote device starting on new device", async () => {
       const addDeviceSuccessView = new AddDeviceSuccessView(browser);
       await addDeviceSuccessView.waitForDisplay();
       await addDeviceSuccessView.continue();
+
+      // browser 2 again
+      // make sure the browser now shows the sign-in screen with the user number
+      // pre-filled
+      await focusBrowser(browser2);
+      const authView = new AuthenticateView(browser2);
+      await authView.waitForDisplay();
+      await authView.expectAnchor(userNumber);
     });
 
     await mainView.waitForDisplay();

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -495,6 +495,10 @@ export class AuthenticateView extends View {
     await this.browser.$(`[data-anchor-id="${anchor}"]`).click();
   }
 
+  async expectAnchor(anchor: string): Promise<void> {
+    await this.browser.$(`[data-anchor-id="${anchor}"]`).waitForDisplayed();
+  }
+
   async expectAnchorInputField(): Promise<void> {
     await this.browser
       .$('[data-role="anchor-input"]')

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -57,7 +57,10 @@ export const iiFlows: Record<string, () => void> = {
       templates: manageTemplates,
       addDevice: () => {
         toast.info(html`Added device`);
-        return Promise.resolve({ alias: "My Device" });
+        return Promise.resolve({
+          alias: "My Device",
+          userNumber: BigInt(1234),
+        });
       },
       loginPasskey: async () => {
         await new Promise((resolve) => setTimeout(resolve, 2000));


### PR DESCRIPTION
This PR fixes a dead end where users would end up stuck after adding a new passkey to an identity from the sign-in screen.

Note: This PR does not yet include the new confirmation screens as per figma. This will be done separately.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/935e9af1a/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
