### PR TITLE
Speed up the onboarding process by parallelizing calls

### DIFF
--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -210,11 +210,9 @@ const authenticate = async (
     autoSelectionIdentity: autoSelectionIdentity,
   });
 
-  
   // at this point, derivationOrigin is either validated or undefined
   const derivationOrigin =
-  authContext.authRequest.derivationOrigin ?? authContext.requestOrigin;
-  
+    authContext.authRequest.derivationOrigin ?? authContext.requestOrigin;
 
   const result = await withLoader(() =>
     fetchDelegation({
@@ -224,7 +222,7 @@ const authenticate = async (
       maxTimeToLive: authContext.authRequest.maxTimeToLive,
     })
   );
-  
+
   if ("error" in result) {
     return {
       kind: "failure",
@@ -240,8 +238,8 @@ const authenticate = async (
     await recoveryWizard(authSuccess.userNumber, authSuccess.connection);
   }
 
-    // Ignore the response of committing the metadata because it's not crucial.
-    void authSuccess.connection.commitMetadata();
+  // Ignore the response of committing the metadata because it's not crucial.
+  void authSuccess.connection.commitMetadata();
 
   const [userKey, parsed_signed_delegation] = result;
 

--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -210,20 +210,12 @@ const authenticate = async (
     autoSelectionIdentity: autoSelectionIdentity,
   });
 
-  // Here, if the user is returning & doesn't have any recovery device, we prompt them to add
-  // one. The exact flow depends on the device they use.
-  // XXX: Must happen before auth protocol is done, otherwise the authenticating dapp
-  // may have already closed the II window
-  if (!authSuccess.newAnchor) {
-    await recoveryWizard(authSuccess.userNumber, authSuccess.connection);
-  }
-
+  
   // at this point, derivationOrigin is either validated or undefined
   const derivationOrigin =
-    authContext.authRequest.derivationOrigin ?? authContext.requestOrigin;
+  authContext.authRequest.derivationOrigin ?? authContext.requestOrigin;
+  
 
-  // Ignore the response of committing the metadata because it's not crucial.
-  void authSuccess.connection.commitMetadata();
   const result = await withLoader(() =>
     fetchDelegation({
       connection: authSuccess.connection,
@@ -232,13 +224,24 @@ const authenticate = async (
       maxTimeToLive: authContext.authRequest.maxTimeToLive,
     })
   );
-
+  
   if ("error" in result) {
     return {
       kind: "failure",
       text: "Unexpected error",
     };
   }
+
+  // Here, if the user is returning & doesn't have any recovery device, we prompt them to add
+  // one. The exact flow depends on the device they use.
+  // XXX: Must happen before auth protocol is done, otherwise the authenticating dapp
+  // may have already closed the II window
+  if (!authSuccess.newAnchor) {
+    await recoveryWizard(authSuccess.userNumber, authSuccess.connection);
+  }
+
+    // Ignore the response of committing the metadata because it's not crucial.
+    void authSuccess.connection.commitMetadata();
 
   const [userKey, parsed_signed_delegation] = result;
 


### PR DESCRIPTION
Moved the recoveryWizard call and the commitMetadata call below the fetchDelegation call. This way they can actually run in parallel.

The reason they ran sequentially before is that the IdentityMetadataRepository in the AuthenticatedConnection class instantiates its metadata with the Promise that wraps the result of the identity_info call. This makes sense, as it allows it to load asynchronously when the connection gets established.

The rub comes when you try to access the data the promise resolves into before it's there - it then blocks access to anything else in the object - and the fetchDelegation call needs to use the AuthenticatedConnection object, though not the metadata inside it. [I made a codepen to demonstrate this](https://codepen.io/LXIF/pen/WNVPLNX?editors=1111).

Here's the result in terms of the sequencing of the network requests:

Before:
<img width="684" alt="Screenshot 2024-11-13 at 16 41 22" src="https://github.com/user-attachments/assets/41545008-b70a-4c64-ad66-846945320ff7">

After:
<img width="694" alt="Screenshot 2024-11-13 at 16 40 44" src="https://github.com/user-attachments/assets/4df6e6f5-0350-449a-a528-4cc0d805965f">

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f444bf431/desktop/allowCredentialsNoAnchor.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f444bf431/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f444bf431/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f444bf431/mobile/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
