### PR TITLE
Update register passkey flow

### DIFF
--- a/src/frontend/src/lib/components/ui/CodeInput.svelte
+++ b/src/frontend/src/lib/components/ui/CodeInput.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import Input from "$lib/components/ui/Input.svelte";
+  import type { HTMLAttributes } from "svelte/elements";
+
+  interface Props extends HTMLAttributes<HTMLDivElement> {
+    element: HTMLInputElement | undefined;
+    value: string;
+    length: number;
+  }
+
+  let {
+    length,
+    element = $bindable(),
+    value = $bindable(),
+    class: className,
+    ...props
+  }: Props = $props();
+
+  let code = $state<string[]>([]);
+  let inputRefs = $state<HTMLInputElement[]>([]);
+
+  const handleKeyDown = (event: KeyboardEvent, index: number) => {
+    if (event.code === "Backspace") {
+      if ((code[index] ?? "").length === 0) {
+        inputRefs[index - 1]?.focus();
+      }
+      code[index] = "";
+      event.preventDefault();
+    }
+    if (event.code === "ArrowLeft") {
+      inputRefs[index - 1]?.focus();
+      event.preventDefault();
+    }
+    if (event.code === "ArrowRight" || event.code === "Space") {
+      inputRefs[index + 1]?.focus();
+      event.preventDefault();
+    }
+  };
+  const handlePaste = (event: ClipboardEvent) => {
+    code =
+      event.clipboardData
+        ?.getData("text/plain")
+        .replace(/\D/g, "")
+        .slice(0, length)
+        .split("") ?? [];
+    inputRefs[code.length - 1]?.focus();
+    event.preventDefault();
+  };
+
+  // Keep value and code in sync
+  $effect(() => {
+    value = code.join("");
+  });
+  $effect(() => {
+    if (value !== code.join("")) {
+      code = value.split("");
+    }
+  });
+  $effect(() => {
+    element = inputRefs[0];
+  });
+</script>
+
+<div {...props} class={["flex gap-2", className]}>
+  {#each { length } as _, index}
+    <Input
+      bind:element={
+        () => inputRefs[index], (element) => (inputRefs[index] = element)
+      }
+      size="md"
+      class="w-0 flex-1"
+      inputClass="w-full text-center text-lg font-bold h-13"
+      inputmode="numeric"
+      autocomplete="off"
+      autocorrect="off"
+      spellcheck="false"
+      bind:value={
+        () => `${code[index] ?? ""}`,
+        (value) => {
+          if (/\d/.test(value.slice(-1))) {
+            code[index] = value.slice(-1);
+            inputRefs[index + 1]?.focus();
+          }
+        }
+      }
+      onkeydown={(event) => handleKeyDown(event, index)}
+      onpaste={handlePaste}
+    />
+  {/each}
+</div>

--- a/src/frontend/src/lib/components/ui/Dialog.svelte
+++ b/src/frontend/src/lib/components/ui/Dialog.svelte
@@ -17,8 +17,8 @@
     children,
     onClose,
     class: className,
-    closeOnOutsideClick = true,
-    showCloseButton = true,
+    closeOnOutsideClick = nonNullish(onClose),
+    showCloseButton = nonNullish(onClose),
     backdrop = true,
     ...props
   }: Props = $props();

--- a/src/frontend/src/lib/components/views/AuthorizeNewDevice.svelte
+++ b/src/frontend/src/lib/components/views/AuthorizeNewDevice.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import Button from "$lib/components/ui/Button.svelte";
-  import Input from "$lib/components/ui/Input.svelte";
   import ConfirmDeviceIllustration from "$lib/components/illustrations/ConfirmDeviceIllustration.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
+  import CodeInput from "$lib/components/ui/CodeInput.svelte";
+  import { RotateCcwIcon } from "@lucide/svelte";
+
+  const CODE_LENGTH = 6;
 
   interface Props {
     confirm: (confirmationCode: string) => Promise<void>;
@@ -13,9 +16,9 @@
   const { confirm, restart }: Props = $props();
 
   let inputRef = $state<HTMLInputElement>();
-  let confirmationCode = $state("");
+  let confirmationCode = $state<string>("");
   let isConfirming = $state(false);
-  let isInvalidCode = $state(true);
+  let isInvalidCode = $state(false);
 
   const handleSubmit = async () => {
     isConfirming = true;
@@ -23,13 +26,15 @@
       await confirm(confirmationCode);
     } catch (error) {
       isInvalidCode = true;
+      confirmationCode = "";
+      inputRef?.focus();
     } finally {
       isConfirming = false;
     }
   };
 
   $effect(() => {
-    if (confirmationCode.length > 0) {
+    if (confirmationCode) {
       isInvalidCode = false;
     }
   });
@@ -54,19 +59,21 @@
     <br /><br />
     <b class="text-text-primary">Never</b> enter a code from another source.
   </p>
-  <Input
+  <CodeInput
+    bind:element={inputRef}
     bind:value={confirmationCode}
-    placeholder="XXXXXX"
-    size="md"
-    class="mb-8"
-    error={isInvalidCode ? "Invalid code, please try again" : undefined}
+    length={CODE_LENGTH}
+    class="mb-1"
   />
+  <div class="text-text-error-primary mb-3 h-5 text-sm">
+    {isInvalidCode ? "Invalid code. Please check and try again." : ""}
+  </div>
   <Button
     onclick={handleSubmit}
     variant="primary"
     size="xl"
     type="submit"
-    disabled={confirmationCode.length === 0 || isConfirming}
+    disabled={confirmationCode.length < CODE_LENGTH || isConfirming}
     class="mb-3"
   >
     {#if isConfirming}
@@ -82,7 +89,8 @@
     size="xl"
     disabled={isConfirming}
   >
-    Start over
+    <RotateCcwIcon size="1rem" />
+    <span>Start over</span>
   </Button>
 </form>
 

--- a/src/frontend/src/lib/components/views/ConfirmThisDevice.svelte
+++ b/src/frontend/src/lib/components/views/ConfirmThisDevice.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import ConfirmDeviceIllustration from "$lib/components/illustrations/ConfirmDeviceIllustration.svelte";
+  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { CopyIcon } from "@lucide/svelte";
+  import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
+  import Button from "$lib/components/ui/Button.svelte";
+  import { waitFor } from "$lib/utils/utils";
+  import Tooltip from "$lib/components/ui/Tooltip.svelte";
+
+  interface Props {
+    confirmationCode?: string;
+  }
+
+  const { confirmationCode }: Props = $props();
+
+  let copied = $state(false);
+
+  const handleCopyCode = async () => {
+    if (isNullish(confirmationCode)) {
+      return;
+    }
+    await navigator.clipboard.writeText(confirmationCode);
+    copied = true;
+    await waitFor(700);
+    copied = false;
+  };
+</script>
+
+<ConfirmDeviceIllustration class="text-text-primary mt-4 mb-8 h-32" />
+<h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
+  Confirm this device
+</h1>
+<p
+  class="text-md text-text-tertiary mb-8 font-medium sm:text-center sm:text-balance"
+>
+  To confirm it's you, enter below code on your
+  <b class="text-text-primary">existing device</b>.
+</p>
+
+<Tooltip label="Code copied to clipboard" hidden={!copied} arrow={false} manual>
+  <Button
+    onclick={handleCopyCode}
+    variant="secondary"
+    size="lg"
+    disabled={isNullish(confirmationCode)}
+  >
+    {#if nonNullish(confirmationCode)}
+      <span>
+        {confirmationCode}
+      </span>
+      <CopyIcon size="1.25rem" />
+    {:else}
+      <ProgressRing />
+      <span>Generating code...</span>
+    {/if}
+  </Button>
+</Tooltip>

--- a/src/frontend/src/lib/components/views/ConfirmYourSignIn.svelte
+++ b/src/frontend/src/lib/components/views/ConfirmYourSignIn.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import PasskeyIllustration from "$lib/components/illustrations/PasskeyIllustration.svelte";
+  import Button from "$lib/components/ui/Button.svelte";
+  import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
+
+  interface Props {
+    name: string;
+    createPasskey: () => Promise<void>;
+  }
+
+  const { name, createPasskey }: Props = $props();
+
+  let isCreatingPasskey = $state(false);
+
+  const handleCreatePasskey = async () => {
+    isCreatingPasskey = true;
+    try {
+      await createPasskey();
+    } finally {
+      isCreatingPasskey = false;
+    }
+  };
+</script>
+
+<PasskeyIllustration class="text-text-primary mt-4 mb-8 h-32" />
+<h1 class="text-text-primary mb-3 text-2xl font-medium">
+  Confirm your sign-in
+</h1>
+<p class="text-md text-text-tertiary mb-8 font-medium text-balance">
+  You're signing in as <b class="text-text-primary">{name}</b>.
+  <br /><br />
+  To continue, create a passkey to secure your identity and simplify future sign-ins.
+</p>
+<Button onclick={handleCreatePasskey} size="xl" disabled={isCreatingPasskey}>
+  {#if isCreatingPasskey}
+    <ProgressRing />
+    <span>Creating passkey...</span>
+  {:else}
+    <span>Create passkey</span>
+  {/if}
+</Button>

--- a/src/frontend/src/lib/components/wizards/AddAccessMethodWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/AddAccessMethodWizard.svelte
@@ -68,7 +68,7 @@
         isCanisterError<AuthnMethodConfirmationError>(error) &&
         error.type === "WrongCode"
       ) {
-        // This error is handled by view
+        // Handle this error in child view instead
         throw error;
       }
       onError(error);

--- a/src/frontend/src/lib/components/wizards/AddAccessMethodWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/AddAccessMethodWizard.svelte
@@ -4,6 +4,7 @@
   import SystemOverlayBackdrop from "$lib/components/utils/SystemOverlayBackdrop.svelte";
   import { AddAccessMethodFlow } from "$lib/flows/addAccessMethodFlow.svelte.js";
   import type {
+    AuthnMethodConfirmationError,
     AuthnMethodData,
     OpenIdCredential,
   } from "$lib/generated/internet_identity_types";
@@ -12,6 +13,7 @@
   import ContinueOnNewDevice from "$lib/components/views/ContinueOnNewDevice.svelte";
   import AddAccessMethod from "$lib/components/views/AddAccessMethod.svelte";
   import AddPasskey from "$lib/components/views/AddPasskey.svelte";
+  import { isCanisterError } from "$lib/utils/utils";
 
   interface Props {
     onGoogleLinked: (credential: OpenIdCredential) => void;
@@ -62,6 +64,13 @@
       onOtherDeviceRegistered();
       onClose();
     } catch (error) {
+      if (
+        isCanisterError<AuthnMethodConfirmationError>(error) &&
+        error.type === "WrongCode"
+      ) {
+        // This error is handled by view
+        throw error;
+      }
       onError(error);
     }
   };

--- a/src/frontend/src/routes/(new-styling)/new-device/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/new-device/+page.svelte
@@ -4,31 +4,41 @@
   import Footer from "$lib/components/layout/Footer.svelte";
   import { RegisterAccessMethodFlow } from "$lib/flows/registerAccessMethodFlow.svelte.js";
   import type { PageProps } from "./$types";
-  import { CopyIcon } from "@lucide/svelte";
-  import Button from "$lib/components/ui/Button.svelte";
-  import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
-  import { isNullish } from "@dfinity/utils";
-  import PasskeyIllustration from "$lib/components/illustrations/PasskeyIllustration.svelte";
-  import ConfirmDeviceIllustration from "$lib/components/illustrations/ConfirmDeviceIllustration.svelte";
-  import Alert from "$lib/components/ui/Alert.svelte";
   import { goto } from "$app/navigation";
+  import ConfirmYourSignIn from "$lib/components/views/ConfirmYourSignIn.svelte";
+  import ConfirmThisDevice from "$lib/components/views/ConfirmThisDevice.svelte";
+  import { onMount } from "svelte";
+  import { handleError } from "$lib/components/utils/error";
+  import { CircleAlertIcon, RotateCcwIcon } from "@lucide/svelte";
+  import Dialog from "$lib/components/ui/Dialog.svelte";
+  import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
+  import Button from "$lib/components/ui/Button.svelte";
 
   const { data }: PageProps = $props();
 
   const registerAccessMethodFlow = new RegisterAccessMethodFlow(
     data.identityNumber,
   );
+  const name = $derived(
+    registerAccessMethodFlow.identityName ?? data.identityNumber.toString(),
+  );
 
-  const handleCopyCode = () => {
-    if (isNullish(registerAccessMethodFlow.confirmationCode)) {
-      return;
-    }
-    navigator.clipboard.writeText(registerAccessMethodFlow.confirmationCode);
-  };
   const handleCreatePasskey = async () => {
-    await registerAccessMethodFlow.createPasskey();
-    await goto("/");
+    try {
+      await registerAccessMethodFlow.createPasskey();
+      await goto("/");
+    } catch (error) {
+      handleError(error);
+    }
   };
+
+  onMount(async () => {
+    try {
+      await registerAccessMethodFlow.registerTempKey();
+    } catch (error) {
+      handleError(error);
+    }
+  });
 </script>
 
 <div class="flex min-h-[100dvh] flex-col">
@@ -37,65 +47,30 @@
   <div class="flex flex-1 flex-col items-center justify-center">
     <AuthPanel class="sm:max-w-100">
       <div class="flex-1"></div>
-      {#if registerAccessMethodFlow.view === "confirmSignIn"}
-        <PasskeyIllustration class="text-text-primary mt-4 mb-8 h-32" />
-        <h1 class="text-text-primary mb-3 text-2xl font-medium">
-          Confirm your sign-in
-        </h1>
-        <p class="text-md text-text-tertiary mb-8 font-medium text-balance">
-          You're signing in as
-          <b class="text-text-primary">
-            {registerAccessMethodFlow.identityName ?? data.identityNumber}
-          </b>.
-          <br /><br />
-          To continue, create a passkey to secure your identity and simplify future
-          sign-ins.
-        </p>
-        <Button onclick={handleCreatePasskey} size="xl">Create passkey</Button>
-      {:else}
-        <ConfirmDeviceIllustration class="text-text-primary mt-4 mb-8 h-32" />
-        <h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
-          Confirm this device
-        </h1>
-        <p
-          class="text-md text-text-tertiary mb-8 font-medium text-balance sm:text-center"
-        >
-          To confirm it's you, enter below code on your
-          <b class="text-text-primary">existing device</b>.
-        </p>
-        {#if registerAccessMethodFlow.view === "confirmDevice"}
-          <Button
-            onclick={handleCopyCode}
-            variant="secondary"
-            size="lg"
-            disabled={isNullish(registerAccessMethodFlow.confirmationCode)}
-          >
-            {#if registerAccessMethodFlow.confirmationCode}
-              <span>
-                {registerAccessMethodFlow.confirmationCode}
-              </span>
-              <CopyIcon size="1.25rem" />
-            {:else}
-              <ProgressRing />
-              <span>Generating code...</span>
-            {/if}
-          </Button>
-        {:else if registerAccessMethodFlow.view === "linkExpired"}
-          <Alert
-            variant="error"
-            title="This link has expired"
-            description="Please go back to your existing device and choose Start over to try again."
-          />
-        {:else if registerAccessMethodFlow.view === "unableToComplete"}
-          <Alert
-            variant="error"
-            title="Unable to complete setup"
-            description="Please go back to your existing device and choose Start over to try again."
-          />
-        {/if}
+      {#if registerAccessMethodFlow.view === "confirmDevice"}
+        <ConfirmThisDevice
+          confirmationCode={registerAccessMethodFlow.confirmationCode}
+        />
+      {:else if registerAccessMethodFlow.view === "confirmSignIn"}
+        <ConfirmYourSignIn {name} createPasskey={handleCreatePasskey} />
       {/if}
     </AuthPanel>
   </div>
   <Footer />
   <div class="h-[env(safe-area-inset-bottom)]"></div>
 </div>
+
+{#if registerAccessMethodFlow.isUnableToComplete}
+  <Dialog>
+    <FeaturedIcon size="lg" variant="error" class="mb-4 self-start">
+      <CircleAlertIcon size="1.5rem" />
+    </FeaturedIcon>
+    <h1 class="text-text-primary mb-3 text-2xl font-medium">
+      Unable to complete setup
+    </h1>
+    <p class="text-md text-text-tertiary font-medium">
+      Please go back to your <b class="text-text-primary">existing device</b>
+      and choose <b class="text-text-primary">Start over</b> to try again.
+    </p>
+  </Dialog>
+{/if}


### PR DESCRIPTION
Update register passkey flow

# Changes

- Handle invalid confirmation code.
- Render 6 digit code input instead of text input for confirmation code.
- Split `new-device` page into multiple views.
- Simplify `registerAccessMethodFlow`, only keep a boolean `unableToContinue`.
- Simplify the render of above error, render a error dialog instead similar to `authorize` flow.

# Tests

- Verified that invalid confirmation codes shows an error to the user.
- Verified that the `CodeInput` component works as expected (special keys, pasting and focus management).
- Verified that the error dialog with instructions is shown when the user can't continue on the new device.