### PR TITLE
Use iframe workaround when needed

### DIFF
--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -190,7 +190,59 @@ describe("Connection.login", () => {
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
           [convertToValidCredentialData(mockDevice)],
           "identity.ic0.app",
-          undefined
+          true
+        );
+      }
+    });
+
+    it("connection excludes rpId when user cancels", async () => {
+      // This one would fail because it's not the device the user is using at the moment.
+      const currentOriginDevice: DeviceData = createMockDevice(currentOrigin);
+      const currentOriginCredentialData =
+        convertToValidCredentialData(currentOriginDevice);
+      const currentDevice: DeviceData = createMockDevice();
+      const currentDeviceCredentialData =
+        convertToValidCredentialData(currentDevice);
+      const mockActor = {
+        identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
+        lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
+      } as unknown as ActorSubclass<_SERVICE>;
+      const connection = new Connection("aaaaa-aa", mockActor);
+
+      failSign = true;
+      const firstLoginResult = await connection.login(BigInt(12345));
+
+      expect(firstLoginResult.kind).toBe("possiblyWrongRPID");
+      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
+      expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          currentOriginCredentialData,
+          currentDeviceCredentialData,
+        ]),
+        undefined,
+        // Do not use iframe
+        false
+      );
+
+      failSign = false;
+      const secondLoginResult = await connection.login(BigInt(12345));
+
+      expect(secondLoginResult.kind).toBe("loginSuccess");
+      if (secondLoginResult.kind === "loginSuccess") {
+        expect(secondLoginResult.showAddCurrentDevice).toBe(true);
+        expect(secondLoginResult.connection).toBeInstanceOf(
+          AuthenticatedConnection
+        );
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(2);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenNthCalledWith(
+          2,
+          expect.arrayContaining([
+            currentDeviceCredentialData,
+            currentDeviceCredentialData,
+          ]),
+          "identity.ic0.app",
+          // Use iframe
+          true
         );
       }
     });
@@ -221,7 +273,7 @@ describe("Connection.login", () => {
           currentOriginCredentialData2,
         ]),
         undefined,
-        undefined
+        false
       );
 
       failSign = false;
@@ -241,7 +293,7 @@ describe("Connection.login", () => {
             currentOriginCredentialData2,
           ]),
           undefined,
-          undefined
+          false
         );
       }
     });
@@ -257,7 +309,7 @@ describe("Connection.login", () => {
       });
     });
 
-    it("login returns authenticated connection without rpID if browser doesn't support it", async () => {
+    it("login returns authenticated connection with expected rpID", async () => {
       const connection = new Connection("aaaaa-aa", mockActor);
 
       const loginResult = await connection.login(BigInt(12345));
@@ -269,8 +321,8 @@ describe("Connection.login", () => {
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
           [convertToValidCredentialData(mockDevice)],
-          undefined,
-          undefined
+          "identity.ic0.app",
+          true
         );
       }
     });
@@ -299,7 +351,7 @@ describe("Connection.login", () => {
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
           [convertToValidCredentialData(mockDevice)],
           undefined,
-          undefined
+          false
         );
       }
     });
@@ -328,7 +380,7 @@ describe("Connection.login", () => {
           currentDeviceCredentialData,
         ]),
         undefined,
-        undefined
+        false
       );
 
       failSign = false;
@@ -348,36 +400,7 @@ describe("Connection.login", () => {
             currentOriginCredentialData,
           ]),
           undefined,
-          undefined
-        );
-      }
-    });
-  });
-
-  describe("domains compatibility flag enabled and browser doesn't support", () => {
-    beforeEach(() => {
-      DOMAIN_COMPATIBILITY.set(true);
-      vi.stubGlobal("navigator", {
-        // Does NOT Supports RoR
-        userAgent:
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0",
-      });
-    });
-
-    it("login returns authenticated connection without rpID if browser doesn't support it", async () => {
-      const connection = new Connection("aaaaa-aa", mockActor);
-
-      const loginResult = await connection.login(BigInt(12345));
-
-      expect(loginResult.kind).toBe("loginSuccess");
-      if (loginResult.kind === "loginSuccess") {
-        expect(loginResult.showAddCurrentDevice).toBe(false);
-        expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
-        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
-        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
-          [convertToValidCredentialData(mockDevice)],
-          undefined,
-          undefined
+          false
         );
       }
     });
@@ -406,7 +429,7 @@ describe("Connection.login", () => {
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
           [convertToValidCredentialData(mockDevice)],
           undefined,
-          undefined
+          false
         );
       }
     });
@@ -435,7 +458,7 @@ describe("Connection.login", () => {
           currentDeviceCredentialData,
         ]),
         undefined,
-        undefined
+        false
       );
 
       failSign = false;
@@ -455,7 +478,7 @@ describe("Connection.login", () => {
             currentOriginCredentialData,
           ]),
           undefined,
-          undefined
+          false
         );
       }
     });
@@ -481,7 +504,7 @@ describe("Connection.login", () => {
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
         [convertToValidCredentialData(deviceWithCredentialId)],
         undefined,
-        undefined
+        false
       );
     });
   });
@@ -506,7 +529,7 @@ describe("Connection.login", () => {
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
         [convertToValidCredentialData(deviceValidCredentialId)],
         undefined,
-        undefined
+        false
       );
     });
   });

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -61,12 +61,8 @@ import {
   convertToValidCredentialData,
   CredentialData,
 } from "./credential-devices";
-import {
-  excludeCredentialsFromOrigins,
-  findWebAuthnRpId,
-  hasCredentialsFromMultipleOrigins,
-  relatedDomains,
-} from "./findWebAuthnRpId";
+import { relatedDomains } from "./findWebAuthnRpId";
+import { findWebAuthnSteps, WebAuthnStep } from "./findWebAuthnSteps";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 import { isRecoveryDevice, RecoveryDevice } from "./recoveryDevice";
 import { supportsWebauthRoR } from "./userAgent";
@@ -157,6 +153,10 @@ export interface IIWebAuthnIdentity extends SignIdentity {
 
 export class Connection {
   private configPromise: Promise<InternetIdentityInit> | undefined;
+  // TODO: Rename `WebAuthnStep` and the util to use `flow` instead of `step`.
+  private webAuthFlows:
+    | { flows: WebAuthnStep[]; currentIndex: number }
+    | undefined;
 
   public constructor(
     readonly canisterId: string,
@@ -424,18 +424,27 @@ export class Connection {
     userNumber: bigint,
     credentials: CredentialData[]
   ): Promise<LoginSuccess | WebAuthnFailed | PossiblyWrongRPID | AuthFail> => {
-    const cancelledRpIds = new Set<string | undefined>();
-    const currentOrigin = window.location.origin;
-    const dynamicRPIdEnabled =
-      DOMAIN_COMPATIBILITY.isEnabled() &&
-      supportsWebauthRoR(window.navigator.userAgent);
-    const filteredCredentials = excludeCredentialsFromOrigins(
-      credentials,
-      cancelledRpIds,
-      currentOrigin
-    );
-    const rpId = dynamicRPIdEnabled
-      ? findWebAuthnRpId(currentOrigin, filteredCredentials, relatedDomains())
+    console.log("in da fromWebauthnCredentials");
+    if (isNullish(this.webAuthFlows) && DOMAIN_COMPATIBILITY.isEnabled()) {
+      const flows = findWebAuthnSteps({
+        supportsRor: supportsWebauthRoR(window.navigator.userAgent),
+        devices: credentials,
+        currentOrigin: window.location.origin,
+        relatedOrigins: relatedDomains(),
+      });
+      this.webAuthFlows = {
+        flows,
+        currentIndex: 0,
+      };
+    }
+    const flowsLength = this.webAuthFlows?.flows.length ?? 0;
+    // We reached the last flow. Start from the beginning.
+    // This might happen if the user cancelled manually in the flow that would have been successful.
+    if (this.webAuthFlows?.currentIndex === flowsLength) {
+      this.webAuthFlows.currentIndex = 0;
+    }
+    const currentFlow = nonNullish(this.webAuthFlows)
+      ? this.webAuthFlows.flows[this.webAuthFlows.currentIndex]
       : undefined;
 
     /* Recover the Identity (i.e. key pair) used when creating the anchor.
@@ -445,7 +454,11 @@ export class Connection {
     const identity = features.DUMMY_AUTH
       ? new DummyIdentity()
       : // Passing all the credentials doesn't hurt and it could help in case an `origin` was wrongly set in the backend.
-        MultiWebAuthnIdentity.fromCredentials(credentials, rpId, undefined);
+        MultiWebAuthnIdentity.fromCredentials(
+          credentials,
+          currentFlow?.rpId,
+          currentFlow?.useIframe ?? false
+        );
     let delegationIdentity: DelegationIdentity;
 
     // Here we expect a webauth exception if the user canceled the webauthn prompt (triggered by
@@ -454,18 +467,17 @@ export class Connection {
       delegationIdentity = await this.requestFEDelegation(identity);
     } catch (e: unknown) {
       if (isWebAuthnCancel(e)) {
-        // We only want to cache cancelled rpids if there can be multiple rpids.
-        if (
-          dynamicRPIdEnabled &&
-          hasCredentialsFromMultipleOrigins(credentials)
-        ) {
-          try {
-            // We want to user to retry again and a new RP ID will be used.
-            return { kind: "possiblyWrongRPID" };
-          } catch (e: unknown) {
-            console.error("Error adding cancelled RP ID to local storage", e);
-            return { kind: "webAuthnFailed" };
-          }
+        console.log("in da isWebAuthnCancel", this.webAuthFlows);
+        // We only want to show a special error if the user might have to choose different web auth flow.
+        if (nonNullish(this.webAuthFlows) && flowsLength > 1) {
+          // Increase the index to try the next flow.
+          this.webAuthFlows = {
+            flows: this.webAuthFlows.flows,
+            currentIndex: this.webAuthFlows.currentIndex + 1,
+          };
+          console.log("in da possiblyWrongRPID", this.webAuthFlows);
+          // TODO: Change `possiblyWrongRPID` for something more descriptive and change the error message.
+          return { kind: "possiblyWrongRPID" };
         }
         return { kind: "webAuthnFailed" };
       }
@@ -488,7 +500,10 @@ export class Connection {
       actor
     );
 
-    const showAddCurrentDevice = cancelledRpIds.size > 0;
+    // If the index is more than 0, it's because the first one failed.
+    // We should offer to add the current device to the current origin.
+    console.log("in da fromWebauthnCredentials", this.webAuthFlows);
+    const showAddCurrentDevice = (this.webAuthFlows?.currentIndex ?? 0) > 0;
 
     return {
       kind: "loginSuccess",

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -424,7 +424,6 @@ export class Connection {
     userNumber: bigint,
     credentials: CredentialData[]
   ): Promise<LoginSuccess | WebAuthnFailed | PossiblyWrongRPID | AuthFail> => {
-    console.log("in da fromWebauthnCredentials");
     if (isNullish(this.webAuthFlows) && DOMAIN_COMPATIBILITY.isEnabled()) {
       const flows = findWebAuthnSteps({
         supportsRor: supportsWebauthRoR(window.navigator.userAgent),
@@ -467,7 +466,6 @@ export class Connection {
       delegationIdentity = await this.requestFEDelegation(identity);
     } catch (e: unknown) {
       if (isWebAuthnCancel(e)) {
-        console.log("in da isWebAuthnCancel", this.webAuthFlows);
         // We only want to show a special error if the user might have to choose different web auth flow.
         if (nonNullish(this.webAuthFlows) && flowsLength > 1) {
           // Increase the index to try the next flow.
@@ -475,7 +473,6 @@ export class Connection {
             flows: this.webAuthFlows.flows,
             currentIndex: this.webAuthFlows.currentIndex + 1,
           };
-          console.log("in da possiblyWrongRPID", this.webAuthFlows);
           // TODO: Change `possiblyWrongRPID` for something more descriptive and change the error message.
           return { kind: "possiblyWrongRPID" };
         }
@@ -502,7 +499,6 @@ export class Connection {
 
     // If the index is more than 0, it's because the first one failed.
     // We should offer to add the current device to the current origin.
-    console.log("in da fromWebauthnCredentials", this.webAuthFlows);
     const showAddCurrentDevice = (this.webAuthFlows?.currentIndex ?? 0) > 0;
 
     return {


### PR DESCRIPTION
# Motivation

Allow users to log in even if the first selected RP ID was the incorrect one.

In this PR, we use the new helper `findWebAuthnSteps` with the new parameters `rpId` and `iframe` of `MultiWebAuthnIdentity`.

In another PR: Change info message on first error.
In another PR: Rename `webAuthnSteps` to `webAuthnFlows`.

# Changes

* New instance variable `webAuthFlows` in iiConnection to keep track of the steps and current step index to try.
* If the new instance is not set, get the flows and set it.
* Use the RP ID and iframe in the current flow.
* Reset the flow index when out of bounds.
* Increase the step when needed.

# Tests

* Reintroduced a test that was removed before `"connection excludes rpId when user cancels"`.
* Remove duplicated test.
* Change expected frame parameter value in current tests.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/65dd58dba/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/65dd58dba/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/65dd58dba/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/65dd58dba/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/65dd58dba/mobile/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

