### PR TITLE
Remove "Migrated" reference from the user

### DIFF
--- a/src/frontend/src/lib/components/wizards/migration/views/AlreadyMigrated.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/views/AlreadyMigrated.svelte
@@ -22,12 +22,12 @@
     </div>
     <div>
       <h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
-        Identity already migrated
+        Identity already upgraded
       </h1>
       <p
         class="text-md text-text-tertiary font-medium text-balance sm:text-center"
       >
-        {`${name} is already migrated to the new experience.`}
+        {`${name} is already upgraded to the new experience.`}
       </p>
     </div>
   </div>


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We talk about "Upgrade" not "Migration". Therefore, there should be no reference to "migrate" words

# Changes

* Change "Identity already migrated" to "Identity already upgraded" and below as well

# Tests

Check locally that I get the right message.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
