### PR TITLE
chore: Re-enable Candid compatibility checks

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -1130,15 +1130,15 @@ jobs:
             exit 1
           fi
 
-  # interface-compatibility:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: ./.github/actions/setup-didc
-  #     - name: "Check canister interface compatibility"
-  #       run: |
-  #         curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
-  #         didc check src/internet_identity/internet_identity.did internet_identity_previous.did
+  interface-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-didc
+      - name: "Check canister interface compatibility"
+        run: |
+          curl -sSL https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did -o internet_identity_previous.did
+          didc check src/internet_identity/internet_identity.did internet_identity_previous.did
 
   sig-verifier-js:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Motivation

These checks were temporarily disabled in https://github.com/dfinity/internet-identity/pull/3298

# Changes

Uncommented `interface-compatibility` in .github/workflows/canister-tests.yml

# Tests

Let's see
