### PR TITLE
Add missing registration event

### DIFF
--- a/src/frontend/src/flows/register/passkey.ts
+++ b/src/frontend/src/flows/register/passkey.ts
@@ -153,6 +153,7 @@ export const savePasskeyPinOrOpenID = async ({
     });
   }
   try {
+    registrationFunnel.trigger(RegistrationEvents.WebauthnStart);
     const identity = await withLoader(() => constructIdentity({}));
     return identity;
   } catch (e) {


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

One of the funnel registration events was not triggered because it was missing from the current flow.

# Changes

* Trigger `RegistrationEvents.WebauthnStart`.

# Tests

Tested locally.
