### PR TITLE
Add account delegation integration tests

### DIFF
--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -336,27 +336,54 @@ pub fn update_account(
     .map(|(x,)| x)
 }
 
-pub fn prepare_account_delegation(
-    env: &PocketIc,
-    canister_id: CanisterId,
-    sender: Principal,
-    identity_number: IdentityNumber,
-    origin: FrontendHostname,
-    account_number: Option<AccountNumber>,
-    session_key: SessionKey,
-    max_ttl: Option<u64>,
-) -> Result<Result<PrepareAccountDelegation, AccountDelegationError>, CallError> {
-    call_candid_as(
-        env,
-        canister_id,
-        RawEffectivePrincipal::None,
-        sender,
-        "prepare_account_delegation",
-        (
+#[derive(Clone)]
+pub struct AccountDelegationParams<'a> {
+    pub env: &'a PocketIc,
+    pub canister_id: CanisterId,
+    pub sender: Principal,
+    pub identity_number: IdentityNumber,
+    pub origin: FrontendHostname,
+    pub account_number: Option<AccountNumber>,
+    pub session_key: SessionKey,
+}
+
+impl<'a> AccountDelegationParams<'a> {
+    pub fn new(
+        env: &'a PocketIc,
+        canister_id: CanisterId,
+        sender: Principal,
+        identity_number: IdentityNumber,
+        origin: FrontendHostname,
+        account_number: Option<AccountNumber>,
+        session_key: SessionKey,
+    ) -> Self {
+        Self {
+            env,
+            canister_id,
+            sender,
             identity_number,
             origin,
             account_number,
             session_key,
+        }
+    }
+}
+
+pub fn prepare_account_delegation(
+    params: &AccountDelegationParams,
+    max_ttl: Option<u64>,
+) -> Result<Result<PrepareAccountDelegation, AccountDelegationError>, CallError> {
+    call_candid_as(
+        params.env,
+        params.canister_id,
+        RawEffectivePrincipal::None,
+        params.sender,
+        "prepare_account_delegation",
+        (
+            params.identity_number,
+            params.origin.clone(),
+            params.account_number,
+            params.session_key.clone(),
             max_ttl,
         ),
     )
@@ -364,25 +391,19 @@ pub fn prepare_account_delegation(
 }
 
 pub fn get_account_delegation(
-    env: &PocketIc,
-    canister_id: CanisterId,
-    sender: Principal,
-    identity_number: IdentityNumber,
-    origin: FrontendHostname,
-    account_number: Option<AccountNumber>,
-    session_key: SessionKey,
+    params: &AccountDelegationParams,
     expiration: u64,
 ) -> Result<Result<SignedDelegation, AccountDelegationError>, CallError> {
     query_candid_as(
-        env,
-        canister_id,
-        sender,
+        params.env,
+        params.canister_id,
+        params.sender,
         "get_account_delegation",
         (
-            identity_number,
-            origin,
-            account_number,
-            session_key,
+            params.identity_number,
+            params.origin.clone(),
+            params.account_number,
+            params.session_key.clone(),
             expiration,
         ),
     )

--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -2,7 +2,7 @@ use candid::Principal;
 use ic_cdk::api::management_canister::main::CanisterId;
 use internet_identity_interface::internet_identity::types::*;
 use pocket_ic::common::rest::RawEffectivePrincipal;
-use pocket_ic::{call_candid, call_candid_as, query_candid, CallError, PocketIc};
+use pocket_ic::{call_candid, call_candid_as, query_candid, query_candid_as, CallError, PocketIc};
 use std::collections::HashMap;
 
 pub fn identity_registration_start(
@@ -306,10 +306,9 @@ pub fn get_accounts(
     identity_number: IdentityNumber,
     origin: FrontendHostname,
 ) -> Result<Result<Vec<AccountInfo>, GetAccountsError>, CallError> {
-    call_candid_as(
+    query_candid_as(
         env,
         canister_id,
-        RawEffectivePrincipal::None,
         sender,
         "get_accounts",
         (identity_number, origin),
@@ -333,6 +332,59 @@ pub fn update_account(
         sender,
         "update_account",
         (identity_number, origin, account_number, update),
+    )
+    .map(|(x,)| x)
+}
+
+pub fn prepare_account_delegation(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+    identity_number: IdentityNumber,
+    origin: FrontendHostname,
+    account_number: Option<AccountNumber>,
+    session_key: SessionKey,
+    max_ttl: Option<u64>,
+) -> Result<Result<PrepareAccountDelegation, AccountDelegationError>, CallError> {
+    call_candid_as(
+        env,
+        canister_id,
+        RawEffectivePrincipal::None,
+        sender,
+        "prepare_account_delegation",
+        (
+            identity_number,
+            origin,
+            account_number,
+            session_key,
+            max_ttl,
+        ),
+    )
+    .map(|(x,)| x)
+}
+
+pub fn get_account_delegation(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+    identity_number: IdentityNumber,
+    origin: FrontendHostname,
+    account_number: Option<AccountNumber>,
+    session_key: SessionKey,
+    expiration: u64,
+) -> Result<Result<SignedDelegation, AccountDelegationError>, CallError> {
+    query_candid_as(
+        env,
+        canister_id,
+        sender,
+        "get_account_delegation",
+        (
+            identity_number,
+            origin,
+            account_number,
+            session_key,
+            expiration,
+        ),
     )
     .map(|(x,)| x)
 }

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -395,7 +395,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const PrepareAccountDelegation = IDL.Record({
     'user_key' : UserKey,
-    'timestamp' : Timestamp,
+    'expiration' : Timestamp,
   });
   const PrepareIdAliasRequest = IDL.Record({
     'issuer' : FrontendHostname,

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -308,7 +308,7 @@ export interface OpenIdPrepareDelegationResponse {
 }
 export interface PrepareAccountDelegation {
   'user_key' : UserKey,
-  'timestamp' : Timestamp,
+  'expiration' : Timestamp,
 }
 export type PrepareIdAliasError = { 'InternalCanisterError' : string } |
   { 'Unauthorized' : Principal };

--- a/src/frontend/src/lib/stores/authorization.store.ts
+++ b/src/frontend/src/lib/stores/authorization.store.ts
@@ -72,7 +72,7 @@ export const authorizationStore: AuthorizationStore = {
             const artificialDelayPromise = waitFor(artificialDelay);
             const { identityNumber, actor } = get(authenticatedStore);
             try {
-              const { user_key, timestamp } = await actor
+              const { user_key, expiration } = await actor
                 .prepare_account_delegation(
                   identityNumber,
                   effectiveOrigin,
@@ -90,7 +90,7 @@ export const authorizationStore: AuthorizationStore = {
                     effectiveOrigin,
                     nonNullish(accountNumber) ? [accountNumber] : [],
                     context.authRequest.sessionPublicKey,
-                    timestamp,
+                    expiration,
                   )
                   .then(throwCanisterError)
                   .then(transformSignedDelegation),

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -582,7 +582,7 @@ type AccountDelegationError = variant {
 
 type PrepareAccountDelegation = record {
     user_key : UserKey;
-    timestamp : Timestamp;
+    expiration : Timestamp;
 };
 
 type GetAccountsError = variant {

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -144,7 +144,7 @@ pub async fn prepare_account_delegation(
 
     Ok(PrepareAccountDelegation {
         user_key: ByteBuf::from(der_encode_canister_sig_key(seed.to_vec())),
-        timestamp: expiration,
+        expiration,
     })
 }
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -289,8 +289,8 @@ async fn prepare_delegation(
     .map(
         |PrepareAccountDelegation {
              user_key,
-             timestamp,
-         }| (user_key, timestamp),
+             expiration,
+         }| (user_key, expiration),
     )
     .unwrap_or_else(|err| trap(&format!("{:?}", err)))
 }

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -194,5 +194,5 @@ impl From<IdentityUpdateError> for AccountDelegationError {
 #[derive(CandidType, Serialize)]
 pub struct PrepareAccountDelegation {
     pub user_key: UserKey,
-    pub timestamp: Timestamp,
+    pub expiration: Timestamp,
 }

--- a/src/internet_identity/tests/integration/accounts.rs
+++ b/src/internet_identity/tests/integration/accounts.rs
@@ -4,7 +4,7 @@ use canister_tests::{
     api::internet_identity::{
         api_v2::{
             create_account, get_account_delegation, get_accounts, prepare_account_delegation,
-            update_account,
+            update_account, AccountDelegationParams,
         },
         get_delegation, prepare_delegation,
     },
@@ -15,7 +15,8 @@ use canister_tests::{
     },
 };
 use internet_identity_interface::internet_identity::types::{
-    AccountInfo, AccountUpdate, GetDelegationResponse, PrepareAccountDelegation,
+    AccountDelegationError, AccountInfo, AccountUpdate, GetDelegationResponse,
+    PrepareAccountDelegation,
 };
 use pocket_ic::CallError;
 use serde_bytes::ByteBuf;
@@ -477,10 +478,7 @@ fn should_get_valid_account_delegation() -> Result<(), CallError> {
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
 
-    let PrepareAccountDelegation {
-        user_key,
-        expiration,
-    } = prepare_account_delegation(
+    let params = AccountDelegationParams::new(
         &env,
         canister_id,
         principal_1(),
@@ -488,28 +486,21 @@ fn should_get_valid_account_delegation() -> Result<(), CallError> {
         frontend_hostname.clone(),
         None,
         pub_session_key.clone(),
-        None,
-    )
-    .unwrap()
-    .unwrap();
+    );
+
+    let PrepareAccountDelegation {
+        user_key,
+        expiration,
+    } = prepare_account_delegation(&params, None).unwrap().unwrap();
 
     assert_eq!(
         expiration,
         time(&env) + Duration::from_secs(30 * 60).as_nanos() as u64 // default expiration: 30 minutes
     );
 
-    let signed_delegation = get_account_delegation(
-        &env,
-        canister_id,
-        principal_1(),
-        user_number,
-        frontend_hostname,
-        None,
-        pub_session_key.clone(),
-        expiration,
-    )
-    .unwrap()
-    .unwrap();
+    let signed_delegation = get_account_delegation(&params, expiration)
+        .unwrap()
+        .unwrap();
 
     verify_delegation(&env, user_key, &signed_delegation, &env.root_key().unwrap());
     assert_eq!(signed_delegation.delegation.pubkey, pub_session_key);
@@ -527,10 +518,7 @@ fn should_get_matching_principals() -> Result<(), CallError> {
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
 
-    let PrepareAccountDelegation {
-        user_key,
-        expiration,
-    } = prepare_account_delegation(
+    let params = AccountDelegationParams::new(
         &env,
         canister_id,
         principal_1(),
@@ -538,28 +526,21 @@ fn should_get_matching_principals() -> Result<(), CallError> {
         frontend_hostname.clone(),
         None,
         pub_session_key.clone(),
-        None,
-    )
-    .unwrap()
-    .unwrap();
+    );
+
+    let PrepareAccountDelegation {
+        user_key,
+        expiration,
+    } = prepare_account_delegation(&params, None).unwrap().unwrap();
 
     assert_eq!(
         expiration,
         time(&env) + Duration::from_secs(30 * 60).as_nanos() as u64 // default expiration: 30 minutes
     );
 
-    let signed_account_delegation = get_account_delegation(
-        &env,
-        canister_id,
-        principal_1(),
-        user_number,
-        frontend_hostname.clone(),
-        None,
-        pub_session_key.clone(),
-        expiration,
-    )
-    .unwrap()
-    .unwrap();
+    let signed_account_delegation = get_account_delegation(&params, expiration)
+        .unwrap()
+        .unwrap();
 
     verify_delegation(
         &env,
@@ -620,10 +601,7 @@ fn should_get_valid_account_delegation_with_custom_expiration() -> Result<(), Ca
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
 
-    let PrepareAccountDelegation {
-        user_key,
-        expiration,
-    } = prepare_account_delegation(
+    let params = AccountDelegationParams::new(
         &env,
         canister_id,
         principal_1(),
@@ -631,28 +609,23 @@ fn should_get_valid_account_delegation_with_custom_expiration() -> Result<(), Ca
         frontend_hostname.clone(),
         None,
         pub_session_key.clone(),
-        Some(3_600_000_000_000), // 1 hour
-    )
-    .unwrap()
-    .unwrap();
+    );
+
+    let PrepareAccountDelegation {
+        user_key,
+        expiration,
+    } = prepare_account_delegation(&params, Some(3_600_000_000_000)) // 1 hour
+        .unwrap()
+        .unwrap();
 
     assert_eq!(
         expiration,
         time(&env) + Duration::from_secs(60 * 60).as_nanos() as u64
     );
 
-    let signed_delegation = get_account_delegation(
-        &env,
-        canister_id,
-        principal_1(),
-        user_number,
-        frontend_hostname,
-        None,
-        pub_session_key.clone(),
-        expiration,
-    )
-    .unwrap()
-    .unwrap();
+    let signed_delegation = get_account_delegation(&params, expiration)
+        .unwrap()
+        .unwrap();
 
     verify_delegation(&env, user_key, &signed_delegation, &env.root_key().unwrap());
     assert_eq!(signed_delegation.delegation.pubkey, pub_session_key);
@@ -670,10 +643,7 @@ fn should_shorten_account_delegation_expiration_greater_max_ttl() -> Result<(), 
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
 
-    let PrepareAccountDelegation {
-        user_key,
-        expiration,
-    } = prepare_account_delegation(
+    let params = AccountDelegationParams::new(
         &env,
         canister_id,
         principal_1(),
@@ -681,8 +651,15 @@ fn should_shorten_account_delegation_expiration_greater_max_ttl() -> Result<(), 
         frontend_hostname.clone(),
         None,
         pub_session_key.clone(),
-        Some(Duration::from_secs(31 * 24 * 60 * 60).as_nanos() as u64), // 31 days
-    )
+    );
+
+    let PrepareAccountDelegation {
+        user_key,
+        expiration,
+    } = prepare_account_delegation(
+        &params,
+        Some(Duration::from_secs(31 * 24 * 60 * 60).as_nanos() as u64),
+    ) // 31 days
     .unwrap()
     .unwrap();
 
@@ -692,18 +669,9 @@ fn should_shorten_account_delegation_expiration_greater_max_ttl() -> Result<(), 
         time(&env) + Duration::from_secs(month_seconds).as_nanos() as u64
     );
 
-    let signed_delegation = get_account_delegation(
-        &env,
-        canister_id,
-        principal_1(),
-        user_number,
-        frontend_hostname,
-        None,
-        pub_session_key.clone(),
-        expiration,
-    )
-    .unwrap()
-    .unwrap();
+    let signed_delegation = get_account_delegation(&params, expiration)
+        .unwrap()
+        .unwrap();
 
     verify_delegation(&env, user_key, &signed_delegation, &env.root_key().unwrap());
     assert_eq!(signed_delegation.delegation.pubkey, pub_session_key);
@@ -752,10 +720,7 @@ fn should_get_multiple_valid_account_delegations() -> Result<(), CallError> {
             .into_iter()
             .map(|(session_key, frontend_hostname, time_shift)| {
                 env.advance_time(time_shift);
-                let PrepareAccountDelegation {
-                    user_key,
-                    expiration,
-                } = prepare_account_delegation(
+                let params = AccountDelegationParams::new(
                     &env,
                     canister_id,
                     principal_1(),
@@ -763,10 +728,13 @@ fn should_get_multiple_valid_account_delegations() -> Result<(), CallError> {
                     frontend_hostname.clone(),
                     None,
                     session_key.clone(),
-                    None,
-                )
-                .unwrap()
-                .expect("prepare_account_delegation failed");
+                );
+                let PrepareAccountDelegation {
+                    user_key,
+                    expiration,
+                } = prepare_account_delegation(&params, None)
+                    .unwrap()
+                    .expect("prepare_account_delegation failed");
 
                 assert_eq!(
                     expiration,
@@ -776,18 +744,18 @@ fn should_get_multiple_valid_account_delegations() -> Result<(), CallError> {
             });
 
     for (session_key, frontend_hostname, user_key, expiration) in prepare_delegation_results {
-        let signed_delegation = get_account_delegation(
+        let params = AccountDelegationParams::new(
             &env,
             canister_id,
             principal_1(),
             user_number,
-            frontend_hostname,
+            frontend_hostname.clone(),
             None,
             session_key.clone(),
-            expiration,
-        )
-        .unwrap()
-        .unwrap();
+        );
+        let signed_delegation = get_account_delegation(&params, expiration)
+            .unwrap()
+            .unwrap();
 
         verify_delegation(&env, user_key, &signed_delegation, &root_key);
         assert_eq!(signed_delegation.delegation.pubkey, session_key.clone());
@@ -806,10 +774,7 @@ fn should_issue_different_principals_for_account_delegations() -> Result<(), Cal
     let frontend_hostname_1 = "https://dapp1.com".to_string();
     let frontend_hostname_2 = "https://dapp2.com".to_string();
 
-    let PrepareAccountDelegation {
-        user_key: user_key_1,
-        ..
-    } = prepare_account_delegation(
+    let params_1 = AccountDelegationParams::new(
         &env,
         canister_id,
         principal_1(),
@@ -817,15 +782,9 @@ fn should_issue_different_principals_for_account_delegations() -> Result<(), Cal
         frontend_hostname_1,
         None,
         pub_session_key.clone(),
-        None,
-    )
-    .unwrap()
-    .unwrap();
+    );
 
-    let PrepareAccountDelegation {
-        user_key: user_key_2,
-        ..
-    } = prepare_account_delegation(
+    let params_2 = AccountDelegationParams::new(
         &env,
         canister_id,
         principal_1(),
@@ -833,48 +792,64 @@ fn should_issue_different_principals_for_account_delegations() -> Result<(), Cal
         frontend_hostname_2,
         None,
         pub_session_key.clone(),
-        None,
-    )
-    .unwrap()
-    .unwrap();
+    );
+
+    let PrepareAccountDelegation {
+        user_key: user_key_1,
+        ..
+    } = prepare_account_delegation(&params_1, None)
+        .unwrap()
+        .unwrap();
+
+    let PrepareAccountDelegation {
+        user_key: user_key_2,
+        ..
+    } = prepare_account_delegation(&params_2, None)
+        .unwrap()
+        .unwrap();
 
     assert_ne!(user_key_1, user_key_2);
     Ok(())
 }
 
-/// Verifies that account delegations can only be prepared by the matching user.
+/// Verifies that prepare_account_delegation can only be called by the matching user.
 #[test]
-#[should_panic]
-fn can_not_prepare_account_delegation_for_different_user() {
-    let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
-    let user_number = flows::register_anchor(&env, canister_id);
-
-    let _ = prepare_account_delegation(
-        &env,
-        canister_id,
-        principal_2(),
-        user_number, // belongs to principal_1
-        "https://some-dapp.com".to_string(),
-        None,
-        ByteBuf::from("session key"),
-        None,
-    )
-    .unwrap()
-    .unwrap();
-}
-
-/// Verifies that get_account_delegation can only be called by the matching user.
-#[test]
-#[should_panic]
-fn can_not_get_account_delegation_for_different_user() {
+fn can_not_prepare_account_delegation_for_different_user() -> Result<(), CallError> {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
 
-    let PrepareAccountDelegation { expiration, .. } = prepare_account_delegation(
+    let params = AccountDelegationParams::new(
+        &env,
+        canister_id,
+        principal_2(), // different user
+        user_number,
+        frontend_hostname,
+        None,
+        pub_session_key,
+    );
+
+    match prepare_account_delegation(&params, None).unwrap() {
+        Ok(_) => panic!("This should not be possible!"),
+        Err(err) => match err {
+            AccountDelegationError::Unauthorized(_) => return Ok(()),
+            _ => panic!("Wrong error type!"),
+        },
+    }
+}
+
+/// Verifies that get_account_delegation can only be called by the matching user.
+#[test]
+fn can_not_get_account_delegation_for_different_user() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let user_number = flows::register_anchor(&env, canister_id);
+    let frontend_hostname = "https://some-dapp.com".to_string();
+    let pub_session_key = ByteBuf::from("session public key");
+
+    let params = AccountDelegationParams::new(
         &env,
         canister_id,
         principal_1(),
@@ -882,23 +857,28 @@ fn can_not_get_account_delegation_for_different_user() {
         frontend_hostname.clone(),
         None,
         pub_session_key.clone(),
-        None,
-    )
-    .unwrap()
-    .unwrap();
+    );
 
-    let _ = get_account_delegation(
+    let PrepareAccountDelegation { expiration, .. } =
+        prepare_account_delegation(&params, None).unwrap().unwrap();
+
+    let params_wrong_user = AccountDelegationParams::new(
         &env,
         canister_id,
-        principal_2(),
+        principal_2(), // different user
         user_number,
         frontend_hostname,
         None,
         pub_session_key,
-        expiration,
-    )
-    .unwrap()
-    .unwrap();
+    );
+
+    match get_account_delegation(&params_wrong_user, expiration).unwrap() {
+        Ok(_) => panic!("This should not be possible!"),
+        Err(err) => match err {
+            AccountDelegationError::Unauthorized(_) => return Ok(()),
+            _ => panic!("Wrong error type!"),
+        },
+    }
 }
 
 /// Verifies that there is a graceful failure if get_account_delegation is called after the expiration.
@@ -910,7 +890,7 @@ fn should_not_get_account_delegation_after_expiration() -> Result<(), CallError>
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
 
-    let PrepareAccountDelegation { expiration, .. } = prepare_account_delegation(
+    let params = AccountDelegationParams::new(
         &env,
         canister_id,
         principal_1(),
@@ -918,40 +898,24 @@ fn should_not_get_account_delegation_after_expiration() -> Result<(), CallError>
         frontend_hostname.clone(),
         None,
         pub_session_key.clone(),
-        None,
-    )
-    .unwrap()
-    .unwrap();
-
-    env.advance_time(Duration::from_secs(30 * 60 + 1)); // one second more than delegation validity of 30 min
-
-    // we have to call prepare again, because expired signatures can only be pruned in update calls
-    prepare_account_delegation(
-        &env,
-        canister_id,
-        principal_1(),
-        user_number,
-        frontend_hostname.clone(),
-        None,
-        pub_session_key.clone(),
-        None,
-    )
-    .unwrap()
-    .unwrap();
-
-    let result = get_account_delegation(
-        &env,
-        canister_id,
-        principal_1(),
-        user_number,
-        frontend_hostname,
-        None,
-        pub_session_key,
-        expiration,
     );
 
-    assert!(result.unwrap().is_err());
-    Ok(())
+    let PrepareAccountDelegation { expiration, .. } =
+        prepare_account_delegation(&params, None).unwrap().unwrap();
+
+    // advance time to after expiration
+    env.advance_time(Duration::from_secs(31 * 60)); // 31 minutes
+
+    // we have to call prepare again, because expired signatures can only be pruned in update calls
+    prepare_account_delegation(&params, None).unwrap().unwrap();
+
+    match get_account_delegation(&params, expiration).unwrap() {
+        Ok(_) => panic!("This should not be possible!"),
+        Err(err) => match err {
+            AccountDelegationError::NoSuchDelegation => return Ok(()),
+            _ => panic!("Wrong error type!"),
+        },
+    }
 }
 
 /// Verifies that different accounts on the same origin yield different principals.
@@ -960,65 +924,69 @@ fn should_issue_different_principals_for_different_accounts() -> Result<(), Call
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM.clone());
     let user_number = flows::register_anchor(&env, canister_id);
+    let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
-    let frontend_hostname = "https://dapp1.com".to_string();
 
     // Create two different accounts
-    let first_account = create_account(
+    let account_1 = create_account(
         &env,
         canister_id,
         principal_1(),
         user_number,
         frontend_hostname.clone(),
-        "First Account".to_string(),
+        "Account 1".to_string(),
     )
     .unwrap()
     .unwrap();
 
-    let second_account = create_account(
+    let account_2 = create_account(
         &env,
         canister_id,
         principal_1(),
         user_number,
         frontend_hostname.clone(),
-        "Second Account".to_string(),
+        "Account 2".to_string(),
     )
     .unwrap()
     .unwrap();
 
     // Get delegations for both accounts
-    let PrepareAccountDelegation {
-        user_key: user_key_1,
-        ..
-    } = prepare_account_delegation(
+    let params_1 = AccountDelegationParams::new(
         &env,
         canister_id,
         principal_1(),
         user_number,
         frontend_hostname.clone(),
-        first_account.account_number,
+        account_1.account_number,
         pub_session_key.clone(),
-        None,
-    )
-    .unwrap()
-    .unwrap();
+    );
 
-    let PrepareAccountDelegation {
-        user_key: user_key_2,
-        ..
-    } = prepare_account_delegation(
+    let params_2 = AccountDelegationParams::new(
         &env,
         canister_id,
         principal_1(),
         user_number,
         frontend_hostname,
-        second_account.account_number,
-        pub_session_key.clone(),
-        None,
-    )
-    .unwrap()
-    .unwrap();
+        account_2.account_number,
+        pub_session_key,
+    );
 
+    let PrepareAccountDelegation {
+        user_key: user_key_1,
+        ..
+    } = prepare_account_delegation(&params_1, None)
+        .unwrap()
+        .unwrap();
+
+    let PrepareAccountDelegation {
+        user_key: user_key_2,
+        ..
+    } = prepare_account_delegation(&params_2, None)
+        .unwrap()
+        .unwrap();
+
+    // Verify that the principals are different
     assert_ne!(user_key_1, user_key_2);
+
     Ok(())
 }

--- a/src/internet_identity/tests/integration/accounts.rs
+++ b/src/internet_identity/tests/integration/accounts.rs
@@ -834,7 +834,7 @@ fn can_not_prepare_account_delegation_for_different_user() -> Result<(), CallErr
     match prepare_account_delegation(&params, None).unwrap() {
         Ok(_) => panic!("This should not be possible!"),
         Err(err) => match err {
-            AccountDelegationError::Unauthorized(_) => return Ok(()),
+            AccountDelegationError::Unauthorized(_) => Ok(()),
             _ => panic!("Wrong error type!"),
         },
     }
@@ -875,7 +875,7 @@ fn can_not_get_account_delegation_for_different_user() -> Result<(), CallError> 
     match get_account_delegation(&params_wrong_user, expiration).unwrap() {
         Ok(_) => panic!("This should not be possible!"),
         Err(err) => match err {
-            AccountDelegationError::Unauthorized(_) => return Ok(()),
+            AccountDelegationError::Unauthorized(_) => Ok(()),
             _ => panic!("Wrong error type!"),
         },
     }
@@ -912,7 +912,7 @@ fn should_not_get_account_delegation_after_expiration() -> Result<(), CallError>
     match get_account_delegation(&params, expiration).unwrap() {
         Ok(_) => panic!("This should not be possible!"),
         Err(err) => match err {
-            AccountDelegationError::NoSuchDelegation => return Ok(()),
+            AccountDelegationError::NoSuchDelegation => Ok(()),
             _ => panic!("Wrong error type!"),
         },
     }

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -353,3 +353,16 @@ pub enum GetAccountsError {
     InternalCanisterError(String),
     Unauthorized(Principal),
 }
+
+#[derive(CandidType, Deserialize)]
+pub struct PrepareAccountDelegation {
+    pub user_key: UserKey,
+    pub expiration: Timestamp,
+}
+
+#[derive(CandidType, Debug, Deserialize)]
+pub enum AccountDelegationError {
+    Unauthorized(Principal),
+    InternalCanisterError(String),
+    NoSuchDelegation,
+}


### PR DESCRIPTION
# Motivation

We want to make sure that our account delegations have good integration test coverage. Also the API should make sense.

# Changes

Add integration tests. Change `timestamp` to the more correct `expiration` in `PrepareDelegation` struct.

# Tests

Yes!



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


