### PR TITLE
OpenID: Improve anchor management

### DIFF
--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -102,6 +102,9 @@ export const authenticateBox = async ({
   authnMethod: "pin" | "passkey" | "recovery";
   showAddCurrentDevice: boolean;
 }> => {
+  const getGoogleClientId = () =>
+    connection.canisterConfig.openid_google[0]?.[0]?.client_id;
+
   const promptAuth = async (autoSelectIdentity?: bigint) =>
     authenticateBoxFlow<PinIdentityMaterial>({
       i18n,
@@ -114,6 +117,7 @@ export const authenticateBox = async ({
       registerFlowOpts: await getRegisterFlowOpts({
         connection,
         allowPinRegistration,
+        getGoogleClientId,
       }),
       verifyPinValidity: ({ userNumber, pinIdentityMaterial }) =>
         pinIdentityAuthenticatorValidity({

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -113,6 +113,7 @@ export const registerFlow = async ({
   | InvalidCaller
   | AlreadyInProgress
   | RateLimitExceeded
+  | MissingGoogleClientId
   | "canceled"
 > => {
   if (!registrationAllowed.isAllowed) {
@@ -184,7 +185,7 @@ export const registerFlow = async ({
           authnMethod: "google",
         };
       } else {
-        return "canceled";
+        return openIdResult;
       }
     } else {
       const identity = savePasskeyResult;

--- a/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
+++ b/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
@@ -214,9 +214,10 @@ fn create_identity(arg: &CreateIdentityData) -> Result<IdentityNumber, IdRegFini
             let open_id_credential =
                 openid::verify(jwt, salt).map_err(IdRegFinishError::InvalidAuthnMethod)?;
 
-            let add_credential_operation = anchor_management::add_openid_credential(&mut identity, open_id_credential.clone())
+            let add_credential_operation =
+                anchor_management::add_openid_credential(&mut identity, open_id_credential.clone())
                     .map_err(|err| IdRegFinishError::InvalidAuthnMethod(err.to_string()))?;
-            
+
             //TODO: add activity bookkeeping
 
             let Operation::AddOpenIdCredential { iss } = add_credential_operation else {

--- a/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
+++ b/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
@@ -3,9 +3,9 @@ use crate::anchor_management::registration::captcha::{
 };
 use crate::anchor_management::registration::rate_limit::process_rate_limit;
 use crate::anchor_management::registration::Base64;
-use crate::anchor_management::{activity_bookkeeping, post_operation_bookkeeping};
+use crate::anchor_management::{self, activity_bookkeeping, post_operation_bookkeeping};
 use crate::state::flow_states::RegistrationFlowState;
-use crate::storage::anchor::Device;
+use crate::storage::anchor::{self, Device};
 use crate::{openid, state};
 use candid::Principal;
 use ic_cdk::api::time;
@@ -214,14 +214,16 @@ fn create_identity(arg: &CreateIdentityData) -> Result<IdentityNumber, IdRegFini
             let open_id_credential =
                 openid::verify(jwt, salt).map_err(IdRegFinishError::InvalidAuthnMethod)?;
 
-            identity
-                .add_openid_credential(open_id_credential.clone())
-                .map_err(|err| IdRegFinishError::InvalidAuthnMethod(err.to_string()))?;
-            //TODO: add bookkeeping
+            let add_credential_operation = anchor_management::add_openid_credential(&mut identity, open_id_credential.clone())
+                    .map_err(|err| IdRegFinishError::InvalidAuthnMethod(err.to_string()))?;
+            
+            //TODO: add activity bookkeeping
 
-            Operation::RegisterAnchorWithOpenIdCredential {
-                iss: open_id_credential.iss.clone(),
-            }
+            let Operation::AddOpenIdCredential { iss } = add_credential_operation else {
+                unreachable!()
+            };
+
+            Operation::RegisterAnchorWithOpenIdCredential { iss }
         }
     };
 

--- a/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
+++ b/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
@@ -5,7 +5,7 @@ use crate::anchor_management::registration::rate_limit::process_rate_limit;
 use crate::anchor_management::registration::Base64;
 use crate::anchor_management::{self, activity_bookkeeping, post_operation_bookkeeping};
 use crate::state::flow_states::RegistrationFlowState;
-use crate::storage::anchor::{self, Device};
+use crate::storage::anchor::Device;
 use crate::{openid, state};
 use candid::Principal;
 use ic_cdk::api::time;

--- a/src/showcase/src/flows.ts
+++ b/src/showcase/src/flows.ts
@@ -125,6 +125,16 @@ const registerFlowOpts: RegisterFlowOpts = {
   pinAllowed: () => Promise.resolve(false),
   uaParser: Promise.resolve(undefined),
   googleAllowed: true,
+  openidIdentityRegistrationFinish: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    return {
+      kind: "loginSuccess",
+      userNumber: BigInt(12356),
+      connection: mockConnection,
+      showAddCurrentDevice: false,
+      authnMethod: "google",
+    };
+  },
 } as const;
 
 export const iiFlows: Record<string, () => void> = {


### PR DESCRIPTION
# Motivation

Fixes a bug in the OIDC registration that would allow multiple identities to be registered with the same credential

# Changes

Use anchor_management instead of adding credential directly to anchor. Add error management in frontend to display error properly.

# Tests

No new tests are added.
