### PR TITLE
Add JWT verification to OpenID Connect registration flow

### DIFF
--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -807,12 +807,10 @@ mod openid_api {
         arg: OpenIDRegFinishArg,
     ) -> Result<IdRegFinishResult, IdRegFinishError> {
         match verify(&arg.jwt, &arg.salt) {
-            Ok(_) => {
-                registration::registration_flow_v2::identity_registration_finish(
-                    CreateIdentityData::OpenID(arg),
-                )
-            },
-            Err(err) => Err(IdRegFinishError::InvalidAuthnMethod(err))
+            Ok(_) => registration::registration_flow_v2::identity_registration_finish(
+                CreateIdentityData::OpenID(arg),
+            ),
+            Err(err) => Err(IdRegFinishError::InvalidAuthnMethod(err)),
         }
     }
 

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -7,9 +7,7 @@ use candid::Principal;
 use canister_tests::{api::internet_identity as api, framework::*};
 use identity_jose::{jwk::Jwk, jws::Decoder};
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose,
-    AuthnMethodSecuritySettings, InternetIdentityInit, OpenIdConfig, OpenIdCredentialKey,
-    OpenIdDelegationError, PublicKeyAuthn,
+    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, AuthnMethodSecuritySettings, CaptchaConfig, InternetIdentityInit, OpenIdConfig, OpenIdCredentialKey, OpenIdDelegationError, PublicKeyAuthn
 };
 use pocket_ic::common::rest::{CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse};
 use pocket_ic::{CallError, PocketIc};
@@ -218,6 +216,28 @@ fn can_register_with_google() -> Result<(), CallError> {
         create_identity_with_openid_credential(&env, canister_id, &jwt, &salt, test_principal);
 
     Ok(())
+}
+
+/// Verifies that you cannot register with a faulty jwt
+#[test]
+#[should_panic]
+fn cannot_register_with_faulty_jwt() {
+    let env = env();
+
+    let canister_id = setup_canister(&env);
+
+    let (_jwt, salt, _claims, test_time, test_principal, _test_authn_method) = openid_test_data();
+
+    let faulty_jwt = "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc2M2Y3YzRjZDI2YTFlYjJiMWIzOWE4OGY0NDM0ZDFmNGQ5YTM2OGIiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiIzNjA1ODc5OTE2NjgtNjNicGMxZ25ncDFzNWdibzFhbGRhbDRhNTBjMWowYmIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiIzNjA1ODc5OTE2NjgtNjNicGMxZ25ncDFzNWdibzFhbGRhbDRhNTBjMWowYmIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDcxNzAzNjg4OTgyMTkwMzU3MjEiLCJoZCI6ImRmaW5pdHkub3JnIiwiZW1haWwiOiJhbmRyaS5zY2hhdHpAZGZpbml0eS5vcmciLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibm9uY2UiOiJmQkcxS3IzUWt5Z0dHelNJWG9Pd2p3RF95QjhXS0FfcVJPUlZjMFp0WHlJIiwibmJmIjoxNzQwNTgzNDEyLCJuYW1lIjoiQW5kcmkgU2NoYXR6IiwicGljdHVyZSI6Imh0dHBzOi8vbGgzLmdvb2dsZXVzZXJjb250ZW50LmNvbS9hL0FDZzhvY0k1YUU0Mmo0Ml9JcEdqSHFjT2lUemVQLXRZaWNhMFZSLURnYklWcjJCWGtOSWxoUT1zOTYtYyIsImdpdmVuX25hbWUiOiJBbmRyaSIsImZhbWlseV9uYW1lIjoiU2NoYXR6IiwiaWF0IjoxNzQwNTgzNzEyLCJleHAiOjE3NDA1ODczMTIsImp0aSI6IjhjNjkzMWE4YmVmZjllOWM3OTRmYjM5ZTkwNTExOTM4MTk4MDgxZDYifQ.PVAbLj1Fv7AUwH16nFiedJkmPOUg1UkPnAkVj6S9MDhpEV467tP7iOxQCx64i0_imTymcjkzH9pcfTsaKpY8fWPrWSWZzDy9S4GygjOQeg13NXg_H23X2-IY_OVHKqtrAibhZZUppvczijqZja7-HmUivoAJIGsMOk1IxbJdalOhE5yQtsYEx4ZBxFemR7CTfMzopsAaRWgPHI7T0MENuiCbkSy_NYQPBzNpmGcKoZoyUbleFUzej8gbkqpoIUVdfwuNtoe_TMjED5eqJxi1Pip85iy4wJTa2RKUTZxUfqVCaTEftVt8U-PV1UgPsxpu0mKS5z5bXylmgclUzcNnmh";
+
+    let time_to_advance = Duration::from_millis(test_time) - Duration::from_nanos(time(&env));
+    env.advance_time(time_to_advance);
+
+    // Create identity - this will panic if it doesn't work. It should panic as we are using a faulty jwt.
+
+    let _identity_number =
+        create_identity_with_openid_credential(&env, canister_id, &faulty_jwt, &salt, test_principal);
+
 }
 
 static CLIENT_ID: &str = "360587991668-63bpc1gngp1s5gbo1aldal4a50c1j0bb.apps.googleusercontent.com";

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -8,7 +8,7 @@ use canister_tests::{api::internet_identity as api, framework::*};
 use identity_jose::{jwk::Jwk, jws::Decoder};
 use internet_identity_interface::internet_identity::types::{
     AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose,
-    AuthnMethodSecuritySettings, CaptchaConfig, InternetIdentityInit, OpenIdConfig,
+    AuthnMethodSecuritySettings, InternetIdentityInit, OpenIdConfig,
     OpenIdCredentialKey, OpenIdDelegationError, PublicKeyAuthn,
 };
 use pocket_ic::common::rest::{CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse};

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -237,13 +237,9 @@ fn cannot_register_with_faulty_jwt() {
 
     // Create identity - this will panic if it doesn't work. It should panic as we are using a faulty jwt.
 
-    let _identity_number = create_identity_with_openid_credential(
-        &env,
-        canister_id,
-        &faulty_jwt,
-        &salt,
-        test_principal,
-    );
+    let _identity_number =
+        create_identity_with_openid_credential(&env, canister_id, faulty_jwt, &salt, test_principal);
+
 }
 
 static CLIENT_ID: &str = "360587991668-63bpc1gngp1s5gbo1aldal4a50c1j0bb.apps.googleusercontent.com";

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -237,9 +237,13 @@ fn cannot_register_with_faulty_jwt() {
 
     // Create identity - this will panic if it doesn't work. It should panic as we are using a faulty jwt.
 
-    let _identity_number =
-        create_identity_with_openid_credential(&env, canister_id, faulty_jwt, &salt, test_principal);
-
+    let _identity_number = create_identity_with_openid_credential(
+        &env,
+        canister_id,
+        faulty_jwt,
+        &salt,
+        test_principal,
+    );
 }
 
 static CLIENT_ID: &str = "360587991668-63bpc1gngp1s5gbo1aldal4a50c1j0bb.apps.googleusercontent.com";

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -7,7 +7,9 @@ use candid::Principal;
 use canister_tests::{api::internet_identity as api, framework::*};
 use identity_jose::{jwk::Jwk, jws::Decoder};
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, AuthnMethodSecuritySettings, CaptchaConfig, InternetIdentityInit, OpenIdConfig, OpenIdCredentialKey, OpenIdDelegationError, PublicKeyAuthn
+    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose,
+    AuthnMethodSecuritySettings, CaptchaConfig, InternetIdentityInit, OpenIdConfig,
+    OpenIdCredentialKey, OpenIdDelegationError, PublicKeyAuthn,
 };
 use pocket_ic::common::rest::{CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse};
 use pocket_ic::{CallError, PocketIc};
@@ -235,9 +237,13 @@ fn cannot_register_with_faulty_jwt() {
 
     // Create identity - this will panic if it doesn't work. It should panic as we are using a faulty jwt.
 
-    let _identity_number =
-        create_identity_with_openid_credential(&env, canister_id, &faulty_jwt, &salt, test_principal);
-
+    let _identity_number = create_identity_with_openid_credential(
+        &env,
+        canister_id,
+        &faulty_jwt,
+        &salt,
+        test_principal,
+    );
 }
 
 static CLIENT_ID: &str = "360587991668-63bpc1gngp1s5gbo1aldal4a50c1j0bb.apps.googleusercontent.com";

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -8,8 +8,8 @@ use canister_tests::{api::internet_identity as api, framework::*};
 use identity_jose::{jwk::Jwk, jws::Decoder};
 use internet_identity_interface::internet_identity::types::{
     AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose,
-    AuthnMethodSecuritySettings, InternetIdentityInit, OpenIdConfig,
-    OpenIdCredentialKey, OpenIdDelegationError, PublicKeyAuthn,
+    AuthnMethodSecuritySettings, InternetIdentityInit, OpenIdConfig, OpenIdCredentialKey,
+    OpenIdDelegationError, PublicKeyAuthn,
 };
 use pocket_ic::common::rest::{CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse};
 use pocket_ic::{CallError, PocketIc};


### PR DESCRIPTION
# Motivation

The ProdSec review had identified that we had missed to validate the OIDC JWT on `openid_identity_registration_finish`. This PR corrects this oversight.

# Changes

Add the check to the endpoint, add integration Test

# Tests

Added integration test.



<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8d52caa5e/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8d52caa5e/desktop/displayManageCredentialsSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8d52caa5e/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8d52caa5e/mobile/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8d52caa5e/mobile/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8d52caa5e/mobile/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8d52caa5e/mobile/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8d52caa5e/mobile/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8d52caa5e/mobile/displayManage.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->


