### PR TITLE
Install Plausible Tracking WebAuthn Flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "idb-keyval": "^6.2.1",
         "lit-html": "^3.2.1",
         "marked": "^11.0.0",
+        "plausible-tracker": "0.3.9",
         "qr-creator": "^1.0.0",
         "stream-browserify": "^3.0.0",
         "ua-parser-js": "^1.0.35",
@@ -10998,6 +10999,15 @@
         "confbox": "^0.1.7",
         "mlly": "^1.7.0",
         "pathe": "^1.1.2"
+      }
+    },
+    "node_modules/plausible-tracker": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.9.tgz",
+      "integrity": "sha512-hMhneYm3GCPyQon88SZrVJx+LlqhM1kZFQbuAgXPoh/Az2YvO1B6bitT9qlhpiTdJlsT5lsr3gPmzoVjb5CDXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "idb-keyval": "^6.2.1",
     "lit-html": "^3.2.1",
     "marked": "^11.0.0",
+    "plausible-tracker": "0.3.9",
     "qr-creator": "^1.0.0",
     "stream-browserify": "^3.0.0",
     "ua-parser-js": "^1.0.35",

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -10,9 +10,10 @@ import { authFlowAuthorize } from "./flows/authorize";
 import { authFlowManage, renderManageWarmup } from "./flows/manage";
 import { createSpa } from "./spa";
 import { getAddDeviceAnchor } from "./utils/addDeviceLink";
-import { analytics } from "./utils/analytics";
+import { analytics, initAnalytics } from "./utils/analytics";
 
 void createSpa(async (connection) => {
+  initAnalytics(connection.canisterConfig.analytics_config[0]?.[0]);
   analytics.pageView();
   // Figure out if user is trying to add a device. If so, use the anchor from the URL.
   const addDeviceAnchor = getAddDeviceAnchor();

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -10,8 +10,10 @@ import { authFlowAuthorize } from "./flows/authorize";
 import { authFlowManage, renderManageWarmup } from "./flows/manage";
 import { createSpa } from "./spa";
 import { getAddDeviceAnchor } from "./utils/addDeviceLink";
+import { analytics } from "./utils/analytics";
 
 void createSpa(async (connection) => {
+  analytics.pageView();
   // Figure out if user is trying to add a device. If so, use the anchor from the URL.
   const addDeviceAnchor = getAddDeviceAnchor();
   if (nonNullish(addDeviceAnchor)) {

--- a/src/frontend/src/utils/analytics.ts
+++ b/src/frontend/src/utils/analytics.ts
@@ -1,0 +1,15 @@
+import Plausible from "plausible-tracker";
+
+const tracker = Plausible({
+  // TODO: Take domain from config
+  domain: "identity.internetcomputer.org",
+});
+
+export const analytics = {
+  pageView: () => {
+    tracker.trackPageview();
+  },
+  event: (name: string, props?: Record<string, string | number | boolean>) => {
+    tracker.trackEvent(name, { props });
+  },
+};

--- a/src/frontend/src/utils/analytics.ts
+++ b/src/frontend/src/utils/analytics.ts
@@ -1,15 +1,50 @@
+import { AnalyticsConfig } from "$generated/internet_identity_types";
+import { isNullish } from "@dfinity/utils";
 import Plausible from "plausible-tracker";
+import { PlausibleInitOptions } from "plausible-tracker/build/main/lib/tracker";
 
-const tracker = Plausible({
-  // TODO: Take domain from config
-  domain: "identity.internetcomputer.org",
-});
+let tracker: undefined | ReturnType<typeof Plausible>;
+
+const convertToPlausibleConfig = (
+  config: AnalyticsConfig | undefined
+): PlausibleInitOptions | undefined => {
+  if (isNullish(config)) {
+    return;
+  }
+  if ("Plausible" in config) {
+    const plausibleConfig = config.Plausible;
+    // `undefined` values in Plausible config are not the same as missing values.
+    return removeUndefinedFields({
+      hashMode: plausibleConfig.hash_mode[0],
+      domain: plausibleConfig.domain[0],
+      trackLocalhost: plausibleConfig.track_localhost[0],
+      apiHost: plausibleConfig.api_host[0],
+    });
+  }
+};
+
+const removeUndefinedFields = (obj: Record<string, unknown | undefined>) => {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([_, value]) => value !== undefined)
+  );
+};
+
+export const initAnalytics = (config: AnalyticsConfig | undefined) => {
+  if (isNullish(config)) {
+    return;
+  }
+  const plausibleConfig = convertToPlausibleConfig(config);
+  if (isNullish(plausibleConfig)) {
+    return;
+  }
+  tracker = Plausible(plausibleConfig);
+};
 
 export const analytics = {
   pageView: () => {
-    tracker.trackPageview();
+    tracker?.trackPageview();
   },
   event: (name: string, props?: Record<string, string | number | boolean>) => {
-    tracker.trackEvent(name, { props });
+    tracker?.trackEvent(name, { props });
   },
 };

--- a/src/frontend/src/vc-flow.ts
+++ b/src/frontend/src/vc-flow.ts
@@ -1,4 +1,8 @@
 import { vcFlow } from "./flows/verifiableCredentials";
 import { createSpa } from "./spa";
+import { analytics } from "./utils/analytics";
 
-void createSpa((connection) => vcFlow({ connection }));
+void createSpa((connection) => {
+  analytics.pageView();
+  return vcFlow({ connection });
+});

--- a/src/frontend/src/vc-flow.ts
+++ b/src/frontend/src/vc-flow.ts
@@ -1,8 +1,9 @@
 import { vcFlow } from "./flows/verifiableCredentials";
 import { createSpa } from "./spa";
-import { analytics } from "./utils/analytics";
+import { analytics, initAnalytics } from "./utils/analytics";
 
 void createSpa((connection) => {
+  initAnalytics(connection.canisterConfig.analytics_config[0]?.[0]);
   analytics.pageView();
   return vcFlow({ connection });
 });


### PR DESCRIPTION
# Motivation

We want to track the success of the webauth flow.

In this PR, I set up Plausible from config and add the necessary events to track the webauth flow.

# Changes

* New analytics util to track page views and events.
* Trigger page view in both pages index and vc-flow.
* Trigger events in webauthn flow.

# Tests

* Tested the functionality in beta domains with a test account in Plausible.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f038c4e35/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f038c4e35/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f038c4e35/desktop/landing_1.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f038c4e35/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f038c4e35/mobile/managePick.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
