### PR TITLE
Exit registration mode with device.

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -169,6 +169,12 @@ export const idlFactory = ({ IDL }) => {
     'AlreadyInProgress' : IDL.Null,
     'Unauthorized' : IDL.Principal,
   });
+  const AuthnMethodRegistrationModeExitError = IDL.Variant({
+    'InternalCanisterError' : IDL.Text,
+    'RegistrationModeOff' : IDL.Null,
+    'Unauthorized' : IDL.Principal,
+    'InvalidMetadata' : IDL.Text,
+  });
   const AuthnMethodReplaceError = IDL.Variant({
     'AuthnMethodNotFound' : IDL.Null,
     'InvalidMetadata' : IDL.Text,
@@ -528,7 +534,12 @@ export const idlFactory = ({ IDL }) => {
       ),
     'authn_method_registration_mode_exit' : IDL.Func(
         [IdentityNumber],
-        [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Null })],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Null,
+            'Err' : AuthnMethodRegistrationModeExitError,
+          }),
+        ],
         [],
       ),
     'authn_method_remove' : IDL.Func(

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -86,6 +86,12 @@ export type AuthnMethodRegistrationModeEnterError = {
   { 'InternalCanisterError' : string } |
   { 'AlreadyInProgress' : null } |
   { 'Unauthorized' : Principal };
+export type AuthnMethodRegistrationModeExitError = {
+    'InternalCanisterError' : string
+  } |
+  { 'RegistrationModeOff' : null } |
+  { 'Unauthorized' : Principal } |
+  { 'InvalidMetadata' : string };
 export type AuthnMethodReplaceError = { 'AuthnMethodNotFound' : null } |
   { 'InvalidMetadata' : string };
 export interface AuthnMethodSecuritySettings {
@@ -444,7 +450,7 @@ export interface _SERVICE {
   'authn_method_registration_mode_exit' : ActorMethod<
     [IdentityNumber],
     { 'Ok' : null } |
-      { 'Err' : null }
+      { 'Err' : AuthnMethodRegistrationModeExitError }
   >,
   'authn_method_remove' : ActorMethod<
     [IdentityNumber, PublicKey],

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -526,6 +526,13 @@ type AuthnMethodRegistrationModeEnterError = variant {
     InternalCanisterError : text;
 };
 
+type AuthnMethodRegistrationModeExitError = variant {
+    Unauthorized : principal;
+    InternalCanisterError : text;
+    RegistrationModeOff;
+    InvalidMetadata : text;
+};
+
 type LookupByRegistrationIdError = variant {
     InvalidRegistrationId : text;
 };
@@ -860,7 +867,7 @@ service : (opt InternetIdentityInit) -> {
 
     // Exits the authentication method registration mode for the identity.
     // Requires authentication.
-    authn_method_registration_mode_exit : (IdentityNumber) -> (variant { Ok; Err });
+    authn_method_registration_mode_exit : (IdentityNumber) -> (variant { Ok; Err : AuthnMethodRegistrationModeExitError });
 
     // Registers a new authentication method to the identity.
     // This authentication method needs to be confirmed before it can be used for authentication on this identity.

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -146,6 +146,14 @@ pub enum AuthnMethodRegistrationModeEnterError {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum AuthnMethodRegistrationModeExitError {
+    Unauthorized(Principal),
+    InternalCanisterError(String),
+    RegistrationModeOff,
+    InvalidMetadata(String),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub enum AuthnMethodConfirmationError {
     Unauthorized(Principal),
     InternalCanisterError(String),


### PR DESCRIPTION
Exit registration mode with device.

# Changes

- Update `authn_method_registration_mode_exit` to allow a confirmed session to exit by registering a authn method.
- Update above method to return new `AuthnMethodRegistrationModeExitError` error.
- Add `get_confirmed_session` method to get the confirmed session principal of a given anchor.

# Tests

- Verified exiting registration mode without device requires authentication and still works as expected.
