### PR TITLE
Add dfx deps default init args

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -168,12 +168,15 @@ function build_canister() {
               asset_name="internet_identity_dev.wasm.gz"
               wasm_url="https://github.com/dfinity/internet-identity/releases/download/$release/$asset_name"
               wasm_hash_url="https://github.com/dfinity/internet-identity/releases/download/$release/$asset_name.sha256"
+              # init_arg that disables the captcha, appropriate for the dev build
+              init_arg="(opt record { captcha_config = opt record { max_unsolved_captchas= 50:nat64; captcha_trigger = variant {Static = variant {CaptchaDisabled}}}})"
               init_guide="Use '(null)' for sensible defaults. See the candid interface for more details."
               metadata_json=$(echo '{}' | jq -cMr \
                   --arg wasm_url "$wasm_url" \
                   --arg wasm_hash_url "$wasm_hash_url" \
+                  --arg init_arg "$init_arg" \
                   --arg init_guide "$init_guide" \
-                  '. | .pullable = { wasm_url: $wasm_url, wasm_hash_url: $wasm_hash_url, dependencies: [], init_guide: $init_guide} ')
+                  '. | .pullable = { wasm_url: $wasm_url, wasm_hash_url: $wasm_hash_url, dependencies: [], init_arg: $init_arg, init_guide: $init_guide} ')
               ic-wasm "$canister.wasm" -o "$canister.wasm" metadata dfx -d "$metadata_json" -v public
           fi
 


### PR DESCRIPTION
This PR adds default init args for the dfx deps feature. The arg will disable the captcha, as it is not needed in dev environments.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/36d2682cf/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/36d2682cf/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/36d2682cf/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/36d2682cf/mobile/confirmSeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/36d2682cf/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
