### PR TITLE
Remove unnecessary counters from persistent state

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -383,7 +383,6 @@ jobs:
           # a relatively small price to pay to make sure PRs are always tested against the latest release.
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_test.wasm.gz -o internet_identity_previous.wasm.gz
           curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/archive.wasm.gz -o archive_previous.wasm.gz
-          curl -SL https://github.com/dfinity/internet-identity/releases/download/release-2024-04-26/internet_identity_test.wasm.gz -o internet_identity_pre_stats.wasm.gz
 
           # We are using --partition hash instead of count, because it makes sure that the tests partition is stable across runs
           # even if tests are added or removed. The tradeoff is that the balancing might be slightly worse, but we have enough

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -69,20 +69,6 @@ lazy_static! {
         get_wasm_path("II_WASM_PREVIOUS".to_string(), &def_path).expect(&err)
     };
 
-        /** The gzipped Wasm module for the II release build 2024-04-26, before the event stats were introduced. */
-    pub static ref II_WASM_PRE_STATS: Vec<u8> = {
-        let def_path = path::PathBuf::from("..").join("..").join("internet_identity_pre_stats.wasm.gz");
-        let err = format!("
-        Could not find Internet Identity Wasm module for pre-stats release.
-
-        I will look for it at {:?}, and you can specify another path with the environment variable II_WASM_PREVIOUS (note that I run from {:?}).
-
-        In order to get the Wasm module, please run the following command:
-            curl -SL https://github.com/dfinity/internet-identity/releases/download/release-2024-04-26/internet_identity_test.wasm.gz -o internet_identity_pre_stats.wasm.gz
-        ", &def_path, &std::env::current_dir().map(|x| x.display().to_string()).unwrap_or_else(|_| "an unknown directory".to_string()));
-        get_wasm_path("II_WASM_PRE_STATS".to_string(), &def_path).expect(&err)
-    };
-
         /** The gzipped Wasm module for the _previous_ archive build, or latest release, which is used when testing
             * upgrades and downgrades */
     pub static ref ARCHIVE_WASM_PREVIOUS: Vec<u8> = {

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -30,10 +30,7 @@ pub struct StorablePersistentState {
     max_inflight_captchas: u64,
 
     // opt fields because of backwards compatibility
-    event_data_count: Option<u64>,
-    event_aggregations_count: Option<u64>,
     event_stats_24h_start: Option<EventKey>,
-
     captcha_config: Option<CaptchaConfig>,
 }
 
@@ -70,8 +67,6 @@ impl From<PersistentState> for StorablePersistentState {
             max_num_latest_delegation_origins: 0,
             // unused, kept for stable memory compatibility
             max_inflight_captchas: 0,
-            event_data_count: Some(s.event_data_count),
-            event_aggregations_count: Some(s.event_aggregations_count),
             event_stats_24h_start: s.event_stats_24h_start,
             captcha_config: Some(s.captcha_config),
         }
@@ -88,8 +83,6 @@ impl From<StorablePersistentState> for PersistentState {
             domain_active_anchor_stats: s.domain_active_anchor_stats,
             active_authn_method_stats: s.active_authn_method_stats,
             captcha_config: s.captcha_config.unwrap_or(DEFAULT_CAPTCHA_CONFIG),
-            event_data_count: s.event_data_count.unwrap_or_default(),
-            event_aggregations_count: s.event_aggregations_count.unwrap_or_default(),
             event_stats_24h_start: s.event_stats_24h_start,
         }
     }
@@ -129,8 +122,6 @@ mod tests {
             latest_delegation_origins: HashMap::new(),
             max_num_latest_delegation_origins: 0,
             max_inflight_captchas: 0,
-            event_data_count: Some(0),
-            event_aggregations_count: Some(0),
             event_stats_24h_start: None,
             captcha_config: Some(CaptchaConfig {
                 max_unsolved_captchas: 500,
@@ -154,8 +145,6 @@ mod tests {
                 max_unsolved_captchas: 500,
                 captcha_trigger: CaptchaTrigger::Static(StaticCaptchaTrigger::CaptchaEnabled),
             },
-            event_data_count: 0,
-            event_aggregations_count: 0,
             event_stats_24h_start: None,
         };
         assert_eq!(PersistentState::default(), expected_defaults);

--- a/src/internet_identity/tests/integration/aggregation_stats.rs
+++ b/src/internet_identity/tests/integration/aggregation_stats.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use canister_tests::api::internet_identity as api;
 use canister_tests::framework::{
     assert_metric, env, get_metrics, install_ii_canister, restore_compressed_stable_memory,
-    upgrade_ii_canister, EMPTY_WASM, II_WASM, II_WASM_PRE_STATS,
+    upgrade_ii_canister, EMPTY_WASM, II_WASM,
 };
 use ic_cdk::api::management_canister::main::CanisterId;
 use internet_identity_interface::internet_identity::types::{
@@ -261,56 +261,6 @@ fn should_keep_aggregations_across_upgrades() -> Result<(), CallError> {
     upgrade_ii_canister(&env, canister_id, II_WASM.clone());
 
     assert_expected_state(&env, canister_id)?;
-    Ok(())
-}
-
-#[test]
-fn should_reset_stats_on_rollback_and_upgrade() -> Result<(), CallError> {
-    const II_ORIGIN: &str = "ic0.app";
-
-    let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
-    let identity_nr = create_identity(&env, canister_id, II_ORIGIN);
-
-    delegation_for_origin(&env, canister_id, identity_nr, "https://some-dapp.com")?;
-    delegation_for_origin(&env, canister_id, identity_nr, "https://some-dapp.com")?;
-
-    let aggregations = api::stats(&env, canister_id)?.event_aggregations;
-    assert_expected_aggregation(
-        &aggregations,
-        &aggregation_key(PD_COUNT, "24h", II_ORIGIN),
-        vec![("https://some-dapp.com".to_string(), 2u64)],
-    );
-    assert_expected_aggregation(
-        &aggregations,
-        &aggregation_key(PD_COUNT, "30d", II_ORIGIN),
-        vec![("https://some-dapp.com".to_string(), 2u64)],
-    );
-    assert_expected_aggregation(
-        &aggregations,
-        &aggregation_key(PD_SESS_SEC, "24h", II_ORIGIN),
-        vec![("https://some-dapp.com".to_string(), 2 * SESSION_LENGTH)],
-    );
-    assert_expected_aggregation(
-        &aggregations,
-        &aggregation_key(PD_SESS_SEC, "30d", II_ORIGIN),
-        vec![("https://some-dapp.com".to_string(), 2 * SESSION_LENGTH)],
-    );
-    let metrics = get_metrics(&env, canister_id);
-    assert_metric(&metrics, "internet_identity_event_data_count", 2f64);
-    assert_metric(&metrics, "internet_identity_event_aggregations_count", 4f64);
-
-    // roll back to a version that does not know about event stats
-    upgrade_ii_canister(&env, canister_id, II_WASM_PRE_STATS.clone());
-    // upgrade to the latest version again --> stats should be reset
-    upgrade_ii_canister(&env, canister_id, II_WASM.clone());
-
-    let aggregations = api::stats(&env, canister_id)?.event_aggregations;
-    assert_eq!(aggregations.len(), 0);
-
-    let metrics = get_metrics(&env, canister_id);
-    assert_metric(&metrics, "internet_identity_event_data_count", 0f64);
-    assert_metric(&metrics, "internet_identity_event_aggregations_count", 0f64);
     Ok(())
 }
 


### PR DESCRIPTION
The `StableBTreeMap` tracks the number of elements on its own, so there is no need for an external counter.

Removing the extra counters also makes the stats resetting obsolete and hence allows to remove the pre_stats II version from the integration tests.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
