### PR TITLE
Add "derivationOrigin" to id_alias credential

### DIFF
--- a/src/internet_identity/src/vc_mvp.rs
+++ b/src/internet_identity/src/vc_mvp.rs
@@ -60,11 +60,11 @@ pub async fn prepare_id_alias(
     };
 
     // rp_signing_input is sent to the relying party.
-    // Therefore, it needs to have the rp origin to confirm from where the principal is derived from.
+    // The relying party needs to have the derivation origin to confirm where the principal is derived from.
     let rp_signing_input = vc_signing_input(&id_alias_credential_jwt(&rp_tuple), &canister_sig_pk)
         .expect("failed getting signing_input");
     // issuer_signing_input is sent to the relying party.
-    // The issuer doesn't care so much from which origin is derived, but we keep it for consistency.
+    // The issuer needs to have the derivation origin to confirm where the principal is derived from.
     let issuer_signing_input =
         vc_signing_input(&id_alias_credential_jwt(&issuer_tuple), &canister_sig_pk)
             .expect("failed getting signing_input");

--- a/src/internet_identity/src/vc_mvp.rs
+++ b/src/internet_identity/src/vc_mvp.rs
@@ -8,7 +8,7 @@ use ic_certification::Hash;
 use ic_verifiable_credentials::issuer_api::{ArgumentValue, CredentialSpec};
 use ic_verifiable_credentials::{
     build_credential_jwt, canister_sig_pk_from_vc_signing_input, did_for_principal,
-    vc_signing_input, vc_signing_input_to_jws, AliasTuple, CredentialParams,
+    vc_signing_input, vc_signing_input_to_jws, CredentialParams,
     II_CREDENTIAL_URL_PREFIX, II_ISSUER_URL, VC_SIGNING_INPUT_DOMAIN,
 };
 use internet_identity_interface::internet_identity::types::vc_mvp::{
@@ -18,6 +18,15 @@ use internet_identity_interface::internet_identity::types::{FrontendHostname, Id
 use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+
+pub struct AliasTuple {
+    /// A temporary identity, used in attribute sharing flow.
+    pub id_alias: Principal,
+    /// An identity under which a user is known to a dapp.
+    pub id_dapp: Principal,
+    /// The derivation origin of the id_dapp
+    pub derivation_origin: String,
+}
 
 // The expiration of id_alias verifiable credentials.
 const ID_ALIAS_VC_EXPIRATION_PERIOD_NS: u64 = 15 * MINUTE_NS;
@@ -42,14 +51,20 @@ pub async fn prepare_id_alias(
     let rp_tuple = AliasTuple {
         id_alias: id_alias_principal,
         id_dapp: delegation::get_principal(identity_number, dapps.relying_party.clone()),
+        derivation_origin: dapps.relying_party.clone()
     };
     let issuer_tuple = AliasTuple {
         id_alias: id_alias_principal,
         id_dapp: delegation::get_principal(identity_number, dapps.issuer.clone()),
+        derivation_origin: dapps.issuer.clone(),
     };
 
+    // rp_signing_input is sent to the relying party.
+    // Therefore, it needs to have the rp origin to confirm from where the principal is derived from.
     let rp_signing_input = vc_signing_input(&id_alias_credential_jwt(&rp_tuple), &canister_sig_pk)
         .expect("failed getting signing_input");
+    // issuer_signing_input is sent to the relying party.
+    // The issuer doesn't care so much from which origin is derived, but we keep it for consistency.
     let issuer_signing_input =
         vc_signing_input(&id_alias_credential_jwt(&issuer_tuple), &canister_sig_pk)
             .expect("failed getting signing_input");
@@ -141,7 +156,7 @@ fn id_alias_credential_jwt(alias_tuple: &AliasTuple) -> String {
     let expiration_timestamp_s: u32 =
         ((time() + ID_ALIAS_VC_EXPIRATION_PERIOD_NS) / 1_000_000_000) as u32;
     let params = CredentialParams {
-        spec: id_alias_credential_spec(alias_tuple.id_alias),
+        spec: id_alias_credential_spec(alias_tuple.id_alias, &alias_tuple.derivation_origin),
         subject_id: did_for_principal(alias_tuple.id_dapp),
         credential_id_url: prepare_credential_id_new(alias_tuple),
         issuer_url: II_ISSUER_URL.to_string(),
@@ -150,11 +165,15 @@ fn id_alias_credential_jwt(alias_tuple: &AliasTuple) -> String {
     build_credential_jwt(params)
 }
 
-fn id_alias_credential_spec(id_alias: Principal) -> CredentialSpec {
+fn id_alias_credential_spec(id_alias: Principal, origin: &FrontendHostname) -> CredentialSpec {
     let mut args = HashMap::new();
     args.insert(
         "hasIdAlias".to_string(),
         ArgumentValue::String(id_alias.to_text()),
+    );
+    args.insert(
+        "derivationOrigin".to_string(),
+        ArgumentValue::String(origin.to_string()),
     );
     CredentialSpec {
         credential_type: "InternetIdentityIdAlias".to_string(),

--- a/src/internet_identity/src/vc_mvp.rs
+++ b/src/internet_identity/src/vc_mvp.rs
@@ -8,8 +8,8 @@ use ic_certification::Hash;
 use ic_verifiable_credentials::issuer_api::{ArgumentValue, CredentialSpec};
 use ic_verifiable_credentials::{
     build_credential_jwt, canister_sig_pk_from_vc_signing_input, did_for_principal,
-    vc_signing_input, vc_signing_input_to_jws, CredentialParams,
-    II_CREDENTIAL_URL_PREFIX, II_ISSUER_URL, VC_SIGNING_INPUT_DOMAIN,
+    vc_signing_input, vc_signing_input_to_jws, CredentialParams, II_CREDENTIAL_URL_PREFIX,
+    II_ISSUER_URL, VC_SIGNING_INPUT_DOMAIN,
 };
 use internet_identity_interface::internet_identity::types::vc_mvp::{
     GetIdAliasError, IdAliasCredentials, PreparedIdAlias, SignedIdAlias,
@@ -51,7 +51,7 @@ pub async fn prepare_id_alias(
     let rp_tuple = AliasTuple {
         id_alias: id_alias_principal,
         id_dapp: delegation::get_principal(identity_number, dapps.relying_party.clone()),
-        derivation_origin: dapps.relying_party.clone()
+        derivation_origin: dapps.relying_party.clone(),
     };
     let issuer_tuple = AliasTuple {
         id_alias: id_alias_principal,


### PR DESCRIPTION
# Motivation

Fix issue raised here: https://dfinity.atlassian.net/browse/FOLLOW-1651

# Changes

* Add the `derivationOrigin` field to the id_alias credential.
* Do not import `AliasTuple` from vc-sdk. It created a dependency when I wanted to change it. Therefore, I assumed it should not come from the sdk because it's just a helper type within the II implementation.

I will add `derivationOrigin` to the `AliasTuple` in the sdk as well, but I believe those two types shouldn't be reused because it creates this dependency where the SDK needs to change for II to use the change, and then the SDK needs to use the new change again. There is no need for this flow with this shared type because it's just a helper type here.

# Testing

I deployed locally and checked with the dummy relying party and issuer that the new field is added.

However, the integration tests rely on the VC SDK which still doesn't validate the new field. As soon as we add this validation, we should upgrade the dependency in II and the new field would be validated as well.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/81e6bdddc/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/81e6bdddc/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/81e6bdddc/mobile/displayManage.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

