### PR TITLE
Add name and frontend string length checking to account management functions.

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -566,6 +566,7 @@ type CreateAccountError = variant {
     InternalCanisterError : text;
     AccountLimitReached;
     Unauthorized : principal;
+    NameTooLong;
 };
 
 type UpdateAccountError = variant {
@@ -578,6 +579,7 @@ type AccountDelegationError = variant {
     InternalCanisterError : text;
     Unauthorized : principal;
     NoSuchDelegation;
+    NameTooLong;
 };
 
 type PrepareAccountDelegation = record {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -573,13 +573,13 @@ type UpdateAccountError = variant {
     InternalCanisterError : text;
     AccountLimitReached;
     Unauthorized : principal;
+    NameTooLong;
 };
 
 type AccountDelegationError = variant {
     InternalCanisterError : text;
     Unauthorized : principal;
     NoSuchDelegation;
-    NameTooLong;
 };
 
 type PrepareAccountDelegation = record {

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -46,7 +46,7 @@ pub fn create_account_for_origin(
     name: String,
 ) -> Result<Account, CreateAccountError> {
     check_frontend_length(&origin);
-    check_name_length(&name);
+    check_name_length(&name).map_err(Into::<CreateAccountError>::into)?;
     let created_account = storage_borrow_mut(|storage| {
         check_or_rebuild_max_anchor_accounts(
             storage,
@@ -84,7 +84,7 @@ pub fn update_account_for_origin(
     match update.name {
         Some(name) => {
             check_frontend_length(&origin);
-            check_name_length(&name);
+            check_name_length(&name).map_err(Into::<UpdateAccountError>::into)?;
             storage_borrow_mut(|storage| {
                 // If the account to be updated is a default account
                 // Check if whe have reached account limit

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -79,7 +79,6 @@ pub fn update_account_for_origin(
     origin: FrontendHostname,
     update: AccountUpdate,
 ) -> Result<Account, UpdateAccountError> {
-    check_frontend_length(&origin);
     match update.name {
         Some(new_name) => {
             validate_account_name(&new_name).map_err(Into::<UpdateAccountError>::into)?;

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -81,33 +81,66 @@ pub fn update_account_for_origin(
     origin: FrontendHostname,
     update: AccountUpdate,
 ) -> Result<Account, UpdateAccountError> {
+    check_frontend_length(&origin);
     match update.name {
-        Some(name) => {
-            check_frontend_length(&origin);
-            check_name_length(&name).map_err(Into::<UpdateAccountError>::into)?;
-            storage_borrow_mut(|storage| {
-                // If the account to be updated is a default account
-                // Check if whe have reached account limit
-                // Because editing a default account turns it into a stored account
-                if account_number.is_none() {
-                    check_or_rebuild_max_anchor_accounts(
-                        storage,
-                        anchor_number,
-                        MAX_ANCHOR_ACCOUNTS as u64,
-                        true,
-                    )
-                    .map_err(Into::<UpdateAccountError>::into)?
-                }
+        Some(new_name) => {
+            check_name_length(&new_name).map_err(Into::<UpdateAccountError>::into)?;
+            let (updated_account, old_account_name) =
+                // Type annotation was necessary for the compiler to infer the correct type
+                storage_borrow_mut(|storage| -> Result<(Account, Option<String>), UpdateAccountError> {
+                    // If the account to be updated is a default account
+                    // Check if we have reached account limit
+                    // Because editing a default account turns it into a stored account
+                    if account_number.is_none() {
+                        check_or_rebuild_max_anchor_accounts(
+                            storage,
+                            anchor_number,
+                            MAX_ANCHOR_ACCOUNTS as u64,
+                            true,
+                        )
+                        .map_err(Into::<UpdateAccountError>::into)?
+                    }
 
-                storage
-                    .update_account(UpdateAccountParams {
-                        account_number,
-                        anchor_number,
-                        name,
-                        origin: origin.clone(),
-                    })
-                    .map_err(|err| UpdateAccountError::InternalCanisterError(format!("{}", err)))
-            })
+                    let old_account = storage
+                        .read_account(ReadAccountParams {
+                            account_number,
+                            anchor_number,
+                            origin: &origin,
+                        })
+                        .expect("Updating an unreadable account should be impossible!");
+
+                    let updated_account = storage
+                        .update_account(UpdateAccountParams {
+                            account_number,
+                            anchor_number,
+                            name: new_name.clone(),
+                            origin: origin.clone(),
+                        })
+                        .map_err(|err| {
+                            UpdateAccountError::InternalCanisterError(format!("{}", err))
+                        })?;
+
+                    Ok((updated_account, old_account.name))
+                })?;
+
+            // No account number meant that the account was a default account and was created before being updated.
+            if account_number.is_none() {
+                post_account_operation_bookkeeping(
+                    anchor_number,
+                    Operation::CreateAccount {
+                        name: Private::Redacted,
+                    },
+                );
+            }
+
+            let name = if updated_account.name == old_account_name {
+                None
+            } else {
+                Some(Private::Redacted)
+            };
+            post_account_operation_bookkeeping(anchor_number, Operation::UpdateAccount { name });
+
+            Ok(updated_account)
         }
         None => Err(UpdateAccountError::InternalCanisterError(
             "No name was provided.".to_string(),

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -9,7 +9,7 @@ use crate::{
     state::{self, storage_borrow, storage_borrow_mut},
     storage::{
         account::{
-            check_name_length, Account, AccountDelegationError, AccountsCounter,
+            validate_account_name, Account, AccountDelegationError, AccountsCounter,
             CreateAccountParams, PrepareAccountDelegation, ReadAccountParams, UpdateAccountParams,
         },
         Storage,
@@ -36,7 +36,6 @@ pub fn get_accounts_for_origin(
     anchor_number: AnchorNumber,
     origin: &FrontendHostname,
 ) -> Vec<Account> {
-    check_frontend_length(origin);
     storage_borrow(|storage| storage.list_accounts(anchor_number, origin))
 }
 
@@ -45,8 +44,7 @@ pub fn create_account_for_origin(
     origin: FrontendHostname,
     name: String,
 ) -> Result<Account, CreateAccountError> {
-    check_frontend_length(&origin);
-    check_name_length(&name).map_err(Into::<CreateAccountError>::into)?;
+    validate_account_name(&name).map_err(Into::<CreateAccountError>::into)?;
     let created_account = storage_borrow_mut(|storage| {
         check_or_rebuild_max_anchor_accounts(
             storage,
@@ -84,7 +82,7 @@ pub fn update_account_for_origin(
     check_frontend_length(&origin);
     match update.name {
         Some(new_name) => {
-            check_name_length(&new_name).map_err(Into::<UpdateAccountError>::into)?;
+            validate_account_name(&new_name).map_err(Into::<UpdateAccountError>::into)?;
             let (updated_account, old_account_name) =
                 // Type annotation was necessary for the compiler to infer the correct type
                 storage_borrow_mut(|storage| -> Result<(Account, Option<String>), UpdateAccountError> {

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -930,6 +930,7 @@ impl<M: Memory + Clone> Storage<M> {
         &mut self,
         params: CreateAccountParams,
     ) -> Result<Account, StorageError> {
+        check_frontend_length(&params.origin);
         let anchor_number = params.anchor_number;
         let origin = &params.origin;
 
@@ -1031,6 +1032,7 @@ impl<M: Memory + Clone> Storage<M> {
     /// If the `Account` number exists but the `Account` doesn't exist, returns None.
     /// If the `Account` exists, returns it as `Account`.
     pub fn read_account(&self, params: ReadAccountParams) -> Option<Account> {
+        check_frontend_length(&params.origin);
         let application_number = self.lookup_application_number_with_origin(params.origin);
 
         match params.account_number {
@@ -1126,6 +1128,7 @@ impl<M: Memory + Clone> Storage<M> {
     /// If the account number exists, then updates that account.
     /// If the account number doesn't exist, then gets or creates an application and creates and stores a default account.
     pub fn update_account(&mut self, params: UpdateAccountParams) -> Result<Account, StorageError> {
+        check_frontend_length(&params.origin);
         match params.account_number {
             Some(account_number) => self.update_existing_account(UpdateExistingAccountParams {
                 account_number,

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -1032,7 +1032,7 @@ impl<M: Memory + Clone> Storage<M> {
     /// If the `Account` number exists but the `Account` doesn't exist, returns None.
     /// If the `Account` exists, returns it as `Account`.
     pub fn read_account(&self, params: ReadAccountParams) -> Option<Account> {
-        check_frontend_length(&params.origin);
+        check_frontend_length(params.origin);
         let application_number = self.lookup_application_number_with_origin(params.origin);
 
         match params.account_number {

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -104,6 +104,7 @@ use ic_stable_structures::{
 };
 use internet_identity_interface::archive::types::BufferedEntry;
 
+use crate::delegation::check_frontend_length;
 use crate::openid::OpenIdCredentialKey;
 use crate::state::PersistentState;
 use crate::stats::event_stats::AggregationKey;
@@ -1003,6 +1004,7 @@ impl<M: Memory + Clone> Storage<M> {
         anchor_number: AnchorNumber,
         origin: &FrontendHostname,
     ) -> Vec<Account> {
+        check_frontend_length(origin);
         match self.lookup_application_number_with_origin(origin) {
             None => vec![Account::new(anchor_number, origin.clone(), None, None)],
             Some(app_num) => match self.lookup_account_references(anchor_number, app_num) {

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -198,3 +198,14 @@ pub struct PrepareAccountDelegation {
     pub user_key: UserKey,
     pub expiration: Timestamp,
 }
+
+pub(crate) fn check_name_length(name: &str) {
+    const ACCOUNT_NAME_LIMIT: usize = 255;
+
+    let n = name.len();
+    if name.len() > ACCOUNT_NAME_LIMIT {
+        trap(&format!(
+            "account name {n} exceeds the limit of {ACCOUNT_NAME_LIMIT} bytes",
+        ));
+    }
+}

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -7,7 +7,7 @@ use crate::{
 use ic_cdk::trap;
 use ic_certification::Hash;
 use internet_identity_interface::internet_identity::types::{
-    AccountInfo, AccountNumber, AnchorNumber, CheckAccountNameLengthError, FrontendHostname,
+    AccountInfo, AccountNameValidationError, AccountNumber, AnchorNumber, FrontendHostname,
     Timestamp, UserKey,
 };
 use serde::{Deserialize, Serialize};
@@ -200,11 +200,11 @@ pub struct PrepareAccountDelegation {
     pub expiration: Timestamp,
 }
 
-pub(crate) fn check_name_length(name: &str) -> Result<(), CheckAccountNameLengthError> {
+pub(crate) fn validate_account_name(name: &str) -> Result<(), AccountNameValidationError> {
     const ACCOUNT_NAME_LIMIT: usize = 255;
 
     if name.len() > ACCOUNT_NAME_LIMIT {
-        return Err(CheckAccountNameLengthError::NameTooLong);
+        return Err(AccountNameValidationError::NameTooLong);
     }
 
     Ok(())

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -203,7 +203,6 @@ pub struct PrepareAccountDelegation {
 pub(crate) fn check_name_length(name: &str) -> Result<(), CheckAccountNameLengthError> {
     const ACCOUNT_NAME_LIMIT: usize = 255;
 
-    let n = name.len();
     if name.len() > ACCOUNT_NAME_LIMIT {
         return Err(CheckAccountNameLengthError::NameTooLong);
     }

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -7,7 +7,8 @@ use crate::{
 use ic_cdk::trap;
 use ic_certification::Hash;
 use internet_identity_interface::internet_identity::types::{
-    AccountInfo, AccountNumber, AnchorNumber, FrontendHostname, Timestamp, UserKey,
+    AccountInfo, AccountNumber, AnchorNumber, CheckAccountNameLengthError, FrontendHostname,
+    Timestamp, UserKey,
 };
 use serde::{Deserialize, Serialize};
 
@@ -199,13 +200,13 @@ pub struct PrepareAccountDelegation {
     pub expiration: Timestamp,
 }
 
-pub(crate) fn check_name_length(name: &str) {
+pub(crate) fn check_name_length(name: &str) -> Result<(), CheckAccountNameLengthError> {
     const ACCOUNT_NAME_LIMIT: usize = 255;
 
     let n = name.len();
     if name.len() > ACCOUNT_NAME_LIMIT {
-        trap(&format!(
-            "account name {n} exceeds the limit of {ACCOUNT_NAME_LIMIT} bytes",
-        ));
+        return Err(CheckAccountNameLengthError::NameTooLong);
     }
+
+    Ok(())
 }

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -339,6 +339,7 @@ pub enum CreateAccountError {
     InternalCanisterError(String),
     AccountLimitReached,
     Unauthorized(Principal),
+    NameTooLong,
 }
 
 impl From<CheckMaxAccountError> for CreateAccountError {
@@ -349,17 +350,34 @@ impl From<CheckMaxAccountError> for CreateAccountError {
     }
 }
 
+impl From<CheckAccountNameLengthError> for CreateAccountError {
+    fn from(err: CheckAccountNameLengthError) -> Self {
+        match err {
+            CheckAccountNameLengthError::NameTooLong => Self::NameTooLong,
+        }
+    }
+}
+
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum UpdateAccountError {
     InternalCanisterError(String),
     AccountLimitReached,
     Unauthorized(Principal),
+    NameTooLong,
 }
 
 impl From<CheckMaxAccountError> for UpdateAccountError {
     fn from(err: CheckMaxAccountError) -> Self {
         match err {
             CheckMaxAccountError::AccountLimitReached => Self::AccountLimitReached,
+        }
+    }
+}
+
+impl From<CheckAccountNameLengthError> for UpdateAccountError {
+    fn from(err: CheckAccountNameLengthError) -> Self {
+        match err {
+            CheckAccountNameLengthError::NameTooLong => Self::NameTooLong,
         }
     }
 }
@@ -386,4 +404,9 @@ pub enum AccountDelegationError {
 #[derive(CandidType, Debug, Deserialize)]
 pub enum CheckMaxAccountError {
     AccountLimitReached,
+}
+
+#[derive(CandidType, Debug, Deserialize)]
+pub enum CheckAccountNameLengthError {
+    NameTooLong,
 }

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -350,10 +350,10 @@ impl From<CheckMaxAccountError> for CreateAccountError {
     }
 }
 
-impl From<CheckAccountNameLengthError> for CreateAccountError {
-    fn from(err: CheckAccountNameLengthError) -> Self {
+impl From<AccountNameValidationError> for CreateAccountError {
+    fn from(err: AccountNameValidationError) -> Self {
         match err {
-            CheckAccountNameLengthError::NameTooLong => Self::NameTooLong,
+            AccountNameValidationError::NameTooLong => Self::NameTooLong,
         }
     }
 }
@@ -374,10 +374,10 @@ impl From<CheckMaxAccountError> for UpdateAccountError {
     }
 }
 
-impl From<CheckAccountNameLengthError> for UpdateAccountError {
-    fn from(err: CheckAccountNameLengthError) -> Self {
+impl From<AccountNameValidationError> for UpdateAccountError {
+    fn from(err: AccountNameValidationError) -> Self {
         match err {
-            CheckAccountNameLengthError::NameTooLong => Self::NameTooLong,
+            AccountNameValidationError::NameTooLong => Self::NameTooLong,
         }
     }
 }
@@ -407,6 +407,6 @@ pub enum CheckMaxAccountError {
 }
 
 #[derive(CandidType, Debug, Deserialize)]
-pub enum CheckAccountNameLengthError {
+pub enum AccountNameValidationError {
     NameTooLong,
 }


### PR DESCRIPTION
# Motivation

Because of how the account seed is constructed, we need to make sure that the length of the frontend is no longer than 255. Also, it makes sense to limit the length of account names on the backend.

# Changes

Add the `check_frontend_length` function to `create_account_for_origin`, `update_account_for_origin` and `get_accounts_for_origin`. Add the `check_name_length` function (following a slightly different pattern to return an error instead of trapping), to limit the account names to the same length (seems like a good length).

# Tests

No manual tests were done.








<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->







