### PR TITLE
Add config to fetch root key

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -35,6 +35,7 @@ export const idlFactory = ({ IDL }) => {
     'time_per_token_ns' : IDL.Nat64,
   });
   const InternetIdentityInit = IDL.Record({
+    'fetch_root_key' : IDL.Opt(IDL.Bool),
     'openid_google' : IDL.Opt(IDL.Opt(OpenIdConfig)),
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
@@ -642,6 +643,7 @@ export const init = ({ IDL }) => {
     'time_per_token_ns' : IDL.Nat64,
   });
   const InternetIdentityInit = IDL.Record({
+    'fetch_root_key' : IDL.Opt(IDL.Bool),
     'openid_google' : IDL.Opt(IDL.Opt(OpenIdConfig)),
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -211,6 +211,7 @@ export type IdentityMetadataReplaceError = {
   };
 export type IdentityNumber = bigint;
 export interface InternetIdentityInit {
+  'fetch_root_key' : [] | [boolean],
   'openid_google' : [] | [[] | [OpenIdConfig]],
   'assigned_user_number_range' : [] | [[bigint, bigint]],
   'archive_config' : [] | [ArchiveConfig],

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -70,6 +70,7 @@ const DEFAULT_INIT: InternetIdentityInit = {
       "https://identity.icp0.io",
     ],
   ],
+  fetch_root_key: [],
 };
 
 const mockActor = {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -268,6 +268,8 @@ type InternetIdentityInit = record {
     openid_google : opt opt OpenIdConfig;
     // Configuration for Web Analytics
     analytics_config : opt opt AnalyticsConfig;
+    // Configuration to fetch root key or not from frontend assets
+    fetch_root_key : opt bool;
 };
 
 type ChallengeKey = text;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -356,6 +356,7 @@ fn config() -> InternetIdentityInit {
         related_origins: persistent_state.related_origins.clone(),
         openid_google: Some(persistent_state.openid_google.clone()),
         analytics_config: Some(persistent_state.analytics_config.clone()),
+        fetch_root_key: persistent_state.fetch_root_key,
     })
 }
 
@@ -447,6 +448,11 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
         if let Some(analytics_config) = arg.analytics_config {
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.analytics_config = analytics_config;
+            })
+        }
+        if let Some(fetch_root_key) = arg.fetch_root_key {
+            state::persistent_state_mut(|persistent_state| {
+                persistent_state.fetch_root_key = Some(fetch_root_key);
             })
         }
     }

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -114,6 +114,7 @@ pub struct PersistentState {
     // If it is `none`, then the 24h window starts from the newest entry in the event_data
     // BTreeMap minus 24h.
     pub event_stats_24h_start: Option<EventKey>,
+    pub fetch_root_key: Option<bool>,
 }
 
 impl Default for PersistentState {
@@ -131,6 +132,7 @@ impl Default for PersistentState {
             openid_google: None,
             analytics_config: None,
             event_stats_24h_start: None,
+            fetch_root_key: None,
         }
     }
 }

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -35,6 +35,7 @@ pub struct StorablePersistentState {
     related_origins: Option<Vec<String>>,
     openid_google: Option<OpenIdConfig>,
     analytics_config: Option<AnalyticsConfig>,
+    fetch_root_key: Option<bool>,
 }
 
 impl Storable for StorablePersistentState {
@@ -75,6 +76,7 @@ impl From<PersistentState> for StorablePersistentState {
             related_origins: s.related_origins,
             openid_google: s.openid_google,
             analytics_config: s.analytics_config,
+            fetch_root_key: s.fetch_root_key,
         }
     }
 }
@@ -93,6 +95,7 @@ impl From<StorablePersistentState> for PersistentState {
             openid_google: s.openid_google,
             analytics_config: s.analytics_config,
             event_stats_24h_start: s.event_stats_24h_start,
+            fetch_root_key: s.fetch_root_key,
         }
     }
 }
@@ -139,6 +142,7 @@ mod tests {
             related_origins: None,
             openid_google: None,
             analytics_config: None,
+            fetch_root_key: None,
         };
 
         assert_eq!(StorablePersistentState::default(), expected_defaults);
@@ -161,6 +165,7 @@ mod tests {
             openid_google: None,
             event_stats_24h_start: None,
             analytics_config: None,
+            fetch_root_key: None,
         };
         assert_eq!(PersistentState::default(), expected_defaults);
     }

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -3,6 +3,7 @@ mod archive_config;
 mod assigned_user_number_range;
 mod canister_creation_cycles_cost;
 mod captcha_config;
+mod fetch_root_key;
 mod openid_google;
 mod register_rate_limit;
 mod related_origins;

--- a/src/internet_identity/tests/integration/config/fetch_root_key.rs
+++ b/src/internet_identity/tests/integration/config/fetch_root_key.rs
@@ -1,0 +1,139 @@
+use canister_tests::api::internet_identity as api;
+use canister_tests::framework::{
+    env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
+};
+use internet_identity_interface::internet_identity::types::{InternetIdentityInit, OpenIdConfig};
+
+#[test]
+fn should_init_default() {
+    let env = env();
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().fetch_root_key,
+        None
+    );
+}
+
+#[test]
+fn should_init_config() {
+    let env = env();
+    let configs = vec![
+        InternetIdentityInit {
+            fetch_root_key: None,
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            fetch_root_key: Some(false),
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            fetch_root_key: Some(true),
+            ..Default::default()
+        },
+    ];
+
+    for config in configs {
+        let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+        assert_eq!(
+            api::config(&env, canister_id).unwrap().fetch_root_key,
+            config.fetch_root_key
+        );
+    }
+}
+
+#[test]
+fn should_enable_config() {
+    let env = env();
+    let mut config = InternetIdentityInit {
+        fetch_root_key: None,
+        ..Default::default()
+    };
+    let enabled_value = Some(true);
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+    config.fetch_root_key = enabled_value.clone();
+    upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().fetch_root_key,
+        enabled_value
+    );
+}
+
+#[test]
+fn should_disable_config() {
+    let env = env();
+    let mut config = InternetIdentityInit {
+        fetch_root_key: Some(true),
+        ..Default::default()
+    };
+    let disabled_value = Some(false);
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+    config.fetch_root_key = disabled_value.clone();
+    upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().fetch_root_key,
+        disabled_value
+    );
+}
+
+#[test]
+fn should_update_config() {
+    let env = env();
+    let mut config = InternetIdentityInit {
+        fetch_root_key: Some(false),
+        ..Default::default()
+    };
+    let updated_value = Some(true);
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+    config.fetch_root_key = updated_value.clone();
+    upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().fetch_root_key,
+        updated_value
+    );
+}
+
+#[test]
+fn should_retain_config() {
+    let env = env();
+    let configs = vec![
+        InternetIdentityInit {
+            fetch_root_key: None,
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            fetch_root_key: Some(false),
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            fetch_root_key: Some(true),
+            ..Default::default()
+        },
+    ];
+
+    for config in configs {
+        let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+        // No config argument
+        upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), None).unwrap();
+        // Unrelated config change
+        upgrade_ii_canister_with_arg(
+            &env,
+            canister_id,
+            II_WASM.clone(),
+            Some(InternetIdentityInit {
+                openid_google: Some(Some(OpenIdConfig {
+                    client_id: "https://example.com".into(),
+                })),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            api::config(&env, canister_id).unwrap().fetch_root_key,
+            config.fetch_root_key
+        );
+    }
+}

--- a/src/internet_identity/tests/integration/config/fetch_root_key.rs
+++ b/src/internet_identity/tests/integration/config/fetch_root_key.rs
@@ -9,10 +9,7 @@ fn should_init_default() {
     let env = env();
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
-    assert_eq!(
-        api::config(&env, canister_id).unwrap().fetch_root_key,
-        None
-    );
+    assert_eq!(api::config(&env, canister_id).unwrap().fetch_root_key, None);
 }
 
 #[test]

--- a/src/internet_identity/tests/integration/config/fetch_root_key.rs
+++ b/src/internet_identity/tests/integration/config/fetch_root_key.rs
@@ -52,7 +52,7 @@ fn should_enable_config() {
     let enabled_value = Some(true);
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
-    config.fetch_root_key = enabled_value.clone();
+    config.fetch_root_key = enabled_value;
     upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
     assert_eq!(
         api::config(&env, canister_id).unwrap().fetch_root_key,

--- a/src/internet_identity/tests/integration/config/fetch_root_key.rs
+++ b/src/internet_identity/tests/integration/config/fetch_root_key.rs
@@ -67,7 +67,7 @@ fn should_disable_config() {
     let disabled_value = Some(false);
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
-    config.fetch_root_key = disabled_value.clone();
+    config.fetch_root_key = disabled_value;
     upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
     assert_eq!(
         api::config(&env, canister_id).unwrap().fetch_root_key,
@@ -85,7 +85,7 @@ fn should_update_config() {
     let updated_value = Some(true);
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
-    config.fetch_root_key = updated_value.clone();
+    config.fetch_root_key = updated_value;
     upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
     assert_eq!(
         api::config(&env, canister_id).unwrap().fetch_root_key,

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -95,6 +95,7 @@ fn ii_canister_serves_webauthn_assets() -> Result<(), CallError> {
         related_origins: Some(related_origins.clone()),
         openid_google: None,
         analytics_config: None,
+        fetch_root_key: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
 
@@ -158,6 +159,7 @@ fn ii_canister_serves_webauthn_assets_after_upgrade() -> Result<(), CallError> {
         related_origins: Some(related_origins.clone()),
         openid_google: None,
         analytics_config: None,
+        fetch_root_key: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 
@@ -197,6 +199,7 @@ fn ii_canister_serves_webauthn_assets_after_upgrade() -> Result<(), CallError> {
         related_origins: Some(related_origins_2.clone()),
         openid_google: None,
         analytics_config: None,
+        fetch_root_key: None,
     };
 
     let _ = upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_2));
@@ -581,6 +584,7 @@ fn must_not_cache_well_known_webauthn() -> Result<(), CallError> {
         related_origins: Some(related_origins.clone()),
         openid_google: None,
         analytics_config: None,
+        fetch_root_key: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -208,6 +208,7 @@ pub struct InternetIdentityInit {
     pub related_origins: Option<Vec<String>>,
     pub openid_google: Option<Option<OpenIdConfig>>,
     pub analytics_config: Option<Option<AnalyticsConfig>>,
+    pub fetch_root_key: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -24,6 +24,7 @@ const DEFAULT_INIT: InternetIdentityInit = {
   openid_google: [],
   register_rate_limit: [],
   related_origins: [],
+  fetch_root_key: [],
 };
 
 const registerSuccessToastTemplate = (result: unknown) => html`


### PR DESCRIPTION
# Motivation

Make production wasm compatible with Utopia environment.

# Changes

This pull request introduces a new configuration option `fetch_root_key` to the Internet Identity service. The changes involve updating the configuration structures, applying the new configuration, and adding tests to ensure the correct behavior of the new option.

This PR doesn't include using the new configuration option.

Changes to configuration and state management:

* [`src/internet_identity/src/main.rs`](diffhunk://#diff-b809f46c5c6e23b881fd88e567e1e38476418b1a2a19cd66acf039db23c1ceb2R359): Added `fetch_root_key` to the `InternetIdentityInit` configuration and applied it in the `apply_install_arg` function. [[1]](diffhunk://#diff-b809f46c5c6e23b881fd88e567e1e38476418b1a2a19cd66acf039db23c1ceb2R359) [[2]](diffhunk://#diff-b809f46c5c6e23b881fd88e567e1e38476418b1a2a19cd66acf039db23c1ceb2R453-R457)
* [`src/internet_identity/src/state.rs`](diffhunk://#diff-5a97eec5e9ae04d618b03164ba7b2c5e9c57853aa7460ee70072de0f7a40f90dR117): Added `fetch_root_key` to the `PersistentState` struct and its `Default` implementation. [[1]](diffhunk://#diff-5a97eec5e9ae04d618b03164ba7b2c5e9c57853aa7460ee70072de0f7a40f90dR117) [[2]](diffhunk://#diff-5a97eec5e9ae04d618b03164ba7b2c5e9c57853aa7460ee70072de0f7a40f90dR135)
* [`src/internet_identity/src/storage/storable_persistent_state.rs`](diffhunk://#diff-e31aeeebe158ca791befc2c2cd3e6119eab79dc74bfe0d78cd8cd7f13c9abbe0R38): Updated `StorablePersistentState` to include `fetch_root_key` and modified the conversion implementations between `PersistentState` and `StorablePersistentState`. [[1]](diffhunk://#diff-e31aeeebe158ca791befc2c2cd3e6119eab79dc74bfe0d78cd8cd7f13c9abbe0R38) [[2]](diffhunk://#diff-e31aeeebe158ca791befc2c2cd3e6119eab79dc74bfe0d78cd8cd7f13c9abbe0R79) [[3]](diffhunk://#diff-e31aeeebe158ca791befc2c2cd3e6119eab79dc74bfe0d78cd8cd7f13c9abbe0R98)

Testing the new configuration:

* [`src/internet_identity/tests/integration/config.rs`](diffhunk://#diff-d12f479e570fb628849620725a91129d9bfdc0f2d31bf20c24ad085ca3df00bfR6): Added a new test module for `fetch_root_key`.
* [`src/internet_identity/tests/integration/config/fetch_root_key.rs`](diffhunk://#diff-f1607e5e0d720ce30718d4854cf7fe9bfd23bd96218b1829baad02cca7b29617R1-R139): Added comprehensive tests to verify the initialization, enabling, disabling, updating, and retention of the `fetch_root_key` configuration.

Updating the interface:

* [`src/internet_identity_interface/src/internet_identity/types.rs`](diffhunk://#diff-fb3aada35d9a34a313238a2b70c389140a44ac43dece8b540b4aa0b7c9f34b79R211): Added `fetch_root_key` to the `InternetIdentityInit` struct.







<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/049c664cc/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/049c664cc/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/049c664cc/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/049c664cc/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/049c664cc/mobile/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/049c664cc/mobile/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/049c664cc/mobile/displayUserNumber.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/049c664cc/mobile/displayUserNumberTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->






