### PR TITLE
Remove add current device screen

### DIFF
--- a/src/frontend/src/flows/authorize/index.ts
+++ b/src/frontend/src/flows/authorize/index.ts
@@ -7,7 +7,6 @@ import { caretDownIcon } from "$src/components/icons";
 import { withLoader } from "$src/components/loader";
 import { showMessage } from "$src/components/message";
 import { showSpinner } from "$src/components/spinner";
-import { DOMAIN_COMPATIBILITY } from "$src/featureFlags";
 import { getDapps } from "$src/flows/dappsExplorer/dapps";
 import { recoveryWizard } from "$src/flows/recovery/recoveryWizard";
 import { I18n } from "$src/i18n";
@@ -21,7 +20,6 @@ import { nonNullish } from "@dfinity/utils";
 import { TemplateResult, html } from "lit-html";
 import { asyncReplace } from "lit-html/directives/async-replace.js";
 import { validateDerivationOrigin } from "../../utils/validateDerivationOrigin";
-import { registerCurrentDeviceCurrentOrigin } from "../addDevice/registerCurrentDeviceCurrentOrigin";
 import { fetchDelegation } from "./fetchDelegation";
 import copyJson from "./index.json";
 import { AuthContext, authenticationProtocol } from "./postMessageInterface";
@@ -214,12 +212,15 @@ const authenticate = async (
     autoSelectionIdentity: autoSelectionIdentity,
   });
 
-  if (authSuccess.showAddCurrentDevice && DOMAIN_COMPATIBILITY.isEnabled()) {
-    await registerCurrentDeviceCurrentOrigin(
-      authSuccess.userNumber,
-      authSuccess.connection
-    );
-  }
+  // TODO: Remove if we see more problems logging in.
+  // The reason to remove this is that two power users (Björn and Jan) were confused with this screen.
+  // If technical power users are confused, then normal users will also be confused.
+  // if (authSuccess.showAddCurrentDevice && DOMAIN_COMPATIBILITY.isEnabled()) {
+  //   await registerCurrentDeviceCurrentOrigin(
+  //     authSuccess.userNumber,
+  //     authSuccess.connection
+  //   );
+  // }
 
   // at this point, derivationOrigin is either validated or undefined
   const derivationOrigin =


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

This step has confused power users. Therefore, any other user will also be confused.

# Changes

* Comment the code that renders the screen to register the current device in the current origin.

# Tests

No new functionality added.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b732b6217/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b732b6217/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b732b6217/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b732b6217/mobile/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b732b6217/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b732b6217/mobile/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
