### PR TITLE
Use config to fetch root key

### DIFF
--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -645,7 +645,8 @@ export class Connection {
     }
 
     const shouldFetchRootKey =
-      features.FETCH_ROOT_KEY || (this.canisterConfig.fetch_root_key[0] ?? false);
+      features.FETCH_ROOT_KEY ||
+      (this.canisterConfig.fetch_root_key[0] ?? false);
     const agent = await HttpAgent.create({
       identity,
       host: inferHost(),

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -643,11 +643,13 @@ export class Connection {
     if (this.overrideActor !== undefined) {
       return this.overrideActor;
     }
+
+    const shouldFetchRootKey =
+      features.FETCH_ROOT_KEY || Boolean(this.canisterConfig.fetch_root_key[0]);
     const agent = await HttpAgent.create({
       identity,
       host: inferHost(),
-      // Only fetch the root key when we're not in prod
-      shouldFetchRootKey: features.FETCH_ROOT_KEY,
+      shouldFetchRootKey,
     });
 
     return Actor.createActor<_SERVICE>(internet_identity_idl, {

--- a/src/frontend/src/utils/iiConnection.ts
+++ b/src/frontend/src/utils/iiConnection.ts
@@ -645,7 +645,7 @@ export class Connection {
     }
 
     const shouldFetchRootKey =
-      features.FETCH_ROOT_KEY || Boolean(this.canisterConfig.fetch_root_key[0]);
+      features.FETCH_ROOT_KEY || (this.canisterConfig.fetch_root_key[0] ?? false);
     const agent = await HttpAgent.create({
       identity,
       host: inferHost(),


### PR DESCRIPTION
# Motivation

Make production build compatible with Utopia.

# Changes

This pull request includes a change to the `Connection` class in the `iiConnection.ts` file to improve the handling of the `shouldFetchRootKey` configuration. The most important change is the introduction of a conditional assignment for the `shouldFetchRootKey` variable, which now considers both the `FETCH_ROOT_KEY` feature flag and the `canisterConfig.fetch_root_key` setting.

Key change:

* [`src/frontend/src/utils/iiConnection.ts`](diffhunk://#diff-f7c49a174f5c76f4cf2b4b99163ad65f188b0b3694803839b160d7bbf8007ff5R646-R652): Added a conditional assignment for the `shouldFetchRootKey` variable to include both the `FETCH_ROOT_KEY` feature flag and the `canisterConfig.fetch_root_key` setting.

# Tests

* Tested by deploying the production wasm build flavor in local replica. When the flag is turned on, II production wasm works in local replica.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9ea225a9b/mobile/displayManageSingle.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


