### PR TITLE
Add is_production config field

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -37,6 +37,7 @@ export const idlFactory = ({ IDL }) => {
   const InternetIdentityInit = IDL.Record({
     'fetch_root_key' : IDL.Opt(IDL.Bool),
     'openid_google' : IDL.Opt(IDL.Opt(OpenIdConfig)),
+    'is_production' : IDL.Opt(IDL.Bool),
     'enable_dapps_explorer' : IDL.Opt(IDL.Bool),
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),
@@ -652,6 +653,7 @@ export const init = ({ IDL }) => {
   const InternetIdentityInit = IDL.Record({
     'fetch_root_key' : IDL.Opt(IDL.Bool),
     'openid_google' : IDL.Opt(IDL.Opt(OpenIdConfig)),
+    'is_production' : IDL.Opt(IDL.Bool),
     'enable_dapps_explorer' : IDL.Opt(IDL.Bool),
     'assigned_user_number_range' : IDL.Opt(IDL.Tuple(IDL.Nat64, IDL.Nat64)),
     'archive_config' : IDL.Opt(ArchiveConfig),

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -213,6 +213,7 @@ export type IdentityNumber = bigint;
 export interface InternetIdentityInit {
   'fetch_root_key' : [] | [boolean],
   'openid_google' : [] | [[] | [OpenIdConfig]],
+  'is_production' : [] | [boolean],
   'enable_dapps_explorer' : [] | [boolean],
   'assigned_user_number_range' : [] | [[bigint, bigint]],
   'archive_config' : [] | [ArchiveConfig],

--- a/src/frontend/src/utils/domainUtils.test.ts
+++ b/src/frontend/src/utils/domainUtils.test.ts
@@ -17,6 +17,7 @@ describe("isOfficialOrigin", () => {
     analytics_config: [],
     captcha_config: [],
     register_rate_limit: [],
+    is_production: [],
   });
 
   // Default related origins for most tests

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -72,6 +72,7 @@ const DEFAULT_INIT: InternetIdentityInit = {
   ],
   fetch_root_key: [],
   enable_dapps_explorer: [],
+  is_production: [],
 };
 
 const mockActor = {

--- a/src/frontend/src/utils/isRegistrationAllowed.test.ts
+++ b/src/frontend/src/utils/isRegistrationAllowed.test.ts
@@ -17,6 +17,7 @@ describe("isRegistrationAllowed", () => {
       register_rate_limit: [],
       analytics_config: [],
       openid_google: [],
+      is_production: [],
     };
   };
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -273,6 +273,9 @@ type InternetIdentityInit = record {
     fetch_root_key : opt bool;
     // Configuration to show dapps explorer or not
     enable_dapps_explorer : opt bool;
+    // Configuration to set the canister as production mode.
+    // For now, this is used only to show or hide the banner.
+    is_production : opt bool;
 };
 
 type ChallengeKey = text;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -358,6 +358,7 @@ fn config() -> InternetIdentityInit {
         analytics_config: Some(persistent_state.analytics_config.clone()),
         fetch_root_key: persistent_state.fetch_root_key,
         enable_dapps_explorer: persistent_state.enable_dapps_explorer,
+        is_production: persistent_state.is_production,
     })
 }
 
@@ -459,6 +460,11 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
         if let Some(enable_dapps_explorer) = arg.enable_dapps_explorer {
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.enable_dapps_explorer = Some(enable_dapps_explorer);
+            })
+        }
+        if let Some(is_production) = arg.is_production {
+            state::persistent_state_mut(|persistent_state| {
+                persistent_state.is_production = Some(is_production);
             })
         }
     }

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -116,6 +116,7 @@ pub struct PersistentState {
     pub event_stats_24h_start: Option<EventKey>,
     pub fetch_root_key: Option<bool>,
     pub enable_dapps_explorer: Option<bool>,
+    pub is_production: Option<bool>,
 }
 
 impl Default for PersistentState {
@@ -135,6 +136,7 @@ impl Default for PersistentState {
             event_stats_24h_start: None,
             fetch_root_key: None,
             enable_dapps_explorer: None,
+            is_production: None,
         }
     }
 }

--- a/src/internet_identity/src/storage/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable_persistent_state.rs
@@ -37,6 +37,7 @@ pub struct StorablePersistentState {
     analytics_config: Option<AnalyticsConfig>,
     fetch_root_key: Option<bool>,
     enable_dapps_explorer: Option<bool>,
+    is_production: Option<bool>,
 }
 
 impl Storable for StorablePersistentState {
@@ -79,6 +80,7 @@ impl From<PersistentState> for StorablePersistentState {
             analytics_config: s.analytics_config,
             fetch_root_key: s.fetch_root_key,
             enable_dapps_explorer: s.enable_dapps_explorer,
+            is_production: s.is_production,
         }
     }
 }
@@ -99,6 +101,7 @@ impl From<StorablePersistentState> for PersistentState {
             event_stats_24h_start: s.event_stats_24h_start,
             fetch_root_key: s.fetch_root_key,
             enable_dapps_explorer: s.enable_dapps_explorer,
+            is_production: s.is_production,
         }
     }
 }
@@ -147,6 +150,7 @@ mod tests {
             analytics_config: None,
             fetch_root_key: None,
             enable_dapps_explorer: None,
+            is_production: None,
         };
 
         assert_eq!(StorablePersistentState::default(), expected_defaults);
@@ -171,6 +175,7 @@ mod tests {
             analytics_config: None,
             fetch_root_key: None,
             enable_dapps_explorer: None,
+            is_production: None,
         };
         assert_eq!(PersistentState::default(), expected_defaults);
     }

--- a/src/internet_identity/tests/integration/config/is_production.rs
+++ b/src/internet_identity/tests/integration/config/is_production.rs
@@ -1,0 +1,136 @@
+use canister_tests::api::internet_identity as api;
+use canister_tests::framework::{
+    env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
+};
+use internet_identity_interface::internet_identity::types::InternetIdentityInit;
+
+#[test]
+fn should_init_default() {
+    let env = env();
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
+    assert_eq!(api::config(&env, canister_id).unwrap().is_production, None);
+}
+
+#[test]
+fn should_init_config() {
+    let env = env();
+    let configs = vec![
+        InternetIdentityInit {
+            is_production: None,
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            is_production: Some(false),
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            is_production: Some(true),
+            ..Default::default()
+        },
+    ];
+
+    for config in configs {
+        let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+        assert_eq!(
+            api::config(&env, canister_id).unwrap().is_production,
+            config.is_production
+        );
+    }
+}
+
+#[test]
+fn should_enable_config() {
+    let env = env();
+    let mut config = InternetIdentityInit {
+        is_production: None,
+        ..Default::default()
+    };
+    let enabled_value = Some(true);
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+    config.is_production = enabled_value;
+    upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().is_production,
+        enabled_value
+    );
+}
+
+#[test]
+fn should_disable_config() {
+    let env = env();
+    let mut config = InternetIdentityInit {
+        is_production: Some(true),
+        ..Default::default()
+    };
+    let disabled_value = Some(false);
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+    config.is_production = disabled_value;
+    upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().is_production,
+        disabled_value
+    );
+}
+
+#[test]
+fn should_update_config() {
+    let env = env();
+    let mut config = InternetIdentityInit {
+        is_production: Some(false),
+        ..Default::default()
+    };
+    let updated_value = Some(true);
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+    config.is_production = updated_value;
+    upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().is_production,
+        updated_value
+    );
+}
+
+#[test]
+fn should_retain_config() {
+    let env = env();
+    let configs = vec![
+        InternetIdentityInit {
+            is_production: None,
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            is_production: Some(false),
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            is_production: Some(true),
+            ..Default::default()
+        },
+    ];
+
+    for config in configs {
+        let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+        // No config argument
+        upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), None).unwrap();
+        // Unrelated config change
+        upgrade_ii_canister_with_arg(
+            &env,
+            canister_id,
+            II_WASM.clone(),
+            Some(InternetIdentityInit {
+                openid_google: Some(Some(OpenIdConfig {
+                    client_id: "https://example.com".into(),
+                })),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            api::config(&env, canister_id).unwrap().is_production,
+            config.is_production
+        );
+    }
+}

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -97,6 +97,7 @@ fn ii_canister_serves_webauthn_assets() -> Result<(), CallError> {
         analytics_config: None,
         fetch_root_key: None,
         enable_dapps_explorer: None,
+        is_production: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
 
@@ -162,6 +163,7 @@ fn ii_canister_serves_webauthn_assets_after_upgrade() -> Result<(), CallError> {
         analytics_config: None,
         fetch_root_key: None,
         enable_dapps_explorer: None,
+        is_production: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 
@@ -203,6 +205,7 @@ fn ii_canister_serves_webauthn_assets_after_upgrade() -> Result<(), CallError> {
         analytics_config: None,
         fetch_root_key: None,
         enable_dapps_explorer: None,
+        is_production: None,
     };
 
     let _ = upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config_2));
@@ -601,6 +604,7 @@ fn must_not_cache_well_known_webauthn() -> Result<(), CallError> {
         analytics_config: None,
         fetch_root_key: None,
         enable_dapps_explorer: None,
+        is_production: None,
     };
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -210,6 +210,7 @@ pub struct InternetIdentityInit {
     pub analytics_config: Option<Option<AnalyticsConfig>>,
     pub fetch_root_key: Option<bool>,
     pub enable_dapps_explorer: Option<bool>,
+    pub is_production: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -26,6 +26,7 @@ const DEFAULT_INIT: InternetIdentityInit = {
   related_origins: [],
   fetch_root_key: [],
   enable_dapps_explorer: [],
+  is_production: [],
 };
 
 const registerSuccessToastTemplate = (result: unknown) => html`


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Make the "test application" banner configurable.

In this PR, a new config field "is_production" is introduced to then be used to hide or show the banner.

# Changes

Key changes:

*Configuration updates:*
- Added `is_production` field to the `InternetIdentityInit` type in `internet_identity.did` to configure the canister as production mode.
- Updated the `PersistentState` struct in `state.rs` to include the `is_production` field.
- Modified the `StorablePersistentState` struct and its conversion implementations in `storable_persistent_state.rs` to handle the `is_production` field.

*Initialization and state application:*
- Updated the `config` function in `main.rs` to include the `is_production` field.
- Modified the `apply_install_arg` function in `main.rs` to apply the `is_production` configuration.

*Testing:*
- Added integration tests in `is_production.rs` to verify the behavior of the `is_production` configuration during initialization, enabling, disabling, updating, and retaining the configuration.

These changes ensure that the new `is_production` configuration is properly integrated and tested across the Internet Identity service.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/90f23cef6/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/90f23cef6/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/90f23cef6/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/90f23cef6/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/90f23cef6/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/90f23cef6/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/90f23cef6/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/90f23cef6/mobile/landing_1.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

