### PR TITLE
Better error for PIN identities in other domains

### DIFF
--- a/src/frontend/src/components/infoToast/copy.json
+++ b/src/frontend/src/components/infoToast/copy.json
@@ -2,6 +2,9 @@
   "en": {
     "title_possibly_wrong_rp_id": "Please try again",
     "message_possibly_wrong_rp_id_1": "The wrong domain was set for the passkey and the browser couldn't find it.",
-    "message_possibly_wrong_rp_id_2": "Try again and another domain will be used."
+    "message_possibly_wrong_rp_id_2": "Try again and another domain will be used.",
+    "title_pin_another_domain": "Pin identity in another domain",
+    "message_pin_another_domain_1": "You seem to be using a PIN identity created in another domain.",
+    "message_pin_another_domain_2": "To access this domain you need to go to the other domain and add a passkey."
   }
 }

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -759,6 +759,36 @@ describe("Connection.login", () => {
     });
   });
 
+  describe("only pin device is available", () => {
+    it("returns a custom error", async () => {
+      const pinDevice: DeviceData = {
+        alias: "mockDevice",
+        metadata: [],
+        origin: origin !== undefined ? [origin] : [],
+        protection: { protected: null },
+        pubkey: new Uint8Array(),
+        key_type: { browser_storage_key: null },
+        purpose: { authentication: null },
+        credential_id: [Uint8Array.from([0, 0, 0, 0, 0])],
+      };
+      const mockActor = {
+        identity_info: vi.fn().mockImplementation(async () => {
+          // The `await` is necessary to make sure that the `getterResponse` is set before the test continues.
+          infoResponse = await mockRawMetadata;
+          return { Ok: { metadata: mockRawMetadata } };
+        }),
+        identity_metadata_replace: vi.fn().mockResolvedValue({ Ok: null }),
+        lookup: vi.fn().mockResolvedValue([pinDevice]),
+      } as unknown as ActorSubclass<_SERVICE>;
+
+      const connection = new Connection("aaaaa-aa", mockActor);
+
+      const loginResult = await connection.login(BigInt(12345));
+
+      expect(loginResult.kind).toBe("pinUserOtherDomain");
+    });
+  });
+
   describe("AuthenticatedConnection#add", () => {
     const alias = "alias";
     const keyType = { platform: null };


### PR DESCRIPTION
# Motivation

If a user was registered with PIN in one domain and tries to log in another domain, it sees an "Unknown user" error.

This will be a problem if we migrate to another domain.

In this PR, a new return type is added to manage this specific case and show a better info message suggesting next steps.

# Changes

* Add a new error return to `login`: `PinUserOtherDomain`.
* If the login produces this error, show a toast with next steps.

# Tests

* Tested in beta as seen in the video.
* New test in `iiConnection.test.ts`.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a065c9583/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a065c9583/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a065c9583/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a065c9583/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a065c9583/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a065c9583/mobile/displayManage.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
