### PR TITLE
Handle error when parsing origin for canister id resolution

### DIFF
--- a/src/frontend/src/utils/canisterIdResolution.test.ts
+++ b/src/frontend/src/utils/canisterIdResolution.test.ts
@@ -78,3 +78,11 @@ test("should not resolve canister id from malformed header", async () => {
     })
   ).toEqual("not_found");
 });
+
+test("should not resolve canister id from malformed origin", async () => {
+  expect(
+    await resolveCanisterId({
+      origin: "not-an-origin",
+    })
+  ).toEqual("not_found");
+});

--- a/src/frontend/src/utils/canisterIdResolution.ts
+++ b/src/frontend/src/utils/canisterIdResolution.ts
@@ -11,7 +11,18 @@ export const resolveCanisterId = ({
 }: {
   origin: string;
 }): Promise<{ ok: Principal } | "not_found"> => {
-  const url = new URL(origin);
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch (error) {
+    console.error(
+      `Failed to parse origin '${origin}' as URL: ${unknownToString(
+        error,
+        "unknown error"
+      )}`
+    );
+    return Promise.resolve("not_found");
+  }
 
   const maybeCanisterId = parseCanisterIdFromHostname(url.hostname);
   if (nonNullish(maybeCanisterId)) {


### PR DESCRIPTION
This PR improves error handling when passing invalid origins for canister id resolution.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
