### PR TITLE
New webauthAuthorizationFunnel to clean up events without funnel

### DIFF
--- a/src/frontend/src/lib/utils/analytics/webauthnAuthorizationFunnel.ts
+++ b/src/frontend/src/lib/utils/analytics/webauthnAuthorizationFunnel.ts
@@ -1,0 +1,19 @@
+import { Funnel } from "./Funnel";
+
+/**
+ * Webauthn Authorization flow events:
+ *
+ * start-webauthn-authentication (INIT)
+ *   failed-webauthn-authentication
+ *     cancelled-webauthn-authentication
+ *   successful-webauthn-authentication
+ */
+export enum WebauthnAuthorizationEvents {
+  Failed = "failed-webauthn-authentication",
+  Cancelled = "cancelled-webauthn-authentication",
+  Success = "successful-webauthn-authentication",
+}
+
+export const webauthnAuthorizationFunnel = new Funnel<
+  typeof WebauthnAuthorizationEvents
+>("webauthn-authentication");


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We want to use Funnel instances to trigger all the events.

In this PR, I move the set of events related to webauthn authentication

# Changes

This pull request introduces a new funnel for tracking Webauthn authorization events and replaces the existing analytics event calls with this new funnel. The most important changes include the addition of the `webauthnAuthorizationFunnel` and updates to the `Connection` class to use this new funnel.

### Introduction of Webauthn Authorization Funnel:

* [`src/frontend/src/lib/utils/analytics/webauthnAuthorizationFunnel.ts`](diffhunk://#diff-81a460b52e9cbbde77135cae5bfc2ced3872af04d31ed1a8956f99057ab91284R1-R19): Added a new file defining the `WebauthnAuthorizationEvents` enum and the `webauthnAuthorizationFunnel` for tracking Webauthn authorization events.

### Updates to `Connection` class:

* [`src/frontend/src/lib/utils/iiConnection.ts`](diffhunk://#diff-1a5c5d2f4270a21f885aad86ecd02e8a87d7e76e0c9836b05eb3bf2b5b066b7fR82): Imported the `webauthnAuthorizationFunnel` and `WebauthnAuthorizationEvents` to replace the existing analytics event calls.
* [`src/frontend/src/lib/utils/iiConnection.ts`](diffhunk://#diff-1a5c5d2f4270a21f885aad86ecd02e8a87d7e76e0c9836b05eb3bf2b5b066b7fL530-R531): Updated the `Connection` class to initialize the `webauthnAuthorizationFunnel` instead of calling `analytics.event` for the "start-webauthn-authentication" event.
* [`src/frontend/src/lib/utils/iiConnection.ts`](diffhunk://#diff-1a5c5d2f4270a21f885aad86ecd02e8a87d7e76e0c9836b05eb3bf2b5b066b7fL561-R565): Replaced the `analytics.event` call with `webauthnAuthorizationFunnel.trigger` for the "failed-webauthn-authentication" and "cancelled-webauthn-authentication" events.
* [`src/frontend/src/lib/utils/iiConnection.ts`](diffhunk://#diff-1a5c5d2f4270a21f885aad86ecd02e8a87d7e76e0c9836b05eb3bf2b5b066b7fL601-R602): Replaced the `analytics.event` call with `webauthnAuthorizationFunnel.trigger` for the "successful-webauthn-authentication" event.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
