### PR TITLE
Ignore messages from own origin

### DIFF
--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -131,6 +131,11 @@ const waitForRequest = (): Promise<{
 }> => {
   return new Promise((resolve) => {
     const messageEventHandler = (evnt: MessageEvent) => {
+      if (evnt.origin === window.location.origin) {
+        // Ignore messages from own origin (e.g. from browser extensions)
+        console.warn("Ignoring message from own origin", evnt);
+        return;
+      }
       const message: unknown = evnt.data;
       const result = AuthRequest.safeParse(message);
 

--- a/src/frontend/src/flows/verifiableCredentials/postMessageInterface.ts
+++ b/src/frontend/src/flows/verifiableCredentials/postMessageInterface.ts
@@ -71,6 +71,11 @@ const waitForRequest = (): Promise<{
 }> => {
   return new Promise((resolve) => {
     const messageEventHandler = (evnt: MessageEvent) => {
+      if (evnt.origin === window.location.origin) {
+        // Ignore messages from own origin (e.g. from browser extensions)
+        console.warn("Ignoring message from own origin", evnt);
+        return;
+      }
       const message: unknown = evnt.data;
       const result = VcFlowRequest.safeParse(message);
 


### PR DESCRIPTION
Currently, II prints a warning to the console (or in case of the VC-flow even shows a toast) when it receives an unexpected message. Messages might get sent from browser extension (i.e. the MetaMask extension does that), which can be recognized by having the same origin as II itself. Since II does not send messages to itself, we can safely ignore all of these messages (and the messages do not warrant an `error`).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47c053385/desktop/banner.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47c053385/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
