### PR TITLE
Disable button on limit of authenticators

### DIFF
--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -92,7 +92,7 @@ export const authenticatorsSection = ({
           )}</ul>
           <div class="c-action-list__actions">
             <button
-              ?disabled=${authenticators.length >= MAX_AUTHENTICATORS}
+              .disabled=${authenticators.length >= MAX_AUTHENTICATORS}
               class="c-button c-button--primary c-tooltip c-tooltip--onDisabled c-tooltip--left"
               @click="${() => onAddDevice()}"
               id="addAdditionalDevice"

--- a/src/showcase/src/pages/displayManageMaxDevices.astro
+++ b/src/showcase/src/pages/displayManageMaxDevices.astro
@@ -1,0 +1,116 @@
+---
+import Screen from "../layouts/Screen.astro";
+---
+
+<Screen title="Display Manage" pageName="displayManage">
+  <script>
+    import { toast } from "$src/components/toast";
+    import { userNumber } from "../constants";
+    import { dapps } from "../constants";
+    import { displayManagePage } from "$src/flows/manage";
+    import { html } from "lit-html";
+    import identityCardBackground from "$src/assets/identityCardBackground.png";
+    import { PreLoadImage } from "$src/utils/preLoadImage";
+
+    const identityBackground = new PreLoadImage(identityCardBackground.src);
+
+    displayManagePage({
+      identityBackground,
+      userNumber,
+      devices: {
+        authenticators: [
+          {
+            alias: "Chrome on iPhone",
+            remove: () => toast.info("remove"),
+            rename: () => toast.info("rename"),
+            last_usage: [BigInt(Date.now() * 1000000)],
+          },
+          {
+            alias: "Yubikey Blue",
+            remove: () => toast.info("remove"),
+            rename: () => toast.info("rename"),
+            last_usage: [
+              BigInt(Date.now() * 1000000 - 1_000_000_000 * 60 * 60 * 24 * 7),
+            ],
+          },
+          {
+            alias: "Yubikey Blue",
+            remove: () => toast.info("remove"),
+            rename: () => toast.info("rename"),
+            last_usage: [
+              BigInt(Date.now() * 1000000 - 1_000_000_000 * 60 * 60 * 24 * 30),
+            ],
+          },
+          {
+            alias: "Yubikey Blue",
+            remove: () => toast.info("remove"),
+            rename: () => toast.info("rename"),
+            last_usage: [
+              BigInt(Date.now() * 1000000 - 1_000_000_000 * 60 * 60 * 24 * 30),
+            ],
+          },
+          {
+            alias: "Yubikey Blue",
+            remove: () => toast.info("remove"),
+            rename: () => toast.info("rename"),
+            last_usage: [
+              BigInt(Date.now() * 1000000 - 1_000_000_000 * 60 * 60 * 24 * 30),
+            ],
+          },
+          {
+            alias: "Yubikey Blue",
+            remove: () => toast.info("remove"),
+            rename: () => toast.info("rename"),
+            last_usage: [
+              BigInt(Date.now() * 1000000 - 1_000_000_000 * 60 * 60 * 24 * 30),
+            ],
+          },
+          {
+            alias: "Yubikey Blue",
+            remove: () => toast.info("remove"),
+            rename: () => toast.info("rename"),
+            last_usage: [
+              BigInt(Date.now() * 1000000 - 1_000_000_000 * 60 * 60 * 24 * 30),
+            ],
+          },
+          {
+            alias: "Yubikey Blue",
+            remove: () => toast.info("remove"),
+            rename: () => toast.info("rename"),
+            last_usage: [
+              BigInt(Date.now() * 1000000 - 1_000_000_000 * 60 * 60 * 24 * 30),
+            ],
+          },
+        ],
+        recoveries: {
+          recoveryPhrase: {
+            isProtected: true,
+            unprotect: () => toast.info("unprotect"),
+            reset: () => toast.info("reset"),
+          },
+        },
+        pinAuthenticators: [],
+      },
+      onAddDevice: () => {
+        toast.info("add device requested");
+      },
+      addRecoveryPhrase: () => {
+        toast.info("add recovery phrase");
+      },
+      addRecoveryKey: () => {
+        toast.info("add recovery key");
+      },
+      credentials: [],
+      onLinkAccount: () => {
+        toast.info("link account");
+      },
+      onUnlinkAccount: () => {
+        toast.info("unlink account");
+      },
+      dapps,
+      exploreDapps: () => {
+        toast.info("explore dapps");
+      },
+    });
+  </script>
+</Screen>


### PR DESCRIPTION
# Motivation

There was a bug in lit-html because the syntax is not `?disabled` but `.disabled`. Therefore, the button was not disabled when the limit was reached,

The limit was still enforced in the backend. But the limit is set to 10 because it includes the seed phrase and a recovery device.

# Changes

* Change `?disabled` for `.disabled`.

# Tests

* Add a showcase page with the disabled button.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/0223c5e57/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/0223c5e57/mobile/displayManageMaxDevices.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/0223c5e57/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/0223c5e57/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/0223c5e57/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/0223c5e57/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/0223c5e57/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
