### PR TITLE
Analytics for Upgrade Flow

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/views/CreatePasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/CreatePasskey.svelte
@@ -8,6 +8,10 @@
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { waitFor } from "$lib/utils/utils";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
+  import {
+    upgradeIdentityFunnel,
+    UpgradeIdentityEvents,
+  } from "$lib/utils/analytics/upgradeIdentityFunnel";
 
   interface Props {
     create: (name: string) => Promise<void | "cancelled">;
@@ -15,6 +19,10 @@
   }
 
   const { create, identityNumber }: Props = $props();
+
+  onMount(() => {
+    upgradeIdentityFunnel.trigger(UpgradeIdentityEvents.CreatePasskeyScreen);
+  });
 
   let inputRef = $state<HTMLInputElement>();
   let name = $state("");

--- a/src/frontend/src/lib/components/wizards/migration/views/AlreadyMigrated.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/views/AlreadyMigrated.svelte
@@ -2,8 +2,17 @@
   import MigrationIllustration from "$lib/components/illustrations/MigrationIllustration.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { SUPPORT_URL } from "$lib/config";
+  import { onMount } from "svelte";
+  import {
+    upgradeIdentityFunnel,
+    UpgradeIdentityEvents,
+  } from "$lib/utils/analytics/upgradeIdentityFunnel";
 
   let { name }: { name: string } = $props();
+
+  onMount(() => {
+    upgradeIdentityFunnel.trigger(UpgradeIdentityEvents.AlreadyMigratedScreen);
+  });
 </script>
 
 <div class="flex flex-1 flex-col">

--- a/src/frontend/src/lib/utils/analytics/upgradeIdentityFunnel.ts
+++ b/src/frontend/src/lib/utils/analytics/upgradeIdentityFunnel.ts
@@ -1,0 +1,27 @@
+import { Funnel } from "./Funnel";
+
+/**
+ * Upgrade identity flow events:
+ *
+ * upgrade-identity-start (INIT)
+ *   upgrade-authentication-successful
+ *     create-passkey-screen
+ *       upgrade-successful
+ *       upgrade-failure
+ *     already-migrated-screen
+ *   upgrade-authentication-failure
+ *     upgrade-authentication-cancelled
+ */
+export const UpgradeIdentityEvents = {
+  AuthenticationSuccessful: "upgrade-authentication-successful",
+  CreatePasskeyScreen: "create-passkey-screen",
+  UpgradeSuccessful: "upgrade-successful",
+  UpgradeFailure: "upgrade-failure",
+  AlreadyMigratedScreen: "already-migrated-screen",
+  AuthenticationFailure: "upgrade-authentication-failure",
+  AuthenticationCancelled: "upgrade-authentication-cancelled",
+} as const;
+
+export const upgradeIdentityFunnel = new Funnel<typeof UpgradeIdentityEvents>(
+  "upgrade-identity",
+);


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We want to track how many people migrate their identity as well as how the flow performs and its churn.

In this PR, I add a Funnel for the flow and trigger its events in the related moments.

# Changes

* Added a new `upgradeIdentityFunnel` and `UpgradeIdentityEvents` definition in `upgradeIdentityFunnel.ts` to centralize event tracking for the upgrade flow.
* Integrated funnel event triggers throughout the migration and passkey creation process, including authentication success/failure/cancellation, passkey creation screen, upgrade success/failure, and already migrated screen.
  - Triggered events for authentication success, failure, and cancellation in `MigrationFlow`.
  - Triggered events for upgrade success and failure during the passkey creation step.
  - Triggered events when users land on the create passkey screen and already migrated screen.
  - Initialized the funnel at the start of the migration wizard.
  - Created the `upgradeIdentityFunnel` and standardized event names in `upgradeIdentityFunnel.ts`.

# Tests

Tested locally by adding a console.log in the trigger function of the analytics module.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

