### PR TITLE
Fix alternative origins for 2.0

### DIFF
--- a/src/frontend/src/lib/utils/validateDerivationOrigin.test.ts
+++ b/src/frontend/src/lib/utils/validateDerivationOrigin.test.ts
@@ -150,7 +150,7 @@ for (const iiUrl of validIIUrls) {
 
   test("should not validate if origin not allowed", async () => {
     setupMocks({
-      iiUrl: "https://identity.ic0.app",
+      iiUrl,
       response: Response.json({
         alternativeOrigins: ["https://not-example.com"],
       }),
@@ -167,7 +167,7 @@ for (const iiUrl of validIIUrls) {
 
   test("should not validate if alternative origins file malformed", async () => {
     setupMocks({
-      iiUrl: "https://identity.ic0.app",
+      iiUrl,
       response: Response.json({
         notAlternativeOrigins: ["https://example.com"],
       }),
@@ -184,7 +184,7 @@ for (const iiUrl of validIIUrls) {
 
   test("should not validate on alternative origins redirect", async () => {
     setupMocks({
-      iiUrl: "https://identity.ic0.app",
+      iiUrl,
       response: Response.redirect("https://some-evil-url.com"),
     });
 
@@ -199,7 +199,7 @@ for (const iiUrl of validIIUrls) {
 
   test("should not validate on alternative origins error", async () => {
     setupMocks({
-      iiUrl: "https://identity.ic0.app",
+      iiUrl,
       response: new Response(undefined, { status: 404 }),
     });
 

--- a/src/frontend/src/lib/utils/validateDerivationOrigin.ts
+++ b/src/frontend/src/lib/utils/validateDerivationOrigin.ts
@@ -140,7 +140,8 @@ const inferAlternativeOriginsUrl = ({
   if (
     location.hostname.endsWith("icp0.io") ||
     location.hostname.endsWith("ic0.app") ||
-    location.hostname.endsWith("internetcomputer.org")
+    location.hostname.endsWith("internetcomputer.org") ||
+    location.hostname.endsWith("id.ai")
   ) {
     // If this is a canister running on one of the official IC domains, then return the
     // official canister id based API endpoint

--- a/src/frontend/src/lib/utils/validateDerivationOrigin.ts
+++ b/src/frontend/src/lib/utils/validateDerivationOrigin.ts
@@ -137,17 +137,6 @@ const inferAlternativeOriginsUrl = ({
     return `https://${canisterId.toText()}.${IC_HTTP_GATEWAY_DOMAIN}${ALTERNATIVE_ORIGINS_PATH}`;
   }
 
-  if (
-    location.hostname.endsWith("icp0.io") ||
-    location.hostname.endsWith("ic0.app") ||
-    location.hostname.endsWith("internetcomputer.org") ||
-    location.hostname.endsWith("id.ai")
-  ) {
-    // If this is a canister running on one of the official IC domains, then return the
-    // official canister id based API endpoint
-    return `https://${canisterId}.${IC_HTTP_GATEWAY_DOMAIN}${ALTERNATIVE_ORIGINS_PATH}`;
-  }
-
   // Local deployment -> add query parameter
   // For this asset the query parameter should work regardless of whether we use a canister id based subdomain or not
   if (location.hostname.endsWith("localhost")) {
@@ -163,9 +152,6 @@ const inferAlternativeOriginsUrl = ({
     return `${location.protocol}//${location.host}${ALTERNATIVE_ORIGINS_PATH}?canisterId=${canisterId}`;
   }
 
-  // Otherwise assume it's a custom setup expecting the gateway to
-  // - be on the same domain
-  // - use HTTPS
-  // - support query parameter based routing
-  return `https://${location.host}${ALTERNATIVE_ORIGINS_PATH}?canisterId=${canisterId}`;
+  // Otherwise, assume it's a mainnet environment.
+  return `https://${canisterId.toText()}.${IC_HTTP_GATEWAY_DOMAIN}${ALTERNATIVE_ORIGINS_PATH}`;
 };

--- a/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "@playwright/test";
+import {
+  dummyAuth,
+  II_URL,
+  NOT_TEST_APP_URL,
+  TEST_APP_CANONICAL_URL,
+  TEST_APP_URL,
+} from "../utils";
+
+// Define canonical URL for testing alternative origins
+// const TEST_APP_CANONICAL_URL = "https://canonical-name.ic0.app";
+
+test("Should not issue delegation when alternative origins are empty", async ({
+  page,
+}) => {
+  // Navigate to the test app
+  await page.goto(TEST_APP_URL);
+
+  // Configure the test app
+  await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
+
+  // Reset alternative origins
+  await page.locator("#hostUrl").fill("https://icp-api.io");
+  await page
+    .locator("#newAlternativeOrigins")
+    .fill('{"alternativeOrigins":[]}');
+  await page.locator("#certified").click();
+  await page.locator("#updateNewAlternativeOrigins").click();
+
+  // Wait for alternative origins to update
+  await expect(page.locator("#alternativeOrigins")).toHaveText(
+    '{"alternativeOrigins":[]}',
+    { timeout: 6000 },
+  );
+
+  // Set derivation origin
+  await page.locator("#derivationOrigin").fill(TEST_APP_CANONICAL_URL);
+
+  // Attempt to sign in
+  const pagePromise = page.context().waitForEvent("page");
+  await page.getByRole("button", { name: "Sign In" }).click();
+  const authPage = await pagePromise;
+
+  // Verify error message is displayed in II
+  await expect(authPage.getByText("Unverified origin")).toBeVisible();
+});
+
+test("Should not issue delegation when origin is missing from /.well-known/ii-alternative-origins", async ({
+  page,
+}) => {
+  // Navigate to the test app
+  await page.goto(TEST_APP_URL);
+
+  // Configure the test app
+  await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
+
+  // Reset alternative origins
+  await page.locator("#hostUrl").fill("https://icp-api.io");
+  const alternativeOrigins = JSON.stringify({
+    alternativeOrigins: [NOT_TEST_APP_URL],
+  });
+  await page.locator("#newAlternativeOrigins").fill(alternativeOrigins);
+  await page.locator("#certified").click();
+  await page.locator("#updateNewAlternativeOrigins").click();
+
+  // Wait for alternative origins to update
+  await expect(page.locator("#alternativeOrigins")).toHaveText(
+    alternativeOrigins,
+    { timeout: 6000 },
+  );
+
+  // Set derivation origin
+  await page.locator("#derivationOrigin").fill(TEST_APP_CANONICAL_URL);
+
+  // Attempt to sign in
+  const pagePromise = page.context().waitForEvent("page");
+  await page.getByRole("button", { name: "Sign In" }).click();
+  const authPage = await pagePromise;
+
+  // Verify error message is displayed in II
+  await expect(authPage.getByText("Unverified origin")).toBeVisible();
+});
+
+// Add a positive test case where alternative origins are properly configured
+test("Should issue delegation when derivationOrigin is properly configured in /.well-known/ii-alternative-origins", async ({
+  page,
+}) => {
+  // Navigate to the test app
+  await page.goto(TEST_APP_URL);
+
+  // Configure the test app
+  await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
+  const alternativeOrigins = JSON.stringify({
+    alternativeOrigins: [TEST_APP_URL],
+  });
+
+  await page.locator("#hostUrl").fill("https://icp-api.io");
+  await page.locator("#newAlternativeOrigins").fill(alternativeOrigins);
+  await page.locator("#certified").click();
+  await page.locator("#updateNewAlternativeOrigins").click();
+
+  // Wait for alternative origins to update
+  await expect(page.locator("#alternativeOrigins")).toHaveText(
+    alternativeOrigins,
+    { timeout: 6000 },
+  );
+
+  // Set derivation origin
+  await page.locator("#derivationOrigin").fill(TEST_APP_CANONICAL_URL);
+
+  // Attempt to sign in
+  const pagePromise = page.context().waitForEvent("page");
+  await page.getByRole("button", { name: "Sign In" }).click();
+  const authPage = await pagePromise;
+
+  // Create a new identity in II
+  const auth = dummyAuth();
+  await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
+  await authPage.getByRole("button", { name: "Set up a new Passkey" }).click();
+  await authPage.getByLabel("Identity name").fill("John Doe");
+  auth(authPage);
+  await authPage.getByRole("button", { name: "Create Passkey" }).click();
+
+  // Wait for II window to close
+  await authPage.waitForEvent("close");
+
+  // Verify successful authentication by checking for a principal
+  const principal = await page.locator("#principal").textContent();
+  expect(principal).toBeTruthy();
+});

--- a/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
@@ -7,19 +7,13 @@ import {
   TEST_APP_URL,
 } from "../utils";
 
-// Define canonical URL for testing alternative origins
-// const TEST_APP_CANONICAL_URL = "https://canonical-name.ic0.app";
-
 test("Should not issue delegation when alternative origins are empty", async ({
   page,
 }) => {
-  // Navigate to the test app
   await page.goto(TEST_APP_URL);
 
   // Configure the test app
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
-
-  // Reset alternative origins
   await page.locator("#hostUrl").fill("https://icp-api.io");
   await page
     .locator("#newAlternativeOrigins")
@@ -48,13 +42,10 @@ test("Should not issue delegation when alternative origins are empty", async ({
 test("Should not issue delegation when origin is missing from /.well-known/ii-alternative-origins", async ({
   page,
 }) => {
-  // Navigate to the test app
   await page.goto(TEST_APP_URL);
 
   // Configure the test app
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
-
-  // Reset alternative origins
   await page.locator("#hostUrl").fill("https://icp-api.io");
   const alternativeOrigins = JSON.stringify({
     alternativeOrigins: [NOT_TEST_APP_URL],
@@ -85,7 +76,6 @@ test("Should not issue delegation when origin is missing from /.well-known/ii-al
 test("Should issue delegation when derivationOrigin is properly configured in /.well-known/ii-alternative-origins", async ({
   page,
 }) => {
-  // Navigate to the test app
   await page.goto(TEST_APP_URL);
 
   // Configure the test app
@@ -93,7 +83,6 @@ test("Should issue delegation when derivationOrigin is properly configured in /.
   const alternativeOrigins = JSON.stringify({
     alternativeOrigins: [TEST_APP_URL],
   });
-
   await page.locator("#hostUrl").fill("https://icp-api.io");
   await page.locator("#newAlternativeOrigins").fill(alternativeOrigins);
   await page.locator("#certified").click();

--- a/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
@@ -103,10 +103,10 @@ test("Should issue delegation when derivationOrigin is properly configured in /.
   const authPage = await pagePromise;
 
   // Create a new identity in II
-  const auth = dummyAuth();
   await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
   await authPage.getByRole("button", { name: "Set up a new Passkey" }).click();
   await authPage.getByLabel("Identity name").fill("John Doe");
+  const auth = dummyAuth();
   auth(authPage);
   await authPage.getByRole("button", { name: "Create Passkey" }).click();
 

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -1,8 +1,12 @@
 import { Page, expect } from "@playwright/test";
 import { Principal } from "@dfinity/principal";
+import { readCanisterId } from "@dfinity/internet-identity-vite-plugins/utils";
 
+const testAppCanisterId = readCanisterId({ canisterName: "test_app" });
 export const II_URL = "https://id.ai";
 export const TEST_APP_URL = "https://nice-name.com";
+export const NOT_TEST_APP_URL = "https://very-nice-name.com";
+export const TEST_APP_CANONICAL_URL = `https://${testAppCanisterId}.icp0.io`;
 
 export type DummyAuthFn = (page: Page) => void;
 


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Derivation origin isn't working on id.ai because it tries to use id.ai as a host to get the well-known file.

This is due to the logic to infer the alternative origins url.

# Changes

* Add "id.ai" to the list of hostnames that use the expected `<canister-id>.icp0.io<alternative-origins-path>`

Relying on the host name is technical debt that we should fix.

# Tests

* Changed and added unit tests.

## Manual test

Deployed to beta.

Successful
1. Go to `https://o6tmp-fqaaa-aaaad-aak5q-cai.icp0.io` and add `https://vt36r-2qaaa-aaaad-aad5a-cai.icp0.io` as alternative origin
2. Go to `https://vt36r-2qaaa-aaaad-aad5a-cai.icp0.io` and login with derivation origin`https://o6tmp-fqaaa-aaaad-aak5q-cai.icp0.io`.
3. User is able to log in.
4. I did this test with beta.id.ai, beta.identity.internetcomputer.org and beta.identity.ic0.app

Error
1. Go to `https://vt36r-2qaaa-aaaad-aad5a-cai.icp0.io` and login with derivation origin`https://nns.ic0.app/`.
2. Error showed in UI
3. I did this test with beta.id.ai, beta.identity.internetcomputer.org and beta.identity.ic0.app





<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->



