### PR TITLE
Remove unnecessary candid annotations

### DIFF
--- a/demos/vc_issuer/src/main.rs
+++ b/demos/vc_issuer/src/main.rs
@@ -1,5 +1,5 @@
 use crate::consent_message::{get_vc_consent_message, SupportedLanguage};
-use candid::{candid_method, CandidType, Deserialize, Principal};
+use candid::{CandidType, Deserialize, Principal};
 use ic_canister_sig_creation::signature_map::{CanisterSigInputs, SignatureMap, LABEL_SIG};
 use ic_canister_sig_creation::{
     extract_raw_root_pk_from_der, CanisterSigPublicKey, IC_ROOT_PUBLIC_KEY,
@@ -142,7 +142,6 @@ struct IssuerInit {
 }
 
 #[init]
-#[candid_method(init)]
 fn init(init_arg: Option<IssuerInit>) {
     if let Some(init) = init_arg {
         apply_config(IssuerConfig::from(init));
@@ -157,7 +156,6 @@ fn post_upgrade(init_arg: Option<IssuerInit>) {
 }
 
 #[update]
-#[candid_method]
 fn configure(init: IssuerInit) {
     apply_config(IssuerConfig::from(init));
 }
@@ -202,7 +200,6 @@ fn authorize_vc_request(
 }
 
 #[update]
-#[candid_method]
 async fn prepare_credential(
     req: PrepareCredentialRequest,
 ) -> Result<PreparedCredentialData, IssueCredentialError> {
@@ -247,7 +244,6 @@ fn update_root_hash() {
 }
 
 #[query]
-#[candid_method(query)]
 fn get_credential(req: GetCredentialRequest) -> Result<IssuedCredentialData, IssueCredentialError> {
     if let Err(err) = authorize_vc_request(&req.signed_id_alias, &caller(), time().into()) {
         return Result::<IssuedCredentialData, IssueCredentialError>::Err(err);
@@ -304,7 +300,6 @@ fn get_credential(req: GetCredentialRequest) -> Result<IssuedCredentialData, Iss
 }
 
 #[update]
-#[candid_method]
 async fn vc_consent_message(
     req: Icrc21VcConsentMessageRequest,
 ) -> Result<Icrc21ConsentInfo, Icrc21Error> {
@@ -315,7 +310,6 @@ async fn vc_consent_message(
 }
 
 #[update]
-#[candid_method]
 async fn derivation_origin(
     req: DerivationOriginRequest,
 ) -> Result<DerivationOriginData, DerivationOriginError> {
@@ -409,28 +403,24 @@ fn verify_single_argument(
 }
 
 #[update]
-#[candid_method]
 fn add_employee(employee_id: Principal) -> String {
     EMPLOYEES.with_borrow_mut(|employees| employees.insert(employee_id));
     format!("Added employee {}", employee_id)
 }
 
 #[update]
-#[candid_method]
 fn add_graduate(graduate_id: Principal) -> String {
     GRADUATES.with_borrow_mut(|graduates| graduates.insert(graduate_id));
     format!("Added graduate {}", graduate_id)
 }
 
 #[update]
-#[candid_method]
 fn add_adult(adult_id: Principal) -> String {
     ADULTS.with_borrow_mut(|adults| adults.insert(adult_id));
     format!("Added adult {}", adult_id)
 }
 
 #[query]
-#[candid_method(query)]
 pub fn http_request(req: HttpRequest) -> HttpResponse {
     let parts: Vec<&str> = req.url.split('?').collect();
     let path = parts[0];
@@ -596,7 +586,7 @@ fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
     hasher.finalize().into()
 }
 
-// Order dependent: do not move above any function annotated with #[candid_method]!
+// Order dependent: do not move above any exposed canister method!
 candid::export_service!();
 
 // Assets

--- a/src/archive/src/main.rs
+++ b/src/archive/src/main.rs
@@ -36,7 +36,7 @@
 //! - prefix scan with anchor to retrieve entries by anchor
 //! - prefix scan with (anchor, timestamp) to narrow down on the time period for a specific anchor
 //! - prefix scan with (anchor, timestamp, log index) to do pagination (with the key of the first entry not included in the previous set)
-use candid::{candid_method, CandidType, Deserialize, Principal};
+use candid::{CandidType, Deserialize, Principal};
 use ic_cdk::api::call::CallResult;
 use ic_cdk::api::management_canister::main::{canister_status, CanisterIdRecord};
 use ic_cdk::api::stable::stable_size;
@@ -239,7 +239,6 @@ impl Storable for AnchorIndexKey {
 /// I.e. this allows rolling back Internet Identity from pull to push without rolling back the
 /// archive.
 #[update]
-#[candid_method]
 fn write_entry(anchor_number: AnchorNumber, timestamp: Timestamp, entry: ByteBuf) {
     with_config(|config| {
         if config.ii_canister != caller() {
@@ -378,7 +377,6 @@ fn store_call_error(call_error: CallErrorInfo) {
 }
 
 #[query]
-#[candid_method(query)]
 fn get_entries(index: Option<u64>, limit: Option<u16>) -> Entries {
     let limit = limit_or_default(limit);
 
@@ -404,7 +402,6 @@ fn get_entries(index: Option<u64>, limit: Option<u16>) -> Entries {
 }
 
 #[query]
-#[candid_method(query)]
 fn get_anchor_entries(
     anchor: AnchorNumber,
     cursor: Option<Cursor>,
@@ -509,7 +506,6 @@ fn set_highest_archived_sequence_number(sequence_number: u64) {
 }
 
 #[init]
-#[candid_method(init)]
 fn initialize(arg: ArchiveInit) {
     write_config(ArchiveConfig {
         ii_canister: arg.ii_canister,
@@ -539,7 +535,6 @@ fn write_config(config: ArchiveConfig) {
 }
 
 #[query]
-#[candid_method(query)]
 fn http_request(req: HttpRequest) -> HttpResponse {
     let parts: Vec<&str> = req.url.split('?').collect();
     match parts[0] {
@@ -660,7 +655,6 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
 /// Publicly exposes the status of the archive canister.
 /// This is useful to check operations or for debugging purposes.
 #[update]
-#[candid_method]
 async fn status() -> ArchiveStatus {
     let canister_id = id();
     let (ic_cdk_canister_status,) = canister_status(CanisterIdRecord { canister_id })
@@ -700,7 +694,7 @@ async fn status() -> ArchiveStatus {
 
 fn main() {}
 
-// Order dependent: do not move above any function annotated with #[candid_method]!
+// Order dependent: do not move above any exposed canister method!
 candid::export_service!();
 
 #[cfg(test)]

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -8,7 +8,7 @@ use crate::stats::event_stats::all_aggregations_top_n;
 use authz_utils::{
     anchor_operation_with_authz_check, check_authorization, check_authz_and_record_activity,
 };
-use candid::{candid_method, Principal};
+use candid::Principal;
 use ic_canister_sig_creation::signature_map::LABEL_SIG;
 use ic_cdk::api::{caller, set_certified_data, trap};
 use ic_cdk::call;
@@ -54,27 +54,23 @@ const INTERNETCOMPUTER_ORG_DOMAIN: &str = "identity.internetcomputer.org";
 const INTERNETCOMPUTER_ORG_ORIGIN: &str = "https://identity.internetcomputer.org";
 
 #[update]
-#[candid_method]
 async fn init_salt() {
     state::init_salt().await;
 }
 
 #[update]
-#[candid_method]
 fn enter_device_registration_mode(anchor_number: AnchorNumber) -> Timestamp {
     check_authz_and_record_activity(anchor_number).unwrap_or_else(|err| trap(&format!("{err}")));
     tentative_device_registration::enter_device_registration_mode(anchor_number)
 }
 
 #[update]
-#[candid_method]
 fn exit_device_registration_mode(anchor_number: AnchorNumber) {
     check_authz_and_record_activity(anchor_number).unwrap_or_else(|err| trap(&format!("{err}")));
     tentative_device_registration::exit_device_registration_mode(anchor_number)
 }
 
 #[update]
-#[candid_method]
 async fn add_tentative_device(
     anchor_number: AnchorNumber,
     device_data: DeviceData,
@@ -105,7 +101,6 @@ async fn add_tentative_device(
 }
 
 #[update]
-#[candid_method]
 fn verify_tentative_device(
     anchor_number: AnchorNumber,
     user_verification_code: DeviceVerificationCode,
@@ -138,13 +133,11 @@ fn verify_tentative_device(
 }
 
 #[update]
-#[candid_method]
 async fn create_challenge() -> Challenge {
     anchor_management::registration::create_challenge().await
 }
 
 #[update]
-#[candid_method]
 fn register(
     device_data: DeviceData,
     challenge_result: ChallengeAttempt,
@@ -154,7 +147,6 @@ fn register(
 }
 
 #[update]
-#[candid_method]
 fn add(anchor_number: AnchorNumber, device_data: DeviceData) {
     anchor_operation_with_authz_check(anchor_number, |anchor| {
         Ok::<_, String>(((), anchor_management::add(anchor, device_data)))
@@ -163,7 +155,6 @@ fn add(anchor_number: AnchorNumber, device_data: DeviceData) {
 }
 
 #[update]
-#[candid_method]
 fn update(anchor_number: AnchorNumber, device_key: DeviceKey, device_data: DeviceData) {
     anchor_operation_with_authz_check(anchor_number, |anchor| {
         Ok::<_, String>((
@@ -175,7 +166,6 @@ fn update(anchor_number: AnchorNumber, device_key: DeviceKey, device_data: Devic
 }
 
 #[update]
-#[candid_method]
 fn replace(anchor_number: AnchorNumber, device_key: DeviceKey, device_data: DeviceData) {
     anchor_operation_with_authz_check(anchor_number, |anchor| {
         Ok::<_, String>((
@@ -187,7 +177,6 @@ fn replace(anchor_number: AnchorNumber, device_key: DeviceKey, device_data: Devi
 }
 
 #[update]
-#[candid_method]
 fn remove(anchor_number: AnchorNumber, device_key: DeviceKey) {
     anchor_operation_with_authz_check(anchor_number, |anchor| {
         Ok::<_, String>((
@@ -201,7 +190,6 @@ fn remove(anchor_number: AnchorNumber, device_key: DeviceKey) {
 /// Returns all devices of the anchor (authentication and recovery) but no information about device registrations.
 /// Deprecated: use [get_anchor_credentials] instead
 #[query]
-#[candid_method(query)]
 fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
     let Ok(anchor) = state::storage_borrow(|storage| storage.read(anchor_number)) else {
         return vec![];
@@ -220,7 +208,6 @@ fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
 }
 
 #[query]
-#[candid_method(query)]
 fn get_anchor_credentials(anchor_number: AnchorNumber) -> AnchorCredentials {
     let Ok(anchor) = state::storage_borrow(|storage| storage.read(anchor_number)) else {
         return AnchorCredentials::default();
@@ -252,14 +239,12 @@ fn get_anchor_credentials(anchor_number: AnchorNumber) -> AnchorCredentials {
 }
 
 #[update] // this is an update call because queries are not (yet) certified
-#[candid_method]
 fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
     check_authz_and_record_activity(anchor_number).unwrap_or_else(|err| trap(&format!("{err}")));
     anchor_management::get_anchor_info(anchor_number)
 }
 
 #[query]
-#[candid_method(query)]
 fn get_principal(anchor_number: AnchorNumber, frontend: FrontendHostname) -> Principal {
     let Ok(_) = check_authorization(anchor_number) else {
         trap(&format!("{} could not be authenticated.", caller()));
@@ -268,7 +253,6 @@ fn get_principal(anchor_number: AnchorNumber, frontend: FrontendHostname) -> Pri
 }
 
 #[update]
-#[candid_method]
 async fn prepare_delegation(
     anchor_number: AnchorNumber,
     frontend: FrontendHostname,
@@ -288,7 +272,6 @@ async fn prepare_delegation(
 }
 
 #[query]
-#[candid_method(query)]
 fn get_delegation(
     anchor_number: AnchorNumber,
     frontend: FrontendHostname,
@@ -302,19 +285,16 @@ fn get_delegation(
 }
 
 #[query]
-#[candid_method(query)]
 fn http_request(req: HttpRequest) -> HttpResponse {
     http::http_request(req)
 }
 
 #[update]
-#[candid_method]
 fn http_request_update(req: HttpRequest) -> HttpResponse {
     http::http_request(req)
 }
 
 #[query]
-#[candid_method(query)]
 fn stats() -> InternetIdentityStats {
     let archive_info = match state::archive_state() {
         ArchiveState::NotConfigured => ArchiveInfo {
@@ -349,7 +329,6 @@ fn stats() -> InternetIdentityStats {
 }
 
 #[update]
-#[candid_method]
 async fn deploy_archive(wasm: ByteBuf) -> DeployArchiveResult {
     archive::deploy_archive(wasm).await
 }
@@ -358,7 +337,6 @@ async fn deploy_archive(wasm: ByteBuf) -> DeployArchiveResult {
 /// This is an update call because the archive information _must_ be certified.
 /// Only callable by this IIs archive canister.
 #[update]
-#[candid_method]
 fn fetch_entries() -> Vec<BufferedEntry> {
     archive::fetch_entries()
 }
@@ -366,13 +344,11 @@ fn fetch_entries() -> Vec<BufferedEntry> {
 /// Removes all buffered archive entries up to sequence number.
 /// Only callable by this IIs archive canister.
 #[update]
-#[candid_method]
 fn acknowledge_entries(sequence_number: u64) {
     archive::acknowledge_entries(sequence_number)
 }
 
 #[init]
-#[candid_method(init)]
 fn init(maybe_arg: Option<InternetIdentityInit>) {
     state::init_new();
     initialize(maybe_arg);
@@ -481,7 +457,6 @@ mod v2_api {
     use super::*;
 
     #[query]
-    #[candid_method(query)]
     fn identity_authn_info(identity_number: IdentityNumber) -> Result<IdentityAuthnInfo, ()> {
         let Ok(anchor) = state::storage_borrow(|storage| storage.read(identity_number)) else {
             return Ok(IdentityAuthnInfo {
@@ -519,14 +494,12 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     async fn captcha_create() -> Result<Challenge, ()> {
         let challenge = anchor_management::registration::create_challenge().await;
         Ok(challenge)
     }
 
     #[update]
-    #[candid_method]
     fn identity_register(
         authn_method: AuthnMethodData,
         challenge_result: ChallengeAttempt,
@@ -543,7 +516,6 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     fn identity_info(identity_number: IdentityNumber) -> Result<IdentityInfo, IdentityInfoError> {
         check_authz_and_record_activity(identity_number).map_err(IdentityInfoError::from)?;
         let anchor_info = anchor_management::get_anchor_info(identity_number);
@@ -571,7 +543,6 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     fn authn_method_add(
         identity_number: IdentityNumber,
         authn_method: AuthnMethodData,
@@ -582,7 +553,6 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     fn authn_method_remove(
         identity_number: IdentityNumber,
         public_key: PublicKey,
@@ -592,7 +562,6 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     fn authn_method_replace(
         identity_number: IdentityNumber,
         authn_method_pk: PublicKey,
@@ -606,7 +575,6 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     fn authn_method_metadata_replace(
         identity_number: IdentityNumber,
         authn_method_pk: PublicKey,
@@ -633,7 +601,6 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     fn authn_method_security_settings_replace(
         identity_number: IdentityNumber,
         authn_method_pk: PublicKey,
@@ -655,7 +622,6 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     fn identity_metadata_replace(
         identity_number: IdentityNumber,
         metadata: HashMap<String, MetadataEntryV2>,
@@ -674,7 +640,6 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     fn authn_method_registration_mode_enter(
         identity_number: IdentityNumber,
     ) -> Result<RegistrationModeInfo, ()> {
@@ -685,14 +650,12 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     fn authn_method_registration_mode_exit(identity_number: IdentityNumber) -> Result<(), ()> {
         exit_device_registration_mode(identity_number);
         Ok(())
     }
 
     #[update]
-    #[candid_method]
     async fn authn_method_register(
         identity_number: IdentityNumber,
         authn_method: AuthnMethodData,
@@ -718,7 +681,6 @@ mod v2_api {
     }
 
     #[update]
-    #[candid_method]
     fn authn_method_confirm(
         identity_number: IdentityNumber,
         confirmation_code: String,
@@ -744,7 +706,6 @@ mod attribute_sharing_mvp {
     use super::*;
 
     #[update]
-    #[candid_method]
     async fn prepare_id_alias(
         req: PrepareIdAliasRequest,
     ) -> Result<PreparedIdAlias, PrepareIdAliasError> {
@@ -761,7 +722,6 @@ mod attribute_sharing_mvp {
     }
 
     #[query]
-    #[candid_method(query)]
     fn get_id_alias(req: GetIdAliasRequest) -> Result<IdAliasCredentials, GetIdAliasError> {
         check_authorization(req.identity_number).map_err(GetIdAliasError::from)?;
         vc_mvp::get_id_alias(
@@ -778,7 +738,7 @@ mod attribute_sharing_mvp {
 
 fn main() {}
 
-// Order dependent: do not move above any function annotated with #[candid_method]!
+// Order dependent: do not move above any exposed canister method!
 candid::export_service!();
 
 #[cfg(test)]


### PR DESCRIPTION
The `candid_method` annotations are no longer necessary, so they are removed in this PR.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/00dee7130/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
