### PR TITLE
Fix create_account and update_account

### DIFF
--- a/src/archive/archive.did
+++ b/src/archive/archive.did
@@ -59,13 +59,10 @@ type Operation = variant {
     update_name;
     remove_name;
     create_account : record {
-        hashed_name : blob;  // This is the Hash type (32 bytes)
+        name : Private;
     };
-    rename_account : record {
-        update : record {
-            hashed_old_name : opt blob;  // Optional Hash
-            hashed_new_name : opt blob;  // Optional Hash
-        };
+    update_account : record {
+        name : opt Private;
     };
     delete_account;
 };

--- a/src/canister_tests/src/api/archive.rs
+++ b/src/canister_tests/src/api/archive.rs
@@ -56,7 +56,7 @@ pub fn status(env: &PocketIc, canister_id: CanisterId) -> Result<ArchiveStatus, 
 pub mod compat {
     use candid::{CandidType, Deserialize, Principal};
     use internet_identity_interface::archive::types::{
-        ArchiveAccountUpdate, DeviceDataUpdate, DeviceDataWithoutAlias, Entry, Hash, Operation,
+        DeviceDataUpdate, DeviceDataWithoutAlias, Entry, Operation, Private,
     };
     use internet_identity_interface::internet_identity::types::{
         AnchorNumber, PublicKey, Timestamp,
@@ -93,9 +93,9 @@ pub mod compat {
         #[serde(rename = "remove_name")]
         RemoveName,
         #[serde(rename = "create_account")]
-        CreateAccount { hashed_name: Hash },
-        #[serde(rename = "rename_account")]
-        UpdateAccount { update: ArchiveAccountUpdate },
+        CreateAccount { name: Private },
+        #[serde(rename = "update_account")]
+        UpdateAccount { name: Option<Private> },
         #[serde(rename = "delete_account")]
         DeleteAccount,
     }
@@ -131,10 +131,10 @@ pub mod compat {
                 Operation::IdentityMetadataReplace { .. } => {
                     panic!("not available in compat type")
                 }
-                Operation::CreateAccount { hashed_name } => {
-                    CompatOperation::CreateAccount { hashed_name }
+                Operation::CreateAccount { name } => {
+                    CompatOperation::CreateAccount { name }
                 }
-                Operation::UpdateAccount { update } => CompatOperation::UpdateAccount { update },
+                Operation::UpdateAccount { name } => CompatOperation::UpdateAccount { name },
                 Operation::DeleteAccount => CompatOperation::DeleteAccount,
             }
         }

--- a/src/canister_tests/src/api/archive.rs
+++ b/src/canister_tests/src/api/archive.rs
@@ -131,9 +131,7 @@ pub mod compat {
                 Operation::IdentityMetadataReplace { .. } => {
                     panic!("not available in compat type")
                 }
-                Operation::CreateAccount { name } => {
-                    CompatOperation::CreateAccount { name }
-                }
+                Operation::CreateAccount { name } => CompatOperation::CreateAccount { name },
                 Operation::UpdateAccount { name } => CompatOperation::UpdateAccount { name },
                 Operation::DeleteAccount => CompatOperation::DeleteAccount,
             }

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -20,17 +20,15 @@ use ic_canister_sig_creation::{
     delegation_signature_msg, signature_map::CanisterSigInputs, DELEGATION_SIG_DOMAIN,
 };
 use ic_cdk::{api::time, caller};
-use ic_certification::Hash;
 use ic_stable_structures::DefaultMemoryImpl;
 use internet_identity_interface::{
-    archive::types::{ArchiveAccountUpdate, Operation},
+    archive::types::{Operation, Private},
     internet_identity::types::{
         AccountNumber, AccountUpdate, AnchorNumber, CheckMaxAccountError, CreateAccountError,
         Delegation, FrontendHostname, SessionKey, SignedDelegation, Timestamp, UpdateAccountError,
     },
 };
 use serde_bytes::ByteBuf;
-use sha2::{Digest, Sha256};
 
 const MAX_ANCHOR_ACCOUNTS: usize = 500;
 
@@ -67,7 +65,7 @@ pub fn create_account_for_origin(
     post_account_operation_bookkeeping(
         anchor_number,
         Operation::CreateAccount {
-            hashed_name: hash_name(name),
+            name: Private::Redacted,
         },
     );
 
@@ -105,9 +103,8 @@ pub fn update_account_for_origin(
                             origin: &origin,
                         })
                         .expect("Updating an unreadable account should be impossible!");
-                    let old_name_for_bookkeeping = old_account.name.clone();
 
-                    let updated_account_internal = storage
+                    let updated_account = storage
                         .update_account(UpdateAccountParams {
                             account_number,
                             anchor_number,
@@ -118,7 +115,7 @@ pub fn update_account_for_origin(
                             UpdateAccountError::InternalCanisterError(format!("{}", err))
                         })?;
 
-                    Ok((updated_account_internal, old_name_for_bookkeeping))
+                    Ok((updated_account, old_account.name))
                 })?;
 
             // No account number meant that the account was a default account and was created before being updated.
@@ -126,19 +123,19 @@ pub fn update_account_for_origin(
                 post_account_operation_bookkeeping(
                     anchor_number,
                     Operation::CreateAccount {
-                        hashed_name: hash_name(new_name.clone()),
+                        name: Private::Redacted,
                     },
                 );
             }
 
+            let name = if updated_account.name == old_account_name {
+                None
+            } else {
+                Some(Private::Redacted)
+            };
             post_account_operation_bookkeeping(
                 anchor_number,
-                Operation::UpdateAccount {
-                    update: ArchiveAccountUpdate {
-                        hashed_old_name: old_account_name.map(hash_name),
-                        hashed_new_name: Some(hash_name(new_name)),
-                    },
-                },
+                Operation::UpdateAccount { name },
             );
 
             Ok(updated_account)
@@ -268,12 +265,6 @@ fn post_account_operation_bookkeeping(anchor_number: AnchorNumber, operation: Op
 // Bookkeeping fails outside of canisters, so we work around it for the unit tests.
 #[cfg(test)]
 fn post_account_operation_bookkeeping(_anchor_number: AnchorNumber, _operation: Operation) {}
-
-fn hash_name(name: String) -> Hash {
-    let mut hasher = Sha256::new();
-    hasher.update(name);
-    hasher.finalize().into()
-}
 
 #[test]
 fn should_create_account_for_origin() {

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -133,10 +133,7 @@ pub fn update_account_for_origin(
             } else {
                 Some(Private::Redacted)
             };
-            post_account_operation_bookkeeping(
-                anchor_number,
-                Operation::UpdateAccount { name },
-            );
+            post_account_operation_bookkeeping(anchor_number, Operation::UpdateAccount { name });
 
             Ok(updated_account)
         }

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -142,7 +142,7 @@ pub fn update_account_for_origin(
             );
 
             Ok(updated_account)
-        },
+        }
         None => Err(UpdateAccountError::InternalCanisterError(
             "No name was provided.".to_string(),
         )),

--- a/src/internet_identity_interface/src/archive/types.rs
+++ b/src/internet_identity_interface/src/archive/types.rs
@@ -49,9 +49,9 @@ pub enum Operation {
 
     // Accounts creating and updating
     #[serde(rename = "create_account")]
-    CreateAccount { hashed_name: Hash },
-    #[serde(rename = "rename_account")]
-    UpdateAccount { update: ArchiveAccountUpdate },
+    CreateAccount { name: Private },
+    #[serde(rename = "update_account")]
+    UpdateAccount { name: Option<Private> },
     #[serde(rename = "delete_account")]
     DeleteAccount,
 }
@@ -217,12 +217,6 @@ pub struct CallErrorInfo {
     pub argument: ByteBuf,
     pub rejection_code: i32,
     pub message: String,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub struct ArchiveAccountUpdate {
-    pub hashed_old_name: Option<Hash>,
-    pub hashed_new_name: Option<Hash>,
 }
 
 /// Sha256 Digest: 32 bytes


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

There was a bug that didn't allow users to create new accounts.

The problem was that the state was borrowed within the function that was already borrowing it.

The second borrowing happened within the archive event trigger, which means that only happened if the environment had an archive canister installed.

# Changes

* Move the bookkeeping outside of the storage_borrow call within the create_account and update_account methods.

# Tests

* Tested locally.
* Unit tests pass because they skip bookkeeping.
* Added a Jira ticket to run the integration tests with the archive canister.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
