### PR TITLE
Remove passkeys

### DIFF
--- a/src/frontend/src/lib/components/views/RemoveOpenIdCredential.svelte
+++ b/src/frontend/src/lib/components/views/RemoveOpenIdCredential.svelte
@@ -3,23 +3,14 @@
   import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { TriangleAlertIcon } from "@lucide/svelte";
-  import identityInfo from "$lib/stores/identity-info.state.svelte";
-  import { handleError } from "../utils/error";
-  import { type OpenIdCredential } from "$lib/generated/internet_identity_types";
 
-  const {
-    onClose,
-    credentialToBeRemoved,
-  }: { onClose: () => void; credentialToBeRemoved: OpenIdCredential } =
-    $props();
+  interface Props {
+    onRemove: () => void;
+    onClose: () => void;
+    isCurrentAccessMethod?: boolean;
+  }
 
-  const handleRemoveCredential = async () => {
-    try {
-      await identityInfo.removeGoogle();
-    } catch (error) {
-      handleError(error);
-    }
-  };
+  const { onRemove, onClose, isCurrentAccessMethod }: Props = $props();
 </script>
 
 <Dialog {onClose}>
@@ -31,14 +22,14 @@
     You're about to unlink your Google Account. If you proceed, you will no
     longer be able to sign-in to your identity or dapps using your Google
     Account.
-    {#if identityInfo.isCurrentAccessMethod({ openid: credentialToBeRemoved })}
+    {#if isCurrentAccessMethod}
       <br /><br />As you are currently signed in with this Account, you will be
       signed out.
     {/if}
   </p>
 
   <div class="flex w-full flex-col gap-3">
-    <Button onclick={handleRemoveCredential} variant="primary" danger>
+    <Button onclick={onRemove} variant="primary" danger>
       Unlink Google Account
     </Button>
     <Button variant="tertiary" onclick={onClose}>Keep linked</Button>

--- a/src/frontend/src/lib/components/views/RemovePasskeyDialog.svelte
+++ b/src/frontend/src/lib/components/views/RemovePasskeyDialog.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
+  import Button from "$lib/components/ui/Button.svelte";
+  import { TriangleAlertIcon } from "@lucide/svelte";
+  import Dialog from "$lib/components/ui/Dialog.svelte";
+
+  interface Props {
+    onRemove: () => void;
+    onClose: () => void;
+    isCurrentAccessMethod?: boolean;
+  }
+
+  const { onRemove, onClose, isCurrentAccessMethod = false }: Props = $props();
+</script>
+
+<Dialog {onClose}>
+  <FeaturedIcon variant="warning" size="lg" class="mb-3">
+    <TriangleAlertIcon size="1.5rem" />
+  </FeaturedIcon>
+  <h1 class="text-text-primary mb-3 text-2xl font-medium">Are you sure?</h1>
+  <p class="text-text-tertiary mb-8 font-medium">
+    Removing this passkeys means you won't be able to use it to sign in anymore.
+    You can always add a new one later.
+    {#if isCurrentAccessMethod}
+      <br /><br />
+      As you are currently signed in with this passkey, you will be signed out.
+    {/if}
+  </p>
+  <Button onclick={onRemove} variant="primary" danger class="mb-3">
+    Remove passkey
+  </Button>
+  <Button onclick={onClose} variant="tertiary">Cancel</Button>
+</Dialog>

--- a/src/frontend/src/lib/components/views/RemovePasskeyDialog.svelte
+++ b/src/frontend/src/lib/components/views/RemovePasskeyDialog.svelte
@@ -19,7 +19,7 @@
   </FeaturedIcon>
   <h1 class="text-text-primary mb-3 text-2xl font-medium">Are you sure?</h1>
   <p class="text-text-tertiary mb-8 font-medium">
-    Removing this passkeys means you won't be able to use it to sign in anymore.
+    Removing this passkey means you won't be able to use it to sign in anymore.
     You can always add a new one later.
     {#if isCurrentAccessMethod}
       <br /><br />

--- a/src/frontend/src/lib/stores/identity-info.state.svelte.ts
+++ b/src/frontend/src/lib/stores/identity-info.state.svelte.ts
@@ -185,11 +185,25 @@ class IdentityInfo {
       await actor
         .authn_method_remove(identityNumber, publicKey)
         .then(throwCanisterError);
+
+      if (
+        "WebAuthn" in authnMethod.authn_method &&
+        this.isCurrentAccessMethod({
+          passkey: {
+            credentialId: new Uint8Array(
+              authnMethod.authn_method.WebAuthn.credential_id,
+            ),
+          },
+        })
+      ) {
+        lastUsedIdentitiesStore.removeIdentity(identityNumber);
+        this.logout();
+        return;
+      }
+      await this.fetch();
     } catch (error) {
       this.authnMethods.splice(index, 0, authnMethod);
       throw error;
-    } finally {
-      await this.fetch();
     }
   }
 

--- a/src/frontend/src/lib/stores/identity-info.state.svelte.ts
+++ b/src/frontend/src/lib/stores/identity-info.state.svelte.ts
@@ -20,8 +20,6 @@ import {
 } from "./last-used-identities.store";
 import { bufEquals } from "@dfinity/agent";
 import { authnMethodEqual } from "$lib/utils/webAuthn";
-import { handleError } from "$lib/components/utils/error";
-import { invalidateAll } from "$app/navigation";
 
 const fetchIdentityInfo = async () => {
   const authenticated = get(authenticatedStore);

--- a/src/frontend/src/lib/utils/webAuthn.ts
+++ b/src/frontend/src/lib/utils/webAuthn.ts
@@ -1,12 +1,17 @@
-import type { DeviceData } from "$lib/generated/internet_identity_types";
+import type {
+  AuthnMethodData,
+  DeviceData,
+} from "$lib/generated/internet_identity_types";
 import { features } from "$lib/legacy/features";
 import {
   DummyIdentity,
   IIWebAuthnIdentity,
   creationOptions,
+  bufferEqual,
 } from "$lib/utils/iiConnection";
 import { diagnosticInfo, unknownToString } from "$lib/utils/utils";
 import { WebAuthnIdentity } from "./webAuthnIdentity";
+import { bufEquals } from "@dfinity/agent";
 
 export const constructIdentity = async ({
   devices,
@@ -66,4 +71,26 @@ export const lookupAAGUID = async (
     await import("$lib/legacy/assets/passkey_aaguid_data.json")
   ).default;
   return knownList[aaguid as keyof typeof knownList];
+};
+
+/**
+ * Check if two `AuthnMethodData` values are equal to one another
+ */
+export const authnMethodEqual = (
+  a: AuthnMethodData,
+  b: AuthnMethodData,
+): boolean => {
+  if ("WebAuthn" in a.authn_method && "WebAuthn" in b.authn_method) {
+    return bufEquals(
+      new Uint8Array(a.authn_method.WebAuthn.pubkey),
+      new Uint8Array(b.authn_method.WebAuthn.pubkey),
+    );
+  }
+  if ("PubKey" in a.authn_method && "PubKey" in b.authn_method) {
+    return bufEquals(
+      new Uint8Array(a.authn_method.PubKey.pubkey),
+      new Uint8Array(b.authn_method.PubKey.pubkey),
+    );
+  }
+  return false;
 };

--- a/src/frontend/src/lib/utils/webAuthn.ts
+++ b/src/frontend/src/lib/utils/webAuthn.ts
@@ -7,7 +7,6 @@ import {
   DummyIdentity,
   IIWebAuthnIdentity,
   creationOptions,
-  bufferEqual,
 } from "$lib/utils/iiConnection";
 import { diagnosticInfo, unknownToString } from "$lib/utils/utils";
 import { WebAuthnIdentity } from "./webAuthnIdentity";

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/security/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/security/+page.svelte
@@ -39,7 +39,7 @@
       : !isMaxOpenIdCredentialsReached,
   );
   const isRemoveAccessMethodVisible = $derived(
-    authnMethods.length > 1 || openIdCredentials.length > 1,
+    authnMethods.length + openIdCredentials.length > 1,
   );
   const isRemovableAuthnMethodCurrentAccessMethod = $derived(
     nonNullish(identityInfo.removableAuthnMethod) &&

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/security/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/security/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Button from "$lib/components/ui/Button.svelte";
   import Panel from "$lib/components/ui/Panel.svelte";
-  import { Link2Off, Plus } from "@lucide/svelte";
+  import { Link2OffIcon, PlusIcon, Trash2Icon } from "@lucide/svelte";
   import GoogleIcon from "$lib/components/icons/GoogleIcon.svelte";
   import identityInfo from "$lib/stores/identity-info.state.svelte";
   import AccessMethod from "$lib/components/ui/AccessMethod.svelte";
@@ -41,26 +41,23 @@
   const isRemoveAccessMethodVisible = $derived(
     authnMethods.length > 1 || openIdCredentials.length > 1,
   );
-  const isRemovableCurrentAccessMethod = $derived.by(() => {
-    if (nonNullish(identityInfo.removableAuthnMethod)) {
-      return (
-        "WebAuthn" in identityInfo.removableAuthnMethod.authn_method &&
-        identityInfo.isCurrentAccessMethod({
-          passkey: {
-            credentialId: new Uint8Array(
-              identityInfo.removableAuthnMethod.authn_method.WebAuthn.credential_id,
-            ),
-          },
-        })
-      );
-    }
-    if (nonNullish(identityInfo.removableOpenIdCredential)) {
-      return identityInfo.isCurrentAccessMethod({
+  const isRemovableAuthnMethodCurrentAccessMethod = $derived(
+    nonNullish(identityInfo.removableAuthnMethod) &&
+      "WebAuthn" in identityInfo.removableAuthnMethod.authn_method &&
+      identityInfo.isCurrentAccessMethod({
+        passkey: {
+          credentialId: new Uint8Array(
+            identityInfo.removableAuthnMethod.authn_method.WebAuthn.credential_id,
+          ),
+        },
+      }),
+  );
+  const isRemovableOpenIdCredentialCurrentAccessMethod = $derived(
+    nonNullish(identityInfo.removableOpenIdCredential) &&
+      identityInfo.isCurrentAccessMethod({
         openid: identityInfo.removableOpenIdCredential,
-      });
-    }
-    return false;
-  });
+      }),
+  );
 
   const handleGoogleLinked = (credential: OpenIdCredential) => {
     openIdCredentials.push(credential);
@@ -108,7 +105,7 @@
           class="max-md:w-full"
         >
           <span>Add</span>
-          <Plus size="1.25rem" />
+          <PlusIcon size="1.25rem" />
         </Button>
       </div>
     {/if}
@@ -129,11 +126,12 @@
         <div class="flex items-center justify-center pr-4">
           {#if isRemoveAccessMethodVisible}
             <Button
-              variant="tertiary"
-              iconOnly={true}
               onclick={() => (identityInfo.removableAuthnMethod = authnMethod)}
+              variant="tertiary"
+              iconOnly
+              class="!text-fg-error-secondary"
             >
-              <Link2Off class="stroke-fg-error-secondary" />
+              <Trash2Icon size="1.25rem" />
             </Button>
           {/if}
         </div>
@@ -154,12 +152,13 @@
         <div class="flex items-center justify-center pr-4">
           {#if isRemoveAccessMethodVisible}
             <Button
-              variant="tertiary"
-              iconOnly={true}
               onclick={() =>
                 (identityInfo.removableOpenIdCredential = credential)}
+              variant="tertiary"
+              iconOnly
+              class="!text-fg-error-secondary"
             >
-              <Link2Off class="stroke-fg-error-secondary" />
+              <Link2OffIcon size="1.25rem" />
             </Button>
           {/if}
         </div>
@@ -172,7 +171,7 @@
   <RemoveOpenIdCredential
     onRemove={handleRemoveOpenIdCredential}
     onClose={() => (identityInfo.removableOpenIdCredential = null)}
-    isCurrentAccessMethod={isRemovableCurrentAccessMethod}
+    isCurrentAccessMethod={isRemovableOpenIdCredentialCurrentAccessMethod}
   />
 {/if}
 
@@ -180,7 +179,7 @@
   <RemovePasskeyDialog
     onRemove={handleRemovePasskey}
     onClose={() => (identityInfo.removableAuthnMethod = null)}
-    isCurrentAccessMethod={isRemovableCurrentAccessMethod}
+    isCurrentAccessMethod={isRemovableAuthnMethodCurrentAccessMethod}
   />
 {/if}
 


### PR DESCRIPTION
Initial implementation of remove passkey UX following existing remove OpenId credential implementation.

# Changes

- Implement `RemoveAuthnMethodDialog`.
- Implement `removePasskey` method in `identityInfo`.
- Update `security/+page`:
   - Show delete button only if there is _more than 1_ access method.
   - Show delete button for passkeys and show confirmation dialog on click

# Tests

- Verified that the delete button is only shown when there is _more than 1_ access method.
- Verified that passkey can be removed successfully
- Verified that the _correct_ passkey is removed
- Verified that user is logged out and identity is removed from last used when the passkey is currently in use.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

