### PR TITLE
Add config endpoint

### DIFF
--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -355,5 +355,12 @@ pub fn acknowledge_entries(
     )
 }
 
+pub fn config(
+    env: &PocketIc,
+    canister_id: CanisterId,
+) -> Result<types::InternetIdentityInit, CallError> {
+    call_candid(env, canister_id, RawEffectivePrincipal::None, "config", ()).map(|(x,)| x)
+}
+
 /// A "compatibility" module for the previous version of II to handle API changes.
 pub mod compat {}

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -402,6 +402,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Variant({ 'Ok' : Challenge, 'Err' : IDL.Null })],
         [],
       ),
+    'config' : IDL.Func([], [InternetIdentityInit], ['query']),
     'create_challenge' : IDL.Func([], [Challenge], []),
     'deploy_archive' : IDL.Func([IDL.Vec(IDL.Nat8)], [DeployArchiveResult], []),
     'enter_device_registration_mode' : IDL.Func([UserNumber], [Timestamp], []),

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -323,6 +323,7 @@ export interface _SERVICE {
       { 'Err' : AuthnMethodSecuritySettingsReplaceError }
   >,
   'captcha_create' : ActorMethod<[], { 'Ok' : Challenge } | { 'Err' : null }>,
+  'config' : ActorMethod<[], InternetIdentityInit>,
   'create_challenge' : ActorMethod<[], Challenge>,
   'deploy_archive' : ActorMethod<[Uint8Array | number[]], DeployArchiveResult>,
   'enter_device_registration_mode' : ActorMethod<[UserNumber], Timestamp>,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -620,6 +620,7 @@ service : (opt InternetIdentityInit) -> {
     // ================
     init_salt: () -> ();
     stats : () -> (InternetIdentityStats) query;
+    config : () -> (InternetIdentityInit) query;
 
     deploy_archive: (wasm: blob) -> (DeployArchiveResult);
     // Returns a batch of entries _sorted by sequence number_ to be archived.

--- a/src/internet_identity/tests/integration/conifg.rs
+++ b/src/internet_identity/tests/integration/conifg.rs
@@ -1,0 +1,31 @@
+use canister_tests::api::internet_identity as api;
+use canister_tests::framework::{env, install_ii_canister_with_arg, II_WASM};
+use internet_identity_interface::internet_identity::types::{
+    ArchiveConfig, InternetIdentityInit, RateLimitConfig,
+};
+use pocket_ic::CallError;
+
+#[test]
+fn should_retain_anchor_on_user_range_change() -> Result<(), CallError> {
+    let env = env();
+    let config = InternetIdentityInit {
+        assigned_user_number_range: Some((3456, 798977)),
+        archive_config: Some(ArchiveConfig {
+            module_hash: [17; 32],
+            entries_buffer_limit: 123789,
+            polling_interval_ns: 659871258,
+            entries_fetch_limit: 33,
+        }),
+        canister_creation_cycles_cost: Some(123),
+        register_rate_limit: Some(RateLimitConfig {
+            time_per_token_ns: 99,
+            max_tokens: 874,
+        }),
+        max_inflight_captchas: Some(456),
+    };
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+
+    assert_eq!(api::config(&env, canister_id)?, config);
+    Ok(())
+}

--- a/src/internet_identity/tests/integration/main.rs
+++ b/src/internet_identity/tests/integration/main.rs
@@ -8,6 +8,7 @@ mod activity_stats;
 mod aggregation_stats;
 mod anchor_management;
 mod archive_integration;
+mod conifg;
 mod delegation;
 mod http;
 mod rollback;

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -190,7 +190,7 @@ pub struct AnchorCredentials {
     pub recovery_phrases: Vec<PublicKey>,
 }
 
-#[derive(Clone, Debug, CandidType, Deserialize, Default)]
+#[derive(Clone, Debug, CandidType, Deserialize, Default, Eq, PartialEq)]
 pub struct InternetIdentityInit {
     pub assigned_user_number_range: Option<(AnchorNumber, AnchorNumber)>,
     pub archive_config: Option<ArchiveConfig>,

--- a/src/vc-api/src/generated/vc_issuer_types.ts
+++ b/src/vc-api/src/generated/vc_issuer_types.ts
@@ -87,8 +87,8 @@ export interface _SERVICE {
     { 'Ok' : PreparedCredentialData } |
       { 'Err' : IssueCredentialError }
   >,
-  'set_derivation_origin' : ActorMethod<[string, string], undefined>,
   'set_alternative_origins' : ActorMethod<[string], undefined>,
+  'set_derivation_origin' : ActorMethod<[string, string], undefined>,
   'vc_consent_message' : ActorMethod<
     [Icrc21VcConsentMessageRequest],
     { 'Ok' : Icrc21ConsentInfo } |


### PR DESCRIPTION
Adds an endpoint to query the currently active config (i.e. `InternetIdentityInit`).

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6200d1ca6/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


