### PR TITLE
Use devices origin when setting up recovery

### DIFF
--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -57,14 +57,15 @@ export const setupKey = async ({
     await withLoader(async () => {
       const devices =
         devices_ ?? (await connection.lookupAll(connection.userNumber));
-      const newDeviceOrigin = getCredentialsOrigin({
-        credentials: devices,
-        userAgent: window.navigator.userAgent,
-      });
-      const rpId =
-        nonNullish(newDeviceOrigin) && DOMAIN_COMPATIBILITY.isEnabled()
-          ? new URL(newDeviceOrigin).host
-          : undefined;
+      const newDeviceOrigin = DOMAIN_COMPATIBILITY.isEnabled()
+        ? getCredentialsOrigin({
+            credentials: devices,
+            userAgent: window.navigator.userAgent,
+          })
+        : undefined;
+      const rpId = nonNullish(newDeviceOrigin)
+        ? new URL(newDeviceOrigin).host
+        : undefined;
       const recoverIdentity = await WebAuthnIdentity.create({
         publicKey: creationOptions(devices, "cross-platform", rpId),
       });

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -3,6 +3,7 @@ import { displayError } from "$src/components/displayError";
 import { withLoader } from "$src/components/loader";
 import { fromMnemonicWithoutValidation } from "$src/crypto/ed25519";
 import { generate } from "$src/crypto/mnemonic";
+import { DOMAIN_COMPATIBILITY } from "$src/featureFlags";
 import { getCredentialsOrigin } from "$src/utils/credential-devices";
 import {
   AuthenticatedConnection,
@@ -60,9 +61,10 @@ export const setupKey = async ({
         credentials: devices,
         userAgent: window.navigator.userAgent,
       });
-      const rpId = nonNullish(newDeviceOrigin)
-        ? new URL(newDeviceOrigin).host
-        : undefined;
+      const rpId =
+        nonNullish(newDeviceOrigin) && DOMAIN_COMPATIBILITY.isEnabled()
+          ? new URL(newDeviceOrigin).host
+          : undefined;
       const recoverIdentity = await WebAuthnIdentity.create({
         publicKey: creationOptions(devices, "cross-platform", rpId),
       });


### PR DESCRIPTION
# Motivation

Register recovery device in the same origin as the other credentials.

This is not strictly necessary, but it can be useful if in the future we want to consider the recovery device as one more authenticator.

# Changes

* Calculate the origin based on the current devices and use it if flag is enabled.

# Tests

* Tested in beta.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d9186b8e9/desktop/allowCredentialsLongMessage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d9186b8e9/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d9186b8e9/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d9186b8e9/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d9186b8e9/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d9186b8e9/mobile/displayManage.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

