### PR TITLE
Add seed phrase to same origin as devices

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -377,7 +377,15 @@ export const displayManage = async (
         return;
       }
       doAdd satisfies "ok";
-      await setupPhrase(userNumber, connection);
+      const newDeviceOrigin = getCredentialsOrigin({
+        credentials: devices_,
+        userAgent: window.navigator.userAgent,
+      });
+      await setupPhrase(
+        userNumber,
+        connection,
+        newDeviceOrigin ?? window.origin
+      );
       resolve();
     };
 

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -377,10 +377,12 @@ export const displayManage = async (
         return;
       }
       doAdd satisfies "ok";
-      const newDeviceOrigin = getCredentialsOrigin({
-        credentials: devices_,
-        userAgent: window.navigator.userAgent,
-      });
+      const newDeviceOrigin = DOMAIN_COMPATIBILITY.isEnabled()
+        ? getCredentialsOrigin({
+            credentials: devices_,
+            userAgent: window.navigator.userAgent,
+          })
+        : undefined;
       await setupPhrase(
         userNumber,
         connection,

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -1,5 +1,4 @@
 import { DeviceData } from "$generated/internet_identity_types";
-import { displayError } from "$src/components/displayError";
 import { withLoader } from "$src/components/loader";
 import { fromMnemonicWithoutValidation } from "$src/crypto/ed25519";
 import { generate } from "$src/crypto/mnemonic";
@@ -16,30 +15,6 @@ import { WebAuthnIdentity } from "@dfinity/identity";
 import { nonNullish } from "@dfinity/utils";
 import { confirmSeedPhrase } from "./confirmSeedPhrase";
 import { displaySeedPhrase } from "./displaySeedPhrase";
-
-export const setupRecovery = async ({
-  userNumber,
-  connection,
-}: {
-  userNumber: bigint;
-  connection: AuthenticatedConnection;
-}): Promise<void> => {
-  // Retry until user explicitly cancels or until a phrase is added successfully
-  for (;;) {
-    const res = await setupPhrase(userNumber, connection);
-    if (res === "ok" || res === "canceled") {
-      return;
-    }
-
-    res satisfies "error";
-    await displayError({
-      title: "Failed to set up recovery",
-      message: "We failed to set up recovery for this Internet Identity.",
-      primaryButton: "Retry",
-    });
-    continue;
-  }
-};
 
 // Set up a recovery device
 export const setupKey = async ({
@@ -90,7 +65,8 @@ export const setupKey = async ({
 // Set up a recovery phrase
 export const setupPhrase = async (
   userNumber: bigint,
-  connection: AuthenticatedConnection
+  connection: AuthenticatedConnection,
+  origin: string
 ): Promise<"ok" | "error" | "canceled"> => {
   const res = await phraseWizard({
     userNumber,
@@ -103,7 +79,7 @@ export const setupPhrase = async (
           { recovery: null },
           pubkey,
           { unprotected: null },
-          window.origin
+          origin
         )
       ),
   });


### PR DESCRIPTION
# Motivation

To keep consistency with `origin` of the devices. This PR adds the seed phrase to the same origin (if it's the same) as the devices.

# Changes

* Add `origin` parameter to `setupPhrase`.
* Calculate origin and pass it when creating a new seed phrase from the manage page.

# Tests

* Tested in beta. I logged in a different domain as my passkey, then I created the seed phrase, and then I checked the origin of the seed phrase in the canister, and it was the other domain.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d2d6184ab/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d2d6184ab/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d2d6184ab/mobile/allowCredentials.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

