### PR TITLE
Share CredentialData param type of fromCredentials

### DIFF
--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -1,6 +1,7 @@
 import { CredentialId, DeviceData } from "$generated/internet_identity_types";
 import { promptUserNumberTemplate } from "$src/components/promptUserNumber";
 import { toast } from "$src/components/toast";
+import { convertToCredentialData } from "$src/utils/credential-devices";
 import {
   AuthFail,
   Connection,
@@ -96,10 +97,7 @@ const attemptRecovery = async ({
 
   const credentialData = recoveryCredentials
     .filter(hasCredentialId)
-    .map(({ credential_id, pubkey }) => ({
-      pubkey,
-      credential_id: credential_id[0],
-    }));
+    .map(convertToCredentialData);
 
   return await connection.fromWebauthnCredentials(userNumber, credentialData);
 };

--- a/src/frontend/src/utils/credential-devices.ts
+++ b/src/frontend/src/utils/credential-devices.ts
@@ -1,0 +1,20 @@
+import { DeviceData, DeviceKey } from "$generated/internet_identity_types";
+import { DerEncodedPublicKey } from "@dfinity/agent";
+
+export type CredentialId = ArrayBuffer;
+export type CredentialData = {
+  pubkey: DerEncodedPublicKey;
+  credentialId: CredentialId;
+  origin?: string;
+};
+
+const derFromPubkey = (pubkey: DeviceKey): DerEncodedPublicKey =>
+  new Uint8Array(pubkey).buffer as DerEncodedPublicKey;
+
+export const convertToCredentialData = (
+  device: Omit<DeviceData, "alias">
+): CredentialData => ({
+  credentialId: Buffer.from(device.credential_id[0] ?? []),
+  pubkey: derFromPubkey(device.pubkey),
+  origin: device.origin[0],
+});

--- a/src/frontend/src/utils/findWebAuthnRpId.test.ts
+++ b/src/frontend/src/utils/findWebAuthnRpId.test.ts
@@ -1,16 +1,11 @@
-import { DeviceData } from "$generated/internet_identity_types";
+import { CredentialData } from "./credential-devices";
 import { findWebAuthnRpId } from "./findWebAuthnRpId";
 
 describe("findWebAuthnRpId", () => {
-  const mockDeviceData = (origin: [] | [string]): DeviceData => ({
+  const mockDeviceData = (origin?: string): CredentialData => ({
     origin,
-    alias: "test-device",
-    metadata: [],
-    protection: { protected: null },
-    pubkey: [],
-    key_type: { platform: null },
-    purpose: { authentication: null },
-    credential_id: [],
+    credentialId: new ArrayBuffer(1),
+    pubkey: new ArrayBuffer(1),
   });
 
   beforeEach(() => {
@@ -18,10 +13,10 @@ describe("findWebAuthnRpId", () => {
   });
 
   test("returns undefined if a device is registered for the current domain", () => {
-    const devices: DeviceData[] = [
-      mockDeviceData(["https://identity.ic0.app"]),
-      mockDeviceData(["https://identity.internetcomputer.org"]),
-      mockDeviceData(["https://identity.icp0.io"]),
+    const devices: CredentialData[] = [
+      mockDeviceData("https://identity.ic0.app"),
+      mockDeviceData("https://identity.internetcomputer.org"),
+      mockDeviceData("https://identity.icp0.io"),
     ];
     const currentUrl = "https://identity.ic0.app";
 
@@ -29,10 +24,10 @@ describe("findWebAuthnRpId", () => {
   });
 
   test("returns undefined for devices with default domain when the current domain matches", () => {
-    const devices: DeviceData[] = [
-      mockDeviceData([]), // Empty origin defaults to defaultDomain `https://identity.ic0.app`
-      mockDeviceData(["https://identity.internetcomputer.org"]),
-      mockDeviceData(["https://identity.icp0.io"]),
+    const devices: CredentialData[] = [
+      mockDeviceData(), // Empty origin defaults to defaultDomain `https://identity.ic0.ap`
+      mockDeviceData("https://identity.internetcomputer.org"),
+      mockDeviceData("https://identity.icp0.io"),
     ];
     const currentUrl = "https://identity.ic0.app";
 
@@ -40,9 +35,9 @@ describe("findWebAuthnRpId", () => {
   });
 
   test("returns undefined if a device is registered for the current domain", () => {
-    const devices: DeviceData[] = [
-      mockDeviceData(["https://beta.identity.ic0.app"]),
-      mockDeviceData(["https://beta.identity.internetcomputer.org"]),
+    const devices: CredentialData[] = [
+      mockDeviceData("https://beta.identity.ic0.app"),
+      mockDeviceData("https://beta.identity.internetcomputer.org"),
     ];
     const currentUrl = "https://beta.identity.ic0.app";
 
@@ -50,10 +45,10 @@ describe("findWebAuthnRpId", () => {
   });
 
   test("returns undefined if a device is registered for the current domain", () => {
-    const devices: DeviceData[] = [
-      mockDeviceData(["https://identity.ic0.app"]),
-      mockDeviceData(["https://identity.internetcomputer.org"]),
-      mockDeviceData(["https://identity.icp0.io"]),
+    const devices: CredentialData[] = [
+      mockDeviceData("https://identity.ic0.app"),
+      mockDeviceData("https://identity.internetcomputer.org"),
+      mockDeviceData("https://identity.icp0.io"),
     ];
     const currentUrl = "https://identity.internetcomputer.org";
 
@@ -61,9 +56,9 @@ describe("findWebAuthnRpId", () => {
   });
 
   test("returns the second default preferred domain if no device is registered for the current domain", () => {
-    const devices: DeviceData[] = [
-      mockDeviceData(["https://identity.internetcomputer.org"]),
-      mockDeviceData(["https://identity.icp0.io"]),
+    const devices: CredentialData[] = [
+      mockDeviceData("https://identity.internetcomputer.org"),
+      mockDeviceData("https://identity.icp0.io"),
     ];
     const currentUrl = "https://identity.ic0.app";
 
@@ -73,9 +68,9 @@ describe("findWebAuthnRpId", () => {
   });
 
   test("returns the first default preferred domain if no device is registered for the current domain", () => {
-    const devices: DeviceData[] = [
-      mockDeviceData(["https://identity.ic0.app"]),
-      mockDeviceData(["https://identity.icp0.io"]),
+    const devices: CredentialData[] = [
+      mockDeviceData("https://identity.ic0.app"),
+      mockDeviceData("https://identity.icp0.io"),
     ];
     const currentUrl = "https://identity.internetcomputer.org";
 
@@ -85,8 +80,8 @@ describe("findWebAuthnRpId", () => {
   });
 
   test("returns the least preferred domain if devices are only on that domain", () => {
-    const devices: DeviceData[] = [
-      mockDeviceData(["https://identity.icp0.io"]),
+    const devices: CredentialData[] = [
+      mockDeviceData("https://identity.icp0.io"),
     ];
     const currentUrl = "https://identity.ic0.app";
 
@@ -98,9 +93,9 @@ describe("findWebAuthnRpId", () => {
   test("uses preferred domains when provided", () => {
     const preferredDomains = ["ic0.app", "icp0.io", "internetcomputer.org"];
 
-    const devices: DeviceData[] = [
-      mockDeviceData(["https://identity.internetcomputer.org"]),
-      mockDeviceData(["https://identity.icp0.io"]),
+    const devices: CredentialData[] = [
+      mockDeviceData("https://identity.internetcomputer.org"),
+      mockDeviceData("https://identity.icp0.io"),
     ];
     const currentUrl = "https://identity.ic0.app";
 
@@ -110,8 +105,8 @@ describe("findWebAuthnRpId", () => {
   });
 
   test("throws an error if the current domain is invalid", () => {
-    const devices: DeviceData[] = [
-      mockDeviceData(["https://identity.ic0.app"]),
+    const devices: CredentialData[] = [
+      mockDeviceData("https://identity.ic0.app"),
     ];
     const currentUrl = "not-a-valid-url";
 
@@ -121,7 +116,9 @@ describe("findWebAuthnRpId", () => {
   });
 
   test("throws an error if no devices are registered for the current or preferred domains", () => {
-    const devices: DeviceData[] = [mockDeviceData(["https://otherdomain.com"])];
+    const devices: CredentialData[] = [
+      mockDeviceData("https://otherdomain.com"),
+    ];
     const currentUrl = "https://identity.ic0.app";
 
     expect(() => findWebAuthnRpId(currentUrl, devices)).toThrowError(
@@ -130,7 +127,7 @@ describe("findWebAuthnRpId", () => {
   });
 
   test("throws an error if there are no registered devices", () => {
-    const devices: DeviceData[] = [];
+    const devices: CredentialData[] = [];
     const currentUrl = "https://identity.ic0.app";
 
     expect(() => findWebAuthnRpId(currentUrl, devices)).toThrowError(

--- a/src/frontend/src/utils/findWebAuthnRpId.ts
+++ b/src/frontend/src/utils/findWebAuthnRpId.ts
@@ -1,4 +1,4 @@
-import { DeviceData } from "$generated/internet_identity_types";
+import { CredentialData } from "./credential-devices";
 
 const DEFAULT_DOMAIN = "https://identity.ic0.app";
 
@@ -32,14 +32,12 @@ const getTopAndSecondaryLevelDomain = (url: string): string => {
  * @returns {DeviceData[]} The list of devices registered for the domain.
  */
 const getDevicesForDomain = (
-  devices: DeviceData[],
+  devices: CredentialData[],
   domain: string
-): DeviceData[] =>
-  devices.filter((d) => {
-    if (d.origin.length === 0)
-      return domain === getTopAndSecondaryLevelDomain(DEFAULT_DOMAIN);
-    return d.origin.some((o) => getTopAndSecondaryLevelDomain(o) === domain);
-  });
+): CredentialData[] =>
+  devices.filter(
+    (d) => getTopAndSecondaryLevelDomain(d.origin ?? DEFAULT_DOMAIN) === domain
+  );
 
 /**
  * Returns the domain to use as the RP ID for WebAuthn registration.
@@ -63,7 +61,7 @@ const getDevicesForDomain = (
  */
 export const findWebAuthnRpId = (
   currentUrl: string,
-  devices: DeviceData[],
+  devices: CredentialData[],
   preferredDomains: string[] = ["ic0.app", "internetcomputer.org", "icp0.io"]
 ): string | undefined => {
   const currentDomain = getTopAndSecondaryLevelDomain(currentUrl);
@@ -74,13 +72,13 @@ export const findWebAuthnRpId = (
     );
   }
 
-  const getFirstDomain = (devices: DeviceData[]): string => {
+  const getFirstDomain = (devices: CredentialData[]): string => {
     if (devices[0] === undefined) {
       throw new Error(
         "Not possible. Call this function only if devices exist."
       );
     }
-    return devices[0].origin[0] ?? DEFAULT_DOMAIN;
+    return devices[0].origin ?? DEFAULT_DOMAIN;
   };
 
   // Try current domain first if devices exist

--- a/src/frontend/src/utils/multiWebAuthnIdentity.ts
+++ b/src/frontend/src/utils/multiWebAuthnIdentity.ts
@@ -7,22 +7,12 @@
  *   then we know which one the user is actually using
  * - It doesn't support creating credentials; use `WebAuthnIdentity` for that
  */
-import {
-  DerEncodedPublicKey,
-  PublicKey,
-  Signature,
-  SignIdentity,
-} from "@dfinity/agent";
+import { PublicKey, Signature, SignIdentity } from "@dfinity/agent";
 import { DER_COSE_OID, unwrapDER, WebAuthnIdentity } from "@dfinity/identity";
 import { isNullish } from "@dfinity/utils";
 import borc from "borc";
+import { CredentialData } from "./credential-devices";
 import { bufferEqual } from "./iiConnection";
-
-export type CredentialId = ArrayBuffer;
-export type CredentialData = {
-  pubkey: DerEncodedPublicKey;
-  credentialId: CredentialId;
-};
 
 /**
  * A SignIdentity that uses `navigator.credentials`. See https://webauthn.guide/ for

--- a/src/frontend/src/utils/webAuthn.ts
+++ b/src/frontend/src/utils/webAuthn.ts
@@ -1,9 +1,9 @@
 import { DeviceData } from "$generated/internet_identity_types";
 import { features } from "$src/features";
 import {
-  creationOptions,
   DummyIdentity,
   IIWebAuthnIdentity,
+  creationOptions,
 } from "$src/utils/iiConnection";
 import { diagnosticInfo, unknownToString } from "$src/utils/utils";
 import { WebAuthnIdentity } from "@dfinity/identity";


### PR DESCRIPTION
# Motivation

To support domain compatibility, we need to use the helper to find the RP ID. 

The idea is to use the helper `findWebAuthnRpId` within `fromCredentials` from `MultiWebAuthnIdentity`.

Therefore, I reused the type expected there in all the chain that uses it.

At the moment, we could have used `DeviceData`, but API v2 doesn't use this type. Therefore, I didn't want to rely on this and reuse the custom type that holds the necessary fields for the logic.

# Changes

* Move `CredentialData` to its own module and add a converter to be used.
* Change parameter type to `CredentialData` in `findWebAuthnRpId` and `fromWebauthnCredentials`.

# Tests

* Change the tests for `findWebAuthnRpId` to use the new parameter type.
