### PR TITLE
Upgrade QA environment on new release

### DIFF
--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -292,6 +292,7 @@ deploy_release_candidate() {
   echo "Deploying II release candidate with same arguments as prod"
   dfx canister --network ic --wallet cvthj-wyaaa-aaaad-aaaaq-cai install jqajs-xiaaa-aaaad-aab5q-cai --mode=upgrade --wasm ./internet_identity.wasm.gz --argument-file ./args.txt
   dfx canister --network ic --wallet cvthj-wyaaa-aaaad-aaaaq-cai install fgte5-ciaaa-aaaad-aaatq-cai --mode=upgrade --wasm ./internet_identity.wasm.gz --argument-file ./args.txt
+  dfx canister --network ic --wallet cvthj-wyaaa-aaaad-aaaaq-cai install y2aaj-miaaa-aaaad-aacxq-cai --mode=upgrade --wasm ./internet_identity.wasm.gz --argument-file ./args.txt
 }
 
 test_release_candidate() {


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We created a new environment to be used for QA agencies: `y2aaj-miaaa-aaaad-aacxq-cai`.

They will be performing recurrent tests and we want their tests to be done in the latest version of II.

# Changes

* Add deployment step to new canister as part of the make proposal script.


<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/230ae4cf6/mobile/managePickMany.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->

