### PR TITLE
Fix remove device button

### DIFF
--- a/src/frontend/src/flows/manage/confirmRemoveDevice.ts
+++ b/src/frontend/src/flows/manage/confirmRemoveDevice.ts
@@ -107,7 +107,7 @@ const confirmRemoveDeviceTemplate = ({
               class="c-input c-input--stack c-input--fullwidth"
               spellcheck="false"
               .onpaste=${(e: Event) => e.preventDefault()}
-              @change=${() =>
+              @input=${() =>
                 withRef(input, (inputElement) =>
                   withRef(confirmButton, (buttonElement) => {
                     if (inputElement.value === alias) {

--- a/src/frontend/src/test-e2e/views.ts
+++ b/src/frontend/src/test-e2e/views.ts
@@ -74,7 +74,7 @@ export class ConfirmRemoveDeviceView extends View {
   }
 
   async submit(): Promise<void> {
-    await this.browser.$("#confirmRemoveDeviceButton").click();
+    await this.browser.$("#confirmRemoveDeviceButton:not([disabled])").click();
   }
 }
 


### PR DESCRIPTION
Make sure that button is enabled immediately after typing device name and that test only passes when confirm button is enabled.
<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a14284eee/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a14284eee/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a14284eee/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a14284eee/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a14284eee/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/a14284eee/mobile/registerCurrentDeviceCurrentOrigin.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
