### PR TITLE
Let user pick RP id instead of automatically picking the RP id

### DIFF
--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -659,7 +659,7 @@ export const pickRpId = (
             >
               <button
                 class="c-list__parcel c-list__parcel--select"
-                @click="${() => resolve({ kind: "picked", rpId })}"
+                @click="${() => resolve({ kind: "rpIdPickSuccess", rpId })}"
                 tabindex="0"
                 data-rp-id="${rpId}"
                 style="font-size: 18px"
@@ -764,6 +764,7 @@ const useIdentityFlow = async <I>({
     | PinUserOtherDomain
     | UnknownUser
     | ApiError
+    | LoginCancel
   >;
   allowPinLogin: boolean;
   verifyPinValidity: (opts: {
@@ -808,7 +809,11 @@ const useIdentityFlow = async <I>({
 
   if (isNullish(pinIdentityMaterial)) {
     // this user number does not have a browser storage identity
-    return doLoginPasskey();
+    const result = await doLoginPasskey();
+    if (result.kind === "loginCancel") {
+      return { tag: "canceled" };
+    }
+    return result;
   }
 
   // Here we ensure the PIN identity is still valid, i.e. the user did not explicitly delete
@@ -824,7 +829,11 @@ const useIdentityFlow = async <I>({
   );
   if (isValid === "expired") {
     // the PIN identity seems to have been expired
-    return doLoginPasskey();
+    const result = await doLoginPasskey();
+    if (result.kind === "loginCancel") {
+      return { tag: "canceled" };
+    }
+    return result;
   }
   isValid satisfies "valid";
 
@@ -857,7 +866,11 @@ const useIdentityFlow = async <I>({
 
   if (result.kind === "passkey") {
     // User still decided to use a passkey
-    return doLoginPasskey();
+    const result = await doLoginPasskey();
+    if (result.kind === "loginCancel") {
+      return { tag: "canceled" };
+    }
+    return result;
   }
 
   result satisfies { kind: "pin" };

--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -656,7 +656,7 @@ export const pickRpId = (
                 class="c-list__parcel c-list__parcel--select"
                 @click="${() => resolve({ kind: "rpIdPickSuccess", rpId })}"
                 tabindex="0"
-                data-rp-id="${rpId}"
+                data-rp-id="${rpId ?? window.location.hostname}"
                 style="font-size: 18px"
               >
                 ${rpId ?? window.location.hostname}

--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -369,7 +369,6 @@ export const handleLoginFlowResult = async <E>(
     | PossiblyWrongWebAuthnFlow
     | PinUserOtherDomain
     | FlowError
-    | LoginCancel
 ): Promise<
   ({ userNumber: bigint; connection: AuthenticatedConnection } & E) | undefined
 > => {
@@ -402,10 +401,6 @@ export const handleLoginFlowResult = async <E>(
         ],
       })
     );
-    return undefined;
-  }
-
-  if (result.kind === "loginCancel") {
     return undefined;
   }
 

--- a/src/frontend/src/flows/authorize/index.json
+++ b/src/frontend/src/flows/authorize/index.json
@@ -40,6 +40,6 @@
     "pick_alternative_of": "Choose the Internet Identity that connects to",
     "pick_alternative_of_join": "and",
     "multiple_domains": "Multiple domains",
-    "multiple_domains_pick_to_continue": "Multiple domains found, pick one to continue"
+    "multiple_domains_pick_to_continue": "We found passkeys registered in multiple domains for this identity. In which domain did you register your current device?"
   }
 }

--- a/src/frontend/src/flows/authorize/index.json
+++ b/src/frontend/src/flows/authorize/index.json
@@ -38,6 +38,8 @@
     "pick_subtitle": "to connect",
     "pick_subtitle_join": "to",
     "pick_alternative_of": "Choose the Internet Identity that connects to",
-    "pick_alternative_of_join": "and"
+    "pick_alternative_of_join": "and",
+    "multiple_domains": "Multiple domains",
+    "multiple_domains_pick_to_continue": "Multiple domains found, pick one to continue"
   }
 }

--- a/src/frontend/src/flows/recovery/recoverWith/device.ts
+++ b/src/frontend/src/flows/recovery/recoverWith/device.ts
@@ -7,6 +7,7 @@ import { convertToValidCredentialData } from "$src/utils/credential-devices";
 import {
   AuthFail,
   Connection,
+  LoginCancel,
   LoginSuccess,
   PossiblyWrongWebAuthnFlow,
   WebAuthnFailed,
@@ -53,6 +54,11 @@ export const recoverWithDevice = ({
           return;
         }
 
+        if (result.kind === "loginCancel") {
+          resolve({ tag: "canceled" });
+          return;
+        }
+
         if (result.kind !== "loginSuccess") {
           if (result.kind === "possiblyWrongWebAuthnFlow") {
             const i18n = new I18n();
@@ -90,6 +96,7 @@ const attemptRecovery = async ({
   | WebAuthnFailed
   | PossiblyWrongWebAuthnFlow
   | AuthFail
+  | LoginCancel
   | { kind: "noRecovery" }
   | { kind: "tooManyRecovery" }
 > => {
@@ -112,5 +119,9 @@ const attemptRecovery = async ({
     .map(convertToValidCredentialData)
     .filter(nonNullish);
 
-  return await connection.fromWebauthnCredentials(userNumber, credentialData);
+  return await connection.fromWebauthnCredentials(
+    userNumber,
+    credentialData,
+    undefined
+  );
 };

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -542,6 +542,12 @@ export class AuthenticateView extends View {
     await this.browser.$('[data-role="anchor-input"]').waitForDisplayed();
     await this.browser.$('[data-role="anchor-input"]').setValue(anchor);
     await this.browser.$('[data-action="continue"]').click();
+
+    // If there are multiple RP ids, always pick the first one
+    const selectRpId = await this.browser.$("[data-rp-id]");
+    if (await selectRpId.isExisting()) {
+      await selectRpId.click();
+    }
   }
 
   async expectAnchorInputField(): Promise<void> {

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -464,7 +464,7 @@ export class Connection {
       if (
         nonNullish(pickRpId) &&
         this.webAuthFlows.currentIndex === 0 &&
-        uniqueRpIds.length > 0
+        uniqueRpIds.length > 1
       ) {
         const result = await pickRpId(uniqueRpIds);
         if (result.kind === "rpIdPickCancelled") {

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -389,7 +389,6 @@ export class Connection {
     | PinUserOtherDomain
     | UnknownUser
     | ApiError
-    | LoginCancel
   > => {
     let devices: Omit<DeviceData, "alias">[];
     try {
@@ -440,11 +439,7 @@ export class Connection {
       rpIds: Array<string | undefined>
     ) => Promise<RpIdPickSuccess | RpIdPickCancelled>
   ): Promise<
-    | LoginSuccess
-    | WebAuthnFailed
-    | PossiblyWrongWebAuthnFlow
-    | AuthFail
-    | LoginCancel
+    LoginSuccess | WebAuthnFailed | PossiblyWrongWebAuthnFlow | AuthFail
   > => {
     if (DOMAIN_COMPATIBILITY.isEnabled()) {
       // Create flows if not initialized yet
@@ -473,7 +468,7 @@ export class Connection {
       ) {
         const result = await pickRpId(uniqueRpIds);
         if (result.kind === "rpIdPickCancelled") {
-          return { kind: "loginCancel" };
+          return { kind: "webAuthnFailed" };
         }
         void (result satisfies RpIdPickSuccess);
 


### PR DESCRIPTION
Let user pick RP id instead of automatically picking the RP id.

# Changes

- Pass optional `pickRpId` method to connection passkey login so that a screen is rendered where user picks RP id to authenticate with.
- Keep existing flow logic "as is", the flows of the picked RP id are prioritized within the existing generated flows.
- Updated e2e tests to automatically pick the first RP id from the list (results in same behavior as previously in e2e)


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5dea7371e/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5dea7371e/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5dea7371e/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5dea7371e/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5dea7371e/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5dea7371e/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5dea7371e/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5dea7371e/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/5dea7371e/mobile/displayUserNumber.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

