### PR TITLE
Update e2e to sign in after continue from another device flow.

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -223,7 +223,7 @@ jobs:
 
   vc-issuer-test:
     runs-on: ubuntu-latest
-    needs: [ docker-build-ii, vc_demo_issuer-build ]
+    needs: [docker-build-ii, vc_demo_issuer-build]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -269,7 +269,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -335,11 +335,11 @@ jobs:
 
   canister-tests-run:
     runs-on: ${{ matrix.os }}
-    needs: [ canister-tests-build, cached-build, docker-build-archive ]
+    needs: [canister-tests-build, cached-build, docker-build-archive]
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        partition: [ "1/3", "2/3", "3/3" ]
+        os: [ubuntu-latest, macos-latest]
+        partition: ["1/3", "2/3", "3/3"]
     steps:
       - uses: actions/checkout@v4
 
@@ -391,7 +391,7 @@ jobs:
           RUST_BACKTRACE: 1
 
   test-canisters-script:
-    needs: [ cached-build, docker-build-archive ]
+    needs: [cached-build, docker-build-archive]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -444,10 +444,10 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    needs: [ cached-build, test-app-build, vc_demo_issuer-build ]
+    needs: [cached-build, test-app-build, vc_demo_issuer-build]
     strategy:
       matrix:
-        device: [ "desktop", "mobile" ]
+        device: ["desktop", "mobile"]
         # We run the integration tests on both the official and legacy domains, to make sure
         # the webapp (routes, csp, etc) works on both. Captchas are statically enabled on one
         # domain and disabled on the other.
@@ -466,7 +466,7 @@ jobs:
         # based on the shard assigned to it)
         # The jest parameter is actually 1/N, 2/N etc but we use a artifact-friendly
         # version here (with underscore).
-        shard: [ "1_6", "2_6", "3_6", "4_6", "5_6", "6_6" ]
+        shard: ["1_6", "2_6", "3_6", "4_6", "5_6", "6_6"]
       # Make sure that one failing test does not cancel all other matrix jobs
       fail-fast: false
 
@@ -576,14 +576,14 @@ jobs:
           name: e2e-test-failures-${{ env.artifact_suffix }}
           path: test-failures/*
           if-no-files-found: ignore
-  
+
   e2e-playwright:
     runs-on: ubuntu-latest
-    needs: [ cached-build, test-app-build ]
+    needs: [cached-build, test-app-build]
     strategy:
       matrix:
-        device: [ "desktop", "mobile" ]
-        shard: [ "1_3", "2_3", "3_3" ]
+        device: ["desktop", "mobile"]
+        shard: ["1_3", "2_3", "3_3"]
       # Make sure that one failing test does not cancel all other matrix jobs
       fail-fast: false
 
@@ -632,7 +632,7 @@ jobs:
       - name: Deploy canisters
         run: |
           # NOTE: dfx install will run the postinstall scripts from dfx.json
-          dfx canister install internet_identity --wasm internet_identity_test.wasm.gz --argument "(opt record { captcha_config = opt record { max_unsolved_captchas= 50:nat64; captcha_trigger = variant {Static = variant { CaptchaDisabled }}}; related_origins = opt vec { \"https://id.ai\" }; new_flow_origins = opt vec { \"https://id.ai\" }; dummy_auth = opt opt record { prompt_for_index = true }})"
+          dfx canister install internet_identity --wasm internet_identity_test.wasm.gz --argument "(opt record { captcha_config = opt record { max_unsolved_captchas= 50:nat64; captcha_trigger = variant {Static = variant { CaptchaDisabled }}}; related_origins = opt vec { \"https://id.ai\" }; new_flow_origins = opt vec { \"https://id.ai\" }; dummy_auth = opt opt record { prompt_for_index = true }; feature_flag_continue_from_another_device = opt true })"
           dfx canister install test_app --wasm demos/test-app/test_app.wasm
 
       - name: Run dev server
@@ -672,7 +672,7 @@ jobs:
   # Aggregate all e2e matrix jobs, used in branch protection
   e2e-all:
     runs-on: ubuntu-latest
-    needs: [ e2e, e2e-playwright ]
+    needs: [e2e, e2e-playwright]
     steps:
       - run: echo e2e ok
 
@@ -823,7 +823,7 @@ jobs:
   # On release tags, a new release is created and the assets are uploaded.
   release:
     runs-on: ubuntu-latest
-    needs: [ docker-build-ii, docker-build-archive, vc_demo_issuer-build ]
+    needs: [docker-build-ii, docker-build-archive, vc_demo_issuer-build]
 
     steps:
       - uses: actions/checkout@v4
@@ -1044,7 +1044,7 @@ jobs:
   # Make sure that the asset we're testing is the same as that produced by the (slower) docker builds
   cached-build-check:
     runs-on: ubuntu-latest
-    needs: [ docker-build-ii, cached-build ]
+    needs: [docker-build-ii, cached-build]
     steps:
       - uses: actions/checkout@v4
       - name: "Download docker build"
@@ -1094,7 +1094,7 @@ jobs:
           path: internet_identity_clean_build_${{ matrix.os }}.wasm.gz
 
   verify-clean-build-hash:
-    needs: [ "clean-build", "docker-build-ii" ]
+    needs: ["clean-build", "docker-build-ii"]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
@@ -113,7 +113,6 @@ test("Authorize by signing in from another device", async ({
     await expect(otherDevicePage.getByText("Chrome")).toHaveCount(2);
 
     // Switch to current device and verify we can authorize
-    authCurrentDevice(authPage);
     await authPage.getByRole("button", { name: "Primary account" }).click();
   });
   expect(principal).toBe(expectedPrincipal);

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -117,11 +117,7 @@ test.describe("First visit", () => {
       .waitFor({ state: "hidden" });
     await expect(existingDevicePage.getByText("Chrome")).toHaveCount(2);
 
-    // Switch to new device and verify we can sign in
-    authNewDevice(newDevicePage);
-    await newDevicePage
-      .getByRole("button", { name: DEFAULT_USER_NAME })
-      .click();
+    // Switch to new device and verify we are signed in
     await newDevicePage.waitForURL(II_URL + "/manage");
     await expect(
       newDevicePage.getByRole("heading", {


### PR DESCRIPTION
Update e2e to sign in after continue from another device flow.

# Changes

- Updated e2e continue from another device from landing page
- Updated e2e continue from another device from authorize page

# Tests

- Visually verified the tests are showing the correct UX besides passing.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
