### PR TITLE
Use new screen when removing passkeys and recovery devices

### DIFF
--- a/src/frontend/src/flows/manage/confirmRemoveDevice.ts
+++ b/src/frontend/src/flows/manage/confirmRemoveDevice.ts
@@ -103,7 +103,7 @@ const confirmRemoveDeviceTemplate = ({
           ? html`<input
               autofocus
               ${ref(input)}
-              id="confirmRemoveDevice"
+              id="confirmRemoveDeviceAlias"
               class="c-input c-input--stack c-input--fullwidth"
               spellcheck="false"
               .onpaste=${(e: Event) => e.preventDefault()}
@@ -126,6 +126,7 @@ const confirmRemoveDeviceTemplate = ({
         .disabled=${purposeType === "authentication"}
         ${ref(confirmButton)}
         @click=${() => next()}
+        id="confirmRemoveDeviceButton"
         data-action="next"
         class="c-button"
       >

--- a/src/frontend/src/flows/manage/deviceSettings.ts
+++ b/src/frontend/src/flows/manage/deviceSettings.ts
@@ -13,11 +13,7 @@ import {
   LoginSuccess,
 } from "$src/utils/iiConnection";
 import { renderPage } from "$src/utils/lit-html";
-import {
-  isProtected,
-  isRecoveryDevice,
-  RecoveryPhrase,
-} from "$src/utils/recoveryDevice";
+import { isProtected, RecoveryPhrase } from "$src/utils/recoveryDevice";
 import { unknownToString } from "$src/utils/utils";
 import { DerEncodedPublicKey } from "@dfinity/agent";
 import copyJson from "./deviceSettings.json";
@@ -49,58 +45,6 @@ export const renameDevice = async ({
   });
   reload();
   return;
-};
-/* Remove the device and return */
-export const deleteDevice = async ({
-  connection,
-  device,
-  reload,
-}: {
-  connection: AuthenticatedConnection;
-  device: DeviceData;
-  reload: () => void;
-}) => {
-  const pubKey: DerEncodedPublicKey = new Uint8Array(device.pubkey)
-    .buffer as DerEncodedPublicKey;
-  const sameDevice = bufferEqual(
-    connection.identity.getPublicKey().toDer(),
-    pubKey
-  );
-
-  // Different confirmation based on the device
-  const confirmationPrompt = [];
-  if (isRecoveryDevice(device)) {
-    confirmationPrompt.push("Remove your Recovery Device");
-    confirmationPrompt.push(
-      "Are you sure you want to remove your recovery device? You will no longer be able to use it to recover your account."
-    );
-  } else {
-    confirmationPrompt.push(
-      `Do you really want to remove the device "${device.alias}"?`
-    );
-  }
-  if (sameDevice) {
-    confirmationPrompt.push(
-      "This will remove your current device and you will be logged out."
-    );
-  }
-  const shouldProceed = confirm(confirmationPrompt.join("\n\n"));
-  if (!shouldProceed) {
-    return;
-  }
-
-  await withLoader(() => {
-    return Promise.all([connection.remove(device.pubkey)]);
-  });
-
-  if (sameDevice) {
-    // reload the page.
-    // do not call "reload", otherwise the management page will try to reload the list of devices which will cause an error
-    location.reload();
-    return;
-  } else {
-    reload();
-  }
 };
 
 /* Resetting */

--- a/src/frontend/src/test-e2e/pinAuth.test.ts
+++ b/src/frontend/src/test-e2e/pinAuth.test.ts
@@ -108,9 +108,6 @@ test("Should not prompt for PIN after deleting temp key", async () => {
 
     await mainView.waitForDisplay();
     await mainView.remove(DEFAULT_PIN_DEVICE_NAME);
-    await browser.waitUntil(() => browser.isAlertOpen());
-    // this is equivalent to logout as we are deleting the device that was used for authentication
-    await browser.acceptAlert();
 
     // login now happens using the WebAuthn flow
     await FLOWS.loginAuthenticateView(userNumber, DEVICE_NAME1, browser);

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -56,6 +56,28 @@ export class RenameView extends View {
   }
 }
 
+export class ConfirmRemoveDeviceView extends View {
+  async waitForDisplay(): Promise<void> {
+    await this.browser
+      .$("[data-page='confirm-remove-device-page']")
+      .waitForDisplayed({ timeout: 10_000 });
+  }
+
+  async waitForAbsence(): Promise<void> {
+    await this.browser
+      .$("[data-page='confirm-remove-device-page']")
+      .waitForExist({ timeout: 10_000, reverse: true });
+  }
+
+  async enterAlias(alias: string): Promise<void> {
+    await this.browser.$("#confirmRemoveDeviceAlias").setValue(alias);
+  }
+
+  async submit(): Promise<void> {
+    await this.browser.$("#confirmRemoveDeviceButton").click();
+  }
+}
+
 export class RegisterView extends View {
   async waitForDisplay(): Promise<void> {
     await this.browser
@@ -317,6 +339,11 @@ export class MainView extends View {
   async remove(deviceName: string): Promise<void> {
     await this.openDeviceActions({ deviceName });
     await this.deviceAction({ deviceName, action: "remove" }).click();
+    const confirmRemoveDeviceView = new ConfirmRemoveDeviceView(this.browser);
+    await confirmRemoveDeviceView.waitForDisplay();
+    await confirmRemoveDeviceView.enterAlias(deviceName);
+    await confirmRemoveDeviceView.submit();
+    await confirmRemoveDeviceView.waitForAbsence();
   }
 
   async protect(deviceName: string, seedPhrase: string): Promise<void> {


### PR DESCRIPTION
# Motivation

Improve the flow to remove a device.

This is the last PR to implement the new flow to remove a device. It uses the new confirm screen instead of triggering the function that used the alert.

# Changes

* Use new screen and remove if the screen returns to do so.
* Remove old helper `deleteDevice` that used alerts to confirm removing the device.

# Tests

* Fixed e2e test.
* Another e2e test just to remove a passkey will be added in another PR.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b0f249132/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b0f249132/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b0f249132/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b0f249132/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b0f249132/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b0f249132/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b0f249132/mobile/displayUserNumber.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

