### PR TITLE
Show add current device page only once

### DIFF
--- a/src/frontend/src/flows/addDevice/addCurrentDevice.ts
+++ b/src/frontend/src/flows/addDevice/addCurrentDevice.ts
@@ -1,5 +1,6 @@
 import { infoScreenTemplate } from "$src/components/infoScreen";
 import { I18n } from "$src/i18n";
+import { setLastShownAddCurrentDevicePage } from "$src/storage";
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
 import { renderPage } from "$src/utils/lit-html";
 import { TemplateResult } from "lit-html";
@@ -35,10 +36,11 @@ export const addCurrentDevicePage = renderPage(addCurrentDeviceTemplate);
 
 // Prompt the user to add the current device (with the current origin).
 // Adding the current device to the current origin improves the UX of the user when they come back to this origin.
-export const addCurrentDeviceScreen = (
+export const addCurrentDeviceScreen = async (
   userNumber: bigint,
   connection: AuthenticatedConnection
 ): Promise<void> => {
+  await setLastShownAddCurrentDevicePage(userNumber);
   return new Promise((resolve) =>
     addCurrentDevicePage({
       i18n: new I18n(),

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -8,6 +8,7 @@ import {
   IdentityMetadata,
   RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
 } from "$src/repositories/identityMetadata";
+import { setLastShownAddCurrentDevicePage } from "$src/storage";
 import { ActorSubclass, DerEncodedPublicKey, Signature } from "@dfinity/agent";
 import { DelegationIdentity, WebAuthnIdentity } from "@dfinity/identity";
 import { IDBFactory } from "fake-indexeddb";
@@ -288,6 +289,61 @@ describe("Connection.login", () => {
       const thirdLoginResult = await newConnection.login(BigInt(12345));
 
       expect(thirdLoginResult.kind).toBe("loginSuccess");
+    });
+
+    it("show add current device depends on the last time the anchor was used", async () => {
+      const creationDate = new Date("2025-01-05");
+      vi.useFakeTimers().setSystemTime(creationDate);
+
+      const userNumber = BigInt(12345);
+      // This one would fail because it's not the device the user is using at the moment.
+      const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
+      const currentDevice: DeviceData = createMockDevice();
+      const mockActor = {
+        identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
+        lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
+      } as unknown as ActorSubclass<_SERVICE>;
+      const connection = new Connection("aaaaa-aa", mockActor);
+
+      failSign = true;
+      const firstLoginResult = await connection.login(userNumber);
+
+      expect(firstLoginResult.kind).toBe("possiblyWrongRPID");
+
+      failSign = false;
+      const secondLoginResult = await connection.login(userNumber);
+
+      expect(secondLoginResult.kind).toBe("loginSuccess");
+      if (secondLoginResult.kind === "loginSuccess") {
+        expect(secondLoginResult.showAddCurrentDevice).toBe(true);
+      }
+
+      // This is necessary to set the last page shown timestamp
+      await setLastShownAddCurrentDevicePage(userNumber);
+      const oneDayMillis = 24 * 60 * 60 * 1000;
+      vi.useFakeTimers().advanceTimersByTime(oneDayMillis);
+
+      const newConnection = new Connection("aaaaa-aa", mockActor);
+      const thirdLoginResult = await newConnection.login(userNumber);
+
+      expect(thirdLoginResult.kind).toBe("loginSuccess");
+      if (thirdLoginResult.kind === "loginSuccess") {
+        expect(thirdLoginResult.showAddCurrentDevice).toBe(false);
+      }
+
+      // This is necessary to set the last page shown timestamp
+      await setLastShownAddCurrentDevicePage(userNumber);
+      vi.useFakeTimers().advanceTimersByTime(oneDayMillis * 7 + 1000);
+
+      const anotherConnection = new Connection("aaaaa-aa", mockActor);
+      const fourthLoginResult = await anotherConnection.login(userNumber);
+
+      expect(fourthLoginResult.kind).toBe("loginSuccess");
+      if (fourthLoginResult.kind === "loginSuccess") {
+        expect(fourthLoginResult.showAddCurrentDevice).toBe(true);
+      }
+
+      vi.useRealTimers();
     });
 
     it("connection doesn't exclude rpId if user has only one domain", async () => {


### PR DESCRIPTION
# Motivation

Do not nudge the user every time there was cancelled RP IDs.

Showing the screen to add current device was introduced when the cancelled RP IDs was persisted.

In this PR, I change the logic to only show the page the first time and when the user hasn't seen it in a week.

# Changes

* Use the new field `lastShownAddCurrentDevicePage` to calculate `showAddCurrentDevice` value.
* Call `setLastShownAddCurrentDevicePage` when the add current device screen is shown.

# Tests

* Add a test to check how `showAddCurrentDevice` evolves with time.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2d6b0c8f3/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/2d6b0c8f3/mobile/allowCredentialsNoAnchor.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
