### PR TITLE
Allow fractions in  helper `assert_metric` helper

### DIFF
--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -469,7 +469,7 @@ pub fn get_metrics(env: &PocketIc, canister_id: CanisterId) -> String {
 
 pub fn parse_metric(body: &str, metric: &str) -> (f64, u64) {
     let metric = metric.replace('{', "\\{").replace('}', "\\}");
-    let metric_capture = Regex::new(&format!("(?m)^{metric} (\\d+) (\\d+)$"))
+    let metric_capture = Regex::new(&format!("(?m)^{metric} ([\\d\\.]+) ([\\d\\.]+)$"))
         .unwrap()
         .captures(body)
         .unwrap_or_else(|| panic!("metric {metric} not found"));


### PR DESCRIPTION
The `assert_metric` helper only parses integers right now, even though the metrics could be fractions.
This is required once the registrations rates are exposed as a metric, hence this PR to fix it.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
