### PR TITLE
Add sessions to device registration state

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -142,7 +142,9 @@ export const idlFactory = ({ IDL }) => {
   });
   const AuthnMethodAddError = IDL.Variant({ 'InvalidMetadata' : IDL.Text });
   const AuthnMethodConfirmationError = IDL.Variant({
+    'InternalCanisterError' : IDL.Text,
     'RegistrationModeOff' : IDL.Null,
+    'Unauthorized' : IDL.Principal,
     'NoAuthnMethodToConfirm' : IDL.Null,
     'WrongCode' : IDL.Record({ 'retries_left' : IDL.Nat8 }),
   });

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -54,7 +54,11 @@ export interface AuthnMethodConfirmationCode {
   'confirmation_code' : string,
   'expiration' : Timestamp,
 }
-export type AuthnMethodConfirmationError = { 'RegistrationModeOff' : null } |
+export type AuthnMethodConfirmationError = {
+    'InternalCanisterError' : string
+  } |
+  { 'RegistrationModeOff' : null } |
+  { 'Unauthorized' : Principal } |
   { 'NoAuthnMethodToConfirm' : null } |
   { 'WrongCode' : { 'retries_left' : number } };
 export interface AuthnMethodData {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -505,6 +505,8 @@ type AuthnMethodRegisterError = variant {
 };
 
 type AuthnMethodConfirmationError = variant {
+    Unauthorized : principal;
+    InternalCanisterError : text;
     // Wrong confirmation code entered. Retry with correct code.
     WrongCode : record {
         retries_left : nat8;

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -1,18 +1,14 @@
-use crate::anchor_management::add_device;
 use crate::authz_utils::IdentityUpdateError;
 use crate::state::RegistrationState::{
     DeviceRegistrationModeActive, DeviceTentativelyAdded, SessionTentativelyAdded,
     SessionTentativelyConfirmed,
 };
 use crate::state::TentativeDeviceRegistration;
-use crate::storage::anchor::Anchor;
 use crate::{secs_to_nanos, state};
 use candid::{CandidType, Principal};
 use ic_cdk::api::time;
 use ic_cdk::{call, trap};
-use internet_identity_interface::archive::types::Operation;
 use internet_identity_interface::internet_identity::types::*;
-use std::collections::hash_map::Entry;
 use std::collections::{hash_map, HashMap};
 use TentativeDeviceRegistrationError::{AnotherDeviceTentativelyAdded, DeviceRegistrationModeOff};
 

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -170,10 +170,10 @@ pub fn confirm_tentative_device_or_session(
                 }
                 DeviceTentativelyAdded {
                     failed_attempts,
-                    confirmation_code: verification_code,
+                    confirmation_code,
                     tentative_device,
                 } => {
-                    if user_confirmation_code == *verification_code {
+                    if user_confirmation_code == *confirmation_code {
                         // Verification successful - return device to be added and remove the registration
                         (true, Ok(Some(tentative_device.clone())))
                     } else {
@@ -191,10 +191,10 @@ pub fn confirm_tentative_device_or_session(
                 }
                 SessionTentativelyAdded {
                     failed_attempts,
-                    confirmation_code: verification_code,
+                    confirmation_code,
                     tentative_session,
                 } => {
-                    if user_confirmation_code == *verification_code {
+                    if user_confirmation_code == *confirmation_code {
                         let principal = *tentative_session;
 
                         // Verification successful - we'll confirm the session and keep the registration

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -1,6 +1,9 @@
 use crate::anchor_management::add_device;
 use crate::authz_utils::IdentityUpdateError;
-use crate::state::RegistrationState::{DeviceRegistrationModeActive, DeviceTentativelyAdded};
+use crate::state::RegistrationState::{
+    DeviceRegistrationModeActive, DeviceTentativelyAdded, SessionTentativelyAdded,
+    SessionTentativelyConfirmed,
+};
 use crate::state::TentativeDeviceRegistration;
 use crate::storage::anchor::Anchor;
 use crate::{secs_to_nanos, state};
@@ -9,6 +12,7 @@ use ic_cdk::api::time;
 use ic_cdk::{call, trap};
 use internet_identity_interface::archive::types::Operation;
 use internet_identity_interface::internet_identity::types::*;
+use std::collections::hash_map::Entry;
 use std::collections::{hash_map, HashMap};
 use TentativeDeviceRegistrationError::{AnotherDeviceTentativelyAdded, DeviceRegistrationModeOff};
 
@@ -77,7 +81,7 @@ pub fn exit_device_registration_mode(anchor_number: AnchorNumber) {
 }
 
 pub struct TentativeRegistrationInfo {
-    pub verification_code: DeviceVerificationCode,
+    pub verification_code: DeviceConfirmationCode,
     pub device_registration_timeout: Timestamp,
 }
 
@@ -96,35 +100,42 @@ impl From<IdentityUpdateError> for TentativeDeviceRegistrationError {
 
 pub async fn add_tentative_device(
     anchor_number: AnchorNumber,
-    device_data: DeviceData,
+    tentative_device: DeviceData,
 ) -> Result<TentativeRegistrationInfo, TentativeDeviceRegistrationError> {
-    let verification_code = new_verification_code().await;
+    let confirmation_code = new_confirmation_code().await;
     let now = time();
 
     state::tentative_device_registrations_mut(|registrations| {
         state::lookup_tentative_device_registration_mut(|lookup| {
             prune_expired_tentative_device_registrations(registrations, lookup);
 
-            match registrations.get_mut(&anchor_number) {
-                None => Err(DeviceRegistrationModeOff),
-                Some(TentativeDeviceRegistration { expiration, .. }) if *expiration <= now => {
+            // Get registration else throw error
+            let registration = registrations
+                .get_mut(&anchor_number)
+                .ok_or(DeviceRegistrationModeOff)?;
+
+            match registration {
+                // Make sure registration isn't expired
+                TentativeDeviceRegistration { expiration, .. } if *expiration <= now => {
                     Err(DeviceRegistrationModeOff)
                 }
-                Some(TentativeDeviceRegistration {
-                    state: DeviceTentativelyAdded { .. },
+                // Add tentative session if registration mode is active
+                TentativeDeviceRegistration {
+                    state: DeviceRegistrationModeActive,
                     ..
-                }) => Err(AnotherDeviceTentativelyAdded),
-                Some(registration) => {
+                } => {
                     registration.state = DeviceTentativelyAdded {
-                        tentative_device: device_data,
+                        tentative_device,
                         failed_attempts: 0,
-                        verification_code: verification_code.clone(),
+                        confirmation_code: confirmation_code.clone(),
                     };
                     Ok(TentativeRegistrationInfo {
                         device_registration_timeout: registration.expiration,
-                        verification_code,
+                        verification_code: confirmation_code,
                     })
                 }
+                // Else return error
+                _ => Err(AnotherDeviceTentativelyAdded),
             }
         })
     })
@@ -135,82 +146,80 @@ pub enum VerifyTentativeDeviceError {
     WrongCode { retries_left: u8 },
     DeviceRegistrationModeOff,
     NoDeviceToVerify,
-    IdentityUpdateError(IdentityUpdateError),
 }
 
-impl From<IdentityUpdateError> for VerifyTentativeDeviceError {
-    fn from(err: IdentityUpdateError) -> Self {
-        VerifyTentativeDeviceError::IdentityUpdateError(err)
-    }
-}
-
-/// Verifies the tentative device using the submitted `user_verification_code` and returns
-/// a result of [VerifyTentativeDeviceResponse]. [VerifyTentativeDeviceResponse] is used both as
-/// a success and an error type because it corresponds to the candid variant unifying success and
-/// error cases. See `authenticated_anchor_operation` for more details on how the [Result] is handled.
-pub fn verify_tentative_device(
-    anchor: &mut Anchor,
+/// Confirm the tentative device or session using the submitted `user_confirmation_code`.
+///
+/// # Returns
+/// [`Some(DeviceData)`] if a device (or [`None`] if a session) has been confirmed
+///
+/// # Errors
+/// Returns an error if either there's no tentative device or session or the code is incorrect.
+pub fn confirm_tentative_device_or_session(
     anchor_number: AnchorNumber,
-    user_verification_code: DeviceVerificationCode,
-) -> Result<((), Operation), VerifyTentativeDeviceError> {
-    match get_verified_device(anchor_number, user_verification_code) {
-        Ok(device) => {
-            let operation = add_device(anchor, device);
-            Ok(((), operation))
-        }
-        Err(err) => Err(err),
-    }
-}
-
-/// Checks the device verification code for a tentative device.
-/// If valid, returns the device to be added and exits device registration mode
-/// If invalid, returns the appropriate error to send to the client and increases failed attempts. Exits device registration mode if there are no retries left.
-fn get_verified_device(
-    anchor_number: AnchorNumber,
-    user_verification_code: DeviceVerificationCode,
-) -> Result<DeviceData, VerifyTentativeDeviceError> {
+    user_confirmation_code: DeviceConfirmationCode,
+) -> Result<Option<DeviceData>, VerifyTentativeDeviceError> {
     state::tentative_device_registrations_mut(|registrations| {
         state::lookup_tentative_device_registration_mut(|lookup| {
             prune_expired_tentative_device_registrations(registrations, lookup);
 
-            // Check if the registration exists
-            if !registrations.contains_key(&anchor_number) {
-                return Err(VerifyTentativeDeviceError::DeviceRegistrationModeOff);
-            }
+            // Get registration else throw error
+            let registration = registrations
+                .get_mut(&anchor_number)
+                .ok_or(VerifyTentativeDeviceError::DeviceRegistrationModeOff)?;
 
-            // Check the state and prepare the response without keeping a mutable reference
-            let (should_remove, response) =
-                match &mut registrations.get_mut(&anchor_number).unwrap().state {
-                    DeviceRegistrationModeActive => {
-                        (false, Err(VerifyTentativeDeviceError::NoDeviceToVerify))
+            let (should_remove, response) = match &mut registration.state {
+                DeviceRegistrationModeActive | SessionTentativelyConfirmed { .. } => {
+                    (false, Err(VerifyTentativeDeviceError::NoDeviceToVerify))
+                }
+                DeviceTentativelyAdded {
+                    failed_attempts,
+                    confirmation_code: verification_code,
+                    tentative_device,
+                } => {
+                    if user_confirmation_code == *verification_code {
+                        // Verification successful - return device to be added and remove the registration
+                        (true, Ok(Some(tentative_device.clone())))
+                    } else {
+                        // Increment failed attempts counter
+                        *failed_attempts += 1;
+
+                        // Remove registration if max attempts reached
+                        (
+                            *failed_attempts >= MAX_DEVICE_REGISTRATION_ATTEMPTS,
+                            Err(VerifyTentativeDeviceError::WrongCode {
+                                retries_left: (MAX_DEVICE_REGISTRATION_ATTEMPTS - *failed_attempts),
+                            }),
+                        )
                     }
-                    DeviceTentativelyAdded {
-                        failed_attempts,
-                        verification_code,
-                        tentative_device,
-                    } => {
-                        if user_verification_code == *verification_code {
-                            // Verification successful - we'll remove the registration
-                            (true, Ok(tentative_device.clone()))
-                        } else {
-                            // Increment failed attempts counter
-                            *failed_attempts += 1;
+                }
+                SessionTentativelyAdded {
+                    failed_attempts,
+                    confirmation_code: verification_code,
+                    tentative_session,
+                } => {
+                    if user_confirmation_code == *verification_code {
+                        let principal = *tentative_session;
 
-                            // Check if max attempts reached
-                            let should_remove =
-                                *failed_attempts >= MAX_DEVICE_REGISTRATION_ATTEMPTS;
+                        // Verification successful - we'll confirm the session and keep the registration
+                        registration.state = SessionTentativelyConfirmed {
+                            tentative_session: principal,
+                        };
+                        (false, Ok(None))
+                    } else {
+                        // Increment failed attempts counter
+                        *failed_attempts += 1;
 
-                            (
-                                should_remove,
-                                Err(VerifyTentativeDeviceError::WrongCode {
-                                    retries_left: (MAX_DEVICE_REGISTRATION_ATTEMPTS
-                                        - *failed_attempts),
-                                }),
-                            )
-                        }
+                        // Remove registration if max attempts reached
+                        (
+                            *failed_attempts >= MAX_DEVICE_REGISTRATION_ATTEMPTS,
+                            Err(VerifyTentativeDeviceError::WrongCode {
+                                retries_left: (MAX_DEVICE_REGISTRATION_ATTEMPTS - *failed_attempts),
+                            }),
+                        )
                     }
-                };
-
+                }
+            };
             // Now handle removal if needed, after we're done with the mutable borrow
             if should_remove {
                 if let Some(TentativeDeviceRegistration {
@@ -221,14 +230,13 @@ fn get_verified_device(
                     lookup.remove(&reg_id);
                 }
             }
-
             response
         })
     })
 }
 
-/// Return a decimal representation of a random `u32` to be used as verification code
-async fn new_verification_code() -> DeviceVerificationCode {
+/// Return a decimal representation of a random `u32` to be used as confirmation code
+async fn new_confirmation_code() -> DeviceConfirmationCode {
     let res: Vec<u8> = match call(Principal::management_canister(), "raw_rand", ()).await {
         Ok((res,)) => res,
         Err((_, err)) => trap(&format!("failed to get randomness: {err}")),

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -154,7 +154,7 @@ pub enum VerifyTentativeDeviceError {
 /// [`Some(DeviceData)`] if a device (or [`None`] if a session) has been confirmed
 ///
 /// # Errors
-/// Returns an error if either there's no tentative device or session or the code is incorrect.
+/// Returns an error if either there's no tentative device (or session) or the code is incorrect.
 pub fn confirm_tentative_device_or_session(
     anchor_number: AnchorNumber,
     user_confirmation_code: DeviceConfirmationCode,

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -74,8 +74,16 @@ impl TentativeDeviceRegistration {
     }
 }
 
-/// Registration state of new devices added using the two step device add flow
+/// Registration state of new devices added using either:
+/// - two-step device add flow
+///   1. `DeviceRegistrationModeActive`
+///   2. `DeviceTentativelyAdded`
+/// - three-step session add flow
+///   1. `DeviceRegistrationModeActive`
+///   2. `SessionTentativelyAdded`
+///   2. `SessionTentativelyConfirmed`
 #[derive(Clone)]
+#[allow(unused)] // TODO: Remove once used
 pub enum RegistrationState {
     DeviceRegistrationModeActive,
     DeviceTentativelyAdded {

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -12,7 +12,7 @@ use crate::storage::anchor::Anchor;
 use crate::storage::MAX_ENTRIES;
 use crate::{random_salt, Storage};
 use asset_util::CertifiedAssets;
-use candid::{CandidType, Deserialize};
+use candid::{CandidType, Deserialize, Principal};
 use ic_canister_sig_creation::signature_map::SignatureMap;
 use ic_cdk::trap;
 use ic_stable_structures::DefaultMemoryImpl;
@@ -80,8 +80,16 @@ pub enum RegistrationState {
     DeviceRegistrationModeActive,
     DeviceTentativelyAdded {
         tentative_device: DeviceData,
-        verification_code: DeviceVerificationCode,
+        confirmation_code: DeviceConfirmationCode,
         failed_attempts: FailedAttemptsCounter,
+    },
+    SessionTentativelyAdded {
+        tentative_session: Principal,
+        confirmation_code: DeviceConfirmationCode,
+        failed_attempts: FailedAttemptsCounter,
+    },
+    SessionTentativelyConfirmed {
+        tentative_session: Principal,
     },
 }
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -13,7 +13,7 @@ pub type FrontendHostname = String;
 pub type ApplicationNumber = u64;
 pub type Timestamp = u64; // in nanos since epoch
 pub type Signature = ByteBuf;
-pub type DeviceVerificationCode = String;
+pub type DeviceConfirmationCode = String;
 pub type FailedAttemptsCounter = u8;
 pub type AccountNumber = u64;
 
@@ -146,7 +146,7 @@ pub enum GetDelegationResponse {
 pub enum AddTentativeDeviceResponse {
     #[serde(rename = "added_tentatively")]
     AddedTentatively {
-        verification_code: DeviceVerificationCode,
+        verification_code: DeviceConfirmationCode,
         device_registration_timeout: Timestamp,
     },
     #[serde(rename = "device_registration_mode_off")]

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -147,6 +147,8 @@ pub enum AuthnMethodRegistrationModeEnterError {
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum AuthnMethodConfirmationError {
+    Unauthorized(Principal),
+    InternalCanisterError(String),
     WrongCode { retries_left: u8 },
     RegistrationModeOff,
     NoAuthnMethodToConfirm,


### PR DESCRIPTION
Add the concept of sessions to the device registration state.

# Changes

- Add `SessionTentativelyAdded` and `SessionTentativelyConfirmed` to `RegistrationState`.
- Refactor `add_tentative_device` to handle above additional states, explicitly only allow adding a tentative device when the current state is `DeviceRegistrationModeActive`.
- Merge `verify_tentative_device` and `get_tentative_device` into new `confirm_tentative_device_or_session` method since this concept has changed with additional session states.
- Refactor the above method to support sessions.
- Remove `IdentityUpdateError` variant from `VerifyTentativeDeviceError` since we no longer directly add the device directly in the above method, instead we return the confirmed device that should be added.
- Add `Unauthorized(Principal)` and `InternalCanisterError(text)` to `AuthnMethodConfirmationError` canister error (v2 did).
- Rename verification code to confirmation code for clarity in various places (v1 methods remain as is).

# Tests

- Manually verified that existing device registration flow still works as expected.



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


