### PR TITLE
Migrate storage layout to v9 on upgrade

### DIFF
--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -402,6 +402,8 @@ fn init(maybe_arg: Option<InternetIdentityInit>) {
 fn post_upgrade(maybe_arg: Option<InternetIdentityInit>) {
     init_assets();
     state::init_from_stable_memory();
+    // immediately migrate the persistent state to the new layout
+    state::storage_borrow_mut(|storage| storage.migrate_persistent_state());
 
     // We drop all the signatures on upgrade, users will
     // re-request them if needed.

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -139,25 +139,6 @@ fn should_always_find_persistent_state_v9() {
 }
 
 #[test]
-fn should_overwrite_persistent_state_with_next_anchor_v8() {
-    let memory = VectorMemory::default();
-    memory.grow(1);
-    memory.write(0, &hex::decode("494943080500000040e2010000000000f1fb090000000000000843434343434343434343434343434343434343434343434343434343434343430002000000000000000000000000000000000000000000000000").unwrap());
-    let mut storage = Storage::from_memory(memory.clone());
-    storage.flush();
-
-    storage.allocate_anchor().unwrap();
-    storage.write_persistent_state(&sample_persistent_state());
-    assert!(storage.read_persistent_state().is_ok());
-
-    let anchor = storage.allocate_anchor().unwrap();
-    storage.write(anchor).unwrap();
-
-    let result = storage.read_persistent_state();
-    assert!(matches!(result, Err(PersistentStateError::NotFound)));
-}
-
-#[test]
 fn should_not_overwrite_persistent_state_with_next_anchor_v9() {
     let memory = VectorMemory::default();
     let mut storage = Storage::new((10_000, 3_784_873), memory.clone());

--- a/src/internet_identity/tests/integration/archive_integration.rs
+++ b/src/internet_identity/tests/integration/archive_integration.rs
@@ -20,13 +20,15 @@ use std::time::SystemTime;
 fn setup_ii_v8(env: &StateMachine, arg: Option<InternetIdentityInit>) -> CanisterId {
     let ii_canister = install_ii_canister(env, EMPTY_WASM.clone());
     restore_compressed_stable_memory(env, ii_canister, "stable_memory/clean_init_v8.bin.gz");
+
+    // upgrade now auto-migrates to storage v9
     upgrade_ii_canister_with_arg(env, ii_canister, II_WASM.clone(), arg)
         .expect("II upgrade failed");
     assert_eq!(
         ii_api::stats(env, ii_canister)
             .unwrap()
             .storage_layout_version,
-        8
+        9
     );
     ii_canister
 }
@@ -305,11 +307,12 @@ mod pull_entries_tests {
             arg_with_wasm_hash(ARCHIVE_WASM.clone()),
         )
         .expect("II upgrade failed");
+        // the upgrade auto-migrates the storage layout to v9
         assert_eq!(
             ii_api::stats(&env, ii_canister)
                 .unwrap()
                 .storage_layout_version,
-            8
+            9
         );
         // deploy the actual archive wasm
         let archive_canister = deploy_archive_via_ii(&env, ii_canister);

--- a/src/internet_identity/tests/integration/stable_memory.rs
+++ b/src/internet_identity/tests/integration/stable_memory.rs
@@ -220,7 +220,7 @@ fn should_allow_modification_after_deleting_second_recovery_phrase() -> Result<(
 }
 
 #[test]
-fn should_read_persistent_state_v7() -> Result<(), CallError> {
+fn should_read_persistent_state_v8() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, EMPTY_WASM.clone());
 
@@ -237,7 +237,8 @@ fn should_read_persistent_state_v7() -> Result<(), CallError> {
     let stats = api::stats(&env, canister_id)?;
     assert!(stats.archive_info.archive_canister.is_none());
     assert!(stats.archive_info.archive_config.is_none());
-    assert_eq!(8, stats.storage_layout_version);
+    // auto-migration to v9
+    assert_eq!(stats.storage_layout_version, 9);
     Ok(())
 }
 
@@ -273,7 +274,8 @@ fn should_read_persistent_state_with_archive() -> Result<(), CallError> {
             .to_vec(),
         hex::decode("12e2c2bd05dfcd86e3004ecd5f00533e6120e7bcf82bac0753af0a7fe14bfea1").unwrap()
     );
-    assert_eq!(stats.storage_layout_version, 8);
+    // auto-migration to v9
+    assert_eq!(stats.storage_layout_version, 9);
     Ok(())
 }
 
@@ -320,7 +322,7 @@ fn should_trap_on_missing_persistent_state() -> Result<(), CallError> {
             assert_eq!(err.code, CanisterCalledTrap);
             assert!(err
                 .description
-                .contains("failed to recover persistent state! Err: NotFound"));
+                .contains("failed to recover persistent state!"));
         }
     }
     Ok(())


### PR DESCRIPTION
This PR introduces the storage layout auto-migration from `v8` to `v9` on upgrade. This finally moves the `PersistentState` out of the identity data structure for good.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d320576c7/desktop/banner.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d320576c7/mobile/banner.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
