### PR TITLE
Use origin on login and registration funnel

### DIFF
--- a/src/frontend/src/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/flows/authorize/postMessageInterface.ts
@@ -2,6 +2,7 @@
 // applications that want to authenticate the user using Internet Identity
 import { analytics } from "$src/utils/analytics/analytics";
 import { loginFunnel } from "$src/utils/analytics/loginFunnel";
+import { registrationFunnel } from "$src/utils/analytics/registrationFunnel";
 import { type SignedDelegation as FrontendSignedDelegation } from "@dfinity/identity";
 import { Principal } from "@dfinity/principal";
 import { z } from "zod";
@@ -131,8 +132,8 @@ export async function authenticationProtocol({
   analytics.event("authorize-client-request-valid", {
     origin: requestOrigin,
   });
-  // TODO: Add origin to login funnel
-  loginFunnel.init();
+  loginFunnel.init({ origin: requestOrigin });
+  registrationFunnel.init({ origin: requestOrigin });
 
   const authContext = {
     authRequest: requestResult.request,

--- a/src/frontend/src/index.ts
+++ b/src/frontend/src/index.ts
@@ -11,6 +11,7 @@ import { createSpa } from "./spa";
 import { getAddDeviceAnchor } from "./utils/addDeviceLink";
 import { analytics, initAnalytics } from "./utils/analytics/analytics";
 import { registrationFunnel } from "./utils/analytics/registrationFunnel";
+import { loginFunnel } from "./utils/analytics/loginFunnel";
 
 void createSpa(async (connection) => {
   initAnalytics(connection.canisterConfig.analytics_config[0]?.[0]);
@@ -51,7 +52,6 @@ void createSpa(async (connection) => {
   // Simple, #-based routing
   if (url.hash === "#authorize") {
     analytics.event("page-authorize");
-    registrationFunnel.init();
     // User was brought here by a dapp for authorization
     return authFlowAuthorize(connection);
   } else if (url.hash === WEBAUTHN_IFRAME_PATH) {
@@ -60,7 +60,9 @@ void createSpa(async (connection) => {
     return webAuthnInIframeFlow(connection);
   } else {
     analytics.event("page-manage");
+    // Initialize funnels without origin.
     registrationFunnel.init();
+    loginFunnel.init();
     // The default flow
     return authFlowManage(connection);
   }


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Enable filtering the funnel per application.

# Changes

This pull request includes changes to improve the initialization of analytics funnels and the authentication protocol in the frontend code. The most important changes include initializing both `loginFunnel` and `registrationFunnel` with the request origin, and ensuring funnels are initialized in the manage flow (when user doesn't come from a dapp).

Improvements to analytics funnels:

* [`src/frontend/src/flows/authorize/postMessageInterface.ts`](diffhunk://#diff-5ee26fc4ed301a9620eb0d91881a239a5017af0ae1bfa5ba896cfb349b5a83a7R5): Initialized both `loginFunnel` and `registrationFunnel` with the request origin in the `authenticationProtocol` function.
* [`src/frontend/src/index.ts`](diffhunk://#diff-033402b31dfd9fe154f6eff49e5f03909de22213326ee238c29df78ee2c3ad9fR14): Initialized both `loginFunnel` and `registrationFunnel` in the default flow without origin.
* [`src/frontend/src/index.ts`](diffhunk://#diff-033402b31dfd9fe154f6eff49e5f03909de22213326ee238c29df78ee2c3ad9fL54): Removed redundant `registrationFunnel.init()` call in the `#authorize` hash routing.

# Tests

Tested locally that events are triggered as expected.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/35d1f135e/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/35d1f135e/desktop/displayManageCredentialsMultiple.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/35d1f135e/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/35d1f135e/desktop/displayManageMaxDevices.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
