### PR TITLE
Bump GHA macos runner versions

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -908,7 +908,7 @@ jobs:
         # (in particular the slow macos builds). A single ubuntu build is not long and gives us some signal.
         # XXX: GHA does not support proper if/else so we implement a workaround: https://github.com/actions/runner/issues/409
         # XXX: GHA fails if we return the matrix object directly, so we have to pretend it's JSON
-        os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-22.04", "ubuntu-20.04", "macos-11", "macos-12" ]') || fromJson('[ "ubuntu-22.04" ]') }}
+        os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-22.04", "ubuntu-20.04", "macos-13", "macos-14" ]') || fromJson('[ "ubuntu-22.04" ]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/check-build

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -57,7 +57,7 @@ jobs:
     needs: latest-release
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-20.04, macos-11, macos-12 ]
+        os: [ ubuntu-22.04, ubuntu-20.04, macos-13, macos-14 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -84,7 +84,9 @@ jobs:
     needs: latest-release
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-20.04, macos-11, macos-12 ]
+        # macos-14 is itself virtualized and does not support nested virtualization which would be required for the docker build.
+        # -> just use macos-13
+        os: [ ubuntu-22.04, ubuntu-20.04, macos-13 ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -93,11 +95,7 @@ jobs:
       - name: Setup docker (missing on MacOS)
         if: runner.os == 'macos'
         run: |
-          brew install docker
-          brew install docker-buildx
-          # The following 2 commands are taken from the post install instructions printed by `brew install docker-buildx` 
-          mkdir -p ~/.docker/cli-plugins
-          ln -sfn /usr/local/opt/docker-buildx/bin/docker-buildx ~/.docker/cli-plugins/docker-buildx
+          brew install docker docker-buildx colima
           colima start
 
       - name: "Verify Hash"


### PR DESCRIPTION
Upgrade GHA macos runners because macos-11 is being removed soon.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/97692bcf5/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/97692bcf5/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
