### PR TITLE
Add bot approved files policy

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,0 +1,3 @@
+# List of approved files that can be changed by a bot via an automated PR
+# This is to increase security and prevent accidentally updating files that shouldn't be changed by a bot
+src/frontend/src/flows/dappsExplorer/dapps.json


### PR DESCRIPTION
# Motivation

Increase security and prevent accidentally updating files that shouldn't be changed by a bot.

Requested by [idx](https://dfinity.slack.com/archives/CH4CADCJX/p1733844276935979)

# Changes

* Add BOT_APPROVED_FILES

# Tests

We'll see in the next bot PR.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/132bd62a1/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/132bd62a1/desktop/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

