### PR TITLE
Bump outdated github script action

### DIFF
--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Download build for Release Candidate"
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             // Find all artifacts for the production build, and filter for non-expired main artifacts

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -299,7 +299,7 @@ jobs:
 
         # Use the GitHub API to post links to screenshots if necessary
       - name: Notify PR of screen changes
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           FILES_ADDED: ${{ steps.diff.outputs.FILES_ADDED }}
           FILES_CHANGED: ${{ steps.diff.outputs.FILES_CHANGED }}


### PR DESCRIPTION
We still use the deprecated github-script action v6 in two places. This PR bumps these to v7.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c5c9e1c5c/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c5c9e1c5c/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
