### PR TITLE
Change mobile layout upgrade success screen

### DIFF
--- a/src/frontend/src/routes/(new-styling)/authorize/upgrade-success/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/upgrade-success/+page.svelte
@@ -28,8 +28,12 @@
   });
 </script>
 
-<div class="flex flex-1 flex-col items-center justify-center p-4 sm:max-w-100">
-  <div class="text-text-primary flex h-50 items-center justify-center">
+<div
+  class="flex flex-1 flex-col items-stretch justify-end p-4 sm:max-w-100 sm:items-center sm:justify-center"
+>
+  <div
+    class="text-text-primary flex h-50 flex-1 items-center justify-center sm:flex-none"
+  >
     <MigrationSuccessIllustration />
   </div>
   <div class="mb-8 flex flex-col gap-2">


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

There was a misunderstanding on what the designer intended with the layout in the success screen.

The layout should push the button and text to the bottom, and have the illustration vertically centered in the remainder of the space.

# Changes

* Change layout for mobile on upgrade-success page.

# Tests

* Tested locally that the new layout looks as expected in mobile (see screenshot) and it looks like before in desktop.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
