### PR TITLE
Redirect activate links to dashboard

### DIFF
--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -88,6 +88,11 @@ export const ADD_ACCESS_METHOD = createFeatureFlagStore(
   true,
 );
 
+export const CONTINUE_FROM_ANOTHER_DEVICE = createFeatureFlagStore(
+  "CONTINUE_FROM_ANOTHER_DEVICE",
+  false,
+);
+
 export default {
   DOMAIN_COMPATIBILITY,
   OPENID_AUTHENTICATION,
@@ -95,4 +100,5 @@ export default {
   DISCOVERABLE_PASSKEY_FLOW,
   ENABLE_MIGRATE_FLOW,
   ADD_ACCESS_METHOD,
+  CONTINUE_FROM_ANOTHER_DEVICE,
 } as Record<string, FeatureFlagStore>;

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -18,11 +18,14 @@
   import { goto } from "$app/navigation";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { AuthWizard } from "$lib/components/wizards/auth";
+  import type { PageProps } from "./$types";
 
-  const gotoManage = () => goto("/manage", { replaceState: true });
+  const { data }: PageProps = $props();
+
+  const gotoNext = () => goto(data.next ?? "/manage", { replaceState: true });
   const onSignIn = async (identityNumber: bigint) => {
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
-    await gotoManage();
+    await gotoNext();
     isAuthDialogOpen = false;
   };
   const onSignUp = async (identityNumber: bigint) => {
@@ -31,7 +34,7 @@
       duration: 2000,
     });
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
-    await gotoManage();
+    await gotoNext();
     isAuthDialogOpen = false;
   };
   const authLastUsedFlow = new AuthLastUsedFlow();

--- a/src/frontend/src/routes/(new-styling)/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/+page.ts
@@ -1,0 +1,5 @@
+import type { PageLoad } from "./$types";
+
+export const load: PageLoad = ({ url }) => {
+  return { next: url.searchParams.get("next") };
+};

--- a/src/frontend/src/routes/(new-styling)/activate/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/activate/+page.svelte
@@ -1,12 +1,24 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
+  import { toaster } from "$lib/components/utils/toaster";
 
   // Confirming a passkey from another device is handled in the dashboard,
   // this can't be a load function since URL hash can't be read in there.
-  onMount(() => {
-    goto(`/manage?activate=${window.location.hash.slice(1)}`, {
-      replaceState: true,
-    });
+  onMount(async () => {
+    const code = window.location.hash.slice(1);
+    const isValid = code.length === 5;
+    await goto(
+      isValid ? `/manage?activate=${window.location.hash.slice(1)}` : "/manage",
+      {
+        replaceState: true,
+      },
+    );
+    if (!isValid) {
+      toaster.error({
+        title: "Invalid code link",
+        description: "We didn't recognize that activation code.",
+      });
+    }
   });
 </script>

--- a/src/frontend/src/routes/(new-styling)/activate/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/activate/+page.svelte
@@ -2,7 +2,8 @@
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
 
-  // Confirming a passkey from another device is handled in the dashboard
+  // Confirming a passkey from another device is handled in the dashboard,
+  // this can't be a load function since URL hash can't be read in there.
   onMount(() => {
     goto(`/manage?activate=${window.location.hash.slice(1)}`, {
       replaceState: true,

--- a/src/frontend/src/routes/(new-styling)/activate/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/activate/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
+
+  // Confirming a passkey from another device is handled in the dashboard
+  onMount(() => {
+    goto(`/manage?activate=${window.location.hash.slice(1)}`, {
+      replaceState: true,
+    });
+  });
+</script>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.ts
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.ts
@@ -15,7 +15,8 @@ export const load: LayoutLoad = ({ url }) => {
     isNullish(selectedIdentity) ||
     authentication.identityNumber !== selectedIdentity.identityNumber
   ) {
-    // Add original target URL as next search param
+    // Add original target URL as next search param,
+    // if it's not the default target URL (/manage).
     const next = url.pathname + url.search;
     const location = new URL("/", url.origin);
     if (next !== "/manage") {

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.ts
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.ts
@@ -6,7 +6,7 @@ import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store"
 import { isNullish } from "@dfinity/utils";
 import identityInfoState from "$lib/stores/identity-info.state.svelte";
 
-export const load: LayoutLoad = () => {
+export const load: LayoutLoad = ({ url }) => {
   // Go back to / if not authenticated with currently selected identity
   const authentication = get(authenticationStore);
   const selectedIdentity = get(lastUsedIdentitiesStore).selected;
@@ -15,7 +15,13 @@ export const load: LayoutLoad = () => {
     isNullish(selectedIdentity) ||
     authentication.identityNumber !== selectedIdentity.identityNumber
   ) {
-    throw redirect(307, "/");
+    // Add original target URL as next search param
+    const next = url.pathname + url.search;
+    const location = new URL("/", url.origin);
+    if (next !== "/manage") {
+      location.searchParams.set("next", next);
+    }
+    throw redirect(307, location);
   }
 
   void identityInfoState.fetch();


### PR DESCRIPTION
Redirect activate links to dashboard.

# Changes

- Add `CONTINUE_FROM_ANOTHER_DEVICE` feature flag.
- Add `/activate#{code}` route that redirects to `/manage?activate={code}`.
- Add `next` search param when navigating to `/manage/**` while not authenticated.
- Navigate to `next` search param after authentication.

# Tests

- Verified that authentication from the landing page still redirects to `/manage` by default.
- Verified that `/activate#{code}` redirects to `/manage?activate={code}` after authentication on the landing page.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

