### PR TITLE
Install imagemagick for dapps update

### DIFF
--- a/.github/workflows/update-dapps.yml
+++ b/.github/workflows/update-dapps.yml
@@ -11,6 +11,7 @@ jobs:
   dapps-update:
     runs-on: ubuntu-latest
     steps:
+      - run: sudo apt-get update && sudo apt-get install -y imagemagick
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node
       - run: npm ci


### PR DESCRIPTION
This ensures the `convert` executable is present when running the dapps update. Seems to have disappeared after a GHA runner update.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/desktop/authorizeUseExisting.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/desktop/authorizeUseExistingKnown.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/desktop/authorizeUseExistingKnownAlt.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/desktop/authorizeUseExistingKnownAlt_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/desktop/authorizeUseExistingKnown_open.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/desktop/dappsExplorer.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/desktop/displayManage.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/desktop/displayManageMaxDevices.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/desktop/displayManageSingle.png" width="250"><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/8270c6c4b/desktop/displayManageTempKey.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
