### PR TITLE
Fix access method item title and subtitle

### DIFF
--- a/src/frontend/src/lib/components/ui/AccessMethod.svelte
+++ b/src/frontend/src/lib/components/ui/AccessMethod.svelte
@@ -4,14 +4,13 @@
     type AuthnMethodData,
   } from "$lib/generated/internet_identity_types";
   import { formatLastUsage } from "$lib/utils/time";
-  import { isNullish, nonNullish } from "@dfinity/utils";
+  import { nonNullish } from "@dfinity/utils";
   import { fade } from "svelte/transition";
   import PlaceHolder from "./PlaceHolder.svelte";
   import Ellipsis from "../utils/Ellipsis.svelte";
   import PulsatingCircleIcon from "../icons/PulsatingCircleIcon.svelte";
   import { getAuthnMethodAlias } from "$lib/utils/webAuthn";
-  import { getRpId } from "$lib/utils/accessMethods";
-  import { findConfig, isOpenIdConfig } from "$lib/utils/openID";
+  import { getOpenIdTitles, getRpId } from "$lib/utils/accessMethods";
 
   let {
     accessMethod,
@@ -26,39 +25,6 @@
     isDisabled?: boolean;
     showOrigin?: boolean;
   } = $props();
-
-  const getOpenIdCredentialName = (credential: OpenIdCredential | null) => {
-    if (!credential) return null;
-    const metadataName = credential.metadata.find(
-      ([key, _val]) => key === "name",
-    )?.[1]!;
-    if (metadataName && "String" in metadataName) {
-      return metadataName.String;
-    }
-    return undefined;
-  };
-
-  const getOpenIdCredentialEmail = (credential: OpenIdCredential | null) => {
-    if (!credential) return null;
-    const metadataEmail = credential.metadata.find(
-      ([key, _val]) => key === "email",
-    )?.[1]!;
-    if (metadataEmail && "String" in metadataEmail) {
-      return metadataEmail.String;
-    }
-    return undefined;
-  };
-
-  let openIdHasName = $derived(
-    accessMethod &&
-      !("authn_method" in accessMethod) &&
-      !!getOpenIdCredentialName(accessMethod),
-  );
-  let openIdHasEmail = $derived(
-    accessMethod &&
-      !("authn_method" in accessMethod) &&
-      !!getOpenIdCredentialEmail(accessMethod),
-  );
 </script>
 
 {#if accessMethod}
@@ -109,6 +75,7 @@
       {/if}
     </div>
   {:else}
+    {@const openIdTitles = getOpenIdTitles(accessMethod)}
     <!-- OpenID -->
     <div
       class={[
@@ -118,53 +85,29 @@
       in:fade={{ delay: 30, duration: 30 }}
       out:fade={{ duration: 30 }}
     >
-      {#if openIdHasName && openIdHasEmail}
-        <div class="flex min-w-32 flex-col justify-center pr-3">
-          <div class="flex items-center gap-2">
-            <span>
-              {getOpenIdCredentialName(accessMethod)}
-            </span>
-            {#if isCurrent}
-              <PulsatingCircleIcon />
-            {/if}
-          </div>
-          <div class="text-text-tertiary font-extralight">
-            <Ellipsis text={getOpenIdCredentialEmail(accessMethod)!}></Ellipsis>
-          </div>
-        </div>
-      {:else if !openIdHasName && openIdHasEmail}
-        <div class="flex min-w-32 items-center gap-2 pr-3">
-          <Ellipsis text={getOpenIdCredentialEmail(accessMethod)!}></Ellipsis>
-          {#if isCurrent}
-            <PulsatingCircleIcon />
-          {/if}
-        </div>
-      {:else if openIdHasName && !openIdHasEmail}
-        <div class="flex min-w-32 items-center gap-2 pr-3">
+      <div class="flex min-w-32 flex-col justify-center pr-3">
+        <div class="flex items-center gap-2">
           <span>
-            {getOpenIdCredentialName(accessMethod)}
-          </span>
-          {#if isCurrent}
-            <PulsatingCircleIcon />
-          {/if}
-        </div>
-      {:else if !openIdHasName && !openIdHasEmail}
-        {@const config = findConfig(accessMethod.iss)}
-        <div class="flex min-w-32 items-center gap-2 pr-3">
-          <span>
-            {#if isNullish(config)}
-              Unknown account
-            {:else if isOpenIdConfig(config)}
-              {config.name} account
+            {#if openIdTitles.title.ellipsis}
+              <Ellipsis text={openIdTitles.title.text}></Ellipsis>
             {:else}
-              Google account
+              {openIdTitles.title.text}
             {/if}
           </span>
           {#if isCurrent}
             <PulsatingCircleIcon />
           {/if}
         </div>
-      {/if}
+        {#if nonNullish(openIdTitles.subtitle)}
+          <div class="text-text-tertiary font-extralight">
+            {#if openIdTitles.subtitle.ellipsis}
+              <Ellipsis text={openIdTitles.subtitle.text}></Ellipsis>
+            {:else}
+              {openIdTitles.subtitle.text}
+            {/if}
+          </div>
+        {/if}
+      </div>
 
       {#if isCurrent}
         <div

--- a/src/frontend/src/lib/utils/accessMethods.test.ts
+++ b/src/frontend/src/lib/utils/accessMethods.test.ts
@@ -6,6 +6,7 @@ import {
   getRpId,
   isSameAccessMethod,
   isNewOriginDevice,
+  getOpenIdTitles,
 } from "./accessMethods";
 import type {
   AuthnMethodData,
@@ -17,15 +18,46 @@ import type {
 } from "$lib/generated/internet_identity_types";
 import { vi } from "vitest";
 import { nonNullish } from "@dfinity/utils";
+import { ENABLE_GENERIC_OPEN_ID } from "$lib/state/featureFlags";
 
-// Mock the canisterConfig
+// Mock the canisterConfig, including OpenID configs used by getOpenIdTitles via findConfig
 vi.mock("$lib/globals", () => ({
   canisterConfig: {
     new_flow_origins: [
       ["https://id.ai", "https://rdmx6-jaaaa-aaaah-qdrqq-cai.ic0.app"],
     ],
+    // Shape matches access in findConfig: openid_google?.[0]?.[0]
+    openid_google: [
+      [
+        {
+          client_id: "test-google-client-id",
+        },
+      ],
+    ],
+    // Shape matches access in findConfig: openid_configs?.[0]?.find(...)
+    openid_configs: [
+      [
+        {
+          issuer: "https://issuer.acme",
+          name: "AcmeID",
+          auth_scope: "openid profile email",
+          logo: "<svg></svg>",
+          client_id: "test-client-id",
+          jwks_uri: "https://issuer.acme/.well-known/jwks.json",
+          auth_uri: "https://issuer.acme/auth",
+          fedcm_uri: [],
+        },
+      ],
+    ],
+    // Provide feature flag defaults to satisfy optional initialization logic
+    feature_flag_enable_generic_open_id_fe: [false],
   },
 }));
+
+// Ensure deterministic default for tests that rely on Google-specific path
+beforeEach(() => {
+  ENABLE_GENERIC_OPEN_ID.set(false);
+});
 
 const makeAuthnMethodWithOrigin = (origin?: string): AuthnMethodData => {
   const metadata: MetadataMapV2 = nonNullish(origin)
@@ -109,6 +141,112 @@ describe("getLastUsedAccessMethod", () => {
     const cred = makeOpenIdCredential("oidc", [999]);
     const result = getLastUsedAccessMethod([method1], [cred]);
     expect(result).toMatchObject({ id: "oidc", last_authentication: [999] });
+  });
+});
+
+describe("getOpenIdTitles", () => {
+  const googleIssuer = "https://accounts.google.com";
+  const makeOpenIdCredential = (
+    iss: string,
+    {
+      name,
+      email,
+      sub = "sub",
+      aud = "audience",
+    }: { name?: string; email?: string; sub?: string; aud?: string },
+  ): OpenIdCredential => ({
+    last_usage_timestamp: [],
+    aud,
+    iss,
+    sub,
+    metadata: [
+      ...(name ? [["name", { String: name }]] : []),
+      ...(email ? [["email", { String: email }]] : []),
+    ] as MetadataMapV2,
+  });
+
+  describe("generic open id disabled", () => {
+    beforeEach(() => {
+      ENABLE_GENERIC_OPEN_ID.set(false);
+    });
+
+    it("returns name and email with provider from OpenID config", () => {
+      const cred = makeOpenIdCredential(googleIssuer, {
+        name: "Alice",
+        email: "alice@example.com",
+      });
+      const res = getOpenIdTitles(cred);
+      expect(res).toEqual({
+        title: { ellipsis: false, text: "Alice" },
+        subtitle: {
+          ellipsis: true,
+          text: "Google Account - alice@example.com",
+        },
+      });
+    });
+  });
+
+  describe("generic open id enabled", () => {
+    beforeEach(() => {
+      ENABLE_GENERIC_OPEN_ID.set(true);
+    });
+
+    it("returns name and email with provider from OpenID config", () => {
+      const cred = makeOpenIdCredential("https://issuer.acme", {
+        name: "Alice",
+        email: "alice@example.com",
+      });
+      const res = getOpenIdTitles(cred);
+      expect(res).toEqual({
+        title: { ellipsis: false, text: "Alice" },
+        subtitle: {
+          ellipsis: true,
+          text: "AcmeID Account - alice@example.com",
+        },
+      });
+    });
+
+    it("returns name only with OpenID provider when email missing", () => {
+      const cred = makeOpenIdCredential("https://issuer.acme", {
+        name: "Bob",
+      });
+      const res = getOpenIdTitles(cred);
+      expect(res).toEqual({
+        title: { ellipsis: false, text: "Bob" },
+        subtitle: { ellipsis: false, text: "AcmeID Account" },
+      });
+    });
+
+    it("returns Unknown account if Google provider but not in config", () => {
+      const cred = makeOpenIdCredential("https://accounts.google.com", {
+        name: "Bob",
+      });
+      const res = getOpenIdTitles(cred);
+      expect(res).toEqual({
+        title: { ellipsis: false, text: "Bob" },
+        subtitle: { ellipsis: false, text: "Unknown Account" },
+      });
+    });
+
+    it("returns email only with Unknown provider when config not found", () => {
+      const cred = makeOpenIdCredential("https://unknown.provider", {
+        email: "charlie@example.com",
+      });
+      const res = getOpenIdTitles(cred);
+      expect(res).toEqual({
+        title: { ellipsis: true, text: "charlie@example.com" },
+        subtitle: { ellipsis: false, text: "Unknown Account" },
+      });
+    });
+
+    it("returns Unknown account when neither name nor email is present", () => {
+      const cred = makeOpenIdCredential("https://issuer.acme", {});
+      const res = getOpenIdTitles(cred);
+      expect(res).toEqual({
+        title: { ellipsis: false, text: "Unknown account" },
+        subtitle: undefined,
+      });
+    });
   });
 });
 


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

It wasn't clear in the list of access items which account belonged to which provider's account.

# Changes

This pull request refactors how OpenID credential display names and subtitles are generated and shown in the UI. It centralizes the logic for determining OpenID credential titles into a new utility function, improves test coverage for this logic, and simplifies the Svelte component code by removing redundant functions and derived state.

* Introduced a new `getOpenIdTitles` utility function in `accessMethods.ts` to consistently generate display titles and subtitles for OpenID credentials, factoring in provider configuration and available metadata.
* Updated `AccessMethod.svelte` to use `getOpenIdTitles`, removing several inline helper functions and derived variables, resulting in cleaner and more maintainable UI code.

# Tests

* Tested locally with Google and Microsoft account, see screenthots.
* Added comprehensive unit tests for `getOpenIdTitles` in `accessMethods.test.ts`, covering various combinations of metadata and provider configuration, and ensuring deterministic test behavior with feature flag setup.
* Refactored metadata extraction in `accessMethods.ts` to use a shared utility (`getMetadataString`), reducing code duplication for extracting `origin`, `name`, and `email` fields.
