### PR TITLE
Fix redirect last used available

### DIFF
--- a/src/frontend/src/routes/(new-styling)/authorize/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/authorize/+page.ts
@@ -6,12 +6,14 @@ import {
   AuthenticationV2Events,
   authenticationV2Funnel,
 } from "$lib/utils/analytics/authenticationV2Funnel";
+import { nonNullish } from "@dfinity/utils";
 
 let firstVisit = true;
 
 export const load: PageLoad = () => {
-  const lastUsedIdentityAvailable =
-    Object.values(get(lastUsedIdentitiesStore)).length > 0;
+  const lastUsedIdentityAvailable = nonNullish(
+    get(lastUsedIdentitiesStore).selected,
+  );
 
   if (firstVisit) {
     firstVisit = false;


### PR DESCRIPTION
Fix redirect last used available, due to a refactor, last used wasn't incorrectly considered to be available.

# Tests

- [x] Verified that the user is only redirect to /continue when an identity is available
