### PR TITLE
Auth with Generic Open ID

### DIFF
--- a/src/frontend/src/lib/flows/authFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.ts
@@ -27,8 +27,13 @@ import {
   IdRegFinishError,
   IdRegStartError,
   OpenIdDelegationError,
+  OpenIdConfig,
 } from "$lib/generated/internet_identity_types";
-import { createGoogleRequestConfig, requestJWT } from "$lib/utils/openID";
+import {
+  createGoogleRequestConfig,
+  requestJWT,
+  RequestConfig,
+} from "$lib/utils/openID";
 
 export class AuthFlow {
   #view = $state<
@@ -200,7 +205,73 @@ export class AuthFlow {
           AuthenticationV2Events.RegisterWithGoogle,
         );
         await this.#startRegistration();
-        const identityNumber = await this.#registerWithGoogle(jwt);
+        const identityNumber = await this.#registerWithOpenId(jwt);
+        return { identityNumber, type: "signUp" };
+      }
+      this.#view = "chooseMethod";
+      throw error;
+    }
+  };
+
+  continueWithOpenId = async (
+    config: OpenIdConfig,
+  ): Promise<{
+    identityNumber: bigint;
+    type: "signIn" | "signUp";
+  }> => {
+    let jwt: string | undefined = undefined;
+    // Convert OpenIdConfig to RequestConfig
+    const requestConfig: RequestConfig = {
+      clientId: config.client_id,
+      authURL: config.auth_uri,
+      configURL: config.fedcm_uri?.[0],
+    };
+    // Create two try-catch blocks to avoid double-triggering the analytics.
+    try {
+      this.#systemOverlay = true;
+      jwt = await requestJWT(requestConfig, {
+        nonce: get(sessionStore).nonce,
+        mediation: "required",
+      });
+    } catch (error) {
+      this.#view = "chooseMethod";
+      throw error;
+    } finally {
+      this.#systemOverlay = false;
+      // Moved after `requestJWT` to avoid Safari from blocking the popup.
+      authenticationV2Funnel.trigger(AuthenticationV2Events.ContinueWithGoogle);
+    }
+    try {
+      const { identity, identityNumber, iss, sub } = await authenticateWithJWT({
+        canisterId,
+        session: get(sessionStore),
+        jwt,
+      });
+      // If the previous call succeeds, it means the OpenID user already exists in II.
+      // Therefore, they are logging in.
+      // If the call fails, it means the OpenID user does not exist in II.
+      // In that case, we register them.
+      authenticationV2Funnel.trigger(AuthenticationV2Events.LoginWithGoogle);
+      authenticationStore.set({ identity, identityNumber });
+      const info =
+        await get(authenticatedStore).actor.get_anchor_info(identityNumber);
+      lastUsedIdentitiesStore.addLastUsedIdentity({
+        identityNumber,
+        name: info.name[0],
+        authMethod: { openid: { iss, sub } },
+      });
+      return { identityNumber, type: "signIn" };
+    } catch (error) {
+      if (
+        isCanisterError<OpenIdDelegationError>(error) &&
+        error.type === "NoSuchAnchor" &&
+        nonNullish(jwt)
+      ) {
+        authenticationV2Funnel.trigger(
+          AuthenticationV2Events.RegisterWithGoogle,
+        );
+        await this.#startRegistration();
+        const identityNumber = await this.#registerWithOpenId(jwt);
         return { identityNumber, type: "signUp" };
       }
       this.#view = "chooseMethod";
@@ -334,7 +405,7 @@ export class AuthFlow {
     }
   };
 
-  #registerWithGoogle = async (jwt: string): Promise<bigint> => {
+  #registerWithOpenId = async (jwt: string): Promise<bigint> => {
     try {
       await get(sessionStore)
         .actor.openid_identity_registration_finish({
@@ -370,7 +441,7 @@ export class AuthFlow {
           await this.#solveCaptcha(
             `data:image/png;base64,${nextStep.CheckCaptcha.captcha_png_base64}`,
           );
-          return this.#registerWithGoogle(jwt);
+          return this.#registerWithOpenId(jwt);
         }
       }
       throw error;


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Use generic open id config for authentication.

In this PR, users can authenticate with the open id configuration instead of custom google

# Changes

**OpenID Authentication Flow Enhancements:**

* Added a new `continueWithOpenId` handler in `AuthWizard.svelte` and `PickAuthenticationMethod.svelte` to support generic OpenID providers, using the new `OpenIdConfig` type. This handler manages authentication state, error handling, and user feedback for cancellations.
* Updated the authentication flow logic in `authFlow.svelte.ts` to generalize OpenID login and registration, including converting `OpenIdConfig` to a request config, handling both sign-in and sign-up, and renaming `#registerWithGoogle` to `#registerWithOpenId`

**UI Updates for Provider Selection:**

* Modified `PickAuthenticationMethod.svelte` to display a button for each configured OpenID provider when the `ENABLE_GENERIC_OPEN_ID` feature flag is enabled, including provider logos and cancellation feedback tooltips.
* Adjusted the logic for showing the Google button to hide it when generic OpenID is enabled, and added support for rendering multiple providers dynamically from `canisterConfig`.

# Tests

Tested locally, see video attached.
I also tested with three buttons locally, see screenshot attached.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
