### PR TITLE
Implement changes from feedback in storage layer.

### DIFF
--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -255,7 +255,7 @@ pub struct Storage<M: Memory> {
     stable_anchor_memory: StableBTreeMap<StorableAnchorNumber, StorableAnchor, ManagedMemory<M>>,
     /// Memory wrapper used to report the size of the stable account memory.
     stable_account_memory_wrapper: MemoryWrapper<ManagedMemory<M>>,
-    stable_account_memory: StableBTreeMap<AccountNumber, StorableAccount, ManagedMemory<M>>,
+    stable_account_memory: StableBTreeMap<StorableAccountNumber, StorableAccount, ManagedMemory<M>>,
     /// Memory wrapper used to report the size of the stable application memory.
     stable_application_memory_wrapper: MemoryWrapper<ManagedMemory<M>>,
     stable_application_memory:
@@ -263,11 +263,11 @@ pub struct Storage<M: Memory> {
     /// Memory wrapper used to report the size of the stable account counter memory.
     stable_anchor_account_counter_memory_wrapper: MemoryWrapper<ManagedMemory<M>>,
     stable_anchor_account_counter_memory:
-        StableBTreeMap<StorableAccountNumber, StorableAccountsCounter, ManagedMemory<M>>,
+        StableBTreeMap<StorableAnchorNumber, StorableAccountsCounter, ManagedMemory<M>>,
     /// Memory wrapper used to report the size of the stable account reference list memory.
     stable_account_reference_list_memory_wrapper: MemoryWrapper<ManagedMemory<M>>,
     stable_account_reference_list_memory: StableBTreeMap<
-        (StorableAccountNumber, StorableApplicationNumber),
+        (StorableAnchorNumber, StorableApplicationNumber),
         StorableAccountReferenceList,
         ManagedMemory<M>,
     >,

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -138,8 +138,7 @@ impl From<Anchor> for (StorableFixedAnchor, StorableAnchor) {
             StorableAnchor {
                 openid_credentials: anchor
                     .openid_credentials
-                    .iter()
-                    .cloned()
+                    .into_iter()
                     .map(Into::into)
                     .collect(),
                 name: anchor.name,
@@ -164,8 +163,7 @@ impl From<(AnchorNumber, StorableFixedAnchor, Option<StorableAnchor>)> for Ancho
                 .map(|anchor| {
                     anchor
                         .openid_credentials
-                        .iter()
-                        .cloned()
+                        .into_iter()
                         .map(Into::into)
                         .collect()
                 })

--- a/src/internet_identity/src/storage/storable/openid_credential.rs
+++ b/src/internet_identity/src/storage/storable/openid_credential.rs
@@ -52,8 +52,8 @@ impl From<StorableOpenIdCredential> for OpenIdCredential {
             last_usage_timestamp: value.last_usage_timestamp,
             metadata: value
                 .metadata
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone().into()))
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
                 .collect(),
         }
     }
@@ -68,8 +68,8 @@ impl From<OpenIdCredential> for StorableOpenIdCredential {
             last_usage_timestamp: value.last_usage_timestamp,
             metadata: value
                 .metadata
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone().into()))
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
                 .collect(),
         }
     }


### PR DESCRIPTION
Implement changes from feedback in storage layer.

- Double check and adjust where needed the variables in memories
- Use `into_iter()` to avoid unnecessarily cloning the whole vector
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
