### PR TITLE
Improve add device flow

### DIFF
--- a/src/frontend/src/flows/addDevice/addDeviceSuccess.json
+++ b/src/frontend/src/flows/addDevice/addDeviceSuccess.json
@@ -2,6 +2,7 @@
   "en": {
     "title": "You successfully added a new Passkey!",
     "continue_to_home": "Continue to Internet Identity",
-    "explore": "Your new Passkey:"
+    "explore": "Your new Passkey:",
+    "internet_identity": "Internet Identity"
   }
 }

--- a/src/frontend/src/flows/addDevice/addDeviceSuccess.test.ts
+++ b/src/frontend/src/flows/addDevice/addDeviceSuccess.test.ts
@@ -8,6 +8,7 @@ describe("addDeviceSuccess", () => {
 
     addDeviceSuccessPage(
       {
+        userNumber: BigInt(123456),
         i18n: new I18n(),
         deviceAlias: "Test device alias",
         onContinue,

--- a/src/frontend/src/flows/addDevice/addDeviceSuccess.ts
+++ b/src/frontend/src/flows/addDevice/addDeviceSuccess.ts
@@ -1,7 +1,7 @@
 import { mainWindow } from "$src/components/mainWindow";
 import { I18n } from "$src/i18n";
 import { renderPage } from "$src/utils/lit-html";
-import { html, render } from "lit-html";
+import { html, render, TemplateResult } from "lit-html";
 import copyJson from "./addDeviceSuccess.json";
 
 export type DeviceAlias = string;
@@ -11,20 +11,28 @@ export type AddDeviceSuccessTemplateProps = Parameters<
 >[0];
 
 const addDeviceSuccessTemplate = ({
+  userNumber,
   deviceAlias,
   onContinue,
+  stepper,
   i18n,
 }: {
+  userNumber: bigint;
   deviceAlias: DeviceAlias;
   onContinue: () => void;
+  stepper?: TemplateResult;
   i18n: I18n;
 }) => {
-  const { title, continue_to_home, explore } = i18n.i18n(copyJson);
+  const copy = i18n.i18n(copyJson);
 
   const slot = html`<article>
+    ${stepper}
     <hgroup>
-      <h1 class="t-title t-title--main">${title}</h1>
-      <p class="t-lead">${explore}</p>
+      <div class="c-card__label">
+        <h2>${copy.internet_identity} ${userNumber}</h2>
+      </div>
+      <h1 class="t-title t-title--main">${copy.title}</h1>
+      <p class="t-lead">${copy.explore}</p>
     </hgroup>
     <output
       class="c-input c-input--stack c-input--fullwidth c-input--readonly t-vip t-vip--small"
@@ -36,7 +44,7 @@ const addDeviceSuccessTemplate = ({
         class="c-button c-button--primary"
         data-action="next"
       >
-        ${continue_to_home}
+        ${copy.continue_to_home}
       </button>
     </div>
   </article>`;
@@ -51,7 +59,10 @@ const addDeviceSuccessTemplate = ({
 export const addDeviceSuccessPage = renderPage(addDeviceSuccessTemplate);
 
 export const addDeviceSuccess = (
-  props: Pick<AddDeviceSuccessTemplateProps, "deviceAlias">
+  props: Pick<
+    AddDeviceSuccessTemplateProps,
+    "userNumber" | "deviceAlias" | "stepper"
+  >
 ): Promise<void> =>
   new Promise<void>((resolve) => {
     const container = document.getElementById("pageContent") as HTMLElement;

--- a/src/frontend/src/flows/addDevice/manage/addDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addDevice.ts
@@ -4,6 +4,7 @@ import {
 } from "$generated/internet_identity_types";
 import { displayError } from "$src/components/displayError";
 import { withLoader } from "$src/components/loader";
+import { tentativeDeviceStepper } from "$src/flows/addDevice/stepper";
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
 import { isNullish } from "@dfinity/utils";
 import { addDeviceSuccess } from "../addDeviceSuccess";
@@ -70,6 +71,10 @@ export const addDevice = async ({
   });
 
   if (result === "verified") {
-    await addDeviceSuccess({ deviceAlias: alias });
+    await addDeviceSuccess({
+      userNumber,
+      deviceAlias: alias,
+      stepper: tentativeDeviceStepper({ step: "success" }),
+    });
   }
 };

--- a/src/frontend/src/flows/addDevice/manage/addFIDODevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addFIDODevice.ts
@@ -78,7 +78,7 @@ export const addFIDODevice = async (
       )
     );
 
-    await addDeviceSuccess({ deviceAlias: deviceName });
+    await addDeviceSuccess({ userNumber, deviceAlias: deviceName });
   } catch (error: unknown) {
     await displayFailedToAddDevice(
       error instanceof Error ? error : unknownError()

--- a/src/frontend/src/flows/addDevice/stepper.ts
+++ b/src/frontend/src/flows/addDevice/stepper.ts
@@ -1,0 +1,26 @@
+import { checkmarkIcon } from "$src/components/icons";
+import { html } from "lit-html";
+
+export const tentativeDeviceStepper = ({
+  step,
+}: {
+  step: "activate" | "verify" | "success";
+}) => html`
+  <div class="c-progress-container">
+    <ol class="c-progress-stepper">
+      <li class="c-progress-stepper__step" aria-current=${step === "activate"}>
+        <span class="c-progress-stepper__label">Activate Passkey</span>
+      </li>
+      <li class="c-progress-stepper__step" aria-current=${step === "verify"}>
+        <span class="c-progress-stepper__label">Verify Device</span>
+      </li>
+      <li
+        class="c-progress-stepper__step c-progress-stepper__step--final"
+        aria-current=${step === "success"}
+      >
+        <i class="c-progress-stepper__icon">${checkmarkIcon}</i>
+        <span class="c-progress-stepper__label">Passkey Activated</span>
+      </li>
+    </ol>
+  </div>
+`;

--- a/src/frontend/src/flows/addDevice/welcomeView/promptDeviceTrusted.json
+++ b/src/frontend/src/flows/addDevice/welcomeView/promptDeviceTrusted.json
@@ -1,0 +1,9 @@
+{
+  "en": {
+    "internet_identity": "Internet Identity",
+    "activate_passkey": "Activate Passkey on this device",
+    "trust_this_device": "Do you trust this device to connect to your Internet Identity?",
+    "yes": "Yes",
+    "no": "No"
+  }
+}

--- a/src/frontend/src/flows/addDevice/welcomeView/promptDeviceTrusted.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/promptDeviceTrusted.ts
@@ -1,0 +1,75 @@
+import { mainWindow } from "$src/components/mainWindow";
+import { tentativeDeviceStepper } from "$src/flows/addDevice/stepper";
+import copyJson from "$src/flows/addDevice/welcomeView/promptDeviceTrusted.json";
+import { I18n } from "$src/i18n";
+import { renderPage } from "$src/utils/lit-html";
+import { html } from "lit-html";
+
+export type PromptDeviceTrustedTemplateProps = Parameters<
+  typeof promptDeviceTrustedTemplate
+>[0];
+
+const promptDeviceTrustedTemplate = ({
+  userNumber,
+  confirm,
+  cancel,
+  i18n,
+}: {
+  userNumber: bigint;
+  confirm: () => void;
+  cancel: () => void;
+  i18n: I18n;
+}) => {
+  const copy = i18n.i18n(copyJson);
+
+  const pageContentSlot = html` <article>
+    ${tentativeDeviceStepper({ step: "activate" })}
+    <hgroup>
+      <div class="c-card__label">
+        <h2>${copy.internet_identity} ${userNumber}</h2>
+      </div>
+      <h1 class="t-title t-title--main">${copy.activate_passkey}</h1>
+    </hgroup>
+    <p class="t-paragraph">${copy.trust_this_device}</p>
+    <div class="l-stack">
+      <button
+        id="trustDeviceConfirm"
+        class="c-button"
+        @click=${() => confirm()}
+      >
+        ${copy.yes}
+      </button>
+      <button
+        id="trustDeviceCancel"
+        class="c-button c-button--secondary"
+        @click=${() => cancel()}
+      >
+        ${copy.no}
+      </button>
+    </div>
+  </article>`;
+
+  return mainWindow({
+    showLogo: false,
+    showFooter: false,
+    slot: pageContentSlot,
+  });
+};
+
+export const promptDeviceTrustedPage = renderPage(promptDeviceTrustedTemplate);
+
+/**
+ * Page to prompt the user whether they trust the current device.
+ */
+export const promptDeviceTrusted = (
+  props: Pick<PromptDeviceTrustedTemplateProps, "userNumber">
+): Promise<"confirmed" | "canceled"> => {
+  return new Promise((resolve) =>
+    promptDeviceTrustedPage({
+      ...props,
+      confirm: () => resolve("confirmed"),
+      cancel: () => resolve("canceled"),
+      i18n: new I18n(),
+    })
+  );
+};

--- a/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
+++ b/src/frontend/src/flows/addDevice/welcomeView/showVerificationCode.ts
@@ -5,6 +5,7 @@ import {
 import { displayError } from "$src/components/displayError";
 import { mainWindow } from "$src/components/mainWindow";
 import { toast } from "$src/components/toast";
+import { tentativeDeviceStepper } from "$src/flows/addDevice/stepper";
 import { setAnchorUsed } from "$src/storage";
 import { AsyncCountdown } from "$src/utils/countdown";
 import { Connection } from "$src/utils/iiConnection";
@@ -20,17 +21,24 @@ type TentativeRegistrationInfo = Extract<
 >["added_tentatively"];
 
 const showVerificationCodeTemplate = ({
+  userNumber,
   alias,
   tentativeRegistrationInfo,
   remaining,
   cancel,
 }: {
+  userNumber: bigint;
   alias: string;
   tentativeRegistrationInfo: TentativeRegistrationInfo;
   remaining: AsyncIterable<string>;
   cancel: () => void;
 }) => {
-  const pageContentSlot = html` <hgroup>
+  const pageContentSlot = html`<article>
+    ${tentativeDeviceStepper({ step: "verify" })}
+    <hgroup>
+      <div class="c-card__label">
+        <h2>Internet Identity ${userNumber}</h2>
+      </div>
       <h1 class="t-title t-title--main">Verify New Passkey</h1>
       <p class="t-paragraph">Your new Passkey:</p>
       <output
@@ -58,7 +66,8 @@ const showVerificationCodeTemplate = ({
           Cancel
         </button>
       </div>
-    </div>`;
+    </div>
+  </article>`;
 
   return mainWindow({
     showLogo: false,
@@ -91,6 +100,7 @@ export const showVerificationCode = async (
     );
 
   showVerificationCodePage({
+    userNumber,
     alias,
     tentativeRegistrationInfo,
     remaining: countdown.remainingFormattedAsync(),

--- a/src/frontend/src/test-e2e/addDevice.test.ts
+++ b/src/frontend/src/test-e2e/addDevice.test.ts
@@ -13,6 +13,7 @@ import {
   AuthenticateView,
   MainView,
   NotInRegistrationModeView,
+  PromptDeviceTrustedView,
   VerifyRemoteDeviceView,
   WelcomeView,
 } from "./views";
@@ -62,6 +63,10 @@ test("Add remote device", async () => {
     await runInBrowser(async (browser2: WebdriverIO.Browser) => {
       await addVirtualAuthenticator(browser2);
       await browser2.url(addDeviceLink);
+
+      const promptDeviceTrustedView = new PromptDeviceTrustedView(browser2);
+      await promptDeviceTrustedView.waitForDisplay();
+      await promptDeviceTrustedView.confirmTrusted();
 
       const verificationCodeView = new AddRemoteDeviceVerificationCodeView(
         browser2
@@ -121,6 +126,10 @@ test("Add remote device starting on new device", async () => {
       const addIdentityAnchorView2 = new AddIdentityAnchorView(browser2);
       await addIdentityAnchorView2.waitForDisplay();
       await addIdentityAnchorView2.continue(userNumber);
+
+      const promptDeviceTrustedView = new PromptDeviceTrustedView(browser2);
+      await promptDeviceTrustedView.waitForDisplay();
+      await promptDeviceTrustedView.confirmTrusted();
 
       const notInRegistrationModeView = new NotInRegistrationModeView(browser2);
       await notInRegistrationModeView.waitForDisplay();

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -472,6 +472,18 @@ export class VerifyRemoteDeviceView extends View {
   }
 }
 
+export class PromptDeviceTrustedView extends View {
+  private readonly SELECTOR = "#trustDeviceConfirm";
+
+  async waitForDisplay(): Promise<void> {
+    await this.browser.$(this.SELECTOR).waitForDisplayed({ timeout: 5_000 });
+  }
+
+  async confirmTrusted(): Promise<void> {
+    await this.browser.$(this.SELECTOR).click();
+  }
+}
+
 export class AddDeviceSuccessView extends View {
   private readonly SELECTOR = "[data-action='next']";
 

--- a/src/showcase/src/pages/addDeviceSuccessStepper.astro
+++ b/src/showcase/src/pages/addDeviceSuccessStepper.astro
@@ -2,17 +2,19 @@
 import Screen from "../layouts/Screen.astro";
 ---
 
-<Screen title="Add Device Success" pageName="addDeviceSuccess">
+<Screen title="Add Device Success Stepper" pageName="addDeviceSuccessStepper">
   <script>
     import { toast } from "$src/components/toast";
     import { i18n } from "../i18n";
     import { chromeDevice, userNumber } from "../constants";
     import { addDeviceSuccessPage } from "$src/flows/addDevice/addDeviceSuccess";
+    import { tentativeDeviceStepper } from "../../../frontend/src/flows/addDevice/stepper";
 
     addDeviceSuccessPage({
       i18n,
       userNumber,
       deviceAlias: chromeDevice.alias,
+      stepper: tentativeDeviceStepper({step: "success"}),
       onContinue: () => toast.info("Continue"),
     })
   </script>

--- a/src/showcase/src/pages/promptDeviceTrusted.astro
+++ b/src/showcase/src/pages/promptDeviceTrusted.astro
@@ -4,9 +4,16 @@ import Screen from "../layouts/Screen.astro";
 
 <Screen title="Prompt for Device Trusted" pageName="promptDeviceTrusted">
   <script>
-    import { promptDeviceTrusted } from "$src/flows/addDevice/welcomeView/promptDeviceTrusted";
     import {userNumber} from "../constants";
+    import { promptDeviceTrustedPage } from "../../../frontend/src/flows/addDevice/welcomeView/promptDeviceTrusted";
+    import { i18n } from "../i18n";
+    import { toast } from "../../../frontend/src/components/toast";
 
-    promptDeviceTrusted({userNumber})
+    promptDeviceTrustedPage({
+      userNumber,
+      cancel: () => toast.info("canceled"),
+      confirm: () => toast.info("confirmed"),
+      i18n
+    });
   </script>
 </Screen>

--- a/src/showcase/src/pages/promptDeviceTrusted.astro
+++ b/src/showcase/src/pages/promptDeviceTrusted.astro
@@ -1,0 +1,12 @@
+---
+import Screen from "../layouts/Screen.astro";
+---
+
+<Screen title="Prompt for Device Trusted" pageName="promptDeviceTrusted">
+  <script>
+    import { promptDeviceTrusted } from "$src/flows/addDevice/welcomeView/promptDeviceTrusted";
+    import {userNumber} from "../constants";
+
+    promptDeviceTrusted({userNumber})
+  </script>
+</Screen>

--- a/src/showcase/src/pages/showVerificationCode.astro
+++ b/src/showcase/src/pages/showVerificationCode.astro
@@ -5,10 +5,11 @@ import Screen from "../layouts/Screen.astro";
 <Screen title="Show Verification Code" pageName="showVerificationCode">
   <script>
     import { toast } from "$src/components/toast";
-    import { chromeDevice } from "../constants";
+    import { chromeDevice, userNumber } from "../constants";
     import { showVerificationCodePage } from "$src/flows/addDevice/welcomeView/showVerificationCode";
 
     showVerificationCodePage({
+      userNumber,
       alias: chromeDevice.alias,
       tentativeRegistrationInfo: {
         verification_code: "123456",

--- a/src/showcase/src/pages/verifyTentativeDevice.astro
+++ b/src/showcase/src/pages/verifyTentativeDevice.astro
@@ -5,10 +5,11 @@ import Screen from "../layouts/Screen.astro";
 <Screen title="Verify Tentative Device" pageName="verifyTentativeDevice">
   <script>
     import { toast } from "$src/components/toast";
-    import { chromeDevice } from "../constants";
+    import { chromeDevice, userNumber } from "../constants";
     import { verifyTentativeDevicePage } from "$src/flows/addDevice/manage/verifyTentativeDevice";
 
     verifyTentativeDevicePage({
+      userNumber,
       alias: chromeDevice.alias,
       cancel: () => toast.info("canceled"),
       // We accept anything that ends with "2"


### PR DESCRIPTION
This PR aligns the add device flow closer with the elements and screens specified in [figma](https://www.figma.com/file/a8jl32LDcYODRwwzrZd5UU/Internet-Identity-Design?type=design&node-id=1013-19687&mode=design&t=Zh0ZcNOnL57MKKqp-0).

The following changes are made:
* there is now a prompt for device trust as a first step (on the new device)
* there is now a stepper for the flow
* the identity number is shown consistently on all screens
* the copy has been changed to the wording specified

There are still visual design differences. These will be solved separately.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/desktop/addDeviceSuccessStepper.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/desktop/promptDeviceTrusted.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/mobile/addDeviceSuccessStepper.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/mobile/promptDeviceTrusted.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/desktop/addDeviceSuccess.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/desktop/showVerificationCode.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/desktop/verifyTentativeDevice.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/mobile/addDeviceSuccess.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/mobile/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/mobile/showVerificationCode.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5ed3099a5/mobile/verifyTentativeDevice.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

