### PR TITLE
Enable domains compatibility

### DIFF
--- a/src/frontend/src/featureFlags/index.ts
+++ b/src/frontend/src/featureFlags/index.ts
@@ -1,6 +1,6 @@
 // Feature flags with default values
 const FEATURE_FLAGS_WITH_DEFAULTS = {
-  DOMAIN_COMPATIBILITY: false,
+  DOMAIN_COMPATIBILITY: true,
   OPENID_AUTHENTICATION: false,
   HARDWARE_KEY_TEST: false,
 } as const satisfies Record<string, boolean>;

--- a/src/frontend/src/flows/manage/migration.test.ts
+++ b/src/frontend/src/flows/manage/migration.test.ts
@@ -1,4 +1,5 @@
 import { DeviceData } from "$generated/internet_identity_types";
+import { DOMAIN_COMPATIBILITY } from "$src/featureFlags";
 import { domainWarning } from "$src/flows/manage";
 
 const recoveryPhrase: DeviceData = {
@@ -32,6 +33,8 @@ describe("recovery phrases don't have origin warnings", () => {
       vi.stubGlobal("location", {
         origin: "https://identity.ic0.app",
       });
+      // domainWarning is used only when DOMAIN_COMPATIBILITY is false
+      DOMAIN_COMPATIBILITY.set(false);
     });
 
     it("returns undefined for recovery phrase", () => {
@@ -67,6 +70,8 @@ describe("recovery phrases don't have origin warnings", () => {
       vi.stubGlobal("location", {
         origin: "https://identity.internetcomputer.org",
       });
+      // domainWarning is used only when DOMAIN_COMPATIBILITY is false
+      DOMAIN_COMPATIBILITY.set(false);
     });
 
     it("undefined for recovery phrase", () => {

--- a/src/frontend/src/test-e2e/relatedOrigins.test.ts
+++ b/src/frontend/src/test-e2e/relatedOrigins.test.ts
@@ -4,7 +4,6 @@ import {
   mimickPasskeyExtension,
   removeVirtualAuthenticator,
   runInBrowser,
-  setDomainCompatibilityFeatureFlag,
 } from "./util";
 
 // Read canister ids from the corresponding dfx files.
@@ -41,8 +40,6 @@ test("Sign in on related origins", async () => {
       await mainView.logout();
       await browser.url(relatedOrigin);
 
-      // Enable feature flag and sign in
-      await setDomainCompatibilityFeatureFlag(browser, true);
       await FLOWS.loginExistingAuthenticateView(
         userNumber,
         DEVICE_NAME1,
@@ -80,9 +77,6 @@ test("Add devices on related origins with same origin", async () => {
       await mainView.logout();
       const additionalDevice = await addVirtualAuthenticator(browser);
       await browser.url(relatedOrigin);
-
-      // Enable feature flag
-      await setDomainCompatibilityFeatureFlag(browser, true);
 
       // Sign in using seed phrase and register device
       await FLOWS.recoverUsingSeedPhrase(browser, seedPhrase);
@@ -125,9 +119,6 @@ test("Add devices on related origins with different origin", async () => {
       await mainView.logout();
       const additionalDevice = await addVirtualAuthenticator(browser);
       await browser.url(relatedOrigin);
-
-      // Enable feature flag
-      await setDomainCompatibilityFeatureFlag(browser, true);
 
       // Disable RoR by mimicking a passkey browser extension,
       // this enables adding devices in different origins.
@@ -174,8 +165,6 @@ test("Use recovery device on related origins", async () => {
       await mainView.logout();
       await browser.url(relatedOrigin);
 
-      // Enable feature flag and recover using device
-      await setDomainCompatibilityFeatureFlag(browser, true);
       await FLOWS.recoverUsingDevice(browser, userNumber);
     }
   });

--- a/src/frontend/src/test-e2e/util.ts
+++ b/src/frontend/src/test-e2e/util.ts
@@ -503,6 +503,7 @@ export const mockFedCM = async (
   }, token);
 };
 
+// TODO: Remove when we remove the domain compatibility feature flag
 export const setDomainCompatibilityFeatureFlag = async (
   browser: WebdriverIO.Browser,
   enabled: boolean

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -503,7 +503,8 @@ describe("Connection.login", () => {
 
   describe("when a device credential id is missing", () => {
     it("connection does not use this device to authenticate", async () => {
-      const deviceWithCredentialId: DeviceData = createMockDevice();
+      const deviceWithCredentialId: DeviceData =
+        createMockDevice(currentOrigin);
       const deviceWithoutCredentialId: DeviceData = createMockDevice();
       deviceWithoutCredentialId.credential_id = [];
       const mockActor = {
@@ -528,7 +529,8 @@ describe("Connection.login", () => {
 
   describe("when device credential id is invalid", () => {
     it("connection does not use this device to authenticate", async () => {
-      const deviceValidCredentialId: DeviceData = createMockDevice();
+      const deviceValidCredentialId: DeviceData =
+        createMockDevice(currentOrigin);
       const deviceInvalidCredentialId: DeviceData = createMockDevice();
       deviceInvalidCredentialId.credential_id = [Uint8Array.from([])];
       const mockActor = {


### PR DESCRIPTION
# Motivation

Enable the domains compatibility functionality for all users.

# Changes

* Set flat default to `true`.

# Tests

* Remove setting the flag to `true` in e2e tests.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5f93813aa/mobile/landing_2.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5f93813aa/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5f93813aa/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5f93813aa/desktop/managePickMany.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5f93813aa/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5f93813aa/mobile/landing_1.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

