### PR TITLE
Implement effective OpenID issuer

### DIFF
--- a/src/frontend/src/lib/flows/authFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.ts
@@ -209,7 +209,6 @@ export class AuthFlow {
         const identityNumber = await this.#registerWithOpenId(jwt);
         return { identityNumber, type: "signUp" };
       }
-      this.#view = "chooseMethod";
       throw error;
     }
   };
@@ -225,6 +224,7 @@ export class AuthFlow {
     const requestConfig: RequestConfig = {
       clientId: config.client_id,
       authURL: config.auth_uri,
+      authScope: config.auth_scope.join(" "),
       configURL: config.fedcm_uri?.[0],
     };
     // Create two try-catch blocks to avoid double-triggering the analytics.
@@ -275,7 +275,6 @@ export class AuthFlow {
         const identityNumber = await this.#registerWithOpenId(jwt);
         return { identityNumber, type: "signUp" };
       }
-      this.#view = "chooseMethod";
       throw error;
     }
   };

--- a/src/frontend/src/lib/legacy/flows/redirect.ts
+++ b/src/frontend/src/lib/legacy/flows/redirect.ts
@@ -2,6 +2,15 @@ import { withLoader } from "$lib/templates/loader";
 
 export const REDIRECT_CALLBACK_PATH = "/callback";
 
+export class PopupClosedError extends Error {
+  constructor() {
+    super();
+    Object.setPrototypeOf(this, PopupClosedError.prototype);
+  }
+
+  message = "Window closed before a response was received";
+}
+
 export const callbackFlow = (): Promise<never> => {
   // User was returned here after redirect from a OpenID flow callback,
   // these flows are always handled in a popup and the callback url is
@@ -26,7 +35,7 @@ export const redirectInPopup = (url: string): Promise<string> => {
     const closeInterval = setInterval(() => {
       if (redirectWindow?.closed === true) {
         clearInterval(closeInterval);
-        reject(new Error("Window closed before a response was received"));
+        reject(new PopupClosedError());
       }
     }, 500);
     const responseListener = (event: MessageEvent) => {

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -54,8 +54,9 @@ const createFeatureFlagStore = (
     return initializedFeatureFlag;
   };
   const initialize = (): void => {
-    if (nonNullish(getInitValue)) {
-      initializedFeatureFlag.set(getInitValue() ?? defaultValue);
+    // Override feature flag with init method if not already set
+    if (nonNullish(getInitValue) && !initializedFeatureFlag.isSet()) {
+      initializedFeatureFlag.temporaryOverride(getInitValue() ?? defaultValue);
     }
   };
 

--- a/src/frontend/src/lib/utils/featureFlags/index.ts
+++ b/src/frontend/src/lib/utils/featureFlags/index.ts
@@ -33,6 +33,10 @@ export class FeatureFlag {
     return get(this.#store);
   }
 
+  isSet(): boolean {
+    return this.#storage.getItem(this.#key) !== null;
+  }
+
   set(value: boolean) {
     this.#store.set(Boolean(value));
     this.#storage.setItem(this.#key, JSON.stringify(get(this.#store)));

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -199,7 +199,11 @@ where
     PROVIDERS.with_borrow(|providers| {
         providers
             .iter()
-            .find(|provider| provider.issuer() == claims.iss)
+            .find(|provider| {
+                let effective_issuer =
+                    replace_issuer_placeholders(&provider.issuer(), validation_item.claims());
+                effective_issuer == claims.iss
+            })
             .ok_or_else(|| {
                 OpenIDJWTVerificationError::GenericError(format!(
                     "Unsupported issuer: {}",
@@ -208,6 +212,52 @@ where
             })
             .and_then(|provider| callback(provider.as_ref()))
     })
+}
+
+/// As seen in https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration,
+/// the Microsoft issuer uri is dynamic based on the `tid` claim, this method makes sure to
+/// replace the placeholders like e.g. `tid` in the issuer uri with the corresponding claims.
+pub fn replace_issuer_placeholders(template: &str, claims_bytes: &[u8]) -> String {
+    let claims: serde_json::Value = match serde_json::from_slice(claims_bytes) {
+        Ok(val) => val,
+        Err(_) => return template.to_string(), // If claims cannot be decoded, return template as-is
+    };
+
+    let mut result = String::with_capacity(template.len());
+    let mut remaining = template;
+
+    while let Some(open_pos) = remaining.find('{') {
+        // Append text before '{'
+        result.push_str(&remaining[..open_pos]);
+        remaining = &remaining[open_pos + 1..];
+
+        if let Some(close_pos) = remaining.find('}') {
+            let key = &remaining[..close_pos];
+
+            // Lookup claim; if missing, leave placeholder as-is
+            if let Some(replacement) = claims.get(key).and_then(|v| v.as_str()) {
+                result.push_str(replacement);
+            } else {
+                // Put back the original placeholder
+                result.push('{');
+                result.push_str(key);
+                result.push('}');
+            }
+
+            // Move past '}'
+            remaining = &remaining[close_pos + 1..];
+        } else {
+            // No closing '}', treat '{' literally and append the rest
+            result.push('{');
+            result.push_str(remaining);
+            return result; // Stop processing
+        }
+    }
+
+    // Append any remaining text
+    result.push_str(remaining);
+
+    result
 }
 
 /// Create `Hash` used for a delegation that can make calls on behalf of a `OpenIdCredential`
@@ -340,5 +390,61 @@ fn should_return_error_when_claims_invalid() {
         Err(OpenIDJWTVerificationError::GenericError(
             "Unable to decode claims".to_string()
         ))
+    );
+}
+
+#[test]
+fn should_replace_placeholders_in_issuer() {
+    assert_eq!(
+        replace_issuer_placeholders(
+            "https://login.microsoftonline.com/{tid}/v2.0",
+            r#"{ "tid": "9188040d-6c67-4c5b-b112-36a304b66dad" }"#.as_bytes()
+        ),
+        "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0".to_string()
+    );
+}
+
+#[test]
+fn should_ignore_placeholders_in_issuer_that_dont_have_claim() {
+    assert_eq!(
+        replace_issuer_placeholders(
+            "https://login.microsoftonline.com/{tid}/v2.0",
+            r#"{ "sub": "MdNi5RU6AxYZr7-2_F83sTswMq_2fvaK6rj8x3fbE9c" }"#.as_bytes()
+        ),
+        "https://login.microsoftonline.com/{tid}/v2.0".to_string()
+    );
+}
+
+#[test]
+fn should_ignore_unclosed_placeholders_in_issuer() {
+    assert_eq!(
+        replace_issuer_placeholders(
+            "https://login.microsoftonline.com/{tid/v2.0",
+            r#"{ "tid": "MdNi5RU6AxYZr7-2_F83sTswMq_2fvaK6rj8x3fbE9c" }"#.as_bytes()
+        ),
+        "https://login.microsoftonline.com/{tid/v2.0"
+    );
+}
+
+#[test]
+fn should_retain_issuer_without_placeholders_as_is() {
+    assert_eq!(
+        replace_issuer_placeholders(
+            "https://accounts.google.com",
+            r#"{ "sub": "MdNi5RU6AxYZr7-2_F83sTswMq_2fvaK6rj8x3fbE9c" }"#.as_bytes()
+        ),
+        "https://accounts.google.com".to_string()
+    );
+}
+
+#[test]
+fn should_replace_multiple_placeholders_in_issuer() {
+    assert_eq!(
+        replace_issuer_placeholders(
+            "https://login.microsoftonline.com/{tid}/{sub}/v2.0",
+            r#"{ "tid": "9188040d-6c67-4c5b-b112-36a304b66dad", "sub": "MdNi5RU6AxYZr7-2_F83sTswMq_2fvaK6rj8x3fbE9c" }"#.as_bytes()
+        ),
+        "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/MdNi5RU6AxYZr7-2_F83sTswMq_2fvaK6rj8x3fbE9c/v2.0"
+            .to_string()
     );
 }

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -130,6 +130,9 @@ impl OpenIdProvider for Provider {
         Ok(OpenIdCredential {
             // Do NOT use claims.iss here since it could be different within the
             // same OpenID provider as seen in Microsoft with multiple tenants.
+            //
+            // The issuer returned there should therefore ALWAYS be the issuer from the config,
+            // so that credentials are always stored with a single issuer per OpenID provider.
             iss: self.issuer.clone(),
             sub: claims.sub,
             aud: claims.aud,

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -128,7 +128,9 @@ impl OpenIdProvider for Provider {
             metadata.insert("name".into(), MetadataEntryV2::String(name));
         }
         Ok(OpenIdCredential {
-            iss: self.issuer.clone(), // Do NOT use claims.iss here, this cou
+            // Do NOT use claims.iss here since it could be different within the
+            // same OpenID provider as seen in Microsoft with multiple tenants.
+            iss: self.issuer.clone(),
             sub: claims.sub,
             aud: claims.aud,
             last_usage_timestamp: None,

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -323,11 +323,6 @@ fn verify_claims(
     let hash: [u8; 32] = hasher.finalize().into();
     let expected_nonce = BASE64_URL_SAFE_NO_PAD.encode(hash);
 
-    // let re = Regex::new(r"\{([^}]+)}").unwrap();
-    // let issuer2 = Regex::new(r"\{([^}]+)}")
-    //     .unwrap()
-    //     .replace_all(issuer, |caps| {});
-
     if claims.iss != issuer {
         return Err(OpenIDJWTVerificationError::GenericError(format!(
             "Invalid issuer: {}",


### PR DESCRIPTION
Implement effective OpenID issuer, replace placeholders in issuer with JWT claims. 

# Changes

- Implement `replace_issuer_placeholders` fn to handle OpenID providers that have multiple tenants e.g. Microsoft with https://login.microsoftonline.com/{tenantid}/v2.0.
- Use this method when matching provider so that generic provider can be found.
- Use this method to create effective issuer used when verifying JWT claims.
- Use the config issuer instead of claim issuer in storage since the latter could be different within the same OpenID provider as seen in the above tenants example.


# Tests

- Verified Google auth is still working as expected.
- Verified that multi tenant auth now works with a Microsoft OpenID config.
