### PR TITLE
Fix dapp logo showcase

### DIFF
--- a/src/frontend/src/flows/dappsExplorer/teaser.ts
+++ b/src/frontend/src/flows/dappsExplorer/teaser.ts
@@ -75,7 +75,9 @@ const marqueeList = (dapps: KnownDapp[]): TemplateResult => {
         // shows an empty space where the image suddenly pops seconds
         // later.
         ({ logoSrc, name }) => html`<div class="c-marquee__item">
-          <img src=${logoSrc} alt="${name}" class="c-marquee__image" />
+          <div class="c-marquee__image-container">
+            <img src=${logoSrc} alt="${name}" class="c-marquee__image" />
+          </div>
         </div>`
       );
 

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -3032,9 +3032,9 @@ input[type="checkbox"] {
 .c-marquee__image-container {
   position: absolute;
   top: 50%;
-  left: 20%;
-  transform: translate(-50%, -50%);
+  transform: translate(0, -50%);
   height: 65%;
+  aspect-ratio: 1;
 }
 
 .c-marquee__image {

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -3029,17 +3029,18 @@ input[type="checkbox"] {
   user-select: none;
 }
 
-.c-marquee__image {
+.c-marquee__image-container {
   position: absolute;
   top: 50%;
-  left: 50%;
+  left: 20%;
   transform: translate(-50%, -50%);
   height: 65%;
-  /*
-    remove the max-width set by the reset, so that the image can be as wide as
-    as required by the height
-  */
-  max-width: unset;
+}
+
+.c-marquee__image {
+  height: 100%;
+  width: 100%;
+  object-fit: contain;
 }
 
 @keyframes marquee {


### PR DESCRIPTION
There was an issue in the home page's showcase of logos when a logo was not square and was instead a rectangle.

In this PR, I add a container to make sure the images have a square ration and the logo is contained within it.
