### PR TITLE
Prevent migrating twice

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/views/CreatePasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/CreatePasskey.svelte
@@ -10,9 +10,10 @@
   interface Props {
     create: (name: string) => Promise<void>;
     identityNumber?: bigint;
+    disabled?: boolean;
   }
 
-  const { create, identityNumber }: Props = $props();
+  const { create, identityNumber, disabled }: Props = $props();
 
   let inputRef = $state<HTMLInputElement>();
   let name = $state("");

--- a/src/frontend/src/lib/components/wizards/migration/views/AlreadyMigrated.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/views/AlreadyMigrated.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import MigrationIllustration from "$lib/components/illustrations/MigrationIllustration.svelte";
+  import Button from "$lib/components/ui/Button.svelte";
+  import { SUPPORT_URL } from "$lib/config";
+
+  let { name }: { name: string } = $props();
+</script>
+
+<div class="flex flex-1 flex-col">
+  <div class="mb-8 flex flex-col">
+    <div class="text-text-primary flex h-32 items-center justify-center py-5">
+      <MigrationIllustration />
+    </div>
+    <div>
+      <h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
+        Identity already migrated
+      </h1>
+      <p
+        class="text-md text-text-tertiary font-medium text-balance sm:text-center"
+      >
+        {`${name} is already migrated to the new experience.`}
+      </p>
+    </div>
+  </div>
+  <div class="flex flex-col items-stretch gap-4">
+    <Button
+      href={SUPPORT_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      variant="tertiary"
+      size="lg"
+    >
+      Help & FAQ
+    </Button>
+  </div>
+</div>

--- a/src/frontend/src/lib/components/wizards/migration/views/EnterIdentityNumber.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/views/EnterIdentityNumber.svelte
@@ -4,28 +4,29 @@
   import Input from "$lib/components/ui/Input.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { SUPPORT_URL } from "$lib/config";
-  import { nonNullish } from "@dfinity/utils";
   import { onMount } from "svelte";
 
   interface Props {
     onSubmit: (identityNumber: bigint, attachElement?: HTMLElement) => void;
-    isAuthenticating?: boolean;
   }
 
-  let { onSubmit, isAuthenticating }: Props = $props();
+  let { onSubmit }: Props = $props();
 
   let identityNumber = $state<string>("");
   let inputElement = $state<HTMLInputElement>();
   let attachElement = $state<HTMLElement>();
+  let submitting = $state(false);
 
   onMount(() => {
     inputElement?.focus();
   });
 
   const handleSubmit = async () => {
-    // Button is disabled if identityNumber is null or undefined so no need to manage that case.
-    if (nonNullish(identityNumber)) {
-      onSubmit(BigInt(identityNumber), attachElement);
+    submitting = true;
+    try {
+      await onSubmit(BigInt(identityNumber), attachElement);
+    } finally {
+      submitting = false;
     }
   };
 </script>
@@ -66,9 +67,9 @@
       variant="primary"
       size="lg"
       type="submit"
-      disabled={isAuthenticating || identityNumber.length === 0}
+      disabled={submitting || identityNumber.length === 0}
     >
-      {#if isAuthenticating}
+      {#if submitting}
         <ProgressRing />
         <span>Authenticating...</span>
       {:else}

--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -92,7 +92,6 @@ export class MigrationFlow {
         delegation,
       );
       authenticationStore.set({ identity, identityNumber });
-      this.view = "enterName";
     } catch (e: unknown) {
       if (isWebAuthnCancelError(e)) {
         // We only want to show a special error if the user might have to choose different web auth flow.

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -90,7 +90,7 @@ export const DISCOVERABLE_PASSKEY_FLOW = createFeatureFlagStore(
 
 export const ENABLE_MIGRATE_FLOW = createFeatureFlagStore(
   "ENABLE_MIGRATE_FLOW",
-  true,
+  false,
 );
 export const ADD_ACCESS_METHOD = createFeatureFlagStore(
   "ADD_ACCESS_METHOD",


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Avoid confusing the users by allowing them to migrate twice.

# Changes

This pull request improves the migration wizard flow by adding a check for already-migrated identities and refining the user experience during the migration process. The main changes include introducing a new view for users whose identity has already been migrated, updating the flow logic to fetch and check migration status, and simplifying the handling of the authentication step UI.

**Migration flow improvements:**

* Added a check in `MigrationWizard.svelte` to detect if an identity has already been migrated, and display a new `AlreadyMigrated` view with relevant information if so.
* After authenticating with an identity number, the wizard now fetches the latest identity info and updates the view accordingly.
* Introduced the new `AlreadyMigrated.svelte` component to show a confirmation message and support link when the identity is already migrated.

**User experience and UI enhancements:**

* Updated `EnterIdentityNumber.svelte` to manage and display a local `submitting` state instead of relying on an external `isAuthenticating` prop, improving feedback during authentication.

**Feature flag adjustment:**

* Set the `ENABLE_MIGRATE_FLOW` feature flag to `false` by default in `featureFlags.ts`, disabling the migration flow unless explicitly enabled.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
