### PR TITLE
Add Related Origins Requests to Config

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -29,6 +29,7 @@ export const idlFactory = ({ IDL }) => {
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
+    'related_origins' : IDL.Opt(IDL.Vec(IDL.Text)),
     'captcha_config' : IDL.Opt(CaptchaConfig),
     'register_rate_limit' : IDL.Opt(RateLimitConfig),
   });
@@ -558,6 +559,7 @@ export const init = ({ IDL }) => {
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
+    'related_origins' : IDL.Opt(IDL.Vec(IDL.Text)),
     'captcha_config' : IDL.Opt(CaptchaConfig),
     'register_rate_limit' : IDL.Opt(RateLimitConfig),
   });

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -203,6 +203,7 @@ export interface InternetIdentityInit {
   'assigned_user_number_range' : [] | [[bigint, bigint]],
   'archive_config' : [] | [ArchiveConfig],
   'canister_creation_cycles_cost' : [] | [bigint],
+  'related_origins' : [] | [Array<string>],
   'captcha_config' : [] | [CaptchaConfig],
   'register_rate_limit' : [] | [RateLimitConfig],
 }

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -257,6 +257,8 @@ type InternetIdentityInit = record {
     register_rate_limit : opt RateLimitConfig;
     // Configuration of the captcha in the registration flow.
     captcha_config: opt CaptchaConfig;
+    // Configuration for Related Origins Requests
+    related_origins: opt vec text;
 };
 
 type ChallengeKey = text;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -346,6 +346,7 @@ fn config() -> InternetIdentityInit {
         canister_creation_cycles_cost: Some(persistent_state.canister_creation_cycles_cost),
         register_rate_limit: Some(persistent_state.registration_rate_limit.clone()),
         captcha_config: Some(persistent_state.captcha_config.clone()),
+        related_origins: persistent_state.related_origins.clone(),
     })
 }
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -416,6 +416,11 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
                 persistent_state.captcha_config = captcha_config;
             })
         }
+        if let Some(related_origins) = arg.related_origins {
+            state::persistent_state_mut(|persistent_state| {
+                persistent_state.related_origins = Some(related_origins);
+            })
+        }
     }
 }
 

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -103,6 +103,8 @@ pub struct PersistentState {
     pub active_authn_method_stats: ActivityStats<AuthnMethodCounter>,
     // Configuration of the captcha challenge during registration flow
     pub captcha_config: CaptchaConfig,
+    // Configuration for Related Origins Requests
+    pub related_origins: Option<Vec<String>>,
     // Key into the event_data BTreeMap where the 24h tracking window starts.
     // This key is used to remove old entries from the 24h event aggregations.
     // If it is `none`, then the 24h window starts from the newest entry in the event_data
@@ -121,6 +123,7 @@ impl Default for PersistentState {
             domain_active_anchor_stats: ActivityStats::new(time),
             active_authn_method_stats: ActivityStats::new(time),
             captcha_config: DEFAULT_CAPTCHA_CONFIG,
+            related_origins: None,
             event_stats_24h_start: None,
         }
     }

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -32,6 +32,7 @@ pub struct StorablePersistentState {
     // opt fields because of backwards compatibility
     event_stats_24h_start: Option<EventKey>,
     captcha_config: Option<CaptchaConfig>,
+    related_origins: Option<Vec<String>>,
 }
 
 impl Storable for StorablePersistentState {
@@ -69,6 +70,7 @@ impl From<PersistentState> for StorablePersistentState {
             max_inflight_captchas: 0,
             event_stats_24h_start: s.event_stats_24h_start,
             captcha_config: Some(s.captcha_config),
+            related_origins: s.related_origins,
         }
     }
 }
@@ -83,6 +85,7 @@ impl From<StorablePersistentState> for PersistentState {
             domain_active_anchor_stats: s.domain_active_anchor_stats,
             active_authn_method_stats: s.active_authn_method_stats,
             captcha_config: s.captcha_config.unwrap_or(DEFAULT_CAPTCHA_CONFIG),
+            related_origins: s.related_origins,
             event_stats_24h_start: s.event_stats_24h_start,
         }
     }
@@ -127,6 +130,7 @@ mod tests {
                 max_unsolved_captchas: 500,
                 captcha_trigger: CaptchaTrigger::Static(StaticCaptchaTrigger::CaptchaEnabled),
             }),
+            related_origins: None,
         };
 
         assert_eq!(StorablePersistentState::default(), expected_defaults);
@@ -145,6 +149,7 @@ mod tests {
                 max_unsolved_captchas: 500,
                 captcha_trigger: CaptchaTrigger::Static(StaticCaptchaTrigger::CaptchaEnabled),
             },
+            related_origins: None,
             event_stats_24h_start: None,
         };
         assert_eq!(PersistentState::default(), expected_defaults);

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -8,6 +8,12 @@ use pocket_ic::CallError;
 #[test]
 fn should_retain_anchor_on_user_range_change() -> Result<(), CallError> {
     let env = env();
+    let related_origins: Vec<String> = [
+        "https://identity.internetcomputer.org".to_string(),
+        "https://identity.ic0.app".to_string(),
+        "https://identity.icp0.io".to_string(),
+    ]
+    .to_vec();
     let config = InternetIdentityInit {
         assigned_user_number_range: Some((3456, 798977)),
         archive_config: Some(ArchiveConfig {
@@ -29,6 +35,7 @@ fn should_retain_anchor_on_user_range_change() -> Result<(), CallError> {
                 reference_rate_sampling_interval_s: 9999,
             },
         }),
+        related_origins: Some(related_origins),
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -37,3 +37,47 @@ fn should_retain_anchor_on_user_range_change() -> Result<(), CallError> {
     assert_eq!(api::config(&env, canister_id)?, config);
     Ok(())
 }
+
+#[test]
+fn should_retain_config_after_none() -> Result<(), CallError> {
+    let env = env();
+    let related_origins: Vec<String> = [
+        "https://identity.internetcomputer.org".to_string(),
+        "https://identity.ic0.app".to_string(),
+        "https://identity.icp0.io".to_string(),
+    ]
+    .to_vec();
+    let config = InternetIdentityInit {
+        assigned_user_number_range: Some((3456, 798977)),
+        archive_config: Some(ArchiveConfig {
+            module_hash: [17; 32],
+            entries_buffer_limit: 123789,
+            polling_interval_ns: 659871258,
+            entries_fetch_limit: 33,
+        }),
+        canister_creation_cycles_cost: Some(123),
+        register_rate_limit: Some(RateLimitConfig {
+            time_per_token_ns: 99,
+            max_tokens: 874,
+        }),
+        captcha_config: Some(CaptchaConfig {
+            max_unsolved_captchas: 788,
+            captcha_trigger: CaptchaTrigger::Dynamic {
+                threshold_pct: 12,
+                current_rate_sampling_interval_s: 456,
+                reference_rate_sampling_interval_s: 9999,
+            },
+        }),
+        related_origins: Some(related_origins),
+    };
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+
+    assert_eq!(api::config(&env, canister_id)?, config);
+    
+    install_ii_canister_with_arg(&env, II_WASM.clone(), None);
+
+    assert_eq!(api::config(&env, canister_id)?, config);
+
+    Ok(())
+}

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -162,7 +162,7 @@ fn should_override_partially() -> Result<(), CallError> {
         related_origins: Some(related_origins_2.clone()),
     };
 
-    let __ =
+    let _ =
         upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_3.clone()));
 
     let expected_config_3 = InternetIdentityInit {

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -1,5 +1,7 @@
 use canister_tests::api::internet_identity as api;
-use canister_tests::framework::{env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM};
+use canister_tests::framework::{
+    env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
+};
 use internet_identity_interface::internet_identity::types::{
     ArchiveConfig, CaptchaConfig, CaptchaTrigger, InternetIdentityInit, RateLimitConfig,
 };
@@ -74,7 +76,7 @@ fn should_retain_config_after_none() -> Result<(), CallError> {
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
 
     assert_eq!(api::config(&env, canister_id)?, config);
-    
+
     let _ = upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), None);
 
     assert_eq!(api::config(&env, canister_id)?, config);
@@ -135,8 +137,9 @@ fn should_override_partially() -> Result<(), CallError> {
         captcha_config: Some(new_captcha.clone()),
         related_origins: None,
     };
-    
-    let _ = upgrade_ii_canister_with_arg(&env,  canister_id, II_WASM.clone(), Some(config_2.clone()));
+
+    let _ =
+        upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_2.clone()));
 
     let expected_config_2 = InternetIdentityInit {
         captcha_config: Some(new_captcha.clone()),
@@ -158,8 +161,9 @@ fn should_override_partially() -> Result<(), CallError> {
         captcha_config: None,
         related_origins: Some(related_origins_2.clone()),
     };
-    
-    let __ = upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_3.clone()));
+
+    let __ =
+        upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_3.clone()));
 
     let expected_config_3 = InternetIdentityInit {
         related_origins: Some(related_origins_2.clone()),

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -8,12 +8,6 @@ use pocket_ic::CallError;
 #[test]
 fn should_retain_anchor_on_user_range_change() -> Result<(), CallError> {
     let env = env();
-    let related_origins: Vec<String> = [
-        "https://identity.internetcomputer.org".to_string(),
-        "https://identity.ic0.app".to_string(),
-        "https://identity.icp0.io".to_string(),
-    ]
-    .to_vec();
     let config = InternetIdentityInit {
         assigned_user_number_range: Some((3456, 798977)),
         archive_config: Some(ArchiveConfig {
@@ -35,7 +29,7 @@ fn should_retain_anchor_on_user_range_change() -> Result<(), CallError> {
                 reference_rate_sampling_interval_s: 9999,
             },
         }),
-        related_origins: Some(related_origins),
+        related_origins: None,
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -1,5 +1,5 @@
 use canister_tests::api::internet_identity as api;
-use canister_tests::framework::{env, install_ii_canister_with_arg, II_WASM};
+use canister_tests::framework::{env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM};
 use internet_identity_interface::internet_identity::types::{
     ArchiveConfig, CaptchaConfig, CaptchaTrigger, InternetIdentityInit, RateLimitConfig,
 };
@@ -75,9 +75,98 @@ fn should_retain_config_after_none() -> Result<(), CallError> {
 
     assert_eq!(api::config(&env, canister_id)?, config);
     
-    install_ii_canister_with_arg(&env, II_WASM.clone(), None);
+    let _ = upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), None);
 
     assert_eq!(api::config(&env, canister_id)?, config);
+
+    Ok(())
+}
+
+#[test]
+fn should_override_partially() -> Result<(), CallError> {
+    let env = env();
+    let related_origins: Vec<String> = [
+        "https://identity.internetcomputer.org".to_string(),
+        "https://identity.ic0.app".to_string(),
+        "https://identity.icp0.io".to_string(),
+    ]
+    .to_vec();
+    let config = InternetIdentityInit {
+        assigned_user_number_range: Some((3456, 798977)),
+        archive_config: Some(ArchiveConfig {
+            module_hash: [17; 32],
+            entries_buffer_limit: 123789,
+            polling_interval_ns: 659871258,
+            entries_fetch_limit: 33,
+        }),
+        canister_creation_cycles_cost: Some(123),
+        register_rate_limit: Some(RateLimitConfig {
+            time_per_token_ns: 99,
+            max_tokens: 874,
+        }),
+        captcha_config: Some(CaptchaConfig {
+            max_unsolved_captchas: 788,
+            captcha_trigger: CaptchaTrigger::Dynamic {
+                threshold_pct: 12,
+                current_rate_sampling_interval_s: 456,
+                reference_rate_sampling_interval_s: 9999,
+            },
+        }),
+        related_origins: Some(related_origins),
+    };
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+
+    assert_eq!(api::config(&env, canister_id)?, config);
+
+    let new_captcha = CaptchaConfig {
+        max_unsolved_captchas: 5000,
+        captcha_trigger: CaptchaTrigger::Dynamic {
+            threshold_pct: 100,
+            current_rate_sampling_interval_s: 600,
+            reference_rate_sampling_interval_s: 3600,
+        },
+    };
+    let config_2 = InternetIdentityInit {
+        assigned_user_number_range: None,
+        archive_config: None,
+        canister_creation_cycles_cost: None,
+        register_rate_limit: None,
+        captcha_config: Some(new_captcha.clone()),
+        related_origins: None,
+    };
+    
+    let _ = upgrade_ii_canister_with_arg(&env,  canister_id, II_WASM.clone(), Some(config_2.clone()));
+
+    let expected_config_2 = InternetIdentityInit {
+        captcha_config: Some(new_captcha.clone()),
+        ..config
+    };
+
+    assert_eq!(api::config(&env, canister_id)?, expected_config_2);
+
+    let related_origins_2: Vec<String> = [
+        "https://identity.internetcomputer.org".to_string(),
+        "https://identity.ic0.app".to_string(),
+    ]
+    .to_vec();
+    let config_3 = InternetIdentityInit {
+        assigned_user_number_range: None,
+        archive_config: None,
+        canister_creation_cycles_cost: None,
+        register_rate_limit: None,
+        captcha_config: None,
+        related_origins: Some(related_origins_2.clone()),
+    };
+    
+    let __ = upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_3.clone()));
+
+    let expected_config_3 = InternetIdentityInit {
+        related_origins: Some(related_origins_2.clone()),
+        ..expected_config_2
+    };
+
+    assert_eq!(api::config(&env, canister_id)?, expected_config_3);
 
     Ok(())
 }

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -195,6 +195,7 @@ pub struct InternetIdentityInit {
     pub canister_creation_cycles_cost: Option<u64>,
     pub register_rate_limit: Option<RateLimitConfig>,
     pub captcha_config: Option<CaptchaConfig>,
+    pub related_origins: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
# Motivation

Support passkeys from multiple domains.

In this PR, I add a new field in the config that will be used in further PRs to set the needed `.well-known/webauthn` asset.

# Changes

* Add `related_origins` to the multiple Config and State related types.

# Tests

* I tested the whole flow with the branch #2720 to make sure it worked.
* I also added the field in the necessary tests






<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/89ab5a0cb/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/89ab5a0cb/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/89ab5a0cb/mobile/allowCredentials.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->





