### PR TITLE
Improve message for unsupported stable memory version

### DIFF
--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -292,7 +292,7 @@ impl<M: Memory + Clone> Storage<M> {
         if &header.version < SUPPORTED_LAYOUT_VERSIONS.start() {
             trap(&format!(
                 "stable memory layout version {} is no longer supported:\n\
-            Either reinstall (wiping stable memory) or migrate using a previous II version\n\
+            Either reinstall (wiping stable memory) or upgrade sequentially to the latest version of II by installing each intermediate version in turn.\n\
             See https://github.com/dfinity/internet-identity#stable-memory-compatibility for more information.",
                 header.version
             ));

--- a/src/internet_identity/tests/integration/stable_memory.rs
+++ b/src/internet_identity/tests/integration/stable_memory.rs
@@ -295,7 +295,7 @@ fn should_trap_on_old_stable_memory() -> Result<(), CallError> {
         CallError::Reject(err) => panic!("unexpected error {err}"),
         CallError::UserError(err) => {
             assert_eq!(err.code, CanisterCalledTrap);
-            assert!(err.description.contains("stable memory layout version 1 is no longer supported:\nEither reinstall (wiping stable memory) or migrate using a previous II version"));
+            assert!(err.description.contains("stable memory layout version 1 is no longer supported:\nEither reinstall (wiping stable memory) or upgrade sequentially to the latest version of II by installing each intermediate version in turn"));
         }
     }
     Ok(())


### PR DESCRIPTION
Improve the error message if an II release is installed on a canister with incompatible stable memory layout.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/37868f487/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/37868f487/mobile/banner.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/37868f487/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/37868f487/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
