### PR TITLE
Simplify Text shown after creating Internet Identity

### DIFF
--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -82,18 +82,8 @@ export const displayUserNumberTemplate = ({
     <section class="c-marketing-block">
       ${marketingIntroSlot}
       <aside class="l-stack">
-        <h3 class="t-title">This number is your Internet Identity</h3>
-        <p class="t-paragraph">With your Internet Identity and your passkey, you will be able to create and securely connect to Internet Computer dapps</p>
-      </aside>
-
-      <aside class="l-stack">
         <h3 class="t-title">Why is it important to save this number?</h3>
-        <p class="t-paragraph">If you lose this number, you will lose access to all of the accounts that you created with it</p>
-      </aside>
-
-      <aside class="l-stack">
-        <h3 class="t-title">Is this number secret?</h3>
-        <p class="t-paragraph"> No, this number is unique to you but it is not secret</p>
+        <p class="t-paragraph">This number is unique but not secret. If you lose this number, you will lose access to all of the accounts that you created with it</p>
       </aside>
     </section>
 


### PR DESCRIPTION
As per https://dfinity.atlassian.net/browse/GIX-3122 - I noticed the breadcrumbs on top (‘Create Passkey → Complete CAPTCHA → …’) had already been removed.
<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/874892c37/desktop/allowCredentialsLongMessage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/874892c37/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/874892c37/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/874892c37/desktop/displayUserNumber.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/874892c37/desktop/displayUserNumberTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/874892c37/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/874892c37/mobile/allowCredentialsNoAnchor.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/874892c37/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/874892c37/mobile/displayUserNumber.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/874892c37/mobile/displayUserNumberTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
