### PR TITLE
Make background animation height configurable

### DIFF
--- a/src/frontend/src/lib/components/backgrounds/FlairCanvas.d.ts
+++ b/src/frontend/src/lib/components/backgrounds/FlairCanvas.d.ts
@@ -29,6 +29,7 @@ export interface FlairAnimationOptions {
   size: "large" | "medium" | "small" | number;
   nImpulses: "single" | "double";
   impulseEasing?: keyof typeof easingFunctions;
+  containerHeight?: "h-full" | "h-[640px]";
 }
 
 export interface FlairCanvasProps {

--- a/src/frontend/src/lib/components/backgrounds/FlairCanvas.svelte
+++ b/src/frontend/src/lib/components/backgrounds/FlairCanvas.svelte
@@ -882,7 +882,7 @@
 </script>
 
 <div
-  class={`${animationHeight ?? defaultHeight} absolute inset-0 top-12
+  class={`${animationHeight ?? defaultHeight} absolute inset-0
     -z-50 w-full select-none`}
   aria-hidden="true"
   bind:this={backgroundRef}

--- a/src/frontend/src/lib/components/backgrounds/constants.ts
+++ b/src/frontend/src/lib/components/backgrounds/constants.ts
@@ -9,4 +9,5 @@ export const DROP_WAVE_ANIMATION: FlairAnimationOptions = {
   nImpulses: "single",
   size: "large",
   impulseEasing: "cubicIn",
+  containerHeight: "h-full",
 };

--- a/src/frontend/src/lib/utils/animation-dispatcher.ts
+++ b/src/frontend/src/lib/utils/animation-dispatcher.ts
@@ -60,14 +60,21 @@ class AnimationDispatcher {
 
   /**
    * Trigger the drop wave animation
+   * @param containerHeight Optional height to use during animation (e.g. "h-full", "h-[640px]")
    * @returns Promise that resolves when the animation completes
    */
-  dropWaveAnimation(): Promise<void> {
+  dropWaveAnimation(
+    overrideOptions: Partial<FlairAnimationOptions>,
+  ): Promise<void> {
     return new Promise((resolve) => {
       this.#animationQueue.push(async () => {
         try {
           if (this.#triggerFunction) {
-            await this.#triggerFunction(DROP_WAVE_ANIMATION);
+            const animationOptions: FlairAnimationOptions = {
+              ...DROP_WAVE_ANIMATION,
+              ...overrideOptions,
+            };
+            await this.#triggerFunction(animationOptions);
           }
         } catch (error) {
           console.warn("Animation failed:", error);
@@ -88,8 +95,9 @@ class AnimationDispatcher {
 const animationDispatcher = new AnimationDispatcher();
 
 // Public API
-export const triggerDropWaveAnimation = (): Promise<void> =>
-  animationDispatcher.dropWaveAnimation();
+export const triggerDropWaveAnimation = (
+  overrideOptions: Partial<FlairAnimationOptions>,
+): Promise<void> => animationDispatcher.dropWaveAnimation(overrideOptions);
 
 export const clearDropWaveAnimation = (): Promise<void> =>
   animationDispatcher.clearWaveAnimation();

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -96,7 +96,10 @@
 
   onMount(() => {
     requestAnimationFrame(() => (showFadeIn = true));
-    setTimeout(async () => await triggerDropWaveAnimation());
+    setTimeout(
+      async () =>
+        await triggerDropWaveAnimation({ containerHeight: "h-[640px]" }),
+    );
   });
 
   onDestroy(() => {


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

The same background animation is used within the landing page, below the hero component and in the whole page during the authentication flow.

However, at the moment, the height is fixed for all animations, which makes it a big weird in the authentication flow.

In this PR, I make the height of the animation background configurable so that it can use a different one in the hero of the landing than on the authentication flow.

# Changes

* Added state management (`animationHeight`, `defaultHeight`, and `heightResetTimeout`) in `FlairCanvas.svelte` to support dynamic height changes during animations, enabling height transitions and automatic resets after animation completion.
* Updated the drop wave animation options (`DROP_WAVE_ANIMATION` in `constants.ts`) to include a `containerHeight` property, allowing the animation to specify its preferred container height.
* Modified the `AnimationDispatcher` and its public API to accept `overrideOptions`, making it possible to pass custom animation options (such as `containerHeight`) when triggering the drop wave animation.
* Updated the main page (`+page.svelte`) to trigger the drop wave animation with a specific container height (`h-[640px]`), demonstrating the new dynamic height capability in practice.

# Tests

Tested with the authentication and landing page flows. See screenshots attached.
