### PR TITLE
Fix CI job to deploy test dapp and issuer

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -695,6 +695,8 @@ jobs:
       - name: "Deploy test app"
         run: |
           wallet="cvthj-wyaaa-aaaad-aaaaq-cai"
+          # Needed to surpass dfx error to use the insecure plaintext identity
+          export DFX_WARNING=-mainnet_plaintext_identity
           dfx canister --network ic --wallet "$wallet" install --mode upgrade \
             --wasm ./test_app.wasm \
             vt36r-2qaaa-aaaad-aad5a-cai
@@ -708,6 +710,8 @@ jobs:
       - name: "Deploy Issuer"
         run: |
           wallet="cvthj-wyaaa-aaaad-aaaaq-cai"
+          # Needed to surpass dfx error to use the insecure plaintext identity
+          export DFX_WARNING=-mainnet_plaintext_identity
           dfx canister --network ic --wallet "$wallet" install --mode upgrade \
             --wasm vc_demo_issuer.wasm.gz \
             v2yvn-myaaa-aaaad-aad4q-cai


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Deploying test dapp and issuer was also broken for the same reason that deploying II was broken.

# Changes

* Add `export DFX_WARNING=-mainnet_plaintext_identity` when deploying dapp and issuer as well.

# Tests

* It will be tested after merging.
