### PR TITLE
Init authentication funnel II landing page

### DIFF
--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -23,6 +23,7 @@
   import { onMount } from "svelte";
   import { FLAIR } from "$lib/state/featureFlags";
   import { triggerDropWaveAnimation } from "$lib/utils/animation-dispatcher";
+  import { authenticationV2Funnel } from "$lib/utils/analytics/authenticationV2Funnel";
 
   const { data }: PageProps = $props();
 
@@ -91,6 +92,7 @@
   };
 
   onMount(() => {
+    authenticationV2Funnel.init({ origin: window.location.origin });
     setTimeout(() => {
       triggerDropWaveAnimation();
     });


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

The authentication funnel was never initialized in the landing page, therefore, we never had the data split per origins of the landing page.

# Changes

* Initialized the v2 authentication funnel in the landing page.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
