### PR TITLE
use checked adds in counters

### DIFF
--- a/src/internet_identity/src/storage/storable/accounts_counter.rs
+++ b/src/internet_identity/src/storage/storable/accounts_counter.rs
@@ -23,11 +23,17 @@ impl StorableAccountsCounter {
     pub fn increment(&self, account_type: &AccountType) -> Self {
         match account_type {
             AccountType::AccountReference => Self {
-                stored_account_references: self.stored_account_references + 1,
+                stored_account_references: self
+                    .stored_account_references
+                    .checked_add(1)
+                    .expect("overflow in stored_account_references"),
                 stored_accounts: self.stored_accounts,
             },
             AccountType::Account => Self {
-                stored_accounts: self.stored_accounts + 1,
+                stored_accounts: self
+                    .stored_accounts
+                    .checked_add(1)
+                    .expect("overflow in stored_accounts"),
                 stored_account_references: self.stored_account_references,
             },
         }

--- a/src/internet_identity/src/storage/storable/discrepancy_counter.rs
+++ b/src/internet_identity/src/storage/storable/discrepancy_counter.rs
@@ -28,7 +28,10 @@ impl StorableDiscrepancyCounter {
     pub fn increment(&self, discrepancy_type: &DiscrepancyType) -> Self {
         match discrepancy_type {
             DiscrepancyType::AccountRebuild => Self {
-                account_counter_rebuilds: self.account_counter_rebuilds + 1,
+                account_counter_rebuilds: self
+                    .account_counter_rebuilds
+                    .checked_add(1)
+                    .expect("overflow in account_counter_rebuilds"),
             },
         }
     }


### PR DESCRIPTION
# Motivation

To address ProdSec finding F08, we should use checked adds on our counters. Realistically, as these are u64, they should never overflow though.

# Changes

Add checked adds to counters.

# Tests

No new tests were added.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
