### PR TITLE
Change the warning icon in devices list

### DIFF
--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -187,7 +187,7 @@ const itemWarning = ({
 const itemInfo = (msg: TemplateResult): TemplateResult => html`<div
   class="c-action-list__action"
 >
-  <span class="c-tooltip c-icon c-icon--ok" tabindex="0"
+  <span class="c-tooltip c-icon" tabindex="0"
     >${infoIcon}<span class="c-tooltip__message c-card c-card--tight"
       >${msg}</span
     ></span

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -1,4 +1,4 @@
-import { warningIcon } from "$src/components/icons";
+import { infoIcon, warningIcon } from "$src/components/icons";
 import { formatLastUsage } from "$src/utils/time";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { TemplateResult, html } from "lit-html";
@@ -110,7 +110,7 @@ export const authenticatorsSection = ({
 };
 
 export const authenticatorItem = ({
-  authenticator: { alias, last_usage, dupCount, warn, remove, rename },
+  authenticator: { alias, last_usage, dupCount, warn, info, remove, rename },
   index,
   icon,
 }: {
@@ -137,9 +137,15 @@ export const authenticatorItem = ({
     lastUsageFormattedString = formatLastUsage(lastUsageTimeStamp);
   }
 
+  // It's up to the caller to take care that only one of the icons is present.
+  // The UI is not ready to support multiple icons.
+  // `warn` is used to show a warning icon when the device was registered in a different oring than current one.
+  // `info` is used to show an info icon of where the device was registered, only when some device has a different origin than the others.
+  // `icon` is used for the PIN authenticator.
   return html`
     <li class="c-action-list__item" data-device=${alias}>
       ${isNullish(warn) ? undefined : itemWarning({ warn })}
+      ${isNullish(info) ? undefined : itemInfo(info)}
       ${isNullish(icon) ? undefined : html`${icon}`}
       <div class="c-action-list__label--stacked c-action-list__label">
         <div class="c-action-list__label c-action-list__label--spacer">
@@ -174,6 +180,16 @@ const itemWarning = ({
   <span class="c-tooltip c-icon c-icon--error" tabindex="0"
     >${warningIcon}<span class="c-tooltip__message c-card c-card--tight"
       >${warn}</span
+    ></span
+  >
+</div>`;
+
+const itemInfo = (msg: TemplateResult): TemplateResult => html`<div
+  class="c-action-list__action"
+>
+  <span class="c-tooltip c-icon c-icon--ok" tabindex="0"
+    >${infoIcon}<span class="c-tooltip__message c-card c-card--tight"
+      >${msg}</span
     ></span
   >
 </div>`;

--- a/src/frontend/src/flows/manage/devicesFromDevicesWithUsage.test.ts
+++ b/src/frontend/src/flows/manage/devicesFromDevicesWithUsage.test.ts
@@ -1,0 +1,108 @@
+import { DeviceWithUsage } from "$generated/internet_identity_types";
+import { DOMAIN_COMPATIBILITY } from "$src/featureFlags";
+import { AuthenticatedConnection } from "$src/utils/iiConnection";
+import { isNullish } from "@dfinity/utils";
+import { devicesFromDevicesWithUsage } from ".";
+
+describe("devicesFromDevicesWithUsage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("location", {
+      origin: "https://identity.ic0.app",
+    });
+    vi.stubGlobal("navigator", {
+      // Supports RoR
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+    });
+    DOMAIN_COMPATIBILITY.reset();
+  });
+
+  const mockConnection = {} as unknown as AuthenticatedConnection;
+
+  const createDevice = (origin: string | undefined): DeviceWithUsage => ({
+    alias: "alias",
+    last_usage: [],
+    metadata: [],
+    origin: isNullish(origin) ? [] : [origin],
+    protection: { unprotected: null },
+    pubkey: [],
+    key_type: { platform: null },
+    purpose: { authentication: null },
+    credential_id: [],
+  });
+
+  describe("domains compatibility flag disabled", () => {
+    beforeEach(() => {
+      DOMAIN_COMPATIBILITY.set(false);
+    });
+
+    it("returns warning icon in the device in different origin als current", () => {
+      const devices = [
+        createDevice(undefined),
+        createDevice("https://identity.ic0.app"),
+        createDevice("https://identity.internetcomputer.org"),
+      ];
+      const expectedDevices = devicesFromDevicesWithUsage({
+        devices,
+        reload: () => undefined,
+        connection: mockConnection,
+        userNumber: BigInt(12345),
+        hasOtherAuthMethods: false,
+      });
+
+      expect(expectedDevices.authenticators[0].warn).toBeUndefined();
+      expect(expectedDevices.authenticators[1].warn).toBeUndefined();
+      expect(expectedDevices.authenticators[2].warn?.strings[0]).toContain(
+        "This Passkey may not be usable on the current URL"
+      );
+    });
+  });
+
+  describe("domains compatibility flag enabled", () => {
+    beforeEach(() => {
+      DOMAIN_COMPATIBILITY.set(true);
+    });
+
+    it("returns an info icon on each device if they are not all in the same origin", () => {
+      const devices = [
+        createDevice(undefined),
+        createDevice("https://identity.ic0.app"),
+        createDevice("https://identity.internetcomputer.org"),
+      ];
+      const expectedDevices = devicesFromDevicesWithUsage({
+        devices,
+        reload: () => undefined,
+        connection: mockConnection,
+        userNumber: BigInt(12345),
+        hasOtherAuthMethods: false,
+      });
+
+      for (const device of expectedDevices.authenticators) {
+        expect(device.info?.strings[0]).toContain(
+          "This passkey was registered in"
+        );
+        expect(device.warn).toBeUndefined();
+      }
+    });
+
+    it("returns no info nor warning if all devices are in the same origin", () => {
+      const devices = [
+        createDevice(undefined),
+        createDevice("https://identity.ic0.app"),
+      ];
+      const expectedDevices = devicesFromDevicesWithUsage({
+        devices,
+        reload: () => undefined,
+        connection: mockConnection,
+        userNumber: BigInt(12345),
+        hasOtherAuthMethods: false,
+      });
+
+      for (const device of expectedDevices.authenticators) {
+        expect(device.info).toBeUndefined();
+        expect(device.warn).toBeUndefined();
+      }
+    });
+  });
+});

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -628,7 +628,7 @@ export const domainWarning = (
   }
 };
 
-export const domainInfo = (
+const domainInfo = (
   device: DeviceData,
   allDevices: DeviceData[]
 ): TemplateResult | undefined => {

--- a/src/frontend/src/flows/manage/migration.test.ts
+++ b/src/frontend/src/flows/manage/migration.test.ts
@@ -1,20 +1,6 @@
 import { DeviceData } from "$generated/internet_identity_types";
 import { domainWarning } from "$src/flows/manage";
 
-function onOrigin(origin: string, fn: () => void) {
-  const oldOrigin = window.origin;
-  Object.defineProperty(window, "origin", {
-    writable: true,
-    value: origin,
-  });
-
-  fn();
-  Object.defineProperty(window, "origin", {
-    writable: true,
-    value: oldOrigin,
-  });
-}
-
 const recoveryPhrase: DeviceData = {
   alias: "Recovery Phrase",
   origin: [],
@@ -39,54 +25,74 @@ const authenticator: DeviceData = {
   metadata: [],
 };
 
-test("recovery phrases don't have origin warnings", () => {
-  onOrigin("https://identity.ic0.app", () => {
-    expect(domainWarning(recoveryPhrase)).toBe(undefined);
-    expect(
-      domainWarning({ ...recoveryPhrase, origin: ["https://elsewhere"] })
-    ).toBe(undefined);
+describe("recovery phrases don't have origin warnings", () => {
+  describe("on legacy domain", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.stubGlobal("location", {
+        origin: "https://identity.ic0.app",
+      });
+    });
+
+    it("returns undefined for recovery phrase", () => {
+      expect(domainWarning(recoveryPhrase)).toBe(undefined);
+      expect(
+        domainWarning({ ...recoveryPhrase, origin: ["https://elsewhere"] })
+      ).toBe(undefined);
+    });
+
+    it("no origin is not warning", () => {
+      expect(domainWarning({ ...authenticator, origin: [] })).toBe(undefined);
+    });
+
+    it("legacy origin in not warning", () => {
+      expect(
+        domainWarning({
+          ...authenticator,
+          origin: ["https://identity.ic0.app"],
+        })
+      ).toBeUndefined();
+    });
+
+    test("bad origin is warning", () => {
+      expect(
+        domainWarning({ ...authenticator, origin: ["https://elsewhere"] })
+      ).toBeDefined();
+    });
   });
 
-  onOrigin("https://identity.internetcomputer.org", () => {
-    expect(domainWarning(recoveryPhrase)).toBe(undefined);
-    expect(
-      domainWarning({ ...recoveryPhrase, origin: ["https://elsewhere"] })
-    ).toBe(undefined);
-  });
-});
+  describe("on internetcomputer.org", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.stubGlobal("location", {
+        origin: "https://identity.internetcomputer.org",
+      });
+    });
 
-test("no origin on legacy domain is not warning", () => {
-  onOrigin("https://identity.ic0.app", () => {
-    expect(domainWarning({ ...authenticator, origin: [] })).toBe(undefined);
-  });
-});
+    it("undefined for recovery phrase", () => {
+      expect(domainWarning(recoveryPhrase)).toBe(undefined);
+      expect(
+        domainWarning({ ...recoveryPhrase, origin: ["https://elsewhere"] })
+      ).toBe(undefined);
+    });
 
-test("bad origin on legacy domain is warning", () => {
-  onOrigin("https://identity.ic0.app", () => {
-    expect(
-      domainWarning({ ...authenticator, origin: ["https://elsewhere"] })
-    ).toBeDefined();
-  });
-});
+    it("no origin is warning", () => {
+      expect(domainWarning({ ...authenticator, origin: [] })).toBeDefined();
+    });
 
-test("no origin on official domain is warning", () => {
-  onOrigin("https://identity.internetcomputer.org", () => {
-    expect(domainWarning({ ...authenticator, origin: [] })).toBeDefined();
-  });
-});
+    it("legacy origin is warning", () => {
+      expect(
+        domainWarning({
+          ...authenticator,
+          origin: ["https://identity.ic0.app"],
+        })
+      ).toBeDefined();
+    });
 
-test("legacy origin on official domain is warning", () => {
-  onOrigin("https://identity.internetcomputer.org", () => {
-    expect(
-      domainWarning({ ...authenticator, origin: ["https://identity.ic0.app"] })
-    ).toBeDefined();
-  });
-});
-
-test("bad origin on official domain is warning", () => {
-  onOrigin("https://identity.internetcomputer.org", () => {
-    expect(
-      domainWarning({ ...authenticator, origin: ["https://elsewhere"] })
-    ).toBeDefined();
+    it("bad origin is warning", () => {
+      expect(
+        domainWarning({ ...authenticator, origin: ["https://elsewhere"] })
+      ).toBeDefined();
+    });
   });
 });

--- a/src/frontend/src/flows/manage/types.ts
+++ b/src/frontend/src/flows/manage/types.ts
@@ -6,7 +6,10 @@ export type Authenticator = {
   last_usage: [] | [bigint];
   rename: () => void;
   remove?: () => void;
+  // `warn` is used to show a warning icon when the device was registered in a different oring than current one.
   warn?: TemplateResult;
+  // `info` is used to show an info icon of where the device was registered, only when some device has a different origin than the others.
+  info?: TemplateResult;
 };
 
 // A recovery phrase, potentially protected


### PR DESCRIPTION
# Motivation

At the moment, there is a warning icon saying that the current device won't work if the origin where it was registered it's different than the current origin. This is not the case anymore with the domains compatibility.

In this PR, we show an info icon of where the device was registered, only if the devices where not registered all in the same origin.

# Changes

* Add new field `info` to `Authenticator`.
* Calculate new field with `domainInfo` in `devicesFromDevicesWithUsage`.
* Templating helper `itemInfo`.
* Use new template helper to render the new icon in `authenticatorItem`.
* Improve documentation of the fields.

# Tests

Add tests for `devicesFromDevicesWithUsage`. Not complete, but at least to test the current behavior I added.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bc229156b/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/bc229156b/mobile/setPin.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


