### PR TITLE
Validate derivation origin

### DIFF
--- a/src/frontend/src/lib/legacy/flows/authorize/index.ts
+++ b/src/frontend/src/lib/legacy/flows/authorize/index.ts
@@ -324,7 +324,7 @@ export const authFlowAuthorize = async (
     return window.location.assign("/") as never;
   }
 
-  if (result === "failure") {
+  if (result === "failure" || result === "unverified-origin") {
     showMessage({
       message: copy.auth_failed,
     });

--- a/src/frontend/src/lib/stores/authorization.store.ts
+++ b/src/frontend/src/lib/stores/authorization.store.ts
@@ -33,6 +33,7 @@ export type AuthorizationStatus =
   | "authenticating"
   | "authorizing"
   | "success"
+  | "unverified-origin"
   | "failure";
 
 type AuthorizationStore = Readable<{
@@ -76,10 +77,10 @@ export const authorizationStore: AuthorizationStore = {
         if (validationResult.result === "invalid") {
           internalStore.update((value) => ({
             ...value,
-            status: "invalid",
+            status: "unverified-origin",
           }));
           return {
-            kind: "failure",
+            kind: "unverified-origin",
             text: `Invalid derivation origin: ${validationResult.message}`,
           };
         }

--- a/src/frontend/src/lib/stores/authorization.store.ts
+++ b/src/frontend/src/lib/stores/authorization.store.ts
@@ -15,6 +15,7 @@ import {
 import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
 import { features } from "$lib/legacy/features";
 import { canisterConfig } from "$lib/globals";
+import { validateDerivationOrigin } from "$lib/utils/validateDerivationOrigin";
 
 export type AuthorizationContext = {
   authRequest: AuthRequest; // Additional details e.g. derivation origin
@@ -58,7 +59,7 @@ let authorize: (
 export const authorizationStore: AuthorizationStore = {
   init: async () => {
     const status = await authenticationProtocol({
-      authenticate: (context) => {
+      authenticate: async (context) => {
         const effectiveOrigin = remapToLegacyDomain(
           context.authRequest.derivationOrigin ?? context.requestOrigin,
         );
@@ -66,6 +67,23 @@ export const authorizationStore: AuthorizationStore = {
           context: { ...context, effectiveOrigin },
           status: "authenticating",
         });
+
+        const validationResult = await validateDerivationOrigin({
+          requestOrigin: context.requestOrigin,
+          derivationOrigin: context.authRequest.derivationOrigin,
+        });
+
+        if (validationResult.result === "invalid") {
+          internalStore.update((value) => ({
+            ...value,
+            status: "invalid",
+          }));
+          return {
+            kind: "failure",
+            text: `Invalid derivation origin: ${validationResult.message}`,
+          };
+        }
+
         return new Promise((resolve) => {
           authorize = async (accountNumber, artificialDelay = 0) => {
             internalStore.update((value) => ({

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -152,12 +152,13 @@
         <ProgressRing class="text-fg-primary size-14" />
         <p class="text-text-secondary text-lg">Redirecting to the app</p>
       </div>
-    {:else if status === "orphan" || status === "closed" || status === "invalid" || status === "failure"}
+    {:else if status === "orphan" || status === "closed" || status === "invalid" || status === "failure" || status === "unverified-origin"}
       {@const title = {
         orphan: "Missing request",
         closed: "Connection closed",
         invalid: "Invalid request",
         failure: "Something went wrong",
+        "unverified-origin": "Unverified origin",
       }[status]}
       {@const description = {
         orphan:
@@ -168,6 +169,8 @@
           "It seems like an invalid authentication request was received.",
         failure:
           "Something went wrong during authentication. Authenticating service was notified and you may close this page.",
+        "unverified-origin":
+          "There was an error verifying the origin of the request. Authenticating service was notified and you may close this page.",
       }[status]}
       <Dialog>
         <FeaturedIcon size="lg" variant="error" class="mb-4 self-start">


### PR DESCRIPTION
# Motivation

Derivation origin should be validated with the apps alternative origins.

# Changes

* Reuse `validateDerivationOrigin` to validate the derivation origin on init in authorization store.
* Add one more failure kind "unverified-origin" to show a more granular error message to help debugging.

# Tests

Deployed and tested in https://jqajs-xiaaa-aaaad-aab5q-cai.ic0.app/
1. Set alternative origins in "https://vt36r-2qaaa-aaaad-aad5a-cai.icp0.io" to "https://o6tmp-fqaaa-aaaad-aak5q-cai.icp0.io"
2. Set derivation origin to "https://vt36r-2qaaa-aaaad-aad5a-cai.icp0.io/" in "https://o6tmp-fqaaa-aaaad-aak5q-cai.icp0.io"
3. Logged in to https://jqajs-xiaaa-aaaad-aab5q-cai.ic0.app/?feature_flag_DISCOVERABLE_PASSKEY_FLOW=true from "https://o6tmp-fqaaa-aaaad-aak5q-cai.icp0.io"
4. It passed

Tried the same setting "https://nns.ic0.app" as derivation origin, and it failed.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
