### PR TITLE
Clean up and enable tests after PIN teste enabled

### DIFF
--- a/demos/using-dev-build/specs/auth.e2e.ts
+++ b/demos/using-dev-build/specs/auth.e2e.ts
@@ -9,14 +9,6 @@ describe("authentication", () => {
     // Click on "Create an Internet Identity Anchor"
     await browser.$("#registerButton").click();
 
-    // Construct Identity (no-op)
-    // TODO: GIX-3138 Clean up after release
-    // const constructIdentity = await browser.$(
-    //   '[data-action="construct-identity"]'
-    // );
-    // await constructIdentity.waitForExist();
-    // await constructIdentity.click();
-
     await browser.$("h1").waitForExist();
     const title = await browser.$("h1");
 

--- a/src/frontend/src/test-e2e/constants.ts
+++ b/src/frontend/src/test-e2e/constants.ts
@@ -41,3 +41,6 @@ export const APPLE_USER_AGENT =
 // Edge on Windows
 export const EDGE_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36 Edg/116.0.1938.81";
+
+// Same as in frontend/src/config.ts
+export const ENABLE_PIN_QUERY_PARAM_KEY = "enablePin";

--- a/src/frontend/src/test-e2e/flows.ts
+++ b/src/frontend/src/test-e2e/flows.ts
@@ -15,9 +15,6 @@ import {
 export const FLOWS = {
   register: async function (browser: WebdriverIO.Browser): Promise<string> {
     const registerView = new RegisterView(browser);
-    // TODO: GIX-3138 Clean up after release
-    // await registerView.waitForDisplay();
-    // await registerView.create();
     if (CAPTCHA_ENABLED) {
       await registerView.waitForRegisterConfirm();
       await registerView.confirmRegisterConfirm();

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -2,6 +2,7 @@ import {
   APPLE_USER_AGENT,
   DEVICE_NAME1,
   EDGE_USER_AGENT,
+  ENABLE_PIN_QUERY_PARAM_KEY,
   II_URL,
   TEST_APP_NICE_URL,
 } from "./constants";
@@ -15,10 +16,7 @@ import {
 import { AuthenticateView, DemoAppView, MainView, PinAuthView } from "./views";
 
 const DEFAULT_PIN_DEVICE_NAME = "Chrome on Mac OS";
-// Same as in frontend/src/config.ts
-const ENABLE_PIN_QUERY_PARAM_KEY = "enablePin";
 
-// TODO: GIX-3138 Clean up after release
 test("PIN registration not enabled on non-Apple device", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     await browser.url(`${II_URL}?${ENABLE_PIN_QUERY_PARAM_KEY}`);

--- a/src/frontend/src/test-e2e/pinAuthDisabled.test.ts
+++ b/src/frontend/src/test-e2e/pinAuthDisabled.test.ts
@@ -1,32 +1,18 @@
-import { APPLE_USER_AGENT, II_URL, TEST_APP_NICE_URL } from "./constants";
+import {
+  APPLE_USER_AGENT,
+  ENABLE_PIN_QUERY_PARAM_KEY,
+  II_URL,
+  TEST_APP_NICE_URL,
+} from "./constants";
 import { FLOWS } from "./flows";
 import { runInBrowser, switchToPopup } from "./util";
-import { AuthenticateView, DemoAppView, RegisterView } from "./views";
+import { AuthenticateView, DemoAppView } from "./views";
 
-// TODO: GIX-3138 Clean up after release
-test.skip("Cannot register with PIN if dapp disallows PIN", async () => {
-  await runInBrowser(async (browser: WebdriverIO.Browser) => {
-    const demoAppView = new DemoAppView(browser);
-    await demoAppView.open(TEST_APP_NICE_URL, II_URL);
-    await demoAppView.waitForDisplay();
-    await demoAppView.setAllowPin(false);
-    expect(await demoAppView.getPrincipal()).toBe("");
-    await demoAppView.signin();
-    await switchToPopup(browser);
-    const authenticateView = new AuthenticateView(browser);
-    await authenticateView.waitForDisplay();
-    await authenticateView.register();
-    const registerView = new RegisterView(browser);
-    await registerView.waitForDisplay();
-    await registerView.assertPinRegistrationNotShown();
-  }, APPLE_USER_AGENT);
-}, 300_000);
-
-test.skip("Cannot auth with PIN if dapp disallows PIN", async () => {
+test("Cannot auth with PIN if dapp disallows PIN", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const pin = "123456";
 
-    await browser.url(II_URL);
+    await browser.url(`${II_URL}?${ENABLE_PIN_QUERY_PARAM_KEY}`);
     const userNumber = await FLOWS.registerPinWelcomeView(browser, pin);
 
     const demoAppView = new DemoAppView(browser);

--- a/src/frontend/src/test-e2e/verifiableCredentials/index.test.ts
+++ b/src/frontend/src/test-e2e/verifiableCredentials/index.test.ts
@@ -2,6 +2,7 @@ import { runInBrowser } from "$src/test-e2e/util";
 
 import {
   APPLE_USER_AGENT,
+  ENABLE_PIN_QUERY_PARAM_KEY,
   II_URL,
   ISSUER_APP_URL,
   ISSUER_APP_URL_LEGACY,
@@ -51,26 +52,29 @@ const testConfigs: Array<{
   relyingParty: string;
   issuer: string;
   authType: "pin" | "webauthn";
+  iiUrl: string;
 }> = [
   {
     relyingParty: TEST_APP_CANONICAL_URL_LEGACY,
     issuer: ISSUER_APP_URL,
     authType: "webauthn",
+    iiUrl: II_URL,
   },
   {
     relyingParty: TEST_APP_CANONICAL_URL,
     issuer: ISSUER_APP_URL_LEGACY,
     authType: "webauthn",
+    iiUrl: II_URL,
   },
-  // TODO: Renable with PIN GIX-3139
-  // {
-  //   relyingParty: TEST_APP_CANONICAL_URL,
-  //   issuer: ISSUER_APP_URL,
-  //   authType: "pin",
-  // },
+  {
+    relyingParty: TEST_APP_CANONICAL_URL,
+    issuer: ISSUER_APP_URL,
+    authType: "pin",
+    iiUrl: `${II_URL}?${ENABLE_PIN_QUERY_PARAM_KEY}`,
+  },
 ];
 
-testConfigs.forEach(({ relyingParty, issuer, authType }) => {
+testConfigs.forEach(({ relyingParty, issuer, authType, iiUrl }) => {
   const testSuffix = `RP: ${getDomain(relyingParty)}, ISS: ${getDomain(
     issuer
   )}, auth: ${authType}`;
@@ -86,7 +90,7 @@ testConfigs.forEach(({ relyingParty, issuer, authType }) => {
             frontendHostname: issuer,
           });
 
-          await browser.url(II_URL);
+          await browser.url(iiUrl);
           const authConfig = await register[authType](browser);
 
           // Add employee

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -57,9 +57,6 @@ export class RenameView extends View {
 }
 
 export class RegisterView extends View {
-  // View: Passkey or PIN registration
-  // TODO: GIX-3138 Clean up after release
-  // At the moment it's used only in skipped tests.
   async waitForDisplay(): Promise<void> {
     await this.browser
       .$('[data-action="construct-identity"]')


### PR DESCRIPTION
# Motivation

We commented some tests and code that needed to cleaned up once we confirmed that we are not reintroducing pin registration.

# Changes

* Remove commented code.
* Enable or remove some e2e tests.

# Tests

Changes only in test files.
