### PR TITLE
Register passkey from another device through session to automatically sign in.

### DIFF
--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -24,6 +24,7 @@
   } from "$lib/utils/accessMethods";
   import { AddAccessMethodWizard } from "$lib/components/wizards/addAccessMethod";
   import { authnMethodEqual, getAuthnMethodAlias } from "$lib/utils/webAuthn";
+  import { toaster } from "$lib/components/utils/toaster";
 
   const MAX_PASSKEYS = 8;
 
@@ -77,6 +78,12 @@
   };
   const handlePasskeyRegistered = (authnMethod: AuthnMethodData) => {
     authnMethods.push(authnMethod);
+    invalidateAll();
+  };
+  const handleOtherDeviceRegistered = () => {
+    toaster.success({
+      title: "Passkey has been registered from another device.",
+    });
     invalidateAll();
   };
   const handleRemoveOpenIdCredential = async () => {
@@ -237,7 +244,7 @@
     <AddAccessMethodWizard
       onGoogleLinked={handleGoogleLinked}
       onPasskeyRegistered={handlePasskeyRegistered}
-      onOtherDeviceRegistered={invalidateAll}
+      onOtherDeviceRegistered={handleOtherDeviceRegistered}
       onClose={() => (isAddAccessMethodWizardOpen = false)}
       {isMaxOpenIdCredentialsReached}
       {isUsingPasskeys}

--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -9,6 +9,7 @@
   import CreatePasskey from "$lib/components/wizards/auth/views/CreatePasskey.svelte";
   import SystemOverlayBackdrop from "$lib/components/utils/SystemOverlayBackdrop.svelte";
   import { RegisterAccessMethodWizard } from "$lib/components/wizards/registerAccessMethod";
+  import { canisterConfig } from "$lib/globals";
 
   interface Props {
     isAuthenticating?: boolean;
@@ -65,6 +66,13 @@
       isAuthenticating = false;
     }
   };
+  const handleRegistered = async (identityNumber: bigint) => {
+    if (canisterConfig.feature_flag_continue_from_another_device[0] === true) {
+      onSignIn(identityNumber);
+    } else {
+      onOtherDevice(identityNumber);
+    }
+  };
 </script>
 
 {#snippet dialogContent()}
@@ -79,7 +87,7 @@
 {/snippet}
 
 {#if isContinueFromAnotherDeviceVisible}
-  <RegisterAccessMethodWizard onRegistered={onOtherDevice} {onError} />
+  <RegisterAccessMethodWizard onRegistered={handleRegistered} {onError} />
 {:else if nonNullish(authFlow.captcha)}
   <SolveCaptcha {...authFlow.captcha} />
 {:else}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
@@ -11,10 +11,18 @@
   import Dialog from "$lib/components/ui/Dialog.svelte";
   import { ConfirmAccessMethodWizard } from "$lib/components/wizards/confirmAccessMethod";
   import { handleError } from "$lib/components/utils/error";
+  import { toaster } from "$lib/components/utils/toaster";
 
   const { data }: PageProps = $props();
 
   let pendingRegistrationId = $state(data.pendingRegistrationId);
+
+  const handleConfirm = () => {
+    toaster.success({
+      title: "Passkey has been registered from another device.",
+    });
+    invalidateAll();
+  };
 
   // Remove registration id from URL bar after assigning it to state
   afterNavigate(() => {
@@ -53,7 +61,7 @@
     <ConfirmAccessMethodWizard
       registrationId={pendingRegistrationId}
       onConfirm={() => {
-        invalidateAll();
+        handleConfirm();
         pendingRegistrationId = null;
       }}
       onError={(error) => {

--- a/src/frontend/src/routes/(new-styling)/pair/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/pair/+page.svelte
@@ -7,8 +7,23 @@
   import Dialog from "$lib/components/ui/Dialog.svelte";
   import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
   import { RegisterAccessMethodWizard } from "$lib/components/wizards/registerAccessMethod";
+  import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
+  import { canisterConfig } from "$lib/globals";
+  import { toaster } from "$lib/components/utils/toaster";
 
   let isUnableToComplete = $state(false);
+
+  const onRegistered = (identityNumber: bigint) => {
+    if (canisterConfig.feature_flag_continue_from_another_device[0] === true) {
+      toaster.success({
+        title: "You're all set. Your passkey has been registered.",
+      });
+      lastUsedIdentitiesStore.selectIdentity(identityNumber);
+      goto("/manage");
+    } else {
+      goto("/");
+    }
+  };
 </script>
 
 <div class="flex min-h-[100dvh] flex-col">
@@ -19,7 +34,7 @@
       <div class="flex-1"></div>
       <RegisterAccessMethodWizard
         registrationId={window.location.hash.slice(1)}
-        onRegistered={() => goto("/")}
+        {onRegistered}
         onError={() => (isUnableToComplete = true)}
       />
     </AuthPanel>


### PR DESCRIPTION
Register passkey from another device through session to automatically sign in.

# Changes

- Updated register and confirm access method flows to use session instead of temp key (behind canister config flag).
- Added additional success toasts for visual feedback after completing the flow on either device.

# Tests

- Verified the session flow is behind a flag, temp key flow is fallback when flag is unset or false.
