### PR TITLE
Remove notice msg from VC flow error page

### DIFF
--- a/src/frontend/src/flows/verifiableCredentials/abortedCredentials.json
+++ b/src/frontend/src/flows/verifiableCredentials/abortedCredentials.json
@@ -12,7 +12,6 @@
     "aborted_no_canister_id": "Internet Identity could not find the canister for the issuer.",
     "aborted_bad_canister_id": "Internet Identity could not confirm the canister ID given for the issuer.",
     "aborted_bad_derivation_origin_rp": "Internet Identity could not confirm the derivation origin for the relying party.",
-    "notice": "We will now let the relying party know there was an issue.",
     "you_may_close": "You may now close this page."
   }
 }

--- a/src/frontend/src/flows/verifiableCredentials/abortedCredentials.ts
+++ b/src/frontend/src/flows/verifiableCredentials/abortedCredentials.ts
@@ -53,8 +53,6 @@ const abortedCredentialsTemplate = ({
     </hgroup>
     <p class="t-paragraph">${copy[`aborted_${reason}`]}</p>
 
-    <p class="t-paragraph">${copy.notice}</p>
-
     <button
       data-action="cancel"
       ?disabled=${asyncReplace(didAck)}


### PR DESCRIPTION
Main motivation is to remove the message: "We will now let the relying party know there was an issue." from the error page of the verifiable credentials flow.

This change was requested by product as a quick fix of the error page. The error page will be further improved in another initiative.
<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8a9ca3d79/desktop/abortedCredentialsInternalError.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8a9ca3d79/mobile/abortedCredentialsInternalError.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8a9ca3d79/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
