### PR TITLE
Add attach element for iframe

### DIFF
--- a/src/frontend/src/lib/components/wizards/migration/MigrationWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/MigrationWizard.svelte
@@ -10,9 +10,12 @@
 
   const migrationFlow = new MigrationFlow();
 
-  const handleSubmit = async (identityNumber: bigint) => {
+  const handleSubmit = async (
+    identityNumber: bigint,
+    attachElement?: HTMLElement,
+  ) => {
     await migrationFlow
-      .authenticateWithIdentityNumber(BigInt(identityNumber))
+      .authenticateWithIdentityNumber(BigInt(identityNumber), attachElement)
       .catch(handleError);
   };
 

--- a/src/frontend/src/lib/components/wizards/migration/views/EnterIdentityNumber.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/views/EnterIdentityNumber.svelte
@@ -8,7 +8,7 @@
   import { onMount } from "svelte";
 
   interface Props {
-    onSubmit: (identityNumber: bigint) => void;
+    onSubmit: (identityNumber: bigint, attachElement?: HTMLElement) => void;
     isAuthenticating?: boolean;
   }
 
@@ -16,6 +16,7 @@
 
   let identityNumber = $state<string>("");
   let inputElement = $state<HTMLInputElement>();
+  let attachElement = $state<HTMLElement>();
 
   onMount(() => {
     inputElement?.focus();
@@ -24,12 +25,12 @@
   const handleSubmit = async () => {
     // Button is disabled if identityNumber is null or undefined so no need to manage that case.
     if (nonNullish(identityNumber)) {
-      onSubmit(BigInt(identityNumber));
+      onSubmit(BigInt(identityNumber), attachElement);
     }
   };
 </script>
 
-<form class="flex flex-1 flex-col">
+<form class="flex flex-1 flex-col" bind:this={attachElement}>
   <div class="mb-8 flex flex-col">
     <div class="text-text-primary flex h-32 items-center justify-center py-5">
       <MigrationIllustration />

--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -111,8 +111,6 @@ export class MigrationFlow {
         }
       }
 
-      console.error(e);
-
       throw new Error(
         "Failed to authenticate using passkey. Please try again and contact support if the issue persists.",
       );

--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -36,6 +36,7 @@ export class MigrationFlow {
 
   authenticateWithIdentityNumber = async (
     identityNumber: UserNumber,
+    attachElement?: HTMLElement,
   ): Promise<void> => {
     this.authenticating = true;
     this.identityNumber = identityNumber;
@@ -76,6 +77,7 @@ export class MigrationFlow {
       currentFlow?.useIframe ?? false,
       // Set user verification to preferred to ensure the user is verified during migration.
       "preferred",
+      attachElement,
     );
     try {
       const session = get(sessionStore);
@@ -84,6 +86,7 @@ export class MigrationFlow {
         session.identity.getPublicKey(),
         new Date(Date.now() + 30 * 60 * 1000),
       );
+
       const identity = DelegationIdentity.fromDelegation(
         session.identity,
         delegation,
@@ -107,6 +110,8 @@ export class MigrationFlow {
           return;
         }
       }
+
+      console.error(e);
 
       throw new Error(
         "Failed to authenticate using passkey. Please try again and contact support if the issue persists.",

--- a/src/frontend/src/lib/legacy/flows/iframeWebAuthn.ts
+++ b/src/frontend/src/lib/legacy/flows/iframeWebAuthn.ts
@@ -164,6 +164,7 @@ export const webAuthnInIframeFlow = async (
 
 export const webAuthnInIframe = async (
   options: CredentialRequestOptions,
+  attachElement?: HTMLElement,
 ): Promise<Credential> => {
   if (isNullish(options.publicKey?.rpId)) {
     throw new Error("RP id is missing");
@@ -171,7 +172,13 @@ export const webAuthnInIframe = async (
   const targetOrigin = `https://${options.publicKey?.rpId}`;
 
   // WebAuthn fails in Safari if the iframe does not remain focused.
-  const iframe = document.body.appendChild(document.createElement("iframe"));
+  // const iframe = document.body.appendChild(document.createElement("iframe"));
+  const iframe = document.createElement("iframe");
+  // Attach iframe to provided element if available, otherwise try the first <dialog>,
+  // and finally fall back to document.body.
+  const dialog = document.getElementsByTagName("dialog")[0];
+  const host = (attachElement ?? dialog ?? document.body) as HTMLElement;
+  host.appendChild(iframe);
   iframe.style.position = "fixed";
   iframe.style.top = "0";
   iframe.style.left = "0";

--- a/src/frontend/src/lib/legacy/flows/iframeWebAuthn.ts
+++ b/src/frontend/src/lib/legacy/flows/iframeWebAuthn.ts
@@ -164,6 +164,7 @@ export const webAuthnInIframeFlow = async (
 
 export const webAuthnInIframe = async (
   options: CredentialRequestOptions,
+  // This is necessary for Safari to have the iframe on focus, for example, when a dialog is open.
   attachElement?: HTMLElement,
 ): Promise<Credential> => {
   if (isNullish(options.publicKey?.rpId)) {
@@ -171,8 +172,6 @@ export const webAuthnInIframe = async (
   }
   const targetOrigin = `https://${options.publicKey?.rpId}`;
 
-  // WebAuthn fails in Safari if the iframe does not remain focused.
-  // const iframe = document.body.appendChild(document.createElement("iframe"));
   const iframe = document.createElement("iframe");
   // Attach iframe to provided element if available, otherwise try the first <dialog>,
   // and finally fall back to document.body.
@@ -189,6 +188,7 @@ export const webAuthnInIframe = async (
   iframe.style.zIndex = "9999";
   iframe.allow = "publickey-credentials-get";
   iframe.src = `${targetOrigin}${WEBAUTHN_IFRAME_PATH}`;
+  // WebAuthn fails in Safari if the iframe does not remain focused.
   iframe.focus();
 
   try {

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -90,7 +90,7 @@ export const DISCOVERABLE_PASSKEY_FLOW = createFeatureFlagStore(
 
 export const ENABLE_MIGRATE_FLOW = createFeatureFlagStore(
   "ENABLE_MIGRATE_FLOW",
-  false,
+  true,
 );
 export const ADD_ACCESS_METHOD = createFeatureFlagStore(
   "ADD_ACCESS_METHOD",

--- a/src/frontend/src/lib/utils/multiWebAuthnIdentity.ts
+++ b/src/frontend/src/lib/utils/multiWebAuthnIdentity.ts
@@ -30,8 +30,15 @@ export class MultiWebAuthnIdentity extends SignIdentity {
     rpId: string | undefined,
     iframe: boolean | undefined,
     userVerification: "discouraged" | "required" | "preferred" = "discouraged",
+    attachElement?: HTMLElement,
   ): MultiWebAuthnIdentity {
-    return new this(credentialData, rpId, iframe, userVerification);
+    return new this(
+      credentialData,
+      rpId,
+      iframe,
+      userVerification,
+      attachElement,
+    );
   }
 
   /* Set after the first `sign`, see `sign()` for more info. */
@@ -45,6 +52,7 @@ export class MultiWebAuthnIdentity extends SignIdentity {
       | "discouraged"
       | "required"
       | "preferred" = "discouraged",
+    readonly attachElement?: HTMLElement,
   ) {
     super();
     this._actualIdentity = undefined;
@@ -89,7 +97,7 @@ export class MultiWebAuthnIdentity extends SignIdentity {
     };
     const result = (
       this.iframe === true && nonNullish(this.rpId)
-        ? await webAuthnInIframe(options)
+        ? await webAuthnInIframe(options, this.attachElement)
         : await navigator.credentials.get(options)
     ) as PublicKeyCredential;
 


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

The migration flow wasn't working in Safari because the iframe workaround wasn't working due to the iframe losing focus.

# Changes

* Add an optional HTML element to the step to authenticate the user with the identity number to attach it there if passed.

# Tests

* Tested in Safari twice and it both worked.
* This branch is deployed on beta domains so it can be tested there: beta.identity.ic0.app and beta.id.ai


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

