### PR TITLE
Remove flag from activate route.

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
@@ -7,7 +7,6 @@
   import type { PageProps } from "./$types";
   import { afterNavigate, invalidateAll, replaceState } from "$app/navigation";
   import { page } from "$app/state";
-  import { CONTINUE_FROM_ANOTHER_DEVICE } from "$lib/state/featureFlags";
   import { nonNullish } from "@dfinity/utils";
   import Dialog from "$lib/components/ui/Dialog.svelte";
   import { ConfirmAccessMethodWizard } from "$lib/components/wizards/confirmAccessMethod";

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
@@ -49,7 +49,7 @@
   </div>
 </div>
 
-{#if $CONTINUE_FROM_ANOTHER_DEVICE && nonNullish(pendingRegistrationId)}
+{#if nonNullish(pendingRegistrationId)}
   <Dialog onClose={() => (pendingRegistrationId = null)}>
     <ConfirmAccessMethodWizard
       registrationId={pendingRegistrationId}

--- a/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
@@ -62,13 +62,10 @@ test("Authorize by signing in from another device", async ({
     await authPage
       .getByRole("button", { name: "Continue from another device" })
       .click();
-    const linkToPair = new URL(
-      `https://${await authPage.getByLabel("Pairing link").innerText()}`,
-    );
-    linkToPair.search = FEATURE_FLAGS;
+    const linkToPair = `https://${await authPage.getByLabel("Pairing link").innerText()}`;
 
     // Switch to other device and authenticate after visiting link
-    await otherDevicePage.goto(linkToPair.href);
+    await otherDevicePage.goto(linkToPair);
     authOtherDevice(otherDevicePage);
     await otherDevicePage
       .getByRole("button", { name: DEFAULT_USER_NAME })

--- a/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
@@ -5,7 +5,6 @@ import {
   clearStorage,
   createIdentity,
   dummyAuth,
-  FEATURE_FLAGS,
   TEST_APP_URL,
   TEST_APP_CANONICAL_URL,
 } from "../utils";

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -1,9 +1,14 @@
 import { expect, test } from "@playwright/test";
-import { clearStorage, createIdentity, dummyAuth, II_URL } from "./utils";
+import {
+  clearStorage,
+  createIdentity,
+  dummyAuth,
+  FEATURE_FLAGS,
+  II_URL,
+} from "./utils";
 
 const DEFAULT_USER_NAME = "John Doe";
 const SECONDARY_USER_NAME = "Jane Doe";
-const FEATURE_FLAG = "?feature_flag_continue_from_another_device=true";
 
 test.describe("First visit", () => {
   test("Sign up with a new passkey", async ({ page }) => {
@@ -57,7 +62,7 @@ test.describe("First visit", () => {
     // Switch to new device and start "Continue from another device" flow to get link
     const newContext = await browser.newContext();
     const newDevicePage = await newContext.newPage();
-    await newDevicePage.goto(II_URL + FEATURE_FLAG);
+    await newDevicePage.goto(II_URL + FEATURE_FLAGS);
     await newDevicePage
       .getByRole("button", { name: "Continue from another device" })
       .click();

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -61,13 +61,10 @@ test.describe("First visit", () => {
     await newDevicePage
       .getByRole("button", { name: "Continue from another device" })
       .click();
-    const linkToPair = new URL(
-      `https://${await newDevicePage.getByLabel("Pairing link").innerText()}`,
-    );
-    linkToPair.search = FEATURE_FLAG;
+    const linkToPair = `https://${await newDevicePage.getByLabel("Pairing link").innerText()}`;
 
     // Switch to existing device and authenticate after visiting link
-    await existingDevicePage.goto(linkToPair.href);
+    await existingDevicePage.goto(linkToPair);
     authExistingDevice(existingDevicePage);
     await existingDevicePage
       .getByRole("button", { name: DEFAULT_USER_NAME })


### PR DESCRIPTION
Remove flag from activate route.

# Changes

- Remove `$CONTINUE_FROM_ANOTHER_DEVICE` condition from activate dialog in dashboard .

# Tests

- Verified that enabled flag is no longer needed when following an /activate link.
- Updated e2e to no longer add feature flag to activate links.
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
