### PR TITLE
Add login and registration flow events

### DIFF
--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -22,6 +22,7 @@ import {
 } from "$src/flows/register";
 import { I18n } from "$src/i18n";
 import { getAnchors, setAnchorUsed } from "$src/storage";
+import { analytics } from "$src/utils/analytics";
 import {
   AlreadyInProgress,
   ApiError,
@@ -246,17 +247,21 @@ export const authenticateBoxFlow = async <I>({
     | FlowError
     | { tag: "canceled" }
   > => {
+    analytics.event("registration-start");
     const result2 = await registerFlow(registerFlowOpts);
 
     if (result2 === "canceled") {
+      analytics.event("registration-canceled");
       return { tag: "canceled" } as const;
     }
 
     if (result2.kind !== "loginSuccess") {
+      analytics.event("registration-error");
       return result2;
     }
 
     result2 satisfies LoginSuccess;
+    analytics.event("registration-success");
     return {
       newAnchor: true,
       ...result2,

--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -125,10 +125,10 @@ export async function authenticationProtocol({
     return "invalid";
   }
   void (requestResult.kind satisfies "received");
-  const requesetOrigin =
+  const requestOrigin =
     requestResult.request.derivationOrigin ?? requestResult.origin;
   analytics.event("authorize-client-request-valid", {
-    origin: requesetOrigin,
+    origin: requestOrigin,
   });
 
   const authContext = {
@@ -150,7 +150,7 @@ export async function authenticationProtocol({
   }
   void (authenticateResult.kind satisfies "success");
   analytics.event("authorize-client-authenticate-success", {
-    origin: requesetOrigin,
+    origin: requestOrigin,
   });
 
   window.opener.postMessage(

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -380,10 +380,12 @@ export class Connection {
     | UnknownUser
     | ApiError
   > => {
+    analytics.event("login-passkey-start");
     let devices: Omit<DeviceData, "alias">[];
     try {
       devices = await this.lookupAuthenticators(userNumber);
     } catch (e: unknown) {
+      analytics.event("login-passkey-error-lookup");
       const errObj =
         e instanceof Error
           ? e
@@ -392,6 +394,7 @@ export class Connection {
     }
 
     if (devices.length === 0) {
+      analytics.event("login-passkey-error-unknown");
       return { kind: "unknownUser", userNumber };
     }
 
@@ -402,6 +405,7 @@ export class Connection {
     // If we reach this point, it's because no PIN identity was found.
     // Therefore, it's because it was created in another domain.
     if (webAuthnAuthenticators.length === 0) {
+      analytics.event("login-passkey-error-pin-other-domain");
       return { kind: "pinUserOtherDomain" };
     }
 


### PR DESCRIPTION
# Motivation

The login flow is the most important flow in II.

We'd like to track how many start and how many succeed.

# Changes

This pull request introduces analytics event tracking to various authentication-related functions in the frontend. The changes primarily involve adding calls to the `analytics.event` method at key points in the authentication flow to track user interactions and outcomes.

## Analytics event tracking:

* [`src/frontend/src/components/authenticateBox/index.ts`](diffhunk://#diff-8f68fae1b679171c3fe2f3232a77b4a003430dbffebae75d2cd3b4ca7ca3d116R250-R264): Added analytics events for registration start, cancellation, error, and success in the `authenticateBoxFlow` function.
* [`src/frontend/src/flows/authorize/postMessageInterface.ts`](diffhunk://#diff-5ee26fc4ed301a9620eb0d91881a239a5017af0ae1bfa5ba896cfb349b5a83a7R120-R132): Added analytics events for client request received, valid client request, client authentication, and successful client authentication in the `authenticationProtocol` function.
* [`src/frontend/src/utils/iiConnection.ts`](diffhunk://#diff-f7c49a174f5c76f4cf2b4b99163ad65f188b0b3694803839b160d7bbf8007ff5R383-R388): Added analytics events for login passkey start, error during lookup, unknown user, and PIN error for other domains in the `Connection` class.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/desktop/landing_1.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/desktop/verifyTentativeDevice.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/4f8d5d7cc/mobile/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

