### PR TITLE
Prevent an anchor from overwriting the credential id lookup of another.

### DIFF
--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -109,7 +109,6 @@ pub fn post_operation_bookkeeping(anchor_number: AnchorNumber, operation: Operat
 /// Panics if this operation violates anchor constraints (see [Anchor]).
 pub fn add_device(anchor: &mut Anchor, device_data: DeviceData) -> Operation {
     let new_device = Device::from(device_data);
-
     anchor
         .add_device(new_device.clone())
         .unwrap_or_else(|err| trap(&format!("failed to add device: {err}")));
@@ -160,7 +159,6 @@ pub fn replace_device(
         .remove_device(&old_device)
         .unwrap_or_else(|err| trap(&format!("failed to replace device: {err}")));
     let new_device = Device::from(new_device);
-
     anchor
         .add_device(new_device.clone())
         .unwrap_or_else(|err| trap(&format!("failed to replace device: {err}")));

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -109,13 +109,7 @@ pub fn post_operation_bookkeeping(anchor_number: AnchorNumber, operation: Operat
 /// Panics if this operation violates anchor constraints (see [Anchor]).
 pub fn add_device(anchor: &mut Anchor, device_data: DeviceData) -> Operation {
     let new_device = Device::from(device_data);
-    if new_device
-        .credential_id
-        .as_ref()
-        .is_some_and(|credential_id| lookup_device_key_with_credential_id(credential_id).is_some())
-    {
-        trap("failed to add device: credential_id is already registered");
-    }
+
     anchor
         .add_device(new_device.clone())
         .unwrap_or_else(|err| trap(&format!("failed to add device: {err}")));
@@ -142,16 +136,6 @@ pub fn update_device(
     new_device.apply_device_data(device_data);
     let diff = device_diff(existing_device, &new_device);
 
-    if new_device
-        .credential_id
-        .as_ref()
-        .is_some_and(|credential_id| {
-            existing_device.credential_id != new_device.credential_id
-                && lookup_device_key_with_credential_id(credential_id).is_some()
-        })
-    {
-        trap("failed to modify device: credential_id is already registered");
-    }
     anchor
         .modify_device(&device_key, new_device)
         .unwrap_or_else(|err| trap(&format!("failed to modify device: {err}")));
@@ -177,13 +161,6 @@ pub fn replace_device(
         .unwrap_or_else(|err| trap(&format!("failed to replace device: {err}")));
     let new_device = Device::from(new_device);
 
-    if new_device
-        .credential_id
-        .as_ref()
-        .is_some_and(|credential_id| lookup_device_key_with_credential_id(credential_id).is_some())
-    {
-        trap("failed to replace device: credential_id is already registered");
-    }
     anchor
         .add_device(new_device.clone())
         .unwrap_or_else(|err| trap(&format!("failed to replace device: {err}")));

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -109,6 +109,13 @@ pub fn post_operation_bookkeeping(anchor_number: AnchorNumber, operation: Operat
 /// Panics if this operation violates anchor constraints (see [Anchor]).
 pub fn add_device(anchor: &mut Anchor, device_data: DeviceData) -> Operation {
     let new_device = Device::from(device_data);
+    if new_device
+        .credential_id
+        .as_ref()
+        .is_some_and(|credential_id| lookup_device_key_with_credential_id(credential_id).is_some())
+    {
+        trap("failed to add device: credential_id is already registered");
+    }
     anchor
         .add_device(new_device.clone())
         .unwrap_or_else(|err| trap(&format!("failed to add device: {err}")));
@@ -135,6 +142,16 @@ pub fn update_device(
     new_device.apply_device_data(device_data);
     let diff = device_diff(existing_device, &new_device);
 
+    if new_device
+        .credential_id
+        .as_ref()
+        .is_some_and(|credential_id| {
+            existing_device.credential_id != new_device.credential_id
+                && lookup_device_key_with_credential_id(credential_id).is_some()
+        })
+    {
+        trap("failed to modify device: credential_id is already registered");
+    }
     anchor
         .modify_device(&device_key, new_device)
         .unwrap_or_else(|err| trap(&format!("failed to modify device: {err}")));
@@ -159,6 +176,14 @@ pub fn replace_device(
         .remove_device(&old_device)
         .unwrap_or_else(|err| trap(&format!("failed to replace device: {err}")));
     let new_device = Device::from(new_device);
+
+    if new_device
+        .credential_id
+        .as_ref()
+        .is_some_and(|credential_id| lookup_device_key_with_credential_id(credential_id).is_some())
+    {
+        trap("failed to replace device: credential_id is already registered");
+    }
     anchor
         .add_device(new_device.clone())
         .unwrap_or_else(|err| trap(&format!("failed to replace device: {err}")));

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -570,7 +570,7 @@ impl<M: Memory + Clone> Storage<M> {
             .cloned()
             .map(StorableCredentialId::from)
             .for_each(|credential_id| {
-                // Only insert if the credential id isn't assigned to an anchor
+                // Only insert if the credential id isn't assigned yet to an anchor
                 if self
                     .lookup_anchor_with_device_credential_memory
                     .get(&credential_id)

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -574,10 +574,9 @@ impl<M: Memory + Clone> Storage<M> {
             .map(StorableCredentialId::from)
             .for_each(|credential_id| {
                 // Only insert if the credential id isn't assigned yet to an anchor
-                if self
+                if !self
                     .lookup_anchor_with_device_credential_memory
-                    .get(&credential_id)
-                    .is_none()
+                    .contains_key(&credential_id)
                 {
                     self.lookup_anchor_with_device_credential_memory
                         .insert(credential_id, anchor_number);

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -562,14 +562,24 @@ impl<M: Memory + Clone> Storage<M> {
             .collect();
         let credential_to_be_removed = previous_set.difference(&current_set);
         let credential_to_be_added = current_set.difference(&previous_set);
-        credential_to_be_removed.cloned().for_each(|key| {
+        credential_to_be_removed.cloned().for_each(|credential_id| {
             self.lookup_anchor_with_device_credential_memory
-                .remove(&key.into());
+                .remove(&credential_id.into());
         });
-        credential_to_be_added.cloned().for_each(|key| {
-            self.lookup_anchor_with_device_credential_memory
-                .insert(key.into(), anchor_number);
-        });
+        credential_to_be_added
+            .cloned()
+            .map(StorableCredentialId::from)
+            .for_each(|credential_id| {
+                // Only insert if the credential id isn't assigned to another anchor
+                if self
+                    .lookup_anchor_with_device_credential_memory
+                    .get(&credential_id)
+                    .is_none_or(|other_anchor_number| other_anchor_number == anchor_number)
+                {
+                    self.lookup_anchor_with_device_credential_memory
+                        .insert(credential_id, anchor_number);
+                }
+            });
     }
 
     #[allow(dead_code)]

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -570,11 +570,11 @@ impl<M: Memory + Clone> Storage<M> {
             .cloned()
             .map(StorableCredentialId::from)
             .for_each(|credential_id| {
-                // Only insert if the credential id isn't assigned to another anchor
+                // Only insert if the credential id isn't assigned to an anchor
                 if self
                     .lookup_anchor_with_device_credential_memory
                     .get(&credential_id)
-                    .is_none_or(|other_anchor_number| other_anchor_number == anchor_number)
+                    .is_none()
                 {
                     self.lookup_anchor_with_device_credential_memory
                         .insert(credential_id, anchor_number);

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -562,10 +562,13 @@ impl<M: Memory + Clone> Storage<M> {
             .collect();
         let credential_to_be_removed = previous_set.difference(&current_set);
         let credential_to_be_added = current_set.difference(&previous_set);
-        credential_to_be_removed.cloned().for_each(|credential_id| {
-            self.lookup_anchor_with_device_credential_memory
-                .remove(&credential_id.into());
-        });
+        credential_to_be_removed
+            .cloned()
+            .map(StorableCredentialId::from)
+            .for_each(|credential_id| {
+                self.lookup_anchor_with_device_credential_memory
+                    .remove(&credential_id);
+            });
         credential_to_be_added
             .cloned()
             .map(StorableCredentialId::from)


### PR DESCRIPTION
Prevent an anchor from overwriting the credential id lookup of another.

# Changes

- Added check to see if lookup has already been written

# Tests

- Added test to make sure lookup is not overwritten by another anchor


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

