### PR TITLE
Store all last used accounts in localstorage

### DIFF
--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -37,6 +37,8 @@ type LastUsedIdentitiesStore = Readable<LastUsedIdentities> & {
   reset: () => void;
 };
 
+export const PRIMARY_ACCOUNT_KEY = "primary";
+
 export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
   const { subscribe, set, update } = writableStored<LastUsedIdentities>({
     key: storeLocalStorageKey.LastUsedIdentities,
@@ -71,7 +73,7 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
         }
         identity.accounts[params.origin][
           isNullish(params.accountNumber)
-            ? "primary"
+            ? PRIMARY_ACCOUNT_KEY
             : params.accountNumber.toString()
         ] = {
           ...params,

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -11,7 +11,9 @@ export type LastUsedAccount = {
   lastUsedTimestampMillis: number;
 };
 export type LastUsedAccounts = {
-  [origin: string]: LastUsedAccount;
+  [origin: string]: {
+    [accountNumber: string]: LastUsedAccount;
+  };
 };
 export type LastUsedIdentity = {
   identityNumber: bigint;
@@ -39,7 +41,7 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
   const { subscribe, set, update } = writableStored<LastUsedIdentities>({
     key: storeLocalStorageKey.LastUsedIdentities,
     defaultValue: {},
-    version: 2,
+    version: 3,
   });
 
   return {
@@ -64,7 +66,14 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
         if (isNullish(identity.accounts)) {
           identity.accounts = {};
         }
-        identity.accounts[params.origin] = {
+        if (isNullish(identity.accounts[params.origin])) {
+          identity.accounts[params.origin] = {};
+        }
+        identity.accounts[params.origin][
+          isNullish(params.accountNumber)
+            ? "primary"
+            : params.accountNumber.toString()
+        ] = {
           ...params,
           lastUsedTimestampMillis: Date.now(),
         };

--- a/src/frontend/src/routes/(new-styling)/authorize/continue/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/continue/+page.svelte
@@ -5,9 +5,9 @@
     authenticateWithJWT,
     authenticateWithPasskey,
   } from "$lib/utils/authentication";
-  import { isNullish } from "@dfinity/utils";
   import {
     lastUsedIdentitiesStore,
+    type LastUsedAccount,
     type LastUsedIdentity,
   } from "$lib/stores/last-used-identities.store";
   import { canisterConfig, canisterId } from "$lib/globals";
@@ -45,8 +45,11 @@
       .slice(0, 3),
   );
   let selectedIdentity = $state.raw(untrack(() => lastUsedIdentities[0]));
-  const lastUsedAccount = $derived(
-    selectedIdentity.accounts?.[$authorizationContextStore.effectiveOrigin],
+  const lastUsedAccount = $derived<LastUsedAccount | undefined>(
+    Object.values(
+      selectedIdentity.accounts?.[$authorizationContextStore.effectiveOrigin] ??
+        {},
+    ).sort((a, b) => b.lastUsedTimestampMillis - a.lastUsedTimestampMillis)[0],
   );
   let continueWith = $state<"lastUsedAccount" | "anotherAccount">(
     "lastUsedAccount",


### PR DESCRIPTION
Store all last used accounts in localstorage, instead of only the "last" one. This local data can be later used when needed in possible future design changes.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

