### PR TITLE
Follow redirects to get canister id to check alternative origins

### DIFF
--- a/src/frontend/src/lib/utils/canisterIdResolution.ts
+++ b/src/frontend/src/lib/utils/canisterIdResolution.ts
@@ -71,16 +71,11 @@ const lookupCanister = async ({
 }): Promise<{ ok: Principal } | "not_found"> => {
   const HEADER_NAME = "x-ic-canister-id";
   try {
-    const response = await fetch(
-      origin,
-      // fail on redirects
-      {
-        redirect: "error",
-        method: "HEAD",
-        // do not send cookies or other credentials
-        credentials: "omit",
-      },
-    );
+    const response = await fetch(origin, {
+      method: "HEAD",
+      // do not send cookies or other credentials
+      credentials: "omit",
+    });
 
     const headerValue = response.headers.get(HEADER_NAME);
     if (isNullish(headerValue)) {


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

II should follow this redirect when using the Alternative Origins feature to get the canister id.

# Changes

* Remove the error on redirect when fetching the canister id of the derivation origin.
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
