### PR TITLE
Add origin field to WebAuthn

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -335,6 +335,7 @@ type MetadataMapV2 = vec record {
 type WebAuthn = record {
     credential_id: CredentialId;
     pubkey: PublicKey;
+    origin: opt text;
 };
 
 // Authentication method using generic signatures

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -509,6 +509,7 @@ mod v2_api {
                     AuthnMethod::WebAuthn(WebAuthn {
                         credential_id,
                         pubkey: device.pubkey,
+                        origin: device.origin,
                     })
                 } else {
                     AuthnMethod::PubKey(PublicKeyAuthn {

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -480,7 +480,6 @@ fn check_device_invariants(device: &Device) -> Result<(), AnchorError> {
         "purpose",
         "key_type",
         "protection",
-        "origin",
         "last_usage_timestamp",
         "metadata",
         "usage",

--- a/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
+++ b/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
@@ -246,6 +246,7 @@ fn authn_methods_all_types() -> Vec<(String, AuthnMethodData)> {
     let webauthn_authn_method = AuthnMethod::WebAuthn(WebAuthn {
         pubkey: ByteBuf::from("example pubkey"),
         credential_id: ByteBuf::from("example credential id"),
+        origin: Some("https://identity.ic0.app".to_string()),
     });
     let ii_domain_entry = (
         "origin".to_string(),

--- a/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_test_helpers.rs
@@ -113,6 +113,7 @@ pub fn sample_webauthn_authn_method(i: u8) -> AuthnMethodData {
         authn_method: AuthnMethod::WebAuthn(WebAuthn {
             pubkey: ByteBuf::from(vec![i; 32]),
             credential_id: ByteBuf::from(vec![i * 2; 32]),
+            origin: None,
         }),
         ..test_authn_method()
     }

--- a/src/internet_identity_interface/src/internet_identity/conversions.rs
+++ b/src/internet_identity_interface/src/internet_identity/conversions.rs
@@ -123,6 +123,7 @@ impl From<DeviceWithUsage> for AuthnMethodData {
             AuthnMethod::WebAuthn(WebAuthn {
                 credential_id,
                 pubkey: device_data.pubkey.clone(),
+                origin: device_data.origin.clone(),
             })
         } else {
             AuthnMethod::PubKey(PublicKeyAuthn {
@@ -261,7 +262,6 @@ impl TryFrom<AuthnMethodData> for DeviceWithUsage {
         // Remove the metadata entries that have a dedicated field in the `DeviceData` struct in
         // order to avoid duplication.
         let alias = remove_metadata_string(&mut data, "alias")?.unwrap_or_default();
-        let origin = remove_metadata_string(&mut data, "origin")?;
 
         let mut key_type = remove_metadata_string(&mut data, "authenticator_attachment")?
             .map(|key_type| match key_type.as_str() {
@@ -281,12 +281,13 @@ impl TryFrom<AuthnMethodData> for DeviceWithUsage {
                 .unwrap_or(KeyType::Unknown);
         }
 
-        let (pubkey, credential_id) = match data.authn_method {
+        let (pubkey, credential_id, origin) = match data.authn_method {
             AuthnMethod::WebAuthn(WebAuthn {
                 pubkey,
                 credential_id,
-            }) => (pubkey, Some(credential_id)),
-            AuthnMethod::PubKey(PublicKeyAuthn { pubkey }) => (pubkey, None),
+                origin,
+            }) => (pubkey, Some(credential_id), origin),
+            AuthnMethod::PubKey(PublicKeyAuthn { pubkey }) => (pubkey, None, None),
         };
 
         Ok(DeviceWithUsage {

--- a/src/internet_identity_interface/src/internet_identity/conversions/test.rs
+++ b/src/internet_identity_interface/src/internet_identity/conversions/test.rs
@@ -165,6 +165,7 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
         authn_method: AuthnMethod::WebAuthn(WebAuthn {
             pubkey: pubkey.clone(),
             credential_id: credential_id.clone(),
+            origin: Some(origin.clone()),
         }),
         metadata: HashMap::from([
             (ALIAS.to_string(), MetadataEntryV2::String(alias.clone())),
@@ -196,6 +197,7 @@ fn test_conversion_pairs() -> Vec<(DeviceWithUsage, AuthnMethodData)> {
         authn_method: AuthnMethod::WebAuthn(WebAuthn {
             pubkey,
             credential_id,
+            origin: Some(origin.clone()),
         }),
         metadata: HashMap::from([
             (

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -33,6 +33,7 @@ pub struct PublicKeyAuthn {
 pub struct WebAuthn {
     pub pubkey: PublicKey,
     pub credential_id: CredentialId,
+    pub origin: Option<String>,
 }
 
 /// Supported authentication methods


### PR DESCRIPTION
# Motivation

This is part of the Domains Compatibility.

To find the right RP ID, I need the origin in the devices. The origin is already available in another endpoint in the legacy API. But I'd rather add it to the v2 API `identity_authn_info` and start using it.

I assume this is not a security issue because the endpoint [lookup](https://github.com/dfinity/internet-identity/blob/0a0ec83077d404fd759b1927015b330d6594bec7/src/internet_identity/internet_identity.did#L606) already returns the `origin` and much more.

# Changes

* Add `origin` field to `WebAuthn` type.
* Use it in the `identity_authn_info` endpoint.

# Tests

* Add new field in test mockups and expect it from the response.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/1b54f44cf/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/1b54f44cf/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/1b54f44cf/desktop/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


