### PR TITLE
Suggest old passkey cleanup

### DIFF
--- a/src/frontend/src/flows/manage/authenticatorsSection.json
+++ b/src/frontend/src/flows/manage/authenticatorsSection.json
@@ -1,0 +1,7 @@
+{
+  "en": {
+    "some_passkeys_may_be_outdated_and": "Some of your passkeys may be outdated, and",
+    "safely_cleaning_them_up": "safely cleaning them up",
+    "can_improve_sign_in": "can improve your sign-in experience."
+  }
+}

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -110,7 +110,16 @@ export const authenticatorsSection = ({
 };
 
 export const authenticatorItem = ({
-  authenticator: { alias, last_usage, dupCount, warn, info, remove, rename },
+  authenticator: {
+    alias,
+    last_usage,
+    dupCount,
+    warn,
+    info,
+    remove,
+    rename,
+    rpId,
+  },
   index,
   icon,
 }: {
@@ -160,6 +169,9 @@ export const authenticatorItem = ({
             settings,
           })}
         </div>
+        ${nonNullish(rpId)
+          ? html`<div class="t-discreet">${rpId}</div>`
+          : undefined}
         <div>
           ${nonNullish(lastUsageFormattedString)
             ? html`<div class="t-muted">

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -3,12 +3,12 @@ import {
   pulsatingCircleIcon,
   warningIcon,
 } from "$src/components/icons";
+import sectionCopyJson from "$src/flows/manage/authenticatorsSection.json";
 import { I18n } from "$src/i18n";
 import { formatLastUsage } from "$src/utils/time";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { TemplateResult, html } from "lit-html";
 import copyJson from "./deviceSettings.json";
-import sectionCopyJson from "$src/flows/manage/authenticatorsSection.json";
 import { settingsDropdown } from "./settingsDropdown";
 import { Authenticator } from "./types";
 
@@ -82,57 +82,58 @@ export const authenticatorsSection = ({
             `
           : ""
       }
-        <div class="t-title t-title--complications">
-          <h2 class="t-title">Passkeys</h2>
-          <span class="t-title__complication c-tooltip" tabindex="0">
+      <div class="t-title t-title--complications">
+        <h2 class="t-title">Passkeys</h2>
+        <span class="t-title__complication c-tooltip" tabindex="0">
             <span class="c-tooltip__message c-card c-card--tight">
               You can register up to ${MAX_AUTHENTICATORS} passkeys
               (recovery devices excluded)</span>
               (${authenticators.length}/${MAX_AUTHENTICATORS})
             </span>
-          </span>
-        </div>
-        <p
-          class="${warnNoPasskeys ? "warning-message" : ""} t-paragraph t-lead"
-        >${
-          warnNoPasskeys
-            ? "Set up a passkey and securely sign into dapps by unlocking your device."
-            : "Use passkeys to hold assets and securely sign into dapps by unlocking your device."
-        }
-        </p>
-        <div class="c-action-list">
-          <ul>
+        </span>
+      </div>
+      <p
+        class="${warnNoPasskeys ? "warning-message" : ""} t-paragraph t-lead"
+      >${
+        warnNoPasskeys
+          ? "Set up a passkey and securely sign into dapps by unlocking your device."
+          : "Use passkeys to hold assets and securely sign into dapps by unlocking your device."
+      }
+      </p>
+      <div class="c-action-list">
+        <ul>
           ${authenticators.map((authenticator, index) =>
             authenticatorItem({ authenticator, index, i18n })
-          )}</ul>
-          <div class="c-action-list__actions">
-            <button
-              .disabled=${authenticators.length >= MAX_AUTHENTICATORS}
-              class="c-button c-button--primary c-tooltip c-tooltip--onDisabled c-tooltip--left"
-              @click="${() => onAddDevice()}"
-              id="addAdditionalDevice"
-            >
+          )}
+        </ul>
+        <div class="c-action-list__actions">
+          <button
+            .disabled=${authenticators.length >= MAX_AUTHENTICATORS}
+            class="c-button c-button--primary c-tooltip c-tooltip--onDisabled c-tooltip--left"
+            @click="${() => onAddDevice()}"
+            id="addAdditionalDevice"
+          >
               <span class="c-tooltip__message c-card c-card--tight"
-                >You can register up to ${MAX_AUTHENTICATORS} authenticator devices.
+              >You can register up to ${MAX_AUTHENTICATORS} authenticator devices.
                 Remove a device before you can add a new one.</span
               >
-              <span>Add new Passkey</span>
-            </button>
-          </div>
+            <span>Add new Passkey</span>
+          </button>
         </div>
-        ${
-          cleanupRecommended
-            ? html`<div>
-                <p class="l-stack--small">
-                  ${copy.some_passkeys_may_be_outdated_and} ${" "}
-                  <a target="_blank" href="${MANAGE_PASSKEYS_SUPPORT_URL}">
-                    ${copy.safely_cleaning_them_up}
-                  </a>
-                  ${" "} ${copy.can_improve_sign_in}
-                </p>
-              </div>`
-            : undefined
-        }
+      </div>
+      ${
+        cleanupRecommended
+          ? html`<div>
+              <p class="l-stack--small">
+                ${copy.some_passkeys_may_be_outdated_and} ${" "}
+                <a target="_blank" href="${MANAGE_PASSKEYS_SUPPORT_URL}">
+                  ${copy.safely_cleaning_them_up}
+                </a>
+                ${" "} ${copy.can_improve_sign_in}
+              </p>
+            </div>`
+          : undefined
+      }
     </aside>`;
 };
 

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -14,7 +14,7 @@ import { Authenticator } from "./types";
 const MAX_AUTHENTICATORS = 8;
 
 const MANAGE_PASSKEYS_SUPPORT_URL =
-  "https://identitysupport.dfinity.org/hc/en-us/articles/32301362727188";
+  "https://identitysupport.dfinity.org/hc/en-us/articles/34973858010132";
 
 // A device with extra information about whether another device (earlier in the list)
 // has the same name.

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -1,4 +1,6 @@
+import { i18n } from "$showcase/i18n";
 import { infoIcon, warningIcon } from "$src/components/icons";
+import copyJson from "$src/flows/manage/authenticatorsSection.json";
 import { formatLastUsage } from "$src/utils/time";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { TemplateResult, html } from "lit-html";
@@ -10,6 +12,9 @@ import { Authenticator } from "./types";
 // and we (the frontend) only allow user one recovery device per type (phrase, fob),
 // which leaves room for 8 authenticator devices.
 const MAX_AUTHENTICATORS = 8;
+
+const MANAGE_PASSKEYS_SUPPORT_URL =
+  "https://identitysupport.dfinity.org/hc/en-us/articles/32301362727188";
 
 // A device with extra information about whether another device (earlier in the list)
 // has the same name.
@@ -35,11 +40,14 @@ export const authenticatorsSection = ({
   authenticators: authenticators_,
   onAddDevice,
   warnNoPasskeys,
+  cleanupRecommended,
 }: {
   authenticators: Authenticator[];
   onAddDevice: () => void;
   warnNoPasskeys: boolean;
+  cleanupRecommended: boolean;
 }): TemplateResult => {
+  const copy = i18n.i18n(copyJson);
   const wrapClasses = [
     "l-stack",
     "c-card",
@@ -104,8 +112,20 @@ export const authenticatorsSection = ({
               <span>Add new Passkey</span>
             </button>
           </div>
-
         </div>
+        ${
+          cleanupRecommended
+            ? html`<div>
+                <p class="l-stack--small">
+                  ${copy.some_passkeys_may_be_outdated_and} ${" "}
+                  <a target="_blank" href="${MANAGE_PASSKEYS_SUPPORT_URL}">
+                    ${copy.safely_cleaning_them_up}
+                  </a>
+                  ${" "} ${copy.can_improve_sign_in}
+                </p>
+              </div>`
+            : undefined
+        }
     </aside>`;
 };
 

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -209,7 +209,8 @@ const displayManageTemplate = ({
 }): TemplateResult => {
   // Nudge the user to add a passkey if there is none
   const warnNoPasskeys = authenticators.length === 0;
-  // Recommend the user to clean up passkeys if there are multiple domains
+  // Recommend the user to clean up passkeys if there are
+  // authenticators registered in multiple domains.
   const cleanupRecommended = authenticators.some((authenticator) =>
     nonNullish(authenticator.rpId)
   );

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -741,7 +741,7 @@ const domainLabel = (
   if (nonNullish(commonOrigin)) {
     return undefined;
   }
-  return device.origin[0] ?? LEGACY_II_URL;
+  return new URL(device.origin[0] ?? LEGACY_II_URL).hostname;
 };
 
 const unknownError = (): Error => {

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -647,6 +647,7 @@ export const devicesFromDevicesWithUsage = ({
 
       const authenticator = {
         alias: device.alias,
+        rpId: domainLabel(device, devices_),
         last_usage: device.last_usage,
         warn: domainWarning(device),
         info: domainInfo(device, devices_),
@@ -721,6 +722,16 @@ const domainInfo = (
   device: DeviceData,
   allDevices: DeviceData[]
 ): TemplateResult | undefined => {
+  const label = domainLabel(device, allDevices);
+  if (nonNullish(label)) {
+    return html`This passkey was registered in ${label}`;
+  }
+};
+
+const domainLabel = (
+  device: DeviceData,
+  allDevices: DeviceData[]
+): string | undefined => {
   if (!DOMAIN_COMPATIBILITY.isEnabled()) {
     return undefined;
   }
@@ -730,8 +741,7 @@ const domainInfo = (
   if (nonNullish(commonOrigin)) {
     return undefined;
   }
-  return html`This passkey was registered in
-  ${device.origin[0] ?? LEGACY_II_URL}`;
+  return device.origin[0] ?? LEGACY_II_URL;
 };
 
 const unknownError = (): Error => {

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -197,9 +197,13 @@ const displayManageTemplate = ({
   identityBackground: PreLoadImage;
   tempKeysWarning?: TempKeyWarningAction;
 }): TemplateResult => {
+  const i18n = new I18n();
   // Nudge the user to add a passkey if there is none
   const warnNoPasskeys = authenticators.length === 0;
-  const i18n = new I18n();
+  // Recommend the user to clean up passkeys if there are multiple domains
+  const cleanupRecommended = authenticators.some((authenticator) =>
+    nonNullish(authenticator.rpId)
+  );
 
   const pageContentSlot = html` <section data-role="identity-management">
     <hgroup>
@@ -216,6 +220,7 @@ const displayManageTemplate = ({
       authenticators,
       onAddDevice,
       warnNoPasskeys,
+      cleanupRecommended,
     })}
     ${OPENID_AUTHENTICATION.isEnabled()
       ? linkedAccountsSection({

--- a/src/frontend/src/flows/manage/types.ts
+++ b/src/frontend/src/flows/manage/types.ts
@@ -4,6 +4,7 @@ import { TemplateResult } from "lit-html";
 export type Authenticator = {
   alias: string;
   last_usage: [] | [bigint];
+  rpId?: string;
   rename: () => void;
   remove?: () => void;
   // `warn` is used to show a warning icon when the device was registered in a different oring than current one.


### PR DESCRIPTION
Suggest old passkey cleanup if passkeys are found across multiple domains.

# Changes

- Add `cleanupRecommended` boolean to `authenticatorsSection` and set it to true based on multiple domains found in passkeys
- Render text to recommended cleanup with link to support page in `authenticatorsSection`.




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b2b371073/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b2b371073/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b2b371073/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b2b371073/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b2b371073/mobile/displayManageSingle.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



