### PR TITLE
Share error message on JWT verification

### DIFF
--- a/src/frontend/src/lib/components/utils/error.ts
+++ b/src/frontend/src/lib/components/utils/error.ts
@@ -10,6 +10,10 @@ import type {
   OpenIdCredentialRemoveError,
 } from "$lib/generated/internet_identity_types";
 import { isOpenIdCancelError } from "$lib/utils/openID";
+import {
+  AuthenticationV2Events,
+  authenticationV2Funnel,
+} from "$lib/utils/analytics/authenticationV2Funnel";
 
 export const handleError = (error: unknown) => {
   // Handle browser errors
@@ -68,8 +72,14 @@ export const handleError = (error: unknown) => {
       case "JwtVerificationFailed":
         toaster.error({
           title: "Authorization invalid",
-          description: `It may have expired — please try again. ${error.value(error.type)}`,
+          description: `It may have expired — please try again.`,
         });
+        authenticationV2Funnel.trigger(
+          AuthenticationV2Events.JwtVerificationFailed,
+          {
+            error: error.value(error.type),
+          },
+        );
         break;
       case "OpenIdCredentialNotFound":
         toaster.error({

--- a/src/frontend/src/lib/components/utils/error.ts
+++ b/src/frontend/src/lib/components/utils/error.ts
@@ -81,9 +81,9 @@ export const handleError = (error: unknown) => {
         break;
       case "JwtExpired":
         toaster.error({
-          title: "Expired Certificates",
+          title: "Expired JWT",
           description:
-            "Certificates have expired — please try again in a few minutes.",
+            "The JWT has expired — please try again in a few minutes.",
         });
         authenticationV2Funnel.trigger(
           AuthenticationV2Events.JwtVerificationExpired,

--- a/src/frontend/src/lib/components/utils/error.ts
+++ b/src/frontend/src/lib/components/utils/error.ts
@@ -68,7 +68,7 @@ export const handleError = (error: unknown) => {
       case "JwtVerificationFailed":
         toaster.error({
           title: "Authorization invalid",
-          description: "It may have expired — please try again",
+          description: `It may have expired — please try again. ${error.value(error.type)}`,
         });
         break;
       case "OpenIdCredentialNotFound":

--- a/src/frontend/src/lib/components/utils/error.ts
+++ b/src/frontend/src/lib/components/utils/error.ts
@@ -72,10 +72,21 @@ export const handleError = (error: unknown) => {
       case "JwtVerificationFailed":
         toaster.error({
           title: "Authorization invalid",
-          description: "It may have expired — please try again.",
+          description:
+            "There was an error verifying your account — please try again.",
         });
         authenticationV2Funnel.trigger(
           AuthenticationV2Events.JwtVerificationFailed,
+        );
+        break;
+      case "JwtExpired":
+        toaster.error({
+          title: "Expired Certificates",
+          description:
+            "Certificates have expired — please try again in a few minutes.",
+        });
+        authenticationV2Funnel.trigger(
+          AuthenticationV2Events.JwtVerificationExpired,
         );
         break;
       case "OpenIdCredentialNotFound":

--- a/src/frontend/src/lib/components/utils/error.ts
+++ b/src/frontend/src/lib/components/utils/error.ts
@@ -75,6 +75,9 @@ export const handleError = (error: unknown) => {
           description:
             "There was an error verifying your account — please try again.",
         });
+        // This is triggered also with errors from the dashboard.
+        // Plausible Funnels filter by the user triggering specific events before.
+        // Triggering the error here, means we'll get the total of these errors.
         authenticationV2Funnel.trigger(
           AuthenticationV2Events.JwtVerificationFailed,
         );
@@ -85,6 +88,9 @@ export const handleError = (error: unknown) => {
           description:
             "The JWT has expired — please try again in a few minutes.",
         });
+        // This is triggered also with errors from the dashboard.
+        // Plausible Funnels filter by the user triggering specific events before.
+        // Triggering the error here, means we'll get the total of these errors.
         authenticationV2Funnel.trigger(
           AuthenticationV2Events.JwtVerificationExpired,
         );

--- a/src/frontend/src/lib/components/utils/error.ts
+++ b/src/frontend/src/lib/components/utils/error.ts
@@ -72,13 +72,10 @@ export const handleError = (error: unknown) => {
       case "JwtVerificationFailed":
         toaster.error({
           title: "Authorization invalid",
-          description: `It may have expired — please try again.`,
+          description: "It may have expired — please try again.",
         });
         authenticationV2Funnel.trigger(
           AuthenticationV2Events.JwtVerificationFailed,
-          {
-            error: error.value(error.type),
-          },
         );
         break;
       case "OpenIdCredentialNotFound":

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -386,6 +386,7 @@ export const idlFactory = ({ IDL }) => {
   const OpenIdCredentialAddError = IDL.Variant({
     'OpenIdCredentialAlreadyRegistered' : IDL.Null,
     'InternalCanisterError' : IDL.Text,
+    'JwtExpired' : IDL.Null,
     'Unauthorized' : IDL.Principal,
     'JwtVerificationFailed' : IDL.Null,
   });
@@ -398,6 +399,7 @@ export const idlFactory = ({ IDL }) => {
   const OpenIdDelegationError = IDL.Variant({
     'NoSuchDelegation' : IDL.Null,
     'NoSuchAnchor' : IDL.Null,
+    'JwtExpired' : IDL.Null,
     'JwtVerificationFailed' : IDL.Null,
   });
   const OpenIDRegFinishArg = IDL.Record({ 'jwt' : JWT, 'salt' : Salt });

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -387,7 +387,7 @@ export const idlFactory = ({ IDL }) => {
     'OpenIdCredentialAlreadyRegistered' : IDL.Null,
     'InternalCanisterError' : IDL.Text,
     'Unauthorized' : IDL.Principal,
-    'JwtVerificationFailed' : IDL.Null,
+    'JwtVerificationFailed' : IDL.Text,
   });
   const OpenIdCredentialKey = IDL.Tuple(Iss, Sub);
   const OpenIdCredentialRemoveError = IDL.Variant({
@@ -398,7 +398,7 @@ export const idlFactory = ({ IDL }) => {
   const OpenIdDelegationError = IDL.Variant({
     'NoSuchDelegation' : IDL.Null,
     'NoSuchAnchor' : IDL.Null,
-    'JwtVerificationFailed' : IDL.Null,
+    'JwtVerificationFailed' : IDL.Text,
   });
   const OpenIDRegFinishArg = IDL.Record({ 'jwt' : JWT, 'salt' : Salt });
   const UserKey = PublicKey;

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -387,7 +387,7 @@ export const idlFactory = ({ IDL }) => {
     'OpenIdCredentialAlreadyRegistered' : IDL.Null,
     'InternalCanisterError' : IDL.Text,
     'Unauthorized' : IDL.Principal,
-    'JwtVerificationFailed' : IDL.Text,
+    'JwtVerificationFailed' : IDL.Null,
   });
   const OpenIdCredentialKey = IDL.Tuple(Iss, Sub);
   const OpenIdCredentialRemoveError = IDL.Variant({
@@ -398,7 +398,7 @@ export const idlFactory = ({ IDL }) => {
   const OpenIdDelegationError = IDL.Variant({
     'NoSuchDelegation' : IDL.Null,
     'NoSuchAnchor' : IDL.Null,
-    'JwtVerificationFailed' : IDL.Text,
+    'JwtVerificationFailed' : IDL.Null,
   });
   const OpenIDRegFinishArg = IDL.Record({ 'jwt' : JWT, 'salt' : Salt });
   const UserKey = PublicKey;

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -308,6 +308,7 @@ export type OpenIdCredentialAddError = {
     'OpenIdCredentialAlreadyRegistered' : null
   } |
   { 'InternalCanisterError' : string } |
+  { 'JwtExpired' : null } |
   { 'Unauthorized' : Principal } |
   { 'JwtVerificationFailed' : null };
 export type OpenIdCredentialKey = [Iss, Sub];
@@ -316,6 +317,7 @@ export type OpenIdCredentialRemoveError = { 'InternalCanisterError' : string } |
   { 'Unauthorized' : Principal };
 export type OpenIdDelegationError = { 'NoSuchDelegation' : null } |
   { 'NoSuchAnchor' : null } |
+  { 'JwtExpired' : null } |
   { 'JwtVerificationFailed' : null };
 export interface OpenIdPrepareDelegationResponse {
   'user_key' : UserKey,

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -309,14 +309,14 @@ export type OpenIdCredentialAddError = {
   } |
   { 'InternalCanisterError' : string } |
   { 'Unauthorized' : Principal } |
-  { 'JwtVerificationFailed' : string };
+  { 'JwtVerificationFailed' : null };
 export type OpenIdCredentialKey = [Iss, Sub];
 export type OpenIdCredentialRemoveError = { 'InternalCanisterError' : string } |
   { 'OpenIdCredentialNotFound' : null } |
   { 'Unauthorized' : Principal };
 export type OpenIdDelegationError = { 'NoSuchDelegation' : null } |
   { 'NoSuchAnchor' : null } |
-  { 'JwtVerificationFailed' : string };
+  { 'JwtVerificationFailed' : null };
 export interface OpenIdPrepareDelegationResponse {
   'user_key' : UserKey,
   'expiration' : Timestamp,

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -309,14 +309,14 @@ export type OpenIdCredentialAddError = {
   } |
   { 'InternalCanisterError' : string } |
   { 'Unauthorized' : Principal } |
-  { 'JwtVerificationFailed' : null };
+  { 'JwtVerificationFailed' : string };
 export type OpenIdCredentialKey = [Iss, Sub];
 export type OpenIdCredentialRemoveError = { 'InternalCanisterError' : string } |
   { 'OpenIdCredentialNotFound' : null } |
   { 'Unauthorized' : Principal };
 export type OpenIdDelegationError = { 'NoSuchDelegation' : null } |
   { 'NoSuchAnchor' : null } |
-  { 'JwtVerificationFailed' : null };
+  { 'JwtVerificationFailed' : string };
 export interface OpenIdPrepareDelegationResponse {
   'user_key' : UserKey,
   'expiration' : Timestamp,

--- a/src/frontend/src/lib/legacy/flows/manage/index.ts
+++ b/src/frontend/src/lib/legacy/flows/manage/index.ts
@@ -537,6 +537,9 @@ export const displayManage = async (
             case "JwtVerificationFailed":
               toast.error(copy.jwt_signature_invalid);
               break;
+            case "JwtExpired":
+              toast.error(copy.jwt_signature_invalid);
+              break;
             case "OpenIdCredentialAlreadyRegistered":
               toast.error(copy.account_already_linked);
               break;

--- a/src/frontend/src/lib/utils/analytics/authenticationV2Funnel.ts
+++ b/src/frontend/src/lib/utils/analytics/authenticationV2Funnel.ts
@@ -20,8 +20,10 @@ import { Funnel } from "./Funnel";
  *        register-with-google
  *          successful-google-registration
  *            auth-success
+ *          jwt-verification-failed
  *        login-with-google
  *          auth-success
+ *          jwt-verification-failed
  *      continue-with-passkey-screen
  *        register-with-passkey
  *          enter-name-screen
@@ -50,6 +52,7 @@ export const AuthenticationV2Events = {
   SuccessfulPasskeyRegistration: "successful-passkey-registration",
   UseExistingPasskey: "use-existing-passkey",
   AuthSuccess: "auth-success",
+  JwtVerificationFailed: "jwt-verification-failed",
 } as const;
 
 export const authenticationV2Funnel = new Funnel<typeof AuthenticationV2Events>(

--- a/src/frontend/src/lib/utils/analytics/authenticationV2Funnel.ts
+++ b/src/frontend/src/lib/utils/analytics/authenticationV2Funnel.ts
@@ -21,9 +21,11 @@ import { Funnel } from "./Funnel";
  *          successful-google-registration
  *            auth-success
  *          jwt-verification-failed
+ *          jwt-verification-expired
  *        login-with-google
  *          auth-success
  *          jwt-verification-failed
+ *          jwt-verification-expired
  *      continue-with-passkey-screen
  *        register-with-passkey
  *          enter-name-screen
@@ -53,6 +55,7 @@ export const AuthenticationV2Events = {
   UseExistingPasskey: "use-existing-passkey",
   AuthSuccess: "auth-success",
   JwtVerificationFailed: "jwt-verification-failed",
+  JwtVerificationExpired: "jwt-verification-expired",
 } as const;
 
 export const authenticationV2Funnel = new Funnel<typeof AuthenticationV2Events>(

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -381,7 +381,7 @@ type OpenIdCredential = record {
 
 type OpenIdCredentialAddError = variant {
     Unauthorized : principal;
-    JwtVerificationFailed : text;
+    JwtVerificationFailed;
     OpenIdCredentialAlreadyRegistered;
     InternalCanisterError : text;
 };
@@ -394,7 +394,7 @@ type OpenIdCredentialRemoveError = variant {
 
 type OpenIdDelegationError = variant {
     NoSuchAnchor;
-    JwtVerificationFailed : text;
+    JwtVerificationFailed;
     NoSuchDelegation;
 };
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -381,7 +381,7 @@ type OpenIdCredential = record {
 
 type OpenIdCredentialAddError = variant {
     Unauthorized : principal;
-    JwtVerificationFailed;
+    JwtVerificationFailed : text;
     OpenIdCredentialAlreadyRegistered;
     InternalCanisterError : text;
 };
@@ -394,7 +394,7 @@ type OpenIdCredentialRemoveError = variant {
 
 type OpenIdDelegationError = variant {
     NoSuchAnchor;
-    JwtVerificationFailed;
+    JwtVerificationFailed: text;
     NoSuchDelegation;
 };
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -384,6 +384,7 @@ type OpenIdCredentialAddError = variant {
     JwtVerificationFailed;
     OpenIdCredentialAlreadyRegistered;
     InternalCanisterError : text;
+    JwtExpired;
 };
 
 type OpenIdCredentialRemoveError = variant {
@@ -396,6 +397,7 @@ type OpenIdDelegationError = variant {
     NoSuchAnchor;
     JwtVerificationFailed;
     NoSuchDelegation;
+    JwtExpired;
 };
 
 type OpenIdPrepareDelegationResponse = record {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -394,7 +394,7 @@ type OpenIdCredentialRemoveError = variant {
 
 type OpenIdDelegationError = variant {
     NoSuchAnchor;
-    JwtVerificationFailed: text;
+    JwtVerificationFailed : text;
     NoSuchDelegation;
 };
 

--- a/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
+++ b/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
@@ -224,8 +224,7 @@ fn create_identity(arg: &CreateIdentityData) -> Result<IdentityNumber, IdRegFini
                 let openid_credential = provider.verify(jwt, salt)?;
                 let name = provider.metadata_name(openid_credential.metadata.clone());
                 Ok((openid_credential, name))
-            })
-            .map_err(IdRegFinishError::InvalidAuthnMethod)?;
+            })?;
             add_openid_credential(&mut identity, openid_credential.clone())
                 .map_err(|err| IdRegFinishError::InvalidAuthnMethod(err.to_string()))?;
             set_name(&mut identity, name)

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -969,7 +969,7 @@ mod openid_api {
         anchor_operation_with_authz_check(identity_number, |anchor| {
             let openid_credential =
                 openid::with_provider(&jwt, |provider| provider.verify(&jwt, &salt))
-                    .map_err(|_| OpenIdCredentialAddError::JwtVerificationFailed)?;
+                    .map_err(|err| OpenIdCredentialAddError::JwtVerificationFailed(err.to_string()))?;
             add_openid_credential(anchor, openid_credential)
                 .map(|operation| ((), operation))
                 .map_err(|err| match err {
@@ -1006,7 +1006,7 @@ mod openid_api {
     ) -> Result<OpenIdPrepareDelegationResponse, OpenIdDelegationError> {
         let openid_credential =
             openid::with_provider(&jwt, |provider| provider.verify(&jwt, &salt))
-                .map_err(|_| OpenIdDelegationError::JwtVerificationFailed)?;
+                .map_err(|err| OpenIdDelegationError::JwtVerificationFailed(err.to_string()))?;
 
         let anchor_number = lookup_anchor_with_openid_credential(&openid_credential.key())
             .ok_or(OpenIdDelegationError::NoSuchAnchor)?;
@@ -1047,7 +1047,7 @@ mod openid_api {
     ) -> Result<SignedDelegation, OpenIdDelegationError> {
         let openid_credential =
             openid::with_provider(&jwt, |provider| provider.verify(&jwt, &salt))
-                .map_err(|_| OpenIdDelegationError::JwtVerificationFailed)?;
+                .map_err(|err| OpenIdDelegationError::JwtVerificationFailed(err.to_string()))?;
 
         match lookup_anchor_with_openid_credential(&openid_credential.key()) {
             Some(anchor_number) => {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -952,12 +952,10 @@ mod openid_api {
     fn openid_identity_registration_finish(
         arg: OpenIDRegFinishArg,
     ) -> Result<IdRegFinishResult, IdRegFinishError> {
-        match openid::with_provider(&arg.jwt, |provider| provider.verify(&arg.jwt, &arg.salt)) {
-            Ok(_) => registration::registration_flow_v2::identity_registration_finish(
-                CreateIdentityData::OpenID(arg),
-            ),
-            Err(err) => Err(IdRegFinishError::InvalidAuthnMethod(err)),
-        }
+        openid::with_provider(&arg.jwt, |provider| provider.verify(&arg.jwt, &arg.salt))?;
+        registration::registration_flow_v2::identity_registration_finish(
+            CreateIdentityData::OpenID(arg),
+        )
     }
 
     #[update]
@@ -968,8 +966,7 @@ mod openid_api {
     ) -> Result<(), OpenIdCredentialAddError> {
         anchor_operation_with_authz_check(identity_number, |anchor| {
             let openid_credential =
-                openid::with_provider(&jwt, |provider| provider.verify(&jwt, &salt))
-                    .map_err(|_| OpenIdCredentialAddError::JwtVerificationFailed)?;
+                openid::with_provider(&jwt, |provider| provider.verify(&jwt, &salt))?;
             add_openid_credential(anchor, openid_credential)
                 .map(|operation| ((), operation))
                 .map_err(|err| match err {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -969,7 +969,7 @@ mod openid_api {
         anchor_operation_with_authz_check(identity_number, |anchor| {
             let openid_credential =
                 openid::with_provider(&jwt, |provider| provider.verify(&jwt, &salt))
-                    .map_err(|err| OpenIdCredentialAddError::JwtVerificationFailed(err.to_string()))?;
+                    .map_err(|_| OpenIdCredentialAddError::JwtVerificationFailed)?;
             add_openid_credential(anchor, openid_credential)
                 .map(|operation| ((), operation))
                 .map_err(|err| match err {
@@ -1006,7 +1006,7 @@ mod openid_api {
     ) -> Result<OpenIdPrepareDelegationResponse, OpenIdDelegationError> {
         let openid_credential =
             openid::with_provider(&jwt, |provider| provider.verify(&jwt, &salt))
-                .map_err(|err| OpenIdDelegationError::JwtVerificationFailed(err.to_string()))?;
+                .map_err(|_| OpenIdDelegationError::JwtVerificationFailed)?;
 
         let anchor_number = lookup_anchor_with_openid_credential(&openid_credential.key())
             .ok_or(OpenIdDelegationError::NoSuchAnchor)?;
@@ -1047,7 +1047,7 @@ mod openid_api {
     ) -> Result<SignedDelegation, OpenIdDelegationError> {
         let openid_credential =
             openid::with_provider(&jwt, |provider| provider.verify(&jwt, &salt))
-                .map_err(|err| OpenIdDelegationError::JwtVerificationFailed(err.to_string()))?;
+                .map_err(|_| OpenIdDelegationError::JwtVerificationFailed)?;
 
         match lookup_anchor_with_openid_credential(&openid_credential.key()) {
             Some(anchor_number) => {

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -66,7 +66,7 @@ impl From<OpenIDJWTVerificationError> for IdRegFinishError {
                 IdRegFinishError::InvalidAuthnMethod("JWT expired".to_string())
             }
             OpenIDJWTVerificationError::GenericError(msg) => {
-                IdRegFinishError::InvalidAuthnMethod(format!("JWT verification failed: {}", msg))
+                IdRegFinishError::InvalidAuthnMethod(format!("JWT verification failed: {msg}"))
             }
         }
     }

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -8,10 +8,9 @@ use ic_canister_sig_creation::{
 use ic_cdk::api::time;
 use ic_certification::Hash;
 use identity_jose::jws::Decoder;
-use internet_identity_interface::internet_identity::types::openid::OpenIdDelegationError;
+use internet_identity_interface::internet_identity::types::openid::{OpenIdCredentialAddError, OpenIdDelegationError};
 use internet_identity_interface::internet_identity::types::{
-    AnchorNumber, Delegation, MetadataEntryV2, OpenIdConfig, PublicKey, SessionKey,
-    SignedDelegation, Timestamp, UserKey,
+    AnchorNumber, Delegation, IdRegFinishError, MetadataEntryV2, OpenIdConfig, PublicKey, SessionKey, SignedDelegation, Timestamp, UserKey
 };
 use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
@@ -25,6 +24,43 @@ pub type OpenIdCredentialKey = (Iss, Sub);
 pub type Iss = String;
 pub type Sub = String;
 pub type Aud = String;
+
+#[derive(PartialEq, Eq, CandidType, Deserialize, Clone, Debug)]
+pub enum OpenIDJWTVerificationError {
+    GenericError(String),
+    JWTExpired,
+}
+
+// Implementation of From trait to convert OpenIDJWTVerificationError to OpenIdCredentialAddError
+impl From<OpenIDJWTVerificationError> for OpenIdCredentialAddError {
+    fn from(error: OpenIDJWTVerificationError) -> Self {
+        match error {
+            OpenIDJWTVerificationError::JWTExpired => OpenIdCredentialAddError::JwtExpired,
+            OpenIDJWTVerificationError::GenericError(_) => OpenIdCredentialAddError::JwtVerificationFailed,
+        }
+    }
+}
+
+// Implementation of From trait to convert OpenIDJWTVerificationError to OpenIdDelegationError
+impl From<OpenIDJWTVerificationError> for OpenIdDelegationError {
+    fn from(error: OpenIDJWTVerificationError) -> Self {
+        match error {
+            OpenIDJWTVerificationError::JWTExpired => OpenIdDelegationError::JwtExpired,
+            OpenIDJWTVerificationError::GenericError(_) => OpenIdDelegationError::JwtVerificationFailed,
+        }
+    }
+}
+
+// Implementation of From trait to convert OpenIDJWTVerificationError to IdRegFinishError
+impl From<OpenIDJWTVerificationError> for IdRegFinishError {
+    fn from(error: OpenIDJWTVerificationError) -> Self {
+        match error {
+            OpenIDJWTVerificationError::JWTExpired => IdRegFinishError::InvalidAuthnMethod("JWT expired".to_string()),
+            OpenIDJWTVerificationError::GenericError(msg) => IdRegFinishError::InvalidAuthnMethod(format!("JWT verification failed: {}", msg)),
+        }
+    }
+}
+
 
 #[derive(Debug, PartialEq, Eq, CandidType, Deserialize, Clone)]
 pub struct OpenIdCredential {
@@ -104,7 +140,7 @@ pub trait OpenIdProvider {
     ///
     /// * `jwt`: The JWT returned by the OpenID authentication flow with the OpenID provider
     /// * `salt`: The random salt that was used to bind the nonce to the caller principal
-    fn verify(&self, jwt: &str, salt: &[u8; 32]) -> Result<OpenIdCredential, String>;
+    fn verify(&self, jwt: &str, salt: &[u8; 32]) -> Result<OpenIdCredential, OpenIDJWTVerificationError>;
 
     fn metadata_name(&self, metadata: HashMap<String, MetadataEntryV2>) -> Option<String>;
 }
@@ -123,22 +159,22 @@ pub fn setup_google(config: OpenIdConfig) {
         .with_borrow_mut(|providers| providers.push(Box::new(google::Provider::create(config))));
 }
 
-pub fn with_provider<F, R>(jwt: &str, callback: F) -> Result<R, String>
+pub fn with_provider<F, R>(jwt: &str, callback: F) -> Result<R, OpenIDJWTVerificationError>
 where
-    F: FnOnce(&dyn OpenIdProvider) -> Result<R, String>,
+    F: FnOnce(&dyn OpenIdProvider) -> Result<R, OpenIDJWTVerificationError>,
 {
     let validation_item = Decoder::new()
         .decode_compact_serialization(jwt.as_bytes(), None)
-        .map_err(|_| "Failed to decode JWT")?;
+        .map_err(|_| OpenIDJWTVerificationError::GenericError("Failed to decode JWT".to_string( )))?;
 
     let claims: PartialClaims =
-        serde_json::from_slice(validation_item.claims()).map_err(|_| "Unable to decode claims")?;
+        serde_json::from_slice(validation_item.claims()).map_err(|_| OpenIDJWTVerificationError::GenericError("Unable to decode claims".to_string()))?;
 
     PROVIDERS.with_borrow(|providers| {
         providers
             .iter()
             .find(|provider| provider.issuer() == claims.iss)
-            .ok_or_else(|| format!("Unsupported issuer: {}", claims.iss))
+            .ok_or_else(|| OpenIDJWTVerificationError::GenericError(format!("Unsupported issuer: {}", claims.iss)))
             .and_then(|provider| callback(provider.as_ref()))
     })
 }
@@ -198,7 +234,7 @@ impl OpenIdProvider for ExampleProvider {
         "https://example.com"
     }
 
-    fn verify(&self, _: &str, _: &[u8; 32]) -> Result<OpenIdCredential, String> {
+    fn verify(&self, _: &str, _: &[u8; 32]) -> Result<OpenIdCredential, OpenIDJWTVerificationError> {
         Ok(self.credential())
     }
 
@@ -240,7 +276,7 @@ fn should_return_error_unsupported_issuer() {
 
     assert_eq!(
         with_provider(jwt, |provider| provider.verify(jwt, &[0u8; 32])),
-        Err("Unsupported issuer: https://example.com".into())
+        Err(OpenIDJWTVerificationError::GenericError("Unsupported issuer: https://example.com".to_string()))
     );
 }
 
@@ -251,7 +287,7 @@ fn should_return_error_when_encoding_invalid() {
     assert_eq!(
         with_provider(invalid_jwt, |provider| provider
             .verify(invalid_jwt, &[0u8; 32])),
-        Err("Failed to decode JWT".to_string())
+        Err(OpenIDJWTVerificationError::GenericError("Failed to decode JWT".to_string()))
     );
 }
 
@@ -262,6 +298,6 @@ fn should_return_error_when_claims_invalid() {
     assert_eq!(
         with_provider(jwt_without_issuer, |provider| provider
             .verify(jwt_without_issuer, &[0u8; 32])),
-        Err("Unable to decode claims".to_string())
+        Err(OpenIDJWTVerificationError::GenericError("Unable to decode claims".to_string()))
     );
 }

--- a/src/internet_identity_interface/src/internet_identity/types/openid.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/openid.rs
@@ -23,6 +23,7 @@ pub enum OpenIdCredentialAddError {
     JwtVerificationFailed,
     OpenIdCredentialAlreadyRegistered,
     InternalCanisterError(String),
+    JwtExpired,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -44,6 +45,7 @@ pub enum OpenIdDelegationError {
     NoSuchAnchor,
     NoSuchDelegation,
     JwtVerificationFailed,
+    JwtExpired,
 }
 
 pub type OpenIdCredentialKey = (Iss, Sub);

--- a/src/internet_identity_interface/src/internet_identity/types/openid.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/openid.rs
@@ -20,7 +20,7 @@ pub struct OpenIdCredentialData {
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum OpenIdCredentialAddError {
     Unauthorized(Principal),
-    JwtVerificationFailed(String),
+    JwtVerificationFailed,
     OpenIdCredentialAlreadyRegistered,
     InternalCanisterError(String),
 }
@@ -43,7 +43,7 @@ pub struct OpenIdPrepareDelegationResponse {
 pub enum OpenIdDelegationError {
     NoSuchAnchor,
     NoSuchDelegation,
-    JwtVerificationFailed(String),
+    JwtVerificationFailed,
 }
 
 pub type OpenIdCredentialKey = (Iss, Sub);

--- a/src/internet_identity_interface/src/internet_identity/types/openid.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/openid.rs
@@ -20,7 +20,7 @@ pub struct OpenIdCredentialData {
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum OpenIdCredentialAddError {
     Unauthorized(Principal),
-    JwtVerificationFailed,
+    JwtVerificationFailed(String),
     OpenIdCredentialAlreadyRegistered,
     InternalCanisterError(String),
 }
@@ -43,7 +43,7 @@ pub struct OpenIdPrepareDelegationResponse {
 pub enum OpenIdDelegationError {
     NoSuchAnchor,
     NoSuchDelegation,
-    JwtVerificationFailed,
+    JwtVerificationFailed(String),
 }
 
 pub type OpenIdCredentialKey = (Iss, Sub);


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

I got a few times an error when authenticating with Google that the verification failed.

However, I didn't get any reason for it.

In this PR, I add the text with the reason and send that to Plausible for debugging.

# Changes

* Add "String" to `JwtVerificationFailed` error types.
* Add event in `AuthenticationV2Events`.
* Trigger the error event when handling the error along with the error text.

# Tests

Hardcoded the following error in `throwCanisterError`: `throw new CanisterError({ JwtVerificationFailed: "Test error" });` and then triggered a Google auth and got the expected error and a console.log of the "Test error" text.



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


