### PR TITLE
Only require captcha if threshold rate is exceeded

### DIFF
--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -209,6 +209,20 @@ pub fn arg_with_anchor_range(
     })
 }
 
+pub fn arg_with_dynamic_captcha() -> Option<InternetIdentityInit> {
+    Some(InternetIdentityInit {
+        captcha_config: Some(CaptchaConfig {
+            max_unsolved_captchas: 50,
+            captcha_trigger: CaptchaTrigger::Dynamic {
+                threshold_pct: 20,
+                current_rate_sampling_interval_s: 10,
+                reference_rate_sampling_interval_s: 100,
+            },
+        }),
+        ..InternetIdentityInit::default()
+    })
+}
+
 pub fn archive_wasm_hash(wasm: &Vec<u8>) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(wasm);

--- a/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
+++ b/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
@@ -52,10 +52,11 @@ pub async fn identity_registration_start() -> Result<IdRegNextStepResult, IdRegS
         return Err(IdRegStartError::InvalidCaller);
     }
 
+    let now = time();
     let flow_state = match captcha_required() {
-        true => captcha_flow_state(time()).await.1,
+        true => captcha_flow_state(now).await.1,
         false => RegistrationFlowState::FinishRegistration {
-            flow_created_timestamp_ns: time(),
+            flow_created_timestamp_ns: now,
         },
     };
 

--- a/src/internet_identity/src/storage/registration_rates.rs
+++ b/src/internet_identity/src/storage/registration_rates.rs
@@ -23,6 +23,12 @@ pub struct NormalizedRegistrationRates {
     pub captcha_threshold_rate: f64,
 }
 
+impl NormalizedRegistrationRates {
+    pub fn captcha_required(&self) -> bool {
+        self.current_rate_per_second > self.captcha_threshold_rate
+    }
+}
+
 struct DynamicCaptchaConfig {
     reference_rate_retention_ns: u64,
     current_rate_retention_ns: u64,

--- a/src/internet_identity/tests/integration/v2_api/identity_register/dynamic_captcha.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_register/dynamic_captcha.rs
@@ -42,8 +42,8 @@ fn should_require_captcha_above_threshold_rate() {
 
     // Double the rate of registrations to one per second
     // The 20% threshold rate should allow 5 registrations before the captcha kicks in
-    let flow_principal = test_principal(0);
-    for _ in 0..5 {
+    for i in 0..5 {
+        let flow_principal = test_principal(i);
         let result = api_v2::identity_registration_start(&env, canister_id, flow_principal)
             .expect("API call failed")
             .expect("registration start failed");
@@ -56,7 +56,7 @@ fn should_require_captcha_above_threshold_rate() {
         env.advance_time(Duration::from_secs(1));
     }
 
-    let result = api_v2::identity_registration_start(&env, canister_id, flow_principal)
+    let result = api_v2::identity_registration_start(&env, canister_id, test_principal(99))
         .expect("API call failed")
         .expect("registration start failed");
 

--- a/src/internet_identity/tests/integration/v2_api/identity_register/dynamic_captcha.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_register/dynamic_captcha.rs
@@ -1,0 +1,68 @@
+use crate::v2_api::authn_method_test_helpers::{
+    create_identity_with_authn_method, test_authn_method,
+};
+use canister_tests::api::internet_identity::api_v2;
+use canister_tests::framework::{
+    arg_with_dynamic_captcha, env, install_ii_canister_with_arg, test_principal, II_WASM,
+};
+use internet_identity_interface::internet_identity::types::RegistrationFlowNextStep;
+use std::time::Duration;
+
+#[test]
+fn should_not_require_captcha_below_threshold_rate() {
+    let env = env();
+    let canister_id =
+        install_ii_canister_with_arg(&env, II_WASM.clone(), arg_with_dynamic_captcha());
+    let authn_method = test_authn_method();
+
+    let flow_principal = test_principal(0);
+    let result = api_v2::identity_registration_start(&env, canister_id, flow_principal)
+        .expect("API call failed")
+        .expect("registration start failed");
+
+    assert!(matches!(result.next_step, RegistrationFlowNextStep::Finish));
+
+    api_v2::identity_registration_finish(&env, canister_id, flow_principal, &authn_method)
+        .expect("API call failed")
+        .expect("registration finish failed");
+}
+
+#[test]
+fn should_require_captcha_above_threshold_rate() {
+    let env = env();
+    let canister_id =
+        install_ii_canister_with_arg(&env, II_WASM.clone(), arg_with_dynamic_captcha());
+    let authn_method = test_authn_method();
+
+    // initialize a base rate of one registration every 2 seconds
+    for _ in 0..10 {
+        create_identity_with_authn_method(&env, canister_id, &authn_method);
+        env.advance_time(Duration::from_secs(2))
+    }
+
+    // Double the rate of registrations to one per second
+    // The 20% threshold rate should allow 5 registrations before the captcha kicks in
+    let flow_principal = test_principal(0);
+    for _ in 0..5 {
+        let result = api_v2::identity_registration_start(&env, canister_id, flow_principal)
+            .expect("API call failed")
+            .expect("registration start failed");
+
+        assert!(matches!(result.next_step, RegistrationFlowNextStep::Finish));
+
+        api_v2::identity_registration_finish(&env, canister_id, flow_principal, &authn_method)
+            .expect("API call failed")
+            .expect("registration finish failed");
+        env.advance_time(Duration::from_secs(1));
+    }
+
+    let result = api_v2::identity_registration_start(&env, canister_id, flow_principal)
+        .expect("API call failed")
+        .expect("registration start failed");
+
+    // captcha kicks in
+    assert!(matches!(
+        result.next_step,
+        RegistrationFlowNextStep::CheckCaptcha { .. }
+    ));
+}


### PR DESCRIPTION
This PR enables the dynamic captcha feature: I.e. if the captcha is configured to be dynamic _and_ the configured threshold has been exceeded, then require a captcha to be solved. Otherwise skip the captcha entirely.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

