### PR TITLE
Refactor MigrationFlow

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -17,7 +17,7 @@
     onSignIn: (identityNumber: bigint) => void;
     onSignUp: (identityNumber: bigint) => void;
     onOtherDevice?: (identityNumber: bigint) => void; // TODO: Remove once we can sign in directly
-    onMigration?: () => void;
+    onMigration?: (identityNumber: bigint) => void;
     onError: (error: unknown) => void;
     withinDialog?: boolean;
     children?: Snippet;
@@ -77,10 +77,6 @@
       onOtherDevice(identityNumber);
     }
   };
-
-  const handleMigrationSuccess = () => {
-    onMigration();
-  };
 </script>
 
 {#snippet dialogContent()}
@@ -101,10 +97,10 @@
 {:else if isMigrating}
   {#if !withinDialog}
     <Dialog onClose={() => (isMigrating = false)}>
-      <MigrationWizard onSuccess={handleMigrationSuccess} />
+      <MigrationWizard onSuccess={onMigration} />
     </Dialog>
   {:else}
-    <MigrationWizard onSuccess={handleMigrationSuccess} />
+    <MigrationWizard onSuccess={onMigration} />
   {/if}
 {:else if nonNullish(authFlow.captcha)}
   <SolveCaptcha {...authFlow.captcha} />

--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -201,11 +201,6 @@ export class MigrationFlow {
         },
       },
     });
-    lastUsedIdentitiesStore.selectIdentity(this.identityNumber);
-    toaster.success({
-      title: "Migration completed successfully",
-      duration: 4000,
-    });
   };
 
   #lookupAuthenticators = async (

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -32,7 +32,12 @@
     void preloadData(data.next ?? "/manage");
   };
 
-  const onMigration = async () => {
+  const onMigration = async (identityNumber: bigint) => {
+    lastUsedIdentitiesStore.selectIdentity(identityNumber);
+    toaster.success({
+      title: "Migration completed successfully",
+      duration: 4000,
+    });
     isAuthDialogOpen = false;
     await goto("/manage");
   };

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -61,9 +61,14 @@
     isAuthDialogOpen = false;
   };
 
-  const onMigration = async () => {
-    await gotoManage();
+  const onMigration = async (identityNumber: bigint) => {
+    lastUsedIdentitiesStore.selectIdentity(identityNumber);
+    toaster.success({
+      title: "Migration completed successfully",
+      duration: 4000,
+    });
     isAuthDialogOpen = false;
+    await gotoManage();
   };
 
   const authLastUsedFlow = new AuthLastUsedFlow();


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Separate responsibilities accordingly.

Showing a toast and selecting the identity during the migration flow happens only when going to the dashboard. Therefore, they shouldn't be part of the the generic flow.

# Changes

* Remove toast and selecting identity from MigrationFlow to the onMigration handlers.
* Add the identityNumber as parameter to onMigration.

# Tests

I tested locally that when migrating from a dapp there is no toast.
When migrating from the landing page, there is toast along with redirection to the dashboard.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
