### PR TITLE
Enable PIN registration with query param

### DIFF
--- a/src/frontend/src/config.ts
+++ b/src/frontend/src/config.ts
@@ -14,3 +14,7 @@ export const PORTAL_II_URL = "https://internetcomputer.org/internet-identity";
 // Default support page URL for when error is shown to user
 export const ERROR_SUPPORT_URL =
   "https://identitysupport.dfinity.org/hc/en-us/articles/32301362727188";
+
+// Pin is disallowed by default unless this query parameter is set.
+// This is used for testing purposes because we still support logging in with PIN but not registering with it.
+export const ENABLE_PIN_QUERY_PARAM_KEY = "enablePin";

--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -7,7 +7,6 @@ import { caretDownIcon } from "$src/components/icons";
 import { withLoader } from "$src/components/loader";
 import { showMessage } from "$src/components/message";
 import { showSpinner } from "$src/components/spinner";
-import { ENABLE_PIN_QUERY_PARAM_KEY } from "$src/config";
 import { getDapps } from "$src/flows/dappsExplorer/dapps";
 import { recoveryWizard } from "$src/flows/recovery/recoveryWizard";
 import { I18n } from "$src/i18n";
@@ -195,13 +194,6 @@ const authenticate = async (
     });
   }
 
-  const params = new URLSearchParams(window.location.search);
-  // Only allow PIN if query param is set and the request allows it
-  const allowPinAuthentication =
-    params.get(ENABLE_PIN_QUERY_PARAM_KEY) !== null
-      ? authContext.authRequest.allowPinAuthentication ?? false
-      : false;
-
   const authSuccess = await authenticateBox({
     connection,
     i18n,
@@ -213,7 +205,9 @@ const authenticate = async (
         dapp.hasOrigin(authContext.requestOrigin)
       ),
     }),
-    allowPinAuthentication,
+    // This allows logging in with a PIN but not registering with a PIN
+    allowPinAuthentication:
+      authContext.authRequest.allowPinAuthentication ?? true,
     autoSelectionIdentity: autoSelectionIdentity,
   });
 

--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -7,6 +7,7 @@ import { caretDownIcon } from "$src/components/icons";
 import { withLoader } from "$src/components/loader";
 import { showMessage } from "$src/components/message";
 import { showSpinner } from "$src/components/spinner";
+import { ENABLE_PIN_QUERY_PARAM_KEY } from "$src/config";
 import { getDapps } from "$src/flows/dappsExplorer/dapps";
 import { recoveryWizard } from "$src/flows/recovery/recoveryWizard";
 import { I18n } from "$src/i18n";
@@ -194,6 +195,13 @@ const authenticate = async (
     });
   }
 
+  const params = new URLSearchParams(window.location.search);
+  // Only allow PIN if query param is set and the request allows it
+  const allowPinAuthentication =
+    params.get(ENABLE_PIN_QUERY_PARAM_KEY) !== null
+      ? authContext.authRequest.allowPinAuthentication ?? false
+      : false;
+
   const authSuccess = await authenticateBox({
     connection,
     i18n,
@@ -205,8 +213,7 @@ const authenticate = async (
         dapp.hasOrigin(authContext.requestOrigin)
       ),
     }),
-    allowPinAuthentication:
-      authContext.authRequest.allowPinAuthentication ?? true,
+    allowPinAuthentication,
     autoSelectionIdentity: autoSelectionIdentity,
   });
 

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -14,7 +14,7 @@ import { withLoader } from "$src/components/loader";
 import { logoutSection } from "$src/components/logout";
 import { mainWindow } from "$src/components/mainWindow";
 import { toast } from "$src/components/toast";
-import { LEGACY_II_URL } from "$src/config";
+import { ENABLE_PIN_QUERY_PARAM_KEY, LEGACY_II_URL } from "$src/config";
 import { addDevice } from "$src/flows/addDevice/manage/addDevice";
 import { dappsExplorer } from "$src/flows/dappsExplorer";
 import { KnownDapp, getDapps } from "$src/flows/dappsExplorer/dapps";
@@ -96,6 +96,10 @@ export const authFlowManage = async (connection: Connection) => {
   const i18n = new I18n();
   const dapps = shuffleArray(getDapps());
 
+  const params = new URLSearchParams(window.location.search);
+  const allowPinAuthentication =
+    params.get(ENABLE_PIN_QUERY_PARAM_KEY) !== null;
+
   const identityBackground = new PreLoadImage(identityCardBackground);
   // Go through the login flow, potentially creating an anchor.
   const {
@@ -106,8 +110,7 @@ export const authFlowManage = async (connection: Connection) => {
     connection,
     i18n,
     templates: authnTemplateManage({ dapps }),
-    allowPinAuthentication:
-      true /* when authenticating to II directly we always allow pin */,
+    allowPinAuthentication,
   });
 
   // Here, if the user is returning & doesn't have any recovery device, we prompt them to add

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -98,7 +98,6 @@ export const registerFlow = async ({
   | RateLimitExceeded
   | "canceled"
 > => {
-  console.log("in da registerFlow");
   if (!registrationAllowed) {
     const result = await registerDisabled();
     result satisfies { tag: "canceled" };

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -1,5 +1,6 @@
 import { AuthnMethodData } from "$generated/internet_identity_types";
 import { withLoader } from "$src/components/loader";
+import { ENABLE_PIN_QUERY_PARAM_KEY } from "$src/config";
 import {
   PinIdentityMaterial,
   constructPinIdentity,
@@ -251,6 +252,10 @@ export const getRegisterFlowOpts = async ({
   const tempIdentity = await ECDSAKeyIdentity.generate({
     extractable: false,
   });
+  const params = new URLSearchParams(window.location.search);
+  // Only allow PIN if query param is set and the request allows it
+  const allowPinRegistration =
+    params.get(ENABLE_PIN_QUERY_PARAM_KEY) !== null && allowPinAuthentication;
   return {
     /** Check that the current origin is not the explicit canister id or a raw url.
      *  Explanation why we need to do this:
@@ -263,7 +268,7 @@ export const getRegisterFlowOpts = async ({
     pinAllowed: () =>
       // If pin auth is disallowed by the authenticating dapp then abort, otherwise check
       // if pin auth is allowed for the user agent
-      allowPinAuthentication
+      allowPinRegistration
         ? pinRegisterAllowed({ userAgent: navigator.userAgent, uaParser })
         : Promise.resolve(false),
     identityRegistrationStart: async () =>

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -15,11 +15,13 @@ import {
 import { AuthenticateView, DemoAppView, MainView, PinAuthView } from "./views";
 
 const DEFAULT_PIN_DEVICE_NAME = "Chrome on Mac OS";
+// Same as in frontend/src/config.ts
+const ENABLE_PIN_QUERY_PARAM_KEY = "enablePin";
 
 // TODO: GIX-3138 Clean up after release
 test("PIN registration not enabled on non-Apple device", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
-    await browser.url(`${II_URL}?enablePin`);
+    await browser.url(`${II_URL}?${ENABLE_PIN_QUERY_PARAM_KEY}`);
     // The PIN registration flow should not be enabled and go directly to login with passkey
     await addVirtualAuthenticator(browser);
     await FLOWS.registerNewIdentityWelcomeView(browser);
@@ -36,7 +38,7 @@ test("Register and Log in with PIN identity", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
 
-    await browser.url(`${II_URL}?enablePin`);
+    await browser.url(`${II_URL}?${ENABLE_PIN_QUERY_PARAM_KEY}`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
     const mainView = new MainView(browser);
     await mainView.waitForDisplay(); // we should be logged in
@@ -50,7 +52,7 @@ test("Register and Log in with PIN identity", async () => {
 test("Register with PIN and login without prefilled identity number", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
-    await browser.url(`${II_URL}?enablePin`);
+    await browser.url(`${II_URL}?${ENABLE_PIN_QUERY_PARAM_KEY}`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
 
     const mainView = new MainView(browser);
@@ -60,7 +62,7 @@ test("Register with PIN and login without prefilled identity number", async () =
     await wipeStorage(browser);
 
     // load the II page again
-    await browser.url(`${II_URL}?enablePin`);
+    await browser.url(`${II_URL}?${ENABLE_PIN_QUERY_PARAM_KEY}`);
     await FLOWS.loginPinWelcomeView(userNumber, pin, browser);
     await mainView.waitForTempKeyDisplay(DEFAULT_PIN_DEVICE_NAME);
   }, APPLE_USER_AGENT);
@@ -71,7 +73,7 @@ test("Register and log in with PIN identity, retry on wrong PIN", async () => {
     const pin = "123456";
     const wrongPin = "456321";
 
-    await browser.url(`${II_URL}?enablePin`);
+    await browser.url(`${II_URL}?${ENABLE_PIN_QUERY_PARAM_KEY}`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
     const mainView = new MainView(browser);
     await mainView.waitForDisplay(); // we should be logged in
@@ -97,7 +99,7 @@ test("Should not prompt for PIN after deleting temp key", async () => {
     const pin = "123456";
     await addVirtualAuthenticator(browser);
 
-    await browser.url(`${II_URL}?enablePin`);
+    await browser.url(`${II_URL}?${ENABLE_PIN_QUERY_PARAM_KEY}`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
     const mainView = new MainView(browser);
     await mainView.waitForDisplay(); // we should be logged in
@@ -119,7 +121,7 @@ test("Register with PIN then log into client application", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
 
-    await browser.url(`${II_URL}?enablePin`);
+    await browser.url(`${II_URL}?${ENABLE_PIN_QUERY_PARAM_KEY}`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
 
     const demoAppView = new DemoAppView(browser);

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -24,10 +24,9 @@ import {
 const DEFAULT_PIN_DEVICE_NAME = "Chrome on Mac OS";
 
 // TODO: GIX-3138 Clean up after release
-// TODO: Test login with PIN only GIX-3139
-test.skip("PIN registration not enabled on non-Apple device", async () => {
+test("PIN registration not enabled on non-Apple device", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
-    await browser.url(II_URL);
+    await browser.url(`${II_URL}?enablePin`);
     const welcomeView = new WelcomeView(browser);
     await welcomeView.waitForDisplay();
     await welcomeView.register();
@@ -40,11 +39,11 @@ test.skip("PIN registration not enabled on non-Apple device", async () => {
 // The PIN auth feature is only enabled for Apple specific user agents, so tests set the user
 // agent to chrome on macOS
 
-test.skip("Register and Log in with PIN identity", async () => {
+test("Register and Log in with PIN identity", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
 
-    await browser.url(II_URL);
+    await browser.url(`${II_URL}?enablePin`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
     const mainView = new MainView(browser);
     await mainView.waitForDisplay(); // we should be logged in
@@ -55,10 +54,10 @@ test.skip("Register and Log in with PIN identity", async () => {
   }, APPLE_USER_AGENT);
 }, 300_000);
 
-test.skip("Register with PIN and login without prefilled identity number", async () => {
+test("Register with PIN and login without prefilled identity number", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
-    await browser.url(II_URL);
+    await browser.url(`${II_URL}?enablePin`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
 
     const mainView = new MainView(browser);
@@ -68,18 +67,18 @@ test.skip("Register with PIN and login without prefilled identity number", async
     await wipeStorage(browser);
 
     // load the II page again
-    await browser.url(II_URL);
+    await browser.url(`${II_URL}?enablePin`);
     await FLOWS.loginPinWelcomeView(userNumber, pin, browser);
     await mainView.waitForTempKeyDisplay(DEFAULT_PIN_DEVICE_NAME);
   }, APPLE_USER_AGENT);
 }, 300_000);
 
-test.skip("Register and log in with PIN identity, retry on wrong PIN", async () => {
+test("Register and log in with PIN identity, retry on wrong PIN", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
     const wrongPin = "456321";
 
-    await browser.url(II_URL);
+    await browser.url(`${II_URL}?enablePin`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
     const mainView = new MainView(browser);
     await mainView.waitForDisplay(); // we should be logged in
@@ -100,12 +99,12 @@ test.skip("Register and log in with PIN identity, retry on wrong PIN", async () 
   }, APPLE_USER_AGENT);
 }, 300_000);
 
-test.skip("Should not prompt for PIN after deleting temp key", async () => {
+test("Should not prompt for PIN after deleting temp key", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
     await addVirtualAuthenticator(browser);
 
-    await browser.url(II_URL);
+    await browser.url(`${II_URL}?enablePin`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
     const mainView = new MainView(browser);
     await mainView.waitForDisplay(); // we should be logged in
@@ -123,6 +122,7 @@ test.skip("Should not prompt for PIN after deleting temp key", async () => {
   }, APPLE_USER_AGENT);
 }, 300_000);
 
+// TODO: Remove. This won't be reenabled.
 test.skip("Log into client application using PIN registration flow", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
@@ -144,11 +144,11 @@ test.skip("Log into client application using PIN registration flow", async () =>
   }, APPLE_USER_AGENT);
 }, 300_000);
 
-test.skip("Register with PIN then log into client application", async () => {
+test("Register with PIN then log into client application", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
 
-    await browser.url(II_URL);
+    await browser.url(`${II_URL}?enablePin`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
 
     const demoAppView = new DemoAppView(browser);


### PR DESCRIPTION
# Motivation

In the PR where we deprecated registering with PIN we disabled the e2e tests to login (and register) with PIN.

However, current PIN users can still login with with the PIN and will continue to do so for a while.

Therefore, to keep the e2e coverage we had before, we want to reintroduce the e2e tests that login with the PIN. For that, we also need to reintroduce registering with PIN. We use a query param `enablePin` to enable registering with a PIN.

# Changes

* Revert most #2687 changes 
* If PIN is disabled, do not show page to choose and create passkey identity directly.

# Tests

* Change the URL used for PIN tests to add the needed query param to register with PIN.







<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7ae384d21/desktop/loader.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7ae384d21/desktop/loaderTakingForever.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7ae384d21/mobile/loader.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7ae384d21/mobile/loaderTakingForever.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7ae384d21/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7ae384d21/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7ae384d21/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7ae384d21/mobile/verifyTentativeDevice.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->




