### PR TITLE
Fix OpenID Delegation Issue

### DIFF
--- a/src/internet_identity/src/authz_utils.rs
+++ b/src/internet_identity/src/authz_utils.rs
@@ -119,7 +119,7 @@ pub fn check_authorization(
     }
     // Else check OpenID authorization
     for credential in anchor.openid_credentials() {
-        if caller == credential.principal() {
+        if caller == credential.principal(anchor_number) {
             return Ok((
                 anchor.clone(),
                 AuthorizationKey::OpenIdCredentialKey(credential.key()),

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -878,7 +878,9 @@ mod openid_api {
         state::storage_borrow_mut(|storage| storage.update(anchor))
             .map_err(|_| OpenIdDelegationError::NoSuchAnchor)?;
 
-        let (user_key, expiration) = openid_credential.prepare_jwt_delegation(session_key).await;
+        let (user_key, expiration) = openid_credential
+            .prepare_jwt_delegation(session_key, anchor_number)
+            .await;
 
         // Checking again because the association could've changed during the .await
         let still_anchor_number = lookup_anchor_with_openid_credential(&openid_credential.key())
@@ -907,7 +909,9 @@ mod openid_api {
                 .map_err(|_| OpenIdDelegationError::JwtVerificationFailed)?;
 
         match lookup_anchor_with_openid_credential(&openid_credential.key()) {
-            Some(_) => openid_credential.get_jwt_delegation(session_key, expiration),
+            Some(anchor_number) => {
+                openid_credential.get_jwt_delegation(session_key, expiration, anchor_number)
+            }
             None => Err(OpenIdDelegationError::NoSuchAnchor),
         }
     }

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -1,4 +1,3 @@
-use crate::anchor_management::lookup_anchor_with_openid_credential;
 use crate::delegation::{add_delegation_signature, der_encode_canister_sig_key};
 use crate::MINUTE_NS;
 use crate::{state, update_root_hash};

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -168,7 +168,8 @@ fn calculate_delegation_seed(
     blob.push(sub.len() as u8);
     blob.extend(sub.bytes());
 
-    blob.push(anchor_number as u8);
+    blob.push(anchor_number.to_be_bytes().len() as u8);
+    blob.extend(anchor_number.to_le_bytes());
 
     let mut hasher = Sha256::new();
     hasher.update(blob);

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -41,8 +41,7 @@ impl OpenIdCredential {
         (self.iss.clone(), self.sub.clone())
     }
 
-    pub fn principal(&self) -> Principal {
-        let anchor_number = lookup_anchor_with_openid_credential(&self.key()).unwrap(); // TODO: handle better?
+    pub fn principal(&self, anchor_number: AnchorNumber) -> Principal {
         let seed = calculate_delegation_seed(&self.aud, &self.key(), anchor_number);
         let public_key: PublicKey = der_encode_canister_sig_key(seed.to_vec()).into();
         Principal::self_authenticating(public_key)
@@ -151,6 +150,7 @@ where
 ///
 /// * `client_id`: The client id for which the `OpenIdCredential` was created
 /// * `(iss, sub)`: The key of the `OpenIdCredential` to create a `Hash` from
+/// * `anchor_number`: The anchor number the credential is assigned to
 #[allow(clippy::cast_possible_truncation)]
 fn calculate_delegation_seed(
     client_id: &str,

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -329,9 +329,6 @@ fn cannot_get_valid_jwt_delegation_after_reassociation() -> Result<(), CallError
     )?
     .map_err(|e| CallError::Reject(format!("Error at second add: {:?}", e)))?;
 
-    // Create session key
-    let second_pub_session_key = ByteBuf::from("session public key");
-
     // Get the delegation
     match api::openid_get_delegation(
         &env,
@@ -339,13 +336,13 @@ fn cannot_get_valid_jwt_delegation_after_reassociation() -> Result<(), CallError
         second_test_principal,
         &second_jwt,
         &second_salt,
-        &second_pub_session_key,
+        &pub_session_key, // Note that this only works if we have access to the original session key
         &prepare_response.expiration,
     )? {
         Ok(_) => Err(CallError::Reject(
             "We shouldn't be able to get this delegation!".to_string(),
         )),
-        Err(err) => Ok(()),
+        Err(_) => Ok(()),
     }
 }
 


### PR DESCRIPTION
# Motivation

There's a minor issue that allows an OpenID Delegation prepared with one Identity to be retrieved by another if the OpenID credential was reassigned to the new one. We wanted to fix this to be on the safe side.

# Changes

Add `anchor_number` to the delegation seed.

# Tests

Add integration test.





<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->




