### PR TITLE
Use is_production to hide or show banner

### DIFF
--- a/src/frontend/src/banner.ts
+++ b/src/frontend/src/banner.ts
@@ -7,6 +7,7 @@ import { anyFeatures } from "./features";
 // is a flavored build, or if the is_production flag is not set to true.
 export const showWarningIfNecessary = (config: InternetIdentityInit): void => {
   const isProduction: boolean = config.is_production[0] ?? false;
+  const firstUrl: string = config.related_origins[0]?.[0] ?? OFFICIAL_II_URL;
   if (anyFeatures()) {
     showWarning(html`Test only. Do not use your regular Internet Identity!
       <a
@@ -22,7 +23,7 @@ export const showWarningIfNecessary = (config: InternetIdentityInit): void => {
         class="features-warning-btn"
         target="_blank"
         rel="noopener noreferrer"
-        href=${config.related_origins[0] ?? OFFICIAL_II_URL}
+        href=${firstUrl}
         >go to official</a
       >`);
   }

--- a/src/frontend/src/banner.ts
+++ b/src/frontend/src/banner.ts
@@ -28,7 +28,8 @@ export const showWarningIfNecessary = (config: InternetIdentityInit): void => {
   }
 };
 
-const showWarning = (message: TemplateResult): HTMLDivElement => {
+// Exported to be used in the showcase
+export const showWarning = (message: TemplateResult): HTMLDivElement => {
   const container = document.createElement("div");
   container.className = "features-warning-container";
   container.setAttribute("role", "alert");

--- a/src/frontend/src/banner.ts
+++ b/src/frontend/src/banner.ts
@@ -2,11 +2,11 @@ import { InternetIdentityInit } from "$generated/internet_identity_types";
 import { html, render, TemplateResult } from "lit-html";
 import { OFFICIAL_II_URL } from "./config";
 import { anyFeatures } from "./features";
-import { isOfficialOrigin } from "./utils/domainUtils";
 
 // Show a warning banner if the build is not "official". This happens if either the build
-// is a flavored build, or if the origin is not in the list of related origins from the canister config.
+// is a flavored build, or if the is_production flag is not set to true.
 export const showWarningIfNecessary = (config: InternetIdentityInit): void => {
+  const isProduction: boolean = config.is_production[0] ?? false;
   if (anyFeatures()) {
     showWarning(html`Test only. Do not use your regular Internet Identity!
       <a
@@ -16,19 +16,19 @@ export const showWarningIfNecessary = (config: InternetIdentityInit): void => {
         href="https://github.com/dfinity/internet-identity#build-features"
         >more</a
       >`);
-  } else if (!isOfficialOrigin(window.location.origin, config)) {
+  } else if (!isProduction) {
     showWarning(html`This is not the official Internet Identity.
       <a
         class="features-warning-btn"
         target="_blank"
         rel="noopener noreferrer"
-        href=${OFFICIAL_II_URL}
+        href=${config.related_origins[0] ?? OFFICIAL_II_URL}
         >go to official</a
       >`);
   }
 };
 
-export const showWarning = (message: TemplateResult): HTMLDivElement => {
+const showWarning = (message: TemplateResult): HTMLDivElement => {
   const container = document.createElement("div");
   container.className = "features-warning-container";
   container.setAttribute("role", "alert");


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Be able to set beta domains with the not official II banner.

# Changes

Changes to warning banner logic:

* Modified the `showWarningIfNecessary` function to use the `is_production` flag from the configuration instead of checking the related_origins.
* Updated the URL in the warning message to use the first related origin from the configuration, if available, or fallback to the official URL.

<!-- List the changes that have been developed -->

# Tests

Tested locally.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/desktop/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/mobile/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/mobile/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/mobile/displayUserNumber.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/07fe29022/mobile/displayUserNumberTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

