### PR TITLE
Store issuer from claim in OpenID credential

### DIFF
--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -58,7 +58,7 @@ pub fn activity_bookkeeping(anchor: &mut Anchor, current_authorization_key: &Aut
         AuthorizationKey::DeviceKey(device_key) => {
             anchor.set_device_usage_timestamp(device_key, time())
         }
-        AuthorizationKey::OpenIdCredentialKey(openid_credential_key) => {
+        AuthorizationKey::OpenIdCredentialKey((openid_credential_key, _)) => {
             anchor.set_openid_credential_usage_timestamp(openid_credential_key, time())
         }
     }

--- a/src/internet_identity/src/authz_utils.rs
+++ b/src/internet_identity/src/authz_utils.rs
@@ -122,7 +122,10 @@ pub fn check_authorization(
         if caller == credential.principal(anchor_number) {
             return Ok((
                 anchor.clone(),
-                AuthorizationKey::OpenIdCredentialKey(credential.key()),
+                AuthorizationKey::OpenIdCredentialKey((
+                    credential.key(),
+                    credential.config_issuer(),
+                )),
             ));
         }
     }

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -1,5 +1,6 @@
 use super::{
-    get_claims, get_issuer_placeholders, replace_issuer_placeholders, OpenIDJWTVerificationError,
+    get_all_claims, get_issuer_placeholders, replace_issuer_placeholders,
+    OpenIDJWTVerificationError,
 };
 use crate::openid::OpenIdCredential;
 use crate::openid::OpenIdProvider;
@@ -102,7 +103,7 @@ impl OpenIdProvider for Provider {
 
         // Calculate effective issuer and use it to verify the JWT claims
         let issuer_placeholders = get_issuer_placeholders(&self.issuer());
-        let issuer_claims = get_claims(validation_item.claims(), issuer_placeholders);
+        let issuer_claims = get_all_claims(validation_item.claims(), issuer_placeholders);
         let effective_issuer = replace_issuer_placeholders(&self.issuer, &issuer_claims);
         verify_claims(&effective_issuer, &self.client_id, &claims, salt)?;
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -329,7 +329,7 @@ pub struct OpenIdConfig {
 
 pub enum AuthorizationKey {
     DeviceKey(DeviceKey),
-    OpenIdCredentialKey(OpenIdCredentialKey),
+    OpenIdCredentialKey((OpenIdCredentialKey, Option<ConfigIss>)),
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/internet_identity_interface/src/internet_identity/types/openid.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/openid.rs
@@ -52,3 +52,6 @@ pub type OpenIdCredentialKey = (Iss, Sub);
 pub type Iss = String;
 pub type Sub = String;
 pub type Aud = String;
+
+// Issuer found in configuration NOT credential/jwt e.g. https://login.microsoftonline.com/{tid}/v2.0
+pub type ConfigIss = String;


### PR DESCRIPTION
Store issuer from claim in OpenID credential and additionally store claims found as placeholders in issuer config as metadata.

# Changes

- Store iss claim found in JWT instead of config issuer in `OpenIdCredential`.
- Add claims found as placeholder in config issuer to credential metadata.
- Split `replace_issuer_placeholders` into multiple smaller functions so it parts of it can be used separately.
- Add `config_issuer` fn to `OpenIdCredential`, this method finds the issuer of the matching config.
- Use the above to add `ConfigIss` to `AuthorizationKey` so that metrics can keep track per issuer as defined in config instead of as defined in JWT.
  - This avoids a possibly large number of issuers in our metrics.
  - This avoids leaking which issuer tenants are used with II through our metrics.

# Tests

Updated the unit tests since `replace_issuer_placeholders` was split into multiple functions.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

