### PR TITLE
Configure up to 10 retries on agent failure

### DIFF
--- a/src/frontend/src/flows/verifiableCredentials/vcIssuer.ts
+++ b/src/frontend/src/flows/verifiableCredentials/vcIssuer.ts
@@ -25,6 +25,7 @@ export class VcIssuer {
     const agent = new HttpAgent({
       host: inferHost(),
       identity,
+      retryTimes: 10,
     });
 
     // Only fetch the root key when we're not in prod

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -379,6 +379,7 @@ export class Connection {
     const agent = new HttpAgent({
       identity: delegationIdentity,
       host: inferHost(),
+      retryTimes: 10,
     });
 
     // Only fetch the root key when we're not in prod


### PR DESCRIPTION
This PR configures the number of retries to 10 (as opposed to just 3, which is the default). This makes the agent more resilient against watermark check failures, because the likelihood of hitting only replicas that are behind gets lowered a lot and retrying takes time too.

Addresses [this comment](https://github.com/dfinity/internet-identity/pull/2446#issuecomment-2078795472).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3304e3f19/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
