### PR TITLE
Handle all well-known domains in canister id resolution

### DIFF
--- a/src/frontend/src/flows/verifiableCredentials/index.ts
+++ b/src/frontend/src/flows/verifiableCredentials/index.ts
@@ -5,7 +5,7 @@ import { showMessage } from "$src/components/message";
 import { showSpinner } from "$src/components/spinner";
 import { fetchDelegation } from "$src/flows/authorize/fetchDelegation";
 import { getAnchorByPrincipal } from "$src/storage";
-import { resolveIssuerCanisterId } from "$src/utils/canisterIdResolution";
+import { resolveCanisterId } from "$src/utils/canisterIdResolution";
 import { AuthenticatedConnection, Connection } from "$src/utils/iiConnection";
 import { validateDerivationOrigin } from "$src/utils/validateDerivationOrigin";
 import {
@@ -77,7 +77,7 @@ const verifyCredentials = async ({
 }: { connection: Connection } & VerifyCredentialsArgs) => {
   // Look up the canister ID from the origin
   const lookedUp = await withLoader(() =>
-    resolveIssuerCanisterId({ origin: issuerOrigin })
+    resolveCanisterId({ origin: issuerOrigin })
   );
   if (lookedUp === "not_found") {
     return abortedCredentials({ reason: "no_canister_id" });

--- a/src/frontend/src/utils/canisterIdResolution.test.ts
+++ b/src/frontend/src/utils/canisterIdResolution.test.ts
@@ -1,0 +1,63 @@
+import { resolveCanisterId } from "$src/utils/canisterIdResolution";
+
+const HEADER_NAME = "x-ic-canister-id";
+
+test("should resolve canister id", async () => {
+  const fetchMock = vi.fn();
+  fetchMock.mockReturnValueOnce(
+    new Response(null, {
+      status: 200,
+      headers: [[HEADER_NAME, "bkyz2-fmaaa-aaaaa-qaaaq-cai"]],
+    })
+  );
+  global.fetch = fetchMock;
+
+  expect(
+    await resolveCanisterId({
+      origin: "https://example.com",
+    })
+  ).toEqual({ ok: "bkyz2-fmaaa-aaaaa-qaaaq-cai" });
+});
+
+test("should not resolve canister id on missing header", async () => {
+  const fetchMock = vi.fn();
+  fetchMock.mockReturnValueOnce(
+    new Response(null, {
+      status: 200,
+    })
+  );
+  global.fetch = fetchMock;
+
+  expect(
+    await resolveCanisterId({
+      origin: "https://example.com",
+    })
+  ).toEqual("not_found");
+});
+
+test("should resolve canister id from well-known domain", async () => {
+  global.fetch = vi.fn();
+  const canisterId = "bkyz2-fmaaa-aaaaa-qaaaq-cai";
+  const wellKnownDomains = [
+    "ic0.app",
+    "icp0.io",
+    "icp0.io",
+    "internetcomputer.org",
+    "localhost",
+  ];
+
+  for (const domain of wellKnownDomains) {
+    expect(
+      await resolveCanisterId({
+        origin: `https://${canisterId}.${domain}`,
+      })
+    ).toEqual({ ok: canisterId });
+    expect(
+      await resolveCanisterId({
+        origin: `https://${canisterId}.raw.${domain}`,
+      })
+    ).toEqual({ ok: canisterId });
+  }
+  // make sure fetch was not called
+  expect(global.fetch).toHaveBeenCalledTimes(0);
+});


### PR DESCRIPTION
This makes the canister id resolution function more versatile to also take advantage of the canister id subdomain for other well-known domains (apart from `localhost`).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ea012f71e/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ea012f71e/desktop/manageNew.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/ea012f71e/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
