### PR TITLE
Rename id_alias-VC-related fields

### DIFF
--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -622,8 +622,8 @@ fn should_issue_credential_e2e() -> Result<(), CallError> {
         identity_number,
         relying_party,
         issuer,
-        rp_id_alias_jwt: prepared_id_alias.rp_id_alias_jwt,
-        issuer_id_alias_jwt: prepared_id_alias.issuer_id_alias_jwt,
+        rp_id_alias_signing_input: prepared_id_alias.rp_id_alias_signing_input,
+        issuer_id_alias_signing_input: prepared_id_alias.issuer_id_alias_signing_input,
     };
     let id_alias_credentials = ii_api::get_id_alias(&env, ii_id, principal_1(), get_id_alias_req)?
         .expect("get id_alias failed");

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -195,9 +195,9 @@ export const idlFactory = ({ IDL }) => {
     'signed_delegation' : SignedDelegation,
   });
   const GetIdAliasRequest = IDL.Record({
-    'rp_id_alias_jwt' : IDL.Text,
     'issuer' : FrontendHostname,
-    'issuer_id_alias_jwt' : IDL.Text,
+    'issuer_id_alias_signing_input' : IDL.Text,
+    'rp_id_alias_signing_input' : IDL.Text,
     'relying_party' : FrontendHostname,
     'identity_number' : IdentityNumber,
   });
@@ -287,9 +287,9 @@ export const idlFactory = ({ IDL }) => {
     'identity_number' : IdentityNumber,
   });
   const PreparedIdAlias = IDL.Record({
-    'rp_id_alias_jwt' : IDL.Text,
-    'issuer_id_alias_jwt' : IDL.Text,
+    'issuer_id_alias_signing_input' : IDL.Text,
     'canister_sig_pk_der' : PublicKey,
+    'rp_id_alias_signing_input' : IDL.Text,
   });
   const PrepareIdAliasError = IDL.Variant({
     'InternalCanisterError' : IDL.Text,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -122,9 +122,9 @@ export type GetIdAliasError = { 'InternalCanisterError' : string } |
   { 'Unauthorized' : Principal } |
   { 'NoSuchCredentials' : string };
 export interface GetIdAliasRequest {
-  'rp_id_alias_jwt' : string,
   'issuer' : FrontendHostname,
-  'issuer_id_alias_jwt' : string,
+  'issuer_id_alias_signing_input' : string,
+  'rp_id_alias_signing_input' : string,
   'relying_party' : FrontendHostname,
   'identity_number' : IdentityNumber,
 }
@@ -222,9 +222,9 @@ export interface PrepareIdAliasRequest {
   'identity_number' : IdentityNumber,
 }
 export interface PreparedIdAlias {
-  'rp_id_alias_jwt' : string,
-  'issuer_id_alias_jwt' : string,
+  'issuer_id_alias_signing_input' : string,
   'canister_sig_pk_der' : PublicKey,
+  'rp_id_alias_signing_input' : string,
 }
 export type PublicKey = Uint8Array | number[];
 export interface PublicKeyAuthn { 'pubkey' : PublicKey }

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -471,8 +471,8 @@ type PrepareIdAliasError = variant {
 /// The prepared id alias contains two (still unsigned) credentials in JWT format,
 /// certifying the id alias for the issuer resp. the relying party.
 type PreparedIdAlias = record {
-    rp_id_alias_jwt : text;
-    issuer_id_alias_jwt : text;
+    rp_id_alias_signing_input : text;
+    issuer_id_alias_signing_input : text;
     canister_sig_pk_der : PublicKey;
 };
 
@@ -480,10 +480,10 @@ type PreparedIdAlias = record {
 /// The field values should be equal to the values of corresponding
 /// fields from the preceding `PrepareIdAliasRequest` and `PrepareIdAliasResponse`.
 type GetIdAliasRequest = record {
-    rp_id_alias_jwt : text;
     issuer : FrontendHostname;
-    issuer_id_alias_jwt : text;
     relying_party : FrontendHostname;
+    rp_id_alias_signing_input : text;
+    issuer_id_alias_signing_input : text;
     identity_number : IdentityNumber;
 };
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -788,8 +788,8 @@ mod attribute_sharing_mvp {
                 relying_party: req.relying_party,
                 issuer: req.issuer,
             },
-            &req.rp_id_alias_jwt,
-            &req.issuer_id_alias_jwt,
+            &req.rp_id_alias_signing_input,
+            &req.issuer_id_alias_signing_input,
         )
     }
 }

--- a/src/internet_identity/src/vc_mvp.rs
+++ b/src/internet_identity/src/vc_mvp.rs
@@ -60,8 +60,8 @@ pub async fn prepare_id_alias(
     update_root_hash();
     PreparedIdAlias {
         canister_sig_pk_der: ByteBuf::from(canister_sig_pk.to_der()),
-        rp_id_alias_jwt: String::from_utf8(rp_signing_input).unwrap(),
-        issuer_id_alias_jwt: String::from_utf8(issuer_signing_input).unwrap(),
+        rp_id_alias_signing_input: String::from_utf8(rp_signing_input).unwrap(),
+        issuer_id_alias_signing_input: String::from_utf8(issuer_signing_input).unwrap(),
     }
 }
 

--- a/src/internet_identity/tests/integration/vc_mvp.rs
+++ b/src/internet_identity/tests/integration/vc_mvp.rs
@@ -49,8 +49,8 @@ fn should_get_valid_id_alias() -> Result<(), CallError> {
         identity_number,
         relying_party,
         issuer,
-        rp_id_alias_jwt: prepared_id_alias.rp_id_alias_jwt,
-        issuer_id_alias_jwt: prepared_id_alias.issuer_id_alias_jwt,
+        rp_id_alias_signing_input: prepared_id_alias.rp_id_alias_signing_input,
+        issuer_id_alias_signing_input: prepared_id_alias.issuer_id_alias_signing_input,
     };
     let id_alias_credentials =
         api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req)?
@@ -142,8 +142,8 @@ fn should_get_different_id_alias_for_different_users() -> Result<(), CallError> 
                 identity_number: identity_number_1,
                 relying_party: relying_party.clone(),
                 issuer: issuer.clone(),
-                rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
-                issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
+                rp_id_alias_signing_input: prepared_id_alias_1.rp_id_alias_signing_input,
+                issuer_id_alias_signing_input: prepared_id_alias_1.issuer_id_alias_signing_input,
             },
             CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
                 .expect("failed parsing canister sig pk"),
@@ -163,8 +163,8 @@ fn should_get_different_id_alias_for_different_users() -> Result<(), CallError> 
                 identity_number: identity_number_2,
                 relying_party,
                 issuer,
-                rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
-                issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
+                rp_id_alias_signing_input: prepared_id_alias_2.rp_id_alias_signing_input,
+                issuer_id_alias_signing_input: prepared_id_alias_2.issuer_id_alias_signing_input,
             },
             CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
                 .expect("failed parsing canister sig pk"),
@@ -265,8 +265,8 @@ fn should_get_different_id_alias_for_different_relying_parties() -> Result<(), C
                 identity_number,
                 relying_party: relying_party_1,
                 issuer: issuer.clone(),
-                rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
-                issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
+                rp_id_alias_signing_input: prepared_id_alias_1.rp_id_alias_signing_input,
+                issuer_id_alias_signing_input: prepared_id_alias_1.issuer_id_alias_signing_input,
             },
             CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
                 .expect("failed parsing canister sig pk"),
@@ -286,8 +286,8 @@ fn should_get_different_id_alias_for_different_relying_parties() -> Result<(), C
                 identity_number,
                 relying_party: relying_party_2,
                 issuer,
-                rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
-                issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
+                rp_id_alias_signing_input: prepared_id_alias_2.rp_id_alias_signing_input,
+                issuer_id_alias_signing_input: prepared_id_alias_2.issuer_id_alias_signing_input,
             },
             CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
                 .expect("failed parsing canister sig pk"),
@@ -392,8 +392,8 @@ fn should_get_different_id_alias_for_different_issuers() -> Result<(), CallError
                 identity_number,
                 relying_party: relying_party.clone(),
                 issuer: issuer_1,
-                rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
-                issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
+                rp_id_alias_signing_input: prepared_id_alias_1.rp_id_alias_signing_input,
+                issuer_id_alias_signing_input: prepared_id_alias_1.issuer_id_alias_signing_input,
             },
             CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
                 .expect("failed parsing canister sig pk"),
@@ -413,8 +413,8 @@ fn should_get_different_id_alias_for_different_issuers() -> Result<(), CallError
                 identity_number,
                 relying_party,
                 issuer: issuer_2,
-                rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
-                issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
+                rp_id_alias_signing_input: prepared_id_alias_2.rp_id_alias_signing_input,
+                issuer_id_alias_signing_input: prepared_id_alias_2.issuer_id_alias_signing_input,
             },
             CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
                 .expect("failed parsing canister sig pk"),
@@ -513,8 +513,8 @@ fn should_get_different_id_alias_for_different_flows() -> Result<(), CallError> 
                 identity_number,
                 relying_party: relying_party.clone(),
                 issuer: issuer.clone(),
-                rp_id_alias_jwt: prepared_id_alias_1.rp_id_alias_jwt,
-                issuer_id_alias_jwt: prepared_id_alias_1.issuer_id_alias_jwt,
+                rp_id_alias_signing_input: prepared_id_alias_1.rp_id_alias_signing_input,
+                issuer_id_alias_signing_input: prepared_id_alias_1.issuer_id_alias_signing_input,
             },
             CanisterSigPublicKey::try_from(prepared_id_alias_1.canister_sig_pk_der.as_ref())
                 .expect("failed parsing canister sig pk"),
@@ -530,8 +530,8 @@ fn should_get_different_id_alias_for_different_flows() -> Result<(), CallError> 
                 identity_number,
                 relying_party,
                 issuer,
-                rp_id_alias_jwt: prepared_id_alias_2.rp_id_alias_jwt,
-                issuer_id_alias_jwt: prepared_id_alias_2.issuer_id_alias_jwt,
+                rp_id_alias_signing_input: prepared_id_alias_2.rp_id_alias_signing_input,
+                issuer_id_alias_signing_input: prepared_id_alias_2.issuer_id_alias_signing_input,
             },
             CanisterSigPublicKey::try_from(prepared_id_alias_2.canister_sig_pk_der.as_ref())
                 .expect("failed parsing canister sig pk"),
@@ -654,8 +654,8 @@ fn should_not_get_id_alias_for_different_user() -> Result<(), CallError> {
             identity_number, // belongs to principal_1
             relying_party,
             issuer,
-            rp_id_alias_jwt: "dummy_jwt".to_string(),
-            issuer_id_alias_jwt: "another_dummy_jwt".to_string(),
+            rp_id_alias_signing_input: "dummy_jwt".to_string(),
+            issuer_id_alias_signing_input: "another_dummy_jwt".to_string(),
         },
     )?;
 
@@ -680,8 +680,8 @@ fn should_not_get_id_alias_if_not_prepared() -> Result<(), CallError> {
             identity_number,
             relying_party,
             issuer,
-            rp_id_alias_jwt: "dummy jwt".to_string(),
-            issuer_id_alias_jwt: "another dummy jwt".to_string(),
+            rp_id_alias_signing_input: "dummy signing input".to_string(),
+            issuer_id_alias_signing_input: "another dummy signing input".to_string(),
         },
     )?;
 
@@ -722,8 +722,8 @@ fn should_not_get_prepared_id_alias_after_ii_upgrade() -> Result<(), CallError> 
         identity_number,
         relying_party,
         issuer,
-        rp_id_alias_jwt: prepared_id_alias.rp_id_alias_jwt,
-        issuer_id_alias_jwt: prepared_id_alias.issuer_id_alias_jwt,
+        rp_id_alias_signing_input: prepared_id_alias.rp_id_alias_signing_input,
+        issuer_id_alias_signing_input: prepared_id_alias.issuer_id_alias_signing_input,
     };
     let response = api::vc_mvp::get_id_alias(&env, canister_id, principal_1(), get_id_alias_req)?;
     assert!(matches!(
@@ -760,8 +760,8 @@ fn should_not_validate_id_alias_with_wrong_canister_key() {
         identity_number,
         relying_party,
         issuer,
-        rp_id_alias_jwt: prepared_id_alias.rp_id_alias_jwt,
-        issuer_id_alias_jwt: prepared_id_alias.issuer_id_alias_jwt,
+        rp_id_alias_signing_input: prepared_id_alias.rp_id_alias_signing_input,
+        issuer_id_alias_signing_input: prepared_id_alias.issuer_id_alias_signing_input,
     };
 
     let id_alias_credentials =

--- a/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/vc_mvp.rs
@@ -12,22 +12,16 @@ pub struct SignedIdAlias {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct PrepareIdAliasRequest {
-    #[serde(rename = "identity_number")]
     pub identity_number: IdentityNumber,
-    #[serde(rename = "relying_party")]
     pub relying_party: FrontendHostname,
-    #[serde(rename = "issuer")]
     pub issuer: FrontendHostname,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct PreparedIdAlias {
-    #[serde(rename = "canister_sig_pk_der")]
     pub canister_sig_pk_der: CanisterSigPublicKeyDer,
-    #[serde(rename = "rp_id_alias_jwt")]
-    pub rp_id_alias_jwt: String,
-    #[serde(rename = "issuer_id_alias_jwt")]
-    pub issuer_id_alias_jwt: String,
+    pub rp_id_alias_signing_input: String,
+    pub issuer_id_alias_signing_input: String,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -44,16 +38,11 @@ pub struct IdAliasCredentials {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct GetIdAliasRequest {
-    #[serde(rename = "identity_number")]
     pub identity_number: IdentityNumber,
-    #[serde(rename = "relying_party")]
     pub relying_party: FrontendHostname,
-    #[serde(rename = "issuer")]
     pub issuer: FrontendHostname,
-    #[serde(rename = "rp_id_alias_jwt")]
-    pub rp_id_alias_jwt: String,
-    #[serde(rename = "issuer_id_alias_jwt")]
-    pub issuer_id_alias_jwt: String,
+    pub rp_id_alias_signing_input: String,
+    pub issuer_id_alias_signing_input: String,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
Rename id_alias-VC fields in `PreparedIdAlias` and `GetIdAliasRequest` to match their actual contents.  The renamed fields contained initially JWT-values, but later the contents changed to JWS signing input, so the new names match the current content.
<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c4900bd6c/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c4900bd6c/mobile/banner.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c4900bd6c/mobile/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c4900bd6c/mobile/manageNew.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
