### PR TITLE
Show device domains if multiple are found

### DIFF
--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -110,7 +110,16 @@ export const authenticatorsSection = ({
 };
 
 export const authenticatorItem = ({
-  authenticator: { alias, last_usage, dupCount, warn, info, remove, rename },
+  authenticator: {
+    alias,
+    last_usage,
+    dupCount,
+    warn,
+    info,
+    remove,
+    rename,
+    rpId,
+  },
   index,
   icon,
 }: {
@@ -160,6 +169,9 @@ export const authenticatorItem = ({
             settings,
           })}
         </div>
+        ${nonNullish(rpId)
+          ? html`<div class="t-discreet">${rpId}</div>`
+          : undefined}
         <div>
           ${nonNullish(lastUsageFormattedString)
             ? html`<div class="t-muted">

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -183,11 +183,11 @@ export const authenticatorItem = ({
         </div>
         ${nonNullish(rpId)
           ? html`<div class="c-tooltip" tabindex="0" data-icon="info">
-            <div class="t-discreet" data-rpid="${rpId}">${rpId}</div>
-            <span class="c-tooltip__message c-card c-card--tight">
-                This passkey was registered in ${rpId}
+              <div class="t-discreet" data-rpid="${rpId}">${rpId}</div>
+              <span class="c-tooltip__message c-card c-card--tight">
+                ${copy.passkey_registered_in} ${rpId}
               </span>
-          </div>`
+            </div>`
           : undefined}
         <div>
           ${isCurrent

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -170,7 +170,12 @@ export const authenticatorItem = ({
           })}
         </div>
         ${nonNullish(rpId)
-          ? html`<div class="t-discreet">${rpId}</div>`
+          ? html`<div class="c-tooltip" tabindex="0" data-icon="info">
+              <div class="t-discreet">${rpId}</div>
+              <span class="c-tooltip__message c-card c-card--tight">
+                This passkey was registered in ${rpId}
+              </span>
+            </div>`
           : undefined}
         <div>
           ${nonNullish(lastUsageFormattedString)

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -171,7 +171,7 @@ export const authenticatorItem = ({
         </div>
         ${nonNullish(rpId)
           ? html`<div class="c-tooltip" tabindex="0" data-icon="info">
-              <div class="t-discreet">${rpId}</div>
+              <div class="t-discreet" data-rpid="${rpId}">${rpId}</div>
               <span class="c-tooltip__message c-card c-card--tight">
                 This passkey was registered in ${rpId}
               </span>

--- a/src/frontend/src/flows/manage/deviceSettings.json
+++ b/src/frontend/src/flows/manage/deviceSettings.json
@@ -46,6 +46,7 @@
     "reset_share_q": "Should I share my recovery phrase?",
     "reset_share_a": "Never! If someone asks for your recovery phrase, they are likely trying to steal access to your accounts",
 
-    "current_device_label": "Current device"
+    "current_device_label": "Current device",
+    "passkey_registered_in": "This passkey was registered in"
   }
 }

--- a/src/frontend/src/flows/manage/devicesFromDevicesWithUsage.test.ts
+++ b/src/frontend/src/flows/manage/devicesFromDevicesWithUsage.test.ts
@@ -64,7 +64,7 @@ describe("devicesFromDevicesWithUsage", () => {
       DOMAIN_COMPATIBILITY.set(true);
     });
 
-    it("returns an info icon on each device if they are not all in the same origin", () => {
+    it("returns an rpId on each device if they are not all in the same origin", () => {
       const devices = [
         createDevice(undefined),
         createDevice("https://identity.ic0.app"),
@@ -79,9 +79,7 @@ describe("devicesFromDevicesWithUsage", () => {
       });
 
       for (const device of expectedDevices.authenticators) {
-        expect(device.info?.strings[0]).toContain(
-          "This passkey was registered in"
-        );
+        expect(device.rpId).toBeDefined();
         expect(device.warn).toBeUndefined();
       }
     });

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -741,7 +741,7 @@ const domainLabel = (
   if (nonNullish(commonOrigin)) {
     return undefined;
   }
-  return device.origin[0] ?? LEGACY_II_URL;
+  return new URL(device.origin[0] ?? LEGACY_II_URL).hostname;
 };
 
 const unknownError = (): Error => {

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -647,10 +647,9 @@ export const devicesFromDevicesWithUsage = ({
 
       const authenticator = {
         alias: device.alias,
-        rpId: domainLabel(device, devices_),
+        rpId: rpIdLabel(device, devices_),
         last_usage: device.last_usage,
         warn: domainWarning(device),
-        info: domainInfo(device, devices_),
         rename: () => renameDevice({ connection, device, reload }),
         remove:
           hasSingleDevice && !hasOtherAuthMethods
@@ -718,17 +717,7 @@ export const domainWarning = (
   }
 };
 
-const domainInfo = (
-  device: DeviceData,
-  allDevices: DeviceData[]
-): TemplateResult | undefined => {
-  const label = domainLabel(device, allDevices);
-  if (nonNullish(label)) {
-    return html`This passkey was registered in ${label}`;
-  }
-};
-
-const domainLabel = (
+const rpIdLabel = (
   device: DeviceData,
   allDevices: DeviceData[]
 ): string | undefined => {

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -647,6 +647,7 @@ export const devicesFromDevicesWithUsage = ({
 
       const authenticator = {
         alias: device.alias,
+        rpId: domainLabel(device, devices_),
         last_usage: device.last_usage,
         warn: domainWarning(device),
         info: domainInfo(device, devices_),
@@ -721,6 +722,16 @@ const domainInfo = (
   device: DeviceData,
   allDevices: DeviceData[]
 ): TemplateResult | undefined => {
+  const label = domainLabel(device, allDevices);
+  if (nonNullish(label)) {
+    return html`This passkey was registered in ${label}`;
+  }
+};
+
+const domainLabel = (
+  device: DeviceData,
+  allDevices: DeviceData[]
+): string | undefined => {
   if (!DOMAIN_COMPATIBILITY.isEnabled()) {
     return undefined;
   }
@@ -730,8 +741,7 @@ const domainInfo = (
   if (nonNullish(commonOrigin)) {
     return undefined;
   }
-  return html`This passkey was registered in
-  ${device.origin[0] ?? LEGACY_II_URL}`;
+  return device.origin[0] ?? LEGACY_II_URL;
 };
 
 const unknownError = (): Error => {

--- a/src/frontend/src/flows/manage/types.ts
+++ b/src/frontend/src/flows/manage/types.ts
@@ -4,6 +4,7 @@ import { TemplateResult } from "lit-html";
 export type Authenticator = {
   alias: string;
   last_usage: [] | [bigint];
+  rpId?: string;
   rename: () => void;
   remove?: () => void;
   // `warn` is used to show a warning icon when the device was registered in a different oring than current one.

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -252,10 +252,10 @@ export class MainView extends View {
   }
 
   async waitForDifferentOriginDevice(exist: boolean): Promise<void> {
-    const differentOriginInfoIcon = await this.browser.$(
-      '[data-role="passkeys"] [data-device] [data-icon="info"]'
+    const differentOriginRpId = await this.browser.$(
+      '[data-role="passkeys"] [data-device] [data-rpid]'
     );
-    if ((await differentOriginInfoIcon.isExisting()) !== exist) {
+    if ((await differentOriginRpId.isExisting()) !== exist) {
       throw Error(
         exist
           ? "Different origin device not found"


### PR DESCRIPTION
Show device domains if multiple are found. 

# Changes

- Add optional `rpId` property to `Authenticator`.
- Assign value to this property using existing logic from `domainInfo`.
- Split `domainInfo` into `domainLabel` to just get the rp Id instead of a TemplateResult.
- Render `rpId` if it's non-nullish, see screenshot below.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/mobile/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/mobile/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/mobile/displayUserNumberTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d59263cda/mobile/registerDisabled.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


