### PR TITLE
Fix Google authentication and related changes based on feedback

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -5,7 +5,7 @@
       "candid": "src/internet_identity/internet_identity.did",
       "wasm": "internet_identity.wasm.gz",
       "build": "bash -c 'II_DEV_CSP=1 II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=${II_DUMMY_CAPTCHA:-1} scripts/build'",
-      "init_arg": "(opt record { captcha_config = opt record { max_unsolved_captchas= 50:nat64; captcha_trigger = variant {Static = variant {CaptchaDisabled}}}; openid_google = opt opt record { client_id = \"360587991668-63bpc1gngp1s5gbo1aldal4a50c1j0bb.apps.googleusercontent.com\" }; related_origins = opt vec { \"https://identity.internetcomputer.org\"; \"https://identity.ic0.app\" } })",
+      "init_arg": "(opt record { captcha_config = opt record { max_unsolved_captchas= 50:nat64; captcha_trigger = variant {Static = variant {CaptchaDisabled}}}; openid_google = opt opt record { client_id = \"775077467414-q1ajffledt8bjj82p2rl5a09co8cf4rf.apps.googleusercontent.com\" }; related_origins = opt vec { \"https://identity.internetcomputer.org\"; \"https://identity.ic0.app\" } })",
       "shrink": false
     },
     "test_app": {

--- a/src/frontend/src/lib/components/ui/Dialog.svelte
+++ b/src/frontend/src/lib/components/ui/Dialog.svelte
@@ -81,7 +81,6 @@
           "scroll",
           updateKeyboardInset,
         );
-        updateKeyboardInset();
       }
     };
   });

--- a/src/frontend/src/lib/components/ui/RadioCard.svelte
+++ b/src/frontend/src/lib/components/ui/RadioCard.svelte
@@ -29,8 +29,9 @@
   aria-checked={checked}
   {...props}
   class={[
-    "bg-bg-primary ring-border-secondary text-text-primary hover:bg-bg-primary_hover relative flex items-center justify-start gap-3 rounded-md p-3 text-sm font-semibold ring-1 outline-none ring-inset not-dark:shadow-xs",
+    "bg-bg-primary ring-border-secondary text-text-primary not-disabled:hover:bg-bg-primary_hover relative flex items-center justify-start gap-3 rounded-md p-3 text-sm font-semibold ring-1 outline-none ring-inset not-dark:shadow-xs",
     checked && "!ring-border-brand ring-2",
+    "disabled:ring-border-disabled disabled:text-text-disabled",
     className,
   ]}
 >

--- a/src/frontend/src/lib/components/utils/SystemOverlayBackdrop.svelte
+++ b/src/frontend/src/lib/components/utils/SystemOverlayBackdrop.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { fade } from "svelte/transition";
+  import { type HTMLAttributes } from "svelte/elements";
+
+  type Props = HTMLAttributes<HTMLElement>;
+
+  const { class: className, ...props }: Props = $props();
+</script>
+
+<div
+  class={[`bg-bg-overlay/80 fixed inset-0 z-999`, className]}
+  transition:fade={{ duration: 0.2 }}
+  {...props}
+></div>

--- a/src/frontend/src/lib/components/utils/error.ts
+++ b/src/frontend/src/lib/components/utils/error.ts
@@ -1,4 +1,4 @@
-import { isWebAuthnCancel } from "$lib/utils/webAuthnErrorUtils";
+import { isWebAuthnCancelError } from "$lib/utils/webAuthnErrorUtils";
 import { toaster } from "$lib/components/utils/toaster";
 import { isCanisterError } from "$lib/utils/utils";
 import type {
@@ -6,23 +6,15 @@ import type {
   IdRegFinishError,
   IdRegStartError,
 } from "$lib/generated/internet_identity_types";
-import { isPermissionError } from "$lib/utils/openID";
+import { isOpenIdCancelError } from "$lib/utils/openID";
 
 export const handleError = (error: unknown) => {
   // Handle browser errors
-  if (isWebAuthnCancel(error)) {
+  if (isWebAuthnCancelError(error) || isOpenIdCancelError(error)) {
     toaster.info({
       title: "Operation canceled",
       description:
         "The interaction was canceled or timed out. Please try again.",
-    });
-    return;
-  }
-  if (isPermissionError(error)) {
-    toaster.error({
-      title: "Permission denied",
-      description:
-        'You need to enable the "Third-party sign-in" browser permission for this site',
     });
     return;
   }

--- a/src/frontend/src/lib/components/views/CreatePasskey.svelte
+++ b/src/frontend/src/lib/components/views/CreatePasskey.svelte
@@ -19,7 +19,7 @@
 
   const handleSubmit = () => {
     loading = true;
-    create(name);
+    create(name.trim());
   };
 
   onMount(() => {

--- a/src/frontend/src/lib/components/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/views/PickAuthenticationMethod.svelte
@@ -4,13 +4,25 @@
   import GoogleIcon from "$lib/components/icons/GoogleIcon.svelte";
   import PasskeyIcon from "$lib/components/icons/PasskeyIcon.svelte";
   import Alert from "$lib/components/ui/Alert.svelte";
+  import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
 
   interface Props {
     setupOrUseExistingPasskey: () => void;
-    continueWithGoogle: () => void;
+    continueWithGoogle: () => Promise<void>;
   }
 
   const { setupOrUseExistingPasskey, continueWithGoogle }: Props = $props();
+
+  let googleLoading = $state(false);
+
+  const handleContinueWithGoogle = async () => {
+    googleLoading = true;
+    try {
+      await continueWithGoogle();
+    } finally {
+      googleLoading = false;
+    }
+  };
 
   const supportsPasskeys = nonNullish(window.PublicKeyCredential);
 </script>
@@ -26,15 +38,25 @@
   <div class="flex flex-col items-stretch gap-3">
     <Button
       onclick={setupOrUseExistingPasskey}
-      disabled={!supportsPasskeys}
+      disabled={!supportsPasskeys || googleLoading}
       size="xl"
     >
       <PasskeyIcon />
       Continue with Passkey
     </Button>
-    <Button onclick={continueWithGoogle} variant="secondary" size="xl">
-      <GoogleIcon />
-      Continue with Google
+    <Button
+      onclick={handleContinueWithGoogle}
+      variant="secondary"
+      size="xl"
+      disabled={googleLoading}
+    >
+      {#if googleLoading}
+        <ProgressRing />
+        <span>Authenticating with Google...</span>
+      {:else}
+        <GoogleIcon />
+        <span>Continue with Google</span>
+      {/if}
     </Button>
   </div>
 </div>

--- a/src/frontend/src/lib/flows/addDevice/manage/addCurrentDevice.ts
+++ b/src/frontend/src/lib/flows/addDevice/manage/addCurrentDevice.ts
@@ -11,8 +11,8 @@ import {
 import {
   displayCancelError,
   displayDuplicateDeviceError,
-  isWebAuthnCancel,
-  isWebAuthnDuplicateDevice,
+  isWebAuthnCancelError,
+  isWebAuthnDuplicateDeviceError,
 } from "$lib/utils/webAuthnErrorUtils";
 import { WebAuthnIdentity } from "$lib/utils/webAuthnIdentity";
 import { nonNullish } from "@dfinity/utils";
@@ -54,9 +54,9 @@ export const addCurrentDevice = async (
       publicKey: creationOptions(devices, undefined, rpId),
     });
   } catch (error: unknown) {
-    if (isWebAuthnDuplicateDevice(error)) {
+    if (isWebAuthnDuplicateDeviceError(error)) {
       await displayDuplicateDeviceError({ primaryButton: "Back to manage" });
-    } else if (isWebAuthnCancel(error)) {
+    } else if (isWebAuthnCancelError(error)) {
       await displayCancelError({ primaryButton: "Back to manage" });
     } else {
       await displayFailedToAddDevice(

--- a/src/frontend/src/lib/flows/addDevice/welcomeView/registerTentativeDevice.ts
+++ b/src/frontend/src/lib/flows/addDevice/welcomeView/registerTentativeDevice.ts
@@ -16,8 +16,8 @@ import { unknownToString, unreachable, unreachableLax } from "$lib/utils/utils";
 import {
   displayCancelError,
   displayDuplicateDeviceError,
-  isWebAuthnCancel,
-  isWebAuthnDuplicateDevice,
+  isWebAuthnCancelError,
+  isWebAuthnDuplicateDeviceError,
 } from "$lib/utils/webAuthnErrorUtils";
 import { WebAuthnIdentity } from "$lib/utils/webAuthnIdentity";
 import { deviceRegistrationDisabledInfo } from "./deviceRegistrationModeDisabled";
@@ -56,12 +56,12 @@ export const registerTentativeDevice = async (
   );
 
   if (result instanceof Error) {
-    if (isWebAuthnDuplicateDevice(result)) {
+    if (isWebAuthnDuplicateDeviceError(result)) {
       // Given that this is a remote device where we get the result that authentication should work,
       // let's help the user and fill in their anchor number.
       await setAnchorUsed(userNumber);
       await displayDuplicateDeviceError({ primaryButton: "Ok" });
-    } else if (isWebAuthnCancel(result)) {
+    } else if (isWebAuthnCancelError(result)) {
       await displayCancelError({ primaryButton: "Ok" });
     } else {
       await displayError({

--- a/src/frontend/src/lib/flows/manage/index.ts
+++ b/src/frontend/src/lib/flows/manage/index.ts
@@ -49,7 +49,7 @@ import {
   createAnonymousNonce,
   createGoogleRequestConfig,
   decodeJWT,
-  isPermissionError,
+  isOpenIdCancelError,
   requestJWT,
 } from "$lib/utils/openID";
 import { PreLoadImage } from "$lib/utils/preLoadImage";
@@ -511,7 +511,7 @@ export const displayManage = async (
         await connection.addOpenIdCredential(jwt, salt);
         resolve();
       } catch (error) {
-        if (isPermissionError(error)) {
+        if (isOpenIdCancelError(error)) {
           toast.error(copy.third_party_sign_in_permission_required);
           return;
         }

--- a/src/frontend/src/lib/flows/recovery/useRecovery.ts
+++ b/src/frontend/src/lib/flows/recovery/useRecovery.ts
@@ -16,8 +16,8 @@ import { constructIdentity } from "$lib/utils/webAuthn";
 import {
   displayCancelError,
   displayDuplicateDeviceError,
-  isWebAuthnCancel,
-  isWebAuthnDuplicateDevice,
+  isWebAuthnCancelError,
+  isWebAuthnDuplicateDeviceError,
 } from "$lib/utils/webAuthnErrorUtils";
 import { nonNullish } from "@dfinity/utils";
 import { html } from "lit-html";
@@ -27,6 +27,7 @@ import { recoverWithDevice } from "./recoverWith/device";
 import { recoverWithPhrase } from "./recoverWith/phrase";
 import { DOMAIN_COMPATIBILITY } from "$lib/state/featureFlags";
 import { get } from "svelte/store";
+
 export const useRecovery = async (
   connection: Connection,
 ): Promise<LoginSuccess | { tag: "canceled" }> => {
@@ -152,9 +153,9 @@ const enrollAuthenticator = async ({
     newDevice = newDeviceData.newDevice;
     newDeviceOrigin = newDeviceData.newDeviceOrigin;
   } catch (error: unknown) {
-    if (isWebAuthnDuplicateDevice(error)) {
+    if (isWebAuthnDuplicateDeviceError(error)) {
       await displayDuplicateDeviceError({ primaryButton: "Ok" });
-    } else if (isWebAuthnCancel(error)) {
+    } else if (isWebAuthnCancelError(error)) {
       await displayCancelError({ primaryButton: "Ok" });
     } else {
       await displayError({

--- a/src/frontend/src/lib/flows/redirect.ts
+++ b/src/frontend/src/lib/flows/redirect.ts
@@ -17,20 +17,27 @@ export const callbackFlow = (): Promise<never> => {
 };
 
 export const redirectInPopup = (url: string): Promise<string> => {
-  const callbackPromise = new Promise<string>((resolve) => {
-    const listener = (event: MessageEvent) => {
+  const callbackPromise = new Promise<string>((resolve, reject) => {
+    const closeInterval = setInterval(() => {
+      if (redirectWindow?.closed === true) {
+        clearInterval(closeInterval);
+        reject(new Error("Window closed before a response was received"));
+      }
+    }, 500);
+    const responseListener = (event: MessageEvent) => {
       if (
         event.source === redirectWindow &&
         event.origin === window.location.origin &&
         typeof event.data === "string"
       ) {
-        window.removeEventListener("message", listener);
+        window.removeEventListener("message", responseListener);
+        clearInterval(closeInterval);
         redirectWindow?.close();
         window.focus();
         resolve(event.data);
       }
     };
-    window.addEventListener("message", listener);
+    window.addEventListener("message", responseListener);
   });
   const width = 500;
   const height = 600;

--- a/src/frontend/src/lib/flows/redirect.ts
+++ b/src/frontend/src/lib/flows/redirect.ts
@@ -18,6 +18,11 @@ export const callbackFlow = (): Promise<never> => {
 
 export const redirectInPopup = (url: string): Promise<string> => {
   const callbackPromise = new Promise<string>((resolve, reject) => {
+    // We need to throw an error when the window is closed, else the page and
+    // thus the user will wait indefinitely for a result that never comes.
+    //
+    // We can't listen to close events since the window is likely cross-origin,
+    // so instead we periodically check the closed attribute with an interval.
     const closeInterval = setInterval(() => {
       if (redirectWindow?.closed === true) {
         clearInterval(closeInterval);

--- a/src/frontend/src/lib/flows/register/passkey.ts
+++ b/src/frontend/src/lib/flows/register/passkey.ts
@@ -7,7 +7,7 @@ import { mount, renderPage, TemplateElement } from "$lib/utils/lit-html";
 import { unknownToString } from "$lib/utils/utils";
 import { constructIdentity } from "$lib/utils/webAuthn";
 import {
-  isWebAuthnCancel,
+  isWebAuthnCancelError,
   webAuthnErrorCopy,
 } from "$lib/utils/webAuthnErrorUtils";
 import { nonNullish } from "@dfinity/utils";
@@ -164,7 +164,7 @@ export const savePasskeyPinOrOpenID = async ({
 
 // Return an appropriate error message depending on the (inferred) type of WebAuthn error
 const errorMessage = (e: unknown): TemplateElement => {
-  if (isWebAuthnCancel(e)) {
+  if (isWebAuthnCancelError(e)) {
     const copy = webAuthnErrorCopy();
     return html`<p class="t-paragraph">
       <strong class="t-strong">${copy.cancel_title}</strong>:

--- a/src/frontend/src/lib/utils/iiConnection.ts
+++ b/src/frontend/src/lib/utils/iiConnection.ts
@@ -78,7 +78,7 @@ import { findWebAuthnFlows, WebAuthnFlow } from "./findWebAuthnFlows";
 import { MultiWebAuthnIdentity } from "./multiWebAuthnIdentity";
 import { isRecoveryDevice, RecoveryDevice } from "./recoveryDevice";
 import { supportsWebauthRoR } from "./userAgent";
-import { isWebAuthnCancel } from "./webAuthnErrorUtils";
+import { isWebAuthnCancelError } from "./webAuthnErrorUtils";
 import { LoginEvents, loginFunnel } from "./analytics/loginFunnel";
 import {
   webauthnAuthenticationFunnel,
@@ -567,7 +567,7 @@ export class Connection {
     } catch (e: unknown) {
       // Better understand which users don't make it all the way.
       webauthnAuthenticationFunnel.trigger(WebauthnAuthenticationEvents.Failed);
-      if (isWebAuthnCancel(e)) {
+      if (isWebAuthnCancelError(e)) {
         // Better understand which users don't make it all the way.
         webauthnAuthenticationFunnel.trigger(
           WebauthnAuthenticationEvents.Cancelled,

--- a/src/frontend/src/lib/utils/openID.ts
+++ b/src/frontend/src/lib/utils/openID.ts
@@ -50,6 +50,7 @@ const requestWithCredentials = async (
           loginHint: options.loginHint,
         },
       ],
+      mode: "active",
     },
     mediation: options.mediation,
   });
@@ -75,8 +76,9 @@ export const isNotSupportedError = (error: unknown) =>
 /**
  * @param error to check whether it is a FedCM no permission error
  */
-export const isPermissionError = (error: unknown) =>
-  error instanceof Error && error.name === "NetworkError";
+export const isOpenIdCancelError = (error: unknown) => {
+  return error instanceof Error && error.name === "NetworkError";
+};
 
 /**
  * Request JWT through redirect flow in a popup

--- a/src/frontend/src/lib/utils/webAuthnErrorUtils.ts
+++ b/src/frontend/src/lib/utils/webAuthnErrorUtils.ts
@@ -35,7 +35,7 @@ export const displayDuplicateDeviceError = (options: {
  *  * https://www.w3.org/TR/webauthn-2/#sctn-op-make-cred (Step 3)
  * @param error error to check
  */
-export const isWebAuthnDuplicateDevice = (error: unknown): boolean => {
+export const isWebAuthnDuplicateDeviceError = (error: unknown): boolean => {
   return error instanceof DOMException && error.name === "InvalidStateError";
 };
 
@@ -50,7 +50,7 @@ export const isWebAuthnDuplicateDevice = (error: unknown): boolean => {
  *
  * @param error error to check
  */
-export const isWebAuthnCancel = (error: unknown): boolean => {
+export const isWebAuthnCancelError = (error: unknown): boolean => {
   return (
     error instanceof DOMException &&
     // According to WebAuthn spec, the browser must throw a NotAllowedError when the user cancels the operation.

--- a/src/frontend/src/routes/(new-styling)/authorize/(authenticated)/account/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/(authenticated)/account/+page.svelte
@@ -17,9 +17,10 @@
   import { nonNullish } from "@dfinity/utils";
   import Dialog from "$lib/components/ui/Dialog.svelte";
   import CreateAccount from "$lib/components/views/CreateAccount.svelte";
-  import { untrack } from "svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import { GlobeIcon } from "@lucide/svelte";
+  import { page } from "$app/state";
+  import { untrack } from "svelte";
 
   const { data }: PageProps = $props();
   let accounts = $derived(data.accounts);
@@ -28,8 +29,15 @@
   const hostname = $derived(new URL(origin).hostname);
   const dapps = getDapps();
   const dapp = $derived(dapps.find((dapp) => dapp.hasOrigin(origin)));
+  const preselectedAccount = untrack(() =>
+    "preselectAccount" in page.state && page.state.preselectAccount === true
+      ? accounts[0].account_number[0]
+      : null,
+  );
 
-  let selectedAccountNumber = $state<bigint | undefined | null>(null);
+  let selectedAccountNumber = $state<bigint | undefined | null>(
+    preselectedAccount,
+  );
   const selectedAccount = $derived(
     accounts.find(
       (account) => account.account_number[0] === selectedAccountNumber,
@@ -44,7 +52,7 @@
           $authenticatedStore.identityNumber,
           $authorizationContextStore.authRequest.derivationOrigin ??
             $authorizationContextStore.requestOrigin,
-          name,
+          name.trim(),
         )
         .then(throwCanisterError);
       accounts = [...accounts, account];

--- a/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
@@ -41,6 +41,7 @@
   import SetupOrUseExistingPasskey from "$lib/components/views/SetupOrUseExistingPasskey.svelte";
   import CreatePasskey from "$lib/components/views/CreatePasskey.svelte";
   import { onMount } from "svelte";
+  import SystemOverlayBackdrop from "$lib/components/utils/SystemOverlayBackdrop.svelte";
 
   let dialog = $state<"setupOrUseExistingPasskey" | "setupNewPasskey">();
   let captcha = $state<{
@@ -48,6 +49,7 @@
     attempt: number;
     solve: (solution: string) => void;
   }>();
+  let systemOverlay = $state(false);
 
   const setupOrUseExistingPasskey = async () => {
     authenticationV2Funnel.trigger(
@@ -72,7 +74,7 @@
         name: info.name[0],
         authMethod: { passkey: { credentialId } },
       });
-      await goto("/authorize/account");
+      await goto("/authorize/account", { state: { preselectAccount: true } });
     } catch (error) {
       handleError(error);
       dialog = undefined;
@@ -186,10 +188,12 @@
       authenticationV2Funnel.trigger(AuthenticationV2Events.ContinueWithGoogle);
       const clientId = canisterConfig.openid_google?.[0]?.[0]?.client_id!;
       const requestConfig = createGoogleRequestConfig(clientId);
+      systemOverlay = true;
       jwt = await requestJWT(requestConfig, {
         nonce: $sessionStore.nonce,
         mediation: "required",
       });
+      systemOverlay = false;
       const { identity, identityNumber, iss, sub } = await authenticateWithJWT({
         canisterId,
         session: $sessionStore,
@@ -208,8 +212,9 @@
         name: info.name[0],
         authMethod: { openid: { iss, sub } },
       });
-      await goto("/authorize/account");
+      await goto("/authorize/account", { state: { preselectAccount: true } });
     } catch (error) {
+      systemOverlay = false;
       if (
         isCanisterError<OpenIdDelegationError>(error) &&
         error.type === "NoSuchAnchor" &&
@@ -294,8 +299,11 @@
         AuthenticationV2Events.SuccessfulGoogleRegistration,
       );
       authenticationStore.set({ identity, identityNumber });
+      const info =
+        await $authenticatedStore.actor.get_anchor_info(identityNumber);
       lastUsedIdentitiesStore.addLastUsedIdentity({
         identityNumber,
+        name: info.name[0],
         authMethod: { openid: { iss, sub } },
       });
       lastUsedIdentitiesStore.addLastUsedAccount({
@@ -355,4 +363,7 @@
       {/if}
     </Dialog>
   {/if}
+{/if}
+{#if systemOverlay}
+  <SystemOverlayBackdrop />
 {/if}


### PR DESCRIPTION
Fix Google authentication and related changes based on feedback

- Update `dfx.json` init args to use Google dev client instead of prod client config
- Use `active` mode with FedCM, this centers the modal and avoids being blocked by a cooldown period
- Add and render `SystemOverlayBackdrop` component in FedCM flow, to align the FedCM UX with Passkey UX
- Store account name after Google registration in last used identity storage.
- Fix error in `Dialog` component, the `updateKeyboardInset` function shouldn't be called on cleanup
- Add disabled style to `RadioCard` component
- Show loader indicator on "Continue with Google" button
- Rename `isWebAuthnCancel` to `isWebAuthnCancelError` to align with other error type method namings
- Trim identity and account name input values
- Preselect first account if user reaches account selection screen from a new sign in
- Throw error if window is closed in `redirectInPopup`, previously the user got stuck after closing the Google sign-in window

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

