### PR TITLE
Remove timer-based pruning

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -965,7 +965,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-didc
+      - name: 'Get latest release'
+        uses: actions/github-script@v7
+        id: latest-release-tag
+        with:
+          result-encoding: string
+          script: return (await github.rest.repos.getLatestRelease({owner:"dfinity", repo:"internet-identity"})).data.tag_name;
       - name: "Check canister interface compatibility"
         run: |
+          release="release-2024-05-13"
+          # undo the breaking changes that we _explicitly_ made
+          # remove after the next release
+          # if we accidentally introduced other breaking changes, the patch would no longer apply / fix them
+          # making this job fail.
+          if [ "${{ steps.latest-release-tag.outputs.result }}" == "$release" ]; then
+            echo "Rolling back intentionally made breaking changes $release"
+            git apply allowed_breaking_change.patch
+          fi
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
           didc check src/internet_identity/internet_identity.did internet_identity_previous.did

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,6 @@ dependencies = [
  "hex-literal",
  "ic-cdk",
  "ic-cdk-macros",
- "ic-cdk-timers",
  "ic-certification 2.5.0",
  "ic-http-certification",
  "ic-metrics-encoder",

--- a/allowed_breaking_change.patch
+++ b/allowed_breaking_change.patch
@@ -1,0 +1,16 @@
+diff --git a/src/internet_identity/internet_identity.did b/src/internet_identity/internet_identity.did
+index 0164427a..f8aa40a1 100644
+--- a/src/internet_identity/internet_identity.did
++++ b/src/internet_identity/internet_identity.did
+@@ -542,6 +542,11 @@ service : (opt InternetIdentityInit) -> {
+     fetch_entries: () -> (vec BufferedArchiveEntry);
+     acknowledge_entries: (sequence_number: nat64) -> ();
+ 
++    // Calls used for event stats housekeeping.
++    // Only callable by the canister itself.
++    prune_events_if_necessary: () -> ();
++    inject_prune_event: (timestamp: Timestamp) -> ();
++
+     // V2 API
+     // WARNING: The following methods are experimental and may change in the future.
+ 

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -456,7 +456,6 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'init_salt' : IDL.Func([], [], []),
-    'inject_prune_event' : IDL.Func([Timestamp], [], []),
     'lookup' : IDL.Func([UserNumber], [IDL.Vec(DeviceData)], ['query']),
     'prepare_delegation' : IDL.Func(
         [UserNumber, FrontendHostname, SessionKey, IDL.Opt(IDL.Nat64)],
@@ -468,7 +467,6 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Variant({ 'Ok' : PreparedIdAlias, 'Err' : PrepareIdAliasError })],
         [],
       ),
-    'prune_events_if_necessary' : IDL.Func([], [], []),
     'register' : IDL.Func(
         [DeviceData, ChallengeResult, IDL.Opt(IDL.Principal)],
         [RegisterResponse],

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -363,7 +363,6 @@ export interface _SERVICE {
       { 'Err' : IdentityRegisterError }
   >,
   'init_salt' : ActorMethod<[], undefined>,
-  'inject_prune_event' : ActorMethod<[Timestamp], undefined>,
   'lookup' : ActorMethod<[UserNumber], Array<DeviceData>>,
   'prepare_delegation' : ActorMethod<
     [UserNumber, FrontendHostname, SessionKey, [] | [bigint]],
@@ -374,7 +373,6 @@ export interface _SERVICE {
     { 'Ok' : PreparedIdAlias } |
       { 'Err' : PrepareIdAliasError }
   >,
-  'prune_events_if_necessary' : ActorMethod<[], undefined>,
   'register' : ActorMethod<
     [DeviceData, ChallengeResult, [] | [Principal]],
     RegisterResponse

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -29,7 +29,6 @@ captcha = { git = "https://github.com/dfinity/captcha", rev = "9c0d2dd9bf519e255
 # All IC deps
 candid.workspace = true
 ic-cdk.workspace = true
-ic-cdk-timers.workspace = true
 ic-cdk-macros.workspace = true
 ic-certification.workspace = true
 ic-metrics-encoder.workspace = true

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -542,11 +542,6 @@ service : (opt InternetIdentityInit) -> {
     fetch_entries: () -> (vec BufferedArchiveEntry);
     acknowledge_entries: (sequence_number: nat64) -> ();
 
-    // Calls used for event stats housekeeping.
-    // Only callable by the canister itself.
-    prune_events_if_necessary: () -> ();
-    inject_prune_event: (timestamp: Timestamp) -> ();
-
     // V2 API
     // WARNING: The following methods are experimental and may change in the future.
 

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -678,7 +678,16 @@ fn should_list_aggregated_session_seconds_and_event_data_counters() -> Result<()
 
     // advance time one day to see it reflected on the daily stats
     env.advance_time(Duration::from_secs(60 * 60 * 24));
-    env.tick(); // trigger automatic pruning
+    // call prepare delegation again to trigger stats update
+    api::prepare_delegation(
+        &env,
+        canister_id,
+        authn_method_internetcomputer.principal(),
+        user_number_1,
+        "https://some-dapp-4.com",
+        &pub_session_key,
+        None,
+    )?;
 
     let metrics = get_metrics(&env, canister_id);
     // make sure aggregations that have no data anymore get removed from stats endpoint
@@ -716,7 +725,7 @@ fn should_list_aggregated_session_seconds_and_event_data_counters() -> Result<()
     assert_metric(
         &get_metrics(&env, canister_id),
         "internet_identity_event_aggregations_count",
-        8f64,
+        10f64,
     );
     Ok(())
 }


### PR DESCRIPTION
This removes the timer based pruning that is no longer needed due to https://github.com/dfinity/internet-identity/pull/2489.
The prune event aggregations will be removed once II reports their value
to be 0 (i.e. in a subsequent release after the next one).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
