### PR TITLE
OpenID bookkeeping integration tests

### DIFF
--- a/src/frontend/generated/internet_identity_idl.js
+++ b/src/frontend/generated/internet_identity_idl.js
@@ -220,7 +220,7 @@ export const idlFactory = ({ IDL }) => {
     'iss' : Iss,
     'sub' : Sub,
     'metadata' : MetadataMapV2,
-    'last_usage_timestamp' : Timestamp,
+    'last_usage_timestamp' : IDL.Opt(Timestamp),
   });
   const DeviceRegistrationInfo = IDL.Record({
     'tentative_device' : IDL.Opt(DeviceData),

--- a/src/frontend/generated/internet_identity_types.d.ts
+++ b/src/frontend/generated/internet_identity_types.d.ts
@@ -261,7 +261,7 @@ export interface OpenIdCredential {
   'iss' : Iss,
   'sub' : Sub,
   'metadata' : MetadataMapV2,
-  'last_usage_timestamp' : Timestamp,
+  'last_usage_timestamp' : [] | [Timestamp],
 }
 export type OpenIdCredentialAddError = {
     'OpenIdCredentialAlreadyRegistered' : null

--- a/src/frontend/src/flows/manage/linkedAccountsSection.ts
+++ b/src/frontend/src/flows/manage/linkedAccountsSection.ts
@@ -97,10 +97,10 @@ export const accountItem = ({
     },
   ];
 
-  const lastUsageTimeStamp = new Date(
-    Number(credential.last_usage_timestamp / BigInt(1000000))
-  );
-  const lastUsageFormattedString = formatLastUsage(lastUsageTimeStamp);
+  const lastUsageTimeStamp = credential.last_usage_timestamp[0];
+  const lastUsageFormattedString = nonNullish(lastUsageTimeStamp)
+    ? formatLastUsage(new Date(Number(lastUsageTimeStamp / BigInt(1000000))))
+    : undefined;
   const name = getMetadataString(credential.metadata, "name");
   const email = getMetadataString(credential.metadata, "email");
   const picture = getMetadataString(credential.metadata, "picture");
@@ -142,9 +142,11 @@ export const accountItem = ({
                   >
                   <span class="t-muted">${copy.current_account_label}</span>
                 </div>`
-              : html`<div class="t-muted">
+              : nonNullish(lastUsageFormattedString)
+              ? html`<div class="t-muted">
                   ${copy.last_used}: ${lastUsageFormattedString}
                 </div>`
+              : ""
           }
         </div>
       </div>

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -362,7 +362,7 @@ type OpenIdCredential = record {
     iss : Iss;
     sub : Sub;
     aud : Aud;
-    last_usage_timestamp : Timestamp;
+    last_usage_timestamp : opt Timestamp;
     metadata : MetadataMapV2;
 };
 

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -246,7 +246,7 @@ fn should_register_openid_credential_only_for_a_single_anchor() {
         iss: "https://example.com".into(),
         sub: "example-sub".into(),
         aud: "example-aud".into(),
-        last_usage_timestamp: 0,
+        last_usage_timestamp: None,
         metadata: HashMap::default(),
     };
 

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -31,7 +31,7 @@ pub struct OpenIdCredential {
     pub iss: Iss,
     pub sub: Sub,
     pub aud: Aud,
-    pub last_usage_timestamp: Timestamp,
+    pub last_usage_timestamp: Option<Timestamp>,
     pub metadata: HashMap<String, MetadataEntryV2>,
 }
 
@@ -192,7 +192,7 @@ impl ExampleProvider {
             iss: self.issuer().into(),
             sub: "example-sub".into(),
             aud: "example-aud".into(),
-            last_usage_timestamp: 0,
+            last_usage_timestamp: None,
             metadata: HashMap::new(),
         }
     }

--- a/src/internet_identity/src/openid/google.rs
+++ b/src/internet_identity/src/openid/google.rs
@@ -124,7 +124,7 @@ impl OpenIdProvider for Provider {
             iss: claims.iss,
             sub: claims.sub,
             aud: claims.aud,
-            last_usage_timestamp: time(),
+            last_usage_timestamp: None,
             metadata,
         })
     }
@@ -412,7 +412,7 @@ fn should_return_credential() {
         iss: claims.iss,
         sub: claims.sub,
         aud: claims.aud,
-        last_usage_timestamp: time(),
+        last_usage_timestamp: None,
         metadata: HashMap::from([
             (
                 "email".into(),

--- a/src/internet_identity/src/stats/activity_stats/activity_counter/authn_method_counter.rs
+++ b/src/internet_identity/src/stats/activity_stats/activity_counter/authn_method_counter.rs
@@ -62,7 +62,7 @@ impl ActivityCounter for AuthnMethodCounter {
         // only count authentications on devices that have not already been counted
         // i.e. the last usage timestamp is before the start of the window
         if let Some(timestamp) = last_usage_timestamp {
-            if timestamp > self.start_timestamp {
+            if timestamp >= self.start_timestamp {
                 return;
             }
         }

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -281,7 +281,7 @@ impl Anchor {
             .chain(
                 self.openid_credentials
                     .iter()
-                    .map(|c| c.last_usage_timestamp),
+                    .filter_map(|c| c.last_usage_timestamp),
             )
             .max()
     }
@@ -412,7 +412,7 @@ impl Anchor {
         else {
             return Err(AnchorError::OpenIdCredentialNotFound);
         };
-        openid_credential.last_usage_timestamp = timestamp;
+        openid_credential.last_usage_timestamp = Some(timestamp);
         Ok(())
     }
 

--- a/src/internet_identity/src/storage/anchor/tests.rs
+++ b/src/internet_identity/src/storage/anchor/tests.rs
@@ -643,7 +643,7 @@ fn openid_credential(n: u8) -> OpenIdCredential {
         iss: "https://example.com".into(),
         sub: n.to_string(),
         aud: "example-aud".into(),
-        last_usage_timestamp: n.into(),
+        last_usage_timestamp: Some(n.into()),
         metadata: HashMap::default(),
     }
 }

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -220,7 +220,7 @@ fn openid_credential(n: u8) -> OpenIdCredential {
         iss: "https://example.com".into(),
         sub: n.to_string(),
         aud: "example-aud".into(),
-        last_usage_timestamp: n.into(),
+        last_usage_timestamp: Some(n.into()),
         metadata: HashMap::default(),
     }
 }

--- a/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
+++ b/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
@@ -256,8 +256,7 @@ fn should_report_active_openid_authn_methods() {
     // OpenID test data and fetch Google certs (mock)
     let (jwt, salt, _claims, test_time, test_principal, _test_authn_method) =
         openid::openid_test_data();
-    let time_to_advance = Duration::from_millis(test_time) - Duration::from_nanos(time(&env));
-    env.advance_time(time_to_advance);
+    env.advance_time(Duration::from_millis(test_time) - Duration::from_nanos(time(&env)));
 
     // Ensure stats are initially absent
     assert!(

--- a/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
+++ b/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
@@ -11,7 +11,7 @@ use canister_tests::framework::{
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose,
-    AuthnMethodSecuritySettings, MetadataEntryV2, PublicKeyAuthn, WebAuthn,
+    AuthnMethodSecuritySettings, MetadataEntryV2, WebAuthn,
 };
 use pocket_ic::CallError;
 use serde_bytes::ByteBuf;

--- a/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
+++ b/src/internet_identity/tests/integration/activity_stats/authn_methods.rs
@@ -246,6 +246,7 @@ fn should_keep_stats_across_upgrades() -> Result<(), CallError> {
 }
 
 /// Tests that active OpenID authn_methods are counted correctly.
+/// TODO: ID-155 Create OpenID mock data on-demand and use this instead in unit/integration tests
 #[test]
 fn should_report_active_openid_authn_methods() {
     // Create II instance that mocks Google certs

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -224,7 +224,7 @@ static CLIENT_ID: &str = "360587991668-63bpc1gngp1s5gbo1aldal4a50c1j0bb.apps.goo
 
 #[derive(Deserialize)]
 #[allow(dead_code)]
-struct Claims {
+pub struct Claims {
     iss: String,
     sub: String,
     aud: String,
@@ -247,7 +247,7 @@ struct Certs {
     keys: Vec<Jwk>,
 }
 
-fn setup_canister(env: &PocketIc) -> Principal {
+pub fn setup_canister(env: &PocketIc) -> Principal {
     let args = InternetIdentityInit {
         openid_google: Some(Some(OpenIdConfig {
             client_id: CLIENT_ID.to_string(),
@@ -309,7 +309,7 @@ fn mock_google_certs_response(env: &PocketIc) {
     }
 }
 
-fn openid_test_data() -> (String, [u8; 32], Claims, u64, Principal, AuthnMethodData) {
+pub fn openid_test_data() -> (String, [u8; 32], Claims, u64, Principal, AuthnMethodData) {
     // This JWT is for testing purposes, it's already been expired before this commit has been made,
     // additionally the audience of this JWT is a test Google client registration, not production.
     let jwt = "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc2M2Y3YzRjZDI2YTFlYjJiMWIzOWE4OGY0NDM0ZDFmNGQ5YTM2OGIiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiIzNjA1ODc5OTE2NjgtNjNicGMxZ25ncDFzNWdibzFhbGRhbDRhNTBjMWowYmIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiIzNjA1ODc5OTE2NjgtNjNicGMxZ25ncDFzNWdibzFhbGRhbDRhNTBjMWowYmIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDcxNzAzNjg4OTgyMTkwMzU3MjEiLCJoZCI6ImRmaW5pdHkub3JnIiwiZW1haWwiOiJhbmRyaS5zY2hhdHpAZGZpbml0eS5vcmciLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibm9uY2UiOiJmQkcxS3IzUWt5Z0dHelNJWG9Pd2p3RF95QjhXS0FfcVJPUlZjMFp0WHlJIiwibmJmIjoxNzQwNTgzNDEyLCJuYW1lIjoiQW5kcmkgU2NoYXR6IiwicGljdHVyZSI6Imh0dHBzOi8vbGgzLmdvb2dsZXVzZXJjb250ZW50LmNvbS9hL0FDZzhvY0k1YUU0Mmo0Ml9JcEdqSHFjT2lUemVQLXRZaWNhMFZSLURnYklWcjJCWGtOSWxoUT1zOTYtYyIsImdpdmVuX25hbWUiOiJBbmRyaSIsImZhbWlseV9uYW1lIjoiU2NoYXR6IiwiaWF0IjoxNzQwNTgzNzEyLCJleHAiOjE3NDA1ODczMTIsImp0aSI6IjhjNjkzMWE4YmVmZjllOWM3OTRmYjM5ZTkwNTExOTM4MTk4MDgxZDYifQ.PVAbLj1Fv7AUwH16nFiedJkmPOUg1UkPnAkVj6S9MDhpEV467tP7iOxQCx64i0_imTymcjkzH9pcfTsaKpY8fWPrWSWZzDy9S4GygjOQeg13NXg_H23X2-IY_OVHKqtrAibhZZUppvczijqZja7-HmUivoAJIGsMOk1IxbJdalOhE5yQtsYEx4ZBxFemR7CTfMzopsAaRWgPHI7T0MENuiCbkSy_NYQPBzNpmGcKoZoyUbleFUzej8gbkqpoIUVdfwuNtoe_TMjED5eqJxi1Pip85iy4wJTa2RKUTZxUfqVCaTEftVt8U-PV1UgPsxpu0mKS5z5bXylmgclUzcNnmg";

--- a/src/internet_identity_interface/src/internet_identity/types/openid.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/openid.rs
@@ -10,7 +10,10 @@ pub struct OpenIdCredentialData {
     pub iss: String,
     pub sub: String,
     pub aud: String,
-    pub last_usage_timestamp: Timestamp,
+    // Must be optional to differentiate between linked anchor and used anchor,
+    // it's not possible to keep track of registrations in bookkeeping
+    // authn method stats if this value is already set to any value.
+    pub last_usage_timestamp: Option<Timestamp>,
     pub metadata: HashMap<String, MetadataEntryV2>,
 }
 


### PR DESCRIPTION
Implement OpenID bookkeeping integration tests. As a result of these tests, make last usage timestamp optional.

# Changes

- Create integration test that asserts both daily and monthly authentication stats for OpenID.
- Change `last_usage_timestamp` from `Timestamp` to `Option<Timestamp>` so that the `AuthnMethodCounter` can differentiate between new registrations and existing OpenID credentials.

# Tests

Tested to make sure that existing stable structures data correctly handles the type change (to an optional) with existing data.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/desktop/confirmUnlinkAccount.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/desktop/confirmUnlinkCurrentAccount.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/mobile/confirmUnlinkAccount.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/mobile/confirmUnlinkCurrentAccount.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/mobile/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/26c025520/mobile/displayManageCredentialsSingle.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

