### PR TITLE
Extract canisterId resolution to shared util

### DIFF
--- a/src/frontend/src/flows/verifiableCredentials/index.ts
+++ b/src/frontend/src/flows/verifiableCredentials/index.ts
@@ -6,6 +6,7 @@ import { showSpinner } from "$src/components/spinner";
 import { fetchDelegation } from "$src/flows/authorize/fetchDelegation";
 import { validateDerivationOrigin } from "$src/flows/authorize/validateDerivationOrigin";
 import { getAnchorByPrincipal } from "$src/storage";
+import { resolveIssuerCanisterId } from "$src/utils/canisterIdResolution";
 import { AuthenticatedConnection, Connection } from "$src/utils/iiConnection";
 import {
   Delegation,
@@ -17,8 +18,7 @@ import {
   CredentialSpec,
   IssuedCredentialData,
 } from "@dfinity/internet-identity-vc-api";
-import { Principal } from "@dfinity/principal";
-import { isNullish, nonNullish } from "@dfinity/utils";
+import { nonNullish } from "@dfinity/utils";
 import { abortedCredentials } from "./abortedCredentials";
 import { allowCredentials } from "./allowCredentials";
 import { VcVerifiablePresentation, vcProtocol } from "./postMessageInterface";
@@ -221,73 +221,6 @@ const verifyCredentials = async ({
     rpAliasCredential: pAlias.rpAliasCredential,
     issuedCredential,
   });
-};
-
-const resolveIssuerCanisterId = ({
-  origin,
-}: {
-  origin: string;
-}): Promise<{ ok: string } | "not_found"> => {
-  const url = new URL(origin);
-
-  if (url.hostname.endsWith("localhost")) {
-    // The issuer is running on a local development environment, infer the canister ID from the hostname directly
-    // (e.g. http://bd3sg-teaaa-aaaaa-qaaba-cai.localhost:4943 -> bd3sg-teaaa-aaaaa-qaaba-cai)
-    const domainParts = url.hostname.split(".");
-
-    // If there is no subdomain, we cannot infer the canister id
-    if (domainParts.length > 1) {
-      const canisterId = domainParts[0];
-      try {
-        Principal.fromText(canisterId); // make sure the inferred part is actually a canister id, throws if not
-        return Promise.resolve({ ok: canisterId });
-      } catch (e) {
-        console.warn(
-          `Unable to infer issuer canister id from origin ${origin}: ${e}`
-        );
-      }
-    }
-  }
-
-  // Look up the canister id by performing a request to the origin
-  return lookupCanister({ origin });
-};
-
-// Lookup the canister by performing a request to the origin and check
-// if the server (probably BN) set a header to inform us of the canister ID
-const lookupCanister = async ({
-  origin,
-}: {
-  origin: string;
-}): Promise<{ ok: string } | "not_found"> => {
-  const response = await fetch(
-    origin,
-    // fail on redirects
-    {
-      redirect: "error",
-      method: "HEAD",
-      // do not send cookies or other credentials
-      credentials: "omit",
-    }
-  );
-
-  if (response.status !== 200) {
-    console.error("Bad response when looking for canister ID", response.status);
-    return "not_found";
-  }
-
-  const HEADER_NAME = "x-ic-canister-id";
-  const canisterId = response.headers.get(HEADER_NAME);
-
-  if (isNullish(canisterId)) {
-    console.error(
-      `Canister ID header '${HEADER_NAME}' was not set on origin ${origin}`
-    );
-
-    return "not_found";
-  }
-
-  return { ok: canisterId };
 };
 
 // Prepare & get aliases

--- a/src/frontend/src/utils/canisterIdResolution.ts
+++ b/src/frontend/src/utils/canisterIdResolution.ts
@@ -1,0 +1,73 @@
+import { Principal } from "@dfinity/principal";
+import { isNullish } from "@dfinity/utils";
+
+/**
+ * Resolve the canister id of a canister based on the front-end origin.
+ * @param origin The origin of the front-end to resolve the canister id of.
+ */
+export const resolveIssuerCanisterId = ({
+  origin,
+}: {
+  origin: string;
+}): Promise<{ ok: string } | "not_found"> => {
+  const url = new URL(origin);
+
+  if (url.hostname.endsWith("localhost")) {
+    // The issuer is running on a local development environment, infer the canister ID from the hostname directly
+    // (e.g. http://bd3sg-teaaa-aaaaa-qaaba-cai.localhost:4943 -> bd3sg-teaaa-aaaaa-qaaba-cai)
+    const domainParts = url.hostname.split(".");
+
+    // If there is no subdomain, we cannot infer the canister id
+    if (domainParts.length > 1) {
+      const canisterId = domainParts[0];
+      try {
+        Principal.fromText(canisterId); // make sure the inferred part is actually a canister id, throws if not
+        return Promise.resolve({ ok: canisterId });
+      } catch (e) {
+        console.warn(
+          `Unable to infer issuer canister id from origin ${origin}: ${e}`
+        );
+      }
+    }
+  }
+
+  // Look up the canister id by performing a request to the origin
+  return lookupCanister({ origin });
+};
+
+// Lookup the canister by performing a request to the origin and check
+// if the server (probably BN) set a header to inform us of the canister ID
+const lookupCanister = async ({
+  origin,
+}: {
+  origin: string;
+}): Promise<{ ok: string } | "not_found"> => {
+  const response = await fetch(
+    origin,
+    // fail on redirects
+    {
+      redirect: "error",
+      method: "HEAD",
+      // do not send cookies or other credentials
+      credentials: "omit",
+    }
+  );
+
+  if (response.status !== 200) {
+    console.error("Bad response when looking for canister ID", response.status);
+    return "not_found";
+  }
+
+  const HEADER_NAME = "x-ic-canister-id";
+  const canisterId = response.headers.get(HEADER_NAME);
+
+  if (isNullish(canisterId)) {
+    console.error(
+      `Canister ID header '${HEADER_NAME}' was not set on origin ${origin}`
+    );
+
+    return "not_found";
+  }
+
+  return { ok: canisterId };
+};


### PR DESCRIPTION
This PR extracts the canisterId resolution mechanism used in the VC flow into a shared utility. This utility will in an upcoming PR also be used from the authentication flow.

This PR only _moves_ code.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/198b625b9/mobile/banner.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/198b625b9/mobile/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/198b625b9/mobile/manageNew.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
