### PR TITLE
Add more E2E to test different scenarios

### DIFF
--- a/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
@@ -250,6 +250,7 @@ test("Should issue the same principal to nice url and canonical url", async ({
   await authPage1.waitForEvent("close");
 
   // Get the first principal
+  await expect(page.locator("#principal")).not.toBeEmpty();
   const principal1 = await page.locator("#principal").textContent();
   expect(principal1).toBeTruthy();
 
@@ -273,6 +274,7 @@ test("Should issue the same principal to nice url and canonical url", async ({
   await authPage2.waitForEvent("close");
 
   // Get the second principal
+  await expect(page.locator("#principal")).not.toBeEmpty();
   const principal2 = await page.locator("#principal").textContent();
   expect(principal2).toBeTruthy();
 

--- a/src/frontend/tests/e2e-playwright/authorize/delegationTtl.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/delegationTtl.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+import {
+  authorize,
+  createIdentity,
+  dummyAuth,
+  II_URL,
+  TEST_APP_URL,
+} from "../utils";
+
+test("Delegation maxTimeToLive: 1 min", async ({ page }) => {
+  const auth = dummyAuth();
+
+  // Open demo app and configure II URL
+  await page.goto(TEST_APP_URL);
+  await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
+
+  // Set maxTimeToLive to 1 minute (60 seconds = 60_000_000_000 nanoseconds)
+  await page.locator("#maxTimeToLive").fill("60000000000");
+
+  // Start authentication flow
+  const pagePromise = page.context().waitForEvent("page");
+  await page.getByRole("button", { name: "Sign In" }).click();
+  const authPage = await pagePromise;
+
+  // Create new identity and authenticate
+  await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
+  await authPage.getByRole("button", { name: "Set up a new Passkey" }).click();
+  await authPage.getByLabel("Identity name").fill("Test User");
+  auth(authPage);
+  await authPage.getByRole("button", { name: "Create Passkey" }).click();
+
+  // Wait for authentication to complete and window to close
+  await authPage.waitForEvent("close");
+
+  // Wait for principal to be populated (indicating successful authentication)
+  await expect(page.locator("#principal")).not.toBeEmpty();
+
+  // Check expiration time - should be close to 1 minute (60_000_000_000 nanoseconds)
+  const expiration = await page.locator("#expiration").textContent();
+  const expirationNs = Number(expiration);
+  // Compare only up to one decimal place for the 1min test
+  expect(expirationNs / 60_000_000_000).toBeCloseTo(1, 0);
+});
+
+test("Delegation maxTimeToLive: 1 day", async ({ page }) => {
+  const auth = dummyAuth();
+
+  // Open demo app and configure II URL
+  await page.goto(TEST_APP_URL);
+  await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
+
+  // Set maxTimeToLive to 1 day (86400 seconds = 86400_000_000_000 nanoseconds)
+  await page.locator("#maxTimeToLive").fill("86400000000000");
+
+  // Start authentication flow
+  const pagePromise = page.context().waitForEvent("page");
+  await page.getByRole("button", { name: "Sign In" }).click();
+  const authPage = await pagePromise;
+
+  // Create new identity and authenticate
+  await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
+  await authPage.getByRole("button", { name: "Set up a new Passkey" }).click();
+  await authPage.getByLabel("Identity name").fill("Test User");
+  auth(authPage);
+  await authPage.getByRole("button", { name: "Create Passkey" }).click();
+
+  // Wait for authentication to complete and window to close
+  await authPage.waitForEvent("close");
+
+  // Wait for principal to be populated (indicating successful authentication)
+  await expect(page.locator("#principal")).not.toBeEmpty();
+
+  // Check expiration time - should be close to 1 day (86400_000_000_000 nanoseconds)
+  const expiration = await page.locator("#expiration").textContent();
+  const expirationNs = Number(expiration);
+  expect(expirationNs / 86400_000_000_000).toBeCloseTo(1);
+});
+
+test("Delegation maxTimeToLive: 2 months", async ({ page }) => {
+  const auth = dummyAuth();
+
+  // Open demo app and configure II URL
+  await page.goto(TEST_APP_URL);
+  await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
+
+  // Set maxTimeToLive to 60 days (5_184_000_000_000_000 nanoseconds)
+  await page.locator("#maxTimeToLive").fill("5184000000000000");
+
+  // Start authentication flow
+  const pagePromise = page.context().waitForEvent("page");
+  await page.getByRole("button", { name: "Sign In" }).click();
+  const authPage = await pagePromise;
+
+  // Create new identity and authenticate
+  await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
+  await authPage.getByRole("button", { name: "Set up a new Passkey" }).click();
+  await authPage.getByLabel("Identity name").fill("Test User");
+  auth(authPage);
+  await authPage.getByRole("button", { name: "Create Passkey" }).click();
+
+  // Wait for authentication to complete and window to close
+  await authPage.waitForEvent("close");
+
+  // Wait for principal to be populated (indicating successful authentication)
+  await expect(page.locator("#principal")).not.toBeEmpty();
+
+  // Check expiration time - should be capped at 30 days (2_592_000_000_000_000 nanoseconds)
+  const expiration = await page.locator("#expiration").textContent();
+  const expirationNs = Number(expiration);
+  // NB: Max out at 30 days
+  expect(expirationNs / 2_592_000_000_000_000).toBeCloseTo(1);
+});

--- a/src/frontend/tests/e2e-playwright/authorize/delegationTtl.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/delegationTtl.spec.ts
@@ -1,11 +1,5 @@
 import { expect, test } from "@playwright/test";
-import {
-  authorize,
-  createIdentity,
-  dummyAuth,
-  II_URL,
-  TEST_APP_URL,
-} from "../utils";
+import { dummyAuth, II_URL, TEST_APP_URL } from "../utils";
 
 test("Delegation maxTimeToLive: 1 min", async ({ page }) => {
   const auth = dummyAuth();

--- a/src/frontend/tests/e2e-playwright/authorize/postMessages.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/postMessages.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test";
+import {
+  createNewIdentityInII,
+  dummyAuth,
+  getMessageText,
+  II_URL,
+  openIiTab,
+  openTestAppWithII,
+  waitForNthMessage,
+} from "../utils";
+
+test("Authorize ready message should be sent immediately", async ({ page }) => {
+  await openTestAppWithII(page);
+  const iiPage = await openIiTab(page);
+  await waitForNthMessage(page, 1);
+  const messageText = await getMessageText(page, 1);
+  expect(messageText).toContain("authorize-ready");
+  await iiPage.close();
+});
+
+test("Should allow valid message", async ({ page }) => {
+  const auth = dummyAuth();
+
+  await openTestAppWithII(page);
+  const iiPage = await openIiTab(page);
+
+  // Wait for authorize-ready message, then send valid message
+  await waitForNthMessage(page, 1); // message 1: authorize-ready
+  await page.locator("#validMessageBtn").click(); // message 2: authorize-client
+
+  // Complete authentication in II popup
+  await createNewIdentityInII(iiPage, "Test User", auth);
+
+  // Wait for success notification in II
+  await iiPage
+    .getByRole("heading", { name: "Authentication successful" })
+    .waitFor({ timeout: 15_000 });
+
+  // Setup the listener because clicking closes the page immediately
+  // and we might not add the listener on time.
+  const closePromise = iiPage.waitForEvent("close");
+  await iiPage.getByRole("button", { name: "Return to app" }).click();
+  await closePromise;
+
+  // Verify success message and expiration in test app
+  await waitForNthMessage(page, 3); // message 3: authorize-success
+  const successMessage = await getMessageText(page, 3);
+  expect(successMessage).toContain("authorize-client-success");
+
+  // Wait for principal to be populated (indicating successful authentication)
+  await expect(page.locator("#principal")).not.toBeEmpty();
+});
+
+test("Should show error for invalid message", async ({ page }) => {
+  await openTestAppWithII(page);
+  const iiPage = await openIiTab(page);
+
+  // Wait for authorize-ready message, then send invalid data
+  await waitForNthMessage(page, 1); // message 1: authorize-ready
+  await page.locator("#invalidDataBtn").click(); // Send invalid post message
+
+  // Check for specific error message in II popup
+  await expect(
+    iiPage.getByRole("heading", { name: "Invalid request" }),
+  ).toBeVisible();
+
+  // Setup the listener because clicking closes the page immediately
+  // and we might not add the listener on time.
+  const closePromise = iiPage.waitForEvent("close");
+  await iiPage.getByRole("button", { name: "Return to app" }).click();
+  await closePromise;
+});
+
+test("Should show error after not receiving message for 10 seconds", async ({
+  page,
+}) => {
+  await openTestAppWithII(page);
+  const iiPage = await openIiTab(page);
+
+  // Check for specific error message in II popup
+  await expect(
+    iiPage.getByRole("heading", { name: "Connection closed" }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Setup the listener because clicking closes the page immediately
+  // and we might not add the listener on time.
+  const closePromise = iiPage.waitForEvent("close");
+  await iiPage.getByRole("button", { name: "Return to app" }).click();
+  await closePromise;
+});
+
+test("Should show error after manually navigating to authorize url", async ({
+  page,
+}) => {
+  await page.goto(II_URL + "#authorize");
+
+  // Check for specific error message in II popup
+  await expect(
+    page.getByRole("heading", { name: "Missing request" }),
+  ).toBeVisible();
+});

--- a/src/frontend/tests/e2e-playwright/authorize/postMessages.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/postMessages.spec.ts
@@ -77,10 +77,12 @@ test("Should show error after not receiving message for 10 seconds", async ({
   await openTestAppWithII(page);
   const iiPage = await openIiTab(page);
 
+  await new Promise((resolve) => setTimeout(resolve, 10_000));
+
   // Check for specific error message in II popup
   await expect(
     iiPage.getByRole("heading", { name: "Connection closed" }),
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible();
 
   // Setup the listener because clicking closes the page immediately
   // and we might not add the listener on time.

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -159,3 +159,44 @@ export const signOut = async (page: Page): Promise<void> => {
   await page.getByLabel("Switch identity").click();
   await page.getByRole("button", { name: "Sign Out" }).click();
 };
+
+/**
+ * Opens test app and configures II URL
+ */
+export const openTestAppWithII = async (page: Page): Promise<void> => {
+  await page.goto(TEST_APP_URL);
+  await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
+};
+
+/**
+ * Opens II popup tab and returns the popup page
+ */
+export const openIiTab = async (page: Page): Promise<Page> => {
+  const pagePromise = page.context().waitForEvent("page");
+  await page.locator("#openIiWindowBtn").click();
+  return await pagePromise;
+};
+
+/**
+ * Waits for nth message to appear in test app
+ */
+export const waitForNthMessage = async (
+  page: Page,
+  messageNo: number,
+): Promise<void> => {
+  await page.locator(`div.postMessage:nth-child(${messageNo})`).waitFor();
+};
+
+/**
+ * Gets message text from nth message in test app
+ */
+export const getMessageText = async (
+  page: Page,
+  messageNo: number,
+): Promise<string> => {
+  return (
+    (await page
+      .locator(`div.postMessage:nth-child(${messageNo}) > div:nth-child(2)`)
+      .textContent()) ?? ""
+  );
+};

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -54,6 +54,7 @@ export const authorize = async (
   await authPage.waitForEvent("close");
 
   // Assert that the user is authenticated (valid principal)
+  await expect(page.locator("#principal")).not.toBeEmpty();
   const principal = (await page.locator("#principal").textContent()) ?? "";
   expect(principal).toEqual(Principal.fromText(principal).toText());
 


### PR DESCRIPTION
# Motivation

Ensure we don't break any functionality in the future.

In this PR, new E2E tests from 1.0 have been ported to 2.0:
* Checking same principal is given by alternative origins.
* Setting the delegation expiration.
* Edge cases of handling post messages from the application.

# Changes

* New test on alternativeOrigins.spec.ts
* New test files delegationTtl.spec.ts and postMessage.spec.ts



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


