### PR TITLE
Improve Closed error message

### DIFF
--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -163,7 +163,7 @@
         orphan:
           "There was an issue connecting with the application. Try a different browser; if the issue persists, contact the developer.",
         closed:
-          "It seems like the connection with the service could not be established.",
+          "It seems like the connection with the service could not be established. Try a different browser; if the issue persists, contact support.",
         invalid:
           "It seems like an invalid authentication request was received.",
         failure:


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Telegram shows the "Closed" error when trying to authenticate with II on a in-app opened link.

However, II works if the user opens the link in another browser

# Changes

* Improve error message and suggest to try another browser.

# Tests

Not necessary.
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
