### PR TITLE
Disable legacy access methods

### DIFF
--- a/src/frontend/src/lib/components/ui/AccessMethod.svelte
+++ b/src/frontend/src/lib/components/ui/AccessMethod.svelte
@@ -10,15 +10,18 @@
   import Ellipsis from "../utils/Ellipsis.svelte";
   import PulsatingCircleIcon from "../icons/PulsatingCircleIcon.svelte";
   import { getAuthnMethodAlias } from "$lib/utils/webAuthn";
+  import { isLegacyAuthnMethod } from "$lib/utils/accessMethods";
 
   let {
     accessMethod,
     class: classes,
     isCurrent,
+    isDisabled,
   }: {
     accessMethod: AuthnMethodData | OpenIdCredential | null;
     class?: string;
     isCurrent?: boolean;
+    isDisabled?: boolean;
   } = $props();
 
   const getOpenIdCredentialName = (credential: OpenIdCredential | null) => {
@@ -60,7 +63,7 @@
     <!-- Passkey -->
     <div
       class={[
-        "text-text-primary foldable-subgrid text-sm font-semibold nth-[2]:hidden",
+        `${isDisabled ? "text-text-disabled" : "text-text-primary"} foldable-subgrid text-sm font-semibold nth-[2]:hidden`,
         classes,
       ]}
       in:fade={{ delay: 30, duration: 30 }}

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -20,6 +20,7 @@
   import { handleError } from "$lib/components/utils/error";
   import {
     getLastUsedAccessMethod,
+    isLegacyAuthnMethod,
     isWebAuthnMetaData,
   } from "$lib/utils/accessMethods";
   import { AddAccessMethodWizard } from "$lib/components/wizards/addAccessMethod";
@@ -149,35 +150,46 @@
         class="border-border-tertiary col-span-3 grid grid-cols-subgrid border-t py-4"
       >
         <div
-          class="text-text-primary flex min-w-8 items-center justify-center px-4 pr-4"
+          class={`${isLegacyAuthnMethod(authnMethod) ? "text-text-disabled" : "text-text-primary"} flex min-w-8 items-center justify-center px-4 pr-4`}
         >
           <PasskeyIcon />
         </div>
+        <!-- TODO: Create Design's ListItem -->
         <AccessMethod
           accessMethod={authnMethod}
+          isDisabled={isLegacyAuthnMethod(authnMethod)}
           isCurrent={isCurrentAccessMethod(authnMethod)}
         />
-        <div class="flex items-center justify-end gap-2 px-4">
-          <Button
-            onclick={() => (identityInfo.renamableAuthnMethod = authnMethod)}
-            variant="tertiary"
-            iconOnly
-            aria-label={`Rename ${isCurrentAccessMethod(authnMethod) ? "current" : ""} passkey`}
-          >
-            <EditIcon size="1.25rem" />
-          </Button>
-          {#if isRemoveAccessMethodVisible}
+        {#if !isLegacyAuthnMethod(authnMethod)}
+          <div class="flex items-center justify-end gap-2 px-4">
             <Button
-              onclick={() => (identityInfo.removableAuthnMethod = authnMethod)}
+              onclick={() => (identityInfo.renamableAuthnMethod = authnMethod)}
               variant="tertiary"
               iconOnly
-              aria-label={`Remove ${isCurrentAccessMethod(authnMethod) ? "current" : ""} passkey`}
-              class="!text-fg-error-secondary"
+              aria-label={`Rename ${isCurrentAccessMethod(authnMethod) ? "current" : ""} passkey`}
+              disabled={isLegacyAuthnMethod(authnMethod)}
             >
-              <Trash2Icon size="1.25rem" />
+              <EditIcon size="1.25rem" />
             </Button>
-          {/if}
-        </div>
+            {#if isRemoveAccessMethodVisible}
+              <Button
+                onclick={() =>
+                  (identityInfo.removableAuthnMethod = authnMethod)}
+                variant="tertiary"
+                iconOnly
+                aria-label={`Remove ${isCurrentAccessMethod(authnMethod) ? "current" : ""} passkey`}
+                class="!text-fg-error-secondary"
+                disabled={isLegacyAuthnMethod(authnMethod)}
+              >
+                <Trash2Icon size="1.25rem" />
+              </Button>
+            {/if}
+          </div>
+        {:else}
+          <!-- Necessary to keep the same height as iconOnly buttons -->
+          <!-- TODO: Align with design what should set the height? -->
+          <div class="size-10"></div>
+        {/if}
       </div>
     {/each}
     {#each openIdCredentials as credential}

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -85,12 +85,12 @@ export const HARDWARE_KEY_TEST = createFeatureFlagStore(
 
 export const DISCOVERABLE_PASSKEY_FLOW = createFeatureFlagStore(
   "DISCOVERABLE_PASSKEY_FLOW",
-  false,
+  true,
 );
 
 export const ENABLE_MIGRATE_FLOW = createFeatureFlagStore(
   "ENABLE_MIGRATE_FLOW",
-  false,
+  true,
 );
 export const ADD_ACCESS_METHOD = createFeatureFlagStore(
   "ADD_ACCESS_METHOD",


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Migrated legacy identities will access the current dashboard and we want them to avoid having a confusing experience.

Therefore, for now we will set all the legacy access methods as read only and shown as disabled.

# Changes

* Added `isLegacyAuthnMethod` utility to detect legacy authentication methods based on their origin and purpose, with comprehensive unit tests for various scenarios. (`src/frontend/src/lib/utils/accessMethods.ts`, `src/frontend/src/lib/utils/accessMethods.test.ts`)
* Updated `AccessMethod` and `AccessMethodsPanel` components to visually indicate legacy methods as disabled and prevent rename/remove actions for them. (`src/frontend/src/lib/components/ui/AccessMethod.svelte`, `src/frontend/src/lib/components/views/AccessMethodsPanel.svelte`)

# Tests

* The screenshots are done by hardcoding a differente logic in `isLegacyAuthnMethod`.
* Added comprehensive tests for `isLegacyAuthnMethod`, including mock configuration for `new_flow_origins`. (`src/frontend/src/lib/utils/accessMethods.test.ts`)
