### PR TITLE
Frontend account limit per dapp

### DIFF
--- a/src/frontend/src/lib/components/ui/Button.svelte
+++ b/src/frontend/src/lib/components/ui/Button.svelte
@@ -33,7 +33,7 @@
   bind:element
   {...props}
   class={[
-    "box-border flex cursor-pointer items-center justify-center justify-self-start rounded-md font-semibold whitespace-nowrap opacity-100",
+    "box-border flex items-center justify-center justify-self-start rounded-md font-semibold whitespace-nowrap opacity-100 not-disabled:cursor-pointer",
     {
       primary: [
         danger

--- a/src/frontend/src/lib/components/ui/FeaturedIcon.svelte
+++ b/src/frontend/src/lib/components/ui/FeaturedIcon.svelte
@@ -5,21 +5,24 @@
   type Variant = "info" | "success" | "warning" | "error";
 
   type Props = HTMLAttributes<HTMLDivElement> & {
+    element?: HTMLElement;
     size?: Size;
     variant?: Variant;
   };
 
-  const {
+  let {
     children,
     class: className,
     size = "md",
     variant = "info",
+    element = $bindable(),
     ...props
   }: Props = $props();
 </script>
 
 <div
   {...props}
+  bind:this={element}
   class={[
     "flex shrink-0 items-center justify-center",
     {

--- a/src/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/src/frontend/src/lib/components/ui/Tooltip.svelte
@@ -11,6 +11,8 @@
     direction?: Direction;
     align?: Align;
     distance?: string;
+    hidden?: boolean;
+    anchor?: HTMLElement;
   };
 
   const id = $props.id();
@@ -20,6 +22,8 @@
     direction = "up",
     align = "center",
     distance = "0.5rem",
+    hidden = false,
+    anchor,
     children,
     class: className,
     ...restProps
@@ -28,8 +32,9 @@
   let wrapperRef = $state<HTMLElement>();
   let tooltipRef = $state<HTMLElement>();
   let isTooltipVisible = $state(false);
-  let anchorRef = $derived(
-    (wrapperRef?.firstElementChild ?? undefined) as HTMLElement | undefined,
+  const anchorRef = $derived(
+    anchor ??
+      ((wrapperRef?.firstElementChild ?? undefined) as HTMLElement | undefined),
   );
 
   $effect(() => {
@@ -82,20 +87,23 @@
   });
 
   $effect(() => {
+    if (hidden) {
+      return;
+    }
     const showListener = () => (isTooltipVisible = true);
     const hideListener = () => (isTooltipVisible = false);
     const toggleListener = () => (isTooltipVisible = false);
-    anchorRef?.addEventListener("mouseenter", showListener);
-    anchorRef?.addEventListener("mouseleave", hideListener);
-    anchorRef?.addEventListener("focusin", showListener);
-    anchorRef?.addEventListener("focusout", hideListener);
-    anchorRef?.addEventListener("touchend", toggleListener);
+    wrapperRef?.addEventListener("mouseenter", showListener);
+    wrapperRef?.addEventListener("mouseleave", hideListener);
+    wrapperRef?.addEventListener("focusin", showListener);
+    wrapperRef?.addEventListener("focusout", hideListener);
+    wrapperRef?.addEventListener("touchend", toggleListener);
     return () => {
-      anchorRef?.removeEventListener("mouseenter", showListener);
-      anchorRef?.removeEventListener("mouseleave", hideListener);
-      anchorRef?.removeEventListener("focusin", showListener);
-      anchorRef?.removeEventListener("focusout", hideListener);
-      anchorRef?.addEventListener("touchend", toggleListener);
+      wrapperRef?.removeEventListener("mouseenter", showListener);
+      wrapperRef?.removeEventListener("mouseleave", hideListener);
+      wrapperRef?.removeEventListener("focusin", showListener);
+      wrapperRef?.removeEventListener("focusout", hideListener);
+      wrapperRef?.addEventListener("touchend", toggleListener);
     };
   });
 

--- a/src/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/src/frontend/src/lib/components/ui/Tooltip.svelte
@@ -32,6 +32,7 @@
   let wrapperRef = $state<HTMLElement>();
   let tooltipRef = $state<HTMLElement>();
   let isTooltipVisible = $state(false);
+
   const anchorRef = $derived(
     anchor ??
       ((wrapperRef?.firstElementChild ?? undefined) as HTMLElement | undefined),

--- a/src/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/src/frontend/src/lib/components/ui/Tooltip.svelte
@@ -88,27 +88,6 @@
   });
 
   $effect(() => {
-    if (hidden) {
-      return;
-    }
-    const showListener = () => (isTooltipVisible = true);
-    const hideListener = () => (isTooltipVisible = false);
-    const toggleListener = () => (isTooltipVisible = false);
-    wrapperRef?.addEventListener("mouseenter", showListener);
-    wrapperRef?.addEventListener("mouseleave", hideListener);
-    wrapperRef?.addEventListener("focusin", showListener);
-    wrapperRef?.addEventListener("focusout", hideListener);
-    wrapperRef?.addEventListener("touchend", toggleListener);
-    return () => {
-      wrapperRef?.removeEventListener("mouseenter", showListener);
-      wrapperRef?.removeEventListener("mouseleave", hideListener);
-      wrapperRef?.removeEventListener("focusin", showListener);
-      wrapperRef?.removeEventListener("focusout", hideListener);
-      wrapperRef?.addEventListener("touchend", toggleListener);
-    };
-  });
-
-  $effect(() => {
     if (isTooltipVisible) {
       tooltipRef?.showPopover();
     } else {
@@ -117,93 +96,113 @@
   });
 </script>
 
-<div bind:this={wrapperRef} class="contents" aria-describedby={id}>
+{#if hidden}
   {@render children?.()}
-</div>
-<div
-  {id}
-  {...restProps}
-  bind:this={tooltipRef}
-  popover={"manual"}
-  class="tooltip pointer-events-none fixed overflow-visible bg-transparent"
-  role="tooltip"
->
+{:else}
+  <!-- Wrapper used for event handlers and (optionally) anchoring -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class={[
-      "bg-fg-primary relative flex max-w-80 flex-col items-start rounded-lg p-3 drop-shadow-lg",
-      {
-        up: {
-          start: "origin-[1.6rem_100%]",
-          center: "origin-bottom",
-          end: "origin-[calc(100%-1.6rem)_100%]",
-        }[align],
-        right: {
-          start: "origin-[0_1.6rem]",
-          center: "origin-left",
-          end: "origin-[0_calc(100%-1.6rem)]",
-        }[align],
-        down: {
-          start: "origin-[1.6rem_0]",
-          center: "origin-top",
-          end: "origin-[calc(100%-1.6rem)_0]",
-        }[align],
-        left: {
-          start: "origin-[100%_1.6rem]",
-          center: "origin-right",
-          end: "origin-[100%_calc(100%-1.6rem)]",
-        }[align],
-      }[direction],
-      className,
-    ]}
+    bind:this={wrapperRef}
+    onmouseenter={() => (isTooltipVisible = true)}
+    onmouseleave={() => (isTooltipVisible = false)}
+    onfocusin={() => (isTooltipVisible = true)}
+    onfocusout={() => (isTooltipVisible = false)}
+    ontouchend={() => (isTooltipVisible = !isTooltipVisible)}
+    class="contents"
+    aria-describedby={id}
   >
-    <span class="text-bg-primary text-start text-xs font-semibold">{label}</span
-    >
-    {#if nonNullish(description)}
-      <span class="text-bg-tertiary mt-1 text-start text-xs font-medium">
-        {description}
-      </span>
-    {/if}
+    {@render children?.()}
+  </div>
+  <!-- Tooltip wrapper that doesn't animate so its dimensions don't change -->
+  <div
+    {id}
+    {...restProps}
+    bind:this={tooltipRef}
+    popover={"manual"}
+    class="tooltip pointer-events-none fixed overflow-visible bg-transparent"
+    role="tooltip"
+  >
+    <!-- Tooltip inner container that animates -->
     <div
       class={[
-        "absolute size-0",
+        "bg-fg-primary relative flex max-w-80 flex-col items-start rounded-lg p-3 drop-shadow-lg",
         {
           up: {
-            start: "bottom-0 left-7",
-            center: "bottom-0 left-[50%]",
-            end: "right-7 bottom-0",
+            start: "origin-[1.6rem_100%]",
+            center: "origin-bottom",
+            end: "origin-[calc(100%-1.6rem)_100%]",
           }[align],
           right: {
-            start: "top-7 left-0",
-            center: "top-[50%] left-0",
-            end: "bottom-7 left-0",
+            start: "origin-[0_1.6rem]",
+            center: "origin-left",
+            end: "origin-[0_calc(100%-1.6rem)]",
           }[align],
           down: {
-            start: "top-0 left-7",
-            center: "top-0 left-[50%]",
-            end: "top-0 right-7",
+            start: "origin-[1.6rem_0]",
+            center: "origin-top",
+            end: "origin-[calc(100%-1.6rem)_0]",
           }[align],
           left: {
-            start: "top-7 right-0",
-            center: "top-[50%] right-0",
-            end: "right-0 bottom-7",
+            start: "origin-[100%_1.6rem]",
+            center: "origin-right",
+            end: "origin-[100%_calc(100%-1.6rem)]",
           }[align],
         }[direction],
+        className,
       ]}
     >
+      <!-- Tooltip content -->
+      <span class="text-bg-primary text-start text-xs font-semibold"
+        >{label}</span
+      >
+      {#if nonNullish(description)}
+        <span class="text-bg-tertiary mt-1 text-start text-xs font-medium">
+          {description}
+        </span>
+      {/if}
+      <!-- Tooltip arrow -->
       <div
         class={[
-          "bg-fg-primary size-2 origin-center -translate-1 rotate-45",
+          "absolute size-0",
           {
-            up: "rounded-br-xs",
-            right: "rounded-bl-xs",
-            down: "rounded-tl-xs",
-            left: "rounded-tr-xs",
+            up: {
+              start: "bottom-0 left-7",
+              center: "bottom-0 left-[50%]",
+              end: "right-7 bottom-0",
+            }[align],
+            right: {
+              start: "top-7 left-0",
+              center: "top-[50%] left-0",
+              end: "bottom-7 left-0",
+            }[align],
+            down: {
+              start: "top-0 left-7",
+              center: "top-0 left-[50%]",
+              end: "top-0 right-7",
+            }[align],
+            left: {
+              start: "top-7 right-0",
+              center: "top-[50%] right-0",
+              end: "right-0 bottom-7",
+            }[align],
           }[direction],
         ]}
-      ></div>
+      >
+        <div
+          class={[
+            "bg-fg-primary size-2 origin-center -translate-1 rotate-45",
+            {
+              up: "rounded-br-xs",
+              right: "rounded-bl-xs",
+              down: "rounded-tl-xs",
+              left: "rounded-tr-xs",
+            }[direction],
+          ]}
+        ></div>
+      </div>
     </div>
   </div>
-</div>
+{/if}
 
 <style>
   .tooltip {

--- a/src/frontend/src/routes/(new-styling)/authorize/(authenticated)/account/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/(authenticated)/account/+page.svelte
@@ -31,13 +31,13 @@
     ),
   );
 
-  const maxAccountsReached = $derived(accounts.length >= 5);
+  const isAccountLimitReached = $derived(accounts.length >= 5);
   const origin = $derived($authorizationContextStore.requestOrigin);
   const dapps = getDapps();
   const dapp = $derived(dapps.find((dapp) => dapp.hasOrigin(origin)));
 
-  let createAccountDialog = $state(false);
-  let loading = $state(false);
+  let isCreateAccountDialogVisible = $state(false);
+  let isAuthorizing = $state(false);
   let tooltipAnchorRef = $state<HTMLElement>();
 
   const createAccount = async (name: string) => {
@@ -53,12 +53,12 @@
     } catch (error) {
       handleError(error);
     } finally {
-      createAccountDialog = false;
+      isCreateAccountDialogVisible = false;
     }
   };
 
   const continueAs = async (account: AccountInfo) => {
-    loading = true;
+    isAuthorizing = true;
     lastUsedIdentitiesStore.addLastUsedAccount({
       origin: $authorizationContextStore.effectiveOrigin,
       identityNumber: $authenticatedStore.identityNumber,
@@ -95,7 +95,10 @@
     <ul class="contents">
       {#each accounts as account}
         <li class="contents">
-          <ButtonCard onclick={() => continueAs(account)} disabled={loading}>
+          <ButtonCard
+            onclick={() => continueAs(account)}
+            disabled={isAuthorizing}
+          >
             <Avatar size="sm">
               {(account.name[0] ?? "Primary account").slice(0, 1).toUpperCase()}
             </Avatar>
@@ -112,16 +115,16 @@
       direction="down"
       align="start"
       anchor={tooltipAnchorRef}
-      hidden={!maxAccountsReached}
+      hidden={!isAccountLimitReached}
     >
       <ButtonCard
-        onclick={() => (createAccountDialog = true)}
-        disabled={loading || maxAccountsReached}
+        onclick={() => (isCreateAccountDialogVisible = true)}
+        disabled={isAuthorizing || isAccountLimitReached}
       >
         <FeaturedIcon
           bind:element={tooltipAnchorRef}
           size="sm"
-          class={[maxAccountsReached ? "opacity-50" : ""]}
+          class={[isAccountLimitReached ? "opacity-50" : ""]}
         >
           <PlusIcon size="1.25rem" />
         </FeaturedIcon>
@@ -130,8 +133,8 @@
     </Tooltip>
   </div>
 </div>
-{#if createAccountDialog}
-  <Dialog onClose={() => (createAccountDialog = false)}>
+{#if isCreateAccountDialogVisible}
+  <Dialog onClose={() => (isCreateAccountDialogVisible = false)}>
     <CreateAccount create={createAccount} />
   </Dialog>
 {/if}

--- a/src/frontend/src/routes/(new-styling)/authorize/(authenticated)/account/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/(authenticated)/account/+page.svelte
@@ -31,7 +31,7 @@
     ),
   );
 
-  const maxAccountsReached = $derived(accounts.length >= 0);
+  const maxAccountsReached = $derived(accounts.length >= 5);
   const origin = $derived($authorizationContextStore.requestOrigin);
   const dapps = getDapps();
   const dapp = $derived(dapps.find((dapp) => dapp.hasOrigin(origin)));

--- a/src/frontend/src/routes/(new-styling)/authorize/(authenticated)/account/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/(authenticated)/account/+page.svelte
@@ -22,6 +22,7 @@
   import { goto } from "$app/navigation";
   import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
   import type { AccountInfo } from "$lib/generated/internet_identity_types";
+  import Tooltip from "$lib/components/ui/Tooltip.svelte";
 
   const { data }: PageProps = $props();
   let accounts = $derived(
@@ -30,12 +31,14 @@
     ),
   );
 
+  const maxAccountsReached = $derived(accounts.length >= 0);
   const origin = $derived($authorizationContextStore.requestOrigin);
   const dapps = getDapps();
   const dapp = $derived(dapps.find((dapp) => dapp.hasOrigin(origin)));
 
   let createAccountDialog = $state(false);
   let loading = $state(false);
+  let tooltipAnchorRef = $state<HTMLElement>();
 
   const createAccount = async (name: string) => {
     try {
@@ -103,12 +106,28 @@
         </li>
       {/each}
     </ul>
-    <ButtonCard onclick={() => (createAccountDialog = true)} disabled={loading}>
-      <FeaturedIcon size="sm">
-        <PlusIcon size="1.25rem" />
-      </FeaturedIcon>
-      <span>Create additional account</span>
-    </ButtonCard>
+    <Tooltip
+      label="Limit reached"
+      description="You’ve reached the maximum of 5 accounts."
+      direction="down"
+      align="start"
+      anchor={tooltipAnchorRef}
+      hidden={!maxAccountsReached}
+    >
+      <ButtonCard
+        onclick={() => (createAccountDialog = true)}
+        disabled={loading || maxAccountsReached}
+      >
+        <FeaturedIcon
+          bind:element={tooltipAnchorRef}
+          size="sm"
+          class={[maxAccountsReached ? "opacity-50" : ""]}
+        >
+          <PlusIcon size="1.25rem" />
+        </FeaturedIcon>
+        <span>Create additional account</span>
+      </ButtonCard>
+    </Tooltip>
   </div>
 </div>
 {#if createAccountDialog}

--- a/src/frontend/tests/e2e-playwright/authorize/account.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/account.spec.ts
@@ -63,3 +63,25 @@ test("Create and authorize with additional account, then switch back to primary 
   expect(principal).toBe(expectedPrincipal);
   expect(principal).not.toBe(otherPrincipal);
 });
+
+test("Can't create more than 5 accounts", async ({ page }) => {
+  const auth = dummyAuth();
+  await createIdentity(page, "John Doe", auth);
+  await authorize(page, async (authPage) => {
+    auth(authPage);
+    await authPage
+      .getByRole("button", { name: "Create or use another account" })
+      .click();
+    for (let i = 1; i <= 4; i++) {
+      await authPage
+        .getByRole("button", { name: "Create additional account" })
+        .click();
+      await authPage.getByLabel("Account name").fill(`Additional account ${i}`);
+      await authPage.getByRole("button", { name: "Create account" }).click();
+    }
+    await expect(
+      authPage.getByRole("button", { name: "Create additional account" }),
+    ).toBeDisabled();
+    await authPage.getByRole("button", { name: "Primary account" }).click();
+  });
+});

--- a/src/frontend/tests/e2e-playwright/authorize/account.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/account.spec.ts
@@ -82,6 +82,7 @@ test("Can't create more than 5 accounts", async ({ page }) => {
     await expect(
       authPage.getByRole("button", { name: "Create additional account" }),
     ).toBeDisabled();
+    // Authentication needs to complete in `authorize()` to pass the test
     await authPage.getByRole("button", { name: "Primary account" }).click();
   });
 });


### PR DESCRIPTION
Frontend account limit per dapp, disable button and show tooltip when account limit has been reached.

# Changes

- Disable button when account limit has been reached
- Add tooltip to button when disabled (anchored to the inner FeatureIcon within)
- Add bindable element prop to FeaturedIcon component (so it can be anchored to)
- Add optional anchor prop to Tooltip component (so it can anchor to elements other than its direct child component)
- Fix cursor style on button, only apply it when the button isn't disabled.

# Tests

- Added e2e test "Can't create more than 5 accounts"

# Screenshot

![image](https://github.com/user-attachments/assets/e464485c-2570-45d7-b5df-b22d674a685b)






<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->




