### PR TITLE
Replace login error page with toast

### DIFF
--- a/src/frontend/src/test-e2e/pinAuthDisabled.test.ts
+++ b/src/frontend/src/test-e2e/pinAuthDisabled.test.ts
@@ -40,8 +40,6 @@ test("Cannot auth with PIN if dapp disallows PIN", async () => {
     const authenticateView = new AuthenticateView(browser);
     await authenticateView.waitForDisplay();
     await authenticateView.pickAnchor(userNumber);
-    await browser
-      .$('#errorContainer [data-error-code="pinNotAllowed"]')
-      .waitForDisplayed();
+    await browser.$('[data-error-code="pinNotAllowed"]').waitForDisplayed();
   }, APPLE_USER_AGENT);
 }, 300_000);


### PR DESCRIPTION
This PR makes the well known errors less obtrusive by replacing the full error page with a simple toast. Users that cancel out of an auto-selected passkey interaction have nicer experience that way.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/27348690f/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/27348690f/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
