### PR TITLE
Hide google if no google config

### DIFF
--- a/src/frontend/src/lib/components/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/views/PickAuthenticationMethod.svelte
@@ -5,6 +5,7 @@
   import PasskeyIcon from "$lib/components/icons/PasskeyIcon.svelte";
   import Alert from "$lib/components/ui/Alert.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
+  import { canisterConfig } from "$lib/globals";
 
   interface Props {
     setupOrUseExistingPasskey: () => void;
@@ -25,6 +26,7 @@
   };
 
   const supportsPasskeys = nonNullish(window.PublicKeyCredential);
+  const showGoogleButton = canisterConfig.openid_google?.[0]?.[0];
 </script>
 
 <div class="flex flex-col items-stretch gap-6">
@@ -44,19 +46,21 @@
       <PasskeyIcon />
       Continue with Passkey
     </Button>
-    <Button
-      onclick={handleContinueWithGoogle}
-      variant="secondary"
-      size="xl"
-      disabled={googleLoading}
-    >
-      {#if googleLoading}
-        <ProgressRing />
-        <span>Authenticating with Google...</span>
-      {:else}
-        <GoogleIcon />
-        <span>Continue with Google</span>
-      {/if}
-    </Button>
+    {#if showGoogleButton}
+      <Button
+        onclick={handleContinueWithGoogle}
+        variant="secondary"
+        size="xl"
+        disabled={googleLoading}
+      >
+        {#if googleLoading}
+          <ProgressRing />
+          <span>Authenticating with Google...</span>
+        {:else}
+          <GoogleIcon />
+          <span>Continue with Google</span>
+        {/if}
+      </Button>
+    {/if}
   </div>
 </div>


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Google integration requires configuration, it doesn't work without it. Therefore, users should not be able to use Google if it's not configured.

# Changes

* Hide the button in the main screen if Google's client id is not present.

# Tests

Checked locally.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
