### PR TITLE
Move sig-verifier-js tests out of e2e

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -475,11 +475,6 @@ jobs:
           until [ -f ~/npm-ci-status ]; do sleep 1; done
           exit $(cat ~/npm-ci-status)
 
-      - name: Build sig-verifier
-        run: npm run --workspace ./src/sig-verifier-js build
-      - name: Run sig-verifier tests
-        run: npm run --workspace ./src/sig-verifier-js test
-
       - name: Run dev server
         id: dev-server-start
         run: |
@@ -964,3 +959,14 @@ jobs:
         run: |
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
           didc check src/internet_identity/internet_identity.did internet_identity_previous.did
+
+  sig-verifier-js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node
+      - run: npm ci
+      - name: Build sig-verifier
+        run: npm run --workspace ./src/sig-verifier-js build
+      - name: Run sig-verifier tests
+        run: npm run --workspace ./src/sig-verifier-js test


### PR DESCRIPTION
This removes a lengthy step from the e2e tests shaving off ~2 minutes per e2e matrix config.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95d02fb5f/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
