### PR TITLE
Remove unused options param to AddAccessMethodFlow

### DIFF
--- a/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
@@ -21,10 +21,6 @@ import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store"
 import { inferPasskeyAlias, loadUAParser } from "$lib/legacy/flows/register";
 import { passkeyAuthnMethodData } from "$lib/utils/authnMethodData";
 
-export interface AddAccessMethodFlowOptions {
-  isMaxOpenIdCredentialsReached?: boolean;
-}
-
 export class AddAccessMethodFlow {
   #view = $state<"chooseMethod" | "addPasskey">("chooseMethod");
   #isSystemOverlayVisible = $state(false);
@@ -35,12 +31,6 @@ export class AddAccessMethodFlow {
 
   get isSystemOverlayVisible() {
     return this.#isSystemOverlayVisible;
-  }
-
-  constructor(options?: AddAccessMethodFlowOptions) {
-    if (options?.isMaxOpenIdCredentialsReached === true) {
-      this.#view = "addPasskey";
-    }
   }
 
   linkOpenIdAccount = async (


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Remove unused code that used to set the view in AddAccessMethodFlow

# Changes

* Removed the `AddAccessMethodFlowOptions` interface and the `constructor` that accepted the `isMaxOpenIdCredentialsReached` flag, which previously allowed the initial view to be set to `"addPasskey"` if the flag was true.

# Tests

Local dev still works to add a new access method.
CI tests suffice.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
