### PR TITLE
Use devices origin if ROR is supported

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -50,6 +50,7 @@ import {
   isRecoveryDevice,
   isRecoveryPhrase,
 } from "$src/utils/recoveryDevice";
+import { supportsWebauthRoR } from "$src/utils/userAgent";
 import {
   OmitParams,
   isCanisterError,
@@ -381,12 +382,14 @@ export const displayManage = async (
     }
 
     const onAddDevice = async () => {
-      const newDeviveOrigin = DOMAIN_COMPATIBILITY.isEnabled()
-        ? getCredentialsOrigin({
-            credentials: devices_,
-            userAgent: navigator.userAgent,
-          })
-        : undefined;
+      const newDeviveOrigin =
+        supportsWebauthRoR(window.navigator.userAgent) &&
+        DOMAIN_COMPATIBILITY.isEnabled()
+          ? getCredentialsOrigin({
+              credentials: devices_,
+              userAgent: navigator.userAgent,
+            })
+          : undefined;
       await addDevice({
         userNumber,
         connection,
@@ -401,6 +404,7 @@ export const displayManage = async (
         return;
       }
       doAdd satisfies "ok";
+      // Recovery phrase doesn't need ROR, this is for consistency reasons.
       const newDeviceOrigin = DOMAIN_COMPATIBILITY.isEnabled()
         ? getCredentialsOrigin({
             credentials: devices_,

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -10,6 +10,7 @@ import { infoScreenTemplate } from "$src/components/infoScreen";
 import { DOMAIN_COMPATIBILITY } from "$src/featureFlags";
 import { IdentityMetadata } from "$src/repositories/identityMetadata";
 import { getCredentialsOrigin } from "$src/utils/credential-devices";
+import { supportsWebauthRoR } from "$src/utils/userAgent";
 import { isNullish } from "@dfinity/utils";
 import { addDevice } from "../addDevice/manage/addDevice";
 import {
@@ -239,12 +240,14 @@ export const recoveryWizard = async (
     nowInMillis,
   });
 
-  const originNewDevice = DOMAIN_COMPATIBILITY.isEnabled()
-    ? getCredentialsOrigin({
-        credentials,
-        userAgent: navigator.userAgent,
-      })
-    : undefined;
+  const originNewDevice =
+    supportsWebauthRoR(window.navigator.userAgent) &&
+    DOMAIN_COMPATIBILITY.isEnabled()
+      ? getCredentialsOrigin({
+          credentials,
+          userAgent: navigator.userAgent,
+        })
+      : undefined;
 
   if (devicesStatus !== "no-warning") {
     connection.updateIdentityMetadata({

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -9,6 +9,7 @@ import {
   creationOptions,
   IC_DERIVATION_PATH,
 } from "$src/utils/iiConnection";
+import { supportsWebauthRoR } from "$src/utils/userAgent";
 import { unreachable, unreachableLax } from "$src/utils/utils";
 import { WebAuthnIdentity } from "$src/utils/webAuthnIdentity";
 import { DerEncodedPublicKey, SignIdentity } from "@dfinity/agent";
@@ -32,12 +33,14 @@ export const setupKey = async ({
     await withLoader(async () => {
       const devices =
         devices_ ?? (await connection.lookupAll(connection.userNumber));
-      const newDeviceOrigin = DOMAIN_COMPATIBILITY.isEnabled()
-        ? getCredentialsOrigin({
-            credentials: devices,
-            userAgent: window.navigator.userAgent,
-          })
-        : undefined;
+      const newDeviceOrigin =
+        supportsWebauthRoR(window.navigator.userAgent) &&
+        DOMAIN_COMPATIBILITY.isEnabled()
+          ? getCredentialsOrigin({
+              credentials: devices,
+              userAgent: window.navigator.userAgent,
+            })
+          : undefined;
       const rpId = nonNullish(newDeviceOrigin)
         ? new URL(newDeviceOrigin).host
         : undefined;

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -11,6 +11,7 @@ import {
   IIWebAuthnIdentity,
   LoginSuccess,
 } from "$src/utils/iiConnection";
+import { supportsWebauthRoR } from "$src/utils/userAgent";
 import { unknownToString, unreachableLax } from "$src/utils/utils";
 import { constructIdentity } from "$src/utils/webAuthn";
 import {
@@ -130,12 +131,14 @@ const enrollAuthenticator = async ({
   try {
     const newDeviceData = await withLoader(async () => {
       const devices = (await connection.getAnchorInfo()).devices;
-      const newDeviceOrigin = DOMAIN_COMPATIBILITY.isEnabled()
-        ? getCredentialsOrigin({
-            credentials: devices,
-            userAgent: window.navigator.userAgent,
-          })
-        : undefined;
+      const newDeviceOrigin =
+        supportsWebauthRoR(window.navigator.userAgent) &&
+        DOMAIN_COMPATIBILITY.isEnabled()
+          ? getCredentialsOrigin({
+              credentials: devices,
+              userAgent: window.navigator.userAgent,
+            })
+          : undefined;
       const rpId = nonNullish(newDeviceOrigin)
         ? new URL(newDeviceOrigin).hostname
         : undefined;


### PR DESCRIPTION
# Motivation

ROR is not supported in all browsers. We can't use it when adding new devices on those browsers.

Not in this PR: Ignore it also when third-party password managers are installed.

# Changes

* Check ROR support when calculating the origin of a new device.

# Tests

* Tested in beta domains.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7eed3c291/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7eed3c291/desktop/displayManageSingle.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
