### PR TITLE
Use identity metadata to not show recovery warning page

### DIFF
--- a/src/frontend/src/components/authenticateBox.ts
+++ b/src/frontend/src/components/authenticateBox.ts
@@ -698,7 +698,7 @@ const pinIdentityToDerPubkey = async (
 };
 
 // Find and use a passkey, whether PIN or webauthn
-const useIdentityFlow = async <T, I>({
+const useIdentityFlow = async <I>({
   userNumber,
   allowPinAuthentication,
   retrievePinIdentityMaterial,

--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -212,14 +212,17 @@ const authenticate = async (
   const derivationOrigin =
     authContext.authRequest.derivationOrigin ?? authContext.requestOrigin;
 
-  // TODO: Commit state
-  const result = await withLoader(() =>
-    fetchDelegation({
-      connection: authSuccess.connection,
-      derivationOrigin,
-      publicKey: authContext.authRequest.sessionPublicKey,
-      maxTimeToLive: authContext.authRequest.maxTimeToLive,
-    })
+  // Ignore the response of committing the metadata because it's not crucial.
+  const [result] = await withLoader(() =>
+    Promise.all([
+      fetchDelegation({
+        connection: authSuccess.connection,
+        derivationOrigin,
+        publicKey: authContext.authRequest.sessionPublicKey,
+        maxTimeToLive: authContext.authRequest.maxTimeToLive,
+      }),
+      authSuccess.connection.commitMetadata(),
+    ])
   );
 
   if ("error" in result) {

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -250,8 +250,10 @@ export const renderManage = async ({
   for (;;) {
     let anchorInfo: IdentityAnchorInfo;
     try {
-      // TODO: commit state
-      anchorInfo = await withLoader(() => connection.getAnchorInfo());
+      // Ignore the `commitMetadata` response, it's not critical for the application.
+      [anchorInfo] = await withLoader(() =>
+        Promise.all([connection.getAnchorInfo(), connection.commitMetadata()])
+      );
     } catch (error: unknown) {
       await displayFailedToListDevices(
         error instanceof Error ? error : unknownError()
@@ -367,13 +369,6 @@ export const displayManage = (
         onAddDevice,
         addRecoveryPhrase,
         addRecoveryKey: async () => {
-          const confirmed = confirm(
-            "Add a Recovery Device\n\nUse a FIDO Security Key, like a YubiKey, as an additional recovery method."
-          );
-          if (!confirmed) {
-            // No resolve here because we don't need to reload the screen
-            return;
-          }
           await setupKey({ connection });
           resolve();
         },

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -80,6 +80,7 @@ export const addPhrase = ({
   );
 };
 
+// TODO: Add e2e test https://dfinity.atlassian.net/browse/GIX-2600
 export const recoveryWizard = async (
   userNumber: bigint,
   connection: AuthenticatedConnection

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -20,7 +20,6 @@ import { authenticatorAttachmentToKeyType } from "$src/utils/authenticatorAttach
 import {
   ApiError,
   AuthFail,
-  AuthenticatedConnection,
   BadChallenge,
   Connection,
   IIWebAuthnIdentity,
@@ -37,7 +36,7 @@ import { displayUserNumberWarmup } from "./finish";
 import { savePasskeyOrPin } from "./passkey";
 
 /** Registration (anchor creation) flow for new users */
-export const registerFlow = async <T>({
+export const registerFlow = async ({
   createChallenge: createChallenge_,
   register,
   storePinIdentity,
@@ -53,7 +52,7 @@ export const registerFlow = async <T>({
     credentialId?: CredentialId;
     challengeResult: { chars: string; challenge: Challenge };
   }) => Promise<
-    LoginSuccess<T> | BadChallenge | ApiError | AuthFail | RegisterNoSpace
+    LoginSuccess | BadChallenge | ApiError | AuthFail | RegisterNoSpace
   >;
   storePinIdentity: (opts: {
     userNumber: bigint;
@@ -63,7 +62,7 @@ export const registerFlow = async <T>({
   pinAllowed: () => Promise<boolean>;
   uaParser: PreloadedUAParser;
 }): Promise<
-  | (LoginSuccess<T> & { authnMethod: "passkey" | "pin" })
+  | (LoginSuccess & { authnMethod: "passkey" | "pin" })
   | BadChallenge
   | ApiError
   | AuthFail
@@ -193,6 +192,13 @@ export const registerFlow = async <T>({
   result.kind satisfies "loginSuccess";
   const userNumber = result.userNumber;
   await finalizeIdentity?.(userNumber);
+  // We don't want to nudge the user with the recovery phrase warning page
+  // right after they've created their anchor.
+  // The metadata it started to fetch when the connection was created.
+  // But it might not have finished yet, so we `await` for `updateIdentityMetadata` to also wait for it.
+  await result.connection.updateIdentityMetadata({
+    recoveryPageShownTimestampMillis: Date.now(),
+  });
   await setAnchorUsed(userNumber);
   await displayUserNumber({
     userNumber,
@@ -202,9 +208,7 @@ export const registerFlow = async <T>({
   return { ...result, authnMethod };
 };
 
-export type RegisterFlowOpts<T = AuthenticatedConnection> = Parameters<
-  typeof registerFlow<T>
->[0];
+export type RegisterFlowOpts = Parameters<typeof registerFlow>[0];
 
 export const getRegisterFlowOpts = ({
   connection,

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -194,7 +194,7 @@ export const registerFlow = async ({
   await finalizeIdentity?.(userNumber);
   // We don't want to nudge the user with the recovery phrase warning page
   // right after they've created their anchor.
-  // The metadata it started to fetch when the connection was created.
+  // The metadata starts to fetch when the connection is created.
   // But it might not have finished yet, so we `await` for `updateIdentityMetadata` to also wait for it.
   await result.connection.updateIdentityMetadata({
     recoveryPageShownTimestampMillis: Date.now(),

--- a/src/frontend/src/repositories/identityMetadata.test.ts
+++ b/src/frontend/src/repositories/identityMetadata.test.ts
@@ -99,23 +99,6 @@ test("IdentityMetadataRepository sets data in memory", async () => {
   });
 });
 
-test("IdentityMetadataRepository sets data in memory", async () => {
-  const noMetadata: MetadataMapV2 = [];
-  const instance = IdentityMetadataRepository.init({
-    getter: vi.fn().mockResolvedValue(noMetadata),
-    setter: setterMockSuccess,
-  });
-
-  const newRecoveryPageShownTimestampMillis = 9876543210;
-  await instance.updateMetadata({
-    recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
-  });
-
-  expect(await instance.getMetadata()).toEqual({
-    recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
-  });
-});
-
 test("IdentityMetadataRepository commits updated metadata to canister", async () => {
   const instance = IdentityMetadataRepository.init({
     getter: getterMockSuccess,

--- a/src/frontend/src/repositories/identityMetadata.test.ts
+++ b/src/frontend/src/repositories/identityMetadata.test.ts
@@ -99,6 +99,23 @@ test("IdentityMetadataRepository sets data in memory", async () => {
   });
 });
 
+test("IdentityMetadataRepository sets data in memory", async () => {
+  const noMetadata: MetadataMapV2 = [];
+  const instance = IdentityMetadataRepository.init({
+    getter: vi.fn().mockResolvedValue(noMetadata),
+    setter: setterMockSuccess,
+  });
+
+  const newRecoveryPageShownTimestampMillis = 9876543210;
+  await instance.updateMetadata({
+    recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
+  });
+
+  expect(await instance.getMetadata()).toEqual({
+    recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
+  });
+});
+
 test("IdentityMetadataRepository commits updated metadata to canister", async () => {
   const instance = IdentityMetadataRepository.init({
     getter: getterMockSuccess,

--- a/src/frontend/src/repositories/identityMetadata.ts
+++ b/src/frontend/src/repositories/identityMetadata.ts
@@ -101,9 +101,9 @@ export class IdentityMetadataRepository {
     metadata: RawMetadataState
   ): metadata is MetadataMapV2 => {
     return (
-      this.rawMetadata !== "loading" &&
-      this.rawMetadata !== "error" &&
-      this.rawMetadata !== "not-loaded"
+      metadata !== "loading" &&
+      metadata !== "error" &&
+      metadata !== "not-loaded"
     );
   };
 

--- a/src/frontend/src/test-e2e/alternativeOrigin/endpointFormat.test.ts
+++ b/src/frontend/src/test-e2e/alternativeOrigin/endpointFormat.test.ts
@@ -21,7 +21,6 @@ test("Should not issue delegation when /.well-known/ii-alternative-origins has t
     const authenticatorId1 = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
     await FLOWS.registerNewIdentityWelcomeView(browser);
-    await FLOWS.addRecoveryMechanismSeedPhrase(browser);
     const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
     expect(credentials).toHaveLength(1);
 
@@ -59,7 +58,6 @@ test("Should not follow redirect returned by /.well-known/ii-alternative-origins
     const authenticatorId1 = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
     await FLOWS.registerNewIdentityWelcomeView(browser);
-    await FLOWS.addRecoveryMechanismSeedPhrase(browser);
     const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
     expect(credentials).toHaveLength(1);
 
@@ -97,7 +95,6 @@ test("Should fetch /.well-known/ii-alternative-origins using the non-raw url", a
     const authenticatorId1 = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
     const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
-    await FLOWS.addRecoveryMechanismSeedPhrase(browser);
     const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
     expect(credentials).toHaveLength(1);
 
@@ -142,7 +139,6 @@ test("Should allow arbitrary URL as derivation origin", async () => {
     const authenticatorId1 = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
     const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
-    await FLOWS.addRecoveryMechanismSeedPhrase(browser);
     const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
     expect(credentials).toHaveLength(1);
 

--- a/src/frontend/src/test-e2e/alternativeOrigin/ingressFormat.test.ts
+++ b/src/frontend/src/test-e2e/alternativeOrigin/ingressFormat.test.ts
@@ -20,7 +20,6 @@ test("Should not issue delegation when derivationOrigin is missing from /.well-k
     const authenticatorId1 = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
     const _userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
-    await FLOWS.addRecoveryMechanismSeedPhrase(browser);
     const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
     expect(credentials).toHaveLength(1);
 

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -80,16 +80,11 @@ export const FLOWS = {
   },
   loginWelcomeView: async (
     userNumber: string,
-    deviceName: string,
     browser: WebdriverIO.Browser
   ): Promise<void> => {
     const welcomeView = new WelcomeView(browser);
     await welcomeView.waitForDisplay();
     await welcomeView.login(userNumber);
-    // This flow assumes no recovery phrase, so we explicitly skip the recovery nag here
-    await FLOWS.skipRecoveryNag(browser);
-    const mainView = new MainView(browser);
-    await mainView.waitForDeviceDisplay(deviceName);
   },
   loginAuthenticateView: async (
     userNumber: string,
@@ -99,8 +94,6 @@ export const FLOWS = {
     const authenticateView = new AuthenticateView(browser);
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
-    // This flow assumes no recovery phrase, so we explicitly skip the recovery nag here
-    await FLOWS.skipRecoveryNag(browser);
     const mainView = new MainView(browser);
     await mainView.waitForDeviceDisplay(deviceName);
   },
@@ -115,8 +108,6 @@ export const FLOWS = {
     const pinAuthView = new PinAuthView(browser);
     await pinAuthView.waitForDisplay();
     await pinAuthView.enterPin(pin);
-    // This flow assumes no recovery phrase, so we explicitly skip the recovery nag here
-    await FLOWS.skipRecoveryNag(browser);
   },
   loginPinWelcomeView: async (
     userNumber: string,
@@ -129,8 +120,6 @@ export const FLOWS = {
     const pinAuthView = new PinAuthView(browser);
     await pinAuthView.waitForDisplay();
     await pinAuthView.enterPin(pin);
-    // This flow assumes no recovery phrase, so we explicitly skip the recovery nag here
-    await FLOWS.skipRecoveryNag(browser);
   },
   addRecoveryMechanismSeedPhrase: async (
     browser: WebdriverIO.Browser
@@ -177,11 +166,6 @@ export const FLOWS = {
     const addDeviceSuccessView = new AddDeviceSuccessView(browser);
     await addDeviceSuccessView.waitForDisplay();
     await addDeviceSuccessView.continue();
-  },
-  skipRecoveryNag: async (browser: WebdriverIO.Browser): Promise<void> => {
-    const recoveryMethodSelectorView = new RecoveryMethodSelectorView(browser);
-    await recoveryMethodSelectorView.waitForDisplay();
-    await recoveryMethodSelectorView.skipRecovery();
   },
   recoverUsingSeedPhrase: async (
     browser: WebdriverIO.Browser,

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -93,8 +93,6 @@ test("Register and log in with PIN identity, retry on wrong PIN", async () => {
     await pinAuthView.waitForError();
     await pinAuthView.enterPin(pin);
 
-    // NOTE: handle recovery nag because there is no recovery phrase
-    await FLOWS.skipRecoveryNag(browser);
     const mainView2 = new MainView(browser);
     await mainView2.waitForDisplay(); // we should be logged in
   }, APPLE_USER_AGENT);

--- a/src/frontend/src/test-e2e/principals.test.ts
+++ b/src/frontend/src/test-e2e/principals.test.ts
@@ -21,7 +21,6 @@ test("Should issue the same principal to nice url and canonical url", async () =
     const authenticatorId1 = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
     const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
-    await FLOWS.addRecoveryMechanismSeedPhrase(browser);
     const credentials = await getWebAuthnCredentials(browser, authenticatorId1);
     expect(credentials).toHaveLength(1);
 
@@ -78,7 +77,6 @@ test("Should issue the same principal to dapps on legacy & official domains", as
     const registrationAuthenticator = await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
     const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
-    await FLOWS.addRecoveryMechanismSeedPhrase(browser); // avoids being prompted later during authz
     const credentials = await getWebAuthnCredentials(
       browser,
       registrationAuthenticator

--- a/src/frontend/src/test-e2e/register.test.ts
+++ b/src/frontend/src/test-e2e/register.test.ts
@@ -39,7 +39,8 @@ test("Register new identity and login without prefilled identity number", async 
 
     // load the II page again
     await browser.url(II_URL);
-    await FLOWS.loginWelcomeView(userNumber, DEVICE_NAME1, browser);
+    await FLOWS.loginWelcomeView(userNumber, browser);
+    await mainView.waitForDeviceDisplay(DEVICE_NAME1);
   });
 }, 300_000);
 
@@ -92,7 +93,6 @@ test("Register first then log into client application", async () => {
     const authenticateView = new AuthenticateView(browser);
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
-    await FLOWS.skipRecoveryNag(browser);
     const principal = await demoAppView.waitForAuthenticated();
     expect(await demoAppView.whoami()).toBe(principal);
 

--- a/src/frontend/src/test-e2e/verifiableCredentials/utils.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/utils.ts
@@ -198,7 +198,6 @@ export const register: Record<
     const authenticatorId = await addVirtualAuthenticator(browser);
     const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const credentials = await getWebAuthnCredentials(browser, authenticatorId);
-    await FLOWS.addRecoveryMechanismSeedPhrase(browser);
 
     return {
       userNumber,
@@ -220,7 +219,6 @@ export const register: Record<
   pin: async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
-    await FLOWS.addRecoveryMechanismSeedPhrase(browser);
 
     return {
       userNumber,

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -84,9 +84,9 @@ export class DummyIdentity
 
 export const IC_DERIVATION_PATH = [44, 223, 0, 0, 0];
 
-export type LoginSuccess<T = AuthenticatedConnection> = {
+export type LoginSuccess = {
   kind: "loginSuccess";
-  connection: T;
+  connection: AuthenticatedConnection;
   userNumber: bigint;
 };
 


### PR DESCRIPTION
Main motivation is to use the IdentityMetadataRepository functionality in the application to avoid showing the recovery warning page always. Instead, it's shown once a week.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/620fe7ba7/desktop/manageNewLanding.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/620fe7ba7/desktop/managePickManyNewLanding.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/620fe7ba7/desktop/managePickNewLanding.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/620fe7ba7/mobile/manageNewLanding.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/620fe7ba7/mobile/managePickManyNewLanding.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/620fe7ba7/mobile/managePickNewLanding.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/620fe7ba7/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


