### PR TITLE
Simplify identity metadata repository

### DIFF
--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -216,16 +216,14 @@ const authenticate = async (
     authContext.authRequest.derivationOrigin ?? authContext.requestOrigin;
 
   // Ignore the response of committing the metadata because it's not crucial.
-  const [result] = await withLoader(() =>
-    Promise.all([
-      fetchDelegation({
-        connection: authSuccess.connection,
-        derivationOrigin,
-        publicKey: authContext.authRequest.sessionPublicKey,
-        maxTimeToLive: authContext.authRequest.maxTimeToLive,
-      }),
-      authSuccess.connection.commitMetadata(),
-    ])
+  void authSuccess.connection.commitMetadata();
+  const result = await withLoader(() =>
+    fetchDelegation({
+      connection: authSuccess.connection,
+      derivationOrigin,
+      publicKey: authContext.authRequest.sessionPublicKey,
+      maxTimeToLive: authContext.authRequest.maxTimeToLive,
+    })
   );
 
   if ("error" in result) {

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -244,9 +244,8 @@ export const renderManage = async ({
     let anchorInfo: IdentityAnchorInfo;
     try {
       // Ignore the `commitMetadata` response, it's not critical for the application.
-      [anchorInfo] = await withLoader(() =>
-        Promise.all([connection.getAnchorInfo(), connection.commitMetadata()])
-      );
+      void connection.commitMetadata();
+      anchorInfo = await withLoader(() => connection.getAnchorInfo());
     } catch (error: unknown) {
       await displayFailedToListDevices(
         error instanceof Error ? error : unknownError()

--- a/src/frontend/src/repositories/identityMetadata.test.ts
+++ b/src/frontend/src/repositories/identityMetadata.test.ts
@@ -25,7 +25,7 @@ const mockIdentityMetadata: IdentityMetadata = {
 
 const getterMockSuccess = vi.fn().mockResolvedValue(mockRawMetadata);
 const getterMockError = vi.fn().mockImplementation(() => {
-  throw new Error("test error");
+  return Promise.reject(Error("test error"));
 });
 const setterMockSuccess = vi.fn();
 const setterMockError = vi.fn().mockRejectedValue("test error");
@@ -64,12 +64,11 @@ test("IdentityMetadataRepository returns undefined without raising an error if f
     setter: setterMockSuccess,
   });
 
-  // Error is not thrown, but warnings is logged.
-  expect(console.warn).toHaveBeenCalledTimes(1);
   expect(getterMockError).toHaveBeenCalledTimes(1);
 
   expect(await instance.getMetadata()).toEqual(undefined);
   expect(getterMockError).toHaveBeenCalledTimes(1);
+  // Error is not thrown, but warnings is logged.
   expect(console.warn).toHaveBeenCalledTimes(1);
 });
 

--- a/src/frontend/src/repositories/identityMetadata.ts
+++ b/src/frontend/src/repositories/identityMetadata.ts
@@ -1,5 +1,5 @@
 import { MetadataMapV2 } from "$generated/internet_identity_types";
-import { isValidKey } from "$src/utils/utils";
+import { isValidKey, unknownToString } from "$src/utils/utils";
 
 export type IdentityMetadata = {
   recoveryPageShownTimestampMillis?: number;
@@ -72,7 +72,6 @@ const updateMetadataMapV2 = ({
 
 type MetadataGetter = () => Promise<MetadataMapV2>;
 type MetadataSetter = (metadata: MetadataMapV2) => Promise<void>;
-type RawMetadataState = MetadataMapV2 | "loading" | "error" | "not-loaded";
 
 /**
  * Class to manage the metadata of the identity and interact with the canister.
@@ -85,11 +84,9 @@ type RawMetadataState = MetadataMapV2 | "loading" | "error" | "not-loaded";
  * The metadata needs to be committed to the canister with the `commitMetadata` method to persist the changes.
  */
 export class IdentityMetadataRepository {
-  // The nice IdentityMetadata is exposed to the outside world, while the raw metadata is kept private.
-  // We keep all the raw data to maintain other metadata fields.
-  private rawMetadata: RawMetadataState;
   // Flag to keep track whether we need to commit the metadata to the canister.
   private updatedMetadata: boolean;
+  private metadata: Promise<MetadataMapV2>;
   private readonly getter: MetadataGetter;
   private readonly setter: MetadataSetter;
 
@@ -100,10 +97,8 @@ export class IdentityMetadataRepository {
     getter: MetadataGetter;
     setter: MetadataSetter;
   }) => {
-    const instance = new IdentityMetadataRepository({ getter, setter });
     // Load the metadata in the background.
-    void instance.loadMetadata();
-    return instance;
+    return new IdentityMetadataRepository({ getter, setter });
   };
 
   private constructor({
@@ -115,55 +110,9 @@ export class IdentityMetadataRepository {
   }) {
     this.getter = getter;
     this.setter = setter;
-    this.rawMetadata = "not-loaded";
+    this.metadata = this.getter();
     this.updatedMetadata = false;
   }
-
-  /**
-   * Load the metadata in the instance variable `rawMetadata`.
-   *
-   * This method won't throw an error if the metadata can't be loaded.
-   * Instead, it will set the instance variable `rawMetadata` to "error".
-   *
-   * @returns {Promise<void>} In case a client wants to wait for the metadata to be loaded.
-   */
-  loadMetadata = async (): Promise<void> => {
-    this.rawMetadata = "loading";
-    try {
-      this.updatedMetadata = false;
-      this.rawMetadata = await this.getter();
-    } catch (error) {
-      // Do not throw the error because this is not critical for the application.
-      this.rawMetadata = "error";
-      console.warn("Error loading metadata", error);
-      return;
-    }
-  };
-
-  private metadataIsLoaded = (
-    metadata: RawMetadataState
-  ): metadata is MetadataMapV2 => {
-    return (
-      metadata !== "loading" &&
-      metadata !== "error" &&
-      metadata !== "not-loaded"
-    );
-  };
-
-  /**
-   * Waits a maximum of 10 seconds for the metadata to be loaded.
-   *
-   * It doesn't throw an error if the metadata is not loaded.
-   */
-  private waitUntilMetadataIsLoaded = async (): Promise<void> => {
-    let currentWait = 0;
-    const MAX_WAIT_MILLIS = 10_000;
-    const ONE_WAIT_MILLIS = 1_000;
-    while (this.rawMetadata === "loading" && currentWait < MAX_WAIT_MILLIS) {
-      await new Promise((resolve) => setTimeout(resolve, ONE_WAIT_MILLIS));
-      currentWait += ONE_WAIT_MILLIS;
-    }
-  };
 
   /**
    * Returns the metadata transformed to `IdentityMetadata`.
@@ -173,9 +122,13 @@ export class IdentityMetadataRepository {
    * @returns {IdentityMetadata | undefined}
    */
   getMetadata = async (): Promise<IdentityMetadata | undefined> => {
-    await this.waitUntilMetadataIsLoaded();
-    if (this.metadataIsLoaded(this.rawMetadata)) {
-      return convertMetadata(this.rawMetadata);
+    try {
+      return convertMetadata(await this.metadata);
+    } catch (e) {
+      console.warn(
+        "Failed to load identity metadata: ",
+        unknownToString(e, "unknown error")
+      );
     }
     return undefined;
   };
@@ -196,13 +149,19 @@ export class IdentityMetadataRepository {
   updateMetadata = async (
     partialMetadata: Partial<IdentityMetadata>
   ): Promise<void> => {
-    await this.waitUntilMetadataIsLoaded();
-    if (this.metadataIsLoaded(this.rawMetadata)) {
+    try {
+      this.metadata = Promise.resolve(
+        updateMetadataMapV2({
+          metadataMap: await this.metadata,
+          partialIdentityMetadata: partialMetadata,
+        })
+      );
       this.updatedMetadata = true;
-      this.rawMetadata = updateMetadataMapV2({
-        metadataMap: this.rawMetadata,
-        partialIdentityMetadata: partialMetadata,
-      });
+    } catch (e) {
+      console.warn(
+        "Error updating identity metadata: ",
+        unknownToString(e, "unknown error")
+      );
     }
     // Do nothing if the metadata is not loaded.
   };
@@ -215,12 +174,15 @@ export class IdentityMetadataRepository {
    * `false` if there was an error committing the metadata.
    */
   commitMetadata = async (): Promise<boolean> => {
-    if (this.metadataIsLoaded(this.rawMetadata) && this.updatedMetadata) {
+    if (this.updatedMetadata) {
       try {
-        await this.setter(this.rawMetadata);
+        await this.setter(await this.metadata);
         return true;
       } catch (error) {
-        console.warn("Error committing metadata", error);
+        console.warn(
+          "Error committing identity metadata: ",
+          unknownToString(error, "unknown error")
+        );
         return false;
       }
     }


### PR DESCRIPTION
The identity metadata repository had special polling logic to time out loading the metadata after 10 seconds.
This introduced flakiness in the end-to-end test because sometimes loading would be too slow resulting in the recoveryWizard showing the recovery reminder page instead.

The PR makes the following changes:
* remove the polling, simply `await` the promise when needed
  * this will fix e2e tests and simplify the code while it should not impact user experience too much (10 seconds timeout was almost never hit, otherwise users would have complained).
* do not wait for the commitMetadata to complete

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/e0099b51d/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/e0099b51d/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
