### PR TITLE
E2E tests to rename and remove passkeys

### DIFF
--- a/src/frontend/src/lib/components/ui/AccessMethod.svelte
+++ b/src/frontend/src/lib/components/ui/AccessMethod.svelte
@@ -69,7 +69,7 @@
       <div class="flex min-w-32 items-center pr-3">
         {getAuthnMethodAlias(accessMethod)}
         {#if isCurrent}
-          <span class="ml-2">
+          <span class="ml-2" aria-label="Current Passkey">
             <PulsatingCircleIcon />
           </span>
         {/if}

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -101,6 +101,14 @@
       handleError(error);
     }
   };
+
+  const isCurrentAccessMethod = (accessMethod: AuthnMethodData) => {
+    return (
+      nonNullish(lastUsedAccessMethod) &&
+      isWebAuthnMetaData(lastUsedAccessMethod) &&
+      authnMethodEqual(accessMethod, lastUsedAccessMethod)
+    );
+  };
 </script>
 
 <Panel>
@@ -140,16 +148,14 @@
         </div>
         <AccessMethod
           accessMethod={authnMethod}
-          isCurrent={nonNullish(lastUsedAccessMethod) &&
-            isWebAuthnMetaData(lastUsedAccessMethod) &&
-            authnMethodEqual(authnMethod, lastUsedAccessMethod)}
+          isCurrent={isCurrentAccessMethod(authnMethod)}
         />
         <div class="flex items-center justify-end gap-2 px-4">
           <Button
             onclick={() => (identityInfo.renamableAuthnMethod = authnMethod)}
             variant="tertiary"
             iconOnly
-            aria-label="Rename Passkey"
+            aria-label={`Rename ${isCurrentAccessMethod(authnMethod) ? "Current" : ""} Passkey`}
           >
             <EditIcon size="1.25rem" />
           </Button>
@@ -158,6 +164,7 @@
               onclick={() => (identityInfo.removableAuthnMethod = authnMethod)}
               variant="tertiary"
               iconOnly
+              aria-label={`Remove ${isCurrentAccessMethod(authnMethod) ? "Current" : ""} Passkey`}
               class="!text-fg-error-secondary"
             >
               <Trash2Icon size="1.25rem" />

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -149,6 +149,7 @@
             onclick={() => (identityInfo.renamableAuthnMethod = authnMethod)}
             variant="tertiary"
             iconOnly
+            aria-label="Rename Passkey"
           >
             <EditIcon size="1.25rem" />
           </Button>

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -155,7 +155,7 @@
             onclick={() => (identityInfo.renamableAuthnMethod = authnMethod)}
             variant="tertiary"
             iconOnly
-            aria-label={`Rename ${isCurrentAccessMethod(authnMethod) ? "Current" : ""} Passkey`}
+            aria-label={`Rename ${isCurrentAccessMethod(authnMethod) ? "current" : ""} passkey`}
           >
             <EditIcon size="1.25rem" />
           </Button>
@@ -164,7 +164,7 @@
               onclick={() => (identityInfo.removableAuthnMethod = authnMethod)}
               variant="tertiary"
               iconOnly
-              aria-label={`Remove ${isCurrentAccessMethod(authnMethod) ? "Current" : ""} Passkey`}
+              aria-label={`Remove ${isCurrentAccessMethod(authnMethod) ? "current" : ""} passkey`}
               class="!text-fg-error-secondary"
             >
               <Trash2Icon size="1.25rem" />

--- a/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
@@ -64,6 +64,7 @@ test("User can log into the dashboard and add a new passkey from the same device
       .locator("..")
       .getByLabel("Current Passkey"),
   ).toHaveCount(1);
+  await newPage.close();
 });
 
 test("User can log in the dashboard and add a new passkey from another device", async ({

--- a/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
@@ -1,15 +1,19 @@
 import { expect, test } from "@playwright/test";
 import {
+  addPasskeyCurrentDevice,
   clearStorage,
   createNewIdentityInII,
   dummyAuth,
   II_URL,
+  renamePasskey,
+  signOut,
 } from "../utils";
 
 const TEST_USER_NAME = "Test User";
 
-test("User can log in the dashboard and add a new passkey from the same device", async ({
+test("User can log in the dashboard and add a new passkey from the same device and log in with it", async ({
   page,
+  context,
 }) => {
   const auth = dummyAuth();
   await page.goto(II_URL);
@@ -26,16 +30,40 @@ test("User can log in the dashboard and add a new passkey from the same device",
   await expect(page.getByText("Chrome")).toHaveCount(1);
 
   // Start the "add passkey" flow
-  await page.getByRole("button", { name: "Add" }).click();
-  await page.getByRole("button", { name: "Continue with Passkey" }).click();
-
-  // Authenticate to add the new passkey
   const auth2 = dummyAuth();
-  auth2(page);
-  await page.getByRole("button", { name: "Create Passkey" }).click();
-
-  // Verify that we now have two passkeys
+  await addPasskeyCurrentDevice(page, auth2);
   await expect(page.getByText("Chrome")).toHaveCount(2);
+  await renamePasskey(page, "New Passkey");
+
+  // Verify that the new passkey is not the current one
+  await expect(
+    page.getByText("Chrome").locator("..").getByLabel("Current Passkey"),
+  ).toHaveCount(1);
+  await expect(
+    page.getByText("New Passkey").locator("..").getByLabel("Current Passkey"),
+  ).toHaveCount(0);
+
+  await signOut(page);
+
+  // Clear storage and log in again with new passkey
+  await clearStorage(page);
+  const newPage = await context.newPage();
+  await newPage.goto(II_URL);
+  await newPage.getByRole("button", { name: "Continue with Passkey" }).click();
+  auth2(newPage);
+  await newPage
+    .getByRole("button", { name: "Use an existing Passkey" })
+    .click();
+
+  await expect(
+    newPage.getByText("Chrome").locator("..").getByLabel("Current Passkey"),
+  ).toHaveCount(0);
+  await expect(
+    newPage
+      .getByText("New Passkey")
+      .locator("..")
+      .getByLabel("Current Passkey"),
+  ).toHaveCount(1);
 });
 
 test("User can log in the dashboard and add a new passkey from another device", async ({

--- a/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
@@ -11,7 +11,7 @@ import {
 
 const TEST_USER_NAME = "Test User";
 
-test("User can log in the dashboard and add a new passkey from the same device and log in with it", async ({
+test("User can log into the dashboard and add a new passkey from the same device and log in with it", async ({
   page,
   context,
 }) => {

--- a/src/frontend/tests/e2e-playwright/dashboard/removePasskey.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/removePasskey.spec.ts
@@ -1,0 +1,237 @@
+import { expect, test } from "@playwright/test";
+import {
+  clearStorage,
+  createNewIdentityInII,
+  dummyAuth,
+  II_URL,
+  addPasskeyCurrentDevice,
+} from "../utils";
+
+const TEST_USER_NAME = "Test User";
+
+test("User can remove a passkey when they have multiple access methods", async ({
+  page,
+}) => {
+  const auth = dummyAuth();
+  await page.goto(II_URL);
+  await createNewIdentityInII(page, TEST_USER_NAME, auth);
+  await page.waitForURL(II_URL + "/manage");
+  await clearStorage(page);
+  await page.goto(II_URL);
+  await page.getByRole("button", { name: "Continue with Passkey" }).click();
+  auth(page);
+  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+
+  // Verify we're at the dashboard and have one passkey
+  await page.waitForURL(II_URL + "/manage");
+  await expect(page.getByText("Chrome")).toHaveCount(1);
+
+  // Start the "add passkey" flow to create a second passkey
+  await addPasskeyCurrentDevice(page, dummyAuth());
+
+  // Verify that we now have two passkeys
+  await expect(page.getByText("Chrome")).toHaveCount(2);
+
+  // Wait for remove buttons to appear (they only show when there are multiple access methods)
+  await expect(page.getByLabel("Remove Passkey")).toBeVisible();
+
+  // Click the remove button for the passkey (not the current one)
+  // Label for current one is "Remove Current Passkey"
+  const removeButtons = page.getByLabel("Remove Passkey");
+  await expect(removeButtons).toHaveCount(1);
+  await removeButtons.click();
+
+  const removePasskeyDialog = page.getByRole("dialog");
+  // Verify the remove dialog opens
+  await expect(
+    removePasskeyDialog.getByRole("heading", {
+      level: 1,
+      name: "Are you sure?",
+    }),
+  ).toBeVisible();
+
+  // Verify the dialog shows the standard warning (not the current access method warning)
+  await expect(
+    removePasskeyDialog.getByText(
+      "Removing this passkey means you won't be able to use it to sign in anymore. You can always add a new one later.",
+    ),
+  ).toBeVisible();
+
+  // Verify the current access method warning is NOT shown
+  await expect(
+    removePasskeyDialog.getByText(
+      "As you are currently signed in with this passkey, you will be signed out.",
+    ),
+  ).not.toBeVisible();
+
+  // Confirm removal
+  await removePasskeyDialog
+    .getByRole("button", { name: "Remove passkey" })
+    .click();
+
+  // Verify the dialog closes and we now have only one passkey
+  await expect(removePasskeyDialog).not.toBeVisible();
+  await expect(page.getByText("Chrome")).toHaveCount(1);
+
+  // Verify we're still logged in and at the dashboard
+  await expect(page).toHaveURL(II_URL + "/manage");
+  await expect(
+    page.getByRole("heading", {
+      name: new RegExp(`Welcome, ${TEST_USER_NAME}!`),
+    }),
+  ).toBeVisible();
+});
+
+test("User cannot remove passkey if they only have one access method", async ({
+  page,
+}) => {
+  const auth = dummyAuth();
+  await page.goto(II_URL);
+  await createNewIdentityInII(page, TEST_USER_NAME, auth);
+  await page.waitForURL(II_URL + "/manage");
+  await clearStorage(page);
+  await page.goto(II_URL);
+  await page.getByRole("button", { name: "Continue with Passkey" }).click();
+  auth(page);
+  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+
+  // Verify we're at the dashboard and have one passkey
+  await page.waitForURL(II_URL + "/manage");
+  await expect(page.getByText("Chrome")).toHaveCount(1);
+
+  // Verify that the remove button is not visible when there's only one access method
+  await expect(page.getByLabel("Remove Current Passkey")).not.toBeVisible();
+
+  // Verify that the rename button is still visible (to ensure we're looking at the right area)
+  await expect(page.getByLabel("Rename Current Passkey")).toBeVisible();
+});
+
+test("User is logged out after removing the passkey they used to authenticate", async ({
+  page,
+}) => {
+  const auth = dummyAuth();
+  await page.goto(II_URL);
+  await createNewIdentityInII(page, TEST_USER_NAME, auth);
+  await page.waitForURL(II_URL + "/manage");
+  await clearStorage(page);
+  await page.goto(II_URL);
+  await page.getByRole("button", { name: "Continue with Passkey" }).click();
+  auth(page);
+  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+
+  // Verify we're at the dashboard and have one passkey
+  await page.waitForURL(II_URL + "/manage");
+  await expect(page.getByText("Chrome")).toHaveCount(1);
+
+  await addPasskeyCurrentDevice(page, dummyAuth());
+
+  // Verify that we now have two passkeys
+  await expect(page.getByText("Chrome")).toHaveCount(2);
+
+  // Click the remove button for the current passkey (the one used for authentication)
+  const removeButtons = page.getByLabel("Remove Current Passkey");
+  await expect(removeButtons).toHaveCount(1);
+  await removeButtons.click();
+
+  // Verify the remove dialog opens
+  const removePasskeyDialog = page.getByRole("dialog");
+  await expect(
+    removePasskeyDialog.getByRole("heading", {
+      level: 1,
+      name: "Are you sure?",
+    }),
+  ).toBeVisible();
+
+  // Verify the dialog shows both the standard warning AND the current access method warning
+  await expect(
+    removePasskeyDialog.getByText(
+      "Removing this passkey means you won't be able to use it to sign in anymore. You can always add a new one later.",
+    ),
+  ).toBeVisible();
+
+  await expect(
+    removePasskeyDialog.getByText(
+      "As you are currently signed in with this passkey, you will be signed out.",
+    ),
+  ).toBeVisible();
+
+  // Confirm removal
+  await removePasskeyDialog
+    .getByRole("button", { name: "Remove passkey" })
+    .click();
+
+  // Verify the user is logged out and redirected to the login page
+  // The URL should change from /manage to the root or login page
+  await page.waitForURL(II_URL);
+
+  // Verify we're back at the login screen without selectable identity
+  await expect(
+    page.getByRole("button", { name: "Continue with Passkey" }),
+  ).toBeVisible();
+
+  // Verify we're no longer at the dashboard
+  await expect(
+    page.getByRole("heading", {
+      name: new RegExp(`Welcome, ${TEST_USER_NAME}!`),
+    }),
+  ).not.toBeVisible();
+});
+
+test("User can cancel passkey removal", async ({ page }) => {
+  const auth = dummyAuth();
+  await page.goto(II_URL);
+  await createNewIdentityInII(page, TEST_USER_NAME, auth);
+  await page.waitForURL(II_URL + "/manage");
+  await clearStorage(page);
+  await page.goto(II_URL);
+  await page.getByRole("button", { name: "Continue with Passkey" }).click();
+  auth(page);
+  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+
+  // Verify we're at the dashboard and have one passkey
+  await page.waitForURL(II_URL + "/manage");
+  await expect(page.getByText("Chrome")).toHaveCount(1);
+
+  await addPasskeyCurrentDevice(page, dummyAuth());
+
+  // Verify that we now have two passkeys
+  await expect(page.getByText("Chrome")).toHaveCount(2);
+
+  // Wait for remove buttons to appear (they only show when there are multiple access methods)
+  await expect(page.getByLabel("Remove Passkey")).toBeVisible();
+
+  // Click the remove button for the passkey
+  const removeButtons = page.getByLabel("Remove Passkey");
+  await expect(removeButtons).toHaveCount(1);
+  await removeButtons.click();
+
+  // Verify the remove dialog opens
+  const removePasskeyDialog = page.getByRole("dialog");
+  await expect(
+    removePasskeyDialog.getByRole("heading", {
+      level: 1,
+      name: "Are you sure?",
+    }),
+  ).toBeVisible();
+
+  // Cancel the removal
+  await removePasskeyDialog.getByRole("button", { name: "Cancel" }).click();
+
+  // Verify the dialog closes and we still have both passkeys
+  await expect(
+    removePasskeyDialog.getByRole("heading", {
+      level: 1,
+      name: "Are you sure?",
+    }),
+  ).not.toBeVisible();
+
+  await expect(page.getByText("Chrome")).toHaveCount(2);
+
+  // Verify we're still logged in and at the dashboard
+  await expect(page).toHaveURL(II_URL + "/manage");
+  await expect(
+    page.getByRole("heading", {
+      name: new RegExp(`Welcome, ${TEST_USER_NAME}!`),
+    }),
+  ).toBeVisible();
+});

--- a/src/frontend/tests/e2e-playwright/dashboard/removePasskey.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/removePasskey.spec.ts
@@ -33,11 +33,11 @@ test("User can remove a passkey when they have multiple access methods", async (
   await expect(page.getByText("Chrome")).toHaveCount(2);
 
   // Wait for remove buttons to appear (they only show when there are multiple access methods)
-  await expect(page.getByLabel("Remove Passkey")).toBeVisible();
+  await expect(page.getByLabel("Remove passkey")).toBeVisible();
 
   // Click the remove button for the passkey (not the current one)
-  // Label for current one is "Remove Current Passkey"
-  const removeButtons = page.getByLabel("Remove Passkey");
+  // Label for current one is "Remove current passkey"
+  const removeButtons = page.getByLabel("Remove passkey");
   await expect(removeButtons).toHaveCount(1);
   await removeButtons.click();
 
@@ -100,10 +100,10 @@ test("User cannot remove passkey if they only have one access method", async ({
   await expect(page.getByText("Chrome")).toHaveCount(1);
 
   // Verify that the remove button is not visible when there's only one access method
-  await expect(page.getByLabel("Remove Current Passkey")).not.toBeVisible();
+  await expect(page.getByLabel("Remove current passkey")).not.toBeVisible();
 
   // Verify that the rename button is still visible (to ensure we're looking at the right area)
-  await expect(page.getByLabel("Rename Current Passkey")).toBeVisible();
+  await expect(page.getByLabel("Rename current passkey")).toBeVisible();
 });
 
 test("User is logged out after removing the passkey they used to authenticate", async ({
@@ -129,7 +129,7 @@ test("User is logged out after removing the passkey they used to authenticate", 
   await expect(page.getByText("Chrome")).toHaveCount(2);
 
   // Click the remove button for the current passkey (the one used for authentication)
-  const removeButtons = page.getByLabel("Remove Current Passkey");
+  const removeButtons = page.getByLabel("Remove current passkey");
   await expect(removeButtons).toHaveCount(1);
   await removeButtons.click();
 
@@ -198,10 +198,10 @@ test("User can cancel passkey removal", async ({ page }) => {
   await expect(page.getByText("Chrome")).toHaveCount(2);
 
   // Wait for remove buttons to appear (they only show when there are multiple access methods)
-  await expect(page.getByLabel("Remove Passkey")).toBeVisible();
+  await expect(page.getByLabel("Remove passkey")).toBeVisible();
 
   // Click the remove button for the passkey
-  const removeButtons = page.getByLabel("Remove Passkey");
+  const removeButtons = page.getByLabel("Remove passkey");
   await expect(removeButtons).toHaveCount(1);
   await removeButtons.click();
 

--- a/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
@@ -1,0 +1,174 @@
+import { expect, test } from "@playwright/test";
+import {
+  clearStorage,
+  createNewIdentityInII,
+  dummyAuth,
+  II_URL,
+} from "../utils";
+
+const TEST_USER_NAME = "Test User";
+
+test("User can rename the current passkey used for authentication", async ({
+  page,
+}) => {
+  const auth = dummyAuth();
+  await page.goto(II_URL);
+  await createNewIdentityInII(page, TEST_USER_NAME, auth);
+  await page.waitForURL(II_URL + "/manage");
+  await clearStorage(page);
+  await page.goto(II_URL);
+  await page.getByRole("button", { name: "Continue with Passkey" }).click();
+  auth(page);
+  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+
+  // Verify we're at the dashboard and have one passkey
+  await page.waitForURL(II_URL + "/manage");
+  await expect(page.getByText("Chrome")).toHaveCount(1);
+
+  // Click the rename button for the passkey
+  await page.getByLabel("Rename Passkey").click();
+
+  // Verify the rename dialog opens
+  await expect(
+    page.getByRole("heading", { name: "Rename passkey" }),
+  ).toBeVisible();
+
+  // Verify the input is pre-filled with current name
+  const input = page.getByRole("textbox");
+  await expect(input).toHaveValue("Chrome");
+
+  // Change the name
+  await input.clear();
+  const passkeyName = "My Main Passkey";
+  await input.fill(passkeyName);
+
+  // Save the changes
+  await page.getByRole("button", { name: "Save" }).click();
+
+  // Verify the dialog closes and the passkey now shows the new name
+  await expect(
+    page.getByRole("heading", { name: "Rename passkey" }),
+  ).not.toBeVisible();
+  await expect(page.getByText(passkeyName)).toBeVisible();
+  await expect(page.getByText("Chrome")).not.toBeVisible();
+});
+
+test("User can rename a newly added passkey from the same device", async ({
+  page,
+}) => {
+  const auth = dummyAuth();
+  await page.goto(II_URL);
+  await createNewIdentityInII(page, TEST_USER_NAME, auth);
+  await page.waitForURL(II_URL + "/manage");
+  await clearStorage(page);
+  await page.goto(II_URL);
+  await page.getByRole("button", { name: "Continue with Passkey" }).click();
+  auth(page);
+  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+
+  // Verify we're at the dashboard and have one passkey
+  await page.waitForURL(II_URL + "/manage");
+  await expect(page.getByText("Chrome")).toHaveCount(1);
+
+  // Start the "add passkey" flow
+  await page.getByRole("button", { name: "Add" }).click();
+  await page.getByRole("button", { name: "Continue with Passkey" }).click();
+
+  // Authenticate to add the new passkey
+  const auth2 = dummyAuth();
+  auth2(page);
+  await page.getByRole("button", { name: "Create Passkey" }).click();
+
+  // Verify that we now have two passkeys
+  await expect(page.getByText("Chrome")).toHaveCount(2);
+
+  // Click the rename button for the second passkey (newly added one)
+  // We need to get all rename buttons and click the second one
+  const renameButtons = page.getByLabel("Rename Passkey");
+  await expect(renameButtons).toHaveCount(2);
+  await renameButtons.nth(1).click();
+
+  // Verify the rename dialog opens
+  await expect(
+    page.getByRole("heading", { name: "Rename passkey" }),
+  ).toBeVisible();
+
+  // Verify the input is pre-filled with current name
+  const input = page.getByRole("textbox");
+  await expect(input).toHaveValue("Chrome");
+
+  // Change the name
+  await input.clear();
+  const passkeyName = "Secondary Passkey";
+  await input.fill(passkeyName);
+
+  // Save the changes
+  await page.getByRole("button", { name: "Save" }).click();
+
+  // Verify the dialog closes and we now have both passkeys with different names
+  await expect(
+    page.getByRole("heading", { name: "Rename passkey" }),
+  ).not.toBeVisible();
+  await expect(page.getByText("Chrome")).toHaveCount(1);
+  await expect(page.getByText(passkeyName)).toHaveCount(1);
+});
+
+test("User cannot rename passkey to an empty name nor it's renamed on cancel", async ({
+  page,
+}) => {
+  const auth = dummyAuth();
+  await page.goto(II_URL);
+  await createNewIdentityInII(page, TEST_USER_NAME, auth);
+  await page.waitForURL(II_URL + "/manage");
+  await clearStorage(page);
+  await page.goto(II_URL);
+  await page.getByRole("button", { name: "Continue with Passkey" }).click();
+  auth(page);
+  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+
+  // Verify we're at the dashboard and have one passkey
+  await page.waitForURL(II_URL + "/manage");
+  await expect(page.getByText("Chrome")).toHaveCount(1);
+
+  // Click the rename button for the passkey
+  await page.getByLabel("Rename Passkey").click();
+
+  // Verify the rename dialog opens
+  await expect(
+    page.getByRole("heading", { name: "Rename passkey" }),
+  ).toBeVisible();
+
+  const input = page.getByRole("textbox");
+  const saveButton = page.getByRole("button", { name: "Save" });
+
+  // Initially, the Save button should be enabled with the pre-filled name
+  await expect(saveButton).toBeEnabled();
+
+  // Clear the input field (make it empty)
+  await input.clear();
+
+  // Verify the Save button is disabled for empty input
+  await expect(saveButton).toBeDisabled();
+
+  // Try entering only whitespace
+  await input.fill("   ");
+
+  // Verify the Save button remains disabled for whitespace-only input
+  await expect(saveButton).toBeDisabled();
+
+  // Enter a valid name to verify Save becomes enabled again
+  await input.clear();
+  const passkeyName = "Valid Name";
+  await input.fill(passkeyName);
+  await expect(saveButton).toBeEnabled();
+
+  // Cancel the dialog and verify no changes were made
+  await page.getByRole("button", { name: "Cancel" }).click();
+
+  // Verify the dialog closes and the original name is still there
+  await expect(
+    page.getByRole("heading", { name: "Rename passkey" }),
+  ).not.toBeVisible();
+  await expect(page.getByText("Chrome")).toHaveCount(1);
+  await expect(page.getByText(passkeyName)).not.toBeVisible();
+});

--- a/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
@@ -27,7 +27,7 @@ test("User can rename the current passkey used for authentication", async ({
   await expect(page.getByText("Chrome")).toHaveCount(1);
 
   // Click the rename button for the passkey
-  await page.getByLabel("Rename Current Passkey").click();
+  await page.getByLabel("Rename current Passkey").click();
 
   // Verify the rename dialog opens
   await expect(
@@ -112,7 +112,7 @@ test("User cannot rename passkey to an empty name nor is it renamed on cancel", 
   await expect(page.getByText("Chrome")).toHaveCount(1);
 
   // Click the rename button for the passkey
-  await page.getByLabel("Rename Current Passkey").click();
+  await page.getByLabel("Rename current Passkey").click();
 
   // Verify the rename dialog opens
   await expect(

--- a/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
@@ -94,7 +94,7 @@ test("User can rename a newly added passkey from the same device", async ({
   await expect(page.getByText(passkeyName)).toHaveCount(1);
 });
 
-test("User cannot rename passkey to an empty name nor it's renamed on cancel", async ({
+test("User cannot rename passkey to an empty name nor is it renamed on cancel", async ({
   page,
 }) => {
   const auth = dummyAuth();

--- a/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
@@ -4,6 +4,7 @@ import {
   createNewIdentityInII,
   dummyAuth,
   II_URL,
+  renamePasskey,
 } from "../utils";
 
 const TEST_USER_NAME = "Test User";
@@ -26,7 +27,7 @@ test("User can rename the current passkey used for authentication", async ({
   await expect(page.getByText("Chrome")).toHaveCount(1);
 
   // Click the rename button for the passkey
-  await page.getByLabel("Rename Passkey").click();
+  await page.getByLabel("Rename Current Passkey").click();
 
   // Verify the rename dialog opens
   await expect(
@@ -82,28 +83,8 @@ test("User can rename a newly added passkey from the same device", async ({
   // Verify that we now have two passkeys
   await expect(page.getByText("Chrome")).toHaveCount(2);
 
-  // Click the rename button for the second passkey (newly added one)
-  // We need to get all rename buttons and click the second one
-  const renameButtons = page.getByLabel("Rename Passkey");
-  await expect(renameButtons).toHaveCount(2);
-  await renameButtons.nth(1).click();
-
-  // Verify the rename dialog opens
-  await expect(
-    page.getByRole("heading", { name: "Rename passkey" }),
-  ).toBeVisible();
-
-  // Verify the input is pre-filled with current name
-  const input = page.getByRole("textbox");
-  await expect(input).toHaveValue("Chrome");
-
-  // Change the name
-  await input.clear();
   const passkeyName = "Secondary Passkey";
-  await input.fill(passkeyName);
-
-  // Save the changes
-  await page.getByRole("button", { name: "Save" }).click();
+  await renamePasskey(page, passkeyName);
 
   // Verify the dialog closes and we now have both passkeys with different names
   await expect(
@@ -131,7 +112,7 @@ test("User cannot rename passkey to an empty name nor it's renamed on cancel", a
   await expect(page.getByText("Chrome")).toHaveCount(1);
 
   // Click the rename button for the passkey
-  await page.getByLabel("Rename Passkey").click();
+  await page.getByLabel("Rename Current Passkey").click();
 
   // Verify the rename dialog opens
   await expect(

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -126,3 +126,36 @@ export const clearStorage = async (page: Page): Promise<void> => {
   await page.goto(II_URL);
   await page.evaluate(() => localStorage.clear());
 };
+
+export const addPasskeyCurrentDevice = async (
+  page: Page,
+  dummyAuth: DummyAuthFn,
+): Promise<void> => {
+  await page.getByRole("button", { name: "Add" }).click();
+  await page.getByRole("button", { name: "Continue with Passkey" }).click();
+  dummyAuth(page);
+  await page.getByRole("button", { name: "Create Passkey" }).click();
+};
+
+export const renamePasskey = async (
+  page: Page,
+  name: string,
+): Promise<void> => {
+  await expect(page.getByLabel("Rename Passkey")).toHaveCount(1);
+  await page.getByLabel("Rename Passkey").click();
+
+  // Wait for the rename dialog to open
+  await expect(
+    page.getByRole("heading", { name: "Rename passkey" }),
+  ).toBeVisible();
+
+  const input = page.getByRole("textbox");
+  await input.clear();
+  await input.fill(name);
+  await page.getByRole("button", { name: "Save" }).click();
+};
+
+export const signOut = async (page: Page): Promise<void> => {
+  await page.getByLabel("Switch identity").click();
+  await page.getByRole("button", { name: "Sign Out" }).click();
+};

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -141,8 +141,8 @@ export const renamePasskey = async (
   page: Page,
   name: string,
 ): Promise<void> => {
-  await expect(page.getByLabel("Rename Passkey")).toHaveCount(1);
-  await page.getByLabel("Rename Passkey").click();
+  await expect(page.getByLabel("Rename passkey")).toHaveCount(1);
+  await page.getByLabel("Rename passkey").click();
 
   // Wait for the rename dialog to open
   await expect(


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Do not break current functionality when adding new one.

In this PR, I add E2E tests for renaming, and removing passkeys.

# Changes

* Add some labels to buttons and pulsating icon used to identify current access method.
* Improve adding passkey E2E test to check whether it can be used to authenticate afterwards.
* Add tests for removing passkeys functionality.
* Add tests for renaming passkeys functionality.
* Add some utils for E2E tests.




<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


