### PR TITLE
Confirm Remove Device Page

### DIFF
--- a/src/frontend/src/components/infoScreen.ts
+++ b/src/frontend/src/components/infoScreen.ts
@@ -128,7 +128,7 @@ const infoLabelIcon: TemplateResult = html`
   >
 `;
 
-const warningLabelIcon: TemplateResult = html`
+export const warningLabelIcon: TemplateResult = html`
   <i class="c-card__icon c-icon c-icon--error__flipped c-icon--inline"
     >${warningIcon}</i
   >

--- a/src/frontend/src/flows/manage/confirmRemoveDevice.json
+++ b/src/frontend/src/flows/manage/confirmRemoveDevice.json
@@ -1,0 +1,11 @@
+{
+  "en": {
+    "confirm": "Remove Device",
+    "cancel": "Cancel",
+    "title_recovery_device": "Confirm Remove Recovery Device",
+    "title_authenticator_device": "Confirm Remove Device",
+    "label": "Security Warning",
+    "message_authenticator_device": "This is an irreversible action. Confirm that you want to remove the device by entering its name:",
+    "message_recovery_device": "This is an irreversible action. By confirming, you are removing the recovery device."
+  }
+}

--- a/src/frontend/src/flows/manage/confirmRemoveDevice.json
+++ b/src/frontend/src/flows/manage/confirmRemoveDevice.json
@@ -7,6 +7,9 @@
     "label": "Security Warning",
     "irreversible_action": "This is an irreversible action.",
     "message_authenticator_device": "Confirm that you want to remove the device by entering the passkey nickname:",
-    "message_recovery_device": "Please, confirm that you want to remove the recovery device."
+    "message_recovery_device": "Please, confirm that you want to remove the recovery device.",
+    "label_nickname": "Nickname:",
+    "label_last_used": "Last used:",
+    "label_origin": "Registered in:"
   }
 }

--- a/src/frontend/src/flows/manage/confirmRemoveDevice.json
+++ b/src/frontend/src/flows/manage/confirmRemoveDevice.json
@@ -5,7 +5,8 @@
     "title_recovery_device": "Confirm Remove Recovery Device",
     "title_authenticator_device": "Confirm Remove Device",
     "label": "Security Warning",
-    "message_authenticator_device": "This is an irreversible action. Confirm that you want to remove the device by entering its name:",
-    "message_recovery_device": "This is an irreversible action. By confirming, you are removing the recovery device."
+    "irreversible_action": "This is an irreversible action.",
+    "message_authenticator_device": "Confirm that you want to remove the device by entering the passkey nickname:",
+    "message_recovery_device": "Please, confirm that you want to remove the recovery device."
   }
 }

--- a/src/frontend/src/flows/manage/confirmRemoveDevice.ts
+++ b/src/frontend/src/flows/manage/confirmRemoveDevice.ts
@@ -1,0 +1,121 @@
+import { Purpose } from "$generated/internet_identity_types";
+import { warningLabelIcon } from "$src/components/infoScreen";
+import { mainWindow } from "$src/components/mainWindow";
+import { DynamicKey, I18n } from "$src/i18n";
+import { renderPage, withRef } from "$src/utils/lit-html";
+import { html } from "lit-html";
+import { Ref, createRef, ref } from "lit-html/directives/ref.js";
+import copyJson from "./confirmRemoveDevice.json";
+
+// 'authentication' | 'recovery' from Purpose type
+export type PurposeType = "authentication" | "recovery";
+const confirmRemoveDeviceTemplate = ({
+  i18n,
+  purpose,
+  next,
+  cancel,
+  alias,
+}: {
+  i18n: I18n;
+  purpose: Purpose;
+  next: () => void;
+  cancel: () => void;
+  alias: string;
+}) => {
+  const copy = i18n.i18n(copyJson);
+  const mapper: Record<
+    PurposeType,
+    { title: DynamicKey; message: DynamicKey }
+  > = {
+    authentication: {
+      title: copy.title_authenticator_device,
+      message: copy.message_authenticator_device,
+    },
+    recovery: {
+      title: copy.title_recovery_device,
+      message: copy.message_recovery_device,
+    },
+  };
+  const purposeType = Object.keys(purpose)[0] as PurposeType;
+  const mappedCopy = mapper[purposeType];
+  const input: Ref<HTMLInputElement> = createRef();
+  const confirmButton: Ref<HTMLButtonElement> = createRef();
+
+  const slot = html`
+    <hgroup data-page="confirm-remove-device-page">
+      <div class="c-card__label c-card__label--hasIcon">
+        ${warningLabelIcon}
+        <h2>${copy.label}</h2>
+      </div>
+      <h1 class="t-title t-title--main">${mappedCopy.title}</h1>
+      <p class="t-paragraph">${mappedCopy.message}</p>
+    </hgroup>
+    <div class="l-stack">
+      ${purposeType === "authentication"
+        ? html`<input
+            autofocus
+            ${ref(input)}
+            id="confirmRemoveDevice"
+            class="c-input c-input--stack c-input--fullwidth"
+            spellcheck="false"
+            @change=${() =>
+              withRef(input, (inputElement) =>
+                withRef(confirmButton, (buttonElement) => {
+                  if (inputElement.value === alias) {
+                    buttonElement.disabled = false;
+                  } else {
+                    buttonElement.disabled = true;
+                  }
+                })
+              )}
+          />`
+        : undefined}
+    </div>
+    <div class="l-stack">
+      <button
+        .disabled=${purposeType === "authentication"}
+        ${ref(confirmButton)}
+        @click=${() => next()}
+        data-action="next"
+        class="c-button"
+      >
+        ${copy.confirm}
+      </button>
+      <button
+        @click=${() => cancel()}
+        data-action="cancel"
+        class="c-button c-button--secondary"
+      >
+        ${copy.cancel}
+      </button>
+    </div>
+  `;
+
+  return mainWindow({
+    showFooter: false,
+    showLogo: false,
+    slot,
+  });
+};
+
+export const confirmRemoveDevicePage = renderPage(confirmRemoveDeviceTemplate);
+
+export const confirmRemoveDevice = ({
+  i18n,
+  purpose,
+  alias,
+}: {
+  i18n: I18n;
+  purpose: Purpose;
+  alias: string;
+}): Promise<"confirmed" | "cancelled"> => {
+  return new Promise((resolve) =>
+    confirmRemoveDevicePage({
+      i18n,
+      purpose,
+      alias,
+      next: () => resolve("confirmed"),
+      cancel: () => resolve("cancelled"),
+    })
+  );
+};

--- a/src/frontend/src/flows/manage/confirmRemoveDevice.ts
+++ b/src/frontend/src/flows/manage/confirmRemoveDevice.ts
@@ -65,33 +65,46 @@ const confirmRemoveDeviceTemplate = ({
       <h1 class="t-title t-title--main">${mappedCopy.title}</h1>
       <p class="t-paragraph">${copy.irreversible_action}</p>
       <ul class="c-list c-list--bulleted">
-        <li>${`Passkey nickname: ${alias}`}</li>
-        <li>${`Last used: ${lastUsageFormattedString}`}</li>
-        <li>${`Registered in: ${originRegistered ?? LEGACY_II_URL}`}</li>
+        <li>${html`${copy.label_nickname}
+          <span class="t-strong">${alias}</span>`}</li>
+        ${
+          nonNullish(lastUsageFormattedString)
+            ? html`<li>
+                ${copy.label_last_used}
+                <span class="t-strong">${lastUsageFormattedString}</span>
+              </li>`
+            : undefined
+        }
+        <li>${html`${copy.label_origin}
+          <span class="t-strong"
+            >${originRegistered ?? LEGACY_II_URL}</span
+          >`}</strong></li>
       </ul>
       <p class="t-paragraph">${mappedCopy.message}</p>
     </hgroup>
     <div>
-      ${purposeType === "authentication"
-        ? html`<input
-            autofocus
-            ${ref(input)}
-            id="confirmRemoveDevice"
-            class="c-input c-input--stack c-input--fullwidth"
-            spellcheck="false"
-            .onpaste=${(e: Event) => e.preventDefault()}
-            @change=${() =>
-              withRef(input, (inputElement) =>
-                withRef(confirmButton, (buttonElement) => {
-                  if (inputElement.value === alias) {
-                    buttonElement.disabled = false;
-                  } else {
-                    buttonElement.disabled = true;
-                  }
-                })
-              )}
-          />`
-        : undefined}
+      ${
+        purposeType === "authentication"
+          ? html`<input
+              autofocus
+              ${ref(input)}
+              id="confirmRemoveDevice"
+              class="c-input c-input--stack c-input--fullwidth"
+              spellcheck="false"
+              .onpaste=${(e: Event) => e.preventDefault()}
+              @change=${() =>
+                withRef(input, (inputElement) =>
+                  withRef(confirmButton, (buttonElement) => {
+                    if (inputElement.value === alias) {
+                      buttonElement.disabled = false;
+                    } else {
+                      buttonElement.disabled = true;
+                    }
+                  })
+                )}
+            />`
+          : undefined
+      }
     </div>
     <div class="l-stack">
       <button

--- a/src/frontend/src/flows/manage/confirmRemoveDevice.ts
+++ b/src/frontend/src/flows/manage/confirmRemoveDevice.ts
@@ -25,7 +25,7 @@ const confirmRemoveDeviceTemplate = ({
   purpose: Purpose;
   next: () => void;
   cancel: () => void;
-  alias: string;
+  alias?: string;
   lastUsedNanoseconds: bigint | undefined;
   originRegistered: string | undefined;
 }) => {
@@ -56,6 +56,9 @@ const confirmRemoveDeviceTemplate = ({
     lastUsageFormattedString = formatLastUsage(lastUsageTimeStamp);
   }
 
+  const showAlias =
+    purposeType === "authentication" && nonNullish(alias) && alias !== "";
+
   const slot = html`
     <hgroup data-page="confirm-remove-device-page">
       <div class="c-card__label c-card__label--hasIcon">
@@ -65,8 +68,13 @@ const confirmRemoveDeviceTemplate = ({
       <h1 class="t-title t-title--main">${mappedCopy.title}</h1>
       <p class="t-paragraph">${copy.irreversible_action}</p>
       <ul class="c-list c-list--bulleted">
-        <li>${html`${copy.label_nickname}
-          <span class="t-strong">${alias}</span>`}</li>
+        ${
+          showAlias
+            ? html`<li>
+                ${copy.label_nickname} <span class="t-strong">${alias}</span>
+              </li>`
+            : undefined
+        }
         ${
           nonNullish(lastUsageFormattedString)
             ? html`<li>

--- a/src/showcase/src/pages/confirmRemoveDevice.astro
+++ b/src/showcase/src/pages/confirmRemoveDevice.astro
@@ -14,6 +14,8 @@ import Screen from "../layouts/Screen.astro";
       i18n,
       purpose: { authentication: null },
       alias: "test",
+      lastUsedNanoseconds: BigInt(Date.now() - 24 * 3600 * 1000) * 1_000_000n,
+      originRegistered: "https://identity.internetcomputer.org",
     });
   </script>
 </Screen>

--- a/src/showcase/src/pages/confirmRemoveDevice.astro
+++ b/src/showcase/src/pages/confirmRemoveDevice.astro
@@ -14,7 +14,8 @@ import Screen from "../layouts/Screen.astro";
       i18n,
       purpose: { authentication: null },
       alias: "test",
-      lastUsedNanoseconds: BigInt(Date.now() - 24 * 3600 * 1000) * 1_000_000n,
+      // This is used for screenshot testing, if we add a real date it will always change the screenshot
+      lastUsedNanoseconds: undefined,
       originRegistered: "https://identity.internetcomputer.org",
     });
   </script>

--- a/src/showcase/src/pages/confirmRemoveDevice.astro
+++ b/src/showcase/src/pages/confirmRemoveDevice.astro
@@ -1,0 +1,19 @@
+---
+import Screen from "../layouts/Screen.astro";
+---
+
+<Screen title="Confirm Remove Device" pageName="confirmRemoveDevice">
+  <script>
+    import { toast } from "$src/components/toast";
+    import { i18n } from "../i18n";
+    import { confirmRemoveDevicePage } from "$src/flows/manage/confirmRemoveDevice";
+
+    confirmRemoveDevicePage({
+      next: () => toast.info("ok"),
+      cancel: () => toast.info("To confirm enter 'test' in the input."),
+      i18n,
+      purpose: { authentication: null },
+      alias: "test",
+    });
+  </script>
+</Screen>

--- a/src/showcase/src/pages/confirmRemoveRecoveryDevice.astro
+++ b/src/showcase/src/pages/confirmRemoveRecoveryDevice.astro
@@ -13,7 +13,6 @@ import Screen from "../layouts/Screen.astro";
       cancel: () => toast.info("cancel"),
       i18n,
       purpose: { recovery: null },
-      alias: "test",
       // This is used for screenshot testing, if we add a real date it will always change the screenshot
       lastUsedNanoseconds: undefined,
       originRegistered: "https://identity.internetcomputer.org",

--- a/src/showcase/src/pages/confirmRemoveRecoveryDevice.astro
+++ b/src/showcase/src/pages/confirmRemoveRecoveryDevice.astro
@@ -14,6 +14,9 @@ import Screen from "../layouts/Screen.astro";
       i18n,
       purpose: { recovery: null },
       alias: "test",
+      // This is used for screenshot testing, if we add a real date it will always change the screenshot
+      lastUsedNanoseconds: undefined,
+      originRegistered: "https://identity.internetcomputer.org",
     });
   </script>
 </Screen>

--- a/src/showcase/src/pages/confirmRemoveRecoveryDevice.astro
+++ b/src/showcase/src/pages/confirmRemoveRecoveryDevice.astro
@@ -1,0 +1,19 @@
+---
+import Screen from "../layouts/Screen.astro";
+---
+
+<Screen title="Confirm Remove Device" pageName="confirmRemoveDevice">
+  <script>
+    import { toast } from "$src/components/toast";
+    import { i18n } from "../i18n";
+    import { confirmRemoveDevicePage } from "$src/flows/manage/confirmRemoveDevice";
+
+    confirmRemoveDevicePage({
+      next: () => toast.info("ok"),
+      cancel: () => toast.info("cancel"),
+      i18n,
+      purpose: { recovery: null },
+      alias: "test",
+    });
+  </script>
+</Screen>


### PR DESCRIPTION
# Motivation

We want to improve the confirmation of removing devices and use a new page instead of an alert.

In this PR, I introduce the page that will be used to remove both a normal device and a recovery device.

# Changes

* Export icon to be used outside the info screen.
* New page confirmRemoveDevice.

# Tests

* Added two new showcase screens.




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟢 Some screens were added</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d3efda700/desktop/confirmRemoveDevice.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d3efda700/desktop/confirmRemoveRecoveryDevice.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d3efda700/mobile/confirmRemoveDevice.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d3efda700/mobile/confirmRemoveRecoveryDevice.png" width="250"></details><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d3efda700/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d3efda700/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d3efda700/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d3efda700/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/d3efda700/mobile/displayUserNumber.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



