### PR TITLE
Fix placeholder width on mobile

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
@@ -21,7 +21,7 @@
     <h1 class="text-text-primary text-3xl font-semibold">
       Welcome,
       {#if !identityInfo.name}
-        <PlaceHolder class="mt-0.5 inline-block h-6 w-64" />
+        <PlaceHolder class="mt-0.5 inline-block h-6 w-40 md:w-64" />
       {:else}
         <span transition:fade={{ delay: 30 }}>
           {identityInfo.name}!


### PR DESCRIPTION
# Motivation

The name placeholder on the dashboard landing page is too wide - it breaks into a new line on modal, which leads to unnecessary jumps.

# Changes

Make the placeholder narrower on mobile to eliminate the jump (at least for short enough names).

Before: 
<video src="https://github.com/user-attachments/assets/2c8ee1f2-bc30-45ac-b167-0c9fb1955f18" />

After:
<video src="https://github.com/user-attachments/assets/215ff24f-0f57-42fb-b9f4-86d72fd76528" />


# Tests

- [x] Navigated to page, no longer jumpy

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
