### PR TITLE
Add a new timestamp and make used one optional in anchor storage

### DIFF
--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -8,6 +8,7 @@ import {
   IdentityMetadata,
   RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
 } from "$src/repositories/identityMetadata";
+import { setAnchorUsed } from "$src/storage";
 import { ActorSubclass, DerEncodedPublicKey, Signature } from "@dfinity/agent";
 import { DelegationIdentity, WebAuthnIdentity } from "@dfinity/identity";
 import { IDBFactory } from "fake-indexeddb";
@@ -292,6 +293,61 @@ describe("Connection.login", () => {
       const thirdLoginResult = await newConnection.login(BigInt(12345));
 
       expect(thirdLoginResult.kind).toBe("loginSuccess");
+    });
+
+    it("show add current device depends on the last time the anchor was used", async () => {
+      const creationDate = new Date("2025-01-05");
+      vi.useFakeTimers().setSystemTime(creationDate);
+
+      const userNumber = BigInt(12345);
+      // This one would fail because it's not the device the user is using at the moment.
+      const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
+      const currentDevice: DeviceData = createMockDevice();
+      const mockActor = {
+        identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
+        lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
+      } as unknown as ActorSubclass<_SERVICE>;
+      const connection = new Connection("aaaaa-aa", mockActor);
+
+      failSign = true;
+      const firstLoginResult = await connection.login(userNumber);
+
+      expect(firstLoginResult.kind).toBe("possiblyWrongRPID");
+
+      failSign = false;
+      const secondLoginResult = await connection.login(userNumber);
+
+      expect(secondLoginResult.kind).toBe("loginSuccess");
+      if (secondLoginResult.kind === "loginSuccess") {
+        expect(secondLoginResult.showAddCurrentDevice).toBe(true);
+      }
+
+      // This is necessary to set the last used anchor timestamp
+      await setAnchorUsed(userNumber);
+      const oneDayMillis = 24 * 60 * 60 * 1000;
+      vi.useFakeTimers().advanceTimersByTime(oneDayMillis);
+
+      const newConnection = new Connection("aaaaa-aa", mockActor);
+      const thirdLoginResult = await newConnection.login(userNumber);
+
+      expect(thirdLoginResult.kind).toBe("loginSuccess");
+      if (thirdLoginResult.kind === "loginSuccess") {
+        expect(thirdLoginResult.showAddCurrentDevice).toBe(false);
+      }
+
+      // This is necessary to set the last used anchor timestamp
+      await setAnchorUsed(userNumber);
+      vi.useFakeTimers().advanceTimersByTime(oneDayMillis * 7 + 1000);
+
+      const anotherConnection = new Connection("aaaaa-aa", mockActor);
+      const fourthLoginResult = await anotherConnection.login(userNumber);
+
+      expect(fourthLoginResult.kind).toBe("loginSuccess");
+      if (fourthLoginResult.kind === "loginSuccess") {
+        expect(fourthLoginResult.showAddCurrentDevice).toBe(true);
+      }
+
+      vi.useRealTimers();
     });
 
     it("connection doesn't exclude rpId if user has only one domain", async () => {

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -405,7 +405,7 @@ export class Connection {
     credentials: CredentialData[]
   ): Promise<LoginSuccess | WebAuthnFailed | PossiblyWrongRPID | AuthFail> => {
     // Get cancelled rpids for the user from local storage.
-    const { cancelledRpIds, lastUsedTimestamp } = await getCancelledRpIds({
+    const { cancelledRpIds } = await getCancelledRpIds({
       userNumber,
       origin: window.location.origin,
     });
@@ -476,19 +476,11 @@ export class Connection {
       actor
     );
 
-    // We want to show the page to add the current device if
-    // there are cancelled rpids and (the anchor is new or was used more than a week ago)
-    const oneWeekMillis = 1000 * 60 * 60 * 24 * 7;
-    const weekAgoMillis = Date.now() - oneWeekMillis;
-    const showAddCurrentDevice =
-      cancelledRpIds.size > 0 &&
-      (lastUsedTimestamp === undefined || lastUsedTimestamp < weekAgoMillis);
-
     return {
       kind: "loginSuccess",
       userNumber,
       connection,
-      showAddCurrentDevice,
+      showAddCurrentDevice: cancelledRpIds.size > 0,
     };
   };
   fromIdentity = async (


### PR DESCRIPTION
# Motivation

Do not nudge the user every time there was cancelled RP IDs.

Showing the screen to add current device was introduced when the cancelled RP IDs was persisted.

In this PR, I add a new optional field `lastShownAddCurrentDevicePage`.

# Changes

<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/62d655de4/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/62d655de4/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/62d655de4/mobile/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
