### PR TITLE
Add flag for generic open id

### DIFF
--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -96,6 +96,10 @@ export const ADD_ACCESS_METHOD = createFeatureFlagStore(
   "ADD_ACCESS_METHOD",
   true,
 );
+export const ENABLE_GENERIC_OPEN_ID = createFeatureFlagStore(
+  "ENABLE_GENERIC_OPEN_ID",
+  false,
+);
 
 export const CONTINUE_FROM_ANOTHER_DEVICE = createFeatureFlagStore(
   "CONTINUE_FROM_ANOTHER_DEVICE",
@@ -111,4 +115,5 @@ export default {
   ENABLE_MIGRATE_FLOW,
   ADD_ACCESS_METHOD,
   CONTINUE_FROM_ANOTHER_DEVICE,
+  ENABLE_GENERIC_OPEN_ID,
 } as Record<string, FeatureFlagStore>;


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

We don't want to show generic open id providers to users even though they might be available in the backend.

# Changes

* New feature flag: `ENABLE_GENERIC_OPEN_ID`

# Tests

New flag is present in console

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
