### PR TITLE
Remove "false" label from loader screen

### DIFF
--- a/src/frontend/src/components/loader.ts
+++ b/src/frontend/src/components/loader.ts
@@ -15,14 +15,15 @@ const TAKING_FOREVER = 10000;
 const loader = (takingForever = false) =>
   html` <div id="loader" class="c-loader">
     <img class="c-loader__image" src="${loaderUrl}" alt="loading" />
-    ${takingForever &&
-    html`<a
-      href="${ERROR_SUPPORT_URL}"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="c-loader__link"
-      >Check ongoing issues</a
-    >`}
+    ${takingForever
+      ? html`<a
+          href="${ERROR_SUPPORT_URL}"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="c-loader__link"
+          >Check ongoing issues</a
+        >`
+      : ""}
   </div>`;
 
 const startLoader = (showCheckOngoingIssues?: boolean) => {


### PR DESCRIPTION
Remove "false" label from loader screen, previously introduced in #2702
<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d7a29096d/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d7a29096d/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d7a29096d/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d7a29096d/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d7a29096d/desktop/loader.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d7a29096d/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d7a29096d/mobile/loader.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
