### PR TITLE
Simplify II init

### DIFF
--- a/src/internet_identity/tests/integration/aggregation_stats.rs
+++ b/src/internet_identity/tests/integration/aggregation_stats.rs
@@ -122,19 +122,6 @@ fn should_report_at_most_100_entries() -> Result<(), CallError> {
     Ok(())
 }
 
-fn assert_expected_aggregation(
-    aggregations: &HashMap<String, Vec<(String, u64)>>,
-    key: &str,
-    data: Vec<(String, u64)>,
-) {
-    assert_eq!(
-        aggregations.get(key).unwrap(),
-        &data,
-        "Aggregation key \"{}\" does not match",
-        key
-    );
-}
-
 #[test]
 fn should_keep_aggregations_across_upgrades() -> Result<(), CallError> {
     const II_ORIGIN: &str = "ic0.app";
@@ -186,6 +173,48 @@ fn should_keep_aggregations_across_upgrades() -> Result<(), CallError> {
 
     assert_expected_state(&env, canister_id)?;
     Ok(())
+}
+
+#[test]
+fn should_prune_automatically_after_upgrade() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let identity_nr = create_identity(&env, canister_id, "ic0.app");
+
+    delegation_for_origin(&env, canister_id, identity_nr, "https://some-dapp.com")?;
+
+    // upgrade then advance time to trigger pruning
+    upgrade_ii_canister(&env, canister_id, II_WASM.clone());
+    env.advance_time(Duration::from_secs(60 * 60 * 24 * 30)); // 30 days
+    env.tick(); // execute timers
+
+    let aggregations = api::stats(&env, canister_id)?.event_aggregations;
+
+    // set of keys only reflects pruning now
+    let mut expected_keys = vec![
+        aggregation_key(PRUNE_EVENT_COUNT, "24h", "other"),
+        aggregation_key(PRUNE_EVENT_COUNT, "30d", "other"),
+    ];
+    let mut keys = aggregations.into_keys().collect::<Vec<_>>();
+    // sort for stable comparison
+    expected_keys.sort();
+    keys.sort();
+    assert_eq!(keys, expected_keys);
+
+    Ok(())
+}
+
+fn assert_expected_aggregation(
+    aggregations: &HashMap<String, Vec<(String, u64)>>,
+    key: &str,
+    data: Vec<(String, u64)>,
+) {
+    assert_eq!(
+        aggregations.get(key).unwrap(),
+        &data,
+        "Aggregation key \"{}\" does not match",
+        key
+    );
 }
 
 fn create_identity(env: &StateMachine, canister_id: CanisterId, ii_origin: &str) -> IdentityNumber {


### PR DESCRIPTION
A bug was introduced in #2460 that did not correctly restart timers after an upgrade.
This PR simplifies the initialization to share more code and adds a test to catch this bug in the future.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/63876d480/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/63876d480/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

