### PR TITLE
Fix update account guard

### DIFF
--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -51,10 +51,10 @@ pub fn create_account_for_origin(
         storage
             .create_additional_account(CreateAccountParams {
                 anchor_number,
-                origin,
                 name,
+                origin,
             })
-            .map_err(|err| CreateAccountError::InternalCanisterError(format!("{}", err)))
+            .map_err(|err| CreateAccountError::InternalCanisterError(format!("{err}")))
     })
 }
 
@@ -87,17 +87,6 @@ pub fn update_account_for_origin(
                     anchor_number,
                     name,
                     origin: origin.clone(),
-                })
-                .and_then(|acc_num| {
-                    storage
-                        .read_account(ReadAccountParams {
-                            account_number: Some(acc_num),
-                            anchor_number,
-                            origin: &origin,
-                        })
-                        .ok_or(StorageError::AccountNotFound {
-                            account_number: acc_num,
-                        })
                 })
                 .map_err(|err| UpdateAccountError::InternalCanisterError(format!("{}", err)))
         }),

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -5,12 +5,9 @@ use crate::{
     },
     ii_domain::IIDomain,
     state::{self, storage_borrow, storage_borrow_mut},
-    storage::{
-        account::{
-            Account, AccountDelegationError, AccountsCounter, CreateAccountParams,
-            PrepareAccountDelegation, ReadAccountParams, UpdateAccountParams,
-        },
-        StorageError,
+    storage::account::{
+        Account, AccountDelegationError, AccountsCounter, CreateAccountParams,
+        PrepareAccountDelegation, ReadAccountParams, UpdateAccountParams,
     },
     update_root_hash,
 };

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -1064,7 +1064,8 @@ impl<M: Memory + Clone> Storage<M> {
         &mut self,
         params: UpdateExistingAccountParams,
     ) -> Result<Account, StorageError> {
-        // Check if account exists for given anchor number, origin and account number
+        // Check if account reference exists for given anchor number, origin and account number,
+        // if the account refence exists for a given anchor, that means the anchor has access.
         let application_number = self.lookup_application_number_with_origin(&params.origin);
         let account_reference = self
             .find_account_reference(
@@ -1075,7 +1076,9 @@ impl<M: Memory + Clone> Storage<M> {
             .ok_or(StorageError::AccountNotFound {
                 account_number: params.account_number,
             })?;
-        // Check if account is an existing account (reserved with an account number)
+        // Check if the account reference has an account number,
+        // throw error if it doesn't since we only want to update
+        // accounts with an account number in this function.
         let account_number =
             account_reference
                 .account_number

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -81,7 +81,7 @@
 //! bucket of 128 pages.
 use account::{
     Account, AccountsCounter, CreateAccountParams, ReadAccountParams, UpdateAccountParams,
-    UpdateExistinAccountParams,
+    UpdateExistingAccountParams,
 };
 use candid::{CandidType, Deserialize};
 use ic_cdk::api::stable::WASM_PAGE_SIZE_IN_BYTES;
@@ -1039,14 +1039,13 @@ impl<M: Memory + Clone> Storage<M> {
     /// Updates an account.
     /// If the account number exists, then updates that account.
     /// If the account number doesn't exist, then gets or creates an application and creates and stores a default account.
-    pub fn update_account(
-        &mut self,
-        params: UpdateAccountParams,
-    ) -> Result<AccountNumber, StorageError> {
+    pub fn update_account(&mut self, params: UpdateAccountParams) -> Result<Account, StorageError> {
         match params.account_number {
-            Some(account_number) => self.update_existing_account(UpdateExistinAccountParams {
+            Some(account_number) => self.update_existing_account(UpdateExistingAccountParams {
                 account_number,
+                anchor_number: params.anchor_number,
                 name: params.name,
+                origin: params.origin,
             }),
             None => {
                 // Default accounts are not stored by default.
@@ -1063,20 +1062,45 @@ impl<M: Memory + Clone> Storage<M> {
     /// Used in `update_account` to update an existing account.
     fn update_existing_account(
         &mut self,
-        params: UpdateExistinAccountParams,
-    ) -> Result<AccountNumber, StorageError> {
-        match self.stable_account_memory.get(&params.account_number) {
-            None => Err(StorageError::AccountNotFound {
+        params: UpdateExistingAccountParams,
+    ) -> Result<Account, StorageError> {
+        // Check if account exists for given anchor number, origin and account number
+        let application_number = self.lookup_application_number_with_origin(&params.origin);
+        let account_reference = self
+            .find_account_reference(
+                params.anchor_number,
+                application_number,
+                Some(params.account_number),
+            )
+            .ok_or(StorageError::AccountNotFound {
                 account_number: params.account_number,
-            }),
-            Some(storable_account) => {
-                let mut storable_account = storable_account.clone();
-                storable_account.name = params.name;
-                self.stable_account_memory
-                    .insert(params.account_number, storable_account);
-                Ok(params.account_number)
-            }
-        }
+            })?;
+        // Check if account is an existing account (reserved with an account number)
+        let account_number =
+            account_reference
+                .account_number
+                .ok_or(StorageError::AccountNotFound {
+                    account_number: params.account_number,
+                })?;
+        // Read account from storage
+        let mut storable_account = self.stable_account_memory.get(&account_number).ok_or(
+            StorageError::AccountNotFound {
+                account_number: params.account_number,
+            },
+        )?;
+        // Update account and write back to storage
+        storable_account.name = params.name;
+        self.stable_account_memory
+            .insert(params.account_number, storable_account.clone());
+        // Return updated account
+        Ok(Account::new_full(
+            params.anchor_number,
+            params.origin,
+            Some(storable_account.name),
+            Some(account_number),
+            account_reference.last_used,
+            storable_account.seed_from_anchor,
+        ))
     }
 
     /// Used in `update_account` to create a default account.
@@ -1086,7 +1110,7 @@ impl<M: Memory + Clone> Storage<M> {
     fn create_default_account(
         &mut self,
         params: CreateAccountParams,
-    ) -> Result<AccountNumber, StorageError> {
+    ) -> Result<Account, StorageError> {
         // Create and store the default account.
         let new_account_number = self.allocate_account_number()?;
         let storable_account = StorableAccount {
@@ -1095,7 +1119,7 @@ impl<M: Memory + Clone> Storage<M> {
             seed_from_anchor: Some(params.anchor_number),
         };
         self.stable_account_memory
-            .insert(new_account_number, storable_account);
+            .insert(new_account_number, storable_account.clone());
 
         // Get or create an application number from the account's origin.
         let application_number =
@@ -1155,7 +1179,15 @@ impl<M: Memory + Clone> Storage<M> {
             }
         }
 
-        Ok(new_account_number)
+        // Return created default account
+        Ok(Account::new_full(
+            params.anchor_number,
+            params.origin,
+            Some(storable_account.name),
+            Some(new_account_number),
+            None,
+            storable_account.seed_from_anchor,
+        ))
     }
 
     /// Make sure all the required metadata is recorded to stable memory.

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -28,9 +28,11 @@ pub struct UpdateAccountParams {
     pub origin: FrontendHostname,
 }
 
-pub struct UpdateExistinAccountParams {
+pub struct UpdateExistingAccountParams {
     pub account_number: AccountNumber,
+    pub anchor_number: AnchorNumber,
     pub name: String,
+    pub origin: FrontendHostname,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/internet_identity/src/storage/account/tests.rs
+++ b/src/internet_identity/src/storage/account/tests.rs
@@ -247,19 +247,20 @@ fn should_update_default_account() {
         name: account_name.clone(),
         account_number: None,
     };
-    let new_account_number = storage.update_account(updated_account_params).unwrap();
+    let new_account = storage.update_account(updated_account_params).unwrap();
 
     // 4. Check that the default account has been created with the updated values.
-    let updated_accounts = storage.list_accounts(anchor_number, &origin);
-    let expected_updated_account = Account::new_full(
-        anchor_number,
-        origin,
-        Some(account_name),
-        Some(new_account_number),
-        None,
-        Some(anchor_number),
+    assert_eq!(
+        new_account,
+        Account::new_full(
+            anchor_number,
+            origin,
+            Some(account_name),
+            new_account.account_number,
+            None,
+            Some(anchor_number),
+        )
     );
-    assert_eq!(updated_accounts, vec![expected_updated_account]);
     assert_eq!(
         storage.get_account_counter(anchor_number),
         AccountsCounter {
@@ -325,27 +326,20 @@ fn should_update_additional_account() {
         name: new_account_name.clone(),
         account_number: Some(1),
     };
-    let update_account_return_value = storage.update_account(updated_account_params).unwrap();
-
-    assert_eq!(update_account_return_value, account_number);
+    let updated_account = storage.update_account(updated_account_params).unwrap();
 
     // 5. Check that the additional account has been created with the updated values.
-    let updated_account = storage
-        .read_account(ReadAccountParams {
-            account_number: Some(update_account_return_value),
+    assert_eq!(
+        updated_account,
+        Account {
+            account_number: Some(1),
             anchor_number,
-            origin: &origin,
-        })
-        .unwrap();
-    let expected_updated_account = Account {
-        account_number: Some(update_account_return_value),
-        anchor_number,
-        origin: origin.clone(),
-        last_used: None,
-        name: Some(new_account_name),
-        seed_from_anchor: None,
-    };
-    assert_eq!(updated_account, expected_updated_account);
+            origin: origin.clone(),
+            last_used: None,
+            name: Some(new_account_name),
+            seed_from_anchor: None,
+        }
+    );
     assert_eq!(
         storage.get_account_counter(anchor_number),
         AccountsCounter {


### PR DESCRIPTION
Make sure that update account, only updates an account if that account belongs to that anchor.

- Always read account reference first before updating an existing account in storage
- Return the updated account from storage, avoids reading an account and a false results in tests.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

