### PR TITLE
Show support links on loading and error screens.

### DIFF
--- a/src/frontend/src/components/displayError.ts
+++ b/src/frontend/src/components/displayError.ts
@@ -1,3 +1,4 @@
+import { ERROR_SUPPORT_URL } from "$src/config";
 import { TemplateElement } from "$src/utils/lit-html";
 import { nonNullish } from "@dfinity/utils";
 import { html, render } from "lit-html";
@@ -40,6 +41,13 @@ ${options.detail}</pre
         >
           ${options.primaryButton}
         </button>
+        <a
+          href="${ERROR_SUPPORT_URL}"
+          target="_blank"
+          class="c-button c-button--secondary"
+        >
+          Go to support
+        </a>
       </div>`,
   });
 

--- a/src/frontend/src/components/loader.ts
+++ b/src/frontend/src/components/loader.ts
@@ -1,22 +1,40 @@
+import { ERROR_SUPPORT_URL } from "$src/config";
 import { html, render } from "lit-html";
 import loaderUrl from "./loader.svg";
 
-const loader = () => html` <div id="loader" class="c-loader">
-  <img class="c-loader__image" src=${loaderUrl} alt="loading" />
-</div>`;
+// Duration in milliseconds a user considers as taking forever
+const TAKING_FOREVER = 10000;
+
+const loader = (takingForever = false) =>
+  html` <div id="loader" class="c-loader">
+    <img class="c-loader__image" src=${loaderUrl} alt="loading" />
+    ${takingForever &&
+    html`<a
+      href="${ERROR_SUPPORT_URL}"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="c-loader__link"
+      >Ongoing issues</a
+    >`}
+  </div>`;
 
 const startLoader = () => {
   const container = document.getElementById("loaderContainer") as HTMLElement;
   render(loader(), container);
-};
 
-const endLoader = () => {
-  const container = document.getElementById("loaderContainer") as HTMLElement;
-  render(html``, container);
+  const takingForeverTimeout = setTimeout(
+    () => render(loader(true), container),
+    TAKING_FOREVER
+  );
+
+  return () => {
+    clearTimeout(takingForeverTimeout);
+    render(html``, container);
+  };
 };
 
 export const withLoader = async <A>(action: () => Promise<A>): Promise<A> => {
-  startLoader();
+  const endLoader = startLoader();
   try {
     return await action();
   } finally {

--- a/src/frontend/src/components/loader.ts
+++ b/src/frontend/src/components/loader.ts
@@ -14,7 +14,7 @@ const loader = (takingForever = false) =>
       target="_blank"
       rel="noopener noreferrer"
       class="c-loader__link"
-      >Ongoing issues</a
+      >Check ongoing issues</a
     >`}
   </div>`;
 

--- a/src/frontend/src/config.ts
+++ b/src/frontend/src/config.ts
@@ -11,6 +11,6 @@ export const LEGACY_II_URL = "https://identity.ic0.app";
 
 export const PORTAL_II_URL = "https://internetcomputer.org/internet-identity";
 
-// Default support page to link when error is shown to user
+// Default support page URL for when error is shown to user
 export const ERROR_SUPPORT_URL =
   "https://identitysupport.dfinity.org/hc/en-us/articles/32301362727188";

--- a/src/frontend/src/config.ts
+++ b/src/frontend/src/config.ts
@@ -10,3 +10,7 @@ export const OFFICIAL_II_URL = "https://" + OFFICIAL_II_URL_NO_PROTOCOL;
 export const LEGACY_II_URL = "https://identity.ic0.app";
 
 export const PORTAL_II_URL = "https://internetcomputer.org/internet-identity";
+
+// Default support page to link when error is shown to user
+export const ERROR_SUPPORT_URL =
+  "https://identitysupport.dfinity.org/hc/en-us/articles/32301362727188";

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -1718,12 +1718,6 @@ by all browsers (FF is missing) */
   fill: currentColor;
 }
 
-.c-button--secondary {
-  background: var(--rc-button-secondary);
-  color: var(--rc-onButton-secondary);
-  border: var(--rs-line) solid var(--rc-line-interaction);
-}
-
 .c-button--textOnly {
   background: transparent;
   color: var(--rc-interaction-text);
@@ -1737,10 +1731,23 @@ by all browsers (FF is missing) */
 
 .c-button:not([disabled]):focus,
 .c-button:not([disabled]):hover {
+  color: var(--rc-onButton);
   opacity: 0.9;
   box-shadow: 0 0 0 2px #ffffff, 0 0 3px 5px var(--rc-interaction);
   outline: 2px dotted transparent;
   outline-offset: 2px;
+  text-decoration: none;
+}
+
+.c-button--secondary {
+  background: var(--rc-button-secondary);
+  color: var(--rc-onButton-secondary);
+  border: var(--rs-line) solid var(--rc-line-interaction);
+}
+
+.c-button--secondary:not([disabled]):hover,
+.c-button--secondary:not([disabled]):focus {
+  color: var(--rc-onButton-secondary);
 }
 
 /* Copy pasted from the focus and hover, but with different opacity to show action */
@@ -3142,6 +3149,19 @@ input[type="checkbox"] {
   animation-duration: 5s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
+}
+
+.c-loader__link {
+  color: var(--rc-surface);
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, 72px);
+}
+
+.c-loader__link:hover, .c-loader__link:focus {
+  color: var(--rc-surface);
 }
 
 /* Wrap QR codes in a white square (for legibility) and prettify a bit */

--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -3160,7 +3160,8 @@ input[type="checkbox"] {
   transform: translate(-50%, 72px);
 }
 
-.c-loader__link:hover, .c-loader__link:focus {
+.c-loader__link:hover,
+.c-loader__link:focus {
   color: var(--rc-surface);
 }
 


### PR DESCRIPTION
Right now both loading and error screens don't link users to support, this PR adds support links on both these screens.
- The loading overlay shows a "Ongoing issues" link if it is shown longer than 10s.
- The error screen has a secondary button "Go to support" below the "Try again" button.

Both links go to the [same support page](https://identitysupport.dfinity.org/hc/en-us/articles/32301362727188), this page will be updated to document common errors and ongoing issues over time.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bbb13e39b/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bbb13e39b/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bbb13e39b/desktop/displayError.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bbb13e39b/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bbb13e39b/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bbb13e39b/desktop/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bbb13e39b/mobile/displayError.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bbb13e39b/mobile/displaySeedPhrase.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bbb13e39b/mobile/verifyTentativeDevice.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



