### PR TITLE
Add tentative session in identity info.

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -277,6 +277,7 @@ export const idlFactory = ({ IDL }) => {
   const DeviceRegistrationInfo = IDL.Record({
     'tentative_device' : IDL.Opt(DeviceData),
     'expiration' : Timestamp,
+    'tentative_session' : IDL.Opt(IDL.Principal),
   });
   const IdentityAnchorInfo = IDL.Record({
     'name' : IDL.Opt(IDL.Text),
@@ -345,6 +346,7 @@ export const idlFactory = ({ IDL }) => {
   });
   const AuthnMethodRegistrationInfo = IDL.Record({
     'expiration' : Timestamp,
+    'session' : IDL.Opt(IDL.Principal),
     'authn_method' : IDL.Opt(AuthnMethodData),
   });
   const IdentityInfo = IDL.Record({

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -78,6 +78,7 @@ export type AuthnMethodRegisterError = { 'RegistrationModeOff' : null } |
   { 'InvalidMetadata' : string };
 export interface AuthnMethodRegistrationInfo {
   'expiration' : Timestamp,
+  'session' : [] | [Principal],
   'authn_method' : [] | [AuthnMethodData],
 }
 export type AuthnMethodRegistrationModeEnterError = {
@@ -162,6 +163,7 @@ export type DeviceProtection = { 'unprotected' : null } |
 export interface DeviceRegistrationInfo {
   'tentative_device' : [] | [DeviceData],
   'expiration' : Timestamp,
+  'tentative_session' : [] | [Principal],
 }
 export interface DeviceWithUsage {
   'alias' : string,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -301,10 +301,12 @@ type CaptchaResult = ChallengeResult;
 
 // Extra information about registration status for new devices
 type DeviceRegistrationInfo = record {
-    // If present, the user has tentatively added a new device. This
-    // new device needs to be verified (see relevant endpoint) before
-    // 'expiration'.
+    // If present, the user has registered a new authentication method. This new authentication
+    // method needs to be confirmed before 'expiration' in order to be added to the identity.
     tentative_device : opt DeviceData;
+    // If present, the user has registered a new session. This new session needs to be confirmed before
+    // 'expiration' in order for it be authorized to register an authentication method to the identity.
+    tentative_session : opt principal;
     // The timestamp at which the anchor will turn off registration mode
     // (and the tentative device will be forgotten, if any, and if not verified)
     expiration : Timestamp;
@@ -481,10 +483,13 @@ type OpenIDRegFinishArg = record {
 
 // Extra information about registration status for new authentication methods
 type AuthnMethodRegistrationInfo = record {
-    // If present, the user has registered a new authentication method. This
-    // new authentication needs to be verified before 'expiration' in order to
-    // be added to the identity.
+
+    // If present, the user has registered a new authentication method. This new authentication
+    // method needs to be confirmed before 'expiration' in order to be added to the identity.
     authn_method : opt AuthnMethodData;
+    // If present, the user has registered a new session. This new session needs to be confirmed before
+    // 'expiration' in order for it be authorized to register an authentication method to the identity.
+    session : opt principal;
     // The timestamp at which the identity will turn off registration mode
     // (and the authentication method will be forgotten, if any, and if not verified)
     expiration : Timestamp;

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -33,15 +33,13 @@ pub fn get_anchor_info(anchor_number: AnchorNumber) -> IdentityAnchorInfo {
             .collect(),
     );
     let name = anchor.name();
-    let now = time();
 
-    let tentative_device_registration =
-        state::get_tentative_device_registration_by_identity(anchor_number);
+    let device_registration =
+        tentative_device_registration::get_tentative_registration(anchor_number);
 
     IdentityAnchorInfo {
         devices,
-        device_registration: tentative_device_registration
-            .and_then(|reg| reg.to_info_if_still_valid(now)),
+        device_registration,
         openid_credentials,
         name,
     }

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -331,6 +331,14 @@ pub fn get_tentative_registration(anchor_number: AnchorNumber) -> Option<DeviceR
                         tentative_device: None,
                         tentative_session: Some(*tentative_session),
                     }),
+                    // Return expiration if no tentative registration exists yet in time window
+                    TentativeDeviceRegistration { expiration, .. } => {
+                        Some(DeviceRegistrationInfo {
+                            expiration: *expiration,
+                            tentative_device: None,
+                            tentative_session: None,
+                        })
+                    }
                     // Else return None
                     _ => None,
                 })

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -293,6 +293,51 @@ pub fn get_confirmed_session(anchor_number: AnchorNumber) -> Option<Principal> {
     })
 }
 
+pub fn get_tentative_registration(anchor_number: AnchorNumber) -> Option<DeviceRegistrationInfo> {
+    let now = time();
+
+    state::tentative_device_registrations_mut(|registrations| {
+        state::lookup_tentative_device_registration_mut(|lookup| {
+            prune_expired_tentative_device_registrations(registrations, lookup);
+
+            registrations
+                .get(&anchor_number)
+                .and_then(|registration| match registration {
+                    // Make sure registration isn't expired
+                    TentativeDeviceRegistration { expiration, .. } if *expiration <= now => None,
+                    // Return tentative device
+                    TentativeDeviceRegistration {
+                        expiration,
+                        state:
+                            DeviceTentativelyAdded {
+                                tentative_device, ..
+                            },
+                        ..
+                    } => Some(DeviceRegistrationInfo {
+                        expiration: *expiration,
+                        tentative_device: Some(tentative_device.clone()),
+                        tentative_session: None,
+                    }),
+                    // Return tentative session
+                    TentativeDeviceRegistration {
+                        expiration,
+                        state:
+                            SessionTentativelyAdded {
+                                tentative_session, ..
+                            },
+                        ..
+                    } => Some(DeviceRegistrationInfo {
+                        expiration: *expiration,
+                        tentative_device: None,
+                        tentative_session: Some(*tentative_session),
+                    }),
+                    // Else return None
+                    _ => None,
+                })
+        })
+    })
+}
+
 /// Removes __all__ expired device registrations -> there is no need to check expiration immediately after pruning.
 fn prune_expired_tentative_device_registrations(
     registrations: &mut HashMap<AnchorNumber, TentativeDeviceRegistration>,

--- a/src/internet_identity/src/anchor_management/tentative_device_registration.rs
+++ b/src/internet_identity/src/anchor_management/tentative_device_registration.rs
@@ -339,8 +339,6 @@ pub fn get_tentative_registration(anchor_number: AnchorNumber) -> Option<DeviceR
                             tentative_session: None,
                         })
                     }
-                    // Else return None
-                    _ => None,
                 })
         })
     })

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -49,31 +49,6 @@ pub struct TentativeDeviceRegistration {
     pub id: Option<ValidatedRegistrationId>,
 }
 
-impl TentativeDeviceRegistration {
-    pub fn to_info_if_still_valid(&self, now: Timestamp) -> Option<DeviceRegistrationInfo> {
-        match self {
-            TentativeDeviceRegistration {
-                expiration,
-                state:
-                    DeviceTentativelyAdded {
-                        tentative_device, ..
-                    },
-                ..
-            } if *expiration > now => Some(DeviceRegistrationInfo {
-                expiration: *expiration,
-                tentative_device: Some(tentative_device.clone()),
-            }),
-            TentativeDeviceRegistration { expiration, .. } if *expiration > now => {
-                Some(DeviceRegistrationInfo {
-                    expiration: *expiration,
-                    tentative_device: None,
-                })
-            }
-            _ => None,
-        }
-    }
-}
-
 /// Registration state of new devices added using either:
 /// - two-step device add flow
 ///   1. `DeviceRegistrationModeActive`

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -2,7 +2,6 @@ use crate::anchor_management::tentative_device_registration::ValidatedRegistrati
 use crate::archive::{ArchiveData, ArchiveState, ArchiveStatusCache};
 use crate::state::flow_states::FlowStates;
 use crate::state::temp_keys::TempKeys;
-use crate::state::RegistrationState::DeviceTentativelyAdded;
 use crate::stats::activity_stats::activity_counter::active_anchor_counter::ActiveAnchorCounter;
 use crate::stats::activity_stats::activity_counter::authn_method_counter::AuthnMethodCounter;
 use crate::stats::activity_stats::activity_counter::domain_active_anchor_counter::DomainActiveAnchorCounter;

--- a/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
@@ -174,10 +174,10 @@ fn identity_info_should_return_authn_method() -> Result<(), CallError> {
     assert!(matches!(
         identity_info.authn_method_registration,
         Some(AuthnMethodRegistration {
-            authn_method: Some(tenative_authn_method),
+            authn_method: Some(tentative_authn_method),
             expiration: tentative_authn_method_expiration,
             session: None
-        }) if tenative_authn_method == authn_method2 && tentative_authn_method_expiration == expiration
+        }) if tentative_authn_method == authn_method2 && tentative_authn_method_expiration == expiration
     ));
     Ok(())
 }

--- a/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
+++ b/src/internet_identity/tests/integration/v2_api/authn_method_registration.rs
@@ -173,8 +173,10 @@ fn identity_info_should_return_authn_method() -> Result<(), CallError> {
 
     assert!(matches!(
         identity_info.authn_method_registration,
-        Some(AuthnMethodRegistration {authn_method: Some(tenative_authn_method),
-            expiration: tentative_authn_method_expiration
+        Some(AuthnMethodRegistration {
+            authn_method: Some(tenative_authn_method),
+            expiration: tentative_authn_method_expiration,
+            session: None
         }) if tenative_authn_method == authn_method2 && tentative_authn_method_expiration == expiration
     ));
     Ok(())

--- a/src/internet_identity_interface/src/internet_identity/conversions.rs
+++ b/src/internet_identity_interface/src/internet_identity/conversions.rs
@@ -190,6 +190,7 @@ impl From<DeviceRegistrationInfo> for AuthnMethodRegistration {
         AuthnMethodRegistration {
             expiration: value.expiration,
             authn_method: value.tentative_device.map(AuthnMethodData::from),
+            session: value.tentative_session,
         }
     }
 }

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -171,6 +171,7 @@ pub enum VerifyTentativeDeviceResponse {
 pub struct DeviceRegistrationInfo {
     pub expiration: Timestamp,
     pub tentative_device: Option<DeviceData>,
+    pub tentative_session: Option<Principal>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -67,6 +67,7 @@ pub struct AuthnMethodData {
 pub struct AuthnMethodRegistration {
     pub expiration: Timestamp,
     pub authn_method: Option<AuthnMethodData>,
+    pub session: Option<Principal>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
Add tentative session in identity info.

# Changes

- Add `get_tentative_registration` method in `tentative_device_registration.rs`
- Remove `to_info_if_still_valid` method in `state.rs`, registrations should be accessed through `tentative_device_registration.rs` instead of directly.
- Add `session` to `AuthnMethodRegistration`.
- Add `tentative_session` to `DeviceRegistrationInfo`.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->





<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->




