### PR TITLE
Fix accessing dashboard after logout

### DIFF
--- a/src/frontend/src/lib/stores/identity-info.state.svelte.ts
+++ b/src/frontend/src/lib/stores/identity-info.state.svelte.ts
@@ -18,8 +18,6 @@ import {
   lastUsedIdentitiesStore,
   lastUsedIdentityStore,
 } from "./last-used-identities.store";
-import { authorizationStore } from "./authorization.store";
-import { goto } from "$app/navigation";
 
 const fetchIdentityInfo = async () => {
   const authenticated = get(authenticatedStore);
@@ -163,9 +161,9 @@ class IdentityInfo {
   };
 
   logout = () => {
-    this.reset();
-    void authorizationStore.init();
-    void goto("/");
+    // TODO: When we keep a session open we'll need to clean that session.
+    // For now we just reload the page to make sure all the states are cleared
+    window.location.reload();
   };
 
   isCurrentAccessMethod = (


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

There was a bug where the user was able to access the dashboard after logging out.

There was some state still left in memory.

Reloading the page ensures all states are reset and there is no need to clean up state by state.

# Changes

* Reload the window on logout.

# Tests

First, I replicated the issue by logging in with Google, logging out, clicking on Google and cancelling. I got redirected to the dashboard.

After the change, I did the same flow but I just got an error after cancelling Google.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
