### PR TITLE
Continue As supports Google

### DIFF
--- a/src/frontend/src/lib/stores/last-used-identities.store.test.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.test.ts
@@ -51,7 +51,8 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
     });
 
     const expected: LastUsedIdentitiesData = {
@@ -59,7 +60,8 @@ describe("lastUsedIdentitiesStore", () => {
         identityNumber: identity1,
         name: name1,
         credentialId: credId1,
-        authMethod: 'passkey',
+        authMethod: "passkey",
+        sub: `mock.user+${identity1}@example.com`,
         lastUsedTimestampMillis: mockTimestamp1,
       },
     };
@@ -72,7 +74,8 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
     });
 
     // Advance time and add second identity
@@ -81,7 +84,8 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity2,
       name: name2,
       credentialId: credId2,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity2}@example.com`,
     });
 
     const expected: LastUsedIdentitiesData = {
@@ -89,14 +93,16 @@ describe("lastUsedIdentitiesStore", () => {
         identityNumber: identity1,
         name: name1,
         credentialId: credId1,
-        authMethod: 'passkey',
+        authMethod: "passkey",
+        sub: `mock.user+${identity1}@example.com`,
         lastUsedTimestampMillis: mockTimestamp1,
       },
       [identity2.toString()]: {
         identityNumber: identity2,
         name: name2,
         credentialId: credId2,
-        authMethod: 'passkey',
+        authMethod: "passkey",
+        sub: `mock.user+${identity2}@example.com`,
         lastUsedTimestampMillis: mockTimestamp2,
       },
     };
@@ -109,7 +115,8 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
     });
     expect(
       get(lastUsedIdentitiesStore)[identity1.toString()]
@@ -122,15 +129,17 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
-    }); // Pass the full object
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
+    });
 
     const expected: LastUsedIdentitiesData = {
       [identity1.toString()]: {
         identityNumber: identity1,
         name: name1, // Name should remain the same from the *last* call
         credentialId: credId1, // Keep original credential ID
-        authMethod: 'passkey',
+        authMethod: "passkey",
+        sub: `mock.user+${identity1}@example.com`, // Expect sub field
         lastUsedTimestampMillis: mockTimestamp3,
       },
     };
@@ -146,7 +155,8 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
     });
     expect(get(lastUsedIdentitiesStore)).not.toEqual({}); // Ensure it's not empty
 
@@ -190,14 +200,16 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
     });
 
     const expected: LastUsedIdentity = {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
       lastUsedTimestampMillis: mockTimestamp1,
     };
     expect(get(lastUsedIdentityStore)).toEqual(expected);
@@ -209,7 +221,8 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity2,
       name: name2,
       credentialId: credId2,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity2}@example.com`,
     });
 
     vi.setSystemTime(mockTimestamp2);
@@ -217,14 +230,16 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
     });
 
     const expectedLatest: LastUsedIdentity = {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
       lastUsedTimestampMillis: mockTimestamp2,
     };
     expect(get(lastUsedIdentityStore)).toEqual(expectedLatest);
@@ -235,13 +250,15 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity3,
       name: name3,
       credentialId: credId3,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity3}@example.com`,
     });
     const expectedNewest: LastUsedIdentity = {
       identityNumber: identity3,
       name: name3,
       credentialId: credId3,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity3}@example.com`,
       lastUsedTimestampMillis: mockTimestamp3,
     };
     expect(get(lastUsedIdentityStore)).toEqual(expectedNewest);
@@ -253,7 +270,8 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
     });
 
     // Add 2 at time 2 (latest is now 2)
@@ -262,7 +280,8 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity2,
       name: name2,
       credentialId: credId2,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity2}@example.com`,
     });
     expect(get(lastUsedIdentityStore)?.identityNumber).toBe(identity2);
 
@@ -272,14 +291,16 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
     });
 
     const expected: LastUsedIdentity = {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
       lastUsedTimestampMillis: mockTimestamp3,
     };
     expect(get(lastUsedIdentityStore)).toEqual(expected);
@@ -290,7 +311,8 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
-      authMethod: 'passkey',
+      authMethod: "passkey",
+      sub: `mock.user+${identity1}@example.com`,
     });
     expect(get(lastUsedIdentityStore)).toBeDefined();
 

--- a/src/frontend/src/lib/stores/last-used-identities.store.test.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.test.ts
@@ -139,7 +139,7 @@ describe("lastUsedIdentitiesStore", () => {
         name: name1, // Name should remain the same from the *last* call
         credentialId: credId1, // Keep original credential ID
         authMethod: "passkey",
-        sub: `mock.user+${identity1}@example.com`, // Expect sub field
+        sub: `mock.user+${identity1}@example.com`,
         lastUsedTimestampMillis: mockTimestamp3,
       },
     };

--- a/src/frontend/src/lib/stores/last-used-identities.store.test.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.test.ts
@@ -51,6 +51,7 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
     });
 
     const expected: LastUsedIdentitiesData = {
@@ -58,6 +59,7 @@ describe("lastUsedIdentitiesStore", () => {
         identityNumber: identity1,
         name: name1,
         credentialId: credId1,
+        authMethod: 'passkey',
         lastUsedTimestampMillis: mockTimestamp1,
       },
     };
@@ -70,6 +72,7 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
     });
 
     // Advance time and add second identity
@@ -78,6 +81,7 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity2,
       name: name2,
       credentialId: credId2,
+      authMethod: 'passkey',
     });
 
     const expected: LastUsedIdentitiesData = {
@@ -85,12 +89,14 @@ describe("lastUsedIdentitiesStore", () => {
         identityNumber: identity1,
         name: name1,
         credentialId: credId1,
+        authMethod: 'passkey',
         lastUsedTimestampMillis: mockTimestamp1,
       },
       [identity2.toString()]: {
         identityNumber: identity2,
         name: name2,
         credentialId: credId2,
+        authMethod: 'passkey',
         lastUsedTimestampMillis: mockTimestamp2,
       },
     };
@@ -103,6 +109,7 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
     });
     expect(
       get(lastUsedIdentitiesStore)[identity1.toString()]
@@ -115,6 +122,7 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
     }); // Pass the full object
 
     const expected: LastUsedIdentitiesData = {
@@ -122,6 +130,7 @@ describe("lastUsedIdentitiesStore", () => {
         identityNumber: identity1,
         name: name1, // Name should remain the same from the *last* call
         credentialId: credId1, // Keep original credential ID
+        authMethod: 'passkey',
         lastUsedTimestampMillis: mockTimestamp3,
       },
     };
@@ -137,6 +146,7 @@ describe("lastUsedIdentitiesStore", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
     });
     expect(get(lastUsedIdentitiesStore)).not.toEqual({}); // Ensure it's not empty
 
@@ -180,12 +190,14 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
     });
 
     const expected: LastUsedIdentity = {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
       lastUsedTimestampMillis: mockTimestamp1,
     };
     expect(get(lastUsedIdentityStore)).toEqual(expected);
@@ -197,6 +209,7 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity2,
       name: name2,
       credentialId: credId2,
+      authMethod: 'passkey',
     });
 
     vi.setSystemTime(mockTimestamp2);
@@ -204,12 +217,14 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
     });
 
     const expectedLatest: LastUsedIdentity = {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
       lastUsedTimestampMillis: mockTimestamp2,
     };
     expect(get(lastUsedIdentityStore)).toEqual(expectedLatest);
@@ -220,11 +235,13 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity3,
       name: name3,
       credentialId: credId3,
+      authMethod: 'passkey',
     });
     const expectedNewest: LastUsedIdentity = {
       identityNumber: identity3,
       name: name3,
       credentialId: credId3,
+      authMethod: 'passkey',
       lastUsedTimestampMillis: mockTimestamp3,
     };
     expect(get(lastUsedIdentityStore)).toEqual(expectedNewest);
@@ -236,6 +253,7 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
     });
 
     // Add 2 at time 2 (latest is now 2)
@@ -244,6 +262,7 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity2,
       name: name2,
       credentialId: credId2,
+      authMethod: 'passkey',
     });
     expect(get(lastUsedIdentityStore)?.identityNumber).toBe(identity2);
 
@@ -253,12 +272,14 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
     });
 
     const expected: LastUsedIdentity = {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
       lastUsedTimestampMillis: mockTimestamp3,
     };
     expect(get(lastUsedIdentityStore)).toEqual(expected);
@@ -269,6 +290,7 @@ describe("lastUsedIdentityStore (derived store)", () => {
       identityNumber: identity1,
       name: name1,
       credentialId: credId1,
+      authMethod: 'passkey',
     });
     expect(get(lastUsedIdentityStore)).toBeDefined();
 

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -8,6 +8,8 @@ export type LastUsedIdentity = {
   identityNumber: bigint;
   credentialId: Uint8Array | undefined;
   authMethod: "passkey" | "google";
+  // In case the auth method is google, this will be the sub (or email)
+  sub?: string;
 };
 export type LastUsedIdentitiesData = {
   [identityNumber: string]: LastUsedIdentity;
@@ -18,6 +20,7 @@ type LastUsedIdentitiesStore = Readable<LastUsedIdentitiesData> & {
     name?: string;
     credentialId: Uint8Array | undefined;
     authMethod: "passkey" | "google";
+    sub?: string;
   }) => void;
   reset: () => void;
 };
@@ -36,11 +39,13 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
       name,
       credentialId,
       authMethod,
+      sub,
     }: {
       identityNumber: bigint;
       name?: string;
       credentialId: Uint8Array | undefined;
       authMethod: "passkey" | "google";
+      sub?: string;
     }) => {
       update((lastUsedIdentities) => {
         lastUsedIdentities[identityNumber.toString()] = {
@@ -49,6 +54,7 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
           identityNumber,
           credentialId,
           authMethod,
+          sub,
         };
         return lastUsedIdentities;
       });

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -7,6 +7,7 @@ export type LastUsedIdentity = {
   lastUsedTimestampMillis: number;
   identityNumber: bigint;
   credentialId: Uint8Array | undefined;
+  authMethod: "passkey" | "google";
 };
 export type LastUsedIdentitiesData = {
   [identityNumber: string]: LastUsedIdentity;
@@ -16,6 +17,7 @@ type LastUsedIdentitiesStore = Readable<LastUsedIdentitiesData> & {
     identityNumber: bigint;
     name?: string;
     credentialId: Uint8Array | undefined;
+    authMethod: "passkey" | "google";
   }) => void;
   reset: () => void;
 };
@@ -33,10 +35,12 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
       identityNumber,
       name,
       credentialId,
+      authMethod,
     }: {
       identityNumber: bigint;
       name?: string;
       credentialId: Uint8Array | undefined;
+      authMethod: "passkey" | "google";
     }) => {
       update((lastUsedIdentities) => {
         lastUsedIdentities[identityNumber.toString()] = {
@@ -44,6 +48,7 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
           lastUsedTimestampMillis: Date.now(),
           identityNumber,
           credentialId,
+          authMethod,
         };
         return lastUsedIdentities;
       });

--- a/src/frontend/src/lib/stores/writable.store.test.ts
+++ b/src/frontend/src/lib/stores/writable.store.test.ts
@@ -14,6 +14,7 @@ const mockIdentity1: LastUsedIdentity = {
   lastUsedTimestampMillis: 1678886400000, // Example timestamp
   identityNumber: BigInt("10001"),
   credentialId: new Uint8Array(),
+  authMethod: "passkey",
 };
 
 const mockIdentity2: LastUsedIdentity = {
@@ -21,6 +22,7 @@ const mockIdentity2: LastUsedIdentity = {
   lastUsedTimestampMillis: 1678887400000, // Slightly later timestamp
   identityNumber: BigInt("10002"),
   credentialId: new Uint8Array(),
+  authMethod: "passkey",
 };
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/src/frontend/src/lib/utils/authenticate/jwt.ts
+++ b/src/frontend/src/lib/utils/authenticate/jwt.ts
@@ -6,7 +6,7 @@ import {
   transformSignedDelegation,
 } from "$lib/utils/utils";
 import { DelegationChain, DelegationIdentity } from "@dfinity/identity";
-import { decodeJwt } from "jose";
+import { decodeJWT } from "$lib/utils/openID";
 
 export const authenticateWithJWT = async ({
   jwt,
@@ -25,7 +25,7 @@ export const authenticateWithJWT = async ({
   const sessionKey = new Uint8Array(identity.getPublicKey().toDer());
 
   // Decode JWT using jose
-  const payload = decodeJwt(jwt);
+  const payload = decodeJWT(jwt);
   const sub = payload?.sub;
 
   const { anchor_number, expiration, user_key } = await actor

--- a/src/frontend/src/routes/(new-styling)/new-authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/new-authorize/+page.svelte
@@ -147,7 +147,7 @@
         actor,
       );
 
-      onAuthenticate(authenticatedConnection, credentialId, undefined); // Pass empty string for sub
+      onAuthenticate(authenticatedConnection, credentialId, undefined);
     } catch (err) {
       console.error("Authentication error:", err);
       handleError(err);


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

User have an easy way to authenticate with their last authentication method when that one was Google.

# Changes

### Updates to `LastUsedIdentity` type and store logic:

* Added a new `authMethod` field to the `LastUsedIdentity` type, which can be either `"passkey"` or `"google"`.
* Updated the `initLastUsedIdentitiesStore` function to include `authMethod` when adding or updating identities in the store.

### Test updates:

* Modified test cases in `last-used-identities.store.test.ts` to include the `authMethod` field in both input data and expected results.

### Updates to the `new-authorize` page:

* Adjusted the `lastUsedIdentitiesStore.addLatestUsed` call to populate the `authMethod` field based on the presence of a credential ID.
* Updated the logic for continuing authentication to handle different methods (`passkey` or `google`) based on the `authMethod` field.




<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->



