### PR TITLE
Fix microsoft logo in dashboard

### DIFF
--- a/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
+++ b/src/frontend/src/lib/components/views/AccessMethodsPanel.svelte
@@ -209,7 +209,7 @@
       </div>
     {/each}
     {#each openIdCredentials as credential}
-      {@const logo = openIdLogo(credential.iss)}
+      {@const logo = openIdLogo(credential.iss, credential.metadata)}
       <div
         class="border-border-tertiary col-span-3 grid grid-cols-subgrid border-t py-4"
       >
@@ -253,7 +253,10 @@
   <RemoveOpenIdCredential
     onRemove={handleRemoveOpenIdCredential}
     onClose={() => (removableOpenIdCredential = null)}
-    openIDName={openIdName(removableOpenIdCredential.iss) ?? "Google"}
+    openIDName={openIdName(
+      removableOpenIdCredential.iss,
+      removableOpenIdCredential.metadata,
+    ) ?? "Google"}
     isCurrentAccessMethod={isRemovableOpenIdCredentialCurrentAccessMethod}
   />
 {/if}

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -6,7 +6,6 @@
   import Button from "$lib/components/ui/Button.svelte";
   import GoogleIcon from "$lib/components/icons/GoogleIcon.svelte";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
-  import { openIdName } from "$lib/utils/openID";
   import { nonNullish } from "@dfinity/utils";
   import { canisterConfig } from "$lib/globals";
   import { ENABLE_GENERIC_OPEN_ID } from "$lib/state/featureFlags";
@@ -105,9 +104,7 @@
       <div class="flex flex-row flex-nowrap justify-stretch gap-3">
         {#each openIdProviders as provider}
           <Tooltip
-            label={`You already have a ${openIdName(
-              provider.issuer,
-            )} account linked`}
+            label={`You already have a ${provider.name} account linked`}
             hidden={!hasCredential(provider.issuer)}
           >
             <Button

--- a/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
@@ -53,7 +53,7 @@ export class AuthLastUsedFlow {
         const issuer = lastUsedIdentity.authMethod.openid.iss;
         const config = findConfig(
           issuer,
-          lastUsedIdentity.authMethod.openid.metadata,
+          lastUsedIdentity.authMethod.openid.metadata ?? [],
         );
         if (isNullish(config)) {
           throw new Error(

--- a/src/frontend/src/lib/utils/lastUsedIdentity.ts
+++ b/src/frontend/src/lib/utils/lastUsedIdentity.ts
@@ -8,7 +8,7 @@ export const lastUsedIdentityTypeName = (
   if ("openid" in lastUsedIdentity.authMethod) {
     const config = findConfig(
       lastUsedIdentity.authMethod.openid.iss,
-      lastUsedIdentity.authMethod.openid.metadata,
+      lastUsedIdentity.authMethod.openid.metadata ?? [],
     );
     if (nonNullish(config) && isOpenIdConfig(config)) {
       return config.name;

--- a/src/frontend/src/lib/utils/openID.ts
+++ b/src/frontend/src/lib/utils/openID.ts
@@ -256,7 +256,7 @@ export const issuerMatches = (
  */
 export const findConfig = (
   issuer: string,
-  metadata: MetadataMapV2 = [],
+  metadata: MetadataMapV2,
 ): OpenIdConfig | GoogleOpenIdConfig | undefined => {
   // First, try to find a match in the generic OpenID configurations
   const fromConfigs = canisterConfig.openid_configs[0]?.find((config) =>
@@ -338,8 +338,11 @@ export const getMetadataString = (metadata: MetadataMapV2, key: string) => {
  * @param issuer
  * @returns {string | undefined} The string is an SVG string that must be embedded in the HTML.
  */
-export const openIdLogo = (issuer: string): string | undefined => {
-  const config = findConfig(issuer);
+export const openIdLogo = (
+  issuer: string,
+  metadata: MetadataMapV2,
+): string | undefined => {
+  const config = findConfig(issuer, metadata);
   if (nonNullish(config) && isOpenIdConfig(config)) {
     return config.logo;
   }
@@ -353,8 +356,11 @@ export const openIdLogo = (issuer: string): string | undefined => {
  * @param issuer
  * @returns {string | undefined} The string is the name of the OpenID provider.
  */
-export const openIdName = (issuer: string): string | undefined => {
-  const config = findConfig(issuer);
+export const openIdName = (
+  issuer: string,
+  metadata: MetadataMapV2,
+): string | undefined => {
+  const config = findConfig(issuer, metadata);
   if (nonNullish(config) && isOpenIdConfig(config)) {
     return config.name;
   }

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -85,7 +85,7 @@
     } else if ("openid" in identity.authMethod) {
       const config = findConfig(
         identity.authMethod.openid.iss,
-        identity.authMethod.openid.metadata,
+        identity.authMethod.openid.metadata ?? [],
       );
       if (nonNullish(config) && isOpenIdConfig(config)) {
         authenticationV2Funnel.addProperties({

--- a/src/frontend/src/routes/(new-styling)/authorize/(panel)/continue/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/(panel)/continue/+page.svelte
@@ -68,7 +68,7 @@
       } else if ("openid" in selectedIdentity.authMethod) {
         const config = findConfig(
           selectedIdentity.authMethod.openid.iss,
-          selectedIdentity.authMethod.openid.metadata,
+          selectedIdentity.authMethod.openid.metadata ?? [],
         );
         if (nonNullish(config) && isOpenIdConfig(config)) {
           authenticationV2Funnel.addProperties({


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

There is a bug in the dashboard where a microsoft account shows the Google logo.

I also discovered another bug which is the name in the unlinke account modal.

The reason was that the metadata in findConfig was optional. I set it to mandatory and found the other bugs.

# Changes

This pull request updates how OpenID provider metadata is handled throughout the frontend codebase. The main change is that functions related to OpenID providers (`findConfig`, `openIdLogo`, and `openIdName`) now require the provider's metadata to be explicitly passed as an argument, rather than relying on a default or optional value. This improves type safety and ensures consistent behavior when working with OpenID provider configurations.

**OpenID Provider Metadata Handling**

* Updated `findConfig`, `openIdLogo`, and `openIdName` in `openID.ts` to require `metadata` as a mandatory argument, removing the default value and ensuring explicit metadata is always provided.
* Updated all usages of `findConfig`, `openIdLogo`, and `openIdName` across the codebase to pass the OpenID provider's metadata, using an empty array fallback (`metadata ?? []`) where necessary. This affects files such as `lastUsedIdentity.ts`, `authLastUsedFlow.svelte.ts`, `(new-styling)/+page.svelte`, and `(new-styling)/authorize/(panel)/continue/+page.svelte`.
* Updated `AccessMethodsPanel.svelte` to pass `credential.metadata` to `openIdLogo` and `openIdName`.

**UI Consistency and Minor Cleanups**

* Updated `AddAccessMethod.svelte` to use the provider's `name` property directly in tooltips, rather than calling `openIdName`, simplifying the code and improving clarity. 


# Tests

Tested locally by registering with microsoft checking the dashboard, then adding a passkey and checking the unlink modal.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
