### PR TITLE
Update spec on VC issuer's derivation_origin

### DIFF
--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -101,7 +101,7 @@ impl Storable for IssuerConfig {
 
 impl Default for IssuerConfig {
     fn default() -> Self {
-        let derivation_origin = format!("https://{}.ic0.app", ic_cdk::id().to_text());
+        let derivation_origin = format!("https://{}.icp0.io", ic_cdk::id().to_text());
         Self {
             ic_root_key_raw: extract_raw_root_pk_from_der(IC_ROOT_PK_DER)
                 .expect("failed to extract raw root pk from der"),

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -340,7 +340,7 @@ fn should_fail_vc_consent_message_if_missing_required_argument() {
 fn should_return_derivation_origin() {
     let env = env();
     let canister_id = install_canister(&env, VC_ISSUER_WASM.clone());
-    let frontend_hostname = format!("https://{}.ic0.app", canister_id.to_text());
+    let frontend_hostname = format!("https://{}.icp0.io", canister_id.to_text());
     let req = DerivationOriginRequest { frontend_hostname };
     let response = api::derivation_origin(&env, canister_id, principal_1(), &req)
         .expect("API call failed")

--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -98,11 +98,14 @@ credential by an issuer, and this happens by approving a human-readable consent 
 Identity provider uses a VC-extension of  [ICRC-21](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md), and requests the consent message via `Icrc21VcConsentMessageRequest`,
 Upon successful response idenity provider displays the consent message from `Icrc21ConsentInfo` to the user.
 
-### 2: Derivation Origin (optional)
+### 2: Derivation Origin
 
-If an issuer wants to take advantage of the [Alternative Derivation Origins](https://internetcomputer.org/docs/current/references/ii-spec#alternative-frontend-origins)-feature,
-it must implement `derivation_origin`-API, which then is called by the identity provider to
-obtain an URL to be used as the derivation origin for user's principal.
+The issuer must implement also `derivation_origin`-API, which allows for taking the advantage
+of the [Alternative Derivation Origins](https://internetcomputer.org/docs/current/references/ii-spec#alternative-frontend-origins)-feature.
+`derivation_origin` is called by the identity provider to obtain an URL to be used as the derivation origin
+for user's principal.  If an issuer doesn't use the _Alternative Derivation Origins_-feature,
+the function should return just the default value, namely the canister's URL: `https://<issuer-canister-id>.icp0.io`.
+
 ```candid
 service: {
     derivation_origin : (DerivationOriginRequest) ->


### PR DESCRIPTION
Update VC-spec making `derivation_origin` mandatory.  This simplifies the overall flow and avoids dependencies on exact wording of error messages.  Although the lack of the method is clearly distinguishable from other errors, per [IC wiki](https://wiki.internetcomputer.org/wiki/Error_Codes_returned_by_Internet_Computer), it is somewhat disguised by `agent.js`-API and needs matching on error messages, which is not quite future proof.  Also, most or even all real-life issuers will use the feature, so it is better to make it mandatory from the beginning, as long as there are only few issuers in development.
Also, fix the demo issuer's default domain for canister URLs.
<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9866d49aa/desktop/banner.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
