### PR TITLE
Add loader animation on registration completion

### DIFF
--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -221,12 +221,10 @@ export const registerFlow = async ({
     recoveryPageShownTimestampMillis: Date.now(),
   });
   // Immediately commit (and await) the metadata, so that the identity is fully set up when the user sees the success page
-  // This way, dropping of at that point does not negatively impact UX with additional nagging
-  // To the user this just looks like the captcha takes a bit longer to verify.
-  await Promise.all([
-    result.connection.commitMetadata(),
-    setAnchorUsed(userNumber),
-  ]);
+  // This way, dropping of at that point does not negatively impact UX with additional nagging.
+  await withLoader(() =>
+    Promise.all([result.connection.commitMetadata(), setAnchorUsed(userNumber)])
+  );
   await displayUserNumber({
     userNumber,
     marketingIntroSlot: finishSlot,


### PR DESCRIPTION
There is currently a bit of an awkward wait time when finalizing the registration without a captcha. This adds a loader animation to convey that something is happening in the background.

I also remove the comment about captcha as it is not necessarily shown.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dd64c7108/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dd64c7108/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dd64c7108/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dd64c7108/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
