### PR TITLE
DO NOT REVIEW OR MERGE OpenID Registration: Implement user flow

### DIFF
--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -122,7 +122,7 @@ export const registerFlow = async ({
     pinAllowed: await pinAllowed(),
     googleAllowed:
       OPENID_AUTHENTICATION.isEnabled() &&
-      (connection.canisterConfig?.openid_google?.[0]?.length ?? 0) > 0,
+      (await (connection.canisterConfig?.openid_google?.[0]?.length ?? 0)) > 0,
     origin: deviceOrigin,
   });
   if (savePasskeyResult === "canceled") {

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -4,6 +4,7 @@ import {
   PinIdentityMaterial,
   constructPinIdentity,
 } from "$src/crypto/pinIdentity";
+import { OPENID_AUTHENTICATION } from "$src/featureFlags";
 import { anyFeatures } from "$src/features";
 import { idbStorePinIdentityMaterial } from "$src/flows/pin/idb";
 import { registerDisabled } from "$src/flows/registerDisabled";
@@ -22,6 +23,7 @@ import {
   InvalidAuthnMethod,
   InvalidCaller,
   LoginSuccess,
+  MissingGoogleClientId,
   NoRegistrationFlow,
   RateLimitExceeded,
   RegisterNoSpace,
@@ -39,6 +41,7 @@ import type { UAParser } from "ua-parser-js";
 import { tempKeyWarningBox } from "../manage/tempKeys";
 import { setPinFlow } from "../pin/setPin";
 import { precomputeFirst, promptCaptcha } from "./captcha";
+import { chooseRegistrationMethod } from "./chooseRegistrationMethod";
 import { displayUserNumberWarmup } from "./finish";
 import { savePasskeyOrPin } from "./passkey";
 
@@ -47,10 +50,12 @@ export const registerFlow = async ({
   identityRegistrationStart,
   checkCaptcha,
   identityRegistrationFinish,
+  openIdRegistrationFinish,
   storePinIdentity,
   registrationAllowed,
   pinAllowed,
   uaParser,
+  connection,
 }: {
   identityRegistrationStart: () => Promise<
     | RegistrationFlowStepSuccess
@@ -82,6 +87,15 @@ export const registerFlow = async ({
     | RegisterNoSpace
     | InvalidAuthnMethod
   >;
+  openIdRegistrationFinish: () => Promise<
+    | LoginSuccess
+    | ApiError
+    | NoRegistrationFlow
+    | UnexpectedCall
+    | RegisterNoSpace
+    | InvalidAuthnMethod
+    | MissingGoogleClientId
+  >;
   storePinIdentity: (opts: {
     userNumber: bigint;
     pinIdentityMaterial: PinIdentityMaterial;
@@ -89,6 +103,7 @@ export const registerFlow = async ({
   registrationAllowed: { isAllowed: boolean; allowedOrigins: string[] };
   pinAllowed: () => Promise<boolean>;
   uaParser: PreloadedUAParser;
+  connection: Connection;
 }): Promise<
   | (LoginSuccess & { authnMethod: "passkey" | "pin" })
   | ApiError
@@ -99,6 +114,7 @@ export const registerFlow = async ({
   | InvalidCaller
   | AlreadyInProgress
   | RateLimitExceeded
+  | MissingGoogleClientId
   | "canceled"
 > => {
   if (!registrationAllowed.isAllowed) {
@@ -115,6 +131,44 @@ export const registerFlow = async ({
   // We register the device's origin in the current domain.
   // If we want to change it, we need to change this line.
   const deviceOrigin = window.location.origin;
+
+  // Prompt the user whether they want to use
+  // for now, this is behind a feature flag -
+  // in addition to only being shown if google is configured
+  let registrationMethodResult: "google" | "passkey" | "canceled";
+
+  if (
+    OPENID_AUTHENTICATION.isEnabled() &&
+    (connection.canisterConfig?.openid_google?.[0]?.length ?? 0) > 0
+  ) {
+    registrationMethodResult = await chooseRegistrationMethod();
+  } else {
+    registrationMethodResult = "passkey";
+  }
+
+  if (registrationMethodResult === "google") {
+    const _startResult = await captchaIfNecessary(flowStart, checkCaptcha);
+    if (_startResult === "canceled") {
+      return "canceled";
+    } else if (_startResult.kind !== "registrationFlowStepSuccess") {
+      return _startResult;
+    }
+
+    const openIdResult = await openIdRegistrationFinish();
+
+    if (openIdResult.kind === "loginSuccess") {
+      analytics.event("registration-openid");
+      return {
+        ...openIdResult,
+        authnMethod: "passkey", //TODO decide if we want to add openid here
+      };
+    } else {
+      return "canceled";
+    }
+  } else if (registrationMethodResult === "canceled") {
+    return "canceled";
+  }
+
   const savePasskeyResult = await savePasskeyOrPin({
     pinAllowed: await pinAllowed(),
     origin: deviceOrigin,
@@ -198,28 +252,9 @@ export const registerFlow = async ({
     authnMethod: "pin" | "passkey";
   } = result_;
 
-  const startResult = await flowStart();
-  if (startResult.kind !== "registrationFlowStepSuccess") {
-    analytics.event("registration-start-error");
-    return startResult;
-  }
-  startResult satisfies RegistrationFlowStepSuccess;
-
-  if (startResult.nextStep.step === "checkCaptcha") {
-    analytics.event("registration-captcha");
-    const captchaResult = await promptCaptcha({
-      captcha_png_base64: startResult.nextStep.captcha_png_base64,
-      checkCaptcha,
-    });
-    if (captchaResult === "canceled") {
-      analytics.event("registration-captcha-cancelled");
-      return "canceled";
-    }
-    if (captchaResult.kind !== "registrationFlowStepSuccess") {
-      analytics.event("registration-captcha-error");
-      return captchaResult;
-    }
-    captchaResult satisfies RegistrationFlowStepSuccess;
+  const startResult = await captchaIfNecessary(flowStart, checkCaptcha);
+  if (startResult === "canceled") {
+    return "canceled";
   }
 
   const result = await withLoader(() =>
@@ -269,6 +304,9 @@ export const getRegisterFlowOpts = async ({
   const tempIdentity = await ECDSAKeyIdentity.generate({
     extractable: false,
   });
+  const getGoogleClientId = () =>
+    connection.canisterConfig.openid_google[0]?.[0]?.client_id;
+
   const registrationAllowed =
     // Allow registration in DEV mode
     anyFeatures() ||
@@ -292,8 +330,14 @@ export const getRegisterFlowOpts = async ({
         identity,
         authnMethod,
       }),
+    openIdRegistrationFinish: async () =>
+      await connection.openid_identity_registration_finish(
+        getGoogleClientId,
+        tempIdentity
+      ),
     uaParser,
     storePinIdentity: idbStorePinIdentityMaterial,
+    connection,
   };
 };
 
@@ -453,3 +497,63 @@ export const loadUAParser = async (): Promise<typeof UAParser | undefined> => {
     console.error(e);
   }
 };
+
+/**
+ * Handles the captcha verification step if required by the registration flow
+ * @returns The registration flow step result or "canceled" if the user canceled
+ */
+async function captchaIfNecessary(
+  flowStart: () => Promise<
+    | RegistrationFlowStepSuccess
+    | ApiError
+    | InvalidCaller
+    | AlreadyInProgress
+    | RateLimitExceeded
+  >,
+  checkCaptcha: (
+    captchaSolution: string
+  ) => Promise<
+    | RegistrationFlowStepSuccess
+    | ApiError
+    | NoRegistrationFlow
+    | UnexpectedCall
+    | WrongCaptchaSolution
+  >
+): Promise<
+  | RegistrationFlowStepSuccess
+  | ApiError
+  | InvalidCaller
+  | AlreadyInProgress
+  | RateLimitExceeded
+  | NoRegistrationFlow
+  | UnexpectedCall
+  | "canceled"
+> {
+  const startResult = await flowStart();
+  if (startResult.kind !== "registrationFlowStepSuccess") {
+    analytics.event("registration-start-error");
+    return startResult;
+  }
+  startResult satisfies RegistrationFlowStepSuccess;
+
+  if (startResult.nextStep.step === "checkCaptcha") {
+    analytics.event("registration-captcha");
+    const captchaResult = await promptCaptcha({
+      captcha_png_base64: startResult.nextStep.captcha_png_base64,
+      checkCaptcha,
+    });
+    if (captchaResult === "canceled") {
+      analytics.event("registration-captcha-cancelled");
+      return "canceled";
+    }
+    if (captchaResult.kind !== "registrationFlowStepSuccess") {
+      analytics.event("registration-captcha-error");
+      return captchaResult;
+    }
+    captchaResult satisfies RegistrationFlowStepSuccess;
+    return captchaResult;
+  }
+
+  // If no captcha was needed, return the original success result
+  return startResult;
+}

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -122,7 +122,7 @@ export const registerFlow = async ({
     pinAllowed: await pinAllowed(),
     googleAllowed:
       OPENID_AUTHENTICATION.isEnabled() &&
-      (await (connection.canisterConfig?.openid_google?.[0]?.length ?? 0)) > 0,
+      (connection.canisterConfig?.openid_google?.[0]?.length ?? 0) > 0,
     origin: deviceOrigin,
   });
   if (savePasskeyResult === "canceled") {

--- a/src/frontend/src/flows/register/passkey.json
+++ b/src/frontend/src/flows/register/passkey.json
@@ -3,7 +3,8 @@
     "select": "Select",
     "cancel": "Cancel",
     "save_passkey": "Create Passkey",
-    "without_passkey": "Continue without Passkey",
+    "with_pin": "Continue with PIN",
+    "with_openid_google": "Continue with Google",
     "and_complete_prompts": "and complete the prompts that pop-up on your device",
 
     "what_is_passkey": "What is a passkey?",

--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -154,6 +154,13 @@ export const savePasskeyPinOrOpenID = async ({
       });
     });
   }
+  try {
+    const identity = await withLoader(() => constructIdentity({}));
+    return identity;
+  } catch (e) {
+    toast.error(errorMessage(e));
+    return undefined;
+  }
 };
 
 // Return an appropriate error message depending on the (inferred) type of WebAuthn error

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -26,6 +26,7 @@ const DEFAULT_INIT: InternetIdentityInit = {
   related_origins: [],
   fetch_root_key: [],
   enable_dapps_explorer: [],
+  is_production: [],
 };
 
 const registerSuccessToastTemplate = (result: unknown) => html`
@@ -113,6 +114,16 @@ const registerFlowOpts: RegisterFlowOpts = {
       showAddCurrentDevice: false,
     };
   },
+  openIdRegistrationFinish: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    return {
+      kind: "loginSuccess",
+      userNumber: BigInt(12356),
+      connection: mockConnection,
+      showAddCurrentDevice: false,
+    };
+  },
   registrationAllowed: {
     isAllowed: true,
     allowedOrigins: ["https://identity.ic0.app"] as string[],
@@ -123,6 +134,7 @@ const registerFlowOpts: RegisterFlowOpts = {
   },
   pinAllowed: () => Promise.resolve(false),
   uaParser: Promise.resolve(undefined),
+  connection: mockConnection,
 } as const;
 
 export const iiFlows: Record<string, () => void> = {

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -114,16 +114,6 @@ const registerFlowOpts: RegisterFlowOpts = {
       showAddCurrentDevice: false,
     };
   },
-  openIdRegistrationFinish: async () => {
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-
-    return {
-      kind: "loginSuccess",
-      userNumber: BigInt(12356),
-      connection: mockConnection,
-      showAddCurrentDevice: false,
-    };
-  },
   registrationAllowed: {
     isAllowed: true,
     allowedOrigins: ["https://identity.ic0.app"] as string[],


### PR DESCRIPTION
WARNING: This PR will fail its tests unless the other related PRs are merged first.

# Motivation

In order to allow for registration via OpenID with Google, we need to add the previously developed template and methods to the existing registration flow.

# Changes

Add OpenID registration to the registration flow behind feature flag and google config. Extract the captcha functionality into a function to keep the code dry.

# Tests

No new tests were added for now. We may look into adding e2e for OpenID at some point, though it is non-trivial and would require non-negligible effort.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/desktop/savePasskeyWithPin.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/allowCredentials.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/6c97da0ff/mobile/savePasskeyWithPin.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


