### PR TITLE
change path in frontend checks to new icons location

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           while read -r logo
           do
-            if [ ! -f src/frontend/assets/icons/"$logo" ]
+            if [ ! -f src/frontend/assets/src/assets/icons/"$logo" ]
             then
               echo "Logo not found: $logo"
               exit 1
@@ -62,7 +62,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'dist-showcase'
+          path: "dist-showcase"
 
   # Deploy the showcase to GitHub Pages
   showcase-deploy:

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           while read -r logo
           do
-            if [ ! -f src/frontend/assets/src/assets/icons/"$logo" ]
+            if [ ! -f src/frontend/src/assets/icons/"$logo" ]
             then
               echo "Logo not found: $logo"
               exit 1


### PR DESCRIPTION
Change frontend check to account for the new icons location introduced by cacheable icons

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b8ecfaefc/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b8ecfaefc/mobile/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

