### PR TITLE
Add properties to Funnel

### DIFF
--- a/src/frontend/src/utils/analytics/Funnel.test.ts
+++ b/src/frontend/src/utils/analytics/Funnel.test.ts
@@ -57,7 +57,7 @@ describe("Funnel", () => {
     document.dispatchEvent(new Event("visibilitychange"));
     expect(analytics.event).toHaveBeenCalledWith(
       "start-login-window-session-enter",
-      undefined
+      undefined,
     );
   });
 
@@ -68,7 +68,7 @@ describe("Funnel", () => {
     document.dispatchEvent(new Event("visibilitychange"));
     expect(analytics.event).toHaveBeenCalledWith(
       "start-login-window-session-enter",
-      properties
+      properties,
     );
   });
 
@@ -78,7 +78,7 @@ describe("Funnel", () => {
     document.dispatchEvent(new Event("visibilitychange"));
     expect(analytics.event).toHaveBeenCalledWith(
       "start-login-window-session-leave",
-      undefined
+      undefined,
     );
   });
 
@@ -89,7 +89,7 @@ describe("Funnel", () => {
     document.dispatchEvent(new Event("visibilitychange"));
     expect(analytics.event).toHaveBeenCalledWith(
       "start-login-window-session-leave",
-      properties
+      properties,
     );
   });
 
@@ -97,7 +97,7 @@ describe("Funnel", () => {
     funnel.trigger(LoginEvents.NewRegistrationStart);
     expect(analytics.event).toHaveBeenCalledWith(
       "login-new-registration-start",
-      undefined
+      undefined,
     );
   });
 
@@ -107,7 +107,7 @@ describe("Funnel", () => {
     funnel.trigger(LoginEvents.NewRegistrationStart);
     expect(analytics.event).toHaveBeenCalledWith(
       "login-new-registration-start",
-      properties
+      properties,
     );
   });
 
@@ -116,7 +116,7 @@ describe("Funnel", () => {
     funnel.trigger(LoginEvents.NewRegistrationStart, additionalProps);
     expect(analytics.event).toHaveBeenCalledWith(
       "login-new-registration-start",
-      additionalProps
+      additionalProps,
     );
   });
 
@@ -124,47 +124,62 @@ describe("Funnel", () => {
     const initProps = { userId: "123", source: "test" };
     const additionalProps = { step: 1, method: "email" };
     const expectedProps = { ...initProps, ...additionalProps };
-    
+
     funnel.init(initProps);
     funnel.trigger(LoginEvents.NewRegistrationStart, additionalProps);
-    
+
     expect(analytics.event).toHaveBeenCalledWith(
       "login-new-registration-start",
-      expectedProps
+      expectedProps,
     );
   });
 
   it("trigger() - tracks complete passkey login flow", () => {
     funnel.trigger(LoginEvents.ExistingUserStart);
-    expect(analytics.event).toHaveBeenCalledWith("login-existing-user-start", undefined);
+    expect(analytics.event).toHaveBeenCalledWith(
+      "login-existing-user-start",
+      undefined,
+    );
 
     funnel.trigger(LoginEvents.ExistingUserPasskey);
-    expect(analytics.event).toHaveBeenCalledWith("login-existing-user-passkey", undefined);
+    expect(analytics.event).toHaveBeenCalledWith(
+      "login-existing-user-passkey",
+      undefined,
+    );
 
     funnel.trigger(LoginEvents.ExistingUserPasskeySuccess);
     expect(analytics.event).toHaveBeenCalledWith(
       "login-existing-user-passkey-success",
-      undefined
+      undefined,
     );
   });
 
   it("trigger() - tracks complete OpenID login flow", () => {
     funnel.trigger(LoginEvents.ExistingUserStart);
-    expect(analytics.event).toHaveBeenCalledWith("login-existing-user-start", undefined);
+    expect(analytics.event).toHaveBeenCalledWith(
+      "login-existing-user-start",
+      undefined,
+    );
 
     funnel.trigger(LoginEvents.ExistingUserOpenId);
-    expect(analytics.event).toHaveBeenCalledWith("login-existing-user-openid", undefined);
+    expect(analytics.event).toHaveBeenCalledWith(
+      "login-existing-user-openid",
+      undefined,
+    );
 
     funnel.trigger(LoginEvents.ExistingUserOpenIdSuccess);
     expect(analytics.event).toHaveBeenCalledWith(
       "login-existing-user-openid-success",
-      undefined
+      undefined,
     );
   });
 
   it("trigger() - tracks recovery start event", () => {
     funnel.trigger(LoginEvents.RecoveryStart);
-    expect(analytics.event).toHaveBeenCalledWith("login-recovery-start", undefined);
+    expect(analytics.event).toHaveBeenCalledWith(
+      "login-recovery-start",
+      undefined,
+    );
   });
 
   it("close() - stops tracking window session events", () => {

--- a/src/frontend/src/utils/analytics/Funnel.ts
+++ b/src/frontend/src/utils/analytics/Funnel.ts
@@ -19,10 +19,16 @@ export class Funnel<T extends Record<string, string>> {
     // Start window session tracking
     this.#cleanupSession = trackWindowSession({
       onEnterSession: () => {
-        analytics.event(`start-${this.#name}-window-session-enter`, this.#properties);
+        analytics.event(
+          `start-${this.#name}-window-session-enter`,
+          this.#properties,
+        );
       },
       onLeaveSession: () => {
-        analytics.event(`start-${this.#name}-window-session-leave`, this.#properties);
+        analytics.event(
+          `start-${this.#name}-window-session-leave`,
+          this.#properties,
+        );
       },
     });
   }
@@ -50,12 +56,18 @@ export class Funnel<T extends Record<string, string>> {
     }
   }
 
-  trigger(event: T[keyof T], additionalProperties?: Record<string, string | number>): void {
+  trigger(
+    event: T[keyof T],
+    additionalProperties?: Record<string, string | number>,
+  ): void {
     const eventProperties = {
       ...(this.#properties || {}),
       ...(additionalProperties || {}),
     };
-    
-    analytics.event(event, Object.keys(eventProperties).length > 0 ? eventProperties : undefined);
+
+    analytics.event(
+      event,
+      Object.keys(eventProperties).length > 0 ? eventProperties : undefined,
+    );
   }
 }

--- a/src/frontend/src/utils/analytics/Funnel.ts
+++ b/src/frontend/src/utils/analytics/Funnel.ts
@@ -5,22 +5,24 @@ export class Funnel<T extends Record<string, string>> {
   #name: string;
   #cleanupSession?: () => void;
   #startTimestamp?: number;
+  #properties?: Record<string, string | number>;
 
   constructor(name: string) {
     this.#name = name;
   }
 
-  init(): void {
+  init(properties?: Record<string, string | number>): void {
     this.#startTimestamp = Date.now();
-    analytics.event("start-" + this.#name);
+    this.#properties = properties;
+    analytics.event("start-" + this.#name, this.#properties);
 
     // Start window session tracking
     this.#cleanupSession = trackWindowSession({
       onEnterSession: () => {
-        analytics.event(`start-${this.#name}-window-session-enter`);
+        analytics.event(`start-${this.#name}-window-session-enter`, this.#properties);
       },
       onLeaveSession: () => {
-        analytics.event(`start-${this.#name}-window-session-leave`);
+        analytics.event(`start-${this.#name}-window-session-leave`, this.#properties);
       },
     });
   }
@@ -39,14 +41,21 @@ export class Funnel<T extends Record<string, string>> {
     ) {
       const durationMs = Date.now() - this.#startTimestamp;
       const durationSec = durationMs / 1000;
-      analytics.event(`end-${this.#name}`, {
+      const eventProperties = {
+        ...(this.#properties || {}),
         [`duration-${this.#name}`]: durationSec,
-      });
+      };
+      analytics.event(`end-${this.#name}`, eventProperties);
       this.#startTimestamp = undefined;
     }
   }
 
-  trigger(event: T[keyof T]): void {
-    analytics.event(event);
+  trigger(event: T[keyof T], additionalProperties?: Record<string, string | number>): void {
+    const eventProperties = {
+      ...(this.#properties || {}),
+      ...(additionalProperties || {}),
+    };
+    
+    analytics.event(event, Object.keys(eventProperties).length > 0 ? eventProperties : undefined);
   }
 }


### PR DESCRIPTION
# Motivation

Properties need to be set in all the events in order to be able filter Funnels by them.

For example, to check the Funnel of NNS Dapp logins, we need to always set the origin of NNS Dapp in all the events triggered in that Funnel.

# Changes

This pull request includes enhancements to the `Funnel` class and its associated tests to support the inclusion of properties in analytics events. The changes ensure that properties can be passed during initialization and triggering of events, and that these properties are correctly merged and tracked.

Enhancements to `Funnel` class:

* [`src/frontend/src/utils/analytics/Funnel.ts`](diffhunk://#diff-77c18658b097c82490940d3d60b40f251a1e264babe075843489f2e792c1f4f0R8-R25): Added support for properties in the `init` and `trigger` methods, and modified the `close` method to include these properties when tracking the duration.

Enhancements to `Funnel` tests:

* [`src/frontend/src/utils/analytics/Funnel.test.ts`](diffhunk://#diff-b0bcd0191acd1797acb69127892c49074e14b2382fb1a04816ed6e6f07f8fd9cL45-R51): Added new test cases to verify that properties are correctly passed and merged in the `init` and `trigger` methods, and that the `close` method tracks the duration with these properties.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9f96121bd/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9f96121bd/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9f96121bd/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9f96121bd/mobile/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9f96121bd/mobile/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9f96121bd/mobile/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9f96121bd/mobile/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9f96121bd/mobile/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/9f96121bd/mobile/displayManage.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
