### PR TITLE
add memory and read/write methods for storing and looking up anchor n…

### DIFF
--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -1,16 +1,17 @@
 use crate::archive::{archive_operation, device_diff};
 use crate::openid::{OpenIdCredential, OpenIdCredentialKey};
 use crate::state::RegistrationState::DeviceTentativelyAdded;
-use crate::state::TentativeDeviceRegistration;
+use crate::state::{storage_borrow_mut, TentativeDeviceRegistration};
 use crate::storage::anchor::{Anchor, AnchorError, Device};
+use crate::storage::DiscoverableCredentialData;
 use crate::{state, stats::activity_stats};
 use ic_cdk::api::time;
 use ic_cdk::{caller, trap};
 use internet_identity_interface::archive::types::{DeviceDataWithoutAlias, Operation};
 use internet_identity_interface::internet_identity::types::openid::OpenIdCredentialData;
 use internet_identity_interface::internet_identity::types::{
-    AnchorNumber, AuthorizationKey, DeviceData, DeviceKey, DeviceRegistrationInfo, DeviceWithUsage,
-    IdentityAnchorInfo, MetadataEntry,
+    AnchorNumber, AuthorizationKey, CredentialId, DeviceData, DeviceKey, DeviceRegistrationInfo,
+    DeviceWithUsage, IdentityAnchorInfo, MetadataEntry, PublicKey,
 };
 use state::storage_borrow;
 use std::collections::HashMap;
@@ -231,6 +232,31 @@ pub fn update_openid_credential(
 /// Lookup `AnchorNumber` for the given `OpenIdCredentialKey`.
 pub fn lookup_anchor_with_openid_credential(key: &OpenIdCredentialKey) -> Option<AnchorNumber> {
     storage_borrow(|storage| storage.lookup_anchor_with_openid_credential(key))
+}
+
+/// Lookup `AnchorNumber` and `PublicKey` for the given `CredentialId`.
+pub fn lookup_anchor_number_and_pubkey_with_credential_id(
+    credential_id: &CredentialId,
+) -> Option<DiscoverableCredentialData> {
+    storage_borrow(|storage| {
+        storage.lookup_anchor_number_and_pubkey_with_credential_id(credential_id)
+    })
+}
+
+/// Store `AnchorNumber` and `PublicKey` for the given `CredentialId`.
+// TODO: this is still dead code, needs to be added to the registration finish.
+pub fn store_anchor_number_and_pubkey_with_credential_id(
+    credential_id: &CredentialId,
+    anchor_number: AnchorNumber,
+    pubkey: PublicKey,
+) -> Option<DiscoverableCredentialData> {
+    storage_borrow_mut(|storage| {
+        storage.store_anchor_number_and_pubkey_with_credential_id(
+            credential_id,
+            anchor_number,
+            pubkey,
+        )
+    })
 }
 
 #[test]

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -28,7 +28,7 @@ use internet_identity_interface::internet_identity::types::vc_mvp::{
 use internet_identity_interface::internet_identity::types::*;
 use serde_bytes::ByteBuf;
 use std::collections::HashMap;
-use storage::{Salt, Storage};
+use storage::{DiscoverableCredentialData, Salt, Storage};
 
 mod anchor_management;
 mod archive;
@@ -902,6 +902,21 @@ mod openid_api {
             Some(_) => openid_credential.get_jwt_delegation(session_key, expiration),
             None => Err(OpenIdDelegationError::NoSuchAnchor),
         }
+    }
+}
+
+/// API required for the discoverable credentials flow
+mod discoverable_credentials {
+    use crate::anchor_management::lookup_anchor_number_and_pubkey_with_credential_id;
+    use crate::DiscoverableCredentialData;
+    use ic_cdk::query;
+    use internet_identity_interface::internet_identity::types::CredentialId;
+
+    #[query]
+    fn get_discoverable_credential_data(
+        credential_id: CredentialId,
+    ) -> Option<DiscoverableCredentialData> {
+        lookup_anchor_number_and_pubkey_with_credential_id(&credential_id)
     }
 }
 

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -86,6 +86,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::fmt;
 use std::io::{Read, Write};
 use std::ops::RangeInclusive;
+use storable_credential_id::StorableCredentialId;
 
 use ic_cdk::api::trap;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
@@ -102,6 +103,7 @@ use crate::state::PersistentState;
 use crate::stats::event_stats::AggregationKey;
 use crate::stats::event_stats::{EventData, EventKey};
 use crate::storage::anchor::Anchor;
+pub use crate::storage::discoverable_credential_data::DiscoverableCredentialData;
 use crate::storage::memory_wrapper::MemoryWrapper;
 use crate::storage::registration_rates::RegistrationRates;
 use crate::storage::stable_anchor::StableAnchor;
@@ -114,10 +116,12 @@ use internet_identity_interface::internet_identity::types::*;
 pub mod anchor;
 pub mod registration_rates;
 
+mod discoverable_credential_data;
 pub mod stable_anchor;
 /// module for the internal serialization format of anchors
 mod storable_anchor;
 mod storable_anchor_number_list;
+mod storable_credential_id;
 mod storable_openid_credential_key;
 mod storable_persistent_state;
 #[cfg(test)]
@@ -143,6 +147,7 @@ const REGISTRATION_REFERENCE_RATE_MEMORY_INDEX: u8 = 5u8;
 const REGISTRATION_CURRENT_RATE_MEMORY_INDEX: u8 = 6u8;
 const STABLE_ANCHOR_MEMORY_INDEX: u8 = 7u8;
 const LOOKUP_ANCHOR_WITH_OPENID_CREDENTIAL_MEMORY_INDEX: u8 = 8u8;
+const LOOKUP_ANCHOR_AND_PUBKEY_WITH_CREDENTIAL_ID_INDEX: u8 = 9u8;
 const ANCHOR_MEMORY_ID: MemoryId = MemoryId::new(ANCHOR_MEMORY_INDEX);
 const ARCHIVE_BUFFER_MEMORY_ID: MemoryId = MemoryId::new(ARCHIVE_BUFFER_MEMORY_INDEX);
 const PERSISTENT_STATE_MEMORY_ID: MemoryId = MemoryId::new(PERSISTENT_STATE_MEMORY_INDEX);
@@ -155,6 +160,8 @@ const REGISTRATION_CURRENT_RATE_MEMORY_ID: MemoryId =
 const STABLE_ANCHOR_MEMORY_ID: MemoryId = MemoryId::new(STABLE_ANCHOR_MEMORY_INDEX);
 const LOOKUP_ANCHOR_WITH_OPENID_CREDENTIAL_MEMORY_ID: MemoryId =
     MemoryId::new(LOOKUP_ANCHOR_WITH_OPENID_CREDENTIAL_MEMORY_INDEX);
+const LOOKUP_ANCHOR_AND_PUBKEY_WITH_CREDENTIAL_ID: MemoryId =
+    MemoryId::new(LOOKUP_ANCHOR_AND_PUBKEY_WITH_CREDENTIAL_ID_INDEX);
 // The bucket size 128 is relatively low, to avoid wasting memory when using
 // multiple virtual memories for smaller amounts of data.
 // This value results in 256 GB of total managed memory, which should be enough
@@ -221,6 +228,9 @@ pub struct Storage<M: Memory> {
     lookup_anchor_with_openid_credential_memory_wrapper: MemoryWrapper<ManagedMemory<M>>,
     lookup_anchor_with_openid_credential_memory:
         StableBTreeMap<StorableOpenIdCredentialKey, StorableAnchorNumberList, ManagedMemory<M>>,
+    lookup_anchor_and_pubkey_with_credential_id_memory_wrapper: MemoryWrapper<ManagedMemory<M>>,
+    lookup_anchor_and_pubkey_with_credential_id_memory:
+        StableBTreeMap<StorableCredentialId, DiscoverableCredentialData, ManagedMemory<M>>,
 }
 
 #[repr(C, packed)]
@@ -285,6 +295,10 @@ impl<M: Memory + Clone> Storage<M> {
         let stable_anchor_memory = memory_manager.get(STABLE_ANCHOR_MEMORY_ID);
         let lookup_anchor_with_openid_credential_memory =
             memory_manager.get(LOOKUP_ANCHOR_WITH_OPENID_CREDENTIAL_MEMORY_ID);
+        let lookup_anchor_and_pubkey_with_credential_id_memory =
+            memory_manager.get(LOOKUP_ANCHOR_AND_PUBKEY_WITH_CREDENTIAL_ID);
+        let lookup_anchor_and_pubkey_with_credential_id_memory =
+            memory_manager.get(LOOKUP_ANCHOR_AND_PUBKEY_WITH_CREDENTIAL_ID);
 
         let registration_rates = RegistrationRates::new(
             MinHeap::init(registration_ref_rate_memory.clone())
@@ -324,6 +338,12 @@ impl<M: Memory + Clone> Storage<M> {
             ),
             lookup_anchor_with_openid_credential_memory: StableBTreeMap::init(
                 lookup_anchor_with_openid_credential_memory,
+            ),
+            lookup_anchor_and_pubkey_with_credential_id_memory_wrapper: MemoryWrapper::new(
+                lookup_anchor_and_pubkey_with_credential_id_memory.clone(),
+            ),
+            lookup_anchor_and_pubkey_with_credential_id_memory: StableBTreeMap::init(
+                lookup_anchor_and_pubkey_with_credential_id_memory,
             ),
         }
     }
@@ -493,6 +513,34 @@ impl<M: Memory + Clone> Storage<M> {
         anchor_numbers.first().copied()
     }
 
+    pub fn lookup_anchor_number_and_pubkey_with_credential_id(
+        &self,
+        credential_id: &CredentialId,
+    ) -> Option<DiscoverableCredentialData> {
+        let anchor_number_and_pubkey: Option<DiscoverableCredentialData> = self
+            .lookup_anchor_and_pubkey_with_credential_id_memory
+            .get(&credential_id.clone().into());
+
+        anchor_number_and_pubkey
+    }
+
+    // this should only return data if there is pre-existing data under that credential id - ergo, never.
+    pub fn store_anchor_number_and_pubkey_with_credential_id(
+        &mut self,
+        credential_id: &CredentialId,
+        anchor_number: AnchorNumber,
+        pubkey: PublicKey,
+    ) -> Option<DiscoverableCredentialData> {
+        let result = self
+            .lookup_anchor_and_pubkey_with_credential_id_memory
+            .insert(
+                credential_id.clone().into(),
+                DiscoverableCredentialData::new(anchor_number, pubkey),
+            );
+
+        result
+    }
+
     /// Make sure all the required metadata is recorded to stable memory.
     pub fn flush(&mut self) {
         let slice = unsafe {
@@ -654,6 +702,11 @@ impl<M: Memory + Clone> Storage<M> {
             (
                 "lookup_anchor_with_openid_credential".to_string(),
                 self.lookup_anchor_with_openid_credential_memory_wrapper
+                    .size(),
+            ),
+            (
+                "lookup_anchor_and_pubkey_with_credential_id".to_string(),
+                self.lookup_anchor_and_pubkey_with_credential_id_memory_wrapper
                     .size(),
             ),
         ])

--- a/src/internet_identity/src/storage/discoverable_credential_data.rs
+++ b/src/internet_identity/src/storage/discoverable_credential_data.rs
@@ -1,0 +1,40 @@
+use std::borrow::Cow;
+
+use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
+use internet_identity_interface::internet_identity::types::{AnchorNumber, PublicKey};
+use serde::Deserialize;
+
+#[derive(CandidType, Deserialize)]
+pub struct DiscoverableCredentialData {
+    pub anchor_number: AnchorNumber,
+    pub pubkey: PublicKey,
+}
+
+impl DiscoverableCredentialData {
+    pub fn new(anchor_number: AnchorNumber, pubkey: PublicKey) -> Self {
+        Self {
+            anchor_number,
+            pubkey,
+        }
+    }
+}
+
+impl Storable for DiscoverableCredentialData {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut candid = candid::encode_one(self)
+            .expect("Failed to serialize StorableAnchorNumberAndPubkey to candid");
+        let mut buf = (candid.len() as u16).to_le_bytes().to_vec(); // 2 bytes for length
+        buf.append(&mut candid);
+        Cow::Owned(buf)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let length = u16::from_le_bytes(bytes[..2].try_into().unwrap()) as usize;
+
+        candid::decode_one(&bytes[2..length + 2])
+            .expect("Failed to deserialize StorableAnchorNumberAndPubkey from candid")
+    }
+
+    const BOUND: Bound = Bound::Unbounded; //TODO: this may be bounded, more research is required.
+}

--- a/src/internet_identity/src/storage/storable_credential_id.rs
+++ b/src/internet_identity/src/storage/storable_credential_id.rs
@@ -1,0 +1,40 @@
+use std::borrow::Cow;
+
+use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
+use internet_identity_interface::internet_identity::types::CredentialId;
+use serde::Deserialize;
+
+#[derive(CandidType, Deserialize, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct StorableCredentialId(CredentialId);
+
+impl From<CredentialId> for StorableCredentialId {
+    fn from(value: CredentialId) -> Self {
+        StorableCredentialId(value)
+    }
+}
+
+impl From<StorableCredentialId> for CredentialId {
+    fn from(value: StorableCredentialId) -> Self {
+        value.0
+    }
+}
+
+impl Storable for StorableCredentialId {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut candid =
+            candid::encode_one(self).expect("Failed to serialize StorableCredentialId to candid");
+        let mut buf = (candid.len() as u16).to_le_bytes().to_vec(); // 2 bytes for length
+        buf.append(&mut candid);
+        Cow::Owned(buf)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let length = u16::from_le_bytes(bytes[..2].try_into().unwrap()) as usize;
+
+        candid::decode_one(&bytes[2..length + 2])
+            .expect("Failed to deserialize StorableCredentialId from candid")
+    }
+
+    const BOUND: Bound = Bound::Unbounded; //TODO: this may be bounded, more research is required.
+}


### PR DESCRIPTION
# Motivation

In order to allow logging in / signing up with discoverable passkeys, we need to be able to retrieve anchor number and pubkey by credential id.

# Changes

Add the map in storage, add read/write methods and related data types.

# Tests

No tests.
