### PR TITLE
Fix warning for initial value capture of opacityWaveDuration in FlairCanvas

### DIFF
--- a/src/frontend/src/lib/components/backgrounds/FlairCanvas.svelte
+++ b/src/frontend/src/lib/components/backgrounds/FlairCanvas.svelte
@@ -86,6 +86,7 @@
 
   $effect(() => {
     opacityWaveMotion = new Tween(0, {
+      easing: easingFunctions.linear,
       duration: opacityWaveDuration,
     });
   });

--- a/src/frontend/src/lib/components/backgrounds/FlairCanvas.svelte
+++ b/src/frontend/src/lib/components/backgrounds/FlairCanvas.svelte
@@ -82,9 +82,12 @@
 
   let opacityWaveDuration = $state(500);
 
-  let opacityWaveMotion = new Tween(0, {
-    easing: easingFunctions.linear,
-    duration: opacityWaveDuration,
+  let opacityWaveMotion: Tween<number>;
+
+  $effect(() => {
+    opacityWaveMotion = new Tween(0, {
+      duration: opacityWaveDuration,
+    });
   });
 
   let motionNoiseScale = $state<number>(0.01);


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

```
This reference only captures the initial value of `opacityWaveDuration`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locallysvelte(state_referenced_locally)
```

This warning pops up during every build and creates unnecessary noise

# Changes

Moved to an `$effect` which will dynamically capture updates

# Tests

Tested locally on Chrome to check if there were any differences between the current wave pre and post change over multiple refreshes, no changes identified in terms of functionality

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

