### PR TITLE
Make identity metadata update synchronous

### DIFF
--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -237,8 +237,7 @@ export const recoveryWizard = async (
   });
 
   if (devicesStatus !== "no-warning") {
-    // `await` here doesn't add any waiting time beacause we already got the metadata earlier.
-    await connection.updateIdentityMetadata({
+    connection.updateIdentityMetadata({
       recoveryPageShownTimestampMillis: nowInMillis,
     });
     const userChoice = await addDeviceWarning({
@@ -248,8 +247,7 @@ export const recoveryWizard = async (
       await addDevice({ userNumber, connection });
     }
     if (userChoice.action === "do-not-remind") {
-      // `await` here doesn't add any waiting time beacause we already got the metadata earlier.
-      await connection.updateIdentityMetadata({
+      connection.updateIdentityMetadata({
         doNotShowRecoveryPageRequestTimestampMillis: nowInMillis,
       });
     }

--- a/src/frontend/src/repositories/identityMetadata.test.ts
+++ b/src/frontend/src/repositories/identityMetadata.test.ts
@@ -79,7 +79,7 @@ test("IdentityMetadataRepository changes partial data in memory", async () => {
   });
 
   const newRecoveryPageShownTimestampMillis = 9876543210;
-  await instance.updateMetadata({
+  instance.updateMetadata({
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
   });
 
@@ -98,7 +98,7 @@ test("IdentityMetadataRepository changes data in memory", async () => {
 
   const newRecoveryPageShownTimestampMillis = 9876543210;
   const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
-  await instance.updateMetadata({
+  instance.updateMetadata({
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
     doNotShowRecoveryPageRequestTimestampMillis:
       newDoNotShowRecoveryPageRequestTimestampMillis,
@@ -128,7 +128,7 @@ test("IdentityMetadataRepository sets data from partial data in memory", async (
   });
 
   const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
-  await instance.updateMetadata({
+  instance.updateMetadata({
     doNotShowRecoveryPageRequestTimestampMillis:
       newDoNotShowRecoveryPageRequestTimestampMillis,
   });
@@ -148,7 +148,7 @@ test("IdentityMetadataRepository sets partial data in memory", async () => {
   });
 
   const newRecoveryPageShownTimestampMillis = 9876543210;
-  await instance.updateMetadata({
+  instance.updateMetadata({
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
   });
 
@@ -166,7 +166,7 @@ test("IdentityMetadataRepository sets data in memory", async () => {
 
   const newRecoveryPageShownTimestampMillis = 9876543210;
   const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
-  await instance.updateMetadata({
+  instance.updateMetadata({
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
     doNotShowRecoveryPageRequestTimestampMillis:
       newDoNotShowRecoveryPageRequestTimestampMillis,
@@ -187,7 +187,7 @@ test("IdentityMetadataRepository commits updated metadata to canister", async ()
 
   const newRecoveryPageShownTimestampMillis = 9876543210;
   const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
-  await instance.updateMetadata({
+  instance.updateMetadata({
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
     doNotShowRecoveryPageRequestTimestampMillis:
       newDoNotShowRecoveryPageRequestTimestampMillis,
@@ -234,7 +234,7 @@ test("IdentityMetadataRepository doesn't raise an error if committing fails", as
     doNotShowRecoveryPageRequestTimestampMillis:
       newDoNotShowRecoveryPageRequestTimestampMillis,
   };
-  await instance.updateMetadata(newMetadata);
+  instance.updateMetadata(newMetadata);
 
   expect(setterMockError).not.toHaveBeenCalled();
   const committed = await instance.commitMetadata();
@@ -275,7 +275,7 @@ test("IdentityMetadataRepository commits additional metadata to canister after u
   });
 
   const newRecoveryPageShownTimestampMillis = 9876543210;
-  await instance.updateMetadata({
+  instance.updateMetadata({
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
   });
 
@@ -309,7 +309,7 @@ test("IdentityMetadataRepository commits from initial partial data after adding 
   });
 
   const newDoNotShowRecoveryPageRequestTimestampMillis = 1234567890;
-  await instance.updateMetadata({
+  instance.updateMetadata({
     doNotShowRecoveryPageRequestTimestampMillis:
       newDoNotShowRecoveryPageRequestTimestampMillis,
   });

--- a/src/frontend/src/repositories/identityMetadata.ts
+++ b/src/frontend/src/repositories/identityMetadata.ts
@@ -143,16 +143,12 @@ export class IdentityMetadataRepository {
    * We consider the metadata to not be crucial for the application.
    * Therefore, we don't want to disrupt user flows if there is an error with the metadata.
    *
-   * @param {Partial<IdentityMetadata>} partialMetadata
-   * @returns {Promise<void>} To indicate that the metadata has been set.
    */
-  updateMetadata = async (
-    partialMetadata: Partial<IdentityMetadata>
-  ): Promise<void> => {
+  updateMetadata = (partialMetadata: Partial<IdentityMetadata>) => {
     try {
-      this.metadata = Promise.resolve(
+      this.metadata = this.metadata.then((metadataMap) =>
         updateMetadataMapV2({
-          metadataMap: await this.metadata,
+          metadataMap: metadataMap,
           partialIdentityMetadata: partialMetadata,
         })
       );
@@ -163,7 +159,6 @@ export class IdentityMetadataRepository {
         unknownToString(e, "unknown error")
       );
     }
-    // Do nothing if the metadata is not loaded.
   };
 
   /**
@@ -177,6 +172,8 @@ export class IdentityMetadataRepository {
     if (this.updatedMetadata) {
       try {
         await this.setter(await this.metadata);
+        // after commiting metadata is no longer 'updated'
+        this.updatedMetadata = false;
         return true;
       } catch (error) {
         console.warn(

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -73,7 +73,7 @@ test("commits changes on identity metadata", async () => {
   expect(await connection.getIdentityMetadata()).toEqual(mockIdentityMetadata);
 
   const newRecoveryPageShownTimestampMillis = 9876543210;
-  await connection.updateIdentityMetadata({
+  connection.updateIdentityMetadata({
     recoveryPageShownTimestampMillis: newRecoveryPageShownTimestampMillis,
   });
 

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -553,9 +553,7 @@ export class AuthenticatedConnection extends Connection {
     return this.metadataRepository.getMetadata();
   };
 
-  updateIdentityMetadata = (
-    partialMetadata: Partial<IdentityMetadata>
-  ): Promise<void> => {
+  updateIdentityMetadata = (partialMetadata: Partial<IdentityMetadata>) => {
     return this.metadataRepository.updateMetadata(partialMetadata);
   };
 


### PR DESCRIPTION
There is no need to `await` metadata if some value needs to be written. Instead we just update the internal promise of the metadata repository to update the value once it is loaded.

This also makes a change to the registration flow to make sure that when
the success page is shown that the metadata is committed to make sure
the identity is fully set up. This should finally resolve the observed
flakiness in the e2e tests.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4fca28fca/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4fca28fca/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4fca28fca/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
