### PR TITLE
Add method to check if session is confirmed

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -566,7 +566,7 @@ export const idlFactory = ({ IDL }) => {
     'authn_method_session_info' : IDL.Func(
         [IdentityNumber],
         [IDL.Opt(AuthnMethodSessionInfo)],
-        [],
+        ['query'],
       ),
     'authn_method_session_register' : IDL.Func(
         [IdentityNumber],

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -182,6 +182,7 @@ export const idlFactory = ({ IDL }) => {
   const AuthnMethodSecuritySettingsReplaceError = IDL.Variant({
     'AuthnMethodNotFound' : IDL.Null,
   });
+  const AuthnMethodSessionInfo = IDL.Record({ 'name' : IDL.Opt(IDL.Text) });
   const CheckCaptchaArg = IDL.Record({ 'solution' : IDL.Text });
   const RegistrationFlowNextStep = IDL.Variant({
     'CheckCaptcha' : IDL.Record({ 'captcha_png_base64' : IDL.Text }),
@@ -562,7 +563,12 @@ export const idlFactory = ({ IDL }) => {
         ],
         [],
       ),
-    'authn_method_session' : IDL.Func(
+    'authn_method_session_info' : IDL.Func(
+        [IdentityNumber],
+        [IDL.Opt(AuthnMethodSessionInfo)],
+        [],
+      ),
+    'authn_method_session_register' : IDL.Func(
         [IdentityNumber],
         [
           IDL.Variant({

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -101,6 +101,7 @@ export interface AuthnMethodSecuritySettings {
 export type AuthnMethodSecuritySettingsReplaceError = {
     'AuthnMethodNotFound' : null
   };
+export interface AuthnMethodSessionInfo { 'name' : [] | [string] }
 export interface BufferedArchiveEntry {
   'sequence_number' : bigint,
   'entry' : Uint8Array | number[],
@@ -467,7 +468,11 @@ export interface _SERVICE {
     { 'Ok' : null } |
       { 'Err' : AuthnMethodSecuritySettingsReplaceError }
   >,
-  'authn_method_session' : ActorMethod<
+  'authn_method_session_info' : ActorMethod<
+    [IdentityNumber],
+    [] | [AuthnMethodSessionInfo]
+  >,
+  'authn_method_session_register' : ActorMethod<
     [IdentityNumber],
     { 'Ok' : AuthnMethodConfirmationCode } |
       { 'Err' : AuthnMethodRegisterError }

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -882,7 +882,7 @@ service : (opt InternetIdentityInit) -> {
     authn_method_session_register : (IdentityNumber) -> (variant { Ok : AuthnMethodConfirmationCode; Err : AuthnMethodRegisterError });
 
     // Returns session info when session is confirmed and caller matches session.
-    authn_method_session_info : (IdentityNumber) -> (opt AuthnMethodSessionInfo);
+    authn_method_session_info : (IdentityNumber) -> (opt AuthnMethodSessionInfo) query;
 
     // Confirms a previously registered authentication method.
     // On successful confirmation, the authentication method is permanently added to the identity and can

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -877,7 +877,7 @@ service : (opt InternetIdentityInit) -> {
     // This authentication method needs to be confirmed before it can be used for authentication on this identity.
     authn_method_register : (IdentityNumber, AuthnMethodData) -> (variant { Ok : AuthnMethodConfirmationCode; Err : AuthnMethodRegisterError });
 
-    // Registers a new session for an identity.
+    // Registers a new session for the identity.
     // This session needs to be confirmed before it can be used to register an authentication method on this identity.
     authn_method_session_register : (IdentityNumber) -> (variant { Ok : AuthnMethodConfirmationCode; Err : AuthnMethodRegisterError });
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -495,6 +495,10 @@ type AuthnMethodConfirmationCode = record {
     expiration : Timestamp;
 };
 
+type AuthnMethodSessionInfo = record {
+    name : opt text;
+};
+
 type RegistrationId = text;
 
 type AuthnMethodRegisterError = variant {
@@ -873,9 +877,12 @@ service : (opt InternetIdentityInit) -> {
     // This authentication method needs to be confirmed before it can be used for authentication on this identity.
     authn_method_register : (IdentityNumber, AuthnMethodData) -> (variant { Ok : AuthnMethodConfirmationCode; Err : AuthnMethodRegisterError });
 
-    // Registers a new session to the identity.
+    // Registers a new session for an identity.
     // This session needs to be confirmed before it can be used to register an authentication method on this identity.
-    authn_method_session : (IdentityNumber) -> (variant { Ok : AuthnMethodConfirmationCode; Err : AuthnMethodRegisterError });
+    authn_method_session_register : (IdentityNumber) -> (variant { Ok : AuthnMethodConfirmationCode; Err : AuthnMethodRegisterError });
+
+    // Returns session info when session is confirmed and caller matches session.
+    authn_method_session_info : (IdentityNumber) -> (opt AuthnMethodSessionInfo);
 
     // Confirms a previously registered authentication method.
     // On successful confirmation, the authentication method is permanently added to the identity and can

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -258,3 +258,8 @@ pub enum CreateIdentityData {
 pub enum LookupByRegistrationIdError {
     InvalidRegistrationId(String),
 }
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct AuthnMethodSessionInfo {
+    pub name: Option<String>,
+}


### PR DESCRIPTION
Add `authn_method_session_info` method to check if session is confirmed and get info (name).

# Changes

- Add `authn_method_session_info` method that returns info (identity name) if session is confirmed and caller matches session. 
- Rename `authn_method_session` method to `authn_method_session_register` for clarity.

# Tests

- Verified that new `authn_method_session_info` traps if flag is false or unset.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

