### PR TITLE
Retry with differen rp id

### DIFF
--- a/src/frontend/src/utils/findWebAuthnRpId.ts
+++ b/src/frontend/src/utils/findWebAuthnRpId.ts
@@ -30,6 +30,43 @@ export const relatedDomains = (): string[] => {
   return [];
 };
 
+export const hasCredentialsFromMultipleOrigins = (
+  credentials: CredentialData[]
+): boolean =>
+  new Set(credentials.map(({ origin }) => origin ?? DEFAULT_DOMAIN)).size > 1;
+
+/**
+ * Filters out credentials from specific origins.
+ *
+ * This function takes a list of credentials and removes any that match the provided origins.
+ * If a credential has no origin (undefined), it is treated as if it had the `DEFAULT_DOMAIN`.
+ * Two origins match if they have the same hostname (domain).
+ *
+ * @param credentials - List of credential devices to filter
+ * @param origins - Set of origins to exclude (undefined values are treated as `currentOrigin`)
+ * @param currentOrigin - The current origin to use when comparing against undefined origins
+ * @returns Filtered list of credentials, excluding those from the specified origins
+ */
+export const excludeCredentialsFromOrigins = (
+  credentials: CredentialData[],
+  origins: Set<string | undefined>,
+  currentOrigin: string
+): CredentialData[] => {
+  if (origins.size === 0) {
+    return credentials;
+  }
+  // Change `undefined` to the current origin.
+  const originsToExclude = Array.from(origins).map(
+    (origin) => origin ?? currentOrigin
+  );
+  return credentials.filter(
+    (credential) =>
+      originsToExclude.filter((originToExclude) =>
+        sameDomain(credential.origin ?? DEFAULT_DOMAIN, originToExclude)
+      ).length === 0
+  );
+};
+
 const sameDomain = (url1: string, url2: string): boolean =>
   new URL(url1).hostname === new URL(url2).hostname;
 

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -14,16 +14,17 @@ import { CredentialData, convertToCredentialData } from "./credential-devices";
 import { AuthenticatedConnection, Connection } from "./iiConnection";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 
-const mockDevice: DeviceData = {
+const createMockDevice = (origin?: string): DeviceData => ({
   alias: "mockDevice",
   metadata: [],
-  origin: [],
+  origin: origin !== undefined ? [origin] : [],
   protection: { protected: null },
   pubkey: new Uint8Array(),
   key_type: { platform: null },
   purpose: { authentication: null },
   credential_id: [],
-};
+});
+const mockDevice = createMockDevice();
 
 const mockDelegationIdentity = {
   getDelegation() {
@@ -116,6 +117,7 @@ test("commits changes on identity metadata", async () => {
 describe("Connection.login", () => {
   let failSign = false;
   beforeEach(() => {
+    failSign = false;
     vi.spyOn(MultiWebAuthnIdentity, "fromCredentials").mockImplementation(
       () => {
         const mockIdentity = {
@@ -148,141 +150,227 @@ describe("Connection.login", () => {
     );
   });
 
-  it("login returns authenticated connection with expected rpID", async () => {
-    DOMAIN_COMPATIBILITY.set(true);
-    vi.stubGlobal("navigator", {
-      // Supports RoR
-      userAgent:
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+  describe("domains compatibility flag enabled and browser support", () => {
+    beforeEach(() => {
+      DOMAIN_COMPATIBILITY.set(true);
+      vi.stubGlobal("navigator", {
+        // Supports RoR
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+      });
     });
-    const connection = new Connection("aaaaa-aa", mockActor);
 
-    const loginResult = await connection.login(BigInt(12345));
+    it("login returns authenticated connection with expected rpID", async () => {
+      const connection = new Connection("aaaaa-aa", mockActor);
 
-    expect(loginResult.kind).toBe("loginSuccess");
-    if (loginResult.kind === "loginSuccess") {
-      expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
+      const loginResult = await connection.login(BigInt(12345));
+
+      expect(loginResult.kind).toBe("loginSuccess");
+      if (loginResult.kind === "loginSuccess") {
+        expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
+          [convertToCredentialData(mockDevice)],
+          "identity.ic0.app"
+        );
+      }
+    });
+
+    it("connection exludes rpId when user cancels", async () => {
+      // This one would fail because it's not the device the user is using at the moment.
+      const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
+      const currentOriginCredentialData =
+        convertToCredentialData(currentOriginDevice);
+      const currentDevice: DeviceData = createMockDevice();
+      const currentDeviceCredentialData =
+        convertToCredentialData(currentDevice);
+      const mockActor = {
+        identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
+        lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
+      } as unknown as ActorSubclass<_SERVICE>;
+      const connection = new Connection("aaaaa-aa", mockActor);
+
+      failSign = true;
+      const firstLoginResult = await connection.login(BigInt(12345));
+
+      expect(firstLoginResult.kind).toBe("webAuthnFailed");
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-        [convertToCredentialData(mockDevice)],
-        "identity.ic0.app"
-      );
-    }
-  });
-
-  it("login returns authenticated connection without rpID if flag is not enabled", async () => {
-    DOMAIN_COMPATIBILITY.set(false);
-    vi.stubGlobal("navigator", {
-      // Supports RoR
-      userAgent:
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
-    });
-    const connection = new Connection("aaaaa-aa", mockActor);
-
-    const loginResult = await connection.login(BigInt(12345));
-
-    expect(loginResult.kind).toBe("loginSuccess");
-    if (loginResult.kind === "loginSuccess") {
-      expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
-      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
-      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-        [convertToCredentialData(mockDevice)],
+        expect.arrayContaining([
+          currentOriginCredentialData,
+          currentDeviceCredentialData,
+        ]),
         undefined
       );
-    }
-  });
 
-  it("login returns authenticated connection without rpID if browser doesn't support it", async () => {
-    DOMAIN_COMPATIBILITY.set(true);
-    vi.stubGlobal("navigator", {
-      // Does NOT Supports RoR
-      userAgent:
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0",
+      failSign = false;
+      const secondLoginResult = await connection.login(BigInt(12345));
+
+      expect(secondLoginResult.kind).toBe("loginSuccess");
+      if (secondLoginResult.kind === "loginSuccess") {
+        expect(secondLoginResult.connection).toBeInstanceOf(
+          AuthenticatedConnection
+        );
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(2);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
+          2,
+          expect.arrayContaining([currentDeviceCredentialData]),
+          "identity.ic0.app"
+        );
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
+          2,
+          expect.not.arrayContaining([currentOriginCredentialData]),
+          "identity.ic0.app"
+        );
+      }
     });
-    const connection = new Connection("aaaaa-aa", mockActor);
 
-    const loginResult = await connection.login(BigInt(12345));
+    it("connection doesn't exclude rpId if user has only one domain", async () => {
+      const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
+      const currentOriginCredentialData =
+        convertToCredentialData(currentOriginDevice);
+      const currentOriginDevice2: DeviceData = createMockDevice(currentOrigin);
+      const currentOriginCredentialData2 =
+        convertToCredentialData(currentOriginDevice2);
+      const mockActor = {
+        identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
+        lookup: vi
+          .fn()
+          .mockResolvedValue([currentOriginDevice, currentOriginDevice2]),
+      } as unknown as ActorSubclass<_SERVICE>;
+      const connection = new Connection("aaaaa-aa", mockActor);
 
-    expect(loginResult.kind).toBe("loginSuccess");
-    if (loginResult.kind === "loginSuccess") {
-      expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
+      failSign = true;
+      const firstLoginResult = await connection.login(BigInt(12345));
+
+      expect(firstLoginResult.kind).toBe("webAuthnFailed");
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-        [convertToCredentialData(mockDevice)],
+        expect.arrayContaining([
+          currentOriginCredentialData,
+          currentOriginCredentialData2,
+        ]),
         undefined
       );
-    }
+
+      failSign = false;
+      const secondLoginResult = await connection.login(BigInt(12345));
+
+      expect(secondLoginResult.kind).toBe("loginSuccess");
+      if (secondLoginResult.kind === "loginSuccess") {
+        expect(secondLoginResult.connection).toBeInstanceOf(
+          AuthenticatedConnection
+        );
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(2);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
+          2,
+          expect.arrayContaining([
+            currentOriginCredentialData,
+            currentOriginCredentialData2,
+          ]),
+          undefined
+        );
+      }
+    });
   });
 
-  it("connection exludes rpId when user cancels", async () => {
-    // This one will fail because it's not the device the user is using at the moment.
-    const currentOriginDevice: DeviceData = {
-      alias: "mockDevice",
-      metadata: [],
-      origin: [currentOrigin],
-      protection: { protected: null },
-      pubkey: new Uint8Array(),
-      key_type: { platform: null },
-      purpose: { authentication: null },
-      credential_id: [],
-    };
-    const currentOriginCredentialData =
-      convertToCredentialData(currentOriginDevice);
-    const currentDevice: DeviceData = {
-      alias: "mockDevice",
-      metadata: [],
-      origin: [],
-      protection: { protected: null },
-      pubkey: new Uint8Array(),
-      key_type: { platform: null },
-      purpose: { authentication: null },
-      credential_id: [],
-    };
-    const currentDeviceCredentialData = convertToCredentialData(currentDevice);
-    const mockActor = {
-      identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
-      lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
-    } as unknown as ActorSubclass<_SERVICE>;
-    DOMAIN_COMPATIBILITY.set(true);
-    vi.stubGlobal("navigator", {
-      // Supports RoR
-      userAgent:
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+  describe("domains compatibility flag enabled and browser doesn't support", () => {
+    beforeEach(() => {
+      DOMAIN_COMPATIBILITY.set(true);
+      vi.stubGlobal("navigator", {
+        // Does NOT Supports RoR
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0",
+      });
     });
-    const connection = new Connection("aaaaa-aa", mockActor);
 
-    failSign = true;
-    const firstLoginResult = await connection.login(BigInt(12345));
+    it("login returns authenticated connection without rpID if browser doesn't support it", async () => {
+      const connection = new Connection("aaaaa-aa", mockActor);
 
-    expect(firstLoginResult.kind).toBe("webAuthnFailed");
-    expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
-    expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        currentOriginCredentialData,
-        currentDeviceCredentialData,
-      ]),
-      undefined
-    );
+      const loginResult = await connection.login(BigInt(12345));
 
-    failSign = false;
-    const secondLoginResult = await connection.login(BigInt(12345));
+      expect(loginResult.kind).toBe("loginSuccess");
+      if (loginResult.kind === "loginSuccess") {
+        expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
+          [convertToCredentialData(mockDevice)],
+          undefined
+        );
+      }
+    });
+  });
 
-    expect(secondLoginResult.kind).toBe("loginSuccess");
-    if (secondLoginResult.kind === "loginSuccess") {
-      expect(secondLoginResult.connection).toBeInstanceOf(
-        AuthenticatedConnection
+  describe("domains compatibility flag disabled", () => {
+    beforeEach(() => {
+      DOMAIN_COMPATIBILITY.set(false);
+      vi.stubGlobal("navigator", {
+        // Supports RoR
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+      });
+    });
+
+    it("login returns authenticated connection without rpID if flag is not enabled", async () => {
+      const connection = new Connection("aaaaa-aa", mockActor);
+
+      const loginResult = await connection.login(BigInt(12345));
+
+      expect(loginResult.kind).toBe("loginSuccess");
+      if (loginResult.kind === "loginSuccess") {
+        expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
+          [convertToCredentialData(mockDevice)],
+          undefined
+        );
+      }
+    });
+
+    it("connection does not exlud rpId when user cancels", async () => {
+      const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
+      const currentOriginCredentialData =
+        convertToCredentialData(currentOriginDevice);
+      const currentDevice: DeviceData = createMockDevice();
+      const currentDeviceCredentialData =
+        convertToCredentialData(currentDevice);
+      const mockActor = {
+        identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
+        lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
+      } as unknown as ActorSubclass<_SERVICE>;
+      const connection = new Connection("aaaaa-aa", mockActor);
+
+      failSign = true;
+      const firstLoginResult = await connection.login(BigInt(12345));
+
+      expect(firstLoginResult.kind).toBe("webAuthnFailed");
+      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
+      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          currentOriginCredentialData,
+          currentDeviceCredentialData,
+        ]),
+        undefined
       );
-      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(2);
-      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
-        2,
-        expect.arrayContaining([currentDeviceCredentialData]),
-        "identity.ic0.app"
-      );
-      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
-        2,
-        expect.not.arrayContaining([currentOriginCredentialData]),
-        "identity.ic0.app"
-      );
-    }
+
+      failSign = false;
+      const secondLoginResult = await connection.login(BigInt(12345));
+
+      expect(secondLoginResult.kind).toBe("loginSuccess");
+      if (secondLoginResult.kind === "loginSuccess") {
+        expect(secondLoginResult.connection).toBeInstanceOf(
+          AuthenticatedConnection
+        );
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(2);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
+          2,
+          expect.arrayContaining([
+            currentDeviceCredentialData,
+            currentOriginCredentialData,
+          ]),
+          undefined
+        );
+      }
+    });
   });
 });


### PR DESCRIPTION
# Motivation

There are scenarios where the RP ID selected is not the correct one for the device the user is in. When that happens, we want to tell the user to try again, but this time, we will select another RP ID.

In this PR, I introduce the logic to use another RP ID on retry. See the video for a demo of how it looks like.

What I haven't improved in this PR is the UX when retrying. I'm thinking on only improving the toast error for now and if users are confused improve it. But this is an edge case that I hope not so many people will encounter.

# Changes

* New helpers `excludeCredentialsFromOrigins` and `hasCredentialsFromMultipleOrigins`.
* Add instance variable in `Connection`: `_cancelledRpIds` to keep track of the cancelled RP IDs.
* Add logic to use the `_cancelledRpIds` to filter the devices with the cancelled RP IDs from the calculation to find the next RP ID.

# Tests

* Test the new functionality.
* Add tests for `excludeCredentialsFromOrigins`.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/739f3d177/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/739f3d177/desktop/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

