### PR TITLE
bump rustup

### DIFF
--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -20,7 +20,7 @@ rust_version=$(cat ./rust-toolchain.toml | sed -n 's/^channel[[:space:]]*=[[:spa
 echo "using rust version '$rust_version'"
 
 # here we set the toolchain to 'none' and rustup will pick up on ./rust-toolchain.toml
-run curl --fail https://raw.githubusercontent.com/rust-lang/rustup/refs/tags/1.28.0/rustup-init.sh -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
+run curl --fail https://raw.githubusercontent.com/rust-lang/rustup/refs/tags/1.28.1/rustup-init.sh -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
 
 # https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
 # Install required toolchain

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -22,7 +22,7 @@ echo "using rust version '$rust_version'"
 # here we set the toolchain to 'none' and rustup will pick up on ./rust-toolchain.toml
 run curl --fail https://raw.githubusercontent.com/rust-lang/rustup/refs/tags/1.28.1/rustup-init.sh -sSf | run sh -s -- -y --default-toolchain "none" --no-modify-path
 
-# https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
+# https://blog.rust-lang.org/2025/03/04/Rustup-1.28.1.html
 # Install required toolchain
 run rustup toolchain install "$rust_version"
 # Set the default toolchain to the required version
@@ -37,8 +37,6 @@ echo "Rust toolchain version $(rustc --version) installed."
 for target in $targets; do
     run rustup target add "$target"
 done
-
-run rustup default "$rust_version"
 
 echo "looking for ic-wasm 0.8.5"
 if [[ ! "$(command -v ic-wasm)" || "$(ic-wasm --version)" != "ic-wasm 0.8.5" ]]


### PR DESCRIPTION
We had previously added code to the bootstrap script because rustup was failing to pick up the `rust-toolchain.toml`. This PR bumps rustup to 1.28.1, which should pick the toolchain up again.

# Motivation

Make tests non-flaky and up to date.

# Changes

Bump rustup, remove unnecessary code

# Tests

No new tests.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5ab2f968/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5ab2f968/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5ab2f968/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5ab2f968/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5ab2f968/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5ab2f968/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f5ab2f968/mobile/displayUserNumber.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

