### PR TITLE
Consistently use // instead of /// in candid files

### DIFF
--- a/demos/vc_issuer/vc_demo_issuer.did
+++ b/demos/vc_issuer/vc_demo_issuer.did
@@ -1,18 +1,18 @@
-/// Candid interface of the example VC issuer canister.
-/// The interface contains both the functionality required by the VC-spec
-/// (https://github.com/dfinity/internet-identity/blob/main/docs/vc-spec.md)
-/// and additional APIs for configuring the canister and using it for testing.
+// Candid interface of the example VC issuer canister.
+// The interface contains both the functionality required by the VC-spec
+// (https://github.com/dfinity/internet-identity/blob/main/docs/vc-spec.md)
+// and additional APIs for configuring the canister and using it for testing.
 
-/// Specification of a requested credential.
+// Specification of a requested credential.
 type CredentialSpec = record {
     credential_type : text;
-    /// arguments are optional, and specific to the credential_name
+    // arguments are optional, and specific to the credential_name
     arguments : opt vec record { text; ArgumentValue };
 };
 type ArgumentValue = variant { "Int" : int32; String : text };
 
-/// Types for ICRC-21 consent message, cf.
-/// https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md
+// Types for ICRC-21 consent message, cf.
+// https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md
 type Icrc21ConsentInfo = record { consent_message : text; language : text };
 type Icrc21ConsentPreferences = record { language : text };
 type Icrc21Error = variant {
@@ -26,22 +26,22 @@ type Icrc21VcConsentMessageRequest = record {
     credential_spec : CredentialSpec;
 };
 
-/// Types for requesting issuance of a credential.
-/// The issuance proceeds in two steps:
-///  - `prepare_credential`, and
-///  - `get_credential`
-/// where the split of work between the two steps depends on the specifics of the issuer,
-/// and the second second step returns the actual credential (if any).
-/// The two steps can use `prepared_context`-value to transfer information between them.
+// Types for requesting issuance of a credential.
+// The issuance proceeds in two steps:
+//  - `prepare_credential`, and
+//  - `get_credential`
+// where the split of work between the two steps depends on the specifics of the issuer,
+// and the second second step returns the actual credential (if any).
+// The two steps can use `prepared_context`-value to transfer information between them.
 
-/// Types for `prepare_credential`.
+// Types for `prepare_credential`.
 type PrepareCredentialRequest = record {
     signed_id_alias : SignedIdAlias;
     credential_spec : CredentialSpec;
 };
 type PreparedCredentialData = record { prepared_context : opt vec nat8 };
 
-/// Types for `get_credential`.
+// Types for `get_credential`.
 type GetCredentialRequest = record {
     signed_id_alias : SignedIdAlias;
     credential_spec : CredentialSpec;
@@ -53,22 +53,22 @@ type SignedIdAlias = record {
 };
 type IssuedCredentialData = record { vc_jws : text };
 type IssueCredentialError = variant {
-    /// The caller is not known to the issuer.  Caller should register first with the issuer before retrying.
+    // The caller is not known to the issuer.  Caller should register first with the issuer before retrying.
     UnknownSubject : text;
-    /// The caller is not authorized to obtain the requested credential.  Caller requested a credential
-    /// for a different principal, or the issuer does not have sufficient knowledge about the caller
-    /// to issue the requested credential.
+    // The caller is not authorized to obtain the requested credential.  Caller requested a credential
+    // for a different principal, or the issuer does not have sufficient knowledge about the caller
+    // to issue the requested credential.
     UnauthorizedSubject : text;
-    /// The id_alias credential provided by the identity provider is invalid.
+    // The id_alias credential provided by the identity provider is invalid.
     InvalidIdAlias : text;
-    /// The issuer does not issue credentials described in the credential spec.
+    // The issuer does not issue credentials described in the credential spec.
     UnsupportedCredentialSpec : text;
-    /// Internal errors, indicate malfunctioning of the issuer.
+    // Internal errors, indicate malfunctioning of the issuer.
     SignatureNotFound : text;
     Internal : text;
 };
 
-/// Types for `derivation_origin`.
+// Types for `derivation_origin`.
 type DerivationOriginRequest = record {
     frontend_hostname : text;
 };
@@ -78,19 +78,19 @@ type DerivationOriginError = variant {
   UnsupportedOrigin : text;
 };
 
-/// Configuration specific to this issuer.
+// Configuration specific to this issuer.
 type IssuerConfig = record {
-    /// Root of trust for checking canister signatures.
+    // Root of trust for checking canister signatures.
     ic_root_key_der : opt blob;
-    /// List of canister ids that are allowed to provide id alias credentials.
+    // List of canister ids that are allowed to provide id alias credentials.
     idp_canister_ids : vec principal;
-    /// The derivation origin to be used by the issuer.
+    // The derivation origin to be used by the issuer.
     derivation_origin : text;
-    /// Frontend hostname be used by the issuer.
+    // Frontend hostname be used by the issuer.
     frontend_hostname : text;
 };
 
-/// Options related to HTTP handling
+// Options related to HTTP handling
 
 type HeaderField = record {
     text;
@@ -112,24 +112,24 @@ type HttpResponse = record {
 };
 
 service: (opt IssuerConfig) -> {
-    /// VC-flow API.
+    // VC-flow API.
     vc_consent_message : (Icrc21VcConsentMessageRequest) -> (variant { Ok : Icrc21ConsentInfo; Err : Icrc21Error;});
     prepare_credential : (PrepareCredentialRequest) -> (variant { Ok : PreparedCredentialData; Err : IssueCredentialError;});
     get_credential : (GetCredentialRequest) -> (variant { Ok : IssuedCredentialData; Err : IssueCredentialError;}) query;
     derivation_origin : (DerivationOriginRequest) -> (variant {Ok: DerivationOriginData; Err: DerivationOriginError});
 
-    /// Configure the issuer (e.g. set the root key), used for deployment/testing.
+    // Configure the issuer (e.g. set the root key), used for deployment/testing.
     configure: (IssuerConfig) -> ();
     set_derivation_origin: (frontend_hostname: text, derivation_origin: text) -> ();
     // Sets the content of the alternative origins file.
     set_alternative_origins: (alternative_origins: text) -> ();
 
-    /// API for obtaining information about users, for testing only.
-    /// In a real-world issuer the data acquisition functionality should be more elaborate and authenticated.
+    // API for obtaining information about users, for testing only.
+    // In a real-world issuer the data acquisition functionality should be more elaborate and authenticated.
     add_employee : (principal) -> (text);
     add_graduate : (principal) -> (text);
     add_adult : (principal) -> (text);
 
-    /// Serve the app
+    // Serve the app
     http_request: (request: HttpRequest) -> (HttpResponse) query;
 }

--- a/src/archive/archive.did
+++ b/src/archive/archive.did
@@ -135,9 +135,9 @@ type CallInfo = record {
 };
 
 type FetchInfo = record {
-    /// Timestamp when the last execution of the archive `fetch_entries` method finished.
+    // Timestamp when the last execution of the archive `fetch_entries` method finished.
     timestamp: Timestamp;
-    /// The number of entries fetched (regardless of how many of those were actually archived).
+    // The number of entries fetched (regardless of how many of those were actually archived).
     number_of_entries: nat16;
 };
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -429,9 +429,9 @@ type IdentityInfo = record {
 };
 
 type IdentityInfoError = variant {
-    /// The principal is not authorized to call this method with the given arguments.
+    // The principal is not authorized to call this method with the given arguments.
     Unauthorized: principal;
-    /// Internal canister error. See the error message for details.
+    // Internal canister error. See the error message for details.
     InternalCanisterError: text;
 };
 
@@ -458,51 +458,51 @@ type AuthnMethodReplaceError = variant {
 
 type AuthnMethodMetadataReplaceError = variant {
     InvalidMetadata: text;
-    /// No authentication method found with the given public key.
+    // No authentication method found with the given public key.
     AuthnMethodNotFound;
 };
 
 type AuthnMethodSecuritySettingsReplaceError = variant {
-    /// No authentication method found with the given public key.
+    // No authentication method found with the given public key.
     AuthnMethodNotFound;
 };
 
 type IdentityMetadataReplaceError = variant {
-    /// The principal is not authorized to call this method with the given arguments.
+    // The principal is not authorized to call this method with the given arguments.
     Unauthorized: principal;
-    /// The identity including the new metadata exceeds the maximum allowed size.
+    // The identity including the new metadata exceeds the maximum allowed size.
     StorageSpaceExceeded: record {space_available: nat64; space_required: nat64};
-    /// Internal canister error. See the error message for details.
+    // Internal canister error. See the error message for details.
     InternalCanisterError: text;
 };
 
 type PrepareIdAliasRequest = record {
-    /// Origin of the issuer in the attribute sharing flow.
+    // Origin of the issuer in the attribute sharing flow.
     issuer : FrontendHostname;
-    /// Origin of the relying party in the attribute sharing flow.
+    // Origin of the relying party in the attribute sharing flow.
     relying_party : FrontendHostname;
-    /// Identity for which the IdAlias should be generated.
+    // Identity for which the IdAlias should be generated.
     identity_number : IdentityNumber;
 };
 
 type PrepareIdAliasError = variant {
-    /// The principal is not authorized to call this method with the given arguments.
+    // The principal is not authorized to call this method with the given arguments.
     Unauthorized: principal;
-    /// Internal canister error. See the error message for details.
+    // Internal canister error. See the error message for details.
     InternalCanisterError: text;
 };
 
-/// The prepared id alias contains two (still unsigned) credentials in JWT format,
-/// certifying the id alias for the issuer resp. the relying party.
+// The prepared id alias contains two (still unsigned) credentials in JWT format,
+// certifying the id alias for the issuer resp. the relying party.
 type PreparedIdAlias = record {
     rp_id_alias_jwt : text;
     issuer_id_alias_jwt : text;
     canister_sig_pk_der : PublicKey;
 };
 
-/// The request to retrieve the actual signed id alias credentials.
-/// The field values should be equal to the values of corresponding
-/// fields from the preceding `PrepareIdAliasRequest` and `PrepareIdAliasResponse`.
+// The request to retrieve the actual signed id alias credentials.
+// The field values should be equal to the values of corresponding
+// fields from the preceding `PrepareIdAliasRequest` and `PrepareIdAliasResponse`.
 type GetIdAliasRequest = record {
     rp_id_alias_jwt : text;
     issuer : FrontendHostname;
@@ -512,15 +512,15 @@ type GetIdAliasRequest = record {
 };
 
 type GetIdAliasError = variant {
-    /// The principal is not authorized to call this method with the given arguments.
+    // The principal is not authorized to call this method with the given arguments.
     Unauthorized: principal;
-    /// The credential(s) are not available: may be expired or not prepared yet (call prepare_id_alias to prepare).
+    // The credential(s) are not available: may be expired or not prepared yet (call prepare_id_alias to prepare).
     NoSuchCredentials : text;
-    /// Internal canister error. See the error message for details.
+    // Internal canister error. See the error message for details.
     InternalCanisterError: text;
 };
 
-/// The signed id alias credentials for each involved party.
+// The signed id alias credentials for each involved party.
 type IdAliasCredentials = record {
     rp_id_alias_credential : SignedIdAlias;
     issuer_id_alias_credential : SignedIdAlias;


### PR DESCRIPTION
In candid /// has no additional meaning over //.
Given // is shorter and used more prevalently in the codebase we switch everything to //.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
