### PR TITLE
first

### DIFF
--- a/src/internet_identity/tests/integration/upgrade.rs
+++ b/src/internet_identity/tests/integration/upgrade.rs
@@ -322,7 +322,9 @@ fn upgrade_and_rollback_with_realistic_data_migration() {
     let env = env();
     let canister_id = install_ii_canister(&env, II_WASM_PREVIOUS.clone());
 
-    for i in 0..2000 {
+    // For manual runs, use (too slow for CI):
+    // for i in 0..2000 {
+    for i in 0..10 {
         let pubkey = format!("pub-key-{}", i);
         let sender = Principal::self_authenticating(pubkey.clone());
         let origin = format!("https://www.app{}.org", i);


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

The original test was meant as a one-off experiment to validate the data migration. We don't plan to change the migration anymore until the next release, so the original test can now start using fewer accounts to speed up the CI.

# Changes

Use 10 instead of 2,000 accounts in `upgrade_and_rollback_with_realistic_data_migration`.

# Tests

The test being adjusted is still active.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
