### PR TITLE
Reactivate interface-compatibility test in canister-tests

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -1038,16 +1038,15 @@ jobs:
             exit 1
           fi
 
-  # DEACTIVATING THIS FOR NOW SO WE CAN UPDATE OUR ENDPOINTS
-  # interface-compatibility:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/setup-didc
-  #     - name: "Check canister interface compatibility"
-  #       run: |
-  #         curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
-  #         didc check src/internet_identity/internet_identity.did internet_identity_previous.did
+  interface-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-didc
+      - name: "Check canister interface compatibility"
+        run: |
+          curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
+          didc check src/internet_identity/internet_identity.did internet_identity_previous.did
 
   sig-verifier-js:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Motivation

Once the account delegation PRs have been merged, we can reactivate the interface compatibility test.

# Changes

Uncommenting the test.

# Tests

Yes
