### PR TITLE
Add beta domains to ic-domains

### DIFF
--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -54,7 +54,7 @@ pub fn get_static_assets() -> Vec<Asset> {
     // See https://internetcomputer.org/docs/current/developer-docs/production/custom-domain/#custom-domains-on-the-boundary-nodes
     assets.push(Asset {
         url_path: "/.well-known/ic-domains".to_string(),
-        content: b"identity.internetcomputer.org".to_vec(),
+        content: b"identity.internetcomputer.org\nbeta.identity.ic0.app\nbeta.identity.internetcomputer.org".to_vec(),
         encoding: ContentEncoding::Identity,
         content_type: ContentType::OCTETSTREAM,
     });


### PR DESCRIPTION
Main motivation is to deploy the latest version of II to `beta.identity.ic0.app` and `beta.identity.internetcomputer.org`.

Add new beta domains to ic-domains file.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
