### PR TITLE
Show add current device screen once a week

### DIFF
--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -8,6 +8,7 @@ import {
   IdentityMetadata,
   RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
 } from "$src/repositories/identityMetadata";
+import { setAnchorUsed } from "$src/storage";
 import { ActorSubclass, DerEncodedPublicKey, Signature } from "@dfinity/agent";
 import { DelegationIdentity, WebAuthnIdentity } from "@dfinity/identity";
 import { IDBFactory } from "fake-indexeddb";
@@ -292,6 +293,61 @@ describe("Connection.login", () => {
       const thirdLoginResult = await newConnection.login(BigInt(12345));
 
       expect(thirdLoginResult.kind).toBe("loginSuccess");
+    });
+
+    it("show add current device depends on the last time the anchor was used", async () => {
+      const creationDate = new Date("2025-01-05");
+      vi.useFakeTimers().setSystemTime(creationDate);
+
+      const userNumber = BigInt(12345);
+      // This one would fail because it's not the device the user is using at the moment.
+      const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
+      const currentDevice: DeviceData = createMockDevice();
+      const mockActor = {
+        identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
+        lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
+      } as unknown as ActorSubclass<_SERVICE>;
+      const connection = new Connection("aaaaa-aa", mockActor);
+
+      failSign = true;
+      const firstLoginResult = await connection.login(userNumber);
+
+      expect(firstLoginResult.kind).toBe("possiblyWrongRPID");
+
+      failSign = false;
+      const secondLoginResult = await connection.login(userNumber);
+
+      expect(secondLoginResult.kind).toBe("loginSuccess");
+      if (secondLoginResult.kind === "loginSuccess") {
+        expect(secondLoginResult.showAddCurrentDevice).toBe(true);
+      }
+
+      // This is necessary to set the last used anchor timestamp
+      await setAnchorUsed(userNumber);
+      const oneDayMillis = 24 * 60 * 60 * 1000;
+      vi.useFakeTimers().advanceTimersByTime(oneDayMillis);
+
+      const newConnection = new Connection("aaaaa-aa", mockActor);
+      const thirdLoginResult = await newConnection.login(userNumber);
+
+      expect(thirdLoginResult.kind).toBe("loginSuccess");
+      if (thirdLoginResult.kind === "loginSuccess") {
+        expect(thirdLoginResult.showAddCurrentDevice).toBe(false);
+      }
+
+      // This is necessary to set the last used anchor timestamp
+      await setAnchorUsed(userNumber);
+      vi.useFakeTimers().advanceTimersByTime(oneDayMillis * 7 + 1000);
+
+      const anotherConnection = new Connection("aaaaa-aa", mockActor);
+      const fourthLoginResult = await anotherConnection.login(userNumber);
+
+      expect(fourthLoginResult.kind).toBe("loginSuccess");
+      if (fourthLoginResult.kind === "loginSuccess") {
+        expect(fourthLoginResult.showAddCurrentDevice).toBe(true);
+      }
+
+      vi.useRealTimers();
     });
 
     it("connection doesn't exclude rpId if user has only one domain", async () => {


### PR DESCRIPTION
# Motivation

Do not nudge the user every time there was cancelled RP IDs.

Showing the screen to add current device was introduced when the cancelled RP IDs was persisted.

In this PR, I change the logic to only show the page the first time and then only if the anchor was used more than a week ago.


# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/99eff7d7f/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/99eff7d7f/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/99eff7d7f/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/99eff7d7f/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/99eff7d7f/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/99eff7d7f/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/99eff7d7f/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/99eff7d7f/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/99eff7d7f/mobile/displayManageSingle.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

