### PR TITLE
Add nice UX when passkey is not found in that RP ID

### DIFF
--- a/src/frontend/src/components/infoToast/copy.json
+++ b/src/frontend/src/components/infoToast/copy.json
@@ -1,0 +1,7 @@
+{
+  "en": {
+    "title_possibly_wrong_rp_id": "Please try again",
+    "message_possibly_wrong_rp_id_1": "The wrong domain was set for the passkey and the browser couldn't find it.",
+    "message_possibly_wrong_rp_id_2": "Try again and another domain will be used."
+  }
+}

--- a/src/frontend/src/components/infoToast/index.ts
+++ b/src/frontend/src/components/infoToast/index.ts
@@ -1,0 +1,16 @@
+import { DynamicKey } from "$src/i18n";
+import { html } from "lit-html";
+
+export const infoToastTemplate = ({
+  title,
+  messages,
+}: {
+  title: string | DynamicKey;
+  messages: string[] | DynamicKey[];
+}) => html`
+  <h3 class="t-title c-card__title">${title}</h3>
+  ${messages.map(
+    (message) =>
+      html`<p data-role="info-message" class="t-paragraph">${message}</p>`
+  )}
+`;

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -1,11 +1,15 @@
 import { CredentialId, DeviceData } from "$generated/internet_identity_types";
+import { infoToastTemplate } from "$src/components/infoToast";
+import infoToastCopy from "$src/components/infoToast/copy.json";
 import { promptUserNumberTemplate } from "$src/components/promptUserNumber";
 import { toast } from "$src/components/toast";
+import { I18n } from "$src/i18n";
 import { convertToCredentialData } from "$src/utils/credential-devices";
 import {
   AuthFail,
   Connection,
   LoginSuccess,
+  PossiblyWrongRPID,
   WebAuthnFailed,
 } from "$src/utils/iiConnection";
 import { renderPage } from "$src/utils/lit-html";
@@ -50,6 +54,21 @@ export const recoverWithDevice = ({
         }
 
         if (result.kind !== "loginSuccess") {
+          if (result.kind === "possiblyWrongRPID") {
+            const i18n = new I18n();
+            const copy = i18n.i18n(infoToastCopy);
+            toast.info(
+              infoToastTemplate({
+                title: copy.title_possibly_wrong_rp_id,
+                messages: [
+                  copy.message_possibly_wrong_rp_id_1,
+                  copy.message_possibly_wrong_rp_id_2,
+                ],
+              })
+            );
+            return;
+          }
+
           result satisfies AuthFail | WebAuthnFailed;
           toast.error("Could not authenticate using the device");
           return;
@@ -72,6 +91,7 @@ const attemptRecovery = async ({
 }): Promise<
   | LoginSuccess
   | WebAuthnFailed
+  | PossiblyWrongRPID
   | AuthFail
   | { kind: "noRecovery" }
   | { kind: "tooManyRecovery" }

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -176,7 +176,7 @@ describe("Connection.login", () => {
       }
     });
 
-    it("connection exludes rpId when user cancels", async () => {
+    it("connection excludes rpId when user cancels", async () => {
       // This one would fail because it's not the device the user is using at the moment.
       const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
       const currentOriginCredentialData =
@@ -193,7 +193,7 @@ describe("Connection.login", () => {
       failSign = true;
       const firstLoginResult = await connection.login(BigInt(12345));
 
-      expect(firstLoginResult.kind).toBe("webAuthnFailed");
+      expect(firstLoginResult.kind).toBe("possiblyWrongRPID");
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
         expect.arrayContaining([
@@ -327,7 +327,7 @@ describe("Connection.login", () => {
       }
     });
 
-    it("connection does not exlud rpId when user cancels", async () => {
+    it("connection does not exclude rpId when user cancels", async () => {
       const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
       const currentOriginCredentialData =
         convertToCredentialData(currentOriginDevice);
@@ -427,7 +427,7 @@ describe("Connection.login", () => {
       }
     });
 
-    it("connection does not exlud rpId when user cancels", async () => {
+    it("connection does not exclude rpId when user cancels", async () => {
       const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
       const currentOriginCredentialData =
         convertToCredentialData(currentOriginDevice);


### PR DESCRIPTION
# Motivation

The algorithm to choose RP ID is not bulletproof. For those scenarios that the user needs to retry, we want to guide the user a bit.

In this PR, the UX is improved by showing an info toast encouraging the user to try again.

# Changes

* Add new return type `PossiblyWrongRPID` to the `login` and `fromWebauthnCredentials` methods.
* Manage the new return type and show a toast info if so.

# Tests

* Tested in beta domains. See screen video.
* Change current test for the scenario that has been changed.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/798698524/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/798698524/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/798698524/mobile/allowCredentialsNoAnchor.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/798698524/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/798698524/mobile/displayManageSingle.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

