### PR TITLE
Add logging to help debugging when credential is not found

### DIFF
--- a/src/frontend/src/lib/utils/authentication/passkey.ts
+++ b/src/frontend/src/lib/utils/authentication/passkey.ts
@@ -14,8 +14,8 @@ import { DiscoverableDummyIdentity } from "$lib/utils/discoverableDummyIdentity"
 import { canisterConfig } from "$lib/globals";
 
 export class CredentialNotFound extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor() {
+    super();
     Object.setPrototypeOf(this, CredentialNotFound.prototype);
   }
 
@@ -54,10 +54,9 @@ export const authenticateWithPasskey = async ({
             await actor.lookup_device_key(new Uint8Array(result.rawId))
           )[0];
           if (isNullish(lookupResult)) {
-            // To help debug, pass the credential id
-            throw new CredentialNotFound(
-              `Credential id ${toHex(result.rawId)} not found`,
-            );
+            // To help debug, log the credential id
+            console.error(`Credential id ${toHex(result.rawId)} not found`);
+            throw new CredentialNotFound();
           }
           identityNumber = lookupResult.anchor_number;
           return CosePublicKey.fromDer(new Uint8Array(lookupResult.pubkey));

--- a/src/frontend/src/lib/utils/authentication/passkey.ts
+++ b/src/frontend/src/lib/utils/authentication/passkey.ts
@@ -50,16 +50,21 @@ export const authenticateWithPasskey = async ({
     : DiscoverablePasskeyIdentity.useExisting({
         credentialIds,
         getPublicKey: async (result) => {
-          const lookupResult = (
-            await actor.lookup_device_key(new Uint8Array(result.rawId))
-          )[0];
-          if (isNullish(lookupResult)) {
+          try {
+            const lookupResult = (
+              await actor.lookup_device_key(new Uint8Array(result.rawId))
+            )[0];
+            if (isNullish(lookupResult)) {
+              throw new CredentialNotFound();
+            }
+            identityNumber = lookupResult.anchor_number;
+            return CosePublicKey.fromDer(new Uint8Array(lookupResult.pubkey));
+          } catch (error: unknown) {
             // To help debug, log the credential id
-            console.error(`Credential id ${toHex(result.rawId)} not found`);
-            throw new CredentialNotFound();
+            console.error(error);
+            console.error(`Error looking up device key ${toHex(result.rawId)}`);
+            throw error;
           }
-          identityNumber = lookupResult.anchor_number;
-          return CosePublicKey.fromDer(new Uint8Array(lookupResult.pubkey));
         },
       });
   if (dummyAuth) {

--- a/src/frontend/src/lib/utils/authentication/passkey.ts
+++ b/src/frontend/src/lib/utils/authentication/passkey.ts
@@ -1,5 +1,5 @@
 import { Principal } from "@dfinity/principal";
-import { Actor } from "@dfinity/agent";
+import { Actor, toHex } from "@dfinity/agent";
 import type { _SERVICE } from "$lib/generated/internet_identity_types";
 import { idlFactory as internet_identity_idl } from "$lib/generated/internet_identity_idl";
 import {
@@ -14,8 +14,8 @@ import { DiscoverableDummyIdentity } from "$lib/utils/discoverableDummyIdentity"
 import { canisterConfig } from "$lib/globals";
 
 export class CredentialNotFound extends Error {
-  constructor() {
-    super();
+  constructor(message: string) {
+    super(message);
     Object.setPrototypeOf(this, CredentialNotFound.prototype);
   }
 
@@ -54,7 +54,10 @@ export const authenticateWithPasskey = async ({
             await actor.lookup_device_key(new Uint8Array(result.rawId))
           )[0];
           if (isNullish(lookupResult)) {
-            throw new CredentialNotFound();
+            // To help debug, pass the credential id
+            throw new CredentialNotFound(
+              `Credential id ${toHex(result.rawId)} not found`,
+            );
           }
           identityNumber = lookupResult.anchor_number;
           return CosePublicKey.fromDer(new Uint8Array(lookupResult.pubkey));

--- a/src/frontend/src/routes/(new-styling)/authorize/(panel)/continue/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/(panel)/continue/+page.svelte
@@ -1,17 +1,9 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import {
-    authenticateWithJWT,
-    authenticateWithPasskey,
-  } from "$lib/utils/authentication";
-  import {
     lastUsedIdentitiesStore,
     type LastUsedAccount,
   } from "$lib/stores/last-used-identities.store";
-  import { canisterConfig, canisterId } from "$lib/globals";
-  import { sessionStore } from "$lib/stores/session.store";
-  import { createGoogleRequestConfig, requestJWT } from "$lib/utils/openID";
-  import { authenticationStore } from "$lib/stores/authentication.store";
   import {
     authorizationStore,
     authorizationContextStore,


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Help debug issues when the credential id is not found.

It might be a temporary problem of the endpoint or that the credential doesn't exist in the mapper.

# Changes

* Clean up unused imports.
* Add try/catch to log the credential id when getting public key.

# Tests

Tested in beta that the hex string can then be used to call the endpoint from the dashboard canister page.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

