### PR TITLE
More granular events in login and registration

### DIFF
--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -14,6 +14,7 @@ import { nonNullish } from "@dfinity/utils";
 import { html, TemplateResult } from "lit-html";
 
 import copyJson from "./passkey.json";
+import { analytics } from "$src/utils/analytics";
 
 /* Anchor construction component (for creating WebAuthn credentials) */
 
@@ -111,6 +112,7 @@ export const savePasskeyOrPin = async ({
         cancel: () => resolve("canceled"),
         scrollToTop: true,
         constructPasskey: async () => {
+          analytics.event("construct-passkey");
           try {
             const rpId =
               origin === window.location.origin
@@ -119,8 +121,10 @@ export const savePasskeyOrPin = async ({
             const identity = await withLoader(() =>
               constructIdentity({ rpId })
             );
+            analytics.event("construct-passkey-success");
             resolve(identity);
           } catch (e) {
+            analytics.event("construct-passkey-error");
             toast.error(errorMessage(e));
           }
         },


### PR DESCRIPTION
# Motivation

The login and registration success rate according to our current data are low.

* Drop-off of more than 15% in the first step of the login flow.
* Drop-off 40% in the registration flow.

For more details check the "Successful Login From Dapp" and "Total Registration Flow" funnels in the [analytics dashboard](https://plausible.io/identity.internetcomputer.org).

# Changes

### Analytics Tracking Enhancements:

* [`src/frontend/src/flows/register/index.ts`](diffhunk://#diff-793891f8131b840661ff4978418ccf45bdd403b840a549b7d866adf7f4a78f92R131): Added multiple analytics events to track different stages of the registration flow, such as pin creation, passkey creation, captcha handling, and final success or error states. [[1]](diffhunk://#diff-793891f8131b840661ff4978418ccf45bdd403b840a549b7d866adf7f4a78f92R131) [[2]](diffhunk://#diff-793891f8131b840661ff4978418ccf45bdd403b840a549b7d866adf7f4a78f92R159-R160) [[3]](diffhunk://#diff-793891f8131b840661ff4978418ccf45bdd403b840a549b7d866adf7f4a78f92R201-R217) [[4]](diffhunk://#diff-793891f8131b840661ff4978418ccf45bdd403b840a549b7d866adf7f4a78f92R231-R235)
* [`src/frontend/src/flows/register/passkey.ts`](diffhunk://#diff-e84ff3598a61a103cc201e18b99e77f810b451b78c48e0a5a36869eb249c4dceR115): Added analytics events to track the construction of passkeys, including success and error states. [[1]](diffhunk://#diff-e84ff3598a61a103cc201e18b99e77f810b451b78c48e0a5a36869eb249c4dceR115) [[2]](diffhunk://#diff-e84ff3598a61a103cc201e18b99e77f810b451b78c48e0a5a36869eb249c4dceR124-R127)

### Error Handling Improvements:

* [`src/frontend/src/flows/authorize/postMessageInterface.ts`](diffhunk://#diff-5ee26fc4ed301a9620eb0d91881a239a5017af0ae1bfa5ba896cfb349b5a83a7L141-R156): Wrapped the authentication call in a try-catch block to handle unexpected errors and log them, providing a fallback error message to the user.

# Tests

Not necessary.
