### PR TITLE
Refactor removing devices

### DIFF
--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -1,3 +1,4 @@
+import { DeviceData } from "$generated/internet_identity_types";
 import {
   infoIcon,
   pulsatingCircleIcon,
@@ -44,12 +45,14 @@ export const dedupLabels = (
 export const authenticatorsSection = ({
   authenticators: authenticators_,
   onAddDevice,
+  onRemoveDevice,
   warnNoPasskeys,
   cleanupRecommended,
   i18n,
 }: {
   authenticators: Authenticator[];
   onAddDevice: () => void;
+  onRemoveDevice: (device: DeviceData) => void;
   warnNoPasskeys: boolean;
   cleanupRecommended: boolean;
   i18n: I18n;
@@ -103,16 +106,15 @@ export const authenticatorsSection = ({
       <div class="c-action-list">
         <ul>
           ${authenticators.map((authenticator, index) =>
-            authenticatorItem({ authenticator, index, i18n })
-          )}
-        </ul>
-        <div class="c-action-list__actions">
-          <button
-            .disabled=${authenticators.length >= MAX_AUTHENTICATORS}
-            class="c-button c-button--primary c-tooltip c-tooltip--onDisabled c-tooltip--left"
-            @click="${() => onAddDevice()}"
-            id="addAdditionalDevice"
-          >
+            authenticatorItem({ authenticator, index, i18n, onRemoveDevice })
+          )}</ul>
+          <div class="c-action-list__actions">
+            <button
+              .disabled=${authenticators.length >= MAX_AUTHENTICATORS}
+              class="c-button c-button--primary c-tooltip c-tooltip--onDisabled c-tooltip--left"
+              @click="${() => onAddDevice()}"
+              id="addAdditionalDevice"
+            >
               <span class="c-tooltip__message c-card c-card--tight"
               >You can register up to ${MAX_AUTHENTICATORS} authenticator devices.
                 Remove a device before you can add a new one.</span
@@ -144,27 +146,34 @@ export const authenticatorItem = ({
     dupCount,
     warn,
     info,
-    remove,
+    device,
     rename,
     rpId,
     isCurrent,
+    canBeRemoved,
   },
   index,
   i18n,
   icon,
+  onRemoveDevice,
 }: {
   authenticator: DedupAuthenticator;
   index: number;
   i18n: I18n;
   icon?: TemplateResult;
+  onRemoveDevice: (device: DeviceData) => void;
 }) => {
   const copy = i18n.i18n(copyJson);
   const settings = [
     { action: "rename", caption: "Rename", fn: () => rename() },
   ];
 
-  if (nonNullish(remove)) {
-    settings.push({ action: "remove", caption: "Remove", fn: () => remove() });
+  if (canBeRemoved) {
+    settings.push({
+      action: "remove",
+      caption: "Remove",
+      fn: () => onRemoveDevice(device),
+    });
   }
 
   let lastUsageTimeStamp: Date | undefined;

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -176,7 +176,7 @@ export const authenticatorItem = ({
     settings.push({
       action: "remove",
       caption: "Remove",
-      fn: () => onRemove(),
+      fn: onRemove,
     });
   }
 

--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -106,7 +106,12 @@ export const authenticatorsSection = ({
       <div class="c-action-list">
         <ul>
           ${authenticators.map((authenticator, index) =>
-            authenticatorItem({ authenticator, index, i18n, onRemoveDevice })
+            authenticatorItem({
+              authenticator,
+              index,
+              i18n,
+              onRemove: () => onRemoveDevice(authenticator.device),
+            })
           )}</ul>
           <div class="c-action-list__actions">
             <button
@@ -146,7 +151,6 @@ export const authenticatorItem = ({
     dupCount,
     warn,
     info,
-    device,
     rename,
     rpId,
     isCurrent,
@@ -155,13 +159,13 @@ export const authenticatorItem = ({
   index,
   i18n,
   icon,
-  onRemoveDevice,
+  onRemove,
 }: {
   authenticator: DedupAuthenticator;
   index: number;
   i18n: I18n;
   icon?: TemplateResult;
-  onRemoveDevice: (device: DeviceData) => void;
+  onRemove: () => void;
 }) => {
   const copy = i18n.i18n(copyJson);
   const settings = [
@@ -172,7 +176,7 @@ export const authenticatorItem = ({
     settings.push({
       action: "remove",
       caption: "Remove",
-      fn: () => onRemoveDevice(device),
+      fn: () => onRemove(),
     });
   }
 

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -227,7 +227,11 @@ const displayManageTemplate = ({
       ? tempKeyWarningBox({ i18n, warningAction: tempKeysWarning })
       : ""}
     ${pinAuthenticators.length > 0
-      ? tempKeysSection({ authenticators: pinAuthenticators, i18n })
+      ? tempKeysSection({
+          authenticators: pinAuthenticators,
+          i18n,
+          onRemoveDevice,
+        })
       : ""}
     ${authenticatorsSection({
       authenticators,

--- a/src/frontend/src/flows/manage/tempKeys.ts
+++ b/src/frontend/src/flows/manage/tempKeys.ts
@@ -8,6 +8,7 @@ import { I18n } from "$src/i18n";
 import { unreachable } from "$src/utils/utils";
 import { TemplateResult, html } from "lit-html";
 
+import { DeviceData } from "$generated/internet_identity_types";
 import { warnBox } from "$src/components/warnBox";
 import { nonNullish } from "@dfinity/utils";
 import copyJson from "./tempKeys.json";
@@ -56,9 +57,11 @@ export const tempKeyWarningBox = ({
 export const tempKeysSection = ({
   authenticators: authenticators_,
   i18n,
+  onRemoveDevice,
 }: {
   authenticators: Authenticator[];
   i18n: I18n;
+  onRemoveDevice: (device: DeviceData) => void;
 }): TemplateResult => {
   const authenticators = dedupLabels(authenticators_);
   const copy = i18n.i18n(copyJson);
@@ -79,6 +82,7 @@ export const tempKeysSection = ({
             authenticator,
             index,
             i18n,
+            onRemoveDevice,
             icon: html`<span class="c-icon c-icon--pin"
               >${cypherIcon}<span></span
             ></span>`,

--- a/src/frontend/src/flows/manage/tempKeys.ts
+++ b/src/frontend/src/flows/manage/tempKeys.ts
@@ -82,7 +82,7 @@ export const tempKeysSection = ({
             authenticator,
             index,
             i18n,
-            onRemoveDevice,
+            onRemove: () => onRemoveDevice(authenticator.device),
             icon: html`<span class="c-icon c-icon--pin"
               >${cypherIcon}<span></span
             ></span>`,

--- a/src/frontend/src/flows/manage/types.ts
+++ b/src/frontend/src/flows/manage/types.ts
@@ -1,3 +1,4 @@
+import { DeviceData } from "$generated/internet_identity_types";
 import { TemplateResult } from "lit-html";
 
 // A simple authenticator (non-recovery device)
@@ -6,13 +7,16 @@ export type Authenticator = {
   last_usage: [] | [bigint];
   rpId?: string;
   rename: () => void;
-  remove?: () => void;
+  // Whether this device can be removed (based on same logic as remove)
+  canBeRemoved: boolean;
   // `warn` is used to show a warning icon when the device was registered in a different oring than current one.
   warn?: TemplateResult;
   // `info` is used to show an info icon of where the device was registered, only when some device has a different origin than the others.
   info?: TemplateResult;
   // `isCurrent` is true when the public key of the DeviceWithUsage is the same as the one returned by the AuthenticatedConnection instance.
   isCurrent: boolean;
+  // The original device data this authenticator was created from
+  device: DeviceData;
 };
 
 // A recovery phrase, potentially protected


### PR DESCRIPTION
# Motivation

We want to add a confirmation screen instead of an alert when removing devices.

To do that, we'll need to use the same pattern as adding a recovery phrase from the manage page. This means, passing a function that will be triggered with the user interaction instead of calling the function in the Authenticator.

In this PR, I refactor the code so that in a subsequent PR I'll be able to render a new page and then send the user back to the manage page.

# Changes

* New fields in the `Authenticator`: `device` and `canBeRemoved`.
* New helper `onRemoveDevice` that calls `deleteDevice`.
* New parameter `onRemoveDevice` accordingly.

# Tests

* No new tests because there is no new functionality.
* Tested locally.





<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/51a4a72a5/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/51a4a72a5/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/51a4a72a5/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/51a4a72a5/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/51a4a72a5/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/51a4a72a5/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/51a4a72a5/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/51a4a72a5/mobile/displayManageCredentialsSingle.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->




