### PR TITLE
Add analytics config

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -8,6 +8,7 @@ export const idlFactory = ({ IDL }) => {
     'module_hash' : IDL.Vec(IDL.Nat8),
     'entries_fetch_limit' : IDL.Nat16,
   });
+  const AnalyticsConfig = IDL.Variant({ 'Plausible' : IDL.Null });
   const CaptchaConfig = IDL.Record({
     'max_unsolved_captchas' : IDL.Nat64,
     'captcha_trigger' : IDL.Variant({
@@ -31,6 +32,7 @@ export const idlFactory = ({ IDL }) => {
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
+    'analytics_config' : IDL.Opt(IDL.Opt(AnalyticsConfig)),
     'related_origins' : IDL.Opt(IDL.Vec(IDL.Text)),
     'captcha_config' : IDL.Opt(CaptchaConfig),
     'register_rate_limit' : IDL.Opt(RateLimitConfig),
@@ -576,6 +578,7 @@ export const init = ({ IDL }) => {
     'module_hash' : IDL.Vec(IDL.Nat8),
     'entries_fetch_limit' : IDL.Nat16,
   });
+  const AnalyticsConfig = IDL.Variant({ 'Plausible' : IDL.Null });
   const CaptchaConfig = IDL.Record({
     'max_unsolved_captchas' : IDL.Nat64,
     'captcha_trigger' : IDL.Variant({
@@ -599,6 +602,7 @@ export const init = ({ IDL }) => {
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
     'canister_creation_cycles_cost' : IDL.Opt(IDL.Nat64),
+    'analytics_config' : IDL.Opt(IDL.Opt(AnalyticsConfig)),
     'related_origins' : IDL.Opt(IDL.Vec(IDL.Text)),
     'captcha_config' : IDL.Opt(CaptchaConfig),
     'register_rate_limit' : IDL.Opt(RateLimitConfig),

--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -8,7 +8,14 @@ export const idlFactory = ({ IDL }) => {
     'module_hash' : IDL.Vec(IDL.Nat8),
     'entries_fetch_limit' : IDL.Nat16,
   });
-  const AnalyticsConfig = IDL.Variant({ 'Plausible' : IDL.Null });
+  const AnalyticsConfig = IDL.Variant({
+    'Plausible' : IDL.Record({
+      'domain' : IDL.Opt(IDL.Text),
+      'track_localhost' : IDL.Opt(IDL.Bool),
+      'hash_mode' : IDL.Opt(IDL.Bool),
+      'api_host' : IDL.Opt(IDL.Text),
+    }),
+  });
   const CaptchaConfig = IDL.Record({
     'max_unsolved_captchas' : IDL.Nat64,
     'captcha_trigger' : IDL.Variant({
@@ -578,7 +585,14 @@ export const init = ({ IDL }) => {
     'module_hash' : IDL.Vec(IDL.Nat8),
     'entries_fetch_limit' : IDL.Nat16,
   });
-  const AnalyticsConfig = IDL.Variant({ 'Plausible' : IDL.Null });
+  const AnalyticsConfig = IDL.Variant({
+    'Plausible' : IDL.Record({
+      'domain' : IDL.Opt(IDL.Text),
+      'track_localhost' : IDL.Opt(IDL.Bool),
+      'hash_mode' : IDL.Opt(IDL.Bool),
+      'api_host' : IDL.Opt(IDL.Text),
+    }),
+  });
   const CaptchaConfig = IDL.Record({
     'max_unsolved_captchas' : IDL.Nat64,
     'captcha_trigger' : IDL.Variant({

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -12,7 +12,14 @@ export type AddTentativeDeviceResponse = {
       'device_registration_timeout' : Timestamp,
     }
   };
-export type AnalyticsConfig = { 'Plausible' : null };
+export type AnalyticsConfig = {
+    'Plausible' : {
+      'domain' : [] | [string],
+      'track_localhost' : [] | [boolean],
+      'hash_mode' : [] | [boolean],
+      'api_host' : [] | [string],
+    }
+  };
 export interface AnchorCredentials {
   'recovery_phrases' : Array<PublicKey>,
   'credentials' : Array<WebAuthnCredential>,

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -12,6 +12,7 @@ export type AddTentativeDeviceResponse = {
       'device_registration_timeout' : Timestamp,
     }
   };
+export type AnalyticsConfig = { 'Plausible' : null };
 export interface AnchorCredentials {
   'recovery_phrases' : Array<PublicKey>,
   'credentials' : Array<WebAuthnCredential>,
@@ -207,6 +208,7 @@ export interface InternetIdentityInit {
   'assigned_user_number_range' : [] | [[bigint, bigint]],
   'archive_config' : [] | [ArchiveConfig],
   'canister_creation_cycles_cost' : [] | [bigint],
+  'analytics_config' : [] | [[] | [AnalyticsConfig]],
   'related_origins' : [] | [Array<string>],
   'captcha_config' : [] | [CaptchaConfig],
   'register_rate_limit' : [] | [RateLimitConfig],

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -342,7 +342,12 @@ type OpenIdConfig = record {
 type OpenIdCredentialKey = record { Iss; Sub };
 
 type AnalyticsConfig = variant {
-    Plausible;
+    Plausible {
+        domain: opt text,
+        hash_mode: opt bool,
+        track_localhost: opt bool,
+        api_host: opt text,
+    };
 };
 
 type OpenIdCredential = record {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -342,7 +342,7 @@ type OpenIdConfig = record {
 type OpenIdCredentialKey = record { Iss; Sub };
 
 type AnalyticsConfig = variant {
-    Plausible {
+    Plausible: record {
         domain: opt text,
         hash_mode: opt bool,
         track_localhost: opt bool,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -343,10 +343,10 @@ type OpenIdCredentialKey = record { Iss; Sub };
 
 type AnalyticsConfig = variant {
     Plausible: record {
-        domain: opt text,
-        hash_mode: opt bool,
-        track_localhost: opt bool,
-        api_host: opt text,
+        domain: opt text;
+        hash_mode: opt bool;
+        track_localhost: opt bool;
+        api_host: opt text;
     };
 };
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -266,6 +266,8 @@ type InternetIdentityInit = record {
     related_origins: opt vec text;
     // Configuration for OpenID Google client
     openid_google: opt opt OpenIdConfig;
+    // Configuration for Web Analytics
+    analytics_config: opt opt AnalyticsConfig;
 };
 
 type ChallengeKey = text;
@@ -338,6 +340,10 @@ type OpenIdConfig = record {
 };
 
 type OpenIdCredentialKey = record { Iss; Sub };
+
+type AnalyticsConfig = variant {
+    Plausible;
+};
 
 type OpenIdCredential = record {
     iss: Iss;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -353,6 +353,7 @@ fn config() -> InternetIdentityInit {
         captcha_config: Some(persistent_state.captcha_config.clone()),
         related_origins: persistent_state.related_origins.clone(),
         openid_google: Some(persistent_state.openid_google.clone()),
+        analytics_config: Some(persistent_state.analytics_config.clone()),
     })
 }
 
@@ -441,6 +442,12 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
         if let Some(openid_google) = arg.openid_google {
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.openid_google = openid_google;
+            })
+        }
+        if let Some(analytics_config) = arg.analytics_config {
+            ic_cdk::println!("setting analytics config {:?}", analytics_config);
+            state::persistent_state_mut(|persistent_state| {
+                persistent_state.analytics_config = analytics_config;
             })
         }
     }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -445,7 +445,6 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
             })
         }
         if let Some(analytics_config) = arg.analytics_config {
-            ic_cdk::println!("setting analytics config {:?}", analytics_config);
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.analytics_config = analytics_config;
             })

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -107,6 +107,8 @@ pub struct PersistentState {
     pub related_origins: Option<Vec<String>>,
     // Configuration for OpenID Google client
     pub openid_google: Option<OpenIdConfig>,
+    // Configuration for Web Analytics tool
+    pub analytics_config: Option<AnalyticsConfig>,
     // Key into the event_data BTreeMap where the 24h tracking window starts.
     // This key is used to remove old entries from the 24h event aggregations.
     // If it is `none`, then the 24h window starts from the newest entry in the event_data
@@ -127,6 +129,7 @@ impl Default for PersistentState {
             captcha_config: DEFAULT_CAPTCHA_CONFIG,
             related_origins: None,
             openid_google: None,
+            analytics_config: None,
             event_stats_24h_start: None,
         }
     }

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -9,7 +9,7 @@ use candid::{CandidType, Deserialize};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
 use internet_identity_interface::internet_identity::types::{
-    CaptchaConfig, FrontendHostname, OpenIdConfig, RateLimitConfig, Timestamp,
+    AnalyticsConfig, CaptchaConfig, FrontendHostname, OpenIdConfig, RateLimitConfig, Timestamp
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -34,6 +34,7 @@ pub struct StorablePersistentState {
     captcha_config: Option<CaptchaConfig>,
     related_origins: Option<Vec<String>>,
     openid_google: Option<OpenIdConfig>,
+    analytics_config: Option<AnalyticsConfig>,
 }
 
 impl Storable for StorablePersistentState {
@@ -73,6 +74,7 @@ impl From<PersistentState> for StorablePersistentState {
             captcha_config: Some(s.captcha_config),
             related_origins: s.related_origins,
             openid_google: s.openid_google,
+            analytics_config: s.analytics_config,
         }
     }
 }
@@ -89,6 +91,7 @@ impl From<StorablePersistentState> for PersistentState {
             captcha_config: s.captcha_config.unwrap_or(DEFAULT_CAPTCHA_CONFIG),
             related_origins: s.related_origins,
             openid_google: s.openid_google,
+            analytics_config: s.analytics_config,
             event_stats_24h_start: s.event_stats_24h_start,
         }
     }
@@ -135,6 +138,7 @@ mod tests {
             }),
             related_origins: None,
             openid_google: None,
+            analytics_config: None,
         };
 
         assert_eq!(StorablePersistentState::default(), expected_defaults);
@@ -156,6 +160,7 @@ mod tests {
             related_origins: None,
             openid_google: None,
             event_stats_24h_start: None,
+            analytics_config: None,
         };
         assert_eq!(PersistentState::default(), expected_defaults);
     }

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -9,7 +9,7 @@ use candid::{CandidType, Deserialize};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
 use internet_identity_interface::internet_identity::types::{
-    AnalyticsConfig, CaptchaConfig, FrontendHostname, OpenIdConfig, RateLimitConfig, Timestamp
+    AnalyticsConfig, CaptchaConfig, FrontendHostname, OpenIdConfig, RateLimitConfig, Timestamp,
 };
 use std::borrow::Cow;
 use std::collections::HashMap;

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -3,7 +3,8 @@ use canister_tests::framework::{
     env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
-    AnalyticsConfig, ArchiveConfig, CaptchaConfig, CaptchaTrigger, InternetIdentityInit, OpenIdConfig, RateLimitConfig
+    AnalyticsConfig, ArchiveConfig, CaptchaConfig, CaptchaTrigger, InternetIdentityInit,
+    OpenIdConfig, RateLimitConfig,
 };
 use pocket_ic::CallError;
 

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -78,7 +78,12 @@ fn should_retain_config_after_none() -> Result<(), CallError> {
         }),
         related_origins: Some(related_origins),
         openid_google: Some(Some(openid_google)),
-        analytics_config: Some(Some(AnalyticsConfig::Plausible)),
+        analytics_config: Some(Some(AnalyticsConfig::Plausible {
+            domain: None,
+            hash_mode: None,
+            track_localhost: None,
+            api_host: None,
+        })),
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
@@ -127,7 +132,12 @@ fn should_override_partially() -> Result<(), CallError> {
         }),
         related_origins: Some(related_origins),
         openid_google: Some(openid_google),
-        analytics_config: Some(Some(AnalyticsConfig::Plausible)),
+        analytics_config: Some(Some(AnalyticsConfig::Plausible {
+            domain: None,
+            hash_mode: None,
+            track_localhost: None,
+            api_host: None,
+        })),
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
@@ -199,14 +209,24 @@ fn should_override_partially() -> Result<(), CallError> {
         captcha_config: None,
         related_origins: None,
         openid_google: None,
-        analytics_config: Some(Some(AnalyticsConfig::Plausible)),
+        analytics_config: Some(Some(AnalyticsConfig::Plausible {
+            domain: Some("internetcomputer.org".to_string()),
+            hash_mode: None,
+            track_localhost: None,
+            api_host: None,
+        })),
     };
 
     let _ =
         upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_4.clone()));
 
     let expected_config_4 = InternetIdentityInit {
-        analytics_config: Some(Some(AnalyticsConfig::Plausible)),
+        analytics_config: Some(Some(AnalyticsConfig::Plausible {
+            domain: Some("internetcomputer.org".to_string()),
+            hash_mode: None,
+            track_localhost: None,
+            api_host: None,
+        })),
         ..expected_config_3
     };
 

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -3,8 +3,7 @@ use canister_tests::framework::{
     env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
-    ArchiveConfig, CaptchaConfig, CaptchaTrigger, InternetIdentityInit, OpenIdConfig,
-    RateLimitConfig,
+    AnalyticsConfig, ArchiveConfig, CaptchaConfig, CaptchaTrigger, InternetIdentityInit, OpenIdConfig, RateLimitConfig
 };
 use pocket_ic::CallError;
 
@@ -34,6 +33,7 @@ fn should_retain_anchor_on_user_range_change() -> Result<(), CallError> {
         }),
         related_origins: None,
         openid_google: Some(None),
+        analytics_config: None,
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
@@ -77,6 +77,7 @@ fn should_retain_config_after_none() -> Result<(), CallError> {
         }),
         related_origins: Some(related_origins),
         openid_google: Some(Some(openid_google)),
+        analytics_config: Some(Some(AnalyticsConfig::Plausible)),
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
@@ -125,6 +126,7 @@ fn should_override_partially() -> Result<(), CallError> {
         }),
         related_origins: Some(related_origins),
         openid_google: Some(openid_google),
+        analytics_config: Some(Some(AnalyticsConfig::Plausible)),
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
@@ -147,6 +149,7 @@ fn should_override_partially() -> Result<(), CallError> {
         captcha_config: Some(new_captcha.clone()),
         related_origins: None,
         openid_google: None,
+        analytics_config: None,
     };
 
     let _ =
@@ -173,6 +176,7 @@ fn should_override_partially() -> Result<(), CallError> {
         captcha_config: None,
         related_origins: Some(related_origins_2.clone()),
         openid_google: Some(openid_google2.clone()),
+        analytics_config: None,
     };
 
     let _ =
@@ -185,6 +189,27 @@ fn should_override_partially() -> Result<(), CallError> {
     };
 
     assert_eq!(api::config(&env, canister_id)?, expected_config_3);
+
+    let config_4 = InternetIdentityInit {
+        assigned_user_number_range: None,
+        archive_config: None,
+        canister_creation_cycles_cost: None,
+        register_rate_limit: None,
+        captcha_config: None,
+        related_origins: None,
+        openid_google: None,
+        analytics_config: Some(Some(AnalyticsConfig::Plausible)),
+    };
+
+    let _ =
+        upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_4.clone()));
+
+    let expected_config_4 = InternetIdentityInit {
+        analytics_config: Some(Some(AnalyticsConfig::Plausible)),
+        ..expected_config_3
+    };
+
+    assert_eq!(api::config(&env, canister_id)?, expected_config_4);
 
     Ok(())
 }

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -34,7 +34,7 @@ fn should_retain_anchor_on_user_range_change() -> Result<(), CallError> {
         }),
         related_origins: None,
         openid_google: Some(None),
-        analytics_config: None,
+        analytics_config: Some(None),
     };
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -94,6 +94,7 @@ fn ii_canister_serves_webauthn_assets() -> Result<(), CallError> {
         captcha_config: None,
         related_origins: Some(related_origins.clone()),
         openid_google: None,
+        analytics_config: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
 
@@ -156,6 +157,7 @@ fn ii_canister_serves_webauthn_assets_after_upgrade() -> Result<(), CallError> {
         captcha_config: None,
         related_origins: Some(related_origins.clone()),
         openid_google: None,
+        analytics_config: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 
@@ -194,6 +196,7 @@ fn ii_canister_serves_webauthn_assets_after_upgrade() -> Result<(), CallError> {
         captcha_config: None,
         related_origins: Some(related_origins_2.clone()),
         openid_google: None,
+        analytics_config: None,
     };
 
     let _ = upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_2));
@@ -577,6 +580,7 @@ fn must_not_cache_well_known_webauthn() -> Result<(), CallError> {
         captcha_config: None,
         related_origins: Some(related_origins.clone()),
         openid_google: None,
+        analytics_config: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -207,6 +207,7 @@ pub struct InternetIdentityInit {
     pub captcha_config: Option<CaptchaConfig>,
     pub related_origins: Option<Vec<String>>,
     pub openid_google: Option<Option<OpenIdConfig>>,
+    pub analytics_config: Option<Option<AnalyticsConfig>>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -243,6 +244,11 @@ pub struct RateLimitConfig {
 pub struct CaptchaConfig {
     pub max_unsolved_captchas: u64,
     pub captcha_trigger: CaptchaTrigger,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum AnalyticsConfig {
+    Plausible,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -248,7 +248,14 @@ pub struct CaptchaConfig {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum AnalyticsConfig {
-    Plausible,
+    Plausible {
+        // Config params from Plausible NPM package
+        // https://www.npmjs.com/package/plausible-tracker
+        domain: Option<String>,
+        hash_mode: Option<bool>,
+        track_localhost: Option<bool>,
+        api_host: Option<String>,
+    },
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
# Motivation

Add analytics config to init parameters to make it possible to enable or disable analytics with a config change.

# Changes

* New `AnalyticsConfig` enum.
* Add `analytics_config` field to `InternetIdentityInit` and `PeristentState`.
* Set the persistent state field on init.

# Tests

* Extend a test to check that the new field is set.





<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b43cb22d7/desktop/allowCredentialsLongOrigins.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->




