### PR TITLE
Wrap Google open id config in option so it can be disabled.

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -1,6 +1,7 @@
 export const idlFactory = ({ IDL }) => {
   const MetadataMap = IDL.Rec();
   const MetadataMapV2 = IDL.Rec();
+  const OpenIdConfig = IDL.Record({ 'client_id' : IDL.Text });
   const ArchiveConfig = IDL.Record({
     'polling_interval_ns' : IDL.Nat64,
     'entries_buffer_limit' : IDL.Nat64,
@@ -26,12 +27,12 @@ export const idlFactory = ({ IDL }) => {
     'time_per_token_ns' : IDL.Nat64,
   });
   const InternetIdentityInit = IDL.Record({
+    'openid_google' : IDL.Opt(IDL.Opt(OpenIdConfig)),
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
     'related_origins' : IDL.Opt(IDL.Vec(IDL.Text)),
     'captcha_config' : IDL.Opt(CaptchaConfig),
-    'openid_google_client_id' : IDL.Opt(IDL.Text),
     'register_rate_limit' : IDL.Opt(RateLimitConfig),
   });
   const UserNumber = IDL.Nat64;
@@ -532,6 +533,7 @@ export const idlFactory = ({ IDL }) => {
   });
 };
 export const init = ({ IDL }) => {
+  const OpenIdConfig = IDL.Record({ 'client_id' : IDL.Text });
   const ArchiveConfig = IDL.Record({
     'polling_interval_ns' : IDL.Nat64,
     'entries_buffer_limit' : IDL.Nat64,
@@ -557,12 +559,12 @@ export const init = ({ IDL }) => {
     'time_per_token_ns' : IDL.Nat64,
   });
   const InternetIdentityInit = IDL.Record({
+    'openid_google' : IDL.Opt(IDL.Opt(OpenIdConfig)),
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
     'related_origins' : IDL.Opt(IDL.Vec(IDL.Text)),
     'captcha_config' : IDL.Opt(CaptchaConfig),
-    'openid_google_client_id' : IDL.Opt(IDL.Text),
     'register_rate_limit' : IDL.Opt(RateLimitConfig),
   });
   return [IDL.Opt(InternetIdentityInit)];

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -200,12 +200,12 @@ export type IdentityMetadataReplaceError = {
   };
 export type IdentityNumber = bigint;
 export interface InternetIdentityInit {
+  'openid_google' : [] | [[] | [OpenIdConfig]],
   'assigned_user_number_range' : [] | [[bigint, bigint]],
   'archive_config' : [] | [ArchiveConfig],
   'canister_creation_cycles_cost' : [] | [bigint],
   'related_origins' : [] | [Array<string>],
   'captcha_config' : [] | [CaptchaConfig],
-  'openid_google_client_id' : [] | [string],
   'register_rate_limit' : [] | [RateLimitConfig],
 }
 export interface InternetIdentityStats {
@@ -237,6 +237,7 @@ export type MetadataMapV2 = Array<
       { 'Bytes' : Uint8Array | number[] },
   ]
 >;
+export interface OpenIdConfig { 'client_id' : string }
 export type PrepareIdAliasError = { 'InternalCanisterError' : string } |
   { 'Unauthorized' : Principal };
 export interface PrepareIdAliasRequest {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -241,8 +241,8 @@ type CaptchaConfig = record {
 // Each field is wrapped is `opt` to indicate whether the field should
 // keep the previous value or update to a new value (e.g. `null` keeps the previous value).
 //
-// Some fields, like `openid_google`, have an additional nested `opt`,
-// this indicates enable/disable status (e.g. `opt null` disables a feature).
+// Some fields, like `openid_google`, have an additional nested `opt`, this indicates
+// enable/disable status (e.g. `opt null` disables a feature while `null` leaves it untouched).
 type InternetIdentityInit = record {
     // Set lowest and highest anchor
     assigned_user_number_range : opt record {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -237,7 +237,12 @@ type CaptchaConfig = record {
 };
 
 // Init arguments of II which can be supplied on install and upgrade.
-// Setting a value to null keeps the previous value.
+//
+// Each field is wrapped is `opt` to indicate whether the field should
+// keep the previous value or update to a new value (e.g. `null` keeps the previous value).
+//
+// Some fields, like `openid_google`, have an additional nested `opt`,
+// this indicates enable/disable status (e.g. `opt null` disables a feature).
 type InternetIdentityInit = record {
     // Set lowest and highest anchor
     assigned_user_number_range : opt record {
@@ -260,7 +265,7 @@ type InternetIdentityInit = record {
     // Configuration for Related Origins Requests
     related_origins: opt vec text;
     // Configuration for OpenID Google client
-    openid_google_client_id: opt text;
+    openid_google: opt opt OpenIdConfig;
 };
 
 type ChallengeKey = text;
@@ -316,6 +321,10 @@ type BufferedArchiveEntry = record {
     timestamp: Timestamp;
     sequence_number: nat64;
     entry: blob;
+};
+
+type OpenIdConfig = record {
+    client_id: text;
 };
 
 // API V2 specific types

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -396,7 +396,7 @@ fn initialize(maybe_arg: Option<InternetIdentityInit>) {
         .as_ref()
         .and_then(|arg| arg.openid_google.clone())
         .unwrap_or(persistent_state(|storage| storage.openid_google.clone()));
-    init_assets(Some(related_origins));
+    init_assets(related_origins.is_empty().then_some(related_origins));
     apply_install_arg(maybe_arg);
     update_root_hash();
     if let Some(config) = openid_google {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -24,6 +24,7 @@ use internet_identity_interface::internet_identity::types::vc_mvp::{
 use internet_identity_interface::internet_identity::types::*;
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
+use std::ops::Not;
 use storage::{Salt, Storage};
 
 mod anchor_management;
@@ -396,7 +397,7 @@ fn initialize(maybe_arg: Option<InternetIdentityInit>) {
         .as_ref()
         .and_then(|arg| arg.openid_google.clone())
         .unwrap_or(persistent_state(|storage| storage.openid_google.clone()));
-    init_assets(related_origins.is_empty().then_some(related_origins));
+    init_assets(related_origins.is_empty().not().then_some(related_origins));
     apply_install_arg(maybe_arg);
     update_root_hash();
     if let Some(config) = openid_google {

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -1,6 +1,6 @@
 use candid::{Deserialize, Principal};
 use identity_jose::jws::Decoder;
-use internet_identity_interface::internet_identity::types::{MetadataEntryV2, Timestamp};
+use internet_identity_interface::internet_identity::types::{MetadataEntryV2, OpenIdConfig, Timestamp};
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -31,9 +31,9 @@ thread_local! {
     static OPEN_ID_PROVIDERS: RefCell<Vec<Box<dyn OpenIdProvider >>> = RefCell::new(vec![]);
 }
 
-pub fn setup_google(client_id: String) {
+pub fn setup_google(config: OpenIdConfig) {
     OPEN_ID_PROVIDERS
-        .with_borrow_mut(|providers| providers.push(Box::new(google::Provider::create(client_id))));
+        .with_borrow_mut(|providers| providers.push(Box::new(google::Provider::create(config))));
 }
 
 #[allow(unused)]

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -1,6 +1,8 @@
 use candid::{Deserialize, Principal};
 use identity_jose::jws::Decoder;
-use internet_identity_interface::internet_identity::types::{MetadataEntryV2, OpenIdConfig, Timestamp};
+use internet_identity_interface::internet_identity::types::{
+    MetadataEntryV2, OpenIdConfig, Timestamp,
+};
 use std::cell::RefCell;
 use std::collections::HashMap;
 

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -105,8 +105,8 @@ pub struct PersistentState {
     pub captcha_config: CaptchaConfig,
     // Configuration for Related Origins Requests
     pub related_origins: Option<Vec<String>>,
-    // Configuration for OpenID Google client id
-    pub openid_google_client_id: Option<String>,
+    // Configuration for OpenID Google client
+    pub openid_google: Option<OpenIdConfig>,
     // Key into the event_data BTreeMap where the 24h tracking window starts.
     // This key is used to remove old entries from the 24h event aggregations.
     // If it is `none`, then the 24h window starts from the newest entry in the event_data
@@ -126,7 +126,7 @@ impl Default for PersistentState {
             active_authn_method_stats: ActivityStats::new(time),
             captcha_config: DEFAULT_CAPTCHA_CONFIG,
             related_origins: None,
-            openid_google_client_id: None,
+            openid_google: None,
             event_stats_24h_start: None,
         }
     }

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -8,7 +8,9 @@ use crate::stats::event_stats::EventKey;
 use candid::{CandidType, Deserialize};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
-use internet_identity_interface::internet_identity::types::{CaptchaConfig, FrontendHostname, OpenIdConfig, RateLimitConfig, Timestamp};
+use internet_identity_interface::internet_identity::types::{
+    CaptchaConfig, FrontendHostname, OpenIdConfig, RateLimitConfig, Timestamp,
+};
 use std::borrow::Cow;
 use std::collections::HashMap;
 

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -8,9 +8,7 @@ use crate::stats::event_stats::EventKey;
 use candid::{CandidType, Deserialize};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
-use internet_identity_interface::internet_identity::types::{
-    CaptchaConfig, FrontendHostname, RateLimitConfig, Timestamp,
-};
+use internet_identity_interface::internet_identity::types::{CaptchaConfig, FrontendHostname, OpenIdConfig, RateLimitConfig, Timestamp};
 use std::borrow::Cow;
 use std::collections::HashMap;
 
@@ -33,7 +31,7 @@ pub struct StorablePersistentState {
     event_stats_24h_start: Option<EventKey>,
     captcha_config: Option<CaptchaConfig>,
     related_origins: Option<Vec<String>>,
-    openid_google_client_id: Option<String>,
+    openid_google: Option<OpenIdConfig>,
 }
 
 impl Storable for StorablePersistentState {
@@ -72,7 +70,7 @@ impl From<PersistentState> for StorablePersistentState {
             event_stats_24h_start: s.event_stats_24h_start,
             captcha_config: Some(s.captcha_config),
             related_origins: s.related_origins,
-            openid_google_client_id: s.openid_google_client_id,
+            openid_google: s.openid_google,
         }
     }
 }
@@ -88,7 +86,7 @@ impl From<StorablePersistentState> for PersistentState {
             active_authn_method_stats: s.active_authn_method_stats,
             captcha_config: s.captcha_config.unwrap_or(DEFAULT_CAPTCHA_CONFIG),
             related_origins: s.related_origins,
-            openid_google_client_id: s.openid_google_client_id,
+            openid_google: s.openid_google,
             event_stats_24h_start: s.event_stats_24h_start,
         }
     }
@@ -134,7 +132,7 @@ mod tests {
                 captcha_trigger: CaptchaTrigger::Static(StaticCaptchaTrigger::CaptchaEnabled),
             }),
             related_origins: None,
-            openid_google_client_id: None,
+            openid_google: None,
         };
 
         assert_eq!(StorablePersistentState::default(), expected_defaults);
@@ -154,7 +152,7 @@ mod tests {
                 captcha_trigger: CaptchaTrigger::Static(StaticCaptchaTrigger::CaptchaEnabled),
             },
             related_origins: None,
-            openid_google_client_id: None,
+            openid_google: None,
             event_stats_24h_start: None,
         };
         assert_eq!(PersistentState::default(), expected_defaults);

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -3,7 +3,8 @@ use canister_tests::framework::{
     env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
-    ArchiveConfig, CaptchaConfig, CaptchaTrigger, InternetIdentityInit, RateLimitConfig,
+    ArchiveConfig, CaptchaConfig, CaptchaTrigger, InternetIdentityInit, OpenIdConfig,
+    RateLimitConfig,
 };
 use pocket_ic::CallError;
 
@@ -32,7 +33,7 @@ fn should_retain_anchor_on_user_range_change() -> Result<(), CallError> {
             },
         }),
         related_origins: None,
-        openid_google_client_id: None,
+        openid_google: None,
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
@@ -50,7 +51,9 @@ fn should_retain_config_after_none() -> Result<(), CallError> {
         "https://identity.icp0.io".to_string(),
     ]
     .to_vec();
-    let openid_google_client_id = "https://example.com".to_string();
+    let openid_google = OpenIdConfig {
+        client_id: "https://example.com".into(),
+    };
     let config = InternetIdentityInit {
         assigned_user_number_range: Some((3456, 798977)),
         archive_config: Some(ArchiveConfig {
@@ -73,7 +76,7 @@ fn should_retain_config_after_none() -> Result<(), CallError> {
             },
         }),
         related_origins: Some(related_origins),
-        openid_google_client_id: Some(openid_google_client_id),
+        openid_google: Some(Some(openid_google)),
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
@@ -96,7 +99,9 @@ fn should_override_partially() -> Result<(), CallError> {
         "https://identity.icp0.io".to_string(),
     ]
     .to_vec();
-    let openid_google_client_id = "https://example.com".to_string();
+    let openid_google = Some(OpenIdConfig {
+        client_id: "https://example.com".into(),
+    });
     let config = InternetIdentityInit {
         assigned_user_number_range: Some((3456, 798977)),
         archive_config: Some(ArchiveConfig {
@@ -119,7 +124,7 @@ fn should_override_partially() -> Result<(), CallError> {
             },
         }),
         related_origins: Some(related_origins),
-        openid_google_client_id: Some(openid_google_client_id),
+        openid_google: Some(openid_google),
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
@@ -141,7 +146,7 @@ fn should_override_partially() -> Result<(), CallError> {
         register_rate_limit: None,
         captcha_config: Some(new_captcha.clone()),
         related_origins: None,
-        openid_google_client_id: None,
+        openid_google: None,
     };
 
     let _ =
@@ -159,7 +164,7 @@ fn should_override_partially() -> Result<(), CallError> {
         "https://identity.ic0.app".to_string(),
     ]
     .to_vec();
-    let openid_google_client_id_2 = "https://example2.com".to_string();
+    let openid_google2 = None;
     let config_3 = InternetIdentityInit {
         assigned_user_number_range: None,
         archive_config: None,
@@ -167,7 +172,7 @@ fn should_override_partially() -> Result<(), CallError> {
         register_rate_limit: None,
         captcha_config: None,
         related_origins: Some(related_origins_2.clone()),
-        openid_google_client_id: Some(openid_google_client_id_2.clone()),
+        openid_google: Some(openid_google2.clone()),
     };
 
     let _ =
@@ -175,7 +180,7 @@ fn should_override_partially() -> Result<(), CallError> {
 
     let expected_config_3 = InternetIdentityInit {
         related_origins: Some(related_origins_2.clone()),
-        openid_google_client_id: Some(openid_google_client_id_2.clone()),
+        openid_google: Some(openid_google2.clone()),
         ..expected_config_2
     };
 

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -33,7 +33,7 @@ fn should_retain_anchor_on_user_range_change() -> Result<(), CallError> {
             },
         }),
         related_origins: None,
-        openid_google: None,
+        openid_google: Some(None),
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -93,7 +93,7 @@ fn ii_canister_serves_webauthn_assets() -> Result<(), CallError> {
         register_rate_limit: None,
         captcha_config: None,
         related_origins: Some(related_origins.clone()),
-        openid_google_client_id: None,
+        openid_google: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 
@@ -155,7 +155,7 @@ fn ii_canister_serves_webauthn_assets_after_upgrade() -> Result<(), CallError> {
         register_rate_limit: None,
         captcha_config: None,
         related_origins: Some(related_origins.clone()),
-        openid_google_client_id: None,
+        openid_google: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 
@@ -193,7 +193,7 @@ fn ii_canister_serves_webauthn_assets_after_upgrade() -> Result<(), CallError> {
         register_rate_limit: None,
         captcha_config: None,
         related_origins: Some(related_origins_2.clone()),
-        openid_google_client_id: None,
+        openid_google: None,
     };
 
     let _ = upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_2));
@@ -576,7 +576,7 @@ fn must_not_cache_well_known_webauthn() -> Result<(), CallError> {
         register_rate_limit: None,
         captcha_config: None,
         related_origins: Some(related_origins.clone()),
-        openid_google_client_id: None,
+        openid_google: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -193,8 +193,8 @@ pub struct AnchorCredentials {
 /// Each field is wrapped in `Option<>` to indicate whether the field should
 /// keep the previous value or update to a new value (e.g. `None` keeps the previous value).
 ///
-/// Some fields, like `openid_google`, have an additional nested `Option<>`,
-/// this indicates enable/disable status (e.g. `Some(None)` disables a feature).
+/// Some fields, like `openid_google`, have an additional nested `Option<>`, this indicates 
+/// enable/disable status (e.g. `Some(None)` disables a feature while `None` leaves it untouched).
 #[derive(Clone, Debug, CandidType, Deserialize, Default, Eq, PartialEq)]
 pub struct InternetIdentityInit {
     pub assigned_user_number_range: Option<(AnchorNumber, AnchorNumber)>,

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -189,10 +189,10 @@ pub struct AnchorCredentials {
 }
 
 /// Init arguments of II which can be supplied on install and upgrade.
-/// 
-/// Each field is wrapped in `Option<>` to indicate whether the field should 
+///
+/// Each field is wrapped in `Option<>` to indicate whether the field should
 /// keep the previous value or update to a new value (e.g. `None` keeps the previous value).
-/// 
+///
 /// Some fields, like `openid_google`, have an additional nested `Option<>`,
 /// this indicates enable/disable status (e.g. `Some(None)` disables a feature).
 #[derive(Clone, Debug, CandidType, Deserialize, Default, Eq, PartialEq)]

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -193,7 +193,7 @@ pub struct AnchorCredentials {
 /// Each field is wrapped in `Option<>` to indicate whether the field should
 /// keep the previous value or update to a new value (e.g. `None` keeps the previous value).
 ///
-/// Some fields, like `openid_google`, have an additional nested `Option<>`, this indicates 
+/// Some fields, like `openid_google`, have an additional nested `Option<>`, this indicates
 /// enable/disable status (e.g. `Some(None)` disables a feature while `None` leaves it untouched).
 #[derive(Clone, Debug, CandidType, Deserialize, Default, Eq, PartialEq)]
 pub struct InternetIdentityInit {

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -188,6 +188,13 @@ pub struct AnchorCredentials {
     pub recovery_phrases: Vec<PublicKey>,
 }
 
+/// Init arguments of II which can be supplied on install and upgrade.
+/// 
+/// Each field is wrapped in `Option<>` to indicate whether the field should 
+/// keep the previous value or update to a new value (e.g. `None` keeps the previous value).
+/// 
+/// Some fields, like `openid_google`, have an additional nested `Option<>`,
+/// this indicates enable/disable status (e.g. `Some(None)` disables a feature).
 #[derive(Clone, Debug, CandidType, Deserialize, Default, Eq, PartialEq)]
 pub struct InternetIdentityInit {
     pub assigned_user_number_range: Option<(AnchorNumber, AnchorNumber)>,
@@ -196,7 +203,7 @@ pub struct InternetIdentityInit {
     pub register_rate_limit: Option<RateLimitConfig>,
     pub captcha_config: Option<CaptchaConfig>,
     pub related_origins: Option<Vec<String>>,
-    pub openid_google_client_id: Option<String>,
+    pub openid_google: Option<Option<OpenIdConfig>>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -273,4 +280,9 @@ pub enum DeployArchiveResult {
     CreationInProgress,
     #[serde(rename = "failed")]
     Failed(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Default, Eq, PartialEq)]
+pub struct OpenIdConfig {
+    pub client_id: String,
 }


### PR DESCRIPTION
Wrap Google open id config in option so it can be disabled. Additionally, change client id to struct to allow multiple properties besides client id for each open id client.

# Tests

- Updated existing test to go from enabled -> disabled





<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c7d9cf744/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c7d9cf744/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c7d9cf744/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c7d9cf744/mobile/displayManage.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->




