### PR TITLE
Registration Funnel

### DIFF
--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -23,7 +23,6 @@ import {
 } from "$src/flows/register";
 import { I18n } from "$src/i18n";
 import { getAnchors, setAnchorUsed } from "$src/storage";
-import { analytics } from "$src/utils/analytics/analytics";
 import {
   AlreadyInProgress,
   ApiError,

--- a/src/frontend/src/components/authenticateBox/index.ts
+++ b/src/frontend/src/components/authenticateBox/index.ts
@@ -266,21 +266,17 @@ export const authenticateBoxFlow = async <I>({
     | FlowError
     | { tag: "canceled" }
   > => {
-    analytics.event("registration-start");
     const result2 = await registerFlow(registerFlowOpts);
 
     if (result2 === "canceled") {
-      analytics.event("registration-canceled");
       return { tag: "canceled" } as const;
     }
 
     if (result2.kind !== "loginSuccess") {
-      analytics.event("registration-error");
       return result2;
     }
 
     result2 satisfies LoginSuccess;
-    analytics.event("registration-success");
     return {
       newAnchor: true,
       ...result2,

--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -3,7 +3,10 @@ import { checkmarkIcon, copyIcon } from "$src/components/icons";
 import { identityCard } from "$src/components/identityCard";
 import { mainWindow } from "$src/components/mainWindow";
 import { toast } from "$src/components/toast";
-import { RegistrationEvents, registrationFunnel } from "$src/utils/analytics/registrationFunnel";
+import {
+  RegistrationEvents,
+  registrationFunnel,
+} from "$src/utils/analytics/registrationFunnel";
 import {
   TemplateElement,
   mount,
@@ -59,7 +62,9 @@ export const displayUserNumberTemplate = ({
           @click=${async () => {
             try {
               await navigator.clipboard.writeText(userNumber.toString());
-              registrationFunnel.trigger(RegistrationEvents.CopyNewIdentityNumber);
+              registrationFunnel.trigger(
+                RegistrationEvents.CopyNewIdentityNumber,
+              );
               withRef(userNumberCopy, (elem) => {
                 elem.classList.add("is-copied");
               });

--- a/src/frontend/src/flows/register/finish.ts
+++ b/src/frontend/src/flows/register/finish.ts
@@ -3,6 +3,7 @@ import { checkmarkIcon, copyIcon } from "$src/components/icons";
 import { identityCard } from "$src/components/identityCard";
 import { mainWindow } from "$src/components/mainWindow";
 import { toast } from "$src/components/toast";
+import { RegistrationEvents, registrationFunnel } from "$src/utils/analytics/registrationFunnel";
 import {
   TemplateElement,
   mount,
@@ -58,6 +59,7 @@ export const displayUserNumberTemplate = ({
           @click=${async () => {
             try {
               await navigator.clipboard.writeText(userNumber.toString());
+              registrationFunnel.trigger(RegistrationEvents.CopyNewIdentityNumber);
               withRef(userNumberCopy, (elem) => {
                 elem.classList.add("is-copied");
               });

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -43,7 +43,10 @@ import { setPinFlow } from "../pin/setPin";
 import { precomputeFirst, promptCaptcha } from "./captcha";
 import { displayUserNumberWarmup } from "./finish";
 import { savePasskeyPinOrOpenID } from "./passkey";
-import { RegistrationEvents, registrationFunnel } from "$src/utils/analytics/registrationFunnel";
+import {
+  RegistrationEvents,
+  registrationFunnel,
+} from "$src/utils/analytics/registrationFunnel";
 
 /** Registration (identity creation) flow for new users */
 export const registerFlow = async ({
@@ -260,12 +263,12 @@ export const registerFlow = async ({
       identity,
     }),
   );
-  
+
   if (result.kind !== "loginSuccess") {
     return result;
   }
   result.kind satisfies "loginSuccess";
-  
+
   registrationFunnel.trigger(RegistrationEvents.Created);
   const userNumber = result.userNumber;
   await finalizeIdentity?.(userNumber);

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -43,6 +43,7 @@ import { setPinFlow } from "../pin/setPin";
 import { precomputeFirst, promptCaptcha } from "./captcha";
 import { displayUserNumberWarmup } from "./finish";
 import { savePasskeyPinOrOpenID } from "./passkey";
+import { RegistrationEvents, registrationFunnel } from "$src/utils/analytics/registrationFunnel";
 
 /** Registration (identity creation) flow for new users */
 export const registerFlow = async ({
@@ -130,6 +131,7 @@ export const registerFlow = async ({
   // We register the device's origin in the current domain.
   // If we want to change it, we need to change this line.
   const deviceOrigin = window.location.origin;
+  registrationFunnel.trigger(RegistrationEvents.Trigger);
   const savePasskeyResult = await savePasskeyPinOrOpenID({
     pinAllowed: await pinAllowed(),
     googleAllowed,
@@ -146,7 +148,6 @@ export const registerFlow = async ({
       }
 
       pinResult.tag satisfies "ok";
-      analytics.event("registration-pin");
 
       // XXX: this withLoader could be replaced with one that indicates what's happening (like the
       // "Hang tight, ..." spinner)
@@ -179,7 +180,6 @@ export const registerFlow = async ({
       const openIdResult = await openidIdentityRegistrationFinish();
 
       if (openIdResult.kind === "loginSuccess") {
-        analytics.event("registration-openid");
         return {
           ...openIdResult,
           authnMethod: "google",
@@ -194,7 +194,6 @@ export const registerFlow = async ({
         return "canceled";
       }
 
-      analytics.event("registration-passkey");
       const alias = await inferPasskeyAlias({
         authenticatorType: identity.getAuthenticatorAttachment(),
         userAgent: navigator.userAgent,
@@ -225,7 +224,6 @@ export const registerFlow = async ({
     result_.kind === "loginSuccess" &&
     result_.authnMethod === "google"
   ) {
-    analytics.event("registration-final-success");
     // for now we switch to passkey here so dapps don't know it's google
     return { ...result_, authnMethod: "passkey" as const };
   } else if ("kind" in result_ && result_.kind === "loginSuccess") {
@@ -233,7 +231,6 @@ export const registerFlow = async ({
     return { ...result_, authnMethod: "passkey" as const };
   } else if ("kind" in result_) {
     // if openid returned some error
-    analytics.event("registration-final-error");
     return result_;
   }
 
@@ -263,14 +260,13 @@ export const registerFlow = async ({
       identity,
     }),
   );
-
+  
   if (result.kind !== "loginSuccess") {
-    analytics.event("registration-final-error");
     return result;
   }
   result.kind satisfies "loginSuccess";
-  analytics.event("registration-final-success");
-
+  
+  registrationFunnel.trigger(RegistrationEvents.Created);
   const userNumber = result.userNumber;
   await finalizeIdentity?.(userNumber);
   // We don't want to nudge the user with the recovery phrase warning page
@@ -290,6 +286,7 @@ export const registerFlow = async ({
     userNumber,
     marketingIntroSlot: finishSlot,
   });
+  registrationFunnel.trigger(RegistrationEvents.Success);
   return { ...result, authnMethod };
 };
 
@@ -535,23 +532,20 @@ async function captchaIfNecessary(
 > {
   const startResult = await flowStart();
   if (startResult.kind !== "registrationFlowStepSuccess") {
-    analytics.event("registration-start-error");
     return startResult;
   }
   startResult satisfies RegistrationFlowStepSuccess;
 
   if (startResult.nextStep.step === "checkCaptcha") {
-    analytics.event("registration-captcha");
+    registrationFunnel.trigger(RegistrationEvents.CaptchaCheck);
     const captchaResult = await promptCaptcha({
       captcha_png_base64: startResult.nextStep.captcha_png_base64,
       checkCaptcha,
     });
     if (captchaResult === "canceled") {
-      analytics.event("registration-captcha-cancelled");
       return "canceled";
     }
     if (captchaResult.kind !== "registrationFlowStepSuccess") {
-      analytics.event("registration-captcha-error");
       return captchaResult;
     }
     captchaResult satisfies RegistrationFlowStepSuccess;

--- a/src/frontend/src/flows/register/index.ts
+++ b/src/frontend/src/flows/register/index.ts
@@ -10,7 +10,6 @@ import { idbStorePinIdentityMaterial } from "$src/flows/pin/idb";
 import { registerDisabled } from "$src/flows/registerDisabled";
 import { I18n } from "$src/i18n";
 import { setAnchorUsed } from "$src/storage";
-import { analytics } from "$src/utils/analytics/analytics";
 import {
   passkeyAuthnMethodData,
   pinAuthnMethodData,

--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -13,7 +13,10 @@ import {
 import { nonNullish } from "@dfinity/utils";
 import { html, TemplateResult } from "lit-html";
 import copyJson from "./passkey.json";
-import { RegistrationEvents, registrationFunnel } from "$src/utils/analytics/registrationFunnel";
+import {
+  RegistrationEvents,
+  registrationFunnel,
+} from "$src/utils/analytics/registrationFunnel";
 
 /* Anchor construction component (for creating WebAuthn credentials) */
 

--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -12,9 +12,8 @@ import {
 } from "$src/utils/webAuthnErrorUtils";
 import { nonNullish } from "@dfinity/utils";
 import { html, TemplateResult } from "lit-html";
-
-import { analytics } from "$src/utils/analytics/analytics";
 import copyJson from "./passkey.json";
+import { RegistrationEvents, registrationFunnel } from "$src/utils/analytics/registrationFunnel";
 
 /* Anchor construction component (for creating WebAuthn credentials) */
 
@@ -129,7 +128,7 @@ export const savePasskeyPinOrOpenID = async ({
         cancel: () => resolve("canceled"),
         scrollToTop: true,
         constructPasskey: async () => {
-          analytics.event("construct-passkey");
+          registrationFunnel.trigger(RegistrationEvents.WebauthnStart);
           try {
             const rpId =
               origin === window.location.origin
@@ -138,10 +137,8 @@ export const savePasskeyPinOrOpenID = async ({
             const identity = await withLoader(() =>
               constructIdentity({ rpId }),
             );
-            analytics.event("construct-passkey-success");
             resolve(identity);
           } catch (e) {
-            analytics.event("construct-passkey-error");
             toast.error(errorMessage(e));
           }
         },

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -10,6 +10,7 @@ import { authFlowManage, renderManageWarmup } from "./flows/manage";
 import { createSpa } from "./spa";
 import { getAddDeviceAnchor } from "./utils/addDeviceLink";
 import { analytics, initAnalytics } from "./utils/analytics/analytics";
+import { registrationFunnel } from "./utils/analytics/registrationFunnel";
 
 void createSpa(async (connection) => {
   initAnalytics(connection.canisterConfig.analytics_config[0]?.[0]);
@@ -50,6 +51,7 @@ void createSpa(async (connection) => {
   // Simple, #-based routing
   if (url.hash === "#authorize") {
     analytics.event("page-authorize");
+    registrationFunnel.init();
     // User was brought here by a dapp for authorization
     return authFlowAuthorize(connection);
   } else if (url.hash === WEBAUTHN_IFRAME_PATH) {
@@ -58,6 +60,7 @@ void createSpa(async (connection) => {
     return webAuthnInIframeFlow(connection);
   } else {
     analytics.event("page-manage");
+    registrationFunnel.init();
     // The default flow
     return authFlowManage(connection);
   }

--- a/src/frontend/src/utils/analytics/registrationFunnel.ts
+++ b/src/frontend/src/utils/analytics/registrationFunnel.ts
@@ -2,9 +2,9 @@ import { Funnel } from "./Funnel";
 
 /**
  * Registration flow events:
- * 
+ *
  * Square brackets [] indicate optional events.
- * 
+ *
  * registration-start (INIT)
  *   registration-trigger
  *     registration-webauthn-start
@@ -22,4 +22,6 @@ export const RegistrationEvents = {
   Success: "registration-success",
 } as const;
 
-export const registrationFunnel = new Funnel<typeof RegistrationEvents>("registration");
+export const registrationFunnel = new Funnel<typeof RegistrationEvents>(
+  "registration",
+);

--- a/src/frontend/src/utils/analytics/registrationFunnel.ts
+++ b/src/frontend/src/utils/analytics/registrationFunnel.ts
@@ -1,0 +1,25 @@
+import { Funnel } from "./Funnel";
+
+/**
+ * Registration flow events:
+ * 
+ * Square brackets [] indicate optional events.
+ * 
+ * registration-start (INIT)
+ *   registration-trigger
+ *     registration-webauthn-start
+ *       [captcha-check]
+ *         registration-created
+ *           [copy-new-identity-number]
+ *             registration-success
+ */
+export const RegistrationEvents = {
+  Trigger: "registration-trigger",
+  CaptchaCheck: "captcha-check",
+  WebauthnStart: "registration-webauthn-start",
+  Created: "registration-created",
+  CopyNewIdentityNumber: "copy-new-identity-number",
+  Success: "registration-success",
+} as const;
+
+export const registrationFunnel = new Funnel<typeof RegistrationEvents>("registration");


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Track registration flow as described in the [design doc](https://docs.google.com/document/d/1jBPWIPmekWDb4BLEsNP5m6NbInCwHzVqwxuRwwL2Bhk/edit?usp=sharing) of the analytics baseline.

The main change is the replacement of the `analytics.event` calls with a new `registrationFunnel` system to track registration events more systematically.

# Changes

* [`src/frontend/src/flows/register/index.ts`](diffhunk://#diff-793891f8131b840661ff4978418ccf45bdd403b840a549b7d866adf7f4a78f92R134): Replaced multiple `analytics.event` calls with `registrationFunnel.trigger` to track various stages of the registration process, such as triggering the registration, checking captcha, creating an identity, and successful registration.
* [`src/frontend/src/flows/register/passkey.ts`](diffhunk://#diff-e84ff3598a61a103cc201e18b99e77f810b451b78c48e0a5a36869eb249c4dceL132-R131): Updated the passkey creation process to use `registrationFunnel.trigger` for tracking events instead of `analytics.event`.
* [`src/frontend/src/components/authenticateBox/index.ts`](diffhunk://#diff-8f68fae1b679171c3fe2f3232a77b4a003430dbffebae75d2cd3b4ca7ca3d116L269-L283): Removed `analytics.event` calls related to registration events.
* [`src/frontend/src/index.ts`](diffhunk://#diff-033402b31dfd9fe154f6eff49e5f03909de22213326ee238c29df78ee2c3ad9fR13): Added initialization of `registrationFunnel` in the SPA creation process to ensure it is set up for tracking registration-related events.
* [`src/frontend/src/utils/analytics/registrationFunnel.ts`](diffhunk://#diff-94b893984ace5724dca73e706278a72597ee57c831cf00291c948a25179b2340R1-R25): Introduced a new `RegistrationEvents` object and `registrationFunnel` instance to standardize the registration event tracking.
* [`src/frontend/src/flows/register/finish.ts`](diffhunk://#diff-e62c3ce3b3766767789effaf39fe79cd468c3d04c26ecab781d50127ef5bb249R62): Added a call to `registrationFunnel.trigger` when the user copies their new identity number.

<!-- List the changes that have been developed -->

# Tests

Tested locally that events are triggered along the registration flow.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9477feb88/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9477feb88/desktop/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9477feb88/desktop/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9477feb88/desktop/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9477feb88/desktop/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9477feb88/desktop/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9477feb88/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9477feb88/desktop/displayManageCredentialsSingle.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

