### PR TITLE
Refactor IIDomain enum for conciseness

### DIFF
--- a/src/internet_identity/src/activity_stats/activity_counter/domain_active_anchor_counter.rs
+++ b/src/internet_identity/src/activity_stats/activity_counter/domain_active_anchor_counter.rs
@@ -20,15 +20,15 @@ pub struct DomainActivityContext<'a> {
 impl DomainActiveAnchorCounter {
     fn increment_counter_for_domain(&mut self, domain: &IIDomain) {
         match domain {
-            IIDomain::Ic0AppDomain => self.ic0_app_counter += 1,
-            IIDomain::InternetComputerOrgDomain => self.internetcomputer_org_counter += 1,
+            IIDomain::Ic0App => self.ic0_app_counter += 1,
+            IIDomain::InternetComputerOrg => self.internetcomputer_org_counter += 1,
         }
     }
 
     fn decrement_counter_for_domain(&mut self, domain: &IIDomain) {
         match domain {
-            IIDomain::Ic0AppDomain => self.ic0_app_counter -= 1,
-            IIDomain::InternetComputerOrgDomain => self.internetcomputer_org_counter -= 1,
+            IIDomain::Ic0App => self.ic0_app_counter -= 1,
+            IIDomain::InternetComputerOrg => self.internetcomputer_org_counter -= 1,
         }
     }
 }

--- a/src/internet_identity/src/ii_domain.rs
+++ b/src/internet_identity/src/ii_domain.rs
@@ -2,15 +2,15 @@ use crate::storage::anchor::DomainActivity;
 use crate::{IC0_APP_ORIGIN, INTERNETCOMPUTER_ORG_ORIGIN};
 #[derive(Eq, PartialEq)]
 pub enum IIDomain {
-    Ic0AppDomain,
-    InternetComputerOrgDomain,
+    Ic0App,
+    InternetComputerOrg,
 }
 
 impl IIDomain {
     pub fn is_same_domain(&self, activity: &DomainActivity) -> bool {
         match self {
-            IIDomain::Ic0AppDomain => matches!(activity, DomainActivity::Ic0App),
-            IIDomain::InternetComputerOrgDomain => {
+            IIDomain::Ic0App => matches!(activity, DomainActivity::Ic0App),
+            IIDomain::InternetComputerOrg => {
                 matches!(activity, DomainActivity::InternetComputerOrg)
             }
         }
@@ -18,8 +18,8 @@ impl IIDomain {
 
     pub fn other_ii_domain(&self) -> IIDomain {
         match self {
-            IIDomain::Ic0AppDomain => IIDomain::InternetComputerOrgDomain,
-            IIDomain::InternetComputerOrgDomain => IIDomain::Ic0AppDomain,
+            IIDomain::Ic0App => IIDomain::InternetComputerOrg,
+            IIDomain::InternetComputerOrg => IIDomain::Ic0App,
         }
     }
 }
@@ -29,8 +29,8 @@ impl TryFrom<&str> for IIDomain {
 
     fn try_from(origin: &str) -> Result<Self, Self::Error> {
         match origin {
-            IC0_APP_ORIGIN => Ok(IIDomain::Ic0AppDomain),
-            INTERNETCOMPUTER_ORG_ORIGIN => Ok(IIDomain::InternetComputerOrgDomain),
+            IC0_APP_ORIGIN => Ok(IIDomain::Ic0App),
+            INTERNETCOMPUTER_ORG_ORIGIN => Ok(IIDomain::InternetComputerOrg),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
Refactors IIDomain to be more concise because the type will be used more often after #2449.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
