### PR TITLE
Fix device recovery e2e test being flaky, remove old duplicate line.

### DIFF
--- a/src/frontend/src/test-e2e/recovery/index.test.ts
+++ b/src/frontend/src/test-e2e/recovery/index.test.ts
@@ -28,7 +28,6 @@ test("Recover with phrase", async () => {
 test("Recover with device", async () => {
   await runInBrowser(async (browser: WebdriverIO.Browser) => {
     const loginAuthenticator = await addVirtualAuthenticator(browser);
-    await addVirtualAuthenticator(browser);
     await browser.url(II_URL);
     const userNumber = await FLOWS.registerNewIdentityWelcomeView(browser);
     const mainView = new MainView(browser);


### PR DESCRIPTION
Fix device recovery e2e test being flaky, remove old duplicate line.

# Tests

- Updated device recovery e2e test

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d127e1faa/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d127e1faa/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d127e1faa/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d127e1faa/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d127e1faa/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d127e1faa/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d127e1faa/desktop/setPin.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d127e1faa/mobile/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
