### PR TITLE
Use new warning page and change the rendering logic

### DIFF
--- a/src/frontend/src/flows/recovery/recoveryWizard.test.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.test.ts
@@ -1,0 +1,147 @@
+import {
+  AnchorCredentials,
+  CredentialId,
+  PublicKey,
+  WebAuthnCredential,
+} from "$generated/internet_identity_types";
+import { shouldShowRecoveryWarning } from "./recoveryWizard";
+
+const ONE_WEEK_MILLIS = 7 * 24 * 60 * 60 * 1000;
+const nowInMillis = 1722259851155;
+const moreThanAWeekAgo = nowInMillis - ONE_WEEK_MILLIS - 1;
+
+const noCredentials: AnchorCredentials = {
+  credentials: [],
+  recovery_credentials: [],
+  recovery_phrases: [],
+};
+
+const device: WebAuthnCredential = {
+  pubkey: [] as PublicKey,
+  credential_id: [] as CredentialId,
+};
+
+const oneDeviceOnly: AnchorCredentials = {
+  credentials: [device],
+  recovery_credentials: [],
+  recovery_phrases: [],
+};
+
+const oneRecoveryDeviceOnly: AnchorCredentials = {
+  credentials: [],
+  recovery_credentials: [device],
+  recovery_phrases: [],
+};
+
+const oneDeviceAndPhrase: AnchorCredentials = {
+  credentials: [device],
+  recovery_credentials: [],
+  recovery_phrases: [[] as PublicKey],
+};
+
+const twoDevices: AnchorCredentials = {
+  credentials: [device, { ...device }],
+  recovery_credentials: [],
+  recovery_phrases: [[] as PublicKey],
+};
+
+const oneNormalOneRecovery: AnchorCredentials = {
+  credentials: [device],
+  recovery_credentials: [device],
+  recovery_phrases: [[] as PublicKey],
+};
+
+test("shouldShowRecoveryWarning returns true for user with pin and has seen recovery longer than a week ago", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: noCredentials,
+      identityMetadata: {
+        recoveryPageShownTimestampMillis: moreThanAWeekAgo,
+      },
+      nowInMillis,
+    })
+  ).toBe(true);
+});
+
+test("shouldShowRecoveryWarning returns true for user with one passkey and has seen recovery longer than a week ago", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: oneDeviceOnly,
+      identityMetadata: {
+        recoveryPageShownTimestampMillis: moreThanAWeekAgo,
+      },
+      nowInMillis,
+    })
+  ).toBe(true);
+});
+
+test("shouldShowRecoveryWarning returns true for user with one passkey and empty identity metadata", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: oneDeviceOnly,
+      identityMetadata: {},
+      nowInMillis,
+    })
+  ).toBe(true);
+});
+
+test("shouldShowRecoveryWarning returns true for user with one recovery device and has seen recovery longer than a week ago", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: oneRecoveryDeviceOnly,
+      identityMetadata: {
+        recoveryPageShownTimestampMillis: moreThanAWeekAgo,
+      },
+      nowInMillis,
+    })
+  ).toBe(true);
+});
+
+test("shouldShowRecoveryWarning doesn't count phrase as one device", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: oneDeviceAndPhrase,
+      identityMetadata: {
+        recoveryPageShownTimestampMillis: moreThanAWeekAgo,
+      },
+      nowInMillis,
+    })
+  ).toBe(true);
+});
+
+test("shouldShowRecoveryWarning returns false for user with pin that has disabled the warning", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: noCredentials,
+      identityMetadata: {
+        recoveryPageShownTimestampMillis: moreThanAWeekAgo,
+        doNotShowRecoveryPageRequestTimestampMillis: moreThanAWeekAgo,
+      },
+      nowInMillis,
+    })
+  ).toBe(false);
+});
+
+test("shouldShowRecoveryWarning returns false for user with two devices", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: twoDevices,
+      identityMetadata: {
+        recoveryPageShownTimestampMillis: moreThanAWeekAgo,
+      },
+      nowInMillis,
+    })
+  ).toBe(false);
+});
+
+test("shouldShowRecoveryWarning returns false for user with one normal device and a recovery device", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: oneNormalOneRecovery,
+      identityMetadata: {
+        recoveryPageShownTimestampMillis: moreThanAWeekAgo,
+      },
+      nowInMillis,
+    })
+  ).toBe(false);
+});

--- a/src/frontend/src/flows/recovery/recoveryWizard.test.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.test.ts
@@ -104,7 +104,7 @@ test("shouldShowRecoveryWarning returns true for user with one recovery device a
   ).toBe(true);
 });
 
-test("shouldShowRecoveryWarning doesn't count phrase as one device", () => {
+test("shouldShowRecoveryWarning returns true for user with one device and a recovery phrase", () => {
   expect(
     shouldShowRecoveryWarning({
       credentials: oneDeviceAndPhrase,

--- a/src/frontend/src/flows/recovery/recoveryWizard.test.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.test.ts
@@ -9,6 +9,7 @@ import { shouldShowRecoveryWarning } from "./recoveryWizard";
 const ONE_WEEK_MILLIS = 7 * 24 * 60 * 60 * 1000;
 const nowInMillis = 1722259851155;
 const moreThanAWeekAgo = nowInMillis - ONE_WEEK_MILLIS - 1;
+const lessThanAWeekAgo = nowInMillis - 1;
 
 const noCredentials: AnchorCredentials = {
   credentials: [],
@@ -41,6 +42,12 @@ const oneDeviceAndPhrase: AnchorCredentials = {
 
 const twoDevices: AnchorCredentials = {
   credentials: [device, { ...device }],
+  recovery_credentials: [],
+  recovery_phrases: [[] as PublicKey],
+};
+
+const threeDevices: AnchorCredentials = {
+  credentials: [device, { ...device }, { ...device }],
   recovery_credentials: [],
   recovery_phrases: [[] as PublicKey],
 };
@@ -122,6 +129,19 @@ test("shouldShowRecoveryWarning returns false for user with pin that has disable
   ).toBe(false);
 });
 
+test("shouldShowRecoveryWarning returns false for user with one device that has disabled the warning", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: oneDeviceOnly,
+      identityMetadata: {
+        recoveryPageShownTimestampMillis: moreThanAWeekAgo,
+        doNotShowRecoveryPageRequestTimestampMillis: moreThanAWeekAgo,
+      },
+      nowInMillis,
+    })
+  ).toBe(false);
+});
+
 test("shouldShowRecoveryWarning returns false for user with two devices", () => {
   expect(
     shouldShowRecoveryWarning({
@@ -140,6 +160,28 @@ test("shouldShowRecoveryWarning returns false for user with one normal device an
       credentials: oneNormalOneRecovery,
       identityMetadata: {
         recoveryPageShownTimestampMillis: moreThanAWeekAgo,
+      },
+      nowInMillis,
+    })
+  ).toBe(false);
+});
+
+test("shouldShowRecoveryWarning returns false for user with more than two devices and empty identity metadata", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: threeDevices,
+      identityMetadata: {},
+      nowInMillis,
+    })
+  ).toBe(false);
+});
+
+test("shouldShowRecoveryWarning returns false for user with pin and has seen recovery less than a week ago", () => {
+  expect(
+    shouldShowRecoveryWarning({
+      credentials: noCredentials,
+      identityMetadata: {
+        recoveryPageShownTimestampMillis: lessThanAWeekAgo,
       },
       nowInMillis,
     })

--- a/src/frontend/src/flows/recovery/recoveryWizard.test.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.test.ts
@@ -4,12 +4,16 @@ import {
   PublicKey,
   WebAuthnCredential,
 } from "$generated/internet_identity_types";
-import { shouldShowRecoveryWarning } from "./recoveryWizard";
+import { PinIdentityMaterial } from "../pin/idb";
+import { getDevicesStatus } from "./recoveryWizard";
 
 const ONE_WEEK_MILLIS = 7 * 24 * 60 * 60 * 1000;
 const nowInMillis = 1722259851155;
 const moreThanAWeekAgo = nowInMillis - ONE_WEEK_MILLIS - 1;
 const lessThanAWeekAgo = nowInMillis - 1;
+
+const pinIdentityMaterial: PinIdentityMaterial =
+  {} as unknown as PinIdentityMaterial;
 
 const noCredentials: AnchorCredentials = {
   credentials: [],
@@ -58,132 +62,143 @@ const oneNormalOneRecovery: AnchorCredentials = {
   recovery_phrases: [[] as PublicKey],
 };
 
-test("shouldShowRecoveryWarning returns true for user with pin and has seen recovery longer than a week ago", () => {
+test("getDevicesStatus returns 'pin-only' for user with pin and has seen recovery longer than a week ago", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: noCredentials,
       identityMetadata: {
         recoveryPageShownTimestampMillis: moreThanAWeekAgo,
       },
+      pinIdentityMaterial,
       nowInMillis,
     })
-  ).toBe(true);
+  ).toBe("pin-only");
 });
 
-test("shouldShowRecoveryWarning returns true for user with one passkey and has seen recovery longer than a week ago", () => {
+test("getDevicesStatus returns 'one-device' for user with one passkey and has seen recovery longer than a week ago", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: oneDeviceOnly,
       identityMetadata: {
         recoveryPageShownTimestampMillis: moreThanAWeekAgo,
       },
+      pinIdentityMaterial: undefined,
       nowInMillis,
     })
-  ).toBe(true);
+  ).toBe("one-device");
 });
 
-test("shouldShowRecoveryWarning returns true for user with one passkey and empty identity metadata", () => {
+test("getDevicesStatus returns true for user with one passkey and empty identity metadata", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: oneDeviceOnly,
       identityMetadata: {},
+      pinIdentityMaterial: undefined,
       nowInMillis,
     })
-  ).toBe(true);
+  ).toBe("one-device");
 });
 
-test("shouldShowRecoveryWarning returns true for user with one recovery device and has seen recovery longer than a week ago", () => {
+test("getDevicesStatus returns 'one-device' for user with one recovery device and has seen recovery longer than a week ago", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: oneRecoveryDeviceOnly,
       identityMetadata: {
         recoveryPageShownTimestampMillis: moreThanAWeekAgo,
       },
+      pinIdentityMaterial: undefined,
       nowInMillis,
     })
-  ).toBe(true);
+  ).toBe("one-device");
 });
 
-test("shouldShowRecoveryWarning returns true for user with one device and a recovery phrase", () => {
+test("getDevicesStatus returns 'one-device' for user with one device and a recovery phrase", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: oneDeviceAndPhrase,
       identityMetadata: {
         recoveryPageShownTimestampMillis: moreThanAWeekAgo,
       },
+      pinIdentityMaterial: undefined,
       nowInMillis,
     })
-  ).toBe(true);
+  ).toBe("one-device");
 });
 
-test("shouldShowRecoveryWarning returns false for user with pin that has disabled the warning", () => {
+test("getDevicesStatus returns 'no-warning' for user with pin that has disabled the warning", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: noCredentials,
       identityMetadata: {
         recoveryPageShownTimestampMillis: moreThanAWeekAgo,
         doNotShowRecoveryPageRequestTimestampMillis: moreThanAWeekAgo,
       },
+      pinIdentityMaterial,
       nowInMillis,
     })
-  ).toBe(false);
+  ).toBe("no-warning");
 });
 
-test("shouldShowRecoveryWarning returns false for user with one device that has disabled the warning", () => {
+test("getDevicesStatus returns 'no-warning' for user with one device that has disabled the warning", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: oneDeviceOnly,
       identityMetadata: {
         recoveryPageShownTimestampMillis: moreThanAWeekAgo,
         doNotShowRecoveryPageRequestTimestampMillis: moreThanAWeekAgo,
       },
+      pinIdentityMaterial: undefined,
       nowInMillis,
     })
-  ).toBe(false);
+  ).toBe("no-warning");
 });
 
-test("shouldShowRecoveryWarning returns false for user with two devices", () => {
+test("getDevicesStatus returns 'no-warning' for user with two devices", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: twoDevices,
       identityMetadata: {
         recoveryPageShownTimestampMillis: moreThanAWeekAgo,
       },
+      pinIdentityMaterial: undefined,
       nowInMillis,
     })
-  ).toBe(false);
+  ).toBe("no-warning");
 });
 
-test("shouldShowRecoveryWarning returns false for user with one normal device and a recovery device", () => {
+test("getDevicesStatus returns 'no-warning' for user with one normal device and a recovery device", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: oneNormalOneRecovery,
       identityMetadata: {
         recoveryPageShownTimestampMillis: moreThanAWeekAgo,
       },
+      pinIdentityMaterial: undefined,
       nowInMillis,
     })
-  ).toBe(false);
+  ).toBe("no-warning");
 });
 
-test("shouldShowRecoveryWarning returns false for user with more than two devices and empty identity metadata", () => {
+test("getDevicesStatus returns 'no-warning' for user with more than two devices and empty identity metadata", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: threeDevices,
       identityMetadata: {},
+      pinIdentityMaterial: undefined,
       nowInMillis,
     })
-  ).toBe(false);
+  ).toBe("no-warning");
 });
 
-test("shouldShowRecoveryWarning returns false for user with pin and has seen recovery less than a week ago", () => {
+test("getDevicesStatus returns 'no-warning' for user with pin and has seen recovery less than a week ago", () => {
   expect(
-    shouldShowRecoveryWarning({
+    getDevicesStatus({
       credentials: noCredentials,
       identityMetadata: {
         recoveryPageShownTimestampMillis: lessThanAWeekAgo,
       },
+      pinIdentityMaterial,
       nowInMillis,
     })
-  ).toBe(false);
+  ).toBe("no-warning");
 });

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -152,7 +152,7 @@ export const addDeviceWarning = ({
 };
 
 /**
- * Helper to encapsulate the logic of when to show the recovery warning page.
+ * Helper to encapsulate the logic of when and which recovery warning page to show.
  *
  * Three conditions must be met for the warning page to be shown:
  * * Not having seen the recovery page in the last week
@@ -162,9 +162,14 @@ export const addDeviceWarning = ({
  * * The user has not disabled the warning.
  *    (users can choose to not see the warning again by clicking "do not remind" button)
  *
+ * If the page is shown, there are two options:
+ * * User has only the pin authentication method.
+ * * User has only one device.
+ *
  * @param params {Object}
  * @param params.credentials {AnchorCredentials}
  * @param params.identityMetadata {IdentityMetadata | undefined}
+ * @param params.pinIdentityMaterial {PinIdentityMaterial | undefined}
  * @param params.nowInMillis {number}
  * @returns {DeviceStatus | "no-warning"}
  */

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -154,8 +154,7 @@ export const addDeviceWarning = ({
  * * Not having seen the recovery page in the last week
  *    (on registration, the user is not shown the page, but set it as seen to not bother during the onboarding)
  * * The user has less than one device.
- *    (a phrase is not considered a device, only normal devices or recovery devices)
- *    (the pin is not considered a device)
+ *    (a phrase and pin are not considered a device, only normal devices or recovery devices)
  * * The user has not disabled the warning.
  *    (users can choose to not see the warning again by clicking "do not remind" button)
  *

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -157,12 +157,12 @@ export const addDeviceWarning = ({
  * Three conditions must be met for the warning page to be shown:
  * * Not having seen the recovery page in the last week
  *    (on registration, the user is not shown the page, but set it as seen to not bother during the onboarding)
- * * The user has less than one device.
+ * * The user has at most one device.
  *    (a phrase and pin are not considered a device, only normal devices or recovery devices)
  * * The user has not disabled the warning.
  *    (users can choose to not see the warning again by clicking "do not remind" button)
  *
- * If the page is shown, there are two options:
+ * When the warning page is shown, two different messages could be displayed:
  * * User has only the pin authentication method.
  * * User has only one device.
  *

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -229,20 +229,20 @@ export const recoveryWizard = async (
   );
   const nowInMillis = Date.now();
 
-  const devivesStatus = getDevicesStatus({
+  const devicesStatus = getDevicesStatus({
     credentials,
     identityMetadata,
     pinIdentityMaterial,
     nowInMillis,
   });
 
-  if (devivesStatus !== "no-warning") {
+  if (devicesStatus !== "no-warning") {
     // `await` here doesn't add any waiting time beacause we already got the metadata earlier.
     await connection.updateIdentityMetadata({
       recoveryPageShownTimestampMillis: nowInMillis,
     });
     const userChoice = await addDeviceWarning({
-      status: devivesStatus,
+      status: devicesStatus,
     });
     if (userChoice.action === "add-device") {
       await addDevice({ userNumber, connection });

--- a/src/frontend/src/repositories/identityMetadata.test.ts
+++ b/src/frontend/src/repositories/identityMetadata.test.ts
@@ -1,19 +1,26 @@
 import { MetadataMapV2 } from "$generated/internet_identity_types";
 import {
+  DO_NOT_SHOW_RECOVERY_PAGE_REQUEST_TIMESTAMP_MILLIS,
   IdentityMetadata,
   IdentityMetadataRepository,
   RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
 } from "./identityMetadata";
 
 const recoveryPageShownTimestampMillis = 1234567890;
+const doNotShowRecoveryPageRequestTimestampMillis = 3456789012;
 const mockRawMetadata: MetadataMapV2 = [
   [
     RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
     { String: String(recoveryPageShownTimestampMillis) },
   ],
+  [
+    DO_NOT_SHOW_RECOVERY_PAGE_REQUEST_TIMESTAMP_MILLIS,
+    { String: String(doNotShowRecoveryPageRequestTimestampMillis) },
+  ],
 ];
 const mockIdentityMetadata: IdentityMetadata = {
   recoveryPageShownTimestampMillis,
+  doNotShowRecoveryPageRequestTimestampMillis,
 };
 
 const getterMockSuccess = vi.fn().mockResolvedValue(mockRawMetadata);
@@ -66,9 +73,78 @@ test("IdentityMetadataRepository returns undefined without raising an error if f
   expect(console.warn).toHaveBeenCalledTimes(1);
 });
 
+test("IdentityMetadataRepository changes partial data in memory", async () => {
+  const instance = IdentityMetadataRepository.init({
+    getter: getterMockSuccess,
+    setter: setterMockSuccess,
+  });
+
+  const newRecoveryPageShownTimestampMillis = 9876543210;
+  await instance.updateMetadata({
+    recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
+  });
+
+  expect(await instance.getMetadata()).toEqual({
+    recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
+    doNotShowRecoveryPageRequestTimestampMillis:
+      doNotShowRecoveryPageRequestTimestampMillis,
+  });
+});
+
 test("IdentityMetadataRepository changes data in memory", async () => {
   const instance = IdentityMetadataRepository.init({
     getter: getterMockSuccess,
+    setter: setterMockSuccess,
+  });
+
+  const newRecoveryPageShownTimestampMillis = 9876543210;
+  const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
+  await instance.updateMetadata({
+    recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
+    doNotShowRecoveryPageRequestTimestampMillis:
+      newDoNotShowRecoveryPageRequestTimestampMillis,
+  });
+
+  expect(await instance.getMetadata()).toEqual({
+    recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
+    doNotShowRecoveryPageRequestTimestampMillis:
+      newDoNotShowRecoveryPageRequestTimestampMillis,
+  });
+});
+
+test("IdentityMetadataRepository sets data from partial data in memory", async () => {
+  const partialMetadata: MetadataMapV2 = [
+    [
+      RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
+      { String: String(recoveryPageShownTimestampMillis) },
+    ],
+  ];
+  const instance = IdentityMetadataRepository.init({
+    getter: vi.fn().mockResolvedValue(partialMetadata),
+    setter: setterMockSuccess,
+  });
+
+  expect(await instance.getMetadata()).toEqual({
+    recoveryPageShownTimestampMillis: recoveryPageShownTimestampMillis,
+  });
+
+  const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
+  await instance.updateMetadata({
+    doNotShowRecoveryPageRequestTimestampMillis:
+      newDoNotShowRecoveryPageRequestTimestampMillis,
+  });
+
+  expect(await instance.getMetadata()).toEqual({
+    recoveryPageShownTimestampMillis: recoveryPageShownTimestampMillis,
+    doNotShowRecoveryPageRequestTimestampMillis:
+      newDoNotShowRecoveryPageRequestTimestampMillis,
+  });
+});
+
+test("IdentityMetadataRepository sets partial data in memory", async () => {
+  const noMetadata: MetadataMapV2 = [];
+  const instance = IdentityMetadataRepository.init({
+    getter: vi.fn().mockResolvedValue(noMetadata),
     setter: setterMockSuccess,
   });
 
@@ -90,12 +166,17 @@ test("IdentityMetadataRepository sets data in memory", async () => {
   });
 
   const newRecoveryPageShownTimestampMillis = 9876543210;
+  const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
   await instance.updateMetadata({
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
+    doNotShowRecoveryPageRequestTimestampMillis:
+      newDoNotShowRecoveryPageRequestTimestampMillis,
   });
 
   expect(await instance.getMetadata()).toEqual({
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
+    doNotShowRecoveryPageRequestTimestampMillis:
+      newDoNotShowRecoveryPageRequestTimestampMillis,
   });
 });
 
@@ -106,8 +187,11 @@ test("IdentityMetadataRepository commits updated metadata to canister", async ()
   });
 
   const newRecoveryPageShownTimestampMillis = 9876543210;
+  const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
   await instance.updateMetadata({
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
+    doNotShowRecoveryPageRequestTimestampMillis:
+      newDoNotShowRecoveryPageRequestTimestampMillis,
   });
 
   expect(setterMockSuccess).not.toHaveBeenCalled();
@@ -118,6 +202,10 @@ test("IdentityMetadataRepository commits updated metadata to canister", async ()
     [
       RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
       { String: String(newRecoveryPageShownTimestampMillis) },
+    ],
+    [
+      DO_NOT_SHOW_RECOVERY_PAGE_REQUEST_TIMESTAMP_MILLIS,
+      { String: String(newDoNotShowRecoveryPageRequestTimestampMillis) },
     ],
   ]);
 });
@@ -141,8 +229,11 @@ test("IdentityMetadataRepository doesn't raise an error if committing fails", as
   });
 
   const newRecoveryPageShownTimestampMillis = 9876543210;
+  const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
   const newMetadata = {
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
+    doNotShowRecoveryPageRequestTimestampMillis:
+      newDoNotShowRecoveryPageRequestTimestampMillis,
   };
   await instance.updateMetadata(newMetadata);
 
@@ -155,6 +246,10 @@ test("IdentityMetadataRepository doesn't raise an error if committing fails", as
     [
       RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
       { String: String(newRecoveryPageShownTimestampMillis) },
+    ],
+    [
+      DO_NOT_SHOW_RECOVERY_PAGE_REQUEST_TIMESTAMP_MILLIS,
+      { String: String(newDoNotShowRecoveryPageRequestTimestampMillis) },
     ],
   ]);
 
@@ -190,10 +285,54 @@ test("IdentityMetadataRepository commits additional metadata to canister after u
 
   expect(setterMockSuccess).toHaveBeenCalledTimes(1);
   expect(setterMockSuccess).toHaveBeenCalledWith([
-    anotherMetadataEntry,
     [
       RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
       { String: String(newRecoveryPageShownTimestampMillis) },
+    ],
+    anotherMetadataEntry,
+  ]);
+});
+
+test("IdentityMetadataRepository commits from initial partial data after adding more partial data", async () => {
+  const partialMetadata: MetadataMapV2 = [
+    [
+      RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
+      { String: String(recoveryPageShownTimestampMillis) },
+    ],
+  ];
+  const instance = IdentityMetadataRepository.init({
+    getter: vi.fn().mockResolvedValue(partialMetadata),
+    setter: setterMockSuccess,
+  });
+
+  expect(await instance.getMetadata()).toEqual({
+    recoveryPageShownTimestampMillis: recoveryPageShownTimestampMillis,
+  });
+
+  const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
+  await instance.updateMetadata({
+    doNotShowRecoveryPageRequestTimestampMillis:
+      newDoNotShowRecoveryPageRequestTimestampMillis,
+  });
+
+  expect(await instance.getMetadata()).toEqual({
+    recoveryPageShownTimestampMillis: recoveryPageShownTimestampMillis,
+    doNotShowRecoveryPageRequestTimestampMillis:
+      newDoNotShowRecoveryPageRequestTimestampMillis,
+  });
+
+  expect(setterMockSuccess).not.toHaveBeenCalled();
+  await instance.commitMetadata();
+
+  expect(setterMockSuccess).toHaveBeenCalledTimes(1);
+  expect(setterMockSuccess).toHaveBeenCalledWith([
+    [
+      RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
+      { String: String(recoveryPageShownTimestampMillis) },
+    ],
+    [
+      DO_NOT_SHOW_RECOVERY_PAGE_REQUEST_TIMESTAMP_MILLIS,
+      { String: String(newDoNotShowRecoveryPageRequestTimestampMillis) },
     ],
   ]);
 });

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -353,3 +353,10 @@ export type OmitParams<T extends (arg: any) => any, A extends string> = (
 // Zip two arrays together
 export const zip = <A, B>(a: A[], b: B[]): [A, B][] =>
   Array.from(Array(Math.min(b.length, a.length)), (_, i) => [a[i], b[i]]);
+
+export const isValidKey = <T>(
+  key: string | number | symbol,
+  keys: Array<keyof T>
+): key is keyof T => {
+  return keys.includes(key as keyof T);
+};

--- a/src/showcase/src/pages/addDeviceWarningOnePasskey.astro
+++ b/src/showcase/src/pages/addDeviceWarningOnePasskey.astro
@@ -13,7 +13,7 @@ import Screen from "../layouts/Screen.astro";
       remindLater: () => toast.info("Remind later"),
       doNotRemindAgain: () => toast.info("Do not remind again"),
       i18n,
-      status: "one-passkey",
+      status: "one-device",
     });
   </script>
 </Screen>


### PR DESCRIPTION
Motivation is to stop recommending recovery phrase and instead recommend securing the identity with multiple devices.

We added a new warning page in #2550.

In this PR, the recoveryWizard uses the new page and also changes the logic of rendering.

Three conditions must be met for the warning page to be shown:

* Not having seen the recovery page in the last week
   (on registration, the user is not shown the page, but set it as seen to not bother during the onboarding)
* The user has less than one device.
   (a phrase and pin are not considered a device, only normal devices or recovery devices)
* The user has not disabled the warning.
   (users can choose to not see the warning again by clicking "do not remind" button)





<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6fe7d000a/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->




