### PR TITLE
Expose origin of adding a device

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/addDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addDevice.ts
@@ -16,9 +16,11 @@ import { verifyTentativeDevice } from "./verifyTentativeDevice";
 export const addDevice = async ({
   userNumber,
   connection,
+  origin,
 }: {
   userNumber: bigint;
   connection: AuthenticatedConnection;
+  origin: string;
 }): Promise<void> => {
   // Enter registration mode and get info about the anchor
   const [timestamp, anchorInfo]: [Timestamp, IdentityAnchorInfo] =
@@ -35,7 +37,8 @@ export const addDevice = async ({
     const result = await pollForTentativeDevice(
       userNumber,
       connection,
-      timestamp
+      timestamp,
+      origin
     );
 
     if (result === "timeout") {

--- a/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/pollForTentativeDevice.ts
@@ -133,7 +133,8 @@ type PollReturn = DeviceData | "use-fido" | "timeout" | "canceled";
 export const pollForTentativeDevice = async (
   userNumber: bigint,
   connection: AuthenticatedConnection,
-  endTimestamp: Timestamp
+  endTimestamp: Timestamp,
+  origin: string
 ): Promise<PollReturn> => {
   const i18n = new I18n();
   const countdown: AsyncCountdown<PollReturn> =
@@ -142,7 +143,7 @@ export const pollForTentativeDevice = async (
   pollForTentativeDevicePage({
     cancel: () => countdown.stop("canceled"),
     useFIDO: () => countdown.stop("use-fido"),
-    origin: window.origin,
+    origin,
     userNumber,
     remaining: countdown.remainingFormattedAsync(),
     i18n,

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -289,7 +289,7 @@ export const renderManage = async ({
     }
     if (anchorInfo.device_registration.length !== 0) {
       // we are actually in a device registration process
-      await addDevice({ userNumber, connection });
+      await addDevice({ userNumber, connection, origin: window.origin });
       continue;
     }
 
@@ -363,7 +363,7 @@ export const displayManage = async (
     }
 
     const onAddDevice = async () => {
-      await addDevice({ userNumber, connection });
+      await addDevice({ userNumber, connection, origin: window.origin });
       resolve();
     };
     const addRecoveryPhrase = async () => {

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -244,7 +244,7 @@ export const recoveryWizard = async (
       status: devicesStatus,
     });
     if (userChoice.action === "add-device") {
-      await addDevice({ userNumber, connection });
+      await addDevice({ userNumber, connection, origin: window.origin });
     }
     if (userChoice.action === "do-not-remind") {
       connection.updateIdentityMetadata({


### PR DESCRIPTION
# Motivation

We want to avoid a bad UX for users when we migrate to `internetcomputer.org`. The bad UX appears when there are devices registered in multiple origins.

In this PR, the origin used for the `addDevice` flow is exposed as an argument instead of hardcoded to `window.origin`. This will be used in upcoming PRs to configure the RP ID of where to register the new device.

# Changes

* Add `origin` parameter to `addDevice` flow and use it.
* Pass `origin` as `window.origin` for now to not change the functionality.

# Tests

No functionality changed.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07f3133e7/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07f3133e7/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07f3133e7/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07f3133e7/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07f3133e7/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07f3133e7/mobile/allowCredentialsLongOrigins.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
