### PR TITLE
Yubikey test feature

### DIFF
--- a/src/frontend/src/featureFlags/index.ts
+++ b/src/frontend/src/featureFlags/index.ts
@@ -2,6 +2,7 @@
 const FEATURE_FLAGS_WITH_DEFAULTS = {
   DOMAIN_COMPATIBILITY: false,
   OPENID_AUTHENTICATION: false,
+  HARDWARE_KEY_TEST: false,
 } as const satisfies Record<string, boolean>;
 
 const LOCALSTORAGE_FEATURE_FLAGS_PREFIX = "ii-localstorage-feature-flags__";
@@ -64,5 +65,8 @@ const initializedFeatureFlags = Object.fromEntries(
 window.__featureFlags = initializedFeatureFlags;
 
 // Export initialized feature flags as named exports
-export const { DOMAIN_COMPATIBILITY, OPENID_AUTHENTICATION } =
-  initializedFeatureFlags;
+export const {
+  DOMAIN_COMPATIBILITY,
+  OPENID_AUTHENTICATION,
+  HARDWARE_KEY_TEST,
+} = initializedFeatureFlags;

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -28,7 +28,7 @@ import {
   VerifyTentativeDeviceResponse,
 } from "$generated/internet_identity_types";
 import { fromMnemonicWithoutValidation } from "$src/crypto/ed25519";
-import { DOMAIN_COMPATIBILITY } from "$src/featureFlags";
+import { DOMAIN_COMPATIBILITY, HARDWARE_KEY_TEST } from "$src/featureFlags";
 import { features } from "$src/features";
 import {
   IdentityMetadata,
@@ -389,6 +389,12 @@ export class Connection {
 
     if (devices.length === 0) {
       return { kind: "unknownUser", userNumber };
+    }
+
+    if (HARDWARE_KEY_TEST.isEnabled()) {
+      devices = devices.filter(
+        (device) => Object.keys(device.key_type)[0] === "unknown"
+      );
     }
 
     return this.fromWebauthnCredentials(


### PR DESCRIPTION

# Motivation

Recent changes in how macOS and Chrome appear to be handling hardware FIDO2 devices, we need to run tests with users who are experiencing major issues.

# Changes

Add HARDWARE_KEY_TEST feature flag, filter out all key_type='unknown'… authenticators if feature flag is enabled. At the very least in identities with only on-device and yubikey authenticators, this filters out all but the yubikey. The effect is that, since only the yubikey is requested by the browser, the UX is restored.

To activate the feature flag, run ```window.__featureFlags.HARDWARE_KEY_TEST.set(true)``` in the browser console.

# Tests

I have tested it manually.
