### PR TITLE
Fix bug in `add` method of authenticated connection

### DIFF
--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -741,7 +741,7 @@ export class AuthenticatedConnection extends Connection {
     // The canister only allow for 50 characters, so for long domains we don't attach an origin
     // (those long domains are most likely a testnet with URL like <canister id>.large03.testnet.dfinity.network, and we basically only care about identity.ic0.app & identity.internetcomputer.org).
     const sanitizedOrigin =
-      nonNullish(origin) && origin.length < 50 ? origin : undefined;
+      nonNullish(origin) && origin.length <= 50 ? origin : undefined;
     return await actor.add(this.userNumber, {
       alias,
       pubkey: Array.from(new Uint8Array(newPublicKey)),

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -741,7 +741,7 @@ export class AuthenticatedConnection extends Connection {
     // The canister only allow for 50 characters, so for long domains we don't attach an origin
     // (those long domains are most likely a testnet with URL like <canister id>.large03.testnet.dfinity.network, and we basically only care about identity.ic0.app & identity.internetcomputer.org).
     const sanitizedOrigin =
-      nonNullish(origin) && origin.length > 50 ? origin : undefined;
+      nonNullish(origin) && origin.length < 50 ? origin : undefined;
     return await actor.add(this.userNumber, {
       alias,
       pubkey: Array.from(new Uint8Array(newPublicKey)),


### PR DESCRIPTION
# Motivation

There was a bug that the origin was not passed to the backend when it was less than 50 characters, not the other way around. This has not been deployed, so no need to worry.

I resolved the problem and added tests to avoid happening in the future.

# Changes

* Change `>` for `<=` when sanitizing the origin.

# Tests

* Add tests for the `add` method.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8f8dce3c4/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8f8dce3c4/desktop/promptCaptcha.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

