### PR TITLE
Use passkeys including recovery device for origin in recovery wizard

### DIFF
--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -220,10 +220,10 @@ export const recoveryWizard = async (
 ): Promise<void> => {
   // Here, if the user doesn't have any recovery device, we prompt them to add
   // one.
-  const [credentials, identityMetadata, pinIdentityMaterial] = await withLoader(
+  const [passkeys, identityMetadata, pinIdentityMaterial] = await withLoader(
     () =>
       Promise.all([
-        connection.lookupAll(userNumber),
+        connection.lookupPasskeys(userNumber),
         connection.getIdentityMetadata(),
         idbRetrievePinIdentityMaterial({
           userNumber,
@@ -233,7 +233,7 @@ export const recoveryWizard = async (
   const nowInMillis = Date.now();
 
   const devicesStatus = getDevicesStatus({
-    credentials,
+    credentials: passkeys,
     identityMetadata,
     pinIdentityMaterial,
     nowInMillis,
@@ -241,7 +241,7 @@ export const recoveryWizard = async (
 
   const originNewDevice = DOMAIN_COMPATIBILITY.isEnabled()
     ? getCredentialsOrigin({
-        credentials,
+        credentials: passkeys,
         userAgent: navigator.userAgent,
       })
     : undefined;

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -578,6 +578,22 @@ export class Connection {
     return await actor.lookup(userNumber);
   };
 
+  /**
+   * Returns all the passkeys for a user. Including the recovery device.
+   * @param userNumber
+   * @returns {Promise<Omit<DeviceData, "alias">[]>}
+   */
+  lookupPasskeys = async (
+    userNumber: UserNumber
+  ): Promise<Omit<DeviceData, "alias">[]> => {
+    const actor = await this.createActor();
+    const allDevices = await actor.lookup(userNumber);
+    return allDevices.filter(
+      (device) =>
+        "platform" in device.key_type || "cross_platform" in device.key_type
+    );
+  };
+
   lookupAuthenticators = async (
     userNumber: UserNumber
   ): Promise<Omit<DeviceData, "alias">[]> => {


### PR DESCRIPTION
# Motivation

In the future, we might want to remove the idea of "recovery device" and use it as authenticator. Therefore, we should take it into account when calculating the origin of the new device to avoid bad UX for having devices registered in multiple origins.

# Changes

* Introduce a new method in Connection to return all the passkeys.
* Use the new method in recoveryWizard.

# Tests

PENDING

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/0e6e207ff/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/0e6e207ff/desktop/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
