### PR TITLE
Refactor finding rpId for login

### DIFF
--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -1,12 +1,29 @@
-import { MetadataMapV2, _SERVICE } from "$generated/internet_identity_types";
+import {
+  DeviceData,
+  MetadataMapV2,
+  _SERVICE,
+} from "$generated/internet_identity_types";
+import { DOMAIN_COMPATIBILITY } from "$src/featureFlags";
 import {
   IdentityMetadata,
   RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
 } from "$src/repositories/identityMetadata";
-import { ActorSubclass } from "@dfinity/agent";
-import { DelegationIdentity } from "@dfinity/identity";
-import { AuthenticatedConnection } from "./iiConnection";
+import { ActorSubclass, DerEncodedPublicKey, Signature } from "@dfinity/agent";
+import { DelegationIdentity, WebAuthnIdentity } from "@dfinity/identity";
+import { CredentialData, convertToCredentialData } from "./credential-devices";
+import { AuthenticatedConnection, Connection } from "./iiConnection";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
+
+const mockDevice: DeviceData = {
+  alias: "mockDevice",
+  metadata: [],
+  origin: [],
+  protection: { protected: null },
+  pubkey: new Uint8Array(),
+  key_type: { platform: null },
+  purpose: { authentication: null },
+  credential_id: [],
+};
 
 const mockDelegationIdentity = {
   getDelegation() {
@@ -37,17 +54,22 @@ const mockActor = {
     return { Ok: { metadata: mockRawMetadata } };
   }),
   identity_metadata_replace: vi.fn().mockResolvedValue({ Ok: null }),
+  lookup: vi.fn().mockResolvedValue([mockDevice]),
 } as unknown as ActorSubclass<_SERVICE>;
 
 beforeEach(() => {
   infoResponse = undefined;
   vi.clearAllMocks();
+  vi.stubGlobal("location", {
+    origin: "https://identity.internetcomputer.org",
+  });
+  DOMAIN_COMPATIBILITY.reset();
 });
 
 test("initializes identity metadata repository", async () => {
   const connection = new AuthenticatedConnection(
     "12345",
-    MultiWebAuthnIdentity.fromCredentials([]),
+    MultiWebAuthnIdentity.fromCredentials([], undefined),
     mockDelegationIdentity,
     BigInt(1234),
     mockActor
@@ -62,7 +84,7 @@ test("commits changes on identity metadata", async () => {
   const userNumber = BigInt(1234);
   const connection = new AuthenticatedConnection(
     "12345",
-    MultiWebAuthnIdentity.fromCredentials([]),
+    MultiWebAuthnIdentity.fromCredentials([], undefined),
     mockDelegationIdentity,
     userNumber,
     mockActor
@@ -87,4 +109,102 @@ test("commits changes on identity metadata", async () => {
       { String: String(newRecoveryPageShownTimestampMillis) },
     ],
   ]);
+});
+
+describe("Connection.login", () => {
+  beforeEach(() => {
+    vi.spyOn(MultiWebAuthnIdentity, "fromCredentials").mockImplementation(
+      () => {
+        const mockIdentity = {
+          getPublicKey: () => {
+            return {
+              toDer: () => new ArrayBuffer(0) as DerEncodedPublicKey,
+              toRaw: () => new ArrayBuffer(0),
+              rawKey: () => new ArrayBuffer(0),
+              derKey: () => new ArrayBuffer(0) as DerEncodedPublicKey,
+            };
+          },
+        } as unknown as WebAuthnIdentity;
+        class MockMultiWebAuthnIdentity extends MultiWebAuthnIdentity {
+          static fromCredentials(
+            credentials: CredentialData[],
+            rpId: string | undefined
+          ) {
+            return new MockMultiWebAuthnIdentity(credentials, rpId);
+          }
+          override sign() {
+            this._actualIdentity = mockIdentity;
+            return Promise.resolve(new ArrayBuffer(0) as Signature);
+          }
+        }
+        return MockMultiWebAuthnIdentity.fromCredentials([], undefined);
+      }
+    );
+  });
+
+  it("login returns authenticated connection with expected rpID", async () => {
+    DOMAIN_COMPATIBILITY.set(true);
+    vi.stubGlobal("navigator", {
+      // Supports RoR
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+    });
+    const connection = new Connection("aaaaa-aa", mockActor);
+
+    const loginResult = await connection.login(BigInt(12345));
+
+    expect(loginResult.kind).toBe("loginSuccess");
+    if (loginResult.kind === "loginSuccess") {
+      expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
+      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
+      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
+        [convertToCredentialData(mockDevice)],
+        "identity.ic0.app"
+      );
+    }
+  });
+
+  it("login returns authenticated connection without rpID if flag is not enabled", async () => {
+    DOMAIN_COMPATIBILITY.set(false);
+    vi.stubGlobal("navigator", {
+      // Supports RoR
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+    });
+    const connection = new Connection("aaaaa-aa", mockActor);
+
+    const loginResult = await connection.login(BigInt(12345));
+
+    expect(loginResult.kind).toBe("loginSuccess");
+    if (loginResult.kind === "loginSuccess") {
+      expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
+      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
+      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
+        [convertToCredentialData(mockDevice)],
+        undefined
+      );
+    }
+  });
+
+  it("login returns authenticated connection without rpID if browser doesn't support it", async () => {
+    DOMAIN_COMPATIBILITY.set(true);
+    vi.stubGlobal("navigator", {
+      // Supports RoR
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0",
+    });
+    const connection = new Connection("aaaaa-aa", mockActor);
+
+    const loginResult = await connection.login(BigInt(12345));
+
+    expect(loginResult.kind).toBe("loginSuccess");
+    if (loginResult.kind === "loginSuccess") {
+      expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
+      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
+      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
+        [convertToCredentialData(mockDevice)],
+        undefined
+      );
+    }
+  });
 });

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -137,7 +137,11 @@ export interface IIWebAuthnIdentity extends SignIdentity {
 }
 
 export class Connection {
-  public constructor(readonly canisterId: string) {}
+  public constructor(
+    readonly canisterId: string,
+    // Used for testing purposes
+    readonly overrideActor?: ActorSubclass<_SERVICE>
+  ) {}
 
   identity_registration_start = async ({
     tempIdentity,
@@ -534,6 +538,9 @@ export class Connection {
   createActor = async (
     identity?: SignIdentity
   ): Promise<ActorSubclass<_SERVICE>> => {
+    if (this.overrideActor !== undefined) {
+      return this.overrideActor;
+    }
     const agent = await HttpAgent.create({
       identity,
       host: inferHost(),

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -28,6 +28,7 @@ import {
   VerifyTentativeDeviceResponse,
 } from "$generated/internet_identity_types";
 import { fromMnemonicWithoutValidation } from "$src/crypto/ed25519";
+import { DOMAIN_COMPATIBILITY } from "$src/featureFlags";
 import { features } from "$src/features";
 import {
   IdentityMetadata,
@@ -50,8 +51,10 @@ import {
 import { Principal } from "@dfinity/principal";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { convertToCredentialData, CredentialData } from "./credential-devices";
+import { findWebAuthnRpId, relatedDomains } from "./findWebAuthnRpId";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 import { isRecoveryDevice, RecoveryDevice } from "./recoveryDevice";
+import { supportsWebauthRoR } from "./userAgent";
 import { isWebAuthnCancel } from "./webAuthnErrorUtils";
 
 /*
@@ -369,13 +372,24 @@ export class Connection {
     userNumber: bigint,
     credentials: CredentialData[]
   ): Promise<LoginSuccess | WebAuthnFailed | AuthFail> => {
+    // TODO: Filter out the credentials from the used rpIDs.
+    const rpId =
+      DOMAIN_COMPATIBILITY.isEnabled() &&
+      supportsWebauthRoR(window.navigator.userAgent)
+        ? findWebAuthnRpId(
+            window.location.origin,
+            credentials,
+            relatedDomains()
+          )
+        : undefined;
+
     /* Recover the Identity (i.e. key pair) used when creating the anchor.
      * If the "DUMMY_AUTH" feature is set, we use a dummy identity, the same identity
      * that is used in the register flow.
      */
     const identity = features.DUMMY_AUTH
       ? new DummyIdentity()
-      : MultiWebAuthnIdentity.fromCredentials(credentials);
+      : MultiWebAuthnIdentity.fromCredentials(credentials, rpId);
     let delegationIdentity: DelegationIdentity;
 
     // Here we expect a webauth exception if the user canceled the webauthn prompt (triggered by

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -48,7 +48,7 @@ class MockAuthenticatedConnection extends AuthenticatedConnection {
   constructor() {
     super(
       "12345",
-      MultiWebAuthnIdentity.fromCredentials([]),
+      MultiWebAuthnIdentity.fromCredentials([], undefined),
       mockDelegationIdentity,
       BigInt(12345),
       mockActor


### PR DESCRIPTION
# Motivation

There are scenarios where the RP ID selected is not the correct one for the device the user is in. When that happens, we want to tell the user to try again, but this time, we will select another RP ID.

To be able to select the right RP ID the second time, we need to remember which RP ID was selected in the first place (or second place). We can't store that in the `MultiWebAuthnIdentity` instance, because there is a new instance every time the user tries to log in.

Instead, I want to store this info in the `Connection` instance, which is the same across tries.

In this PR, I move the logic of selecting the RP ID to the `Connection.fromWebauthnCredentials`.

# Changes

* Move logic of selecting RP ID to `Connection.fromWebauthnCredentials`.
* Add `rpId` parameter to `MultiWebAuthnIdentity` constructors.

# Tests

* Add tests for the `login` method of `Connection` class to check that rpID is passed as expected.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7979cf04b/mobile/allowCredentials.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


