### PR TITLE
Add new field to LoginSuccess to show add current device screen

### DIFF
--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -89,6 +89,7 @@ export const authenticateBox = async ({
   connection: AuthenticatedConnection;
   newAnchor: boolean;
   authnMethod: "pin" | "passkey" | "recovery";
+  showAddCurrentDevice: boolean;
 }> => {
   const promptAuth = async (autoSelectIdentity?: bigint) =>
     authenticateBoxFlow<PinIdentityMaterial>({

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -94,6 +94,7 @@ export type LoginSuccess = {
   kind: "loginSuccess";
   connection: AuthenticatedConnection;
   userNumber: bigint;
+  showAddCurrentDevice: boolean;
 };
 
 export type RegFlowNextStep =
@@ -323,6 +324,7 @@ export class Connection {
           actor
         ),
         userNumber,
+        showAddCurrentDevice: false,
       };
     }
 
@@ -460,6 +462,7 @@ export class Connection {
       kind: "loginSuccess",
       userNumber,
       connection,
+      showAddCurrentDevice: cancelledRpIds.size > 0,
     };
   };
   fromIdentity = async (
@@ -480,6 +483,7 @@ export class Connection {
       kind: "loginSuccess",
       userNumber,
       connection,
+      showAddCurrentDevice: false,
     };
   };
 
@@ -520,6 +524,7 @@ export class Connection {
         userNumber,
         actor
       ),
+      showAddCurrentDevice: false,
     };
   };
 

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -92,6 +92,7 @@ const registerFlowOpts: RegisterFlowOpts = {
       kind: "loginSuccess",
       userNumber: BigInt(12356),
       connection: mockConnection,
+      showAddCurrentDevice: false,
     };
   },
   registrationAllowed: true,
@@ -122,6 +123,7 @@ export const iiFlows: Record<string, () => void> = {
           kind: "loginSuccess",
           userNumber: BigInt(1234),
           connection: mockConnection,
+          showAddCurrentDevice: false,
         });
       },
       allowPinLogin: true,
@@ -138,6 +140,7 @@ export const iiFlows: Record<string, () => void> = {
           kind: "loginSuccess",
           userNumber: BigInt(1234),
           connection: mockConnection,
+          showAddCurrentDevice: false,
         });
       },
       recover: () => {
@@ -146,6 +149,7 @@ export const iiFlows: Record<string, () => void> = {
           kind: "loginSuccess",
           userNumber: BigInt(1234),
           connection: mockConnection,
+          showAddCurrentDevice: false,
         });
       },
       retrievePinIdentityMaterial: ({ userNumber }) => {


### PR DESCRIPTION
# Motivation

We want to show a page to the users to add the current device to the current origin.

In this PR, I added a new field to LoginSuccess type that will be used in future PRs to render the new page.

# Changes

* Add new mandatory field `showAddCurrentDevice` to `LoginSuccess` type.
* Return `true` for `showAddCurrentDevice` only when the user needed multiple changes when logging in. This can be calculation by checking the cancelled RP IDs

# Tests

* I deployed it to the beta domains and checked the expected value of the field.
* Add a test for the new field.
