### PR TITLE
Runtime frontend feature flags.

### DIFF
--- a/src/frontend/src/featureFlags/index.test.ts
+++ b/src/frontend/src/featureFlags/index.test.ts
@@ -1,0 +1,63 @@
+import { FeatureFlag } from "$src/featureFlags/index";
+
+class MockStorage {
+  #data: Record<string, string> = {};
+
+  getItem(key: string): string | null {
+    return this.#data[key] ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.#data[key] = value;
+  }
+
+  removeItem(key: string): void {
+    delete this.#data[key];
+  }
+}
+
+test("feature flag to be initialized", () => {
+  const storage = new MockStorage();
+  storage.setItem("c", "true");
+  storage.setItem("d", "false");
+
+  const enabledFlag = new FeatureFlag(storage, "a", true);
+  const disabledFlag = new FeatureFlag(storage, "b", false);
+  const storedOverrideFlag = new FeatureFlag(storage, "c", false);
+  const storedDisabledFlag = new FeatureFlag(storage, "d", true);
+
+  expect(enabledFlag.isEnabled()).toEqual(true);
+  expect(disabledFlag.isEnabled()).toEqual(false);
+  expect(storedOverrideFlag.isEnabled()).toEqual(true);
+  expect(storedDisabledFlag.isEnabled()).toEqual(false);
+});
+
+test("feature flag to be set", () => {
+  const storage = new MockStorage();
+  const enabledFlag = new FeatureFlag(storage, "a", true);
+  const disabledFlag = new FeatureFlag(storage, "b", false);
+
+  enabledFlag.set(false);
+  disabledFlag.set(true);
+
+  expect(enabledFlag.isEnabled()).toEqual(false);
+  expect(disabledFlag.isEnabled()).toEqual(true);
+  expect(storage.getItem("a")).toEqual("false");
+  expect(storage.getItem("b")).toEqual("true");
+});
+
+test("feature flag to be reset", () => {
+  const storage = new MockStorage();
+  const enabledFlag = new FeatureFlag(storage, "a", true);
+  const disabledFlag = new FeatureFlag(storage, "b", false);
+
+  enabledFlag.set(false);
+  disabledFlag.set(true);
+  enabledFlag.reset();
+  disabledFlag.reset();
+
+  expect(enabledFlag.isEnabled()).toEqual(true);
+  expect(disabledFlag.isEnabled()).toEqual(false);
+  expect(storage.getItem("a")).toEqual(null);
+  expect(storage.getItem("b")).toEqual(null);
+});

--- a/src/frontend/src/featureFlags/index.ts
+++ b/src/frontend/src/featureFlags/index.ts
@@ -54,7 +54,9 @@ const initializedFeatureFlags = Object.fromEntries(
 );
 
 // Make feature flags configurable from browser console
-Object.assign(window, "__featureFlags", initializedFeatureFlags);
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+window.__featureFlags = initializedFeatureFlags;
 
 // Export initialized feature flags as named exports
 export const { DOMAIN_COMPATIBILITY } = initializedFeatureFlags;

--- a/src/frontend/src/featureFlags/index.ts
+++ b/src/frontend/src/featureFlags/index.ts
@@ -20,10 +20,14 @@ export class FeatureFlag {
     this.#key = key;
     this.#defaultValue = defaultValue;
     const storedValue = this.#storage.getItem(this.#key);
-    this.#value =
-      storedValue === null
-        ? this.#defaultValue
-        : Boolean(JSON.parse(storedValue));
+    try {
+      this.#value =
+        storedValue === null
+          ? this.#defaultValue
+          : Boolean(JSON.parse(storedValue));
+    } catch {
+      this.#value = this.#defaultValue;
+    }
   }
 
   isEnabled(): boolean {

--- a/src/frontend/src/featureFlags/index.ts
+++ b/src/frontend/src/featureFlags/index.ts
@@ -1,0 +1,60 @@
+// Feature flags with default values
+const FEATURE_FLAGS_WITH_DEFAULTS = {
+  DOMAIN_COMPATIBILITY: false,
+} as const satisfies Record<string, boolean>;
+
+const LOCALSTORAGE_FEATURE_FLAGS_PREFIX = "ii-localstorage-feature-flags__";
+
+export class FeatureFlag {
+  readonly #storage: Pick<Storage, "getItem" | "setItem" | "removeItem">;
+  readonly #key: string;
+  readonly #defaultValue: boolean;
+  #value: boolean;
+
+  constructor(
+    storage: Pick<Storage, "getItem" | "setItem" | "removeItem">,
+    key: string,
+    defaultValue: boolean
+  ) {
+    this.#storage = storage;
+    this.#key = key;
+    this.#defaultValue = defaultValue;
+    const storedValue = this.#storage.getItem(this.#key);
+    this.#value =
+      storedValue === null
+        ? this.#defaultValue
+        : Boolean(JSON.parse(storedValue));
+  }
+
+  isEnabled(): boolean {
+    return this.#value;
+  }
+
+  set(value: boolean) {
+    this.#value = Boolean(value);
+    this.#storage.setItem(this.#key, JSON.stringify(this.#value));
+  }
+
+  reset(): void {
+    this.#value = this.#defaultValue;
+    this.#storage.removeItem(this.#key);
+  }
+}
+
+// Initialize feature flags with values from localstorage
+const initializedFeatureFlags = Object.fromEntries(
+  Object.entries(FEATURE_FLAGS_WITH_DEFAULTS).map(([key, defaultValue]) => [
+    key,
+    new FeatureFlag(
+      window.localStorage,
+      LOCALSTORAGE_FEATURE_FLAGS_PREFIX + key,
+      defaultValue
+    ),
+  ])
+);
+
+// Make feature flags configurable from browser console
+Object.assign(window, "__featureFlags", initializedFeatureFlags);
+
+// Export initialized feature flags as named exports
+export const { DOMAIN_COMPATIBILITY } = initializedFeatureFlags;


### PR DESCRIPTION
Runtime frontend feature flags, uses local storage for sync read/write of flags.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2258e2cae/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2258e2cae/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2258e2cae/mobile/allowCredentials.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

