### PR TITLE
Fetch identity credentials

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { nonNullish } from "@dfinity/utils";
   import { AuthFlow } from "$lib/flows/authFlow.svelte";
-  import { AuthLastUsedFlow } from "$lib/flows/authLastUsedFlow.svelte";
   import type { Snippet } from "svelte";
   import SolveCaptcha from "$lib/components/wizards/auth/views/SolveCaptcha.svelte";
   import PickAuthenticationMethod from "$lib/components/wizards/auth/views/PickAuthenticationMethod.svelte";
@@ -32,7 +31,6 @@
   }: Props = $props();
 
   const authFlow = new AuthFlow();
-  const authLastUsedFlow = new AuthLastUsedFlow();
 
   let isContinueFromAnotherDeviceVisible = $state(false);
 
@@ -109,6 +107,6 @@
   {/if}
 {/if}
 
-{#if authFlow.systemOverlay || authLastUsedFlow.systemOverlay}
+{#if authFlow.systemOverlay}
   <SystemOverlayBackdrop />
 {/if}

--- a/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
@@ -2,7 +2,7 @@ import {
   authenticateWithJWT,
   authenticateWithPasskey,
 } from "$lib/utils/authentication";
-import { canisterConfig, canisterId } from "$lib/globals";
+import { anonymousActor, canisterConfig, canisterId } from "$lib/globals";
 import { authenticationStore } from "$lib/stores/authentication.store";
 import {
   lastUsedIdentitiesStore,
@@ -18,8 +18,7 @@ const fetchIdentityCredentials = async (
   identityNumber: bigint,
 ): Promise<Uint8Array[] | undefined> => {
   try {
-    const identityCredentials =
-      await get(sessionStore).actor.lookup(identityNumber);
+    const identityCredentials = await anonymousActor.lookup(identityNumber);
     const validCredentials = identityCredentials
       .filter((device) => "authentication" in device.purpose)
       .filter(({ key_type }) => !("browser_storage_key" in key_type))

--- a/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
@@ -20,7 +20,6 @@ export class AuthLastUsedFlow {
     this.authenticatingIdentity = lastUsedIdentity.identityNumber;
     try {
       if ("passkey" in lastUsedIdentity.authMethod) {
-        // If there is a problem looking up the credentials, we fallback to the credentialId provided by the lastUsedIdentity
         const credentialIds = lastUsedIdentity.credentialIds ?? [
           lastUsedIdentity.authMethod.passkey.credentialId,
         ];

--- a/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
@@ -12,17 +12,25 @@ import { createGoogleRequestConfig, requestJWT } from "$lib/utils/openID";
 import { get } from "svelte/store";
 import { sessionStore } from "$lib/stores/session.store";
 import { isNullish } from "@dfinity/utils";
+import { fetchIdentityCredentials } from "$lib/utils/fetchCredentials";
 
 export class AuthLastUsedFlow {
   systemOverlay = $state(false);
   authenticatingIdentity = $state<bigint | null>(null);
+  #identityCredentials: Map<bigint, Uint8Array[] | undefined> = new Map();
+  init(identities: bigint[]) {
+    identities.forEach(async (identityNumber) => {
+      const credentials = await fetchIdentityCredentials(identityNumber);
+      this.#identityCredentials.set(identityNumber, credentials);
+    });
+  }
   authenticate = async (lastUsedIdentity: LastUsedIdentity): Promise<void> => {
     this.authenticatingIdentity = lastUsedIdentity.identityNumber;
     try {
       if ("passkey" in lastUsedIdentity.authMethod) {
-        const credentialIds = lastUsedIdentity.credentialIds ?? [
-          lastUsedIdentity.authMethod.passkey.credentialId,
-        ];
+        const credentialIds = this.#identityCredentials.get(
+          lastUsedIdentity.identityNumber,
+        ) ?? [lastUsedIdentity.authMethod.passkey.credentialId];
         const { identity, identityNumber } = await authenticateWithPasskey({
           canisterId,
           session: get(sessionStore),

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -19,6 +19,8 @@ export type LastUsedAccounts = {
 export type LastUsedIdentity = {
   identityNumber: bigint;
   name?: string;
+  // We only use the cached `credentialId` as a fallback.
+  // We look up the authenticators to pass all credential ids.
   authMethod:
     | { passkey: { credentialId: Uint8Array } }
     | { openid: { iss: string; sub: string } };

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -22,8 +22,6 @@ export type LastUsedIdentity = {
   authMethod:
     | { passkey: { credentialId: Uint8Array } }
     | { openid: { iss: string; sub: string } };
-  // Field populated on store initialization
-  credentialIds?: Uint8Array[];
   accounts?: LastUsedAccounts;
   lastUsedTimestampMillis: number;
 };

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -3,35 +3,6 @@ import { derived, get, Readable, writable } from "svelte/store";
 import { writableStored } from "./writable.store";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { AccountInfo } from "$lib/generated/internet_identity_types";
-import { anonymousActor } from "$lib/globals";
-import { convertToValidCredentialData } from "$lib/utils/credential-devices";
-
-const fetchIdentityCredentials = async (
-  identityNumber: bigint,
-): Promise<Uint8Array[] | undefined> => {
-  try {
-    const identityCredentials = await anonymousActor.lookup(identityNumber);
-    const validCredentials = identityCredentials
-      .filter((device) => "authentication" in device.purpose)
-      .filter(({ key_type }) => !("browser_storage_key" in key_type))
-      .map(convertToValidCredentialData)
-      .filter(nonNullish);
-
-    if (validCredentials.length > 0) {
-      return validCredentials.map(
-        (credential) => new Uint8Array(credential.credentialId),
-      );
-    }
-
-    return undefined;
-  } catch (error) {
-    console.warn(
-      `Error looking up identity ${identityNumber} credentials:`,
-      error,
-    );
-    return undefined;
-  }
-};
 
 export type LastUsedAccount = {
   identityNumber: bigint;
@@ -103,20 +74,6 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
         : undefined,
     }),
   );
-
-  // Fetch credentials for all passkey identities
-  Object.values(get(lastUsedStore)).forEach(async (identity) => {
-    // Only fetch if the identity was used with passkey
-    if ("passkey" in identity.authMethod) {
-      const identityNumber = identity.identityNumber;
-      const credentials = await fetchIdentityCredentials(identityNumber);
-      lastUsedStore.update((lastUsedIdentities) => {
-        const identity = lastUsedIdentities[identityNumber.toString()];
-        identity.credentialIds = credentials;
-        return lastUsedIdentities;
-      });
-    }
-  });
 
   return {
     subscribe,

--- a/src/frontend/src/lib/utils/fetchCredentials.ts
+++ b/src/frontend/src/lib/utils/fetchCredentials.ts
@@ -1,0 +1,35 @@
+import { anonymousActor } from "$lib/globals";
+import { nonNullish } from "@dfinity/utils";
+import { convertToValidCredentialData } from "./credential-devices";
+
+/**
+ * Fetches the credentials for a given identity number.
+ * @param identityNumber The identity number to fetch credentials for.
+ * @returns An array of credentials or undefined if no valid credentials are found.
+ */
+export const fetchIdentityCredentials = async (
+  identityNumber: bigint,
+): Promise<Uint8Array[] | undefined> => {
+  try {
+    const identityCredentials = await anonymousActor.lookup(identityNumber);
+    const validCredentials = identityCredentials
+      .filter((device) => "authentication" in device.purpose)
+      .filter(({ key_type }) => !("browser_storage_key" in key_type))
+      .map(convertToValidCredentialData)
+      .filter(nonNullish);
+
+    if (validCredentials.length > 0) {
+      return validCredentials.map(
+        (credential) => new Uint8Array(credential.credentialId),
+      );
+    }
+
+    return undefined;
+  } catch (error) {
+    console.warn(
+      `Error looking up identity ${identityNumber} credentials:`,
+      error,
+    );
+    return undefined;
+  }
+};

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -70,12 +70,18 @@
       await gotoNext();
     }
   };
-  const authLastUsedFlow = new AuthLastUsedFlow();
 
   const lastUsedIdentities = $derived(
     Object.values($lastUsedIdentitiesStore.identities)
       .sort((a, b) => b.lastUsedTimestampMillis - a.lastUsedTimestampMillis)
       .slice(0, 3),
+  );
+  const authLastUsedFlow = new AuthLastUsedFlow();
+  // Initialize the flow every time the last used identities change
+  $effect(() =>
+    authLastUsedFlow.init(
+      lastUsedIdentities.map(({ identityNumber }) => identityNumber),
+    ),
   );
 
   let isAuthDialogOpen = $state(false);

--- a/src/frontend/src/routes/(new-styling)/authorize/continue/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/continue/+page.svelte
@@ -56,6 +56,12 @@
     return accounts;
   });
   const authLastUsedFlow = new AuthLastUsedFlow();
+  // Initialize the flow every time the last used identities change
+  $effect(() =>
+    authLastUsedFlow.init(
+      lastUsedAccounts.map(({ identityNumber }) => identityNumber),
+    ),
+  );
   let loading = $state(false);
 
   const handleContinueAs = async (account: LastUsedAccount) => {

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -60,8 +60,14 @@
     isAuthDialogOpen = false;
   };
 
+  const authLastUsedFlow = new AuthLastUsedFlow();
+  $effect(() =>
+    authLastUsedFlow.init(
+      lastUsedIdentities.map(({ identityNumber }) => identityNumber),
+    ),
+  );
+
   const handleSwitchIdentity = async (identityNumber: bigint) => {
-    const authLastUsedFlow = new AuthLastUsedFlow();
     const chosenIdentity =
       $lastUsedIdentitiesStore.identities[Number(identityNumber)];
     await authLastUsedFlow.authenticate(chosenIdentity);

--- a/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
@@ -179,9 +179,9 @@ test("User can add a new passkey and use it with cached identity without clearin
   await newPage.goto(II_URL);
 
   // Click on the cached identity button directly
-  await newPage.getByRole("button", { name: TEST_USER_NAME }).click();
   // But use the new passkey to authenticate
   auth2(newPage);
+  await newPage.getByRole("button", { name: TEST_USER_NAME }).click();
 
   // Verify we're logged in with the new passkey
   await newPage.waitForURL(II_URL + "/manage");


### PR DESCRIPTION
# Motivation

We want to enable new passkeys added from the same device as soon as they are added.

To do this, we fetch the identity's credentials before passing them for authentication using the `lookup` endpoint.

# Changes

* Fetch credentials with `lookup` in `init` in `AuthLastUsedFlow`.
* Trigger the init when creating `AuthLastUsedFlow` instance.

# Tests

* Tested locally by adding a new passkey from 1Password (initial one was iCloud) and then using immediately afterwards to log in. See video attached.
* I tested the flow from an application.
* I tested switching identity that the new passkey was requested as well.
* I teted that I could switch the identity from an application or dashboard.





<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->




