### PR TITLE
Improve message to call for testing the release candidate

### DIFF
--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -307,7 +307,7 @@ test_release_candidate() {
   echo "Testing applications 2.0: https://try.id.ai/"
   echo "Dummy relying party: https://l7rua-raaaa-aaaap-ahh6a-cai.icp0.io/"
   echo ""
-  echo "Please, share the outcome of your tesing in this thread and specify which device and browser you used."
+  echo "Please, share the outcome of your testing in this thread and specify which device and browser you used."
   echo "----------"
   echo ""
   echo "Perform some testing yourself and wait for feedback from the team before moving forward."


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Make it easier for the release manager to request testing from the team.

# Changes

* Improved the message of the step `test_release_candidate` in the upgrade proposal script.

# Tests

* I copied all the commands and run them in the terminal, see screeenshot attached.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

