### PR TITLE
Add auth scope to OpenID config.

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -23,6 +23,7 @@ export const idlFactory = ({ IDL }) => {
     'name' : IDL.Text,
     'fedcm_uri' : IDL.Opt(IDL.Text),
     'issuer' : IDL.Text,
+    'auth_scope' : IDL.Vec(IDL.Text),
     'client_id' : IDL.Text,
   });
   const CaptchaConfig = IDL.Record({
@@ -817,6 +818,7 @@ export const init = ({ IDL }) => {
     'name' : IDL.Text,
     'fedcm_uri' : IDL.Opt(IDL.Text),
     'issuer' : IDL.Text,
+    'auth_scope' : IDL.Vec(IDL.Text),
     'client_id' : IDL.Text,
   });
   const CaptchaConfig = IDL.Record({

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -326,6 +326,7 @@ export interface OpenIdConfig {
   'name' : string,
   'fedcm_uri' : [] | [string],
   'issuer' : string,
+  'auth_scope' : Array<string>,
   'client_id' : string,
 }
 export interface OpenIdCredential {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -373,6 +373,7 @@ type OpenIdConfig = record {
     client_id : text;
     jwks_uri : text;
     auth_uri : text;
+    auth_scope : vec text;
     fedcm_uri : opt text;
 };
 

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -439,6 +439,7 @@ fn test_data() -> (String, [u8; 32], OpenIdConfig, Claims) {
         client_id: claims.aud.clone(),
         jwks_uri: "https://www.googleapis.com/oauth2/v3/certs".to_string(),
         auth_uri: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
+        auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://accounts.google.com/gsi/fedcm.json".into()),
     };
 

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -439,7 +439,7 @@ fn test_data() -> (String, [u8; 32], OpenIdConfig, Claims) {
         client_id: claims.aud.clone(),
         jwks_uri: "https://www.googleapis.com/oauth2/v3/certs".to_string(),
         auth_uri: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
-        auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
+        auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://accounts.google.com/gsi/fedcm.json".into()),
     };
 

--- a/src/internet_identity/tests/integration/config/openid_configs.rs
+++ b/src/internet_identity/tests/integration/config/openid_configs.rs
@@ -32,7 +32,7 @@ fn should_init_config() {
                 client_id: "app.example.com".into(),
                 jwks_uri: "https://example.com/oauth2/v3/certs".into(),
                 auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
-                auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
+                auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
                 fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
             }]),
             ..Default::default()
@@ -46,7 +46,7 @@ fn should_init_config() {
                     client_id: "app.example.com".into(),
                     jwks_uri: "https://example.com/oauth2/v3/certs".into(),
                     auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
-                    auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
+                    auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
                     fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
                 },
                 OpenIdConfig {
@@ -55,7 +55,7 @@ fn should_init_config() {
                     issuer: "https://example2.com".into(),
                     client_id: "app.example2.com".into(),
                     jwks_uri: "https://example2.com/oauth2/v3/certs".into(),
-                    auth_scopes: vec!["openid".into()],
+                    auth_scope: vec!["openid".into()],
                     auth_uri: "https://example2.com/o/oauth2/v2/auth".into(),
                     fedcm_uri: None,
                 },
@@ -87,7 +87,7 @@ fn should_enable_config() {
         client_id: "app.example.com".into(),
         jwks_uri: "https://example.com/oauth2/v3/certs".into(),
         auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
-        auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
+        auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://example.com/fedcm.json".into()),
     }]);
 
@@ -111,7 +111,7 @@ fn should_disable_config() {
             client_id: "app.example.com".into(),
             jwks_uri: "https://example.com/oauth2/v3/certs".into(),
             auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
-            auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
+            auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
             fedcm_uri: Some("https://example.com/fedcm.json".into()),
         }]),
         ..Default::default()
@@ -138,7 +138,7 @@ fn should_update_config() {
             client_id: "app.example.com".into(),
             jwks_uri: "https://example.com/oauth2/v3/certs".into(),
             auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
-            auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
+            auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
             fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
         }]),
         ..Default::default()
@@ -150,7 +150,7 @@ fn should_update_config() {
         client_id: "app.example2.com".into(),
         jwks_uri: "https://example2.com/oauth2/v3/certs".into(),
         auth_uri: "https://example2.com/o/oauth2/v2/auth".into(),
-        auth_scopes: vec!["openid".into()],
+        auth_scope: vec!["openid".into()],
         fedcm_uri: None,
     }]);
 
@@ -183,7 +183,7 @@ fn should_retain_config() {
                 client_id: "app.example.com".into(),
                 jwks_uri: "https://example.com/oauth2/v3/certs".into(),
                 auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
-                auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
+                auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
                 fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
             }]),
             ..Default::default()
@@ -197,7 +197,7 @@ fn should_retain_config() {
                     client_id: "app.example.com".into(),
                     jwks_uri: "https://example.com/oauth2/v3/certs".into(),
                     auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
-                    auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
+                    auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
                     fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
                 },
                 OpenIdConfig {
@@ -207,7 +207,7 @@ fn should_retain_config() {
                     client_id: "app.example2.com".into(),
                     jwks_uri: "https://example2.com/oauth2/v3/certs".into(),
                     auth_uri: "https://example2.com/o/oauth2/v2/auth".into(),
-                    auth_scopes: vec!["openid".into()],
+                    auth_scope: vec!["openid".into()],
                     fedcm_uri: None,
                 },
             ]),

--- a/src/internet_identity/tests/integration/config/openid_configs.rs
+++ b/src/internet_identity/tests/integration/config/openid_configs.rs
@@ -32,6 +32,7 @@ fn should_init_config() {
                 client_id: "app.example.com".into(),
                 jwks_uri: "https://example.com/oauth2/v3/certs".into(),
                 auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
+                auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
                 fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
             }]),
             ..Default::default()
@@ -45,6 +46,7 @@ fn should_init_config() {
                     client_id: "app.example.com".into(),
                     jwks_uri: "https://example.com/oauth2/v3/certs".into(),
                     auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
+                    auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
                     fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
                 },
                 OpenIdConfig {
@@ -53,6 +55,7 @@ fn should_init_config() {
                     issuer: "https://example2.com".into(),
                     client_id: "app.example2.com".into(),
                     jwks_uri: "https://example2.com/oauth2/v3/certs".into(),
+                    auth_scopes: vec!["openid".into()],
                     auth_uri: "https://example2.com/o/oauth2/v2/auth".into(),
                     fedcm_uri: None,
                 },
@@ -84,6 +87,7 @@ fn should_enable_config() {
         client_id: "app.example.com".into(),
         jwks_uri: "https://example.com/oauth2/v3/certs".into(),
         auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
+        auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://example.com/fedcm.json".into()),
     }]);
 
@@ -107,6 +111,7 @@ fn should_disable_config() {
             client_id: "app.example.com".into(),
             jwks_uri: "https://example.com/oauth2/v3/certs".into(),
             auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
+            auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
             fedcm_uri: Some("https://example.com/fedcm.json".into()),
         }]),
         ..Default::default()
@@ -133,6 +138,7 @@ fn should_update_config() {
             client_id: "app.example.com".into(),
             jwks_uri: "https://example.com/oauth2/v3/certs".into(),
             auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
+            auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
             fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
         }]),
         ..Default::default()
@@ -144,6 +150,7 @@ fn should_update_config() {
         client_id: "app.example2.com".into(),
         jwks_uri: "https://example2.com/oauth2/v3/certs".into(),
         auth_uri: "https://example2.com/o/oauth2/v2/auth".into(),
+        auth_scopes: vec!["openid".into()],
         fedcm_uri: None,
     }]);
 
@@ -176,6 +183,7 @@ fn should_retain_config() {
                 client_id: "app.example.com".into(),
                 jwks_uri: "https://example.com/oauth2/v3/certs".into(),
                 auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
+                auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
                 fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
             }]),
             ..Default::default()
@@ -189,6 +197,7 @@ fn should_retain_config() {
                     client_id: "app.example.com".into(),
                     jwks_uri: "https://example.com/oauth2/v3/certs".into(),
                     auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
+                    auth_scopes: vec!["openid".into(), "profile".into(), "email".into()],
                     fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
                 },
                 OpenIdConfig {
@@ -198,6 +207,7 @@ fn should_retain_config() {
                     client_id: "app.example2.com".into(),
                     jwks_uri: "https://example2.com/oauth2/v3/certs".into(),
                     auth_uri: "https://example2.com/o/oauth2/v2/auth".into(),
+                    auth_scopes: vec!["openid".into()],
                     fedcm_uri: None,
                 },
             ]),

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -322,7 +322,7 @@ pub struct OpenIdConfig {
     pub client_id: String,
     pub jwks_uri: String,
     pub auth_uri: String,
-    pub auth_scopes: Vec<String>,
+    pub auth_scope: Vec<String>,
     pub fedcm_uri: Option<String>,
 }
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -322,6 +322,7 @@ pub struct OpenIdConfig {
     pub client_id: String,
     pub jwks_uri: String,
     pub auth_uri: String,
+    pub auth_scopes: Vec<String>,
     pub fedcm_uri: Option<String>,
 }
 


### PR DESCRIPTION
Add auth scope to OpenID config, some identity providers (AppleID) throw an error when unsupported scopes (profile) are passed. This PR resolves this by making the scopes configurable per identity provider. 

# Changes

- Add `auth_scope` to `OpenIdConfig`.

# Tests

- Update configuration tests 



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


