### PR TITLE
Add unlink account page

### DIFF
--- a/src/frontend/src/flows/manage/confirmUnlinkAccount.json
+++ b/src/frontend/src/flows/manage/confirmUnlinkAccount.json
@@ -1,0 +1,10 @@
+{
+  "en": {
+    "confirm": "Unlink Account",
+    "cancel": "Cancel",
+    "title": "Confirm Unlink Account",
+    "label": "Security Warning",
+    "message": "Please, confirm that you want to unlink the following account:",
+    "current_credential_warning": "You will be logged out after unlinking this account."
+  }
+}

--- a/src/frontend/src/flows/manage/confirmUnlinkAccount.ts
+++ b/src/frontend/src/flows/manage/confirmUnlinkAccount.ts
@@ -1,0 +1,87 @@
+import { OpenIdCredential } from "$generated/internet_identity_types";
+import { warningLabelIcon } from "$src/components/infoScreen";
+import { mainWindow } from "$src/components/mainWindow";
+import { accountItem } from "$src/flows/manage/linkedAccountsSection";
+import { I18n } from "$src/i18n";
+import { renderPage } from "$src/utils/lit-html";
+import { nonNullish } from "@dfinity/utils";
+import { html } from "lit-html";
+import copyJson from "./confirmUnlinkAccount.json";
+
+const confirmUnlinkAccountTemplate = ({
+  i18n,
+  credential,
+  next,
+  cancel,
+  isCurrentCredential,
+}: {
+  i18n: I18n;
+  credential: OpenIdCredential;
+  next: () => void;
+  cancel: () => void;
+  isCurrentCredential?: boolean;
+}) => {
+  const copy = i18n.i18n(copyJson);
+
+  const slot = html`
+    <hgroup data-page="confirm-unlink-account-page">
+      <div class="c-card__label c-card__label--hasIcon">
+        ${warningLabelIcon}
+        <h2>${copy.label}</h2>
+      </div>
+      <h1 class="t-title t-title--main">${copy.title}</h1>
+      <p class="t-paragraph">${copy.message}</p>
+      ${accountItem({ credential })}
+      ${nonNullish(isCurrentCredential) && isCurrentCredential
+        ? html`<p class="t-paragraph">${copy.current_credential_warning}</p>`
+        : undefined}
+    </hgroup>
+    <div class="l-stack">
+      <button
+        @click=${() => next()}
+        id="confirmUnlinkAccountButton"
+        data-action="next"
+        class="c-button"
+      >
+        ${copy.confirm}
+      </button>
+      <button
+        @click=${() => cancel()}
+        data-action="cancel"
+        class="c-button c-button--secondary"
+      >
+        ${copy.cancel}
+      </button>
+    </div>
+  `;
+
+  return mainWindow({
+    showFooter: false,
+    showLogo: false,
+    slot,
+  });
+};
+
+export const confirmUnlinkAccountPage = renderPage(
+  confirmUnlinkAccountTemplate
+);
+
+export const confirmUnlinkAccount = ({
+  i18n,
+  credential,
+  isCurrentCredential,
+}: {
+  i18n: I18n;
+  credential: OpenIdCredential;
+  isCurrentCredential?: boolean;
+}): Promise<"confirmed" | "cancelled"> => {
+  return new Promise((resolve) =>
+    confirmUnlinkAccountPage({
+      i18n,
+      credential,
+      next: () => resolve("confirmed"),
+      cancel: () => resolve("cancelled"),
+      isCurrentCredential,
+    })
+  );
+};

--- a/src/frontend/src/flows/manage/linkedAccountsSection.ts
+++ b/src/frontend/src/flows/manage/linkedAccountsSection.ts
@@ -46,7 +46,6 @@ export const linkedAccountsSection = ({
             credential,
             index,
             unlink: onUnlinkAccount,
-            unlinkAvailable,
           })
         )}
       </ul>
@@ -73,14 +72,12 @@ export const linkedAccountsSection = ({
 
 export const accountItem = ({
   credential,
-  index,
+  index = 0,
   unlink,
-  unlinkAvailable,
 }: {
   credential: OpenIdCredential;
-  index: number;
-  unlink: (credential: OpenIdCredential) => void;
-  unlinkAvailable: boolean;
+  index?: number;
+  unlink?: (credential: OpenIdCredential) => void;
 }) => {
   const i18n = new I18n();
   const copy = i18n.i18n(copyJson);
@@ -88,7 +85,7 @@ export const accountItem = ({
     {
       action: "unlink",
       caption: copy.unlink.toString(),
-      fn: () => unlink(credential),
+      fn: () => unlink?.(credential),
     },
   ];
 
@@ -119,7 +116,7 @@ export const accountItem = ({
             </span>
           </div>
           ${
-            unlinkAvailable
+            nonNullish(unlink)
               ? settingsDropdown({
                   alias: credential.sub,
                   id: `account-${index}`,

--- a/src/showcase/src/pages/confirmUnlinkAccount.astro
+++ b/src/showcase/src/pages/confirmUnlinkAccount.astro
@@ -1,0 +1,30 @@
+---
+import Screen from "../layouts/Screen.astro";
+---
+
+<Screen title="Confirm Remove Device" pageName="confirmUnlinkAccount">
+  <script>
+    import { toast } from "$src/components/toast";
+    import { i18n } from "../i18n";
+    import { confirmUnlinkAccountPage } from "../../../frontend/src/flows/manage/confirmUnlinkAccount";
+    import { exampleAvatar } from "../constants";
+
+    confirmUnlinkAccountPage({
+      next: () => toast.info("ok"),
+      cancel: () => toast.info("cancelled"),
+      i18n,
+      credential: {
+        iss: "accounts.google.com",
+        sub: "2342987923",
+        aud: "example.com",
+        last_usage_timestamp: BigInt(1735825231139) * BigInt(1000000),
+        metadata: [
+          ["email", { String: "john.doe@gmail.com" }],
+          ["name", { String: "John Doe" }],
+          ["picture", { String: exampleAvatar }]
+        ]
+      },
+      isCurrentCredential: false
+    });
+  </script>
+</Screen>

--- a/src/showcase/src/pages/confirmUnlinkCurrentAccount.astro
+++ b/src/showcase/src/pages/confirmUnlinkCurrentAccount.astro
@@ -1,0 +1,30 @@
+---
+import Screen from "../layouts/Screen.astro";
+---
+
+<Screen title="Confirm Remove Device" pageName="confirmUnlinkAccount">
+  <script>
+    import { toast } from "$src/components/toast";
+    import { i18n } from "../i18n";
+    import { confirmUnlinkAccountPage } from "../../../frontend/src/flows/manage/confirmUnlinkAccount";
+    import { exampleAvatar } from "../constants";
+
+    confirmUnlinkAccountPage({
+      next: () => toast.info("ok"),
+      cancel: () => toast.info("cancelled"),
+      i18n,
+      credential: {
+        iss: "accounts.google.com",
+        sub: "2342987923",
+        aud: "example.com",
+        last_usage_timestamp: BigInt(1735825231139) * BigInt(1000000),
+        metadata: [
+          ["email", { String: "john.doe@gmail.com" }],
+          ["name", { String: "John Doe" }],
+          ["picture", { String: exampleAvatar }]
+        ]
+      },
+      isCurrentCredential: true
+    });
+  </script>
+</Screen>


### PR DESCRIPTION
Add unlink account page, will be used in another PR to unlink an account. This page is also needed to explain to the user that they will be signed out if they're currently signed in with this linked account.

# Changes

- Create unlink account template and page
- Add unlink account page to showcase