### PR TITLE
Fix identity switcher subtitle

### DIFF
--- a/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
+++ b/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
@@ -21,6 +21,7 @@
   } from "$lib/config";
   import { nonNullish } from "@dfinity/utils";
   import Checkbox from "$lib/components/ui/Checkbox.svelte";
+  import { lastUsedIdentityTypeName } from "$lib/utils/lastUsedIdentity";
 
   type Props = HTMLAttributes<HTMLElement> & {
     selected: bigint;
@@ -93,7 +94,7 @@
               {identity.name ?? identity.identityNumber}
             </div>
             <div class="text-text-tertiary" aria-hidden="true">
-              {"passkey" in identity.authMethod ? "Passkey" : "Google"}
+              {lastUsedIdentityTypeName(identity)}
             </div>
           </div>
           {#if selected === identity.identityNumber}


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

The identity switcher's subtitle doesn't match the right open id provider.

# Changes

* Use helper `lastUsedIdentityTypeName` to set the subtitle as in the list of used identities.

# Tests

* Checked locally that it nows shows Microsoft as expected instead of Google.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
