### PR TITLE
Set "preferred" user verification during user migration

### DIFF
--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -74,6 +74,8 @@ export class MigrationFlow {
       webAuthnAuthenticators,
       currentFlow?.rpId,
       currentFlow?.useIframe ?? false,
+      // Set user verification to preferred to ensure the user is verified during migration.
+      "preferred",
     );
     try {
       const session = get(sessionStore);

--- a/src/frontend/src/lib/utils/multiWebAuthnIdentity.ts
+++ b/src/frontend/src/lib/utils/multiWebAuthnIdentity.ts
@@ -36,7 +36,6 @@ export class MultiWebAuthnIdentity extends SignIdentity {
 
   /* Set after the first `sign`, see `sign()` for more info. */
   protected _actualIdentity?: WebAuthnIdentity;
-  private _userVerification: "discouraged" | "required" | "preferred";
 
   protected constructor(
     readonly credentialData: CredentialData[],
@@ -49,7 +48,6 @@ export class MultiWebAuthnIdentity extends SignIdentity {
   ) {
     super();
     this._actualIdentity = undefined;
-    this._userVerification = userVerification;
   }
 
   /* This whole class is a bit of a hack since we can only consider it a
@@ -85,7 +83,7 @@ export class MultiWebAuthnIdentity extends SignIdentity {
           id: cd.credentialId,
         })),
         challenge: blob,
-        userVerification: this._userVerification,
+        userVerification: this.userVerification,
         rpId: this.rpId,
       },
     };

--- a/src/frontend/src/lib/utils/multiWebAuthnIdentity.ts
+++ b/src/frontend/src/lib/utils/multiWebAuthnIdentity.ts
@@ -29,20 +29,27 @@ export class MultiWebAuthnIdentity extends SignIdentity {
     credentialData: CredentialData[],
     rpId: string | undefined,
     iframe: boolean | undefined,
+    userVerification: "discouraged" | "required" | "preferred" = "discouraged",
   ): MultiWebAuthnIdentity {
-    return new this(credentialData, rpId, iframe);
+    return new this(credentialData, rpId, iframe, userVerification);
   }
 
   /* Set after the first `sign`, see `sign()` for more info. */
   protected _actualIdentity?: WebAuthnIdentity;
+  private _userVerification: "discouraged" | "required" | "preferred";
 
   protected constructor(
     readonly credentialData: CredentialData[],
     readonly rpId: string | undefined,
     readonly iframe: boolean | undefined,
+    readonly userVerification:
+      | "discouraged"
+      | "required"
+      | "preferred" = "discouraged",
   ) {
     super();
     this._actualIdentity = undefined;
+    this._userVerification = userVerification;
   }
 
   /* This whole class is a bit of a hack since we can only consider it a
@@ -78,7 +85,7 @@ export class MultiWebAuthnIdentity extends SignIdentity {
           id: cd.credentialId,
         })),
         challenge: blob,
-        userVerification: "discouraged",
+        userVerification: this._userVerification,
         rpId: this.rpId,
       },
     };


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Internet Identity uses "preferred" user verification. Therefore, the migration flow should also use it.

# Changes

* Add optional parameter to `MultiWebAuthnIdentity` to set `userVerification` option when requesting credentials.
* Pass `"preferred"` to `MultiWebAuthnIdentity` during migration flow.

# Tests

Tested locally:
1. Created a user with 1.0 with Yubikey.
2. Logged in with that user in 1.0 (no PIN required)
3. Went to 2.0 flow.
4. Triggered the migration
5. Yubikey PIN required
6. Successfully migrated


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

