### PR TITLE
Clean up cancelled RP IDs after removing device

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -506,7 +506,8 @@ export const readRecovery = ({
     } else {
       return {
         recoveryKey: {
-          remove: () => deleteDevice({ connection, device, reload }),
+          remove: () =>
+            deleteDevice({ connection, device, reload, userNumber }),
         },
       };
     }
@@ -558,7 +559,7 @@ export const devicesFromDevicesWithUsage = ({
         remove:
           hasSingleDevice && !hasOtherAuthMethods
             ? undefined
-            : () => deleteDevice({ connection, device, reload }),
+            : () => deleteDevice({ connection, device, reload, userNumber }),
       };
 
       if ("browser_storage_key" in device.key_type) {


### PR DESCRIPTION
# Motivation

The calculation of the RP ID depends on the devices. When a device is removed, a cancelled RP ID could be the solution. Therefore, we clean up the mapper that stores RP IDs.

# Changes

* Add `userNumber` in `deleteDevice` to call `cleanUpRpIdMapper` in parallel to removing the device.
* Pass the `userNumber` when `deleteDevice` is called.

# Tests

Tested in beta with #2781 PR
