### PR TITLE
Add authorize client funnel analytics and replace direct analytics calls

### DIFF
--- a/src/frontend/src/lib/utils/analytics/authorizeClientFunnel.ts
+++ b/src/frontend/src/lib/utils/analytics/authorizeClientFunnel.ts
@@ -1,0 +1,23 @@
+import { Funnel } from "./Funnel";
+
+/**
+ * Authorize client flow events:
+ * 
+ * authorize-client-start (INIT)
+ *   authorize-client-request-received
+ *     authorize-client-request-valid
+ *       authorize-client-authenticate
+ *         authorize-client-authenticate-success
+ *         authorize-client-authenticate-error
+ */
+export const AuthorizeClientEvents = {
+  RequestReceived: "authorize-client-request-received",
+  RequestValid: "authorize-client-request-valid",
+  Authenticate: "authorize-client-authenticate",
+  AuthenticateError: "authorize-client-authenticate-error",
+  AuthenticateSuccess: "authorize-client-authenticate-success",
+} as const;
+
+export const authorizeClientFunnel = new Funnel<typeof AuthorizeClientEvents>(
+  "authorize-client",
+);


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We want to avoid sending events that are not part of any funnel to keep events maintainable and understandable.

In this PR, a new funnel is created to trigger the events of authorizing client applications. This is not a user funnel, but a technical funnel to understand error rates and reason for the errors.

# Changes

* [`src/frontend/src/lib/utils/analytics/authorizeClientFunnel.ts`](diffhunk://#diff-67f893fd324dd654fc43ef9655dc12803ed0159c28c05891da04508d986dba05R1-R23): Created a new file to define specific events for the authorization client flow, including `RequestReceived`, `RequestValid`, `Authenticate`, `AuthenticateError`, and `AuthenticateSuccess`.
* [`src/frontend/src/lib/flows/authorize/postMessageInterface.ts`](diffhunk://#diff-488105e468e154f5dd545cfde411407cb23fc09cfe9b2b4ab98217924aca3521L3-R3): Replaced generic `analytics` events with specific `authorizeClientFunnel` events to enhance tracking granularity.

# Tests

No new functionality.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
