### PR TITLE
Reset event data on empty persistent state counts

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -390,6 +390,7 @@ jobs:
           # a relatively small price to pay to make sure PRs are always tested against the latest release.
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_test.wasm.gz -o internet_identity_previous.wasm.gz
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/archive.wasm.gz -o archive_previous.wasm.gz
+          curl -SL https://github.com/dfinity/internet-identity/releases/download/release-2024-04-26/internet_identity_test.wasm.gz -o internet_identity_pre_stats.wasm.gz
 
           # We are using --partition hash instead of count, because it makes sure that the tests partition is stable across runs
           # even if tests are added or removed. The tradeoff is that the balancing might be slightly worse, but we have enough

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -70,6 +70,20 @@ lazy_static! {
         get_wasm_path("II_WASM_PREVIOUS".to_string(), &def_path).expect(&err)
     };
 
+        /** The gzipped Wasm module for the II release build 2024-04-26, before the event stats were introduced. */
+    pub static ref II_WASM_PRE_STATS: Vec<u8> = {
+        let def_path = path::PathBuf::from("..").join("..").join("internet_identity_pre_stats.wasm.gz");
+        let err = format!("
+        Could not find Internet Identity Wasm module for pre-stats release.
+
+        I will look for it at {:?}, and you can specify another path with the environment variable II_WASM_PREVIOUS (note that I run from {:?}).
+
+        In order to get the Wasm module, please run the following command:
+            curl -SL https://github.com/dfinity/internet-identity/releases/download/release-2024-04-26/internet_identity_test.wasm.gz -o internet_identity_pre_stats.wasm.gz
+        ", &def_path, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));
+        get_wasm_path("II_WASM_PRE_STATS".to_string(), &def_path).expect(&err)
+    };
+
         /** The gzipped Wasm module for the _previous_ archive build, or latest release, which is used when testing
             * upgrades and downgrades */
     pub static ref ARCHIVE_WASM_PREVIOUS: Vec<u8> = {

--- a/src/internet_identity/src/stats/event_stats.rs
+++ b/src/internet_identity/src/stats/event_stats.rs
@@ -358,7 +358,7 @@ impl<'a, M: Memory> CountingAggregationsWrapper<'a, M> {
         if prev_value.is_none() {
             // Increase count because we added a new value
             state::persistent_state_mut(|s| {
-                s.event_aggregations_count += 1;
+                s.event_aggregations_count = s.event_aggregations_count.saturating_add(1);
             })
         }
     }
@@ -372,7 +372,7 @@ impl<'a, M: Memory> CountingAggregationsWrapper<'a, M> {
         if prev_value.is_some() {
             // Decrease count because we removed a value
             state::persistent_state_mut(|s| {
-                s.event_aggregations_count -= 1;
+                s.event_aggregations_count = s.event_aggregations_count.saturating_sub(1);
             })
         }
     }

--- a/src/internet_identity/src/stats/event_stats.rs
+++ b/src/internet_identity/src/stats/event_stats.rs
@@ -208,7 +208,7 @@ fn update_events_internal<M: Memory>(event: EventData, now: Timestamp, s: &mut S
         ic_cdk::println!("WARN: Event already exists for key {:?}", current_key);
     }
     state::persistent_state_mut(|s| {
-        s.event_data_count += 1;
+        s.event_data_count = s.event_data_count.saturating_add(1);
     });
 
     let mut aggregations_db_wrapper = CountingAggregationsWrapper(&mut s.event_aggregations);
@@ -344,7 +344,9 @@ fn prune_events<M: Memory>(
         db.remove(&entry.0);
     }
     state::persistent_state_mut(|s| {
-        s.event_data_count -= pruned_events.len() as u64;
+        s.event_data_count = s
+            .event_data_count
+            .saturating_sub(pruned_events.len() as u64);
     });
     pruned_events
 }


### PR DESCRIPTION
This is necessary because the persistent state will reinitialize the event and aggregation count to 0, if rolled back across a version that did not have the event data feature yet.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9767d2477/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



