### PR TITLE
Retry different RP ID in VC flow

### DIFF
--- a/src/frontend/src/components/infoToast/copy.json
+++ b/src/frontend/src/components/infoToast/copy.json
@@ -3,6 +3,7 @@
     "title_possibly_wrong_web_authn_flow": "Please try again",
     "message_possibly_wrong_web_authn_flow_1": "The wrong domain was set for the passkey and the browser couldn't find it.",
     "title_pin_another_domain": "Pin identity in another domain",
+    "title_trying_again": "Trying again",
     "message_pin_another_domain_1": "You seem to be using a PIN identity created in another domain.",
     "message_pin_another_domain_2": "To access this domain you need to go to the other domain and add a passkey."
   }

--- a/src/frontend/src/flows/verifiableCredentials/index.ts
+++ b/src/frontend/src/flows/verifiableCredentials/index.ts
@@ -139,8 +139,6 @@ const verifyCredentials = async ({
     allowPinLogin: true,
   });
 
-  console.log("after da first authResult", authResult);
-
   if ("tag" in authResult) {
     authResult satisfies { tag: "canceled" };
     return "aborted";
@@ -148,6 +146,8 @@ const verifyCredentials = async ({
 
   authResult satisfies { kind: unknown };
 
+  // There are three supported origins. I wanted to give the user a chance to cancel once the correct one and maybe still make it work.
+  // Therefore, the max retries should allow to iterate through all the 3 origins twice.
   const MAX_RETRIES = 5;
   let currentRetry = 0;
   // This is ugly, but I couldn't find a better way to handle the retry without disrupting the whole flow.
@@ -164,13 +164,11 @@ const verifyCredentials = async ({
         messages: [copy.message_possibly_wrong_web_authn_flow_1],
       })
     );
-    console.log(`before da second authResult ${currentRetry}`);
     authResult = await useIdentity({
       userNumber,
       connection,
       allowPinLogin: true,
     });
-    console.log("after da second authResult", authResult);
 
     if ("tag" in authResult) {
       authResult satisfies { tag: "canceled" };


### PR DESCRIPTION
# Motivation

The retry flow logic was not part of the VC flow because there the authentication flow is different.

I added the logic within the vc flow itself with a "while" loop. I wonder whether this is a better UX than asking the user to retry again by clicking or whether II should retry after a cancellation. For best use case is nice, but it's annoying if you really wanted to cancel.

# Changes

* Add a "while" look that requests authentication as long as the return is `possiblyWrongWebAuthnFlow`.
* Add a different title in that info toast "Retrying again".

# Tests

* Tested in beta domains. The flow to exit is pretty ugly. We can reduce the number of retries... But this is anyway an edge case. Most people shouldn't be cancelling when the credential is found. Specially during VC, which is a flow they triggered.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cf440d89e/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cf440d89e/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cf440d89e/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cf440d89e/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cf440d89e/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cf440d89e/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/cf440d89e/mobile/allowCredentials.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
