### PR TITLE
Bump astro to 4.4.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@typescript-eslint/parser": "6.7.5",
         "@vitejs/plugin-basic-ssl": "^1.0.1",
         "@wdio/globals": "8.32.3",
-        "astro": "4.3.6",
+        "astro": "4.4.15",
         "eslint": "8.51.0",
         "fake-indexeddb": "^4.0.2",
         "lit-analyzer": "^2.0.2",
@@ -1574,6 +1574,12 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@medv/finder": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@medv/finder/-/finder-3.2.0.tgz",
+      "integrity": "sha512-JmU7JIBwyL8RAzefvzALT4sP2M0biGk8i2invAgpQmma/QgfsaqoHIvJ7S0YC8n9hUVG8X3Leul2nGa06PvhbQ==",
+      "dev": true
+    },
     "node_modules/@noble/hashes": {
       "version": "1.3.2",
       "license": "MIT",
@@ -1682,9 +1688,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.10.0.tgz",
-      "integrity": "sha512-/MeDQmcD96nVoRumKUljsYOLqfv1YFJps+0pTrb2Z9Nl/w5qNUysMaWQsrd1mvAlNT4yza1iVyIu4Q4AgF6V3A==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.1.tgz",
+      "integrity": "sha512-iU2Sya8hNn1LhsYyf0N+L4Gf9Qc+9eBTJJJsaOGUp+7x4n2M9dxTt8UvhJl3oeftSjblSlpCfvjA/IfP3g5VjQ==",
       "cpu": [
         "arm"
       ],
@@ -1695,9 +1701,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.10.0.tgz",
-      "integrity": "sha512-lvu0jK97mZDJdpZKDnZI93I0Om8lSDaiPx3OiCk0RXn3E8CMPJNS/wxjAvSJJzhhZpfjXsjLWL8LnS6qET4VNQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.1.tgz",
+      "integrity": "sha512-wlzcWiH2Ir7rdMELxFE5vuM7D6TsOcJ2Yw0c3vaBR3VOsJFVTx9xvwnAvhgU5Ii8Gd6+I11qNHwndDscIm0HXg==",
       "cpu": [
         "arm64"
       ],
@@ -1708,9 +1714,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.10.0.tgz",
-      "integrity": "sha512-uFpayx8I8tyOvDkD7X6n0PriDRWxcqEjqgtlxnUA/G9oS93ur9aZ8c8BEpzFmsed1TH5WZNG5IONB8IiW90TQg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.1.tgz",
+      "integrity": "sha512-YRXa1+aZIFN5BaImK+84B3uNK8C6+ynKLPgvn29X9s0LTVCByp54TB7tdSMHDR7GTV39bz1lOmlLDuedgTwwHg==",
       "cpu": [
         "arm64"
       ],
@@ -1721,9 +1727,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.10.0.tgz",
-      "integrity": "sha512-nIdCX03qFKoR/MwQegQBK+qZoSpO3LESurVAC6s6jazLA1Mpmgzo3Nj3H1vydXp/JM29bkCiuF7tDuToj4+U9Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.1.tgz",
+      "integrity": "sha512-opjWJ4MevxeA8FhlngQWPBOvVWYNPFkq6/25rGgG+KOy0r8clYwL1CFd+PGwRqqMFVQ4/Qd3sQu5t7ucP7C/Uw==",
       "cpu": [
         "x64"
       ],
@@ -1734,9 +1740,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.10.0.tgz",
-      "integrity": "sha512-Fz7a+y5sYhYZMQFRkOyCs4PLhICAnxRX/GnWYReaAoruUzuRtcf+Qnw+T0CoAWbHCuz2gBUwmWnUgQ67fb3FYw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.1.tgz",
+      "integrity": "sha512-uBkwaI+gBUlIe+EfbNnY5xNyXuhZbDSx2nzzW8tRMjUmpScd6lCQYKY2V9BATHtv5Ef2OBq6SChEP8h+/cxifQ==",
       "cpu": [
         "arm"
       ],
@@ -1747,9 +1753,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.10.0.tgz",
-      "integrity": "sha512-yPtF9jIix88orwfTi0lJiqINnlWo6p93MtZEoaehZnmCzEmLL0eqjA3eGVeyQhMtxdV+Mlsgfwhh0+M/k1/V7Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.1.tgz",
+      "integrity": "sha512-0bK9aG1kIg0Su7OcFTlexkVeNZ5IzEsnz1ept87a0TUgZ6HplSgkJAnFpEVRW7GRcikT4GlPV0pbtVedOaXHQQ==",
       "cpu": [
         "arm64"
       ],
@@ -1760,9 +1766,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.10.0.tgz",
-      "integrity": "sha512-9GW9yA30ib+vfFiwjX+N7PnjTnCMiUffhWj4vkG4ukYv1kJ4T9gHNg8zw+ChsOccM27G9yXrEtMScf1LaCuoWQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.1.tgz",
+      "integrity": "sha512-qB6AFRXuP8bdkBI4D7UPUbE7OQf7u5OL+R94JE42Z2Qjmyj74FtDdLGeriRyBDhm4rQSvqAGCGC01b8Fu2LthQ==",
       "cpu": [
         "arm64"
       ],
@@ -1773,9 +1779,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.10.0.tgz",
-      "integrity": "sha512-X1ES+V4bMq2ws5fF4zHornxebNxMXye0ZZjUrzOrf7UMx1d6wMQtfcchZ8SqUnQPPHdOyOLW6fTcUiFgHFadRA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.1.tgz",
+      "integrity": "sha512-sHig3LaGlpNgDj5o8uPEoGs98RII8HpNIqFtAI8/pYABO8i0nb1QzT0JDoXF/pxzqO+FkxvwkHZo9k0NJYDedg==",
       "cpu": [
         "riscv64"
       ],
@@ -1786,9 +1792,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.10.0.tgz",
-      "integrity": "sha512-w/5OpT2EnI/Xvypw4FIhV34jmNqU5PZjZue2l2Y3ty1Ootm3SqhI+AmfhlUYGBTd9JnpneZCDnt3uNOiOBkMyw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.1.tgz",
+      "integrity": "sha512-nD3YcUv6jBJbBNFvSbp0IV66+ba/1teuBcu+fBBPZ33sidxitc6ErhON3JNavaH8HlswhWMC3s5rgZpM4MtPqQ==",
       "cpu": [
         "x64"
       ],
@@ -1799,9 +1805,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.10.0.tgz",
-      "integrity": "sha512-q/meftEe3QlwQiGYxD9rWwB21DoKQ9Q8wA40of/of6yGHhZuGfZO0c3WYkN9dNlopHlNT3mf5BPsUSxoPuVQaw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.1.tgz",
+      "integrity": "sha512-7/XVZqgBby2qp/cO0TQ8uJK+9xnSdJ9ct6gSDdEr4MfABrjTyrW6Bau7HQ73a2a5tPB7hno49A0y1jhWGDN9OQ==",
       "cpu": [
         "x64"
       ],
@@ -1812,9 +1818,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.10.0.tgz",
-      "integrity": "sha512-NrR6667wlUfP0BHaEIKgYM/2va+Oj+RjZSASbBMnszM9k+1AmliRjHc3lJIiOehtSSjqYiO7R6KLNrWOX+YNSQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.1.tgz",
+      "integrity": "sha512-CYc64bnICG42UPL7TrhIwsJW4QcKkIt9gGlj21gq3VV0LL6XNb1yAdHVp1pIi9gkts9gGcT3OfUYHjGP7ETAiw==",
       "cpu": [
         "arm64"
       ],
@@ -1825,9 +1831,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.10.0.tgz",
-      "integrity": "sha512-FV0Tpt84LPYDduIDcXvEC7HKtyXxdvhdAOvOeWMWbQNulxViH2O07QXkT/FffX4FqEI02jEbCJbr+YcuKdyyMg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.1.tgz",
+      "integrity": "sha512-LN+vnlZ9g0qlHGlS920GR4zFCqAwbv2lULrR29yGaWP9u7wF5L7GqWu9Ah6/kFZPXPUkpdZwd//TNR+9XC9hvA==",
       "cpu": [
         "ia32"
       ],
@@ -1838,9 +1844,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.10.0.tgz",
-      "integrity": "sha512-OZoJd+o5TaTSQeFFQ6WjFCiltiYVjIdsXxwu/XZ8qRpsvMQr4UsVrE5UyT9RIvsnuF47DqkJKhhVZ2Q9YW9IpQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.1.tgz",
+      "integrity": "sha512-n+vkrSyphvmU0qkQ6QBNXCGr2mKjhP08mPRM/Xp5Ck2FV4NrHU+y6axzDeixUrCBHVUS51TZhjqrKBBsHLKb2Q==",
       "cpu": [
         "x64"
       ],
@@ -3301,9 +3307,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-4.3.6.tgz",
-      "integrity": "sha512-VYJGsBygMtPM/qTRgn5QdxkSILgjpW2uHVw3snp/Gkl+N9uRAAnuYxrUO7wkbLejfrmlb0nZyyKG+H5VDQPbeg==",
+      "version": "4.4.15",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-4.4.15.tgz",
+      "integrity": "sha512-RTiAnlO8hDp6GqMVvaeJxyuCJhHNEho09lHshMNQBqgRabYPOJGW0HZZrbLRGNOqN9I14ivhZIunYGgAaGQpWw==",
       "dev": true,
       "dependencies": {
         "@astrojs/compiler": "^2.5.3",
@@ -3316,6 +3322,7 @@
         "@babel/plugin-transform-react-jsx": "^7.22.5",
         "@babel/traverse": "^7.23.3",
         "@babel/types": "^7.23.3",
+        "@medv/finder": "^3.1.0",
         "@types/babel__core": "^7.20.4",
         "acorn": "^8.11.2",
         "aria-query": "^5.3.0",
@@ -3353,12 +3360,10 @@
         "p-queue": "^8.0.1",
         "path-to-regexp": "^6.2.1",
         "preferred-pm": "^3.1.2",
-        "probe-image-size": "^7.2.3",
         "prompts": "^2.4.2",
         "rehype": "^13.0.1",
         "resolve": "^1.22.4",
         "semver": "^7.5.4",
-        "server-destroy": "^1.0.1",
         "shikiji": "^0.9.19",
         "shikiji-core": "^0.9.19",
         "string-width": "^7.0.0",
@@ -3366,7 +3371,7 @@
         "tsconfck": "^3.0.0",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.1",
-        "vite": "^5.0.12",
+        "vite": "^5.1.4",
         "vitefu": "^0.2.5",
         "which-pm": "^2.1.1",
         "yargs-parser": "^21.1.1",
@@ -3452,9 +3457,9 @@
       }
     },
     "node_modules/astro/node_modules/rollup": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.10.0.tgz",
-      "integrity": "sha512-t2v9G2AKxcQ8yrG+WGxctBes1AomT0M4ND7jTFBCVPXQ/WFTvNSefIrNSmLKhIKBrvN8SG+CZslimJcT3W2u2g==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.1.tgz",
+      "integrity": "sha512-ggqQKvx/PsB0FaWXhIvVkSWh7a/PCLQAsMjBc+nA2M8Rv2/HG0X6zvixAB7KyZBRtifBUhy5k8voQX/mRnABPg==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -3467,19 +3472,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.10.0",
-        "@rollup/rollup-android-arm64": "4.10.0",
-        "@rollup/rollup-darwin-arm64": "4.10.0",
-        "@rollup/rollup-darwin-x64": "4.10.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.10.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.10.0",
-        "@rollup/rollup-linux-arm64-musl": "4.10.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.10.0",
-        "@rollup/rollup-linux-x64-gnu": "4.10.0",
-        "@rollup/rollup-linux-x64-musl": "4.10.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.10.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.10.0",
-        "@rollup/rollup-win32-x64-msvc": "4.10.0",
+        "@rollup/rollup-android-arm-eabi": "4.12.1",
+        "@rollup/rollup-android-arm64": "4.12.1",
+        "@rollup/rollup-darwin-arm64": "4.12.1",
+        "@rollup/rollup-darwin-x64": "4.12.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.12.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.12.1",
+        "@rollup/rollup-linux-arm64-musl": "4.12.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.12.1",
+        "@rollup/rollup-linux-x64-gnu": "4.12.1",
+        "@rollup/rollup-linux-x64-musl": "4.12.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.12.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.12.1",
+        "@rollup/rollup-win32-x64-msvc": "4.12.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -3516,9 +3521,9 @@
       }
     },
     "node_modules/astro/node_modules/vite": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.1.tgz",
-      "integrity": "sha512-wclpAgY3F1tR7t9LL5CcHC41YPkQIpKUGeIuT8MdNwNZr6OqOTLs7JX5vIHAtzqLWXts0T+GDrh9pN2arneKqg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
+      "integrity": "sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
@@ -6993,18 +6998,6 @@
         "node": ">=16.17.0"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/idb": {
       "version": "7.1.1",
       "license": "ISC"
@@ -9113,32 +9106,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/needle": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
-    },
-    "node_modules/needle/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "dev": true,
@@ -10029,17 +9996,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/probe-image-size": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
-      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
-      "dev": true,
-      "dependencies": {
-        "lodash.merge": "^4.6.2",
-        "needle": "^2.5.2",
-        "stream-parser": "~0.3.1"
       }
     },
     "node_modules/process-nextick-args": {
@@ -11440,13 +11396,9 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
-      "dev": true
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -11534,11 +11486,6 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
-    },
-    "node_modules/server-destroy": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -11904,30 +11851,6 @@
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
       }
-    },
-    "node_modules/stream-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
-      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "2"
-      }
-    },
-    "node_modules/stream-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/stream-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
     },
     "node_modules/streamx": {
       "version": "2.15.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/parser": "6.7.5",
     "@vitejs/plugin-basic-ssl": "^1.0.1",
     "@wdio/globals": "8.32.3",
-    "astro": "4.3.6",
+    "astro": "4.4.15",
     "eslint": "8.51.0",
     "fake-indexeddb": "^4.0.2",
     "lit-analyzer": "^2.0.2",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,13 +29,6 @@ export default defineConfig(({ command, mode }): UserConfig => {
     II_VERSION: `${process.env.II_VERSION ?? ""}`,
   };
 
-  // Astro gets a bit confused and tries to load the server config (including devserver-only
-  // plugins) on build. This ensures that plugins that need dfx are only invoked on serve.
-  // https://github.com/withastro/astro/issues/10262
-  const isAstro =
-    process.env["npm_lifecycle_script"]?.includes("astro") === true;
-  const isServe = command === "serve" && !isAstro;
-
   // Path "../../" have to be expressed relative to the "root".
   // e.g.
   // root = src/frontend
@@ -101,7 +94,7 @@ export default defineConfig(({ command, mode }): UserConfig => {
               : []),
           ],
         }),
-        apply: () => isServe,
+        apply: "serve",
       },
     ],
     optimizeDeps: {
@@ -111,13 +104,14 @@ export default defineConfig(({ command, mode }): UserConfig => {
         },
       },
     },
-    server: !isServe
-      ? {}
-      : {
-          https: process.env.TLS_DEV_SERVER === "1",
-          proxy: {
-            "/api": `http://127.0.0.1:${readReplicaPort()}`,
+    server:
+      command !== "serve"
+        ? {}
+        : {
+            https: process.env.TLS_DEV_SERVER === "1",
+            proxy: {
+              "/api": `http://127.0.0.1:${readReplicaPort()}`,
+            },
           },
-        },
   };
 });


### PR DESCRIPTION
This bumps astro to the latest version. The latest version includes a fix for an issue we had where astro loaded our `serve` build config. The workaround we implemented is removed.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
