### PR TITLE
Simplify authorization error

### DIFF
--- a/src/internet_identity/src/authz_utils.rs
+++ b/src/internet_identity/src/authz_utils.rs
@@ -19,17 +19,19 @@ pub enum IdentityUpdateError {
 }
 
 #[derive(Debug)]
-pub enum AuthorizationError {
-    Unauthorized(Principal),
+pub struct AuthorizationError {
+    pub principal: Principal,
+}
+
+impl From<Principal> for AuthorizationError {
+    fn from(principal: Principal) -> Self {
+        Self { principal }
+    }
 }
 
 impl From<AuthorizationError> for IdentityUpdateError {
     fn from(err: AuthorizationError) -> Self {
-        match err {
-            AuthorizationError::Unauthorized(principal) => {
-                IdentityUpdateError::Unauthorized(principal)
-            }
-        }
+        IdentityUpdateError::Unauthorized(err.principal)
     }
 }
 
@@ -110,7 +112,7 @@ pub fn check_authorization(
             return Ok((anchor.clone(), device.pubkey.clone()));
         }
     }
-    Err(AuthorizationError::Unauthorized(caller))
+    Err(AuthorizationError::from(caller))
 }
 
 /// Checks that the caller is authorized to operate on the given anchor_number and updates the device used to

--- a/src/internet_identity/src/conversions/api_errors.rs
+++ b/src/internet_identity/src/conversions/api_errors.rs
@@ -68,8 +68,6 @@ impl From<IdentityUpdateError> for IdentityInfoError {
 
 impl From<AuthorizationError> for GetIdAliasError {
     fn from(value: AuthorizationError) -> Self {
-        match value {
-            AuthorizationError::Unauthorized(principal) => GetIdAliasError::Unauthorized(principal),
-        }
+        Self::Unauthorized(value.principal)
     }
 }


### PR DESCRIPTION
There is no good reason for the (internal) `AuthorizationEror` to be an enum and it complicates things. Hence it is changed to a struct.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
