### PR TITLE
Add toasts for openid add/remove failures

### DIFF
--- a/src/frontend/src/lib/stores/identity-info.state.svelte.ts
+++ b/src/frontend/src/lib/stores/identity-info.state.svelte.ts
@@ -3,6 +3,8 @@ import {
   AuthnMethodData,
   AuthnMethodRegistrationInfo,
   OpenIdCredential,
+  OpenIdCredentialAddError,
+  OpenIdCredentialRemoveError,
 } from "$lib/generated/internet_identity_types";
 import { authenticatedStore } from "./authentication.store";
 import { isNullish, nonNullish } from "@dfinity/utils";
@@ -13,6 +15,7 @@ import {
   decodeJWTWithNameAndEmail,
   requestJWT,
 } from "$lib/utils/openID";
+import { toaster } from "$lib/components/utils/toaster";
 
 const fetchIdentityInfo = async () => {
   const authenticated = get(authenticatedStore);
@@ -25,6 +28,35 @@ const fetchIdentityInfo = async () => {
     throw Error("Failed to fetch identity info");
 
   return identityInfoResponse.Ok;
+};
+
+const formatOpenIdAddError = (err: OpenIdCredentialAddError) => {
+  if ("OpenIdCredentialAlreadyRegistered" in err) {
+    return "This credential is already linked to another identity";
+  }
+  if ("Unauthorized" in err) {
+    return "You are not authorized to add this credential";
+  }
+  if ("InternalCanisterError" in err) {
+    return "An internal error occurred: " + err.InternalCanisterError;
+  }
+  if ("JwtVerificationFailed" in err) {
+    return "The JWT is invalid";
+  }
+  return "An unknown error occurred";
+};
+
+const formatOpenIdRemoveError = (err: OpenIdCredentialRemoveError) => {
+  if ("OpenIdCredentialNotFound" in err) {
+    return "This credential is not linked to this identity";
+  }
+  if ("Unauthorized" in err) {
+    return "You are not authorized to remove this credential";
+  }
+  if ("InternalCanisterError" in err) {
+    return "An internal error occurred: " + err.InternalCanisterError;
+  }
+  return "An unknown error occurred";
 };
 
 class IdentityInfo {
@@ -111,7 +143,11 @@ class IdentityInfo {
       this.openIdCredentials = this.openIdCredentials.filter(
         (cred) => !(cred.iss === iss && cred.sub === sub),
       );
-      throw new Error(Object.keys(await googleAddResult.Err)[0]);
+      toaster.error({
+        title: "Failed to add Google Account",
+        description: formatOpenIdAddError(googleAddResult.Err),
+      });
+      throw new Error(Object.keys(googleAddResult.Err)[0]);
     }
   };
 
@@ -142,6 +178,10 @@ class IdentityInfo {
       void this.fetch();
     } else {
       this.openIdCredentials.push(temporaryCredential);
+      toaster.error({
+        title: "Failed to remove Google Account",
+        description: formatOpenIdRemoveError(googleRemoveResult.Err),
+      });
       throw new Error(Object.keys(googleRemoveResult.Err)[0]);
     }
   };


### PR DESCRIPTION
# Motivation

Errors when adding/removing OpenID Credentials should give some user feedback.

# Changes

Add the toasts and formatting functions for the different error types.

# Tests

- [x] Tested adding an account that's already linked to another identity

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
