### PR TITLE
Avoid code splitting

### DIFF
--- a/src/frontend/tests/e2e/featureFlagRerouting.test.ts
+++ b/src/frontend/tests/e2e/featureFlagRerouting.test.ts
@@ -3,9 +3,9 @@ import { II_URL } from "./constants";
 import { NewAuthorizeView, AuthenticateView } from "./views";
 
 const checkIfHasTailwind = (browser: WebdriverIO.Browser) => {
-  return browser.execute(async () => {
+  return browser.execute(() => {
     for (const style of Array.from(document.styleSheets)) {
-      const rules = await style.cssRules;
+      const rules = style.cssRules;
       for (const rule of Array.from(rules)) {
         if (rule.cssText.includes("@layer base")) {
           // This should be tailwind only but can be made more specific
@@ -18,9 +18,9 @@ const checkIfHasTailwind = (browser: WebdriverIO.Browser) => {
 };
 
 const checkIfHasSkeleton = (browser: WebdriverIO.Browser) => {
-  return browser.execute(async () => {
+  return browser.execute(() => {
     for (const style of Array.from(document.styleSheets)) {
-      const rules = await style.cssRules;
+      const rules = style.cssRules;
       for (const rule of Array.from(rules)) {
         if (rule.cssText.includes("cerberus")) {
           // This should be tailwind only but can be made more specific

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig(({ command, mode }): UserConfig => {
           manualChunks: (id) => {
             const folder = dirname(id);
 
+            if (folder.includes("tailwind")) {
+              return "tailwind";
+            }
+
             if (
               ["@sveltejs", "svelte"].find((lib) => folder.includes(lib)) ===
                 undefined &&

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { sveltekit } from "@sveltejs/kit/vite";
 import basicSsl from "@vitejs/plugin-basic-ssl";
 import { type AliasOptions, type UserConfig, defineConfig } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
-import path from "path";
+import { dirname } from "node:path";
 
 export const aliasConfig: AliasOptions = {
   // Polyfill stream for the browser. e.g. needed in "Recovery Phrase" features.
@@ -33,6 +33,21 @@ export default defineConfig(({ command, mode }): UserConfig => {
       rollupOptions: {
         // Bundle only english words in bip39.
         external: /.*\/wordlists\/(?!english).*\.json/,
+        output: {
+          manualChunks: (id) => {
+            const folder = dirname(id);
+
+            if (
+              ["@sveltejs", "svelte"].find((lib) => folder.includes(lib)) ===
+                undefined &&
+              folder.includes("node_modules")
+            ) {
+              return "vendor";
+            }
+
+            return "index";
+          },
+        },
       },
       commonjsOptions: {
         // Source: https://github.com/rollup/plugins/issues/1425#issuecomment-1465626736


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

There is a glitch in Internet Identity where the content appears in a white background and without any style. That's because the CSS is loaded too late.

This glitch also happened in OISY and they fixed by reducing the chunks.

# Changes

* Apply manual chunking to have two chunks. One from the dependencies and one from II code. To be determined whether we could keep the same name of the vendor chunk so that it can use the browser cache.

# Tests

* See screenshots with the chunks folder.



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


