### PR TITLE
Fix duplicated domain in test

### DIFF
--- a/src/frontend/src/utils/canisterIdResolution.test.ts
+++ b/src/frontend/src/utils/canisterIdResolution.test.ts
@@ -41,7 +41,6 @@ test("should resolve canister id from well-known domain", async () => {
   const wellKnownDomains = [
     "ic0.app",
     "icp0.io",
-    "icp0.io",
     "internetcomputer.org",
     "localhost",
   ];


### PR DESCRIPTION
This fixes an error introduced in #2392 that duplicates a domain in a test for canister id resolution.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/247aad141/desktop/displayManageSingle.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
