### PR TITLE
Make sure continue from another device flow is always rendered in a dialog.

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -155,7 +155,13 @@
 {/snippet}
 
 {#if isContinueFromAnotherDeviceVisible}
-  <RegisterAccessMethodWizard onRegistered={handleRegistered} {onError} />
+  {#if !withinDialog}
+    <Dialog onClose={() => (isContinueFromAnotherDeviceVisible = false)}>
+      <RegisterAccessMethodWizard onRegistered={handleRegistered} {onError} />
+    </Dialog>
+  {:else}
+    <RegisterAccessMethodWizard onRegistered={handleRegistered} {onError} />
+  {/if}
 {:else if isMigrating}
   {#if !withinDialog}
     <Dialog onClose={() => (isMigrating = false)}>


### PR DESCRIPTION
Make sure continue from another device flow is always rendered in a dialog, so that users can cancel the flow by closing the dialog.

# Changes

- Wrap `RegisterAccessMethodWizard` in `Dialog` if `withinDialog` is false.

# Tests

- Verified that the flow still works as expected and can be cancelled now.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
