### PR TITLE
Fix e2e CI job by downgrading runner

### DIFF
--- a/.github/actions/file-size/README.md
+++ b/.github/actions/file-size/README.md
@@ -4,25 +4,25 @@ A GitHub Action for recording file sizes in git notes.
 
 ## Usage
 
-``` yaml
-  record-readme-size:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/file-size
-        with:
-          file: README.md
+```yaml
+record-readme-size:
+  runs-on: ubuntu-22.04
+  steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/file-size
+      with:
+        file: README.md
 ```
 
 To use the notes, first fetch them:
 
-``` bash
+```bash
 $ git fetch origin refs/notes/file-size/*:refs/notes/file-size/*
 ```
 
 Then, each note contains a number, which is the size in bytes. The following example plots the values:
 
-``` bash
+```bash
 $ git log \
     --reverse --notes="notes/file-size/README.md" \
     --pretty='format:%h%x09%s%x09%N' | tail -n 10 \

--- a/.github/actions/slack/README.md
+++ b/.github/actions/slack/README.md
@@ -2,10 +2,9 @@
 
 A GitHub Action for sending slack notifications. For more information, see slack's [documentation](https://api.slack.com/messaging/webhooks). In particular, note that the channel and workspace are set by the webhook URL, not directly by this action.
 
-
 ## Usage
 
-``` yaml
+```yaml
 name: My Action
 
 on:
@@ -13,7 +12,7 @@ on:
 
 jobs:
   share-love:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: ./.github/actions/slack
         with:

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
   # The image shared by all builds, containing pre-built rust deps
   docker-build-base:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -35,7 +35,7 @@ jobs:
           target: deps
 
   docker-build-ii:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: docker-build-base
     strategy:
       # NOTE: the 'name' in the matrix should match the asset filename, because it is used in
@@ -108,7 +108,7 @@ jobs:
           path: ${{ matrix.name }}
 
   docker-build-archive:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: docker-build-base
     steps:
       - uses: actions/checkout@v4
@@ -138,7 +138,7 @@ jobs:
           path: archive.wasm.gz
 
   wasm-size:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: docker-build-ii
     steps:
       - uses: actions/checkout@v4
@@ -164,7 +164,7 @@ jobs:
           fi
 
   vc_demo_issuer-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -192,7 +192,7 @@ jobs:
           path: ./demos/vc_issuer/vc_demo_issuer.wasm.gz
 
   test-app-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -222,7 +222,7 @@ jobs:
   #####################################
 
   vc-issuer-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [docker-build-ii, vc_demo_issuer-build]
     steps:
       - uses: actions/checkout@v4
@@ -269,7 +269,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -338,7 +338,7 @@ jobs:
     needs: [canister-tests-build, cached-build, docker-build-archive]
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         partition: ["1/3", "2/3", "3/3"]
     steps:
       - uses: actions/checkout@v4
@@ -392,7 +392,7 @@ jobs:
 
   test-canisters-script:
     needs: [cached-build, docker-build-archive]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -443,7 +443,7 @@ jobs:
   ######################
 
   e2e:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [cached-build, test-app-build, vc_demo_issuer-build]
     strategy:
       matrix:
@@ -579,13 +579,13 @@ jobs:
 
   # Aggregate all e2e matrix jobs, used in branch protection
   e2e-all:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: e2e
     steps:
       - run: echo e2e ok
 
   using-dev-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: docker-build-ii
     steps:
       - uses: actions/checkout@v4
@@ -640,7 +640,7 @@ jobs:
   # This deploys the production build to mainnet (to a canister that we use for release testing) alongside
   # some other canisters useful for testing & playing with II.
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/release-')
     needs:
       [
@@ -721,7 +721,7 @@ jobs:
   # This prepares all the files necessary for a release (all flavors of Wasm, release notes).
   # On release tags, a new release is created and the assets are uploaded.
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [docker-build-ii, docker-build-archive, vc_demo_issuer-build]
 
     steps:
@@ -887,7 +887,7 @@ jobs:
   # A native, fast cached build. We use the produced test assets to run the canister & e2e tests.
   # The asset's checksum is compared against that of the (slower) docker build.
   cached-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -926,7 +926,7 @@ jobs:
 
   # Make sure that the asset we're testing is the same as that produced by the (slower) docker builds
   cached-build-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [docker-build-ii, cached-build]
     steps:
       - uses: actions/checkout@v4
@@ -962,7 +962,7 @@ jobs:
         # (in particular the slow macos builds). A single ubuntu build is not long and gives us some signal.
         # XXX: GHA does not support proper if/else so we implement a workaround: https://github.com/actions/runner/issues/409
         # XXX: GHA fails if we return the matrix object directly, so we have to pretend it's JSON
-        os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-22.04", "ubuntu-20.04", "macos-13", "macos-14" ]') || fromJson('[ "ubuntu-22.04" ]') }}
+        os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-latest", "ubuntu-20.04", "macos-13", "macos-14" ]') || fromJson('[ "ubuntu-latest" ]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/check-build
@@ -985,7 +985,7 @@ jobs:
         # On other branches, in order to speed up checks (on PRs) we skip most platforms. A single ubuntu build is not long and gives us some signal.
         # XXX: GHA does not support proper if/else so we implement a workaround: https://github.com/actions/runner/issues/409
         # XXX: GHA fails if we return the matrix object directly, so we have to pretend it's JSON
-        os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-22.04", "ubuntu-20.04"]') || fromJson('[ "ubuntu-22.04" ]') }}
+        os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-latest", "ubuntu-20.04"]') || fromJson('[ "ubuntu-latest" ]') }}
     steps:
       - name: Download internet_identity_clean_build_${{ matrix.os }}.wasm.gz
         uses: actions/download-artifact@v4
@@ -1014,7 +1014,7 @@ jobs:
           fi
 
   interface-compatibility:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-didc
@@ -1024,7 +1024,7 @@ jobs:
           didc check src/internet_identity/internet_identity.did internet_identity_previous.did
 
   sig-verifier-js:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
   # The image shared by all builds, containing pre-built rust deps
   docker-build-base:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -35,7 +35,7 @@ jobs:
           target: deps
 
   docker-build-ii:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: docker-build-base
     strategy:
       # NOTE: the 'name' in the matrix should match the asset filename, because it is used in
@@ -108,7 +108,7 @@ jobs:
           path: ${{ matrix.name }}
 
   docker-build-archive:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: docker-build-base
     steps:
       - uses: actions/checkout@v4
@@ -138,7 +138,7 @@ jobs:
           path: archive.wasm.gz
 
   wasm-size:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: docker-build-ii
     steps:
       - uses: actions/checkout@v4
@@ -164,7 +164,7 @@ jobs:
           fi
 
   vc_demo_issuer-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -192,7 +192,7 @@ jobs:
           path: ./demos/vc_issuer/vc_demo_issuer.wasm.gz
 
   test-app-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -222,7 +222,7 @@ jobs:
   #####################################
 
   vc-issuer-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [docker-build-ii, vc_demo_issuer-build]
     steps:
       - uses: actions/checkout@v4
@@ -269,7 +269,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -338,7 +338,7 @@ jobs:
     needs: [canister-tests-build, cached-build, docker-build-archive]
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
         partition: ["1/3", "2/3", "3/3"]
     steps:
       - uses: actions/checkout@v4
@@ -392,7 +392,7 @@ jobs:
 
   test-canisters-script:
     needs: [cached-build, docker-build-archive]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -443,7 +443,7 @@ jobs:
   ######################
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [cached-build, test-app-build, vc_demo_issuer-build]
     strategy:
       matrix:
@@ -579,13 +579,13 @@ jobs:
 
   # Aggregate all e2e matrix jobs, used in branch protection
   e2e-all:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: e2e
     steps:
       - run: echo e2e ok
 
   using-dev-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: docker-build-ii
     steps:
       - uses: actions/checkout@v4
@@ -640,7 +640,7 @@ jobs:
   # This deploys the production build to mainnet (to a canister that we use for release testing) alongside
   # some other canisters useful for testing & playing with II.
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/release-')
     needs:
       [
@@ -721,7 +721,7 @@ jobs:
   # This prepares all the files necessary for a release (all flavors of Wasm, release notes).
   # On release tags, a new release is created and the assets are uploaded.
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [docker-build-ii, docker-build-archive, vc_demo_issuer-build]
 
     steps:
@@ -1014,7 +1014,7 @@ jobs:
           fi
 
   interface-compatibility:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-didc
@@ -1024,7 +1024,7 @@ jobs:
           didc check src/internet_identity/internet_identity.did internet_identity_previous.did
 
   sig-verifier-js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
   # The image shared by all builds, containing pre-built rust deps
   docker-build-base:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -35,7 +35,7 @@ jobs:
           target: deps
 
   docker-build-ii:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: docker-build-base
     strategy:
       # NOTE: the 'name' in the matrix should match the asset filename, because it is used in
@@ -108,7 +108,7 @@ jobs:
           path: ${{ matrix.name }}
 
   docker-build-archive:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: docker-build-base
     steps:
       - uses: actions/checkout@v4
@@ -138,7 +138,7 @@ jobs:
           path: archive.wasm.gz
 
   wasm-size:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: docker-build-ii
     steps:
       - uses: actions/checkout@v4
@@ -164,7 +164,7 @@ jobs:
           fi
 
   vc_demo_issuer-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -192,7 +192,7 @@ jobs:
           path: ./demos/vc_issuer/vc_demo_issuer.wasm.gz
 
   test-app-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -222,7 +222,7 @@ jobs:
   #####################################
 
   vc-issuer-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [docker-build-ii, vc_demo_issuer-build]
     steps:
       - uses: actions/checkout@v4
@@ -269,7 +269,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -338,7 +338,7 @@ jobs:
     needs: [canister-tests-build, cached-build, docker-build-archive]
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
         partition: ["1/3", "2/3", "3/3"]
     steps:
       - uses: actions/checkout@v4
@@ -392,7 +392,7 @@ jobs:
 
   test-canisters-script:
     needs: [cached-build, docker-build-archive]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -443,7 +443,7 @@ jobs:
   ######################
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [cached-build, test-app-build, vc_demo_issuer-build]
     strategy:
       matrix:
@@ -579,13 +579,13 @@ jobs:
 
   # Aggregate all e2e matrix jobs, used in branch protection
   e2e-all:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: e2e
     steps:
       - run: echo e2e ok
 
   using-dev-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: docker-build-ii
     steps:
       - uses: actions/checkout@v4
@@ -640,7 +640,7 @@ jobs:
   # This deploys the production build to mainnet (to a canister that we use for release testing) alongside
   # some other canisters useful for testing & playing with II.
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/release-')
     needs:
       [
@@ -721,7 +721,7 @@ jobs:
   # This prepares all the files necessary for a release (all flavors of Wasm, release notes).
   # On release tags, a new release is created and the assets are uploaded.
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [docker-build-ii, docker-build-archive, vc_demo_issuer-build]
 
     steps:
@@ -887,7 +887,7 @@ jobs:
   # A native, fast cached build. We use the produced test assets to run the canister & e2e tests.
   # The asset's checksum is compared against that of the (slower) docker build.
   cached-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -926,7 +926,7 @@ jobs:
 
   # Make sure that the asset we're testing is the same as that produced by the (slower) docker builds
   cached-build-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [docker-build-ii, cached-build]
     steps:
       - uses: actions/checkout@v4
@@ -962,7 +962,7 @@ jobs:
         # (in particular the slow macos builds). A single ubuntu build is not long and gives us some signal.
         # XXX: GHA does not support proper if/else so we implement a workaround: https://github.com/actions/runner/issues/409
         # XXX: GHA fails if we return the matrix object directly, so we have to pretend it's JSON
-        os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-latest", "ubuntu-20.04", "macos-13", "macos-14" ]') || fromJson('[ "ubuntu-latest" ]') }}
+        os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-22.04", "ubuntu-20.04", "macos-13", "macos-14" ]') || fromJson('[ "ubuntu-22.04" ]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/check-build
@@ -985,7 +985,7 @@ jobs:
         # On other branches, in order to speed up checks (on PRs) we skip most platforms. A single ubuntu build is not long and gives us some signal.
         # XXX: GHA does not support proper if/else so we implement a workaround: https://github.com/actions/runner/issues/409
         # XXX: GHA fails if we return the matrix object directly, so we have to pretend it's JSON
-        os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-latest", "ubuntu-20.04"]') || fromJson('[ "ubuntu-latest" ]') }}
+        os: ${{ github.ref == 'refs/heads/main' && fromJson('[ "ubuntu-22.04", "ubuntu-20.04"]') || fromJson('[ "ubuntu-22.04" ]') }}
     steps:
       - name: Download internet_identity_clean_build_${{ matrix.os }}.wasm.gz
         uses: actions/download-artifact@v4
@@ -1014,7 +1014,7 @@ jobs:
           fi
 
   interface-compatibility:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-didc
@@ -1024,7 +1024,7 @@ jobs:
           didc check src/internet_identity/internet_identity.did internet_identity_previous.did
 
   sig-verifier-js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -269,7 +269,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -338,7 +338,7 @@ jobs:
     needs: [canister-tests-build, cached-build, docker-build-archive]
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         partition: ["1/3", "2/3", "3/3"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -6,12 +6,12 @@ on:
     # Run every Tuesday:
     #   summer: 7pm Zurich time
     #   winter: 8pm Zurich time
-    - cron:  '0 18 * * 2'
+    - cron: "0 18 * * 2"
   workflow_dispatch:
 
 jobs:
   deploy-rc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       ii_canister_id: jqajs-xiaaa-aaaad-aab5q-cai
       testnet_app_canister_id: jlfvx-nqaaa-aaaad-aab7a-cai
@@ -60,7 +60,7 @@ jobs:
 
       - uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365
 
-      - name: 'Install key'
+      - name: "Install key"
         env:
           DFX_DEPLOY_KEY: ${{ secrets.DFX_DEPLOY_KEY }}
         run: |

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   frontend-checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,7 +48,7 @@ jobs:
 
   # Deploy the showcase to GitHub Pages
   showcase:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
@@ -66,7 +66,7 @@ jobs:
 
   # Deploy the showcase to GitHub Pages
   showcase-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: showcase
     if: github.ref == 'refs/heads/main'
     environment:

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -8,7 +8,7 @@ name: Release Build Check
 on:
   schedule:
     # check build daily at 7:30
-    - cron:  '30 7 * * *'
+    - cron: "30 7 * * *"
 
 jobs:
   # First, gather some info about the latest release, namely:
@@ -19,7 +19,7 @@ jobs:
       ref: ${{ steps.release.outputs.ref }}
       ii_prod_sha256: ${{ steps.release.outputs.ii_prod_sha256 }}
       archive_sha256: ${{ steps.release.outputs.archive_sha256 }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Get latest release information
         run: |
@@ -57,7 +57,7 @@ jobs:
     needs: latest-release
     strategy:
       matrix:
-        os: [ ubuntu-22.04, ubuntu-20.04, macos-13, macos-14 ]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -86,7 +86,7 @@ jobs:
       matrix:
         # docker builds on macos are flaky or not supported at all (in case of ARM based runners). The signal they gave
         # was minimal, so we will skip them for now until there is a reliable way to run docker images on macos runners.
-        os: [ ubuntu-22.04, ubuntu-20.04 ]
+        os: [ubuntu-22.04, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   cargo-fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -36,7 +36,7 @@ jobs:
           message: "🤖 cargo-fmt auto-update"
 
   cargo-clippy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bootstrap
@@ -69,7 +69,7 @@ jobs:
           cargo clippy --tests --benches -- -D clippy::all -D warnings -A clippy::manual_range_contains
 
   check-lockfile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bootstrap

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -14,7 +14,7 @@ jobs:
   # Job that starts the showcase and takes a screenshot of every page and
   # saves it in artifacts (both head & base branches)
   screenshots:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         device: ["desktop", "mobile"]

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -11,15 +11,14 @@ on:
   pull_request:
 
 jobs:
-
   # Job that starts the showcase and takes a screenshot of every page and
   # saves it in artifacts (both head & base branches)
   screenshots:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        device: [ 'desktop', 'mobile' ]
-        ref: [ 'head', 'base' ]
+        device: ["desktop", "mobile"]
+        ref: ["head", "base"]
       # Make sure that one failing test does not cancel all other matrix jobs
       fail-fast: false
     steps:
@@ -49,6 +48,8 @@ jobs:
             SCREENSHOTS_TYPE=${{ matrix.device }} \
             npm run screenshots
           kill "$showcase_pid"
+          chromedriver --version
+          google-chrome --version
 
       - name: Summary
         run: |
@@ -69,8 +70,7 @@ jobs:
     # and this starts taking longer than expected, then we want to be aware of it.
     timeout-minutes: 5
     steps:
-
-        # Configuration used throughout the job
+      # Configuration used throughout the job
       - name: Initialize config
         run: |
           now=$(date +%s)
@@ -295,7 +295,6 @@ jobs:
           git config --add --bool push.autoSetupRemote true
 
           git push --force
-
 
         # Use the GitHub API to post links to screenshots if necessary
       - name: Notify PR of screen changes

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -36,6 +36,8 @@ jobs:
       - run: npm ci
       - name: Save screenshots
         run: |
+          chromedriver --version
+          google-chrome --version
           npm run showcase&
           showcase_pid=$!
 
@@ -48,8 +50,6 @@ jobs:
             SCREENSHOTS_TYPE=${{ matrix.device }} \
             npm run screenshots
           kill "$showcase_pid"
-          chromedriver --version
-          google-chrome --version
 
       - name: Summary
         run: |

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -63,7 +63,7 @@ jobs:
           path: screenshots/${{ matrix.device }}/*.png
 
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: screenshots
     concurrency: image-dumpster
     # This should never take long, but _in case_ our setup changes inadvertently

--- a/.github/workflows/update-dapps.yml
+++ b/.github/workflows/update-dapps.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   dapps-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -5,12 +5,12 @@ name: dfx Update
 on:
   schedule:
     # check for new dfx releases daily at 7:30
-    - cron:  '30 7 * * *'
+    - cron: "30 7 * * *"
   workflow_dispatch:
 
 jobs:
   dfx-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -50,7 +50,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-dfx-update
           delete-branch: true
-          title: 'Update dfx'
+          title: "Update dfx"
 
         # Since this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -5,11 +5,11 @@ name: didc Update
 on:
   schedule:
     # check for new didc releases daily at 7:30
-    - cron:  '30 7 * * *'
+    - cron: "30 7 * * *"
 
 jobs:
   didc-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -49,7 +49,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-didc-update
           delete-branch: true
-          title: 'Update didc release'
+          title: "Update didc release"
 
         # Since this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.

--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -5,11 +5,11 @@ name: Node Update
 on:
   schedule:
     # check for new node versions daily at 7:30
-    - cron:  '30 7 * * *'
+    - cron: "30 7 * * *"
 
 jobs:
   node-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -51,7 +51,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-node-update
           delete-branch: true
-          title: 'Update node version'
+          title: "Update node version"
 
         # Since the this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -5,11 +5,11 @@ name: Rust Update
 on:
   schedule:
     # check for new rust versions weekly
-    - cron:  '30 3 * * FRI'
+    - cron: "30 3 * * FRI"
 
 jobs:
   rust-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -58,7 +58,7 @@ jobs:
           author: gix-bot <gix-bot@users.noreply.github.com>
           branch: bot-rust-update
           delete-branch: true
-          title: 'Update rust version'
+          title: "Update rust version"
 
         # Since the this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.

--- a/demos/using-dev-build/wdio.conf.ts
+++ b/demos/using-dev-build/wdio.conf.ts
@@ -15,7 +15,7 @@ export const config: WebdriverIO.Config = {
   capabilities: [
     {
       browserName: "chrome",
-      browserVersion: "131.0.6778.108", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "122.0.6261.111", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": {
         args: ["headless", "disable-gpu", "disable-dev-shm-usage"],
       },

--- a/demos/using-dev-build/wdio.conf.ts
+++ b/demos/using-dev-build/wdio.conf.ts
@@ -15,7 +15,7 @@ export const config: WebdriverIO.Config = {
   capabilities: [
     {
       browserName: "chrome",
-      browserVersion: "122.0.6261.111	", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "131.0.6778.139", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": {
         args: ["headless", "disable-gpu", "disable-dev-shm-usage"],
       },

--- a/demos/using-dev-build/wdio.conf.ts
+++ b/demos/using-dev-build/wdio.conf.ts
@@ -15,7 +15,7 @@ export const config: WebdriverIO.Config = {
   capabilities: [
     {
       browserName: "chrome",
-      browserVersion: "131.0.6778.139", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "131.0.6778.108", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": {
         args: ["headless", "disable-gpu", "disable-dev-shm-usage"],
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@typescript-eslint/eslint-plugin": "6.7.5",
         "@typescript-eslint/parser": "6.7.5",
         "@vitejs/plugin-basic-ssl": "^1.1.0",
-        "@wdio/globals": "^8.39.0",
+        "@wdio/globals": "^8.41.0",
         "astro": "4.16.18",
         "eslint": "8.51.0",
         "fake-indexeddb": "^4.0.2",
@@ -54,7 +54,7 @@
         "typescript": "5.2.2",
         "vite": "^5.4.6",
         "vitest": "^1.6.0",
-        "webdriverio": "^8.39.0"
+        "webdriverio": "^8.41.0"
       },
       "engines": {
         "node": ">=20.0.0 <21.0.0",
@@ -1875,7 +1875,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.8.0",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2219,6 +2221,7 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
       "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -2231,6 +2234,7 @@
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
       "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.1"
       },
@@ -2372,7 +2376,8 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2500,10 +2505,11 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
-      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2973,6 +2979,8 @@
       "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.39.0.tgz",
       "integrity": "sha512-yNuGPMPibY91s936gnJCHWlStvIyDrwLwGfLC/NCdTin4F7HL4Gp5iJnHWkJFty1/DfFi8jjoIUBNLM8HEez+A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@wdio/logger": "8.38.0",
         "@wdio/types": "8.39.0",
@@ -2991,6 +2999,8 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3000,6 +3010,8 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
       "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -3023,6 +3035,8 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
       "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3034,16 +3048,17 @@
       }
     },
     "node_modules/@wdio/globals": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.39.0.tgz",
-      "integrity": "sha512-qZo6JjRCIOtdvba6fdSqj6b91TnWXD6rmamyud93FTqbcspnhBvr8lmgOs5wnslTKeeTTigCjpsT310b4/AyHA==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.41.0.tgz",
+      "integrity": "sha512-xfUpEppdKzMHy4qoSoQN1cXoBPPh7oMeX+U/jtdvOtla+dd/YZ8pu47zLhQ/GM3gDVrBGnO4w3u4L6Zf/P3KEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^16.13 || >=18"
       },
       "optionalDependencies": {
         "expect-webdriverio": "^4.11.2",
-        "webdriverio": "8.39.0"
+        "webdriverio": "8.41.0"
       }
     },
     "node_modules/@wdio/logger": {
@@ -3101,25 +3116,47 @@
       "version": "8.38.0",
       "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.38.0.tgz",
       "integrity": "sha512-7BPi7aXwUtnXZPeWJRmnCNFjyDvGrXlBmN9D4Pi58nILkyjVRQKEY9/qv/pcdyB0cvmIvw++Kl/1Lg+RxG++UA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@wdio/repl": {
-      "version": "8.24.12",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-8.24.12.tgz",
-      "integrity": "sha512-321F3sWafnlw93uRTSjEBVuvWCxTkWNDs7ektQS15drrroL3TMeFOynu4rDrIz0jXD9Vas0HCD2Tq/P0uxFLdw==",
+      "version": "8.40.3",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-8.40.3.tgz",
+      "integrity": "sha512-mWEiBbaC7CgxvSd2/ozpbZWebnRIc8KRu/J81Hlw/txUWio27S7IpXBlZGVvhEsNzq0+cuxB/8gDkkXvMPbesw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^20.1.0"
+        "@types/node": "^22.2.0"
       },
       "engines": {
         "node": "^16.13 || >=18"
       }
+    },
+    "node_modules/@wdio/repl/node_modules/@types/node": {
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@wdio/repl/node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wdio/types": {
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.39.0.tgz",
       "integrity": "sha512-86lcYROTapOJuFd9ouomFDfzDnv3Kn+jE0RmqfvN9frZAeLVJ5IKjX9M6HjplsyTZhjGO1uCaehmzx+HJus33Q==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -3132,6 +3169,8 @@
       "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.39.0.tgz",
       "integrity": "sha512-jY+n6jlGeK+9Tx8T659PKLwMQTGpLW5H78CSEWgZLbjbVSr2LfGR8Lx0CRktNXxAtqEVZPj16Pi74OtAhvhE6Q==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "^1.6.0",
         "@wdio/logger": "8.38.0",
@@ -3723,7 +3762,8 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.0.tgz",
       "integrity": "sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/bare-fs": {
       "version": "2.1.5",
@@ -3731,6 +3771,7 @@
       "integrity": "sha512-5t0nlecX+N2uJqdxe9d18A98cp2u9BETelbjKpiVgQqzzmVNFYWEAjQHqS+2Khgto1vcwhik9cXucaj5ve2WWA==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-events": "^2.0.0",
         "bare-os": "^2.0.0",
@@ -3743,7 +3784,8 @@
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.0.tgz",
       "integrity": "sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/bare-path": {
       "version": "2.1.0",
@@ -3751,6 +3793,7 @@
       "integrity": "sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-os": "^2.1.0"
       }
@@ -4169,6 +4212,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       }
@@ -4178,6 +4222,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
       "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.2",
         "get-stream": "^6.0.1",
@@ -4196,6 +4241,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4411,15 +4457,25 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.16",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "mitt": "3.0.0"
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
       }
+    },
+    "node_modules/chromium-bidi/node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
@@ -4769,6 +4825,8 @@
     },
     "node_modules/cross-fetch": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4777,6 +4835,8 @@
     },
     "node_modules/cross-fetch/node_modules/node-fetch": {
       "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4796,16 +4856,22 @@
     },
     "node_modules/cross-fetch/node_modules/tr46": {
       "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/cross-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4952,6 +5018,8 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4966,6 +5034,8 @@
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5005,6 +5075,7 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -5114,11 +5185,11 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1262051",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1262051.tgz",
-      "integrity": "sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g==",
+      "version": "0.0.1359167",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1359167.tgz",
+      "integrity": "sha512-f/9PeTaSH3weS/WAwrQb5/s9R3KMOeTGe+Jkhg5952yInub7iDPjdlzRdrDgpLZfxHbTrBuG9aUkAMM+ocVkXQ==",
       "dev": true,
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/devtools/node_modules/@puppeteer/browsers": {
       "version": "1.3.0",
@@ -6275,6 +6346,7 @@
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
       "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14.17"
       }
@@ -6368,6 +6440,8 @@
       "integrity": "sha512-we2c2COgxFkLVuoknJNx+ioP+7VDq0sr6SCqWHTzlA4kzIbzR0EQ1Pps34s8WrsOnQqPC8a4sZV9dRPROOrkSg==",
       "dev": true,
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@wdio/logger": "^8.28.0",
         "decamelize": "^6.0.0",
@@ -6390,6 +6464,8 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
       "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -6402,6 +6478,8 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -6415,6 +6493,8 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
       "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -6427,6 +6507,8 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -6436,6 +6518,8 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
       "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -6449,6 +6533,8 @@
       "version": "4.0.0",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -6641,6 +6727,7 @@
       "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
       "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
         "@szmarczak/http-timer": "^5.0.1",
@@ -6666,6 +6753,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7000,6 +7088,7 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
       "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -7528,7 +7617,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -7624,6 +7714,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -7650,6 +7741,7 @@
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.33.3.tgz",
       "integrity": "sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -8097,6 +8189,7 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -9052,6 +9145,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -9090,7 +9184,9 @@
     "node_modules/mitt": {
       "version": "3.0.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -9262,6 +9358,7 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
       "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -9427,6 +9524,7 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
       "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       }
@@ -10081,157 +10179,29 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "20.9.0",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "1.4.6",
-        "chromium-bidi": "0.4.16",
+        "@puppeteer/browsers": "1.9.1",
+        "chromium-bidi": "0.5.8",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1147663",
-        "ws": "8.13.0"
+        "devtools-protocol": "0.0.1232444",
+        "ws": "8.16.0"
       },
       "engines": {
-        "node": ">=16.3.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-      "version": "1.4.6",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.0",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.1"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.7.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/agent-base": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
+        "node": ">=16.13.2"
       }
     },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.1147663",
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/puppeteer-core/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/puppeteer-core/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/proxy-agent": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/yargs": {
-      "version": "17.7.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/pvtsutils": {
       "version": "1.3.2",
@@ -10294,6 +10264,7 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -10622,7 +10593,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -10637,6 +10609,7 @@
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
       "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
@@ -12007,6 +11980,13 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/userhome": {
       "version": "1.0.0",
       "dev": true,
@@ -12592,18 +12572,19 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.39.0.tgz",
-      "integrity": "sha512-Kc3+SfiH4ufyrIht683VT2vnJocx0pfH8rYdyPvEh1b2OYewtFTHK36k9rBDHZiBmk6jcSXs4M2xeFgOuon9Lg==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.41.0.tgz",
+      "integrity": "sha512-n8OrFnVT4hAaGa0Advr3T8ObJdeKNTRklHIEzM2CYVx/5DZt+2KwaKSxWsURNd4zU7FbsfaJUU4rQWCmvozQLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^20.1.0",
+        "@types/node": "^22.2.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "8.39.0",
+        "@wdio/config": "8.41.0",
         "@wdio/logger": "8.38.0",
-        "@wdio/protocols": "8.38.0",
-        "@wdio/types": "8.39.0",
-        "@wdio/utils": "8.39.0",
+        "@wdio/protocols": "8.40.3",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.41.0",
         "deepmerge-ts": "^5.1.0",
         "got": "^12.6.1",
         "ky": "^0.33.0",
@@ -12613,24 +12594,241 @@
         "node": "^16.13 || >=18"
       }
     },
-    "node_modules/webdriverio": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.39.0.tgz",
-      "integrity": "sha512-pDpGu0V+TL1LkXPode67m3s+IPto4TcmcOzMpzFgu2oeLMBornoLN3yQSFR1fjZd1gK4UfnG3lJ4poTGOfbWfw==",
+    "node_modules/webdriver/node_modules/@types/node": {
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^20.1.0",
-        "@wdio/config": "8.39.0",
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/webdriver/node_modules/@wdio/config": {
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.41.0.tgz",
+      "integrity": "sha512-/6Z3sfSyhX5oVde0l01fyHimbqRYIVUDBnhDG2EMSCoC2lsaJX3Bm3IYpYHYHHFsgoDCi3B3Gv++t9dn2eSZZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@wdio/logger": "8.38.0",
-        "@wdio/protocols": "8.38.0",
-        "@wdio/repl": "8.24.12",
-        "@wdio/types": "8.39.0",
-        "@wdio/utils": "8.39.0",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.41.0",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.0.0",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/webdriver/node_modules/@wdio/protocols": {
+      "version": "8.40.3",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.40.3.tgz",
+      "integrity": "sha512-wK7+eyrB3TAei8RwbdkcyoNk2dPu+mduMBOdPJjp8jf/mavd15nIUXLID1zA+w5m1Qt1DsT1NbvaeO9+aJQ33A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webdriver/node_modules/@wdio/types": {
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.41.0.tgz",
+      "integrity": "sha512-t4NaNTvJZci3Xv/yUZPH4eTL0hxrVTf5wdwNnYIBrzMnlRDbNefjQ0P7FM7ZjQCLaH92AEH6t/XanUId7Webug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/webdriver/node_modules/@wdio/utils": {
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.41.0.tgz",
+      "integrity": "sha512-0TcTjBiax1VxtJQ/iQA0ZyYOSHjjX2ARVmEI0AMo9+AuIq+xBfnY561+v8k9GqOMPKsiH/HrK3xwjx8xCVS03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@puppeteer/browsers": "^1.6.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.41.0",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.1.0",
+        "edgedriver": "^5.5.0",
+        "geckodriver": "~4.2.0",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.1.0",
+        "safaridriver": "^0.1.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.0.4"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/webdriver/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webdriver/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/webdriver/node_modules/geckodriver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
+      "integrity": "sha512-4m/CRk0OI8MaANRuFIahvOxYTSjlNAO2p9JmE14zxueknq6cdtB5M9UGRQ8R9aMV0bLGNVHHDnDXmoXdOwJfWg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@wdio/logger": "^8.11.0",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.1",
+        "tar-fs": "^3.0.4",
+        "unzipper": "^0.10.14",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": "^16.13 || >=18 || >=20"
+      }
+    },
+    "node_modules/webdriver/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/webdriver/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webdriver/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webdriver/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/webdriver/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/webdriver/node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webdriver/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/webdriverio": {
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.41.0.tgz",
+      "integrity": "sha512-WlQfw0mUEhTS8DPr+TBSYMhEnqXkFr2dcUwPb5XkffTB+i0wftf+BLXJPSVD9M1PTLyYcFdCIu68pqR54dq5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0",
+        "@wdio/config": "8.41.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/protocols": "8.40.3",
+        "@wdio/repl": "8.40.3",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.41.0",
         "archiver": "^7.0.0",
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools-protocol": "^0.0.1302984",
+        "devtools-protocol": "^0.0.1359167",
         "grapheme-splitter": "^1.0.2",
         "import-meta-resolve": "^4.0.0",
         "is-plain-obj": "^4.1.0",
@@ -12638,12 +12836,12 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.zip": "^4.2.0",
         "minimatch": "^9.0.0",
-        "puppeteer-core": "^20.9.0",
+        "puppeteer-core": "^21.11.0",
         "query-selector-shadow-dom": "^1.0.0",
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^11.0.1",
-        "webdriver": "8.39.0"
+        "webdriver": "8.41.0"
       },
       "engines": {
         "node": "^16.13 || >=18"
@@ -12657,6 +12855,90 @@
         }
       }
     },
+    "node_modules/webdriverio/node_modules/@types/node": {
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/webdriverio/node_modules/@wdio/config": {
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.41.0.tgz",
+      "integrity": "sha512-/6Z3sfSyhX5oVde0l01fyHimbqRYIVUDBnhDG2EMSCoC2lsaJX3Bm3IYpYHYHHFsgoDCi3B3Gv++t9dn2eSZZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.41.0",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.0.0",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/webdriverio/node_modules/@wdio/protocols": {
+      "version": "8.40.3",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.40.3.tgz",
+      "integrity": "sha512-wK7+eyrB3TAei8RwbdkcyoNk2dPu+mduMBOdPJjp8jf/mavd15nIUXLID1zA+w5m1Qt1DsT1NbvaeO9+aJQ33A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webdriverio/node_modules/@wdio/types": {
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.41.0.tgz",
+      "integrity": "sha512-t4NaNTvJZci3Xv/yUZPH4eTL0hxrVTf5wdwNnYIBrzMnlRDbNefjQ0P7FM7ZjQCLaH92AEH6t/XanUId7Webug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/webdriverio/node_modules/@wdio/utils": {
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.41.0.tgz",
+      "integrity": "sha512-0TcTjBiax1VxtJQ/iQA0ZyYOSHjjX2ARVmEI0AMo9+AuIq+xBfnY561+v8k9GqOMPKsiH/HrK3xwjx8xCVS03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@puppeteer/browsers": "^1.6.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.41.0",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.1.0",
+        "edgedriver": "^5.5.0",
+        "geckodriver": "~4.2.0",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.1.0",
+        "safaridriver": "^0.1.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.0.4"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/webdriverio/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/webdriverio/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -12666,11 +12948,88 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/webdriverio/node_modules/devtools-protocol": {
-      "version": "0.0.1302984",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1302984.tgz",
-      "integrity": "sha512-Rgh2Sk5fUSCtEx4QGH9iwTyECdFPySG2nlz5J8guGh2Wlha6uzSOCq/DCEC8faHlLaMPZJMuZ4ovgcX4LvOkKA==",
-      "dev": true
+    "node_modules/webdriverio/node_modules/geckodriver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
+      "integrity": "sha512-4m/CRk0OI8MaANRuFIahvOxYTSjlNAO2p9JmE14zxueknq6cdtB5M9UGRQ8R9aMV0bLGNVHHDnDXmoXdOwJfWg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@wdio/logger": "^8.11.0",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.1",
+        "tar-fs": "^3.0.4",
+        "unzipper": "^0.10.14",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": "^16.13 || >=18 || >=20"
+      }
+    },
+    "node_modules/webdriverio/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/webdriverio/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webdriverio/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webdriverio/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/webdriverio/node_modules/minimatch": {
       "version": "9.0.4",
@@ -12685,6 +13044,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/webdriverio/node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webdriverio/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/eslint-plugin": "6.7.5",
     "@typescript-eslint/parser": "6.7.5",
     "@vitejs/plugin-basic-ssl": "^1.1.0",
-    "@wdio/globals": "^8.39.0",
+    "@wdio/globals": "^8.41.0",
     "astro": "4.16.18",
     "eslint": "8.51.0",
     "fake-indexeddb": "^4.0.2",
@@ -53,7 +53,7 @@
     "typescript": "5.2.2",
     "vite": "^5.4.6",
     "vitest": "^1.6.0",
-    "webdriverio": "^8.39.0"
+    "webdriverio": "^8.41.0"
   },
   "dependencies": {
     "@dfinity/agent": "^2.1.2",

--- a/src/frontend/screenshots.ts
+++ b/src/frontend/screenshots.ts
@@ -104,7 +104,7 @@ async function withChrome<T>(
   const browser = await remote({
     capabilities: {
       browserName: "chrome",
-      browserVersion: "122.0.6261.111	", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "131.0.6778.139", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": chromeOptions,
     },
   });

--- a/src/frontend/screenshots.ts
+++ b/src/frontend/screenshots.ts
@@ -104,7 +104,7 @@ async function withChrome<T>(
   const browser = await remote({
     capabilities: {
       browserName: "chrome",
-      browserVersion: "131.0.6778.139", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "131.0.6778.108", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": chromeOptions,
     },
   });

--- a/src/frontend/screenshots.ts
+++ b/src/frontend/screenshots.ts
@@ -104,7 +104,7 @@ async function withChrome<T>(
   const browser = await remote({
     capabilities: {
       browserName: "chrome",
-      browserVersion: "131.0.6778.108", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "122.0.6261.111", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": chromeOptions,
     },
   });

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -95,7 +95,7 @@ export async function runInBrowser(
   const browser = await remoteRetry({
     capabilities: {
       browserName: "chrome",
-      browserVersion: "131.0.6778.108", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "122.0.6261.111", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": chromeOptions,
     },
   });

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -95,7 +95,7 @@ export async function runInBrowser(
   const browser = await remoteRetry({
     capabilities: {
       browserName: "chrome",
-      browserVersion: "131.0.6778.139", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "131.0.6778.108", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": chromeOptions,
     },
   });

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -95,7 +95,7 @@ export async function runInBrowser(
   const browser = await remoteRetry({
     capabilities: {
       browserName: "chrome",
-      browserVersion: "122.0.6261.111	", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
+      browserVersion: "131.0.6778.139", // More information about available versions can be found here: https://github.com/GoogleChromeLabs/chrome-for-testing
       "goog:chromeOptions": chromeOptions,
     },
   });


### PR DESCRIPTION
# Motivation

CI e2e jobs and others are failing.

The problem was a new version of the Ubuntu runner 24.04 used as latest.

In this PR, I downgrade almost all jobs to use 22.04.

In subsequent PRs, I'll introduce ubuntu-latest job per job.

# Changes

* Change `ubuntu-latest` to `ubuntu-22.04`.
* Formatting changes done by IDE's prettier when saving the files.

# Tests

* Tests passing.




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/04e846b7e/mobile/allowCredentials.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



