### PR TITLE
OpenID Registration: Extend JWT validity

### DIFF
--- a/src/internet_identity/src/openid/google.rs
+++ b/src/internet_identity/src/openid/google.rs
@@ -45,7 +45,9 @@ const NANOSECONDS_PER_SECOND: u64 = 1_000_000_000;
 
 // A JWT is only valid for a very small window, even if the JWT itself says it's valid for longer,
 // we only need it right after it's being issued to create a JWT delegation with its own expiry.
-const MAX_VALIDITY_WINDOW: u64 = 5 * MINUTE_NS; // Same as ingress expiry
+// As the JWT is also used for registration, which may include longer user interaction,
+// we are using 10 minutes to account for potential clock offsets as well as users.
+const MAX_VALIDITY_WINDOW: u64 = 10 * MINUTE_NS; // Same as ingress expiry
 
 // Maximum length of the email claim in the Google JWT, in practice we expect Google to already
 // validate the email on their end for a sane maximum length. This is an additional sanity check.


### PR DESCRIPTION
# Motivation

In order to account for user interaction in addition to potential clock offsets, we are extending the JWT validity to 10 minutes.

# Changes

Extending the JWT validity to 10 minutes and adding a comment to explain.

# Tests

No new tests were added.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47df92deb/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47df92deb/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47df92deb/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47df92deb/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47df92deb/desktop/displayManageTempKey.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47df92deb/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47df92deb/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47df92deb/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/47df92deb/mobile/displaySeedPhrase.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

