### PR TITLE
Wait longer for e2e test window to close

### DIFF
--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -446,7 +446,7 @@ export async function waitToClose(browser: WebdriverIO.Browser): Promise<void> {
   await browser.waitUntil(
     async () => (await browser.getWindowHandles()).length == 1,
     {
-      timeout: 20_000,
+      timeout: 20_000, // this is relatively long, but we observed flakiness when just waiting for 10 seconds
       timeoutMsg: "expected only one window to exist after 20s",
     }
   );

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -446,8 +446,8 @@ export async function waitToClose(browser: WebdriverIO.Browser): Promise<void> {
   await browser.waitUntil(
     async () => (await browser.getWindowHandles()).length == 1,
     {
-      timeout: 10_000,
-      timeoutMsg: "expected only one window to exist after 10s",
+      timeout: 20_000,
+      timeoutMsg: "expected only one window to exist after 20s",
     }
   );
   const handles = await browser.getWindowHandles();


### PR DESCRIPTION
E2e tests are flaky due to windows not closing in time. This PR increases the timeout to see if it makes the tests more robust.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/e2e7c9e1b/desktop/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

