### PR TITLE
Improve passkey modal UX

### DIFF
--- a/src/frontend/src/routes/(new-styling)/new-authorize/components/ConnectOrCreatePasskey.svelte
+++ b/src/frontend/src/routes/(new-styling)/new-authorize/components/ConnectOrCreatePasskey.svelte
@@ -19,8 +19,8 @@
   </p>
 </div>
 <div class="mt-auto flex flex-col items-stretch gap-4">
-  <Button onclick={connect} variant="primary">Connect my Passkey</Button>
   <Button onclick={create} variant="secondary"
     >Don't have a passkey? Create one</Button
   >
+  <Button onclick={connect} variant="secondary">Connect my Passkey</Button>
 </div>


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Improve the UX for the passkey flow.

Uses read from top to bottom and stop reading when they think they found what they were looking for. Therefore, we want to show the possibilities in an order that makes it easier to select what they want.

"Connect my passkey" could be interpreted as creating one. Therefore, we move the "Create one" button first.

# Changes

* Change the order of the buttons and make them both secondary.

# Tests

Tested locally. See screenshot attached.
