### PR TITLE
Change credential id param to list of credentials

### DIFF
--- a/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
@@ -23,7 +23,7 @@ export class AuthLastUsedFlow {
         const { identity, identityNumber } = await authenticateWithPasskey({
           canisterId,
           session: get(sessionStore),
-          credentialId: lastUsedIdentity.authMethod.passkey.credentialId,
+          credentialIds: [lastUsedIdentity.authMethod.passkey.credentialId],
         });
         authenticationStore.set({ identity, identityNumber });
         lastUsedIdentitiesStore.addLastUsedIdentity(lastUsedIdentity);

--- a/src/frontend/src/lib/utils/authentication/passkey.ts
+++ b/src/frontend/src/lib/utils/authentication/passkey.ts
@@ -25,12 +25,12 @@ export class IdentityNotMigratedError extends Error {
 export const authenticateWithPasskey = async ({
   canisterId,
   session,
-  credentialId,
+  credentialIds,
   expiration = 30 * 60 * 1000,
 }: {
   canisterId: Principal;
   session: Pick<Session, "identity" | "agent">;
-  credentialId?: Uint8Array;
+  credentialIds?: Uint8Array[];
   expiration?: number;
 }): Promise<{
   identity: DelegationIdentity;
@@ -47,7 +47,7 @@ export const authenticateWithPasskey = async ({
   const passkeyIdentity = dummyAuth
     ? DiscoverableDummyIdentity.useExisting()
     : DiscoverablePasskeyIdentity.useExisting({
-        credentialId,
+        credentialIds,
         getPublicKey: async (result) => {
           const lookupResult = (
             await actor.lookup_device_key(new Uint8Array(result.rawId))

--- a/src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts
+++ b/src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts
@@ -183,17 +183,17 @@ export class DiscoverablePasskeyIdentity extends SignIdentity {
   }
 
   static useExisting({
-    credentialId,
+    credentialIds,
     getPublicKey,
   }: {
-    credentialId?: Uint8Array;
+    credentialIds?: Uint8Array[];
     getPublicKey: (
       result: PublicKeyCredentialWithAttachment,
     ) => Promise<CosePublicKey>;
   }): DiscoverablePasskeyIdentity {
     return new DiscoverablePasskeyIdentity({
       getPublicKey,
-      credentialRequestOptions: requestOptions(credentialId),
+      credentialRequestOptions: requestOptions(credentialIds),
     });
   }
 
@@ -315,13 +315,14 @@ export const creationOptions = (
 });
 
 export const requestOptions = (
-  credentialId?: Uint8Array,
+  credentialIds?: Uint8Array[],
 ): CredentialRequestOptionsWithoutChallenge => ({
   publicKey: {
-    // Either use the specified credential id or let the user pick a passkey
-    allowCredentials: nonNullish(credentialId)
-      ? [{ id: credentialId, type: "public-key" }]
-      : undefined,
+    // Either use the specified credential ids or let the user pick a passkey
+    allowCredentials:
+      nonNullish(credentialIds) && credentialIds.length > 0
+        ? credentialIds.map((id) => ({ id, type: "public-key" as const }))
+        : undefined,
     // Require passkeys to verify the user e.g. TouchID
     userVerification: "required",
   },


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We want to support multiple credentials being passed during the "Continue As" flow.

Therefore, we need to support passing a list of credentials instead of a single one in the helper functions.

This PR doesn't change any functionality, it just changes the parameter credential id from one to an array credentials. This way, we will be able to fetch the credentials based on the identity number and pass them for authentication.

# Changes

  - Updated `authenticateWithPasskey` to accept `credentialIds` (an array) instead of a single `credentialId`. This change is reflected in both the function signature and its internal logic.
  - Modified `DiscoverablePasskeyIdentity.useExisting` to handle `credentialIds` and updated the `credentialRequestOptions` accordingly. (`src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts`
* **Credential Request Options**:
  - Updated `requestOptions` to map over `credentialIds` and create an array of `allowCredentials` if `credentialIds` are provided. This ensures compatibility with multiple passkeys.

* **Integration with Frontend Flow**:
  - Adjusted the `AuthLastUsedFlow` component to pass `credentialIds` to the authentication function, ensuring the updated API is utilized. (`src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts`

# Tests

No change in functionality.
