### PR TITLE
Update readme only on release tags

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -867,7 +867,7 @@ jobs:
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
-    
+
       # Checkout project
       - name: Checkout
         uses: actions/checkout@v4
@@ -876,6 +876,7 @@ jobs:
 
         # Bump the version in the download links and create A Pull Request
       - name: Update README
+        if: startsWith(github.ref, 'refs/tags/release-')
         env:
           PREVIOUS_RELEASE_TAG: ${{ steps.latest-release-tag.outputs.result }}
           NEW_RELEASE_TAG: ${{ github.ref_name }}


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Make sure the job to update the readme is not triggered when not needed.

# Changes

* Add the condition to check the release tag for the update readme job

# Tests

We should see less PRs like #2937 

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/f29767ff5/desktop/displayManageCredentialsMultiple.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
