### PR TITLE
Migration flow for existing users base functionality

### DIFF
--- a/src/frontend/src/lib/components/layout/Footer.svelte
+++ b/src/frontend/src/lib/components/layout/Footer.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { HTMLAttributes } from "svelte/elements";
   import { SOURCE_CODE_URL, SUPPORT_URL } from "$lib/config";
+  import Button from "../ui/Button.svelte";
+  import { goto } from "$app/navigation";
+  import { ENABLE_MIGRATE_FLOW } from "$lib/state/featureFlags";
 
   type Props = HTMLAttributes<HTMLElement>;
 
@@ -15,6 +18,9 @@
   ]}
 >
   <div class="text-text-tertiary text-xs font-medium">© Internet Identity</div>
+  {#if $ENABLE_MIGRATE_FLOW}
+    <Button variant="primary" onclick={() => goto("/migrate")}>Migrate</Button>
+  {/if}
   <nav class="text-text-primary flex gap-4 text-xs font-semibold">
     <a
       href={SUPPORT_URL}

--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -1,0 +1,137 @@
+import {
+  authenticatedStore,
+  authenticationStore,
+} from "$lib/stores/authentication.store";
+import { sessionStore } from "$lib/stores/session.store";
+import { get } from "svelte/store";
+import { isNullish, nonNullish } from "@dfinity/utils";
+import type {
+  AuthnMethodSecuritySettings,
+  DeviceData,
+  MetadataMapV2,
+  UserNumber,
+} from "$lib/generated/internet_identity_types";
+import { MultiWebAuthnIdentity } from "$lib/utils/multiWebAuthnIdentity";
+import { convertToValidCredentialData } from "$lib/utils/credential-devices";
+import { DelegationChain, DelegationIdentity } from "@dfinity/identity";
+import { DiscoverablePasskeyIdentity } from "$lib/utils/discoverablePasskeyIdentity";
+import { inferPasskeyAlias, loadUAParser } from "$lib/legacy/flows/register";
+
+export class MigrationFlow {
+  view = $state<"enterNumber" | "enterName" | "success">("enterNumber");
+  #identityNumber: UserNumber | undefined;
+
+  constructor() {
+    this.#identityNumber = undefined;
+  }
+
+  authenticateWithIdentityNumber = async (
+    identityNumber: UserNumber,
+  ): Promise<void> => {
+    this.#identityNumber = identityNumber;
+    const devices = await this.#lookupAuthenticators(identityNumber);
+    const webAuthnAuthenticators = devices
+      .filter(({ key_type }) => !("browser_storage_key" in key_type))
+      .map(convertToValidCredentialData)
+      .filter(nonNullish);
+    const passkeyIdentity = MultiWebAuthnIdentity.fromCredentials(
+      webAuthnAuthenticators,
+      undefined,
+      false,
+    );
+    const session = get(sessionStore);
+    const delegation = await DelegationChain.create(
+      passkeyIdentity,
+      session.identity.getPublicKey(),
+      new Date(Date.now() + 30 * 60 * 1000),
+    );
+    const identity = DelegationIdentity.fromDelegation(
+      session.identity,
+      delegation,
+    );
+    authenticationStore.set({ identity, identityNumber });
+    this.view = "enterName";
+  };
+
+  createPasskey = async (name: string): Promise<void> => {
+    if (isNullish(this.#identityNumber)) {
+      // Cannot call createPasskey before authenticateWithIdentityNumber.
+      throw new Error("Identity number is null");
+    }
+    // TODO: Create the passkey in id.ai
+    const passkeyIdentity = await DiscoverablePasskeyIdentity.createNew(name);
+    // The canister only allow for 50 characters, so for long domains we don't attach an origin
+    // (those long domains are most likely a testnet with URL like <canister id>.large03.testnet.dfinity.network, and we basically only care about identity.ic0.app & identity.internetcomputer.org).
+    const sanitizedOrigin =
+      nonNullish(origin) && origin.length <= 50 ? origin : undefined;
+    // Kick-off fetching "ua-parser-js";
+    const uaParser = loadUAParser();
+    const authenticatorAttachement =
+      passkeyIdentity.getAuthenticatorAttachment();
+    const deviceName = await inferPasskeyAlias({
+      authenticatorType: authenticatorAttachement,
+      userAgent: navigator.userAgent,
+      uaParser,
+      aaguid: passkeyIdentity.getAaguid(),
+    });
+    const credentialId = passkeyIdentity.getCredentialId();
+    if (isNullish(credentialId)) {
+      throw new Error("Credential ID is null");
+    }
+    const securitySettings: AuthnMethodSecuritySettings = {
+      protection: { Unprotected: null },
+      purpose: { Authentication: null },
+    };
+    const metadata: MetadataMapV2 = [
+      [
+        "alias",
+        {
+          String: deviceName,
+        },
+      ],
+    ];
+    if (nonNullish(authenticatorAttachement)) {
+      metadata.push([
+        "authenticator_attachment",
+        {
+          String: authenticatorAttachement,
+        },
+      ]);
+    }
+    if (nonNullish(sanitizedOrigin)) {
+      metadata.push([
+        "origin",
+        {
+          String: sanitizedOrigin,
+        },
+      ]);
+    }
+    const response = await get(authenticatedStore).actor.authn_method_add(
+      this.#identityNumber,
+      {
+        security_settings: securitySettings,
+        metadata,
+        last_authentication: [],
+        authn_method: {
+          WebAuthn: {
+            pubkey: Array.from(
+              new Uint8Array(passkeyIdentity.getPublicKey().toDer()),
+            ),
+            credential_id: Array.from(new Uint8Array(credentialId)),
+          },
+        },
+      },
+    );
+    if ("Ok" in response) {
+      this.view = "success";
+    }
+  };
+
+  #lookupAuthenticators = async (
+    userNumber: UserNumber,
+  ): Promise<Omit<DeviceData, "alias">[]> => {
+    const actor = await get(sessionStore).actor;
+    const allDevices = await actor.lookup(userNumber);
+    return allDevices.filter((device) => "authentication" in device.purpose);
+  };
+}

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -79,6 +79,11 @@ export const DISCOVERABLE_PASSKEY_FLOW = createFeatureFlagStore(
   false,
 );
 
+export const ENABLE_MIGRATE_FLOW = createFeatureFlagStore(
+  "ENABLE_MIGRATE_FLOW",
+  false,
+);
+
 export default {
   DOMAIN_COMPATIBILITY,
   OPENID_AUTHENTICATION,

--- a/src/frontend/src/routes/(new-styling)/migrate/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/migrate/+page.svelte
@@ -2,13 +2,13 @@
   import AuthPanel from "$lib/components/layout/AuthPanel.svelte";
   import Header from "$lib/components/layout/Header.svelte";
   import Footer from "$lib/components/layout/Footer.svelte";
-  import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
-  import { UserIcon } from "@lucide/svelte";
   import Input from "$lib/components/ui/Input.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { isNullish, nonNullish } from "@dfinity/utils";
   import { MigrationFlow } from "$lib/flows/migrationFlow.svelte";
   import CreatePasskey from "$lib/components/views/CreatePasskey.svelte";
+  import { goto } from "$app/navigation";
+  import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
 
   let identityNumber = $state(undefined);
   const migrationFlow = new MigrationFlow();
@@ -20,7 +20,11 @@
   };
 
   const handleCreate = async (name: string) => {
+    if (isNullish(migrationFlow.identityNumber)) {
+      throw new Error("Identity number is null");
+    }
     await migrationFlow.createPasskey(name);
+    lastUsedIdentitiesStore.selectIdentity(migrationFlow.identityNumber);
   };
 </script>
 
@@ -35,7 +39,7 @@
         {:else if migrationFlow.view === "enterName"}
           <CreatePasskey create={handleCreate} />
         {:else}
-          <p>Migration completed</p>
+          {@render successfulMigration()}
         {/if}
       </AuthPanel>
     </div>
@@ -47,9 +51,6 @@
 {#snippet enterIndentitNumber()}
   <form class="flex flex-1 flex-col">
     <div class="mb-8 flex flex-col">
-      <FeaturedIcon size="lg" class="mb-4 self-start">
-        <UserIcon size="1.5rem" />
-      </FeaturedIcon>
       <h1 class="text-text-primary mb-3 text-2xl font-medium">
         Enter the identity number
       </h1>
@@ -80,4 +81,23 @@
       </Button>
     </div>
   </form>
+{/snippet}
+
+{#snippet successfulMigration()}
+  <div class="mb-8 flex flex-col">
+    <h1 class="text-text-primary mb-3 text-2xl font-medium">
+      Migration completed
+    </h1>
+    <p class="text-md text-text-tertiary mb-6 font-medium">
+      You can now authenticate with your identity in the new flow.
+    </p>
+    <Button
+      onclick={() => goto("/manage")}
+      variant="primary"
+      size="lg"
+      type="submit"
+    >
+      <span>Go to manage</span>
+    </Button>
+  </div>
 {/snippet}

--- a/src/frontend/src/routes/(new-styling)/migrate/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/migrate/+page.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import AuthPanel from "$lib/components/layout/AuthPanel.svelte";
+  import Header from "$lib/components/layout/Header.svelte";
+  import Footer from "$lib/components/layout/Footer.svelte";
+  import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
+  import { UserIcon } from "@lucide/svelte";
+  import Input from "$lib/components/ui/Input.svelte";
+  import Button from "$lib/components/ui/Button.svelte";
+  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { MigrationFlow } from "$lib/flows/migrationFlow.svelte";
+  import CreatePasskey from "$lib/components/views/CreatePasskey.svelte";
+
+  let identityNumber = $state(undefined);
+  const migrationFlow = new MigrationFlow();
+
+  const handleSubmit = async () => {
+    if (nonNullish(identityNumber)) {
+      await migrationFlow.authenticateWithIdentityNumber(identityNumber);
+    }
+  };
+
+  const handleCreate = async (name: string) => {
+    await migrationFlow.createPasskey(name);
+  };
+</script>
+
+<div class="flex min-h-[100dvh] flex-col" data-page="migration-view">
+  <div class="h-[env(safe-area-inset-top)]"></div>
+  <Header />
+  <div class="flex flex-1 flex-col items-center justify-center">
+    <div class="col-start-1 row-start-1 flex flex-col">
+      <AuthPanel>
+        {#if migrationFlow.view === "enterNumber"}
+          {@render enterIndentitNumber()}
+        {:else if migrationFlow.view === "enterName"}
+          <CreatePasskey create={handleCreate} />
+        {:else}
+          <p>Migration completed</p>
+        {/if}
+      </AuthPanel>
+    </div>
+  </div>
+  <Footer />
+  <div class="h-[env(safe-area-inset-bottom)]"></div>
+</div>
+
+{#snippet enterIndentitNumber()}
+  <form class="flex flex-1 flex-col">
+    <div class="mb-8 flex flex-col">
+      <FeaturedIcon size="lg" class="mb-4 self-start">
+        <UserIcon size="1.5rem" />
+      </FeaturedIcon>
+      <h1 class="text-text-primary mb-3 text-2xl font-medium">
+        Enter the identity number
+      </h1>
+      <p class="text-md text-text-tertiary mb-6 font-medium">
+        This process will allow you to use the new authentication flow.
+      </p>
+      <Input
+        bind:value={identityNumber}
+        inputmode="numeric"
+        placeholder="Identity number"
+        type="number"
+        size="md"
+        autocomplete="off"
+        autocorrect="off"
+        spellcheck="false"
+        aria-label="Identity number"
+      />
+    </div>
+    <div class="mt-auto flex flex-col items-stretch gap-3">
+      <Button
+        onclick={handleSubmit}
+        variant="primary"
+        size="lg"
+        type="submit"
+        disabled={isNullish(identityNumber)}
+      >
+        <span>Migrate Identity</span>
+      </Button>
+    </div>
+  </form>
+{/snippet}


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Existing users can use id.ai with the new flow.

This PR includes the base functionality for the migration flow. It already works when users access directly the main page.

# Changes

* Added the `MigrationFlow` class in `migrationFlow.svelte.ts` to handle the migration process, including authenticating with an identity number and creating a passkey. This class encapsulates the logic for transitioning users to the new authentication system.
* Updated `Footer.svelte` to conditionally display a "Migrate" button when the `ENABLE_MIGRATE_FLOW` feature flag is enabled. This button navigates users to the migration page.
* Added a new migration page (`migrate/+page.svelte`) that guides users through the migration process, including entering their identity number, creating a passkey, and confirming successful migration.
* Introduced the `ENABLE_MIGRATE_FLOW` feature flag in `featureFlags.ts` to control the visibility of the migration flow functionality.

# Tests

Tested manually:
1. Create user with old flow.
2. Go to new flow, perform migration.
3. Logging successful.
4. Refresh page and clean up local storage.
5. Loging new flow with Use Existing by selecting the passkey created in step 2.
