### PR TITLE
Reactivate Interface Compatibility Test

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -1038,16 +1038,15 @@ jobs:
             exit 1
           fi
 
-  # DEACTIVATED SO WE CAN UPDATE THE ERROR TYPE IN CREATE AND UPDATE ACCOUNTS
-  # interface-compatibility:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/setup-didc
-  #     - name: "Check canister interface compatibility"
-  #       run: |
-  #         curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
-  #         didc check src/internet_identity/internet_identity.did internet_identity_previous.did
+  interface-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-didc
+      - name: "Check canister interface compatibility"
+        run: |
+          curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
+          didc check src/internet_identity/internet_identity.did internet_identity_previous.did
 
   sig-verifier-js:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Motivation

Reactivating the interface compatibility test after changing the error return values in PR #3115.

# Changes

Uncomment the test and remove the notice.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
