### PR TITLE
Limit test threads in canister tests

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -385,7 +385,7 @@ jobs:
           # We are using --partition hash instead of count, because it makes sure that the tests partition is stable across runs
           # even if tests are added or removed. The tradeoff is that the balancing might be slightly worse, but we have enough
           # tests that it should not be a big issue.
-          ./cargo-nextest nextest run --archive-file canister-tests-${{ matrix.os }}.tar.zst --partition hash:${{ matrix.partition }}
+          ./cargo-nextest nextest run --archive-file canister-tests-${{ matrix.os }}.tar.zst --partition hash:${{ matrix.partition }} --test-threads=2
         env:
           RUST_BACKTRACE: 1
 

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -385,7 +385,7 @@ jobs:
           # We are using --partition hash instead of count, because it makes sure that the tests partition is stable across runs
           # even if tests are added or removed. The tradeoff is that the balancing might be slightly worse, but we have enough
           # tests that it should not be a big issue.
-          ./cargo-nextest nextest run --archive-file canister-tests-${{ matrix.os }}.tar.zst --partition hash:${{ matrix.partition }} --test-threads=2
+          ./cargo-nextest nextest run --archive-file canister-tests-${{ matrix.os }}.tar.zst --partition hash:${{ matrix.partition }} --test-threads=1
         env:
           RUST_BACKTRACE: 1
 


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We see randome failures in our CI.

The problem might be that pocket-ic gets overloaded.

Limiting the number of test threads should fix the problem.

# Changes

* Pass `--test-threads=2` when running canister tests.

# Tests

See CI.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

