### PR TITLE
Setup multiple accounts API

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -2,6 +2,14 @@ import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 import type { IDL } from '@dfinity/candid';
 
+export interface Account {
+  'name' : [] | [string],
+  'origin' : string,
+  'account' : [] | [AccountNumber],
+  'last_used' : [] | [Timestamp],
+}
+export type AccountNumber = bigint;
+export interface AccountUpdate { 'name' : [] | [string] }
 export type AddTentativeDeviceResponse = {
     'device_registration_mode_off' : null
   } |
@@ -102,6 +110,7 @@ export interface CheckCaptchaArg { 'solution' : string }
 export type CheckCaptchaError = { 'NoRegistrationFlow' : null } |
   { 'UnexpectedCall' : { 'next_step' : RegistrationFlowNextStep } } |
   { 'WrongSolution' : { 'new_captcha_png_base64' : string } };
+export type CreateAccountError = { 'InternalError' : null };
 export type CredentialId = Uint8Array | number[];
 export interface Delegation {
   'pubkey' : PublicKey,
@@ -337,6 +346,7 @@ export type StreamingStrategy = {
 export type Sub = string;
 export type Timestamp = bigint;
 export type Token = {};
+export type UpdateAccountError = { 'InternalError' : null };
 export type UserKey = PublicKey;
 export type UserNumber = bigint;
 export type VerifyTentativeDeviceResponse = {
@@ -411,11 +421,24 @@ export interface _SERVICE {
       { 'Err' : CheckCaptchaError }
   >,
   'config' : ActorMethod<[], InternetIdentityInit>,
+  'create_account' : ActorMethod<
+    [UserNumber, FrontendHostname, string],
+    { 'Ok' : Account } |
+      { 'Err' : CreateAccountError }
+  >,
   'create_challenge' : ActorMethod<[], Challenge>,
   'deploy_archive' : ActorMethod<[Uint8Array | number[]], DeployArchiveResult>,
   'enter_device_registration_mode' : ActorMethod<[UserNumber], Timestamp>,
   'exit_device_registration_mode' : ActorMethod<[UserNumber], undefined>,
   'fetch_entries' : ActorMethod<[], Array<BufferedArchiveEntry>>,
+  'get_account_delegation' : ActorMethod<
+    [UserNumber, FrontendHostname, AccountNumber, SessionKey, Timestamp],
+    GetDelegationResponse
+  >,
+  'get_accounts' : ActorMethod<
+    [UserNumber, [] | [FrontendHostname]],
+    Array<Account>
+  >,
   'get_anchor_credentials' : ActorMethod<[UserNumber], AnchorCredentials>,
   'get_anchor_info' : ActorMethod<[UserNumber], IdentityAnchorInfo>,
   'get_delegation' : ActorMethod<
@@ -486,6 +509,16 @@ export interface _SERVICE {
     { 'Ok' : OpenIdPrepareDelegationResponse } |
       { 'Err' : OpenIdDelegationError }
   >,
+  'prepare_account_delegation' : ActorMethod<
+    [
+      UserNumber,
+      FrontendHostname,
+      [] | [AccountNumber],
+      SessionKey,
+      [] | [bigint],
+    ],
+    [UserKey, Timestamp]
+  >,
   'prepare_delegation' : ActorMethod<
     [UserNumber, FrontendHostname, SessionKey, [] | [bigint]],
     [UserKey, Timestamp]
@@ -503,6 +536,11 @@ export interface _SERVICE {
   'replace' : ActorMethod<[UserNumber, DeviceKey, DeviceData], undefined>,
   'stats' : ActorMethod<[], InternetIdentityStats>,
   'update' : ActorMethod<[UserNumber, DeviceKey, DeviceData], undefined>,
+  'update_account' : ActorMethod<
+    [UserNumber, FrontendHostname, [] | [AccountNumber], AccountUpdate],
+    { 'Ok' : Account } |
+      { 'Err' : UpdateAccountError }
+  >,
   'verify_tentative_device' : ActorMethod<
     [UserNumber, string],
     VerifyTentativeDeviceResponse

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -692,7 +692,7 @@ type IdRegFinishError = variant {
 
 type Account = record {
     // Null is unreserved default account
-    account : opt AccountNumber;
+    account_number : opt AccountNumber;
     origin : text;
     last_used : opt Timestamp;
     // Configurable properties
@@ -842,7 +842,7 @@ service : (opt InternetIdentityInit) -> {
     // Multiple accounts
     get_accounts : (
         anchor_number : UserNumber,
-        origin : opt FrontendHostname, // Either get all accounts or a specific origin
+        origin : FrontendHostname, // Either get all accounts or a specific origin
     ) -> (vec Account) query;
 
     create_account : (

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -560,11 +560,11 @@ type IdentityMetadataReplaceError = variant {
 };
 
 type CreateAccountError = variant {
-    InternalError;
+    InternalCanisterError : text;
 };
 
 type UpdateAccountError = variant {
-    InternalError;
+    InternalCanisterError : text;
 };
 
 type PrepareIdAliasRequest = record {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1,4 +1,5 @@
 type UserNumber = nat64;
+type AccountNumber = nat64;
 type PublicKey = blob;
 type CredentialId = blob;
 type DeviceKey = PublicKey;
@@ -558,6 +559,14 @@ type IdentityMetadataReplaceError = variant {
     InternalCanisterError : text;
 };
 
+type CreateAccountError = variant {
+    InternalError;
+};
+
+type UpdateAccountError = variant {
+    InternalError;
+};
+
 type PrepareIdAliasRequest = record {
     // Origin of the issuer in the attribute sharing flow.
     issuer : FrontendHostname;
@@ -680,6 +689,20 @@ type IdRegFinishError = variant {
     // Error while persisting the new identity.
     StorageError : text;
 };
+
+type Account = record {
+    // Null is unreserved default account
+    account : opt AccountNumber;
+    origin : text;
+    last_used : opt Timestamp;
+    // Configurable properties
+    name : opt text;
+};
+
+type AccountUpdate = record {
+    name : opt text;
+};
+
 
 service : (opt InternetIdentityInit) -> {
     // Legacy identity management API
@@ -815,4 +838,39 @@ service : (opt InternetIdentityInit) -> {
 
     // Discoverable passkeys protocol
     lookup_device_key : (credential_id : blob) -> (opt DeviceKeyWithAnchor) query;
+
+    // Multiple accounts
+    get_accounts : (
+        anchor_number : UserNumber,
+        origin : opt FrontendHostname, // Either get all accounts or a specific origin
+    ) -> (vec Account) query;
+
+    create_account : (
+        anchor_number : UserNumber,
+        origin : FrontendHostname,
+        name : text
+    ) -> (variant { Ok : Account; Err: CreateAccountError });
+
+    update_account : (
+        anchor_number : UserNumber,
+        origin : FrontendHostname,
+        account_number : opt AccountNumber, // Null is unreserved default account
+        update : AccountUpdate
+    ) ->  (variant { Ok : Account; Err: UpdateAccountError });
+
+    prepare_account_delegation : (
+        anchor_number : UserNumber,
+        origin : FrontendHostname,
+        account_number : opt AccountNumber, // Null is unreserved default account
+        session_key : SessionKey,
+        max_ttl : opt nat64
+    ) -> (UserKey, Timestamp);
+    
+    get_account_delegation : (
+        anchor_number : UserNumber,
+        origin : FrontendHostname,
+        account_number : AccountNumber, // Null is unreserved default account
+        session_key : SessionKey,
+        expiration : Timestamp
+    ) -> (GetDelegationResponse) query;
 };

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -298,6 +298,72 @@ fn get_delegation(
 }
 
 #[query]
+fn get_accounts(
+    _anchor_number: AnchorNumber,
+    _origin: Option<FrontendHostname>,
+) -> Vec<Account> {
+    vec![
+        Account {
+            account: None,
+            origin: "example.com".to_string(),
+            last_used: Some(0u64),
+            name: Some("Default Mock Account".to_string()),
+        }
+    ]
+}
+
+#[update]
+fn create_account(
+    _anchor_number: AnchorNumber,
+    _origin: FrontendHostname,
+    _name: String,
+) -> Result<Account, CreateAccountError> {
+    Ok(Account {
+        account: None,
+        origin: "example.com".to_string(),
+        last_used: Some(0u64),
+        name: Some("Default Mock Account".to_string()),
+    })
+}
+
+#[update]
+fn update_account(
+    _anchor_number: AnchorNumber,
+    _origin: FrontendHostname,
+    _account_number: Option<AccountNumber>,
+    _update: AccountUpdate,
+) -> Result<Account, UpdateAccountError> {
+    Ok(Account {
+        account: None,
+        origin: "example.com".to_string(),
+        last_used: Some(0u64),
+        name: Some("Default Mock Account".to_string()),
+    })
+}
+
+#[update]
+fn prepare_account_delegation(
+    _anchor_number: AnchorNumber,
+    _origin: FrontendHostname,
+    _account_number: Option<AccountNumber>,
+    _session_key: SessionKey,
+    _max_ttl: Option<u64>,
+) -> (UserKey, Timestamp) {
+    (ByteBuf::new(), 0)
+}
+
+#[query]
+fn get_account_delegation(
+    _anchor_number: AnchorNumber,
+    _origin: FrontendHostname,
+    _account_number: AccountNumber,
+    _session_key: SessionKey,
+    _expiration: Timestamp,
+) -> GetDelegationResponse {
+    GetDelegationResponse::NoSuchDelegation
+}
+
+#[query]
 fn http_request(req: HttpRequest) -> HttpResponse {
     http::http_request(req)
 }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -298,9 +298,9 @@ fn get_delegation(
 }
 
 #[query]
-fn get_accounts(_anchor_number: AnchorNumber, _origin: Option<FrontendHostname>) -> Vec<Account> {
+fn get_accounts(_anchor_number: AnchorNumber, _origin: FrontendHostname) -> Vec<Account> {
     vec![Account {
-        account: None,
+        account_number: None,
         origin: "example.com".to_string(),
         last_used: Some(0u64),
         name: Some("Default Mock Account".to_string()),
@@ -314,7 +314,7 @@ fn create_account(
     _name: String,
 ) -> Result<Account, CreateAccountError> {
     Ok(Account {
-        account: None,
+        account_number: None,
         origin: "example.com".to_string(),
         last_used: Some(0u64),
         name: Some("Default Mock Account".to_string()),
@@ -329,7 +329,7 @@ fn update_account(
     _update: AccountUpdate,
 ) -> Result<Account, UpdateAccountError> {
     Ok(Account {
-        account: None,
+        account_number: None,
         origin: "example.com".to_string(),
         last_used: Some(0u64),
         name: Some("Default Mock Account".to_string()),

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -298,18 +298,13 @@ fn get_delegation(
 }
 
 #[query]
-fn get_accounts(
-    _anchor_number: AnchorNumber,
-    _origin: Option<FrontendHostname>,
-) -> Vec<Account> {
-    vec![
-        Account {
-            account: None,
-            origin: "example.com".to_string(),
-            last_used: Some(0u64),
-            name: Some("Default Mock Account".to_string()),
-        }
-    ]
+fn get_accounts(_anchor_number: AnchorNumber, _origin: Option<FrontendHostname>) -> Vec<Account> {
+    vec![Account {
+        account: None,
+        origin: "example.com".to_string(),
+        last_used: Some(0u64),
+        name: Some("Default Mock Account".to_string()),
+    }]
 }
 
 #[update]

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -330,7 +330,6 @@ pub struct Account {
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct AccountUpdate {
   pub name : Option<String>,
-  pub hidden : Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -321,15 +321,15 @@ pub struct DeviceKeyWithAnchor {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct Account {
-  pub account : Option<AccountNumber>, // Null is unreserved default account
-  pub origin : FrontendHostname,
-  pub last_used : Option<Timestamp>,
-  pub name : Option<String>,
+    pub account: Option<AccountNumber>, // Null is unreserved default account
+    pub origin: FrontendHostname,
+    pub last_used: Option<Timestamp>,
+    pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct AccountUpdate {
-  pub name : Option<String>,
+    pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -339,5 +339,5 @@ pub enum CreateAccountError {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum UpdateAccountError {
-    InternlError,
+    InternalError,
 }

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -321,7 +321,7 @@ pub struct DeviceKeyWithAnchor {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct Account {
-    pub account: Option<AccountNumber>, // Null is unreserved default account
+    pub account_number: Option<AccountNumber>, // Null is unreserved default account
     pub origin: FrontendHostname,
     pub last_used: Option<Timestamp>,
     pub name: Option<String>,
@@ -334,10 +334,10 @@ pub struct AccountUpdate {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum CreateAccountError {
-    InternalError,
+    InternalCanisterError(String),
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum UpdateAccountError {
-    InternalError,
+    InternalCanisterError(String),
 }

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -14,6 +14,7 @@ pub type Timestamp = u64; // in nanos since epoch
 pub type Signature = ByteBuf;
 pub type DeviceVerificationCode = String;
 pub type FailedAttemptsCounter = u8;
+pub type AccountNumber = u64;
 
 mod api_v2;
 pub mod openid;
@@ -316,4 +317,28 @@ pub enum AuthorizationKey {
 pub struct DeviceKeyWithAnchor {
     pub pubkey: DeviceKey,
     pub anchor_number: AnchorNumber,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct Account {
+  pub account : Option<AccountNumber>, // Null is unreserved default account
+  pub origin : FrontendHostname,
+  pub last_used : Option<Timestamp>,
+  pub name : Option<String>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct AccountUpdate {
+  pub name : Option<String>,
+  pub hidden : Option<bool>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum CreateAccountError {
+    InternalError,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum UpdateAccountError {
+    InternlError,
 }


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Setup the interface on multiple accounts to be able to start working in parallel in backend and frontend.

# Changes

### Interface Updates (`.did` file)

* **New Types for Accounts**: Added `Account`, `AccountUpdate`, `CreateAccountError`, and `UpdateAccountError` types to represent account data and potential errors. (`src/internet_identity/internet_identity.did`.
* **New Service Methods**:
  - `get_accounts`: Fetches accounts associated with a user and origin.
  - `create_account`: Creates a new account for a user.
  - `update_account`: Updates account properties.
  - `prepare_account_delegation` and `get_account_delegation`: Manage account delegations.

### Backend Implementation (Rust)

* **New Functions**: Implemented corresponding backend functions for the `.did` interface methods, including `get_accounts`, `create_account`, `update_account`, `prepare_account_delegation`, and `get_account_delegation`. These functions currently return mock data or default responses.

### Type Definitions

* **New Structs and Enums**:
  - Added `Account` and `AccountUpdate` structs to represent account data.
  - Added `CreateAccountError` and `UpdateAccountError` enums for error handling.
  - Introduced `AccountNumber` as a new type alias for `u64`.

These changes lay the foundation for supporting multiple accounts in the Internet Identity service, enabling more granular identity management.




<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->



