### PR TITLE
Adjust dashboard width and spacing around delete buttons.

### DIFF
--- a/src/frontend/src/lib/components/layout/MainContent.svelte
+++ b/src/frontend/src/lib/components/layout/MainContent.svelte
@@ -14,7 +14,7 @@
   <div
     class="bg-bg-primary_alt col-start-1 col-end-4 row-start-1 row-end-6"
   ></div>
-  <div class="col-start-2 col-end-3 row-start-3 row-end-4 p-4 md:p-0">
+  <div class="col-start-2 col-end-3 row-start-3 row-end-4 p-4">
     {@render content?.()}
   </div>
   <header class="col-start-2 col-end-5 row-start-1 row-end-2 pt-2 pr-0 md:pr-6">
@@ -28,7 +28,7 @@
 <style>
   .sidebar-layout {
     display: grid;
-    grid-template-columns: 1fr 4fr 1fr;
+    grid-template-columns: 1fr minmax(auto, 920px) 1fr;
 
     grid-template-rows: min-content 1fr max-content 1fr min-content;
     min-height: 100dvh;

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -135,7 +135,7 @@
             isWebAuthnMetaData(lastUsedAccessMethod) &&
             authnMethodEqual(authnMethod, lastUsedAccessMethod)}
         />
-        <div class="flex items-center justify-center pr-4">
+        <div class="flex items-center justify-center px-4">
           {#if isRemoveAccessMethodVisible}
             <Button
               onclick={() => (identityInfo.removableAuthnMethod = authnMethod)}
@@ -166,7 +166,7 @@
             lastUsedAccessMethod.sub === credential.sub}
         />
 
-        <div class="flex items-center justify-center pr-4">
+        <div class="flex items-center justify-center px-4">
           {#if isRemoveAccessMethodVisible}
             <Button
               onclick={() =>


### PR DESCRIPTION
Adjust dashboard width and spacing around delete buttons.

# Changes

- Set dashboard content max-width to 920px
- Add spacing to the left of passkey/credential delete buttons.

# Tests

- Verified the layout looks correctly on desktop and mobile

<img width="1920" height="966" alt="image" src="https://github.com/user-attachments/assets/cce476a5-ca5d-4247-a5d3-4e274cde16f9" />


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
