### PR TITLE
Fix popover shadows

### DIFF
--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -103,7 +103,6 @@
       popoverRef?.classList.add("shadow-xl");
     }}
     onoutrostart={() => {
-      popoverRef?.classList.remove("shadow-xl");
       popoverRef?.hidePopover();
     }}
     class="popover slow-shadow fixed rounded-xl bg-transparent"

--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -100,16 +100,15 @@
     out:fade|global={{ delay: 160, duration: 1 }}
     onintrostart={() => {
       popoverRef?.showPopover();
-      popoverRef?.classList.add("shadow-xl");
     }}
     onoutrostart={() => {
       popoverRef?.hidePopover();
     }}
-    class="popover slow-shadow fixed rounded-xl bg-transparent"
+    class="popover fixed overflow-visible bg-transparent"
   >
     <div
       class={[
-        "bg-bg-primary_alt border-border-secondary flex w-90 flex-col rounded-xl border p-4",
+        "bg-bg-primary_alt border-border-secondary flex w-90 flex-col rounded-xl border p-4 shadow-xl",
         {
           up: {
             start: "origin-bottom-left",
@@ -149,11 +148,6 @@
     transition-property: overlay, display;
     transition-duration: 0.16s;
     transition-behavior: allow-discrete;
-  }
-
-  .slow-shadow {
-    transition-property: box-shadow;
-    transition-duration: 0.8s;
   }
 
   .popover > div {

--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -98,12 +98,8 @@
     popover={closeOnOutsideClick ? "auto" : "manual"}
     in:fade|global={{ duration: 1 }}
     out:fade|global={{ delay: 160, duration: 1 }}
-    onintrostart={() => {
-      popoverRef?.showPopover();
-    }}
-    onoutrostart={() => {
-      popoverRef?.hidePopover();
-    }}
+    onintrostart={() => popoverRef?.showPopover()}
+    onoutrostart={() => popoverRef?.hidePopover()}
     class="popover fixed overflow-visible bg-transparent"
   >
     <div

--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -98,9 +98,15 @@
     popover={closeOnOutsideClick ? "auto" : "manual"}
     in:fade|global={{ duration: 1 }}
     out:fade|global={{ delay: 160, duration: 1 }}
-    onintrostart={() => popoverRef?.showPopover()}
-    onoutrostart={() => popoverRef?.hidePopover()}
-    class="popover fixed rounded-xl bg-transparent shadow-xl"
+    onintrostart={() => {
+      popoverRef?.showPopover();
+      popoverRef?.classList.add("shadow-xl");
+    }}
+    onoutrostart={() => {
+      popoverRef?.classList.remove("shadow-xl");
+      popoverRef?.hidePopover();
+    }}
+    class="popover slow-shadow fixed rounded-xl bg-transparent"
   >
     <div
       class={[
@@ -144,6 +150,11 @@
     transition-property: overlay, display;
     transition-duration: 0.16s;
     transition-behavior: allow-discrete;
+  }
+
+  .slow-shadow {
+    transition-property: box-shadow;
+    transition-duration: 0.8s;
   }
 
   .popover > div {

--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -100,11 +100,11 @@
     out:fade|global={{ delay: 160, duration: 1 }}
     onintrostart={() => popoverRef?.showPopover()}
     onoutrostart={() => popoverRef?.hidePopover()}
-    class="popover fixed bg-transparent"
+    class="popover fixed rounded-xl bg-transparent shadow-xl"
   >
     <div
       class={[
-        "bg-bg-primary_alt border-border-secondary flex w-90 flex-col rounded-xl border p-4 shadow-xl",
+        "bg-bg-primary_alt border-border-secondary flex w-90 flex-col rounded-xl border p-4",
         {
           up: {
             start: "origin-bottom-left",


### PR DESCRIPTION
# Motivation

The popover had a css bug that clipped its shadows.

# Changes

Move the shadow to the parent element, add some transition adjustments so it fades in smoothly.

Old:

<img width="422" alt="Screenshot 2025-07-01 at 10 57 09" src="https://github.com/user-attachments/assets/b79da01d-f6a2-4144-bfb3-cc13171ceb1e" />

New:

<img width="399" alt="Screenshot 2025-07-01 at 10 57 19" src="https://github.com/user-attachments/assets/f5ef6a6d-4913-4ba2-8777-acaf35df4bdf" />
<video src="https://github.com/user-attachments/assets/02af5ef4-7046-443c-9d24-9748f58b9098" />



# Tests

- [x] Tested with my eyes.



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


