### PR TITLE
Sort lookup devices by most recently used

### DIFF
--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -200,13 +200,14 @@ fn lookup(anchor_number: AnchorNumber) -> Vec<DeviceData> {
     let Ok(anchor) = state::storage_borrow(|storage| storage.read(anchor_number)) else {
         return vec![];
     };
-    anchor
-        .into_devices()
+    let mut devices = anchor.into_devices();
+    devices.sort_by(|a, b| b.last_usage_timestamp.cmp(&a.last_usage_timestamp));
+    devices
         .into_iter()
         .map(DeviceData::from)
         .map(|mut d| {
             // Remove non-public fields.
-            d.alias = "".to_string();
+            d.alias = String::new();
             d.metadata = None;
             d
         })


### PR DESCRIPTION
Sort lookup devices by most recently used, this enables the frontend to prioritize the most recently used device during sign in, avoiding sign in retries in future sign ins.
<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3a1356b89/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3a1356b89/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3a1356b89/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3a1356b89/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3a1356b89/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3a1356b89/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3a1356b89/mobile/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/3a1356b89/mobile/promptDeviceAlias.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
