### PR TITLE
Update identity name in migration flow

### DIFF
--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -80,11 +80,6 @@ export class MigrationFlow {
       uaParser,
       aaguid: passkeyIdentity.getAaguid(),
     });
-
-    const info = await get(authenticatedStore).actor.identity_info(
-      this.identityNumber,
-    );
-    console.log("in da create before setting name", info);
     const credentialId = passkeyIdentity.getCredentialId();
     if (isNullish(credentialId)) {
       throw new Error("Credential ID is null");
@@ -148,10 +143,6 @@ export class MigrationFlow {
         },
       },
     });
-    const info2 = await get(authenticatedStore).actor.identity_info(
-      this.identityNumber,
-    );
-    console.log("in da create after setting name", info2);
     this.view = "success";
   };
 

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -334,6 +334,7 @@ export const idlFactory = ({ IDL }) => {
   const IdentityInfo = IDL.Record({
     'authn_methods' : IDL.Vec(AuthnMethodData),
     'metadata' : MetadataMapV2,
+    'name' : IDL.Opt(IDL.Text),
     'authn_method_registration' : IDL.Opt(AuthnMethodRegistrationInfo),
     'openid_credentials' : IDL.Opt(IDL.Vec(OpenIdCredential)),
   });

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -220,6 +220,7 @@ export interface IdentityAuthnInfo {
 export interface IdentityInfo {
   'authn_methods' : Array<AuthnMethodData>,
   'metadata' : MetadataMapV2,
+  'name' : [] | [string],
   'authn_method_registration' : [] | [AuthnMethodRegistrationInfo],
   'openid_credentials' : [] | [Array<OpenIdCredential>],
 }


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

When migrating an identity to new flow, we want to let them choose a name.

In this PR, the name entered during migration is used to update the identity name in the canister.

# Changes

* Added functionality to update the identity name in the canister using the `identity_properties_replace` method. This ensures the identity name is properly set during the migration flow.
* Added missing declaration of "name" within the IdentityInfo.

# Tests

Tested locally by fetching the identity info before and after migration. See screenshot attached.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
