### PR TITLE
Remove apt-get update step from using-dev-build CI check

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -539,11 +539,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: |
-          sudo apt-get update
-          sudo apt-get --only-upgrade install google-chrome-stable
-          google-chrome --version
-
       - uses: ./.github/actions/setup-node
       - uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365
 


### PR DESCRIPTION
This PR removes the `apt-get` update and Chrome installation from the `using-dev-build` CI check because it is causing problems and is not actually needed. The e2e tests use `wdio` to download Chrome for testing internally.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/937394747/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/937394747/mobile/displayManage.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
