### PR TITLE
Improve message when removing passkeys

### DIFF
--- a/src/frontend/src/lib/components/views/RemovePasskeyDialog.svelte
+++ b/src/frontend/src/lib/components/views/RemovePasskeyDialog.svelte
@@ -21,6 +21,8 @@
   <p class="text-text-tertiary mb-8 font-medium">
     Removing this passkey means you won't be able to use it to sign in anymore.
     You can always add a new one later.
+    <br /><br />
+    It won't be removed from your device or password manager.
     {#if isCurrentAccessMethod}
       <br /><br />
       As you are currently signed in with this passkey, you will be signed out.


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

It's not obvious that removing a passkey from the dashboard doesn't remove it from the user's device or password manager.

# Changes

* Add a text in the remove passkey modal to specify that.

# Tests

* Tested locally that the message appears.
