### PR TITLE
Use related origins to show banner

### DIFF
--- a/src/frontend/src/banner.ts
+++ b/src/frontend/src/banner.ts
@@ -1,10 +1,12 @@
+import { InternetIdentityInit } from "$generated/internet_identity_types";
 import { html, render, TemplateResult } from "lit-html";
-import { LEGACY_II_URL, OFFICIAL_II_URL } from "./config";
+import { OFFICIAL_II_URL } from "./config";
 import { anyFeatures } from "./features";
+import { isOfficialOrigin } from "./utils/domainUtils";
 
 // Show a warning banner if the build is not "official". This happens if either the build
-// is a flavored build, or if the origin is not the official II URL.
-export const showWarningIfNecessary = (): void => {
+// is a flavored build, or if the origin is not in the list of related origins from the canister config.
+export const showWarningIfNecessary = (config: InternetIdentityInit): void => {
   if (anyFeatures()) {
     showWarning(html`Test only. Do not use your regular Internet Identity!
       <a
@@ -14,10 +16,7 @@ export const showWarningIfNecessary = (): void => {
         href="https://github.com/dfinity/internet-identity#build-features"
         >more</a
       >`);
-  } else if (
-    window.location.origin !== OFFICIAL_II_URL &&
-    window.location.origin !== LEGACY_II_URL
-  ) {
+  } else if (!isOfficialOrigin(window.location.origin, config)) {
     showWarning(html`This is not the official Internet Identity.
       <a
         class="features-warning-btn"

--- a/src/frontend/src/spa.ts
+++ b/src/frontend/src/spa.ts
@@ -127,16 +127,16 @@ export const createSpa = (app: (connection: Connection) => Promise<never>) => {
   // Preload the loader
   preloadLoaderImage();
 
+  // Prepare the actor/connection to talk to the canister
+  const connection = new Connection(readCanisterId(), readCanisterConfig());
+
   // If the build is not "official", show a warning
   // https://github.com/dfinity/internet-identity#build-features
-  showWarningIfNecessary();
+  showWarningIfNecessary(connection.canisterConfig);
 
   if (!supportsWebAuthn()) {
     return compatibilityNotice();
   }
-
-  // Prepare the actor/connection to talk to the canister
-  const connection = new Connection(readCanisterId(), readCanisterConfig());
 
   return app(connection);
 };

--- a/src/frontend/src/utils/domainUtils.test.ts
+++ b/src/frontend/src/utils/domainUtils.test.ts
@@ -1,0 +1,145 @@
+import { InternetIdentityInit } from "$generated/internet_identity_types";
+import { describe, expect, it, vi } from "vitest";
+import { isOfficialOrigin } from "./domainUtils";
+
+describe("isOfficialOrigin", () => {
+  // Base mock config with all required fields - requires explicit related_origins parameter
+  const createBaseMockConfig = (
+    related_origins: string[]
+  ): InternetIdentityInit => ({
+    related_origins: [related_origins],
+    fetch_root_key: [false],
+    openid_google: [],
+    enable_dapps_explorer: [],
+    assigned_user_number_range: [],
+    archive_config: [],
+    canister_creation_cycles_cost: [],
+    analytics_config: [],
+    captcha_config: [],
+    register_rate_limit: [],
+  });
+
+  // Default related origins for most tests
+  const defaultRelatedOrigins = [
+    "https://identity.internetcomputer.org",
+    "https://identity.ic0.app",
+    "https://test.internetcomputer.org",
+    "http://localhost:8080",
+  ];
+
+  // Create the different mock configs from the base
+  const mockConfig = createBaseMockConfig(defaultRelatedOrigins);
+  const emptyConfig = createBaseMockConfig([]);
+  const nullConfig = createBaseMockConfig(defaultRelatedOrigins);
+  nullConfig.related_origins = [];
+
+  it("should return true if origin is in the related origins list", () => {
+    expect(
+      isOfficialOrigin("https://identity.internetcomputer.org", mockConfig)
+    ).toBe(true);
+    expect(isOfficialOrigin("https://identity.ic0.app", mockConfig)).toBe(true);
+    expect(
+      isOfficialOrigin("https://test.internetcomputer.org", mockConfig)
+    ).toBe(true);
+    expect(isOfficialOrigin("http://localhost:8080", mockConfig)).toBe(true);
+  });
+
+  it("should return false if origin is not in the related origins list", () => {
+    expect(isOfficialOrigin("https://example.com", mockConfig)).toBe(false);
+    expect(isOfficialOrigin("https://identity.example.org", mockConfig)).toBe(
+      false
+    );
+  });
+
+  it("should compare origins correctly, ignoring path and query params", () => {
+    // Same origin but with paths should still match
+    expect(
+      isOfficialOrigin("https://identity.internetcomputer.org/path", mockConfig)
+    ).toBe(true);
+    expect(
+      isOfficialOrigin("https://identity.ic0.app/path/to/resource", mockConfig)
+    ).toBe(true);
+    expect(
+      isOfficialOrigin(
+        "https://identity.internetcomputer.org?query=param",
+        mockConfig
+      )
+    ).toBe(true);
+  });
+
+  it("should handle empty related origins", () => {
+    expect(
+      isOfficialOrigin("https://identity.internetcomputer.org", emptyConfig)
+    ).toBe(false);
+  });
+
+  it("should handle null related origins", () => {
+    expect(
+      isOfficialOrigin("https://identity.internetcomputer.org", nullConfig)
+    ).toBe(false);
+  });
+
+  it("should handle invalid URLs gracefully", () => {
+    // Test with invalid current origin
+    expect(isOfficialOrigin("invalid-url", mockConfig)).toBe(false);
+
+    // Mock console.error for the next test to avoid cluttering test output
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    // Create a config with an invalid URL in related_origins
+    const invalidConfig = createBaseMockConfig([
+      ...defaultRelatedOrigins,
+      "invalid-url",
+    ]);
+
+    // Should still work with valid URLs and skip the invalid one
+    expect(
+      isOfficialOrigin("https://identity.internetcomputer.org", invalidConfig)
+    ).toBe(true);
+
+    // Restore console.error
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should handle URLs with different protocols", () => {
+    // Different protocol should not match
+    expect(
+      isOfficialOrigin("http://identity.internetcomputer.org", mockConfig)
+    ).toBe(false);
+  });
+
+  it("should handle subdomains correctly", () => {
+    // Subdomain should be treated as a different origin
+    expect(
+      isOfficialOrigin("https://sub.identity.internetcomputer.org", mockConfig)
+    ).toBe(false);
+    expect(isOfficialOrigin("https://sub.identity.ic0.app", mockConfig)).toBe(
+      false
+    );
+  });
+
+  it("should handle ports correctly", () => {
+    // Different port should be treated as a different origin
+    expect(
+      isOfficialOrigin("https://identity.internetcomputer.org:8080", mockConfig)
+    ).toBe(false);
+
+    // Test with a config that includes a port
+    const configWithPort = createBaseMockConfig([
+      ...defaultRelatedOrigins,
+      "https://identity.internetcomputer.org:8080",
+    ]);
+
+    expect(
+      isOfficialOrigin(
+        "https://identity.internetcomputer.org:8080",
+        configWithPort
+      )
+    ).toBe(true);
+    expect(
+      isOfficialOrigin("https://identity.internetcomputer.org", configWithPort)
+    ).toBe(true);
+  });
+});

--- a/src/frontend/src/utils/domainUtils.ts
+++ b/src/frontend/src/utils/domainUtils.ts
@@ -1,0 +1,29 @@
+import { InternetIdentityInit } from "$generated/internet_identity_types";
+
+/**
+ * Check if the current origin is in the list of related origins from the canister config
+ * by comparing the URL origins (protocol, hostname, port)
+ */
+export const isOfficialOrigin = (
+  origin: string,
+  config: InternetIdentityInit
+): boolean => {
+  const relatedOrigins = config.related_origins[0] ?? [];
+
+  try {
+    const currentURL = new URL(origin);
+
+    return relatedOrigins.some((relatedOrigin) => {
+      try {
+        const relatedURL = new URL(relatedOrigin);
+        return currentURL.origin === relatedURL.origin;
+      } catch (e) {
+        console.error(`Invalid URL in related origins: ${relatedOrigin}`, e);
+        return false;
+      }
+    });
+  } catch (e) {
+    console.error(`Invalid current origin: ${origin}`, e);
+    return false;
+  }
+};


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Make banner rendering configurable and not hardcoded to II's mainnet URLs.

# Changes

This pull request introduces several changes to improve the handling of origin validation and configuration in the `src/frontend` directory. The most important changes include updating the `showWarningIfNecessary` function to accept a configuration parameter, modifying the `createSpa` function to pass the canister configuration, and adding a new utility function `isOfficialOrigin` with corresponding tests.

## Updates to origin validation and configuration:

* [`src/frontend/src/banner.ts`](diffhunk://#diff-0a8817bcc6c470ee73889cdc29ac7935c620d939a6ddf97f1b15027589cadbc2R1-R9): Updated `showWarningIfNecessary` to accept a `config` parameter and use the new `isOfficialOrigin` function for origin validation.
* [`src/frontend/src/spa.ts`](diffhunk://#diff-41f973f9f386513da55f15edd8752a7ecc46ae237a289d788396ccd27eb8e567R130-L140): Modified `createSpa` to pass the canister configuration to `showWarningIfNecessary`.

## New utility function and tests:

* [`src/frontend/src/utils/domainUtils.ts`](diffhunk://#diff-0cdc3332fda20b8bdbe1bae4e2083304218099e67b3c5b557213dee2126a0b24R1-R29): Added the `isOfficialOrigin` function to check if the current origin is in the list of related origins from the canister configuration.
* [`src/frontend/src/utils/domainUtils.test.ts`](diffhunk://#diff-2be30346e233993cea9d2ff6b5fa5cadb37b833191e3f1c0e13f6f10bbfec157R1-R145): Added comprehensive tests for the `isOfficialOrigin` function to ensure correct behavior under various scenarios.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b6de53f2f/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b6de53f2f/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b6de53f2f/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b6de53f2f/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b6de53f2f/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b6de53f2f/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b6de53f2f/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b6de53f2f/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b6de53f2f/mobile/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b6de53f2f/mobile/displayUserNumberTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
