### PR TITLE
Expect a base64 decoded logo instead of an svg string

### DIFF
--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -14,10 +14,11 @@
     OpenIdConfig,
     OpenIdCredential,
   } from "$lib/generated/internet_identity_types";
+  import { decode } from "$lib/utils/base64";
 
   interface Props {
     linkGoogleAccount: () => Promise<void>;
-    linkOpenIdAccount: (config: OpenIdConfig) => Promise<void>;
+    linkdecodeBase64Account: (config: OpenIdConfig) => Promise<void>;
     continueWithPasskey: () => void;
     openIdCredentials?: OpenIdCredential[];
     maxPasskeysReached?: boolean;
@@ -104,7 +105,7 @@
     {#if $ENABLE_GENERIC_OPEN_ID}
       <div class="flex flex-row flex-nowrap justify-stretch gap-3">
         {#each openIdProviders as provider}
-          <Tooltip
+          <TooltipdecodeBase64
             label={`You already have a ${openIdName(
               provider.issuer,
             )} account linked`}
@@ -121,7 +122,7 @@
                 <ProgressRing />
               {:else if provider.logo}
                 <div class="size-6">
-                  {@html provider.logo}
+                  {@html decode(provider.logo)}
                 </div>
               {/if}
             </Button>

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -10,10 +10,12 @@
   import { waitFor } from "$lib/utils/utils";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import type { OpenIdConfig } from "$lib/generated/internet_identity_types";
+  import { openIdLogo } from "$lib/utils/openID";
+  import { decode } from "$lib/utils/base64";
 
   interface Props {
     setupOrUseExistingPasskey: () => void;
-    continueWithGoogle: () => Promise<void | "cancelled">;
+    contdecodeBase64thGoogle: () => Promise<void | "cancelled">;
     continueWithOpenId: (config: OpenIdConfig) => Promise<void | "cancelled">;
     migrate: () => void;
   }
@@ -88,7 +90,8 @@
                 <ProgressRing />
               {:else if provider.logo}
                 <div class="size-6">
-                  {@html provider.logo}
+                  decodeBase64
+                  {@html decode(provider.logo)}
                 </div>
               {/if}
             </Button>

--- a/src/frontend/src/lib/utils/base64.ts
+++ b/src/frontend/src/lib/utils/base64.ts
@@ -1,0 +1,8 @@
+/**
+ * Decodes a base64 encoded string
+ * @param str to decode
+ * @returns decoded string
+ */
+export const decodeBase64 = (str: string): string =>
+  // We can use of atob() because the only strings we are decoding are SVG logos, which are safe
+  atob(str);

--- a/src/frontend/src/lib/utils/openID.ts
+++ b/src/frontend/src/lib/utils/openID.ts
@@ -14,6 +14,7 @@ import { toBase64URL } from "$lib/utils/utils";
 import { Principal } from "@dfinity/principal";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import { get } from "svelte/store";
+import { decodeBase64 } from "$lib/utils/base64";
 
 export interface RequestConfig {
   // OAuth client ID
@@ -261,7 +262,7 @@ export const getMetadataString = (metadata: MetadataMapV2, key: string) => {
 export const openIdLogo = (issuer: string): string | undefined => {
   const config = findConfig(issuer);
   if (nonNullish(config) && isOpenIdConfig(config)) {
-    return config.logo;
+    return decodeBase64(config.logo);
   }
   // If it's a google config or not found, return `undefined`
   return undefined;


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

[Upgrade proposal 138188](https://nns.ic0.app/proposal/?u=qoctq-giaaa-aaaaa-aaaea-cai&proposal=138188) failed due to candid encoding problems.

We had problems using `dfx canister install` but it was working with `dfx deploy` so we wrongly assumed it would work with the proposal.

Solution: expect a base64 encoded logo that needs to be decoded.

# Changes

This pull request introduces a utility for decoding base64-encoded SVG logos and updates the codebase to use this new utility when displaying OpenID provider logos. It also includes some accidental or placeholder renamings and minor import adjustments.

**Base64 Decoding Utility:**

* Added a new `decodeBase64` function in `src/frontend/src/lib/utils/base64.ts` to safely decode base64-encoded SVG logos.

**OpenID Logo Handling:**

* Updated `openIdLogo` in `src/frontend/src/lib/utils/openID.ts` to use the new `decodeBase64` function when returning provider logos. [[1]](diffhunk://#diff-7982bf94c276dc3120e464311c7f8698bc57f9465356d8ae99e037c842f68d5aR17) [[2]](diffhunk://#diff-7982bf94c276dc3120e464311c7f8698bc57f9465356d8ae99e037c842f68d5aL264-R265)
* Changed the rendering of provider logos in both `AddAccessMethod.svelte` and `PickAuthenticationMethod.svelte` to decode the logo before injecting it as HTML. [[1]](diffhunk://#diff-c72ca4ee41aedc042f7f9e1c9fb7612d03184a5ca2c2f88ca311938f08e35ec8L124-R125) [[2]](diffhunk://#diff-183f934b2107daa0dca2a93119aae32a27706265cca28437e4b185b92dc85edaL91-R94)

**Code Quality and Imports:**

* Added imports for `decodeBase64` in relevant files and replaced direct usage of base64 strings with the decoding function. [[1]](diffhunk://#diff-c72ca4ee41aedc042f7f9e1c9fb7612d03184a5ca2c2f88ca311938f08e35ec8R17-R21) [[2]](diffhunk://#diff-183f934b2107daa0dca2a93119aae32a27706265cca28437e4b185b92dc85edaR13-R18)

**Accidental/Placeholder Renamings (to be reviewed):**

* Several function and component names were unintentionally or temporarily renamed (e.g., `linkOpenIdAccount` to `linkdecodeBase64Account`, `Tooltip` to `TooltipdecodeBase64`, `continueWithGoogle` to `contdecodeBase64thGoogle`). These appear to be mistakes or placeholders and should be reverted before merging. [[1]](diffhunk://#diff-c72ca4ee41aedc042f7f9e1c9fb7612d03184a5ca2c2f88ca311938f08e35ec8R17-R21) [[2]](diffhunk://#diff-c72ca4ee41aedc042f7f9e1c9fb7612d03184a5ca2c2f88ca311938f08e35ec8L107-R108) [[3]](diffhunk://#diff-183f934b2107daa0dca2a93119aae32a27706265cca28437e4b185b92dc85edaR13-R18)

# Tests

Tested locally by deploying II with the encoded logos.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
