### PR TITLE
Upgrade stable structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
  "ic-cdk-macros",
  "ic-cdk-timers",
  "ic-metrics-encoder",
- "ic-stable-structures 0.6.2",
+ "ic-stable-structures 0.6.4",
  "ic-test-state-machine-client",
  "internet_identity_interface",
  "regex",
@@ -1923,9 +1923,9 @@ checksum = "95dce29e3ceb0e6da3e78b305d95365530f2efd2146ca18590c0ef3aa6038568"
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774d7d26420c095f2b5f0f71f7b2ff4a5b58b87e0959dccc78b3d513a7db5112"
+checksum = "07e2282054c8ddf0cb2a7abf5c174c373917b4345c9a096ae4aa7f7185cdcdc7"
 dependencies = [
  "ic_principal",
 ]
@@ -2229,7 +2229,7 @@ dependencies = [
  "ic-http-certification",
  "ic-metrics-encoder",
  "ic-response-verification",
- "ic-stable-structures 0.6.2",
+ "ic-stable-structures 0.6.4",
  "ic-test-state-machine-client",
  "identity_jose",
  "include_dir",


### PR DESCRIPTION
This upgrades the `ic-stable-structures` crate to fix a memory leak in the `BTreeMap`.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
