### PR TITLE
Add rpId to createOptions for new devices

### DIFF
--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -966,7 +966,8 @@ export const readDeviceOrigin = (): [] | [string] => {
 //  * https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/Attestation_and_Assertion
 export const creationOptions = (
   exclude: Omit<DeviceData, "alias">[] = [],
-  authenticatorAttachment?: AuthenticatorAttachment
+  authenticatorAttachment?: AuthenticatorAttachment,
+  rpId?: string
 ): PublicKeyCredentialCreationOptions => {
   return {
     authenticatorSelection: {
@@ -996,6 +997,7 @@ export const creationOptions = (
     ],
     rp: {
       name: "Internet Identity Service",
+      id: rpId,
     },
     user: {
       id: window.crypto.getRandomValues(new Uint8Array(16)),


### PR DESCRIPTION
# Motivation

We want to avoid a bad UX for users when we migrate to internetcomputer.org. The bad UX appears when there are devices registered in multiple origins.

In this PR, I add a new parameter `rpId` to the `createOptions` helper to create Webauthn passkey options. This will be used in following PRs.

# Changes

* Add `rpId` as optional parameter to `createOptions`.

# Tests

Tested locally that the parameter works as expected.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f59bc3ce5/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f59bc3ce5/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f59bc3ce5/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f59bc3ce5/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f59bc3ce5/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f59bc3ce5/mobile/recoverWithDevice.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
