### PR TITLE
Add canonical link

### DIFF
--- a/src/frontend/src/app.html
+++ b/src/frontend/src/app.html
@@ -8,6 +8,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
+    <link rel="canonical" href="https://identity.internetcomputer.org/" />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

To avoid id.ai being crawled by bots, we can point them to identity.internetcomputer.org.

This is a simpler solution than telling the bot to ignore the site when it's id.ai with a header or meta tag only for id.ai.

The only problem is that we will also be pointing the testing domains to the canonical URL. But that is probably also correct.

# Changes

* Add canonical link to identity.internetcomputer.org in the app.html

# Tests

Tested locally. It's added.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/b302babe9/mobile/manageUseExisting.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
