### PR TITLE
Success screen after successful migration on authorize flow

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -17,6 +17,7 @@
     onSignIn: (identityNumber: bigint) => void;
     onSignUp: (identityNumber: bigint) => void;
     onOtherDevice?: (identityNumber: bigint) => void; // TODO: Remove once we can sign in directly
+    onMigration?: () => void;
     onError: (error: unknown) => void;
     withinDialog?: boolean;
     children?: Snippet;
@@ -27,6 +28,7 @@
     onSignIn,
     onSignUp,
     onOtherDevice = () => {},
+    onMigration = () => {},
     onError,
     withinDialog = false,
     children,
@@ -76,8 +78,8 @@
     }
   };
 
-  const handleMigrationSuccess = (identityNumber: bigint) => {
-    onSignIn(identityNumber);
+  const handleMigrationSuccess = () => {
+    onMigration();
   };
 </script>
 

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -31,6 +31,11 @@
     void preloadCode(data.next ?? "/manage");
     void preloadData(data.next ?? "/manage");
   };
+
+  const onMigration = async () => {
+    isAuthDialogOpen = false;
+    await goto("/manage");
+  };
   const onSignIn = async (identityNumber: bigint) => {
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
     isAuthDialogOpen = false;
@@ -147,6 +152,7 @@
               bind:isAuthenticating
               {onSignIn}
               {onSignUp}
+              {onMigration}
               onOtherDevice={() => (isAuthDialogOpen = false)}
               onError={(error) => {
                 isAuthDialogOpen = false;
@@ -166,7 +172,7 @@
           </Dialog>
         {/if}
       {:else}
-        <AuthWizard {onSignIn} {onSignUp} onError={handleError}>
+        <AuthWizard {onSignIn} {onSignUp} {onMigration} onError={handleError}>
           <h1 class="text-text-primary my-2 self-start text-2xl font-medium">
             Manage your Internet&nbsp;Identity
           </h1>

--- a/src/frontend/src/routes/(new-styling)/authorize/(authenticated)/upgrade-success/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/(authenticated)/upgrade-success/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import Button from "$lib/components/ui/Button.svelte";
+  import { authorizationStore } from "$lib/stores/authorization.store";
+
+  const handleRedirect = () => {
+    authorizationStore.authorize(undefined, 0);
+  };
+</script>
+
+<Button onclick={handleRedirect}>Go to app</Button>

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -88,6 +88,10 @@
     await goto("/authorize/continue");
     isAuthDialogOpen = false;
   };
+  const onMigration = async () => {
+    await goto("/authorize/upgrade-success");
+    isAuthDialogOpen = false;
+  };
 
   onMount(() => {
     authorizationStore.init();
@@ -147,6 +151,7 @@
             {onSignIn}
             {onSignUp}
             {onOtherDevice}
+            {onMigration}
             onError={(error) => {
               isAuthDialogOpen = false;
               handleError(error);

--- a/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
@@ -49,9 +49,18 @@
     });
     await goto("/authorize/continue");
   };
+  const onMigration = async () => {
+    await goto("/authorize/upgrade-success");
+  };
 </script>
 
-<AuthWizard {onSignIn} {onSignUp} {onOtherDevice} onError={handleError}>
+<AuthWizard
+  {onSignIn}
+  {onSignUp}
+  {onOtherDevice}
+  {onMigration}
+  onError={handleError}
+>
   <AuthorizeHeader origin={$authorizationContextStore.requestOrigin} />
   <h1 class="text-text-primary mb-2 self-start text-2xl font-medium">
     Choose method

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -61,6 +61,11 @@
     isAuthDialogOpen = false;
   };
 
+  const onMigration = async () => {
+    await gotoManage();
+    isAuthDialogOpen = false;
+  };
+
   const authLastUsedFlow = new AuthLastUsedFlow();
   $effect(() =>
     authLastUsedFlow.init(
@@ -231,6 +236,7 @@
             bind:isAuthenticating
             {onSignIn}
             {onSignUp}
+            {onMigration}
             onOtherDevice={() => (isAuthDialogOpen = false)}
             onError={(error) => {
               isAuthDialogOpen = false;


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We want to show a success screen after a successful migration to the users that perform it during an authorize flow.

In this PR, I introduce the new flow without UI nor final UX (pending automatic redirect after 5 seconds)

# Changes

* Create a new route where the user will be redirected to the dapp on click of a button.
* Added an onMigration prop to AuthWizard and used it to redirect to the new route or manage page.
* Use the new onMigration prop accordingly.

# Tests

Tested locally with both use cases from a dapp (see video) and from the landing page.
