### PR TITLE
Remove userAgent from `getCredentialsOrigin`

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -386,7 +386,6 @@ export const displayManage = async (
         userSupportsWebauthRoR() && DOMAIN_COMPATIBILITY.isEnabled()
           ? getCredentialsOrigin({
               credentials: devices_,
-              userAgent: navigator.userAgent,
             })
           : undefined;
       await addDevice({
@@ -407,7 +406,6 @@ export const displayManage = async (
       const newDeviceOrigin = DOMAIN_COMPATIBILITY.isEnabled()
         ? getCredentialsOrigin({
             credentials: devices_,
-            userAgent: window.navigator.userAgent,
           })
         : undefined;
       await setupPhrase(

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -731,7 +731,6 @@ const domainInfo = (
   }
   const commonOrigin = getCredentialsOrigin({
     credentials: allDevices,
-    userAgent: window.navigator.userAgent,
   });
   if (nonNullish(commonOrigin)) {
     return undefined;

--- a/src/frontend/src/flows/recovery/recoveryWizard.ts
+++ b/src/frontend/src/flows/recovery/recoveryWizard.ts
@@ -244,7 +244,6 @@ export const recoveryWizard = async (
     userSupportsWebauthRoR() && DOMAIN_COMPATIBILITY.isEnabled()
       ? getCredentialsOrigin({
           credentials,
-          userAgent: navigator.userAgent,
         })
       : undefined;
 

--- a/src/frontend/src/flows/recovery/setupRecovery.ts
+++ b/src/frontend/src/flows/recovery/setupRecovery.ts
@@ -37,7 +37,6 @@ export const setupKey = async ({
         userSupportsWebauthRoR() && DOMAIN_COMPATIBILITY.isEnabled()
           ? getCredentialsOrigin({
               credentials: devices,
-              userAgent: window.navigator.userAgent,
             })
           : undefined;
       const rpId = nonNullish(newDeviceOrigin)

--- a/src/frontend/src/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/flows/recovery/useRecovery.ts
@@ -135,7 +135,6 @@ const enrollAuthenticator = async ({
         userSupportsWebauthRoR() && DOMAIN_COMPATIBILITY.isEnabled()
           ? getCredentialsOrigin({
               credentials: devices,
-              userAgent: window.navigator.userAgent,
             })
           : undefined;
       const rpId = nonNullish(newDeviceOrigin)

--- a/src/frontend/src/utils/credential-devices.test.ts
+++ b/src/frontend/src/utils/credential-devices.test.ts
@@ -27,16 +27,11 @@ describe("credetial-devices test", () => {
     const icIoOriginDevice: Omit<DeviceData, "alias"> = createDevice(
       "https://identity.icp0.io"
     );
-    const userAgentSupportingRoR =
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
-    const userAgentNotSupportingRoR =
-      "Mozilla/5.0 (Android 13; Mobile; rv:132.0) Gecko/132.0 Firefox/132.0";
 
-    it("should return a set of origins", () => {
+    it("should return a set of origins or `undefined`", () => {
       expect(
         getCredentialsOrigin({
           credentials: [ic0OriginDevice, icOrgOriginDevice, icIoOriginDevice],
-          userAgent: userAgentSupportingRoR,
         })
       ).toBeUndefined();
 
@@ -47,21 +42,18 @@ describe("credetial-devices test", () => {
             { ...ic0OriginDevice },
             icIoOriginDevice,
           ],
-          userAgent: userAgentSupportingRoR,
         })
       ).toBeUndefined();
 
       expect(
         getCredentialsOrigin({
           credentials: [ic0OriginDevice, { ...ic0OriginDevice }],
-          userAgent: userAgentSupportingRoR,
         })
       ).toBe("https://identity.ic0.app");
 
       expect(
         getCredentialsOrigin({
           credentials: [icOrgOriginDevice, { ...icOrgOriginDevice }],
-          userAgent: userAgentSupportingRoR,
         })
       ).toBe("https://identity.internetcomputer.org");
     });
@@ -70,30 +62,18 @@ describe("credetial-devices test", () => {
       expect(
         getCredentialsOrigin({
           credentials: [undefinedOriginDevice],
-          userAgent: userAgentSupportingRoR,
         })
       ).toBe("https://identity.ic0.app");
 
       expect(
         getCredentialsOrigin({
           credentials: [undefinedOriginDevice, ic0OriginDevice],
-          userAgent: userAgentSupportingRoR,
         })
       ).toBe("https://identity.ic0.app");
 
       expect(
         getCredentialsOrigin({
           credentials: [undefinedOriginDevice, icOrgOriginDevice],
-          userAgent: userAgentSupportingRoR,
-        })
-      ).toBeUndefined();
-    });
-
-    it("returns `undefined` if user doesn't support RoR", () => {
-      expect(
-        getCredentialsOrigin({
-          credentials: [ic0OriginDevice, icOrgOriginDevice, icIoOriginDevice],
-          userAgent: userAgentNotSupportingRoR,
         })
       ).toBeUndefined();
     });

--- a/src/frontend/src/utils/credential-devices.ts
+++ b/src/frontend/src/utils/credential-devices.ts
@@ -1,7 +1,6 @@
 import { DeviceData, DeviceKey } from "$generated/internet_identity_types";
 import { II_LEGACY_ORIGIN } from "$src/constants";
 import { DerEncodedPublicKey } from "@dfinity/agent";
-import { supportsWebauthRoR } from "./userAgent";
 
 export type CredentialId = ArrayBuffer;
 export type CredentialData = {
@@ -44,28 +43,23 @@ export const convertToValidCredentialData = (
  *
  * Therefore, we want to avoid devices registered in multiple origins.
  *
- * First, it checks whether the browser supports ROR.
- * Second, it checks whether all the devices have the same origin.
+ * It checks whether all the devices have the same origin.
  * - If they do, it returns the origin.
  * - If they don't, it returns `undefined`.
  *
+ * This function is commonly used along `userSupportsWebauthRoR` to check for ROR support first.
+ *
  * @param {Object} params
  * @param {DeviceData[]} params.credentials - The devices to check.
- * @param {string} params.userAgent - The user agent string.
  * @returns {string | undefined} The origin to use when adding a new device.
  * - If `undefined` then no common origin was found. Probalby use `window.origin` or `undefined` for RP ID.
  * - If `string` then the origin can be used to add a new device. Remember to use the hostname only for RP ID.
  */
 export const getCredentialsOrigin = ({
   credentials,
-  userAgent,
 }: {
   credentials: Omit<DeviceData, "alias">[];
-  userAgent: string;
 }): string | undefined => {
-  if (!supportsWebauthRoR(userAgent)) {
-    return undefined;
-  }
   const credentialOrigins = new Set(
     credentials.map((c) => c.origin[0] ?? II_LEGACY_ORIGIN)
   );


### PR DESCRIPTION
# Motivation

Bring consistency and keep `getCredentialsOrigin` util doing one thing only.

No functionality has been added or removed. Before any call to `getCredentialsOrigin` a call to `userSupportsWebauthRoR` was done anyway. Checking the support is more complex than checking the user agent. That's why it's own util makes sense.

# Changes

* Remove `userAgent` param from `getCredentialsOrigin`'s signature and calls.

# Tests

* Remove tests for `userAgent` param.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8503d0ef1/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8503d0ef1/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8503d0ef1/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8503d0ef1/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8503d0ef1/desktop/managePickMany.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8503d0ef1/mobile/allowCredentialsLongOrigins.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

