### PR TITLE
Add NNS Dapp new origin

### DIFF
--- a/src/frontend/src/lib/flows/dappsExplorer/dapps.json
+++ b/src/frontend/src/lib/flows/dappsExplorer/dapps.json
@@ -103,6 +103,12 @@
     "logo": "nnsfront-enddapp_logo-dark.webp"
   },
   {
+    "name": "NNS Dapp",
+    "oneLiner": "Dapp for Staking Neurons + Voting Onchain",
+    "website": "https://nns.internetcomputer.org",
+    "logo": "nnsfront-enddapp_logo-dark.webp"
+  },
+  {
     "name": "Trax",
     "website": "https://trax.so/",
     "logo": "trax_logo.webp"


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Show NNS Dapp as a known dapp with logo and name when a user comes from `nns.internetcomputer.org`.

# Changes

* Add one entry to the dapps explorer json file.

# Tests

No new functionality
