### PR TITLE
Add issuer and RP expect in VC e2e flow

### DIFF
--- a/src/frontend/src/flows/verifiableCredentials/allowCredentials.ts
+++ b/src/frontend/src/flows/verifiableCredentials/allowCredentials.ts
@@ -108,7 +108,7 @@ const allowCredentialsTemplate = ({
           <div class="c-card__label">
             <h3>${copy.issued_by}</h3>
           </div>
-          <h2 class="t-title">${originDapp.name}</h2>
+          <h2 class="t-title" data-role="issuer">${originDapp.name}</h2>
         </div>
       </div>
     </div>
@@ -136,7 +136,7 @@ const allowCredentialsTemplate = ({
           <div class="c-card__label">
             <h3>${copy.relying_party}</h3>
           </div>
-          <h2 class="t-title">${relyingDapp.name}</h2>
+          <h2 class="t-title" data-role="relying-party">${relyingDapp.name}</h2>
         </div>
       </div>
     </div>

--- a/src/frontend/src/test-e2e/constants.ts
+++ b/src/frontend/src/test-e2e/constants.ts
@@ -1,3 +1,4 @@
+import { KnownDapp } from "$src/flows/dappsExplorer/dapps";
 import { readCanisterId } from "@dfinity/internet-identity-vite-plugins/utils";
 
 // XXX: this is not exactly a constant (since it might change on every node eval) but in
@@ -9,6 +10,11 @@ export const TEST_APP_CANONICAL_URL = `https://${testAppCanisterId}.icp0.io`;
 export const TEST_APP_CANONICAL_URL_RAW = `https://${testAppCanisterId}.raw.icp0.io`;
 export const TEST_APP_CANONICAL_URL_LEGACY = `https://${testAppCanisterId}.ic0.app`;
 export const TEST_APP_NICE_URL = "https://nice-name.com";
+export const KNOWN_TEST_DAPP = new KnownDapp({
+  name: "Test Dapp",
+  website: "https://nice-name.com",
+  logo: "no-such-logo",
+});
 
 export const ISSUER_APP_URL = `https://${issuerAppCanisterId}.icp0.io`;
 export const ISSUER_APP_URL_LEGACY = `https://${issuerAppCanisterId}.ic0.app`;

--- a/src/frontend/src/test-e2e/verifiableCredentials/alternativeOrigins.test.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/alternativeOrigins.test.ts
@@ -62,6 +62,8 @@ test("Can issue credential with alternative RP derivation origin", async () => {
       vcTestApp,
       browser,
       authConfig,
+      relyingParty: TEST_APP_CANONICAL_URL,
+      issuer: ISSUER_APP_URL,
     });
     const alias = JSON.parse(alias_);
 
@@ -86,6 +88,8 @@ test("Can issue credential with alternative RP derivation origin", async () => {
       vcTestApp: vcTestAppAlt,
       browser,
       authConfig,
+      relyingParty: TEST_APP_NICE_URL,
+      issuer: ISSUER_APP_URL,
     });
 
     const aliasAlt = JSON.parse(aliasAlt_);
@@ -188,6 +192,8 @@ test("Can issue credential with alternative issuer derivation origin", async () 
       vcTestApp,
       browser,
       authConfig,
+      relyingParty,
+      issuer,
     });
   });
 }, 300_000);

--- a/src/frontend/src/test-e2e/verifiableCredentials/alternativeOrigins.test.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/alternativeOrigins.test.ts
@@ -5,6 +5,7 @@ import {
   II_URL,
   ISSUER_APP_URL,
   ISSUER_CUSTOM_ORIGIN_NICE_URL,
+  KNOWN_TEST_DAPP,
   TEST_APP_CANONICAL_URL,
   TEST_APP_NICE_URL,
 } from "$src/test-e2e/constants";
@@ -90,6 +91,7 @@ test("Can issue credential with alternative RP derivation origin", async () => {
       authConfig,
       relyingParty: TEST_APP_NICE_URL,
       issuer: ISSUER_APP_URL,
+      knownDapps: [KNOWN_TEST_DAPP],
     });
 
     const aliasAlt = JSON.parse(aliasAlt_);
@@ -129,6 +131,7 @@ test("Cannot issue credential with bad alternative RP derivation origin", async 
       authConfig,
       relyingParty: TEST_APP_NICE_URL,
       issuer: ISSUER_APP_URL,
+      knownDapps: [KNOWN_TEST_DAPP],
     });
 
     expect(result.result).toBe("aborted");
@@ -196,6 +199,7 @@ test("Can issue credential with alternative issuer derivation origin", async () 
       authConfig,
       relyingParty,
       issuer,
+      knownDapps: [KNOWN_TEST_DAPP],
     });
   });
 }, 300_000);

--- a/src/frontend/src/test-e2e/verifiableCredentials/alternativeOrigins.test.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/alternativeOrigins.test.ts
@@ -127,6 +127,8 @@ test("Cannot issue credential with bad alternative RP derivation origin", async 
       vcTestApp: vcTestAppAlt,
       browser,
       authConfig,
+      relyingParty: TEST_APP_NICE_URL,
+      issuer: ISSUER_APP_URL,
     });
 
     expect(result.result).toBe("aborted");

--- a/src/frontend/src/test-e2e/verifiableCredentials/index.test.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/index.test.ts
@@ -5,6 +5,7 @@ import {
   II_URL,
   ISSUER_APP_URL,
   ISSUER_APP_URL_LEGACY,
+  KNOWN_TEST_DAPP,
   TEST_APP_CANONICAL_URL,
   TEST_APP_CANONICAL_URL_LEGACY,
 } from "$src/test-e2e/constants";
@@ -112,6 +113,7 @@ testConfigs.forEach(({ relyingParty, issuer, authType }) => {
             authConfig,
             relyingParty,
             issuer,
+            knownDapps: [KNOWN_TEST_DAPP],
           });
 
           // Perform a basic check on the alias

--- a/src/frontend/src/test-e2e/verifiableCredentials/index.test.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/index.test.ts
@@ -110,6 +110,8 @@ testConfigs.forEach(({ relyingParty, issuer, authType }) => {
             vcTestApp,
             browser,
             authConfig,
+            relyingParty,
+            issuer,
           });
 
           // Perform a basic check on the alias

--- a/src/frontend/src/test-e2e/verifiableCredentials/utils.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/utils.ts
@@ -113,6 +113,8 @@ export const getVCPresentation = async (args: {
   vcTestApp: VcTestAppView;
   browser: WebdriverIO.Browser;
   authConfig: AuthConfig;
+  relyingParty: string;
+  issuer: string;
 }): Promise<{ alias: string; credential: string }> => {
   const result = await getVCPresentation_(args);
   if (result.result === "aborted") {
@@ -129,10 +131,14 @@ export const getVCPresentation_ = async ({
   vcTestApp,
   browser,
   authConfig: { setupAuth, finalizeAuth },
+  relyingParty,
+  issuer,
 }: {
   vcTestApp: VcTestAppView;
   browser: WebdriverIO.Browser;
   authConfig: AuthConfig;
+  relyingParty: string;
+  issuer: string;
 }): Promise<
   | { result: "ok"; alias: string; credential: string }
   | { result: "aborted"; reason: string }
@@ -148,6 +154,8 @@ export const getVCPresentation_ = async ({
     return { result: "aborted", reason };
   }
 
+  expect(await vcAllow.getIssuer()).toBe(issuer);
+  expect(await vcAllow.getRelyingParty()).toBe(relyingParty);
   expect(await vcAllow.hasUserNumberInput()).toBe(false);
 
   await vcAllow.allow();

--- a/src/frontend/src/test-e2e/verifiableCredentials/utils.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/utils.ts
@@ -18,6 +18,7 @@ import {
 
 import { II_URL } from "$src/test-e2e/constants";
 
+import { KnownDapp } from "$src/flows/dappsExplorer/dapps";
 import { nonNullish } from "@dfinity/utils";
 
 // Open the issuer demo, authenticate and register as an employee
@@ -115,6 +116,7 @@ export const getVCPresentation = async (args: {
   authConfig: AuthConfig;
   relyingParty: string;
   issuer: string;
+  knownDapps?: KnownDapp[];
 }): Promise<{ alias: string; credential: string }> => {
   const result = await getVCPresentation_(args);
   if (result.result === "aborted") {
@@ -133,12 +135,14 @@ export const getVCPresentation_ = async ({
   authConfig: { setupAuth, finalizeAuth },
   relyingParty,
   issuer,
+  knownDapps = [],
 }: {
   vcTestApp: VcTestAppView;
   browser: WebdriverIO.Browser;
   authConfig: AuthConfig;
   relyingParty: string;
   issuer: string;
+  knownDapps?: KnownDapp[];
 }): Promise<
   | { result: "ok"; alias: string; credential: string }
   | { result: "aborted"; reason: string }
@@ -154,8 +158,15 @@ export const getVCPresentation_ = async ({
     return { result: "aborted", reason };
   }
 
-  expect(await vcAllow.getIssuer()).toBe(issuer);
-  expect(await vcAllow.getRelyingParty()).toBe(relyingParty);
+  // II will show the issuer and relying party name if they are known dapps.
+  const issuerName: string =
+    knownDapps.find((dapp) => dapp.hasOrigin(issuer))?.name ?? issuer;
+  const rpName: string =
+    knownDapps.find((dapp) => dapp.hasOrigin(relyingParty))?.name ??
+    relyingParty;
+
+  expect(await vcAllow.getIssuer()).toBe(issuerName);
+  expect(await vcAllow.getRelyingParty()).toBe(rpName);
   expect(await vcAllow.hasUserNumberInput()).toBe(false);
 
   await vcAllow.allow();

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -618,6 +618,14 @@ export class VcAllowView extends View {
   async hasUserNumberInput(): Promise<boolean> {
     return await this.browser.$('[data-role="anchor-input"]').isExisting();
   }
+
+  async getRelyingParty(): Promise<string> {
+    return await this.browser.$('[data-role="relying-party"]').getText();
+  }
+
+  async getIssuer(): Promise<string> {
+    return await this.browser.$('[data-role="issuer"]').getText();
+  }
 }
 
 export class IssuerAppView extends View {


### PR DESCRIPTION
Yesterday I introduced a bug where the relying party was in the issuer card and viceversa. This morning I fixed it in #2414 but I didn't add a test for it.

In this PR, I introduce two expects that that would have caught the bug.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fb666c9b1/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


