### PR TITLE
Rename WebAuthnSteps to WebAuthnFlows

### DIFF
--- a/src/frontend/src/utils/findWebAuthnFlows.test.ts
+++ b/src/frontend/src/utils/findWebAuthnFlows.test.ts
@@ -1,9 +1,9 @@
 import { LEGACY_II_URL } from "$src/config";
 import { CredentialData } from "./credential-devices";
+import { findWebAuthnFlows } from "./findWebAuthnFlows";
 import { PROD_DOMAINS } from "./findWebAuthnRpId";
-import { findWebAuthnSteps } from "./findWebAuthnSteps";
 
-describe("findWebAuthnSteps", () => {
+describe("findWebAuthnFlows", () => {
   const currentOrigin = "https://identity.internetcomputer.org";
   const nonCurrentOrigin1 = "https://identity.ic0.app";
   const nonCurrentOrigin1RpId = new URL(nonCurrentOrigin1).hostname;
@@ -20,7 +20,7 @@ describe("findWebAuthnSteps", () => {
   });
 
   it("should return an empty array if no devices are provided", () => {
-    const result = findWebAuthnSteps({
+    const result = findWebAuthnFlows({
       supportsRor: true,
       devices: [],
       currentOrigin: currentOrigin,
@@ -30,7 +30,7 @@ describe("findWebAuthnSteps", () => {
   });
 
   it("should use iframe if the RP ID does not match the current origin", () => {
-    const result = findWebAuthnSteps({
+    const result = findWebAuthnFlows({
       supportsRor: true,
       devices: [createMockCredential(nonCurrentOrigin1)],
       currentOrigin: currentOrigin,
@@ -41,7 +41,7 @@ describe("findWebAuthnSteps", () => {
   });
 
   it("should not use iframe if the RP ID matches the current origin", () => {
-    const result = findWebAuthnSteps({
+    const result = findWebAuthnFlows({
       supportsRor: true,
       devices: [
         createMockCredential(currentOrigin),
@@ -55,7 +55,7 @@ describe("findWebAuthnSteps", () => {
   });
 
   it("should use ic0.app when origin is undefined", () => {
-    const result = findWebAuthnSteps({
+    const result = findWebAuthnFlows({
       supportsRor: true,
       devices: [
         createMockCredential(undefined),
@@ -69,7 +69,7 @@ describe("findWebAuthnSteps", () => {
   });
 
   it("should handle multiple RP IDs and filter credentials accordingly", () => {
-    const result = findWebAuthnSteps({
+    const result = findWebAuthnFlows({
       supportsRor: true,
       devices: [
         createMockCredential(currentOrigin),

--- a/src/frontend/src/utils/findWebAuthnFlows.ts
+++ b/src/frontend/src/utils/findWebAuthnFlows.ts
@@ -4,7 +4,7 @@ import {
   findWebAuthnRpId,
 } from "./findWebAuthnRpId";
 
-export type WebAuthnStep = {
+export type WebAuthnFlow = {
   useIframe: boolean;
   rpId: string | undefined;
 };
@@ -32,14 +32,14 @@ type Parameters = {
  * - At the moment, we only use non-iframe if the RP ID matches the current origin. to avoid bad UX, if the RP ID doesn't match the current origin, the iframe will be used.
  *
  * @param {Parameters} params - The parameters to find the webauthn steps.
- * @returns {WebAuthnStep[]} The ordered steps to try to perform the webauthn authentication.
+ * @returns {WebAuthnFlow[]} The ordered steps to try to perform the webauthn authentication.
  */
-export const findWebAuthnSteps = ({
+export const findWebAuthnFlows = ({
   devices,
   currentOrigin,
   relatedOrigins,
-}: Parameters): WebAuthnStep[] => {
-  const steps: WebAuthnStep[] = [];
+}: Parameters): WebAuthnFlow[] => {
+  const steps: WebAuthnFlow[] = [];
   let filteredCredentials = devices;
   const rpIds = new Set<string | undefined>();
 

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -61,8 +61,8 @@ import {
   convertToValidCredentialData,
   CredentialData,
 } from "./credential-devices";
+import { findWebAuthnFlows, WebAuthnFlow } from "./findWebAuthnFlows";
 import { relatedDomains } from "./findWebAuthnRpId";
-import { findWebAuthnSteps, WebAuthnStep } from "./findWebAuthnSteps";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 import { isRecoveryDevice, RecoveryDevice } from "./recoveryDevice";
 import { supportsWebauthRoR } from "./userAgent";
@@ -153,9 +153,8 @@ export interface IIWebAuthnIdentity extends SignIdentity {
 
 export class Connection {
   private configPromise: Promise<InternetIdentityInit> | undefined;
-  // TODO: Rename `WebAuthnStep` and the util to use `flow` instead of `step`.
   private webAuthFlows:
-    | { flows: WebAuthnStep[]; currentIndex: number }
+    | { flows: WebAuthnFlow[]; currentIndex: number }
     | undefined;
 
   public constructor(
@@ -425,7 +424,7 @@ export class Connection {
     credentials: CredentialData[]
   ): Promise<LoginSuccess | WebAuthnFailed | PossiblyWrongRPID | AuthFail> => {
     if (isNullish(this.webAuthFlows) && DOMAIN_COMPATIBILITY.isEnabled()) {
-      const flows = findWebAuthnSteps({
+      const flows = findWebAuthnFlows({
         supportsRor: supportsWebauthRoR(window.navigator.userAgent),
         devices: credentials,
         currentOrigin: window.location.origin,


### PR DESCRIPTION
# Motivation

WebAuthnSteps is confusing because those are not a set of steps that the user needs to perform.

WebAuthnFlows is a better (but not perfect) name to understand that the user will perform one of those.

# Changes

* Rename file, util and type.

# Tests

* Rename test files and describe.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/44de00528/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/44de00528/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/44de00528/desktop/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
