### PR TITLE
Catch unexpected errors during authentication

### DIFF
--- a/src/frontend/src/utils/webAuthnErrorUtils.ts
+++ b/src/frontend/src/utils/webAuthnErrorUtils.ts
@@ -51,5 +51,10 @@ export const isWebAuthnDuplicateDevice = (error: unknown): boolean => {
  * @param error error to check
  */
 export const isWebAuthnCancel = (error: unknown): boolean => {
-  return error instanceof DOMException && error.name === "NotAllowedError";
+  return (
+    error instanceof DOMException &&
+    // According to WebAuthn spec, the browser must throw a NotAllowedError when the user cancels the operation.
+    // However, some browsers (Firefox) throw an AbortError instead.
+    (error.name === "NotAllowedError" || error.name === "AbortError")
+  );
 };


### PR DESCRIPTION
This PR adds a top-level `catch` to the authentication loop in order to recover from inform users about errors that happen during authentication.

In addition, the WebAuthn cancel check now also triggers on `AbortError` because this is what Firefox throws.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
