### PR TITLE
Fix OpenID logo and name in credentials list.

### DIFF
--- a/src/frontend/src/lib/components/ui/AccessMethod.svelte
+++ b/src/frontend/src/lib/components/ui/AccessMethod.svelte
@@ -4,13 +4,14 @@
     type AuthnMethodData,
   } from "$lib/generated/internet_identity_types";
   import { formatLastUsage } from "$lib/utils/time";
-  import { nonNullish } from "@dfinity/utils";
+  import { isNullish, nonNullish } from "@dfinity/utils";
   import { fade } from "svelte/transition";
   import PlaceHolder from "./PlaceHolder.svelte";
   import Ellipsis from "../utils/Ellipsis.svelte";
   import PulsatingCircleIcon from "../icons/PulsatingCircleIcon.svelte";
   import { getAuthnMethodAlias } from "$lib/utils/webAuthn";
   import { getRpId } from "$lib/utils/accessMethods";
+  import { findConfig, isOpenIdConfig } from "$lib/utils/openID";
 
   let {
     accessMethod,
@@ -142,6 +143,22 @@
         <div class="flex min-w-32 items-center gap-2 pr-3">
           <span>
             {getOpenIdCredentialName(accessMethod)}
+          </span>
+          {#if isCurrent}
+            <PulsatingCircleIcon />
+          {/if}
+        </div>
+      {:else if !openIdHasName && !openIdHasEmail}
+        {@const config = findConfig(accessMethod.iss)}
+        <div class="flex min-w-32 items-center gap-2 pr-3">
+          <span>
+            {#if isNullish(config)}
+              Unknown account
+            {:else if isOpenIdConfig(config)}
+              {config.name} account
+            {:else}
+              Google account
+            {/if}
           </span>
           {#if isCurrent}
             <PulsatingCircleIcon />

--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -217,7 +217,9 @@
           class="text-text-primary flex min-w-8 items-center justify-center px-4 pr-4"
         >
           {#if nonNullish(logo)}
-            {@html logo}
+            <div class="size-6">
+              {@html logo}
+            </div>
           {:else}
             <GoogleIcon />
           {/if}


### PR DESCRIPTION
Fix OpenID logo and name in credentials list.

# Changes

- Wrap logo in `<div class="size-6">` so it doesn't collapse.
- Add fallback when both name and email are unavailable e.g. "Apple account" .

# Tests

- Manually verified the list items are rendered as expected.

<!-- Please provide any information or screenshots about the tests that have been done -->

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
