### PR TITLE
Fix width toast in small devices

### DIFF
--- a/src/frontend/src/styles/main.css
+++ b/src/frontend/src/styles/main.css
@@ -304,6 +304,7 @@
 
   --rs-marketing-block-stack: calc(var(--vs-stack) * 5);
 
+  --rs-toasts-brezel: var(--vs-bezel);
   --rs-toast-body-stack: calc(var(--vs-stack) * 0.5);
   --rs-toast-stack: var(--rs-toast-body-stack);
 
@@ -1417,6 +1418,13 @@ by all browsers (FF is missing) */
   right: 0;
   z-index: var(--z-toasts);
   margin: 0 auto calc(var(--rs-footer-height) + 0.5rem);
+}
+
+@media screen and (max-width: 512px) {
+  .c-toasts {
+    min-width: unset;
+    padding: 0 var(--rs-toasts-brezel);
+  }
 }
 
 .c-toast + .c-toast {


### PR DESCRIPTION
# Motivation

Fix minor UI issue with toasts in small devices. The toast was overflowing the horizontal space.

# Changes

* Unset the min-width when toasts, which was causing the overflow.
* Add padding in toasts container to declutter them from the side.

# Tests

* Checked in the showcase.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/668ae37d1/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/668ae37d1/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/668ae37d1/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/668ae37d1/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/668ae37d1/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/668ae37d1/mobile/toasts.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
