### PR TITLE
Implement e2e test for "Continue from another device" flow.

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -15,7 +15,7 @@
     isAuthenticating?: boolean;
     onSignIn: (identityNumber: bigint) => void;
     onSignUp: (identityNumber: bigint) => void;
-    onOtherDevice?: () => void; // TODO: Remove once we can sign in directly
+    onOtherDevice?: (identityNumber: bigint) => void; // TODO: Remove once we can sign in directly
     onError: (error: unknown) => void;
     withinDialog?: boolean;
     children?: Snippet;

--- a/src/frontend/src/lib/components/wizards/registerAccessMethod/RegisterAccessMethodWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/registerAccessMethod/RegisterAccessMethodWizard.svelte
@@ -8,7 +8,7 @@
 
   interface Props {
     registrationId?: string;
-    onRegistered: () => void;
+    onRegistered: (identityNumber: bigint) => void;
     onError: (error: unknown) => void;
   }
 
@@ -18,8 +18,7 @@
 
   const handleCreatePasskey = async () => {
     try {
-      await registerAccessMethodFlow.createPasskey();
-      onRegistered();
+      onRegistered(await registerAccessMethodFlow.createPasskey());
     } catch (error) {
       onError(error);
     }

--- a/src/frontend/src/lib/flows/registerAccessMethodFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/registerAccessMethodFlow.svelte.ts
@@ -115,7 +115,7 @@ export class RegisterAccessMethodFlow {
     throw new Error("Registration not completed within time window");
   };
 
-  createPasskey = async (): Promise<void> => {
+  createPasskey = async (): Promise<bigint> => {
     const session = get(sessionStore);
     const { actor, identityNumber } = get(authenticatedStore);
     const name = this.#identityName ?? identityNumber.toString(10);
@@ -157,5 +157,6 @@ export class RegisterAccessMethodFlow {
         },
       },
     });
+    return identityNumber;
   };
 }

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -4,6 +4,7 @@
   import {
     authorizationStore,
     authorizationStatusStore,
+    authorizationContextStore,
   } from "$lib/stores/authorization.store";
   import AuthPanel from "$lib/components/layout/AuthPanel.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
@@ -65,6 +66,16 @@
     await gotoAccounts();
     isAuthDialogOpen = false;
   };
+  const onOtherDevice = async (identityNumber: bigint) => {
+    lastUsedIdentitiesStore.selectIdentity(identityNumber);
+    lastUsedIdentitiesStore.addLastUsedAccount({
+      origin: $authorizationContextStore.effectiveOrigin,
+      identityNumber,
+      accountNumber: undefined,
+    });
+    await goto("/authorize/continue");
+    isAuthDialogOpen = false;
+  };
 
   onMount(() => {
     authorizationStore.init();
@@ -119,7 +130,7 @@
             bind:isAuthenticating
             {onSignIn}
             {onSignUp}
-            onOtherDevice={() => (isAuthDialogOpen = false)}
+            {onOtherDevice}
             onError={(error) => {
               isAuthDialogOpen = false;
               handleError(error);

--- a/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
@@ -37,9 +37,19 @@
     });
     await authorizationStore.authorize(undefined, 4000);
   };
+  // TODO: Remove this method once we have sessions
+  const onOtherDevice = async (identityNumber: bigint) => {
+    lastUsedIdentitiesStore.selectIdentity(identityNumber);
+    lastUsedIdentitiesStore.addLastUsedAccount({
+      origin: $authorizationContextStore.effectiveOrigin,
+      identityNumber,
+      accountNumber: undefined,
+    });
+    await goto("/authorize/continue");
+  };
 </script>
 
-<AuthWizard {onSignIn} {onSignUp} onError={handleError}>
+<AuthWizard {onSignIn} {onSignUp} {onOtherDevice} onError={handleError}>
   <AuthorizeHeader origin={$authorizationContextStore.requestOrigin} />
   <h1 class="text-text-primary mb-2 self-start text-2xl font-medium">
     Choose method

--- a/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
@@ -5,7 +5,6 @@ import {
   createIdentity,
   dummyAuth,
   FEATURE_FLAGS,
-  II_URL,
 } from "../utils";
 
 const DEFAULT_USER_NAME = "John Doe";

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -65,9 +65,6 @@ test.describe("First visit", () => {
       `https://${await newDevicePage.getByLabel("Pairing link").innerText()}`,
     );
     linkToPair.search = FEATURE_FLAG;
-    const authorizeNewDevicePromise = existingDevicePage
-      .getByRole("heading", { level: 1, name: "Authorize new device" })
-      .waitFor();
 
     // Switch to existing device and authenticate after visiting link
     await existingDevicePage.goto(linkToPair.href);
@@ -87,7 +84,9 @@ test.describe("First visit", () => {
     const confirmationCodeArray = confirmationCode.split("");
 
     // Switch to existing device and enter confirmation code
-    await authorizeNewDevicePromise;
+    await existingDevicePage
+      .getByRole("heading", { level: 1, name: "Authorize new device" })
+      .waitFor();
     for (let i = 0; i < confirmationCodeArray.length; i++) {
       const code = confirmationCodeArray[i];
       await existingDevicePage.getByLabel(`Code input ${i}`).fill(code);

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -54,7 +54,7 @@ test.describe("First visit", () => {
       authExistingDevice,
     );
 
-    // Start "continue from another device" flow from another device
+    // Switch to new device and start "Continue from another device" flow to get link
     const newContext = await browser.newContext();
     const newDevicePage = await newContext.newPage();
     await newDevicePage.goto(II_URL + FEATURE_FLAG);
@@ -69,7 +69,7 @@ test.describe("First visit", () => {
       .getByRole("heading", { level: 1, name: "Authorize new device" })
       .waitFor();
 
-    // Go to link from existing device and authenticate
+    // Switch to existing device and authenticate after visiting link
     await existingDevicePage.goto(linkToPair.href);
     authExistingDevice(page);
     await existingDevicePage

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -71,7 +71,7 @@ test.describe("First visit", () => {
 
     // Switch to existing device and authenticate after visiting link
     await existingDevicePage.goto(linkToPair.href);
-    authExistingDevice(page);
+    authExistingDevice(existingDevicePage);
     await existingDevicePage
       .getByRole("button", { name: DEFAULT_USER_NAME })
       .click();

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -46,7 +46,7 @@ test.describe("First visit", () => {
 
   test("Sign in from another device", async ({ browser, page }) => {
     // Create identity on existing device
-    const existingDevicePage = page;
+    const existingDevicePage = page; // Create alias variable for clarity
     const authExistingDevice = dummyAuth();
     await createIdentity(
       existingDevicePage,

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -92,8 +92,10 @@ test.describe("First visit", () => {
       const code = confirmationCodeArray[i];
       await existingDevicePage.getByLabel(`Code input ${i}`).fill(code);
     }
-    await page.getByRole("button", { name: "Confirm sign-in" }).click();
-    await page
+    await existingDevicePage
+      .getByRole("button", { name: "Confirm sign-in" })
+      .click();
+    await existingDevicePage
       .getByRole("heading", { level: 1, name: "Continue on your new device" })
       .waitFor();
 

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -3,6 +3,7 @@ import { Principal } from "@dfinity/principal";
 import { readCanisterId } from "@dfinity/internet-identity-vite-plugins/utils";
 
 const testAppCanisterId = readCanisterId({ canisterName: "test_app" });
+export const FEATURE_FLAGS = "?feature_flag_continue_from_another_device=true";
 export const II_URL = "https://id.ai";
 export const TEST_APP_URL = "https://nice-name.com";
 export const NOT_TEST_APP_URL = "https://very-nice-name.com";
@@ -39,7 +40,9 @@ export const authorize = async (
 ): Promise<string> => {
   // Open demo app and assert that user isn't authenticated yet
   await page.goto(TEST_APP_URL);
-  await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
+  await page
+    .getByRole("textbox", { name: "Identity Provider" })
+    .fill(II_URL + FEATURE_FLAGS);
   await expect(page.locator("#principal")).toBeHidden();
   const pagePromise = page.context().waitForEvent("page");
 


### PR DESCRIPTION
Implement e2e test for "Continue from another device" flow.

# Changes

- Add "Sign in from another device" to `index.spec.ts`.
- Add "Sign in from another device" to `authorize/index.spec.ts`.
- Fix issue found while adding the above: make sure to go back to authorize screen after creating passkey.

# Tests

- Visually verified the e2e test from the landing page behaved as expected and passed.
- Visually verified the e2e test from the authorize page behaved as expected and passed.






<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->





