### PR TITLE
Remove obsolete IC commit file

### DIFF
--- a/.ic-commit
+++ b/.ic-commit
@@ -1,3 +1,0 @@
-# the commit used to pull the state machine executable
-# see rust canister tests for more info
-08b0e064eef80a4dc8aa523c02852a29ec968604


### PR DESCRIPTION
Remove the now obsolete .ic-commit file. It was forgotten to be removed in #2557.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2f37de10d/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
