### PR TITLE
Add device based on credentials' origin

### DIFF
--- a/src/frontend/src/flows/addDevice/addCurrentDevice.ts
+++ b/src/frontend/src/flows/addDevice/addCurrentDevice.ts
@@ -1,5 +1,6 @@
 import { infoScreenTemplate } from "$src/components/infoScreen";
 import { I18n } from "$src/i18n";
+import { getCredentialsOrigin } from "$src/utils/credential-devices";
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
 import { renderPage } from "$src/utils/lit-html";
 import { TemplateResult } from "lit-html";
@@ -43,10 +44,17 @@ export const addCurrentDeviceScreen = (
     addCurrentDevicePage({
       i18n: new I18n(),
       add: async () => {
-        const existingDevices = await connection.lookupAuthenticators(
-          userNumber
+        const credentials = await connection.lookupAuthenticators(userNumber);
+        const originNewDevice = getCredentialsOrigin({
+          credentials,
+          userAgent: navigator.userAgent,
+        });
+        await addCurrentDevice(
+          userNumber,
+          connection,
+          credentials,
+          originNewDevice
         );
-        await addCurrentDevice(userNumber, connection, existingDevices);
         resolve();
       },
       skip: () => resolve(),

--- a/src/frontend/src/flows/addDevice/manage/addDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addDevice.ts
@@ -54,7 +54,12 @@ export const addDevice = async ({
       // If the user wants to add a FIDO device then we can (should) exit registration mode
       // (only used for adding extra browsers)
       await withLoader(() => connection.exitDeviceRegistrationMode());
-      await addCurrentDevice(userNumber, connection, anchorInfo.devices);
+      await addCurrentDevice(
+        userNumber,
+        connection,
+        anchorInfo.devices,
+        origin
+      );
       return;
     } else if (result === "canceled") {
       // If the user canceled, disable registration mode and return

--- a/src/frontend/src/flows/recovery/recoveryWizard.test.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.test.ts
@@ -1,9 +1,4 @@
-import {
-  AnchorCredentials,
-  CredentialId,
-  PublicKey,
-  WebAuthnCredential,
-} from "$generated/internet_identity_types";
+import { DeviceData } from "$generated/internet_identity_types";
 import { PinIdentityMaterial } from "../pin/idb";
 import { getDevicesStatus } from "./recoveryWizard";
 
@@ -15,52 +10,67 @@ const lessThanAWeekAgo = nowInMillis - 1;
 const pinIdentityMaterial: PinIdentityMaterial =
   {} as unknown as PinIdentityMaterial;
 
-const noCredentials: AnchorCredentials = {
-  credentials: [],
-  recovery_credentials: [],
-  recovery_phrases: [],
+const noCredentials: Omit<DeviceData, "alias">[] = [];
+
+const recoveryPhrase: Omit<DeviceData, "alias"> = {
+  origin: [],
+  protection: { unprotected: null },
+  // eslint-disable-next-line
+  pubkey: undefined as any,
+  key_type: { seed_phrase: null },
+  purpose: { recovery: null },
+  credential_id: [],
+  metadata: [],
 };
 
-const device: WebAuthnCredential = {
-  pubkey: [] as PublicKey,
-  credential_id: [] as CredentialId,
+const device: Omit<DeviceData, "alias"> = {
+  origin: [],
+  protection: { unprotected: null },
+  // eslint-disable-next-line
+  pubkey: undefined as any,
+  key_type: { unknown: null },
+  purpose: { authentication: null },
+  credential_id: [],
+  metadata: [],
 };
 
-const oneDeviceOnly: AnchorCredentials = {
-  credentials: [device],
-  recovery_credentials: [],
-  recovery_phrases: [],
+const recoveryDevice: Omit<DeviceData, "alias"> = {
+  metadata: [],
+  origin: [],
+  protection: { protected: null },
+  pubkey: new Uint8Array(),
+  key_type: { cross_platform: null },
+  purpose: { recovery: null },
+  credential_id: [Uint8Array.from([0, 0, 0, 0, 0])],
 };
 
-const oneRecoveryDeviceOnly: AnchorCredentials = {
-  credentials: [],
-  recovery_credentials: [device],
-  recovery_phrases: [],
-};
+const oneDeviceOnly: Omit<DeviceData, "alias">[] = [device];
 
-const oneDeviceAndPhrase: AnchorCredentials = {
-  credentials: [device],
-  recovery_credentials: [],
-  recovery_phrases: [[] as PublicKey],
-};
+const oneRecoveryDeviceOnly: Omit<DeviceData, "alias">[] = [recoveryDevice];
 
-const twoDevices: AnchorCredentials = {
-  credentials: [device, { ...device }],
-  recovery_credentials: [],
-  recovery_phrases: [[] as PublicKey],
-};
+const oneDeviceAndPhrase: Omit<DeviceData, "alias">[] = [
+  device,
+  recoveryPhrase,
+];
 
-const threeDevices: AnchorCredentials = {
-  credentials: [device, { ...device }, { ...device }],
-  recovery_credentials: [],
-  recovery_phrases: [[] as PublicKey],
-};
+const twoDevices: Omit<DeviceData, "alias">[] = [
+  device,
+  { ...device },
+  recoveryPhrase,
+];
 
-const oneNormalOneRecovery: AnchorCredentials = {
-  credentials: [device],
-  recovery_credentials: [device],
-  recovery_phrases: [[] as PublicKey],
-};
+const threeDevices: Omit<DeviceData, "alias">[] = [
+  device,
+  { ...device },
+  { ...device },
+  recoveryPhrase,
+];
+
+const oneNormalOneRecovery: Omit<DeviceData, "alias">[] = [
+  device,
+  recoveryDevice,
+  recoveryPhrase,
+];
 
 test("getDevicesStatus returns 'pin-only' for user with pin and has seen recovery longer than a week ago", () => {
   expect(

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -5,9 +5,10 @@ import { TemplateResult } from "lit-html";
 
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
 
-import { AnchorCredentials } from "$generated/internet_identity_types";
+import { DeviceData } from "$generated/internet_identity_types";
 import { infoScreenTemplate } from "$src/components/infoScreen";
 import { IdentityMetadata } from "$src/repositories/identityMetadata";
+import { getCredentialsOrigin } from "$src/utils/credential-devices";
 import { isNullish } from "@dfinity/utils";
 import { addDevice } from "../addDevice/manage/addDevice";
 import {
@@ -167,7 +168,7 @@ export const addDeviceWarning = ({
  * * User has only one device.
  *
  * @param params {Object}
- * @param params.credentials {AnchorCredentials}
+ * @param params.credentials {Omit<DeviceData, "alias">[]}
  * @param params.identityMetadata {IdentityMetadata | undefined}
  * @param params.pinIdentityMaterial {PinIdentityMaterial | undefined}
  * @param params.nowInMillis {number}
@@ -180,7 +181,7 @@ export const getDevicesStatus = ({
   pinIdentityMaterial,
   nowInMillis,
 }: {
-  credentials: AnchorCredentials;
+  credentials: Omit<DeviceData, "alias">[];
   identityMetadata: IdentityMetadata | undefined;
   pinIdentityMaterial: PinIdentityMaterial | undefined;
   nowInMillis: number;
@@ -193,8 +194,10 @@ export const getDevicesStatus = ({
   const showWarningPageEnabled = isNullish(
     identityMetadata?.doNotShowRecoveryPageRequestTimestampMillis
   );
-  const totalDevicesCount =
-    credentials.credentials.length + credentials.recovery_credentials.length;
+  const totalDevicesCount = credentials.filter(
+    (c) => !("seed_phrase" in c.key_type)
+  ).length;
+
   if (
     totalDevicesCount <= 1 &&
     hasNotSeenRecoveryPageLastWeek &&
@@ -220,7 +223,7 @@ export const recoveryWizard = async (
   const [credentials, identityMetadata, pinIdentityMaterial] = await withLoader(
     () =>
       Promise.all([
-        connection.lookupCredentials(userNumber),
+        connection.lookupAll(userNumber),
         connection.getIdentityMetadata(),
         idbRetrievePinIdentityMaterial({
           userNumber,
@@ -236,6 +239,11 @@ export const recoveryWizard = async (
     nowInMillis,
   });
 
+  const originNewDevice = getCredentialsOrigin({
+    credentials,
+    userAgent: navigator.userAgent,
+  });
+
   if (devicesStatus !== "no-warning") {
     connection.updateIdentityMetadata({
       recoveryPageShownTimestampMillis: nowInMillis,
@@ -244,7 +252,11 @@ export const recoveryWizard = async (
       status: devicesStatus,
     });
     if (userChoice.action === "add-device") {
-      await addDevice({ userNumber, connection, origin: window.origin });
+      await addDevice({
+        userNumber,
+        connection,
+        origin: originNewDevice ?? window.origin,
+      });
     }
     if (userChoice.action === "do-not-remind") {
       connection.updateIdentityMetadata({

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -8,6 +8,7 @@ import {
   creationOptions,
   IC_DERIVATION_PATH,
 } from "$src/utils/iiConnection";
+import { readDeviceOrigin } from "$src/utils/readDeviceOrigin";
 import { unreachable, unreachableLax } from "$src/utils/utils";
 import { DerEncodedPublicKey, SignIdentity } from "@dfinity/agent";
 import { WebAuthnIdentity } from "@dfinity/identity";
@@ -64,6 +65,7 @@ export const setupKey = async ({
         { recovery: null },
         recoverIdentity.getPublicKey().toDer(),
         { unprotected: null },
+        readDeviceOrigin(),
         recoverIdentity.rawId
       );
     });
@@ -89,7 +91,8 @@ export const setupPhrase = async (
           { seed_phrase: null },
           { recovery: null },
           pubkey,
-          { unprotected: null }
+          { unprotected: null },
+          readDeviceOrigin()
         )
       ),
   });

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -8,6 +8,7 @@ import {
   Connection,
   LoginSuccess,
 } from "$src/utils/iiConnection";
+import { readDeviceOrigin } from "$src/utils/readDeviceOrigin";
 import { unknownToString, unreachableLax } from "$src/utils/utils";
 import { constructIdentity } from "$src/utils/webAuthn";
 import {
@@ -160,6 +161,7 @@ const enrollAuthenticator = async ({
       { authentication: null },
       newDevice.getPublicKey().toDer(),
       { unprotected: null },
+      readDeviceOrigin(),
       newDevice.rawId
     );
   } catch (error: unknown) {

--- a/src/frontend/src/utils/authnMethodData.ts
+++ b/src/frontend/src/utils/authnMethodData.ts
@@ -4,9 +4,9 @@ import {
   MetadataMapV2,
 } from "$generated/internet_identity_types";
 import { CredentialId } from "$src/utils/credential-devices";
-import { readDeviceOrigin } from "$src/utils/iiConnection";
 import { DerEncodedPublicKey } from "@dfinity/agent";
 import { nonNullish } from "@dfinity/utils";
+import { readDeviceOrigin } from "./readDeviceOrigin";
 
 /**
  * Helper to create a new PinIdentity authn method to be used in a registration flow.
@@ -77,7 +77,7 @@ const defaultSecuritySettings = (): AuthnMethodSecuritySettings => {
 
 const addOriginToMetadata = (metadata: MetadataMapV2) => {
   const origin = readDeviceOrigin();
-  if (origin.length !== 0) {
+  if (origin !== undefined) {
     metadata.push(["origin", { String: origin[0] }]);
   }
 };

--- a/src/frontend/src/utils/credential-devices.test.ts
+++ b/src/frontend/src/utils/credential-devices.test.ts
@@ -1,0 +1,101 @@
+import { DeviceData } from "$generated/internet_identity_types";
+import { getCredentialsOrigin } from "./credential-devices";
+
+describe("credetial-devices test", () => {
+  describe("getCredentialsOrigin", () => {
+    const createDevice = (
+      origin: string | undefined
+    ): Omit<DeviceData, "alias"> => ({
+      origin: origin === undefined ? [] : [origin],
+      protection: { unprotected: null },
+      // eslint-disable-next-line
+      pubkey: undefined as any,
+      key_type: { unknown: null },
+      purpose: { authentication: null },
+      credential_id: [],
+      metadata: [],
+    });
+
+    const undefinedOriginDevice: Omit<DeviceData, "alias"> =
+      createDevice(undefined);
+    const ic0OriginDevice: Omit<DeviceData, "alias"> = createDevice(
+      "https://identity.ic0.app"
+    );
+    const icOrgOriginDevice: Omit<DeviceData, "alias"> = createDevice(
+      "https://identity.internetcomputer.org"
+    );
+    const icIoOriginDevice: Omit<DeviceData, "alias"> = createDevice(
+      "https://identity.icp0.io"
+    );
+    const userAgentSupportingRoR =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+    const userAgentNotSupportingRoR =
+      "Mozilla/5.0 (Android 13; Mobile; rv:132.0) Gecko/132.0 Firefox/132.0";
+
+    it("should return a set of origins", () => {
+      expect(
+        getCredentialsOrigin({
+          credentials: [ic0OriginDevice, icOrgOriginDevice, icIoOriginDevice],
+          userAgent: userAgentSupportingRoR,
+        })
+      ).toBeUndefined();
+
+      expect(
+        getCredentialsOrigin({
+          credentials: [
+            ic0OriginDevice,
+            { ...ic0OriginDevice },
+            icIoOriginDevice,
+          ],
+          userAgent: userAgentSupportingRoR,
+        })
+      ).toBeUndefined();
+
+      expect(
+        getCredentialsOrigin({
+          credentials: [ic0OriginDevice, { ...ic0OriginDevice }],
+          userAgent: userAgentSupportingRoR,
+        })
+      ).toBe("https://identity.ic0.app");
+
+      expect(
+        getCredentialsOrigin({
+          credentials: [icOrgOriginDevice, { ...icOrgOriginDevice }],
+          userAgent: userAgentSupportingRoR,
+        })
+      ).toBe("https://identity.internetcomputer.org");
+    });
+
+    it("should consider `undefined` as the default domain", () => {
+      expect(
+        getCredentialsOrigin({
+          credentials: [undefinedOriginDevice],
+          userAgent: userAgentSupportingRoR,
+        })
+      ).toBe("https://identity.ic0.app");
+
+      expect(
+        getCredentialsOrigin({
+          credentials: [undefinedOriginDevice, ic0OriginDevice],
+          userAgent: userAgentSupportingRoR,
+        })
+      ).toBe("https://identity.ic0.app");
+
+      expect(
+        getCredentialsOrigin({
+          credentials: [undefinedOriginDevice, icOrgOriginDevice],
+          userAgent: userAgentSupportingRoR,
+        })
+      ).toBeUndefined();
+    });
+
+    it("returns `undefined` if user doesn't support RoR", () => {
+      expect(
+        getCredentialsOrigin({
+          credentials: [ic0OriginDevice, icOrgOriginDevice, icIoOriginDevice],
+          userAgent: userAgentNotSupportingRoR,
+        })
+      ).toBeUndefined();
+    });
+  });
+});

--- a/src/frontend/src/utils/credential-devices.ts
+++ b/src/frontend/src/utils/credential-devices.ts
@@ -1,5 +1,7 @@
 import { DeviceData, DeviceKey } from "$generated/internet_identity_types";
+import { DEFAULT_DOMAIN } from "$showcase/constants";
 import { DerEncodedPublicKey } from "@dfinity/agent";
+import { supportsWebauthRoR } from "./userAgent";
 
 export type CredentialId = ArrayBuffer;
 export type CredentialData = {
@@ -31,4 +33,42 @@ export const convertToValidCredentialData = (
     pubkey: derFromPubkey(device.pubkey),
     origin: device.origin[0],
   };
+};
+
+/**
+ * Helper to encapsulate the logic of finding the RP ID needed when a device will be added.
+ *
+ * We want to avoid a bad UX when users log in.
+ * If the user has multiple devices registered in different origins,
+ * it can lead to bad UX when calculating the RP ID.
+ *
+ * Therefore, we want to avoid devices registered in multiple origins.
+ *
+ * First, it checks whether the browser supports ROR.
+ * Second, it checks whether all the devices have the same origin.
+ * - If they do, it returns the origin.
+ * - If they don't, it returns `undefined`.
+ *
+ * @param credentials
+ * @returns {string | undefined} The origin to use when adding a new device.
+ * - If `undefined` then no common origin was found. Probalby use `window.origin` or `undefined` for RP ID.
+ * - If `string` then the origin can be used to add a new device. Remember to use the hostname only for RP ID.
+ */
+export const getCredentialsOrigin = ({
+  credentials,
+  userAgent,
+}: {
+  credentials: Omit<DeviceData, "alias">[];
+  userAgent: string;
+}): string | undefined => {
+  if (!supportsWebauthRoR(userAgent)) {
+    return undefined;
+  }
+  const credentialOrigins = new Set(
+    credentials.map((c) => c.origin[0] ?? DEFAULT_DOMAIN)
+  );
+  if (credentialOrigins.size === 1) {
+    return credentialOrigins.values().next().value;
+  }
+  return undefined;
 };

--- a/src/frontend/src/utils/findWebAuthnRpId.ts
+++ b/src/frontend/src/utils/findWebAuthnRpId.ts
@@ -1,7 +1,6 @@
+import { DEFAULT_DOMAIN } from "$showcase/constants";
 import { CredentialData } from "./credential-devices";
 
-// This is used when the origin is empty in the device data.
-const DEFAULT_DOMAIN = "https://identity.ic0.app";
 export const PROD_DOMAINS = [
   "https://identity.ic0.app",
   "https://identity.internetcomputer.org",

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -723,6 +723,7 @@ export class AuthenticatedConnection extends Connection {
     purpose: Purpose,
     newPublicKey: DerEncodedPublicKey,
     protection: DeviceData["protection"],
+    origin: string | undefined,
     credentialId?: ArrayBuffer
   ): Promise<void> => {
     const actor = await this.getActor();
@@ -735,7 +736,7 @@ export class AuthenticatedConnection extends Connection {
       key_type: keyType,
       purpose,
       protection,
-      origin: readDeviceOrigin(),
+      origin: origin === undefined ? [] : [origin],
       metadata: [],
     });
   };
@@ -937,19 +938,6 @@ export class AuthenticatedConnection extends Connection {
     await this._mockOpenID.remove_jwt(this.userNumber, iss, sub);
   };
 }
-
-// Reads the "origin" used to infer what domain a FIDO device is available on.
-// The canister only allow for 50 characters, so for long domains we don't attach an origin
-// (those long domains are most likely a testnet with URL like <canister id>.large03.testnet.dfinity.network, and we basically only care about identity.ic0.app & identity.internetcomputer.org).
-//
-// The return type is odd but that's what our didc version expects.
-export const readDeviceOrigin = (): [] | [string] => {
-  if (isNullish(window?.origin) || window.origin.length > 50) {
-    return [];
-  }
-
-  return [window.origin];
-};
 
 // The options sent to the browser when creating the credentials.
 // Credentials (key pair) creation is signed with a private key that is unique per device

--- a/src/frontend/src/utils/readDeviceOrigin.ts
+++ b/src/frontend/src/utils/readDeviceOrigin.ts
@@ -1,0 +1,14 @@
+import { isNullish } from "@dfinity/utils";
+
+// Reads the "origin" used to infer what domain a FIDO device is available on.
+// The canister only allow for 50 characters, so for long domains we don't attach an origin
+// (those long domains are most likely a testnet with URL like <canister id>.large03.testnet.dfinity.network, and we basically only care about identity.ic0.app & identity.internetcomputer.org).
+//
+// The return type is odd but that's what our didc version expects.
+export const readDeviceOrigin = (): string | undefined => {
+  if (isNullish(window?.origin) || window.origin.length > 50) {
+    return undefined;
+  }
+
+  return window.origin;
+};

--- a/src/showcase/src/constants.ts
+++ b/src/showcase/src/constants.ts
@@ -5,6 +5,9 @@ export const dapps = getDapps();
 
 export const iiLegacyOrigin = "https://identity.ic0.app";
 
+// This is used when the origin is empty in the device data.
+export const DEFAULT_DOMAIN = iiLegacyOrigin;
+
 const recoveryPhraseText =
   "10050 mandate vague same suspect eight pet gentle repeat maple actor about legal sword text food print material churn perfect sword blossom sleep vintage blouse";
 


### PR DESCRIPTION
# Motivation

Draft PR that enforces that new devices added through adding one device use the same origin as current credentials.

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/acfc9eb45/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/acfc9eb45/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/acfc9eb45/mobile/allowCredentialsNoAnchor.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/acfc9eb45/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/acfc9eb45/mobile/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
