### PR TITLE
Add useIframe to MultiWebAuthIdentity

### DIFF
--- a/src/frontend/src/utils/multiWebAuthnIdentity.ts
+++ b/src/frontend/src/utils/multiWebAuthnIdentity.ts
@@ -26,9 +26,10 @@ export class MultiWebAuthnIdentity extends SignIdentity {
    */
   public static fromCredentials(
     credentialData: CredentialData[],
-    rpId: string | undefined
+    rpId: string | undefined,
+    useIframe: boolean | undefined = false
   ): MultiWebAuthnIdentity {
-    return new this(credentialData, rpId);
+    return new this(credentialData, rpId, useIframe);
   }
 
   /* Set after the first `sign`, see `sign()` for more info. */
@@ -36,7 +37,8 @@ export class MultiWebAuthnIdentity extends SignIdentity {
 
   protected constructor(
     readonly credentialData: CredentialData[],
-    readonly rpId: string | undefined
+    readonly rpId: string | undefined,
+    readonly useIframe: boolean | undefined = false
   ) {
     super();
     this._actualIdentity = undefined;


### PR DESCRIPTION
# Motivation

Be able to use the iframe workaround.

# Changes

* Introduce an optional boolean parameter to `MultiWebAuthnIdentity`.

# Tests

* No new functionality has been added yet.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9e1f01052/desktop/allowCredentials.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

