### PR TITLE
OpenID Registration: Extend Connection class

### DIFF
--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -9,7 +9,12 @@ import {
   IdentityMetadata,
   RECOVERY_PAGE_SHOW_TIMESTAMP_MILLIS,
 } from "$src/repositories/identityMetadata";
-import { ActorSubclass, DerEncodedPublicKey, Signature } from "@dfinity/agent";
+import {
+  ActorSubclass,
+  DerEncodedPublicKey,
+  SignIdentity,
+  Signature,
+} from "@dfinity/agent";
 import { DelegationIdentity } from "@dfinity/identity";
 import { IDBFactory } from "fake-indexeddb";
 import { clear as idbClear } from "idb-keyval";
@@ -767,5 +772,150 @@ describe("Connection.login", () => {
         metadata: [],
       });
     });
+  });
+});
+
+// First define the mock values at the top level
+const mockJwt = "mock.jwt.token";
+const mockSalt = [1, 2, 3];
+const mockNonce = "mock-nonce";
+
+// Mock the openID utilities
+vi.mock("$src/utils/openID", () => ({
+  createAnonymousNonce: () =>
+    Promise.resolve({ nonce: mockNonce, salt: mockSalt }),
+  createGoogleRequestConfig: () => ({}),
+  requestJWT: () => Promise.resolve(mockJwt),
+}));
+
+vi.mock("$src/components/loader", () => ({
+  withLoader: (fn: () => Promise<any>) => fn(),
+}));
+
+describe("openid_identity_registration_finish", () => {
+  const mockIdentity = {
+    getPrincipal: () => ({ toString: () => "mock-principal" }),
+    getPublicKey: () => ({
+      toDer: () => new Uint8Array([1, 2, 3]).buffer,
+    }),
+    sign: (blob: ArrayBuffer) =>
+      Promise.resolve(new Uint8Array([4, 5, 6]).buffer),
+  } as unknown as SignIdentity;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return MissingGoogleClientId when client ID is not provided", async () => {
+    const mockActor = {} as unknown as ActorSubclass<_SERVICE>;
+    const connection = new Connection("aaaaa-aa", DEFAULT_INIT, mockActor);
+    const getGoogleClientId = () => undefined;
+
+    const result = await connection.openid_identity_registration_finish(
+      getGoogleClientId,
+      mockIdentity
+    );
+
+    expect(result).toEqual({ kind: "missingGoogleClientId" });
+  });
+
+  it("should handle successful registration", async () => {
+    const mockUserNumber = BigInt(12345);
+    const mockActor = {
+      openid_identity_registration_finish: vi.fn().mockResolvedValue({
+        Ok: { identity_number: mockUserNumber },
+      }),
+    } as unknown as ActorSubclass<_SERVICE>;
+
+    // Mock createActor to return our mockActor
+    const connection = new Connection("aaaaa-aa", DEFAULT_INIT, mockActor);
+    vi.spyOn(connection, "createActor").mockResolvedValue(mockActor);
+
+    const getGoogleClientId = () => "mock-client-id";
+
+    // Mock the fromJwt method
+    const mockAuthConnection = {} as AuthenticatedConnection;
+    vi.spyOn(connection, "fromJwt").mockResolvedValue(mockAuthConnection);
+
+    const result = await connection.openid_identity_registration_finish(
+      getGoogleClientId,
+      mockIdentity
+    );
+
+    expect(result).toEqual({
+      kind: "loginSuccess",
+      connection: mockAuthConnection,
+      userNumber: mockUserNumber,
+      showAddCurrentDevice: false,
+    });
+    expect(mockActor.openid_identity_registration_finish).toHaveBeenCalledWith({
+      jwt: mockJwt,
+      salt: mockSalt,
+    });
+  });
+
+  it("should handle API errors", async () => {
+    const mockError = new Error("API Error");
+    const mockActor = {
+      openid_identity_registration_finish: vi.fn().mockRejectedValue(mockError),
+    } as unknown as ActorSubclass<_SERVICE>;
+
+    const connection = new Connection("aaaaa-aa", DEFAULT_INIT, mockActor);
+    vi.spyOn(connection, "createActor").mockResolvedValue(mockActor);
+
+    const getGoogleClientId = () => "mock-client-id";
+
+    const result = await connection.openid_identity_registration_finish(
+      getGoogleClientId,
+      mockIdentity
+    );
+
+    expect(result).toEqual({
+      kind: "apiError",
+      error: mockError,
+    });
+  });
+
+  it("should handle unknown errors", async () => {
+    const mockActor = {
+      openid_identity_registration_finish: vi
+        .fn()
+        .mockRejectedValue("Unknown error"),
+    } as unknown as ActorSubclass<_SERVICE>;
+
+    const connection = new Connection("aaaaa-aa", DEFAULT_INIT, mockActor);
+    vi.spyOn(connection, "createActor").mockResolvedValue(mockActor);
+
+    const getGoogleClientId = () => "mock-client-id";
+
+    const result = await connection.openid_identity_registration_finish(
+      getGoogleClientId,
+      mockIdentity
+    );
+
+    expect(result).toEqual({
+      kind: "apiError",
+      error: new Error("Unknown error when registering"),
+    });
+  });
+
+  it("should handle registration errors", async () => {
+    const mockActor = {
+      openid_identity_registration_finish: vi.fn().mockResolvedValue({
+        Err: { NoRegistrationFlow: null },
+      }),
+    } as unknown as ActorSubclass<_SERVICE>;
+
+    const connection = new Connection("aaaaa-aa", DEFAULT_INIT, mockActor);
+    vi.spyOn(connection, "createActor").mockResolvedValue(mockActor);
+
+    const getGoogleClientId = () => "mock-client-id";
+
+    const result = await connection.openid_identity_registration_finish(
+      getGoogleClientId,
+      mockIdentity
+    );
+
+    expect(result).toEqual({ kind: "noRegistrationFlow" });
   });
 });

--- a/src/frontend/src/utils/iiConnection.test.ts
+++ b/src/frontend/src/utils/iiConnection.test.ts
@@ -789,7 +789,7 @@ vi.mock("$src/utils/openID", () => ({
 }));
 
 vi.mock("$src/components/loader", () => ({
-  withLoader: (fn: () => Promise<any>) => fn(),
+  withLoader: <T>(fn: () => Promise<T>) => fn(),
 }));
 
 describe("openid_identity_registration_finish", () => {
@@ -798,8 +798,7 @@ describe("openid_identity_registration_finish", () => {
     getPublicKey: () => ({
       toDer: () => new Uint8Array([1, 2, 3]).buffer,
     }),
-    sign: (blob: ArrayBuffer) =>
-      Promise.resolve(new Uint8Array([4, 5, 6]).buffer),
+    sign: () => Promise.resolve(new Uint8Array([4, 5, 6]).buffer),
   } as unknown as SignIdentity;
 
   beforeEach(() => {


### PR DESCRIPTION
# Motivation
In order to be able to register with an OpenID credential, the Connection class needs to be able to call the appropriate backend endpoints.

# Changes

Add the `openid_identity_registration_finish` method on the Connection class. I stayed with the rusty naming because the other identity registration related methods (`identity_registration_start` and `identity_registration_finish`) do the same. The error handling is the same as in `identity_registration_finish`, so I extracted it into a private method.

# Tests

No new tests were added.




<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/mobile/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/mobile/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/mobile/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/mobile/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/mobile/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/mobile/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/857e9f550/mobile/displayUserNumberTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->



