### PR TITLE
Add new onRemoveDevice to recovery device

### DIFF
--- a/src/frontend/src/flows/manage/authenticatorsSection.ts
+++ b/src/frontend/src/flows/manage/authenticatorsSection.ts
@@ -1,4 +1,4 @@
-import { DeviceData } from "$generated/internet_identity_types";
+import { DeviceWithUsage } from "$generated/internet_identity_types";
 import {
   infoIcon,
   pulsatingCircleIcon,
@@ -52,7 +52,7 @@ export const authenticatorsSection = ({
 }: {
   authenticators: Authenticator[];
   onAddDevice: () => void;
-  onRemoveDevice: (device: DeviceData) => void;
+  onRemoveDevice: (device: DeviceWithUsage) => void;
   warnNoPasskeys: boolean;
   cleanupRecommended: boolean;
   i18n: I18n;

--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -198,7 +198,7 @@ const displayManageTemplate = ({
   userNumber: bigint;
   devices: Devices;
   onAddDevice: () => void;
-  onRemoveDevice: (device: DeviceData) => void;
+  onRemoveDevice: (device: DeviceWithUsage) => void;
   addRecoveryPhrase: () => void;
   addRecoveryKey: () => void;
   credentials: OpenIdCredential[];
@@ -249,7 +249,12 @@ const displayManageTemplate = ({
           hasOtherAuthMethods: authenticators.length > 0,
         })
       : ""}
-    ${recoveryMethodsSection({ recoveries, addRecoveryPhrase, addRecoveryKey })}
+    ${recoveryMethodsSection({
+      recoveries,
+      addRecoveryPhrase,
+      addRecoveryKey,
+      onRemoveDevice,
+    })}
     <aside class="l-stack">
       ${dappsTeaser({
         dapps,
@@ -416,7 +421,7 @@ export const displayManage = async (
       resolve();
     };
 
-    const onRemoveDevice = async (device: DeviceData) => {
+    const onRemoveDevice = async (device: DeviceWithUsage) => {
       await deleteDevice({ connection, device, reload: resolve });
     };
 
@@ -591,7 +596,7 @@ export const readRecovery = ({
   reload,
   device,
 }: {
-  device: DeviceData;
+  device: DeviceWithUsage;
   userNumber: bigint;
   connection: AuthenticatedConnection;
   reload: () => void;
@@ -630,7 +635,7 @@ export const readRecovery = ({
     } else {
       return {
         recoveryKey: {
-          remove: () => deleteDevice({ connection, device, reload }),
+          device,
         },
       };
     }

--- a/src/frontend/src/flows/manage/recoveryMethodsSection.ts
+++ b/src/frontend/src/flows/manage/recoveryMethodsSection.ts
@@ -12,8 +12,9 @@ import {
 import { isNullish } from "@dfinity/utils";
 import { TemplateResult, html } from "lit-html";
 import { settingsDropdown } from "./settingsDropdown";
-import { Devices, RecoveryKey, RecoveryPhrase } from "./types";
+import { Devices, RecoveryPhrase } from "./types";
 
+import { DeviceWithUsage } from "$generated/internet_identity_types";
 import copyJson from "./recoveryMethodsSection.json";
 
 // The list of recovery devices
@@ -21,10 +22,12 @@ export const recoveryMethodsSection = ({
   recoveries: { recoveryPhrase, recoveryKey },
   addRecoveryPhrase,
   addRecoveryKey,
+  onRemoveDevice,
 }: {
   recoveries: Devices["recoveries"];
   addRecoveryPhrase: () => void;
   addRecoveryKey: () => void;
+  onRemoveDevice: (device: DeviceWithUsage) => void;
 }): TemplateResult => {
   const i18n = new I18n();
 
@@ -64,7 +67,10 @@ export const recoveryMethodsSection = ({
             : recoveryPhraseItem({ recoveryPhrase, i18n })}
           ${isNullish(recoveryKey)
             ? missingRecovery({ recovery: "key", addRecoveryKey })
-            : recoveryKeyItem({ recoveryKey, i18n })}
+            : recoveryKeyItem({
+                onRemoveDevice: () => onRemoveDevice(recoveryKey.device),
+                i18n,
+              })}
         </ul>
       </div>
     </aside>
@@ -173,16 +179,16 @@ const lock = (): TemplateResult => {
 
 // List a recovery key (non-phrase recovery device)
 export const recoveryKeyItem = ({
-  recoveryKey,
+  onRemoveDevice,
   i18n,
 }: {
-  recoveryKey: RecoveryKey;
+  onRemoveDevice: () => void;
   i18n: I18n;
 }) => {
   const alias = recoveryKeyLabel;
   const id = "recovery-key";
   const settings = [
-    { action: "remove", caption: "Remove", fn: () => recoveryKey.remove() },
+    { action: "remove", caption: "Remove", fn: onRemoveDevice },
   ];
 
   const { recovery_key_enabled } = i18n.i18n(copyJson);

--- a/src/frontend/src/flows/manage/tempKeys.ts
+++ b/src/frontend/src/flows/manage/tempKeys.ts
@@ -8,7 +8,7 @@ import { I18n } from "$src/i18n";
 import { unreachable } from "$src/utils/utils";
 import { TemplateResult, html } from "lit-html";
 
-import { DeviceData } from "$generated/internet_identity_types";
+import { DeviceWithUsage } from "$generated/internet_identity_types";
 import { warnBox } from "$src/components/warnBox";
 import { nonNullish } from "@dfinity/utils";
 import copyJson from "./tempKeys.json";
@@ -61,7 +61,7 @@ export const tempKeysSection = ({
 }: {
   authenticators: Authenticator[];
   i18n: I18n;
-  onRemoveDevice: (device: DeviceData) => void;
+  onRemoveDevice: (device: DeviceWithUsage) => void;
 }): TemplateResult => {
   const authenticators = dedupLabels(authenticators_);
   const copy = i18n.i18n(copyJson);

--- a/src/frontend/src/flows/manage/types.ts
+++ b/src/frontend/src/flows/manage/types.ts
@@ -1,4 +1,4 @@
-import { DeviceData } from "$generated/internet_identity_types";
+import { DeviceWithUsage } from "$generated/internet_identity_types";
 import { TemplateResult } from "lit-html";
 
 // A simple authenticator (non-recovery device)
@@ -16,7 +16,7 @@ export type Authenticator = {
   // `isCurrent` is true when the public key of the DeviceWithUsage is the same as the one returned by the AuthenticatedConnection instance.
   isCurrent: boolean;
   // The original device data this authenticator was created from
-  device: DeviceData;
+  device: DeviceWithUsage;
 };
 
 // A recovery phrase, potentially protected
@@ -30,7 +30,7 @@ export type Protection =
 
 // A recovery key, i.e. "external hardware"
 export type RecoveryKey = {
-  remove: () => void;
+  device: DeviceWithUsage;
 };
 
 // The devices an anchor is expected to have


### PR DESCRIPTION
# Motivation

Start using the new confirmation screen when removing passkey.

In this PR, I use the new parameter `onRemoveDevice` also for the recovery device.

I also changed the type to `DeviceWithUsage` which is the actual type being passed not `DeviceData`.

# Changes

* Add new parameter `onRemove` to the recovery device components and use it.
* Change `DeviceData` for `DeviceWithUsage` in the `Authenticator` and the `onRemove` parameter.
* Change `RecoveryKey` remove field by a `device` used to then call the `onRemove` parameter. This could be further refactored in another PR to not need the extra type.

# Tests

No new functionality.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02a017a09/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02a017a09/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02a017a09/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02a017a09/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02a017a09/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02a017a09/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02a017a09/mobile/displayUserNumber.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
