### PR TITLE
Add e2e test alternative origins edge cases

### DIFF
--- a/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
@@ -180,7 +180,10 @@ test("Should not follow redirect returned by /.well-known/ii-alternative-origins
   });
 
   await page.locator("#newAlternativeOrigins").fill(redirectOrigins);
-  await page.locator("#redirect").click(); // Use redirect mode instead of certified
+  // Enable redirect mode to configure the test app to simulate a scenario where
+  // alternative origins return a redirect. This is necessary to verify that the
+  // system does not follow unverified redirects, ensuring security.
+  await page.locator("#redirect").click();
   await page.locator("#updateNewAlternativeOrigins").click();
 
   // Wait for alternative origins to update


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Make sure we don't break current functionality.

In this PR I added two edge cases of alternative origins:
* "Should not issue delegation when /.well-known/ii-alternative-origins has too many entries"
* "Should not follow redirect returned by /.well-known/ii-alternative-origins"

# Changes

* Two new E2E tests.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

