### PR TITLE
Show dialog if users is still in II after successful auth

### DIFF
--- a/src/frontend/src/lib/stores/authorization.store.ts
+++ b/src/frontend/src/lib/stores/authorization.store.ts
@@ -24,14 +24,24 @@ export type AuthorizationContext = {
 };
 
 export type AuthorizationStatus =
+  // Not handled in `authorize/+layout.svelte`.
   | "init"
+  // Sent in postMessageInterface, kept for backwards compatibility.
+  // Not handled in `authorize/+layout.svelte`.
+  | "waiting"
+  // Sent in postMessageInterface, kept for backwards compatibility
+  // Not handled in `authorize/+layout.svelte`.
+  | "validating"
+  // Set on starting the authenticate flow.
+  | "authenticating"
+  // Set on starting the authorization flow.
+  | "authorizing"
+  // Set after "success" if the user is still here after 2 seconds.
+  | "late-success"
+  // All the following are returned by `authenticationProtocol`
+  | "invalid"
   | "orphan"
   | "closed"
-  | "waiting"
-  | "validating"
-  | "invalid"
-  | "authenticating"
-  | "authorizing"
   | "success"
   | "unverified-origin"
   | "failure";
@@ -155,6 +165,17 @@ export const authorizationStore: AuthorizationStore = {
         internalStore.update((value) => ({ ...value, status })),
     });
     internalStore.update((value) => ({ ...value, status }));
+    if (status === "success") {
+      const LATE_SUCCESS_MESSAGE_DELAY_MS = 2000;
+      // If the user is still here after 2 seconds, show a message
+      // "Authentication successful, close page"
+      setTimeout(() => {
+        internalStore.update((value) => ({
+          ...value,
+          status: "late-success",
+        }));
+      }, LATE_SUCCESS_MESSAGE_DELAY_MS);
+    }
   },
   subscribe: (...args) => internalStore.subscribe(...args),
   authorize: (accountNumber, artificialDelay) => {

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -183,6 +183,22 @@
           Return to app
         </Button>
       </Dialog>
+    {:else if status === "late-success"}
+      <Dialog>
+        <FeaturedIcon size="lg" class="mb-4 self-start">
+          <CircleAlertIcon size="1.5rem" />
+        </FeaturedIcon>
+        <h1 class="text-text-primary mb-3 text-2xl font-medium">
+          Authentication successful
+        </h1>
+        <p class="text-md text-text-tertiary mb-6 font-medium">
+          You may close this page.
+        </p>
+        <Button onclick={() => window.close()} variant="secondary">
+          <RotateCcwIcon size="1rem" />
+          Return to app
+        </Button>
+      </Dialog>
     {/if}
   </div>
   <Footer />


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Some users are stuck in II after successful auth because the window doesn't close.

II 1.0 had a message for those users to manually close the window.

# Changes

* Improve documentation on `AuthorizationStatus`.
* Add one more status "late-success".
* Show a dialog to prompt the user the close the window on "late-success" in authorize layout.
* Add a timeout on auth success to set the status to "late-success" after two seconds.

# Tests

I couldn't replicate the window not closing on successful auth. But I hardcoded a failure and triggered the timeout on that failure to simulate the ux on successful auth. See vide recording.
