### PR TITLE
Samsung Browser doesn't support FedCM with our params

### DIFF
--- a/src/frontend/src/lib/utils/openID.ts
+++ b/src/frontend/src/lib/utils/openID.ts
@@ -164,8 +164,6 @@ export const isFedCMSupported = (
   if (isSamsungBrowser) {
     return false;
   }
-
-  // Same check as in requestJWT
   return nonNullish(config.configURL) && "IdentityCredential" in window;
 };
 


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

User got stuck in a loading state when trying to authenticate with Google with a Samsung browser.

Samsung browser might use an older version of FedCM not compatible with our parameters.

# Changes

* Fallback to authentication with redirect for Samsung browsers.
* Created helper to check for FedCM support.

# Tests

Deployed to beta.
Tried to authenticate on beta with Google on Samsung browser after deploying.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

