### PR TITLE
Add Migration flow into AuthFlow

### DIFF
--- a/src/frontend/src/lib/components/wizards/MigrationWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/MigrationWizard.svelte
@@ -7,7 +7,8 @@
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { handleError } from "$lib/components/utils/error";
 
-  const { onSuccess }: { onSuccess: () => void } = $props();
+  const { onSuccess }: { onSuccess: (identityNumber: bigint) => void } =
+    $props();
 
   let identityNumber: number | undefined = $state(undefined);
   const migrationFlow = new MigrationFlow();
@@ -23,7 +24,10 @@
 
   const handleCreate = async (name: string) => {
     await migrationFlow.createPasskey(name);
-    onSuccess();
+    // Button is disabled if identityNumber is null or undefined so no need to manage that case.
+    if (nonNullish(migrationFlow.identityNumber)) {
+      onSuccess(migrationFlow.identityNumber);
+    }
   };
 </script>
 

--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -35,6 +35,7 @@
   const authFlow = new AuthFlow();
 
   let isContinueFromAnotherDeviceVisible = $state(false);
+  let isMigrating = $state(false);
 
   const handleContinueWithExistingPasskey = async () => {
     isAuthenticating = true;
@@ -88,13 +89,19 @@
     />
   {:else if authFlow.view === "setupNewPasskey"}
     <CreatePasskey create={handleCreatePasskey} />
-  {:else if authFlow.view === "migrate"}
-    <MigrationWizard onSuccess={handleMigrationSuccess} />
   {/if}
 {/snippet}
 
 {#if isContinueFromAnotherDeviceVisible}
   <RegisterAccessMethodWizard onRegistered={handleRegistered} {onError} />
+{:else if isMigrating}
+  {#if !withinDialog}
+    <Dialog onClose={() => (isMigrating = false)}>
+      <MigrationWizard onSuccess={handleMigrationSuccess} />
+    </Dialog>
+  {:else}
+    <MigrationWizard onSuccess={handleMigrationSuccess} />
+  {/if}
 {:else if nonNullish(authFlow.captcha)}
   <SolveCaptcha {...authFlow.captcha} />
 {:else}
@@ -105,7 +112,7 @@
       continueWithGoogle={handleContinueWithGoogle}
       continueFromAnotherDevice={() =>
         (isContinueFromAnotherDeviceVisible = true)}
-      migrate={authFlow.migrate}
+      migrate={() => (isMigrating = true)}
     />
   {/if}
   {#if authFlow.view !== "chooseMethod"}

--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -10,6 +10,7 @@
   import SystemOverlayBackdrop from "$lib/components/utils/SystemOverlayBackdrop.svelte";
   import { RegisterAccessMethodWizard } from "$lib/components/wizards/registerAccessMethod";
   import { canisterConfig } from "$lib/globals";
+  import MigrationWizard from "../MigrationWizard.svelte";
 
   interface Props {
     isAuthenticating?: boolean;
@@ -73,6 +74,10 @@
       onOtherDevice(identityNumber);
     }
   };
+
+  const handleMigrationSuccess = (identityNumber: bigint) => {
+    onSignIn(identityNumber);
+  };
 </script>
 
 {#snippet dialogContent()}
@@ -83,6 +88,8 @@
     />
   {:else if authFlow.view === "setupNewPasskey"}
     <CreatePasskey create={handleCreatePasskey} />
+  {:else if authFlow.view === "migrate"}
+    <MigrationWizard onSuccess={handleMigrationSuccess} />
   {/if}
 {/snippet}
 
@@ -98,6 +105,7 @@
       continueWithGoogle={handleContinueWithGoogle}
       continueFromAnotherDevice={() =>
         (isContinueFromAnotherDeviceVisible = true)}
+      migrate={authFlow.migrate}
     />
   {/if}
   {#if authFlow.view !== "chooseMethod"}

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -15,12 +15,14 @@
     setupOrUseExistingPasskey: () => void;
     continueWithGoogle: () => Promise<void>;
     continueFromAnotherDevice: () => void;
+    migrate: () => void;
   }
 
   const {
     setupOrUseExistingPasskey,
     continueWithGoogle,
     continueFromAnotherDevice,
+    migrate,
   }: Props = $props();
 
   let isAuthenticating = $state(false);
@@ -87,7 +89,7 @@
       class="text-text-primary text-md flex flex-row items-center justify-between"
     >
       <p>Still have an identity number?</p>
-      <a href="/migrate" class="font-bold">Upgrade</a>
+      <button onclick={migrate} class="font-bold">Upgrade</button>
     </div>
   {/if}
 </div>

--- a/src/frontend/src/lib/flows/authFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.ts
@@ -32,7 +32,7 @@ import { createGoogleRequestConfig, requestJWT } from "$lib/utils/openID";
 
 export class AuthFlow {
   #view = $state<
-    "chooseMethod" | "setupOrUseExistingPasskey" | "setupNewPasskey" | "migrate"
+    "chooseMethod" | "setupOrUseExistingPasskey" | "setupNewPasskey"
   >("chooseMethod");
   #captcha = $state<{
     image: string;
@@ -65,10 +65,6 @@ export class AuthFlow {
   chooseMethod = (): void => {
     authenticationV2Funnel.trigger(AuthenticationV2Events.SelectMethodScreen);
     this.#view = "chooseMethod";
-  };
-
-  migrate = (): void => {
-    this.#view = "migrate";
   };
 
   setupOrUseExistingPasskey = (): void => {

--- a/src/frontend/src/lib/flows/authFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.ts
@@ -32,7 +32,7 @@ import { createGoogleRequestConfig, requestJWT } from "$lib/utils/openID";
 
 export class AuthFlow {
   #view = $state<
-    "chooseMethod" | "setupOrUseExistingPasskey" | "setupNewPasskey"
+    "chooseMethod" | "setupOrUseExistingPasskey" | "setupNewPasskey" | "migrate"
   >("chooseMethod");
   #captcha = $state<{
     image: string;
@@ -65,6 +65,10 @@ export class AuthFlow {
   chooseMethod = (): void => {
     authenticationV2Funnel.trigger(AuthenticationV2Events.SelectMethodScreen);
     this.#view = "chooseMethod";
+  };
+
+  migrate = (): void => {
+    this.#view = "migrate";
   };
 
   setupOrUseExistingPasskey = (): void => {


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Enable users to migrate their identities either from II landing page or when coming from an app.

In this PR, the migration flow is embedded within the AuthFlow.

# Changes

* Added a new `"migrate"` view to the `AuthFlow` class and implemented a `migrate` method to switch to this view.
* Updated the authentication wizard (`AuthWizard.svelte`) to render the `MigrationWizard` component when the `"migrate"` view is active and handle migration success by signing in the user with their identity number.
* Modified the authentication method picker (`PickAuthenticationMethod.svelte`) to show an "Upgrade" button that triggers the migration flow using the new `migrate` prop and handler, replacing the previous link.
* Passed the `migrate` handler from the authentication flow to the authentication method picker and connected it through the wizard component tree.
* Updated the `MigrationWizard` component to accept an `onSuccess` callback that receives the `identityNumber` as a parameter and triggers it only when a valid identity number is present.

# Tests

Tested manually the following flows:
- Desktop: User from dapp and no cached identities.
- Desktop: User from dapp and cached identities.
- Desktop: User from landing page and cached identities.
- Desktop: User from landing page and no cached identities (see video below)
- Mobile simulator: User from dapp and cached identities
- Mobile simulator: User from dapp and no cached identities



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


