### PR TITLE
Use config related origins

### DIFF
--- a/src/frontend/src/utils/findWebAuthnFlows.test.ts
+++ b/src/frontend/src/utils/findWebAuthnFlows.test.ts
@@ -1,7 +1,6 @@
 import { LEGACY_II_URL } from "$src/config";
 import { CredentialData } from "./credential-devices";
 import { findWebAuthnFlows } from "./findWebAuthnFlows";
-import { PROD_DOMAINS } from "./findWebAuthnRpId";
 
 describe("findWebAuthnFlows", () => {
   const currentOrigin = "https://identity.internetcomputer.org";
@@ -9,7 +8,11 @@ describe("findWebAuthnFlows", () => {
   const nonCurrentOrigin1RpId = new URL(nonCurrentOrigin1).hostname;
   const nonCurrentOrigin2 = "https://identity.icp0.io";
   const nonCurrentOrigin2RpId = new URL(nonCurrentOrigin2).hostname;
-  const relatedOrigins = PROD_DOMAINS;
+  const relatedOrigins = [
+    "https://identity.ic0.app",
+    "https://identity.internetcomputer.org",
+    "https://identity.icp0.io",
+  ];
 
   const createMockCredential = (
     origin: string | undefined

--- a/src/frontend/src/utils/findWebAuthnRpId.test.ts
+++ b/src/frontend/src/utils/findWebAuthnRpId.test.ts
@@ -1,10 +1,20 @@
 import { CredentialData } from "./credential-devices";
 import {
-  BETA_DOMAINS,
-  PROD_DOMAINS,
   excludeCredentialsFromOrigins,
   findWebAuthnRpId,
 } from "./findWebAuthnRpId";
+
+const BETA_DOMAINS = [
+  "https://beta.identity.ic0.app",
+  "https://beta.identity.internetcomputer.org",
+  "https://fgte5-ciaaa-aaaad-aaatq-cai.ic0.app",
+];
+
+const PROD_DOMAINS = [
+  "https://identity.ic0.app",
+  "https://identity.internetcomputer.org",
+  "https://identity.icp0.io",
+];
 
 describe("findWebAuthnRpId", () => {
   const mockDeviceData = (origin?: string): CredentialData => ({

--- a/src/frontend/src/utils/findWebAuthnRpId.ts
+++ b/src/frontend/src/utils/findWebAuthnRpId.ts
@@ -1,34 +1,6 @@
 import { II_LEGACY_ORIGIN } from "$src/constants";
 import { CredentialData } from "./credential-devices";
 
-export const PROD_DOMAINS = [
-  "https://identity.ic0.app",
-  "https://identity.internetcomputer.org",
-  "https://identity.icp0.io",
-];
-export const BETA_DOMAINS = [
-  "https://beta.identity.ic0.app",
-  "https://beta.identity.internetcomputer.org",
-  "https://fgte5-ciaaa-aaaad-aaatq-cai.ic0.app",
-];
-
-/**
- * Returns the related domains ordered by preference.
- *
- * It reads the current URL and returns the set related to the current url.
- */
-export const relatedDomains = (): string[] => {
-  const currentUrl = new URL(window.location.origin);
-  if (PROD_DOMAINS.includes(currentUrl.origin)) {
-    return PROD_DOMAINS;
-  }
-  if (BETA_DOMAINS.includes(currentUrl.origin)) {
-    return BETA_DOMAINS;
-  }
-  // Only beta and prod have related domains.
-  return [];
-};
-
 export const hasCredentialsFromMultipleOrigins = (
   credentials: CredentialData[]
 ): boolean =>

--- a/src/frontend/src/utils/findWebAuthnRpId.ts
+++ b/src/frontend/src/utils/findWebAuthnRpId.ts
@@ -1,6 +1,34 @@
 import { II_LEGACY_ORIGIN } from "$src/constants";
 import { CredentialData } from "./credential-devices";
 
+export const PROD_DOMAINS = [
+  "https://identity.ic0.app",
+  "https://identity.internetcomputer.org",
+  "https://identity.icp0.io",
+];
+export const BETA_DOMAINS = [
+  "https://beta.identity.ic0.app",
+  "https://beta.identity.internetcomputer.org",
+  "https://fgte5-ciaaa-aaaad-aaatq-cai.ic0.app",
+];
+
+/**
+ * Returns the related domains ordered by preference.
+ *
+ * It reads the current URL and returns the set related to the current url.
+ */
+export const relatedDomains = (): string[] => {
+  const currentUrl = new URL(window.location.origin);
+  if (PROD_DOMAINS.includes(currentUrl.origin)) {
+    return PROD_DOMAINS;
+  }
+  if (BETA_DOMAINS.includes(currentUrl.origin)) {
+    return BETA_DOMAINS;
+  }
+  // Only beta and prod have related domains.
+  return [];
+};
+
 export const hasCredentialsFromMultipleOrigins = (
   credentials: CredentialData[]
 ): boolean =>

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -235,8 +235,8 @@ describe("Connection.login", () => {
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
         expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
           [convertToValidCredentialData(mockDevice)],
-          "identity.ic0.app",
-          true
+          undefined,
+          false
         );
       }
     });

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -63,7 +63,13 @@ const DEFAULT_INIT: InternetIdentityInit = {
   captcha_config: [],
   openid_google: [],
   register_rate_limit: [],
-  related_origins: [],
+  related_origins: [
+    [
+      "https://identity.ic0.app",
+      "https://identity.internetcomputer.org",
+      "https://identity.icp0.io",
+    ],
+  ],
 };
 
 const mockActor = {
@@ -119,6 +125,7 @@ test("commits changes on identity metadata", async () => {
     mockActor
   );
 
+  expect(infoResponse).toBeUndefined();
   await vi.waitFor(() => expect(infoResponse).toEqual(mockRawMetadata));
 
   expect(await connection.getIdentityMetadata()).toEqual(mockIdentityMetadata);
@@ -196,6 +203,28 @@ describe("Connection.login", () => {
 
     it("login returns authenticated connection with expected rpID", async () => {
       const connection = new Connection("aaaaa-aa", DEFAULT_INIT, mockActor);
+
+      const loginResult = await connection.login(BigInt(12345));
+
+      expect(loginResult.kind).toBe("loginSuccess");
+      if (loginResult.kind === "loginSuccess") {
+        expect(loginResult.connection).toBeInstanceOf(AuthenticatedConnection);
+        expect(loginResult.showAddCurrentDevice).toBe(false);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledTimes(1);
+        expect(MultiWebAuthnIdentity.fromCredentials).toHaveBeenCalledWith(
+          [convertToValidCredentialData(mockDevice)],
+          "identity.ic0.app",
+          true
+        );
+      }
+    });
+
+    it("login returns undefined RP ID if no related origins are in the config", async () => {
+      const config: InternetIdentityInit = {
+        ...DEFAULT_INIT,
+        related_origins: [],
+      };
+      const connection = new Connection("aaaaa-aa", config, mockActor);
 
       const loginResult = await connection.login(BigInt(12345));
 
@@ -566,12 +595,6 @@ describe("Connection.login", () => {
         credential_id: [Uint8Array.from([0, 0, 0, 0, 0])],
       };
       const mockActor = {
-        identity_info: vi.fn().mockImplementation(async () => {
-          // The `await` is necessary to make sure that the `getterResponse` is set before the test continues.
-          infoResponse = await mockRawMetadata;
-          return { Ok: { metadata: mockRawMetadata } };
-        }),
-        identity_metadata_replace: vi.fn().mockResolvedValue({ Ok: null }),
         lookup: vi.fn().mockResolvedValue([pinDevice]),
       } as unknown as ActorSubclass<_SERVICE>;
 

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -433,7 +433,6 @@ export class Connection {
         currentOrigin: window.location.origin,
         // Empty array is the same as no related origins.
         relatedOrigins: this.canisterConfig.related_origins[0] ?? [],
-        // relatedOrigins: relatedDomains(),
       });
       this.webAuthFlows = {
         flows,

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -63,7 +63,6 @@ import {
   CredentialData,
 } from "./credential-devices";
 import { findWebAuthnFlows, WebAuthnFlow } from "./findWebAuthnFlows";
-import { relatedDomains } from "./findWebAuthnRpId";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 import { isRecoveryDevice, RecoveryDevice } from "./recoveryDevice";
 import { supportsWebauthRoR } from "./userAgent";
@@ -433,8 +432,8 @@ export class Connection {
         devices: credentials,
         currentOrigin: window.location.origin,
         // Empty array is the same as no related origins.
-        // relatedOrigins: this.canisterConfig.related_origins[0] ?? [],
-        relatedOrigins: relatedDomains(),
+        relatedOrigins: this.canisterConfig.related_origins[0] ?? [],
+        // relatedOrigins: relatedDomains(),
       });
       this.webAuthFlows = {
         flows,

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -63,7 +63,6 @@ import {
   CredentialData,
 } from "./credential-devices";
 import { findWebAuthnFlows, WebAuthnFlow } from "./findWebAuthnFlows";
-import { relatedDomains } from "./findWebAuthnRpId";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 import { isRecoveryDevice, RecoveryDevice } from "./recoveryDevice";
 import { supportsWebauthRoR } from "./userAgent";
@@ -432,7 +431,8 @@ export class Connection {
         supportsRor: supportsWebauthRoR(window.navigator.userAgent),
         devices: credentials,
         currentOrigin: window.location.origin,
-        relatedOrigins: relatedDomains(),
+        // Empty array is the same as no related origins.
+        relatedOrigins: this.canisterConfig.related_origins[0] ?? [],
       });
       this.webAuthFlows = {
         flows,

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -63,6 +63,7 @@ import {
   CredentialData,
 } from "./credential-devices";
 import { findWebAuthnFlows, WebAuthnFlow } from "./findWebAuthnFlows";
+import { relatedDomains } from "./findWebAuthnRpId";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 import { isRecoveryDevice, RecoveryDevice } from "./recoveryDevice";
 import { supportsWebauthRoR } from "./userAgent";
@@ -432,7 +433,8 @@ export class Connection {
         devices: credentials,
         currentOrigin: window.location.origin,
         // Empty array is the same as no related origins.
-        relatedOrigins: this.canisterConfig.related_origins[0] ?? [],
+        // relatedOrigins: this.canisterConfig.related_origins[0] ?? [],
+        relatedOrigins: relatedDomains(),
       });
       this.webAuthFlows = {
         flows,


### PR DESCRIPTION
# Motivation

Use related origins from config instead of hardcoded ones.

# Changes

* Remove `relatedOrigins` util and instead use the canister config in iiConnection.

# Tests

* Tested all works in beta domains.






<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7028afa4f/mobile/landing_2.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7028afa4f/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7028afa4f/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7028afa4f/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7028afa4f/desktop/managePick.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7028afa4f/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7028afa4f/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/7028afa4f/mobile/landing_1.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->





