### PR TITLE
Add feature flag to VC issuer to exclude custom origin

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -164,6 +164,33 @@ jobs:
             exit 1
           fi
 
+  vc_demo_issuer_exclude_custom_origin-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            demos/vc_issuer/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('demos/vc_issuer/Cargo.lock', 'rust-toolchain.toml') }}-exclude-custom-origin
+      - uses: ./.github/actions/bootstrap
+      - uses: ./.github/actions/setup-node
+      - run: npm ci
+      - name: "Build VC issuer canister without custom origin"
+        working-directory: demos/vc_issuer
+        run: |
+          ./build.sh --exclude-custom-origin -o ./vc_demo_issuer_exclude_custom_origin.wasm.gz
+      - name: 'Upload VC issuer without custom origin'
+        uses: actions/upload-artifact@v4
+        with:
+          # name is the name used to display and retrieve the artifact
+          name: vc_demo_issuer_exclude_custom_origin.wasm.gz
+          # path is the name used as the file to upload and the name of the
+          # downloaded file
+          path: ./demos/vc_issuer/vc_demo_issuer_exclude_custom_origin.wasm.gz
+
   vc_demo_issuer-build:
     runs-on: ubuntu-latest
     steps:
@@ -404,7 +431,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [cached-build, test-app-build, vc_demo_issuer-build]
+    needs: [cached-build, test-app-build, vc_demo_issuer-build, vc_demo_issuer_exclude_custom_origin-build]
     strategy:
       matrix:
         device: [ 'desktop', 'mobile' ]
@@ -463,6 +490,12 @@ jobs:
           name: vc_demo_issuer.wasm.gz
           path: demos/vc_issuer
 
+      - name: 'Download VC issuer without custom origin wasm'
+        uses: actions/download-artifact@v4
+        with:
+          name: vc_demo_issuer_exclude_custom_origin.wasm.gz
+          path: demos/vc_issuer
+
       - name: Create Canisters
         run: dfx canister create --all
 
@@ -471,9 +504,13 @@ jobs:
           dfx canister install internet_identity --wasm internet_identity_test.wasm.gz
           dfx canister install test_app --wasm demos/test-app/test_app.wasm
           dfx canister install issuer --wasm demos/vc_issuer/vc_demo_issuer.wasm.gz
+          dfx canister install issuer_exclude_custom_origin --wasm demos/vc_issuer/vc_demo_issuer_exclude_custom_origin.wasm.gz
 
       - name: Provision issuer canister
-        run: ./demos/vc_issuer/provision
+        run: ./demos/vc_issuer/provision --issuer-canister issuer --issuer-frontend-hostname https://nice-issuer-custom-orig.com --issuer-derivation-origin https://$(dfx canister id test_app).icp0.io
+
+      - name: Provision issuer canister that excludes custom origin
+        run: ./demos/vc_issuer/provision --issuer-canister issuer_exclude_custom_origin
 
       # Check the return code of npm ci
       - name: Check on npm ci

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -164,7 +164,7 @@ jobs:
             exit 1
           fi
 
-  vc_demo_issuer_exclude_custom_origin-build:
+  vc_issuer_without_custom_origin_for_test-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -431,7 +431,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [cached-build, test-app-build, vc_demo_issuer-build, vc_demo_issuer_exclude_custom_origin-build]
+    needs: [cached-build, test-app-build, vc_demo_issuer-build, vc_issuer_without_custom_origin_for_test-build]
     strategy:
       matrix:
         device: [ 'desktop', 'mobile' ]

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -6,6 +6,10 @@ description = "Verifiable Credentials Issuer"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Builds the issuer without support for alternative derivaiton origin feature, for testing only.
+exclude_custom_origin = []
+
 [dependencies]
 # local dependencies
 canister_sig_util = { path = "../../src/canister_sig_util" }

--- a/demos/vc_issuer/build.sh
+++ b/demos/vc_issuer/build.sh
@@ -1,6 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+#########
+# USAGE #
+#########
+
+function title() {
+    echo "Build issuer canister" >&2
+}
+
+function usage() {
+    cat >&2 << EOF
+
+Usage:
+  $0 [--exclude-custom-origin] [-o FILENAME}
+
+Options:
+  --exclude-custom-origin         When set, the canister will NOT support querying its derivation origin
+  -o                              When set, specifies the file to write the built Wasm to
+EOF
+}
+
+BUILD_OUTPUT=
+ISSUER_FEATURES=()
+
+while [[ $# -gt 0  ]]
+do
+    case "$1" in
+        -h|--help)
+            title
+            usage
+            exit 0
+            ;;
+        -o)
+            BUILD_OUTPUT="${2:?missing value for '-o'}"
+            BUILD_OUTPUT="$(realpath $(dirname "$BUILD_OUTPUT"))/$(basename "$BUILD_OUTPUT")"
+            echo "build output is '$BUILD_OUTPUT'"
+            shift; # shift past -o and value
+            shift;
+            ;;
+        --exclude-custom-origin)
+            ISSUER_FEATURES+=("exclude_custom_origin")
+            shift; # shift past --exclude-custom-origin
+            ;;
+        *)
+            echo "ERROR: unknown argument $1"
+            usage
+            echo
+            echo "Use '$0 --help' for more information"
+            exit 1
+            ;;
+    esac
+done
 
 # Make sure we always run from the issuer root
 VC_ISSUER_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -11,10 +62,15 @@ pushd ../../
 npm run --workspace ./demos/vc_issuer build
 popd
 
-cargo build --release --target wasm32-unknown-unknown --manifest-path ./Cargo.toml -j1
-ic-wasm "target/wasm32-unknown-unknown/release/vc_issuer.wasm" -o "./vc_demo_issuer.wasm" shrink
-ic-wasm vc_demo_issuer.wasm -o vc_demo_issuer.wasm metadata candid:service -f vc_demo_issuer.did -v public
-# indicate support for certificate version 1 and 2 in the canister metadata
-ic-wasm vc_demo_issuer.wasm -o vc_demo_issuer.wasm metadata supported_certificate_versions -d "1,2" -v public
-gzip --no-name --force "vc_demo_issuer.wasm"
+tmp_wasm=$(mktemp)
 
+cargo build --release \
+    --features "${ISSUER_FEATURES[*]:-}" \
+    --target wasm32-unknown-unknown --manifest-path ./Cargo.toml
+ic-wasm "target/wasm32-unknown-unknown/release/vc_issuer.wasm" -o "$tmp_wasm" shrink
+ic-wasm "$tmp_wasm" -o "$tmp_wasm" metadata candid:service -f vc_demo_issuer.did -v public
+# indicate support for certificate version 1 and 2 in the canister metadata
+ic-wasm "$tmp_wasm" -o "$tmp_wasm" metadata supported_certificate_versions -d "1,2" -v public
+
+# NOTE: this automatically removes tmp_wasm
+gzip --no-name --force "$tmp_wasm" --to-stdout > "${BUILD_OUTPUT:-./vc_demo_issuer.wasm.gz}"

--- a/demos/vc_issuer/provision
+++ b/demos/vc_issuer/provision
@@ -61,12 +61,12 @@ do
             shift;
             ;;
         --issuer-derivation-origin)
-            DERIVATION_ORIGIN="${2:?missing value for '--issuer-derivation-origin'}"
+            ISSUER_DERIVATION_ORIGIN="${2:?missing value for '--issuer-derivation-origin'}"
             shift; # shift past --issuer-canister & value
             shift;
             ;;
         --issuer-frontend-hostname)
-            FRONTEND_HOSTNAME="${2:?missing value for '--issuer-frontend-hostname'}"
+            ISSUER_FRONTEND_HOSTNAME="${2:?missing value for '--issuer-frontend-hostname'}"
             shift; # shift past --issuer-canister & value
             shift;
             ;;
@@ -84,11 +84,12 @@ done
 DFX_NETWORK="${DFX_NETWORK:-local}"
 II_CANISTER_ID="${II_CANISTER_ID:-$(dfx canister id internet_identity)}"
 ISSUER_CANISTER="${ISSUER_CANISTER:-issuer}"
-ISSUER_CANISTER_ID=$(dfx canister id $ISSUER_CANISTER)
+ISSUER_CANISTER_ID=$(dfx canister id "$ISSUER_CANISTER")
 DEFAULT_DERIVATION_ORIGIN="https://$ISSUER_CANISTER_ID.icp0.io"
 ISSUER_DERIVATION_ORIGIN="${ISSUER_DERIVATION_ORIGIN:-$DEFAULT_DERIVATION_ORIGIN}"
 ISSUER_FRONTEND_HOSTNAME="${ISSUER_FRONTEND_HOSTNAME:-$ISSUER_DERIVATION_ORIGIN}"
 
+echo "Provisioning canister $ISSUER_CANISTER"
 echo "Using DFX network: $DFX_NETWORK" >&2
 
 # At the time of writing dfx outputs incorrect JSON with dfx ping (commas between object

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -125,7 +125,6 @@ mod api {
     }
 
     #[cfg_attr(feature = "exclude_custom_origin", ignore)]
-    #[allow(unused)]
     pub fn derivation_origin(
         env: &StateMachine,
         canister_id: CanisterId,
@@ -339,7 +338,6 @@ fn should_fail_vc_consent_message_if_missing_required_argument() {
 }
 
 #[test]
-#[cfg_attr(feature = "exclude_custom_origin", ignore)]
 fn should_return_derivation_origin() {
     let env = env();
     let canister_id = install_canister(&env, VC_ISSUER_WASM.clone());
@@ -352,7 +350,6 @@ fn should_return_derivation_origin() {
 }
 
 #[test]
-#[cfg_attr(feature = "exclude_custom_origin", ignore)]
 fn should_return_derivation_origin_with_custom_init() {
     let env = env();
     let custom_init = IssuerInit {
@@ -376,7 +373,6 @@ fn should_return_derivation_origin_with_custom_init() {
 }
 
 #[test]
-#[cfg_attr(feature = "exclude_custom_origin", ignore)]
 fn should_fail_derivation_origin_if_unsupported_origin() {
     let env = env();
     let canister_id = install_canister(&env, VC_ISSUER_WASM.clone());

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -124,6 +124,8 @@ mod api {
         .map(|(x,)| x)
     }
 
+    #[cfg_attr(feature = "exclude_custom_origin", ignore)]
+    #[allow(unused)]
     pub fn derivation_origin(
         env: &StateMachine,
         canister_id: CanisterId,
@@ -337,6 +339,7 @@ fn should_fail_vc_consent_message_if_missing_required_argument() {
 }
 
 #[test]
+#[cfg_attr(feature = "exclude_custom_origin", ignore)]
 fn should_return_derivation_origin() {
     let env = env();
     let canister_id = install_canister(&env, VC_ISSUER_WASM.clone());
@@ -349,6 +352,7 @@ fn should_return_derivation_origin() {
 }
 
 #[test]
+#[cfg_attr(feature = "exclude_custom_origin", ignore)]
 fn should_return_derivation_origin_with_custom_init() {
     let env = env();
     let custom_init = IssuerInit {
@@ -372,6 +376,7 @@ fn should_return_derivation_origin_with_custom_init() {
 }
 
 #[test]
+#[cfg_attr(feature = "exclude_custom_origin", ignore)]
 fn should_fail_derivation_origin_if_unsupported_origin() {
     let env = env();
     let canister_id = install_canister(&env, VC_ISSUER_WASM.clone());

--- a/dfx.json
+++ b/dfx.json
@@ -17,8 +17,16 @@
       "type": "custom",
       "candid": "demos/vc_issuer/vc_demo_issuer.did",
       "wasm": "demos/vc_issuer/vc_demo_issuer.wasm.gz",
-      "build": "demos/vc_issuer/build.sh",
-      "post_install": "demos/vc_issuer/provision",
+      "build": "demos/vc_issuer/build.sh -o demos/vc_issuer/vc_demo_issuer.wasm.gz",
+      "post_install": "bash -c 'demos/vc_issuer/provision --issuer-frontend-hostname https://nice-issuer-custom-orig.com --issuer-canister issuer --issuer-derivation-origin https://$(dfx canister id test_app).icp0.io'",
+      "dependencies": [ "internet_identity" ]
+    },
+    "issuer_exclude_custom_origin": {
+      "type": "custom",
+      "candid": "demos/vc_issuer/vc_demo_issuer.did",
+      "wasm": "demos/vc_issuer/vc_demo_issuer_exclude_custom_origin.wasm.gz",
+      "build": "demos/vc_issuer/build.sh --exclude-custom-origin -o demos/vc_issuer/vc_demo_issuer_exclude_custom_origin.wasm.gz",
+      "post_install": "demos/vc_issuer/provision --issuer-canister issuer_exclude_custom_origin",
       "dependencies": [ "internet_identity" ]
     }
   },


### PR DESCRIPTION
Add a feature flag to vc_issuer, to enable build without support for custom origin/`derivation_origin`-API.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/66485deb6/desktop/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/66485deb6/desktop/flows.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/66485deb6/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/66485deb6/mobile/flows.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/66485deb6/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/66485deb6/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/66485deb6/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


