### PR TITLE
Fix popup blocked by Safari when linking openID accounts

### DIFF
--- a/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
@@ -48,7 +48,6 @@ export class AddAccessMethodFlow {
     config: OpenIdConfig,
   ): Promise<OpenIdCredential> => {
     const { actor, identityNumber, salt, nonce } = get(authenticatedStore);
-    console.log(actor, identityNumber, salt, nonce);
 
     try {
       this.#isSystemOverlayVisible = true;
@@ -60,7 +59,7 @@ export class AddAccessMethodFlow {
           authScope: config.auth_scope.join(" "),
         },
         {
-          nonce: nonce,
+          nonce,
           mediation: "required",
         },
       );

--- a/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
@@ -2,7 +2,6 @@ import { canisterConfig } from "$lib/globals";
 import { get } from "svelte/store";
 import { isNullish, nonNullish } from "@dfinity/utils";
 import {
-  createAnonymousNonce,
   createGoogleRequestConfig,
   decodeJWT,
   requestJWT,

--- a/src/frontend/src/lib/flows/authFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.ts
@@ -108,7 +108,7 @@ export class AuthFlow {
         canisterId,
         session: get(sessionStore),
       });
-    authenticationStore.set({ identity, identityNumber });
+    await authenticationStore.set({ identity, identityNumber });
     const info =
       await get(authenticatedStore).actor.get_anchor_info(identityNumber);
     lastUsedIdentitiesStore.addLastUsedIdentity({
@@ -197,7 +197,7 @@ export class AuthFlow {
       // If the call fails, it means the Google user does not exist in II.
       // In that case, we register them.
       authenticationV2Funnel.trigger(AuthenticationV2Events.LoginWithOpenID);
-      authenticationStore.set({ identity, identityNumber });
+      await authenticationStore.set({ identity, identityNumber });
       const info =
         await get(authenticatedStore).actor.get_anchor_info(identityNumber);
       const authnMethod = info.openid_credentials[0]?.find(
@@ -283,7 +283,7 @@ export class AuthFlow {
       // If the call fails, it means the OpenID user does not exist in II.
       // In that case, we register them.
       authenticationV2Funnel.trigger(AuthenticationV2Events.LoginWithOpenID);
-      authenticationStore.set({ identity, identityNumber });
+      await authenticationStore.set({ identity, identityNumber });
       const info =
         await get(authenticatedStore).actor.get_anchor_info(identityNumber);
       const authnMethod = info.openid_credentials[0]?.find(
@@ -393,7 +393,7 @@ export class AuthFlow {
       const identity = await authenticateWithSession({
         session: get(sessionStore),
       });
-      authenticationStore.set({ identity, identityNumber });
+      await authenticationStore.set({ identity, identityNumber });
       lastUsedIdentitiesStore.addLastUsedIdentity({
         identityNumber,
         name: passkeyIdentity.getName(),
@@ -483,7 +483,7 @@ export class AuthFlow {
       authenticationV2Funnel.trigger(
         AuthenticationV2Events.SuccessfulOpenIDRegistration,
       );
-      authenticationStore.set({ identity, identityNumber });
+      await authenticationStore.set({ identity, identityNumber });
       const metadata: MetadataMapV2 = [];
       if (nonNullish(jwtName)) {
         metadata.push(["name", { String: jwtName }]);

--- a/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
@@ -46,7 +46,7 @@ export class AuthLastUsedFlow {
           session: get(sessionStore),
           credentialIds,
         });
-        authenticationStore.set({ identity, identityNumber });
+        await authenticationStore.set({ identity, identityNumber });
         lastUsedIdentitiesStore.addLastUsedIdentity(lastUsedIdentity);
       } else if ("openid" in lastUsedIdentity.authMethod) {
         this.systemOverlay = true;
@@ -80,7 +80,7 @@ export class AuthLastUsedFlow {
           session: get(sessionStore),
           jwt,
         });
-        authenticationStore.set({ identity, identityNumber });
+        await authenticationStore.set({ identity, identityNumber });
         lastUsedIdentitiesStore.addLastUsedIdentity(lastUsedIdentity);
       } else {
         throw new Error("Unrecognized authentication method");

--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -241,7 +241,7 @@ export class MigrationFlow {
         session.identity,
         delegation,
       );
-      authenticationStore.set({
+      await authenticationStore.set({
         identity,
         identityNumber,
       });

--- a/src/frontend/src/lib/flows/registerAccessMethodFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/registerAccessMethodFlow.svelte.ts
@@ -108,7 +108,7 @@ export class RegisterAccessMethodFlow {
         )
       ) {
         const identity = await authenticateWithSession({ session });
-        authenticationStore.set({
+        await authenticationStore.set({
           identity,
           identityNumber,
         });
@@ -184,7 +184,7 @@ export class RegisterAccessMethodFlow {
         ])
         .then(throwCanisterError);
       const identity = await authenticateWithSession({ session });
-      authenticationStore.set({
+      await authenticationStore.set({
         identity,
         identityNumber: this.#identityNumber,
       });

--- a/src/frontend/src/lib/stores/authentication.store.ts
+++ b/src/frontend/src/lib/stores/authentication.store.ts
@@ -63,7 +63,7 @@ export const authenticationStore: AuthenticationStore = {
       }
       initialized.agent.replaceIdentity(authenticated.identity);
       // Create the OpenID nonce using the identity's principal
-      createAnonymousNonce(authenticated.identity.getPrincipal()).then(
+      void createAnonymousNonce(authenticated.identity.getPrincipal()).then(
         ({ nonce, salt }) => {
           internalStore.update((currentState) => ({
             ...currentState,


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Safari blocked the popup to link a Google account from the dashboard during testing.

We saw that we were doing an async call to get the nonce and salt for the account verification.

To avoid async calls after user interaction, I added the `salt` and `nonce` to the authenticated store similar to what we do for the sessionStore.

# Changes

* The `authenticationStore.set` method is now asynchronous and always generates and stores a `nonce` and `salt` using `createAnonymousNonce`, ensuring these values are present in the authentication context. The method signature and implementation have been updated accordingly. (`src/frontend/src/lib/stores/authentication.store.ts`)
* All usages of `authenticationStore.set` in authentication-related flows (`AuthFlow`, `AuthLastUsedFlow`, `MigrationFlow`, `RegisterAccessMethodFlow`) have been updated to use `await`, reflecting the new asynchronous nature of the method. This ensures that the authentication state is fully updated before proceeding.
* The `AddAccessMethodFlow` and `linkGoogleAccount` flows now retrieve `nonce` and `salt` directly from the authenticated store instead of generating them again, ensuring consistency and reducing redundant calls.

# Tests

Tested locally that the salt and nonce were set when linking an openID account.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
