### PR TITLE
User can link generic openID providers

### DIFF
--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -71,7 +71,7 @@
       isSameAccessMethod(removableOpenIdCredential, lastUsedAccessMethod),
   );
 
-  const handleGoogleLinked = (credential: OpenIdCredential) => {
+  const handleOpenIDLinked = (credential: OpenIdCredential) => {
     openIdCredentials.push(credential);
     invalidateAll();
   };
@@ -279,7 +279,7 @@
 {#if isAddAccessMethodWizardOpen}
   {#if $ADD_ACCESS_METHOD}
     <AddAccessMethodWizard
-      onGoogleLinked={handleGoogleLinked}
+      onOpenIDLinked={handleOpenIDLinked}
       onPasskeyRegistered={handlePasskeyRegistered}
       onOtherDeviceRegistered={handleOtherDeviceRegistered}
       onClose={() => (isAddAccessMethodWizardOpen = false)}

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/AddAccessMethodWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/AddAccessMethodWizard.svelte
@@ -6,6 +6,7 @@
   import type {
     AuthnMethodData,
     OpenIdCredential,
+    OpenIdConfig,
   } from "$lib/generated/internet_identity_types";
   import AddAccessMethod from "$lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte";
   import AddPasskey from "$lib/components/wizards/addAccessMethod/views/AddPasskey.svelte";
@@ -48,6 +49,15 @@
       onError(error);
     }
   };
+
+  const handleContinueWithOpenId = async (config: OpenIdConfig) => {
+    try {
+      onGoogleLinked(await addAccessMethodFlow.linkOpenIdAccount(config));
+      onClose();
+    } catch (error) {
+      onError(error);
+    }
+  };
   const handleCreatePasskey = async () => {
     try {
       onPasskeyRegistered(await addAccessMethodFlow.createPasskey());
@@ -72,6 +82,7 @@
     <AddAccessMethod
       continueWithPasskey={addAccessMethodFlow.continueWithPasskey}
       linkGoogleAccount={handleContinueWithGoogle}
+      linkOpenIdAccount={handleContinueWithOpenId}
     />
   {:else if addAccessMethodFlow.view === "addPasskey"}
     <AddPasskey

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/AddAccessMethodWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/AddAccessMethodWizard.svelte
@@ -13,7 +13,7 @@
   import { ConfirmAccessMethodWizard } from "$lib/components/wizards/confirmAccessMethod";
 
   interface Props {
-    onGoogleLinked: (credential: OpenIdCredential) => void;
+    onOpenIDLinked: (credential: OpenIdCredential) => void;
     onPasskeyRegistered: (credential: AuthnMethodData) => void;
     onOtherDeviceRegistered: () => void;
     onClose: () => void;
@@ -23,7 +23,7 @@
   }
 
   const {
-    onGoogleLinked,
+    onOpenIDLinked,
     onPasskeyRegistered,
     onOtherDeviceRegistered,
     onClose,
@@ -43,7 +43,7 @@
 
   const handleContinueWithGoogle = async () => {
     try {
-      onGoogleLinked(await addAccessMethodFlow.linkGoogleAccount());
+      onOpenIDLinked(await addAccessMethodFlow.linkGoogleAccount());
       onClose();
     } catch (error) {
       onError(error);
@@ -52,7 +52,7 @@
 
   const handleContinueWithOpenId = async (config: OpenIdConfig) => {
     try {
-      onGoogleLinked(await addAccessMethodFlow.linkOpenIdAccount(config));
+      onOpenIDLinked(await addAccessMethodFlow.linkOpenIdAccount(config));
       onClose();
     } catch (error) {
       onError(error);

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -59,7 +59,7 @@
     Add access method
   </h1>
   <p class="text-md text-text-tertiary font-medium text-balance sm:text-center">
-    Add another way to sign in with a passkey or identity provider for secure
+    Add another way to sign in with a passkey or third-party account for secure
     access.
   </p>
 </div>

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -20,10 +20,9 @@
     $props();
 
   let authenticatingGoogle = $state(false);
-  let authenticatingProviderId = $state<Record<string, boolean>>({});
+  let authenticatingProviderId = $state<string | null>();
   let authenticating = $derived(
-    Object.values(authenticatingProviderId).some(Boolean) ||
-      authenticatingGoogle,
+    nonNullish(authenticatingProviderId) || authenticatingGoogle,
   );
 
   const isPasskeySupported = nonNullish(window.PublicKeyCredential);
@@ -38,11 +37,11 @@
   };
 
   const handleContinueWithOpenId = async (config: OpenIdConfig) => {
-    authenticatingProviderId[config.client_id] = true;
+    authenticatingProviderId = config.client_id;
     try {
       await linkOpenIdAccount(config);
     } finally {
-      authenticatingProviderId[config.client_id] = false;
+      authenticatingProviderId = null;
     }
   };
 
@@ -91,7 +90,7 @@
             size="xl"
             class="flex-1"
           >
-            {#if authenticatingProviderId[provider.client_id]}
+            {#if authenticatingProviderId === provider.client_id}
               <ProgressRing />
             {:else if provider.logo}
               <div class="size-6">

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -82,23 +82,26 @@
       Continue with Passkey
     </Button>
     {#if $ENABLE_GENERIC_OPEN_ID}
-      {#each openIdProviders as provider}
-        <Button
-          onclick={() => handleContinueWithOpenId(provider)}
-          variant="secondary"
-          disabled={authenticating}
-          size="xl"
-        >
-          {#if authenticatingProviderId[provider.client_id]}
-            <ProgressRing />
-            <span>Authenticating with {provider.name}...</span>
-          {:else if provider.logo}
-            <div class="size-6">
-              {@html provider.logo}
-            </div>
-          {/if}
-        </Button>
-      {/each}
+      <div class="flex flex-row flex-nowrap justify-stretch gap-3">
+        {#each openIdProviders as provider}
+          <Button
+            onclick={() => handleContinueWithOpenId(provider)}
+            variant="secondary"
+            disabled={authenticating}
+            size="xl"
+            class="flex-1"
+          >
+            {#if authenticatingProviderId[provider.client_id]}
+              <ProgressRing />
+              <span>Authenticating with {provider.name}...</span>
+            {:else if provider.logo}
+              <div class="size-6">
+                {@html provider.logo}
+              </div>
+            {/if}
+          </Button>
+        {/each}
+      </div>
     {:else if showGoogleButton}
       <Button
         onclick={handleContinueWithGoogle}

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -93,7 +93,6 @@
           >
             {#if authenticatingProviderId[provider.client_id]}
               <ProgressRing />
-              <span>Authenticating with {provider.name}...</span>
             {:else if provider.logo}
               <div class="size-6">
                 {@html provider.logo}

--- a/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
@@ -59,6 +59,7 @@ export class AddAccessMethodFlow {
           clientId: config.client_id,
           authURL: config.auth_uri,
           configURL: config.fedcm_uri?.[0],
+          authScope: config.auth_scope.join(" "),
         },
         {
           nonce,

--- a/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
@@ -13,6 +13,7 @@ import type {
   AuthnMethodData,
   OpenIdCredential,
   OpenIdConfig,
+  MetadataMapV2,
 } from "$lib/generated/internet_identity_types";
 import { features } from "$lib/legacy/features";
 import { DiscoverableDummyIdentity } from "$lib/utils/discoverableDummyIdentity";
@@ -69,14 +70,19 @@ export class AddAccessMethodFlow {
       await actor
         .openid_credential_add(identityNumber, jwt, salt)
         .then(throwCanisterError);
+
+      const metadata: MetadataMapV2 = [];
+      if (nonNullish(name)) {
+        metadata.push(["name", { String: name }]);
+      }
+      if (nonNullish(email)) {
+        metadata.push(["email", { String: email }]);
+      }
       return {
         aud,
         iss,
         sub,
-        metadata: [
-          ["name", { String: name }],
-          ["email", { String: email }],
-        ],
+        metadata,
         last_usage_timestamp: [],
       };
     } finally {

--- a/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
@@ -53,11 +53,6 @@ export class AddAccessMethodFlow {
       const { nonce, salt } = await createAnonymousNonce(
         identity.getPrincipal(),
       );
-      console.log("in da generic", {
-        clientId: config.client_id,
-        authURL: config.auth_uri,
-        configURL: config.fedcm_uri?.[0],
-      });
       const jwt = await requestJWT(
         {
           clientId: config.client_id,
@@ -98,7 +93,6 @@ export class AddAccessMethodFlow {
     }
     try {
       const requestConfig = createGoogleRequestConfig(clientId);
-      console.log("in da google", requestConfig);
       this.#isSystemOverlayVisible = true;
       const { nonce, salt } = await createAnonymousNonce(
         identity.getPrincipal(),

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -95,7 +95,7 @@ export const ADD_ACCESS_METHOD = createFeatureFlagStore(
 );
 export const ENABLE_GENERIC_OPEN_ID = createFeatureFlagStore(
   "ENABLE_GENERIC_OPEN_ID",
-  false,
+  true,
   () => canisterConfig.feature_flag_enable_generic_open_id_fe[0],
 );
 

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -95,7 +95,7 @@ export const ADD_ACCESS_METHOD = createFeatureFlagStore(
 );
 export const ENABLE_GENERIC_OPEN_ID = createFeatureFlagStore(
   "ENABLE_GENERIC_OPEN_ID",
-  true,
+  false,
   () => canisterConfig.feature_flag_enable_generic_open_id_fe[0],
 );
 


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

If users can register and log in with the generic openID providers, they should also be able to link them from the dashboard.

In this PR, we add the openID provider buttons in the modal when the user clicks in "Add +" in the dashboard.

# Changes

* Added a new `linkOpenIdAccount` method to the `AddAccessMethodFlow` class, which handles the authentication flow and linking of generic OpenID accounts.
* Updated the `AddAccessMethod` and `AddAccessMethodWizard` components to accept and handle the new `linkOpenIdAccount` callback, enabling the UI to trigger the OpenID linking flow.
* Modified the UI to display a button for each configured OpenID provider when the generic OpenID feature flag is enabled, showing provider logos and handling authentication state per provider.
* Updated text in the wizard to refer to "identity provider" instead of just "Google account" for broader applicability.

# Tests

* Tested locally with Google and Microsoft.




<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->



