### PR TITLE
Implement canister config in html.

### DIFF
--- a/src/asset_util/src/lib.rs
+++ b/src/asset_util/src/lib.rs
@@ -8,6 +8,7 @@ use ic_certification::{
 use ic_representation_independent_hash::{representation_independent_hash, Value};
 use include_dir::Dir;
 use internet_identity_interface::http_gateway::HeaderField;
+use internet_identity_interface::internet_identity::types::InternetIdentityInit;
 use lazy_static::lazy_static;
 use serde::Serialize;
 use sha2::Digest;
@@ -416,7 +417,11 @@ fn response_hash(status_code: u16, headers: &[HeaderField], body_hash: &Hash) ->
 
 /// Collects all assets from the given directory, recursing into subdirectories.
 /// Optionally, a transformer function can be provided to transform the HTML files.
-pub fn collect_assets(dir: &Dir, html_transformer: Option<fn(&str) -> String>) -> Vec<Asset> {
+pub fn collect_assets(
+    dir: &Dir,
+    html_transformer: Option<fn(&str, &InternetIdentityInit) -> String>,
+    config: &InternetIdentityInit,
+) -> Vec<Asset> {
     let mut assets = vec![];
 
     // Collect all assets, recursively
@@ -426,9 +431,10 @@ pub fn collect_assets(dir: &Dir, html_transformer: Option<fn(&str) -> String>) -
     if let Some(html_transformer) = html_transformer {
         for asset in &mut assets {
             if let ContentType::HTML = asset.content_type {
-                asset.content = html_transformer(std::str::from_utf8(&asset.content).unwrap())
-                    .as_bytes()
-                    .to_vec();
+                asset.content =
+                    html_transformer(std::str::from_utf8(&asset.content).unwrap(), config)
+                        .as_bytes()
+                        .to_vec();
             }
         }
     }

--- a/src/frontend/src/flows/iframeWebAuthn.ts
+++ b/src/frontend/src/flows/iframeWebAuthn.ts
@@ -141,7 +141,6 @@ export const webAuthnInIframeFlow = async (
   connection: Connection
 ): Promise<never> => {
   // Establish cross-origin connection with parent window
-  const config = await connection.getConfig();
   const targetOrigin = await waitForWindowReadyRequest(
     window.parent,
     // We only establish a connection for the related origins in the II config,
@@ -149,7 +148,7 @@ export const webAuthnInIframeFlow = async (
     //
     // Additionally, the CSP configuration will block any attempt to render II
     // inside an iframe from domains that are not related origins.
-    config.related_origins[0] ?? []
+    connection.canisterConfig.related_origins[0] ?? []
   );
 
   // Get credential and send to parent window

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -2,7 +2,6 @@ import {
   DeviceData,
   DeviceWithUsage,
   IdentityAnchorInfo,
-  InternetIdentityInit,
   OpenIdCredential,
   OpenIdCredentialAddError,
   OpenIdCredentialRemoveError,
@@ -355,11 +354,8 @@ export const displayManage = async (
     connection.identity.getPrincipal()
   );
 
-  // Get Google client id from config in background
-  const configRef: { current?: InternetIdentityInit } = {};
-  void connection.getConfig().then((config) => (configRef.current = config));
-  const getGoogleClientId = () =>
-    configRef.current?.openid_google[0]?.[0]?.client_id;
+  const googleClientId =
+    connection.canisterConfig.openid_google[0]?.[0]?.client_id;
 
   return new Promise((resolve) => {
     const devices = devicesFromDevicesWithUsage({
@@ -417,7 +413,6 @@ export const displayManage = async (
     };
 
     const onLinkAccount = async () => {
-      const googleClientId = getGoogleClientId();
       if (isNullish(googleClientId)) {
         toast.error(copy.linking_google_accounts_is_unavailable);
         return;

--- a/src/frontend/src/spa.ts
+++ b/src/frontend/src/spa.ts
@@ -11,7 +11,12 @@ import { version } from "./version";
 import { isNullish, nonNullish } from "@dfinity/utils";
 
 // Polyfill Buffer globally for the browser
+import { init } from "$generated/internet_identity_idl";
+import { InternetIdentityInit } from "$generated/internet_identity_types";
+import { fromBase64 } from "$src/utils/utils";
+import { IDL } from "@dfinity/candid";
 import { Buffer } from "buffer";
+
 globalThis.Buffer = Buffer;
 
 /** Reads the canister ID from the <script> tag.
@@ -36,6 +41,42 @@ const readCanisterId = (): string => {
   }
 
   return setupJs.dataset.canisterId;
+};
+
+const readCanisterConfig = (): InternetIdentityInit => {
+  // The backend uses a known element ID so that we can pick up the value from here
+  const setupJs = document.querySelector(
+    "[data-canister-config]"
+  ) as HTMLElement | null;
+  if (isNullish(setupJs) || isNullish(setupJs.dataset.canisterConfig)) {
+    void displayError({
+      title: "Canister config not set",
+      message:
+        "There was a problem contacting the IC. The host serving this page did not give us the canister config. Try reloading the page and contact support if the problem persists.",
+      primaryButton: "Reload",
+    }).then(() => {
+      window.location.reload();
+    });
+    throw new Error("canister config is undefined"); // abort further execution of this script
+  }
+
+  try {
+    const [jsonValue] = IDL.decode(
+      [init({ IDL })[0]._type],
+      fromBase64(setupJs.dataset.canisterConfig)
+    );
+    return jsonValue as unknown as InternetIdentityInit;
+  } catch (e) {
+    void displayError({
+      title: "Canister config not valid",
+      message:
+        "There was a problem contacting the IC. The host serving this page did not give us a valid canister config. Try reloading the page and contact support if the problem persists.",
+      primaryButton: "Reload",
+    }).then(() => {
+      window.location.reload();
+    });
+    throw new Error("canister config is invalid"); // abort further execution of this script
+  }
 };
 
 // Show version information for the curious programmer
@@ -96,7 +137,7 @@ export const createSpa = (app: (connection: Connection) => Promise<never>) => {
   }
 
   // Prepare the actor/connection to talk to the canister
-  const connection = new Connection(readCanisterId());
+  const connection = new Connection(readCanisterId(), readCanisterConfig());
 
   return app(connection);
 };

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -1,5 +1,6 @@
 import {
   DeviceData,
+  InternetIdentityInit,
   MetadataMapV2,
   _SERVICE,
 } from "$generated/internet_identity_types";
@@ -84,6 +85,7 @@ beforeEach(async () => {
 test("initializes identity metadata repository", async () => {
   const connection = new AuthenticatedConnection(
     "12345",
+    {} as InternetIdentityInit,
     MultiWebAuthnIdentity.fromCredentials([], undefined, undefined),
     mockDelegationIdentity,
     BigInt(1234),
@@ -99,6 +101,7 @@ test("commits changes on identity metadata", async () => {
   const userNumber = BigInt(1234);
   const connection = new AuthenticatedConnection(
     "12345",
+    {} as InternetIdentityInit,
     MultiWebAuthnIdentity.fromCredentials([], undefined, undefined),
     mockDelegationIdentity,
     userNumber,
@@ -178,7 +181,11 @@ describe("Connection.login", () => {
     });
 
     it("login returns authenticated connection with expected rpID", async () => {
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
 
       const loginResult = await connection.login(BigInt(12345));
 
@@ -207,7 +214,11 @@ describe("Connection.login", () => {
         identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
         lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
       } as unknown as ActorSubclass<_SERVICE>;
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
 
       failSign = true;
       const firstLoginResult = await connection.login(BigInt(12345));
@@ -260,7 +271,11 @@ describe("Connection.login", () => {
           .fn()
           .mockResolvedValue([currentOriginDevice, currentOriginDevice2]),
       } as unknown as ActorSubclass<_SERVICE>;
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
 
       failSign = true;
       const firstLoginResult = await connection.login(BigInt(12345));
@@ -310,7 +325,11 @@ describe("Connection.login", () => {
     });
 
     it("login returns authenticated connection with expected rpID", async () => {
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
 
       const loginResult = await connection.login(BigInt(12345));
 
@@ -339,7 +358,11 @@ describe("Connection.login", () => {
     });
 
     it("login returns authenticated connection without rpID if flag is not enabled", async () => {
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
 
       const loginResult = await connection.login(BigInt(12345));
 
@@ -367,7 +390,11 @@ describe("Connection.login", () => {
         identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
         lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
       } as unknown as ActorSubclass<_SERVICE>;
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
 
       failSign = true;
       const firstLoginResult = await connection.login(BigInt(12345));
@@ -417,7 +444,11 @@ describe("Connection.login", () => {
     });
 
     it("login returns authenticated connection without rpID if flag is not enabled", async () => {
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
 
       const loginResult = await connection.login(BigInt(12345));
 
@@ -445,7 +476,11 @@ describe("Connection.login", () => {
         identity_info: vi.fn().mockResolvedValue({ Ok: { metadata: [] } }),
         lookup: vi.fn().mockResolvedValue([currentOriginDevice, currentDevice]),
       } as unknown as ActorSubclass<_SERVICE>;
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
 
       failSign = true;
       const firstLoginResult = await connection.login(BigInt(12345));
@@ -498,7 +533,11 @@ describe("Connection.login", () => {
             deviceWithoutCredentialId,
           ]),
       } as unknown as ActorSubclass<_SERVICE>;
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
       await connection.login(BigInt(12345));
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
@@ -523,7 +562,11 @@ describe("Connection.login", () => {
             deviceInvalidCredentialId,
           ]),
       } as unknown as ActorSubclass<_SERVICE>;
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
       await connection.login(BigInt(12345));
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
       expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
@@ -556,7 +599,11 @@ describe("Connection.login", () => {
         lookup: vi.fn().mockResolvedValue([pinDevice]),
       } as unknown as ActorSubclass<_SERVICE>;
 
-      const connection = new Connection("aaaaa-aa", mockActor);
+      const connection = new Connection(
+        "aaaaa-aa",
+        {} as InternetIdentityInit,
+        mockActor
+      );
 
       const loginResult = await connection.login(BigInt(12345));
 
@@ -579,6 +626,7 @@ describe("Connection.login", () => {
       const userNumber = BigInt(12345);
       const connection = new AuthenticatedConnection(
         "aaaaa-aa",
+        {} as InternetIdentityInit,
         MultiWebAuthnIdentity.fromCredentials([], undefined, undefined),
         mockDelegationIdentity,
         userNumber,
@@ -616,6 +664,7 @@ describe("Connection.login", () => {
       const userNumber = BigInt(12345);
       const connection = new AuthenticatedConnection(
         "aaaaa-aa",
+        {} as InternetIdentityInit,
         MultiWebAuthnIdentity.fromCredentials([], undefined, undefined),
         mockDelegationIdentity,
         userNumber,
@@ -653,6 +702,7 @@ describe("Connection.login", () => {
       const userNumber = BigInt(12345);
       const connection = new AuthenticatedConnection(
         "aaaaa-aa",
+        {} as InternetIdentityInit,
         MultiWebAuthnIdentity.fromCredentials([], undefined, undefined),
         mockDelegationIdentity,
         userNumber,
@@ -689,6 +739,7 @@ describe("Connection.login", () => {
       const userNumber = BigInt(12345);
       const connection = new AuthenticatedConnection(
         "aaaaa-aa",
+        {} as InternetIdentityInit,
         MultiWebAuthnIdentity.fromCredentials([], undefined, undefined),
         mockDelegationIdentity,
         userNumber,

--- a/src/frontend/src/utils/openID.ts
+++ b/src/frontend/src/utils/openID.ts
@@ -1,5 +1,6 @@
 import { MetadataMapV2 } from "$generated/internet_identity_types";
 import { REDIRECT_CALLBACK_PATH, redirectInPopup } from "$src/flows/redirect";
+import { toBase64URL } from "$src/utils/utils";
 import { Principal } from "@dfinity/principal";
 import { isNullish, nonNullish } from "@dfinity/utils";
 
@@ -75,12 +76,6 @@ export const isNotSupportedError = (error: unknown) =>
  */
 export const isPermissionError = (error: unknown) =>
   error instanceof Error && error.name === "NetworkError";
-
-const toBase64 = (bytes: ArrayBuffer): string =>
-  btoa(String.fromCharCode(...new Uint8Array(bytes)));
-
-const toBase64URL = (bytes: ArrayBuffer): string =>
-  toBase64(bytes).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 
 /**
  * Request JWT through redirect flow in a popup

--- a/src/frontend/src/utils/utils.ts
+++ b/src/frontend/src/utils/utils.ts
@@ -394,3 +394,20 @@ export const isCanisterError = <T extends Record<string, unknown>>(
 ): error is CanisterError<T> => {
   return error instanceof CanisterError;
 };
+
+export const toBase64 = (bytes: ArrayBuffer): string =>
+  btoa(String.fromCharCode(...new Uint8Array(bytes)));
+
+export const toBase64URL = (bytes: ArrayBuffer): string =>
+  toBase64(bytes).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+export const fromBase64 = (base64: string): ArrayBuffer =>
+  Uint8Array.from(globalThis.atob(base64), (m) => m.charCodeAt(0)).buffer;
+
+export const fromBase64URL = (base64Url: string): ArrayBuffer =>
+  fromBase64(
+    base64Url
+      .replace(/-/g, "+")
+      .replace(/_/g, "/")
+      .padEnd(Math.ceil(base64Url.length / 4) * 4, "=")
+  );

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -392,19 +392,17 @@ fn post_upgrade(maybe_arg: Option<InternetIdentityInit>) {
 }
 
 fn initialize(maybe_arg: Option<InternetIdentityInit>) {
-    let related_origins = maybe_arg
-        .as_ref()
-        .and_then(|arg| arg.related_origins.clone())
-        .unwrap_or(persistent_state(|storage| storage.related_origins.clone()).unwrap_or(vec![]));
-    let openid_google = maybe_arg
-        .as_ref()
-        .and_then(|arg| arg.openid_google.clone())
-        .unwrap_or(persistent_state(|storage| storage.openid_google.clone()));
-    init_assets(related_origins.is_empty().not().then_some(related_origins));
+    // Apply arguments
     apply_install_arg(maybe_arg);
+
+    // Get config that possibly has been updated above
+    let config = config();
+
+    // Initiate assets and OpenID providers
+    init_assets(&config);
     update_root_hash();
-    if let Some(config) = openid_google {
-        openid::setup_google(config);
+    if let Some(Some(openid_config)) = config.openid_google {
+        openid::setup_google(openid_config);
     }
 }
 

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -1,4 +1,7 @@
-import { _SERVICE } from "$generated/internet_identity_types";
+import {
+  _SERVICE,
+  InternetIdentityInit,
+} from "$generated/internet_identity_types";
 import { authenticateBoxFlow } from "$src/components/authenticateBox";
 import { withLoader } from "$src/components/loader";
 import { toast } from "$src/components/toast";
@@ -48,6 +51,7 @@ class MockAuthenticatedConnection extends AuthenticatedConnection {
   constructor() {
     super(
       "12345",
+      {} as InternetIdentityInit,
       MultiWebAuthnIdentity.fromCredentials([], undefined, undefined),
       mockDelegationIdentity,
       BigInt(12345),

--- a/src/vite-plugins/src/index.ts
+++ b/src/vite-plugins/src/index.ts
@@ -3,7 +3,12 @@ import { minify } from "html-minifier-terser";
 import { extname } from "path";
 import type { Plugin, ViteDevServer } from "vite";
 import viteCompression from "vite-plugin-compression";
-import { forwardToReplica, readCanisterId, readReplicaPort } from "./utils.js";
+import {
+  forwardToReplica,
+  readCanisterConfig,
+  readCanisterId,
+  readReplicaPort,
+} from "./utils.js";
 
 export * from "./utils.js";
 
@@ -11,17 +16,18 @@ export * from "./utils.js";
  * Inject the canister ID of 'canisterName' as a <script /> tag in index.html for local development. Will process
  * at most 1 script tag.
  */
-export const injectCanisterIdPlugin = ({
+export const injectCanisterIdAndConfigPlugin = ({
   canisterName,
 }: {
   canisterName: string;
 }): Plugin => ({
-  name: "inject-canister-id",
+  name: "inject-canister-id-and-config",
   transformIndexHtml(html): string {
     const rgx = /<script type="module" src="(?<src>[^"]+)"><\/script>/;
     const canisterId = readCanisterId({ canisterName });
+    const canisterConfig = readCanisterConfig({ canisterName });
     return html.replace(rgx, (_match, src) => {
-      return `<script data-canister-id="${canisterId}" type="module" src="${src}"></script>`;
+      return `<script data-canister-id="${canisterId}" data-canister-config="${canisterConfig}" type="module" src="${src}"></script>`;
     });
   },
 });

--- a/src/vite-plugins/src/index.ts
+++ b/src/vite-plugins/src/index.ts
@@ -16,6 +16,25 @@ export * from "./utils.js";
  * Inject the canister ID of 'canisterName' as a <script /> tag in index.html for local development. Will process
  * at most 1 script tag.
  */
+export const injectCanisterIdPlugin = ({
+  canisterName,
+}: {
+  canisterName: string;
+}): Plugin => ({
+  name: "inject-canister-id",
+  transformIndexHtml(html): string {
+    const rgx = /<script type="module" src="(?<src>[^"]+)"><\/script>/;
+    const canisterId = readCanisterId({ canisterName });
+    return html.replace(rgx, (_match, src) => {
+      return `<script data-canister-id="${canisterId}" type="module" src="${src}"></script>`;
+    });
+  },
+});
+
+/**
+ * Inject the canister ID and config of 'canisterName' as a <script /> tag in index.html for local development. Will process
+ * at most 1 script tag.
+ */
 export const injectCanisterIdAndConfigPlugin = ({
   canisterName,
 }: {

--- a/src/vite-plugins/src/utils.ts
+++ b/src/vite-plugins/src/utils.ts
@@ -31,6 +31,25 @@ export const readCanisterId = ({
   }
 };
 
+/**
+ * Read a canister config from dfx's local state
+ */
+export const readCanisterConfig = ({
+  canisterName,
+}: {
+  canisterName: string;
+}): string => {
+  const command = `dfx canister call ${canisterName} config --output raw`;
+  try {
+    const stdout = execSync(command);
+    return Buffer.from(stdout.toString().trim(), "hex").toString("base64");
+  } catch (e) {
+    throw Error(
+      `Could not get canister config for '${canisterName}' with command '${command}', was the canister deployed? ${e}`
+    );
+  }
+};
+
 /** Get the http host of a running replica */
 export const getReplicaHost = (): string => {
   const command = `dfx info webserver-port`;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import {
   compression,
-  injectCanisterIdPlugin,
+  injectCanisterIdAndConfigPlugin,
   inlineScriptsPlugin,
   minifyHTML,
   replicaForwardPlugin,
@@ -75,7 +75,11 @@ export default defineConfig(({ command, mode }): UserConfig => {
       }),
       [
         ...(mode === "development"
-          ? [injectCanisterIdPlugin({ canisterName: "internet_identity" })]
+          ? [
+              injectCanisterIdAndConfigPlugin({
+                canisterName: "internet_identity",
+              }),
+            ]
           : []),
       ],
       [...(mode === "production" ? [minifyHTML(), compression()] : [])],


### PR DESCRIPTION
Implement canister config in html.

# Changes

Changes were made to match the same approach as `data-canister-id` was added previously.

- Refactor `initialize` method to first `apply_install_arg` and then re-use `config` method to get the merged config.
- Pass this merged config to `init_assets` so that `fixup_html` can add the config as `data-canister-config` attribute.
- Implement `readCanisterConfig` method to decode this attribute on page load to `InternetIdentityInit`
- Update `Connection` to remove `getConfig` and have a `canisterConfig` attribute instead.
- Replace usages of `getConfig` with `canisterConfig`.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8ecf95f0c/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8ecf95f0c/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8ecf95f0c/desktop/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

