### PR TITLE
Use dynamic RP ID

### DIFF
--- a/src/frontend/src/utils/multiWebAuthnIdentity.ts
+++ b/src/frontend/src/utils/multiWebAuthnIdentity.ts
@@ -67,12 +67,14 @@ export class MultiWebAuthnIdentity extends SignIdentity {
       return this._actualIdentity.sign(blob);
     }
 
-    const currentUrl = new URL(window.location.origin);
-    const userAgent = window.navigator.userAgent;
-    const rorDomains = relatedDomains();
     const rpId =
-      DOMAIN_COMPATIBILITY.isEnabled() && supportsWebauthRoR(userAgent)
-        ? findWebAuthnRpId(currentUrl.origin, this.credentialData, rorDomains)
+      DOMAIN_COMPATIBILITY.isEnabled() &&
+      supportsWebauthRoR(window.navigator.userAgent)
+        ? findWebAuthnRpId(
+            window.location.origin,
+            this.credentialData,
+            relatedDomains()
+          )
         : undefined;
 
     const result = (await navigator.credentials.get({


### PR DESCRIPTION
# Motivation

Support users registered in different II domains.

After this PR, if the `related_origins` is set (which they are in beta) and flag `DOMAIN_COMPATIBILITY` is enabled, users can register in any domain and login in any other domain with the same passkey.

# Changes

* Calculate the corresponding rpId based on the user devices and the current origin when getting user credentials.

# Tests

* Tested in `https://beta.identity.ic0.app/` and `https://beta.identity.internetcomputer.org/`.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94e8842ed/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94e8842ed/mobile/allowCredentials.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

