### PR TITLE
Add missing tests for dapps_explorer_enabled config filed

### DIFF
--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -3,6 +3,7 @@ mod archive_config;
 mod assigned_user_number_range;
 mod canister_creation_cycles_cost;
 mod captcha_config;
+mod enable_dapps_explorer;
 mod fetch_root_key;
 mod openid_google;
 mod register_rate_limit;

--- a/src/internet_identity/tests/integration/config/enable_dapps_explorer.rs
+++ b/src/internet_identity/tests/integration/config/enable_dapps_explorer.rs
@@ -9,7 +9,12 @@ fn should_init_default() {
     let env = env();
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
-    assert_eq!(api::config(&env, canister_id).unwrap().enable_dapps_explorer, None);
+    assert_eq!(
+        api::config(&env, canister_id)
+            .unwrap()
+            .enable_dapps_explorer,
+        None
+    );
 }
 
 #[test]
@@ -33,7 +38,9 @@ fn should_init_config() {
     for config in configs {
         let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
         assert_eq!(
-            api::config(&env, canister_id).unwrap().enable_dapps_explorer,
+            api::config(&env, canister_id)
+                .unwrap()
+                .enable_dapps_explorer,
             config.enable_dapps_explorer
         );
     }
@@ -52,7 +59,9 @@ fn should_enable_config() {
     config.enable_dapps_explorer = enabled_value;
     upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
     assert_eq!(
-        api::config(&env, canister_id).unwrap().enable_dapps_explorer,
+        api::config(&env, canister_id)
+            .unwrap()
+            .enable_dapps_explorer,
         enabled_value
     );
 }
@@ -70,7 +79,9 @@ fn should_disable_config() {
     config.enable_dapps_explorer = disabled_value;
     upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
     assert_eq!(
-        api::config(&env, canister_id).unwrap().enable_dapps_explorer,
+        api::config(&env, canister_id)
+            .unwrap()
+            .enable_dapps_explorer,
         disabled_value
     );
 }
@@ -88,7 +99,9 @@ fn should_update_config() {
     config.enable_dapps_explorer = updated_value;
     upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
     assert_eq!(
-        api::config(&env, canister_id).unwrap().enable_dapps_explorer,
+        api::config(&env, canister_id)
+            .unwrap()
+            .enable_dapps_explorer,
         updated_value
     );
 }
@@ -129,7 +142,9 @@ fn should_retain_config() {
         )
         .unwrap();
         assert_eq!(
-            api::config(&env, canister_id).unwrap().enable_dapps_explorer,
+            api::config(&env, canister_id)
+                .unwrap()
+                .enable_dapps_explorer,
             config.enable_dapps_explorer
         );
     }

--- a/src/internet_identity/tests/integration/config/enable_dapps_explorer.rs
+++ b/src/internet_identity/tests/integration/config/enable_dapps_explorer.rs
@@ -1,0 +1,136 @@
+use canister_tests::api::internet_identity as api;
+use canister_tests::framework::{
+    env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
+};
+use internet_identity_interface::internet_identity::types::{InternetIdentityInit, OpenIdConfig};
+
+#[test]
+fn should_init_default() {
+    let env = env();
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
+    assert_eq!(api::config(&env, canister_id).unwrap().enable_dapps_explorer, None);
+}
+
+#[test]
+fn should_init_config() {
+    let env = env();
+    let configs = vec![
+        InternetIdentityInit {
+            enable_dapps_explorer: None,
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            enable_dapps_explorer: Some(false),
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            enable_dapps_explorer: Some(true),
+            ..Default::default()
+        },
+    ];
+
+    for config in configs {
+        let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+        assert_eq!(
+            api::config(&env, canister_id).unwrap().enable_dapps_explorer,
+            config.enable_dapps_explorer
+        );
+    }
+}
+
+#[test]
+fn should_enable_config() {
+    let env = env();
+    let mut config = InternetIdentityInit {
+        enable_dapps_explorer: None,
+        ..Default::default()
+    };
+    let enabled_value = Some(true);
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+    config.enable_dapps_explorer = enabled_value;
+    upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().enable_dapps_explorer,
+        enabled_value
+    );
+}
+
+#[test]
+fn should_disable_config() {
+    let env = env();
+    let mut config = InternetIdentityInit {
+        enable_dapps_explorer: Some(true),
+        ..Default::default()
+    };
+    let disabled_value = Some(false);
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+    config.enable_dapps_explorer = disabled_value;
+    upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().enable_dapps_explorer,
+        disabled_value
+    );
+}
+
+#[test]
+fn should_update_config() {
+    let env = env();
+    let mut config = InternetIdentityInit {
+        enable_dapps_explorer: Some(false),
+        ..Default::default()
+    };
+    let updated_value = Some(true);
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+    config.enable_dapps_explorer = updated_value;
+    upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), Some(config.clone())).unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().enable_dapps_explorer,
+        updated_value
+    );
+}
+
+#[test]
+fn should_retain_config() {
+    let env = env();
+    let configs = vec![
+        InternetIdentityInit {
+            enable_dapps_explorer: None,
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            enable_dapps_explorer: Some(false),
+            ..Default::default()
+        },
+        InternetIdentityInit {
+            enable_dapps_explorer: Some(true),
+            ..Default::default()
+        },
+    ];
+
+    for config in configs {
+        let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+        // No config argument
+        upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), None).unwrap();
+        // Unrelated config change
+        upgrade_ii_canister_with_arg(
+            &env,
+            canister_id,
+            II_WASM.clone(),
+            Some(InternetIdentityInit {
+                openid_google: Some(Some(OpenIdConfig {
+                    client_id: "https://example.com".into(),
+                })),
+                ..Default::default()
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            api::config(&env, canister_id).unwrap().enable_dapps_explorer,
+            config.enable_dapps_explorer
+        );
+    }
+}


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

The config field `dapps_explorer_enabled` was not being tested in isolation.

# Changes

* Added `enable_dapps_explorer` module to the list of configurations in `src/internet_identity/tests/integration/config.rs`.
* Created `src/internet_identity/tests/integration/config/enable_dapps_explorer.rs` to test the `enable_dapps_explorer` configuration, including:
  - Initialization with default and specific configurations.
  - Enabling and disabling the configuration.
  - Updating and retaining the configuration through canister upgrades.
