### PR TITLE
Update create PR action

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -812,7 +812,7 @@ jobs:
 
       - name: Create Pull Request
         if: startsWith(github.ref, 'refs/tags/release-')
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main

--- a/.github/workflows/update-dapps.yml
+++ b/.github/workflows/update-dapps.yml
@@ -26,7 +26,7 @@ jobs:
       # If the dapps changed, create a PR.
       # This action creates a PR only if there are changes.
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -39,7 +39,7 @@ jobs:
         # If the .didc-release was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main

--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -41,7 +41,7 @@ jobs:
         # If the .node-version was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -48,7 +48,7 @@ jobs:
         # If the rust-toolchain was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main

--- a/.github/workflows/update-state-machine.yml
+++ b/.github/workflows/update-state-machine.yml
@@ -70,7 +70,7 @@ jobs:
       # If the ic commit was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main


### PR DESCRIPTION
This PR updates all the `peter-evans/create-pull-request` actions to v6 (from v4) due to `node16` being deprecated.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
