### PR TITLE
Expose gauge for number of entries in event_data and event_aggregations

### DIFF
--- a/src/internet_identity/src/http/metrics.rs
+++ b/src/internet_identity/src/http/metrics.rs
@@ -204,6 +204,16 @@ fn persistent_state_metrics(
         Duration::from_nanos(register_rate_limit_config.time_per_token_ns).as_secs() as f64,
         "Min number of seconds between two register calls to not exceed the rate limit (sustained).",
     )?;
+    w.encode_gauge(
+        "internet_identity_event_data_count",
+        persistent_state.event_data_count as f64,
+        "Number of events stored in event_data map.",
+    )?;
+    w.encode_gauge(
+        "internet_identity_event_aggregations_count",
+        persistent_state.event_aggregations_count as f64,
+        "Number of entries in the event_aggregations map.",
+    )?;
 
     let stats = &persistent_state.active_anchor_stats;
     if let Some(ref daily_active_anchor_stats) = stats.completed.daily_events {

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -95,6 +95,14 @@ pub struct PersistentState {
     pub active_authn_method_stats: ActivityStats<AuthnMethodCounter>,
     // Maximum number of inflight captchas
     pub max_inflight_captchas: u64,
+    // Count of entries in the event_data BTreeMap
+    // event_data is expected to have a lot of entries, thus counting by iterating over it is not
+    // an option.
+    pub event_data_count: u64,
+    // Count of entries in the event_aggregations BTreeMap
+    // event_aggregations is expected to have a lot of entries, thus counting by iterating over it is not
+    // an option.
+    pub event_aggregations_count: u64,
 }
 
 impl Default for PersistentState {
@@ -108,6 +116,8 @@ impl Default for PersistentState {
             domain_active_anchor_stats: ActivityStats::new(time),
             active_authn_method_stats: ActivityStats::new(time),
             max_inflight_captchas: DEFAULT_MAX_INFLIGHT_CAPTCHAS,
+            event_data_count: 0,
+            event_aggregations_count: 0,
         }
     }
 }

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -26,6 +26,10 @@ pub struct StorablePersistentState {
     // unused, kept for stable memory compatibility
     max_num_latest_delegation_origins: u64,
     max_inflight_captchas: u64,
+    // opt of backwards compatibility
+    event_data_count: Option<u64>,
+    // opt of backwards compatibility
+    event_aggregations_count: Option<u64>,
 }
 
 impl Storable for StorablePersistentState {
@@ -60,6 +64,8 @@ impl From<PersistentState> for StorablePersistentState {
             // unused, kept for stable memory compatibility
             max_num_latest_delegation_origins: 0,
             max_inflight_captchas: s.max_inflight_captchas,
+            event_data_count: Some(s.event_data_count),
+            event_aggregations_count: Some(s.event_aggregations_count),
         }
     }
 }
@@ -74,6 +80,8 @@ impl From<StorablePersistentState> for PersistentState {
             domain_active_anchor_stats: s.domain_active_anchor_stats,
             active_authn_method_stats: s.active_authn_method_stats,
             max_inflight_captchas: s.max_inflight_captchas,
+            event_data_count: s.event_data_count.unwrap_or_default(),
+            event_aggregations_count: s.event_aggregations_count.unwrap_or_default(),
         }
     }
 }
@@ -110,6 +118,8 @@ mod tests {
             latest_delegation_origins: HashMap::new(),
             max_num_latest_delegation_origins: 0,
             max_inflight_captchas: DEFAULT_MAX_INFLIGHT_CAPTCHAS,
+            event_data_count: Some(0),
+            event_aggregations_count: Some(0),
         };
 
         assert_eq!(StorablePersistentState::default(), expected_defaults);
@@ -125,6 +135,8 @@ mod tests {
             domain_active_anchor_stats: ActivityStats::new(test_time),
             active_authn_method_stats: ActivityStats::new(test_time),
             max_inflight_captchas: DEFAULT_MAX_INFLIGHT_CAPTCHAS,
+            event_data_count: 0,
+            event_aggregations_count: 0,
         };
         assert_eq!(PersistentState::default(), expected_defaults);
     }


### PR DESCRIPTION
Add counters for the event_data and event_aggregations BTreeMaps because these data structures can only be counted by iterating over them, which is not efficient enough for our use-case.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cad2285a9/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cad2285a9/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
