### PR TITLE
Expose top 10 dapps by session seconds on /metrics

### DIFF
--- a/src/internet_identity/src/activity_stats/event_stats/event_aggregations/tests.rs
+++ b/src/internet_identity/src/activity_stats/event_stats/event_aggregations/tests.rs
@@ -1,0 +1,195 @@
+use crate::activity_stats::event_stats::event_aggregations::AggregationWindow::{Day, Month};
+use crate::activity_stats::event_stats::event_aggregations::{
+    retrieve_aggregation_internal, PD_COUNT, PD_SESS_SEC,
+};
+use crate::activity_stats::event_stats::{
+    update_events_internal, Event, EventData, PrepareDelegationEvent,
+};
+use crate::ii_domain::IIDomain;
+use crate::storage::Storage;
+use crate::DAY_NS;
+use ic_stable_structures::VectorMemory;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+const TIMESTAMP: u64 = 1_714_387_451 * 10u64.pow(9);
+const EXAMPLE_URL: &str = "https://example.com";
+
+#[test]
+fn should_retrieve_aggregations() {
+    let mut storage = test_storage();
+    let event = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0App),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(900).as_nanos() as u64,
+        }),
+    };
+
+    update_events_internal(event.clone(), TIMESTAMP, &mut storage);
+
+    // expected existing
+    let results = retrieve_aggregation_internal(PD_COUNT, Day, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 1)]);
+
+    let results = retrieve_aggregation_internal(PD_SESS_SEC, Day, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 900)]);
+
+    let results = retrieve_aggregation_internal(PD_COUNT, Month, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 1)]);
+
+    let results =
+        retrieve_aggregation_internal(PD_SESS_SEC, Month, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 900)]);
+
+    // expected non-existing
+    let results = retrieve_aggregation_internal(
+        PD_SESS_SEC,
+        Day,
+        Some(IIDomain::InternetComputerOrg),
+        &storage,
+    );
+    assert_eq!(results, vec![]);
+
+    let results = retrieve_aggregation_internal(PD_SESS_SEC, Day, None, &storage);
+    assert_eq!(results, vec![]);
+
+    let results = retrieve_aggregation_internal(
+        PD_SESS_SEC,
+        Month,
+        Some(IIDomain::InternetComputerOrg),
+        &storage,
+    );
+    assert_eq!(results, vec![]);
+
+    let results = retrieve_aggregation_internal(PD_SESS_SEC, Month, None, &storage);
+    assert_eq!(results, vec![]);
+}
+
+#[test]
+fn should_retrieve_aggregations_for_multiple_frontend_origins_sorted() {
+    let mut storage = test_storage();
+    for i in 0..10 {
+        let event = EventData {
+            event: Event::PrepareDelegation(PrepareDelegationEvent {
+                ii_domain: Some(IIDomain::Ic0App),
+                frontend: format!("https://example{}.com", i),
+                session_duration_ns: Duration::from_secs(900 + i).as_nanos() as u64,
+            }),
+        };
+        update_events_internal(event.clone(), TIMESTAMP, &mut storage);
+    }
+
+    let per_origin_weight_one = (0..10)
+        .map(|i| (format!("https://example{}.com", i), 1))
+        .collect::<Vec<_>>();
+    let per_origin_sess_weight = (0..10)
+        .rev() // aggregations are sorted by weight descending
+        .map(|i| (format!("https://example{}.com", i), 900 + i))
+        .collect::<Vec<_>>();
+    let results = retrieve_aggregation_internal(PD_COUNT, Day, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, per_origin_weight_one);
+
+    let results = retrieve_aggregation_internal(PD_SESS_SEC, Day, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, per_origin_sess_weight);
+
+    let results = retrieve_aggregation_internal(PD_COUNT, Month, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, per_origin_weight_one);
+
+    let results =
+        retrieve_aggregation_internal(PD_SESS_SEC, Month, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, per_origin_sess_weight);
+}
+
+#[test]
+fn should_retrieve_aggregations_by_domain() {
+    let fe1 = "https://example1.com".to_string();
+    let fe2 = "https://example2.com".to_string();
+    let fe3 = "https://example3.com".to_string();
+    let mut storage = test_storage();
+
+    let event = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0App),
+            frontend: fe1.clone(),
+            session_duration_ns: Duration::from_secs(10).as_nanos() as u64,
+        }),
+    };
+    update_events_internal(event.clone(), TIMESTAMP, &mut storage);
+
+    let event = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::InternetComputerOrg),
+            frontend: fe2.clone(),
+            session_duration_ns: Duration::from_secs(20).as_nanos() as u64,
+        }),
+    };
+    update_events_internal(event.clone(), TIMESTAMP, &mut storage);
+
+    let event = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: None,
+            frontend: fe3.clone(),
+            session_duration_ns: Duration::from_secs(30).as_nanos() as u64,
+        }),
+    };
+    update_events_internal(event.clone(), TIMESTAMP, &mut storage);
+
+    let results = retrieve_aggregation_internal(PD_COUNT, Day, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, vec![(fe1.clone(), 1)]);
+
+    let results = retrieve_aggregation_internal(PD_SESS_SEC, Day, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, vec![(fe1.clone(), 10)]);
+
+    let results =
+        retrieve_aggregation_internal(PD_COUNT, Day, Some(IIDomain::InternetComputerOrg), &storage);
+    assert_eq!(results, vec![(fe2.clone(), 1)]);
+
+    let results = retrieve_aggregation_internal(
+        PD_SESS_SEC,
+        Day,
+        Some(IIDomain::InternetComputerOrg),
+        &storage,
+    );
+    assert_eq!(results, vec![(fe2.clone(), 20)]);
+
+    let results = retrieve_aggregation_internal(PD_COUNT, Month, None, &storage);
+    assert_eq!(results, vec![(fe3.clone(), 1)]);
+
+    let results = retrieve_aggregation_internal(PD_SESS_SEC, Month, None, &storage);
+    assert_eq!(results, vec![(fe3.clone(), 30)]);
+}
+
+#[test]
+fn should_retrieve_aggregation_by_time_window() {
+    let mut storage = test_storage();
+    let event = EventData {
+        event: Event::PrepareDelegation(PrepareDelegationEvent {
+            ii_domain: Some(IIDomain::Ic0App),
+            frontend: EXAMPLE_URL.to_string(),
+            session_duration_ns: Duration::from_secs(900).as_nanos() as u64,
+        }),
+    };
+
+    update_events_internal(event.clone(), TIMESTAMP, &mut storage);
+    update_events_internal(event.clone(), TIMESTAMP + DAY_NS, &mut storage);
+
+    let results = retrieve_aggregation_internal(PD_COUNT, Day, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 1)]);
+
+    let results = retrieve_aggregation_internal(PD_SESS_SEC, Day, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 900)]);
+
+    let results = retrieve_aggregation_internal(PD_COUNT, Month, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 2)]);
+
+    let results =
+        retrieve_aggregation_internal(PD_SESS_SEC, Month, Some(IIDomain::Ic0App), &storage);
+    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 1800)]);
+}
+
+fn test_storage() -> Storage<Rc<RefCell<Vec<u8>>>> {
+    let memory = VectorMemory::default();
+    Storage::new((1, 100), memory.clone())
+}

--- a/src/internet_identity/src/activity_stats/event_stats/event_aggregations/tests.rs
+++ b/src/internet_identity/src/activity_stats/event_stats/event_aggregations/tests.rs
@@ -36,14 +36,20 @@ fn should_retrieve_aggregations() {
     assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 1)]);
 
     let results = retrieve_aggregation_internal(PD_SESS_SEC, Day, Some(IIDomain::Ic0App), &storage);
-    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), DUMMY_SESSION_LENGTH_SEC)]);
+    assert_eq!(
+        results,
+        vec![(EXAMPLE_URL.to_string(), DUMMY_SESSION_LENGTH_SEC)]
+    );
 
     let results = retrieve_aggregation_internal(PD_COUNT, Month, Some(IIDomain::Ic0App), &storage);
     assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 1)]);
 
     let results =
         retrieve_aggregation_internal(PD_SESS_SEC, Month, Some(IIDomain::Ic0App), &storage);
-    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), DUMMY_SESSION_LENGTH_SEC)]);
+    assert_eq!(
+        results,
+        vec![(EXAMPLE_URL.to_string(), DUMMY_SESSION_LENGTH_SEC)]
+    );
 
     // expected non-existing
     let results = retrieve_aggregation_internal(
@@ -77,7 +83,8 @@ fn should_retrieve_aggregations_for_multiple_frontend_origins_sorted_by_weight()
             event: Event::PrepareDelegation(PrepareDelegationEvent {
                 ii_domain: Some(IIDomain::Ic0App),
                 frontend: format!("https://example{}.com", i),
-                session_duration_ns: Duration::from_secs(DUMMY_SESSION_LENGTH_SEC + i).as_nanos() as u64,
+                session_duration_ns: Duration::from_secs(DUMMY_SESSION_LENGTH_SEC + i).as_nanos()
+                    as u64,
             }),
         };
         update_events_internal(event.clone(), TIMESTAMP, &mut storage);
@@ -88,7 +95,12 @@ fn should_retrieve_aggregations_for_multiple_frontend_origins_sorted_by_weight()
         .collect::<Vec<_>>();
     let per_origin_sess_weight = (0..10)
         .rev() // aggregations are sorted by weight descending
-        .map(|i| (format!("https://example{}.com", i), DUMMY_SESSION_LENGTH_SEC + i))
+        .map(|i| {
+            (
+                format!("https://example{}.com", i),
+                DUMMY_SESSION_LENGTH_SEC + i,
+            )
+        })
         .collect::<Vec<_>>();
     let results = retrieve_aggregation_internal(PD_COUNT, Day, Some(IIDomain::Ic0App), &storage);
     assert_eq!(results, per_origin_weight_one);
@@ -184,7 +196,10 @@ fn should_retrieve_aggregation_by_time_window() {
     assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 1)]);
 
     let results = retrieve_aggregation_internal(PD_SESS_SEC, Day, Some(IIDomain::Ic0App), &storage);
-    assert_eq!(results, vec![(EXAMPLE_URL.to_string(), DUMMY_SESSION_LENGTH_SEC)]);
+    assert_eq!(
+        results,
+        vec![(EXAMPLE_URL.to_string(), DUMMY_SESSION_LENGTH_SEC)]
+    );
 
     let results = retrieve_aggregation_internal(PD_COUNT, Month, Some(IIDomain::Ic0App), &storage);
     assert_eq!(results, vec![(EXAMPLE_URL.to_string(), 2)]);

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -2,7 +2,8 @@
 //! Includes tests for the HTTP endpoint (including asset certification) and the metrics endpoint.
 
 use crate::v2_api::authn_method_test_helpers::{
-    create_identity_with_authn_method, test_authn_method,
+    create_identity_with_authn_method, create_identity_with_authn_methods,
+    sample_pubkey_authn_method, test_authn_method,
 };
 use canister_tests::api::{http_request, internet_identity as api};
 use canister_tests::flows;
@@ -12,8 +13,11 @@ use ic_response_verification::types::VerificationInfo;
 use ic_response_verification::verify_request_response_pair;
 use ic_test_state_machine_client::{CallError, StateMachine};
 use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
-use internet_identity_interface::internet_identity::types::ChallengeAttempt;
+use internet_identity_interface::internet_identity::types::{
+    AuthnMethodData, ChallengeAttempt, MetadataEntryV2,
+};
 use serde_bytes::ByteBuf;
+use std::collections::HashMap;
 use std::time::{Duration, UNIX_EPOCH};
 
 /// Verifies that some expected assets are delivered, certified and have security headers.
@@ -545,6 +549,152 @@ fn should_list_virtual_memory_metrics() -> Result<(), CallError> {
     // Or load a prepared state with a large number of entries.
     // This is not done here, as it would either require brittle setup or a long-running test.
 
+    Ok(())
+}
+
+#[test]
+fn should_list_aggregated_session_seconds() -> Result<(), CallError> {
+    let pub_session_key = ByteBuf::from("session public key");
+    let authn_method_ic0 = AuthnMethodData {
+        metadata: HashMap::from([(
+            "origin".to_string(),
+            MetadataEntryV2::String("https://identity.ic0.app".to_string()),
+        )]),
+        ..sample_pubkey_authn_method(1)
+    };
+    let authn_method_internetcomputer = AuthnMethodData {
+        metadata: HashMap::from([(
+            "origin".to_string(),
+            MetadataEntryV2::String("https://identity.internetcomputer.org".to_string()),
+        )]),
+        ..sample_pubkey_authn_method(2)
+    };
+
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let user_number_1 = create_identity_with_authn_methods(
+        &env,
+        canister_id,
+        &[
+            test_authn_method(),
+            authn_method_ic0.clone(),
+            authn_method_internetcomputer.clone(),
+        ],
+    );
+
+    let metrics = get_metrics(&env, canister_id);
+    // make sure empty data is not listed on the metrics endpoint
+    assert!(!metrics.contains("internet_identity_prepare_delegation_session_seconds{"));
+
+    api::prepare_delegation(
+        &env,
+        canister_id,
+        test_authn_method().principal(),
+        user_number_1,
+        "https://some-dapp-1.com",
+        &pub_session_key,
+        None,
+    )?;
+    api::prepare_delegation(
+        &env,
+        canister_id,
+        test_authn_method().principal(),
+        user_number_1,
+        "https://some-dapp-1.com",
+        &pub_session_key,
+        Some(Duration::from_secs(3600).as_nanos() as u64),
+    )?;
+    api::prepare_delegation(
+        &env,
+        canister_id,
+        authn_method_ic0.principal(),
+        user_number_1,
+        "https://some-dapp-2.com",
+        &pub_session_key,
+        None,
+    )?;
+    api::prepare_delegation(
+        &env,
+        canister_id,
+        authn_method_internetcomputer.principal(),
+        user_number_1,
+        "https://some-dapp-3.com",
+        &pub_session_key,
+        None,
+    )?;
+
+    let metrics = get_metrics(&env, canister_id);
+    assert_metric(
+        &metrics,
+        "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-1.com\",window=\"24h\",ii_origin=\"other\"}",
+        5400f64,
+    );
+    assert_metric(
+        &metrics,
+        "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-1.com\",window=\"30d\",ii_origin=\"other\"}",
+        5400f64,
+    );
+    assert_metric(
+        &metrics,
+        "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-2.com\",window=\"24h\",ii_origin=\"ic0.app\"}",
+        1800f64,
+    );
+    assert_metric(
+        &metrics,
+        "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-2.com\",window=\"30d\",ii_origin=\"ic0.app\"}",
+        1800f64,
+    );
+    assert_metric(
+        &metrics,
+        "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-3.com\",window=\"24h\",ii_origin=\"internetcomputer.org\"}",
+        1800f64,
+    );
+    assert_metric(
+        &metrics,
+        "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-3.com\",window=\"30d\",ii_origin=\"internetcomputer.org\"}",
+        1800f64,
+    );
+
+    env.advance_time(Duration::from_secs(60 * 60 * 24)); // advance time to see it reflected on the metrics endpoint
+                                                         // call prepare delegation again to trigger stats update
+    api::prepare_delegation(
+        &env,
+        canister_id,
+        authn_method_internetcomputer.principal(),
+        user_number_1,
+        "https://some-dapp-4.com",
+        &pub_session_key,
+        None,
+    )?;
+
+    let metrics = get_metrics(&env, canister_id);
+    // make sure aggregations that hav no data anymore get removed from stats endpoint
+    assert!(
+        !metrics.contains(
+        "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-1.com\",window=\"24h\""));
+    assert!(
+        !metrics.contains(
+            "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-2.com\",window=\"24h\""));
+    assert!(
+        !metrics.contains(
+            "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-3.com\",window=\"24h\""));
+
+    // The 30d metrics should still be there
+    assert_metric(
+        &metrics,
+        "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-1.com\",window=\"30d\",ii_origin=\"other\"}",
+        5400f64,
+    );
+    assert_metric(
+        &metrics,
+        "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-2.com\",window=\"30d\",ii_origin=\"ic0.app\"}",
+        1800f64,
+    );
+    assert_metric(
+        &metrics,
+        "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-3.com\",window=\"30d\",ii_origin=\"internetcomputer.org\"}",
+        1800f64,
+    );
     Ok(())
 }
 

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -668,7 +668,7 @@ fn should_list_aggregated_session_seconds() -> Result<(), CallError> {
     )?;
 
     let metrics = get_metrics(&env, canister_id);
-    // make sure aggregations that hav no data anymore get removed from stats endpoint
+    // make sure aggregations that have no data anymore get removed from stats endpoint
     assert!(
         !metrics.contains(
         "internet_identity_prepare_delegation_session_seconds{dapp=\"https://some-dapp-1.com\",window=\"24h\""));


### PR DESCRIPTION
This PR adds the `internet_identity_prepare_delegation_session_seconds` metric to the `/metrics` endpoint. It will expose the top ten dapps per
  * II origin (ic0.app, internetcomputer.org, other)
  * time window (24h and 30d)

At most, this will add 60 new stats to the endpoint.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f1b71c857/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

