### PR TITLE
Change event in v2 authentication funnel

### DIFF
--- a/src/frontend/src/lib/flows/authFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.ts
@@ -135,10 +135,6 @@ export class AuthFlow {
   };
 
   createPasskey = async (): Promise<bigint> => {
-    authenticationV2Funnel.trigger(
-      AuthenticationV2Events.StartWebauthnCreation,
-      { abTestGroup: this.abTestGroup },
-    );
     if (isNullish(this.#name)) {
       throw new Error("Name is not set");
     }
@@ -146,6 +142,12 @@ export class AuthFlow {
       features.DUMMY_AUTH || nonNullish(canisterConfig.dummy_auth[0]?.[0])
         ? await DiscoverableDummyIdentity.createNew(this.#name)
         : await DiscoverablePasskeyIdentity.createNew(this.#name);
+    // If we trigger the analytics before the password creation,
+    // it might get blocked by Safari.
+    authenticationV2Funnel.trigger(
+      AuthenticationV2Events.SuccessfulWebauthnCreation,
+      { abTestGroup: this.abTestGroup },
+    );
     await this.#startRegistration();
     return this.#registerWithPasskey(passkeyIdentity);
   };

--- a/src/frontend/src/lib/utils/analytics/authenticationV2Funnel.ts
+++ b/src/frontend/src/lib/utils/analytics/authenticationV2Funnel.ts
@@ -27,7 +27,7 @@ import { Funnel } from "./Funnel";
  *      continue-with-passkey-screen
  *        enter-name-screen
  *          [info-passkey-screen]
- *          start-webauthn-creation
+ *          successful-webauthn-creation
  *            register-with-passkey
  *              successful-passkey-registration
  *                auth-success
@@ -46,7 +46,7 @@ export const AuthenticationV2Events = {
   LoginWithGoogle: "login-with-google",
   ContinueWithPasskeyScreen: "continue-with-passkey-screen",
   EnterNameScreen: "enter-name-screen",
-  StartWebauthnCreation: "start-webauthn-creation",
+  SuccessfulWebauthnCreation: "successful-webauthn-creation",
   RegisterWithPasskey: "register-with-passkey",
   SuccessfulPasskeyRegistration: "successful-passkey-registration",
   UseExistingPasskey: "use-existing-passkey",


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Safari sometimes blocks WebAuthn interactions if there is some async activity between the click and the webauthn call.

Therefore, we should move the analytics call to after the passkey creation.

# Changes

* Changed the event name from `start-webauthn-creation` to `successful-webauthn-creation` throughout the codebase for more accurate tracking.
* Moved the analytics trigger in `AuthFlow.createPasskey` to fire after passkey creation, which avoids issues with Safari blocking the event if triggered too early.

# Tests

No new functionality. CI checks suffice.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
