### PR TITLE
Change registration on API v2 to flow with 3 steps

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -955,8 +955,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-didc
+      - name: 'Get latest release'
+        uses: actions/github-script@v7
+        id: latest-release-tag
+        with:
+          result-encoding: string
+          script: return (await github.rest.repos.getLatestRelease({owner:"dfinity", repo:"internet-identity"})).data.tag_name;
       - name: "Check canister interface compatibility"
         run: |
+          release="release-2024-09-17"
+          # undo the breaking changes that we _explicitly_ made
+          # remove after the next release
+          # if we accidentally introduced other breaking changes, the patch would no longer apply / fix them
+          # making this job fail.
+          if [ "${{ steps.latest-release-tag.outputs.result }}" == "$release" ]; then
+            echo "Rolling back intentionally made breaking changes $release"
+            git apply allowed_breaking_change.patch
+          fi
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
           didc check src/internet_identity/internet_identity.did internet_identity_previous.did
 

--- a/allowed_breaking_change.patch
+++ b/allowed_breaking_change.patch
@@ -1,0 +1,121 @@
+diff --git a/src/internet_identity/internet_identity.did b/src/internet_identity/internet_identity.did
+index 500ef4d6..eb75b075 100644
+--- a/src/internet_identity/internet_identity.did
++++ b/src/internet_identity/internet_identity.did
+@@ -435,6 +435,17 @@ type IdentityInfoError = variant {
+     InternalCanisterError: text;
+ };
+ 
++
++
++type IdentityRegisterError = variant {
++    // No more registrations are possible in this instance of the II service canister.
++    CanisterFull;
++    // The captcha check was not successful.
++    BadCaptcha;
++    // The metadata of the provided authentication method contains invalid entries.
++    InvalidMetadata: text;
++};
++
+ type AuthnMethodAddError = variant {
+     InvalidMetadata: text;
+ };
+@@ -521,72 +532,6 @@ type SignedIdAlias = record {
+     id_dapp : principal;
+ };
+ 
+-type IdRegNextStepResult = record {
+-    // The next step in the registration flow
+-    next_step: RegistrationFlowNextStep;
+-};
+-
+-type IdRegStartError = variant {
+-    // The method was called anonymously, which is not supported.
+-    InvalidCaller;
+-    // Too many registrations. Please try again later.
+-    RateLimitExceeded;
+-    // A registration flow is already in progress.
+-    AlreadyInProgress;
+-};
+-
+-// The next step in the registration flow:
+-// - CheckCaptcha: supply the solution to the captcha using `check_captcha`
+-// - Finish: finish the registration using `identity_registration_finish`
+-type RegistrationFlowNextStep = variant {
+-    // Supply the captcha solution using check_captcha
+-    CheckCaptcha: record {
+-        captcha_png_base64: text;
+-    };
+-    // Finish the registration using identity_registration_finish
+-    Finish;
+-};
+-
+-type CheckCaptchaArg = record {
+-    solution : text;
+-};
+-
+-type CheckCaptchaError = variant {
+-    // The supplied solution was wrong. Try again with the new captcha.
+-    WrongSolution: record {
+-        new_captcha_png_base64: text;
+-    };
+-    // This call is unexpected, see next_step.
+-    UnexpectedCall: record {
+-        next_step: RegistrationFlowNextStep;
+-    };
+-    // No registration flow ongoing for the caller.
+-    NoRegistrationFlow;
+-};
+-
+-type IdRegFinishArg = record {
+-    authn_method: AuthnMethodData;
+-};
+-
+-type IdRegFinishResult = record {
+-    identity_number: nat64;
+-};
+-
+-type IdRegFinishError = variant {
+-    // The configured maximum number of identities has been reached.
+-    IdentityLimitReached;
+-    // This call is unexpected, see next_step.
+-    UnexpectedCall: record {
+-        next_step: RegistrationFlowNextStep;
+-    };
+-    // No registration flow ongoing for the caller.
+-    NoRegistrationFlow;
+-    // The supplied authn_method is not valid.
+-    InvalidAuthnMethod: text;
+-    // Error while persisting the new identity.
+-    StorageError: text;
+-};
+-
+ service : (opt InternetIdentityInit) -> {
+     // Legacy identity management API
+     // ==============================
+@@ -613,17 +558,16 @@ service : (opt InternetIdentityInit) -> {
+ 
+     // V2 Identity Management API
+     // ==========================
+-    // WARNING: The following methods are experimental and may ch 0ange in the future.
+-
+-    // Starts the identity registration flow to create a new identity.
+-    identity_registration_start: () -> (variant {Ok: IdRegNextStepResult; Err: IdRegStartError;});
++    // WARNING: The following methods are experimental and may change in the future.
+ 
+-    // Check the captcha challenge
+-    // If successful, the registration can be finished with `identity_registration_finish`.
+-    check_captcha: (CheckCaptchaArg) -> (variant {Ok: IdRegNextStepResult; Err: CheckCaptchaError;});
++    // Creates a new captcha. The solution needs to be submitted using the
++    // `identity_register` call.
++    captcha_create: () -> (variant {Ok: Challenge; Err;});
+ 
+-    // Starts the identity registration flow to create a new identity.
+-    identity_registration_finish: (IdRegFinishArg) -> (variant {Ok: IdRegFinishResult; Err: IdRegFinishError;});
++    // Registers a new identity with the given authn_method.
++    // A valid captcha solution to a previously generated captcha (using create_captcha) must be provided.
++    // The sender needs to match the supplied authn_method.
++    identity_register: (AuthnMethodData, CaptchaResult, opt principal) -> (variant {Ok: IdentityNumber; Err: IdentityRegisterError;});
+ 
+     // Returns information about the authentication methods of the identity with the given number.
+     // Only returns the minimal information required for authentication without exposing any metadata such as aliases.

--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -5,35 +5,54 @@ use pocket_ic::common::rest::RawEffectivePrincipal;
 use pocket_ic::{call_candid, call_candid_as, query_candid, CallError, PocketIc};
 use std::collections::HashMap;
 
-pub fn captcha_create(
-    env: &PocketIc,
-    canister_id: CanisterId,
-) -> Result<Result<Challenge, ()>, CallError> {
-    call_candid(
-        env,
-        canister_id,
-        RawEffectivePrincipal::None,
-        "captcha_create",
-        (),
-    )
-    .map(|(x,)| x)
-}
-
-pub fn identity_register(
+pub fn identity_registration_start(
     env: &PocketIc,
     canister_id: CanisterId,
     sender: Principal,
-    authn_method: &AuthnMethodData,
-    challenge_attempt: &ChallengeAttempt,
-    temp_key: Option<Principal>,
-) -> Result<Result<IdentityNumber, IdentityRegisterError>, CallError> {
+) -> Result<Result<IdRegNextStepResult, IdRegStartError>, CallError> {
     call_candid_as(
         env,
         canister_id,
         RawEffectivePrincipal::None,
         sender,
-        "identity_register",
-        (authn_method, challenge_attempt, temp_key),
+        "identity_registration_start",
+        (),
+    )
+    .map(|(x,)| x)
+}
+
+pub fn check_captcha(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+    solution: String,
+) -> Result<Result<IdRegNextStepResult, CheckCaptchaError>, CallError> {
+    call_candid_as(
+        env,
+        canister_id,
+        RawEffectivePrincipal::None,
+        sender,
+        "check_captcha",
+        (CheckCaptchaArg { solution },),
+    )
+    .map(|(x,)| x)
+}
+
+pub fn identity_registration_finish(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+    authn_method: &AuthnMethodData,
+) -> Result<Result<IdRegFinishResult, IdRegFinishError>, CallError> {
+    call_candid_as(
+        env,
+        canister_id,
+        RawEffectivePrincipal::None,
+        sender,
+        "identity_registration_finish",
+        (IdRegFinishArg {
+            authn_method: authn_method.clone(),
+        },),
     )
     .map(|(x,)| x)
 }

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -435,17 +435,6 @@ type IdentityInfoError = variant {
     InternalCanisterError: text;
 };
 
-
-
-type IdentityRegisterError = variant {
-    // No more registrations are possible in this instance of the II service canister.
-    CanisterFull;
-    // The captcha check was not successful.
-    BadCaptcha;
-    // The metadata of the provided authentication method contains invalid entries.
-    InvalidMetadata: text;
-};
-
 type AuthnMethodAddError = variant {
     InvalidMetadata: text;
 };
@@ -532,6 +521,72 @@ type SignedIdAlias = record {
     id_dapp : principal;
 };
 
+type IdRegNextStepResult = record {
+    // The next step in the registration flow
+    next_step: RegistrationFlowNextStep;
+};
+
+type IdRegStartError = variant {
+    // The method was called anonymously, which is not supported.
+    InvalidCaller;
+    // Too many registrations. Please try again later.
+    RateLimitExceeded;
+    // A registration flow is already in progress.
+    AlreadyInProgress;
+};
+
+// The next step in the registration flow:
+// - CheckCaptcha: supply the solution to the captcha using `check_captcha`
+// - Finish: finish the registration using `identity_registration_finish`
+type RegistrationFlowNextStep = variant {
+    // Supply the captcha solution using check_captcha
+    CheckCaptcha: record {
+        captcha_png_base64: text;
+    };
+    // Finish the registration using identity_registration_finish
+    Finish;
+};
+
+type CheckCaptchaArg = record {
+    solution : text;
+};
+
+type CheckCaptchaError = variant {
+    // The supplied solution was wrong. Try again with the new captcha.
+    WrongSolution: record {
+        new_captcha_png_base64: text;
+    };
+    // This call is unexpected, see next_step.
+    UnexpectedCall: record {
+        next_step: RegistrationFlowNextStep;
+    };
+    // No registration flow ongoing for the caller.
+    NoRegistrationFlow;
+};
+
+type IdRegFinishArg = record {
+    authn_method: AuthnMethodData;
+};
+
+type IdRegFinishResult = record {
+    identity_number: nat64;
+};
+
+type IdRegFinishError = variant {
+    // The configured maximum number of identities has been reached.
+    IdentityLimitReached;
+    // This call is unexpected, see next_step.
+    UnexpectedCall: record {
+        next_step: RegistrationFlowNextStep;
+    };
+    // No registration flow ongoing for the caller.
+    NoRegistrationFlow;
+    // The supplied authn_method is not valid.
+    InvalidAuthnMethod: text;
+    // Error while persisting the new identity.
+    StorageError: text;
+};
+
 service : (opt InternetIdentityInit) -> {
     // Legacy identity management API
     // ==============================
@@ -558,16 +613,17 @@ service : (opt InternetIdentityInit) -> {
 
     // V2 Identity Management API
     // ==========================
-    // WARNING: The following methods are experimental and may change in the future.
+    // WARNING: The following methods are experimental and may ch 0ange in the future.
 
-    // Creates a new captcha. The solution needs to be submitted using the
-    // `identity_register` call.
-    captcha_create: () -> (variant {Ok: Challenge; Err;});
+    // Starts the identity registration flow to create a new identity.
+    identity_registration_start: () -> (variant {Ok: IdRegNextStepResult; Err: IdRegStartError;});
 
-    // Registers a new identity with the given authn_method.
-    // A valid captcha solution to a previously generated captcha (using create_captcha) must be provided.
-    // The sender needs to match the supplied authn_method.
-    identity_register: (AuthnMethodData, CaptchaResult, opt principal) -> (variant {Ok: IdentityNumber; Err: IdentityRegisterError;});
+    // Check the captcha challenge
+    // If successful, the registration can be finished with `identity_registration_finish`.
+    check_captcha: (CheckCaptchaArg) -> (variant {Ok: IdRegNextStepResult; Err: CheckCaptchaError;});
+
+    // Starts the identity registration flow to create a new identity.
+    identity_registration_finish: (IdRegFinishArg) -> (variant {Ok: IdRegFinishResult; Err: IdRegFinishError;});
 
     // Returns information about the authentication methods of the identity with the given number.
     // Only returns the minimal information required for authentication without exposing any metadata such as aliases.

--- a/src/internet_identity/src/anchor_management/registration/captcha.rs
+++ b/src/internet_identity/src/anchor_management/registration/captcha.rs
@@ -9,6 +9,7 @@ use lazy_static::lazy_static;
 use rand_core::{RngCore, SeedableRng};
 use std::collections::{HashMap, HashSet};
 
+#[derive(Clone, Debug)]
 pub struct Base64(pub String);
 
 lazy_static! {
@@ -143,7 +144,7 @@ pub fn check_challenge(res: ChallengeAttempt) -> Result<(), ()> {
 
 /// Check whether the supplied CAPTCHA solution attempt matches the expected solution (after
 /// normalizing ambiguous characters).
-fn check_captcha_solution(solution_attempt: String, solution: String) -> Result<(), ()> {
+pub fn check_captcha_solution(solution_attempt: String, solution: String) -> Result<(), ()> {
     // avoid processing too many characters
     if solution_attempt.len() > CAPTCHA_LENGTH {
         return Err(());

--- a/src/internet_identity/src/anchor_management/registration/rate_limit.rs
+++ b/src/internet_identity/src/anchor_management/registration/rate_limit.rs
@@ -1,7 +1,6 @@
 use crate::state;
 use crate::state::RateLimitState;
 use ic_cdk::api::time;
-use ic_cdk::trap;
 use internet_identity_interface::internet_identity::types::RateLimitConfig;
 use std::cmp::min;
 
@@ -15,7 +14,7 @@ use std::cmp::min;
 /// tokens have replenished.
 /// There is a maximum of `max_tokens` tokens, when reached the tokens not increase any further.
 /// This is the maximum number of calls that can be handled in a burst.
-pub fn process_rate_limit() {
+pub fn process_rate_limit() -> Result<(), ()> {
     let config = state::persistent_state(|ps| ps.registration_rate_limit.clone());
 
     state::registration_rate_limit_mut(|state_opt| {
@@ -35,8 +34,9 @@ pub fn process_rate_limit() {
         if state.tokens > 0 {
             state.tokens -= 1;
         } else {
-            trap("rate limit reached, try again later");
+            return Err(());
         }
+        Ok(())
     })
 }
 

--- a/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
+++ b/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
@@ -1,0 +1,172 @@
+use crate::anchor_management::registration::captcha::{
+    check_captcha_solution, create_captcha, make_rng, Base64,
+};
+use crate::anchor_management::registration::rate_limit::process_rate_limit;
+use crate::anchor_management::{activity_bookkeeping, post_operation_bookkeeping};
+use crate::state;
+use crate::state::flow_states::RegistrationFlowState;
+use crate::state::temp_keys::TempKeyId;
+use crate::storage::anchor::Device;
+use candid::Principal;
+use ic_cdk::api::time;
+use ic_cdk::caller;
+use internet_identity_interface::archive::types::{DeviceDataWithoutAlias, Operation};
+use internet_identity_interface::internet_identity::types::IdRegFinishError::IdentityLimitReached;
+use internet_identity_interface::internet_identity::types::{
+    CheckCaptchaArg, CheckCaptchaError, DeviceData, DeviceWithUsage, IdRegFinishArg,
+    IdRegFinishError, IdRegFinishResult, IdRegNextStepResult, IdRegStartError, IdentityNumber,
+    RegistrationFlowNextStep,
+};
+
+impl From<RegistrationFlowState> for RegistrationFlowNextStep {
+    fn from(value: RegistrationFlowState) -> Self {
+        match value {
+            RegistrationFlowState::CheckCaptcha {
+                captcha_png_base64, ..
+            } => RegistrationFlowNextStep::CheckCaptcha {
+                captcha_png_base64: captcha_png_base64.0,
+            },
+            RegistrationFlowState::FinishRegistration { .. } => RegistrationFlowNextStep::Finish,
+        }
+    }
+}
+
+pub async fn identity_registration_start() -> Result<IdRegNextStepResult, IdRegStartError> {
+    process_rate_limit().map_err(|_| IdRegStartError::RateLimitExceeded)?;
+
+    let caller = caller();
+    if caller == Principal::anonymous() {
+        return Err(IdRegStartError::InvalidCaller);
+    }
+
+    let (captcha_png_base64, flow_state) = captcha_flow_state(time()).await;
+    state::with_flow_states_mut(|flow_states| {
+        flow_states.new_registration_flow(caller, flow_state)
+    })
+    .map_err(|_| IdRegStartError::AlreadyInProgress)?;
+
+    Ok(IdRegNextStepResult {
+        next_step: RegistrationFlowNextStep::CheckCaptcha {
+            captcha_png_base64: captcha_png_base64.0,
+        },
+    })
+}
+
+async fn captcha_flow_state(flow_created_timestamp_ns: u64) -> (Base64, RegistrationFlowState) {
+    let mut rng = &mut make_rng().await;
+    let (captcha_png_base64, captcha_solution) = create_captcha(&mut rng);
+    let flow_state = RegistrationFlowState::CheckCaptcha {
+        flow_created_timestamp_ns,
+        captcha_solution,
+        captcha_png_base64: captcha_png_base64.clone(),
+    };
+    (captcha_png_base64, flow_state)
+}
+
+pub async fn check_captcha(arg: CheckCaptchaArg) -> Result<IdRegNextStepResult, CheckCaptchaError> {
+    let Some(current_state) = state::with_flow_states(|s| s.registration_flow_state(&caller()))
+    else {
+        return Err(CheckCaptchaError::NoRegistrationFlow);
+    };
+
+    let RegistrationFlowState::CheckCaptcha {
+        flow_created_timestamp_ns,
+        captcha_solution,
+        ..
+    } = current_state
+    else {
+        return Err(CheckCaptchaError::UnexpectedCall {
+            next_step: RegistrationFlowNextStep::from(current_state),
+        });
+    };
+
+    let caller = caller();
+    if check_captcha_solution(arg.solution, captcha_solution).is_err() {
+        let (captcha_png_base64, flow_state) = captcha_flow_state(flow_created_timestamp_ns).await;
+        state::with_flow_states_mut(|flow_states| {
+            flow_states.update_registration_flow(caller, flow_state)
+        })
+        // If we fail to update the flow, then the flow has expired in the time it took to create
+        // the captcha.
+        .map_err(|_| CheckCaptchaError::NoRegistrationFlow)?;
+
+        return Err(CheckCaptchaError::WrongSolution {
+            new_captcha_png_base64: captcha_png_base64.0,
+        });
+    }
+
+    let flow_state = RegistrationFlowState::FinishRegistration {
+        flow_created_timestamp_ns,
+    };
+
+    state::with_flow_states_mut(|flow_states| {
+        flow_states.update_registration_flow(caller, flow_state)
+    })
+    // The update_registration_flow triggers a clean-up as well, which could lead to a situation where
+    // the flow being processed here is cleaned up. In that case, abort with an error.
+    .map_err(|_| CheckCaptchaError::NoRegistrationFlow)?;
+
+    Ok(IdRegNextStepResult {
+        next_step: RegistrationFlowNextStep::Finish,
+    })
+}
+
+pub fn identity_registration_finish(
+    arg: IdRegFinishArg,
+) -> Result<IdRegFinishResult, IdRegFinishError> {
+    let Some(current_state) = state::with_flow_states(|s| s.registration_flow_state(&caller()))
+    else {
+        return Err(IdRegFinishError::NoRegistrationFlow);
+    };
+
+    let RegistrationFlowState::FinishRegistration { .. } = current_state else {
+        return Err(IdRegFinishError::UnexpectedCall {
+            next_step: RegistrationFlowNextStep::from(current_state),
+        });
+    };
+
+    let identity_number = create_identity(&arg)?;
+
+    let caller = caller();
+    // flow completed --> remove flow state
+    state::with_flow_states_mut(|flow_states| flow_states.remove_registration_flow(&caller));
+
+    // add temp key so the user can keep using the identity used for the registration flow
+    state::with_temp_keys_mut(|temp_keys| {
+        temp_keys.add_temp_key(
+            TempKeyId::IdentityAuthnMethod {
+                identity_number,
+                authn_method_pubkey: arg.authn_method.public_key(),
+            },
+            caller,
+        )
+    });
+
+    Ok(IdRegFinishResult { identity_number })
+}
+
+fn create_identity(arg: &IdRegFinishArg) -> Result<IdentityNumber, IdRegFinishError> {
+    let Some(mut identity) = state::storage_borrow_mut(|s| s.allocate_anchor()) else {
+        return Err(IdentityLimitReached);
+    };
+    let device = DeviceWithUsage::try_from(arg.authn_method.clone())
+        .map(|device| Device::from(DeviceData::from(device)))
+        .map_err(|err| IdRegFinishError::InvalidAuthnMethod(err.to_string()))?;
+
+    identity
+        .add_device(device.clone())
+        .map_err(|err| IdRegFinishError::InvalidAuthnMethod(err.to_string()))?;
+    activity_bookkeeping(&mut identity, &device.pubkey);
+
+    let identity_number = identity.anchor_number();
+
+    state::storage_borrow_mut(|s| s.write(identity))
+        .map_err(|err| IdRegFinishError::StorageError(err.to_string()))?;
+
+    let operation = Operation::RegisterAnchor {
+        device: DeviceDataWithoutAlias::from(device),
+    };
+    post_operation_bookkeeping(identity_number, operation);
+
+    Ok(identity_number)
+}

--- a/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
+++ b/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
@@ -64,7 +64,8 @@ async fn captcha_flow_state(flow_created_timestamp_ns: u64) -> (Base64, Registra
 }
 
 pub async fn check_captcha(arg: CheckCaptchaArg) -> Result<IdRegNextStepResult, CheckCaptchaError> {
-    let Some(current_state) = state::with_flow_states(|s| s.registration_flow_state(&caller()))
+    let caller = caller();
+    let Some(current_state) = state::with_flow_states(|s| s.registration_flow_state(&caller))
     else {
         return Err(CheckCaptchaError::NoRegistrationFlow);
     };
@@ -80,7 +81,6 @@ pub async fn check_captcha(arg: CheckCaptchaArg) -> Result<IdRegNextStepResult, 
         });
     };
 
-    let caller = caller();
     if check_captcha_solution(arg.solution, captcha_solution).is_err() {
         let (captcha_png_base64, flow_state) = captcha_flow_state(flow_created_timestamp_ns).await;
         state::with_flow_states_mut(|flow_states| {
@@ -114,7 +114,8 @@ pub async fn check_captcha(arg: CheckCaptchaArg) -> Result<IdRegNextStepResult, 
 pub fn identity_registration_finish(
     arg: IdRegFinishArg,
 ) -> Result<IdRegFinishResult, IdRegFinishError> {
-    let Some(current_state) = state::with_flow_states(|s| s.registration_flow_state(&caller()))
+    let caller = caller();
+    let Some(current_state) = state::with_flow_states(|s| s.registration_flow_state(&caller))
     else {
         return Err(IdRegFinishError::NoRegistrationFlow);
     };
@@ -127,7 +128,6 @@ pub fn identity_registration_finish(
 
     let identity_number = create_identity(&arg)?;
 
-    let caller = caller();
     // flow completed --> remove flow state
     state::with_flow_states_mut(|flow_states| flow_states.remove_registration_flow(&caller));
 

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -1,4 +1,5 @@
 use crate::archive::{ArchiveData, ArchiveState, ArchiveStatusCache};
+use crate::state::flow_states::FlowStates;
 use crate::state::temp_keys::TempKeys;
 use crate::stats::activity_stats::activity_counter::active_anchor_counter::ActiveAnchorCounter;
 use crate::stats::activity_stats::activity_counter::authn_method_counter::AuthnMethodCounter;
@@ -19,6 +20,7 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::time::Duration;
 
+pub mod flow_states;
 pub mod temp_keys;
 
 /// Default captcha config
@@ -169,6 +171,7 @@ struct State {
     sigs: RefCell<SignatureMap>,
     // Temporary keys that can be used in lieu of a particular device
     temp_keys: RefCell<TempKeys>,
+    flow_states: RefCell<FlowStates>,
     last_upgrade_timestamp: Cell<Timestamp>,
     // note: we COULD persist this through upgrades, although this is currently NOT persisted
     // through upgrades
@@ -348,6 +351,14 @@ pub fn with_temp_keys_mut<R>(f: impl FnOnce(&mut TempKeys) -> R) -> R {
 
 pub fn with_temp_keys<R>(f: impl FnOnce(&TempKeys) -> R) -> R {
     STATE.with(|s| f(&mut s.temp_keys.borrow()))
+}
+
+pub fn with_flow_states_mut<R>(f: impl FnOnce(&mut FlowStates) -> R) -> R {
+    STATE.with(|s| f(&mut s.flow_states.borrow_mut()))
+}
+
+pub fn with_flow_states<R>(f: impl FnOnce(&FlowStates) -> R) -> R {
+    STATE.with(|s| f(&mut s.flow_states.borrow()))
 }
 
 pub fn usage_metrics<R>(f: impl FnOnce(&UsageMetrics) -> R) -> R {

--- a/src/internet_identity/src/state/flow_states.rs
+++ b/src/internet_identity/src/state/flow_states.rs
@@ -1,0 +1,131 @@
+use crate::anchor_management::registration::Base64;
+use crate::MINUTE_NS;
+use candid::Principal;
+use ic_cdk::api::time;
+use internet_identity_interface::internet_identity::types::Timestamp;
+use std::collections::{HashMap, VecDeque};
+
+// Expiration for a registration flow, the same as the captcha expiry
+const FLOW_EXPIRATION_NS: u64 = 5 * MINUTE_NS;
+
+#[derive(Default)]
+pub struct FlowStates {
+    /// In-progress registration flows tied to the respective principal. The principal will become
+    /// a temp key upon successful completion of the registration flow.
+    /// Registration flows are removed on three conditions:
+    /// * The registration flow is completed successfully
+    /// * Once the flow expires
+    /// * The Internet Identity canister is upgraded
+    ///
+    /// The total number of flow states is limited by the registration rate limit.
+    registration_flows: HashMap<Principal, RegistrationFlowState>,
+
+    /// Deque to efficiently prune expired registration flows
+    ///
+    /// The total number of flow state expirations is limited by the registration rate limit.
+    expirations: VecDeque<FlowExpiration>,
+}
+
+/// State of a registration flow. The state expresses which action is expected next.
+#[derive(Debug, Clone)]
+pub enum RegistrationFlowState {
+    /// Client is expected to supply the `captcha_solution` using
+    /// `check_captcha`.
+    CheckCaptcha {
+        flow_created_timestamp_ns: u64,
+        captcha_solution: String,
+        captcha_png_base64: Base64,
+    },
+    /// Client is expected to finish the registration (supply an [authn_method](internet_identity_interface::internet_identity::types::AuthnMethodData))
+    /// using `identity_registration_finish`.
+    FinishRegistration { flow_created_timestamp_ns: u64 },
+}
+
+impl RegistrationFlowState {
+    pub fn create_at_timestamp_ns(&self) -> u64 {
+        match self {
+            RegistrationFlowState::CheckCaptcha {
+                flow_created_timestamp_ns,
+                ..
+            }
+            | RegistrationFlowState::FinishRegistration {
+                flow_created_timestamp_ns,
+            } => *flow_created_timestamp_ns,
+        }
+    }
+}
+
+impl FlowStates {
+    pub fn new_registration_flow(
+        &mut self,
+        principal: Principal,
+        flow_state: RegistrationFlowState,
+    ) -> Result<(), String> {
+        self.prune_expired_flows();
+        if self.registration_flows.contains_key(&principal) {
+            return Err("already exists".to_string());
+        }
+
+        self.expirations.push_back(FlowExpiration {
+            principal,
+            expiration: flow_state.create_at_timestamp_ns() + FLOW_EXPIRATION_NS,
+        });
+
+        self.registration_flows.insert(principal, flow_state);
+        Ok(())
+    }
+
+    pub fn update_registration_flow(
+        &mut self,
+        principal: Principal,
+        flow_state: RegistrationFlowState,
+    ) -> Result<(), String> {
+        self.prune_expired_flows();
+        if self.registration_flows.remove(&principal).is_none() {
+            return Err("no flow_state to update".to_string());
+        }
+        self.registration_flows.insert(principal, flow_state);
+        Ok(())
+    }
+
+    pub fn remove_registration_flow(&mut self, principal: &Principal) {
+        self.prune_expired_flows();
+        self.registration_flows.remove(principal);
+    }
+
+    pub fn registration_flow_state(&self, principal: &Principal) -> Option<RegistrationFlowState> {
+        self.registration_flows
+            .get(principal)
+            // filter out expired flow
+            .filter(|flow_state| flow_state.create_at_timestamp_ns() + FLOW_EXPIRATION_NS > time())
+            .cloned()
+    }
+
+    fn prune_expired_flows(&mut self) {
+        const MAX_TO_PRUNE: usize = 100;
+
+        let now = time();
+        for _ in 0..MAX_TO_PRUNE {
+            let Some(expiration) = self.expirations.front() else {
+                break;
+            };
+
+            // The expirations are sorted by expiration time because the expiration is constant
+            // and time() is monotonic
+            // -> we can stop pruning once we reach a flow that is not expired
+            if expiration.expiration > now {
+                break;
+            }
+            self.registration_flows.remove(&expiration.principal);
+            self.expirations.pop_front();
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FlowExpiration {
+    /// Principal which the flow is tied to.
+    pub principal: Principal,
+    /// The expiration timestamp of the temp key
+    pub expiration: Timestamp,
+}

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -149,3 +149,54 @@ pub enum IdentityMetadataReplaceError {
     },
     InternalCanisterError(String),
 }
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct IdRegNextStepResult {
+    pub next_step: RegistrationFlowNextStep,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum IdRegStartError {
+    RateLimitExceeded,
+    InvalidCaller,
+    AlreadyInProgress,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum RegistrationFlowNextStep {
+    /// Supply the captcha solution using check_captcha
+    CheckCaptcha { captcha_png_base64: String },
+    /// Finish the registration using identity_registration_finish
+    Finish,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct CheckCaptchaArg {
+    pub solution: String,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum CheckCaptchaError {
+    WrongSolution { new_captcha_png_base64: String },
+    UnexpectedCall { next_step: RegistrationFlowNextStep },
+    NoRegistrationFlow,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct IdRegFinishArg {
+    pub authn_method: AuthnMethodData,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct IdRegFinishResult {
+    pub identity_number: IdentityNumber,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum IdRegFinishError {
+    IdentityLimitReached,
+    UnexpectedCall { next_step: RegistrationFlowNextStep },
+    NoRegistrationFlow,
+    InvalidAuthnMethod(String),
+    StorageError(String),
+}


### PR DESCRIPTION
The registration for new identities using API v2 is now split into 3 different steps:
1. start a flow, providing a principal to track progress on that flow
2. solve captcha
3. submit authn_method to tie the identity to

This PR is a preparation to making the step 2 dynamically remove step 2 on low load.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

