### PR TITLE
Create warning page to add a device

### DIFF
--- a/src/frontend/src/components/infoScreen.ts
+++ b/src/frontend/src/components/infoScreen.ts
@@ -24,6 +24,8 @@ export const infoScreenTemplate = ({
   nextText,
   cancel,
   cancelText,
+  additionalAction,
+  additionalActionText,
   title,
   paragraph,
   entries,
@@ -36,6 +38,8 @@ export const infoScreenTemplate = ({
   nextText: DynamicKey | string;
   cancel: () => void;
   cancelText: DynamicKey | string;
+  additionalAction?: () => void;
+  additionalActionText?: DynamicKey | string;
   title: DynamicKey | string;
   paragraph: TemplateElement;
   entries?: {
@@ -71,6 +75,15 @@ export const infoScreenTemplate = ({
       >
         ${cancelText}
       </button>
+      ${nonNullish(additionalAction)
+        ? html`<button
+            @click=${() => additionalAction()}
+            data-action="additional"
+            class="c-button c-button--textOnly"
+          >
+            ${additionalActionText}
+          </button>`
+        : undefined}
     </div>
     ${nonNullish(entries) && entries.length > 0
       ? html`<section class="c-marketing-block">

--- a/src/frontend/src/flows/recovery/recoveryWizard.json
+++ b/src/frontend/src/flows/recovery/recoveryWizard.json
@@ -9,6 +9,14 @@
     "skip": "Remind me later",
     "cancel": "Cancel",
 
+    "add_device_title_pin_only": "Add a device",
+    "add_device_title_one_passkey": "Add another device",
+    "add_device": "Add device",
+    "remind_later": "Remind me later",
+    "do_not_remind": "Do not remind me again",
+    "paragraph_add_device_one_passkey": "You only have one passkey attached to this identity. If you lose access to this device, you will lose access to your identity. Add another device to protect your identity.",
+    "paragraph_add_device_pin_only": "You are using a temporary key. If you lose access to this device or clear the storage of the browser, you will lose access to your identity. Add another device to protect your identity.",
+
     "what_is_phrase_q": "What is a recovery phrase?",
     "what_is_phrase_a": "A secret phrase that includes your Internet Identity number and a unique combination of 24 words that represent your private key",
 

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -80,6 +80,53 @@ export const addPhrase = ({
   );
 };
 
+type DeviceStatus = "pin-only" | "one-passkey";
+
+const addDeviceWarningTemplate = ({
+  ok,
+  remindLater,
+  doNotRemindAgain,
+  i18n,
+  status,
+}: {
+  ok: () => void;
+  remindLater: () => void;
+  doNotRemindAgain: () => void;
+  i18n: I18n;
+  status: DeviceStatus;
+}): TemplateResult => {
+  const copy = i18n.i18n(copyJson);
+
+  const [paragraph, title] = {
+    "pin-only": [
+      copy.paragraph_add_device_pin_only,
+      copy.add_device_title_pin_only,
+    ],
+    "one-passkey": [
+      copy.paragraph_add_device_one_passkey,
+      copy.add_device_title_one_passkey,
+    ],
+  }[status];
+
+  return infoScreenTemplate({
+    cancel: remindLater,
+    cancelText: copy.remind_later,
+    next: ok,
+    nextText: copy.add_device,
+    additionalAction: doNotRemindAgain,
+    additionalActionText: copy.do_not_remind,
+    title,
+    paragraph,
+    scrollToTop: true,
+    icon: "warning",
+    pageId: "add-another-device-warning",
+    label: copy.label_warning,
+  });
+};
+
+// TODO: Create the `addDeviceWarning` page and use it in `recoveryWizard` function.
+export const addDeviceWarningPage = renderPage(addDeviceWarningTemplate);
+
 // TODO: Add e2e test https://dfinity.atlassian.net/browse/GIX-2600
 export const recoveryWizard = async (
   userNumber: bigint,

--- a/src/showcase/src/pages/addDeviceWarningOnePasskey.astro
+++ b/src/showcase/src/pages/addDeviceWarningOnePasskey.astro
@@ -1,0 +1,19 @@
+---
+import Screen from "../layouts/Screen.astro";
+---
+
+<Screen title="Add Phrase" pageName="addPhrase">
+  <script>
+    import { toast } from "$src/components/toast";
+    import { i18n } from "../i18n";
+    import { addDeviceWarningPage } from "$src/flows/recovery/recoveryWizard";
+
+    addDeviceWarningPage({
+      ok: () => toast.info("ok"),
+      remindLater: () => toast.info("Remind later"),
+      doNotRemindAgain: () => toast.info("Do not remind again"),
+      i18n,
+      status: "one-passkey",
+    });
+  </script>
+</Screen>

--- a/src/showcase/src/pages/addDeviceWarningOnlyPin.astro
+++ b/src/showcase/src/pages/addDeviceWarningOnlyPin.astro
@@ -1,0 +1,19 @@
+---
+import Screen from "../layouts/Screen.astro";
+---
+
+<Screen title="Add Phrase" pageName="addPhrase">
+  <script>
+    import { toast } from "$src/components/toast";
+    import { i18n } from "../i18n";
+    import { addDeviceWarningPage } from "$src/flows/recovery/recoveryWizard";
+
+    addDeviceWarningPage({
+      ok: () => toast.info("ok"),
+      remindLater: () => toast.info("Remind later"),
+      doNotRemindAgain: () => toast.info("Do not remind again"),
+      i18n,
+      status: "pin-only",
+    });
+  </script>
+</Screen>


### PR DESCRIPTION
The main motivation is to stop using "Recovery" concept.

In this PR, we create a page that will substitute the warning page shown to users with a pin key once a week.

At the moment, the warning page suggests the users to add a recovery phrase.

The new page will have two flavors:
* User has only pin key: It will suggest to add a device.
* User has only one passkey: It will suggest to add another device.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5d1d12f7d/desktop/addDeviceWarningOnePasskey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5d1d12f7d/desktop/addDeviceWarningOnlyPin.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5d1d12f7d/mobile/addDeviceWarningOnePasskey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5d1d12f7d/mobile/addDeviceWarningOnlyPin.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
