### PR TITLE
Mention proposal payload in hash verification

### DIFF
--- a/.github/actions/release/run.sh
+++ b/.github/actions/release/run.sh
@@ -40,6 +40,8 @@ git pull # to ensure you have the latest changes.
 git checkout $GITHUB_SHA
 ./scripts/verify-hash --ii-hash $(shasum -a 256 "$PRODUCTION_ASSET" | cut -d ' ' -f1)
 \`\`\`
+
+Make sure to compare the hashes also with the proposal payload when verifying canister upgrade proposals.
 EOF
 
 # Read all "INPUT_ASSETS" (where "ASSETS" is the input specified in action.yml)


### PR DESCRIPTION
This change adds a line to the hash verification instructions to remind people to also check the proposal payload.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
