### PR TITLE
Persist cancelled RP IDs

### DIFF
--- a/src/frontend/src/storage/index.ts
+++ b/src/frontend/src/storage/index.ts
@@ -744,6 +744,12 @@ const PrincipalDataV4 = z.object({
 /**
  * Mapper of which RP ID didn't work for the user
  *
+ * The Relying Party ID is used to get the passkey from the browser's WebAuthn API.
+ * Using different RP IDs allows us to have compatibility across multiple domains.
+ * However, when one RP ID is used and the user cancels, it must be because the user is in a device
+ * registered in another domain. In this case, we must try the other RP ID.
+ * By persisting this information, we ensure that the user won't have a bad UX a second time.
+ *
  * Record<ii_origin, Set<rp_id>>
  */
 const cancelledRpIdsMapper = z.record(


### PR DESCRIPTION
# Motivation

We want to improve the UX of users with credentials created in different domains. In their case, we might need to iterate through RP IDs to find the right one. Therefore, remembering which didn't work will avoid bad UX on returning users.

# Changes

* Move the stored cancelled RP IDs from an instance variable in `Connection` to browser storage.

# Tests

* Same tests apply. I added one extra test to check that a new `Connection` instance works the same way.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/abba50b69/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/abba50b69/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/abba50b69/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/abba50b69/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/abba50b69/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/abba50b69/mobile/displayManageSingle.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
