### PR TITLE
Lm event closing window

### DIFF
--- a/src/frontend/src/utils/trackWindowClose.ts
+++ b/src/frontend/src/utils/trackWindowClose.ts
@@ -1,0 +1,25 @@
+// Utility functions to track window close events
+
+let windowCloseListener: (() => void) | null = null;
+
+/**
+ * Adds an event listener to track when the window is closed.
+ * @param callback - The function to call when the window is closed.
+ */
+export function trackWindowClose(callback: () => void): void {
+  if (windowCloseListener) {
+    window.removeEventListener('beforeunload', windowCloseListener);
+  }
+  windowCloseListener = callback;
+  window.addEventListener('beforeunload', windowCloseListener);
+}
+
+/**
+ * Removes the event listener that tracks when the window is closed.
+ */
+export function removeWindowCloseTracker(): void {
+  if (windowCloseListener) {
+    window.removeEventListener('beforeunload', windowCloseListener);
+    windowCloseListener = null;
+  }
+}


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Understand where we lose users.

In this PR, I intro

# Changes


This pull request introduces functionality to track when a user closes the window during the authentication process. The changes include adding utility functions to manage the window close event listener and integrating these functions into the authentication protocol.

### Enhancements to authentication flow:

* [`src/frontend/src/flows/authorize/postMessageInterface.ts`](diffhunk://#diff-5ee26fc4ed301a9620eb0d91881a239a5017af0ae1bfa5ba896cfb349b5a83a7R7): Imported `trackWindowClose` and `removeWindowCloseTracker` utilities to manage window close events.
* [`src/frontend/src/flows/authorize/postMessageInterface.ts`](diffhunk://#diff-5ee26fc4ed301a9620eb0d91881a239a5017af0ae1bfa5ba896cfb349b5a83a7R146): Added `trackWindowClose` call to log an analytics event when the window is closed by the user during the authentication process.
* [`src/frontend/src/flows/authorize/postMessageInterface.ts`](diffhunk://#diff-5ee26fc4ed301a9620eb0d91881a239a5017af0ae1bfa5ba896cfb349b5a83a7R155-R156): Added `removeWindowCloseTracker` call in the `finally` block to clean up the event listener after the authentication process completes.

### Utility functions for window close tracking:

* [`src/frontend/src/utils/trackWindowClose.ts`](diffhunk://#diff-5f152fde4392c27c2d74cefb885edb3e94d0c75057f6629a185d4fc43bf3d3f0R1-R25): Added new utility functions `trackWindowClose` and `removeWindowCloseTracker` to manage the window close event listener.
<!-- List the changes that have been developed -->

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
