### PR TITLE
Revert didc upgrade

### DIFF
--- a/.didc-release
+++ b/.didc-release
@@ -1,3 +1,3 @@
 # the release used to pull the didc executable
 # see frontend-checks for more info
-2025-08-04
+2025-07-29


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

CI is broken because didc is not found. This happened after the upgrade.

This PR reverts the upgrade.

# Changes

* Change didc version.

# Tests

See CI pipeline.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
