### PR TITLE
Provide error message for files unsupported by asset_util

### DIFF
--- a/src/asset_util/src/lib.rs
+++ b/src/asset_util/src/lib.rs
@@ -463,7 +463,14 @@ fn collect_assets_rec(dir: &Dir, assets: &mut Vec<Asset>) {
 /// Otherwise the content type is determined by the text after the last dot in the file name,
 /// and the encoding is `ContentEncoding::Identity`.
 fn content_type_and_encoding(asset_path: &Path) -> (ContentType, ContentEncoding) {
-    let extension = asset_path.extension().unwrap().to_str().unwrap();
+    let extension = asset_path
+        .extension()
+        .expect(&format!(
+            "Unsupported file without extension: {:?}",
+            asset_path
+        ))
+        .to_str()
+        .unwrap();
     let (extension, encoding) = if extension == "gz" {
         let type_extension = asset_path
             .file_name()

--- a/src/asset_util/src/lib.rs
+++ b/src/asset_util/src/lib.rs
@@ -465,10 +465,7 @@ fn collect_assets_rec(dir: &Dir, assets: &mut Vec<Asset>) {
 fn content_type_and_encoding(asset_path: &Path) -> (ContentType, ContentEncoding) {
     let extension = asset_path
         .extension()
-        .expect(&format!(
-            "Unsupported file without extension: {:?}",
-            asset_path
-        ))
+        .unwrap_or_else(|| panic!("Unsupported file without extension: {:?}", asset_path))
         .to_str()
         .unwrap();
     let (extension, encoding) = if extension == "gz" {


### PR DESCRIPTION
`asset_util` does not support files without extensions, and this PR provides information about offending files in a case of a failure.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/334fbf323/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/334fbf323/mobile/banner.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

