### PR TITLE
Page error handler

### DIFF
--- a/src/frontend/src/lib/utils/toaster.ts
+++ b/src/frontend/src/lib/utils/toaster.ts
@@ -1,0 +1,3 @@
+import { createToaster } from "@skeletonlabs/skeleton-svelte";
+
+export const toaster = createToaster();

--- a/src/frontend/src/routes/(new-styling)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/+layout.svelte
@@ -2,6 +2,8 @@
   // Enable new styles only in the new layout pages.
   import "$lib/app.css";
   import Background from "$lib/components/UI/Background.svelte";
+  import { Toaster } from "@skeletonlabs/skeleton-svelte";
+  import { toaster } from "$lib/utils/toaster";
 
   const { children, data } = $props();
 </script>
@@ -12,4 +14,5 @@
   >
     {@render children()}
   </Background>
+  <Toaster {toaster}></Toaster>
 {/key}

--- a/src/frontend/src/routes/(new-styling)/new-authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/new-authorize/+page.svelte
@@ -346,14 +346,13 @@
             authnMethod: "passkey",
           });
         };
-        currentState =
-          false && nonNullish(data.lastUsedIdentity)
-            ? {
-                state: "continueAs",
-                number: data.lastUsedIdentity.identityNumber,
-                name: data.lastUsedIdentity.name,
-              }
-            : { state: "pickAuthenticationMethod" };
+        currentState = nonNullish(data.lastUsedIdentity)
+          ? {
+              state: "continueAs",
+              number: data.lastUsedIdentity.identityNumber,
+              name: data.lastUsedIdentity.name,
+            }
+          : { state: "pickAuthenticationMethod" };
       });
     },
     onProgress: () => {},

--- a/src/frontend/src/routes/(new-styling)/new-authorize/error.ts
+++ b/src/frontend/src/routes/(new-styling)/new-authorize/error.ts
@@ -1,0 +1,68 @@
+import { isWebAuthnCancel } from "$lib/utils/webAuthnErrorUtils";
+import { toaster } from "$lib/utils/toaster";
+import { isCanisterError } from "$lib/utils/utils";
+import type {
+  CheckCaptchaError,
+  IdRegFinishError,
+  IdRegStartError,
+} from "$lib/generated/internet_identity_types";
+
+export const handleError = (error: unknown) => {
+  // Handle browser errors
+  if (isWebAuthnCancel(error)) {
+    toaster.info({
+      title: "Operation canceled",
+      description:
+        "The interaction was canceled or timed out. Please try again.",
+    });
+    return;
+  }
+
+  // Handle canister errors
+  if (
+    isCanisterError<IdRegStartError | IdRegFinishError | CheckCaptchaError>(
+      error,
+    )
+  ) {
+    switch (error.type) {
+      case "RateLimitExceeded":
+      case "IdentityLimitReached":
+        toaster.error({
+          title: "It seems like registration is unavailable at this moment",
+        });
+        break;
+      case "InvalidCaller":
+      case "UnexpectedCall":
+      case "NoRegistrationFlow":
+        toaster.error({
+          title: "Something went wrong during registration",
+        });
+        break;
+      case "InvalidAuthnMethod":
+      case "StorageError":
+        toaster.error({
+          title: "Something went wrong during registration",
+          description: error.value(error.type),
+        });
+        break;
+      case "AlreadyInProgress":
+      case "WrongSolution":
+        // This error should have been handled
+        toaster.error({
+          title: "Unhandled error",
+          description: error.type,
+        });
+        break;
+      default: {
+        void (error.type satisfies never);
+      }
+    }
+    return;
+  }
+
+  // Handle unexpected errors
+  toaster.error({
+    title: "Unexpected error",
+    description: error instanceof Error ? error.message : undefined,
+  });
+};

--- a/src/frontend/src/routes/(new-styling)/new-authorize/error.ts
+++ b/src/frontend/src/routes/(new-styling)/new-authorize/error.ts
@@ -47,7 +47,7 @@ export const handleError = (error: unknown) => {
         break;
       case "AlreadyInProgress":
       case "WrongSolution":
-        // Errors that should have been handled but weren't
+        // Should be handled up the stack; reaching here means they weren’t.
         toaster.error({
           title: "Unhandled error",
           description: error.type,

--- a/src/frontend/src/routes/(new-styling)/new-authorize/error.ts
+++ b/src/frontend/src/routes/(new-styling)/new-authorize/error.ts
@@ -47,7 +47,7 @@ export const handleError = (error: unknown) => {
         break;
       case "AlreadyInProgress":
       case "WrongSolution":
-        // This error should have been handled
+        // Errors that should have been handled but weren't
         toaster.error({
           title: "Unhandled error",
           description: error.type,


### PR DESCRIPTION
Move page error handling into its own file, the +page.svelte file can then focus on only handling the errors that need to be explicitly handled while the `handleError` method can be used as catch all.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

