### PR TITLE
Fix device recovery flow, filter out recovery methods that aren't devices

### DIFF
--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -99,7 +99,8 @@ const attemptRecovery = async ({
   const devices = await connection.lookupAll(userNumber);
 
   const recoveryCredentials = devices.filter(
-    ({ purpose }) => "recovery" in purpose
+    ({ purpose, key_type }) =>
+      "recovery" in purpose && !("seed_phrase" in key_type)
   );
 
   if (recoveryCredentials.length === 0) {


### PR DESCRIPTION
Fix device recovery flow, filter out recovery methods that aren't devices

# Changes

- Filter out recovery methods that aren't devices (seed phrase recovery method)

# Tests

See device recovery flow e2e tests in this PR: https://github.com/dfinity/internet-identity/pull/2790

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c0d6dc9b8/desktop/allowCredentialsNoAnchor.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c0d6dc9b8/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c0d6dc9b8/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c0d6dc9b8/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c0d6dc9b8/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c0d6dc9b8/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c0d6dc9b8/mobile/allowCredentialsLongOrigins.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
