### PR TITLE
Fix flaky test by checking all console logs messages instead of only last message

### DIFF
--- a/src/frontend/src/test-e2e/alternativeOrigin/endpointFormat.test.ts
+++ b/src/frontend/src/test-e2e/alternativeOrigin/endpointFormat.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../util";
 import { AuthenticateView, DemoAppView, ErrorView } from "../views";
 
+import { nonNullish } from "@dfinity/utils";
 import {
   II_URL,
   TEST_APP_CANONICAL_URL,
@@ -124,7 +125,12 @@ test("Should fetch /.well-known/ii-alternative-origins using the non-raw url", a
     );
 
     const logs = (await browser.getLogs("browser")) as { message: string }[];
-    expect(logs.at(-1)?.message).toContain(`Failed to load resource`);
+    const errorLog = logs.find(
+      ({ message }) =>
+        message.includes("/.well-known/ii-alternative-origins") &&
+        message.includes("Failed to load resource")
+    );
+    expect(nonNullish(errorLog)).toBeTruthy();
 
     // This works anyway --> fetched using non-raw
     const authenticateView = new AuthenticateView(browser);


### PR DESCRIPTION
Fix flaky test by checking all console logs messages instead of only last message

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/70e1dd3d6/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/70e1dd3d6/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/70e1dd3d6/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/70e1dd3d6/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/70e1dd3d6/mobile/landing_1.png" width="250"></details><details><summary>🔴 Some screens were removed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/70e1dd3d6/mobile/landing_2.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
