### PR TITLE
Add to vc-issuer a default root key, guard configure()

### DIFF
--- a/demos/vc_issuer/app/generated/vc_issuer_idl.js
+++ b/demos/vc_issuer/app/generated/vc_issuer_idl.js
@@ -2,7 +2,7 @@ export const idlFactory = ({ IDL }) => {
   const IssuerConfig = IDL.Record({
     'derivation_origin' : IDL.Text,
     'idp_canister_ids' : IDL.Vec(IDL.Principal),
-    'ic_root_key_der' : IDL.Vec(IDL.Nat8),
+    'ic_root_key_der' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'frontend_hostname' : IDL.Text,
   });
   const DerivationOriginRequest = IDL.Record({
@@ -118,7 +118,7 @@ export const init = ({ IDL }) => {
   const IssuerConfig = IDL.Record({
     'derivation_origin' : IDL.Text,
     'idp_canister_ids' : IDL.Vec(IDL.Principal),
-    'ic_root_key_der' : IDL.Vec(IDL.Nat8),
+    'ic_root_key_der' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'frontend_hostname' : IDL.Text,
   });
   return [IDL.Opt(IssuerConfig)];

--- a/demos/vc_issuer/app/generated/vc_issuer_types.d.ts
+++ b/demos/vc_issuer/app/generated/vc_issuer_types.d.ts
@@ -55,7 +55,7 @@ export interface IssuedCredentialData { 'vc_jws' : string }
 export interface IssuerConfig {
   'derivation_origin' : string,
   'idp_canister_ids' : Array<Principal>,
-  'ic_root_key_der' : Uint8Array | number[],
+  'ic_root_key_der' : [] | [Uint8Array | number[]],
   'frontend_hostname' : string,
 }
 export interface PrepareCredentialRequest {

--- a/demos/vc_issuer/provision
+++ b/demos/vc_issuer/provision
@@ -109,4 +109,4 @@ echo "Using issuer derivation origin: $ISSUER_DERIVATION_ORIGIN" >&2
 echo "Using issuer frontend_hostname: $ISSUER_FRONTEND_HOSTNAME" >&2
 
 dfx canister call --network "$DFX_NETWORK" "$ISSUER_CANISTER" configure \
-    '(record { idp_canister_ids = vec{ principal "'"$II_CANISTER_ID"'" }; ic_root_key_der = vec '"$rootkey_did"'; derivation_origin = "'"$ISSUER_DERIVATION_ORIGIN"'"; frontend_hostname = "'"$ISSUER_FRONTEND_HOSTNAME"'"})'
+    '(record { idp_canister_ids = vec{ principal "'"$II_CANISTER_ID"'" }; ic_root_key_der = opt vec '"$rootkey_did"'; derivation_origin = "'"$ISSUER_DERIVATION_ORIGIN"'"; frontend_hostname = "'"$ISSUER_FRONTEND_HOSTNAME"'"})'

--- a/demos/vc_issuer/vc_demo_issuer.did
+++ b/demos/vc_issuer/vc_demo_issuer.did
@@ -81,7 +81,7 @@ type DerivationOriginError = variant {
 /// Configuration specific to this issuer.
 type IssuerConfig = record {
     /// Root of trust for checking canister signatures.
-    ic_root_key_der : blob;
+    ic_root_key_der : opt blob;
     /// List of canister ids that are allowed to provide id alias credentials.
     idp_canister_ids : vec principal;
     /// The derivation origin to be used by the issuer.

--- a/src/frontend/generated/vc_issuer_idl.js
+++ b/src/frontend/generated/vc_issuer_idl.js
@@ -2,7 +2,7 @@ export const idlFactory = ({ IDL }) => {
   const IssuerConfig = IDL.Record({
     'derivation_origin' : IDL.Text,
     'idp_canister_ids' : IDL.Vec(IDL.Principal),
-    'ic_root_key_der' : IDL.Vec(IDL.Nat8),
+    'ic_root_key_der' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'frontend_hostname' : IDL.Text,
   });
   const DerivationOriginRequest = IDL.Record({
@@ -118,7 +118,7 @@ export const init = ({ IDL }) => {
   const IssuerConfig = IDL.Record({
     'derivation_origin' : IDL.Text,
     'idp_canister_ids' : IDL.Vec(IDL.Principal),
-    'ic_root_key_der' : IDL.Vec(IDL.Nat8),
+    'ic_root_key_der' : IDL.Opt(IDL.Vec(IDL.Nat8)),
     'frontend_hostname' : IDL.Text,
   });
   return [IDL.Opt(IssuerConfig)];


### PR DESCRIPTION
Change the demo VC issuer to use the mainnet IC root public key by default, and guard `configure()` endpoint, so that only canister controller(s) can change the configuration.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8c3e8ddf5/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

