### PR TITLE
Change WebAuthn create challenge to 16 random bytes

### DIFF
--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -762,7 +762,7 @@ export const creationOptions = (
             type: "public-key",
           }
     ),
-    challenge: Uint8Array.from("<ic0.app>", (c) => c.charCodeAt(0)),
+    challenge: window.crypto.getRandomValues(new Uint8Array(16)),
     pubKeyCredParams: [
       {
         type: "public-key",


### PR DESCRIPTION
According to the WebAuthn spec the challenge _should_ be at least 16 bytes. So far it was 9. Apparently, KeePassXC verifies the challenge length and refuses to sign shorter values.

This changes the length to 16 bytes which should address the problem.

Closes #2560.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6d9e64e71/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6d9e64e71/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
