### PR TITLE
Pass `origin` to `add` call in addCurrentDevice

### DIFF
--- a/src/frontend/src/flows/addDevice/manage/addCurrentDevice.ts
+++ b/src/frontend/src/flows/addDevice/manage/addCurrentDevice.ts
@@ -81,7 +81,7 @@ export const addCurrentDevice = async (
         { authentication: null },
         newDevice.getPublicKey().toDer(),
         { unprotected: null },
-        window.origin,
+        origin ?? window.origin,
         newDevice.rawId
       )
     );

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -367,7 +367,17 @@ export const displayManage = async (
     }
 
     const onAddDevice = async () => {
-      await addDevice({ userNumber, connection, origin: window.origin });
+      const newDeviveOrigin = DOMAIN_COMPATIBILITY.isEnabled()
+        ? getCredentialsOrigin({
+            credentials: devices_,
+            userAgent: navigator.userAgent,
+          })
+        : undefined;
+      await addDevice({
+        userNumber,
+        connection,
+        origin: newDeviveOrigin ?? window.origin,
+      });
       resolve();
     };
     const addRecoveryPhrase = async () => {


### PR DESCRIPTION
# Motivation

This PR uses the origin of the devices in the flow to add a new device triggered from the Manage page.

# Changes

* Calculate the new device origin based on devices and pass it to `addDevice`.
* Pass `origin` if present in to `add` call in `addCurrentDevice`.

# Tests

* Tested in beta domains.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/477a0c507/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/477a0c507/desktop/allowCredentialsLongMessage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/477a0c507/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/477a0c507/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/477a0c507/mobile/confirmSeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

