### PR TITLE
Revert erroneous candid blob encoding change

### DIFF
--- a/scripts/deploy-archive
+++ b/scripts/deploy-archive
@@ -93,4 +93,4 @@ then
     network_arg+=( "--network" "$network")
 fi
 
-dfx canister "${network_arg[@]}" call "$canister_id" deploy_archive --argument-file <(echo "(blob \"$(hexdump -ve '1/1 "%.2x"' "$wasm")\")")
+dfx canister "${network_arg[@]}" call "$canister_id" deploy_archive --argument-file <(echo "(blob \"$(hexdump -ve '1/1 "%.2x"' "$wasm" | sed 's/../\\&/g')\")")


### PR DESCRIPTION
In #2425 a change was introduced assuming that `blob` types are handled differently with `dfx` 0.19.0. However, this change only affected printing hex values and not encoding. Hence the change introduced a bug that is reverted with this PR.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c7ee89a77/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
