### PR TITLE
Disable registration using related_origins configuration

### DIFF
--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -28,6 +28,7 @@ import {
   UnexpectedCall,
   WrongCaptchaSolution,
 } from "$src/utils/iiConnection";
+import { isRegistrationAllowed } from "$src/utils/isRegistrationAllowed";
 import { lookupAAGUID } from "$src/utils/webAuthn";
 import { SignIdentity } from "@dfinity/agent";
 import { ECDSAKeyIdentity } from "@dfinity/identity";
@@ -84,7 +85,7 @@ export const registerFlow = async ({
     userNumber: bigint;
     pinIdentityMaterial: PinIdentityMaterial;
   }) => Promise<void>;
-  registrationAllowed: boolean;
+  registrationAllowed: { isAllowed: boolean; allowedOrigins: string[] };
   pinAllowed: () => Promise<boolean>;
   uaParser: PreloadedUAParser;
 }): Promise<
@@ -99,8 +100,8 @@ export const registerFlow = async ({
   | RateLimitExceeded
   | "canceled"
 > => {
-  if (!registrationAllowed) {
-    const result = await registerDisabled();
+  if (!registrationAllowed.isAllowed) {
+    const result = await registerDisabled(registrationAllowed.allowedOrigins);
     result satisfies { tag: "canceled" };
     return "canceled";
   }
@@ -267,15 +268,13 @@ export const getRegisterFlowOpts = async ({
   const tempIdentity = await ECDSAKeyIdentity.generate({
     extractable: false,
   });
+  const registrationAllowed = isRegistrationAllowed(
+    connection.canisterConfig,
+    window.location.origin
+  );
+  const allowedOrigins = connection.canisterConfig.related_origins[0] || [];
   return {
-    /** Check that the current origin is not the explicit canister id or a raw url.
-     *  Explanation why we need to do this:
-     *  https://forum.dfinity.org/t/internet-identity-deprecation-of-account-creation-on-all-origins-other-than-https-identity-ic0-app/9694
-     **/
-    registrationAllowed:
-      !/(^https:\/\/rdmx6-jaaaa-aaaaa-aaadq-cai\.ic0\.app$)|(.+\.raw\..+)/.test(
-        window.origin
-      ),
+    registrationAllowed: { isAllowed: registrationAllowed, allowedOrigins },
     pinAllowed: () =>
       // If pin auth is disallowed by the authenticating dapp then abort, otherwise check
       // if pin auth is allowed for the user agent

--- a/src/frontend/src/flows/registerDisabled.ts
+++ b/src/frontend/src/flows/registerDisabled.ts
@@ -3,7 +3,13 @@ import { warnBox } from "$src/components/warnBox";
 import { LEGACY_II_URL } from "$src/config";
 import { html, render } from "lit-html";
 
-const pageContent = (onCancel: () => void) => {
+const pageContent = ({
+  onCancel,
+  allowedOrigins = [LEGACY_II_URL],
+}: {
+  onCancel: () => void;
+  allowedOrigins?: string[];
+}) => {
   const pageContentSlot = html`<hgroup>
       <h1 class="t-title t-title--main">Registration Disabled</h1>
     </hgroup>
@@ -13,7 +19,20 @@ const pageContent = (onCancel: () => void) => {
         message: html`<p class="t-paragraph t-lead">
             To keep you safe, we disabled registration from this address. If you
             want to securely create a new Internet Identity, visit:
-            <a class="t-link" href=${LEGACY_II_URL}>${LEGACY_II_URL}</a>.
+            ${allowedOrigins.length === 1
+              ? html`<a class="t-link" href=${allowedOrigins[0]}
+                    >${allowedOrigins[0]}</a
+                  >.`
+              : html`
+                  <ul>
+                    ${allowedOrigins.map(
+                      (origin) =>
+                        html`<li>
+                          <a class="t-link" href=${origin}>${origin}</a>
+                        </li>`
+                    )}
+                  </ul>
+                `}
           </p>
           <p class="t-paragraph">
             If you were redirected here by another website, please inform the
@@ -39,12 +58,22 @@ const pageContent = (onCancel: () => void) => {
   });
 };
 
-export const registerDisabled = (): Promise<{ tag: "canceled" }> => {
+/**
+ * Shows the register disabled page with a list of allowed origins
+ * @param allowedOrigins Optional list of allowed origins. If not provided, defaults to LEGACY_II_URL
+ * @returns Promise resolved when the user clicks cancel
+ */
+export const registerDisabled = (
+  allowedOrigins?: string[]
+): Promise<{ tag: "canceled" }> => {
   return new Promise((resolve) => {
     const container = document.getElementById("pageContent") as HTMLElement;
     render(
-      pageContent(() => {
-        resolve({ tag: "canceled" });
+      pageContent({
+        onCancel: () => {
+          resolve({ tag: "canceled" });
+        },
+        allowedOrigins,
       }),
       container
     );

--- a/src/frontend/src/utils/isRegistrationAllowed.test.ts
+++ b/src/frontend/src/utils/isRegistrationAllowed.test.ts
@@ -1,0 +1,58 @@
+import { InternetIdentityInit } from "$generated/internet_identity_types";
+import { describe, expect, it } from "vitest";
+import { isRegistrationAllowed } from "./isRegistrationAllowed";
+
+describe("isRegistrationAllowed", () => {
+  const createConfig = (
+    relatedOrigins: string[] | null = null
+  ): InternetIdentityInit => {
+    return {
+      fetch_root_key: [],
+      enable_dapps_explorer: [],
+      assigned_user_number_range: [],
+      archive_config: [],
+      canister_creation_cycles_cost: [],
+      related_origins: relatedOrigins === null ? [] : [relatedOrigins],
+      captcha_config: [],
+      register_rate_limit: [],
+      analytics_config: [],
+      openid_google: [],
+    };
+  };
+
+  it("allows registration when related_origins is empty (undefined)", () => {
+    const config = createConfig();
+    expect(isRegistrationAllowed(config, "https://example.com")).toBe(true);
+  });
+
+  it("allows registration when related_origins is an empty array", () => {
+    const config = createConfig([]);
+    expect(isRegistrationAllowed(config, "https://example.com")).toBe(true);
+  });
+
+  it("allows registration when the origin is in the related_origins list", () => {
+    const config = createConfig([
+      "https://identity.ic0.app",
+      "https://identity.icp0.io",
+      "https://example.com",
+    ]);
+    expect(isRegistrationAllowed(config, "https://example.com")).toBe(true);
+  });
+
+  it("disallows registration when the origin is not in the related_origins list", () => {
+    const config = createConfig([
+      "https://identity.ic0.app",
+      "https://identity.icp0.io",
+    ]);
+    expect(isRegistrationAllowed(config, "https://example.com")).toBe(false);
+  });
+
+  it("handles case-sensitive origins correctly", () => {
+    const config = createConfig([
+      "https://identity.ic0.app",
+      "https://Example.com",
+    ]);
+    expect(isRegistrationAllowed(config, "https://example.com")).toBe(true);
+    expect(isRegistrationAllowed(config, "https://Example.com")).toBe(true);
+  });
+});

--- a/src/frontend/src/utils/isRegistrationAllowed.ts
+++ b/src/frontend/src/utils/isRegistrationAllowed.ts
@@ -1,0 +1,29 @@
+/**
+ * Check if registration is allowed based on the Internet Identity configuration and current origin.
+ *
+ * @param config - The InternetIdentityInit configuration
+ * @param currentOrigin - The current origin from where the request is made
+ * @returns Whether registration is allowed from the current origin
+ */
+import { InternetIdentityInit } from "$generated/internet_identity_types";
+import { isNullish } from "@dfinity/utils";
+import { isSameOrigin } from "./urlUtils";
+
+export const isRegistrationAllowed = (
+  config: InternetIdentityInit,
+  currentOrigin: string
+): boolean => {
+  // If there are no related origins defined or the related_origins list is empty, registration is allowed
+  if (
+    isNullish(config.related_origins[0]) ||
+    config.related_origins[0].length === 0
+  ) {
+    return true;
+  }
+
+  // Get the related origins array
+  const relatedOrigins = config.related_origins[0];
+
+  // Check if the current origin matches any of the related origins
+  return relatedOrigins.some((origin) => isSameOrigin(origin, currentOrigin));
+};

--- a/src/frontend/src/utils/urlUtils.test.ts
+++ b/src/frontend/src/utils/urlUtils.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { isSameOrigin } from "./urlUtils";
+
+describe("urlUtils", () => {
+  describe("isSameOrigin", () => {
+    it("should return true for identical URLs", () => {
+      expect(isSameOrigin("https://example.com", "https://example.com")).toBe(
+        true
+      );
+    });
+
+    it("should return true for URLs with the same origin but different paths", () => {
+      expect(
+        isSameOrigin("https://example.com/path1", "https://example.com/path2")
+      ).toBe(true);
+    });
+
+    it("should return true for URLs with the same origin but different query parameters", () => {
+      expect(
+        isSameOrigin(
+          "https://example.com?param1=value1",
+          "https://example.com?param2=value2"
+        )
+      ).toBe(true);
+    });
+
+    it("should return true for URLs with the same origin but different hash fragments", () => {
+      expect(
+        isSameOrigin(
+          "https://example.com#section1",
+          "https://example.com#section2"
+        )
+      ).toBe(true);
+    });
+
+    it("should return false for URLs with different protocols", () => {
+      expect(isSameOrigin("https://example.com", "http://example.com")).toBe(
+        false
+      );
+    });
+
+    it("should return false for URLs with different hostnames", () => {
+      expect(isSameOrigin("https://example.com", "https://example.org")).toBe(
+        false
+      );
+    });
+
+    it("should return false for URLs with different ports", () => {
+      expect(
+        isSameOrigin("https://example.com:443", "https://example.com:8080")
+      ).toBe(false);
+    });
+
+    it("should return false for URLs with different subdomains", () => {
+      expect(
+        isSameOrigin("https://sub1.example.com", "https://sub2.example.com")
+      ).toBe(false);
+    });
+
+    it("should handle URLs with default ports correctly", () => {
+      expect(
+        isSameOrigin("https://example.com", "https://example.com:443")
+      ).toBe(true);
+      expect(isSameOrigin("http://example.com", "http://example.com:80")).toBe(
+        true
+      );
+    });
+
+    it("should handle invalid URLs by falling back to string comparison", () => {
+      expect(isSameOrigin("invalid-url", "invalid-url")).toBe(true);
+      expect(isSameOrigin("invalid-url", "another-invalid-url")).toBe(false);
+    });
+  });
+});

--- a/src/frontend/src/utils/urlUtils.ts
+++ b/src/frontend/src/utils/urlUtils.ts
@@ -1,0 +1,22 @@
+/**
+ * Helper function to compare two URL origins to check if they're the same.
+ * This normalizes the URLs and compares their protocol, hostname, and port.
+ *
+ * @param urlA - The first URL to compare
+ * @param urlB - The second URL to compare
+ * @returns True if both origins are the same, false otherwise
+ */
+export const isSameOrigin = (urlA: string, urlB: string): boolean => {
+  try {
+    // Parse URLs to get access to their components
+    const a = new URL(urlA);
+    const b = new URL(urlB);
+
+    // Compare protocol, hostname and port
+    return a.origin === b.origin;
+  } catch (error) {
+    // If URL parsing fails, do a direct string comparison
+    console.warn(`Failed to parse URLs for comparison: ${error}`);
+    return urlA === urlB;
+  }
+};

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -262,7 +262,8 @@ type InternetIdentityInit = record {
     register_rate_limit : opt RateLimitConfig;
     // Configuration of the captcha in the registration flow.
     captcha_config : opt CaptchaConfig;
-    // Configuration for Related Origins Requests
+    // Configuration for Related Origins Requests.
+    // If present, list of origins from where registration is allowed.
     related_origins : opt vec text;
     // Configuration for OpenID Google client
     openid_google : opt opt OpenIdConfig;

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -113,7 +113,10 @@ const registerFlowOpts: RegisterFlowOpts = {
       showAddCurrentDevice: false,
     };
   },
-  registrationAllowed: true,
+  registrationAllowed: {
+    isAllowed: true,
+    allowedOrigins: ["https://idenitty.ic0.app"] as string[],
+  },
   storePinIdentity: () => {
     toast.info("PIN identity was stored");
     return Promise.resolve();


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Make the URLs where registration is allowed or not configurable using the related_origins config field.

# Changes

## Changes to Registration Permission Logic:

* [`src/frontend/src/flows/register/index.ts`](diffhunk://#diff-793891f8131b840661ff4978418ccf45bdd403b840a549b7d866adf7f4a78f92R31): Introduced a new `isRegistrationAllowed` utility function to determine if registration is permitted based on the Internet Identity configuration and the current origin. Updated the `registerFlow` function to use this new logic and pass allowed origins to the `registerDisabled` function.

## Updates to User Interface:

* [`src/frontend/src/flows/registerDisabled.ts`](diffhunk://#diff-58cc934d6c96f4819e048dd4a960c301e34048d5fbd947505df8b242ba72dcc3L6-R12): Modified the `registerDisabled` function to accept and display a list of allowed origins. Updated the UI to show multiple allowed origins if applicable.

### New Utility Functions and Tests:

* [`src/frontend/src/utils/isRegistrationAllowed.ts`](diffhunk://#diff-34c8929812f1b8701e67b33611dcb916a5a293989b662978dbd9961203cf4048R1-R29): Added the `isRegistrationAllowed` function to check registration permissions based on origin.
* [`src/frontend/src/utils/isRegistrationAllowed.test.ts`](diffhunk://#diff-11bf0f891b0a223d820eae79a01f07fe23662527f964f7f8715c5835a5e5b2feR1-R58): Created tests for the `isRegistrationAllowed` function to ensure correct behavior under various conditions.
* [`src/frontend/src/utils/urlUtils.ts`](diffhunk://#diff-6fa30eee09ad0714309eddc266de83a246bc948ad1f1f30cd7ced8eaf85cc445R1-R22): Added the `isSameOrigin` helper function to compare URL origins.
* [`src/frontend/src/utils/urlUtils.test.ts`](diffhunk://#diff-714d3e1b715c44b6285c1339caccfc6a488e94cd7c02ade1c0fbc41ac72b2889R1-R74): Created tests for the `isSameOrigin` function to verify URL comparison logic.

### Configuration Updates:

* [`src/internet_identity/internet_identity.did`](diffhunk://#diff-623401f1d9297ecff25efc7dc8e6e87983a4d8e0b62e82b8e029375805708392L265-R266): Updated the `InternetIdentityInit` type to include a description for the `related_origins` field, specifying its role in registration permissions.
* [`src/showcase/src/flows.ts`](diffhunk://#diff-086924bf1448eed77a8143b3e58d0af88adc6a08045235d1d788fe74950318c1L116-R119): Adjusted the `registerFlowOpts` to align with the new registration permission structure.
