### PR TITLE
Enable continue from another device flow with temp key.

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -80,6 +80,8 @@
     <SetupOrUseExistingPasskey
       setupNew={authFlow.setupNewPasskey}
       useExisting={handleContinueWithExistingPasskey}
+      continueFromAnotherDevice={() =>
+        (isContinueFromAnotherDeviceVisible = true)}
     />
   {:else if authFlow.view === "setupNewPasskey"}
     <CreatePasskey create={handleCreatePasskey} />
@@ -96,8 +98,6 @@
     <PickAuthenticationMethod
       setupOrUseExistingPasskey={authFlow.setupOrUseExistingPasskey}
       continueWithGoogle={handleContinueWithGoogle}
-      continueFromAnotherDevice={() =>
-        (isContinueFromAnotherDeviceVisible = true)}
     />
   {/if}
   {#if authFlow.view !== "chooseMethod"}

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -14,7 +14,8 @@
     migrate: () => void;
   }
 
-  const { setupOrUseExistingPasskey, continueWithGoogle, migrate }: Props = $props();
+  const { setupOrUseExistingPasskey, continueWithGoogle, migrate }: Props =
+    $props();
 
   let isAuthenticating = $state(false);
 
@@ -66,11 +67,14 @@
     {/if}
   </div>
   {#if $ENABLE_MIGRATE_FLOW}
-    <div
-      class="text-text-primary text-md flex flex-row items-center justify-between"
-    >
-      <p>Still have an identity number?</p>
-      <button onclick={migrate} class="font-bold">Upgrade</button>
+    <div class="flex flex-row items-center justify-between">
+      <p class="text-md text-text-secondary">Still have an identity number?</p>
+      <button
+        onclick={migrate}
+        class="text-md text-text-primary font-semibold outline-0 focus-visible:underline"
+      >
+        Upgrade
+      </button>
     </div>
   {/if}
 </div>

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -6,22 +6,14 @@
   import Alert from "$lib/components/ui/Alert.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { canisterConfig } from "$lib/globals";
-  import {
-    CONTINUE_FROM_ANOTHER_DEVICE,
-    ENABLE_MIGRATE_FLOW,
-  } from "$lib/state/featureFlags";
+  import { ENABLE_MIGRATE_FLOW } from "$lib/state/featureFlags";
 
   interface Props {
     setupOrUseExistingPasskey: () => void;
     continueWithGoogle: () => Promise<void>;
-    continueFromAnotherDevice: () => void;
   }
 
-  const {
-    setupOrUseExistingPasskey,
-    continueWithGoogle,
-    continueFromAnotherDevice,
-  }: Props = $props();
+  const { setupOrUseExistingPasskey, continueWithGoogle }: Props = $props();
 
   let isAuthenticating = $state(false);
 
@@ -69,16 +61,6 @@
           <GoogleIcon />
           <span>Continue with Google</span>
         {/if}
-      </Button>
-    {/if}
-    {#if $CONTINUE_FROM_ANOTHER_DEVICE}
-      <Button
-        onclick={continueFromAnotherDevice}
-        variant="tertiary"
-        disabled={isAuthenticating}
-        size="xl"
-      >
-        Continue from another device
       </Button>
     {/if}
   </div>

--- a/src/frontend/src/lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte
@@ -3,13 +3,15 @@
   import Button from "$lib/components/ui/Button.svelte";
   import PasskeyIllustration from "$lib/components/illustrations/PasskeyIllustration.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
+  import { CONTINUE_FROM_ANOTHER_DEVICE } from "$lib/state/featureFlags";
 
   interface Props {
     setupNew: () => void;
     useExisting: () => Promise<void>;
+    continueFromAnotherDevice: () => void;
   }
 
-  const { setupNew, useExisting }: Props = $props();
+  const { setupNew, useExisting, continueFromAnotherDevice }: Props = $props();
 
   let isAuthenticating = $state(false);
 
@@ -50,4 +52,14 @@
       <span>Use an existing Passkey</span>
     {/if}
   </Button>
+  {#if $CONTINUE_FROM_ANOTHER_DEVICE}
+    <Button
+      onclick={continueFromAnotherDevice}
+      variant="tertiary"
+      disabled={isAuthenticating}
+      size="lg"
+    >
+      Continue from another device
+    </Button>
+  {/if}
 </div>

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -99,7 +99,7 @@ export const ADD_ACCESS_METHOD = createFeatureFlagStore(
 
 export const CONTINUE_FROM_ANOTHER_DEVICE = createFeatureFlagStore(
   "CONTINUE_FROM_ANOTHER_DEVICE",
-  false,
+  true, // Enable temp key flow (until backend changes can be enabled)
   () => canisterConfig.feature_flag_continue_from_another_device[0],
 );
 

--- a/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
@@ -59,6 +59,9 @@ test("Authorize by signing in from another device", async ({
   const principal = await authorize(page, async (authPage) => {
     // Switch to current device and start "Continue from another device" flow to get link
     await authPage
+      .getByRole("button", { name: "Continue with Passkey" })
+      .click();
+    await authPage
       .getByRole("button", { name: "Continue from another device" })
       .click();
     const linkToPair = `https://${await authPage.getByLabel("Pairing link").innerText()}`;

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -1,11 +1,5 @@
 import { expect, test } from "@playwright/test";
-import {
-  clearStorage,
-  createIdentity,
-  dummyAuth,
-  FEATURE_FLAGS,
-  II_URL,
-} from "./utils";
+import { clearStorage, createIdentity, dummyAuth, II_URL } from "./utils";
 
 const DEFAULT_USER_NAME = "John Doe";
 const SECONDARY_USER_NAME = "Jane Doe";
@@ -62,7 +56,10 @@ test.describe("First visit", () => {
     // Switch to new device and start "Continue from another device" flow to get link
     const newContext = await browser.newContext();
     const newDevicePage = await newContext.newPage();
-    await newDevicePage.goto(II_URL + FEATURE_FLAGS);
+    await newDevicePage.goto(II_URL);
+    await newDevicePage
+      .getByRole("button", { name: "Continue with Passkey" })
+      .click();
     await newDevicePage
       .getByRole("button", { name: "Continue from another device" })
       .click();

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -3,7 +3,6 @@ import { Principal } from "@dfinity/principal";
 import { readCanisterId } from "@dfinity/internet-identity-vite-plugins/utils";
 
 const testAppCanisterId = readCanisterId({ canisterName: "test_app" });
-export const FEATURE_FLAGS = "?feature_flag_continue_from_another_device=true";
 export const II_URL = "https://id.ai";
 export const TEST_APP_URL = "https://nice-name.com";
 export const NOT_TEST_APP_URL = "https://very-nice-name.com";
@@ -55,9 +54,7 @@ export const authorizeWithUrl = async (
 ): Promise<string> => {
   // Open demo app and assert that user isn't authenticated yet
   await page.goto(appUrl);
-  await page
-    .getByRole("textbox", { name: "Identity Provider" })
-    .fill(II_URL + FEATURE_FLAGS);
+  await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
   await expect(page.locator("#principal")).toBeHidden();
   const pagePromise = page.context().waitForEvent("page");
 


### PR DESCRIPTION
Enable continue from another device flow with temp key.

# Changes

- Set default value for `CONTINUE_FROM_ANOTHER_DEVICE ` frontend flag to true.
- Move "Continue from another device" button to passkey view.
- Fix e2e now that the button has moved to the passkey view.
- Remove feature flags from e2e since they are no longer needed (flags can be enabled in canister init instead).

# Tests

- Verified the continue from another device flow works as expected now that the button has moved.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

