### PR TITLE
Add prefix and origin to account seed.

### DIFF
--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -157,8 +157,8 @@ impl Account {
                 delegation::calculate_anchor_seed(seed_from_anchor, &self.origin)
             }
             (None, Some(account_number)) => {
-                // If this is an added account, we derive from the account number.
-                delegation::calculate_account_seed(account_number)
+                // If this is an added account, we derive from the account number and origin.
+                delegation::calculate_account_seed(account_number, &self.origin)
             }
             (None, None) => trap("Attempted to calculate an account seed from an account without seed anchor or anchor number - this should never happen!")
         }


### PR DESCRIPTION
As discussed, this PR adds a prefix and origin to seed calculations of additional accounts, making sure they're tied to a given origin while avoiding collisions with existing primary account seed calculations.
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
