### PR TITLE
Support multiple window session trackeres

### DIFF
--- a/src/frontend/src/utils/trackWindowSession.test.ts
+++ b/src/frontend/src/utils/trackWindowSession.test.ts
@@ -1,5 +1,5 @@
 import {
-  removeWindowSessionTracker,
+  cleanUpWindowSessionTrackers,
   trackWindowSession,
 } from "./trackWindowSession";
 
@@ -24,7 +24,7 @@ describe("trackWindowSession", () => {
   });
 
   afterEach(() => {
-    removeWindowSessionTracker();
+    cleanUpWindowSessionTrackers();
   });
 
   it("should call onLeaveSession when the window is hidden", () => {
@@ -46,12 +46,100 @@ describe("trackWindowSession", () => {
     mockVisibilityState("hidden");
     document.dispatchEvent(new Event("visibilitychange"));
     expect(onLeaveSession).toHaveBeenCalled();
-    removeWindowSessionTracker();
+    cleanUpWindowSessionTrackers();
     mockVisibilityState("hidden");
     document.dispatchEvent(new Event("visibilitychange"));
     expect(onLeaveSession).not.toHaveBeenCalledTimes(2);
     mockVisibilityState("visible");
     document.dispatchEvent(new Event("visibilitychange"));
     expect(onEnterSession).not.toHaveBeenCalled();
+  });
+
+  it("should remove only the specific listener when the cleanup function is called", () => {
+    const cleanup = trackWindowSession({ onLeaveSession, onEnterSession });
+
+    // Create a second set of listeners
+    const onLeaveSession2 = vi.fn();
+    const onEnterSession2 = vi.fn();
+    trackWindowSession({
+      onLeaveSession: onLeaveSession2,
+      onEnterSession: onEnterSession2,
+    });
+
+    // Trigger events, both listeners should respond
+    mockVisibilityState("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(onLeaveSession).toHaveBeenCalledTimes(1);
+    expect(onLeaveSession2).toHaveBeenCalledTimes(1);
+
+    // Clean up the first listener
+    cleanup();
+
+    // Only the second listener should respond now
+    mockVisibilityState("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(onLeaveSession).toHaveBeenCalledTimes(1); // Count should still be 1
+    expect(onLeaveSession2).toHaveBeenCalledTimes(2); // Count should increase to 2
+  });
+
+  it("should support multiple listeners that can be independently removed", () => {
+    // Create three sets of listeners
+    const onLeaveSession1 = vi.fn();
+    const onEnterSession1 = vi.fn();
+    const cleanup1 = trackWindowSession({
+      onLeaveSession: onLeaveSession1,
+      onEnterSession: onEnterSession1,
+    });
+
+    const onLeaveSession2 = vi.fn();
+    const onEnterSession2 = vi.fn();
+    const cleanup2 = trackWindowSession({
+      onLeaveSession: onLeaveSession2,
+      onEnterSession: onEnterSession2,
+    });
+
+    const onLeaveSession3 = vi.fn();
+    const onEnterSession3 = vi.fn();
+    const cleanup3 = trackWindowSession({
+      onLeaveSession: onLeaveSession3,
+      onEnterSession: onEnterSession3,
+    });
+
+    // Test all three listeners respond
+    mockVisibilityState("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(onEnterSession1).toHaveBeenCalledTimes(1);
+    expect(onEnterSession2).toHaveBeenCalledTimes(1);
+    expect(onEnterSession3).toHaveBeenCalledTimes(1);
+
+    // Remove the middle listener
+    cleanup2();
+
+    // Test that only listeners 1 and 3 respond
+    mockVisibilityState("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(onEnterSession1).toHaveBeenCalledTimes(2);
+    expect(onEnterSession2).toHaveBeenCalledTimes(1); // Should remain at 1
+    expect(onEnterSession3).toHaveBeenCalledTimes(2);
+
+    // Remove the first listener
+    cleanup1();
+
+    // Test that only listener 3 responds
+    mockVisibilityState("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(onEnterSession1).toHaveBeenCalledTimes(2); // Should remain at 2
+    expect(onEnterSession2).toHaveBeenCalledTimes(1); // Should remain at 1
+    expect(onEnterSession3).toHaveBeenCalledTimes(3);
+
+    // Remove the last listener
+    cleanup3();
+
+    // Test that no listeners respond
+    mockVisibilityState("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(onEnterSession1).toHaveBeenCalledTimes(2); // Still 2
+    expect(onEnterSession2).toHaveBeenCalledTimes(1); // Still 1
+    expect(onEnterSession3).toHaveBeenCalledTimes(3); // Still 3
   });
 });

--- a/src/frontend/src/utils/trackWindowSession.test.ts
+++ b/src/frontend/src/utils/trackWindowSession.test.ts
@@ -82,7 +82,7 @@ describe("trackWindowSession", () => {
     expect(onLeaveSession2).toHaveBeenCalledTimes(2); // Count should increase to 2
   });
 
-  it("should support multiple listeners that can be independently removed", () => {
+  it("should support multiple listeners that can be independently removed and added", () => {
     // Create three sets of listeners
     const onLeaveSession1 = vi.fn();
     const onEnterSession1 = vi.fn();
@@ -112,28 +112,46 @@ describe("trackWindowSession", () => {
     expect(onEnterSession2).toHaveBeenCalledTimes(1);
     expect(onEnterSession3).toHaveBeenCalledTimes(1);
 
-    // Remove the middle listener
+    // Remove the third listener first
     cleanup2();
 
-    // Test that only listeners 1 and 3 respond
+    const onLeaveSession4 = vi.fn();
+    const onEnterSession4 = vi.fn();
+    const cleanup4 = trackWindowSession({
+      onLeaveSession: onLeaveSession4,
+      onEnterSession: onEnterSession4,
+    });
+
+    // Test that only listeners 1 and 2 respond
     mockVisibilityState("visible");
     document.dispatchEvent(new Event("visibilitychange"));
     expect(onEnterSession1).toHaveBeenCalledTimes(2);
     expect(onEnterSession2).toHaveBeenCalledTimes(1); // Should remain at 1
     expect(onEnterSession3).toHaveBeenCalledTimes(2);
+    expect(onEnterSession4).toHaveBeenCalledTimes(1); // New listener should respond
 
     // Remove the first listener
     cleanup1();
 
-    // Test that only listener 3 responds
+    // Test that only listener 2 responds
     mockVisibilityState("visible");
     document.dispatchEvent(new Event("visibilitychange"));
     expect(onEnterSession1).toHaveBeenCalledTimes(2); // Should remain at 2
-    expect(onEnterSession2).toHaveBeenCalledTimes(1); // Should remain at 1
+    expect(onEnterSession2).toHaveBeenCalledTimes(1); // Still 1
     expect(onEnterSession3).toHaveBeenCalledTimes(3);
+    expect(onEnterSession4).toHaveBeenCalledTimes(2);
 
-    // Remove the last listener
     cleanup3();
+
+    mockVisibilityState("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(onEnterSession1).toHaveBeenCalledTimes(2); // Still 2
+    expect(onEnterSession2).toHaveBeenCalledTimes(1); // Still 1
+    expect(onEnterSession3).toHaveBeenCalledTimes(3); // Should remain at 3
+    expect(onEnterSession4).toHaveBeenCalledTimes(3);
+
+    // Remove the last remaining listener
+    cleanup4();
 
     // Test that no listeners respond
     mockVisibilityState("visible");
@@ -141,5 +159,6 @@ describe("trackWindowSession", () => {
     expect(onEnterSession1).toHaveBeenCalledTimes(2); // Still 2
     expect(onEnterSession2).toHaveBeenCalledTimes(1); // Still 1
     expect(onEnterSession3).toHaveBeenCalledTimes(3); // Still 3
+    expect(onEnterSession4).toHaveBeenCalledTimes(3); // Still 3
   });
 });

--- a/src/frontend/src/utils/trackWindowSession.ts
+++ b/src/frontend/src/utils/trackWindowSession.ts
@@ -1,12 +1,14 @@
 // Utility functions to track window visibility state changes
 
-let visibilityChangeListener: (() => void) | null = null;
+// Array to store all visibility change listeners
+const visibilityChangeListeners: (() => void)[] = [];
 
 /**
  * Adds an event listener to track when the window visibility state changes.
  * @param params - An object containing the functions to call when the window visibility state changes.
  * @param params.onLeaveSession - The function to call when the window is hidden.
  * @param params.onEnterSession - The function to call when the window becomes visible.
+ * @returns A function that removes this specific listener when called
  */
 export function trackWindowSession({
   onLeaveSession,
@@ -14,26 +16,39 @@ export function trackWindowSession({
 }: {
   onLeaveSession: () => void;
   onEnterSession: () => void;
-}): void {
-  if (visibilityChangeListener) {
-    document.removeEventListener("visibilitychange", visibilityChangeListener);
-  }
-  visibilityChangeListener = () => {
+}): () => void {
+  const listener = () => {
     if (document.visibilityState === "hidden") {
       onLeaveSession();
     } else if (document.visibilityState === "visible") {
       onEnterSession();
     }
   };
-  document.addEventListener("visibilitychange", visibilityChangeListener);
+
+  // Store the index when adding the listener
+  const index = visibilityChangeListeners.push(listener) - 1;
+  document.addEventListener("visibilitychange", listener);
+
+  // Return cleanup function
+  return () => {
+    // Use the stored index directly instead of indexOf
+    if (
+      index >= 0 &&
+      index < visibilityChangeListeners.length &&
+      visibilityChangeListeners[index] === listener
+    ) {
+      visibilityChangeListeners.splice(index, 1);
+    }
+    document.removeEventListener("visibilitychange", listener);
+  };
 }
 
 /**
- * Removes the event listener that tracks window visibility state changes.
+ * Removes all event listeners that track window visibility state changes.
  */
-export function removeWindowSessionTracker(): void {
-  if (visibilityChangeListener) {
-    document.removeEventListener("visibilitychange", visibilityChangeListener);
-    visibilityChangeListener = null;
-  }
+export function cleanUpWindowSessionTrackers(): void {
+  visibilityChangeListeners.forEach((listener) => {
+    document.removeEventListener("visibilitychange", listener);
+  });
+  visibilityChangeListeners.length = 0;
 }

--- a/src/frontend/src/utils/trackWindowSession.ts
+++ b/src/frontend/src/utils/trackWindowSession.ts
@@ -25,18 +25,15 @@ export function trackWindowSession({
     }
   };
 
-  // Store the index when adding the listener
-  const index = visibilityChangeListeners.push(listener) - 1;
+  // Add the listener to the array
+  visibilityChangeListeners.push(listener);
   document.addEventListener("visibilitychange", listener);
 
   // Return cleanup function
   return () => {
-    // Use the stored index directly instead of indexOf
-    if (
-      index >= 0 &&
-      index < visibilityChangeListeners.length &&
-      visibilityChangeListeners[index] === listener
-    ) {
+    // Use indexOf to find and remove the listener
+    const index = visibilityChangeListeners.indexOf(listener);
+    if (index !== -1) {
       visibilityChangeListeners.splice(index, 1);
     }
     document.removeEventListener("visibilitychange", listener);


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Enable to track multiple window sessions concurrently.

# Changes

Improvements to window visibility state tracking:

* [`src/frontend/src/utils/trackWindowSession.ts`](diffhunk://#diff-a8816d9827bab7bc62fb7c2168bbd016ffdcb907f9f8395f911789fd83019020L3-R53): Modified `trackWindowSession` to return a cleanup function for each listener and updated the implementation to handle multiple listeners using an array.
* [`src/frontend/src/utils/trackWindowSession.ts`](diffhunk://#diff-a8816d9827bab7bc62fb7c2168bbd016ffdcb907f9f8395f911789fd83019020L3-R53): Renamed `removeWindowSessionTracker` to `cleanUpWindowSessionTrackers` to better reflect its purpose of removing all listeners.

Updates to tests:

* [`src/frontend/src/utils/trackWindowSession.test.ts`](diffhunk://#diff-71c3c48ac2adb6ee08bdc94cf9322f0c2bf58750cef29836acf8f4ecb7ccf873L2-R2): Updated tests to use `cleanUpWindowSessionTrackers` instead of `removeWindowSessionTracker`. [[1]](diffhunk://#diff-71c3c48ac2adb6ee08bdc94cf9322f0c2bf58750cef29836acf8f4ecb7ccf873L2-R2) [[2]](diffhunk://#diff-71c3c48ac2adb6ee08bdc94cf9322f0c2bf58750cef29836acf8f4ecb7ccf873L27-R27) [[3]](diffhunk://#diff-71c3c48ac2adb6ee08bdc94cf9322f0c2bf58750cef29836acf8f4ecb7ccf873L49-R144)
* [`src/frontend/src/utils/trackWindowSession.test.ts`](diffhunk://#diff-71c3c48ac2adb6ee08bdc94cf9322f0c2bf58750cef29836acf8f4ecb7ccf873L49-R144): Added new tests to verify that multiple listeners can be independently added and removed, and that specific listeners can be cleaned up without affecting others.




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/confirmRemoveDevice.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/displayUserNumber.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/02404c033/mobile/showVerificationCode.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

