### PR TITLE
Prevent multiple google accounts from being added on the frontend.

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/security/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/security/+page.svelte
@@ -26,15 +26,17 @@
         </h4>
       </div>
 
-      <div>
-        <Button
-          onclick={() => {
-            displayAddCredentialDialog = true;
-          }}
-          class="bg-bg-brand-solid text-text-primary-inversed text-[] top-0 flex w-full items-center justify-center gap-1 rounded-sm px-3.5 py-2 font-semibold md:max-w-fit"
-          >Add <Plus size="1.25rem" /></Button
-        >
-      </div>
+      {#if identityInfo.openIdCredentials.length === 0}
+        <div>
+          <Button
+            onclick={() => {
+              displayAddCredentialDialog = true;
+            }}
+            class="bg-bg-brand-solid text-text-primary-inversed text-[] top-0 flex w-full items-center justify-center gap-1 rounded-sm px-3.5 py-2 font-semibold md:max-w-fit"
+            >Add <Plus size="1.25rem" /></Button
+          >
+        </div>
+      {/if}
     </div>
     <div
       class={`grid grid-cols-[min-content_1fr_min-content] grid-rows-[${identityInfo.totalAccessMethods}]`}


### PR DESCRIPTION
# Motivation

To comply with product management, we are limiting the number of google accounts that can be added to one.

# Changes

Hide the "Add" button when a google account is linked.
NOTE: This need to be updated once we have adding/removing other access methods.

# Tests

- [x] Added google account. Button disappeared.
