### PR TITLE
Add accounts metrics

### DIFF
--- a/src/internet_identity/src/http/metrics.rs
+++ b/src/internet_identity/src/http/metrics.rs
@@ -55,7 +55,9 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         )?;
         w.encode_gauge(
             "internet_identity_total_account_references_count",
-            storage.get_total_accounts_counter().stored_account_references as f64,
+            storage
+                .get_total_accounts_counter()
+                .stored_account_references as f64,
             "Number of total account references registered in this canister.",
         )?;
         w.encode_gauge(

--- a/src/internet_identity/src/http/metrics.rs
+++ b/src/internet_identity/src/http/metrics.rs
@@ -48,6 +48,21 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             storage.event_aggregations.len() as f64,
             "Number of entries in the event_aggregations map.",
         )?;
+        w.encode_gauge(
+            "internet_identity_total_accounts_count",
+            storage.get_total_accounts_counter().stored_accounts as f64,
+            "Number of total accounts registered in this canister.",
+        )?;
+        w.encode_gauge(
+            "internet_identity_total_account_references_count",
+            storage.get_total_accounts_counter().stored_account_references as f64,
+            "Number of total account references registered in this canister.",
+        )?;
+        w.encode_gauge(
+            "internet_identity_total_application_count",
+            storage.get_total_application_count() as f64,
+            "Number of total applications registered in this canister.",
+        )?;
         if let Some(registration_rates) = storage.registration_rates.registration_rates() {
             w.gauge_vec(
                 "internet_identity_registrations_per_second",

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -818,7 +818,7 @@ impl<M: Memory + Clone> Storage<M> {
 
     /// Returns the total application count.
     pub fn get_total_application_count(&self) -> u64 {
-        self.stable_application_memory.len() as u64
+        self.stable_application_memory.len()
     }
 
     // Increments the `stable_account_counter_memory` account counter by one and returns the new number.

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -811,10 +811,14 @@ impl<M: Memory + Clone> Storage<M> {
             .into()
     }
 
-    #[allow(dead_code)]
     /// Returns the total account counter.
     pub fn get_total_accounts_counter(&self) -> AccountsCounter {
         self.stable_account_counter_memory.get().clone().into()
+    }
+
+    /// Returns the total application count.
+    pub fn get_total_application_count(&self) -> u64 {
+        self.stable_application_memory.len() as u64
     }
 
     // Increments the `stable_account_counter_memory` account counter by one and returns the new number.

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -5,6 +5,7 @@ use crate::v2_api::authn_method_test_helpers::{
     create_identity_with_authn_method, create_identity_with_authn_methods,
     sample_pubkey_authn_method, test_authn_method,
 };
+use canister_tests::api::internet_identity::api_v2;
 use canister_tests::api::{http_request, internet_identity as api};
 use canister_tests::flows;
 use canister_tests::framework::*;
@@ -1326,6 +1327,59 @@ fn should_report_registration_rates() -> Result<(), CallError> {
         "internet_identity_registrations_per_second{type=\"captcha_threshold_rate\"}",
         0.48,
         0.1,
+    );
+    Ok(())
+}
+
+#[test]
+fn should_report_total_account_metrics() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let identity_number = flows::register_anchor(&env, canister_id);
+    let origin = "https://some-dapp.com".to_string();
+    let name = "Callisto".to_string();
+
+    let initial_metrics = get_metrics(&env, canister_id);
+    assert_metric(
+        &initial_metrics,
+        "internet_identity_total_accounts_count",
+        0f64,
+    );
+    assert_metric(
+        &initial_metrics,
+        "internet_identity_total_account_references_count",
+        0f64,
+    );
+    assert_metric(
+        &initial_metrics,
+        "internet_identity_total_application_count",
+        0f64,
+    );
+
+    let _ = api_v2::create_account(
+        &env,
+        canister_id,
+        principal_1(),
+        identity_number,
+        origin.clone(),
+        name.clone(),
+    )?;
+    let metrics = get_metrics(&env, canister_id);
+    assert_metric(
+        &metrics,
+        "internet_identity_total_accounts_count",
+        1f64,
+    );
+    assert_metric(
+        &metrics,
+        "internet_identity_total_account_references_count",
+        // One for default account, one for created account
+        2f64,
+    );
+    assert_metric(
+        &metrics,
+        "internet_identity_total_application_count",
+        1f64,
     );
     Ok(())
 }

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -1365,22 +1365,14 @@ fn should_report_total_account_metrics() -> Result<(), CallError> {
         name.clone(),
     )?;
     let metrics = get_metrics(&env, canister_id);
-    assert_metric(
-        &metrics,
-        "internet_identity_total_accounts_count",
-        1f64,
-    );
+    assert_metric(&metrics, "internet_identity_total_accounts_count", 1f64);
     assert_metric(
         &metrics,
         "internet_identity_total_account_references_count",
         // One for default account, one for created account
         2f64,
     );
-    assert_metric(
-        &metrics,
-        "internet_identity_total_application_count",
-        1f64,
-    );
+    assert_metric(&metrics, "internet_identity_total_application_count", 1f64);
     Ok(())
 }
 


### PR DESCRIPTION
# Motivation

We want to monitor the new accounts functionality.

# Changes

Three more metrics that will be tracked:
* internet_identity_total_accounts_count
* internet_identity_total_account_references_count
* internet_identity_total_application_count

Expose the total accounts number from storage

# Tests

Add tests for new metrics.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

