### PR TITLE
Add verification and rebuilding of account limit

### DIFF
--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -847,22 +847,25 @@ impl<M: Memory + Clone> Storage<M> {
         // get actual list of stored references and accounts
         let acc_ref_list = self.list_identity_account_references(anchor_number);
 
-        let acc_counter = StorableAccountsCounter {
-            stored_accounts: 0,
-            stored_account_references: 0,
-        };
+        let mut stored_accounts = 0;
+        let mut stored_account_references = 0;
 
         acc_ref_list.iter().for_each(|acc_ref| {
             // for every reference, we increment the account references counter
-            acc_counter.increment(&AccountType::AccountReference);
+            stored_account_references += 1;
             // if the account reference has an account number and is thus stored, also increment the stored accounts counter
             if let Some(_) = acc_ref.account_number {
-                acc_counter.increment(&AccountType::Account);
+                stored_accounts += 1;
             }
         });
 
-        self.stable_anchor_account_counter_memory
-            .insert(anchor_number, acc_counter);
+        self.stable_anchor_account_counter_memory.insert(
+            anchor_number,
+            StorableAccountsCounter {
+                stored_accounts,
+                stored_account_references,
+            },
+        );
     }
 
     pub fn create_additional_account(

--- a/src/internet_identity/src/storage/account/tests.rs
+++ b/src/internet_identity/src/storage/account/tests.rs
@@ -175,7 +175,7 @@ fn should_list_all_identity_accounts() {
     storage.create(anchor).unwrap();
 
     // 3. List accounts returns default account
-    let listed_accounts = storage.list_identity_accounts(anchor_number);
+    let listed_accounts = storage.list_identity_account_references(anchor_number);
     assert_eq!(listed_accounts.len(), 0);
 
     // 4. Create additional account
@@ -189,7 +189,7 @@ fn should_list_all_identity_accounts() {
         .unwrap();
 
     // 5. List accounts returns default account
-    let listed_accounts = storage.list_identity_accounts(anchor_number);
+    let listed_accounts = storage.list_identity_account_references(anchor_number);
     // Default account + additional account for the origin application.
     assert_eq!(listed_accounts.len(), 2);
 
@@ -204,7 +204,7 @@ fn should_list_all_identity_accounts() {
         .unwrap();
 
     // 7. List accounts returns default account
-    let listed_accounts = storage.list_identity_accounts(anchor_number);
+    let listed_accounts = storage.list_identity_account_references(anchor_number);
     // Default account + additional account for the origin_2 application.
     assert_eq!(listed_accounts.len(), 4);
 

--- a/src/internet_identity/src/storage/storable/accounts_counter.rs
+++ b/src/internet_identity/src/storage/storable/accounts_counter.rs
@@ -4,7 +4,7 @@ use ic_stable_structures::Storable;
 use minicbor::{Decode, Encode};
 use std::borrow::Cow;
 
-#[derive(Encode, Decode, Clone, Ord, Eq, PartialEq, PartialOrd, Default)]
+#[derive(Encode, Decode, Clone, Debug, Ord, Eq, PartialEq, PartialOrd, Default)]
 #[cbor(map)]
 pub struct StorableAccountsCounter {
     #[n(0)]

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -341,11 +341,27 @@ pub enum CreateAccountError {
     Unauthorized(Principal),
 }
 
+impl From<CheckMaxAccountError> for CreateAccountError {
+    fn from(err: CheckMaxAccountError) -> Self {
+        match err {
+            CheckMaxAccountError::AccountLimitReached => Self::AccountLimitReached,
+        }
+    }
+}
+
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum UpdateAccountError {
     InternalCanisterError(String),
     AccountLimitReached,
     Unauthorized(Principal),
+}
+
+impl From<CheckMaxAccountError> for UpdateAccountError {
+    fn from(err: CheckMaxAccountError) -> Self {
+        match err {
+            CheckMaxAccountError::AccountLimitReached => Self::AccountLimitReached,
+        }
+    }
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -365,4 +381,9 @@ pub enum AccountDelegationError {
     Unauthorized(Principal),
     InternalCanisterError(String),
     NoSuchDelegation,
+}
+
+#[derive(CandidType, Debug, Deserialize)]
+pub enum CheckMaxAccountError {
+    AccountLimitReached,
 }


### PR DESCRIPTION
# Motivation

Since we are relying on a counter to enforce the maximum number of accounts per anchor, we want to double-check by rebuilding the counter if the counter is reached.

# Changes

Added functionality to do that.

# Tests

Currently no additional tests, adding these still.
