### PR TITLE
Rename PossiblyWrongRPID to PossiblyWrongWebAuthnFlow

### DIFF
--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -379,10 +379,7 @@ export const handleLoginFlowResult = async <E>(
     toast.info(
       infoToastTemplate({
         title: copy.title_possibly_wrong_web_authn_flow,
-        messages: [
-          copy.message_possibly_wrong_web_authn_flow_1,
-          copy.message_possibly_wrong_web_authn_flow_2,
-        ],
+        messages: [copy.message_possibly_wrong_web_authn_flow_1],
       })
     );
     return undefined;

--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -34,7 +34,7 @@ import {
   LoginSuccess,
   NoRegistrationFlow,
   PinUserOtherDomain,
-  PossiblyWrongRPID,
+  PossiblyWrongWebAuthnFlow,
   RateLimitExceeded,
   RegisterNoSpace,
   UnexpectedCall,
@@ -197,7 +197,7 @@ export const authenticateBoxFlow = async <I>({
     | LoginSuccess
     | AuthFail
     | WebAuthnFailed
-    | PossiblyWrongRPID
+    | PossiblyWrongWebAuthnFlow
     | PinUserOtherDomain
     | UnknownUser
     | ApiError
@@ -229,7 +229,7 @@ export const authenticateBoxFlow = async <I>({
       newAnchor: boolean;
       authnMethod: "pin" | "passkey" | "recovery";
     })
-  | PossiblyWrongRPID
+  | PossiblyWrongWebAuthnFlow
   | PinUserOtherDomain
   | FlowError
   | { tag: "canceled" }
@@ -280,7 +280,7 @@ export const authenticateBoxFlow = async <I>({
         newAnchor: boolean;
         authnMethod: "pin" | "passkey" | "recovery";
       })
-    | PossiblyWrongRPID
+    | PossiblyWrongWebAuthnFlow
     | PinUserOtherDomain
     | FlowError
     | { tag: "canceled" }
@@ -362,7 +362,7 @@ export type FlowError =
 export const handleLoginFlowResult = async <E>(
   result:
     | (LoginSuccess & E)
-    | PossiblyWrongRPID
+    | PossiblyWrongWebAuthnFlow
     | PinUserOtherDomain
     | FlowError
 ): Promise<
@@ -373,15 +373,15 @@ export const handleLoginFlowResult = async <E>(
     return result;
   }
 
-  if (result.kind === "possiblyWrongRPID") {
+  if (result.kind === "possiblyWrongWebAuthnFlow") {
     const i18n = new I18n();
     const copy = i18n.i18n(infoToastCopy);
     toast.info(
       infoToastTemplate({
-        title: copy.title_possibly_wrong_rp_id,
+        title: copy.title_possibly_wrong_web_authn_flow,
         messages: [
-          copy.message_possibly_wrong_rp_id_1,
-          copy.message_possibly_wrong_rp_id_2,
+          copy.message_possibly_wrong_web_authn_flow_1,
+          copy.message_possibly_wrong_web_authn_flow_2,
         ],
       })
     );
@@ -709,7 +709,7 @@ const useIdentityFlow = async <I>({
     | LoginSuccess
     | AuthFail
     | WebAuthnFailed
-    | PossiblyWrongRPID
+    | PossiblyWrongWebAuthnFlow
     | PinUserOtherDomain
     | UnknownUser
     | ApiError
@@ -735,7 +735,7 @@ const useIdentityFlow = async <I>({
     })
   | AuthFail
   | WebAuthnFailed
-  | PossiblyWrongRPID
+  | PossiblyWrongWebAuthnFlow
   | PinUserOtherDomain
   | UnknownUser
   | ApiError

--- a/src/frontend/src/components/infoToast/copy.json
+++ b/src/frontend/src/components/infoToast/copy.json
@@ -1,8 +1,8 @@
 {
   "en": {
-    "title_possibly_wrong_rp_id": "Please try again",
-    "message_possibly_wrong_rp_id_1": "The wrong domain was set for the passkey and the browser couldn't find it.",
-    "message_possibly_wrong_rp_id_2": "Try again and another domain will be used.",
+    "title_possibly_wrong_web_authn_flow": "Please try again",
+    "message_possibly_wrong_web_authn_flow_1": "The wrong domain was set for the passkey and the browser couldn't find it.",
+    "message_possibly_wrong_web_authn_flow_2": "Try again and another domain will be used.",
     "title_pin_another_domain": "Pin identity in another domain",
     "message_pin_another_domain_1": "You seem to be using a PIN identity created in another domain.",
     "message_pin_another_domain_2": "To access this domain you need to go to the other domain and add a passkey."

--- a/src/frontend/src/components/infoToast/copy.json
+++ b/src/frontend/src/components/infoToast/copy.json
@@ -2,7 +2,6 @@
   "en": {
     "title_possibly_wrong_web_authn_flow": "Please try again",
     "message_possibly_wrong_web_authn_flow_1": "The wrong domain was set for the passkey and the browser couldn't find it.",
-    "message_possibly_wrong_web_authn_flow_2": "Try again and another domain will be used.",
     "title_pin_another_domain": "Pin identity in another domain",
     "message_pin_another_domain_1": "You seem to be using a PIN identity created in another domain.",
     "message_pin_another_domain_2": "To access this domain you need to go to the other domain and add a passkey."

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -60,10 +60,7 @@ export const recoverWithDevice = ({
             toast.info(
               infoToastTemplate({
                 title: copy.title_possibly_wrong_web_authn_flow,
-                messages: [
-                  copy.message_possibly_wrong_web_authn_flow_1,
-                  copy.message_possibly_wrong_web_authn_flow_2,
-                ],
+                messages: [copy.message_possibly_wrong_web_authn_flow_1],
               })
             );
             return;

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -8,7 +8,7 @@ import {
   AuthFail,
   Connection,
   LoginSuccess,
-  PossiblyWrongRPID,
+  PossiblyWrongWebAuthnFlow,
   WebAuthnFailed,
 } from "$src/utils/iiConnection";
 import { renderPage } from "$src/utils/lit-html";
@@ -54,15 +54,15 @@ export const recoverWithDevice = ({
         }
 
         if (result.kind !== "loginSuccess") {
-          if (result.kind === "possiblyWrongRPID") {
+          if (result.kind === "possiblyWrongWebAuthnFlow") {
             const i18n = new I18n();
             const copy = i18n.i18n(infoToastCopy);
             toast.info(
               infoToastTemplate({
-                title: copy.title_possibly_wrong_rp_id,
+                title: copy.title_possibly_wrong_web_authn_flow,
                 messages: [
-                  copy.message_possibly_wrong_rp_id_1,
-                  copy.message_possibly_wrong_rp_id_2,
+                  copy.message_possibly_wrong_web_authn_flow_1,
+                  copy.message_possibly_wrong_web_authn_flow_2,
                 ],
               })
             );
@@ -91,7 +91,7 @@ const attemptRecovery = async ({
 }): Promise<
   | LoginSuccess
   | WebAuthnFailed
-  | PossiblyWrongRPID
+  | PossiblyWrongWebAuthnFlow
   | AuthFail
   | { kind: "noRecovery" }
   | { kind: "tooManyRecovery" }

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -212,7 +212,7 @@ describe("Connection.login", () => {
       failSign = true;
       const firstLoginResult = await connection.login(BigInt(12345));
 
-      expect(firstLoginResult.kind).toBe("possiblyWrongRPID");
+      expect(firstLoginResult.kind).toBe("possiblyWrongWebAuthnFlow");
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
         expect.arrayContaining([

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -131,7 +131,7 @@ export type RegisterNoSpace = { kind: "registerNoSpace" };
 export type NoSeedPhrase = { kind: "noSeedPhrase" };
 export type SeedPhraseFail = { kind: "seedPhraseFail" };
 export type WebAuthnFailed = { kind: "webAuthnFailed" };
-export type PossiblyWrongRPID = { kind: "possiblyWrongRPID" };
+export type PossiblyWrongWebAuthnFlow = { kind: "possiblyWrongWebAuthnFlow" };
 // The user has PIN identity but in another domain and II can't access it.
 export type PinUserOtherDomain = { kind: "pinUserOtherDomain" };
 export type InvalidAuthnMethod = {
@@ -374,7 +374,7 @@ export class Connection {
     | LoginSuccess
     | AuthFail
     | WebAuthnFailed
-    | PossiblyWrongRPID
+    | PossiblyWrongWebAuthnFlow
     | PinUserOtherDomain
     | UnknownUser
     | ApiError
@@ -423,7 +423,9 @@ export class Connection {
   fromWebauthnCredentials = async (
     userNumber: bigint,
     credentials: CredentialData[]
-  ): Promise<LoginSuccess | WebAuthnFailed | PossiblyWrongRPID | AuthFail> => {
+  ): Promise<
+    LoginSuccess | WebAuthnFailed | PossiblyWrongWebAuthnFlow | AuthFail
+  > => {
     if (isNullish(this.webAuthFlows) && DOMAIN_COMPATIBILITY.isEnabled()) {
       const flows = findWebAuthnSteps({
         supportsRor: supportsWebauthRoR(window.navigator.userAgent),
@@ -473,8 +475,7 @@ export class Connection {
             flows: this.webAuthFlows.flows,
             currentIndex: this.webAuthFlows.currentIndex + 1,
           };
-          // TODO: Change `possiblyWrongRPID` for something more descriptive and change the error message.
-          return { kind: "possiblyWrongRPID" };
+          return { kind: "possiblyWrongWebAuthnFlow" };
         }
         return { kind: "webAuthnFailed" };
       }


### PR DESCRIPTION
# Motivation

PossiblyWrongRPID is confusing now that we moved to the concept of WebAuthn flows.

# Changes

* Change `PossiblyWrongRPID` and i18n keys.

# Tests

No new functionality was added.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c629a5662/mobile/landing_1.png" width="250"></details><details><summary>🔴 Some screens were removed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/c629a5662/mobile/landing_2.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


