### PR TITLE
Hide system overlay on error.

### DIFF
--- a/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
@@ -54,6 +54,7 @@ export class AuthLastUsedFlow {
         throw new Error("Unrecognized authentication method");
       }
     } finally {
+      this.systemOverlay = false;
       this.authenticatingIdentity = null;
     }
   };


### PR DESCRIPTION
Hide system overlay on error.

# Changes

- Set `systemOverlay` to `false` in `finally` block.

# Tests

- Verified that that the system overlay now correctly hides on error e.g. cancellation.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
