### PR TITLE
Fix authentication with (older) identities that have devices without a (valid) credential id.

### DIFF
--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -1,4 +1,3 @@
-import { CredentialId, DeviceData } from "$generated/internet_identity_types";
 import { infoToastTemplate } from "$src/components/infoToast";
 import infoToastCopy from "$src/components/infoToast/copy.json";
 import { promptUserNumberTemplate } from "$src/components/promptUserNumber";
@@ -13,6 +12,7 @@ import {
   WebAuthnFailed,
 } from "$src/utils/iiConnection";
 import { renderPage } from "$src/utils/lit-html";
+import { nonNullish } from "@dfinity/utils";
 
 export const recoverWithDeviceTemplate = ({
   next,
@@ -110,14 +110,9 @@ const attemptRecovery = async ({
     return { kind: "tooManyRecovery" };
   }
 
-  const hasCredentialId = (
-    device: Omit<DeviceData, "alias">
-  ): device is Omit<DeviceData, "alias"> & { credential_id: [CredentialId] } =>
-    device.credential_id.length === 1;
-
   const credentialData = recoveryCredentials
-    .filter(hasCredentialId)
-    .map(convertToCredentialData);
+    .map(convertToCredentialData)
+    .filter(nonNullish);
 
   return await connection.fromWebauthnCredentials(userNumber, credentialData);
 };

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -3,7 +3,7 @@ import infoToastCopy from "$src/components/infoToast/copy.json";
 import { promptUserNumberTemplate } from "$src/components/promptUserNumber";
 import { toast } from "$src/components/toast";
 import { I18n } from "$src/i18n";
-import { convertToCredentialData } from "$src/utils/credential-devices";
+import { convertToValidCredentialData } from "$src/utils/credential-devices";
 import {
   AuthFail,
   Connection,
@@ -111,7 +111,7 @@ const attemptRecovery = async ({
   }
 
   const credentialData = recoveryCredentials
-    .map(convertToCredentialData)
+    .map(convertToValidCredentialData)
     .filter(nonNullish);
 
   return await connection.fromWebauthnCredentials(userNumber, credentialData);

--- a/src/frontend/src/utils/credential-devices.ts
+++ b/src/frontend/src/utils/credential-devices.ts
@@ -13,8 +13,22 @@ const derFromPubkey = (pubkey: DeviceKey): DerEncodedPublicKey =>
 
 export const convertToCredentialData = (
   device: Omit<DeviceData, "alias">
-): CredentialData => ({
-  credentialId: Buffer.from(device.credential_id[0] ?? []),
-  pubkey: derFromPubkey(device.pubkey),
-  origin: device.origin[0],
-});
+): CredentialData | undefined => {
+  // In certain cases, e.g. Chrome on Windows 10, an invalid credential id is
+  // not ignored but instead will result in a WebAuthn error that prevents a
+  // user from authenticating with any of their registered devices.
+  //
+  // Instead of throwing an error, we return `undefined` to make sure that the
+  // device will be filtered out to unblock the user from authenticating.
+  if (
+    device.credential_id.length !== 1 ||
+    device.credential_id[0].length === 0
+  ) {
+    return;
+  }
+  return {
+    credentialId: Buffer.from(device.credential_id[0]),
+    pubkey: derFromPubkey(device.pubkey),
+    origin: device.origin[0],
+  };
+};

--- a/src/frontend/src/utils/credential-devices.ts
+++ b/src/frontend/src/utils/credential-devices.ts
@@ -11,7 +11,7 @@ export type CredentialData = {
 const derFromPubkey = (pubkey: DeviceKey): DerEncodedPublicKey =>
   new Uint8Array(pubkey).buffer as DerEncodedPublicKey;
 
-export const convertToCredentialData = (
+export const convertToValidCredentialData = (
   device: Omit<DeviceData, "alias">
 ): CredentialData | undefined => {
   // In certain cases, e.g. Chrome on Windows 10, an invalid credential id is

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -10,7 +10,10 @@ import {
 } from "$src/repositories/identityMetadata";
 import { ActorSubclass, DerEncodedPublicKey, Signature } from "@dfinity/agent";
 import { DelegationIdentity, WebAuthnIdentity } from "@dfinity/identity";
-import { CredentialData, convertToCredentialData } from "./credential-devices";
+import {
+  CredentialData,
+  convertToValidCredentialData,
+} from "./credential-devices";
 import { AuthenticatedConnection, Connection } from "./iiConnection";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 
@@ -171,7 +174,7 @@ describe("Connection.login", () => {
         expect(loginResult.showAddCurrentDevice).toBe(false);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-          [convertToCredentialData(mockDevice)],
+          [convertToValidCredentialData(mockDevice)],
           "identity.ic0.app"
         );
       }
@@ -181,10 +184,10 @@ describe("Connection.login", () => {
       // This one would fail because it's not the device the user is using at the moment.
       const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
       const currentOriginCredentialData =
-        convertToCredentialData(currentOriginDevice);
+        convertToValidCredentialData(currentOriginDevice);
       const currentDevice: DeviceData = createMockDevice();
       const currentDeviceCredentialData =
-        convertToCredentialData(currentDevice);
+        convertToValidCredentialData(currentDevice);
       const mockActor = {
         identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
         lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
@@ -230,10 +233,10 @@ describe("Connection.login", () => {
     it("connection doesn't exclude rpId if user has only one domain", async () => {
       const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
       const currentOriginCredentialData =
-        convertToCredentialData(currentOriginDevice);
+        convertToValidCredentialData(currentOriginDevice);
       const currentOriginDevice2: DeviceData = createMockDevice(currentOrigin);
       const currentOriginCredentialData2 =
-        convertToCredentialData(currentOriginDevice2);
+        convertToValidCredentialData(currentOriginDevice2);
       const mockActor = {
         identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
         lookup: vi
@@ -298,7 +301,7 @@ describe("Connection.login", () => {
         expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-          [convertToCredentialData(mockDevice)],
+          [convertToValidCredentialData(mockDevice)],
           undefined
         );
       }
@@ -326,7 +329,7 @@ describe("Connection.login", () => {
         expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-          [convertToCredentialData(mockDevice)],
+          [convertToValidCredentialData(mockDevice)],
           undefined
         );
       }
@@ -335,10 +338,10 @@ describe("Connection.login", () => {
     it("connection does not exclude rpId when user cancels", async () => {
       const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
       const currentOriginCredentialData =
-        convertToCredentialData(currentOriginDevice);
+        convertToValidCredentialData(currentOriginDevice);
       const currentDevice: DeviceData = createMockDevice();
       const currentDeviceCredentialData =
-        convertToCredentialData(currentDevice);
+        convertToValidCredentialData(currentDevice);
       const mockActor = {
         identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
         lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
@@ -401,7 +404,7 @@ describe("Connection.login", () => {
         expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-          [convertToCredentialData(mockDevice)],
+          [convertToValidCredentialData(mockDevice)],
           undefined
         );
       }
@@ -429,7 +432,7 @@ describe("Connection.login", () => {
         expect(loginResult.showAddCurrentDevice).toBe(false);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-          [convertToCredentialData(mockDevice)],
+          [convertToValidCredentialData(mockDevice)],
           undefined
         );
       }
@@ -438,10 +441,10 @@ describe("Connection.login", () => {
     it("connection does not exclude rpId when user cancels", async () => {
       const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
       const currentOriginCredentialData =
-        convertToCredentialData(currentOriginDevice);
+        convertToValidCredentialData(currentOriginDevice);
       const currentDevice: DeviceData = createMockDevice();
       const currentDeviceCredentialData =
-        convertToCredentialData(currentDevice);
+        convertToValidCredentialData(currentDevice);
       const mockActor = {
         identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
         lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
@@ -501,7 +504,7 @@ describe("Connection.login", () => {
       await connection.login(BigInt(12345));
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-        [convertToCredentialData(deviceWithCredentialId)],
+        [convertToValidCredentialData(deviceWithCredentialId)],
         undefined
       );
     });
@@ -525,7 +528,7 @@ describe("Connection.login", () => {
       await connection.login(BigInt(12345));
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-        [convertToCredentialData(deviceValidCredentialId)],
+        [convertToValidCredentialData(deviceValidCredentialId)],
         undefined
       );
     });

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -387,7 +387,7 @@ export class Connection {
 
     return this.fromWebauthnCredentials(
       userNumber,
-      devices.map(convertToCredentialData)
+      devices.map(convertToCredentialData).filter(nonNullish)
     );
   };
 

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -50,7 +50,10 @@ import {
 } from "@dfinity/identity";
 import { Principal } from "@dfinity/principal";
 import { isNullish, nonNullish } from "@dfinity/utils";
-import { convertToCredentialData, CredentialData } from "./credential-devices";
+import {
+  convertToValidCredentialData,
+  CredentialData,
+} from "./credential-devices";
 import {
   excludeCredentialsFromOrigins,
   findWebAuthnRpId,
@@ -387,7 +390,7 @@ export class Connection {
 
     return this.fromWebauthnCredentials(
       userNumber,
-      devices.map(convertToCredentialData).filter(nonNullish)
+      devices.map(convertToValidCredentialData).filter(nonNullish)
     );
   };
 


### PR DESCRIPTION
Fix authentication when (older) identities have devices without a (valid) credential id.

# Changes

- Reimplement old behavior from previous release where devices without a (valid) credential id are filtered out.
- Improve guarantees during build time by moving credential id checks into `convertToCredentialData` method itself.

# Added Tests

- Check if devices are ignored with missing credential id
- Check if devices are ignored with invalid credential id

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/692daaffb/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/692daaffb/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/692daaffb/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/692daaffb/mobile/allowCredentialsLongOrigins.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

