### PR TITLE
Expose Aggregations on `stats` endpoint

### DIFF
--- a/allowed_breaking_change.patch
+++ b/allowed_breaking_change.patch
@@ -1,5 +1,5 @@
 diff --git a/src/internet_identity/internet_identity.did b/src/internet_identity/internet_identity.did
-index 55cd4667..dd464712 100644
+index a47af160..4d75a7fe 100644
 --- a/src/internet_identity/internet_identity.did
 +++ b/src/internet_identity/internet_identity.did
 @@ -171,6 +171,8 @@ type InternetIdentityStats = record {
@@ -7,7 +7,7 @@ index 55cd4667..dd464712 100644
      archive_info: ArchiveInfo;
      canister_creation_cycles_cost: nat64;
 +    max_num_latest_delegation_origins: nat64;
-+    latest_delegation_origins: vec FrontendHostname
- };
- 
- // Configuration parameters related to the archive.
++    latest_delegation_origins: vec FrontendHostname;
+     // Map from event aggregation to a sorted list of top 100 sub-keys to their weights.
+     // Example: {"prepare_delegation_count 24h ic0.app": [{"https://dapp.com", 100}, {"https://dapp2.com", 50}]}
+     event_aggregations: vec record {text; vec record {text; nat64}};

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -309,6 +309,9 @@ export const idlFactory = ({ IDL }) => {
     'assigned_user_number_range' : IDL.Tuple(IDL.Nat64, IDL.Nat64),
     'archive_info' : ArchiveInfo,
     'canister_creation_cycles_cost' : IDL.Nat64,
+    'event_aggregations' : IDL.Vec(
+      IDL.Tuple(IDL.Text, IDL.Vec(IDL.Tuple(IDL.Text, IDL.Nat64)))
+    ),
   });
   const VerifyTentativeDeviceResponse = IDL.Variant({
     'device_registration_mode_off' : IDL.Null,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -189,6 +189,7 @@ export interface InternetIdentityStats {
   'assigned_user_number_range' : [bigint, bigint],
   'archive_info' : ArchiveInfo,
   'canister_creation_cycles_cost' : bigint,
+  'event_aggregations' : Array<[string, Array<[string, bigint]>]>,
 }
 export type KeyType = { 'platform' : null } |
   { 'seed_phrase' : null } |

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -171,6 +171,9 @@ type InternetIdentityStats = record {
     };
     archive_info: ArchiveInfo;
     canister_creation_cycles_cost: nat64;
+    // Map from event aggregation to a sorted list of top 100 sub-keys to their weights.
+    // Example: {"prepare_delegation_count 24h ic0.app": [{"https://dapp.com", 100}, {"https://dapp2.com", 50}]}
+    event_aggregations: vec record {text; vec record {text; nat64}};
 };
 
 // Configuration parameters related to the archive.

--- a/src/internet_identity/src/ii_domain.rs
+++ b/src/internet_identity/src/ii_domain.rs
@@ -7,6 +7,14 @@ pub enum IIDomain {
     InternetComputerOrg,
 }
 
+pub fn maybe_domain_to_label(domain: &Option<IIDomain>) -> &'static str {
+    match domain {
+        Some(IIDomain::Ic0App) => "ic0.app",
+        Some(IIDomain::InternetComputerOrg) => "internetcomputer.org",
+        None => "other",
+    }
+}
+
 impl IIDomain {
     pub fn is_same_domain(&self, activity: &DomainActivity) -> bool {
         match self {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1,3 +1,4 @@
+use crate::activity_stats::event_stats::event_aggregations::all_aggregations_top_n;
 use crate::anchor_management::tentative_device_registration;
 use crate::anchor_management::tentative_device_registration::{
     TentativeDeviceRegistrationError, TentativeRegistrationInfo, VerifyTentativeDeviceError,
@@ -336,12 +337,15 @@ fn stats() -> InternetIdentityStats {
     let canister_creation_cycles_cost =
         state::persistent_state(|persistent_state| persistent_state.canister_creation_cycles_cost);
 
+    let event_aggregations = all_aggregations_top_n(100);
+
     state::storage_borrow(|storage| InternetIdentityStats {
         assigned_user_number_range: storage.assigned_anchor_number_range(),
         users_registered: storage.anchor_count() as u64,
         archive_info,
         canister_creation_cycles_cost,
         storage_layout_version: storage.version(),
+        event_aggregations,
     })
 }
 

--- a/src/internet_identity/tests/integration/aggregation_stats.rs
+++ b/src/internet_identity/tests/integration/aggregation_stats.rs
@@ -1,0 +1,171 @@
+use crate::v2_api::authn_method_test_helpers::{
+    create_identity_with_authn_method, test_authn_method,
+};
+use canister_tests::api::internet_identity as api;
+use canister_tests::framework::{env, install_ii_canister, II_WASM};
+use ic_cdk::api::management_canister::main::CanisterId;
+use ic_test_state_machine_client::{CallError, StateMachine};
+use internet_identity_interface::internet_identity::types::{
+    AuthnMethodData, IdentityNumber, MetadataEntryV2,
+};
+use serde_bytes::ByteBuf;
+use std::collections::HashMap;
+use std::time::Duration;
+
+const SESSION_LENGTH: u64 = 900; // 900 seconds
+const PD_COUNT: &str = "prepare_delegation_count";
+const PD_SESS_SEC: &str = "prepare_delegation_session_seconds";
+
+#[test]
+fn should_report_expected_aggregations() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    for ii_origin in ["internetcomputer.org", "ic0.app", "other"] {
+        let identity_nr = create_identity(&env, canister_id, ii_origin);
+
+        delegation_for_origin(&env, canister_id, identity_nr, "https://some-dapp.com")?;
+        delegation_for_origin(&env, canister_id, identity_nr, "https://some-dapp.com")?;
+
+        let aggregations = api::stats(&env, canister_id)?.event_aggregations;
+        assert_expected_aggregation(
+            &aggregations,
+            &aggregation_key(PD_COUNT, "24h", ii_origin),
+            vec![("https://some-dapp.com".to_string(), 2u64)],
+        );
+        assert_expected_aggregation(
+            &aggregations,
+            &aggregation_key(PD_COUNT, "30d", ii_origin),
+            vec![("https://some-dapp.com".to_string(), 2u64)],
+        );
+        assert_expected_aggregation(
+            &aggregations,
+            &aggregation_key(PD_SESS_SEC, "24h", ii_origin),
+            vec![("https://some-dapp.com".to_string(), 2 * SESSION_LENGTH)],
+        );
+        assert_expected_aggregation(
+            &aggregations,
+            &aggregation_key(PD_SESS_SEC, "30d", ii_origin),
+            vec![("https://some-dapp.com".to_string(), 2 * SESSION_LENGTH)],
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn should_not_report_empty_aggregations() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let ii_origin = "ic0.app";
+    let ii_origin2 = "internetcomputer.org";
+    let identity_nr = create_identity(&env, canister_id, ii_origin);
+
+    delegation_for_origin(&env, canister_id, identity_nr, "https://some-dapp.com")?;
+
+    let aggregations = api::stats(&env, canister_id)?.event_aggregations;
+    let mut expected_keys = vec![
+        aggregation_key(PD_COUNT, "24h", ii_origin),
+        aggregation_key(PD_COUNT, "30d", ii_origin),
+        aggregation_key(PD_SESS_SEC, "24h", ii_origin),
+        aggregation_key(PD_SESS_SEC, "30d", ii_origin),
+    ];
+    let mut keys = aggregations.into_keys().collect::<Vec<_>>();
+    // sort for stable comparison
+    expected_keys.sort();
+    keys.sort();
+    assert_eq!(keys, expected_keys);
+
+    env.advance_time(Duration::from_secs(60 * 60 * 24 * 30)); // 30 days
+
+    let identity_nr2 = create_identity(&env, canister_id, ii_origin2);
+    delegation_for_origin(&env, canister_id, identity_nr2, "https://some-dapp.com")?;
+
+    let aggregations = api::stats(&env, canister_id)?.event_aggregations;
+
+    // set of keys is now entirely different, because the other origin has been pruned after 30 days
+    let mut expected_keys = vec![
+        aggregation_key(PD_COUNT, "24h", ii_origin2),
+        aggregation_key(PD_COUNT, "30d", ii_origin2),
+        aggregation_key(PD_SESS_SEC, "24h", ii_origin2),
+        aggregation_key(PD_SESS_SEC, "30d", ii_origin2),
+    ];
+    let mut keys = aggregations.into_keys().collect::<Vec<_>>();
+    // sort for stable comparison
+    expected_keys.sort();
+    keys.sort();
+    assert_eq!(keys, expected_keys);
+
+    Ok(())
+}
+
+#[test]
+fn should_report_at_most_100_entries() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let ii_origin = "ic0.app";
+    let identity_nr = create_identity(&env, canister_id, ii_origin);
+
+    for i in 0..102 {
+        delegation_for_origin(
+            &env,
+            canister_id,
+            identity_nr,
+            &format!("https://some-dapp-{}", i),
+        )?;
+    }
+
+    let aggregations = api::stats(&env, canister_id)?.event_aggregations;
+    assert_eq!(
+        aggregations
+            .get(&aggregation_key(PD_COUNT, "24h", ii_origin))
+            .unwrap()
+            .len(),
+        100
+    );
+    Ok(())
+}
+
+fn assert_expected_aggregation(
+    aggregations: &HashMap<String, Vec<(String, u64)>>,
+    key: &str,
+    data: Vec<(String, u64)>,
+) {
+    assert_eq!(
+        aggregations.get(key).unwrap(),
+        &data,
+        "Aggregation key \"{}\" does not match",
+        key
+    );
+}
+
+fn create_identity(env: &StateMachine, canister_id: CanisterId, ii_origin: &str) -> IdentityNumber {
+    let authn_method = AuthnMethodData {
+        metadata: HashMap::from([(
+            "origin".to_string(),
+            MetadataEntryV2::String(format!("https://identity.{}", ii_origin)),
+        )]),
+        ..test_authn_method()
+    };
+    create_identity_with_authn_method(env, canister_id, &authn_method)
+}
+
+fn aggregation_key(aggregation: &str, window: &str, ii_domain: &str) -> String {
+    format!("{} {} {}", aggregation, window, ii_domain)
+}
+
+fn delegation_for_origin(
+    env: &StateMachine,
+    canister_id: CanisterId,
+    identity_nr: IdentityNumber,
+    frontend_hostname: &str,
+) -> Result<(), CallError> {
+    api::prepare_delegation(
+        env,
+        canister_id,
+        test_authn_method().principal(),
+        identity_nr,
+        frontend_hostname,
+        &ByteBuf::from("session public key"),
+        Some(SESSION_LENGTH * 10u64.pow(9)), // seconds to nanoseconds
+    )?;
+    Ok(())
+}

--- a/src/internet_identity/tests/integration/main.rs
+++ b/src/internet_identity/tests/integration/main.rs
@@ -5,6 +5,7 @@
 //! See https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html#Implications for more details.
 
 mod activity_stats;
+mod aggregation_stats;
 mod anchor_management;
 mod archive_integration;
 mod delegation;

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -206,6 +206,10 @@ pub struct InternetIdentityStats {
     pub archive_info: ArchiveInfo,
     pub canister_creation_cycles_cost: u64,
     pub storage_layout_version: u8,
+    /// Aggregations of events that have been processed by the II.
+    /// The map contains a key for each aggregation type, and the value is a list of tuples
+    /// from aggregated sub-key (i.e. for prepare_delegation it's the frontend origin) to weight.
+    pub event_aggregations: HashMap<String, Vec<(String, u64)>>,
 }
 
 /// Information about the archive.


### PR DESCRIPTION
This PR exposes the top 100 data points of every aggregation on the `stats` endpoint. For the current number of aggregations this works fine. In the future we might need to introduce an endpoint to query specific aggregations.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/589aff0c2/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
