### PR TITLE
Fix feedback from previous design impl PR

### DIFF
--- a/src/frontend/src/lib/components/layout/Footer.svelte
+++ b/src/frontend/src/lib/components/layout/Footer.svelte
@@ -2,7 +2,7 @@
   import type { HTMLAttributes } from "svelte/elements";
   import { SOURCE_CODE_URL, SUPPORT_URL } from "$lib/config";
 
-  type Props = HTMLAttributes<HTMLHeadElement>;
+  type Props = HTMLAttributes<HTMLElement>;
 
   const { children, class: className, ...props }: Props = $props();
 </script>

--- a/src/frontend/src/lib/components/views/CreateAccount.svelte
+++ b/src/frontend/src/lib/components/views/CreateAccount.svelte
@@ -49,6 +49,7 @@
       autocorrect="off"
       spellcheck="false"
       disabled={loading}
+      error={name.length > 32 ? "Maximum length is 32 characters." : undefined}
     />
   </div>
   <div class="mt-auto flex flex-col items-stretch gap-3">
@@ -57,7 +58,7 @@
       variant="primary"
       size="lg"
       type="submit"
-      disabled={name.length === 0 || loading}
+      disabled={name.length === 0 || name.length > 32 || loading}
     >
       {#if loading}
         <ProgressRing />

--- a/src/frontend/src/lib/components/views/CreatePasskey.svelte
+++ b/src/frontend/src/lib/components/views/CreatePasskey.svelte
@@ -50,6 +50,7 @@
       autocorrect="off"
       spellcheck="false"
       disabled={loading}
+      error={name.length > 64 ? "Maximum length is 64 characters." : undefined}
     />
   </div>
   <div class="mt-auto flex flex-col items-stretch gap-3">
@@ -58,7 +59,7 @@
       variant="primary"
       size="lg"
       type="submit"
-      disabled={name.length === 0 || loading}
+      disabled={name.length === 0 || name.length > 64 || loading}
     >
       {#if loading}
         <ProgressRing />

--- a/src/frontend/src/lib/utils/authentication/passkey.ts
+++ b/src/frontend/src/lib/utils/authentication/passkey.ts
@@ -42,14 +42,12 @@ export const authenticateWithPasskey = async ({
   const passkeyIdentity = DiscoverablePasskeyIdentity.useExisting({
     credentialId,
     getPublicKey: async (result) => {
-      console.log("lookup_device_key", result.rawId);
       const lookupResult = (
         await actor.lookup_device_key(new Uint8Array(result.rawId))
       )[0];
       if (isNullish(lookupResult)) {
         throw new IdentityNotMigratedError();
       }
-      console.log("lookupResult", lookupResult);
       identityNumber = lookupResult.anchor_number;
       return CosePublicKey.fromDer(new Uint8Array(lookupResult.pubkey));
     },


### PR DESCRIPTION
Fix feedback from previous PR.

- Props typing of Footer component
- Add max length to identity name input
   - Limit is set to 64 to make sure that e.g. YubiKeys won't throw an error
   - Storage limit in the canister is meanwhile higher to handle longer names coming from OpenID
- Add max length to account name input, matches storage limit (32).
- Remove console logs
- Avoid the need for `!` in discoverable passkey identity implementation

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
