### PR TITLE
Fix link to github CI job run id

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -907,7 +907,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') && failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Release creation failed: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "Release creation failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   # A native, fast cached build. We use the produced test assets to run the canister & e2e tests.
   # The asset's checksum is compared against that of the (slower) docker build.

--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -96,4 +96,4 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "RC deployment failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}""
+          MESSAGE: "RC deployment failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -87,7 +87,7 @@ jobs:
             RC link: https://${{ env.ii_canister_id }}.ic0.app
             test app: https://${{ env.testnet_app_canister_id }}.ic0.app
 
-            https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
         # Since the this is a scheduled job, a failure won't be shown on any
         # PR status. To notify the team, we send a message to our Slack channel on failure.
@@ -96,4 +96,4 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "RC deployment failed: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "RC deployment failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}""

--- a/.github/workflows/pr-review-requested.yml
+++ b/.github/workflows/pr-review-requested.yml
@@ -16,4 +16,3 @@ jobs:
           WEBHOOK_URL: ${{ secrets.SLACK_PRIVATE_IDENTITY_WEBHOOK_URL }}
           MESSAGE: |
             <@${{ github.event.requested_reviewer.login == 'LXIF' && 'U07QU4DNV5Y' || github.event.requested_reviewer.login == 'sea-snake' && 'U07QU79GX0T' || github.event.requested_reviewer.login == 'lmuntaner' && 'U02TEQHKV35' }}>: New PR ready for review: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>.
-            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/pr-review-requested.yml
+++ b/.github/workflows/pr-review-requested.yml
@@ -16,3 +16,4 @@ jobs:
           WEBHOOK_URL: ${{ secrets.SLACK_PRIVATE_IDENTITY_WEBHOOK_URL }}
           MESSAGE: |
             <@${{ github.event.requested_reviewer.login == 'LXIF' && 'U07QU4DNV5Y' || github.event.requested_reviewer.login == 'sea-snake' && 'U07QU79GX0T' || github.event.requested_reviewer.login == 'lmuntaner' && 'U02TEQHKV35' }}>: New PR ready for review: <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>.
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Release build check failed (could not get release): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}""
+          MESSAGE: "Release build check failed (could not get release): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   # Perform the clean build (non-docker), using the release as checkout
   clean-build:

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Release build check failed (could not get release): https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "Release build check failed (could not get release): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}""
 
   # Perform the clean build (non-docker), using the release as checkout
   clean-build:
@@ -75,7 +75,7 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Release build check failed: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "Release build check failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   # Verify the hash using the verify-hash script, using the release as checkout.
   # This runs the build using docker and should work on all platforms.
@@ -103,4 +103,4 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Verify hash check failed: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "Verify hash check failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/update-dapps.yml
+++ b/.github/workflows/update-dapps.yml
@@ -48,4 +48,4 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Dapps update failed: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "Dapps update failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -59,4 +59,4 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "dfx update failed: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "dfx update failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -58,4 +58,4 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "didc update failed: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "didc update failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -60,4 +60,4 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Node update failed: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "Node update failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/update-passkey-aaguid.yml
+++ b/.github/workflows/update-passkey-aaguid.yml
@@ -57,4 +57,4 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Passkey AAGUID data update failed: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "Passkey AAGUID data update failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -67,4 +67,4 @@ jobs:
         if: ${{ failure() }}
         with:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MESSAGE: "Rust update failed: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          MESSAGE: "Rust update failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Current failure Slack messages that include the link to the GH job run are broken. See [this for example](https://dfinity.slack.com/archives/C01TTU2B15Z/p1742925902374349).

# Changes

This pull request includes several changes to the GitHub Actions workflows to standardize the format of URLs in failure messages. The changes replace the older GitHub environment variables with the newer GitHub context variables.

Standardization of failure message URLs:

* Changed the variable being interpolated when constructing the URLs from `GITHUB_REPOSITORY` to `github.repository` and from `GITHUB_RUN_ID` to `github.run_id`.

# Tests

Tested in the [slack message.](https://dfinity.slack.com/archives/C08J96E8CFL/p1743173275149809) 

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/desktop/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/desktop/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/desktop/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/desktop/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/desktop/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/mobile/components.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/mobile/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/mobile/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/mobile/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/94a8debaa/mobile/displayUserNumber.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
