### PR TITLE
Add account archive events

### DIFF
--- a/src/archive/archive.did
+++ b/src/archive/archive.did
@@ -58,8 +58,15 @@ type Operation = variant {
     add_name;
     update_name;
     remove_name;
-    create_account;
-    rename_account;
+    create_account : record {
+        hashed_name : blob;  // This is the Hash type (32 bytes)
+    };
+    rename_account : record {
+        update : record {
+            hashed_old_name : opt blob;  // Optional Hash
+            hashed_new_name : opt blob;  // Optional Hash
+        };
+    };
     delete_account;
 };
 

--- a/src/archive/archive.did
+++ b/src/archive/archive.did
@@ -58,6 +58,9 @@ type Operation = variant {
     add_name;
     update_name;
     remove_name;
+    create_account;
+    rename_account;
+    delete_account;
 };
 
 type Entry = record {

--- a/src/canister_tests/src/api/archive.rs
+++ b/src/canister_tests/src/api/archive.rs
@@ -92,6 +92,12 @@ pub mod compat {
         UpdateName,
         #[serde(rename = "remove_name")]
         RemoveName,
+        #[serde(rename = "create_account")]
+        CreateAccount { anchor_number: AnchorNumber },
+        #[serde(rename = "rename_account")]
+        RenameAccount { anchor_number: AnchorNumber },
+        #[serde(rename = "delete_account")]
+        DeleteAccount { anchor_number: AnchorNumber },
     }
 
     impl From<Operation> for CompatOperation {
@@ -124,6 +130,15 @@ pub mod compat {
                 Operation::RemoveName => CompatOperation::RemoveName,
                 Operation::IdentityMetadataReplace { .. } => {
                     panic!("not available in compat type")
+                }
+                Operation::CreateAccount { anchor_number } => {
+                    CompatOperation::CreateAccount { anchor_number }
+                }
+                Operation::RenameAccount { anchor_number } => {
+                    CompatOperation::RenameAccount { anchor_number }
+                }
+                Operation::DeleteAccount { anchor_number } => {
+                    CompatOperation::DeleteAccount { anchor_number }
                 }
             }
         }

--- a/src/canister_tests/src/api/archive.rs
+++ b/src/canister_tests/src/api/archive.rs
@@ -56,7 +56,7 @@ pub fn status(env: &PocketIc, canister_id: CanisterId) -> Result<ArchiveStatus, 
 pub mod compat {
     use candid::{CandidType, Deserialize, Principal};
     use internet_identity_interface::archive::types::{
-        DeviceDataUpdate, DeviceDataWithoutAlias, Entry, Operation,
+        ArchiveAccountUpdate, DeviceDataUpdate, DeviceDataWithoutAlias, Entry, Hash, Operation,
     };
     use internet_identity_interface::internet_identity::types::{
         AnchorNumber, PublicKey, Timestamp,
@@ -93,9 +93,9 @@ pub mod compat {
         #[serde(rename = "remove_name")]
         RemoveName,
         #[serde(rename = "create_account")]
-        CreateAccount,
+        CreateAccount { hashed_name: Hash },
         #[serde(rename = "rename_account")]
-        RenameAccount,
+        UpdateAccount { update: ArchiveAccountUpdate },
         #[serde(rename = "delete_account")]
         DeleteAccount,
     }
@@ -131,8 +131,10 @@ pub mod compat {
                 Operation::IdentityMetadataReplace { .. } => {
                     panic!("not available in compat type")
                 }
-                Operation::CreateAccount => CompatOperation::CreateAccount,
-                Operation::RenameAccount => CompatOperation::RenameAccount,
+                Operation::CreateAccount { hashed_name } => {
+                    CompatOperation::CreateAccount { hashed_name }
+                }
+                Operation::UpdateAccount { update } => CompatOperation::UpdateAccount { update },
                 Operation::DeleteAccount => CompatOperation::DeleteAccount,
             }
         }

--- a/src/canister_tests/src/api/archive.rs
+++ b/src/canister_tests/src/api/archive.rs
@@ -93,11 +93,11 @@ pub mod compat {
         #[serde(rename = "remove_name")]
         RemoveName,
         #[serde(rename = "create_account")]
-        CreateAccount { anchor_number: AnchorNumber },
+        CreateAccount,
         #[serde(rename = "rename_account")]
-        RenameAccount { anchor_number: AnchorNumber },
+        RenameAccount,
         #[serde(rename = "delete_account")]
-        DeleteAccount { anchor_number: AnchorNumber },
+        DeleteAccount,
     }
 
     impl From<Operation> for CompatOperation {
@@ -131,15 +131,9 @@ pub mod compat {
                 Operation::IdentityMetadataReplace { .. } => {
                     panic!("not available in compat type")
                 }
-                Operation::CreateAccount { anchor_number } => {
-                    CompatOperation::CreateAccount { anchor_number }
-                }
-                Operation::RenameAccount { anchor_number } => {
-                    CompatOperation::RenameAccount { anchor_number }
-                }
-                Operation::DeleteAccount { anchor_number } => {
-                    CompatOperation::DeleteAccount { anchor_number }
-                }
+                Operation::CreateAccount => CompatOperation::CreateAccount,
+                Operation::RenameAccount => CompatOperation::RenameAccount,
+                Operation::DeleteAccount => CompatOperation::DeleteAccount,
             }
         }
     }

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -70,14 +70,13 @@ pub fn update_account_for_origin(
             // Check if whe have reached account limit
             // Because editing a default account turns it into a stored account
             if account_number.is_none() {
-                if let Err(err) = check_or_rebuild_max_anchor_accounts(
+                check_or_rebuild_max_anchor_accounts(
                     storage,
                     anchor_number,
                     MAX_ANCHOR_ACCOUNTS as u64,
                     true,
-                ) {
-                    return Err(err.into());
-                }
+                )
+                .map_err(Into::<UpdateAccountError>::into)?
             }
 
             storage

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -20,15 +20,17 @@ use ic_canister_sig_creation::{
     delegation_signature_msg, signature_map::CanisterSigInputs, DELEGATION_SIG_DOMAIN,
 };
 use ic_cdk::{api::time, caller};
+use ic_certification::Hash;
 use ic_stable_structures::DefaultMemoryImpl;
 use internet_identity_interface::{
-    archive::types::Operation,
+    archive::types::{ArchiveAccountUpdate, Operation},
     internet_identity::types::{
         AccountNumber, AccountUpdate, AnchorNumber, CheckMaxAccountError, CreateAccountError,
         Delegation, FrontendHostname, SessionKey, SignedDelegation, Timestamp, UpdateAccountError,
     },
 };
 use serde_bytes::ByteBuf;
+use sha2::{Digest, Sha256};
 
 const MAX_ANCHOR_ACCOUNTS: usize = 500;
 
@@ -56,12 +58,17 @@ pub fn create_account_for_origin(
         let created_account = storage
             .create_additional_account(CreateAccountParams {
                 anchor_number,
-                name,
+                name: name.clone(),
                 origin,
             })
             .map_err(|err| CreateAccountError::InternalCanisterError(format!("{err}")))?;
 
-        post_account_operation_bookkeeping(anchor_number, Operation::CreateAccount);
+        post_account_operation_bookkeeping(
+            anchor_number,
+            Operation::CreateAccount {
+                hashed_name: hash_name(name),
+            },
+        );
 
         Ok(created_account)
     })
@@ -88,21 +95,42 @@ pub fn update_account_for_origin(
                 .map_err(Into::<UpdateAccountError>::into)?
             }
 
+            let old_account = storage
+                .read_account(ReadAccountParams {
+                    account_number,
+                    anchor_number,
+                    origin: &origin,
+                })
+                .expect("Updating an unreadable account should be impossible!");
+
             let updated_account = storage
                 .update_account(UpdateAccountParams {
                     account_number,
                     anchor_number,
-                    name,
+                    name: name.clone(),
                     origin: origin.clone(),
                 })
                 .map_err(|err| UpdateAccountError::InternalCanisterError(format!("{}", err)))?;
 
             // if we updated a default account, we need to archive an account creation as well!
             if account_number.is_none() {
-                post_account_operation_bookkeeping(anchor_number, Operation::CreateAccount);
+                post_account_operation_bookkeeping(
+                    anchor_number,
+                    Operation::CreateAccount {
+                        hashed_name: hash_name(name.clone()),
+                    },
+                );
             }
 
-            post_account_operation_bookkeeping(anchor_number, Operation::RenameAccount);
+            post_account_operation_bookkeeping(
+                anchor_number,
+                Operation::UpdateAccount {
+                    update: ArchiveAccountUpdate {
+                        hashed_old_name: old_account.name.map(hash_name),
+                        hashed_new_name: Some(hash_name(name)),
+                    },
+                },
+            );
 
             Ok(updated_account)
         }),
@@ -231,6 +259,12 @@ fn post_account_operation_bookkeeping(anchor_number: AnchorNumber, operation: Op
 // Bookkeeping fails outside of canisters, so we work around it for the unit tests.
 #[cfg(test)]
 fn post_account_operation_bookkeeping(_anchor_number: AnchorNumber, _operation: Operation) {}
+
+fn hash_name(name: String) -> Hash {
+    let mut hasher = Sha256::new();
+    hasher.update(name);
+    hasher.finalize().into()
+}
 
 #[test]
 fn should_create_account_for_origin() {

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -1,5 +1,5 @@
 use crate::{
-    archive::archive_operation,
+    anchor_management::post_operation_bookkeeping,
     delegation::{
         add_delegation_signature, check_frontend_length, delegation_bookkeeping,
         der_encode_canister_sig_key,
@@ -60,7 +60,7 @@ pub fn create_account_for_origin(
             })
             .map_err(|err| CreateAccountError::InternalCanisterError(format!("{err}")))?;
 
-        archive_operation(anchor_number, caller(), Operation::CreateAccount);
+        post_operation_bookkeeping(anchor_number, Operation::CreateAccount);
 
         Ok(created_account)
     })
@@ -98,10 +98,10 @@ pub fn update_account_for_origin(
 
             // if we updated a default account, we need to archive an account creation as well!
             if account_number.is_none() {
-                archive_operation(anchor_number, caller(), Operation::CreateAccount);
+                post_operation_bookkeeping(anchor_number, Operation::CreateAccount);
             }
 
-            archive_operation(anchor_number, caller(), Operation::RenameAccount);
+            post_operation_bookkeeping(anchor_number, Operation::RenameAccount);
 
             Ok(updated_account)
         }),

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -60,11 +60,7 @@ pub fn create_account_for_origin(
             })
             .map_err(|err| CreateAccountError::InternalCanisterError(format!("{err}")))?;
 
-        archive_operation(
-            anchor_number,
-            caller(),
-            Operation::CreateAccount { anchor_number },
-        );
+        archive_operation(anchor_number, caller(), Operation::CreateAccount);
 
         Ok(created_account)
     })
@@ -102,18 +98,10 @@ pub fn update_account_for_origin(
 
             // if we updated a default account, we need to archive an account creation as well!
             if account_number.is_none() {
-                archive_operation(
-                    anchor_number,
-                    caller(),
-                    Operation::CreateAccount { anchor_number },
-                );
+                archive_operation(anchor_number, caller(), Operation::CreateAccount);
             }
 
-            archive_operation(
-                anchor_number,
-                caller(),
-                Operation::RenameAccount { anchor_number },
-            );
+            archive_operation(anchor_number, caller(), Operation::RenameAccount);
 
             Ok(updated_account)
         }),

--- a/src/internet_identity_interface/src/archive/types.rs
+++ b/src/internet_identity_interface/src/archive/types.rs
@@ -49,9 +49,9 @@ pub enum Operation {
 
     // Accounts creating and updating
     #[serde(rename = "create_account")]
-    CreateAccount,
+    CreateAccount { hashed_name: Hash },
     #[serde(rename = "rename_account")]
-    RenameAccount,
+    UpdateAccount { update: ArchiveAccountUpdate },
     #[serde(rename = "delete_account")]
     DeleteAccount,
 }
@@ -218,3 +218,12 @@ pub struct CallErrorInfo {
     pub rejection_code: i32,
     pub message: String,
 }
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct ArchiveAccountUpdate {
+    pub hashed_old_name: Option<Hash>,
+    pub hashed_new_name: Option<Hash>,
+}
+
+/// Sha256 Digest: 32 bytes
+pub type Hash = [u8; 32];

--- a/src/internet_identity_interface/src/archive/types.rs
+++ b/src/internet_identity_interface/src/archive/types.rs
@@ -1,5 +1,6 @@
 use crate::internet_identity::types::{
-    AnchorNumber, CredentialId, DeviceKey, DeviceProtection, KeyType, PublicKey, Purpose, Timestamp,
+    AccountNumber, AnchorNumber, CredentialId, DeviceKey, DeviceProtection, KeyType, PublicKey,
+    Purpose, Timestamp,
 };
 use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_cdk::api::management_canister::main::{CanisterStatusType, QueryStats};
@@ -39,13 +40,21 @@ pub enum Operation {
     #[serde(rename = "register_anchor_with_openid_credential")]
     RegisterAnchorWithOpenIdCredential { iss: String },
 
-    // Account name, set for new users in new discoverable passkeys flow
+    // Identity name, set for new users in new discoverable passkeys flow
     #[serde(rename = "add_name")]
     AddName,
     #[serde(rename = "update_name")]
     UpdateName,
     #[serde(rename = "remove_name")]
     RemoveName,
+
+    // Accounts creating and updating
+    #[serde(rename = "create_account")]
+    CreateAccount { anchor_number: AnchorNumber },
+    #[serde(rename = "rename_account")]
+    RenameAccount { anchor_number: AnchorNumber },
+    #[serde(rename = "delete_account")]
+    DeleteAccount { anchor_number: AnchorNumber },
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]

--- a/src/internet_identity_interface/src/archive/types.rs
+++ b/src/internet_identity_interface/src/archive/types.rs
@@ -1,6 +1,5 @@
 use crate::internet_identity::types::{
-    AccountNumber, AnchorNumber, CredentialId, DeviceKey, DeviceProtection, KeyType, PublicKey,
-    Purpose, Timestamp,
+    AnchorNumber, CredentialId, DeviceKey, DeviceProtection, KeyType, PublicKey, Purpose, Timestamp,
 };
 use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_cdk::api::management_canister::main::{CanisterStatusType, QueryStats};
@@ -50,11 +49,11 @@ pub enum Operation {
 
     // Accounts creating and updating
     #[serde(rename = "create_account")]
-    CreateAccount { anchor_number: AnchorNumber },
+    CreateAccount,
     #[serde(rename = "rename_account")]
-    RenameAccount { anchor_number: AnchorNumber },
+    RenameAccount,
     #[serde(rename = "delete_account")]
-    DeleteAccount { anchor_number: AnchorNumber },
+    DeleteAccount,
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]


### PR DESCRIPTION
# Motivation

We want to be able to read create, update and delete account operations from the archive for potential debugging purposes.

# Changes

Adding the necessary types to `Operation` and `CompatOperation` and calling the archiving function in the respective account operations.

# Tests

No new tests were added, had to create a workaround in the `account_management` tests because calling the bookkeeping in unit tests is not supported.




<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->




