### PR TITLE
Make canisterId mandatory for VC flow

### DIFF
--- a/demos/test-app/src/index.tsx
+++ b/demos/test-app/src/index.tsx
@@ -397,6 +397,7 @@ let latestOpts:
   | undefined
   | {
       issuerOrigin: string;
+      issuerCanisterId: string;
       derivationOrigin?: string;
       credTy: CredType;
       flowId: number;
@@ -443,6 +444,7 @@ function handleFlowReady(evnt: MessageEvent) {
     params: {
       issuer: {
         origin: opts.issuerOrigin,
+        canisterId: opts.issuerCanisterId,
       },
       credentialSpec: credentialSpecs[opts.credTy],
       credentialSubject: principal,
@@ -450,7 +452,7 @@ function handleFlowReady(evnt: MessageEvent) {
     },
   };
 
-  // register a handler for the "done" message, kick start the flow and then
+  // register a handler for the "done" message, kickstart the flow and then
   // unregister ourselves
   try {
     window.addEventListener("message", handleFlowFinished);
@@ -497,6 +499,8 @@ const App = () => {
     "http://issuer.localhost:5173"
   );
 
+  const [issuerCanisterId, setIssuerCanisterId] = useState<string>("");
+
   // Alternative origin for the RP, if any
   const [derivationOrigin, setDerivationOrigin] = useState<string>("");
 
@@ -527,7 +531,8 @@ const App = () => {
     latestOpts = {
       flowId,
       credTy,
-      issuerOrigin: issuerUrl,
+      issuerOrigin: new URL(issuerUrl).origin,
+      issuerCanisterId,
       derivationOrigin: derivationOrigin !== "" ? derivationOrigin : undefined,
       win: iiWindow,
     };
@@ -545,6 +550,15 @@ const App = () => {
           type="text"
           value={issuerUrl}
           onChange={(evt) => setIssuerUrl(evt.target.value)}
+        />
+      </label>
+      <label>
+        Issuer canister Id:
+        <input
+          data-role="issuer-canister-id"
+          type="text"
+          value={issuerCanisterId}
+          onChange={(evt) => setIssuerCanisterId(evt.target.value)}
         />
       </label>
       <label>

--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -259,9 +259,8 @@ After receiving the notification that II is ready, the relying party can request
 * Method: `request_credential`
 * Params:
   * `issuer`: An issuer that the relying party trusts. It has the following properties:
-    * `origin`: The origin of the issuer.
-    * `canisterId`: (optional) The canister id of the issuer, if applicable/known. If specified and not the same
-       as the one reported by a boundary node for `origin`, this is an error.
+    * `origin`: The front-end origin of the issuer. If this value is different from the value returned from the `derivation_origin` canister call, then the `origin` must be a valid alternative origin as per the [Alternative Frontend Origins](https://internetcomputer.org/docs/current/references/ii-spec#alternative-frontend-origins)-feature.
+    * `canisterId`: The canister id of the issuer canister (i.e. the one, that implements the candid issuer API as defined above). 
   * `credentialSpec`: The spec of the credential that the relying party wants to request from the issuer.
     * `credentialType`: The type of the requested credential.
     * `arguments`: (optional) A map with arguments specific to the requested credentials. It maps string keys to values that must be either strings or integers.
@@ -321,7 +320,9 @@ After receiving the notification that II is ready, the relying party can request
   "method": "request_credential",
   "params": {
     "issuer": {
-        "origin": "https://kyc-resident-info.org"
+        "type": "IC",
+        "origin": "https://kyc-resident-info.org",
+        "canisterId": "rwlgt-iiaaa-aaaaa-aaaaa-cai"
     },
     "credentialSpec": {
         "credentialType": "VerifiedResident",

--- a/docs/vc-spec.md
+++ b/docs/vc-spec.md
@@ -320,7 +320,6 @@ After receiving the notification that II is ready, the relying party can request
   "method": "request_credential",
   "params": {
     "issuer": {
-        "type": "IC",
         "origin": "https://kyc-resident-info.org",
         "canisterId": "rwlgt-iiaaa-aaaaa-aaaaa-cai"
     },

--- a/src/frontend/src/flows/verifiableCredentials/postMessageInterface.ts
+++ b/src/frontend/src/flows/verifiableCredentials/postMessageInterface.ts
@@ -1,9 +1,10 @@
 import { toast } from "$src/components/toast";
-import type {
+import {
+  VcFlowReady,
+  VcFlowRequest,
   VcResponse,
   VcVerifiablePresentation,
 } from "@dfinity/internet-identity-vc-api";
-import { VcFlowReady, VcFlowRequest } from "@dfinity/internet-identity-vc-api";
 
 export type { VcVerifiablePresentation } from "@dfinity/internet-identity-vc-api";
 

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -738,11 +738,17 @@ export class VcTestAppView extends View {
   async open(
     demoAppUrl: string,
     iiUrl: string,
-    issuerUrl: string
+    issuerUrl: string,
+    issuerCanisterId: string
   ): Promise<void> {
     await this.browser.url(demoAppUrl);
     await setInputValue(this.browser, '[data-role="ii-url"]', iiUrl);
     await setInputValue(this.browser, '[data-role="issuer-url"]', issuerUrl);
+    await setInputValue(
+      this.browser,
+      '[data-role="issuer-canister-id"]',
+      issuerCanisterId
+    );
   }
 
   async startSignIn(): Promise<void> {

--- a/src/vc-api/src/index.ts
+++ b/src/vc-api/src/index.ts
@@ -70,7 +70,7 @@ export const VcFlowRequest = z.object({
       origin: z
         .string()
         .url() /* XXX: we limit to URLs, but in practice should even be an origin */,
-      canisterId: z.optional(zodPrincipal),
+      canisterId: zodPrincipal,
     }),
     credentialSpec: zodCredentialSpec,
     credentialSubject: zodPrincipal,


### PR DESCRIPTION
This PR makes it mandatory for the relying party to specify the canisterId when initiating the VC flow.

The change brings the following advantages:
* simpler logic on the II side
* support issuers with different front-end and back-end canisters without having them resort to alternative origins
* make the flow easier to understand for developers

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9dda84329/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

