### PR TITLE
Collect anonymous prepare_delegation events for stats purposes

### DIFF
--- a/src/internet_identity/src/activity_stats.rs
+++ b/src/internet_identity/src/activity_stats.rs
@@ -6,6 +6,7 @@ use candid::{CandidType, Deserialize};
 use internet_identity_interface::internet_identity::types::Timestamp;
 
 pub mod activity_counter;
+pub mod event_stats;
 mod stats_maintenance;
 
 #[derive(Clone, CandidType, Deserialize, Eq, PartialEq, Debug)]

--- a/src/internet_identity/src/activity_stats/event_stats.rs
+++ b/src/internet_identity/src/activity_stats/event_stats.rs
@@ -31,10 +31,11 @@
 //! Example of event_aggregations:
 //! ```
 //! event_aggregations: {
-//!   "PD_count_24h_ic0.app_https://dapp.example.com": 5,
-//!   "PD_sess_sec_24h_ic0.app_https://dapp.example.com": 15,
-//!   "PD_count_30d_internetcomputer.org_https://anotherapp.example.com": 20,
-//!   "PD_sess_sec_30d_internetcomputer.org_https://anotherapp.example.com": 60
+//!   "PD_count>24h>ic0.app>https://dapp.example.com": 5,
+//!   "PD_sess_sec>24h>ic0.app>https://dapp.example.com": 15,
+//!   "PD_count>30d>internetcomputer.org>https://anotherapp.example.com": 20,
+//!   "PD_sess_sec>30d>internetcomputer.org>https://anotherapp.example.com": 60
+//!   //...
 //! }
 //! ```
 

--- a/src/internet_identity/src/activity_stats/event_stats.rs
+++ b/src/internet_identity/src/activity_stats/event_stats.rs
@@ -1,0 +1,195 @@
+use crate::activity_stats::event_stats::event_aggregations::AGGREGATIONS;
+use crate::ii_domain::IIDomain;
+use crate::state::storage_borrow_mut;
+use crate::storage::Storage;
+use crate::DAY_NS;
+use ic_cdk::api::time;
+use ic_stable_structures::storable::Bound;
+use ic_stable_structures::{Memory, StableBTreeMap, Storable};
+use internet_identity_interface::internet_identity::types::{FrontendHostname, Timestamp};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+/// This module defines the aggregations over the events.
+mod event_aggregations;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug)]
+pub struct EventData {
+    pub event: Event,
+}
+
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug)]
+pub enum Event {
+    PrepareDelegation(PrepareDelegationEvent),
+}
+
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug)]
+pub struct PrepareDelegationEvent {
+    pub ii_domain: Option<IIDomain>,
+    pub frontend: FrontendHostname,
+    pub session_duration_ns: u64,
+}
+
+impl Storable for EventData {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(serde_cbor::to_vec(&self).unwrap())
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        serde_cbor::from_slice(&bytes).unwrap()
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+struct WeightedAggregation {
+    key: String,
+    weight: u64,
+}
+
+/// Updates the event-based stats with the given event.
+///
+/// This adds the event to the event_data map and updates the daily and monthly aggregations over
+/// the event data.
+pub fn update_event_based_stats(event: EventData) {
+    let now = time();
+    storage_borrow_mut(|s| {
+        update_events_internal(event, now, s);
+    })
+}
+
+/// Internal helper useful for testing.
+fn update_events_internal<M: Memory>(event: EventData, now: u64, s: &mut Storage<M>) {
+    s.event_data.insert(now, event.clone());
+
+    let pruned_24h = if let Some((timestamp, _)) = s.event_data.iter_upper_bound(&now).next() {
+        // `timestamp` denotes the time of the last event recorded just before `now`
+        // The difference (now - timestamp) is the time that has passed since the last event
+        // and hence the last time the daily stats were updated.
+        // Therefore, we need to prune all events from the daily aggregations that happened in
+        // that same difference, but 24 hours ago.
+        //
+        //    |<----------------------- 24h ----------------------->|
+        // |--|--------------------------------------------------|--|   --> time
+        // ^  ^                                                  ^  ^
+        // |  |                                                  |  └ now
+        // |  └ now - 24h (prune_window_end)                     └ timestamp
+        // └ timestamp - 24h (prune_window_start)
+
+        let prune_window_start = timestamp - DAY_NS;
+        let prune_window_end = now - DAY_NS;
+        s.event_data
+            .range(prune_window_start..=prune_window_end)
+            .collect::<Vec<_>>()
+    } else {
+        // there is no event before `now` in the db, so the list of pruned events is empty
+        vec![]
+    };
+
+    // Update 24h aggregations
+    AGGREGATIONS.iter().for_each(|aggregation_filter_map| {
+        update_aggregation(
+            |input| aggregation_filter_map("24h", input),
+            now,
+            event.clone(),
+            &pruned_24h,
+            &mut s.event_aggregations,
+        );
+    });
+
+    // This pruning _deletes_ the data older than 30 days. Do this after the 24h aggregation
+    // otherwise the daily stats become inaccurate on the unlikely event that there is no activity
+    // for 30 days.
+    let pruned_30d = prune_events(&mut s.event_data, now);
+
+    // Update 30d aggregations
+    AGGREGATIONS.iter().for_each(|aggregation_filter_map| {
+        update_aggregation(
+            |input| aggregation_filter_map("30d", input),
+            now,
+            event.clone(),
+            &pruned_30d,
+            &mut s.event_aggregations,
+        );
+    });
+}
+
+/// Adds an event to the event_data map and simultaneously removes events older than the retention period (30d).
+/// Returns a vec of tuples of the pruned events and their timestamps.
+fn prune_events<M: Memory>(
+    db: &mut StableBTreeMap<Timestamp, EventData, M>,
+    now: Timestamp,
+) -> Vec<(Timestamp, EventData)> {
+    const RETENTION_PERIOD: u64 = 30 * DAY_NS;
+
+    let pruned_events = db.range(..=now - RETENTION_PERIOD).collect();
+    for entry in &pruned_events {
+        let entry: &(Timestamp, EventData) = entry;
+        db.remove(&entry.0);
+    }
+
+    pruned_events
+}
+
+fn update_aggregation<M: Memory, F>(
+    aggregation_filter_map: F,
+    now: Timestamp,
+    new_event: EventData,
+    pruned_events: &[(Timestamp, EventData)],
+    db: &mut StableBTreeMap<String, u64, M>,
+) where
+    F: Fn(&(u64, EventData)) -> Option<WeightedAggregation>,
+{
+    // Process the pruned events to calculate the pruned weight by aggregation key
+    let mut pruned_weight_by_key = pruned_events
+        .iter()
+        .filter_map(&aggregation_filter_map)
+        .fold(HashMap::<_, u64>::new(), |mut map, weighted_aggregation| {
+            let value =
+                map.get(&weighted_aggregation.key).unwrap_or(&0) + weighted_aggregation.weight;
+            map.insert(weighted_aggregation.key, value);
+            map
+        });
+
+    // Process the new event and merge it with the pruned events
+    if let Some(WeightedAggregation { key, mut weight }) = aggregation_filter_map(&(now, new_event))
+    {
+        if let Some(pruned_weight) = pruned_weight_by_key.get_mut(&key) {
+            if *pruned_weight <= weight {
+                weight -= *pruned_weight;
+                // more weight is added than pruned, so the key can be removed from the pruned map
+                pruned_weight_by_key.remove(&key);
+            } else {
+                // we can just reduce the amount of pruned weight
+                *pruned_weight -= weight;
+                weight = 0; // no weight left to add
+            }
+        }
+        // if there is more weight of the current event, write it to the db
+        if weight > 0 {
+            let current_weight = db.get(&key).unwrap_or(0);
+            db.insert(key, current_weight + weight);
+        }
+    }
+
+    // Update the db to reflect the pruned weights
+    pruned_weight_by_key
+        .into_iter()
+        .for_each(|(key, pruned_weight)| {
+            let current_weight = db.get(&key).unwrap_or_else(|| {
+                panic!("aggregation key \"{}\" not found in DB when pruning", key)
+            });
+            assert!(
+                current_weight >= pruned_weight,
+                "pruned weight {} exceeds current weight {} for key \"{}\"",
+                pruned_weight,
+                current_weight,
+                key
+            );
+            db.insert(key, current_weight - pruned_weight);
+        });
+}

--- a/src/internet_identity/src/activity_stats/event_stats.rs
+++ b/src/internet_identity/src/activity_stats/event_stats.rs
@@ -190,6 +190,11 @@ fn update_aggregation<M: Memory, F>(
                 current_weight,
                 key
             );
-            db.insert(key, current_weight - pruned_weight);
+            let new_weight = current_weight - pruned_weight;
+            if new_weight == 0 {
+                db.remove(&key);
+            } else {
+                db.insert(key, new_weight);
+            }
         });
 }

--- a/src/internet_identity/src/activity_stats/event_stats/event_aggregations.rs
+++ b/src/internet_identity/src/activity_stats/event_stats/event_aggregations.rs
@@ -1,5 +1,5 @@
 use crate::activity_stats::event_stats::{
-    AggregationEvent, Event, EventData, PrepareDelegationEvent,
+    AggregationEvent, Event, EventData, EventKey, PrepareDelegationEvent,
 };
 use crate::ii_domain::IIDomain;
 use std::time::Duration;
@@ -10,7 +10,7 @@ use std::time::Duration;
 /// and a tuple of `(timestamp, event_data)` and maps it to an optional [AggregationEvent]
 /// (i.e. a key for the aggregation and a weight for the event).
 /// If the event is not part of the aggregation, the function should return [None].
-type Aggregation = fn(&str, &(u64, EventData)) -> Option<AggregationEvent>;
+type Aggregation = fn(&str, &(EventKey, EventData)) -> Option<AggregationEvent>;
 
 /// All aggregations currently maintained over event data.
 pub const AGGREGATIONS: [Aggregation; 2] =
@@ -23,8 +23,8 @@ pub const AGGREGATIONS: [Aggregation; 2] =
 ///
 /// Results in labels like "PD_count_<bucket_length>_<ii_domain>_<frontend_hostname>"
 /// e.g "PD_count>24h>ic0.app>https://dapp.example.com"
-const PREPARE_DELEGATION_COUNT: fn(&str, &(u64, EventData)) -> Option<AggregationEvent> =
-    |key_duration: &str, (_timestamp, event): &(u64, EventData)| -> Option<AggregationEvent> {
+const PREPARE_DELEGATION_COUNT: fn(&str, &(EventKey, EventData)) -> Option<AggregationEvent> =
+    |key_duration: &str, (_, event): &(EventKey, EventData)| -> Option<AggregationEvent> {
         prepare_delegation_aggregation("PD_count", key_duration, |_| 1, event)
     };
 
@@ -35,8 +35,11 @@ const PREPARE_DELEGATION_COUNT: fn(&str, &(u64, EventData)) -> Option<Aggregatio
 ///
 /// Results in labels like "PD_sess_sec_<bucket_length>_<ii_domain>_<frontend_hostname>"
 /// e.g "PD_sess_sec>24h>ic0.app>https://dapp.example.com"
-const PREPARE_DELEGATION_SESSION_SECONDS: fn(&str, &(u64, EventData)) -> Option<AggregationEvent> =
-    |key_duration: &str, (_timestamp, event): &(u64, EventData)| -> Option<AggregationEvent> {
+const PREPARE_DELEGATION_SESSION_SECONDS: fn(
+    &str,
+    &(EventKey, EventData),
+) -> Option<AggregationEvent> =
+    |key_duration: &str, (_, event): &(EventKey, EventData)| -> Option<AggregationEvent> {
         prepare_delegation_aggregation(
             "PD_sess_sec",
             key_duration,

--- a/src/internet_identity/src/activity_stats/event_stats/event_aggregations.rs
+++ b/src/internet_identity/src/activity_stats/event_stats/event_aggregations.rs
@@ -22,7 +22,7 @@ pub const AGGREGATIONS: [Aggregation; 2] =
 /// - over 24h and 30d buckets
 ///
 /// Results in labels like "PD_count_<bucket_length>_<ii_domain>_<frontend_hostname>"
-/// e.g "PD_count_24h_ic0.app_https://dapp.example.com"
+/// e.g "PD_count>24h>ic0.app>https://dapp.example.com"
 const PREPARE_DELEGATION_COUNT: fn(&str, &(u64, EventData)) -> Option<AggregationEvent> =
     |key_duration: &str, (_timestamp, event): &(u64, EventData)| -> Option<AggregationEvent> {
         prepare_delegation_aggregation("PD_count", key_duration, |_| 1, event)
@@ -34,7 +34,7 @@ const PREPARE_DELEGATION_COUNT: fn(&str, &(u64, EventData)) -> Option<Aggregatio
 /// - over 24h and 30d buckets
 ///
 /// Results in labels like "PD_sess_sec_<bucket_length>_<ii_domain>_<frontend_hostname>"
-/// e.g "PD_sess_sec_24h_ic0.app_https://dapp.example.com"
+/// e.g "PD_sess_sec>24h>ic0.app>https://dapp.example.com"
 const PREPARE_DELEGATION_SESSION_SECONDS: fn(&str, &(u64, EventData)) -> Option<AggregationEvent> =
     |key_duration: &str, (_timestamp, event): &(u64, EventData)| -> Option<AggregationEvent> {
         prepare_delegation_aggregation(
@@ -54,7 +54,7 @@ fn prepare_delegation_aggregation(
     match &event.event {
         Event::PrepareDelegation(prepare_delegation_event) => {
             let key = format!(
-                "{}_{}_{}_{}",
+                "{}>{}>{}>{}", // '>' is chosen as delimiter because it is not allowed in URLs
                 key_prefix,
                 key_duration,
                 ii_domain_to_label(&prepare_delegation_event.ii_domain),

--- a/src/internet_identity/src/activity_stats/event_stats/event_aggregations.rs
+++ b/src/internet_identity/src/activity_stats/event_stats/event_aggregations.rs
@@ -1,80 +1,151 @@
 use crate::activity_stats::event_stats::{
-    AggregationEvent, Event, EventData, EventKey, PrepareDelegationEvent,
+    AggregationEvent, Event, EventData, PrepareDelegationEvent,
 };
 use crate::ii_domain::IIDomain;
+use candid::Deserialize;
+use ic_stable_structures::storable::Bound;
+use ic_stable_structures::Storable;
+use serde::Serialize;
+use serde_bytes::ByteBuf;
+use std::borrow::Cow;
 use std::time::Duration;
 
-/// Type definition for an aggregation function.
+/// Trait for an event aggregation.
 ///
-/// Each aggregation is defined as a function that takes a bucket size label (i.e. "24h" or "30d")
-/// and a tuple of `(timestamp, event_data)` and maps it to an optional [AggregationEvent]
-/// (i.e. a key for the aggregation and a weight for the event).
+/// Each aggregation provides a `process_event` function that takes an [AggregationWindow] and [EventData]
+/// and maps it to an optional [AggregationEvent] (i.e. a key for the aggregation and a weight for the event).
 /// If the event is not part of the aggregation, the function should return [None].
-type Aggregation = fn(&str, &(EventKey, EventData)) -> Option<AggregationEvent>;
-
-/// All aggregations currently maintained over event data.
-pub const AGGREGATIONS: [Aggregation; 2] =
-    [PREPARE_DELEGATION_COUNT, PREPARE_DELEGATION_SESSION_SECONDS];
+pub trait Aggregation {
+    fn kind(&self) -> AggregationKind;
+    fn process_event(
+        &self,
+        window: AggregationWindow,
+        event: &EventData,
+    ) -> Option<AggregationEvent>;
+}
 
 /// Aggregates the count of prepare delegation events
 /// - per dapp frontend
 /// - per II domain
 /// - over 24h and 30d buckets
-///
-/// Results in labels like "PD_count_<bucket_length>_<ii_domain>_<frontend_hostname>"
-/// e.g "PD_count>24h>ic0.app>https://dapp.example.com"
-const PREPARE_DELEGATION_COUNT: fn(&str, &(EventKey, EventData)) -> Option<AggregationEvent> =
-    |key_duration: &str, (_, event): &(EventKey, EventData)| -> Option<AggregationEvent> {
-        prepare_delegation_aggregation("PD_count", key_duration, |_| 1, event)
-    };
+struct PrepareDelegationCount;
+
+impl Aggregation for PrepareDelegationCount {
+    fn kind(&self) -> AggregationKind {
+        AggregationKind::PrepareDelegationCount
+    }
+
+    fn process_event(
+        &self,
+        window: AggregationWindow,
+        event: &EventData,
+    ) -> Option<AggregationEvent> {
+        prepare_delegation_aggregation(self.kind(), window, |_| 1, event)
+    }
+}
 
 /// Aggregates the cumulative session duration in seconds of prepare delegation events
 /// - per dapp frontend
 /// - per II domain
 /// - over 24h and 30d buckets
-///
-/// Results in labels like "PD_sess_sec_<bucket_length>_<ii_domain>_<frontend_hostname>"
-/// e.g "PD_sess_sec>24h>ic0.app>https://dapp.example.com"
-const PREPARE_DELEGATION_SESSION_SECONDS: fn(
-    &str,
-    &(EventKey, EventData),
-) -> Option<AggregationEvent> =
-    |key_duration: &str, (_, event): &(EventKey, EventData)| -> Option<AggregationEvent> {
+struct PrepareDelegationSessionSeconds;
+
+impl Aggregation for PrepareDelegationSessionSeconds {
+    fn kind(&self) -> AggregationKind {
+        AggregationKind::PrepareDelegationSessionSeconds
+    }
+
+    fn process_event(
+        &self,
+        window: AggregationWindow,
+        event: &EventData,
+    ) -> Option<AggregationEvent> {
         prepare_delegation_aggregation(
-            "PD_sess_sec",
-            key_duration,
+            self.kind(),
+            window,
             |event| Duration::from_nanos(event.session_duration_ns).as_secs(),
             event,
         )
-    };
+    }
+}
+
+/// List of aggregations currently maintained over events.
+pub const AGGREGATIONS: [&'static dyn Aggregation; 2] =
+    [&PrepareDelegationCount, &PrepareDelegationSessionSeconds];
+
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
+pub enum AggregationWindow {
+    Day,   // 24 hours
+    Month, // 30 days
+}
+
+/// All kinds of aggregation types currently supported.
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
+pub enum AggregationKind {
+    PrepareDelegationCount,
+    PrepareDelegationSessionSeconds,
+}
+
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq, Debug, Ord, PartialOrd, Hash)]
+pub struct AggregationKey {
+    /// The aggregation kind (i.e. category).
+    kind: AggregationKind,
+    /// The aggregation window (i.e. bucket size).
+    window: AggregationWindow,
+    /// The II domain, if any, that is associated with the aggregation.
+    ii_domain: Option<IIDomain>,
+    /// Additional data that is used to differentiate multiple entries of the same aggregation.
+    /// For example, the frontend origin of a dapp in the case of `prepare_delegation` aggregations.
+    data: ByteBuf,
+}
+
+impl AggregationKey {
+    #[cfg(test)] // currently only used in tests
+    pub fn new(
+        kind: AggregationKind,
+        window: AggregationWindow,
+        ii_domain: Option<IIDomain>,
+        frontend: String,
+    ) -> Self {
+        Self {
+            kind,
+            window,
+            ii_domain,
+            data: ByteBuf::from(frontend.as_bytes()),
+        }
+    }
+}
+
+impl Storable for AggregationKey {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(serde_cbor::to_vec(&self).unwrap())
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        serde_cbor::from_slice(&bytes).unwrap()
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
 
 fn prepare_delegation_aggregation(
-    key_prefix: &str,
-    key_duration: &str,
+    kind: AggregationKind,
+    window: AggregationWindow,
     weight_func: fn(&PrepareDelegationEvent) -> u64,
     event: &EventData,
 ) -> Option<AggregationEvent> {
     match &event.event {
         Event::PrepareDelegation(prepare_delegation_event) => {
-            let key = format!(
-                "{}>{}>{}>{}", // '>' is chosen as delimiter because it is not allowed in URLs
-                key_prefix,
-                key_duration,
-                ii_domain_to_label(&prepare_delegation_event.ii_domain),
-                prepare_delegation_event.frontend
-            );
+            let key = AggregationKey {
+                kind,
+                window,
+                ii_domain: prepare_delegation_event.ii_domain.clone(),
+                data: ByteBuf::from(prepare_delegation_event.frontend.as_bytes()),
+            };
             Some(AggregationEvent {
                 key,
                 weight: weight_func(prepare_delegation_event),
             })
         }
-    }
-}
-
-fn ii_domain_to_label(domain: &Option<IIDomain>) -> &str {
-    match domain {
-        Some(IIDomain::Ic0AppDomain) => "ic0.app",
-        Some(IIDomain::InternetComputerOrgDomain) => "internetcomputer.org",
-        None => "other",
     }
 }

--- a/src/internet_identity/src/activity_stats/event_stats/event_aggregations.rs
+++ b/src/internet_identity/src/activity_stats/event_stats/event_aggregations.rs
@@ -1,0 +1,80 @@
+use crate::activity_stats::event_stats::{
+    Event, EventData, PrepareDelegationEvent, WeightedAggregation,
+};
+use crate::ii_domain::IIDomain;
+use std::time::Duration;
+
+/// Type definition for an aggregation function.
+///
+/// Each aggregation is defined as a function that takes a bucket size label (i.e. "24h" or "30d")
+/// and a tuple of `(timestamp, event_data)` and maps it to an optional [WeightedAggregation]
+/// (i.e. a key for the aggregation and a weight for the event).
+/// If the event is not part of the aggregation, the function should return [None].
+type Aggregation = fn(&str, &(u64, EventData)) -> Option<WeightedAggregation>;
+
+/// All aggregations currently maintained over event data.
+pub const AGGREGATIONS: [Aggregation; 2] =
+    [PREPARE_DELEGATION_COUNT, PREPARE_DELEGATION_SESSION_SECONDS];
+
+/// Aggregates the count of prepare delegation events
+/// - per dapp frontend
+/// - per II domain
+/// - over 24h and 30d buckets
+///
+/// Results in labels like "PD_count_<bucket_length>_<ii_domain>_<frontend_hostname>"
+/// e.g "PD_count_24h_ic0.app_https://dapp.example.com"
+const PREPARE_DELEGATION_COUNT: fn(&str, &(u64, EventData)) -> Option<WeightedAggregation> =
+    |key_duration: &str, (_timestamp, event): &(u64, EventData)| -> Option<WeightedAggregation> {
+        prepare_delegation_aggregation("PD_count", key_duration, |_| 1, event)
+    };
+
+/// Aggregates the cumulative session duration in seconds of prepare delegation events
+/// - per dapp frontend
+/// - per II domain
+/// - over 24h and 30d buckets
+///
+/// Results in labels like "PD_sess_sec_<bucket_length>_<ii_domain>_<frontend_hostname>"
+/// e.g "PD_sess_sec_24h_ic0.app_https://dapp.example.com"
+const PREPARE_DELEGATION_SESSION_SECONDS: fn(
+    &str,
+    &(u64, EventData),
+) -> Option<WeightedAggregation> =
+    |key_duration: &str, (_timestamp, event): &(u64, EventData)| -> Option<WeightedAggregation> {
+        prepare_delegation_aggregation(
+            "PD_sess_sec",
+            key_duration,
+            |event| Duration::from_nanos(event.session_duration_ns).as_secs(),
+            event,
+        )
+    };
+
+fn prepare_delegation_aggregation(
+    key_prefix: &str,
+    key_duration: &str,
+    weight_func: fn(&PrepareDelegationEvent) -> u64,
+    event: &EventData,
+) -> Option<WeightedAggregation> {
+    match &event.event {
+        Event::PrepareDelegation(prepare_delegation_event) => {
+            let key = format!(
+                "{}_{}_{}_{}",
+                key_prefix,
+                key_duration,
+                ii_domain_to_label(&prepare_delegation_event.ii_domain),
+                prepare_delegation_event.frontend
+            );
+            Some(WeightedAggregation {
+                key,
+                weight: weight_func(prepare_delegation_event),
+            })
+        }
+    }
+}
+
+fn ii_domain_to_label(domain: &Option<IIDomain>) -> &str {
+    match domain {
+        Some(IIDomain::Ic0AppDomain) => "ic0.app",
+        Some(IIDomain::InternetComputerOrgDomain) => "internetcomputer.org",
+        None => "other",
+    }
+}

--- a/src/internet_identity/src/activity_stats/event_stats/tests.rs
+++ b/src/internet_identity/src/activity_stats/event_stats/tests.rs
@@ -1,0 +1,315 @@
+use crate::activity_stats::event_stats::{
+    update_events_internal, Event, EventData, PrepareDelegationEvent,
+};
+use crate::ii_domain::IIDomain;
+use crate::storage::Storage;
+use crate::DAY_NS;
+use ic_stable_structures::VectorMemory;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+const TIMESTAMP: u64 = 1_714_387_451 * 10u64.pow(9);
+const EXAMPLE_URL: &str = "https://example.com";
+const EXAMPLE_URL_2: &str = "https://other-example.com";
+
+#[test]
+fn should_store_event_and_add_to_aggregations() {
+    let mut storage = test_storage();
+    let event = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0AppDomain),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(900).as_nanos() as u64,
+        }),
+    };
+
+    update_events_internal(event.clone(), TIMESTAMP, &mut storage);
+
+    assert_eq!(storage.event_aggregations.len(), 4);
+    const EXPECTED_AGGREGATIONS: [&str; 4] = [
+        "PD_count_24h_ic0.app_https://example.com",
+        "PD_sess_sec_24h_ic0.app_https://example.com",
+        "PD_count_30d_ic0.app_https://example.com",
+        "PD_sess_sec_24h_ic0.app_https://example.com",
+    ];
+    for key in EXPECTED_AGGREGATIONS.iter() {
+        assert!(storage.event_aggregations.contains_key(&key.to_string()));
+    }
+
+    assert_eq!(storage.event_data.len(), 1);
+    assert_eq!(storage.event_data.get(&TIMESTAMP).unwrap(), event);
+}
+
+#[test]
+fn should_track_ii_domains() {
+    let mut storage = test_storage();
+    let event1 = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0AppDomain),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(900).as_nanos() as u64,
+        }),
+    };
+    let event2 = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::InternetComputerOrgDomain),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(900).as_nanos() as u64,
+        }),
+    };
+    let event3 = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: None,
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(900).as_nanos() as u64,
+        }),
+    };
+
+    update_events_internal(event1, TIMESTAMP, &mut storage);
+    update_events_internal(event2, TIMESTAMP + 1, &mut storage);
+    update_events_internal(event3, TIMESTAMP + 2, &mut storage);
+
+    assert_eq!(storage.event_aggregations.len(), 12); // 4 per domain
+    const EXPECTED_AGGREGATIONS: [&str; 3] = [
+        "PD_count_24h_ic0.app_https://example.com",
+        "PD_count_24h_internetcomputer.org_https://example.com",
+        "PD_count_24h_other_https://example.com",
+    ];
+    for key in EXPECTED_AGGREGATIONS.iter() {
+        assert!(storage.event_aggregations.contains_key(&key.to_string()));
+    }
+}
+
+#[test]
+fn should_track_multiple_frontends() {
+    let mut storage = test_storage();
+    let event1 = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0AppDomain),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(900).as_nanos() as u64,
+        }),
+    };
+    let event2 = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0AppDomain),
+            frontend: EXAMPLE_URL_2.to_string(),
+            session_duration_ns: Duration::from_secs(900).as_nanos() as u64,
+        }),
+    };
+
+    update_events_internal(event1, TIMESTAMP, &mut storage);
+    update_events_internal(event2, TIMESTAMP + 1, &mut storage);
+
+    assert_eq!(storage.event_aggregations.len(), 8); // 4 per domain
+    const EXPECTED_AGGREGATIONS: [&str; 2] = [
+        "PD_count_24h_ic0.app_https://example.com",
+        "PD_count_24h_ic0.app_https://other-example.com",
+    ];
+    for key in EXPECTED_AGGREGATIONS.iter() {
+        assert!(storage.event_aggregations.contains_key(&key.to_string()));
+    }
+}
+
+#[test]
+fn should_store_multiple_events_and_aggregate_expected_weight_count() {
+    let mut storage = test_storage();
+    let sess_duration_secs = 900;
+    let event = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0AppDomain),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(sess_duration_secs).as_nanos() as u64,
+        }),
+    };
+
+    update_events_internal(event.clone(), TIMESTAMP, &mut storage);
+    update_events_internal(event.clone(), TIMESTAMP + 1, &mut storage);
+
+    assert_eq!(storage.event_data.len(), 2);
+    assert_eq!(storage.event_aggregations.len(), 4);
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_count_24h_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        sess_duration_secs * 2
+    );
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_count_30d_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_sess_sec_30d_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        sess_duration_secs * 2
+    );
+}
+
+#[test]
+fn should_store_prune_daily_events_after_24h() {
+    let mut storage = test_storage();
+    let sess_duration_secs = 900;
+    let event = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0AppDomain),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(sess_duration_secs).as_nanos() as u64,
+        }),
+    };
+
+    update_events_internal(event.clone(), TIMESTAMP, &mut storage);
+    update_events_internal(event.clone(), TIMESTAMP + DAY_NS, &mut storage);
+
+    assert_eq!(storage.event_data.len(), 2);
+    assert_eq!(storage.event_aggregations.len(), 4);
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_count_24h_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        sess_duration_secs
+    );
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_count_30d_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_sess_sec_30d_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        sess_duration_secs * 2
+    );
+}
+
+#[test]
+fn should_store_prune_monthly_events_after_30d() {
+    let mut storage = test_storage();
+    let sess_duration_secs = 900;
+    let event = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0AppDomain),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(sess_duration_secs).as_nanos() as u64,
+        }),
+    };
+
+    update_events_internal(event.clone(), TIMESTAMP, &mut storage);
+    update_events_internal(event.clone(), TIMESTAMP + DAY_NS * 30, &mut storage);
+
+    assert_eq!(storage.event_data.len(), 1);
+    assert_eq!(storage.event_aggregations.len(), 4);
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_count_24h_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        sess_duration_secs
+    );
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_count_30d_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_sess_sec_30d_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        sess_duration_secs
+    );
+}
+
+#[test]
+fn should_account_for_dapps_changing_session_lifetime() {
+    let mut storage = test_storage();
+    let event1 = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0AppDomain),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(1800).as_nanos() as u64,
+        }),
+    };
+    update_events_internal(event1, TIMESTAMP, &mut storage);
+
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        1800
+    );
+
+    let event2 = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0AppDomain),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(900).as_nanos() as u64,
+        }),
+    };
+    update_events_internal(event2, TIMESTAMP + 1, &mut storage);
+
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        2700
+    );
+
+    let event3 = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0AppDomain),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(1).as_nanos() as u64,
+        }),
+    };
+    update_events_internal(event3, TIMESTAMP + 1 + DAY_NS, &mut storage);
+
+    assert_eq!(
+        storage
+            .event_aggregations
+            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .unwrap(),
+        1
+    );
+}
+
+fn test_storage() -> Storage<Rc<RefCell<Vec<u8>>>> {
+    const DEFAULT_ID_RANGE: (u64, u64) = (1, 100);
+    let memory = VectorMemory::default();
+    Storage::new(DEFAULT_ID_RANGE, memory.clone())
+}

--- a/src/internet_identity/src/activity_stats/event_stats/tests.rs
+++ b/src/internet_identity/src/activity_stats/event_stats/tests.rs
@@ -309,7 +309,7 @@ fn should_account_for_dapps_changing_session_lifetime() {
 }
 
 #[test]
-fn should_remove_zero_weighted_aggregations() {
+fn should_remove_aggregations_without_events_when_pruning() {
     let mut storage = test_storage();
     let event = EventData {
         event: Event::PrepareDelegation(PrepareDelegationEvent {
@@ -341,6 +341,7 @@ fn should_remove_zero_weighted_aggregations() {
     };
 
     // after this update, the previous aggregations should be removed as their weight is 0
+    // (this means that there is no event being counted for them)
     update_events_internal(event2, TIMESTAMP + 30 * DAY_NS, &mut storage);
 
     const EXPECTED_AGGREGATIONS_2: [&str; 4] = [

--- a/src/internet_identity/src/activity_stats/event_stats/tests.rs
+++ b/src/internet_identity/src/activity_stats/event_stats/tests.rs
@@ -28,10 +28,10 @@ fn should_store_event_and_add_to_aggregations() {
 
     assert_eq!(storage.event_aggregations.len(), 4);
     const EXPECTED_AGGREGATIONS: [&str; 4] = [
-        "PD_count_24h_ic0.app_https://example.com",
-        "PD_sess_sec_24h_ic0.app_https://example.com",
-        "PD_count_30d_ic0.app_https://example.com",
-        "PD_sess_sec_24h_ic0.app_https://example.com",
+        "PD_count>24h>ic0.app>https://example.com",
+        "PD_sess_sec>24h>ic0.app>https://example.com",
+        "PD_count>30d>ic0.app>https://example.com",
+        "PD_sess_sec>30d>ic0.app>https://example.com",
     ];
     for key in EXPECTED_AGGREGATIONS.iter() {
         assert!(storage.event_aggregations.contains_key(&key.to_string()));
@@ -72,9 +72,9 @@ fn should_track_ii_domains() {
 
     assert_eq!(storage.event_aggregations.len(), 12); // 4 per domain
     const EXPECTED_AGGREGATIONS: [&str; 3] = [
-        "PD_count_24h_ic0.app_https://example.com",
-        "PD_count_24h_internetcomputer.org_https://example.com",
-        "PD_count_24h_other_https://example.com",
+        "PD_count>24h>ic0.app>https://example.com",
+        "PD_count>24h>internetcomputer.org>https://example.com",
+        "PD_count>24h>other>https://example.com",
     ];
     for key in EXPECTED_AGGREGATIONS.iter() {
         assert!(storage.event_aggregations.contains_key(&key.to_string()));
@@ -104,8 +104,8 @@ fn should_track_multiple_frontends() {
 
     assert_eq!(storage.event_aggregations.len(), 8); // 4 per domain
     const EXPECTED_AGGREGATIONS: [&str; 2] = [
-        "PD_count_24h_ic0.app_https://example.com",
-        "PD_count_24h_ic0.app_https://other-example.com",
+        "PD_count>24h>ic0.app>https://example.com",
+        "PD_count>24h>ic0.app>https://other-example.com",
     ];
     for key in EXPECTED_AGGREGATIONS.iter() {
         assert!(storage.event_aggregations.contains_key(&key.to_string()));
@@ -132,28 +132,28 @@ fn should_store_multiple_events_and_aggregate_expected_weight_count() {
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_count_24h_ic0.app_https://example.com".to_string())
+            .get(&"PD_count>24h>ic0.app>https://example.com".to_string())
             .unwrap(),
         2
     );
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .get(&"PD_sess_sec>24h>ic0.app>https://example.com".to_string())
             .unwrap(),
         sess_duration_secs * 2
     );
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_count_30d_ic0.app_https://example.com".to_string())
+            .get(&"PD_count>30d>ic0.app>https://example.com".to_string())
             .unwrap(),
         2
     );
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_sess_sec_30d_ic0.app_https://example.com".to_string())
+            .get(&"PD_sess_sec>30d>ic0.app>https://example.com".to_string())
             .unwrap(),
         sess_duration_secs * 2
     );
@@ -179,28 +179,28 @@ fn should_store_prune_daily_events_after_24h() {
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_count_24h_ic0.app_https://example.com".to_string())
+            .get(&"PD_count>24h>ic0.app>https://example.com".to_string())
             .unwrap(),
         1
     );
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .get(&"PD_sess_sec>24h>ic0.app>https://example.com".to_string())
             .unwrap(),
         sess_duration_secs
     );
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_count_30d_ic0.app_https://example.com".to_string())
+            .get(&"PD_count>30d>ic0.app>https://example.com".to_string())
             .unwrap(),
         2
     );
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_sess_sec_30d_ic0.app_https://example.com".to_string())
+            .get(&"PD_sess_sec>30d>ic0.app>https://example.com".to_string())
             .unwrap(),
         sess_duration_secs * 2
     );
@@ -226,28 +226,28 @@ fn should_store_prune_monthly_events_after_30d() {
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_count_24h_ic0.app_https://example.com".to_string())
+            .get(&"PD_count>24h>ic0.app>https://example.com".to_string())
             .unwrap(),
         1
     );
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .get(&"PD_sess_sec>24h>ic0.app>https://example.com".to_string())
             .unwrap(),
         sess_duration_secs
     );
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_count_30d_ic0.app_https://example.com".to_string())
+            .get(&"PD_count>30d>ic0.app>https://example.com".to_string())
             .unwrap(),
         1
     );
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_sess_sec_30d_ic0.app_https://example.com".to_string())
+            .get(&"PD_sess_sec>30d>ic0.app>https://example.com".to_string())
             .unwrap(),
         sess_duration_secs
     );
@@ -268,7 +268,7 @@ fn should_account_for_dapps_changing_session_lifetime() {
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .get(&"PD_sess_sec>24h>ic0.app>https://example.com".to_string())
             .unwrap(),
         1800
     );
@@ -285,7 +285,7 @@ fn should_account_for_dapps_changing_session_lifetime() {
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .get(&"PD_sess_sec>24h>ic0.app>https://example.com".to_string())
             .unwrap(),
         2700
     );
@@ -302,7 +302,7 @@ fn should_account_for_dapps_changing_session_lifetime() {
     assert_eq!(
         storage
             .event_aggregations
-            .get(&"PD_sess_sec_24h_ic0.app_https://example.com".to_string())
+            .get(&"PD_sess_sec>24h>ic0.app>https://example.com".to_string())
             .unwrap(),
         1
     );
@@ -323,10 +323,10 @@ fn should_remove_aggregations_without_events_when_pruning() {
 
     assert_eq!(storage.event_aggregations.len(), 4);
     const EXPECTED_AGGREGATIONS: [&str; 4] = [
-        "PD_count_24h_ic0.app_https://example.com",
-        "PD_sess_sec_24h_ic0.app_https://example.com",
-        "PD_count_30d_ic0.app_https://example.com",
-        "PD_sess_sec_24h_ic0.app_https://example.com",
+        "PD_count>24h>ic0.app>https://example.com",
+        "PD_sess_sec>24h>ic0.app>https://example.com",
+        "PD_count>30d>ic0.app>https://example.com",
+        "PD_sess_sec>24h>ic0.app>https://example.com",
     ];
     for key in EXPECTED_AGGREGATIONS.iter() {
         assert!(storage.event_aggregations.contains_key(&key.to_string()));
@@ -345,10 +345,10 @@ fn should_remove_aggregations_without_events_when_pruning() {
     update_events_internal(event2, TIMESTAMP + 30 * DAY_NS, &mut storage);
 
     const EXPECTED_AGGREGATIONS_2: [&str; 4] = [
-        "PD_count_24h_ic0.app_https://other-example.com",
-        "PD_sess_sec_24h_ic0.app_https://other-example.com",
-        "PD_count_30d_ic0.app_https://other-example.com",
-        "PD_sess_sec_24h_ic0.app_https://other-example.com",
+        "PD_count>24h>ic0.app>https://other-example.com",
+        "PD_sess_sec>24h>ic0.app>https://other-example.com",
+        "PD_count>30d>ic0.app>https://other-example.com",
+        "PD_sess_sec>24h>ic0.app>https://other-example.com",
     ];
     assert_eq!(storage.event_aggregations.len(), 4);
     for key in EXPECTED_AGGREGATIONS_2.iter() {

--- a/src/internet_identity/src/activity_stats/event_stats/tests.rs
+++ b/src/internet_identity/src/activity_stats/event_stats/tests.rs
@@ -61,7 +61,7 @@ fn should_store_event_and_add_to_aggregations() {
         ),
     ];
     for key in expected_aggregations.iter() {
-        assert!(storage.event_aggregations.contains_key(&key));
+        assert!(storage.event_aggregations.contains_key(key));
     }
 
     assert_eq!(storage.event_data.len(), 1);
@@ -141,7 +141,7 @@ fn should_track_ii_domains() {
         AggregationKey::new(PrepareDelegationCount, Day, None, EXAMPLE_URL.to_string()),
     ];
     for key in expected_aggregations.iter() {
-        assert!(storage.event_aggregations.contains_key(&key));
+        assert!(storage.event_aggregations.contains_key(key));
     }
 }
 
@@ -182,7 +182,7 @@ fn should_track_multiple_frontends() {
         ),
     ];
     for key in expected_aggregations.iter() {
-        assert!(storage.event_aggregations.contains_key(&key));
+        assert!(storage.event_aggregations.contains_key(key));
     }
 }
 
@@ -498,7 +498,7 @@ fn should_remove_aggregations_without_events_when_pruning() {
         ),
     ];
     for key in expected_aggregations.iter() {
-        assert!(storage.event_aggregations.contains_key(&key));
+        assert!(storage.event_aggregations.contains_key(key));
     }
 
     let event2 = EventData {
@@ -541,7 +541,7 @@ fn should_remove_aggregations_without_events_when_pruning() {
     ];
     assert_eq!(storage.event_aggregations.len(), 4);
     for key in expected_aggregations_2.iter() {
-        assert!(storage.event_aggregations.contains_key(&key));
+        assert!(storage.event_aggregations.contains_key(key));
     }
 
     assert_eq!(storage.event_data.len(), 1);

--- a/src/internet_identity/src/ii_domain.rs
+++ b/src/internet_identity/src/ii_domain.rs
@@ -1,7 +1,7 @@
 use crate::storage::anchor::DomainActivity;
 use crate::{IC0_APP_ORIGIN, INTERNETCOMPUTER_ORG_ORIGIN};
 use serde::{Deserialize, Serialize};
-#[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Debug)]
+#[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Debug, Ord, PartialOrd, Hash)]
 pub enum IIDomain {
     Ic0AppDomain,
     InternetComputerOrgDomain,

--- a/src/internet_identity/src/ii_domain.rs
+++ b/src/internet_identity/src/ii_domain.rs
@@ -1,6 +1,7 @@
 use crate::storage::anchor::DomainActivity;
 use crate::{IC0_APP_ORIGIN, INTERNETCOMPUTER_ORG_ORIGIN};
-#[derive(Eq, PartialEq)]
+use serde::{Deserialize, Serialize};
+#[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Debug)]
 pub enum IIDomain {
     Ic0AppDomain,
     InternetComputerOrgDomain,

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -95,6 +95,7 @@ use ic_stable_structures::writer::Writer;
 use ic_stable_structures::{Memory, RestrictedMemory, StableBTreeMap, StableCell, Storable};
 use internet_identity_interface::archive::types::BufferedEntry;
 
+use crate::activity_stats::event_stats::event_aggregations::AggregationKey;
 use crate::activity_stats::event_stats::{EventData, EventKey};
 use internet_identity_interface::internet_identity::types::*;
 
@@ -184,7 +185,7 @@ pub struct Storage<M: Memory> {
     pub event_data: StableBTreeMap<EventKey, EventData, VirtualMemory<RestrictedMemory<M>>>,
     /// Memory wrapper used to report the size of the stats aggregation memory.
     event_aggregations_memory_wrapper: MemoryWrapper<VirtualMemory<RestrictedMemory<M>>>,
-    pub event_aggregations: StableBTreeMap<String, u64, VirtualMemory<RestrictedMemory<M>>>,
+    pub event_aggregations: StableBTreeMap<AggregationKey, u64, VirtualMemory<RestrictedMemory<M>>>,
 }
 
 #[repr(packed)]

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -95,7 +95,7 @@ use ic_stable_structures::writer::Writer;
 use ic_stable_structures::{Memory, RestrictedMemory, StableBTreeMap, StableCell, Storable};
 use internet_identity_interface::archive::types::BufferedEntry;
 
-use crate::activity_stats::event_stats::EventData;
+use crate::activity_stats::event_stats::{EventData, EventKey};
 use internet_identity_interface::internet_identity::types::*;
 
 use crate::state::PersistentState;
@@ -181,7 +181,7 @@ pub struct Storage<M: Memory> {
     persistent_state: StableCell<StorablePersistentState, VirtualMemory<RestrictedMemory<M>>>,
     /// Memory wrapper used to report the size of the event data memory.
     event_data_memory_wrapper: MemoryWrapper<VirtualMemory<RestrictedMemory<M>>>,
-    pub event_data: StableBTreeMap<Timestamp, EventData, VirtualMemory<RestrictedMemory<M>>>,
+    pub event_data: StableBTreeMap<EventKey, EventData, VirtualMemory<RestrictedMemory<M>>>,
     /// Memory wrapper used to report the size of the stats aggregation memory.
     event_aggregations_memory_wrapper: MemoryWrapper<VirtualMemory<RestrictedMemory<M>>>,
     pub event_aggregations: StableBTreeMap<String, u64, VirtualMemory<RestrictedMemory<M>>>,


### PR DESCRIPTION
This PR adds storage to stable memory to keep anonymous(!) events about `prepare_delegation` calls. This will allow II to create the following stats:
* number of sign-ins per dapp per ii domain for the last
  * 24h
  * 30d
* cumulative seconds of session time per dapp per ii domain for the last
  * 24h
  * 30d

The latter is necessary to have some comparability between dapps that use a different session timeout.

The stats are not yet exposed by II. In subsequent PRs:
1. the old collection of observed front-end origins will be removed
2. the new data will be exposed
3. integration tests will be added
4. additional performance metrics will be collected in order to better judge the impact it has on the `prepare_delegation` call.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->










<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/862e79122/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->









