### PR TITLE
make the c-landingPage__container fixed width

### DIFF
--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1111,7 +1111,7 @@ a:hover,
 
     padding: 0 var(--rs-split-page-bezzel--mobile);
 
-    max-width: var(--rs-main-content-width);
+    width: var(--rs-main-content-width);
   }
 
   .c-landingPage__logo {
@@ -1161,7 +1161,7 @@ a:hover,
 
 @media (max-width: 512px) {
   .c-landingPage__container {
-    max-width: none;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Small CSS changes so the centered white box is always the same width, regardless of content.

Before:
<img width="1394" alt="Screenshot 2024-11-11 at 11 00 34" src="https://github.com/user-attachments/assets/a54346d4-b045-4719-921f-4eb410662ceb">

After:
<img width="1136" alt="Screenshot 2024-11-11 at 11 01 32" src="https://github.com/user-attachments/assets/7127bb30-a5ce-4da1-b40d-1d5c1cf95684">

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/20900953a/mobile/authorizeNewKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/20900953a/mobile/authorizeNewKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/20900953a/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/20900953a/mobile/landing_1.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/20900953a/mobile/landing_2.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
