### PR TITLE
Change dynamic captcha registration rates calculation

### DIFF
--- a/src/internet_identity/src/storage/registration_rates.rs
+++ b/src/internet_identity/src/storage/registration_rates.rs
@@ -58,18 +58,24 @@ impl<M: Memory> RegistrationRates<M> {
     }
 
     /// Calculates the registration rates for the current and reference intervals along with the threschold.
-    /// 
+    ///
     /// The calculation assumes that the data has been pruned of old timestamps before the rates are calculated.
-    /// 
+    ///
     /// Initially the window for the rate calculation was the difference between now and the oldest point.
     /// However, we have accumulated data the last 3 weeks.
     /// Therefore, we can assume that we have data for all the interval and use the interval as the window.
     /// Otherwise, the rate will be underestimated.
     pub fn registration_rates(&self) -> Option<NormalizedRegistrationRates> {
         let config = dynamic_captcha_config()?;
-        
-        let reference_rate_per_second = rate_per_second(self.reference_rate_data.len(), config.reference_rate_retention_ns);
-        let current_rate_per_second = rate_per_second(self.current_rate_data.len(), config.current_rate_retention_ns);
+
+        let reference_rate_per_second = rate_per_second(
+            self.reference_rate_data.len(),
+            config.reference_rate_retention_ns,
+        );
+        let current_rate_per_second = rate_per_second(
+            self.current_rate_data.len(),
+            config.current_rate_retention_ns,
+        );
         let captcha_threshold_rate = reference_rate_per_second * config.threshold_multiplier;
         let rates = NormalizedRegistrationRates {
             reference_rate_per_second,
@@ -181,8 +187,8 @@ mod test {
             registration_rates.registration_rates().unwrap(),
             NormalizedRegistrationRates {
                 reference_rate_per_second: 0.001, // 1 / 1000, as per config
-                current_rate_per_second: 0.01, // 1 / 100, as per config
-                captcha_threshold_rate: 0.0012, // 20% more than the reference rate, as per config
+                current_rate_per_second: 0.01,    // 1 / 100, as per config
+                captcha_threshold_rate: 0.0012,   // 20% more than the reference rate, as per config
             }
         );
 
@@ -194,8 +200,8 @@ mod test {
             registration_rates.registration_rates().unwrap(),
             NormalizedRegistrationRates {
                 reference_rate_per_second: 0.002, // 2 / 1000, as per config
-                current_rate_per_second: 0.02, // 2 / 100, as per config
-                captcha_threshold_rate: 0.0024, // 20% more than the reference rate, as per config
+                current_rate_per_second: 0.02,    // 2 / 100, as per config
+                captcha_threshold_rate: 0.0024,   // 20% more than the reference rate, as per config
             }
         );
     }

--- a/src/internet_identity/src/storage/registration_rates.rs
+++ b/src/internet_identity/src/storage/registration_rates.rs
@@ -319,9 +319,9 @@ mod test {
         assert_eq!(
             registration_rates.registration_rates().unwrap(),
             NormalizedRegistrationRates {
-                current_rate_per_second: 100.0,
-                reference_rate_per_second: 100.0,
-                captcha_threshold_rate: 120.0,
+                current_rate_per_second: 1.0,
+                reference_rate_per_second: 0.1,
+                captcha_threshold_rate: 0.12,
             }
         );
 
@@ -329,16 +329,14 @@ mod test {
         TIME.with_borrow_mut(|t| *t += Duration::from_secs(1000).as_nanos() as u64);
 
         // Adding a new data point prunes everything except the one data point added now
-        // -> there are at least 2 data points required to calculate a rate
-        // -> rates are 0.0
         registration_rates.new_registration();
 
         assert_eq!(
             registration_rates.registration_rates().unwrap(),
             NormalizedRegistrationRates {
-                current_rate_per_second: 0.0,
-                reference_rate_per_second: 0.0,
-                captcha_threshold_rate: 0.0,
+                current_rate_per_second: 0.01,
+                reference_rate_per_second: 0.001,
+                captcha_threshold_rate: 0.0012,
             }
         );
     }

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -811,13 +811,13 @@ fn should_report_registration_rates() -> Result<(), CallError> {
     assert_metric_approx(
         &metrics,
         "internet_identity_registrations_per_second{type=\"current_rate\"}",
-        1.3,
+        2f64,
         0.1,
     );
     assert_metric_approx(
         &metrics,
         "internet_identity_registrations_per_second{type=\"captcha_threshold_rate\"}",
-        1.9,
+        0.48,
         0.1,
     );
     Ok(())

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -805,7 +805,7 @@ fn should_report_registration_rates() -> Result<(), CallError> {
     assert_metric_approx(
         &metrics,
         "internet_identity_registrations_per_second{type=\"reference_rate\"}",
-        1.6,
+        0.4,
         0.1,
     );
     assert_metric_approx(

--- a/src/internet_identity/tests/integration/v2_api/identity_register/dynamic_captcha.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_register/dynamic_captcha.rs
@@ -34,15 +34,15 @@ fn should_require_captcha_above_threshold_rate() {
         install_ii_canister_with_arg(&env, II_WASM.clone(), arg_with_dynamic_captcha());
     let authn_method = test_authn_method();
 
-    // initialize a base rate of one registration every 2 seconds
-    for _ in 0..10 {
+    // initialize a base rate of one registration every 4 seconds for 100 seconds (reference rate)
+    for _ in 0..25 {
         create_identity_with_authn_method(&env, canister_id, &authn_method);
-        env.advance_time(Duration::from_secs(2))
+        env.advance_time(Duration::from_secs(4))
     }
 
     // Double the rate of registrations to one per second
-    // The 20% threshold rate should allow 5 registrations before the captcha kicks in
-    for i in 0..5 {
+    // The 20% threshold rate should allow 2 registrations before the captcha kicks in
+    for i in 0..2 {
         let flow_principal = test_principal(i);
         let result = api_v2::identity_registration_start(&env, canister_id, flow_principal)
             .expect("API call failed")


### PR DESCRIPTION
# Motivation

The dynamic captcha is triggered without user registration spikes.

This is due to the current calculation of the current rate which doesn't use the current interval, and instead uses as interval the difference between now and the oldest point.

For example:
* current_rate_interval is 5 minutes.
* There are no registrations in the last 5 minutes.
* Then two new registrations are added in 2 seconds.
* The calculation right afterwards will be 2 seconds. Therefore, the rate would be 2 registrations / 2 seconds -> 1. Instead of 2 registrations / 5 minutes.

# Changes

* Change the rate calculation in `registration_rates`.

# Tests

* Change the test expectations.






<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2c7187d44/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2c7187d44/mobile/confirmSeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2c7187d44/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2c7187d44/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->





