### PR TITLE
Refactor tentative device add flow to no longer reload the page

### DIFF
--- a/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
@@ -84,7 +84,7 @@ export const showVerificationCode = async (
   alias: string,
   tentativeRegistrationInfo: TentativeRegistrationInfo,
   credentialToBeVerified: CredentialId
-): Promise<"ok"> => {
+): Promise<"ok" | "canceled"> => {
   const countdown: AsyncCountdown<"match" | "canceled"> =
     AsyncCountdown.fromNanos(
       tentativeRegistrationInfo.device_registration_timeout
@@ -96,7 +96,7 @@ export const showVerificationCode = async (
     remaining: countdown.remainingFormattedAsync(),
     cancel: () => {
       countdown.stop("canceled");
-      window.location.reload();
+      return "canceled";
     },
   });
 
@@ -166,7 +166,7 @@ const handlePollResult = async ({
 }: {
   userNumber: bigint;
   result: "match" | "canceled" | typeof AsyncCountdown.timeout;
-}): Promise<"ok"> => {
+}): Promise<"ok" | "canceled"> => {
   if (result === "match") {
     await setAnchorUsed(userNumber);
     return "ok";
@@ -177,10 +177,10 @@ const handlePollResult = async ({
         'The timeout has been reached. For security reasons the "add device" process has been aborted.',
       primaryButton: "Ok",
     });
-    return window.location.reload as never;
+    return "canceled";
   } else {
     result satisfies "canceled";
-    return window.location.reload as never;
+    return "canceled";
   }
 };
 

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -13,10 +13,16 @@ void createSpa(async (connection) => {
   if (nonNullish(addDeviceAnchor)) {
     const userNumber = addDeviceAnchor;
     // Register this device (tentatively)
-    const { alias: deviceAlias } = await registerTentativeDevice(
+    const registerDeviceResult = await registerTentativeDevice(
       addDeviceAnchor,
       connection
     );
+    if (registerDeviceResult.tag === "canceled") {
+      // Adding a device was canceled, fall back into default flow
+      return authFlowManage(connection);
+    }
+    registerDeviceResult satisfies { tag: "deviceAdded" };
+    const { alias: deviceAlias } = registerDeviceResult;
 
     // Display a success page once device added (above registerTentativeDevice **never** returns if it fails)
     await addDeviceSuccess({ deviceAlias });

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -60,8 +60,8 @@ export const iiFlows: Record<string, () => void> = {
       addDevice: () => {
         toast.info(html`Added device`);
         return Promise.resolve({
+          tag: "deviceAdded",
           alias: "My Device",
-          userNumber: BigInt(1234),
         });
       },
       loginPasskey: async () => {


### PR DESCRIPTION
This PR refactors the tentative device add flow to no longer call `window.location.reload()` which was an ugly hack to avoid implementing the cancel action properly.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/e71cdf63c/mobile/banner.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/e71cdf63c/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
