### PR TITLE
Return confirmed session in public identity_authn_info method.

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -342,6 +342,7 @@ export const idlFactory = ({ IDL }) => {
   const IdentityAuthnInfo = IDL.Record({
     'authn_methods' : IDL.Vec(AuthnMethod),
     'recovery_authn_methods' : IDL.Vec(AuthnMethod),
+    'authn_method_session' : IDL.Opt(IDL.Principal),
   });
   const AuthnMethodRegistrationInfo = IDL.Record({
     'expiration' : Timestamp,

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -232,6 +232,7 @@ export interface IdentityAnchorInfo {
 export interface IdentityAuthnInfo {
   'authn_methods' : Array<AuthnMethod>,
   'recovery_authn_methods' : Array<AuthnMethod>,
+  'authn_method_session' : [] | [Principal],
 }
 export interface IdentityInfo {
   'authn_methods' : Array<AuthnMethodData>,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -540,6 +540,7 @@ type LookupByRegistrationIdError = variant {
 type IdentityAuthnInfo = record {
     authn_methods : vec AuthnMethod;
     recovery_authn_methods : vec AuthnMethod;
+    authn_method_session : opt principal;
 };
 
 type IdentityInfo = record {
@@ -805,7 +806,7 @@ service : (opt InternetIdentityInit) -> {
 
     // V2 Identity Management API
     // ==========================
-    // WARNING: The following methods are experimental and may ch 0ange in the future.
+    // WARNING: The following methods are experimental and may change in the future.
 
     // Starts the identity registration flow to create a new identity.
     identity_registration_start : () -> (variant { Ok : IdRegNextStepResult; Err : IdRegStartError });

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -73,6 +73,7 @@ pub struct AuthnMethodRegistration {
 pub struct IdentityAuthnInfo {
     pub authn_methods: Vec<AuthnMethod>,
     pub recovery_authn_methods: Vec<AuthnMethod>,
+    pub authn_method_session: Option<Principal>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
Return confirmed session in public identity_authn_info method.

# Changes

- Add additional optional `authn_method_session` field in `IdentityAuthnInfo` which returns a confirmed session principal.

# Tests

- Verified that None is returned when the flag is false or unset. 

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
