### PR TITLE
Add Safari E2E tests to CI

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -57,7 +57,7 @@ jobs:
             II_FETCH_ROOT_KEY: 1
             II_DUMMY_CAPTCHA: 1
             II_DUMMY_AUTH: 0
-            II_DEV_CSP: 0
+            II_DEV_CSP: 1
 
           # Everything disabled, used by third party developers who only care
           # about the login flow

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -582,6 +582,7 @@ jobs:
     needs: [cached-build, test-app-build]
     strategy:
       matrix:
+        browser: ["chrome", "safari"]
         device: ["desktop", "mobile"]
         shard: ["1_3", "2_3", "3_3"]
       # Make sure that one failing test does not cancel all other matrix jobs
@@ -589,7 +590,7 @@ jobs:
 
     env:
       # Suffix used for tagging artifacts
-      artifact_suffix: next-${{ matrix.device }}-${{ matrix.shard }}
+      artifact_suffix: next-${{ matrix.browser }}-${{ matrix.device }}-${{ matrix.shard }}
       # OpenID configuration for provider in /src/test_openid_provider
       openid_name: Test OpenID
       openid_logo: |
@@ -615,7 +616,12 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Install Playwright Browsers
-        run: npx playwright install chromium
+        run: |
+          if [ "${{ matrix.browser }}" = "chrome" ]; then
+            npx playwright install chromium
+          else
+            npx playwright install webkit
+          fi
 
       - uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365
 
@@ -666,7 +672,7 @@ jobs:
           echo "dev_server_pid=$dev_server_pid" >> "$GITHUB_OUTPUT"
 
       - run: |
-          npx playwright test --project ${{ matrix.device }} --workers 1 --shard=$(tr <<<'${{ matrix.shard }}' -s _ /)
+          npx playwright test --project ${{ matrix.browser }}-${{ matrix.device }} --workers 1 --shard=$(tr <<<'${{ matrix.shard }}' -s _ /)
 
       - name: Stop dfx
         if: ${{ always() }}

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -618,9 +618,9 @@ jobs:
       - name: Install Playwright Browsers
         run: |
           if [ "${{ matrix.browser }}" = "chrome" ]; then
-            npx playwright install chromium
+            npx playwright install --with-deps chromium
           else
-            npx playwright install webkit
+            npx playwright install --with-deps webkit
           fi
 
       - uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365

--- a/HACKING.md
+++ b/HACKING.md
@@ -136,6 +136,22 @@ npx playwright test --ui
 > II_CAPTCHA=enabled npm run test:e2e
 > ```
 
+**Writing new Playwright E2E tests:**
+
+When creating new E2E Playwright tests, always import `test` and `expect` from the custom fixtures file:
+
+```typescript
+// ✅ Correct
+import { test, expect } from "./fixtures";
+// or from subdirectories:
+import { test, expect } from "../fixtures";
+
+// ❌ Wrong - will fail ESLint
+import { test, expect } from "@playwright/test";
+```
+
+The custom fixtures provide automatic host routing for Safari/WebKit tests, which don't support `--host-resolver-rules`. ESLint will enforce this pattern and show an error if you try to import directly from `@playwright/test`.
+
 We autoformat our code using `prettier`. Running `npm run format` formats all files in the frontend.
 If you open a PR that isn't formatted according to `prettier`, CI will automatically add a formatting commit to your PR.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,4 +60,22 @@ export default ts.config(
   {
     ignores: ["src/frontend/src/lib/generated/*", "src/showcase/.astro/*"],
   },
+  {
+    files: ["src/frontend/tests/e2e-playwright/**/*.spec.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@playwright/test",
+              importNames: ["test", "expect"],
+              message:
+                "Import 'test' and 'expect' from './fixtures' or '../fixtures' instead to use custom test fixtures with host routing for Safari/WebKit.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 );

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -66,12 +66,18 @@ export default defineConfig({
       name: "safari-desktop",
       use: {
         ...devices["Desktop Safari"],
+        launchOptions: {
+          args: ["--ignore-certificate-errors"],
+        },
       },
     },
     {
       name: "safari-mobile",
       use: {
         ...devices["iPhone 12"],
+        launchOptions: {
+          args: ["--ignore-certificate-errors"],
+        },
       },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,8 +30,6 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
-    /* Accept self-signed certificates when dev server runs with TLS */
-    ignoreHTTPSErrors: true,
   },
   timeout: 60000,
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
+
+    /* Ignore HTTPS errors, which is needed for the self-signed certificate. */
+    ignoreHTTPSErrors: true,
   },
   timeout: 60000,
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
+    /* Accept self-signed certificates when dev server runs with TLS */
+    ignoreHTTPSErrors: true,
   },
   timeout: 60000,
 
@@ -63,22 +65,12 @@ export default defineConfig({
       name: "safari-desktop",
       use: {
         ...devices["Desktop Safari"],
-        launchOptions: {
-          args: [
-            "--host-resolver-rules=MAP * localhost:5173, EXCLUDE localhost",
-          ],
-        },
       },
     },
     {
       name: "safari-mobile",
       use: {
         ...devices["iPhone 12"],
-        launchOptions: {
-          args: [
-            "--host-resolver-rules=MAP * localhost:5173, EXCLUDE localhost",
-          ],
-        },
       },
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -65,7 +65,6 @@ export default defineConfig({
         ...devices["Desktop Safari"],
         launchOptions: {
           args: [
-            "--ignore-certificate-errors",
             "--host-resolver-rules=MAP * localhost:5173, EXCLUDE localhost",
           ],
         },
@@ -77,7 +76,6 @@ export default defineConfig({
         ...devices["iPhone 12"],
         launchOptions: {
           args: [
-            "--ignore-certificate-errors",
             "--host-resolver-rules=MAP * localhost:5173, EXCLUDE localhost",
           ],
         },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,7 +32,8 @@ export default defineConfig({
     trace: "on-first-retry",
 
     /* Ignore HTTPS errors, which is needed for the self-signed certificate. */
-    ignoreHTTPSErrors: true,
+    // It doesn't seem to fix it
+    // ignoreHTTPSErrors: true,
   },
   timeout: 60000,
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     {
-      name: "desktop",
+      name: "chrome-desktop",
       use: {
         ...devices["Desktop Chrome"],
         launchOptions: {
@@ -48,9 +48,33 @@ export default defineConfig({
       },
     },
     {
-      name: "mobile",
+      name: "chrome-mobile",
       use: {
         ...devices["Pixel 5"],
+        launchOptions: {
+          args: [
+            "--ignore-certificate-errors",
+            "--host-resolver-rules=MAP * localhost:5173, EXCLUDE localhost",
+          ],
+        },
+      },
+    },
+    {
+      name: "safari-desktop",
+      use: {
+        ...devices["Desktop Safari"],
+        launchOptions: {
+          args: [
+            "--ignore-certificate-errors",
+            "--host-resolver-rules=MAP * localhost:5173, EXCLUDE localhost",
+          ],
+        },
+      },
+    },
+    {
+      name: "safari-mobile",
+      use: {
+        ...devices["iPhone 12"],
         launchOptions: {
           args: [
             "--ignore-certificate-errors",

--- a/src/frontend/tests/e2e-playwright/authorize/account.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/account.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
 import { authorize, createIdentity, dummyAuth } from "../utils";
 
 test("Create and authorize with additional account", async ({ page }) => {

--- a/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../fixtures";
 import {
   dummyAuth,
   II_URL,

--- a/src/frontend/tests/e2e-playwright/authorize/continue.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/continue.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
 import {
   authorize,
   authorizeWithUrl,

--- a/src/frontend/tests/e2e-playwright/authorize/delegationTtl.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/delegationTtl.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
 import { dummyAuth, II_URL, TEST_APP_URL } from "../utils";
 
 test("Delegation maxTimeToLive: 1 min", async ({ page }) => {

--- a/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
 import {
   authorize,
   authorizeWithUrl,

--- a/src/frontend/tests/e2e-playwright/authorize/migration.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/migration.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
 import type Protocol from "devtools-protocol";
 import {
   addCredentialToVirtualAuthenticator,

--- a/src/frontend/tests/e2e-playwright/authorize/migration.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/migration.spec.ts
@@ -15,6 +15,11 @@ import { isNullish } from "@dfinity/utils";
 const TEST_USER_NAME = "Test User";
 
 test.describe("Migration from an app", () => {
+  test.skip(
+    ({ browserName }) => browserName === "webkit",
+    "Migration test not supported on Safari because it uses virtual authenticators which are not supported.",
+  );
+
   test("User can migrate a legacy identity", async ({ page }) => {
     const auth = dummyAuth();
     let credential: Protocol.WebAuthn.Credential | undefined;

--- a/src/frontend/tests/e2e-playwright/authorize/postMessages.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/postMessages.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
 import {
   createNewIdentityInII,
   dummyAuth,

--- a/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
 import {
   addPasskeyCurrentDevice,
   clearStorage,

--- a/src/frontend/tests/e2e-playwright/dashboard/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/index.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
 import { clearStorage, createIdentity, dummyAuth, II_URL } from "../utils";
 
 const TEST_USER_NAME = "Test User";

--- a/src/frontend/tests/e2e-playwright/dashboard/migration.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/migration.spec.ts
@@ -39,6 +39,11 @@ const upgradeLegacyIdentity = async (
 };
 
 test.describe("Migration", () => {
+  test.skip(
+    ({ browserName }) => browserName === "webkit",
+    "Migration test not supported on Safari because it uses virtual authenticators which are not supported.",
+  );
+
   test("User can migrate a legacy identity", async ({ page }) => {
     // Step 1: Create a legacy identity
     await page.goto(LEGACY_II_URL);

--- a/src/frontend/tests/e2e-playwright/dashboard/migration.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/migration.spec.ts
@@ -1,4 +1,5 @@
-import { expect, Page, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
+import { Page } from "@playwright/test";
 import {
   addVirtualAuthenticator,
   clearStorage,

--- a/src/frontend/tests/e2e-playwright/dashboard/migration.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/migration.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "../fixtures";
-import { Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
   addVirtualAuthenticator,
   clearStorage,

--- a/src/frontend/tests/e2e-playwright/dashboard/removePasskey.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/removePasskey.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
 import {
   clearStorage,
   createNewIdentityInII,

--- a/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures";
 import {
   clearStorage,
   createNewIdentityInII,

--- a/src/frontend/tests/e2e-playwright/fixtures.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures.ts
@@ -24,7 +24,8 @@ export const test = base.extend({
         }
 
         const newUrl = `https://localhost:5173${url.pathname}${url.search}`;
-        return route.continue({ url: newUrl });
+        // The vite server uses the Host header to determine where the redirect the request.
+        return route.continue({ url: newUrl, headers: { Host: url.hostname } });
       });
     }
 

--- a/src/frontend/tests/e2e-playwright/fixtures.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures.ts
@@ -23,9 +23,17 @@ export const test = base.extend({
           return route.continue();
         }
 
-        const newUrl = `https://localhost:5173${url.pathname}${url.search}`;
-        // The vite server uses the Host header to determine where the redirect the request.
-        return route.continue({ url: newUrl, headers: { Host: url.hostname } });
+        if (url.hostname.includes("localhost")) {
+          return route.continue();
+        }
+
+        // The vite server uses
+        const newUrl = `https://internet_identity.localhost:5173${url.pathname}${url.search}`;
+        return route.continue({
+          url: newUrl,
+          // The vite server uses the Host header to determine where the redirect the request.
+          headers: { ...req.headers(), Host: url.hostname },
+        });
       });
     }
 

--- a/src/frontend/tests/e2e-playwright/fixtures.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures.ts
@@ -3,6 +3,18 @@ import { test as base, expect } from "@playwright/test";
 /**
  * Custom test fixture that automatically applies host resolution routing
  * to redirect all non-localhost requests to localhost:5173
+ *
+ * ⚠️ IMPORTANT: All E2E test files MUST import { test, expect } from this file
+ * instead of from '@playwright/test' to ensure proper host routing for Safari/WebKit.
+ *
+ * @example
+ * // ✅ Correct
+ * import { test, expect } from "./fixtures";
+ * // or from subdirectories:
+ * import { test, expect } from "../fixtures";
+ *
+ * // ❌ Wrong - will fail ESLint
+ * import { test, expect } from "@playwright/test";
  */
 export const test = base.extend({
   page: async ({ page }, use) => {

--- a/src/frontend/tests/e2e-playwright/fixtures.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures.ts
@@ -1,0 +1,37 @@
+import { test as base, expect } from "@playwright/test";
+
+/**
+ * Custom test fixture that automatically applies host resolution routing
+ * to redirect all non-localhost requests to localhost:5173
+ */
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    // Safari doesn't support --host-resolver-rules, so we need page routing for Safari
+    // Chromium browsers will use host-resolver-rules which preserves Host headers better
+    const browserName = page.context().browser()?.browserType().name();
+
+    if (browserName === "webkit") {
+      // Apply routing for Safari since it doesn't support host-resolver-rules
+      await page.route("**/*", (route) => {
+        const req = route.request();
+        const urlStr = req.url();
+
+        let url: URL;
+        try {
+          url = new URL(urlStr);
+        } catch {
+          return route.continue();
+        }
+
+        const newUrl = `https://localhost:5173${url.pathname}${url.search}`;
+        return route.continue({ url: newUrl });
+      });
+    }
+
+    // Use the page with routing applied
+    await use(page);
+  },
+});
+
+// Re-export expect for convenience
+export { expect };

--- a/src/frontend/tests/e2e-playwright/fixtures.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures.ts
@@ -36,7 +36,7 @@ export const test = base.extend({
         }
 
         const canister_name = hostToCanisterName[url.hostname];
-        if (!canister_name) {
+        if (canister_name === undefined) {
           return route.continue();
         }
         // The vite server uses the Host header and the localhost subdomain to determine where the redirect the request.

--- a/src/frontend/tests/e2e-playwright/fixtures.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures.ts
@@ -18,12 +18,11 @@ import { test as base, expect } from "@playwright/test";
  */
 export const test = base.extend({
   page: async ({ page }, use) => {
-    // Safari doesn't support --host-resolver-rules, so we need page routing for Safari
-    // Chromium browsers will use host-resolver-rules which preserves Host headers better
     const browserName = page.context().browser()?.browserType().name();
 
+    // Safari doesn't support --host-resolver-rules, so we need page routing for Safari
+    // Chromium browsers will use host-resolver-rules which preserves Host headers better
     if (browserName === "webkit") {
-      // Apply routing for Safari since it doesn't support host-resolver-rules
       await page.context().route("**/*", (route) => {
         // Should map the config in `vite.config.ts`
         const hostToCanisterName: Record<string, string> = {
@@ -51,7 +50,6 @@ export const test = base.extend({
         if (canister_name === undefined) {
           return route.continue();
         }
-        // The vite server uses the Host header and the localhost subdomain to determine where the redirect the request.
         const newUrl = `https://${canister_name}.localhost:5173${url.pathname}${url.search}`;
         return route.continue({
           url: newUrl,

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures";
 import { clearStorage, createIdentity, dummyAuth, II_URL } from "./utils";
 
 // This is chosen on purpose to exhibit a JWT token that is encoded in base64url but cannot

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -259,10 +259,19 @@ fn content_security_policy_header(
     };
 
     let connect_src = "'self' https:";
+    let script_src = format!("{strict_dynamic} 'unsafe-inline' 'unsafe-eval' https:");
+    let style_src = "'self' 'unsafe-inline'";
+    let img_src = "'self' data: https://*.googleusercontent.com";
 
-    // Allow connecting via http for development purposes
+    // Allow connecting via http and localhost (including subdomains) for development purposes
     #[cfg(feature = "dev_csp")]
-    let connect_src = format!("{connect_src} http:");
+    let connect_src = format!("{connect_src} http: http://localhost:* http://*.localhost:*");
+    #[cfg(feature = "dev_csp")]
+    let script_src = format!("{script_src} http: http://localhost:* http://*.localhost:*");
+    #[cfg(feature = "dev_csp")]
+    let style_src = format!("{style_src} http: http://localhost:* http://*.localhost:*");
+    #[cfg(feature = "dev_csp")]
+    let img_src = format!("{img_src} http: http://localhost:* http://*.localhost:*");
 
     // Allow related origins to embed one another for cross-domain WebAuthn
     let frame_src = maybe_related_origins
@@ -273,12 +282,12 @@ fn content_security_policy_header(
     let csp = format!(
         "default-src 'none';\
          connect-src {connect_src};\
-         img-src 'self' data: https://*.googleusercontent.com;\
-         script-src {strict_dynamic} 'unsafe-inline' 'unsafe-eval' https:;\
+         img-src {img_src};\
+         script-src {script_src};\
          base-uri 'none';\
          form-action 'none';\
-         style-src 'self' 'unsafe-inline';\
-         style-src-elem 'self' 'unsafe-inline';\
+         style-src {style_src};\
+         style-src-elem {style_src};\
          font-src 'self';\
          frame-ancestors {frame_src};\
          frame-src {frame_src};"

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -126,10 +126,10 @@ pub fn security_headers(
         // Content-Security-Policy (CSP)
         // Comprehensive policy to prevent XSS attacks and data injection
         // See content_security_policy_header() function for detailed explanation
-        // (
-        //     "Content-Security-Policy".to_string(),
-        //     content_security_policy_header(integrity_hashes, maybe_related_origins),
-        // ),
+        (
+            "Content-Security-Policy".to_string(),
+            content_security_policy_header(integrity_hashes, maybe_related_origins),
+        ),
         // Strict-Transport-Security (HSTS)
         // Forces browsers to use HTTPS for all future requests to this domain
         // max-age=31536000: Valid for 1 year (31,536,000 seconds)

--- a/src/internet_identity/src/http.rs
+++ b/src/internet_identity/src/http.rs
@@ -126,10 +126,10 @@ pub fn security_headers(
         // Content-Security-Policy (CSP)
         // Comprehensive policy to prevent XSS attacks and data injection
         // See content_security_policy_header() function for detailed explanation
-        (
-            "Content-Security-Policy".to_string(),
-            content_security_policy_header(integrity_hashes, maybe_related_origins),
-        ),
+        // (
+        //     "Content-Security-Policy".to_string(),
+        //     content_security_policy_header(integrity_hashes, maybe_related_origins),
+        // ),
         // Strict-Transport-Security (HSTS)
         // Forces browsers to use HTTPS for all future requests to this domain
         // max-age=31536000: Valid for 1 year (31,536,000 seconds)


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Improve the reliability of the test coverage by adding Safari as a supported browser.

# Changes

- Updated the Playwright test matrix in `.github/workflows/canister-tests.yml` to run tests on both Chrome and Safari, for both desktop and mobile, and adjusted artifact naming to include the browser. Playwright browser installation is now conditional based on the matrix browser. Test execution now uses browser-specific project names.
- Enhanced `playwright.config.ts` to define separate projects for `chrome-desktop`, `chrome-mobile`, `safari-desktop`, and `safari-mobile`, and enabled `ignoreHTTPSErrors` to support self-signed certificates during tests.
- Added a custom Playwright fixture in `fixtures.ts` that implements host resolution routing for Safari, ensuring all non-localhost requests are redirected correctly during tests. This fixture is now used in all test files.
- Refactored all E2E test files to import `test` and `expect` from the new `fixtures.ts` instead of `@playwright/test`, ensuring consistent use of the custom fixture across the suite.
- Skipped migration tests on Safari (`webkit`) in both `authorize/migration.spec.ts` and `dashboard/migration.spec.ts` because virtual authenticators are not supported in that browser.

# Tests

Only test changes.




<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->




