### PR TITLE
Add domain to passkeys in new dashboard

### DIFF
--- a/src/frontend/src/lib/components/ui/AccessMethod.svelte
+++ b/src/frontend/src/lib/components/ui/AccessMethod.svelte
@@ -73,28 +73,19 @@
       out:fade={{ duration: 30 }}
     >
       <div class="flex min-w-32 pr-3">
-        {#if showOrigin && getOrigin(accessMethod)}
-          <div class="flex flex-col justify-center">
-            <div class="flex items-center gap-2">
-              <span>{getAuthnMethodAlias(accessMethod)}</span>
-              {#if isCurrent}
-                <PulsatingCircleIcon />
-              {/if}
-            </div>
-            <div class="text-text-tertiary text-xs font-extralight">
-              {getOrigin(accessMethod)}
-            </div>
-          </div>
-        {:else}
-          <div class="flex items-center">
-            {getAuthnMethodAlias(accessMethod)}
+        <div class="flex flex-col justify-center">
+          <div class="flex items-center gap-2">
+            <span>{getAuthnMethodAlias(accessMethod)}</span>
             {#if isCurrent}
-              <span class="ml-2" aria-label="Current Passkey">
-                <PulsatingCircleIcon />
-              </span>
+              <PulsatingCircleIcon />
             {/if}
           </div>
-        {/if}
+          {#if showOrigin && getOrigin(accessMethod)}
+            <div class="text-text-tertiary font-extralight">
+              <Ellipsis text={getOrigin(accessMethod)!}></Ellipsis>
+            </div>
+          {/if}
+        </div>
       </div>
       {#if isCurrent}
         <div

--- a/src/frontend/src/lib/components/ui/AccessMethod.svelte
+++ b/src/frontend/src/lib/components/ui/AccessMethod.svelte
@@ -10,18 +10,20 @@
   import Ellipsis from "../utils/Ellipsis.svelte";
   import PulsatingCircleIcon from "../icons/PulsatingCircleIcon.svelte";
   import { getAuthnMethodAlias } from "$lib/utils/webAuthn";
-  import { isLegacyAuthnMethod } from "$lib/utils/accessMethods";
+  import { getOrigin } from "$lib/utils/accessMethods";
 
   let {
     accessMethod,
     class: classes,
     isCurrent,
     isDisabled,
+    showOrigin,
   }: {
     accessMethod: AuthnMethodData | OpenIdCredential | null;
     class?: string;
     isCurrent?: boolean;
     isDisabled?: boolean;
+    showOrigin?: boolean;
   } = $props();
 
   const getOpenIdCredentialName = (credential: OpenIdCredential | null) => {
@@ -70,12 +72,28 @@
       in:fade={{ delay: 30, duration: 30 }}
       out:fade={{ duration: 30 }}
     >
-      <div class="flex min-w-32 items-center pr-3">
-        {getAuthnMethodAlias(accessMethod)}
-        {#if isCurrent}
-          <span class="ml-2" aria-label="Current Passkey">
-            <PulsatingCircleIcon />
-          </span>
+      <div class="flex min-w-32 pr-3">
+        {#if showOrigin && getOrigin(accessMethod)}
+          <div class="flex flex-col justify-center">
+            <div class="flex items-center gap-2">
+              <span>{getAuthnMethodAlias(accessMethod)}</span>
+              {#if isCurrent}
+                <PulsatingCircleIcon />
+              {/if}
+            </div>
+            <div class="text-text-tertiary text-xs font-extralight">
+              {getOrigin(accessMethod)}
+            </div>
+          </div>
+        {:else}
+          <div class="flex items-center">
+            {getAuthnMethodAlias(accessMethod)}
+            {#if isCurrent}
+              <span class="ml-2" aria-label="Current Passkey">
+                <PulsatingCircleIcon />
+              </span>
+            {/if}
+          </div>
         {/if}
       </div>
       {#if isCurrent}

--- a/src/frontend/src/lib/components/ui/AccessMethod.svelte
+++ b/src/frontend/src/lib/components/ui/AccessMethod.svelte
@@ -77,7 +77,9 @@
           <div class="flex items-center gap-2">
             <span>{getAuthnMethodAlias(accessMethod)}</span>
             {#if isCurrent}
-              <PulsatingCircleIcon />
+              <span aria-label="Current Passkey">
+                <PulsatingCircleIcon />
+              </span>
             {/if}
           </div>
           {#if showOrigin && getOrigin(accessMethod)}

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -167,7 +167,7 @@
           accessMethod={authnMethod}
           isDisabled={isLegacyAuthnMethod(authnMethod)}
           isCurrent={isCurrentAccessMethod(authnMethod)}
-          showOrigin={showPasskeyOrigin || true}
+          showOrigin={showPasskeyOrigin}
         />
         {#if !isLegacyAuthnMethod(authnMethod)}
           <div class="flex items-center justify-end gap-2 px-4">

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -22,6 +22,7 @@
     getLastUsedAccessMethod,
     isLegacyAuthnMethod,
     isWebAuthnMetaData,
+    hasMultipleOrigins,
   } from "$lib/utils/accessMethods";
   import { AddAccessMethodWizard } from "$lib/components/wizards/addAccessMethod";
   import { authnMethodEqual, getAuthnMethodAlias } from "$lib/utils/webAuthn";
@@ -117,6 +118,8 @@
       authnMethodEqual(accessMethod, lastUsedAccessMethod)
     );
   };
+
+  const showOrigins = $derived(hasMultipleOrigins(authnMethods));
 </script>
 
 <Panel>
@@ -164,6 +167,7 @@
           accessMethod={authnMethod}
           isDisabled={isLegacyAuthnMethod(authnMethod)}
           isCurrent={isCurrentAccessMethod(authnMethod)}
+          showOrigin={showOrigins}
         />
         {#if !isLegacyAuthnMethod(authnMethod)}
           <div class="flex items-center justify-end gap-2 px-4">

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -167,7 +167,7 @@
           accessMethod={authnMethod}
           isDisabled={isLegacyAuthnMethod(authnMethod)}
           isCurrent={isCurrentAccessMethod(authnMethod)}
-          showOrigin={showPasskeyOrigin}
+          showOrigin={showPasskeyOrigin || true}
         />
         {#if !isLegacyAuthnMethod(authnMethod)}
           <div class="flex items-center justify-end gap-2 px-4">

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -22,7 +22,7 @@
     getLastUsedAccessMethod,
     isLegacyAuthnMethod,
     isWebAuthnMetaData,
-    hasMultipleOrigins,
+    haveMultipleOrigins,
   } from "$lib/utils/accessMethods";
   import { AddAccessMethodWizard } from "$lib/components/wizards/addAccessMethod";
   import { authnMethodEqual, getAuthnMethodAlias } from "$lib/utils/webAuthn";
@@ -119,7 +119,7 @@
     );
   };
 
-  const showOrigins = $derived(hasMultipleOrigins(authnMethods));
+  const showOrigins = $derived(haveMultipleOrigins(authnMethods));
 </script>
 
 <Panel>

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -119,7 +119,7 @@
     );
   };
 
-  const showOrigins = $derived(haveMultipleOrigins(authnMethods));
+  const showPasskeyOrigin = $derived(haveMultipleOrigins(authnMethods));
 </script>
 
 <Panel>
@@ -167,7 +167,7 @@
           accessMethod={authnMethod}
           isDisabled={isLegacyAuthnMethod(authnMethod)}
           isCurrent={isCurrentAccessMethod(authnMethod)}
-          showOrigin={showOrigins}
+          showOrigin={showPasskeyOrigin}
         />
         {#if !isLegacyAuthnMethod(authnMethod)}
           <div class="flex items-center justify-end gap-2 px-4">

--- a/src/frontend/src/lib/utils/accessMethods.test.ts
+++ b/src/frontend/src/lib/utils/accessMethods.test.ts
@@ -12,6 +12,7 @@ import type {
   MetadataMapV2,
 } from "$lib/generated/internet_identity_types";
 import { vi } from "vitest";
+import { nonNullish } from "@dfinity/utils";
 
 // Mock the canisterConfig
 vi.mock("$lib/globals", () => ({
@@ -23,7 +24,7 @@ vi.mock("$lib/globals", () => ({
 }));
 
 const makeAuthnMethodWithOrigin = (origin?: string): AuthnMethodData => {
-  const metadata: MetadataMapV2 = origin
+  const metadata: MetadataMapV2 = nonNullish(origin)
     ? [["origin", { String: origin }]]
     : [];
 

--- a/src/frontend/src/lib/utils/accessMethods.ts
+++ b/src/frontend/src/lib/utils/accessMethods.ts
@@ -70,15 +70,8 @@ export const getOrigin = (
 /**
  * Check if there are multiple unique origins across authentication methods
  */
-export const haveMultipleOrigins = (
-  authnMethods: AuthnMethodData[],
-): boolean => {
-  const origins = new Set<string | undefined>();
-  for (const method of authnMethods) {
-    origins.add(getOrigin(method));
-  }
-  return origins.size > 1;
-};
+export const haveMultipleOrigins = (authnMethods: AuthnMethodData[]): boolean =>
+  new Set(authnMethods.map(getOrigin)).size > 1;
 
 const hasSomeOrigin = (
   accessMethod: AuthnMethodData,

--- a/src/frontend/src/lib/utils/accessMethods.ts
+++ b/src/frontend/src/lib/utils/accessMethods.ts
@@ -79,26 +79,16 @@ const hasOrigin = (
 };
 
 /**
- * Get all unique origins from a list of authentication methods
- */
-export const getUniqueOrigins = (authnMethods: AuthnMethodData[]): string[] => {
-  const origins = new Set<string>();
-  for (const method of authnMethods) {
-    const origin = getOrigin(method);
-    if (origin) {
-      origins.add(origin);
-    }
-  }
-  return Array.from(origins);
-};
-
-/**
  * Check if there are multiple unique origins across authentication methods
  */
-export const hasMultipleOrigins = (
+export const haveMultipleOrigins = (
   authnMethods: AuthnMethodData[],
 ): boolean => {
-  return getUniqueOrigins(authnMethods).length > 1;
+  const origins = new Set<string | undefined>();
+  for (const method of authnMethods) {
+    origins.add(getOrigin(method));
+  }
+  return origins.size > 1;
 };
 
 /**

--- a/src/frontend/src/lib/utils/accessMethods.ts
+++ b/src/frontend/src/lib/utils/accessMethods.ts
@@ -67,17 +67,6 @@ export const getOrigin = (
   return undefined;
 };
 
-const hasOrigin = (
-  accessMethod: AuthnMethodData,
-  origins: string[],
-): boolean => {
-  const accessMethodOrigin = getOrigin(accessMethod);
-  if (nonNullish(accessMethodOrigin)) {
-    return origins.some((o) => isSameOrigin(o, accessMethodOrigin));
-  }
-  return false;
-};
-
 /**
  * Check if there are multiple unique origins across authentication methods
  */
@@ -89,6 +78,17 @@ export const haveMultipleOrigins = (
     origins.add(getOrigin(method));
   }
   return origins.size > 1;
+};
+
+const hasSomeOrigin = (
+  accessMethod: AuthnMethodData,
+  origins: string[],
+): boolean => {
+  const accessMethodOrigin = getOrigin(accessMethod);
+  if (nonNullish(accessMethodOrigin)) {
+    return origins.some((o) => isSameOrigin(o, accessMethodOrigin));
+  }
+  return false;
 };
 
 /**
@@ -106,7 +106,7 @@ export const haveMultipleOrigins = (
  */
 export const isLegacyAuthnMethod = (accessMethod: AuthnMethodData): boolean => {
   return (
-    !hasOrigin(accessMethod, canisterConfig.new_flow_origins[0] ?? []) ||
+    !hasSomeOrigin(accessMethod, canisterConfig.new_flow_origins[0] ?? []) ||
     "Recovery" in accessMethod.security_settings.purpose
   );
 };


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Help the user understand the status after migration.

In this PR, we introduce the origin of the passkey in the new dashboard. But only if the passkeys are from different origins.

# Changes

* Added a new utility function `getOrigin` to extract the origin from an authentication method's metadata, and a function `haveMultipleOrigins` to detect if multiple unique origins exist among the available authentication methods.
* Updated the `AccessMethod.svelte` component to optionally display the origin below the authentication method alias when the `showOrigin` prop is `true` and an origin exists.
* Modified the `AccessMethodsPanel.svelte` component to compute whether to show origins using the new `haveMultipleOrigins` utility and pass this information as a prop to each `AccessMethod` component.

# Tests

* Added unit tests for `getOrigin` and `haveMultipleOrigins` to verify correct behavior with various combinations of authentication methods and metadata.
* Tested in beta with an upgraded identity. See screenshot attached.
* I also checked that a user with only passkeys in one domain doesn't see them.






<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->





