### PR TITLE
Lm remove https passkey origin

### DIFF
--- a/src/frontend/src/lib/components/ui/AccessMethod.svelte
+++ b/src/frontend/src/lib/components/ui/AccessMethod.svelte
@@ -10,7 +10,7 @@
   import Ellipsis from "../utils/Ellipsis.svelte";
   import PulsatingCircleIcon from "../icons/PulsatingCircleIcon.svelte";
   import { getAuthnMethodAlias } from "$lib/utils/webAuthn";
-  import { getOrigin } from "$lib/utils/accessMethods";
+  import { getRpId } from "$lib/utils/accessMethods";
 
   let {
     accessMethod,
@@ -82,9 +82,9 @@
               </span>
             {/if}
           </div>
-          {#if showOrigin && getOrigin(accessMethod)}
+          {#if showOrigin && getRpId(accessMethod)}
             <div class="text-text-tertiary font-extralight">
-              <Ellipsis text={getOrigin(accessMethod)!}></Ellipsis>
+              <Ellipsis text={getRpId(accessMethod)!}></Ellipsis>
             </div>
           {/if}
         </div>

--- a/src/frontend/src/lib/utils/accessMethods.test.ts
+++ b/src/frontend/src/lib/utils/accessMethods.test.ts
@@ -3,6 +3,7 @@ import {
   isLegacyAuthnMethod,
   getOrigin,
   haveMultipleOrigins,
+  getRpId,
 } from "./accessMethods";
 import type {
   AuthnMethodData,
@@ -310,5 +311,24 @@ describe("isLegacyAuthnMethod", () => {
       });
       expect(isLegacyAuthnMethod(method)).toBe(true);
     });
+  });
+});
+
+describe("getRpId", () => {
+  it("should return the hostname from the origin metadata", () => {
+    const accessMethod: AuthnMethodData = makeAuthnMethodWithOrigin(
+      "https://example.com",
+    );
+    expect(getRpId(accessMethod)).toBe("example.com");
+  });
+
+  it("should return undefined if origin metadata is not present", () => {
+    const accessMethod: AuthnMethodData = makeAuthnMethodWithOrigin();
+    expect(getRpId(accessMethod)).toBeUndefined();
+  });
+
+  it("should return undefined if origin metadata is not a string", () => {
+    const accessMethod: AuthnMethodData = makeAuthnMethodWithOrigin("foo");
+    expect(getRpId(accessMethod)).toBeUndefined();
   });
 });

--- a/src/frontend/src/lib/utils/accessMethods.ts
+++ b/src/frontend/src/lib/utils/accessMethods.ts
@@ -68,6 +68,17 @@ export const getOrigin = (
 };
 
 /**
+ * Extract the RP ID (origin without protocol) from an AuthnMethodData's metadata
+ */
+export const getRpId = (accessMethod: AuthnMethodData): string | undefined => {
+  const origin = getOrigin(accessMethod);
+  if (nonNullish(origin)) {
+    return new URL(origin).hostname;
+  }
+  return undefined;
+};
+
+/**
  * Check if there are multiple unique origins across authentication methods
  */
 export const haveMultipleOrigins = (authnMethods: AuthnMethodData[]): boolean =>

--- a/src/frontend/src/lib/utils/accessMethods.ts
+++ b/src/frontend/src/lib/utils/accessMethods.ts
@@ -73,7 +73,11 @@ export const getOrigin = (
 export const getRpId = (accessMethod: AuthnMethodData): string | undefined => {
   const origin = getOrigin(accessMethod);
   if (nonNullish(origin)) {
-    return new URL(origin).hostname;
+    try {
+      return new URL(origin).hostname;
+    } catch (e) {
+      return undefined;
+    }
   }
   return undefined;
 };


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Make the origin shown to the user for passkeys more friendly by removing the protocol.

# Changes

- Updated `AccessMethod.svelte` to use the new `getRpId` function instead of `getOrigin`, so that only the hostname (RP ID) is displayed in the UI instead of the full origin URL. 
- Added a new function `getRpId` in `accessMethods.ts` that extracts the hostname from the origin metadata of an authentication method.

# Tests

* Added unit tests for `getRpId` in `accessMethods.test.ts`, covering cases with valid, missing, and invalid origin metadata.
* Checked locally, see screenshots.
