### PR TITLE
Add support for alternative origins to VC issuer

### DIFF
--- a/demos/vc_issuer/app/generated/vc_issuer_idl.js
+++ b/demos/vc_issuer/app/generated/vc_issuer_idl.js
@@ -107,6 +107,7 @@ export const idlFactory = ({ IDL }) => {
         ],
         [],
       ),
+    'set_alternative_origins' : IDL.Func([IDL.Text], [], []),
     'vc_consent_message' : IDL.Func(
         [Icrc21VcConsentMessageRequest],
         [IDL.Variant({ 'Ok' : Icrc21ConsentInfo, 'Err' : Icrc21Error })],

--- a/demos/vc_issuer/app/generated/vc_issuer_types.d.ts
+++ b/demos/vc_issuer/app/generated/vc_issuer_types.d.ts
@@ -87,6 +87,7 @@ export interface _SERVICE {
     { 'Ok' : PreparedCredentialData } |
       { 'Err' : IssueCredentialError }
   >,
+  'set_alternative_origins' : ActorMethod<[string], undefined>,
   'vc_consent_message' : ActorMethod<
     [Icrc21VcConsentMessageRequest],
     { 'Ok' : Icrc21ConsentInfo } |

--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -25,7 +25,7 @@ use vc_util::{
 };
 use SupportedCredentialType::{UniversityDegree, VerifiedAdult, VerifiedEmployee};
 
-use asset_util::{collect_assets, CertifiedAssets};
+use asset_util::{collect_assets, Asset, CertifiedAssets, ContentEncoding, ContentType};
 use ic_cdk::api;
 use ic_cdk_macros::post_upgrade;
 use lazy_static::lazy_static;
@@ -449,6 +449,21 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
 
 fn static_headers() -> Vec<HeaderField> {
     vec![("Access-Control-Allow-Origin".to_string(), "*".to_string())]
+}
+
+#[update]
+fn set_alternative_origins(alternative_origins: String) {
+    const ALTERNATIVE_ORIGINS_PATH: &str = "/.well-known/ii-alternative-origins";
+    ASSETS.with_borrow_mut(|assets| {
+        let asset = Asset {
+            url_path: ALTERNATIVE_ORIGINS_PATH.to_string(),
+            content: alternative_origins.as_bytes().to_vec(),
+            encoding: ContentEncoding::Identity,
+            content_type: ContentType::JSON,
+        };
+        assets.certify_asset(asset, &static_headers())
+    });
+    update_root_hash()
 }
 
 fn main() {}

--- a/demos/vc_issuer/tests/issue_credential.rs
+++ b/demos/vc_issuer/tests/issue_credential.rs
@@ -750,8 +750,6 @@ fn should_set_alternative_origins() {
     let env = env();
     let issuer_id = install_canister(&env, VC_ISSUER_WASM.clone());
     let alternative_origins = r#"{"alternativeOrigins":["https://test.issuer"]}"#;
-    api::set_alternative_origins(&env, issuer_id, alternative_origins).expect("API call failed");
-
     let request = HttpRequest {
         method: "GET".to_string(),
         url: "/.well-known/ii-alternative-origins".to_string(),
@@ -759,6 +757,12 @@ fn should_set_alternative_origins() {
         body: ByteBuf::new(),
         certificate_version: Some(2),
     };
+
+    let http_response = http_request(&env, issuer_id, &request).expect("HTTP request failed");
+    assert_eq!(http_response.status_code, 404);
+
+    api::set_alternative_origins(&env, issuer_id, alternative_origins).expect("API call failed");
+
     let http_response = http_request(&env, issuer_id, &request).expect("HTTP request failed");
     assert_eq!(http_response.status_code, 200);
     assert_eq!(&http_response.body, alternative_origins.as_bytes())

--- a/demos/vc_issuer/vc_demo_issuer.did
+++ b/demos/vc_issuer/vc_demo_issuer.did
@@ -120,6 +120,8 @@ service: (opt IssuerConfig) -> {
 
     /// Configure the issuer (e.g. set the root key), used for deployment/testing.
     configure: (IssuerConfig) -> ();
+    // Sets the content of the alternative origins file.
+    set_alternative_origins: (alternative_origins: text) -> ();
 
     /// API for obtaining information about users, for testing only.
     /// In a real-world issuer the data acquisition functionality should be more elaborate and authenticated.

--- a/src/frontend/generated/vc_issuer_idl.js
+++ b/src/frontend/generated/vc_issuer_idl.js
@@ -107,6 +107,7 @@ export const idlFactory = ({ IDL }) => {
         ],
         [],
       ),
+    'set_alternative_origins' : IDL.Func([IDL.Text], [], []),
     'vc_consent_message' : IDL.Func(
         [Icrc21VcConsentMessageRequest],
         [IDL.Variant({ 'Ok' : Icrc21ConsentInfo, 'Err' : Icrc21Error })],

--- a/src/vc-api/src/generated/vc_issuer_types.ts
+++ b/src/vc-api/src/generated/vc_issuer_types.ts
@@ -55,7 +55,7 @@ export interface IssuedCredentialData { 'vc_jws' : string }
 export interface IssuerConfig {
   'derivation_origin' : string,
   'idp_canister_ids' : Array<Principal>,
-  'ic_root_key_der' : Uint8Array | number[],
+  'ic_root_key_der' : [] | [Uint8Array | number[]],
   'frontend_hostname' : string,
 }
 export interface PrepareCredentialRequest {
@@ -87,6 +87,7 @@ export interface _SERVICE {
     { 'Ok' : PreparedCredentialData } |
       { 'Err' : IssueCredentialError }
   >,
+  'set_alternative_origins' : ActorMethod<[string], undefined>,
   'vc_consent_message' : ActorMethod<
     [Icrc21VcConsentMessageRequest],
     { 'Ok' : Icrc21ConsentInfo } |


### PR DESCRIPTION
Having alternative_origins support allows to simplify the VC e2e tests. This will be done in follow-up PRs.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/09beb781e/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



