### PR TITLE
Bump chrome version used for e2e tests

### DIFF
--- a/demos/using-dev-build/wdio.conf.ts
+++ b/demos/using-dev-build/wdio.conf.ts
@@ -15,7 +15,7 @@ export const config: WebdriverIO.Config = {
   capabilities: [
     {
       browserName: "chrome",
-      browserVersion: "119.0.6045.105", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "122.0.6261.111	", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": {
         args: ["headless", "disable-gpu", "disable-dev-shm-usage"],
       },

--- a/src/frontend/screenshots.ts
+++ b/src/frontend/screenshots.ts
@@ -109,7 +109,7 @@ async function withChrome<T>(
   const browser = await remote({
     capabilities: {
       browserName: "chrome",
-      browserVersion: "119.0.6045.105", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "122.0.6261.111	", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": chromeOptions,
     },
   });

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -95,7 +95,7 @@ export async function runInBrowser(
   const browser = await remoteRetry({
     capabilities: {
       browserName: "chrome",
-      browserVersion: "119.0.6045.105", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "122.0.6261.111	", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": chromeOptions,
     },
   });


### PR DESCRIPTION
This upgrades the chrome version used for testing in the hopes that it will be more stable than the current one.
Currently there are quite a few failures due to chromedriver crashing (like [this](https://github.com/dfinity/internet-identity/actions/runs/8250693687/job/22566116401#step:17:15993)).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2fd4ca42a/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2fd4ca42a/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2fd4ca42a/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
