### PR TITLE
Update e2e test documentation in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -34,9 +34,12 @@ dfx deploy internet_identity --no-wallet
 ```
 
 > [!NOTE]\
-> By default, a dummy (fixed) CAPTCHA is used. If you want to use the real (random) CAPTCHA, set
-> `II_DUMMY_CAPTCHA` to `0`:\
-> `II_DUMMY_CAPTCHA=0 dfx deploy internet_identity --no-wallet`
+> By default, the CAPTCHA is disabled used. If you want to use the real (random) CAPTCHA, set
+> `II_DUMMY_CAPTCHA` to `0` and configure II to use a CAPTCHA:
+> ```
+> II_DUMMY_CAPTCHA=0 dfx deploy internet_identity --no-wallet \
+>     --argument '(opt record { captcha_config = opt record { max_unsolved_captchas= 50:nat64; captcha_trigger = variant {Static = variant {CaptchaEnabled}}}})'
+> ```
 
 Then the canister can be used as
 
@@ -106,6 +109,12 @@ The tests can be executed by running:
 ```bash
 npm run test:e2e
 ```
+
+> [!NOTE]\
+> By default, the e2e tests expect the CAPTCHA to be disabled. If you want to run the e2e tests against II with (dummy) CAPTCHA enabled, make sure that the II_DUMMY_CAPTCHA=1 was set when building II and then run:
+> ```
+> II_CAPTCHA=enabled npm run test:e2e
+> ```
 
 We autoformat our code using `prettier`. Running `npm run format` formats all files in the frontend.
 If you open a PR that isn't formatted according to `prettier`, CI will automatically add a formatting commit to your PR.

--- a/dfx.json
+++ b/dfx.json
@@ -5,6 +5,7 @@
       "candid": "src/internet_identity/internet_identity.did",
       "wasm": "internet_identity.wasm.gz",
       "build": "bash -c 'II_DEV_CSP=1 II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=${II_DUMMY_CAPTCHA:-1} scripts/build'",
+      "init_arg": "(opt record { captcha_config = opt record { max_unsolved_captchas= 50:nat64; captcha_trigger = variant {Static = variant {CaptchaDisabled}}}})",
       "shrink" : false
     },
     "test_app": {


### PR DESCRIPTION
This PR updates the documentation to be inline with the recent changes related to dynamic captcha. It also flips the default to deploy II locally _without_ captcha.

<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9e05b8b62/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9e05b8b62/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9e05b8b62/mobile/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
