### PR TITLE
Use new config to enable new authentication flow

### DIFF
--- a/src/frontend/src/hooks.client.ts
+++ b/src/frontend/src/hooks.client.ts
@@ -2,7 +2,14 @@ import type { ClientInit } from "@sveltejs/kit";
 import featureFlags from "$lib/state/featureFlags";
 import { authenticationStore } from "$lib/stores/authentication.store";
 import { sessionStore } from "$lib/stores/session.store";
-import { initGlobals, canisterId, agentOptions } from "$lib/globals";
+import {
+  initGlobals,
+  canisterId,
+  agentOptions,
+  canisterConfig,
+} from "$lib/globals";
+import { isNullish } from "@dfinity/utils";
+import { isSameOrigin } from "$lib/utils/urlUtils";
 
 const FEATURE_FLAG_PREFIX = "feature_flag_";
 
@@ -40,9 +47,25 @@ const overrideFeatureFlags = () => {
   window.history.replaceState(undefined, "", url);
 };
 
+// Set the discoverable passkey flag based on the new flow origins config.
+// This will be used for id.ai and Utopia to enable the new authentication flow.
+// Once the feature is enabled for all users, this can be removed.
+const maybeSetDiscoverablePasskeyFlowFlag = () => {
+  const newFlowOrigins = canisterConfig.new_flow_origins[0];
+  if (isNullish(newFlowOrigins)) {
+    return;
+  }
+  const origin = window.location.origin;
+  if (newFlowOrigins.filter((o) => isSameOrigin(o, origin)).length === 0) {
+    return;
+  }
+  featureFlags.DISCOVERABLE_PASSKEY_FLOW.set(true);
+};
+
 export const init: ClientInit = async () => {
   overrideFeatureFlags();
   initGlobals();
+  maybeSetDiscoverablePasskeyFlowFlag();
   await sessionStore.init({ canisterId, agentOptions });
   authenticationStore.init({ canisterId, agentOptions });
 };


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We want to enable the new flow in the new domain and Utopia.

# Changes

* Check the current domain and config to enable the new authentication flow flag or not.

# Tests

* Tested locally by adding localhost in the config and then removing it.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
