### PR TITLE
Report heap size on /metrics

### DIFF
--- a/src/internet_identity/src/http/metrics.rs
+++ b/src/internet_identity/src/http/metrics.rs
@@ -61,6 +61,12 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         stable64_size() as f64,
         "Number of stable memory pages used by this canister.",
     )?;
+    #[cfg(target_arch = "wasm32")]
+    w.encode_gauge(
+        "internet_identity_heap_pages",
+        core::arch::wasm32::memory_size::<0>() as f64,
+        "Number of heap memory pages used by this canister.",
+    )?;
     w.encode_gauge(
         "internet_identity_temp_keys_count",
         state::with_temp_keys(|temp_keys| temp_keys.num_temp_keys()) as f64,

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -145,6 +145,7 @@ fn ii_canister_serves_http_metrics() -> Result<(), CallError> {
         "internet_identity_max_user_number",
         "internet_identity_signature_count",
         "internet_identity_stable_memory_pages",
+        "internet_identity_heap_pages",
         "internet_identity_last_upgrade_timestamp",
         "internet_identity_inflight_challenges",
         "internet_identity_users_in_registration_mode",


### PR DESCRIPTION
Currently, there is no reporting of the heap size and that metric has to be obtained from the respective replica dashboard. This PR makes the heap size more easily accessible so that we can put it onto the Grafana dashboard too.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/98be6b33a/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
