### PR TITLE
Allow longer credential_id values to accommodate Titan security key

### DIFF
--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -515,7 +515,7 @@ fn check_device_limits(device: &Device) -> Result<(), AnchorError> {
     const ORIGIN_LEN_LIMIT: usize = 50;
     const ALIAS_LEN_LIMIT: usize = 64;
     const PK_LEN_LIMIT: usize = 300;
-    const CREDENTIAL_ID_LEN_LIMIT: usize = 200;
+    const CREDENTIAL_ID_LEN_LIMIT: usize = 350;
 
     let n = device.alias.len();
     if n > ALIAS_LEN_LIMIT {

--- a/src/internet_identity/src/storage/anchor/tests.rs
+++ b/src/internet_identity/src/storage/anchor/tests.rs
@@ -75,7 +75,7 @@ fn should_enforce_pubkey_limit() {
 fn should_enforce_credential_id_limit() {
     let mut anchor = Anchor::new(ANCHOR_NUMBER);
     let mut device = sample_device();
-    device.credential_id = Some(ByteBuf::from([0; 201]));
+    device.credential_id = Some(ByteBuf::from([0; 351]));
 
     let result = anchor.add_device(device);
 


### PR DESCRIPTION
As per [report from a user](https://forum.dfinity.org/t/error-when-adding-fido-device/28523/4), the [Titan security key](https://store.google.com/us/product/titan_security_key) offered by Google generates `credential_id` values of 304 bytes. This PR increases the limit of that field up to 350 bytes to accommodate it. However, the limits for a single identity in general have not been raised. This means that the potential for abuse is negligible as users now just have more flexibility _how_ to allocate their space among the different fields.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/de163ab80/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
