### PR TITLE
Use new account delegation methods.

### DIFF
--- a/src/frontend/src/lib/utils/iiConnection.ts
+++ b/src/frontend/src/lib/utils/iiConnection.ts
@@ -1265,7 +1265,7 @@ export const creationOptions = (
 
 // In order to give dapps a stable principal regardless whether they use the legacy (ic0.app) or the new domain (icp0.io)
 // we map back the derivation origin to the ic0.app domain.
-const remapToLegacyDomain = (origin: string): string => {
+export const remapToLegacyDomain = (origin: string): string => {
   const ORIGIN_MAPPING_REGEX =
     /^https:\/\/(?<subdomain>[\w-]+(?:\.raw)?)\.icp0\.io$/;
   const match = origin.match(ORIGIN_MAPPING_REGEX);

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -2,7 +2,6 @@
   import type { LayoutProps } from "./$types";
   import { onMount } from "svelte";
   import CenterLayout from "$lib/components/layout/CenterLayout.svelte";
-  import { canisterConfig, canisterId } from "$lib/globals";
   import {
     authorizationStore,
     authorizationStatusStore,
@@ -15,7 +14,7 @@
   const status = $derived($authorizationStatusStore);
 
   onMount(() => {
-    authorizationStore.init({ canisterId, canisterConfig });
+    authorizationStore.init();
   });
 </script>
 


### PR DESCRIPTION
Use new account delegation methods.

- Replace connection fetchDelegation with prepare and get account delegation calls instead.
- Make sure legacy domains (ic0.app) are mapped to new domains (icp0.io).