### PR TITLE
Add login funnel

### DIFF
--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -1,6 +1,7 @@
 // Types and functions related to the window post message interface used by
 // applications that want to authenticate the user using Internet Identity
 import { analytics } from "$src/utils/analytics/analytics";
+import { loginFunnel } from "$src/utils/analytics/loginFunnel";
 import { type SignedDelegation as FrontendSignedDelegation } from "@dfinity/identity";
 import { Principal } from "@dfinity/principal";
 import { z } from "zod";
@@ -130,6 +131,8 @@ export async function authenticationProtocol({
   analytics.event("authorize-client-request-valid", {
     origin: requestOrigin,
   });
+  // TODO: Add origin to login funnel
+  loginFunnel.init();
 
   const authContext = {
     authRequest: requestResult.request,

--- a/src/frontend/src/utils/analytics/loginFunnel.ts
+++ b/src/frontend/src/utils/analytics/loginFunnel.ts
@@ -1,0 +1,25 @@
+import { Funnel } from "./Funnel";
+
+/**
+ * Login flow events:
+ *
+ * Square brackets [] indicate optional events.
+ *
+ * login-start (INIT) - Triggered in Landing Page or List of identities
+ *   login-trigger-list-item - Triggered when user clicks on a number
+ *     login-webauthn-start - Triggered when the webauthn is triggered
+ *       login-success - Triggered after successful webauthn interaction
+ *   go-use-existing - Triggered on visiting the Use Existing page
+ *     login-trigger-use-existing - Triggered when user clicks "Continue" in the Use Existing
+ *       login-webauthn-start - Triggered when the webauthn is triggered
+ *         login-success - Triggered after successful webauthn interaction
+ */
+export enum LoginEvents {
+  GoUseExisting = "go-use-existing",
+  TriggerListItem = "login-trigger-list-item",
+  TriggerUseExisting = "login-trigger-use-existing",
+  WebauthnStart = "login-webauthn-start",
+  Success = "login-success",
+}
+
+export const loginFunnel = new Funnel<typeof LoginEvents>("login");


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Create a funnel to track the user during logging from an application.

# Changes

This pull request introduces significant enhancements to the login flow by integrating a new analytics funnel to track user interactions.

Key changes include:

* [`src/frontend/src/utils/analytics/loginFunnel.ts`](diffhunk://#diff-daff21dda796f216df5453a9f5cb911eaecae0e08352735c9ce16f7d9f244c68R1-R25): Defined the `LoginEvents` enum and created a new `Funnel` instance for login events to standardize the logging of user interactions during the login process.
* [`src/frontend/src/components/authenticateBox/index.ts`](diffhunk://#diff-8f68fae1b679171c3fe2f3232a77b4a003430dbffebae75d2cd3b4ca7ca3d116R67): Added triggers for various login events such as `TriggerUseExisting`, `TriggerListItem`, and `GoUseExisting` to the `loginFunnel` to track user actions during the authentication process.
* [`src/frontend/src/flows/authorize/postMessageInterface.ts`](diffhunk://#diff-5ee26fc4ed301a9620eb0d91881a239a5017af0ae1bfa5ba896cfb349b5a83a7R4): Initialized the `loginFunnel` in the `authenticationProtocol` function to start tracking login-related events.
* [`src/frontend/src/utils/iiConnection.ts`](diffhunk://#diff-f7c49a174f5c76f4cf2b4b99163ad65f188b0b3694803839b160d7bbf8007ff5R81): Replaced several `analytics.event` calls with `loginFunnel` triggers to streamline the event logging process and ensure consistency.

# Tests

Tested locally that events are triggered as expected along the login flow, but not registration (except the "start-login" which is expected to be triggered)

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74102848f/desktop/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74102848f/desktop/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74102848f/desktop/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74102848f/desktop/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74102848f/desktop/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74102848f/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74102848f/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74102848f/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74102848f/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/74102848f/desktop/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
