### PR TITLE
Avoid actions during loading state

### DIFF
--- a/src/frontend/src/lib/components/views/AuthDialog.svelte
+++ b/src/frontend/src/lib/components/views/AuthDialog.svelte
@@ -29,9 +29,16 @@
   }: Props = $props();
 
   const authFlow = new AuthFlow({ onSignIn, onSignUp });
+
+  const handleClose = () => {
+    // Allow closing only if not authenticating.
+    if (!authFlow.authenticating) {
+      onClose();
+    }
+  };
 </script>
 
-<Dialog {onClose}>
+<Dialog onClose={handleClose} showCloseButton={!authFlow.authenticating}>
   {#if nonNullish(authFlow.captcha)}
     <SolveCaptcha {...authFlow.captcha} />
   {:else if authFlow.view === "chooseMethod"}

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -23,6 +23,7 @@
   import Header from "$lib/components/layout/Header.svelte";
   import Footer from "$lib/components/layout/Footer.svelte";
   import { goto } from "$app/navigation";
+  import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
 
   const gotoManage = () => goto("/manage", { replaceState: true });
   const onSignIn = async (identityNumber: bigint) => {
@@ -78,12 +79,21 @@
             <ul class="contents">
               {#each lastUsedIdentities as identity}
                 <li class="contents">
-                  <ButtonCard onclick={() => handleContinueAs(identity)}>
+                  <ButtonCard
+                    onclick={() => handleContinueAs(identity)}
+                    disabled={nonNullish(
+                      authLastUsedFlow.authenticatingIdentity,
+                    )}
+                  >
                     <Avatar size="sm">
-                      <UserIcon size="1.25rem" />
+                      {#if identity.identityNumber === authLastUsedFlow.authenticatingIdentity}
+                        <ProgressRing />
+                      {:else}
+                        <UserIcon size="1.25rem" />
+                      {/if}
                     </Avatar>
                     <div class="flex flex-col text-left text-sm">
-                      <div class="text-text-primary font-semibold">
+                      <div class="font-semibold">
                         {identity.name ?? identity.identityNumber}
                       </div>
                       <div class="text-text-tertiary" aria-hidden="true">
@@ -96,7 +106,10 @@
                 </li>
               {/each}
             </ul>
-            <ButtonCard onclick={() => (isAuthDialogOpen = true)}>
+            <ButtonCard
+              onclick={() => (isAuthDialogOpen = true)}
+              disabled={nonNullish(authLastUsedFlow.authenticatingIdentity)}
+            >
               <FeaturedIcon size="sm">
                 <PlusIcon size="1.25rem" />
               </FeaturedIcon>


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

There were some moments that the user was waiting for the application to perform something, but some actions were still enabled.

For example, when switching identity and choosing Google. The user was able to close the modal and trigger another identity after the Google popup was closed.

# Changes

This pull request introduces improvements to authentication flows and user interface behavior. The key changes include adding an `authenticating` state to manage authentication progress, updating components to reflect this state, and enhancing user experience with visual indicators like a progress ring.

* Added an `authenticating` state to the `AuthFlow` class to track authentication progress and prevent actions like closing dialogs during authentication.
* Introduced an `authenticatingIdentity` state in the `AuthLastUsedFlow` class to track the identity being authenticated. This ensures proper handling of authentication states for individual identities.
* Updated `AuthDialog.svelte` to disable the close button when authentication is in progress.
* Enhanced the user interface in `+page.svelte` by disabling buttons during authentication and adding a `ProgressRing` component to visually indicate ongoing authentication for specific identities.

# Tests

Tested locally. See videos attached.
