### PR TITLE
Temporarily configure sveltekit to create a single JS bundle

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -26,6 +26,9 @@ const config = {
       },
     },
     version: { name: packagejson.version },
+    output: {
+      bundleStrategy: "single",
+    },
   },
 };
 


### PR DESCRIPTION
Temporarily configure sveltekit to create a single JS bundle ~350kb. This speeds up the page load significantly, particularly in e2e tests. Should be replaced with proper manual chunks config at a later date.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
