### PR TITLE
Change how dynamic captcha stores data

### DIFF
--- a/src/internet_identity/src/storage/registration_rates.rs
+++ b/src/internet_identity/src/storage/registration_rates.rs
@@ -112,6 +112,8 @@ fn calculate_registration_rate<M: Memory>(now: u64, data: &MinHeap<Timestamp, M>
         .peek()
         // calculate the time window length with respect to the current time
         .map(|ts| now - ts)
+        // the value _could_ be 0 if the oldest timestamp was added in the same execution round
+        .filter(|val| *val != 0)
         // use the value to calculate the rate per second
         .map(|val| rate_per_second(data.len(), val))
         // if we don't have data, the rate is 0


### PR DESCRIPTION
# Motivation

We realized that when the config changes, the stored data still takes into account the old config because it was stored by expiration date which took into account the config.

In this PR, the PR is stored with the create timestamp and pruned taking into account the config intervals.

There is a new test to check that the old config doesn't affect the new rates (given enough time to prune the old data).




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dfa62a814/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dfa62a814/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dfa62a814/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dfa62a814/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/dfa62a814/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



