### PR TITLE
Remove mobile footer title and text

### DIFF
--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1136,6 +1136,7 @@ a:hover,
     padding: 0;
     /* We don't need to account for the logo with absolute position */
     margin-top: 0;
+    display: none;
   }
 
   .c-landingPage__right {


### PR DESCRIPTION
Remove mobile footer and text as per https://dfinity.atlassian.net/browse/GIX-3120 (Note: this removes it also from the landing page. If we need to handle this case-by-case, please let me know)