### PR TITLE
dedupe read_account in list_accounts

### DIFF
--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -101,6 +101,7 @@ pub fn update_account_for_origin(
                             account_number,
                             anchor_number,
                             origin: &origin,
+                            known_app_num: None
                         })
                         .expect("Updating an unreadable account should be impossible!");
 
@@ -160,6 +161,7 @@ pub async fn prepare_account_delegation(
                 account_number,
                 anchor_number,
                 origin: &origin,
+                known_app_num: None,
             })
             .ok_or(AccountDelegationError::Unauthorized(caller()))
     })?;
@@ -199,6 +201,7 @@ pub fn get_account_delegation(
                 account_number,
                 anchor_number,
                 origin,
+                known_app_num: None,
             })
             .ok_or(AccountDelegationError::Unauthorized(caller()))?;
 

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -1014,6 +1014,7 @@ impl<M: Memory + Clone> Storage<M> {
                             account_number: acc_ref.account_number,
                             anchor_number,
                             origin,
+                            known_app_num: Some(app_num),
                         })
                     })
                     .collect(),
@@ -1028,8 +1029,13 @@ impl<M: Memory + Clone> Storage<M> {
     /// If the `Account` number doesn't esist, returns a default `Account`.
     /// If the `Account` number exists but the `Account` doesn't exist, returns None.
     /// If the `Account` exists, returns it as `Account`.
+    /// Optionally an application number can be passed if it is already known, so we don't look it up more than necessary.
     pub fn read_account(&self, params: ReadAccountParams) -> Option<Account> {
-        let application_number = self.lookup_application_number_with_origin(params.origin);
+        let application_number = if params.known_app_num.is_none() {
+            self.lookup_application_number_with_origin(params.origin)
+        } else {
+            params.known_app_num
+        };
 
         match params.account_number {
             // If a default account is requested

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -7,7 +7,8 @@ use crate::{
 use ic_cdk::trap;
 use ic_certification::Hash;
 use internet_identity_interface::internet_identity::types::{
-    AccountInfo, AccountNumber, AnchorNumber, FrontendHostname, Timestamp, UserKey,
+    AccountInfo, AccountNumber, AnchorNumber, ApplicationNumber, FrontendHostname, Timestamp,
+    UserKey,
 };
 use serde::{Deserialize, Serialize};
 
@@ -40,6 +41,7 @@ pub struct ReadAccountParams<'a> {
     pub account_number: Option<AccountNumber>,
     pub anchor_number: AnchorNumber,
     pub origin: &'a FrontendHostname,
+    pub known_app_num: Option<ApplicationNumber>,
 }
 
 // Types used internally to encapsulate business logic and data.

--- a/src/internet_identity/src/storage/account/tests.rs
+++ b/src/internet_identity/src/storage/account/tests.rs
@@ -34,6 +34,7 @@ fn should_create_additional_account() {
         account_number: Some(1), // First account created
         anchor_number,
         origin: &origin,
+        known_app_num: None,
     };
     let additional_account_1 = storage.read_account(read_params.clone());
     assert!(
@@ -295,6 +296,7 @@ fn should_update_additional_account() {
         account_number: Some(account_number), // First account created is 1
         anchor_number,
         origin: &origin,
+        known_app_num: None,
     };
     let additional_account_1 = storage.read_account(read_params.clone());
     assert!(
@@ -518,6 +520,7 @@ fn should_read_default_account_with_empty_reference_list() {
         account_number: None,
         anchor_number,
         origin: &origin,
+        known_app_num: Some(app_num),
     };
     let default_account = storage.read_account(read_params).unwrap();
 
@@ -551,6 +554,7 @@ fn should_not_read_account_from_wrong_anchor() {
         account_number: Some(1),        // First account created
         anchor_number: anchor_number_2, // Different anchor
         origin: &origin,
+        known_app_num: None,
     };
     let account = storage.read_account(read_params);
 


### PR DESCRIPTION
# Motivation

When `list_accounts` is called, it already looks up the application number. It is thus unnecessary to call it again in `read_account` in this specific case.

# Changes

Add an optional `known_app_num` to `ReadAccountParams`. Set it to `None` everywhere but in `list_accounts`

# Tests

No new tests were added.
