### PR TITLE
Remove Promise.race() in e2e test

### DIFF
--- a/src/frontend/src/test-e2e/pinAuthDisabled.test.ts
+++ b/src/frontend/src/test-e2e/pinAuthDisabled.test.ts
@@ -37,11 +37,11 @@ test("Cannot auth with PIN if dapp disallows PIN", async () => {
 
     await switchToPopup(browser);
 
-    const result = await FLOWS.loginPinAuthenticateView_(
-      userNumber,
-      pin,
-      browser
-    );
-    expect(result).toBe("pin_disallowed");
+    const authenticateView = new AuthenticateView(browser);
+    await authenticateView.waitForDisplay();
+    await authenticateView.pickAnchor(userNumber);
+    await browser
+      .$('#errorContainer [data-error-code="pinNotAllowed"]')
+      .waitForDisplayed();
   }, APPLE_USER_AGENT);
 }, 300_000);


### PR DESCRIPTION
This PR refactors the e2e tests to not use `Promise.race`. This  `Promise.race` is problematic because one of the Promises keeps polling the chromedriver until the timeout is reached.

The observed flakiness of the 
"Register with PIN then log into client application" test (due to chromedriver becoming unresponsive, presumably crashing) during polling when waiting for auth to finish seems to be reduced with this change.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b28b25f37/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
