### PR TITLE
Common origin when registering

### DIFF
--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -108,8 +108,12 @@ export const registerFlow = async ({
   const flowStart = precomputeFirst(() => identityRegistrationStart());
 
   const displayUserNumber = displayUserNumberWarmup();
+  // We register the device's origin in the current domain.
+  // If we want to change it, we need to change this line.
+  const deviceOrigin = window.location.origin;
   const savePasskeyResult = await savePasskeyOrPin({
     pinAllowed: await pinAllowed(),
+    origin: deviceOrigin,
   });
   if (savePasskeyResult === "canceled") {
     return "canceled";
@@ -161,6 +165,7 @@ export const registerFlow = async ({
           pubKey: identity.getPublicKey().toDer(),
           credentialId: identity.rawId,
           authenticatorAttachment: identity.getAuthenticatorAttachment(),
+          origin: deviceOrigin,
         }),
         authnMethod: "passkey" as const,
       };

--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -99,8 +99,10 @@ export const savePasskeyPage = renderPage(savePasskeyTemplate);
 // Prompt the user to create a WebAuthn identity or a PIN identity (if allowed)
 export const savePasskeyOrPin = async ({
   pinAllowed,
+  origin,
 }: {
   pinAllowed: boolean;
+  origin: string;
 }): Promise<IIWebAuthnIdentity | "pin" | "canceled" | undefined> => {
   if (pinAllowed) {
     return new Promise((resolve) => {
@@ -110,7 +112,13 @@ export const savePasskeyOrPin = async ({
         scrollToTop: true,
         constructPasskey: async () => {
           try {
-            const identity = await withLoader(() => constructIdentity({}));
+            const rpId =
+              origin === window.location.origin
+                ? undefined
+                : new URL(origin).hostname;
+            const identity = await withLoader(() =>
+              constructIdentity({ rpId })
+            );
             resolve(identity);
           } catch (e) {
             toast.error(errorMessage(e));

--- a/src/frontend/src/utils/authnMethodData.ts
+++ b/src/frontend/src/utils/authnMethodData.ts
@@ -40,17 +40,18 @@ export const passkeyAuthnMethodData = ({
   pubKey,
   credentialId,
   authenticatorAttachment,
+  origin,
 }: {
   alias: string;
   pubKey: DerEncodedPublicKey;
   credentialId: CredentialId;
   authenticatorAttachment?: AuthenticatorAttachment;
+  origin: string;
 }): AuthnMethodData => {
   const metadata: MetadataMapV2 = [
     ["alias", { String: alias }],
     // The origin in the metadata might not match the origin in the auth method if the origin is longer than 50 characters.
-    // TODO: Expect the origin as parameter because it might be different than the window if a RP ID is used.
-    ["origin", { String: window.origin }],
+    ["origin", { String: origin }],
   ];
   if (nonNullish(authenticatorAttachment)) {
     metadata.push([


### PR DESCRIPTION
# Motivation

Make sure that the metadata's `origin` matches the devices `origin` and the actual RP ID on the passkey manager (iCloud, 1Password, etc)

# Changes

* Add an `origin` parameter to `passkeyAuthnMethodData` which creates the device's metadata.
* Add an `origin` parameter to `savePasskeyOrPin` and use it to calculate the RP ID for `constructIdentity`.
* Use a common variable to pass the same origin to `passkeyAuthnMethodData` and `savePasskeyOrPin`.

# Tests

Tested in beta domains by creating one new identity in `ic0.app` and another in `internetcomputer.org` and checking that the `origin` matched the expected. Metadata is private data. I couldn't check that.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/desktop/promptCaptcha.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/831feaee4/mobile/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
