### PR TITLE
Andri/yubikey test feature

### DIFF
--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -393,7 +393,9 @@ export class Connection {
 
     if (HARDWARE_KEY_TEST.isEnabled()) {
       devices = devices.filter(
-        (device) => Object.keys(device.key_type)[0] === "unknown"
+        (device) =>
+          Object.keys(device.key_type)[0] === "unknown" ||
+          Object.keys(device.key_type)[0] === "cross_platform"
       );
     }
 


### PR DESCRIPTION
# Motivation

See previous PR, Chrome yubikey UX is somewhat broken

# Changes

Add feature flag to filter out platform passkeys to test that UX works consistently if only hardware keys  are presented to credentials.get (this may not work if the hardware key was registered on Safari, as these are now also considered "platform"

# Tests

Manually in browser.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4d99e03c4/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4d99e03c4/desktop/allowCredentialsNoAnchor.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4d99e03c4/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4d99e03c4/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4d99e03c4/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4d99e03c4/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4d99e03c4/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4d99e03c4/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4d99e03c4/mobile/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4d99e03c4/mobile/verifyTentativeDevice.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
