### PR TITLE
Close analytics funnel on funnel success

### DIFF
--- a/src/frontend/src/lib/components/wizards/migration/MigrationWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/MigrationWizard.svelte
@@ -55,6 +55,7 @@
     try {
       await migrationFlow.createPasskey(name);
       upgradeIdentityFunnel.trigger(UpgradeIdentityEvents.UpgradeSuccessful);
+      upgradeIdentityFunnel.close();
       onSuccess(migrationFlow.identityNumber);
     } catch (error) {
       upgradeIdentityFunnel.trigger(UpgradeIdentityEvents.UpgradeFailure);

--- a/src/frontend/src/lib/legacy/flows/authorize/postMessageInterface.ts
+++ b/src/frontend/src/lib/legacy/flows/authorize/postMessageInterface.ts
@@ -162,7 +162,9 @@ export async function authenticationProtocol({
   try {
     authenticateResult = await authenticate(authContext);
     authorizeClientFunnel.trigger(AuthorizeClientEvents.Authenticate);
+    authorizeClientFunnel.close();
     authenticationV2Funnel.trigger(AuthenticationV2Events.AuthSuccess);
+    authenticationV2Funnel.close();
   } catch (error: unknown) {
     console.error("Unexpected error during authentication", error);
     authenticateResult = {

--- a/src/frontend/src/lib/utils/analytics/authenticationV2Funnel.ts
+++ b/src/frontend/src/lib/utils/analytics/authenticationV2Funnel.ts
@@ -11,8 +11,10 @@ import { Funnel } from "./Funnel";
  *        -> Move to select-method-screen
  *      continue-as-passkey
  *        auth-success
+ *        go-to-dashboard
  *      continue-as-google
  *        auth-success
+ *        go-to-dashboard
  *    select-method-screen
  *      continue-with-google
  *        register-with-google
@@ -31,8 +33,10 @@ import { Funnel } from "./Funnel";
  *            register-with-passkey
  *              successful-passkey-registration
  *                auth-success
+ *                go-to-dashboard
  *        use-existing-passkey
  *          auth-success
+ *          go-to-dashboard
  */
 export const AuthenticationV2Events = {
   UseAnother: "use-another",
@@ -54,6 +58,7 @@ export const AuthenticationV2Events = {
   JwtVerificationFailed: "jwt-verification-failed",
   JwtVerificationExpired: "jwt-verification-expired",
   InfoPasskeyScreen: "info-passkey-screen",
+  GoToDashboard: "go-to-dashboard",
 } as const;
 
 export const authenticationV2Funnel = new Funnel<typeof AuthenticationV2Events>(

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -21,7 +21,10 @@
   import type { PageProps } from "./$types";
   import { onMount } from "svelte";
   import { triggerDropWaveAnimation } from "$lib/utils/animation-dispatcher";
-  import { authenticationV2Funnel } from "$lib/utils/analytics/authenticationV2Funnel";
+  import {
+    AuthenticationV2Events,
+    authenticationV2Funnel,
+  } from "$lib/utils/analytics/authenticationV2Funnel";
 
   const { data }: PageProps = $props();
 
@@ -40,6 +43,8 @@
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
     isAuthDialogOpen = false;
     void triggerDropWaveAnimation();
+    authenticationV2Funnel.trigger(AuthenticationV2Events.GoToDashboard);
+    authenticationV2Funnel.close();
     await gotoNext();
   };
   const onSignUp = async (identityNumber: bigint) => {
@@ -50,6 +55,8 @@
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
     isAuthDialogOpen = false;
     void triggerDropWaveAnimation();
+    authenticationV2Funnel.trigger(AuthenticationV2Events.GoToDashboard);
+    authenticationV2Funnel.close();
     await gotoNext();
   };
 


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Have a better understanding of how usres go through our flows.

I realized that the session leave events were triggered as well on success. Which means that we can't really know how many people left the flow in the middle because all users trigger the session leave at some point.

In this PR, I call the `close` method of the funnel on success. I don't close it on errors or cancellations because the user can still continue with the flow and succeed.

# Changes

* Add one success event to the V2 authentication funnel.
* Call `close` on success of V2 authentication and upgrade funnels.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
