### PR TITLE
Fix linking Google account after register.

### DIFF
--- a/src/frontend/src/flows/manage/index.ts
+++ b/src/frontend/src/flows/manage/index.ts
@@ -378,9 +378,9 @@ export const displayManage = async (
   // (dapps are suffled to encourage discovery of new dapps)
   const dapps = shuffleArray(getDapps());
 
-  // Create anonymous nonce and salt for connection principal
+  // Create anonymous nonce and salt for calling principal from connection
   const { nonce, salt } = await createAnonymousNonce(
-    connection.identity.getPrincipal()
+    connection.delegationIdentity.getPrincipal()
   );
 
   const googleClientId =


### PR DESCRIPTION
Fix linking Google account after register.

# Changes

Use `connection.delegationIdentity` instead of `connection.identity` since the first is actually the caller principal to the II canister.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc8b426a8/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc8b426a8/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc8b426a8/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc8b426a8/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc8b426a8/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc8b426a8/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc8b426a8/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc8b426a8/mobile/displayUserNumber.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/fc8b426a8/mobile/displayUserNumberTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
