### PR TITLE
Authorize after registration

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -82,7 +82,7 @@
   const handleContinueCreatePasskey = async (): Promise<void | "cancelled"> => {
     isAuthenticating = true;
     try {
-      onSignIn(await authFlow.createPasskey());
+      onSignUp(await authFlow.createPasskey());
     } catch (error) {
       if (isWebAuthnCancelError(error)) {
         return "cancelled";

--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -82,7 +82,7 @@
   const handleContinueCreatePasskey = async (): Promise<void | "cancelled"> => {
     isAuthenticating = true;
     try {
-      onSignUp(await authFlow.createPasskey());
+      onSignIn(await authFlow.createPasskey());
     } catch (error) {
       if (isWebAuthnCancelError(error)) {
         return "cancelled";

--- a/src/frontend/src/routes/(new-styling)/authorize/(panel)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/(panel)/+page.svelte
@@ -11,6 +11,7 @@
   import { getDapps } from "$lib/legacy/flows/dappsExplorer/dapps";
   import { handleError } from "$lib/components/utils/error";
   import { AuthWizard } from "$lib/components/wizards/auth";
+  import { triggerDropWaveAnimation } from "$lib/utils/animation-dispatcher";
 
   const dapps = getDapps();
   const dapp = $derived(
@@ -37,6 +38,7 @@
       identityNumber,
       accountNumber: undefined,
     });
+    triggerDropWaveAnimation();
     await authorizationStore.authorize(undefined, 4000);
   };
   // TODO: Remove this method once we have sessions

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -68,12 +68,9 @@
       closable: false,
     });
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
-    preloadAccounts();
     triggerDropWaveAnimation();
-
-    await gotoAccounts();
-
     isAuthDialogOpen = false;
+    await authorizationStore.authorize(undefined, 4000);
   };
   const onOtherDevice = async (identityNumber: bigint) => {
     lastUsedIdentitiesStore.selectIdentity(identityNumber);

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -49,13 +49,8 @@
       invalidateAll: true,
       state: { disableNavigationAnimation: true },
     });
-  const preloadAccounts = () => {
-    void preloadCode("/authorize/account");
-    void preloadData("/authorize/account");
-  };
   const onSignIn = async (identityNumber: bigint) => {
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
-    preloadAccounts();
     triggerDropWaveAnimation();
     isAuthDialogOpen = false;
 

--- a/src/frontend/tests/e2e-playwright/authorize/continue.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/continue.spec.ts
@@ -7,6 +7,7 @@ import {
   TEST_APP_URL,
   TEST_APP_CANONICAL_URL,
   II_URL,
+  createNewIdentityInII,
 } from "../utils";
 
 test("Authorize with last used identity", async ({ page }) => {
@@ -26,11 +27,22 @@ test("Authorize by switching to another identity", async ({ page }) => {
   const otherPrincipal = await createIdentity(page, "Jane Doe", auth2);
   const principal = await authorize(page, async (authPage) => {
     await authPage.getByRole("button", { name: "Switch identity" }).click();
-    auth1(authPage);
     await authPage.getByRole("button", { name: "John Doe" }).click();
+    auth1(authPage);
+    await authPage.getByRole("button", { name: "Primary account" }).click();
   });
   expect(principal).toBe(expectedPrincipal);
   expect(principal).not.toBe(otherPrincipal);
+});
+
+test("Authorize by creating a new identity", async ({ page }) => {
+  const auth1 = dummyAuth();
+  const auth2 = dummyAuth();
+  const initialPrincipal = await createIdentity(page, "John Doe", auth1);
+  const newIdentityPrincipal = await authorize(page, async (authPage) => {
+    await createNewIdentityInII(authPage, "Jane Doe", auth2);
+  });
+  expect(newIdentityPrincipal).not.toBe(initialPrincipal);
 });
 
 test("Authorize by signing in with a different passkey", async ({ page }) => {

--- a/src/frontend/tests/e2e-playwright/authorize/continue.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/continue.spec.ts
@@ -26,9 +26,8 @@ test("Authorize by switching to another identity", async ({ page }) => {
   const otherPrincipal = await createIdentity(page, "Jane Doe", auth2);
   const principal = await authorize(page, async (authPage) => {
     await authPage.getByRole("button", { name: "Switch identity" }).click();
-    await authPage.getByRole("button", { name: "John Doe" }).click();
     auth1(authPage);
-    await authPage.getByRole("button", { name: "Primary account" }).click();
+    await authPage.getByRole("button", { name: "John Doe" }).click();
   });
   expect(principal).toBe(expectedPrincipal);
   expect(principal).not.toBe(otherPrincipal);

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -114,12 +114,6 @@ export const createNewIdentityInII = async (
   await page.getByLabel("Identity name").fill(name);
   dummyAuth(page);
   await page.getByRole("button", { name: "Create Passkey" }).click();
-
-  if (onContinueScreen) {
-    // If we're coming from the continue screen (through identity switcher),
-    // we'll also need to explicitly select the primary account to continue.
-    await page.getByRole("button", { name: "Primary account" }).click();
-  }
 };
 
 /**


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Users should not be required to select an account after registration.

The accounts page was being shown if the user created a new identity from the identity switcher.

# Changes

* Added a call to `triggerDropWaveAnimation` in the `authorize` handler of `+page.svelte` to provide visual feedback when authorization is triggered.
* Changed the authorization process in `+layout.svelte` to call `authorizationStore.authorize` directly after triggering the drop wave animation, and removed the call to `preloadAccounts` and `gotoAccounts`, simplifying the flow.

# Tests

Tested locally by registering from identity switcher and also with clean local storage.




<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->



