### PR TITLE
Increase stack size to 3MB

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -120,7 +120,7 @@ function build_canister() {
     TARGET="wasm32-unknown-unknown"
     # standardize source references
     CARGO_HOME="${CARGO_HOME:-"$HOME/.cargo"}"
-    RUSTFLAGS="--remap-path-prefix $CARGO_HOME=/cargo"
+    RUSTFLAGS="--remap-path-prefix $CARGO_HOME=/cargo -C link-args=-zstack-size=3000000"
 
     cargo_build_args=(
         --manifest-path "$SRC_DIR/Cargo.toml"


### PR DESCRIPTION
This PR increases the stack size from the 1MB default to 3MB as per recommendation [here](https://dfinity.slack.com/archives/CH4CADCJX/p1717748706241909?thread_ts=1716464873.584739&cid=CH4CADCJX).

I did some tests with very small stack sizes to see when we hit errors to get a feeling for the current stack usage of II. The tests indicate that we currently use more than 48KB but fewer than 200KB of stack.

Since we are also very lean on heap usage (~6.5 MB currently) we can afford to increase the stack size to have more leeway with regards to the stack.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
