### PR TITLE
Replace assert with warning

### DIFF
--- a/src/internet_identity/src/stats/event_stats.rs
+++ b/src/internet_identity/src/stats/event_stats.rs
@@ -269,11 +269,9 @@ pub fn inject_prune_event(timestamp: Timestamp) {
 fn update_events_internal<M: Memory>(event: EventData, now: Timestamp, s: &mut Storage<M>) {
     let current_key = EventKey::new(now);
     let option = s.event_data.insert(current_key.clone(), event.clone());
-    assert!(
-        option.is_none(),
-        "event already exists for key {:?}",
-        current_key
-    );
+    if option.is_some() {
+        ic_cdk::println!("WARN: Event already exists for key {:?}", current_key);
+    }
     state::persistent_state_mut(|s| {
         s.event_data_count += 1;
     });


### PR DESCRIPTION
This replaces another consistency check with a warning, such that II would continues to operate if there are duplicate keys for some reason.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
