### PR TITLE
Fix ic-wasm action failing on wrong version

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -26,7 +26,7 @@ echo "looking for ic-wasm 0.8.5"
 if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.8.5" ]]
 then
     echo "installing ic-wasm 0.8.5"
-    run cargo install ic-wasm --version 0.8.5
+    run cargo install ic-wasm --version 0.8.5 --force
 fi
 
 # make sure the packages are actually installed (rustup waits for the first invoke to lazyload)


### PR DESCRIPTION
If `ic-wasm` is not detected properly (this was encountered when caching actions became unreliable due to hitting the rate limit), then the bootstrap script attempts to install the right version. However, if cargo is not aware that a binary already exists, it will then fail. By using `--force` we allow the script to continue an override the existing binary.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
