### PR TITLE
Change global import for specific import in Archive

### DIFF
--- a/src/archive/src/main.rs
+++ b/src/archive/src/main.rs
@@ -53,7 +53,7 @@ use ic_stable_structures::{
 };
 use internet_identity_interface::archive::types::*;
 use internet_identity_interface::http_gateway::{HttpRequest, HttpResponse};
-use internet_identity_interface::internet_identity::types::*;
+use internet_identity_interface::internet_identity::types::{AnchorNumber, Timestamp};
 use serde_bytes::ByteBuf;
 use std::borrow::Cow;
 use std::cell::RefCell;


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Archive canister wasm changes with II interface changes.

# Changes

* Change the global import by the specific import in archive canister main file.

# Tests

I attempted to test this, but failed. I'll give it another shot. But it's such a small change that it's ok to just add it.