### PR TITLE
Enable dev CSP by default when running dfx deploy

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -4,7 +4,7 @@
       "type": "custom",
       "candid": "src/internet_identity/internet_identity.did",
       "wasm": "internet_identity.wasm.gz",
-      "build": "bash -c 'II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=${II_DUMMY_CAPTCHA:-1} scripts/build'",
+      "build": "bash -c 'II_DEV_CSP=1 II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=${II_DUMMY_CAPTCHA:-1} scripts/build'",
       "shrink" : false
     },
     "test_app": {


### PR DESCRIPTION
The dev CSP feature flag makes it possible to connect to II using http (no upgrade to https) which is required when using safari.

In addition, II may connect to other services using http which is also useful for development purposes.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2109f1103/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
