### PR TITLE
Fix bug where current passkey is wrongly set when removing it.

### DIFF
--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -23,14 +23,18 @@
     isLegacyAuthnMethod,
     isWebAuthnMetaData,
     haveMultipleOrigins,
+    isSameAccessMethod,
   } from "$lib/utils/accessMethods";
   import { AddAccessMethodWizard } from "$lib/components/wizards/addAccessMethod";
-  import { authnMethodEqual, getAuthnMethodAlias } from "$lib/utils/webAuthn";
+  import { getAuthnMethodAlias } from "$lib/utils/webAuthn";
   import { toaster } from "$lib/components/utils/toaster";
 
   const MAX_PASSKEYS = 8;
 
   let isAddAccessMethodWizardOpen = $state(false);
+  let removableAuthnMethod = $state<AuthnMethodData | null>(null);
+  let removableOpenIdCredential = $state<OpenIdCredential | null>(null);
+  let renamableAuthnMethod = $state<AuthnMethodData | null>(null);
 
   const lastUsedAccessMethod = $derived(
     getLastUsedAccessMethod(
@@ -57,21 +61,14 @@
     authnMethods.length + openIdCredentials.length > 1,
   );
   const isRemovableAuthnMethodCurrentAccessMethod = $derived(
-    nonNullish(identityInfo.removableAuthnMethod) &&
-      "WebAuthn" in identityInfo.removableAuthnMethod.authn_method &&
-      identityInfo.isCurrentAccessMethod({
-        passkey: {
-          credentialId: new Uint8Array(
-            identityInfo.removableAuthnMethod.authn_method.WebAuthn.credential_id,
-          ),
-        },
-      }),
+    nonNullish(removableAuthnMethod) &&
+      nonNullish(lastUsedAccessMethod) &&
+      isSameAccessMethod(removableAuthnMethod, lastUsedAccessMethod),
   );
   const isRemovableOpenIdCredentialCurrentAccessMethod = $derived(
-    nonNullish(identityInfo.removableOpenIdCredential) &&
-      identityInfo.isCurrentAccessMethod({
-        openid: identityInfo.removableOpenIdCredential,
-      }),
+    nonNullish(removableOpenIdCredential) &&
+      nonNullish(lastUsedAccessMethod) &&
+      isSameAccessMethod(removableOpenIdCredential, lastUsedAccessMethod),
   );
 
   const handleGoogleLinked = (credential: OpenIdCredential) => {
@@ -89,23 +86,41 @@
     invalidateAll();
   };
   const handleRemoveOpenIdCredential = async () => {
+    if (!removableOpenIdCredential) return;
+
     try {
-      await identityInfo.removeGoogle();
+      await identityInfo.removeGoogle({
+        credential: removableOpenIdCredential,
+        isCurrent: isRemovableOpenIdCredentialCurrentAccessMethod,
+      });
+      removableOpenIdCredential = null;
     } catch (error) {
       handleError(error);
     }
   };
   const handleRemovePasskey = async () => {
+    if (!removableAuthnMethod) return;
+
     try {
-      await identityInfo.removePasskey();
+      await identityInfo.removePasskey({
+        authnMethod: removableAuthnMethod,
+        isCurrent: isRemovableAuthnMethodCurrentAccessMethod,
+      });
+      removableAuthnMethod = null;
     } catch (error) {
       handleError(error);
     }
   };
 
   const handleRenamePasskey = async (newName: string) => {
+    if (!renamableAuthnMethod) return;
+
     try {
-      await identityInfo.renamePasskey(newName);
+      await identityInfo.renamePasskey({
+        authnMethod: renamableAuthnMethod,
+        newName,
+      });
+      renamableAuthnMethod = null;
     } catch (error) {
       handleError(error);
     }
@@ -114,8 +129,7 @@
   const isCurrentAccessMethod = (accessMethod: AuthnMethodData) => {
     return (
       nonNullish(lastUsedAccessMethod) &&
-      isWebAuthnMetaData(lastUsedAccessMethod) &&
-      authnMethodEqual(accessMethod, lastUsedAccessMethod)
+      isSameAccessMethod(accessMethod, lastUsedAccessMethod)
     );
   };
 
@@ -172,7 +186,7 @@
         {#if !isLegacyAuthnMethod(authnMethod)}
           <div class="flex items-center justify-end gap-2 px-4">
             <Button
-              onclick={() => (identityInfo.renamableAuthnMethod = authnMethod)}
+              onclick={() => (renamableAuthnMethod = authnMethod)}
               variant="tertiary"
               iconOnly
               aria-label={`Rename ${isCurrentAccessMethod(authnMethod) ? "current" : ""} passkey`}
@@ -181,8 +195,7 @@
             </Button>
             {#if isRemoveAccessMethodVisible}
               <Button
-                onclick={() =>
-                  (identityInfo.removableAuthnMethod = authnMethod)}
+                onclick={() => (removableAuthnMethod = authnMethod)}
                 variant="tertiary"
                 iconOnly
                 aria-label={`Remove ${isCurrentAccessMethod(authnMethod) ? "current" : ""} passkey`}
@@ -219,8 +232,7 @@
         <div class="flex items-center justify-end px-4">
           {#if isRemoveAccessMethodVisible}
             <Button
-              onclick={() =>
-                (identityInfo.removableOpenIdCredential = credential)}
+              onclick={() => (removableOpenIdCredential = credential)}
               variant="tertiary"
               iconOnly
               class="!text-fg-error-secondary"
@@ -234,27 +246,27 @@
   </div>
 </Panel>
 
-{#if identityInfo.removableOpenIdCredential}
+{#if removableOpenIdCredential}
   <RemoveOpenIdCredential
     onRemove={handleRemoveOpenIdCredential}
-    onClose={() => (identityInfo.removableOpenIdCredential = null)}
+    onClose={() => (removableOpenIdCredential = null)}
     isCurrentAccessMethod={isRemovableOpenIdCredentialCurrentAccessMethod}
   />
 {/if}
 
-{#if identityInfo.removableAuthnMethod}
+{#if removableAuthnMethod}
   <RemovePasskeyDialog
     onRemove={handleRemovePasskey}
-    onClose={() => (identityInfo.removableAuthnMethod = null)}
+    onClose={() => (removableAuthnMethod = null)}
     isCurrentAccessMethod={isRemovableAuthnMethodCurrentAccessMethod}
   />
 {/if}
 
-{#if identityInfo.renamableAuthnMethod}
+{#if renamableAuthnMethod}
   <RenamePasskeyDialog
-    currentName={getAuthnMethodAlias(identityInfo.renamableAuthnMethod)}
+    currentName={getAuthnMethodAlias(renamableAuthnMethod)}
     onRename={handleRenamePasskey}
-    onClose={() => (identityInfo.renamableAuthnMethod = null)}
+    onClose={() => (renamableAuthnMethod = null)}
   />
 {/if}
 

--- a/src/frontend/src/lib/utils/accessMethods.test.ts
+++ b/src/frontend/src/lib/utils/accessMethods.test.ts
@@ -4,6 +4,7 @@ import {
   getOrigin,
   haveMultipleOrigins,
   getRpId,
+  isSameAccessMethod,
 } from "./accessMethods";
 import type {
   AuthnMethodData,
@@ -330,5 +331,68 @@ describe("getRpId", () => {
   it("should return undefined if origin metadata is not a string", () => {
     const accessMethod: AuthnMethodData = makeAuthnMethodWithOrigin("foo");
     expect(getRpId(accessMethod)).toBeUndefined();
+  });
+});
+
+describe("isSameAccessMethod", () => {
+  const makeWebAuthnMethod = (pubkeyBytes: number[]): AuthnMethodData => {
+    return {
+      id: "webauthn-id",
+      last_authentication: [],
+      security_settings: {
+        purpose: { Authentication: null },
+        protection: { Unprotected: null },
+      },
+      metadata: [],
+      authn_method: {
+        WebAuthn: {
+          pubkey: new Uint8Array(pubkeyBytes),
+          credential_id: new Uint8Array([1, 2, 3]),
+        },
+      },
+    } as AuthnMethodData;
+  };
+
+  const makeOpenIdCredential = (
+    iss: string,
+    sub: string,
+  ): OpenIdCredential =>
+    ({
+      id: "oidc-id",
+      last_usage_timestamp: [],
+      aud: "audience",
+      iss,
+      sub,
+      metadata: [],
+    } as unknown as OpenIdCredential);
+
+  it("returns true for identical WebAuthn methods (same pubkey)", () => {
+    const a = makeWebAuthnMethod([1, 2, 3]);
+    const b = makeWebAuthnMethod([1, 2, 3]);
+    expect(isSameAccessMethod(a, b)).toBe(true);
+  });
+
+  it("returns false for different WebAuthn methods (different pubkey)", () => {
+    const a = makeWebAuthnMethod([1, 2, 3]);
+    const b = makeWebAuthnMethod([4, 5, 6]);
+    expect(isSameAccessMethod(a, b)).toBe(false);
+  });
+
+  it("returns true for identical OpenID credentials (same iss and sub)", () => {
+    const a = makeOpenIdCredential("https://issuer", "user-sub");
+    const b = makeOpenIdCredential("https://issuer", "user-sub");
+    expect(isSameAccessMethod(a, b)).toBe(true);
+  });
+
+  it("returns false for different OpenID credentials (different sub)", () => {
+    const a = makeOpenIdCredential("https://issuer", "user-sub");
+    const b = makeOpenIdCredential("https://issuer", "other-sub");
+    expect(isSameAccessMethod(a, b)).toBe(false);
+  });
+
+  it("returns false for mixed types (WebAuthn vs OpenID)", () => {
+    const webAuthn = makeWebAuthnMethod([1, 2, 3]);
+    const oidc = makeOpenIdCredential("https://issuer", "user-sub");
+    expect(isSameAccessMethod(webAuthn, oidc)).toBe(false);
   });
 });

--- a/src/frontend/src/lib/utils/accessMethods.ts
+++ b/src/frontend/src/lib/utils/accessMethods.ts
@@ -5,6 +5,10 @@ import {
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { isSameOrigin } from "./urlUtils";
 import { canisterConfig } from "$lib/globals";
+import { bufEquals } from "@dfinity/agent";
+import { get } from "svelte/store";
+import { lastUsedIdentityStore } from "$lib/stores/last-used-identities.store";
+import { authnMethodEqual } from "./webAuthn";
 
 /**
  * Check if a `AuthnMethodData` or `OpenIdCredential` is a WebAuthn method
@@ -13,6 +17,10 @@ export const isWebAuthnMetaData = (
   accessMethod: AuthnMethodData | OpenIdCredential,
 ): accessMethod is AuthnMethodData =>
   "authn_method" in accessMethod && "WebAuthn" in accessMethod.authn_method;
+
+export const isOpenIdCredential = (
+  accessMethod: AuthnMethodData | OpenIdCredential,
+): accessMethod is OpenIdCredential => "iss" in accessMethod;
 
 export const getLastUsedAccessMethod = (
   authnMethods: AuthnMethodData[],
@@ -117,4 +125,24 @@ export const isLegacyAuthnMethod = (accessMethod: AuthnMethodData): boolean => {
     !hasSomeOrigin(accessMethod, canisterConfig.new_flow_origins[0] ?? []) ||
     "Recovery" in accessMethod.security_settings.purpose
   );
+};
+
+/**
+ * Check if an access method is the currently used access method for authentication
+ */
+export const isSameAccessMethod = (
+  accessMethod1: AuthnMethodData | OpenIdCredential,
+  accessMethod2: AuthnMethodData | OpenIdCredential,
+): boolean => {
+  if (isWebAuthnMetaData(accessMethod1) && isWebAuthnMetaData(accessMethod2)) {
+    return authnMethodEqual(accessMethod1, accessMethod2);
+  }
+
+  if (isOpenIdCredential(accessMethod1) && isOpenIdCredential(accessMethod2)) {
+    return (
+      accessMethod2.iss === accessMethod1.iss &&
+      accessMethod2.sub === accessMethod1.sub
+    );
+  }
+  return false;
 };


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We had a bug that removing the current passkey didn't trigger a logout. Or the opposite, removing the non-current passkey triggered a logout.

The problem was that there were two diffrent methods to check which one was the current passkey and there was a bug in one of them (the one in identity-info) because it checked the last used method from the stored last used identity.

This was true until we started looking up the credentials and ignoring the cached credential in the identity.

# Changes



# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
