### PR TITLE
Fix typescript error Type 'Uint8Array' is not assignable to type 'ArrayBuffer'

### DIFF
--- a/src/frontend/src/lib/utils/openID.ts
+++ b/src/frontend/src/lib/utils/openID.ts
@@ -105,7 +105,9 @@ const requestWithRedirect = async (
   config: Omit<RequestConfig, "configURL">,
   options: RequestOptions,
 ): Promise<string> => {
-  const state = toBase64URL(window.crypto.getRandomValues(new Uint8Array(12)));
+  const state = toBase64URL(
+    window.crypto.getRandomValues(new Uint8Array(12)).buffer,
+  );
   const redirectURL = new URL(REDIRECT_CALLBACK_PATH, window.location.origin);
   const authURL = new URL(config.authURL);
   // Even though we only need an id token, we're still asking for a code


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

```
Argument of type 'Uint8Array<ArrayBuffer>' is not assignable to parameter of type 'ArrayBuffer'.
  Types of property '[Symbol.toStringTag]' are incompatible.
    Type '"Uint8Array"' is not assignable to type '"ArrayBuffer"'.ts(2345)
```

# Changes

Added `.buffer` to the `window.crypto.getRandomValues` within `toBase64URL`

# Tests

Checked both pre and post change generated state codes for consistency in size and generation.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
