### PR TITLE
Allow users to upgrade again.

### DIFF
--- a/src/frontend/src/lib/components/wizards/migration/views/AlreadyMigrated.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/views/AlreadyMigrated.svelte
@@ -8,7 +8,8 @@
     UpgradeIdentityEvents,
   } from "$lib/utils/analytics/upgradeIdentityFunnel";
 
-  let { name }: { name: string } = $props();
+  let { name, onUpgradeAgain }: { name: string; onUpgradeAgain: () => void } =
+    $props();
 
   onMount(() => {
     upgradeIdentityFunnel.trigger(UpgradeIdentityEvents.AlreadyMigratedScreen);
@@ -25,9 +26,14 @@
         Identity already upgraded
       </h1>
       <p
-        class="text-md text-text-tertiary font-medium text-balance sm:text-center"
+        class="text-md text-text-tertiary mb-2 font-medium text-balance sm:text-center"
       >
         {`${name} is already upgraded to the new experience.`}
+      </p>
+      <p
+        class="text-md text-text-tertiary font-medium text-balance sm:text-center"
+      >
+        Select "Use existing Passkey" in the login flow.
       </p>
     </div>
   </div>
@@ -36,10 +42,13 @@
       href={SUPPORT_URL}
       target="_blank"
       rel="noopener noreferrer"
-      variant="tertiary"
+      variant="secondary"
       size="lg"
     >
       Help & FAQ
+    </Button>
+    <Button onclick={onUpgradeAgain} variant="tertiary" size="lg">
+      Upgrade again
     </Button>
   </div>
 </div>

--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -28,6 +28,7 @@ import {
 } from "$lib/utils/analytics/upgradeIdentityFunnel";
 import { features } from "$lib/legacy/features";
 import { DiscoverableDummyIdentity } from "$lib/utils/discoverableDummyIdentity";
+import { isNewOriginDevice } from "$lib/utils/accessMethods";
 
 export class WrongDomainError extends Error {
   constructor() {
@@ -40,9 +41,11 @@ export class WrongDomainError extends Error {
 }
 
 export class MigrationFlow {
-  view = $state<"enterNumber" | "enterName">("enterNumber");
+  view = $state<"enterNumber" | "enterName" | "alreadyMigrated">("enterNumber");
   identityNumber: UserNumber | undefined;
   #webAuthFlows: { flows: WebAuthnFlow[]; currentIndex: number } | undefined;
+  #attachElement?: HTMLElement;
+  #devices: Omit<DeviceData, "alias">[] = [];
 
   constructor() {
     this.identityNumber = undefined;
@@ -53,85 +56,32 @@ export class MigrationFlow {
     attachElement?: HTMLElement,
   ): Promise<void> => {
     this.identityNumber = identityNumber;
-    const devices = await this.#lookupAuthenticators(identityNumber);
-
-    const webAuthnAuthenticators = devices
-      .filter(({ key_type }) => !("browser_storage_key" in key_type))
-      .map(convertToValidCredentialData)
-      .filter(nonNullish);
-
-    if (isNullish(this.#webAuthFlows)) {
-      const flows = findWebAuthnFlows({
-        supportsRor: supportsWebauthRoR(window.navigator.userAgent),
-        devices: webAuthnAuthenticators,
-        currentOrigin: window.location.origin,
-        // Empty array is the same as no related origins.
-        relatedOrigins: canisterConfig.related_origins[0] ?? [],
-      });
-      this.#webAuthFlows = {
-        flows,
-        currentIndex: 0,
-      };
+    this.#attachElement = attachElement;
+    this.#devices = await this.#lookupAuthenticators(identityNumber);
+    const alreadyMigrated = this.#devices.some(isNewOriginDevice);
+    if (alreadyMigrated) {
+      this.view = "alreadyMigrated";
+      return;
     }
 
-    const flowsLength = this.#webAuthFlows?.flows.length ?? 0;
-    // We reached the last flow. Start from the beginning.
-    // This might happen if the user cancelled manually in the flow that would have been successful.
-    if (this.#webAuthFlows?.currentIndex === flowsLength) {
-      this.#webAuthFlows.currentIndex = 0;
-    }
-    const currentFlow = nonNullish(this.#webAuthFlows)
-      ? this.#webAuthFlows.flows[this.#webAuthFlows.currentIndex]
-      : undefined;
-
-    const passkeyIdentity = MultiWebAuthnIdentity.fromCredentials(
-      webAuthnAuthenticators,
-      currentFlow?.rpId,
-      currentFlow?.useIframe ?? false,
-      // Set user verification to preferred to ensure the user is verified during migration.
-      "preferred",
+    return this.#authenticate({
+      identityNumber,
       attachElement,
-    );
-    try {
-      const session = get(sessionStore);
-      const delegation = await DelegationChain.create(
-        passkeyIdentity,
-        session.identity.getPublicKey(),
-        new Date(Date.now() + 30 * 60 * 1000),
-      );
+      devices: this.#devices,
+    });
+  };
 
-      const identity = DelegationIdentity.fromDelegation(
-        session.identity,
-        delegation,
-      );
-      authenticationStore.set({ identity, identityNumber });
-      upgradeIdentityFunnel.trigger(
-        UpgradeIdentityEvents.AuthenticationSuccessful,
-      );
-    } catch (error) {
-      upgradeIdentityFunnel.trigger(
-        UpgradeIdentityEvents.AuthenticationFailure,
-      );
-      if (isWebAuthnCancelError(error)) {
-        upgradeIdentityFunnel.trigger(
-          UpgradeIdentityEvents.AuthenticationCancelled,
-        );
-      }
-      // We only want to show a special error if the user might have to choose different web auth flow.
-      if (
-        isWebAuthnCancelError(error) &&
-        nonNullish(this.#webAuthFlows) &&
-        flowsLength > 1
-      ) {
-        // Increase the index to try the next flow.
-        this.#webAuthFlows = {
-          flows: this.#webAuthFlows.flows,
-          currentIndex: this.#webAuthFlows.currentIndex + 1,
-        };
-        throw new WrongDomainError();
-      }
-      throw error;
+  upgradeAgain = () => {
+    if (isNullish(this.identityNumber) || isNullish(this.#attachElement)) {
+      // The identityNumber and attachElement are set in authenticateWithIdentityNumber from "enterNumber" view.
+      this.view = "enterNumber";
+      throw new Error("Enter your identity number and try again.");
     }
+    return this.#authenticate({
+      identityNumber: this.identityNumber,
+      devices: this.#devices,
+      attachElement: this.#attachElement,
+    });
   };
 
   createPasskey = async (name: string): Promise<void> => {
@@ -230,5 +180,97 @@ export class MigrationFlow {
     const actor = await get(sessionStore).actor;
     const allDevices = await actor.lookup(userNumber);
     return allDevices.filter((device) => "authentication" in device.purpose);
+  };
+
+  #authenticate = async ({
+    identityNumber,
+    attachElement,
+    devices,
+  }: {
+    identityNumber: UserNumber;
+    attachElement?: HTMLElement;
+    devices: Omit<DeviceData, "alias">[];
+  }) => {
+    const webAuthnAuthenticators = devices
+      .filter(({ key_type }) => !("browser_storage_key" in key_type))
+      .map(convertToValidCredentialData)
+      .filter(nonNullish);
+
+    if (isNullish(this.#webAuthFlows)) {
+      const flows = findWebAuthnFlows({
+        supportsRor: supportsWebauthRoR(window.navigator.userAgent),
+        devices: webAuthnAuthenticators,
+        currentOrigin: window.location.origin,
+        // Empty array is the same as no related origins.
+        relatedOrigins: canisterConfig.related_origins[0] ?? [],
+      });
+      this.#webAuthFlows = {
+        flows,
+        currentIndex: 0,
+      };
+    }
+
+    const flowsLength = this.#webAuthFlows?.flows.length ?? 0;
+    // We reached the last flow. Start from the beginning.
+    // This might happen if the user cancelled manually in the flow that would have been successful.
+    if (this.#webAuthFlows?.currentIndex === flowsLength) {
+      this.#webAuthFlows.currentIndex = 0;
+    }
+    const currentFlow = nonNullish(this.#webAuthFlows)
+      ? this.#webAuthFlows.flows[this.#webAuthFlows.currentIndex]
+      : undefined;
+
+    const passkeyIdentity = MultiWebAuthnIdentity.fromCredentials(
+      webAuthnAuthenticators,
+      currentFlow?.rpId,
+      currentFlow?.useIframe ?? false,
+      // Set user verification to preferred to ensure the user is verified during migration.
+      "preferred",
+      attachElement,
+    );
+    try {
+      const session = get(sessionStore);
+      const delegation = await DelegationChain.create(
+        passkeyIdentity,
+        session.identity.getPublicKey(),
+        new Date(Date.now() + 30 * 60 * 1000),
+      );
+
+      const identity = DelegationIdentity.fromDelegation(
+        session.identity,
+        delegation,
+      );
+      authenticationStore.set({
+        identity,
+        identityNumber,
+      });
+      upgradeIdentityFunnel.trigger(
+        UpgradeIdentityEvents.AuthenticationSuccessful,
+      );
+      this.view = "enterName";
+    } catch (error) {
+      upgradeIdentityFunnel.trigger(
+        UpgradeIdentityEvents.AuthenticationFailure,
+      );
+      if (isWebAuthnCancelError(error)) {
+        upgradeIdentityFunnel.trigger(
+          UpgradeIdentityEvents.AuthenticationCancelled,
+        );
+      }
+      // We only want to show a special error if the user might have to choose different web auth flow.
+      if (
+        isWebAuthnCancelError(error) &&
+        nonNullish(this.#webAuthFlows) &&
+        flowsLength > 1
+      ) {
+        // Increase the index to try the next flow.
+        this.#webAuthFlows = {
+          flows: this.#webAuthFlows.flows,
+          currentIndex: this.#webAuthFlows.currentIndex + 1,
+        };
+        throw new WrongDomainError();
+      }
+      throw error;
+    }
   };
 }

--- a/src/frontend/src/lib/utils/accessMethods.ts
+++ b/src/frontend/src/lib/utils/accessMethods.ts
@@ -1,11 +1,13 @@
 import {
   AuthnMethodData,
+  DeviceData,
   OpenIdCredential,
 } from "$lib/generated/internet_identity_types";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { isSameOrigin } from "./urlUtils";
 import { canisterConfig } from "$lib/globals";
 import { authnMethodEqual } from "./webAuthn";
+import { LEGACY_II_URL } from "$lib/config";
 
 /**
  * Check if a `AuthnMethodData` or `OpenIdCredential` is a WebAuthn method
@@ -121,6 +123,26 @@ export const isLegacyAuthnMethod = (accessMethod: AuthnMethodData): boolean => {
   return (
     !hasSomeOrigin(accessMethod, canisterConfig.new_flow_origins[0] ?? []) ||
     "Recovery" in accessMethod.security_settings.purpose
+  );
+};
+
+/**
+ * Returns true if the device's origin is one of the new flow origins.
+ * As long as the device is not a recovery device (which are not yet supported in the new flow origins).
+ *
+ * TODO: Do not use new_flow_origins when old domains move to new flow.
+ * TODO: Remove recovery once they are supported in new flow.
+ *
+ * @param device
+ * @returns {boolean}
+ */
+export const isNewOriginDevice = (
+  device: Omit<DeviceData, "alias">,
+): boolean => {
+  return (
+    (canisterConfig.new_flow_origins[0] ?? []).some((new_origin) =>
+      isSameOrigin(new_origin, device.origin[0] ?? LEGACY_II_URL),
+    ) && !("Recovery" in device.purpose)
   );
 };
 


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

There are some cases where users need to upgrade a second time. For example, if they lose the passkey they created in id.ai they would be blocked even though they have access to their access methods from 1.0.

I also realized that we can know whether the user upgraded or not before authenticating, using the lookup of the authenticators. Therefore, I refactored to flow to do the check first. Which means that on upgrading again, the user need to authenticate because it didn't before. This is nicer because we about one biometric before telling the user that it's already upgraded.

# Changes

* Refactored the migration flow to detect already-migrated identities by checking if any device is associated with a new flow origin using the new `isNewOriginDevice` utility, instead of relying on authentication method types. When such a device is found, the wizard now shows an `alreadyMigrated` view.
* Added an `upgradeAgain` handler in the migration flow and UI, allowing users to retry the upgrade process from the `alreadyMigrated` screen.
* Updated the `AlreadyMigrated` component to display clearer instructions and provide an "Upgrade again" button, improving user guidance.
* Changed the help button style from tertiary to secondary for better visibility and make it more prominent than "Upgrade again"
* Removed the legacy `alreadyMigrated` logic from the migration wizard, shifting responsibility to the migration flow class.
* Added comprehensive unit tests for the new `isNewOriginDevice` utility to ensure correct detection of migrated devices based on origin and purpose.

These changes make the migration process more robust and user-friendly, especially for users who have already upgraded their identity.

# Tests

* Tested locally as seen in the video.
* Added tests for the new util `isNewOriginDevice`.
