### PR TITLE
Lm fix convert rp id to url

### DIFF
--- a/src/frontend/src/utils/findWebAuthnRpId.test.ts
+++ b/src/frontend/src/utils/findWebAuthnRpId.test.ts
@@ -180,7 +180,7 @@ describe("excludeCredentialsFromOrigins", () => {
       mockDeviceData("https://identity.internetcomputer.org"),
       mockDeviceData("https://identity.icp0.io"),
     ];
-    const originsToExclude = new Set(["https://identity.ic0.app"]);
+    const originsToExclude = new Set(["identity.ic0.app"]);
     const currentOrigin = "https://identity.internetcomputer.org";
 
     const result = excludeCredentialsFromOrigins(
@@ -201,7 +201,7 @@ describe("excludeCredentialsFromOrigins", () => {
       mockDeviceData(undefined), // Should be treated as DEFAULT_DOMAIN
       mockDeviceData("https://identity.internetcomputer.org"),
     ];
-    const originsToExclude = new Set(["https://identity.ic0.app"]); // Should match DEFAULT_DOMAIN
+    const originsToExclude = new Set(["identity.ic0.app"]); // Should match DEFAULT_DOMAIN
     const currentOrigin = "https://identity.internetcomputer.org";
 
     const result = excludeCredentialsFromOrigins(
@@ -240,8 +240,8 @@ describe("excludeCredentialsFromOrigins", () => {
       mockDeviceData("https://identity.internetcomputer.org"),
     ];
     const originsToExclude = new Set([
-      "https://identity.ic0.app",
-      "https://identity.internetcomputer.org",
+      "identity.ic0.app",
+      "identity.internetcomputer.org",
     ]);
     const currentOrigin = "https://identity.ic0.app";
 

--- a/src/frontend/src/utils/findWebAuthnRpId.ts
+++ b/src/frontend/src/utils/findWebAuthnRpId.ts
@@ -56,8 +56,8 @@ export const excludeCredentialsFromOrigins = (
     return credentials;
   }
   // Change `undefined` to the current origin.
-  const originsToExclude = Array.from(rpIds).map(
-    (origin) => `https://${origin}` ?? currentOrigin
+  const originsToExclude = Array.from(rpIds).map((origin) =>
+    origin === undefined ? currentOrigin : `https://${origin}`
   );
   return credentials.filter(
     (credential) =>

--- a/src/frontend/src/utils/findWebAuthnRpId.ts
+++ b/src/frontend/src/utils/findWebAuthnRpId.ts
@@ -43,21 +43,21 @@ export const hasCredentialsFromMultipleOrigins = (
  * Two origins match if they have the same hostname (domain).
  *
  * @param credentials - List of credential devices to filter
- * @param origins - Set of origins to exclude (undefined values are treated as `currentOrigin`)
+ * @param rpIds - Set of origins to exclude (undefined values are treated as `currentOrigin`)
  * @param currentOrigin - The current origin to use when comparing against undefined origins
  * @returns Filtered list of credentials, excluding those from the specified origins
  */
 export const excludeCredentialsFromOrigins = (
   credentials: CredentialData[],
-  origins: Set<string | undefined>,
+  rpIds: Set<string | undefined>,
   currentOrigin: string
 ): CredentialData[] => {
-  if (origins.size === 0) {
+  if (rpIds.size === 0) {
     return credentials;
   }
   // Change `undefined` to the current origin.
-  const originsToExclude = Array.from(origins).map(
-    (origin) => origin ?? currentOrigin
+  const originsToExclude = Array.from(rpIds).map(
+    (origin) => `https://${origin}` ?? currentOrigin
   );
   return credentials.filter(
     (credential) =>


### PR DESCRIPTION
# Motivation

There was a bug in the code for dynamic RP IDs becuase the cancelled RP IDs were only hostnames, not origins. Therefore, they couldn't be converted to `URL` to be compared with the origins of the devices.

# Changes

* Append `https://` in front of the RP ID when present.

# Tests

* Change tests to have as input hostnames only without the schema.
