### PR TITLE
Extract error toast from authn box

### DIFF
--- a/src/frontend/src/components/authenticateBox/authenticateBox.test.ts
+++ b/src/frontend/src/components/authenticateBox/authenticateBox.test.ts
@@ -1,8 +1,8 @@
+import { authnTemplates } from "$src/components/authenticateBox";
 import { I18n } from "$src/utils/i18n";
 import { IDBFactory } from "fake-indexeddb";
 import { html, render } from "lit-html";
 import { vi } from "vitest";
-import { authnTemplates } from "./authenticateBox";
 
 beforeEach(() => {
   // Create a fresh IDB before each test

--- a/src/frontend/src/components/authenticateBox/errorToast.ts
+++ b/src/frontend/src/components/authenticateBox/errorToast.ts
@@ -1,0 +1,78 @@
+import { FlowError } from "$src/components/authenticateBox";
+import { nonNullish } from "@dfinity/utils";
+import { html, TemplateResult } from "lit-html";
+
+// Maps all errors kinds to their error types (without kind field):
+//  KindToError<'authFail'> = { ...fields of AuthFail with kind...};
+// The 'Omit' seems to be a necessary step while looking up the error, otherwise typescript
+// thinks the types conflict
+type KindToError<K extends FlowError["kind"]> = Omit<
+  FlowError & { kind: K },
+  "kind"
+>;
+
+// Makes the error human readable
+const clarifyError: {
+  [K in FlowError["kind"]]: (err: KindToError<K>) => {
+    title: string;
+    message: string;
+    detail?: string;
+  };
+} = {
+  authFail: (err) => ({
+    title: "Failed to authenticate",
+    message:
+      "We failed to authenticate you using your security device. If this is the first time you're trying to log in with this device, you have to add it as a new device first.",
+    detail: err.error.message,
+  }),
+  webAuthnFailed: () => ({
+    title: "Operation canceled",
+    message:
+      "The interaction with your security device was canceled or timed out. Please try again.",
+  }),
+  unknownUser: (err) => ({
+    title: "Unknown Internet Identity",
+    message: `Failed to find Internet Identity ${err.userNumber}. Please check your Internet Identity and try again.`,
+  }),
+  apiError: (err) => ({
+    title: "We couldn't reach Internet Identity",
+    message:
+      "We failed to call the Internet Identity service, please try again.",
+    detail: err.error.message,
+  }),
+  badPin: () => ({ title: "Could not authenticate", message: "Invalid PIN" }),
+  badChallenge: () => ({
+    title: "Failed to register",
+    message:
+      "Failed to register with Internet Identity, because the CAPTCHA challenge wasn't successful",
+  }),
+  registerNoSpace: () => ({
+    title: "Failed to register",
+    message:
+      "Failed to register with Internet Identity, because there is no space left at the moment. We're working on increasing the capacity.",
+  }),
+  pinNotAllowed: () => ({
+    title: "PIN method not allowed",
+    message:
+      "The Dapp you are authenticating to does not allow PIN identities and you only have a PIN identity. Please retry using a Passkey: open a new Internet Identity page, add a passkey and retry.",
+  }),
+};
+
+export const flowErrorToastTemplate = <K extends FlowError["kind"]>(
+  flowError: KindToError<K> & { kind: K }
+): TemplateResult => {
+  const props = clarifyError[flowError.kind](flowError);
+  const detailSlot = nonNullish(props.detail)
+    ? html`<div class="l-stack">
+        <h4>Error details:</h4>
+        <pre data-role="error-detail" class="t-paragraph">${props.detail}</pre>
+      </div>`
+    : undefined;
+  return html`
+    <h3 data-error-code=${flowError.kind} class="t-title c-card__title">
+      ${props.title}
+    </h3>
+    <div data-role="warning-message" class="t-paragraph">${props.message}</div>
+    ${detailSlot}
+  `;
+};

--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -1,4 +1,12 @@
+import { mkAnchorInput } from "$src/components/anchorInput";
+import { mkAnchorPicker } from "$src/components/anchorPicker";
+import { flowErrorToastTemplate } from "$src/components/authenticateBox/errorToast";
+import { displayError } from "$src/components/displayError";
+import { landingPage } from "$src/components/landingPage";
 import { withLoader } from "$src/components/loader";
+import { mainWindow } from "$src/components/mainWindow";
+import { promptUserNumber } from "$src/components/promptUserNumber";
+import { toast } from "$src/components/toast";
 import {
   PinIdentityMaterial,
   reconstructPinIdentity,
@@ -34,17 +42,9 @@ import {
   isNonEmptyArray,
   unknownToString,
 } from "$src/utils/utils";
+import { DerEncodedPublicKey } from "@dfinity/agent";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { TemplateResult, html, render } from "lit-html";
-import { mkAnchorInput } from "./anchorInput";
-import { mkAnchorPicker } from "./anchorPicker";
-import { mainWindow } from "./mainWindow";
-import { promptUserNumber } from "./promptUserNumber";
-
-import { displayError } from "$src/components/displayError";
-import { toast } from "$src/components/toast";
-import { DerEncodedPublicKey } from "@dfinity/agent";
-import { landingPage } from "./landingPage";
 
 /** Template used for rendering specific authentication screens. See `authnScreens` below
  * for meaning of "firstTime", "useExisting" and "pick". */
@@ -325,7 +325,7 @@ export const authenticateBoxFlow = async <I>({
 };
 
 // A type representing flow errors present in most flows
-type FlowError =
+export type FlowError =
   | AuthFail
   | BadPin
   | { kind: "pinNotAllowed" }
@@ -334,81 +334,6 @@ type FlowError =
   | UnknownUser
   | ApiError
   | RegisterNoSpace;
-
-// Maps all errors kinds to their error types (without kind field):
-//  KindToError<'authFail'> = { ...fields of AuthFail with kind...};
-// The 'Omit' seems to be a necessary step while looking up the error, otherwise typescript
-// thinks the types conflict
-type KindToError<K extends FlowError["kind"]> = Omit<
-  FlowError & { kind: K },
-  "kind"
->;
-
-// Makes the error human readable
-const clarifyError: {
-  [K in FlowError["kind"]]: (err: KindToError<K>) => {
-    title: string;
-    message: string;
-    detail?: string;
-  };
-} = {
-  authFail: (err) => ({
-    title: "Failed to authenticate",
-    message:
-      "We failed to authenticate you using your security device. If this is the first time you're trying to log in with this device, you have to add it as a new device first.",
-    detail: err.error.message,
-  }),
-  webAuthnFailed: () => ({
-    title: "Operation canceled",
-    message:
-      "The interaction with your security device was canceled or timed out. Please try again.",
-  }),
-  unknownUser: (err) => ({
-    title: "Unknown Internet Identity",
-    message: `Failed to find Internet Identity ${err.userNumber}. Please check your Internet Identity and try again.`,
-  }),
-  apiError: (err) => ({
-    title: "We couldn't reach Internet Identity",
-    message:
-      "We failed to call the Internet Identity service, please try again.",
-    detail: err.error.message,
-  }),
-  badPin: () => ({ title: "Could not authenticate", message: "Invalid PIN" }),
-  badChallenge: () => ({
-    title: "Failed to register",
-    message:
-      "Failed to register with Internet Identity, because the CAPTCHA challenge wasn't successful",
-  }),
-  registerNoSpace: () => ({
-    title: "Failed to register",
-    message:
-      "Failed to register with Internet Identity, because there is no space left at the moment. We're working on increasing the capacity.",
-  }),
-  pinNotAllowed: () => ({
-    title: "PIN method not allowed",
-    message:
-      "The Dapp you are authenticating to does not allow PIN identities and you only have a PIN identity. Please retry using a Passkey: open a new Internet Identity page, add a passkey and retry.",
-  }),
-};
-
-const flowErrorToastTemplate = <K extends FlowError["kind"]>(
-  flowError: KindToError<K> & { kind: K }
-): TemplateResult => {
-  const props = clarifyError[flowError.kind](flowError);
-  const detailSlot = nonNullish(props.detail)
-    ? html`<div class="l-stack">
-        <h4>Error details:</h4>
-        <pre data-role="error-detail" class="t-paragraph">${props.detail}</pre>
-      </div>`
-    : undefined;
-  return html`
-    <h3 data-error-code=${flowError.kind} class="t-title c-card__title">
-      ${props.title}
-    </h3>
-    <div data-role="warning-message" class="t-paragraph">${props.message}</div>
-    ${detailSlot}
-  `;
-};
 
 export const handleLoginFlowResult = async <E>(
   result: (LoginSuccess & E) | FlowError

--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -1,6 +1,6 @@
 import {
-  authenticateBox,
   AuthnTemplates,
+  authenticateBox,
 } from "$src/components/authenticateBox";
 import { displayError } from "$src/components/displayError";
 import { caretDownIcon } from "$src/components/icons";
@@ -15,14 +15,13 @@ import { Connection } from "$src/utils/iiConnection";
 import { TemplateElement } from "$src/utils/lit-html";
 import { Chan } from "$src/utils/utils";
 import { Principal } from "@dfinity/principal";
-import { html, TemplateResult } from "lit-html";
+import { nonNullish } from "@dfinity/utils";
+import { TemplateResult, html } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { validateDerivationOrigin } from "../../utils/validateDerivationOrigin";
 import { Delegation, fetchDelegation } from "./fetchDelegation";
-import { AuthContext, authenticationProtocol } from "./postMessageInterface";
-
-import { nonNullish } from "@dfinity/utils";
 import copyJson from "./index.json";
+import { AuthContext, authenticationProtocol } from "./postMessageInterface";
 
 /* Template for the authbox when authenticating to a dapp */
 export const authnTemplateAuthorize = ({


### PR DESCRIPTION
This PR is a small refactoring that pulls out the error toast related code from the authn box component into its own file.

This is the follow-up refactoring for #2570.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/771601d10/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/771601d10/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
