### PR TITLE
Pass all credentials when logging in

### DIFF
--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -227,12 +227,10 @@ describe("Connection.login", () => {
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(2);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
           2,
-          expect.arrayContaining([currentDeviceCredentialData]),
-          "identity.ic0.app"
-        );
-        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
-          2,
-          expect.not.arrayContaining([currentOriginCredentialData]),
+          expect.arrayContaining([
+            currentDeviceCredentialData,
+            currentDeviceCredentialData,
+          ]),
           "identity.ic0.app"
         );
       }
@@ -278,12 +276,10 @@ describe("Connection.login", () => {
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(2);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
           2,
-          expect.arrayContaining([currentDeviceCredentialData]),
-          "identity.ic0.app"
-        );
-        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
-          2,
-          expect.not.arrayContaining([currentOriginCredentialData]),
+          expect.arrayContaining([
+            currentDeviceCredentialData,
+            currentDeviceCredentialData,
+          ]),
           "identity.ic0.app"
         );
       }

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -428,7 +428,8 @@ export class Connection {
      */
     const identity = features.DUMMY_AUTH
       ? new DummyIdentity()
-      : MultiWebAuthnIdentity.fromCredentials(filteredCredentials, rpId);
+      : // Passing all the credentials doesn't hurt and it could help in case an `origin` was wrongly set in the backend.
+        MultiWebAuthnIdentity.fromCredentials(credentials, rpId);
     let delegationIdentity: DelegationIdentity;
 
     // Here we expect a webauth exception if the user canceled the webauthn prompt (triggered by


### PR DESCRIPTION
# Motivation

In case there is a bug when setting the origin of a device, we don't want to prevent that device from being used.

Therefore, we pass all the credentials when getting the `MultiWebAuthnIdentity` instead of the filtered ones. This doesn't hurt the UX.

# Changes

* Use `credentials` instead of `filteredCredentials` when creating `MultiWebAuthnIdentity`.

# Tests

* Tested in beta that UX is the same.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2f5bcb114/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2f5bcb114/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2f5bcb114/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2f5bcb114/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2f5bcb114/mobile/displayManage.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


