### PR TITLE
Use proper type for resolved canister Id

### DIFF
--- a/src/frontend/src/flows/verifiableCredentials/index.ts
+++ b/src/frontend/src/flows/verifiableCredentials/index.ts
@@ -87,7 +87,7 @@ const verifyCredentials = async ({
 
   // If the RP provided a canister ID, check that it matches what we got
   if (nonNullish(expectedIssuerCanisterId)) {
-    if (expectedIssuerCanisterId !== issuerCanisterId) {
+    if (expectedIssuerCanisterId.compareTo(issuerCanisterId) !== "eq") {
       return abortedCredentials({ reason: "bad_canister_id" });
     }
   }

--- a/src/frontend/src/flows/verifiableCredentials/index.ts
+++ b/src/frontend/src/flows/verifiableCredentials/index.ts
@@ -18,6 +18,7 @@ import {
   CredentialSpec,
   IssuedCredentialData,
 } from "@dfinity/internet-identity-vc-api";
+import { Principal } from "@dfinity/principal";
 import { nonNullish } from "@dfinity/utils";
 import { abortedCredentials } from "./abortedCredentials";
 import { allowCredentials } from "./allowCredentials";
@@ -69,7 +70,7 @@ const verifyCredentials = async ({
   connection,
   request: {
     credentialSubject: givenP_RP,
-    issuer: { origin: issuerOrigin, canisterId: expectedIssuerCanisterId_ },
+    issuer: { origin: issuerOrigin, canisterId: expectedIssuerCanisterId },
     credentialSpec,
     derivationOrigin: rpDerivationOrigin,
   },
@@ -85,9 +86,8 @@ const verifyCredentials = async ({
   const issuerCanisterId = lookedUp.ok;
 
   // If the RP provided a canister ID, check that it matches what we got
-  if (nonNullish(expectedIssuerCanisterId_)) {
-    const expectedCanisterId = expectedIssuerCanisterId_?.toText();
-    if (expectedCanisterId !== issuerCanisterId) {
+  if (nonNullish(expectedIssuerCanisterId)) {
+    if (expectedIssuerCanisterId !== issuerCanisterId) {
       return abortedCredentials({ reason: "bad_canister_id" });
     }
   }
@@ -435,7 +435,7 @@ const createPresentation = ({
   rpAliasCredential,
   issuedCredential,
 }: {
-  issuerCanisterId: string;
+  issuerCanisterId: Principal;
   rpAliasCredential: SignedIdAlias;
   issuedCredential: IssuedCredentialData;
 }): VcVerifiablePresentation => {
@@ -443,7 +443,7 @@ const createPresentation = ({
   const headerObj = { typ: "JWT", alg: "none" };
 
   const payloadObj = {
-    iss: `did:icp:${issuerCanisterId}` /* JWT Issuer is set to the issuer's canister ID as per spec */,
+    iss: `did:icp:${issuerCanisterId.toText()}` /* JWT Issuer is set to the issuer's canister ID as per spec */,
     vp: {
       "@context": "https://www.w3.org/2018/credentials/v1",
       type: "VerifiablePresentation",

--- a/src/frontend/src/flows/verifiableCredentials/vcIssuer.ts
+++ b/src/frontend/src/flows/verifiableCredentials/vcIssuer.ts
@@ -12,10 +12,11 @@ import {
 } from "@dfinity/internet-identity-vc-api";
 
 import { inferHost } from "$src/utils/iiConnection";
+import { Principal } from "@dfinity/principal";
 
 // Boilerplate for contacting a canister implementing the Issuer API
 export class VcIssuer {
-  public constructor(readonly canisterId: string) {}
+  public constructor(readonly canisterId: Principal) {}
 
   // Create an actor representing the backend
   createActor = async (


### PR DESCRIPTION
This PR adds proper typing (`Principal`) to the `resolveCanisterId` function. It also adds error handling for malformed header values.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3de9c7daf/desktop/banner.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3de9c7daf/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3de9c7daf/mobile/manageNew.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

