### PR TITLE
Safari blocking Google popup

### DIFF
--- a/src/frontend/src/lib/flows/authFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.ts
@@ -142,7 +142,6 @@ export class AuthFlow {
       });
       this.#options.onSignIn(identityNumber);
     } catch (error) {
-      this.systemOverlay = false;
       if (
         isCanisterError<OpenIdDelegationError>(error) &&
         error.type === "NoSuchAnchor" &&
@@ -157,6 +156,8 @@ export class AuthFlow {
       }
       this.view = "chooseMethod";
       throw error;
+    } finally {
+      this.systemOverlay = false;
     }
   };
 

--- a/src/frontend/src/lib/flows/authFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.ts
@@ -122,7 +122,6 @@ export class AuthFlow {
       authenticationV2Funnel.trigger(AuthenticationV2Events.ContinueWithGoogle);
     }
     try {
-      this.systemOverlay = false;
       const { identity, identityNumber, iss, sub } = await authenticateWithJWT({
         canisterId,
         session: get(sessionStore),


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

During my testing round, Safari blocked the popup to authenticate with Google.

The reason must be similar to why II pop up is blocked in Safari. In our case, we were triggering analytics before opening the popup.

# Changes

* Move analytics call to after the popup is open.

# Tests

Deployed to beta, but I couldn't replicate the blocking anymore, so I can't test that this is indeed the solution.

According to the docs, it's not clear what is necessary for Safari to block or not block: https://webkit.org/blog/13862/the-user-activation-api/

Deployed to beta and tested that registering and signing it works.



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->



