### PR TITLE
Use config to render dapps explorer

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -595,7 +595,7 @@ export const displayManage = async (
 
     const dappsExplorerEnabled: boolean =
       connection.canisterConfig.enable_dapps_explorer[0] ?? false;
-    const onExplorDapps = async () => {
+    const onExploreDapps = async () => {
       await dappsExplorer({ dapps });
       // We know that the user couldn't have changed anything (the user can't delete e.g. delete
       // a device from the explorer), so we just re-display without reloading devices etc.
@@ -618,7 +618,7 @@ export const displayManage = async (
         onLinkAccount,
         onUnlinkAccount,
         dapps,
-        exploreDapps: dappsExplorerEnabled ? onExplorDapps : undefined,
+        exploreDapps: dappsExplorerEnabled ? onExploreDapps : undefined,
         identityBackground,
         tempKeysWarning: determineTempKeysWarning(),
       });


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Make dapps explorer configurable by using the config field in the frontend.

# Changes

* [`src/frontend/src/flows/manage/index.ts`](diffhunk://#diff-a6c0dbc27de94e34fd96cf852c03cb69a1adba91b4e2c7913731790dc0acf194L209-R209): Made the `exploreDapps` function optional in the `displayManageTemplate` function parameters.
* [`src/frontend/src/flows/manage/index.ts`](diffhunk://#diff-a6c0dbc27de94e34fd96cf852c03cb69a1adba91b4e2c7913731790dc0acf194L258-R259): Added a condition to render the Dapps section only if `exploreDapps` is defined. [[1]](diffhunk://#diff-a6c0dbc27de94e34fd96cf852c03cb69a1adba91b4e2c7913731790dc0acf194L258-R259) [[2]](diffhunk://#diff-a6c0dbc27de94e34fd96cf852c03cb69a1adba91b4e2c7913731790dc0acf194L267-R269)
* [`src/frontend/src/flows/manage/index.ts`](diffhunk://#diff-a6c0dbc27de94e34fd96cf852c03cb69a1adba91b4e2c7913731790dc0acf194R596-R605): Defined a new function `onExplorDapps` to handle the Dapps explorer logic and set `exploreDapps` based on the `dappsExplorerEnabled` flag. [[1]](diffhunk://#diff-a6c0dbc27de94e34fd96cf852c03cb69a1adba91b4e2c7913731790dc0acf194R596-R605) [[2]](diffhunk://#diff-a6c0dbc27de94e34fd96cf852c03cb69a1adba91b4e2c7913731790dc0acf194L609-R621)

<!-- List the changes that have been developed -->

# Tests

Tested locally that I can show or hide based on the config.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/desktop/manageUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/displayUserNumberTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/95c673bcb/mobile/manageUseExisting.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

