### PR TITLE
Ignore extension messages in test app

### DIFF
--- a/demos/test-app/src/auth.ts
+++ b/demos/test-app/src/auth.ts
@@ -49,6 +49,10 @@ export const authWithII = async ({
   // Wait for II to say it's ready
   const evnt = await new Promise<MessageEvent>((resolve) => {
     const readyHandler = (e: MessageEvent) => {
+      if (e.origin !== iiUrl.origin) {
+        // Ignore messages from other origins (e.g. from a metamask extension)
+        return;
+      }
       window.removeEventListener("message", readyHandler);
       resolve(e);
     };
@@ -77,6 +81,10 @@ export const authWithII = async ({
   // Wait for the II response and update the local state
   const response = await new Promise<MessageEvent>((resolve) => {
     const responseHandler = (e: MessageEvent) => {
+      if (e.origin !== iiUrl.origin) {
+        // Ignore messages from other origins (e.g. from a metamask extension)
+        return;
+      }
       window.removeEventListener("message", responseHandler);
       win.close();
       resolve(e);


### PR DESCRIPTION
The sign-in flow in the test-app was broken if one had an extension installed (such as metamask) that sends messages to the webpage.

This PR now makes the test app correctly ignore messages from origins it does not expect.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/1f5cb11c6/mobile/banner.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/1f5cb11c6/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
