### PR TITLE
Fix mobile dashboard layout

### DIFF
--- a/src/frontend/src/lib/components/ui/AccessMethod.svelte
+++ b/src/frontend/src/lib/components/ui/AccessMethod.svelte
@@ -141,6 +141,6 @@
   .foldable-subgrid {
     display: grid;
     /* We may need to update the minimum width for really long emails, but it seems fine for now.  */
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   }
 </style>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
@@ -45,7 +45,9 @@
       <div
         class="border-border-tertiary col-span-3 grid grid-cols-subgrid border-t px-4 py-4"
       >
-        <h5 class="text-text-tertiary flex min-w-30 items-center pr-4 text-sm">
+        <h5
+          class="text-text-tertiary flex min-w-30 items-center pr-2 text-sm md:pr-4"
+        >
           Identity Name
         </h5>
         <div class="flex items-center">
@@ -76,7 +78,7 @@
         aria-label="Go to Security"
       >
         <h5
-          class="text-text-tertiary flex min-w-30 items-center pr-4 text-sm nth-[2]:hidden"
+          class="text-text-tertiary flex min-w-30 items-center pr-2 text-sm nth-[2]:hidden md:pr-4"
         >
           Access Methods
         </h5>


### PR DESCRIPTION
# Motivation

There's a small layout bug in the current minimal dashboard on some mobile phones.

# Changes

Small css changes to alleviate the bug. Will need to check with Design about potentially changing font size on mobile.

Before:
<img width="388" alt="Screenshot 2025-06-27 at 14 58 32" src="https://github.com/user-attachments/assets/f16277b8-875f-483a-913c-423dddb8016e" />

After:
<img width="388" alt="Screenshot 2025-06-27 at 14 58 10" src="https://github.com/user-attachments/assets/06edf398-2dfb-4646-b4ea-3f2c0b4e76a3" />

# Tests

- [x] Looked at it with my eyeballs
