### PR TITLE
add disco flow rerouting and feature flag

### DIFF
--- a/src/frontend/src/hooks.ts
+++ b/src/frontend/src/hooks.ts
@@ -2,6 +2,8 @@ import { Reroute } from "@sveltejs/kit";
 import { WEBAUTHN_IFRAME_PATH } from "$lib/flows/iframeWebAuthn";
 import { getAddDeviceAnchor } from "$lib/utils/addDeviceLink";
 import { nonNullish } from "@dfinity/utils";
+import { DISCOVERABLE_PASSKEY_FLOW } from "$lib/state/featureFlags";
+import { get } from "svelte/store";
 
 export const reroute: Reroute = ({ url }) => {
   if (nonNullish(getAddDeviceAnchor(url))) {
@@ -15,5 +17,8 @@ export const reroute: Reroute = ({ url }) => {
   }
   if (url.pathname.startsWith("/vc-flow")) {
     return "/vc-flow/index";
+  }
+  if (url.pathname === "/" && get(DISCOVERABLE_PASSKEY_FLOW)) {
+    return "/new-authenticate";
   }
 };

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -1,5 +1,6 @@
 import { writable, type Writable } from "svelte/store";
 import { FeatureFlag } from "$lib/utils/featureFlags";
+import { isNullish } from "@dfinity/utils";
 
 declare global {
   interface Window {
@@ -20,7 +21,7 @@ const createFeatureFlagStore = (
   const { subscribe, set, update } = writable(defaultValue);
 
   // We cannot use browser because this is also imported in our showcase
-  if (typeof window === "undefined") {
+  if (isNullish(globalThis.window)) {
     return {
       subscribe,
       set,
@@ -73,8 +74,14 @@ export const HARDWARE_KEY_TEST = createFeatureFlagStore(
   false,
 );
 
+export const DISCOVERABLE_PASSKEY_FLOW = createFeatureFlagStore(
+  "DISCOVERABLE_PASSKEY_FLOW",
+  false,
+);
+
 export default {
   DOMAIN_COMPATIBILITY,
   OPENID_AUTHENTICATION,
   HARDWARE_KEY_TEST,
+  DISCOVERABLE_PASSKEY_FLOW,
 } as Record<string, FeatureFlagStore>;


### PR DESCRIPTION
# Motivation

We want to be able to reroute users to the new discoverable passkey flow based on feature flag and query param. The query param and route itself should disappear from the address bar. The new styling should be scoped to only the new routes via a routing group.

# Changes

Add new feature flag, rerouting logic

# Tests

Another PR

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
