### PR TITLE
Remove persistent state size restriction

### DIFF
--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -178,8 +178,8 @@ pub struct Storage<M: Memory> {
     archive_buffer_memory_wrapper: MemoryWrapper<NestedRestrictedMemory<M>>,
     archive_entries_buffer: StableBTreeMap<u64, BufferedEntryWrapper, NestedRestrictedMemory<M>>,
     /// Memory wrapper used to report the size of the persistent state memory.
-    persistent_state_memory_wrapper: MemoryWrapper<NestedRestrictedMemory<M>>,
-    persistent_state: StableCell<StorablePersistentState, NestedRestrictedMemory<M>>,
+    persistent_state_memory_wrapper: MemoryWrapper<VirtualMemory<RestrictedMemory<M>>>,
+    persistent_state: StableCell<StorablePersistentState, VirtualMemory<RestrictedMemory<M>>>,
 }
 
 #[repr(packed)]
@@ -238,8 +238,7 @@ impl<M: Memory + Clone> Storage<M> {
         // To have space for 10_000 entries (accounting for ~10% overhead) we need 82 pages or ~5 MB.
         // Since the memory manager allocates memory in buckets of 128 pages, we use a full bucket here.
         let archive_buffer_memory = single_bucket_memory(&memory_manager, ARCHIVE_BUFFER_MEMORY_ID);
-        let persistent_state_memory =
-            single_bucket_memory(&memory_manager, PERSISTENT_STATE_MEMORY_ID);
+        let persistent_state_memory = memory_manager.get(PERSISTENT_STATE_MEMORY_ID);
         Self {
             header,
             header_memory,


### PR DESCRIPTION
This PR removes the size restriction on the persistent state memory. The reason is, that the persistent state is saved during the `pre_upgrade` hook. If the canister hits the size restriction, it will panic and hence the canister would be un-upgradeable.

The size restriction included a safety margin of 20x, but given that the limitation is only enforced in specific places, not having a size limit at all is much safer.
We will add an alert that triggers on the memory size instead. Additionally, we should get rid of the `pre_upgrade` hook altogether.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
