### PR TITLE
Add well-known asset for Related Origin Requests

### DIFF
--- a/src/asset_util/src/lib.rs
+++ b/src/asset_util/src/lib.rs
@@ -387,6 +387,7 @@ lazy_static! {
         let mut map = HashMap::new();
         map.insert(Path::new(".well-known/ic-domains").to_owned(), (ContentType::JSON, ContentEncoding::Identity));
         map.insert(Path::new(".well-known/ii-alternative-origins").to_owned(), (ContentType::JSON, ContentEncoding::Identity));
+        map.insert(Path::new(".well-known/webauthn").to_owned(), (ContentType::JSON, ContentEncoding::Identity));
         map
     };
 }
@@ -642,6 +643,11 @@ fn should_return_correct_extension() {
     let path_extension_encoding = [
         (
             ".well-known/ic-domains",
+            ContentType::JSON,
+            ContentEncoding::Identity,
+        ),
+        (
+            ".well-known/webauthn",
             ContentType::JSON,
             ContentEncoding::Identity,
         ),

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -6,14 +6,15 @@ use crate::state;
 use asset_util::{collect_assets, Asset, CertifiedAssets, ContentEncoding, ContentType};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
-use ic_cdk::api;
+use ic_cdk::{api, println};
 use include_dir::{include_dir, Dir};
+use serde_json::json;
 use sha2::Digest;
 
 // used both in init and post_upgrade
-pub fn init_assets() {
+pub fn init_assets(maybe_related_origins: Option<Vec<String>>) {
     state::assets_mut(|certified_assets| {
-        let assets = get_static_assets();
+        let assets = get_static_assets(maybe_related_origins);
 
         // Extract integrity hashes for all inlined scripts, from all the HTML files.
         let integrity_hashes = assets
@@ -47,7 +48,7 @@ fn fixup_html(html: &str) -> String {
 static ASSET_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/../../dist");
 
 // Gets the static assets. All static assets are prepared only once (like injecting the canister ID).
-pub fn get_static_assets() -> Vec<Asset> {
+pub fn get_static_assets(maybe_related_origins: Option<Vec<String>>) -> Vec<Asset> {
     let mut assets = collect_assets(&ASSET_DIR, Some(fixup_html));
 
     // Required to make II available on the identity.internetcomputer.org domain.
@@ -59,15 +60,26 @@ pub fn get_static_assets() -> Vec<Asset> {
         content_type: ContentType::OCTETSTREAM,
     });
 
-    // Required to share passkeys with the different domains.
-    // See https://web.dev/articles/webauthn-related-origin-requests#step_2_set_up_your_well-knownwebauthn_json_file_in_site-1
-    // Maximum of 5 labels. If we want to support more, we'll need to set them in the configuration.
-    assets.push(Asset {
-        url_path: "/.well-known/webauthn".to_string(),
-        content: b"{\"origins\":[\"https://beta.identity.ic0.app\",\"https://beta.identity.internetcomputer.org\",\"https://identity.internetcomputer.org\",\"https://identity.ic0.app\",\"https://identity.icp0.io\"]}".to_vec(),
-        encoding: ContentEncoding::Identity,
-        content_type: ContentType::OCTETSTREAM,
-    });
+    println!("in da get_static_assets");
+
+    // if let Some(related_origins) = maybe_related_origins {
+    //     println!("related_origin: {}", related_origins[0]);
+    //     // Serialize the content into JSON and convert it to a Vec<u8>
+    //     let content = json!({
+    //         "origins": related_origins,
+    //     })
+    //     .to_string()
+    //     .into_bytes();
+    //     // Required to share passkeys with the different domains.
+    //     // See https://web.dev/articles/webauthn-related-origin-requests#step_2_set_up_your_well-knownwebauthn_json_file_in_site-1
+    //     // Maximum of 5 labels. If we want to support more, we'll need to set them in the configuration.
+    //     assets.push(Asset {
+    //         url_path: "/.well-known/webauthn".to_string(),
+    //         content,
+    //         encoding: ContentEncoding::Identity,
+    //         content_type: ContentType::OCTETSTREAM,
+    //     });
+    // }
     assets
 }
 

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -58,6 +58,16 @@ pub fn get_static_assets() -> Vec<Asset> {
         encoding: ContentEncoding::Identity,
         content_type: ContentType::OCTETSTREAM,
     });
+
+    // Required to share passkeys with the different domains.
+    // See https://web.dev/articles/webauthn-related-origin-requests#step_2_set_up_your_well-knownwebauthn_json_file_in_site-1
+    // Maximum of 5 labels. If we want to support more, we'll need to set them in the configuration.
+    assets.push(Asset {
+        url_path: "/.well-known/webauthn".to_string(),
+        content: b"{\"origins\":[\"https://beta.identity.ic0.app\",\"https://beta.identity.internetcomputer.org\",\"https://identity.internetcomputer.org\",\"https://identity.ic0.app\",\"https://identity.icp0.io\"]}".to_vec(),
+        encoding: ContentEncoding::Identity,
+        content_type: ContentType::OCTETSTREAM,
+    });
     assets
 }
 

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -62,24 +62,24 @@ pub fn get_static_assets(maybe_related_origins: Option<Vec<String>>) -> Vec<Asse
 
     println!("in da get_static_assets");
 
-    // if let Some(related_origins) = maybe_related_origins {
-    //     println!("related_origin: {}", related_origins[0]);
-    //     // Serialize the content into JSON and convert it to a Vec<u8>
-    //     let content = json!({
-    //         "origins": related_origins,
-    //     })
-    //     .to_string()
-    //     .into_bytes();
-    //     // Required to share passkeys with the different domains.
-    //     // See https://web.dev/articles/webauthn-related-origin-requests#step_2_set_up_your_well-knownwebauthn_json_file_in_site-1
-    //     // Maximum of 5 labels. If we want to support more, we'll need to set them in the configuration.
-    //     assets.push(Asset {
-    //         url_path: "/.well-known/webauthn".to_string(),
-    //         content,
-    //         encoding: ContentEncoding::Identity,
-    //         content_type: ContentType::OCTETSTREAM,
-    //     });
-    // }
+    if let Some(related_origins) = maybe_related_origins {
+        println!("related_origin: {}", related_origins[0]);
+        // Serialize the content into JSON and convert it to a Vec<u8>
+        let content = json!({
+            "origins": related_origins,
+        })
+        .to_string()
+        .into_bytes();
+        // Required to share passkeys with the different domains.
+        // See https://web.dev/articles/webauthn-related-origin-requests#step_2_set_up_your_well-knownwebauthn_json_file_in_site-1
+        // Maximum of 5 labels. If we want to support more, we'll need to set them in the configuration.
+        assets.push(Asset {
+            url_path: "/.well-known/webauthn".to_string(),
+            content,
+            encoding: ContentEncoding::Identity,
+            content_type: ContentType::OCTETSTREAM,
+        });
+    }
     assets
 }
 

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -61,15 +61,13 @@ pub fn get_static_assets(maybe_related_origins: Option<Vec<String>>) -> Vec<Asse
     });
 
     if let Some(related_origins) = maybe_related_origins {
-        // Serialize the content into JSON and convert it to a Vec<u8>
+        // Required to share passkeys with the different domains. Maximum of 5 labels.
+        // See https://web.dev/articles/webauthn-related-origin-requests#step_2_set_up_your_well-knownwebauthn_json_file_in_site-1
         let content = json!({
             "origins": related_origins,
         })
         .to_string()
         .into_bytes();
-        // Required to share passkeys with the different domains.
-        // See https://web.dev/articles/webauthn-related-origin-requests#step_2_set_up_your_well-knownwebauthn_json_file_in_site-1
-        // Maximum of 5 labels. If we want to support more, we'll need to set them in the configuration.
         assets.push(Asset {
             url_path: "/.well-known/webauthn".to_string(),
             content,

--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -6,7 +6,7 @@ use crate::state;
 use asset_util::{collect_assets, Asset, CertifiedAssets, ContentEncoding, ContentType};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
-use ic_cdk::{api, println};
+use ic_cdk::api;
 use include_dir::{include_dir, Dir};
 use serde_json::json;
 use sha2::Digest;
@@ -60,10 +60,7 @@ pub fn get_static_assets(maybe_related_origins: Option<Vec<String>>) -> Vec<Asse
         content_type: ContentType::OCTETSTREAM,
     });
 
-    println!("in da get_static_assets");
-
     if let Some(related_origins) = maybe_related_origins {
-        println!("related_origin: {}", related_origins[0]);
         // Serialize the content into JSON and convert it to a Vec<u8>
         let content = json!({
             "origins": related_origins,
@@ -77,7 +74,7 @@ pub fn get_static_assets(maybe_related_origins: Option<Vec<String>>) -> Vec<Asse
             url_path: "/.well-known/webauthn".to_string(),
             content,
             encoding: ContentEncoding::Identity,
-            content_type: ContentType::OCTETSTREAM,
+            content_type: ContentType::JSON,
         });
     }
     assets

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -13,7 +13,7 @@ use authz_utils::{
 use candid::Principal;
 use ic_canister_sig_creation::signature_map::LABEL_SIG;
 use ic_cdk::api::{caller, set_certified_data, trap};
-use ic_cdk::call;
+use ic_cdk::{call, println};
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use internet_identity_interface::archive::types::BufferedEntry;
 use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
@@ -378,6 +378,7 @@ fn init(maybe_arg: Option<InternetIdentityInit>) {
 
 #[post_upgrade]
 fn post_upgrade(maybe_arg: Option<InternetIdentityInit>) {
+    println!("in da post_upgrade");
     state::init_from_stable_memory();
     // load the persistent state after initializing storage as it manages the respective stable cell
     state::load_persistent_state();
@@ -386,7 +387,11 @@ fn post_upgrade(maybe_arg: Option<InternetIdentityInit>) {
 }
 
 fn initialize(maybe_arg: Option<InternetIdentityInit>) {
-    init_assets();
+    let state_related_origins = state::persistent_state(|storage| {
+        storage.related_origins.clone()
+    });
+    let related_origins = maybe_arg.clone().map(|arg| arg.related_origins).unwrap_or(state_related_origins);
+    init_assets(related_origins);
     apply_install_arg(maybe_arg);
     update_root_hash();
 }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -13,7 +13,7 @@ use authz_utils::{
 use candid::Principal;
 use ic_canister_sig_creation::signature_map::LABEL_SIG;
 use ic_cdk::api::{caller, set_certified_data, trap};
-use ic_cdk::{call, println};
+use ic_cdk::call;
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, query, update};
 use internet_identity_interface::archive::types::BufferedEntry;
 use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
@@ -378,7 +378,6 @@ fn init(maybe_arg: Option<InternetIdentityInit>) {
 
 #[post_upgrade]
 fn post_upgrade(maybe_arg: Option<InternetIdentityInit>) {
-    println!("in da post_upgrade");
     state::init_from_stable_memory();
     // load the persistent state after initializing storage as it manages the respective stable cell
     state::load_persistent_state();

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -386,10 +386,11 @@ fn post_upgrade(maybe_arg: Option<InternetIdentityInit>) {
 }
 
 fn initialize(maybe_arg: Option<InternetIdentityInit>) {
-    let state_related_origins = state::persistent_state(|storage| {
-        storage.related_origins.clone()
-    });
-    let related_origins = maybe_arg.clone().map(|arg| arg.related_origins).unwrap_or(state_related_origins);
+    let state_related_origins = state::persistent_state(|storage| storage.related_origins.clone());
+    let related_origins = maybe_arg
+        .clone()
+        .map(|arg| arg.related_origins)
+        .unwrap_or(state_related_origins);
     init_assets(related_origins);
     apply_install_arg(maybe_arg);
     update_root_hash();

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -87,6 +87,7 @@ impl From<StorablePersistentState> for PersistentState {
             captcha_config: s.captcha_config.unwrap_or(DEFAULT_CAPTCHA_CONFIG),
             related_origins: s.related_origins,
             event_stats_24h_start: s.event_stats_24h_start,
+            related_origins: s.related_origins,
         }
     }
 }
@@ -151,6 +152,7 @@ mod tests {
             },
             related_origins: None,
             event_stats_24h_start: None,
+            related_origins: None,
         };
         assert_eq!(PersistentState::default(), expected_defaults);
     }

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -87,7 +87,6 @@ impl From<StorablePersistentState> for PersistentState {
             captcha_config: s.captcha_config.unwrap_or(DEFAULT_CAPTCHA_CONFIG),
             related_origins: s.related_origins,
             event_stats_24h_start: s.event_stats_24h_start,
-            related_origins: s.related_origins,
         }
     }
 }
@@ -152,7 +151,6 @@ mod tests {
             },
             related_origins: None,
             event_stats_24h_start: None,
-            related_origins: None,
         };
         assert_eq!(PersistentState::default(), expected_defaults);
     }

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -31,6 +31,7 @@ fn ii_canister_serves_http_assets() -> Result<(), CallError> {
         ("/", None),
         ("/index.js", Some("gzip")),
         ("/.well-known/ic-domains", None),
+        ("/.well-known/webauthn", None),
     ];
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());


### PR DESCRIPTION
# Motivation

Support passkeys from multiple domains.

In this PR, we implement the first step which is an asset: `.well-known/webauthn` as requested by the standard.

# Changes

* Add new path `.well-known/webauth`. The value depends on the value in the config.

# Tests

* Tested locally that the file is present.
* New tests to http to check the new asset is present in different scenarios.




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8903037c1/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8903037c1/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8903037c1/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8903037c1/mobile/allowCredentialsNoAnchor.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8903037c1/mobile/verifyTentativeDevice.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->




