### PR TITLE
Support link from dashboard not working

### DIFF
--- a/src/frontend/src/lib/components/layout/MainContent.svelte
+++ b/src/frontend/src/lib/components/layout/MainContent.svelte
@@ -20,7 +20,7 @@
   <header class="col-start-2 col-end-5 row-start-1 row-end-2 pt-2 pr-0 md:pr-6">
     {@render header?.()}
   </header>
-  <footer class="col-start-1 col-end-5 row-start-5 row-end-6 px-4 py-4 md:px-6">
+  <footer class="col-start-1 col-end-5 row-start-5 row-end-6">
     {@render footer?.()}
   </footer>
 </div>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -18,6 +18,7 @@
   import { handleError } from "$lib/components/utils/error";
   import Dialog from "$lib/components/ui/Dialog.svelte";
   import AuthWizard from "$lib/components/wizards/auth/AuthWizard.svelte";
+  import Footer from "$lib/components/layout/Footer.svelte";
 
   const { children } = $props();
 
@@ -257,12 +258,6 @@
     </div>
   {/snippet}
   {#snippet footer()}
-    <div class="flex">
-      <p class="text-text-primary">© Internet Identity</p>
-      <div class="flex-1"></div>
-      <ButtonOrAnchor class="text-text-primary hover:underline" href="/support"
-        >Support
-      </ButtonOrAnchor>
-    </div>
+    <Footer />
   {/snippet}
 </MainContent>


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

A user reported that the support link in the footer from the dashboard was broken.

I realized that we were using different footers when authenticated or not authenticated.

# Changes

* Reuse the Footer component for the dashboard.
* Remove extra padding added by the MainComponent to the footer.

# Tests

Checked locally how it looks in mobile and desktop. See screenshots for more details.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
