### PR TITLE
Store and retrieve latest identity used

### DIFF
--- a/src/frontend/src/lib/constants/store.constants.ts
+++ b/src/frontend/src/lib/constants/store.constants.ts
@@ -2,4 +2,5 @@ export const storeLocalStorageKey = {
   LastUsedIdentities: "ii-last-used-identities",
 } as const;
 
-export type StoreLocalStorageKey = (typeof storeLocalStorageKey)[keyof typeof storeLocalStorageKey]
+export type StoreLocalStorageKey =
+  (typeof storeLocalStorageKey)[keyof typeof storeLocalStorageKey];

--- a/src/frontend/src/lib/constants/store.constants.ts
+++ b/src/frontend/src/lib/constants/store.constants.ts
@@ -1,0 +1,5 @@
+export const storeLocalStorageKey = {
+  LastUsedIdentities: "ii-last-used-identities",
+} as const;
+
+export type StoreLocalStorageKey = (typeof storeLocalStorageKey)[keyof typeof storeLocalStorageKey]

--- a/src/frontend/src/lib/stores/last-used-identities.store.test.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+
+// Mock the dependency: writableStored
+vi.mock('$app/environment', () => ({
+  browser: true // Or false, depending on the test case
+}));
+
+
+// Import the stores AFTER mocking the dependency
+import { lastUsedIdentitiesStore, lastUsedIdentityStore } from './last-used-identities.store';
+import type { LastUsedIdentity, LastUsedIdentitiesData } from './last-used-identities.store';
+
+describe('lastUsedIdentitiesStore', () => {
+  const mockTimestamp1 = 1700000000000;
+  const mockTimestamp2 = 1700000001000;
+  const mockTimestamp3 = 1700000002000;
+
+  const identity1 = BigInt('111');
+  const name1 = 'Test ID 1';
+  const identity2 = BigInt('222');
+  const name2 = 'Test ID 2';
+
+  beforeEach(() => {
+    // Reset the store state and time before each test
+    vi.useFakeTimers();
+    vi.setSystemTime(mockTimestamp1);
+    localStorage.clear();
+    lastUsedIdentitiesStore.reset(); // Use the store's reset method
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should initialize with an empty object', () => {
+    expect(get(lastUsedIdentitiesStore)).toEqual({});
+  });
+
+  it('should add the first identity correctly', () => {
+    lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
+
+    const expected: LastUsedIdentitiesData = {
+      [identity1.toString()]: {
+        identityNumber: identity1,
+        name: name1,
+        lastUsedTimestampMillis: mockTimestamp1,
+      },
+    };
+    expect(get(lastUsedIdentitiesStore)).toEqual(expected);
+  });
+
+  it('should add multiple identities with correct timestamps', () => {
+    // Add first identity
+    lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
+
+    // Advance time and add second identity
+    vi.setSystemTime(mockTimestamp2);
+    lastUsedIdentitiesStore.addLatestUsed(identity2, name2);
+
+    const expected: LastUsedIdentitiesData = {
+      [identity1.toString()]: { identityNumber: identity1, name: name1, lastUsedTimestampMillis: mockTimestamp1 },
+      [identity2.toString()]: { identityNumber: identity2, name: name2, lastUsedTimestampMillis: mockTimestamp2 },
+    };
+    expect(get(lastUsedIdentitiesStore)).toEqual(expected);
+  });
+
+  it('should update the timestamp when adding an existing identity', () => {
+    // Add identity initially
+    lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
+    expect(get(lastUsedIdentitiesStore)[identity1.toString()].lastUsedTimestampMillis).toBe(mockTimestamp1);
+
+    // Advance time and add the same identity again
+    vi.setSystemTime(mockTimestamp3);
+    lastUsedIdentitiesStore.addLatestUsed(identity1, name1); // Name doesn't matter for update logic here
+
+    const expected: LastUsedIdentitiesData = {
+      [identity1.toString()]: {
+        identityNumber: identity1,
+        name: name1, // Name should remain the same from the *last* call
+        lastUsedTimestampMillis: mockTimestamp3,
+      },
+    };
+    expect(get(lastUsedIdentitiesStore)).toEqual(expected);
+    expect(get(lastUsedIdentitiesStore)[identity1.toString()].lastUsedTimestampMillis).toBe(mockTimestamp3);
+  });
+
+  it('should reset the store to an empty object', () => {
+    lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
+    expect(get(lastUsedIdentitiesStore)).not.toEqual({}); // Ensure it's not empty
+
+    lastUsedIdentitiesStore.reset();
+    expect(get(lastUsedIdentitiesStore)).toEqual({});
+  });
+});
+
+describe('lastUsedIdentityStore (derived)', () => {
+  const mockTimestamp1 = 1700000000000;
+  const mockTimestamp2 = 1700000001000;
+  const mockTimestamp3 = 1700000002000;
+
+  const identity1 = BigInt('101');
+  const name1 = 'Derived ID 1';
+  const identity2 = BigInt('202');
+  const name2 = 'Derived ID 2';
+  const identity3 = BigInt('303');
+  const name3 = 'Derived ID 3';
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(mockTimestamp1);
+    localStorage.clear();
+    lastUsedIdentitiesStore.reset(); // Reset the source store
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should be undefined when the source store is empty', () => {
+    expect(get(lastUsedIdentityStore)).toBeUndefined();
+  });
+
+  it('should return the only identity when one is added', () => {
+    lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
+
+    const expected: LastUsedIdentity = {
+      identityNumber: identity1,
+      name: name1,
+      lastUsedTimestampMillis: mockTimestamp1,
+    };
+    expect(get(lastUsedIdentityStore)).toEqual(expected);
+  });
+
+   it('should return the latest identity when multiple are added', () => {
+    vi.setSystemTime(mockTimestamp1);
+    lastUsedIdentitiesStore.addLatestUsed(identity2, name2);
+
+    vi.setSystemTime(mockTimestamp2);
+    lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
+
+    const expectedLatest: LastUsedIdentity = {
+      identityNumber: identity1,
+      name: name1,
+      lastUsedTimestampMillis: mockTimestamp2,
+    };
+    expect(get(lastUsedIdentityStore)).toEqual(expectedLatest);
+
+    // Add identity 3 (at time 3) - Should become the latest
+    vi.setSystemTime(mockTimestamp3);
+    lastUsedIdentitiesStore.addLatestUsed(identity3, name3);
+     const expectedNewest: LastUsedIdentity = {
+      identityNumber: identity3,
+      name: name3,
+      lastUsedTimestampMillis: mockTimestamp3,
+    };
+    expect(get(lastUsedIdentityStore)).toEqual(expectedNewest);
+  });
+
+  it('should update when an existing identity becomes the latest again', () => {
+    // Add 1 at time 1
+    lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
+
+    // Add 2 at time 2 (latest is now 2)
+    vi.setSystemTime(mockTimestamp2);
+    lastUsedIdentitiesStore.addLatestUsed(identity2, name2);
+    expect(get(lastUsedIdentityStore)?.identityNumber).toBe(identity2);
+
+    // Add 1 again at time 3 (latest is now 1 again)
+    vi.setSystemTime(mockTimestamp3);
+    lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
+
+    const expected: LastUsedIdentity = {
+      identityNumber: identity1,
+      name: name1,
+      lastUsedTimestampMillis: mockTimestamp3,
+    };
+    expect(get(lastUsedIdentityStore)).toEqual(expected);
+  });
+
+  it('should become undefined after the source store is reset', () => {
+    lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
+    expect(get(lastUsedIdentityStore)).toBeDefined();
+
+    lastUsedIdentitiesStore.reset();
+    expect(get(lastUsedIdentityStore)).toBeUndefined();
+  });
+});

--- a/src/frontend/src/lib/stores/last-used-identities.store.test.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.test.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { get } from "svelte/store";
-
-// Mock the dependency: writableStored
-vi.mock("$app/environment", () => ({
-  browser: true, // Or false, depending on the test case
-}));
-
-// Import the stores AFTER mocking the dependency
 import {
   lastUsedIdentitiesStore,
   lastUsedIdentityStore,
@@ -15,6 +8,11 @@ import type {
   LastUsedIdentity,
   LastUsedIdentitiesData,
 } from "./last-used-identities.store";
+
+// Mock the dependency: writableStored
+vi.mock("$app/environment", () => ({
+  browser: true, // Or false, depending on the test case
+}));
 
 describe("lastUsedIdentitiesStore", () => {
   const mockTimestamp1 = 1700000000000;

--- a/src/frontend/src/lib/stores/last-used-identities.store.test.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.test.ts
@@ -1,25 +1,30 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { get } from 'svelte/store';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { get } from "svelte/store";
 
 // Mock the dependency: writableStored
-vi.mock('$app/environment', () => ({
-  browser: true // Or false, depending on the test case
+vi.mock("$app/environment", () => ({
+  browser: true, // Or false, depending on the test case
 }));
 
-
 // Import the stores AFTER mocking the dependency
-import { lastUsedIdentitiesStore, lastUsedIdentityStore } from './last-used-identities.store';
-import type { LastUsedIdentity, LastUsedIdentitiesData } from './last-used-identities.store';
+import {
+  lastUsedIdentitiesStore,
+  lastUsedIdentityStore,
+} from "./last-used-identities.store";
+import type {
+  LastUsedIdentity,
+  LastUsedIdentitiesData,
+} from "./last-used-identities.store";
 
-describe('lastUsedIdentitiesStore', () => {
+describe("lastUsedIdentitiesStore", () => {
   const mockTimestamp1 = 1700000000000;
   const mockTimestamp2 = 1700000001000;
   const mockTimestamp3 = 1700000002000;
 
-  const identity1 = BigInt('111');
-  const name1 = 'Test ID 1';
-  const identity2 = BigInt('222');
-  const name2 = 'Test ID 2';
+  const identity1 = BigInt("111");
+  const name1 = "Test ID 1";
+  const identity2 = BigInt("222");
+  const name2 = "Test ID 2";
 
   beforeEach(() => {
     // Reset the store state and time before each test
@@ -33,11 +38,11 @@ describe('lastUsedIdentitiesStore', () => {
     vi.useRealTimers();
   });
 
-  it('should initialize with an empty object', () => {
+  it("should initialize with an empty object", () => {
     expect(get(lastUsedIdentitiesStore)).toEqual({});
   });
 
-  it('should add the first identity correctly', () => {
+  it("should add the first identity correctly", () => {
     lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
 
     const expected: LastUsedIdentitiesData = {
@@ -50,7 +55,7 @@ describe('lastUsedIdentitiesStore', () => {
     expect(get(lastUsedIdentitiesStore)).toEqual(expected);
   });
 
-  it('should add multiple identities with correct timestamps', () => {
+  it("should add multiple identities with correct timestamps", () => {
     // Add first identity
     lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
 
@@ -59,16 +64,27 @@ describe('lastUsedIdentitiesStore', () => {
     lastUsedIdentitiesStore.addLatestUsed(identity2, name2);
 
     const expected: LastUsedIdentitiesData = {
-      [identity1.toString()]: { identityNumber: identity1, name: name1, lastUsedTimestampMillis: mockTimestamp1 },
-      [identity2.toString()]: { identityNumber: identity2, name: name2, lastUsedTimestampMillis: mockTimestamp2 },
+      [identity1.toString()]: {
+        identityNumber: identity1,
+        name: name1,
+        lastUsedTimestampMillis: mockTimestamp1,
+      },
+      [identity2.toString()]: {
+        identityNumber: identity2,
+        name: name2,
+        lastUsedTimestampMillis: mockTimestamp2,
+      },
     };
     expect(get(lastUsedIdentitiesStore)).toEqual(expected);
   });
 
-  it('should update the timestamp when adding an existing identity', () => {
+  it("should update the timestamp when adding an existing identity", () => {
     // Add identity initially
     lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
-    expect(get(lastUsedIdentitiesStore)[identity1.toString()].lastUsedTimestampMillis).toBe(mockTimestamp1);
+    expect(
+      get(lastUsedIdentitiesStore)[identity1.toString()]
+        .lastUsedTimestampMillis,
+    ).toBe(mockTimestamp1);
 
     // Advance time and add the same identity again
     vi.setSystemTime(mockTimestamp3);
@@ -82,10 +98,13 @@ describe('lastUsedIdentitiesStore', () => {
       },
     };
     expect(get(lastUsedIdentitiesStore)).toEqual(expected);
-    expect(get(lastUsedIdentitiesStore)[identity1.toString()].lastUsedTimestampMillis).toBe(mockTimestamp3);
+    expect(
+      get(lastUsedIdentitiesStore)[identity1.toString()]
+        .lastUsedTimestampMillis,
+    ).toBe(mockTimestamp3);
   });
 
-  it('should reset the store to an empty object', () => {
+  it("should reset the store to an empty object", () => {
     lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
     expect(get(lastUsedIdentitiesStore)).not.toEqual({}); // Ensure it's not empty
 
@@ -94,17 +113,17 @@ describe('lastUsedIdentitiesStore', () => {
   });
 });
 
-describe('lastUsedIdentityStore (derived)', () => {
+describe("lastUsedIdentityStore (derived)", () => {
   const mockTimestamp1 = 1700000000000;
   const mockTimestamp2 = 1700000001000;
   const mockTimestamp3 = 1700000002000;
 
-  const identity1 = BigInt('101');
-  const name1 = 'Derived ID 1';
-  const identity2 = BigInt('202');
-  const name2 = 'Derived ID 2';
-  const identity3 = BigInt('303');
-  const name3 = 'Derived ID 3';
+  const identity1 = BigInt("101");
+  const name1 = "Derived ID 1";
+  const identity2 = BigInt("202");
+  const name2 = "Derived ID 2";
+  const identity3 = BigInt("303");
+  const name3 = "Derived ID 3";
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -117,11 +136,11 @@ describe('lastUsedIdentityStore (derived)', () => {
     vi.useRealTimers();
   });
 
-  it('should be undefined when the source store is empty', () => {
+  it("should be undefined when the source store is empty", () => {
     expect(get(lastUsedIdentityStore)).toBeUndefined();
   });
 
-  it('should return the only identity when one is added', () => {
+  it("should return the only identity when one is added", () => {
     lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
 
     const expected: LastUsedIdentity = {
@@ -132,7 +151,7 @@ describe('lastUsedIdentityStore (derived)', () => {
     expect(get(lastUsedIdentityStore)).toEqual(expected);
   });
 
-   it('should return the latest identity when multiple are added', () => {
+  it("should return the latest identity when multiple are added", () => {
     vi.setSystemTime(mockTimestamp1);
     lastUsedIdentitiesStore.addLatestUsed(identity2, name2);
 
@@ -149,7 +168,7 @@ describe('lastUsedIdentityStore (derived)', () => {
     // Add identity 3 (at time 3) - Should become the latest
     vi.setSystemTime(mockTimestamp3);
     lastUsedIdentitiesStore.addLatestUsed(identity3, name3);
-     const expectedNewest: LastUsedIdentity = {
+    const expectedNewest: LastUsedIdentity = {
       identityNumber: identity3,
       name: name3,
       lastUsedTimestampMillis: mockTimestamp3,
@@ -157,7 +176,7 @@ describe('lastUsedIdentityStore (derived)', () => {
     expect(get(lastUsedIdentityStore)).toEqual(expectedNewest);
   });
 
-  it('should update when an existing identity becomes the latest again', () => {
+  it("should update when an existing identity becomes the latest again", () => {
     // Add 1 at time 1
     lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
 
@@ -178,7 +197,7 @@ describe('lastUsedIdentityStore (derived)', () => {
     expect(get(lastUsedIdentityStore)).toEqual(expected);
   });
 
-  it('should become undefined after the source store is reset', () => {
+  it("should become undefined after the source store is reset", () => {
     lastUsedIdentitiesStore.addLatestUsed(identity1, name1);
     expect(get(lastUsedIdentityStore)).toBeDefined();
 

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -7,7 +7,7 @@ export type LastUsedIdentity = {
   lastUsedTimestampMillis: number;
   identityNumber: bigint;
 };
-export type LastUsedIdentitiesData = {
+type LastUsedIdentitiesData = {
   [identityNumber: string]: LastUsedIdentity;
 };
 type LastUsedIdentitiesStore = Readable<LastUsedIdentitiesData> & {

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -7,7 +7,7 @@ export type LastUsedIdentity = {
   lastUsedTimestampMillis: number;
   identityNumber: bigint;
 };
-type LastUsedIdentitiesData = {
+export type LastUsedIdentitiesData = {
   [identityNumber: string]: LastUsedIdentity;
 };
 type LastUsedIdentitiesStore = Readable<LastUsedIdentitiesData> & {

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -1,0 +1,47 @@
+import { storeLocalStorageKey } from "$lib/constants/store.constants";
+import { derived, Readable } from "svelte/store";
+import { writableStored } from "./writable.store";
+
+export type LastUsedIdentity = {
+  name: string;
+  lastUsedTimestampMillis: number;
+  identityNumber: bigint;
+};
+export type LastUsedIdentitiesData = {
+  [identityNumber: string]: LastUsedIdentity;
+};
+type LastUsedIdentitiesStore = Readable<LastUsedIdentitiesData> & {
+  addLatestUsed: (identityNumber: bigint, name: string) => void;
+  reset: () => void;
+}
+
+export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
+  const { subscribe, set, update } = writableStored<LastUsedIdentitiesData>({
+    key: storeLocalStorageKey.LastUsedIdentities,
+    defaultValue: {},
+    version: 1,
+  });
+
+  return {
+    subscribe,
+    addLatestUsed: (identityNumber: bigint, name: string) => {
+      update((lastUsedIdentities) => {
+        lastUsedIdentities[identityNumber.toString()] = {
+          name,
+          lastUsedTimestampMillis: Date.now(),
+          identityNumber,
+        };
+        return lastUsedIdentities;
+      });
+    },
+    reset: () => {
+      set({});
+    },
+  }
+};
+
+export const lastUsedIdentitiesStore = initLastUsedIdentitiesStore();
+
+export const lastUsedIdentityStore: Readable<LastUsedIdentity> = derived(lastUsedIdentitiesStore, (lastUsedIdentities) => {
+  return Object.values(lastUsedIdentities).sort((a, b) => b.lastUsedTimestampMillis - a.lastUsedTimestampMillis)[0];
+});

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -13,7 +13,7 @@ export type LastUsedIdentitiesData = {
 type LastUsedIdentitiesStore = Readable<LastUsedIdentitiesData> & {
   addLatestUsed: (identityNumber: bigint, name: string) => void;
   reset: () => void;
-}
+};
 
 export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
   const { subscribe, set, update } = writableStored<LastUsedIdentitiesData>({
@@ -37,11 +37,16 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
     reset: () => {
       set({});
     },
-  }
+  };
 };
 
 export const lastUsedIdentitiesStore = initLastUsedIdentitiesStore();
 
-export const lastUsedIdentityStore: Readable<LastUsedIdentity> = derived(lastUsedIdentitiesStore, (lastUsedIdentities) => {
-  return Object.values(lastUsedIdentities).sort((a, b) => b.lastUsedTimestampMillis - a.lastUsedTimestampMillis)[0];
-});
+export const lastUsedIdentityStore: Readable<LastUsedIdentity> = derived(
+  lastUsedIdentitiesStore,
+  (lastUsedIdentities) => {
+    return Object.values(lastUsedIdentities).sort(
+      (a, b) => b.lastUsedTimestampMillis - a.lastUsedTimestampMillis,
+    )[0];
+  },
+);

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -3,7 +3,7 @@ import { derived, Readable } from "svelte/store";
 import { writableStored } from "./writable.store";
 
 export type LastUsedIdentity = {
-  name: string;
+  name?: string;
   lastUsedTimestampMillis: number;
   identityNumber: bigint;
 };
@@ -11,7 +11,7 @@ export type LastUsedIdentitiesData = {
   [identityNumber: string]: LastUsedIdentity;
 };
 type LastUsedIdentitiesStore = Readable<LastUsedIdentitiesData> & {
-  addLatestUsed: (identityNumber: bigint, name: string) => void;
+  addLatestUsed: (identityNumber: bigint, name?: string) => void;
   reset: () => void;
 };
 
@@ -24,7 +24,7 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
 
   return {
     subscribe,
-    addLatestUsed: (identityNumber: bigint, name: string) => {
+    addLatestUsed: (identityNumber: bigint, name?: string) => {
       update((lastUsedIdentities) => {
         lastUsedIdentities[identityNumber.toString()] = {
           name,

--- a/src/frontend/src/lib/stores/writable.store.test.ts
+++ b/src/frontend/src/lib/stores/writable.store.test.ts
@@ -4,8 +4,8 @@ import { get } from "svelte/store";
 import type { LastUsedIdentity } from "$lib/stores/last-used-identities.store";
 import { jsonReplacer } from "@dfinity/utils";
 
-vi.mock('$app/environment', () => ({
-  browser: true // Or false, depending on the test case
+vi.mock("$app/environment", () => ({
+  browser: true, // Or false, depending on the test case
 }));
 
 // Mock data based on LastUsedIdentity type
@@ -27,7 +27,7 @@ const stringigyJson = (data: any) => JSON.stringify(data, jsonReplacer);
 describe("writableStored", () => {
   beforeEach(() => {
     localStorage.clear();
-  })
+  });
 
   it("writes to local storage when state changes", () => {
     const store = writableStored<LastUsedIdentity>({
@@ -39,7 +39,7 @@ describe("writableStored", () => {
     store.set(newState);
 
     expect(
-      window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities)
+      window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities),
     ).toEqual(stringigyJson(newState));
   });
 
@@ -47,7 +47,7 @@ describe("writableStored", () => {
     const storedState = mockIdentity2;
     window.localStorage.setItem(
       storeLocalStorageKey.LastUsedIdentities,
-      stringigyJson(storedState)
+      stringigyJson(storedState),
     );
     const store = writableStored<LastUsedIdentity>({
       key: storeLocalStorageKey.LastUsedIdentities,
@@ -68,7 +68,8 @@ describe("writableStored", () => {
   });
 
   it("should serialize bigint values", () => {
-    const defaultValue = BigInt(1000000000000000000000000000000000000000000000000000000);
+    const defaultValue =
+      BigInt(1000000000000000000000000000000000000000000000000000000);
     const store = writableStored({
       key: storeLocalStorageKey.LastUsedIdentities,
       defaultValue,
@@ -88,7 +89,7 @@ describe("writableStored", () => {
       const defaultValue = mockIdentity1;
       window.localStorage.setItem(
         storeLocalStorageKey.LastUsedIdentities,
-        stringigyJson({ data: storedState, version: 0 })
+        stringigyJson({ data: storedState, version: 0 }),
       );
       const store = writableStored<LastUsedIdentity>({
         key: storeLocalStorageKey.LastUsedIdentities,
@@ -104,7 +105,7 @@ describe("writableStored", () => {
       const defaultValue = mockIdentity1;
       window.localStorage.setItem(
         storeLocalStorageKey.LastUsedIdentities,
-        stringigyJson({ data: storedState, version: 2 })
+        stringigyJson({ data: storedState, version: 2 }),
       );
       const store = writableStored<LastUsedIdentity>({
         key: storeLocalStorageKey.LastUsedIdentities,
@@ -114,12 +115,12 @@ describe("writableStored", () => {
 
       expect(get(store)).toEqual(defaultValue);
       expect(
-        localStorage.getItem(storeLocalStorageKey.LastUsedIdentities)
+        localStorage.getItem(storeLocalStorageKey.LastUsedIdentities),
       ).toEqual(
         stringigyJson({
           data: defaultValue,
           version: 1,
-        })
+        }),
       );
     });
 
@@ -128,16 +129,17 @@ describe("writableStored", () => {
       const defaultValue = mockIdentity1;
       window.localStorage.setItem(
         storeLocalStorageKey.LastUsedIdentities,
-        stringigyJson({ data: storedState, version: 2 }) // Stored data has a version
+        stringigyJson({ data: storedState, version: 2 }), // Stored data has a version
       );
-      const store = writableStored<LastUsedIdentity>({ // New store definition has no version
+      const store = writableStored<LastUsedIdentity>({
+        // New store definition has no version
         key: storeLocalStorageKey.LastUsedIdentities,
         defaultValue,
       });
 
       expect(get(store)).toEqual(defaultValue);
       expect(
-        localStorage.getItem(storeLocalStorageKey.LastUsedIdentities)
+        localStorage.getItem(storeLocalStorageKey.LastUsedIdentities),
       ).toEqual(stringigyJson(defaultValue)); // Expect default value because stored had version, new didn't
     });
 
@@ -146,9 +148,10 @@ describe("writableStored", () => {
       const defaultValue = mockIdentity1;
       window.localStorage.setItem(
         storeLocalStorageKey.LastUsedIdentities,
-        stringigyJson(storedState) // No version in stored data
+        stringigyJson(storedState), // No version in stored data
       );
-      const store = writableStored<LastUsedIdentity>({ // No version in store definition
+      const store = writableStored<LastUsedIdentity>({
+        // No version in store definition
         key: storeLocalStorageKey.LastUsedIdentities,
         defaultValue,
       });
@@ -161,7 +164,7 @@ describe("writableStored", () => {
       const defaultValue = mockIdentity1;
       window.localStorage.setItem(
         storeLocalStorageKey.LastUsedIdentities,
-        stringigyJson({ data: storedState, version: 5 })
+        stringigyJson({ data: storedState, version: 5 }),
       );
       const store = writableStored<LastUsedIdentity>({
         key: storeLocalStorageKey.LastUsedIdentities,
@@ -183,13 +186,13 @@ describe("writableStored", () => {
       const newState = mockIdentity2;
       store.set(newState);
       expect(
-        window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities)
+        window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities),
       ).toEqual(stringigyJson(newState));
 
       store.unsubscribeStorage();
       store.set(defaultValue);
       expect(
-        window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities)
+        window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities),
       ).toEqual(stringigyJson(newState));
     });
   });
@@ -203,7 +206,7 @@ describe("writableStored", () => {
     });
 
     expect(get(store)).toEqual(defaultState);
-  
+
     const newState = mockIdentity2;
 
     store.set(newState);

--- a/src/frontend/src/lib/stores/writable.store.test.ts
+++ b/src/frontend/src/lib/stores/writable.store.test.ts
@@ -22,7 +22,7 @@ const mockIdentity2: LastUsedIdentity = {
 };
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-const stringigyJson = (data: any) => JSON.stringify(data, jsonReplacer);
+const stringifyJson = (data: any) => JSON.stringify(data, jsonReplacer);
 
 describe("writableStored", () => {
   beforeEach(() => {
@@ -40,14 +40,14 @@ describe("writableStored", () => {
 
     expect(
       window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities),
-    ).toEqual(stringigyJson(newState));
+    ).toEqual(stringifyJson(newState));
   });
 
   it("loads initial value from local storage if present", () => {
     const storedState = mockIdentity2;
     window.localStorage.setItem(
       storeLocalStorageKey.LastUsedIdentities,
-      stringigyJson(storedState),
+      stringifyJson(storedState),
     );
     const store = writableStored<LastUsedIdentity>({
       key: storeLocalStorageKey.LastUsedIdentities,
@@ -89,7 +89,7 @@ describe("writableStored", () => {
       const defaultValue = mockIdentity1;
       window.localStorage.setItem(
         storeLocalStorageKey.LastUsedIdentities,
-        stringigyJson({ data: storedState, version: 0 }),
+        stringifyJson({ data: storedState, version: 0 }),
       );
       const store = writableStored<LastUsedIdentity>({
         key: storeLocalStorageKey.LastUsedIdentities,
@@ -105,7 +105,7 @@ describe("writableStored", () => {
       const defaultValue = mockIdentity1;
       window.localStorage.setItem(
         storeLocalStorageKey.LastUsedIdentities,
-        stringigyJson({ data: storedState, version: 2 }),
+        stringifyJson({ data: storedState, version: 2 }),
       );
       const store = writableStored<LastUsedIdentity>({
         key: storeLocalStorageKey.LastUsedIdentities,
@@ -117,7 +117,7 @@ describe("writableStored", () => {
       expect(
         localStorage.getItem(storeLocalStorageKey.LastUsedIdentities),
       ).toEqual(
-        stringigyJson({
+        stringifyJson({
           data: defaultValue,
           version: 1,
         }),
@@ -129,7 +129,7 @@ describe("writableStored", () => {
       const defaultValue = mockIdentity1;
       window.localStorage.setItem(
         storeLocalStorageKey.LastUsedIdentities,
-        stringigyJson({ data: storedState, version: 2 }), // Stored data has a version
+        stringifyJson({ data: storedState, version: 2 }), // Stored data has a version
       );
       const store = writableStored<LastUsedIdentity>({
         // New store definition has no version
@@ -140,7 +140,7 @@ describe("writableStored", () => {
       expect(get(store)).toEqual(defaultValue);
       expect(
         localStorage.getItem(storeLocalStorageKey.LastUsedIdentities),
-      ).toEqual(stringigyJson(defaultValue)); // Expect default value because stored had version, new didn't
+      ).toEqual(stringifyJson(defaultValue)); // Expect default value because stored had version, new didn't
     });
 
     it("should not replace value in local storage when no versions provided", () => {
@@ -148,7 +148,7 @@ describe("writableStored", () => {
       const defaultValue = mockIdentity1;
       window.localStorage.setItem(
         storeLocalStorageKey.LastUsedIdentities,
-        stringigyJson(storedState), // No version in stored data
+        stringifyJson(storedState), // No version in stored data
       );
       const store = writableStored<LastUsedIdentity>({
         // No version in store definition
@@ -164,7 +164,7 @@ describe("writableStored", () => {
       const defaultValue = mockIdentity1;
       window.localStorage.setItem(
         storeLocalStorageKey.LastUsedIdentities,
-        stringigyJson({ data: storedState, version: 5 }),
+        stringifyJson({ data: storedState, version: 5 }),
       );
       const store = writableStored<LastUsedIdentity>({
         key: storeLocalStorageKey.LastUsedIdentities,
@@ -187,13 +187,13 @@ describe("writableStored", () => {
       store.set(newState);
       expect(
         window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities),
-      ).toEqual(stringigyJson(newState));
+      ).toEqual(stringifyJson(newState));
 
       store.unsubscribeStorage();
       store.set(defaultValue);
       expect(
         window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities),
-      ).toEqual(stringigyJson(newState));
+      ).toEqual(stringifyJson(newState));
     });
   });
 

--- a/src/frontend/src/lib/stores/writable.store.test.ts
+++ b/src/frontend/src/lib/stores/writable.store.test.ts
@@ -1,0 +1,215 @@
+import { storeLocalStorageKey } from "$lib/constants/store.constants";
+import { writableStored } from "$lib/stores/writable.store";
+import { get } from "svelte/store";
+import type { LastUsedIdentity } from "$lib/stores/last-used-identities.store";
+import { jsonReplacer } from "@dfinity/utils";
+
+vi.mock('$app/environment', () => ({
+  browser: true // Or false, depending on the test case
+}));
+
+// Mock data based on LastUsedIdentity type
+const mockIdentity1: LastUsedIdentity = {
+  name: "Test Identity 1",
+  lastUsedTimestampMillis: 1678886400000, // Example timestamp
+  identityNumber: BigInt("10001"),
+};
+
+const mockIdentity2: LastUsedIdentity = {
+  name: "Test Identity 2",
+  lastUsedTimestampMillis: 1678887400000, // Slightly later timestamp
+  identityNumber: BigInt("10002"),
+};
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+const stringigyJson = (data: any) => JSON.stringify(data, jsonReplacer);
+
+describe("writableStored", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  })
+
+  it("writes to local storage when state changes", () => {
+    const store = writableStored<LastUsedIdentity>({
+      key: storeLocalStorageKey.LastUsedIdentities,
+      defaultValue: mockIdentity1,
+    });
+
+    const newState = mockIdentity2;
+    store.set(newState);
+
+    expect(
+      window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities)
+    ).toEqual(stringigyJson(newState));
+  });
+
+  it("loads initial value from local storage if present", () => {
+    const storedState = mockIdentity2;
+    window.localStorage.setItem(
+      storeLocalStorageKey.LastUsedIdentities,
+      stringigyJson(storedState)
+    );
+    const store = writableStored<LastUsedIdentity>({
+      key: storeLocalStorageKey.LastUsedIdentities,
+      defaultValue: mockIdentity1,
+    });
+
+    expect(get(store)).toEqual(storedState);
+  });
+
+  it("loads default value if no value in local storage", () => {
+    const defaultValue = mockIdentity1;
+    const store = writableStored<LastUsedIdentity>({
+      key: storeLocalStorageKey.LastUsedIdentities,
+      defaultValue,
+    });
+
+    expect(get(store)).toEqual(defaultValue);
+  });
+
+  it("should serialize bigint values", () => {
+    const defaultValue = BigInt(1000000000000000000000000000000000000000000000000000000);
+    const store = writableStored({
+      key: storeLocalStorageKey.LastUsedIdentities,
+      defaultValue,
+    });
+    expect(get(store)).toEqual(defaultValue);
+
+    const store2 = writableStored({
+      key: storeLocalStorageKey.LastUsedIdentities,
+      defaultValue: 1,
+    });
+    expect(get(store2)).toEqual(defaultValue);
+  });
+
+  describe("version upgrade", () => {
+    it("should replace value from local storage when it has not the same version", () => {
+      const storedState = "old-data-string"; // Representing arbitrary old data
+      const defaultValue = mockIdentity1;
+      window.localStorage.setItem(
+        storeLocalStorageKey.LastUsedIdentities,
+        stringigyJson({ data: storedState, version: 0 })
+      );
+      const store = writableStored<LastUsedIdentity>({
+        key: storeLocalStorageKey.LastUsedIdentities,
+        defaultValue,
+        version: 1,
+      });
+
+      expect(get(store)).toEqual(defaultValue);
+    });
+
+    it("should replace value from local storage even when it has newer version", () => {
+      const storedState = mockIdentity2;
+      const defaultValue = mockIdentity1;
+      window.localStorage.setItem(
+        storeLocalStorageKey.LastUsedIdentities,
+        stringigyJson({ data: storedState, version: 2 })
+      );
+      const store = writableStored<LastUsedIdentity>({
+        key: storeLocalStorageKey.LastUsedIdentities,
+        defaultValue,
+        version: 1,
+      });
+
+      expect(get(store)).toEqual(defaultValue);
+      expect(
+        localStorage.getItem(storeLocalStorageKey.LastUsedIdentities)
+      ).toEqual(
+        stringigyJson({
+          data: defaultValue,
+          version: 1,
+        })
+      );
+    });
+
+    it("should replace value from local storage even when the default has no version", () => {
+      const storedState = mockIdentity2;
+      const defaultValue = mockIdentity1;
+      window.localStorage.setItem(
+        storeLocalStorageKey.LastUsedIdentities,
+        stringigyJson({ data: storedState, version: 2 }) // Stored data has a version
+      );
+      const store = writableStored<LastUsedIdentity>({ // New store definition has no version
+        key: storeLocalStorageKey.LastUsedIdentities,
+        defaultValue,
+      });
+
+      expect(get(store)).toEqual(defaultValue);
+      expect(
+        localStorage.getItem(storeLocalStorageKey.LastUsedIdentities)
+      ).toEqual(stringigyJson(defaultValue)); // Expect default value because stored had version, new didn't
+    });
+
+    it("should not replace value in local storage when no versions provided", () => {
+      const storedState = mockIdentity2;
+      const defaultValue = mockIdentity1;
+      window.localStorage.setItem(
+        storeLocalStorageKey.LastUsedIdentities,
+        stringigyJson(storedState) // No version in stored data
+      );
+      const store = writableStored<LastUsedIdentity>({ // No version in store definition
+        key: storeLocalStorageKey.LastUsedIdentities,
+        defaultValue,
+      });
+
+      expect(get(store)).toEqual(storedState); // Expect stored state because no versions involved
+    });
+
+    it("should not replace default value in local storage when same version", () => {
+      const storedState = mockIdentity2;
+      const defaultValue = mockIdentity1;
+      window.localStorage.setItem(
+        storeLocalStorageKey.LastUsedIdentities,
+        stringigyJson({ data: storedState, version: 5 })
+      );
+      const store = writableStored<LastUsedIdentity>({
+        key: storeLocalStorageKey.LastUsedIdentities,
+        defaultValue,
+        version: 5,
+      });
+
+      expect(get(store)).toEqual(storedState);
+    });
+  });
+
+  describe("unsubscribeStorage", () => {
+    it("unsubscribes storing in local storage", () => {
+      const defaultValue = mockIdentity1;
+      const store = writableStored<LastUsedIdentity>({
+        key: storeLocalStorageKey.LastUsedIdentities,
+        defaultValue,
+      });
+      const newState = mockIdentity2;
+      store.set(newState);
+      expect(
+        window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities)
+      ).toEqual(stringigyJson(newState));
+
+      store.unsubscribeStorage();
+      store.set(defaultValue);
+      expect(
+        window.localStorage.getItem(storeLocalStorageKey.LastUsedIdentities)
+      ).toEqual(stringigyJson(newState));
+    });
+  });
+
+  it("should resetForTesting", () => {
+    const defaultState = mockIdentity1;
+
+    const store = writableStored<LastUsedIdentity>({
+      key: storeLocalStorageKey.LastUsedIdentities,
+      defaultValue: defaultState,
+    });
+
+    expect(get(store)).toEqual(defaultState);
+  
+    const newState = mockIdentity2;
+
+    store.set(newState);
+    expect(get(store)).toEqual(newState);
+
+    store.resetForTesting();
+    expect(get(store)).toEqual(defaultState);
+  });
+});

--- a/src/frontend/src/lib/stores/writable.store.ts
+++ b/src/frontend/src/lib/stores/writable.store.ts
@@ -1,0 +1,132 @@
+import { browser } from "$app/environment";
+import { jsonReplacer, jsonReviver, nonNullish } from "@dfinity/utils";
+import { writable, type Unsubscriber, type Writable } from "svelte/store";
+import { type StoreLocalStorageKey } from "$lib/constants/store.constants";
+
+type WritableStored<T> = Writable<T> & {
+  unsubscribeStorage: Unsubscriber;
+  resetForTesting: () => void;
+};
+
+type VersionedData<T> = { data: T | undefined; version: number | undefined };
+
+/** Returns true when the value has numeric version and data fields. */
+const isVersionedData = <T>(
+  data: T | VersionedData<T>
+): data is VersionedData<T> =>
+  nonNullish(data) &&
+  typeof data === "object" &&
+  getVersion(data) !== undefined &&
+  "data" in data;
+
+/** Writes the state (w/ or w/o the version) to local storage. */
+const writeData = <T>({
+  key,
+  data,
+  version,
+}: {
+  key: StoreLocalStorageKey;
+  data: T;
+  version?: number;
+}) => {
+  // Do not break UI if local storage fails
+  try {
+    // Data structure  `{ data, version }` vs `data` depends on version absence.
+    const storeData: T | VersionedData<T> = nonNullish(version)
+      ? { data, version }
+      : data;
+    localStorage.setItem(key, JSON.stringify(storeData, jsonReplacer));
+  } catch (error: unknown) {
+    console.error(error);
+  }
+};
+
+/** Returns the version field of the value if it has one, otherwise undefined. */
+const getVersion = <T>(data: T | VersionedData<T>): number | undefined => {
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    "version" in data
+  ) {
+    const version = Number(
+      (data as unknown as { version: number | string }).version
+    );
+    if (!isNaN(version)) {
+      return version;
+    }
+  }
+  // default
+  return undefined;
+};
+
+/** Reads the state (w/ or w/o the version) from local storage and returns the versioned state. */
+const readData = <T>(key: StoreLocalStorageKey): VersionedData<T> => {
+  // Do not break UI if local storage fails
+  try {
+    const storedValue = localStorage.getItem(key);
+    // `theme` stored "undefined" string which is not a valid JSON string.
+    if (
+      storedValue !== null &&
+      storedValue !== undefined &&
+      storedValue !== "undefined"
+    ) {
+      const parsedValue = JSON.parse(storedValue, jsonReviver);
+
+      if (isVersionedData(parsedValue)) {
+        return parsedValue;
+      }
+
+      return { data: parsedValue, version: undefined };
+    }
+  } catch (error: unknown) {
+    console.error(error);
+  }
+
+  return { data: undefined, version: undefined };
+};
+
+export const writableStored = <T>({
+  key,
+  defaultValue,
+  version: defaultVersion,
+}: {
+  key: StoreLocalStorageKey;
+  defaultValue: T;
+  version?: number;
+}): WritableStored<T> => {
+  const getInitialValue = (): VersionedData<T> => {
+    if (!browser) {
+      return { data: defaultValue, version: defaultVersion };
+    }
+
+    const storedValue = readData<T>(key);
+    // Use always the default value when the versions do not match.
+    if (
+      storedValue.data === undefined ||
+      defaultVersion !== storedValue.version
+    ) {
+      return { data: defaultValue, version: defaultVersion };
+    }
+
+    return storedValue;
+  };
+
+  const initialValue = getInitialValue();
+  const store = writable<T>(initialValue.data);
+
+  const unsubscribeStorage = store.subscribe((store: T) => {
+    if (!browser) {
+      return;
+    }
+
+    writeData({ key, data: store, version: initialValue.version });
+  });
+
+  return {
+    ...store,
+    unsubscribeStorage,
+    resetForTesting: () => {
+      store.set(defaultValue);
+    },
+  };
+};

--- a/src/frontend/src/lib/stores/writable.store.ts
+++ b/src/frontend/src/lib/stores/writable.store.ts
@@ -12,7 +12,7 @@ type VersionedData<T> = { data: T | undefined; version: number | undefined };
 
 /** Returns true when the value has numeric version and data fields. */
 const isVersionedData = <T>(
-  data: T | VersionedData<T>
+  data: T | VersionedData<T>,
 ): data is VersionedData<T> =>
   nonNullish(data) &&
   typeof data === "object" &&
@@ -43,13 +43,9 @@ const writeData = <T>({
 
 /** Returns the version field of the value if it has one, otherwise undefined. */
 const getVersion = <T>(data: T | VersionedData<T>): number | undefined => {
-  if (
-    typeof data === "object" &&
-    data !== null &&
-    "version" in data
-  ) {
+  if (typeof data === "object" && data !== null && "version" in data) {
     const version = Number(
-      (data as unknown as { version: number | string }).version
+      (data as unknown as { version: number | string }).version,
     );
     if (!isNaN(version)) {
       return version;

--- a/src/frontend/src/routes/(new-styling)/new-authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/new-authorize/+page.svelte
@@ -312,19 +312,22 @@
             context.authRequest.derivationOrigin ?? context.requestOrigin;
           const [result, anchorInfo] = await Promise.all([
             fetchDelegation({
-            connection: authenticatedConnection,
-            derivationOrigin,
-            publicKey: context.authRequest.sessionPublicKey,
-            maxTimeToLive: context.authRequest.maxTimeToLive,
-          }),
-          authenticatedConnection.getAnchorInfo(),
-        ]);
+              connection: authenticatedConnection,
+              derivationOrigin,
+              publicKey: context.authRequest.sessionPublicKey,
+              maxTimeToLive: context.authRequest.maxTimeToLive,
+            }),
+            authenticatedConnection.getAnchorInfo(),
+          ]);
           if ("error" in result) {
             return;
           }
           const [userKey, parsed_signed_delegation] = result;
           // TODO: Handle when the "name" is not defined
-          lastUsedIdentitiesStore.addLatestUsed(authenticatedConnection.userNumber, anchorInfo.name[0] ?? "");
+          lastUsedIdentitiesStore.addLatestUsed(
+            authenticatedConnection.userNumber,
+            anchorInfo.name[0] ?? "",
+          );
           resolve({
             kind: "success",
             delegations: [parsed_signed_delegation],
@@ -333,7 +336,11 @@
           });
         };
         currentState = nonNullish(data.lastUsedIdentity)
-          ? { state: "continueAs", number: data.lastUsedIdentity.identityNumber, name: data.lastUsedIdentity.name }
+          ? {
+              state: "continueAs",
+              number: data.lastUsedIdentity.identityNumber,
+              name: data.lastUsedIdentity.name,
+            }
           : { state: "pickAuthenticationMethod" };
       });
     },

--- a/src/frontend/src/routes/(new-styling)/new-authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/new-authorize/+page.svelte
@@ -323,10 +323,9 @@
             return;
           }
           const [userKey, parsed_signed_delegation] = result;
-          // TODO: Handle when the "name" is not defined
           lastUsedIdentitiesStore.addLatestUsed(
             authenticatedConnection.userNumber,
-            anchorInfo.name[0] ?? "",
+            anchorInfo.name[0],
           );
           resolve({
             kind: "success",

--- a/src/frontend/src/routes/(new-styling)/new-authorize/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/new-authorize/+page.ts
@@ -3,6 +3,8 @@ import type { PageLoad } from "./$types";
 import { createAnonymousNonce } from "$lib/utils/openID";
 import { readCanisterConfig, readCanisterId } from "$lib/utils/init";
 import { Connection } from "$lib/utils/iiConnection";
+import { get } from "svelte/store";
+import { lastUsedIdentityStore } from "$lib/stores/last-used-identities.store";
 
 export const ssr = false;
 
@@ -15,7 +17,9 @@ export const load: PageLoad = async () => {
   });
   const actor = await connection.createActor(identity);
   const { nonce, salt } = await createAnonymousNonce(identity.getPrincipal());
+  const lastUsedIdentity = get(lastUsedIdentityStore);
   return {
     session: { config, actor, identity, nonce, salt },
+    lastUsedIdentity,
   };
 };


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Make a nicer experience by remembering the name and the credentials used in a specific device and browser.

In this PR, we store the identities used and use the latest one to render a different flow.

NOT IN THIS PR: Make the "Continue as alice" button to work, nor manage edge cases like no name.

# Changes

* [`src/frontend/src/lib/constants/store.constants.ts`](diffhunk://#diff-990033d8e3d219c0d788e30681d288cc1f2815ffb873cb6768fb2489e6570d7aR1-R5): Added `storeLocalStorageKey` constant for managing local storage keys.
* [`src/frontend/src/lib/stores/last-used-identities.store.ts`](diffhunk://#diff-01a6b3aa505a256c0721a6b233609346e2822508435a246a458380acb62cfd9eR1-R47): Implemented `lastUsedIdentitiesStore` and `lastUsedIdentityStore` for managing and retrieving the last-used identities.
* [`src/frontend/src/lib/stores/writable.store.ts`](diffhunk://#diff-e4e3407e6a2d3f0f2099c88e39cf7e337d417ebb51537312fd6e9f85e2ef5debR1-R132): Added `writableStored` utility for creating writable stores that sync with local storage, including version handling and serialization.
* [`src/frontend/src/routes/(new-styling)/new-authorize/+page.svelte`](diffhunk://#diff-f7ec9346e44f01b23ab07800cf1a9b6628bbc98aa2fc137be3c4b846cf80f006R40): Use `lastUsedIdentitiesStore` for managing the last-used identities during authentication.
* [`src/frontend/src/routes/(new-styling)/new-authorize/+page.ts`](diffhunk://#diff-cfa9be2c34bdf23a24ff6f65a117a7bc62b3dc6a71d1c76305d0aa74995f7a03R6-R7): Updated to include `lastUsedIdentity` in the page load function.

# Tests

* [`src/frontend/src/lib/stores/last-used-identities.store.test.ts`](diffhunk://#diff-b7e227d233aa80eeda49c7d378b37328ed1b647579451ecb16a5202d095045aeR1-R188): Added tests for `lastUsedIdentitiesStore` and `lastUsedIdentityStore` to ensure correct functionality, including adding, updating, and resetting identities.
* [`src/frontend/src/lib/stores/writable.store.test.ts`](diffhunk://#diff-742df6615aed8cd0d4d8f0c755ab39cd9f0a583e185cd752e502987faa43c599R1-R215): Added tests for `writableStored` to verify local storage synchronization, version handling, and resetting for testing purposes.
* Tested flow locally, see video attached.





<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->




