### PR TITLE
Update identity name endpoint

### DIFF
--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -119,6 +119,24 @@ pub fn identity_metadata_replace(
     .map(|(x,)| x)
 }
 
+pub fn identity_properties_replace(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+    identity_number: IdentityNumber,
+    properties: &IdentityPropertiesReplace,
+) -> Result<Result<(), IdentityPropertiesReplaceError>, CallError> {
+    call_candid_as(
+        env,
+        canister_id,
+        RawEffectivePrincipal::None,
+        sender,
+        "identity_properties_replace",
+        (identity_number, properties),
+    )
+    .map(|(x,)| x)
+}
+
 pub fn authn_method_add(
     env: &PocketIc,
     canister_id: CanisterId,

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -349,6 +349,16 @@ export const idlFactory = ({ IDL }) => {
       'space_available' : IDL.Nat64,
     }),
   });
+  const IdentityPropertiesReplace = IDL.Record({ 'name' : IDL.Opt(IDL.Text) });
+  const IdentityPropertiesReplaceError = IDL.Variant({
+    'InternalCanisterError' : IDL.Text,
+    'Unauthorized' : IDL.Principal,
+    'NameTooLong' : IDL.Record({ 'limit' : IDL.Nat64 }),
+    'StorageSpaceExceeded' : IDL.Record({
+      'space_required' : IDL.Nat64,
+      'space_available' : IDL.Nat64,
+    }),
+  });
   const IdRegFinishArg = IDL.Record({
     'name' : IDL.Opt(IDL.Text),
     'authn_method' : AuthnMethodData,
@@ -614,6 +624,16 @@ export const idlFactory = ({ IDL }) => {
           IDL.Variant({
             'Ok' : IDL.Null,
             'Err' : IdentityMetadataReplaceError,
+          }),
+        ],
+        [],
+      ),
+    'identity_properties_replace' : IDL.Func(
+        [IdentityNumber, IdentityPropertiesReplace],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Null,
+            'Err' : IdentityPropertiesReplaceError,
           }),
         ],
         [],

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -236,6 +236,18 @@ export type IdentityMetadataReplaceError = {
     }
   };
 export type IdentityNumber = bigint;
+export interface IdentityPropertiesReplace { 'name' : [] | [string] }
+export type IdentityPropertiesReplaceError = {
+    'InternalCanisterError' : string
+  } |
+  { 'Unauthorized' : Principal } |
+  { 'NameTooLong' : { 'limit' : bigint } } |
+  {
+    'StorageSpaceExceeded' : {
+      'space_required' : bigint,
+      'space_available' : bigint,
+    }
+  };
 export interface InternetIdentityInit {
   'fetch_root_key' : [] | [boolean],
   'openid_google' : [] | [[] | [OpenIdConfig]],
@@ -487,6 +499,11 @@ export interface _SERVICE {
     [IdentityNumber, MetadataMapV2],
     { 'Ok' : null } |
       { 'Err' : IdentityMetadataReplaceError }
+  >,
+  'identity_properties_replace' : ActorMethod<
+    [IdentityNumber, IdentityPropertiesReplace],
+    { 'Ok' : null } |
+      { 'Err' : IdentityPropertiesReplaceError }
   >,
   'identity_registration_finish' : ActorMethod<
     [IdRegFinishArg],

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -522,6 +522,7 @@ type IdentityInfo = record {
     openid_credentials : opt vec OpenIdCredential;
     // Authentication method independent metadata
     metadata : MetadataMapV2;
+    name : opt text;
 };
 
 type IdentityInfoError = variant {
@@ -736,6 +737,22 @@ type DummyAuthConfig = record {
     prompt_for_index : bool;
 };
 
+type IdentityPropertiesReplace = record {
+    name : opt text;
+};
+
+type IdentityPropertiesReplaceError = variant {
+    Unauthorized : principal;
+    StorageSpaceExceeded : record {
+        space_available : nat64;
+        space_required : nat64;
+    };
+    NameTooLong : record {
+        limit : nat64;
+    };
+    InternalCanisterError : text;
+};
+
 service : (opt InternetIdentityInit) -> {
     // Legacy identity management API
     // ==============================
@@ -786,6 +803,11 @@ service : (opt InternetIdentityInit) -> {
     // The existing metadata map will be overwritten.
     // Requires authentication.
     identity_metadata_replace : (IdentityNumber, MetadataMapV2) -> (variant { Ok; Err : IdentityMetadataReplaceError });
+
+    // Replaces the identity properties.
+    // The existing properties will be overwritten.
+    // Requires authentication.
+    identity_properties_replace : (IdentityNumber, IdentityPropertiesReplace) -> (variant { Ok; Err : IdentityPropertiesReplaceError });
 
     // Adds a new authentication method to the identity.
     // Requires authentication.

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -9,7 +9,9 @@ use ic_cdk::{caller, trap};
 use internet_identity_interface::archive::types::{DeviceDataWithoutAlias, Operation};
 use internet_identity_interface::internet_identity::types::openid::OpenIdCredentialData;
 use internet_identity_interface::internet_identity::types::{
-    AnchorNumber, AuthorizationKey, CredentialId, DeviceData, DeviceKey, DeviceKeyWithAnchor, DeviceRegistrationInfo, DeviceWithUsage, IdentityAnchorInfo, IdentityPropertiesReplace, MetadataEntry
+    AnchorNumber, AuthorizationKey, CredentialId, DeviceData, DeviceKey, DeviceKeyWithAnchor,
+    DeviceRegistrationInfo, DeviceWithUsage, IdentityAnchorInfo, IdentityPropertiesReplace,
+    MetadataEntry,
 };
 use state::storage_borrow;
 use std::collections::HashMap;

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -9,8 +9,7 @@ use ic_cdk::{caller, trap};
 use internet_identity_interface::archive::types::{DeviceDataWithoutAlias, Operation};
 use internet_identity_interface::internet_identity::types::openid::OpenIdCredentialData;
 use internet_identity_interface::internet_identity::types::{
-    AnchorNumber, AuthorizationKey, CredentialId, DeviceData, DeviceKey, DeviceKeyWithAnchor,
-    DeviceRegistrationInfo, DeviceWithUsage, IdentityAnchorInfo, MetadataEntry,
+    AnchorNumber, AuthorizationKey, CredentialId, DeviceData, DeviceKey, DeviceKeyWithAnchor, DeviceRegistrationInfo, DeviceWithUsage, IdentityAnchorInfo, IdentityPropertiesReplace, MetadataEntry
 };
 use state::storage_borrow;
 use std::collections::HashMap;
@@ -194,6 +193,15 @@ pub fn identity_metadata_replace(
     let metadata_keys = metadata.keys().cloned().collect();
     anchor.replace_identity_metadata(metadata)?;
     Ok(Operation::IdentityMetadataReplace { metadata_keys })
+}
+
+/// Replaces the identity properties and returns the operation to be archived.
+/// Currently only supports setting the name property.
+pub fn identity_properties_replace(
+    anchor: &mut Anchor,
+    properties: IdentityPropertiesReplace,
+) -> Result<Operation, AnchorError> {
+    set_name(anchor, properties.name)
 }
 
 /// Adds an `OpenIdCredential` to the given anchor and returns the operation to be archived.

--- a/src/internet_identity/src/conversions/api_errors.rs
+++ b/src/internet_identity/src/conversions/api_errors.rs
@@ -5,7 +5,7 @@ use internet_identity_interface::internet_identity::types::vc_mvp::{
     GetIdAliasError, PrepareIdAliasError,
 };
 use internet_identity_interface::internet_identity::types::{
-    IdentityInfoError, IdentityMetadataReplaceError,
+    IdentityInfoError, IdentityMetadataReplaceError, IdentityPropertiesReplaceError,
 };
 
 impl From<IdentityUpdateError> for IdentityMetadataReplaceError {
@@ -62,6 +62,39 @@ impl From<IdentityUpdateError> for IdentityInfoError {
                 IdentityInfoError::Unauthorized(principal)
             }
             err => IdentityInfoError::InternalCanisterError(err.to_string()),
+        }
+    }
+}
+
+impl From<IdentityUpdateError> for IdentityPropertiesReplaceError {
+    fn from(value: IdentityUpdateError) -> Self {
+        let storage_err = match value {
+            IdentityUpdateError::Unauthorized(principal) => {
+                return IdentityPropertiesReplaceError::Unauthorized(principal)
+            }
+            IdentityUpdateError::StorageError(_, storage_err) => storage_err,
+        };
+
+        match storage_err {
+            StorageError::EntrySizeLimitExceeded {
+                space_available,
+                space_required,
+            } => IdentityPropertiesReplaceError::StorageSpaceExceeded {
+                space_available,
+                space_required,
+            },
+            err => IdentityPropertiesReplaceError::InternalCanisterError(err.to_string()),
+        }
+    }
+}
+
+impl From<AnchorError> for IdentityPropertiesReplaceError {
+    fn from(value: AnchorError) -> Self {
+        match value {
+            AnchorError::NameTooLong { limit } => {
+                IdentityPropertiesReplaceError::NameTooLong { limit }
+            }
+            err => IdentityPropertiesReplaceError::InternalCanisterError(err.to_string()),
         }
     }
 }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -739,6 +739,7 @@ mod v2_api {
                 .map(AuthnMethodRegistration::from),
             openid_credentials: anchor_info.openid_credentials,
             metadata,
+            name: anchor_info.name,
         };
         Ok(identity_info)
     }
@@ -836,6 +837,20 @@ mod v2_api {
                 (),
                 anchor_management::identity_metadata_replace(anchor, metadata)
                     .map_err(IdentityMetadataReplaceError::from)?,
+            ))
+        })
+    }
+
+    #[update]
+    fn identity_properties_replace(
+        identity_number: IdentityNumber,
+        properties: IdentityPropertiesReplace,
+    ) -> Result<(), IdentityPropertiesReplaceError> {
+        anchor_operation_with_authz_check(identity_number, |anchor| {
+            Ok::<_, IdentityPropertiesReplaceError>((
+                (),
+                anchor_management::identity_properties_replace(anchor, properties)
+                    .map_err(IdentityPropertiesReplaceError::from)?,
             ))
         })
     }

--- a/src/internet_identity/tests/integration/v2_api/identity_properties.rs
+++ b/src/internet_identity/tests/integration/v2_api/identity_properties.rs
@@ -1,0 +1,139 @@
+use crate::v2_api::authn_method_test_helpers::{
+    create_identity_with_authn_method, test_authn_method,
+};
+use candid::Principal;
+use canister_tests::api::internet_identity::api_v2;
+use canister_tests::framework::{env, install_ii_with_archive};
+use internet_identity_interface::internet_identity::types::{
+    IdentityPropertiesReplace, IdentityPropertiesReplaceError,
+};
+use pocket_ic::CallError;
+
+#[test]
+fn should_set_name() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let authn_method = test_authn_method();
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
+
+    let identity_info =
+        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?
+            .expect("identity info failed");
+    assert!(identity_info.name.is_none());
+
+    let properties = IdentityPropertiesReplace {
+        name: Some("Test Name".to_string()),
+    };
+
+    api_v2::identity_properties_replace(
+        &env,
+        canister_id,
+        authn_method.principal(),
+        identity_number,
+        &properties,
+    )?
+    .expect("identity properties replace failed");
+
+    let identity_info =
+        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?
+            .expect("identity info failed");
+    assert_eq!(identity_info.name, Some("Test Name".to_string()));
+    Ok(())
+}
+
+#[test]
+fn should_clear_name() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let authn_method = test_authn_method();
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
+
+    // First set a name
+    let properties = IdentityPropertiesReplace {
+        name: Some("Test Name".to_string()),
+    };
+
+    api_v2::identity_properties_replace(
+        &env,
+        canister_id,
+        authn_method.principal(),
+        identity_number,
+        &properties,
+    )?
+    .expect("identity properties replace failed");
+
+    // Verify name is set
+    let identity_info =
+        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?
+            .expect("identity info failed");
+    assert_eq!(identity_info.name, Some("Test Name".to_string()));
+
+    // Now clear the name
+    let properties = IdentityPropertiesReplace { name: None };
+
+    api_v2::identity_properties_replace(
+        &env,
+        canister_id,
+        authn_method.principal(),
+        identity_number,
+        &properties,
+    )?
+    .expect("identity properties replace failed");
+
+    // Verify name is cleared
+    let identity_info =
+        api_v2::identity_info(&env, canister_id, authn_method.principal(), identity_number)?
+            .expect("identity info failed");
+    assert!(identity_info.name.is_none());
+    Ok(())
+}
+
+#[test]
+fn should_require_authentication_to_replace_identity_properties() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let authn_method = test_authn_method();
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
+
+    let properties = IdentityPropertiesReplace {
+        name: Some("Test Name".to_string()),
+    };
+
+    let result = api_v2::identity_properties_replace(
+        &env,
+        canister_id,
+        Principal::anonymous(),
+        identity_number,
+        &properties,
+    )?;
+    assert!(matches!(
+        result,
+        Err(IdentityPropertiesReplaceError::Unauthorized(_))
+    ));
+    Ok(())
+}
+
+#[test]
+fn should_not_set_too_long_name() -> Result<(), CallError> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let authn_method = test_authn_method();
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &authn_method);
+
+    let properties = IdentityPropertiesReplace {
+        name: Some("a".repeat(3000)), // Very long name
+    };
+
+    let result = api_v2::identity_properties_replace(
+        &env,
+        canister_id,
+        authn_method.principal(),
+        identity_number,
+        &properties,
+    )?;
+    assert!(matches!(
+        result,
+        Err(IdentityPropertiesReplaceError::StorageSpaceExceeded { .. })
+    ));
+    Ok(())
+}

--- a/src/internet_identity/tests/integration/v2_api/mod.rs
+++ b/src/internet_identity/tests/integration/v2_api/mod.rs
@@ -8,4 +8,5 @@ pub mod authn_method_test_helpers;
 mod identity_authn_info;
 mod identity_info;
 mod identity_metadata;
+mod identity_properties;
 mod identity_register;

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -80,6 +80,7 @@ pub struct IdentityInfo {
     pub authn_method_registration: Option<AuthnMethodRegistration>,
     pub openid_credentials: Option<Vec<OpenIdCredentialData>>,
     pub metadata: HashMap<String, MetadataEntryV2>,
+    pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -148,6 +149,24 @@ pub enum IdentityMetadataReplaceError {
     StorageSpaceExceeded {
         space_available: u64,
         space_required: u64,
+    },
+    InternalCanisterError(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct IdentityPropertiesReplace {
+    pub name: Option<String>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum IdentityPropertiesReplaceError {
+    Unauthorized(Principal),
+    StorageSpaceExceeded {
+        space_available: u64,
+        space_required: u64,
+    },
+    NameTooLong {
+        limit: usize,
     },
     InternalCanisterError(String),
 }


### PR DESCRIPTION
# Motivation

When migrating an identity to new flow, we want to let them choose a name.

Until now, the name was only set during registration.

In this PR, I introduce a new endpoint "identity_properties_replace" (following current patterns) to update the name of an identity.

# Changes

* New update function `identity_properties_replace` in main.rs
* Introdced a new function in anchor_management `identity_properties_replace`.
* Updated the `service` definition in `src/internet_identity/internet_identity.did` to include the new `identity_properties_replace` endpoint, which overwrites existing properties and requires authentication.
* Introduced `IdentityPropertiesReplace` and `IdentityPropertiesReplaceError` types in `src/internet_identity/internet_identity.did` and `src/internet_identity_interface/src/internet_identity/types/api_v2.rs` to represent the properties being replaced and potential errors.
* Added a `name` field to the `IdentityInfo` structure to return the identity's name.
* Implemented conversions from `IdentityUpdateError` and `AnchorError` to `IdentityPropertiesReplaceError` in `src/internet_identity/src/conversions/api_errors.rs` to handle various error scenarios like unauthorized access, storage space exceeded, and name length violations.


# Tests

* Added a new function `identity_properties_replace` in `src/canister_tests/src/api/internet_identity/api_v2.rs` to allow replacing identity properties via the API.
* Added comprehensive tests in `src/internet_identity/tests/integration/v2_api/identity_properties.rs` to verify functionality, including setting, clearing, and validating restrictions on the `name` property.
* Registered the new test module in `src/internet_identity/tests/integration/v2_api/mod.rs`.
