### PR TITLE
Move and fix dapps explorer

### DIFF
--- a/src/frontend/src/flows/dappsExplorer/teaser.ts
+++ b/src/frontend/src/flows/dappsExplorer/teaser.ts
@@ -28,7 +28,7 @@ export const dappsTeaser = ({
   click: () => void;
   copy: { dapps_explorer: DynamicKey; sign_into_dapps: DynamicKey };
 }): TemplateResult => {
-  return html`<article class="c-card c-card--narrow">
+  return html`<article class="c-card c-card--narrow c-card--hide-overflow">
     <div class="c-card__label" role="presentation">
       <h3>${dapps_explorer}</h3>
     </div>

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -170,16 +170,6 @@ const displayManageTemplate = ({
     ${nonNullish(tempKeysWarning)
       ? tempKeyWarningBox({ i18n, warningAction: tempKeysWarning })
       : ""}
-    <p class="t-paragraph">
-      ${dappsTeaser({
-        dapps,
-        click: () => exploreDapps(),
-        copy: {
-          dapps_explorer: "Dapps explorer",
-          sign_into_dapps: "Connect to these dapps",
-        },
-      })}
-    </p>
     ${pinAuthenticators.length > 0
       ? tempKeysSection({ authenticators: pinAuthenticators, i18n })
       : ""}
@@ -189,6 +179,16 @@ const displayManageTemplate = ({
       warnNoPasskeys,
     })}
     ${recoveryMethodsSection({ recoveries, addRecoveryPhrase, addRecoveryKey })}
+    <aside class="l-stack">
+      ${dappsTeaser({
+        dapps,
+        click: () => exploreDapps(),
+        copy: {
+          dapps_explorer: "Dapps explorer",
+          sign_into_dapps: "Connect to these dapps",
+        },
+      })}
+    </aside>
     ${logoutSection()}
   </section>`;
 

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1187,6 +1187,10 @@ a:hover,
   max-width: 100%;
 }
 
+.c-card--hide-overflow {
+  overflow: hidden;
+}
+
 /* c-cards pretty much fill up the screen on small devices so we disable rounding */
 @media (max-width: 512px) {
   .c-card {


### PR DESCRIPTION
Main motivation is to move the dapps explorer in the manage page to the bottom and fix a minor UI issue regarding the bottom left corner not having radius when a logo was passing through.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/868347ae4/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/868347ae4/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/868347ae4/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/868347ae4/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/868347ae4/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/868347ae4/mobile/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
