### PR TITLE
Add metric for number of successful prepare_id_alias calls

### DIFF
--- a/src/internet_identity/src/http/metrics.rs
+++ b/src/internet_identity/src/http/metrics.rs
@@ -101,6 +101,11 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             "internet_identity_anchor_operations_counter",
             usage_metrics.anchor_operation_counter as f64,
             "The number of anchor operations since last upgrade",
+        )?;
+        w.encode_gauge(
+            "internet_identity_prepare_id_alias_counter",
+            usage_metrics.prepare_id_alias_counter as f64,
+            "The number of successful prepare_id_alias calls handled since last upgrade. For each VC presentation flow, exactly one prepare_id_alias is made.",
         )
     })?;
     if let ArchiveState::Created { ref data, config } = state::archive_state() {

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -56,6 +56,8 @@ pub struct UsageMetrics {
     pub delegation_counter: u64,
     // number of anchor operations (register, add, remove, update) since last upgrade
     pub anchor_operation_counter: u64,
+    // number of prepare_id_alias calls since last upgrade
+    pub prepare_id_alias_counter: u64,
 }
 
 // The challenges we store and check against

--- a/src/internet_identity/src/vc_mvp.rs
+++ b/src/internet_identity/src/vc_mvp.rs
@@ -58,6 +58,11 @@ pub async fn prepare_id_alias(
         sigs.add_signature(seed.as_ref(), vc_signing_input_hash(&issuer_signing_input));
     });
     update_root_hash();
+
+    state::usage_metrics_mut(|metrics| {
+        metrics.prepare_id_alias_counter += 1;
+    });
+
     PreparedIdAlias {
         canister_sig_pk_der: ByteBuf::from(canister_sig_pk.to_der()),
         rp_id_alias_jwt: String::from_utf8(rp_signing_input).unwrap(),

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -151,7 +151,7 @@ fn ii_canister_serves_http_metrics() -> Result<(), CallError> {
         "internet_identity_inflight_challenges",
         "internet_identity_users_in_registration_mode",
         "internet_identity_buffered_archive_entries",
-        "internet_identity_id_alias_counter",
+        "internet_identity_prepare_id_alias_counter",
     ];
     let env = env();
     env.advance_time(Duration::from_secs(300)); // advance time to see it reflected on the metrics endpoint

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -13,8 +13,9 @@ use ic_response_verification::types::VerificationInfo;
 use ic_response_verification::verify_request_response_pair;
 use ic_test_state_machine_client::{CallError, StateMachine};
 use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
+use internet_identity_interface::internet_identity::types::vc_mvp::PrepareIdAliasRequest;
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethodData, ChallengeAttempt, MetadataEntryV2,
+    AuthnMethodData, ChallengeAttempt, FrontendHostname, MetadataEntryV2,
 };
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
@@ -136,7 +137,7 @@ fn should_set_cache_control_for_fonts() -> Result<(), CallError> {
     Ok(())
 }
 
-/// Verifies that all expected metrics are available via the HTTP endpoint.
+/// Verifies that expected metrics are available via the HTTP endpoint.
 #[test]
 fn ii_canister_serves_http_metrics() -> Result<(), CallError> {
     let metrics = vec![
@@ -150,6 +151,7 @@ fn ii_canister_serves_http_metrics() -> Result<(), CallError> {
         "internet_identity_inflight_challenges",
         "internet_identity_users_in_registration_mode",
         "internet_identity_buffered_archive_entries",
+        "internet_identity_id_alias_counter",
     ];
     let env = env();
     env.advance_time(Duration::from_secs(300)); // advance time to see it reflected on the metrics endpoint
@@ -717,6 +719,36 @@ fn should_list_aggregated_session_seconds_and_event_data_counters() -> Result<()
         &get_metrics(&env, canister_id),
         "internet_identity_event_aggregations_count",
         10f64,
+    );
+    Ok(())
+}
+
+#[test]
+fn should_get_different_id_alias_for_different_flows() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let prepare_id_alias_req = PrepareIdAliasRequest {
+        identity_number,
+        relying_party: FrontendHostname::from("https://some-dapp.com"),
+        issuer: FrontendHostname::from("https://some-issuer-1.com"),
+    };
+
+    for _ in 0..3 {
+        api::vc_mvp::prepare_id_alias(
+            &env,
+            canister_id,
+            principal_1(),
+            prepare_id_alias_req.clone(),
+        )?
+        .expect("Got 'None' from prepare_id_alias");
+    }
+
+    assert_metric(
+        &get_metrics(&env, canister_id),
+        "internet_identity_prepare_id_alias_counter",
+        3f64,
     );
     Ok(())
 }


### PR DESCRIPTION
This PR adds a metric for how many prepare_id_alias calls have been handled. This number can be used to infer the number of VCs presented using Internet Identity.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a5673d338/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a5673d338/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

