### PR TITLE
Increase time to show "Check ongoing issues"

### DIFF
--- a/src/frontend/src/components/loader.ts
+++ b/src/frontend/src/components/loader.ts
@@ -10,7 +10,7 @@ const loaderUrl = import.meta.glob("./loader.svg", {
 })["./loader.svg"] as string;
 
 // Duration in milliseconds a user considers as taking forever
-const TAKING_FOREVER = 10000;
+const TAKING_FOREVER = 20000;
 
 const loader = (takingForever = false) =>
   html`<div id="loader" class="c-loader">


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Some users are seeing a degraded time. Not sure why, but they see the "Check Ongoing Issues" when in reality there is no issue.

# Changes

* Increase `TAKING_FOREVER` to 20s.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/17383e4cc/desktop/allowCredentialsLongMessage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/17383e4cc/desktop/allowCredentialsLongOrigins.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/17383e4cc/desktop/dappsExplorer.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
