### PR TITLE
fix: Candid file rendering in spec

### DIFF
--- a/docs/ii-spec.mdx
+++ b/docs/ii-spec.mdx
@@ -1,3 +1,6 @@
+import CodeBlock from "@theme/CodeBlock";
+import IICandidInterface from "!!raw-loader!../src/internet_identity/internet_identity.did";
+
 # The Internet Identity Specification
 
 ## Introduction
@@ -291,11 +294,7 @@ This interface is currently only used by its own frontend. This tight coupling m
 
 The summary is given by the Candid interface:
 
-<!-- The '_attachments/` bit is an implementation detail of the docusaurus deploy -->
-
-``` candid name=https://raw.githubusercontent.com/dfinity/internet-identity/main/src/internet_identity/internet_identity.did
-```
-
+<CodeBlock language="candid">{IICandidInterface}</CodeBlock>
 
 The `init_salt` method is mostly internal, see [Salt](#salt).
 


### PR DESCRIPTION
Adds support to import the Candid interface file as a codeblock in the spec document

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->
