### PR TITLE
Add archive canister to integration tests

### DIFF
--- a/.windsurf/workflows/pre-push-checks.md
+++ b/.windsurf/workflows/pre-push-checks.md
@@ -1,0 +1,9 @@
+---
+description: Perform some checks and fix them before pushing the branch
+---
+
+1. Run `cargo fmt`.
+2. If any changes were made in step 1, commit them with message "Fix fomat".
+3. Run `cargo clippy`.
+4. If it fails, check the output of `cargo clippy`, fix it and run `cargo clippy` again. Repeat for a maximum of three times or until `cargo clippy` is successful.
+5. If any changes were made in step 4, commit them with message "fix cargo clippy"

--- a/.windsurf/workflows/pre-push-checks.md
+++ b/.windsurf/workflows/pre-push-checks.md
@@ -1,9 +1,0 @@
----
-description: Perform some checks and fix them before pushing the branch
----
-
-1. Run `cargo fmt`.
-2. If any changes were made in step 1, commit them with message "Fix fomat".
-3. Run `cargo clippy`.
-4. If it fails, check the output of `cargo clippy`, fix it and run `cargo clippy` again. Repeat for a maximum of three times or until `cargo clippy` is successful.
-5. If any changes were made in step 4, commit them with message "fix cargo clippy"

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -230,8 +230,7 @@ pub fn install_ii_with_archive(
     let ii_arg = arg_with_wasm_hash(archive_wasm.clone());
     let ii_canister_id = install_ii_canister_with_arg(env, ii_wasm, ii_arg);
 
-    // 3. Deploy the archive using the II canister
-    // api::internet_identity::deploy_archive takes &Vec<u8> for wasm
+    // Deploy the archive using the II canister
     match api::internet_identity::deploy_archive(env, ii_canister_id, &archive_wasm) {
         Ok(DeployArchiveResult::Success(_archive_principal)) => {
             // Successfully deployed.

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -221,13 +221,18 @@ pub fn arg_with_dynamic_captcha() -> Option<InternetIdentityInit> {
 
 pub fn install_ii_with_archive(
     env: &PocketIc,
+    ii_wasm_opt: Option<Vec<u8>>,
+    archive_wasm_opt: Option<Vec<u8>>,
 ) -> CanisterId {
-    let ii_arg = arg_with_wasm_hash(ARCHIVE_WASM.clone());
-    let ii_canister_id = install_ii_canister_with_arg(env, II_WASM.clone(), ii_arg);
+    let archive_wasm = archive_wasm_opt.unwrap_or_else(|| ARCHIVE_WASM.clone());
+    let ii_wasm = ii_wasm_opt.unwrap_or_else(|| II_WASM.clone());
+
+    let ii_arg = arg_with_wasm_hash(archive_wasm.clone());
+    let ii_canister_id = install_ii_canister_with_arg(env, ii_wasm, ii_arg);
 
     // 3. Deploy the archive using the II canister
     // api::internet_identity::deploy_archive takes &Vec<u8> for wasm
-    match api::internet_identity::deploy_archive(env, ii_canister_id, &ARCHIVE_WASM) {
+    match api::internet_identity::deploy_archive(env, ii_canister_id, &archive_wasm) {
         Ok(DeployArchiveResult::Success(_archive_principal)) => {
             // Successfully deployed.
         }

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -219,6 +219,31 @@ pub fn arg_with_dynamic_captcha() -> Option<InternetIdentityInit> {
     })
 }
 
+pub fn install_ii_with_archive(
+    env: &PocketIc,
+) -> CanisterId {
+    let ii_arg = arg_with_wasm_hash(ARCHIVE_WASM.clone());
+    let ii_canister_id = install_ii_canister_with_arg(env, II_WASM.clone(), ii_arg);
+
+    // 3. Deploy the archive using the II canister
+    // api::internet_identity::deploy_archive takes &Vec<u8> for wasm
+    match api::internet_identity::deploy_archive(env, ii_canister_id, &ARCHIVE_WASM) {
+        Ok(DeployArchiveResult::Success(_archive_principal)) => {
+            // Successfully deployed.
+        }
+        Ok(unexpected_result) => {
+            panic!(
+                "archive deployment returned unexpected Ok result: {:?}",
+                unexpected_result
+            );
+        }
+        Err(err) => {
+            panic!("archive deployment failed: {:?}", err);
+        }
+    }
+    ii_canister_id
+}
+
 pub fn archive_wasm_hash(wasm: &Vec<u8>) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(wasm);

--- a/src/internet_identity/tests/integration/accounts.rs
+++ b/src/internet_identity/tests/integration/accounts.rs
@@ -10,7 +10,8 @@ use canister_tests::{
     },
     flows,
     framework::{
-        device_data_2, env, install_ii_with_archive, principal_1, principal_2, time, verify_delegation
+        device_data_2, env, install_ii_with_archive, principal_1, principal_2, time,
+        verify_delegation,
     },
 };
 use internet_identity_interface::internet_identity::types::{

--- a/src/internet_identity/tests/integration/accounts.rs
+++ b/src/internet_identity/tests/integration/accounts.rs
@@ -24,7 +24,7 @@ use serde_bytes::ByteBuf;
 #[test]
 fn should_create_account() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let origin = "https://some-dapp.com".to_string();
     let name = "Callisto".to_string();
@@ -56,7 +56,7 @@ fn should_create_account() -> Result<(), CallError> {
 #[test]
 fn should_list_accounts() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let origin = "https://some-dapp.com".to_string();
     let name = "Ganymede".to_string();
@@ -143,7 +143,7 @@ fn should_list_accounts() -> Result<(), CallError> {
 #[test]
 fn should_list_default_account() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let origin = "https://some-dapp.com".to_string();
 
@@ -174,7 +174,7 @@ fn should_list_default_account() -> Result<(), CallError> {
 #[test]
 fn should_list_only_own_accounts() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let another_identity_number =
         flows::register_anchor_with_device(&env, canister_id, &device_data_2());
@@ -286,7 +286,7 @@ fn should_list_only_own_accounts() -> Result<(), CallError> {
 #[test]
 fn should_update_account() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let origin = "https://some-dapp.com".to_string();
     let name = "Callisto".to_string();
@@ -336,7 +336,7 @@ fn should_update_account() -> Result<(), CallError> {
 #[test]
 fn should_update_default_account() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let origin = "https://some-dapp.com".to_string();
     let name = "Callisto".to_string();
@@ -417,7 +417,7 @@ fn should_update_default_account() -> Result<(), CallError> {
 #[should_panic]
 fn should_only_update_owned_account() {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let another_identity_number =
         flows::register_anchor_with_device(&env, canister_id, &device_data_2());
@@ -472,7 +472,7 @@ fn should_only_update_owned_account() {
 #[test]
 fn should_get_valid_account_delegation() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -512,7 +512,7 @@ fn should_get_valid_account_delegation() -> Result<(), CallError> {
 #[test]
 fn should_get_matching_principals() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -595,7 +595,7 @@ fn should_get_matching_principals() -> Result<(), CallError> {
 #[test]
 fn should_get_valid_account_delegation_with_custom_expiration() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -637,7 +637,7 @@ fn should_get_valid_account_delegation_with_custom_expiration() -> Result<(), Ca
 #[test]
 fn should_shorten_account_delegation_expiration_greater_max_ttl() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -684,7 +684,7 @@ fn should_shorten_account_delegation_expiration_greater_max_ttl() -> Result<(), 
 fn should_get_multiple_valid_account_delegations() -> Result<(), CallError> {
     let env = env();
     let root_key = env.root_key().unwrap();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname_1 = "https://dapp1.com".to_string();
     let frontend_hostname_2 = "https://dapp2.com".to_string();
@@ -767,7 +767,7 @@ fn should_get_multiple_valid_account_delegations() -> Result<(), CallError> {
 #[test]
 fn should_issue_different_principals_for_account_delegations() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let pub_session_key = ByteBuf::from("session public key");
     let frontend_hostname_1 = "https://dapp1.com".to_string();
@@ -815,7 +815,7 @@ fn should_issue_different_principals_for_account_delegations() -> Result<(), Cal
 #[test]
 fn can_not_prepare_account_delegation_for_different_user() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -843,7 +843,7 @@ fn can_not_prepare_account_delegation_for_different_user() -> Result<(), CallErr
 #[test]
 fn can_not_get_account_delegation_for_different_user() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -884,7 +884,7 @@ fn can_not_get_account_delegation_for_different_user() -> Result<(), CallError> 
 #[test]
 fn should_not_get_account_delegation_after_expiration() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -921,7 +921,7 @@ fn should_not_get_account_delegation_after_expiration() -> Result<(), CallError>
 #[test]
 fn should_issue_different_principals_for_different_accounts() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env);
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");

--- a/src/internet_identity/tests/integration/accounts.rs
+++ b/src/internet_identity/tests/integration/accounts.rs
@@ -10,8 +10,7 @@ use canister_tests::{
     },
     flows,
     framework::{
-        device_data_2, env, install_ii_canister, principal_1, principal_2, time, verify_delegation,
-        II_WASM,
+        device_data_2, env, install_ii_with_archive, principal_1, principal_2, time, verify_delegation
     },
 };
 use internet_identity_interface::internet_identity::types::{
@@ -25,7 +24,7 @@ use serde_bytes::ByteBuf;
 #[test]
 fn should_create_account() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let identity_number = flows::register_anchor(&env, canister_id);
     let origin = "https://some-dapp.com".to_string();
     let name = "Callisto".to_string();
@@ -57,7 +56,7 @@ fn should_create_account() -> Result<(), CallError> {
 #[test]
 fn should_list_accounts() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let identity_number = flows::register_anchor(&env, canister_id);
     let origin = "https://some-dapp.com".to_string();
     let name = "Ganymede".to_string();
@@ -144,7 +143,7 @@ fn should_list_accounts() -> Result<(), CallError> {
 #[test]
 fn should_list_default_account() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let identity_number = flows::register_anchor(&env, canister_id);
     let origin = "https://some-dapp.com".to_string();
 
@@ -175,7 +174,7 @@ fn should_list_default_account() -> Result<(), CallError> {
 #[test]
 fn should_list_only_own_accounts() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let identity_number = flows::register_anchor(&env, canister_id);
     let another_identity_number =
         flows::register_anchor_with_device(&env, canister_id, &device_data_2());
@@ -287,7 +286,7 @@ fn should_list_only_own_accounts() -> Result<(), CallError> {
 #[test]
 fn should_update_account() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let identity_number = flows::register_anchor(&env, canister_id);
     let origin = "https://some-dapp.com".to_string();
     let name = "Callisto".to_string();
@@ -337,7 +336,7 @@ fn should_update_account() -> Result<(), CallError> {
 #[test]
 fn should_update_default_account() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let identity_number = flows::register_anchor(&env, canister_id);
     let origin = "https://some-dapp.com".to_string();
     let name = "Callisto".to_string();
@@ -418,7 +417,7 @@ fn should_update_default_account() -> Result<(), CallError> {
 #[should_panic]
 fn should_only_update_owned_account() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let identity_number = flows::register_anchor(&env, canister_id);
     let another_identity_number =
         flows::register_anchor_with_device(&env, canister_id, &device_data_2());
@@ -473,7 +472,7 @@ fn should_only_update_owned_account() {
 #[test]
 fn should_get_valid_account_delegation() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -513,7 +512,7 @@ fn should_get_valid_account_delegation() -> Result<(), CallError> {
 #[test]
 fn should_get_matching_principals() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -596,7 +595,7 @@ fn should_get_matching_principals() -> Result<(), CallError> {
 #[test]
 fn should_get_valid_account_delegation_with_custom_expiration() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -638,7 +637,7 @@ fn should_get_valid_account_delegation_with_custom_expiration() -> Result<(), Ca
 #[test]
 fn should_shorten_account_delegation_expiration_greater_max_ttl() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -685,7 +684,7 @@ fn should_shorten_account_delegation_expiration_greater_max_ttl() -> Result<(), 
 fn should_get_multiple_valid_account_delegations() -> Result<(), CallError> {
     let env = env();
     let root_key = env.root_key().unwrap();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname_1 = "https://dapp1.com".to_string();
     let frontend_hostname_2 = "https://dapp2.com".to_string();
@@ -768,7 +767,7 @@ fn should_get_multiple_valid_account_delegations() -> Result<(), CallError> {
 #[test]
 fn should_issue_different_principals_for_account_delegations() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let user_number = flows::register_anchor(&env, canister_id);
     let pub_session_key = ByteBuf::from("session public key");
     let frontend_hostname_1 = "https://dapp1.com".to_string();
@@ -816,7 +815,7 @@ fn should_issue_different_principals_for_account_delegations() -> Result<(), Cal
 #[test]
 fn can_not_prepare_account_delegation_for_different_user() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -844,7 +843,7 @@ fn can_not_prepare_account_delegation_for_different_user() -> Result<(), CallErr
 #[test]
 fn can_not_get_account_delegation_for_different_user() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -885,7 +884,7 @@ fn can_not_get_account_delegation_for_different_user() -> Result<(), CallError> 
 #[test]
 fn should_not_get_account_delegation_after_expiration() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");
@@ -922,7 +921,7 @@ fn should_not_get_account_delegation_after_expiration() -> Result<(), CallError>
 #[test]
 fn should_issue_different_principals_for_different_accounts() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com".to_string();
     let pub_session_key = ByteBuf::from("session public key");

--- a/src/internet_identity/tests/integration/anchor_management/device_management.rs
+++ b/src/internet_identity/tests/integration/anchor_management/device_management.rs
@@ -168,7 +168,11 @@ fn should_not_add_device_for_different_user() {
 #[test]
 fn should_add_additional_device_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env, Some(II_WASM_PREVIOUS.clone()), Some(ARCHIVE_WASM_PREVIOUS.clone()));
+    let canister_id = install_ii_with_archive(
+        &env,
+        Some(II_WASM_PREVIOUS.clone()),
+        Some(ARCHIVE_WASM_PREVIOUS.clone()),
+    );
     let user_number = flows::register_anchor(&env, canister_id);
 
     upgrade_ii_canister(&env, canister_id, II_WASM.clone());
@@ -673,7 +677,11 @@ fn should_not_remove_protected_with_different_device() {
 #[test]
 fn should_remove_device_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env, Some(II_WASM_PREVIOUS.clone()), Some(ARCHIVE_WASM_PREVIOUS.clone()));
+    let canister_id = install_ii_with_archive(
+        &env,
+        Some(II_WASM_PREVIOUS.clone()),
+        Some(ARCHIVE_WASM_PREVIOUS.clone()),
+    );
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(

--- a/src/internet_identity/tests/integration/anchor_management/device_management.rs
+++ b/src/internet_identity/tests/integration/anchor_management/device_management.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 #[test]
 fn should_lookup() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     api::init_salt(&env, canister_id)?;
     let user_number = flows::register_anchor(&env, canister_id);
     api::add(
@@ -59,7 +59,7 @@ fn should_lookup() -> Result<(), CallError> {
 #[test]
 fn should_add_additional_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(
@@ -91,7 +91,7 @@ fn should_add_additional_device() -> Result<(), CallError> {
 #[test]
 fn should_not_add_existing_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let result = api::add(
@@ -114,7 +114,7 @@ fn should_not_add_existing_device() -> Result<(), CallError> {
 #[test]
 fn should_not_add_second_recovery_phrase() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(
@@ -144,7 +144,7 @@ fn should_not_add_second_recovery_phrase() -> Result<(), CallError> {
 #[test]
 fn should_not_add_device_for_different_user() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
     let user_number_2 =
         flows::register_anchor_with(&env, canister_id, principal_2(), &device_data_2());
@@ -168,7 +168,7 @@ fn should_not_add_device_for_different_user() {
 #[test]
 fn should_add_additional_device_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
+    let canister_id = install_ii_with_archive(&env, Some(II_WASM_PREVIOUS.clone()), Some(ARCHIVE_WASM_PREVIOUS.clone()));
     let user_number = flows::register_anchor(&env, canister_id);
 
     upgrade_ii_canister(&env, canister_id, II_WASM.clone());
@@ -193,7 +193,7 @@ fn should_add_additional_device_after_ii_upgrade() -> Result<(), CallError> {
 #[test]
 fn should_respect_total_size_limit() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     for i in 0..3u8 {
@@ -225,7 +225,7 @@ fn should_respect_total_size_limit() -> Result<(), CallError> {
 #[test]
 fn should_update_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let principal = principal_1();
     let mut device = device_data_1();
 
@@ -255,7 +255,7 @@ fn should_update_device() -> Result<(), CallError> {
 #[test]
 fn should_update_protected_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let principal = principal_1();
     let mut device = DeviceData {
         protection: DeviceProtection::Protected,
@@ -290,7 +290,7 @@ fn should_update_protected_device() -> Result<(), CallError> {
 #[test]
 fn should_not_modify_pubkey() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let principal = principal_1();
     let mut device = device_data_1();
 
@@ -321,7 +321,7 @@ fn should_not_modify_pubkey() {
 #[test]
 fn should_not_update_device_of_different_user() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
     let user_number_2 =
         flows::register_anchor_with(&env, canister_id, principal_2(), &device_data_2());
@@ -346,7 +346,7 @@ fn should_not_update_device_of_different_user() {
 #[test]
 fn should_not_update_protected_with_different_device() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let device1 = DeviceData {
         protection: DeviceProtection::Protected,
         key_type: KeyType::SeedPhrase,
@@ -385,7 +385,7 @@ fn should_not_update_protected_with_different_device() {
 #[test]
 fn should_not_update_non_recovery_device_to_be_protected() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let mut device1 = device_data_1();
@@ -410,7 +410,7 @@ fn should_not_update_non_recovery_device_to_be_protected() {
 #[test]
 fn should_get_credentials() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let recovery_webauthn_device = DeviceData {
@@ -477,7 +477,7 @@ fn should_get_credentials() -> Result<(), CallError> {
 #[test]
 fn should_return_empty_credentials_on_invalid_anchor_number() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
 
     let response = api::get_anchor_credentials(&env, canister_id, 1234564)?;
 
@@ -489,7 +489,7 @@ fn should_return_empty_credentials_on_invalid_anchor_number() -> Result<(), Call
 #[test]
 fn should_not_get_recovery_credentials_if_there_are_none() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let response = api::get_anchor_credentials(&env, canister_id, user_number)?;
@@ -511,7 +511,7 @@ fn should_not_get_recovery_credentials_if_there_are_none() -> Result<(), CallErr
 #[test]
 fn should_remove_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(
@@ -549,7 +549,7 @@ fn should_remove_device() -> Result<(), CallError> {
 #[test]
 fn should_remove_protected_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let mut device2 = device_data_2();
@@ -591,7 +591,7 @@ fn should_remove_protected_device() -> Result<(), CallError> {
 #[test]
 fn should_remove_last_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::remove(
@@ -611,7 +611,7 @@ fn should_remove_last_device() -> Result<(), CallError> {
 #[test]
 fn should_not_remove_device_of_different_user() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
     let user_number_2 =
         flows::register_anchor_with(&env, canister_id, principal_2(), &device_data_2());
@@ -635,7 +635,7 @@ fn should_not_remove_device_of_different_user() {
 #[test]
 fn should_not_remove_protected_with_different_device() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let device1 = DeviceData {
         protection: DeviceProtection::Protected,
         key_type: KeyType::SeedPhrase,
@@ -673,7 +673,7 @@ fn should_not_remove_protected_with_different_device() {
 #[test]
 fn should_remove_device_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
+    let canister_id = install_ii_with_archive(&env, Some(II_WASM_PREVIOUS.clone()), Some(ARCHIVE_WASM_PREVIOUS.clone()));
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(
@@ -708,7 +708,7 @@ fn should_remove_device_after_ii_upgrade() -> Result<(), CallError> {
 #[test]
 fn should_not_allow_get_anchor_info_for_different_user() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let result = api::get_anchor_info(&env, canister_id, principal_2(), user_number);
@@ -724,7 +724,7 @@ fn should_not_allow_get_anchor_info_for_different_user() {
 #[test]
 fn should_replace_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let anchor_info = api::get_anchor_info(&env, canister_id, principal_1(), user_number)?;
@@ -748,7 +748,7 @@ fn should_replace_device() -> Result<(), CallError> {
 #[test]
 fn should_keep_metadata() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let device = DeviceData {
         metadata: Some(HashMap::from([(
             "key".to_string(),
@@ -783,7 +783,7 @@ fn should_not_allow_reserved_metadata_keys() -> Result<(), CallError> {
     ];
 
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     for reserved_key in RESERVED_KEYS {
@@ -814,7 +814,7 @@ fn should_not_allow_reserved_metadata_keys() -> Result<(), CallError> {
 #[test]
 fn should_add_device_with_key_type_browser_storage_key() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let device = DeviceData {
@@ -837,7 +837,7 @@ fn should_add_device_with_key_type_browser_storage_key() -> Result<(), CallError
 #[test]
 fn should_lookup_device_key_with_credential_id() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let credential_id = ByteBuf::from(vec![1, 2, 3]);
     let device = DeviceData {

--- a/src/internet_identity/tests/integration/anchor_management/last_usage_timestamp.rs
+++ b/src/internet_identity/tests/integration/anchor_management/last_usage_timestamp.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 #[test]
 fn should_set_last_usage_on_get_anchor_info() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     env.advance_time(Duration::from_secs(1));
@@ -26,7 +26,7 @@ fn should_set_last_usage_on_get_anchor_info() -> Result<(), CallError> {
 #[test]
 fn should_set_last_usage_on_add() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(
@@ -66,7 +66,7 @@ fn should_set_last_usage_on_add() -> Result<(), CallError> {
 #[test]
 fn should_set_last_usage_on_remove() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(
@@ -109,7 +109,7 @@ fn should_set_last_usage_on_remove() -> Result<(), CallError> {
 #[test]
 fn should_set_last_usage_on_update() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(
@@ -172,7 +172,7 @@ fn should_set_last_usage_on_update() -> Result<(), CallError> {
 #[test]
 fn should_set_last_usage_on_replace() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(
@@ -220,7 +220,7 @@ fn should_set_last_usage_on_replace() -> Result<(), CallError> {
 #[test]
 fn should_set_last_usage_on_prepare_delegation() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     // initialize the salt otherwise prepare_delegation will take two execution rounds
     // throwing off the expected timestamp
     api::init_salt(&env, canister_id)?;
@@ -261,7 +261,7 @@ fn should_set_last_usage_on_prepare_delegation() -> Result<(), CallError> {
 #[test]
 fn should_update_last_usage_on_tentative_device_registration() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(
@@ -314,7 +314,7 @@ fn should_update_last_usage_on_tentative_device_registration() -> Result<(), Cal
 #[test]
 fn should_update_last_usage_on_exit_device_registration_mode() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::add(

--- a/src/internet_identity/tests/integration/anchor_management/registration/mod.rs
+++ b/src/internet_identity/tests/integration/anchor_management/registration/mod.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 #[test]
 fn should_register_new_anchor() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     api::init_salt(&env, canister_id)?;
     let user_number = flows::register_anchor(&env, canister_id);
 
@@ -45,7 +45,7 @@ fn should_register_new_anchor() -> Result<(), CallError> {
 #[test]
 fn should_allow_multiple_registrations() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number_1 =
         flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
     let user_number_2 =
@@ -88,7 +88,7 @@ fn should_assign_correct_user_numbers() -> Result<(), CallError> {
 #[test]
 fn registration_with_mismatched_sender_fails() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let challenge = api::create_challenge(&env, canister_id)?;
     let result = api::register(
         &env,
@@ -114,7 +114,7 @@ fn registration_with_mismatched_sender_fails() -> Result<(), CallError> {
 #[test]
 fn should_not_register_non_recovery_device_as_protected() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let mut device1 = device_data_1();
     device1.protection = DeviceProtection::Protected;
 
@@ -143,7 +143,7 @@ fn should_not_register_non_recovery_device_as_protected() -> Result<(), CallErro
 #[test]
 fn should_not_allow_wrong_captcha() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
 
     let challenge = api::create_challenge(&env, canister_id)?;
     let result = api::register(
@@ -166,7 +166,7 @@ fn should_not_allow_wrong_captcha() -> Result<(), CallError> {
 #[test]
 fn should_not_allow_expired_captcha() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
 
     let challenge = api::create_challenge(&env, canister_id)?;
     env.advance_time(Duration::from_secs(301)); // one second longer than captcha validity

--- a/src/internet_identity/tests/integration/anchor_management/remote_device_registration.rs
+++ b/src/internet_identity/tests/integration/anchor_management/remote_device_registration.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 #[test]
 fn can_enter_device_registration_mode() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let result =
@@ -38,7 +38,7 @@ fn can_enter_device_registration_mode() -> Result<(), CallError> {
 #[test]
 fn can_not_enter_device_registration_mode_for_other_user() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let result = api::enter_device_registration_mode(&env, canister_id, principal_2(), user_number);
@@ -54,7 +54,7 @@ fn can_not_enter_device_registration_mode_for_other_user() {
 #[test]
 fn can_register_remote_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -84,7 +84,7 @@ fn can_register_remote_device() -> Result<(), CallError> {
 #[test]
 fn can_verify_remote_device_after_failed_attempt() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -127,7 +127,7 @@ fn can_verify_remote_device_after_failed_attempt() -> Result<(), CallError> {
 #[test]
 fn anchor_info_should_return_tentative_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -149,7 +149,7 @@ fn anchor_info_should_return_tentative_device() -> Result<(), CallError> {
 #[test]
 fn reject_tentative_device_if_not_in_registration_mode() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -168,7 +168,7 @@ fn reject_tentative_device_if_not_in_registration_mode() -> Result<(), CallError
 fn reject_tentative_device_if_registration_mode_is_expired() -> Result<(), CallError> {
     const REGISTRATION_MODE_EXPIRATION: Duration = Duration::from_secs(900);
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -187,7 +187,7 @@ fn reject_tentative_device_if_registration_mode_is_expired() -> Result<(), CallE
 #[test]
 fn reject_verification_without_tentative_device() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;
@@ -206,7 +206,7 @@ fn reject_verification_without_tentative_device() -> Result<(), CallError> {
 fn reject_verification_with_wrong_code() -> Result<(), CallError> {
     const MAX_RETRIES: u8 = 3;
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     api::enter_device_registration_mode(&env, canister_id, principal_1(), user_number)?;

--- a/src/internet_identity/tests/integration/delegation.rs
+++ b/src/internet_identity/tests/integration/delegation.rs
@@ -237,7 +237,11 @@ fn should_get_multiple_valid_delegations() -> Result<(), CallError> {
 #[test]
 fn should_get_valid_delegation_for_old_anchor_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_with_archive(&env, Some(II_WASM_PREVIOUS.clone()), Some(ARCHIVE_WASM_PREVIOUS.clone()));
+    let canister_id = install_ii_with_archive(
+        &env,
+        Some(II_WASM_PREVIOUS.clone()),
+        Some(ARCHIVE_WASM_PREVIOUS.clone()),
+    );
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com";
     let pub_session_key = ByteBuf::from("session public key");

--- a/src/internet_identity/tests/integration/delegation.rs
+++ b/src/internet_identity/tests/integration/delegation.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 #[test]
 fn should_get_valid_delegation() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com";
     let pub_session_key = ByteBuf::from("session public key");
@@ -62,7 +62,7 @@ fn should_get_valid_delegation() -> Result<(), CallError> {
 #[test]
 fn should_get_valid_delegation_with_custom_expiration() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com";
     let pub_session_key = ByteBuf::from("session public key");
@@ -109,7 +109,7 @@ fn should_get_valid_delegation_with_custom_expiration() -> Result<(), CallError>
 #[test]
 fn should_shorten_expiration_greater_max_ttl() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com";
     let pub_session_key = ByteBuf::from("session public key");
@@ -158,7 +158,7 @@ fn should_shorten_expiration_greater_max_ttl() -> Result<(), CallError> {
 fn should_get_multiple_valid_delegations() -> Result<(), CallError> {
     let env = env();
     let root_key = env.root_key().unwrap();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname_1 = "https://dapp1.com";
     let frontend_hostname_2 = "https://dapp2.com";
@@ -237,7 +237,7 @@ fn should_get_multiple_valid_delegations() -> Result<(), CallError> {
 #[test]
 fn should_get_valid_delegation_for_old_anchor_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
+    let canister_id = install_ii_with_archive(&env, Some(II_WASM_PREVIOUS.clone()), Some(ARCHIVE_WASM_PREVIOUS.clone()));
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com";
     let pub_session_key = ByteBuf::from("session public key");
@@ -286,7 +286,7 @@ fn should_get_valid_delegation_for_old_anchor_after_ii_upgrade() -> Result<(), C
 #[test]
 fn should_issue_different_principals() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let pub_session_key = ByteBuf::from("session public key");
     let frontend_hostname_1 = "https://dapp1.com";
@@ -319,7 +319,7 @@ fn should_issue_different_principals() -> Result<(), CallError> {
 #[test]
 fn should_not_get_prepared_delegation_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com";
     let pub_session_key = ByteBuf::from("session public key");
@@ -356,7 +356,7 @@ fn should_not_get_prepared_delegation_after_ii_upgrade() -> Result<(), CallError
 #[test]
 fn should_not_get_delegation_after_expiration() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com";
     let pub_session_key = ByteBuf::from("session public key");
@@ -403,7 +403,7 @@ fn should_not_get_delegation_after_expiration() -> Result<(), CallError> {
 #[test]
 fn can_not_prepare_delegation_for_different_user() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
 
     let result = api::prepare_delegation(
@@ -427,7 +427,7 @@ fn can_not_prepare_delegation_for_different_user() {
 #[test]
 fn can_not_get_delegation_for_different_user() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com";
     let pub_session_key = ByteBuf::from("session public key");
@@ -463,7 +463,7 @@ fn can_not_get_delegation_for_different_user() -> Result<(), CallError> {
 #[test]
 fn get_principal_should_match_prepare_delegation() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname = "https://some-dapp.com";
     let pub_session_key = ByteBuf::from("session public key");
@@ -493,7 +493,7 @@ fn get_principal_should_match_prepare_delegation() -> Result<(), CallError> {
 #[test]
 fn should_return_different_principals_for_different_frontends() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     api::init_salt(&env, canister_id)?;
     let user_number = flows::register_anchor(&env, canister_id);
     let frontend_hostname_1 = "https://dapp1.com";
@@ -523,7 +523,7 @@ fn should_return_different_principals_for_different_frontends() -> Result<(), Ca
 #[test]
 fn should_return_different_principals_for_different_users() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     api::init_salt(&env, canister_id)?;
     let user_number_1 =
         flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
@@ -555,7 +555,7 @@ fn should_return_different_principals_for_different_users() -> Result<(), CallEr
 #[test]
 fn should_not_allow_get_principal_for_other_user() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     flows::register_anchor_with(&env, canister_id, principal_1(), &device_data_1());
     let user_number_2 =
         flows::register_anchor_with(&env, canister_id, principal_2(), &device_data_2());

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -7,9 +7,7 @@ use candid::Principal;
 use canister_tests::{api::internet_identity as api, framework::*};
 use identity_jose::{jwk::Jwk, jws::Decoder};
 use internet_identity_interface::internet_identity::types::{
-    AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose,
-    AuthnMethodSecuritySettings, InternetIdentityInit, OpenIdConfig, OpenIdCredentialKey,
-    OpenIdDelegationError, PublicKeyAuthn,
+    ArchiveConfig, AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, AuthnMethodSecuritySettings, DeployArchiveResult, InternetIdentityInit, OpenIdConfig, OpenIdCredentialKey, OpenIdDelegationError, PublicKeyAuthn
 };
 use pocket_ic::common::rest::{CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse};
 use pocket_ic::{CallError, PocketIc};
@@ -378,6 +376,13 @@ pub fn setup_canister(env: &PocketIc) -> Principal {
         openid_google: Some(Some(OpenIdConfig {
             client_id: CLIENT_ID.to_string(),
         })),
+        archive_config: Some(ArchiveConfig {
+            module_hash: archive_wasm_hash(&ARCHIVE_WASM),
+            entries_buffer_limit: 10_000,
+            polling_interval_ns: Duration::from_secs(1).as_nanos() as u64,
+            entries_fetch_limit: 10,
+        }),
+        canister_creation_cycles_cost: Some(0),
         ..Default::default()
     };
     // Cycles are needed before installation because of the async HTTP outcalls
@@ -387,6 +392,21 @@ pub fn setup_canister(env: &PocketIc) -> Principal {
         Some(args),
         10_000_000_000_000,
     );
+
+    match api::deploy_archive(env, canister_id, &ARCHIVE_WASM) {
+        Ok(DeployArchiveResult::Success(_archive_principal)) => {
+            // Successfully deployed.
+        }
+        Ok(unexpected_result) => {
+            panic!(
+                "archive deployment returned unexpected Ok result: {:?}",
+                unexpected_result
+            );
+        }
+        Err(err) => {
+            panic!("archive deployment failed: {:?}", err);
+        }
+    }
 
     // Mock google certs response
     mock_google_certs_response(env);

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -7,7 +7,9 @@ use candid::Principal;
 use canister_tests::{api::internet_identity as api, framework::*};
 use identity_jose::{jwk::Jwk, jws::Decoder};
 use internet_identity_interface::internet_identity::types::{
-    ArchiveConfig, AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, AuthnMethodSecuritySettings, DeployArchiveResult, InternetIdentityInit, OpenIdConfig, OpenIdCredentialKey, OpenIdDelegationError, PublicKeyAuthn
+    ArchiveConfig, AuthnMethod, AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose,
+    AuthnMethodSecuritySettings, DeployArchiveResult, InternetIdentityInit, OpenIdConfig,
+    OpenIdCredentialKey, OpenIdDelegationError, PublicKeyAuthn,
 };
 use pocket_ic::common::rest::{CanisterHttpReply, CanisterHttpResponse, MockCanisterHttpResponse};
 use pocket_ic::{CallError, PocketIc};

--- a/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_canister, II_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive
 };
 use internet_identity_interface::internet_identity::types::{AuthnMethodAddError, MetadataEntryV2};
 use pocket_ic::CallError;
@@ -15,7 +15,7 @@ use serde_bytes::ByteBuf;
 #[test]
 fn should_add_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method_1 = sample_pubkey_authn_method(1);
     let principal = authn_method_1.principal();
     let authn_method_2 = sample_pubkey_authn_method(2);
@@ -44,7 +44,7 @@ fn should_add_authn_method() -> Result<(), CallError> {
 #[test]
 fn should_require_authentication_to_add_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = sample_pubkey_authn_method(1);
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -67,7 +67,7 @@ fn should_require_authentication_to_add_authn_method() -> Result<(), CallError> 
 #[test]
 fn should_report_error_on_failed_conversion() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method_1 = sample_pubkey_authn_method(1);
     let principal = authn_method_1.principal();
     let mut authn_method_2 = sample_pubkey_authn_method(2);

--- a/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_add.rs
@@ -3,9 +3,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive
-};
+use canister_tests::framework::{env, expect_user_error_with_message, install_ii_with_archive};
 use internet_identity_interface::internet_identity::types::{AuthnMethodAddError, MetadataEntryV2};
 use pocket_ic::CallError;
 use pocket_ic::ErrorCode::CanisterCalledTrap;

--- a/src/internet_identity/tests/integration/v2_api/authn_method_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_metadata.rs
@@ -3,9 +3,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive
-};
+use canister_tests::framework::{env, expect_user_error_with_message, install_ii_with_archive};
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, AuthnMethodMetadataReplaceError, AuthnMethodProtection, AuthnMethodPurpose,
     AuthnMethodSecuritySettings, MetadataEntryV2,

--- a/src/internet_identity/tests/integration/v2_api/authn_method_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_metadata.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_canister, II_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, AuthnMethodMetadataReplaceError, AuthnMethodProtection, AuthnMethodPurpose,
@@ -21,7 +21,7 @@ fn should_write_authn_method_metadata() -> Result<(), CallError> {
     const METADATA_KEY: &str = "some-key";
 
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -67,7 +67,7 @@ fn should_replace_authn_method_metadata() -> Result<(), CallError> {
     const METADATA_KEY: &str = "some-key";
 
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = AuthnMethodData {
         metadata: HashMap::from([
             (
@@ -133,7 +133,7 @@ fn should_require_authentication_to_replace_identity_metadata() {
     const METADATA_KEY: &str = "some-key";
 
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -165,7 +165,7 @@ fn should_not_write_too_large_identity_metadata_map() -> Result<(), CallError> {
     const VARIABLE_FIELDS_LIMIT: usize = 2500;
 
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -214,7 +214,7 @@ fn should_not_allow_reserved_metadata_keys() -> Result<(), CallError> {
     ];
 
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -250,7 +250,7 @@ fn should_enforce_string_type_for_legacy_keys() -> Result<(), CallError> {
     const RESERVED_KEYS: &[&str] = &["alias", "usage", "authenticator_attachment", "origin"];
 
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 

--- a/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, time, 
+    env, expect_user_error_with_message, install_ii_with_archive, time,
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodConfirmationCode, AuthnMethodConfirmationError, AuthnMethodRegisterError,

--- a/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_canister, time, II_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, time, II_WASM, ARCHIVE_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodConfirmationCode, AuthnMethodConfirmationError, AuthnMethodRegisterError,
@@ -18,7 +18,7 @@ use std::time::Duration;
 #[test]
 fn should_enter_authn_method_registration_mode() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -40,7 +40,7 @@ fn should_enter_authn_method_registration_mode() -> Result<(), CallError> {
 #[test]
 fn should_require_authentication_to_enter_authn_method_registration_mode() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -61,7 +61,7 @@ fn should_require_authentication_to_enter_authn_method_registration_mode() {
 #[test]
 fn should_register_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -96,7 +96,7 @@ fn should_register_authn_method() -> Result<(), CallError> {
 #[test]
 fn should_verify_authn_method_after_failed_attempt() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -144,7 +144,7 @@ fn should_verify_authn_method_after_failed_attempt() -> Result<(), CallError> {
 #[test]
 fn identity_info_should_return_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -177,7 +177,7 @@ fn identity_info_should_return_authn_method() -> Result<(), CallError> {
 #[test]
 fn should_reject_authn_method_if_not_in_registration_mode() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -226,7 +226,7 @@ fn should_reject_authn_method_if_not_in_registration_mode() -> Result<(), CallEr
 fn should_reject_authn_method_if_registration_mode_is_expired() -> Result<(), CallError> {
     const REGISTRATION_MODE_EXPIRATION: Duration = Duration::from_secs(900);
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -257,7 +257,7 @@ fn should_reject_authn_method_if_registration_mode_is_expired() -> Result<(), Ca
 #[test]
 fn should_reject_confirmation_without_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -288,7 +288,7 @@ fn should_reject_confirmation_without_authn_method() -> Result<(), CallError> {
 fn should_reject_confirmation_with_wrong_code() -> Result<(), CallError> {
     const MAX_RETRIES: u8 = 3;
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 

--- a/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, time, ARCHIVE_WASM, II_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, time, 
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodConfirmationCode, AuthnMethodConfirmationError, AuthnMethodRegisterError,

--- a/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, time, II_WASM, ARCHIVE_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, time, ARCHIVE_WASM, II_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodConfirmationCode, AuthnMethodConfirmationError, AuthnMethodRegisterError,

--- a/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, ARCHIVE_WASM, II_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, 
 };
 use pocket_ic::CallError;
 use pocket_ic::ErrorCode::CanisterCalledTrap;

--- a/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
@@ -3,9 +3,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, 
-};
+use canister_tests::framework::{env, expect_user_error_with_message, install_ii_with_archive};
 use pocket_ic::CallError;
 use pocket_ic::ErrorCode::CanisterCalledTrap;
 use regex::Regex;

--- a/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_canister, II_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, II_WASM, ARCHIVE_WASM,
 };
 use pocket_ic::CallError;
 use pocket_ic::ErrorCode::CanisterCalledTrap;
@@ -13,7 +13,7 @@ use regex::Regex;
 #[test]
 fn should_remove_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method_1 = sample_pubkey_authn_method(1);
     let principal = authn_method_1.principal();
     let authn_method_2 = sample_pubkey_authn_method(2);
@@ -47,7 +47,7 @@ fn should_remove_authn_method() -> Result<(), CallError> {
 #[test]
 fn should_require_authentication_to_remove_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = sample_pubkey_authn_method(1);
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
@@ -72,7 +72,7 @@ fn should_require_authentication_to_remove_authn_method() -> Result<(), CallErro
 #[test]
 fn should_remove_last_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = sample_pubkey_authn_method(1);
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 

--- a/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_remove.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, II_WASM, ARCHIVE_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, ARCHIVE_WASM, II_WASM,
 };
 use pocket_ic::CallError;
 use pocket_ic::ErrorCode::CanisterCalledTrap;

--- a/src/internet_identity/tests/integration/v2_api/authn_method_replace.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_replace.rs
@@ -4,9 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, 
-};
+use canister_tests::framework::{env, expect_user_error_with_message, install_ii_with_archive};
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, AuthnMethodReplaceError, MetadataEntryV2,
 };

--- a/src/internet_identity/tests/integration/v2_api/authn_method_replace.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_replace.rs
@@ -5,7 +5,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_canister, II_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, II_WASM, ARCHIVE_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, AuthnMethodReplaceError, MetadataEntryV2,
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 #[test]
 fn should_replace_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method_1 = sample_pubkey_authn_method(1);
     let authn_method_2 = sample_webauthn_authn_method(2);
 
@@ -50,7 +50,7 @@ fn should_replace_authn_method() -> Result<(), CallError> {
 #[test]
 fn should_require_authentication_to_replace_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method_1 = sample_pubkey_authn_method(1);
     let authn_method_2 = sample_pubkey_authn_method(2);
 
@@ -85,7 +85,7 @@ fn should_require_authentication_to_replace_authn_method() -> Result<(), CallErr
 #[test]
 fn should_validate_metadata_of_new_authn_method() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method_1 = sample_pubkey_authn_method(1);
     let authn_method_2 = AuthnMethodData {
         metadata: HashMap::from([(

--- a/src/internet_identity/tests/integration/v2_api/authn_method_replace.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_replace.rs
@@ -5,7 +5,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, II_WASM, ARCHIVE_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, ARCHIVE_WASM, II_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, AuthnMethodReplaceError, MetadataEntryV2,

--- a/src/internet_identity/tests/integration/v2_api/authn_method_replace.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_replace.rs
@@ -5,7 +5,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, ARCHIVE_WASM, II_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, 
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, AuthnMethodReplaceError, MetadataEntryV2,

--- a/src/internet_identity/tests/integration/v2_api/authn_method_security_settings.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_security_settings.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_canister, II_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, II_WASM, ARCHIVE_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, AuthnMethodSecuritySettings,
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 #[test]
 fn should_replace_authn_method_security_settings() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = recovery_phrase_authn_method();
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
@@ -63,7 +63,7 @@ fn should_replace_authn_method_security_settings() -> Result<(), CallError> {
 #[test]
 fn should_require_authentication_to_replace_security_settings() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = recovery_phrase_authn_method();
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
@@ -102,7 +102,7 @@ fn should_require_authentication_to_replace_security_settings() -> Result<(), Ca
 #[test]
 fn should_check_authn_method_exists() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = recovery_phrase_authn_method();
 
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);

--- a/src/internet_identity/tests/integration/v2_api/authn_method_security_settings.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_security_settings.rs
@@ -3,9 +3,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, 
-};
+use canister_tests::framework::{env, expect_user_error_with_message, install_ii_with_archive};
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, AuthnMethodSecuritySettings,
     AuthnMethodSecuritySettingsReplaceError, MetadataEntryV2,

--- a/src/internet_identity/tests/integration/v2_api/authn_method_security_settings.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_security_settings.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, ARCHIVE_WASM, II_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, 
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, AuthnMethodSecuritySettings,

--- a/src/internet_identity/tests/integration/v2_api/authn_method_security_settings.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_security_settings.rs
@@ -4,7 +4,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
 use canister_tests::framework::{
-    env, expect_user_error_with_message, install_ii_with_archive, II_WASM, ARCHIVE_WASM,
+    env, expect_user_error_with_message, install_ii_with_archive, ARCHIVE_WASM, II_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, AuthnMethodProtection, AuthnMethodPurpose, AuthnMethodSecuritySettings,

--- a/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
@@ -2,7 +2,7 @@ use crate::v2_api::authn_method_test_helpers::{
     create_identity_with_authn_methods, sample_authn_methods,
 };
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{env, install_ii_with_archive, II_WASM, ARCHIVE_WASM};
+use canister_tests::framework::{env, install_ii_with_archive, ARCHIVE_WASM, II_WASM};
 use internet_identity_interface::internet_identity::types::AuthnMethodPurpose;
 use pocket_ic::CallError;
 

--- a/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
@@ -2,7 +2,7 @@ use crate::v2_api::authn_method_test_helpers::{
     create_identity_with_authn_methods, sample_authn_methods,
 };
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{env, install_ii_with_archive, ARCHIVE_WASM, II_WASM};
+use canister_tests::framework::{env, install_ii_with_archive};
 use internet_identity_interface::internet_identity::types::AuthnMethodPurpose;
 use pocket_ic::CallError;
 

--- a/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_authn_info.rs
@@ -2,14 +2,14 @@ use crate::v2_api::authn_method_test_helpers::{
     create_identity_with_authn_methods, sample_authn_methods,
 };
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{env, install_ii_canister, II_WASM};
+use canister_tests::framework::{env, install_ii_with_archive, II_WASM, ARCHIVE_WASM};
 use internet_identity_interface::internet_identity::types::AuthnMethodPurpose;
 use pocket_ic::CallError;
 
 #[test]
 fn should_get_identity_authn_info() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_methods = sample_authn_methods();
     let identity_number = create_identity_with_authn_methods(&env, canister_id, &authn_methods);
 

--- a/src/internet_identity/tests/integration/v2_api/identity_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_info.rs
@@ -7,7 +7,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity as api;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{env, install_ii_with_archive, time, II_WASM, ARCHIVE_WASM};
+use canister_tests::framework::{env, install_ii_with_archive, time, ARCHIVE_WASM, II_WASM};
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, DeviceData, DeviceWithUsage, IdentityInfoError, MetadataEntry,
 };

--- a/src/internet_identity/tests/integration/v2_api/identity_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_info.rs
@@ -7,7 +7,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity as api;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{env, install_ii_canister, time, II_WASM};
+use canister_tests::framework::{env, install_ii_with_archive, time, II_WASM, ARCHIVE_WASM};
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, DeviceData, DeviceWithUsage, IdentityInfoError, MetadataEntry,
 };
@@ -19,7 +19,7 @@ use std::time::Duration;
 #[test]
 fn should_get_identity_info() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_methods = sample_authn_methods();
     let identity_number = create_identity_with_authn_methods(&env, canister_id, &authn_methods);
 
@@ -47,7 +47,7 @@ fn should_get_identity_info() -> Result<(), CallError> {
 #[test]
 fn should_require_authentication_for_identity_info() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_methods = sample_authn_methods();
     let identity_number = create_identity_with_authn_methods(&env, canister_id, &authn_methods);
 
@@ -60,7 +60,7 @@ fn should_require_authentication_for_identity_info() -> Result<(), CallError> {
 fn should_provide_authn_registration() -> Result<(), CallError> {
     const AUTHN_METHOD_REGISTRATION_TIMEOUT: u64 = Duration::from_secs(900).as_nanos() as u64; // 15 minutes
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method1 = sample_authn_methods().remove(0);
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method1);
     let device2 = DeviceData {

--- a/src/internet_identity/tests/integration/v2_api/identity_info.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_info.rs
@@ -7,7 +7,7 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::api::internet_identity as api;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{env, install_ii_with_archive, time, ARCHIVE_WASM, II_WASM};
+use canister_tests::framework::{env, install_ii_with_archive, time};
 use internet_identity_interface::internet_identity::types::{
     AuthnMethodData, DeviceData, DeviceWithUsage, IdentityInfoError, MetadataEntry,
 };

--- a/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
@@ -3,7 +3,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{env, install_ii_canister, II_WASM};
+use canister_tests::framework::{env, install_ii_with_archive, II_WASM, ARCHIVE_WASM};
 use internet_identity_interface::internet_identity::types::{
     IdentityMetadataReplaceError, MetadataEntryV2,
 };
@@ -15,7 +15,7 @@ fn should_write_metadata() -> Result<(), CallError> {
     const METADATA_KEY: &str = "some-key";
 
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -50,7 +50,7 @@ fn should_require_authentication_to_replace_identity_metadata() -> Result<(), Ca
     const METADATA_KEY: &str = "some-key";
 
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 
@@ -78,7 +78,7 @@ fn should_not_write_too_large_identity_metadata_map() -> Result<(), CallError> {
     const METADATA_KEY: &str = "some-key";
 
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
 

--- a/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
@@ -3,7 +3,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{env, install_ii_with_archive, ARCHIVE_WASM, II_WASM};
+use canister_tests::framework::{env, install_ii_with_archive};
 use internet_identity_interface::internet_identity::types::{
     IdentityMetadataReplaceError, MetadataEntryV2,
 };

--- a/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_metadata.rs
@@ -3,7 +3,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use candid::Principal;
 use canister_tests::api::internet_identity::api_v2;
-use canister_tests::framework::{env, install_ii_with_archive, II_WASM, ARCHIVE_WASM};
+use canister_tests::framework::{env, install_ii_with_archive, ARCHIVE_WASM, II_WASM};
 use internet_identity_interface::internet_identity::types::{
     IdentityMetadataReplaceError, MetadataEntryV2,
 };

--- a/src/internet_identity/tests/integration/v2_api/identity_register.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_register.rs
@@ -8,7 +8,7 @@ use candid::Principal;
 use canister_tests::api::internet_identity::{api_v2, get_anchor_info};
 use canister_tests::framework::{
     arg_with_anchor_range, arg_with_rate_limit, assert_metric, env, get_metrics,
-    install_ii_canister, install_ii_canister_with_arg, test_principal, time, II_WASM,
+    install_ii_with_archive, install_ii_canister_with_arg, test_principal, time, II_WASM, ARCHIVE_WASM,
 };
 use internet_identity_interface::internet_identity::types::IdentityInfoError::Unauthorized;
 use internet_identity_interface::internet_identity::types::{
@@ -34,7 +34,7 @@ fn should_register_new_identity() {
 #[test]
 fn should_register_multiple_identities() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let identity_number_1 = create_identity_with_authn_method(&env, canister_id, &authn_method);
     let identity_number_2 = create_identity_with_authn_method(&env, canister_id, &authn_method);
@@ -45,7 +45,7 @@ fn should_register_multiple_identities() {
 #[test]
 fn should_transition_flow_principal_to_temp_key() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let authn_method = test_authn_method();
     let flow_principal = test_principal(time(&env));
 
@@ -117,7 +117,7 @@ fn should_not_exceed_configured_identity_range() {
 #[test]
 fn should_not_allow_wrong_captcha() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
 
     let flow_principal = test_principal(0);
     api_v2::identity_registration_start(&env, canister_id, flow_principal)
@@ -141,7 +141,7 @@ fn should_not_allow_wrong_captcha() {
 #[test]
 fn should_not_allow_anonymous_principal_to_start_registration() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
 
     let result = api_v2::identity_registration_start(&env, canister_id, Principal::anonymous())
         .expect("API call failed");
@@ -152,7 +152,7 @@ fn should_not_allow_anonymous_principal_to_start_registration() {
 #[test]
 fn should_not_allow_different_principal() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
 
     let flow_principal1 = test_principal(1);
     let flow_principal2 = test_principal(2);
@@ -169,7 +169,7 @@ fn should_not_allow_different_principal() {
 #[test]
 fn should_allow_captcha_retries() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
 
     let flow_principal = test_principal(0);
     api_v2::identity_registration_start(&env, canister_id, flow_principal)
@@ -198,7 +198,7 @@ fn should_allow_captcha_retries() {
 #[test]
 fn should_not_allow_to_continue_expired_flow() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
 
     let flow_principal = test_principal(0);
     api_v2::identity_registration_start(&env, canister_id, flow_principal)
@@ -217,7 +217,7 @@ fn should_not_allow_to_continue_expired_flow() {
 #[test]
 fn should_fail_on_invalid_metadata() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let mut authn_method = test_authn_method();
     authn_method.metadata.insert(
         "usage".to_string(),

--- a/src/internet_identity/tests/integration/v2_api/identity_register.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_register.rs
@@ -8,8 +8,7 @@ use candid::Principal;
 use canister_tests::api::internet_identity::{api_v2, get_anchor_info};
 use canister_tests::framework::{
     arg_with_anchor_range, arg_with_rate_limit, assert_metric, env, get_metrics,
-    install_ii_canister_with_arg, install_ii_with_archive, test_principal, time, 
-    II_WASM,
+    install_ii_canister_with_arg, install_ii_with_archive, test_principal, time, II_WASM,
 };
 use internet_identity_interface::internet_identity::types::IdentityInfoError::Unauthorized;
 use internet_identity_interface::internet_identity::types::{

--- a/src/internet_identity/tests/integration/v2_api/identity_register.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_register.rs
@@ -8,7 +8,7 @@ use candid::Principal;
 use canister_tests::api::internet_identity::{api_v2, get_anchor_info};
 use canister_tests::framework::{
     arg_with_anchor_range, arg_with_rate_limit, assert_metric, env, get_metrics,
-    install_ii_canister_with_arg, install_ii_with_archive, test_principal, time, ARCHIVE_WASM,
+    install_ii_canister_with_arg, install_ii_with_archive, test_principal, time, 
     II_WASM,
 };
 use internet_identity_interface::internet_identity::types::IdentityInfoError::Unauthorized;

--- a/src/internet_identity/tests/integration/v2_api/identity_register.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_register.rs
@@ -8,7 +8,8 @@ use candid::Principal;
 use canister_tests::api::internet_identity::{api_v2, get_anchor_info};
 use canister_tests::framework::{
     arg_with_anchor_range, arg_with_rate_limit, assert_metric, env, get_metrics,
-    install_ii_with_archive, install_ii_canister_with_arg, test_principal, time, II_WASM, ARCHIVE_WASM,
+    install_ii_canister_with_arg, install_ii_with_archive, test_principal, time, ARCHIVE_WASM,
+    II_WASM,
 };
 use internet_identity_interface::internet_identity::types::IdentityInfoError::Unauthorized;
 use internet_identity_interface::internet_identity::types::{

--- a/src/internet_identity/tests/integration/vc_mvp.rs
+++ b/src/internet_identity/tests/integration/vc_mvp.rs
@@ -31,7 +31,7 @@ fn verify_canister_sig_pk(credential_jws: &str, canister_sig_pk_der: &[u8]) {
 #[test]
 fn should_get_valid_id_alias() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let relying_party = FrontendHostname::from("https://some-dapp.com");
     let issuer = FrontendHostname::from("https://some-issuer.com");
@@ -114,7 +114,7 @@ fn should_get_valid_id_alias() -> Result<(), CallError> {
 #[test]
 fn should_get_different_id_alias_for_different_users() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number_1 = flows::register_anchor(&env, canister_id);
     let identity_number_2 = flows::register_anchor(&env, canister_id);
     let relying_party = FrontendHostname::from("https://some-dapp.com");
@@ -237,7 +237,7 @@ fn should_get_different_id_alias_for_different_users() -> Result<(), CallError> 
 #[test]
 fn should_get_different_id_alias_for_different_relying_parties() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let relying_party_1 = FrontendHostname::from("https://some-dapp-1.com");
     let relying_party_2 = FrontendHostname::from("https://some-dapp-2.com");
@@ -364,7 +364,7 @@ fn should_get_different_id_alias_for_different_relying_parties() -> Result<(), C
 #[test]
 fn should_get_different_id_alias_for_different_issuers() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let relying_party = FrontendHostname::from("https://some-dapp.com");
     let issuer_1 = FrontendHostname::from("https://some-issuer-1.com");
@@ -491,7 +491,7 @@ fn should_get_different_id_alias_for_different_issuers() -> Result<(), CallError
 #[test]
 fn should_get_different_id_alias_for_different_flows() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let relying_party = FrontendHostname::from("https://some-dapp.com");
     let issuer = FrontendHostname::from("https://some-issuer-1.com");
@@ -608,7 +608,7 @@ fn should_get_different_id_alias_for_different_flows() -> Result<(), CallError> 
 #[test]
 fn should_not_prepare_id_alias_for_different_user() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let relying_party = FrontendHostname::from("https://some-dapp.com");
     let issuer = FrontendHostname::from("https://some-issuer.com");
@@ -630,7 +630,7 @@ fn should_not_prepare_id_alias_for_different_user() -> Result<(), CallError> {
 #[test]
 fn should_not_get_id_alias_for_different_user() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let relying_party = FrontendHostname::from("https://some-dapp.com");
     let issuer = FrontendHostname::from("https://some-issuer.com");
@@ -667,7 +667,7 @@ fn should_not_get_id_alias_for_different_user() -> Result<(), CallError> {
 #[test]
 fn should_not_get_id_alias_if_not_prepared() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     api::init_salt(&env, canister_id)?;
     let identity_number = flows::register_anchor(&env, canister_id);
     let relying_party = FrontendHostname::from("https://some-dapp.com");
@@ -698,7 +698,7 @@ fn should_not_get_id_alias_if_not_prepared() -> Result<(), CallError> {
 #[test]
 fn should_not_get_prepared_id_alias_after_ii_upgrade() -> Result<(), CallError> {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let relying_party = FrontendHostname::from("https://some-dapp.com");
     let issuer = FrontendHostname::from("https://some-issuer.com");
@@ -738,7 +738,7 @@ fn should_not_get_prepared_id_alias_after_ii_upgrade() -> Result<(), CallError> 
 #[should_panic(expected = "id_alias signature invalid")]
 fn should_not_validate_id_alias_with_wrong_canister_key() {
     let env = env();
-    let canister_id = install_ii_canister(&env, II_WASM.clone());
+    let canister_id = install_ii_with_archive(&env, None, None);
     let identity_number = flows::register_anchor(&env, canister_id);
     let relying_party = FrontendHostname::from("https://some-dapp.com");
     let issuer = FrontendHostname::from("https://some-issuer.com");


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

A bug was introduced when adding archive entries into the account flow, and the integration tests didn't catch it.

This is because the integration tests don't use the archive canister.

To make integration tests more aligned with production, in the PR, we also deploy an archive canister along the II installation.

# Changes

* New helper `install_ii_with_archive` that is used instead of `install_ii_canister`.
* Use the new helper in integration tests that test some logic. I didn't add it in the config nor metrics tests.

# Tests

Only test changes.



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


