### PR TITLE
Reenable Interface Compatibility Test in CI

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -1129,16 +1129,15 @@ jobs:
             exit 1
           fi
 
-  # DEACTIVATED SO WE CAN UPDATE THE ERROR TYPE IN CREATE AND UPDATE ACCOUNTS
-  # interface-compatibility:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/setup-didc
-  #     - name: "Check canister interface compatibility"
-  #       run: |
-  #         curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
-  #         didc check src/internet_identity/internet_identity.did internet_identity_previous.did
+  interface-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-didc
+      - name: "Check canister interface compatibility"
+        run: |
+          curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
+          didc check src/internet_identity/internet_identity.did internet_identity_previous.did
 
   sig-verifier-js:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We want to make sure that we don't break the interface unintentionally.

We forgot to reenable the compatibility test last time we did a breaking change.

# Changes

* Reenable interface compatibility test.

# Tests

CI will do
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
