### PR TITLE
Exclude dapps without website entry from dapps explorer

### DIFF
--- a/scripts/update-dapps
+++ b/scripts/update-dapps
@@ -83,6 +83,7 @@ function update() {
             | select(.usesInternetIdentity == true) # ensure the dapp actually uses II
             | select(.name != "Internet Identity") # skip II itself
             | select(.logo != null) # only use dapps with logo
+            | select(.website != null) # only use dapps with website
             | .logo |= sub("^/" + $portal_logo_prefix + "/"; "") # swap the logo for our prefix
             | with_entries( # drop entries we do not care about to reduce size
                 select(


### PR DESCRIPTION
The dapps explorer is meant for deployed applications that users can visit. If a dapp does not have a website to visit, it will be filtered out from the list included in II.

This fixes automatic dapps update (#2426) which fails due to a missing `website` entry.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7daa8ec86/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
