### PR TITLE
Use devices' origin in add new device from recovery wizard

### DIFF
--- a/src/frontend/src/flows/recovery/recoveryWizard.test.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.test.ts
@@ -1,9 +1,4 @@
-import {
-  AnchorCredentials,
-  CredentialId,
-  PublicKey,
-  WebAuthnCredential,
-} from "$generated/internet_identity_types";
+import { DeviceData } from "$generated/internet_identity_types";
 import { PinIdentityMaterial } from "../pin/idb";
 import { getDevicesStatus } from "./recoveryWizard";
 
@@ -15,52 +10,67 @@ const lessThanAWeekAgo = nowInMillis - 1;
 const pinIdentityMaterial: PinIdentityMaterial =
   {} as unknown as PinIdentityMaterial;
 
-const noCredentials: AnchorCredentials = {
-  credentials: [],
-  recovery_credentials: [],
-  recovery_phrases: [],
+const noCredentials: Omit<DeviceData, "alias">[] = [];
+
+const recoveryPhrase: Omit<DeviceData, "alias"> = {
+  origin: [],
+  protection: { unprotected: null },
+  // eslint-disable-next-line
+  pubkey: undefined as any,
+  key_type: { seed_phrase: null },
+  purpose: { recovery: null },
+  credential_id: [],
+  metadata: [],
 };
 
-const device: WebAuthnCredential = {
-  pubkey: [] as PublicKey,
-  credential_id: [] as CredentialId,
+const device: Omit<DeviceData, "alias"> = {
+  origin: [],
+  protection: { unprotected: null },
+  // eslint-disable-next-line
+  pubkey: undefined as any,
+  key_type: { unknown: null },
+  purpose: { authentication: null },
+  credential_id: [],
+  metadata: [],
 };
 
-const oneDeviceOnly: AnchorCredentials = {
-  credentials: [device],
-  recovery_credentials: [],
-  recovery_phrases: [],
+const recoveryDevice: Omit<DeviceData, "alias"> = {
+  metadata: [],
+  origin: [],
+  protection: { protected: null },
+  pubkey: new Uint8Array(),
+  key_type: { cross_platform: null },
+  purpose: { recovery: null },
+  credential_id: [Uint8Array.from([0, 0, 0, 0, 0])],
 };
 
-const oneRecoveryDeviceOnly: AnchorCredentials = {
-  credentials: [],
-  recovery_credentials: [device],
-  recovery_phrases: [],
-};
+const oneDeviceOnly: Omit<DeviceData, "alias">[] = [device];
 
-const oneDeviceAndPhrase: AnchorCredentials = {
-  credentials: [device],
-  recovery_credentials: [],
-  recovery_phrases: [[] as PublicKey],
-};
+const oneRecoveryDeviceOnly: Omit<DeviceData, "alias">[] = [recoveryDevice];
 
-const twoDevices: AnchorCredentials = {
-  credentials: [device, { ...device }],
-  recovery_credentials: [],
-  recovery_phrases: [[] as PublicKey],
-};
+const oneDeviceAndPhrase: Omit<DeviceData, "alias">[] = [
+  device,
+  recoveryPhrase,
+];
 
-const threeDevices: AnchorCredentials = {
-  credentials: [device, { ...device }, { ...device }],
-  recovery_credentials: [],
-  recovery_phrases: [[] as PublicKey],
-};
+const twoDevices: Omit<DeviceData, "alias">[] = [
+  device,
+  { ...device },
+  recoveryPhrase,
+];
 
-const oneNormalOneRecovery: AnchorCredentials = {
-  credentials: [device],
-  recovery_credentials: [device],
-  recovery_phrases: [[] as PublicKey],
-};
+const threeDevices: Omit<DeviceData, "alias">[] = [
+  device,
+  { ...device },
+  { ...device },
+  recoveryPhrase,
+];
+
+const oneNormalOneRecovery: Omit<DeviceData, "alias">[] = [
+  device,
+  recoveryDevice,
+  recoveryPhrase,
+];
 
 test("getDevicesStatus returns 'pin-only' for user with pin and has seen recovery longer than a week ago", () => {
   expect(

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -7,6 +7,7 @@ import { AuthenticatedConnection } from "$src/utils/iiConnection";
 
 import { DeviceData } from "$generated/internet_identity_types";
 import { infoScreenTemplate } from "$src/components/infoScreen";
+import { DOMAIN_COMPATIBILITY } from "$src/featureFlags";
 import { IdentityMetadata } from "$src/repositories/identityMetadata";
 import { getCredentialsOrigin } from "$src/utils/credential-devices";
 import { isNullish } from "@dfinity/utils";
@@ -238,10 +239,12 @@ export const recoveryWizard = async (
     nowInMillis,
   });
 
-  const originNewDevice = getCredentialsOrigin({
-    credentials,
-    userAgent: navigator.userAgent,
-  });
+  const originNewDevice = DOMAIN_COMPATIBILITY.isEnabled()
+    ? getCredentialsOrigin({
+        credentials,
+        userAgent: navigator.userAgent,
+      })
+    : undefined;
 
   if (devicesStatus !== "no-warning") {
     connection.updateIdentityMetadata({

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -5,9 +5,10 @@ import { TemplateResult } from "lit-html";
 
 import { AuthenticatedConnection } from "$src/utils/iiConnection";
 
-import { AnchorCredentials } from "$generated/internet_identity_types";
+import { DeviceData } from "$generated/internet_identity_types";
 import { infoScreenTemplate } from "$src/components/infoScreen";
 import { IdentityMetadata } from "$src/repositories/identityMetadata";
+import { getCredentialsOrigin } from "$src/utils/credential-devices";
 import { isNullish } from "@dfinity/utils";
 import { addDevice } from "../addDevice/manage/addDevice";
 import {
@@ -167,7 +168,7 @@ export const addDeviceWarning = ({
  * * User has only one device.
  *
  * @param params {Object}
- * @param params.credentials {AnchorCredentials}
+ * @param params.credentials {Omit<DeviceData, "alias">[]}
  * @param params.identityMetadata {IdentityMetadata | undefined}
  * @param params.pinIdentityMaterial {PinIdentityMaterial | undefined}
  * @param params.nowInMillis {number}
@@ -180,7 +181,7 @@ export const getDevicesStatus = ({
   pinIdentityMaterial,
   nowInMillis,
 }: {
-  credentials: AnchorCredentials;
+  credentials: Omit<DeviceData, "alias">[];
   identityMetadata: IdentityMetadata | undefined;
   pinIdentityMaterial: PinIdentityMaterial | undefined;
   nowInMillis: number;
@@ -193,8 +194,9 @@ export const getDevicesStatus = ({
   const showWarningPageEnabled = isNullish(
     identityMetadata?.doNotShowRecoveryPageRequestTimestampMillis
   );
-  const totalDevicesCount =
-    credentials.credentials.length + credentials.recovery_credentials.length;
+  const totalDevicesCount = credentials.filter(
+    ({ key_type }) => !("seed_phrase" in key_type)
+  ).length;
   if (
     totalDevicesCount <= 1 &&
     hasNotSeenRecoveryPageLastWeek &&
@@ -220,7 +222,7 @@ export const recoveryWizard = async (
   const [credentials, identityMetadata, pinIdentityMaterial] = await withLoader(
     () =>
       Promise.all([
-        connection.lookupCredentials(userNumber),
+        connection.lookupAll(userNumber),
         connection.getIdentityMetadata(),
         idbRetrievePinIdentityMaterial({
           userNumber,
@@ -236,6 +238,11 @@ export const recoveryWizard = async (
     nowInMillis,
   });
 
+  const originNewDevice = getCredentialsOrigin({
+    credentials,
+    userAgent: navigator.userAgent,
+  });
+
   if (devicesStatus !== "no-warning") {
     connection.updateIdentityMetadata({
       recoveryPageShownTimestampMillis: nowInMillis,
@@ -244,7 +251,11 @@ export const recoveryWizard = async (
       status: devicesStatus,
     });
     if (userChoice.action === "add-device") {
-      await addDevice({ userNumber, connection, origin: window.origin });
+      await addDevice({
+        userNumber,
+        connection,
+        origin: originNewDevice ?? window.origin,
+      });
     }
     if (userChoice.action === "do-not-remind") {
       connection.updateIdentityMetadata({


### PR DESCRIPTION
# Motivation

Avoid bad UX by making sure that new devices are registered in the same origin as all the other devices.

In this PR, add this functionality in the recoveryWizard flow. See screenshot.

# Changes

* Calculate the origin of the devices and use it to add a new device in the recoveryWizard screen.
* Change `lookupCredentials` call to `lookupAll` because the `origin` is necessary.

# Tests

* Change the tests to use the data type from `lookupAll`.
* Flow tested in beta.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/77515bf45/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/77515bf45/desktop/allowCredentialsNoAnchor.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/77515bf45/desktop/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/77515bf45/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/77515bf45/mobile/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

