### PR TITLE
Fix test-canisters script when no arguments

### DIFF
--- a/scripts/test-canisters.sh
+++ b/scripts/test-canisters.sh
@@ -22,9 +22,8 @@ fi
 
 # Parse arguments for --no-build flag
 NO_BUILD=false
-args=("$@")
 filtered_args=()
-for arg in "${args[@]}"; do
+for arg in "$@"; do
   if [ "$arg" != "--no-build" ]; then
     filtered_args+=("$arg")
   else
@@ -70,4 +69,4 @@ fi
 # Run tests
 
 echo "Running integration tests."
-cargo test "${filtered_args[@]}"
+cargo test "${filtered_args[@]:-}"


### PR DESCRIPTION
# Motivation

The script `test-canisters.sh` didn't work when no arguments were passed.

# Changes

Handle scenario when the arguments and filtered arguments are empty.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fcc7c5c5f/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fcc7c5c5f/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fcc7c5c5f/mobile/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
