### PR TITLE
Add explicit bound to amortized clean-up

### DIFF
--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -4,6 +4,7 @@ use crate::stats::activity_stats::activity_counter::active_anchor_counter::Activ
 use crate::stats::activity_stats::activity_counter::authn_method_counter::AuthnMethodCounter;
 use crate::stats::activity_stats::activity_counter::domain_active_anchor_counter::DomainActiveAnchorCounter;
 use crate::stats::activity_stats::ActivityStats;
+use crate::stats::event_stats::EventKey;
 use crate::storage::anchor::Anchor;
 use crate::storage::MAX_ENTRIES;
 use crate::{random_salt, Storage};
@@ -103,6 +104,11 @@ pub struct PersistentState {
     // event_aggregations is expected to have a lot of entries, thus counting by iterating over it is not
     // an option.
     pub event_aggregations_count: u64,
+    // Key into the event_data BTreeMap where the 24h tracking window starts.
+    // This key is used to prune old entries from the 24h event aggregations.
+    // If it is `none`, then the 24h pruning window starts from the newest entry in the event_data
+    // BTreeMap minus 24h.
+    pub event_stats_24h_pruning_start: Option<EventKey>,
 }
 
 impl Default for PersistentState {
@@ -118,6 +124,7 @@ impl Default for PersistentState {
             max_inflight_captchas: DEFAULT_MAX_INFLIGHT_CAPTCHAS,
             event_data_count: 0,
             event_aggregations_count: 0,
+            event_stats_24h_pruning_start: None,
         }
     }
 }

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -105,10 +105,10 @@ pub struct PersistentState {
     // an option.
     pub event_aggregations_count: u64,
     // Key into the event_data BTreeMap where the 24h tracking window starts.
-    // This key is used to prune old entries from the 24h event aggregations.
-    // If it is `none`, then the 24h pruning window starts from the newest entry in the event_data
+    // This key is used to remove old entries from the 24h event aggregations.
+    // If it is `none`, then the 24h window starts from the newest entry in the event_data
     // BTreeMap minus 24h.
-    pub event_stats_24h_pruning_start: Option<EventKey>,
+    pub event_stats_24h_start: Option<EventKey>,
 }
 
 impl Default for PersistentState {
@@ -124,7 +124,7 @@ impl Default for PersistentState {
             max_inflight_captchas: DEFAULT_MAX_INFLIGHT_CAPTCHAS,
             event_data_count: 0,
             event_aggregations_count: 0,
-            event_stats_24h_pruning_start: None,
+            event_stats_24h_start: None,
         }
     }
 }

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -4,6 +4,7 @@ use crate::stats::activity_stats::activity_counter::active_anchor_counter::Activ
 use crate::stats::activity_stats::activity_counter::authn_method_counter::AuthnMethodCounter;
 use crate::stats::activity_stats::activity_counter::domain_active_anchor_counter::DomainActiveAnchorCounter;
 use crate::stats::activity_stats::ActivityStats;
+use crate::stats::event_stats::EventKey;
 use candid::{CandidType, Deserialize};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
@@ -30,6 +31,7 @@ pub struct StorablePersistentState {
     event_data_count: Option<u64>,
     // opt of backwards compatibility
     event_aggregations_count: Option<u64>,
+    event_stats_24h_pruning_start: Option<EventKey>,
 }
 
 impl Storable for StorablePersistentState {
@@ -66,6 +68,7 @@ impl From<PersistentState> for StorablePersistentState {
             max_inflight_captchas: s.max_inflight_captchas,
             event_data_count: Some(s.event_data_count),
             event_aggregations_count: Some(s.event_aggregations_count),
+            event_stats_24h_pruning_start: s.event_stats_24h_pruning_start,
         }
     }
 }
@@ -82,6 +85,7 @@ impl From<StorablePersistentState> for PersistentState {
             max_inflight_captchas: s.max_inflight_captchas,
             event_data_count: s.event_data_count.unwrap_or_default(),
             event_aggregations_count: s.event_aggregations_count.unwrap_or_default(),
+            event_stats_24h_pruning_start: s.event_stats_24h_pruning_start,
         }
     }
 }
@@ -120,6 +124,7 @@ mod tests {
             max_inflight_captchas: DEFAULT_MAX_INFLIGHT_CAPTCHAS,
             event_data_count: Some(0),
             event_aggregations_count: Some(0),
+            event_stats_24h_pruning_start: None,
         };
 
         assert_eq!(StorablePersistentState::default(), expected_defaults);
@@ -137,6 +142,7 @@ mod tests {
             max_inflight_captchas: DEFAULT_MAX_INFLIGHT_CAPTCHAS,
             event_data_count: 0,
             event_aggregations_count: 0,
+            event_stats_24h_pruning_start: None,
         };
         assert_eq!(PersistentState::default(), expected_defaults);
     }

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -31,7 +31,7 @@ pub struct StorablePersistentState {
     event_data_count: Option<u64>,
     // opt of backwards compatibility
     event_aggregations_count: Option<u64>,
-    event_stats_24h_pruning_start: Option<EventKey>,
+    event_stats_24h_start: Option<EventKey>,
 }
 
 impl Storable for StorablePersistentState {
@@ -68,7 +68,7 @@ impl From<PersistentState> for StorablePersistentState {
             max_inflight_captchas: s.max_inflight_captchas,
             event_data_count: Some(s.event_data_count),
             event_aggregations_count: Some(s.event_aggregations_count),
-            event_stats_24h_pruning_start: s.event_stats_24h_pruning_start,
+            event_stats_24h_start: s.event_stats_24h_start,
         }
     }
 }
@@ -85,7 +85,7 @@ impl From<StorablePersistentState> for PersistentState {
             max_inflight_captchas: s.max_inflight_captchas,
             event_data_count: s.event_data_count.unwrap_or_default(),
             event_aggregations_count: s.event_aggregations_count.unwrap_or_default(),
-            event_stats_24h_pruning_start: s.event_stats_24h_pruning_start,
+            event_stats_24h_start: s.event_stats_24h_start,
         }
     }
 }
@@ -124,7 +124,7 @@ mod tests {
             max_inflight_captchas: DEFAULT_MAX_INFLIGHT_CAPTCHAS,
             event_data_count: Some(0),
             event_aggregations_count: Some(0),
-            event_stats_24h_pruning_start: None,
+            event_stats_24h_start: None,
         };
 
         assert_eq!(StorablePersistentState::default(), expected_defaults);
@@ -142,7 +142,7 @@ mod tests {
             max_inflight_captchas: DEFAULT_MAX_INFLIGHT_CAPTCHAS,
             event_data_count: 0,
             event_aggregations_count: 0,
-            event_stats_24h_pruning_start: None,
+            event_stats_24h_start: None,
         };
         assert_eq!(PersistentState::default(), expected_defaults);
     }

--- a/src/internet_identity/tests/integration/aggregation_stats.rs
+++ b/src/internet_identity/tests/integration/aggregation_stats.rs
@@ -123,6 +123,90 @@ fn should_report_at_most_100_entries() -> Result<(), CallError> {
 }
 
 #[test]
+fn should_prune_at_most_100_entries_24h() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let ii_origin = "ic0.app";
+    let identity_nr = create_identity(&env, canister_id, ii_origin);
+
+    for i in 0..102 {
+        delegation_for_origin(
+            &env,
+            canister_id,
+            identity_nr,
+            &format!("https://some-dapp-{}", i),
+        )?;
+    }
+
+    env.advance_time(Duration::from_secs(60 * 60 * 24));
+    delegation_for_origin(&env, canister_id, identity_nr, "https://some-dapp.com")?;
+
+    // 100 entries should have been pruned, leaving 3
+    let aggregations = api::stats(&env, canister_id)?.event_aggregations;
+    assert_eq!(
+        aggregations
+            .get(&aggregation_key(PD_COUNT, "24h", ii_origin))
+            .unwrap()
+            .len(),
+        3
+    );
+
+    // The rest should have been pruned, leaving 1
+    delegation_for_origin(&env, canister_id, identity_nr, "https://some-dapp.com")?;
+    let aggregations = api::stats(&env, canister_id)?.event_aggregations;
+    assert_eq!(
+        aggregations
+            .get(&aggregation_key(PD_COUNT, "24h", ii_origin))
+            .unwrap()
+            .len(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
+fn should_prune_at_most_100_entries_30d() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let ii_origin = "ic0.app";
+    let identity_nr = create_identity(&env, canister_id, ii_origin);
+
+    for i in 0..102 {
+        delegation_for_origin(
+            &env,
+            canister_id,
+            identity_nr,
+            &format!("https://some-dapp-{}", i),
+        )?;
+    }
+
+    env.advance_time(Duration::from_secs(60 * 60 * 24 * 30));
+    delegation_for_origin(&env, canister_id, identity_nr, "https://some-dapp.com")?;
+
+    // 100 entries should have been pruned, leaving 3
+    let aggregations = api::stats(&env, canister_id)?.event_aggregations;
+    assert_eq!(
+        aggregations
+            .get(&aggregation_key(PD_COUNT, "30d", ii_origin))
+            .unwrap()
+            .len(),
+        3
+    );
+
+    // The rest should have been pruned, leaving 1
+    delegation_for_origin(&env, canister_id, identity_nr, "https://some-dapp.com")?;
+    let aggregations = api::stats(&env, canister_id)?.event_aggregations;
+    assert_eq!(
+        aggregations
+            .get(&aggregation_key(PD_COUNT, "30d", ii_origin))
+            .unwrap()
+            .len(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
 fn should_keep_aggregations_across_upgrades() -> Result<(), CallError> {
     const II_ORIGIN: &str = "ic0.app";
     fn assert_expected_state(env: &StateMachine, canister_id: CanisterId) -> Result<(), CallError> {

--- a/src/internet_identity/tests/integration/aggregation_stats.rs
+++ b/src/internet_identity/tests/integration/aggregation_stats.rs
@@ -123,7 +123,7 @@ fn should_report_at_most_100_entries() -> Result<(), CallError> {
 }
 
 #[test]
-fn should_prune_at_most_100_entries_24h() -> Result<(), CallError> {
+fn should_remove_at_most_100_entries_24h() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
     let ii_origin = "ic0.app";


### PR DESCRIPTION
This adds an explicit limit to the number of events processed during amortized clean-up (100 events per time window). If more than 100 events need to be cleaned up, then the next call that adds an event will continue where the previous one left off.

Using that, we can (in a future PR) remove the timer based mechanism for pruning data.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5f53ecc3b/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



