### PR TITLE
Change origin hash to 32 bytes

### DIFF
--- a/src/internet_identity/src/storage/storable/application.rs
+++ b/src/internet_identity/src/storage/storable/application.rs
@@ -31,7 +31,7 @@ impl Storable for StorableApplication {
 
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub struct StorableOriginHash {
-    hash: [u8; 8],
+    hash: [u8; 32],
 }
 
 impl StorableOriginHash {
@@ -39,13 +39,10 @@ impl StorableOriginHash {
         let mut hasher = Sha256::new();
         hasher.update(origin.as_bytes());
         let full_hash_result = hasher.finalize();
-        // Truncate the 32-byte SHA-256 hash to the first 8 bytes.
-        let truncated_hash_slice: &[u8] = &full_hash_result[0..8];
-        let hash_8_bytes: [u8; 8] = truncated_hash_slice
-            .try_into()
-            .expect("Failed to truncate SHA256 hash to 8 bytes; slice length should be 8.");
 
-        Self { hash: hash_8_bytes }
+        Self {
+            hash: full_hash_result.into(),
+        }
     }
 }
 
@@ -61,7 +58,7 @@ impl Storable for StorableOriginHash {
     }
 
     const BOUND: Bound = Bound::Bounded {
-        max_size: 8,
+        max_size: 32,
         is_fixed_size: true,
     };
 }


### PR DESCRIPTION
# Motivation

To address ProdSec finding F01, we are changing the OriginHash to be the full 32-byte 

# Changes

Change the StorableOriginHash to 32 bytes, update its functions accordingly.

# Tests

No new tests were added.
