### PR TITLE
feat: Support `AccountInfo.is_default` in II backend API (approach 2)

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -775,7 +775,7 @@ type AccountInfo = record {
     last_used : opt Timestamp;
     // Configurable properties
     name : opt text;
-    is_default : opt bool;
+    is_default : bool;
 };
 
 type AccountUpdate = record {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -775,6 +775,7 @@ type AccountInfo = record {
     last_used : opt Timestamp;
     // Configurable properties
     name : opt text;
+    is_default : opt bool;
 };
 
 type AccountUpdate = record {

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -283,6 +283,7 @@ fn should_create_account_for_origin() {
             anchor.anchor_number(),
             origin,
             Some(name),
+            None,
             Some(1),
             None,
             None
@@ -357,11 +358,12 @@ fn should_get_accounts_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number, &origin),
         vec![
-            Account::new(anchor_number, origin.clone(), None, None),
+            Account::new(anchor_number, origin.clone(), None, None, None),
             Account::new_full(
                 anchor_number,
                 origin.clone(),
                 Some("Alice".to_string()),
+                None,
                 Some(1),
                 None,
                 None
@@ -370,6 +372,7 @@ fn should_get_accounts_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Bob".to_string()),
+                None,
                 Some(2),
                 None,
                 None
@@ -399,11 +402,12 @@ fn should_only_get_own_accounts_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number, &origin),
         vec![
-            Account::new(anchor_number, origin.clone(), None, None),
+            Account::new(anchor_number, origin.clone(), None, None, None),
             Account::new_full(
                 anchor_number,
                 origin.clone(),
                 Some("Alice".to_string()),
+                None,
                 Some(1),
                 None,
                 None
@@ -414,11 +418,12 @@ fn should_only_get_own_accounts_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number_two, &origin),
         vec![
-            Account::new(anchor_number_two, origin.clone(), None, None),
+            Account::new(anchor_number_two, origin.clone(), None, None, None),
             Account::new_full(
                 anchor_number_two,
                 origin.clone(),
                 Some("Bob".to_string()),
+                None,
                 Some(2),
                 None,
                 None
@@ -446,11 +451,12 @@ fn should_update_account_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number, &origin),
         vec![
-            Account::new(anchor_number, origin.clone(), None, None),
+            Account::new(anchor_number, origin.clone(), None, None, None),
             Account::new_full(
                 anchor_number,
                 origin.clone(),
                 Some("Alice".to_string()),
+                None,
                 Some(1),
                 None,
                 None
@@ -459,6 +465,7 @@ fn should_update_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Bob".to_string()),
+                None,
                 Some(2),
                 None,
                 None
@@ -479,6 +486,7 @@ fn should_update_account_for_origin() {
             anchor_number,
             origin.clone(),
             Some("Becky".to_string()),
+            None,
             Some(1),
             None,
             None
@@ -488,11 +496,12 @@ fn should_update_account_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number, &origin),
         vec![
-            Account::new(anchor_number, origin.clone(), None, None),
+            Account::new(anchor_number, origin.clone(), None, None, None),
             Account::new_full(
                 anchor_number,
                 origin.clone(),
                 Some("Becky".to_string()),
+                None,
                 Some(1),
                 None,
                 None
@@ -501,6 +510,7 @@ fn should_update_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Bob".to_string()),
+                None,
                 Some(2),
                 None,
                 None
@@ -528,11 +538,12 @@ fn should_update_default_account_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number, &origin),
         vec![
-            Account::new(anchor_number, origin.clone(), None, None),
+            Account::new(anchor_number, origin.clone(), None, None, None),
             Account::new_full(
                 anchor_number,
                 origin.clone(),
                 Some("Alice".to_string()),
+                None,
                 Some(1),
                 None,
                 None
@@ -541,6 +552,7 @@ fn should_update_default_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Bob".to_string()),
+                None,
                 Some(2),
                 None,
                 None
@@ -561,6 +573,7 @@ fn should_update_default_account_for_origin() {
             anchor_number,
             origin.clone(),
             Some("Becky".to_string()),
+            None,
             Some(3),
             None,
             Some(anchor_number)
@@ -574,6 +587,7 @@ fn should_update_default_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Becky".to_string()),
+                None,
                 Some(3),
                 None,
                 Some(anchor_number)
@@ -582,6 +596,7 @@ fn should_update_default_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Alice".to_string()),
+                None,
                 Some(1),
                 None,
                 None
@@ -590,6 +605,7 @@ fn should_update_default_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Bob".to_string()),
+                None,
                 Some(2),
                 None,
                 None

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -60,7 +60,7 @@ pub fn create_account_for_origin(
                 name: name.clone(),
                 origin,
                 // TODO[ID-361]: Read the is_default function parameter when it becomes available.
-                // For now, assume that the newly creted account should be the default.
+                // For now, assume that the newly created account should be the default.
                 is_default: true,
             })
             .map_err(|err| CreateAccountError::InternalCanisterError(format!("{err}")))
@@ -291,7 +291,7 @@ fn should_create_account_for_origin() {
             anchor.anchor_number(),
             origin,
             Some(name),
-            None,
+            false,
             Some(1),
             None,
             None
@@ -366,12 +366,12 @@ fn should_get_accounts_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number, &origin),
         vec![
-            Account::new(anchor_number, origin.clone(), None, None, None),
+            Account::new(anchor_number, origin.clone(), None, true, None),
             Account::new_full(
                 anchor_number,
                 origin.clone(),
                 Some("Alice".to_string()),
-                None,
+                false,
                 Some(1),
                 None,
                 None
@@ -380,7 +380,7 @@ fn should_get_accounts_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Bob".to_string()),
-                None,
+                false,
                 Some(2),
                 None,
                 None
@@ -410,12 +410,12 @@ fn should_only_get_own_accounts_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number, &origin),
         vec![
-            Account::new(anchor_number, origin.clone(), None, None, None),
+            Account::new(anchor_number, origin.clone(), None, true, None),
             Account::new_full(
                 anchor_number,
                 origin.clone(),
                 Some("Alice".to_string()),
-                None,
+                false,
                 Some(1),
                 None,
                 None
@@ -426,12 +426,12 @@ fn should_only_get_own_accounts_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number_two, &origin),
         vec![
-            Account::new(anchor_number_two, origin.clone(), None, None, None),
+            Account::new(anchor_number_two, origin.clone(), None, true, None),
             Account::new_full(
                 anchor_number_two,
                 origin.clone(),
                 Some("Bob".to_string()),
-                None,
+                false,
                 Some(2),
                 None,
                 None
@@ -459,12 +459,12 @@ fn should_update_account_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number, &origin),
         vec![
-            Account::new(anchor_number, origin.clone(), None, None, None),
+            Account::new(anchor_number, origin.clone(), None, true, None),
             Account::new_full(
                 anchor_number,
                 origin.clone(),
                 Some("Alice".to_string()),
-                None,
+                false,
                 Some(1),
                 None,
                 None
@@ -473,7 +473,7 @@ fn should_update_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Bob".to_string()),
-                None,
+                false,
                 Some(2),
                 None,
                 None
@@ -494,7 +494,7 @@ fn should_update_account_for_origin() {
             anchor_number,
             origin.clone(),
             Some("Becky".to_string()),
-            None,
+            false,
             Some(1),
             None,
             None
@@ -504,12 +504,12 @@ fn should_update_account_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number, &origin),
         vec![
-            Account::new(anchor_number, origin.clone(), None, None, None),
+            Account::new(anchor_number, origin.clone(), None, true, None),
             Account::new_full(
                 anchor_number,
                 origin.clone(),
                 Some("Becky".to_string()),
-                None,
+                false,
                 Some(1),
                 None,
                 None
@@ -518,7 +518,7 @@ fn should_update_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Bob".to_string()),
-                None,
+                false,
                 Some(2),
                 None,
                 None
@@ -546,12 +546,12 @@ fn should_update_default_account_for_origin() {
     assert_eq!(
         get_accounts_for_origin(anchor_number, &origin),
         vec![
-            Account::new(anchor_number, origin.clone(), None, None, None),
+            Account::new(anchor_number, origin.clone(), None, true, None),
             Account::new_full(
                 anchor_number,
                 origin.clone(),
                 Some("Alice".to_string()),
-                None,
+                false,
                 Some(1),
                 None,
                 None
@@ -560,7 +560,7 @@ fn should_update_default_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Bob".to_string()),
-                None,
+                false,
                 Some(2),
                 None,
                 None
@@ -581,7 +581,7 @@ fn should_update_default_account_for_origin() {
             anchor_number,
             origin.clone(),
             Some("Becky".to_string()),
-            None,
+            true,
             Some(3),
             None,
             Some(anchor_number)
@@ -595,7 +595,7 @@ fn should_update_default_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Becky".to_string()),
-                None,
+                true,
                 Some(3),
                 None,
                 Some(anchor_number)
@@ -604,7 +604,7 @@ fn should_update_default_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Alice".to_string()),
-                None,
+                false,
                 Some(1),
                 None,
                 None
@@ -613,7 +613,7 @@ fn should_update_default_account_for_origin() {
                 anchor_number,
                 origin.clone(),
                 Some("Bob".to_string()),
-                None,
+                false,
                 Some(2),
                 None,
                 None

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -59,6 +59,9 @@ pub fn create_account_for_origin(
                 anchor_number,
                 name: name.clone(),
                 origin,
+                // TODO[ID-361]: Read the is_default function parameter when it becomes available.
+                // For now, assume that the newly creted account should be the default.
+                is_default: true,
             })
             .map_err(|err| CreateAccountError::InternalCanisterError(format!("{err}")))
     })?;
@@ -113,6 +116,11 @@ pub fn update_account_for_origin(
                             anchor_number,
                             name: new_name.clone(),
                             origin: origin.clone(),
+                            // TODO[ID-362]: Read the is_default function parameter when it becomes
+                            // TODO[ID-362]: available.
+                            // For now, the default status of the account cannot be changed using
+                            // this function.
+                            is_default: None,
                         })
                         .map_err(|err| UpdateAccountError::InternalCanisterError(err.to_string()))?;
 

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -1004,6 +1004,7 @@ impl<M: Memory + Clone> Storage<M> {
             anchor_number,
             origin.to_string(),
             Some(params.name),
+            None,
             Some(account_number),
         ))
     }
@@ -1019,9 +1020,21 @@ impl<M: Memory + Clone> Storage<M> {
     ) -> Vec<Account> {
         check_frontend_length(origin);
         match self.lookup_application_number_with_origin(origin) {
-            None => vec![Account::new(anchor_number, origin.clone(), None, None)],
+            None => vec![Account::new(
+                anchor_number,
+                origin.clone(),
+                None,
+                None,
+                None,
+            )],
             Some(app_num) => match self.lookup_account_references(anchor_number, app_num) {
-                None => vec![Account::new(anchor_number, origin.clone(), None, None)],
+                None => vec![Account::new(
+                    anchor_number,
+                    origin.clone(),
+                    None,
+                    None,
+                    None,
+                )],
                 Some(refs) => refs
                     .iter()
                     .filter_map(|acc_ref| {
@@ -1061,6 +1074,7 @@ impl<M: Memory + Clone> Storage<M> {
                         params.origin.clone(),
                         None,
                         None,
+                        None,
                     ));
                 }
                 // check if there is a stored account reference list
@@ -1085,6 +1099,7 @@ impl<M: Memory + Clone> Storage<M> {
                             params.origin.clone(),
                             None,
                             None,
+                            None,
                         ));
                     }
 
@@ -1099,6 +1114,7 @@ impl<M: Memory + Clone> Storage<M> {
                                 params.anchor_number,
                                 params.origin.clone(),
                                 None,
+                                None,
                                 acc_ref.account_number,
                                 acc_ref.last_used,
                             )
@@ -1108,6 +1124,7 @@ impl<M: Memory + Clone> Storage<M> {
                     Some(Account::new(
                         params.anchor_number,
                         params.origin.clone(),
+                        None,
                         None,
                         None,
                     ))
@@ -1130,6 +1147,7 @@ impl<M: Memory + Clone> Storage<M> {
                             params.anchor_number,
                             params.origin.clone(),
                             Some(storable_account.name.clone()),
+                            None,
                             Some(account_number),
                             acc_ref.last_used,
                             storable_account.seed_from_anchor,
@@ -1205,6 +1223,7 @@ impl<M: Memory + Clone> Storage<M> {
             params.anchor_number,
             params.origin,
             Some(storable_account.name),
+            None,
             Some(account_number),
             account_reference.last_used,
             storable_account.seed_from_anchor,
@@ -1292,6 +1311,7 @@ impl<M: Memory + Clone> Storage<M> {
             params.anchor_number,
             params.origin,
             Some(storable_account.name),
+            None,
             Some(new_account_number),
             None,
             storable_account.seed_from_anchor,

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -942,21 +942,26 @@ impl<M: Memory + Clone> Storage<M> {
         &mut self,
         params: CreateAccountParams,
     ) -> Result<Account, StorageError> {
-        check_frontend_length(&params.origin);
-        let anchor_number = params.anchor_number;
-        let origin = &params.origin;
+        let CreateAccountParams {
+            anchor_number,
+            name,
+            origin,
+            is_default,
+        } = params;
+
+        check_frontend_length(&origin);
 
         // Create and store account in stable memory
         let account_number = self.allocate_account_number()?;
         let storable_account = StorableAccount {
-            name: params.name.clone(),
+            name: name.clone(),
             seed_from_anchor: None,
         };
         self.stable_account_memory
             .insert(account_number, storable_account);
 
         // Update application data
-        let app_num = self.lookup_or_insert_application_number_with_origin(origin);
+        let app_num = self.lookup_or_insert_application_number_with_origin(&origin);
 
         // Update counters with one more account.
         self.update_counters(app_num, anchor_number, AccountType::Account)?;
@@ -1003,8 +1008,8 @@ impl<M: Memory + Clone> Storage<M> {
         Ok(Account::new(
             anchor_number,
             origin.to_string(),
-            Some(params.name),
-            None,
+            Some(name),
+            is_default,
             Some(account_number),
         ))
     }
@@ -1024,7 +1029,7 @@ impl<M: Memory + Clone> Storage<M> {
                 anchor_number,
                 origin.clone(),
                 None,
-                None,
+                true,
                 None,
             )],
             Some(app_num) => match self.lookup_account_references(anchor_number, app_num) {
@@ -1032,7 +1037,8 @@ impl<M: Memory + Clone> Storage<M> {
                     anchor_number,
                     origin.clone(),
                     None,
-                    None,
+                    // Only the primary account exists, so it must be the default.
+                    true,
                     None,
                 )],
                 Some(refs) => refs
@@ -1073,7 +1079,7 @@ impl<M: Memory + Clone> Storage<M> {
                         params.anchor_number,
                         params.origin.clone(),
                         None,
-                        None,
+                        true,
                         None,
                     ));
                 }
@@ -1098,7 +1104,7 @@ impl<M: Memory + Clone> Storage<M> {
                             params.anchor_number,
                             params.origin.clone(),
                             None,
-                            None,
+                            true,
                             None,
                         ));
                     }
@@ -1114,7 +1120,7 @@ impl<M: Memory + Clone> Storage<M> {
                                 params.anchor_number,
                                 params.origin.clone(),
                                 None,
-                                None,
+                                true,
                                 acc_ref.account_number,
                                 acc_ref.last_used,
                             )
@@ -1125,7 +1131,7 @@ impl<M: Memory + Clone> Storage<M> {
                         params.anchor_number,
                         params.origin.clone(),
                         None,
-                        None,
+                        true,
                         None,
                     ))
                 }
@@ -1147,7 +1153,8 @@ impl<M: Memory + Clone> Storage<M> {
                             params.anchor_number,
                             params.origin.clone(),
                             Some(storable_account.name.clone()),
-                            None,
+                            // TODO[ID-363]: Read from the storage.
+                            false,
                             Some(account_number),
                             acc_ref.last_used,
                             storable_account.seed_from_anchor,
@@ -1162,21 +1169,44 @@ impl<M: Memory + Clone> Storage<M> {
     /// If the account number exists, then updates that account.
     /// If the account number doesn't exist, then gets or creates an application and creates and stores a default account.
     pub fn update_account(&mut self, params: UpdateAccountParams) -> Result<Account, StorageError> {
-        check_frontend_length(&params.origin);
-        match params.account_number {
+        let UpdateAccountParams {
+            anchor_number,
+            name,
+            origin,
+            account_number,
+            is_default,
+        } = params;
+
+        check_frontend_length(&origin);
+
+        // TODO[ID-363]: Once the default accounts are stored in the storage, we should start using
+        // TODO[ID-363]: the pre-existing value when `is_default` is None.
+        //
+        // TODO[ID-363]: If `is_default` is Some(true), we should unset the respective flag for
+        // TODO[ID-363]: the previous default account AND set the flag for this account.
+        //
+        // TODO[ID-363]: If `is_default` is Some(false), we should return an error if this account
+        // TODO[ID-363]: was the default account before, as we cannot have no default account.
+        // TODO[ID-363]: Otherwise, no changes required for the `is_default` flag of any accounts.
+        let is_default = is_default.unwrap_or(true);
+
+        match account_number {
             Some(account_number) => self.update_existing_account(UpdateExistingAccountParams {
                 account_number,
-                anchor_number: params.anchor_number,
-                name: params.name,
-                origin: params.origin,
+                anchor_number,
+                name,
+                origin,
+                is_default,
             }),
             None => {
                 // Default accounts are not stored by default.
                 // They are created only once they are updated.
                 self.create_default_account(CreateAccountParams {
-                    anchor_number: params.anchor_number,
-                    name: params.name,
-                    origin: params.origin.clone(),
+                    anchor_number,
+                    name,
+                    origin,
+                    // Ensure the first account is set as the default account.
+                    is_default: true,
                 })
             }
         }
@@ -1187,43 +1217,41 @@ impl<M: Memory + Clone> Storage<M> {
         &mut self,
         params: UpdateExistingAccountParams,
     ) -> Result<Account, StorageError> {
+        let UpdateExistingAccountParams {
+            account_number,
+            anchor_number,
+            name,
+            origin,
+            is_default,
+        } = params;
+
         // Check if account reference exists for given anchor number, origin and account number,
         // if the account refence exists for a given anchor, that means the anchor has access.
-        let application_number = self.lookup_application_number_with_origin(&params.origin);
+        let application_number = self.lookup_application_number_with_origin(&origin);
         let account_reference = self
-            .find_account_reference(
-                params.anchor_number,
-                application_number,
-                Some(params.account_number),
-            )
-            .ok_or(StorageError::AccountNotFound {
-                account_number: params.account_number,
-            })?;
+            .find_account_reference(anchor_number, application_number, Some(account_number))
+            .ok_or(StorageError::AccountNotFound { account_number })?;
         // Check if the account reference has an account number,
         // throw error if it doesn't since we only want to update
         // accounts with an account number in this function.
-        let account_number =
-            account_reference
-                .account_number
-                .ok_or(StorageError::AccountNotFound {
-                    account_number: params.account_number,
-                })?;
+        let account_number = account_reference
+            .account_number
+            .ok_or(StorageError::AccountNotFound { account_number })?;
         // Read account from storage
-        let mut storable_account = self.stable_account_memory.get(&account_number).ok_or(
-            StorageError::AccountNotFound {
-                account_number: params.account_number,
-            },
-        )?;
+        let mut storable_account = self
+            .stable_account_memory
+            .get(&account_number)
+            .ok_or(StorageError::AccountNotFound { account_number })?;
         // Update account and write back to storage
-        storable_account.name = params.name;
+        storable_account.name = name;
         self.stable_account_memory
-            .insert(params.account_number, storable_account.clone());
+            .insert(account_number, storable_account.clone());
         // Return updated account
         Ok(Account::new_full(
-            params.anchor_number,
-            params.origin,
+            anchor_number,
+            origin,
             Some(storable_account.name),
-            None,
+            is_default,
             Some(account_number),
             account_reference.last_used,
             storable_account.seed_from_anchor,
@@ -1238,28 +1266,30 @@ impl<M: Memory + Clone> Storage<M> {
         &mut self,
         params: CreateAccountParams,
     ) -> Result<Account, StorageError> {
+        let CreateAccountParams {
+            anchor_number,
+            name,
+            origin,
+            is_default,
+        } = params;
+
         // Create and store the default account.
         let new_account_number = self.allocate_account_number()?;
         let storable_account = StorableAccount {
-            name: params.name.clone(),
+            name: name.clone(),
             // This was a default account which uses the anchor number for the seed.
-            seed_from_anchor: Some(params.anchor_number),
+            seed_from_anchor: Some(anchor_number),
         };
         self.stable_account_memory
             .insert(new_account_number, storable_account.clone());
 
         // Get or create an application number from the account's origin.
-        let application_number =
-            self.lookup_or_insert_application_number_with_origin(&params.origin);
+        let application_number = self.lookup_or_insert_application_number_with_origin(&origin);
         // Update counters with one more account.
-        self.update_counters(
-            application_number,
-            params.anchor_number,
-            AccountType::Account,
-        )?;
+        self.update_counters(application_number, anchor_number, AccountType::Account)?;
 
         // Update the account references list.
-        let account_references_key = (params.anchor_number, application_number);
+        let account_references_key = (anchor_number, application_number);
         match self
             .stable_account_reference_list_memory
             .get(&account_references_key)
@@ -1277,7 +1307,7 @@ impl<M: Memory + Clone> Storage<M> {
                 // One new account reference was created.
                 self.update_counters(
                     application_number,
-                    params.anchor_number,
+                    anchor_number,
                     AccountType::AccountReference,
                 )?;
             }
@@ -1297,8 +1327,8 @@ impl<M: Memory + Clone> Storage<M> {
                 // This could happen if the account was removed and now we try to update it.
                 if !found_and_updated {
                     return Err(StorageError::MissingAccount {
-                        anchor_number: params.anchor_number,
-                        name: params.name.clone(),
+                        anchor_number,
+                        name: name.clone(),
                     });
                 }
                 self.stable_account_reference_list_memory
@@ -1308,10 +1338,10 @@ impl<M: Memory + Clone> Storage<M> {
 
         // Return created default account
         Ok(Account::new_full(
-            params.anchor_number,
-            params.origin,
+            anchor_number,
+            origin,
             Some(storable_account.name),
-            None,
+            is_default,
             Some(new_account_number),
             None,
             storable_account.seed_from_anchor,

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -65,6 +65,7 @@ pub struct Account {
     pub origin: FrontendHostname,
     pub last_used: Option<Timestamp>,
     pub name: Option<String>,
+    pub is_default: Option<bool>,
     seed_from_anchor: Option<AnchorNumber>,
 }
 
@@ -73,6 +74,7 @@ impl Account {
         anchor_number: AnchorNumber,
         origin: FrontendHostname,
         name: Option<String>,
+        is_default: Option<bool>,
         account_number: Option<AccountNumber>,
     ) -> Account {
         Self {
@@ -81,6 +83,7 @@ impl Account {
             origin,
             last_used: None,
             name,
+            is_default,
             seed_from_anchor: None,
         }
     }
@@ -89,6 +92,7 @@ impl Account {
         anchor_number: AnchorNumber,
         origin: FrontendHostname,
         name: Option<String>,
+        is_default: Option<bool>,
         account_number: Option<AccountNumber>,
         last_used: Option<Timestamp>,
     ) -> Account {
@@ -98,6 +102,7 @@ impl Account {
             origin,
             last_used,
             name,
+            is_default,
             seed_from_anchor: None,
         }
     }
@@ -106,6 +111,7 @@ impl Account {
         anchor_number: AnchorNumber,
         origin: FrontendHostname,
         name: Option<String>,
+        is_default: Option<bool>,
         account_number: Option<AccountNumber>,
         last_used: Option<Timestamp>,
         seed_from_anchor: Option<AnchorNumber>,
@@ -116,6 +122,7 @@ impl Account {
             origin,
             last_used,
             name,
+            is_default,
             seed_from_anchor,
         }
     }
@@ -139,6 +146,7 @@ impl Account {
             origin: self.origin.clone(),
             last_used: self.last_used,
             name: self.name.clone(),
+            is_default: self.is_default.clone(),
         }
     }
 

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -20,6 +20,7 @@ pub struct CreateAccountParams {
     pub anchor_number: AnchorNumber,
     pub name: String,
     pub origin: FrontendHostname,
+    pub is_default: bool,
 }
 
 pub struct UpdateAccountParams {
@@ -27,6 +28,7 @@ pub struct UpdateAccountParams {
     pub anchor_number: AnchorNumber,
     pub name: String,
     pub origin: FrontendHostname,
+    pub is_default: Option<bool>,
 }
 
 pub struct UpdateExistingAccountParams {
@@ -34,6 +36,7 @@ pub struct UpdateExistingAccountParams {
     pub anchor_number: AnchorNumber,
     pub name: String,
     pub origin: FrontendHostname,
+    pub is_default: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -65,7 +68,7 @@ pub struct Account {
     pub origin: FrontendHostname,
     pub last_used: Option<Timestamp>,
     pub name: Option<String>,
-    pub is_default: Option<bool>,
+    pub is_default: bool,
     seed_from_anchor: Option<AnchorNumber>,
 }
 
@@ -74,7 +77,7 @@ impl Account {
         anchor_number: AnchorNumber,
         origin: FrontendHostname,
         name: Option<String>,
-        is_default: Option<bool>,
+        is_default: bool,
         account_number: Option<AccountNumber>,
     ) -> Account {
         Self {
@@ -92,7 +95,7 @@ impl Account {
         anchor_number: AnchorNumber,
         origin: FrontendHostname,
         name: Option<String>,
-        is_default: Option<bool>,
+        is_default: bool,
         account_number: Option<AccountNumber>,
         last_used: Option<Timestamp>,
     ) -> Account {
@@ -111,7 +114,7 @@ impl Account {
         anchor_number: AnchorNumber,
         origin: FrontendHostname,
         name: Option<String>,
-        is_default: Option<bool>,
+        is_default: bool,
         account_number: Option<AccountNumber>,
         last_used: Option<Timestamp>,
         seed_from_anchor: Option<AnchorNumber>,

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -146,7 +146,7 @@ impl Account {
             origin: self.origin.clone(),
             last_used: self.last_used,
             name: self.name.clone(),
-            is_default: self.is_default.clone(),
+            is_default: self.is_default,
         }
     }
 

--- a/src/internet_identity/src/storage/account/tests.rs
+++ b/src/internet_identity/src/storage/account/tests.rs
@@ -54,6 +54,7 @@ fn should_create_additional_account() {
         anchor_number,
         origin: origin.clone(),
         name: account_name.clone(),
+        is_default: false,
     };
     storage
         .create_additional_account(new_account_params)
@@ -66,7 +67,7 @@ fn should_create_additional_account() {
         anchor_number,
         origin: origin.clone(),
         name: Some(account_name.clone()),
-        is_default: None,
+        is_default: false,
         last_used: None,
         seed_from_anchor: None,
     };
@@ -121,15 +122,16 @@ fn should_list_accounts() {
         anchor_number,
         origin: origin.clone(),
         name: account_name.clone(),
+        is_default: true,
     };
     let expected_additional_account = Account::new(
         anchor_number,
         origin.clone(),
         Some(account_name),
-        None,
+        false,
         Some(1),
     );
-    let expected_default_account = Account::new(anchor_number, origin.clone(), None, None, None);
+    let expected_default_account = Account::new(anchor_number, origin.clone(), None, true, None);
     storage.create_additional_account(new_account).unwrap();
 
     // 5. List accounts returns default account
@@ -190,6 +192,7 @@ fn should_list_all_identity_accounts() {
         anchor_number,
         origin: origin.clone(),
         name: account_name.clone(),
+        is_default: false,
     };
     storage
         .create_additional_account(new_account_params)
@@ -205,6 +208,7 @@ fn should_list_all_identity_accounts() {
         anchor_number,
         origin: origin_2.clone(),
         name: account_name.clone(),
+        is_default: false,
     };
     storage
         .create_additional_account(new_account_params)
@@ -244,7 +248,7 @@ fn should_update_default_account() {
 
     // 2. Default account exists withuot creating it
     let initial_accounts = storage.list_accounts(anchor_number, &origin);
-    let expected_unreserved_account = Account::new(anchor_number, origin.clone(), None, None, None);
+    let expected_unreserved_account = Account::new(anchor_number, origin.clone(), None, true, None);
     assert_eq!(initial_accounts, vec![expected_unreserved_account]);
 
     // 3. Update default account
@@ -253,6 +257,7 @@ fn should_update_default_account() {
         origin: origin.clone(),
         name: account_name.clone(),
         account_number: None,
+        is_default: None,
     };
     let new_account = storage.update_account(updated_account_params).unwrap();
 
@@ -263,7 +268,7 @@ fn should_update_default_account() {
             anchor_number,
             origin,
             Some(account_name),
-            None,
+            true,
             new_account.account_number,
             None,
             Some(anchor_number),
@@ -322,6 +327,7 @@ fn should_update_additional_account() {
         anchor_number,
         origin: origin.clone(),
         name: account_name.clone(),
+        is_default: false,
     };
     storage
         .create_additional_account(new_account_params)
@@ -333,6 +339,7 @@ fn should_update_additional_account() {
         anchor_number,
         origin: origin.clone(),
         name: new_account_name.clone(),
+        is_default: None,
         account_number: Some(1),
     };
     let updated_account = storage.update_account(updated_account_params).unwrap();
@@ -346,7 +353,7 @@ fn should_update_additional_account() {
             origin: origin.clone(),
             last_used: None,
             name: Some(new_account_name),
-            is_default: None,
+            is_default: false,
             seed_from_anchor: None,
         }
     );
@@ -409,6 +416,7 @@ fn should_count_accounts_different_anchors() {
         anchor_number: anchor_number_1,
         origin: origin_1.clone(),
         name: account_name_1.clone(),
+        is_default: false,
     };
     storage.create_additional_account(create_params_1).unwrap();
 
@@ -467,6 +475,7 @@ fn should_count_accounts_different_anchors() {
         anchor_number: anchor_number_2,
         origin: origin_2.clone(),
         name: account_name_2.clone(),
+        is_default: false,
     };
     storage.create_additional_account(create_params_2).unwrap();
 
@@ -533,7 +542,7 @@ fn should_read_default_account_with_empty_reference_list() {
     let default_account = storage.read_account(read_params).unwrap();
 
     // 4. Verify we get a synthetic default account
-    let expected_account = Account::new(anchor_number, origin, None, None, None);
+    let expected_account = Account::new(anchor_number, origin, None, true, None);
     assert_eq!(default_account, expected_account);
 }
 
@@ -554,6 +563,7 @@ fn should_not_read_account_from_wrong_anchor() {
         anchor_number: anchor_number_1,
         origin: origin.clone(),
         name: account_name,
+        is_default: true,
     };
     storage.create_additional_account(create_params).unwrap();
 

--- a/src/internet_identity/src/storage/account/tests.rs
+++ b/src/internet_identity/src/storage/account/tests.rs
@@ -66,6 +66,7 @@ fn should_create_additional_account() {
         anchor_number,
         origin: origin.clone(),
         name: Some(account_name.clone()),
+        is_default: None,
         last_used: None,
         seed_from_anchor: None,
     };
@@ -121,9 +122,14 @@ fn should_list_accounts() {
         origin: origin.clone(),
         name: account_name.clone(),
     };
-    let expected_additional_account =
-        Account::new(anchor_number, origin.clone(), Some(account_name), Some(1));
-    let expected_default_account = Account::new(anchor_number, origin.clone(), None, None);
+    let expected_additional_account = Account::new(
+        anchor_number,
+        origin.clone(),
+        Some(account_name),
+        None,
+        Some(1),
+    );
+    let expected_default_account = Account::new(anchor_number, origin.clone(), None, None, None);
     storage.create_additional_account(new_account).unwrap();
 
     // 5. List accounts returns default account
@@ -238,7 +244,7 @@ fn should_update_default_account() {
 
     // 2. Default account exists withuot creating it
     let initial_accounts = storage.list_accounts(anchor_number, &origin);
-    let expected_unreserved_account = Account::new(anchor_number, origin.clone(), None, None);
+    let expected_unreserved_account = Account::new(anchor_number, origin.clone(), None, None, None);
     assert_eq!(initial_accounts, vec![expected_unreserved_account]);
 
     // 3. Update default account
@@ -257,6 +263,7 @@ fn should_update_default_account() {
             anchor_number,
             origin,
             Some(account_name),
+            None,
             new_account.account_number,
             None,
             Some(anchor_number),
@@ -339,6 +346,7 @@ fn should_update_additional_account() {
             origin: origin.clone(),
             last_used: None,
             name: Some(new_account_name),
+            is_default: None,
             seed_from_anchor: None,
         }
     );
@@ -525,7 +533,7 @@ fn should_read_default_account_with_empty_reference_list() {
     let default_account = storage.read_account(read_params).unwrap();
 
     // 4. Verify we get a synthetic default account
-    let expected_account = Account::new(anchor_number, origin, None, None);
+    let expected_account = Account::new(anchor_number, origin, None, None, None);
     assert_eq!(default_account, expected_account);
 }
 

--- a/src/internet_identity/tests/integration/accounts.rs
+++ b/src/internet_identity/tests/integration/accounts.rs
@@ -48,7 +48,7 @@ fn should_create_account() -> Result<(), RejectResponse> {
             last_used: None,
             origin,
             name: Some(name),
-            is_default: false,
+            is_default: true,
         }
     );
     Ok(())

--- a/src/internet_identity/tests/integration/accounts.rs
+++ b/src/internet_identity/tests/integration/accounts.rs
@@ -339,7 +339,7 @@ fn should_update_account() -> Result<(), RejectResponse> {
             last_used: None,
             origin,
             name: new_name,
-            is_default: false,
+            is_default: true,
         }
     );
     Ok(())

--- a/src/internet_identity/tests/integration/accounts.rs
+++ b/src/internet_identity/tests/integration/accounts.rs
@@ -48,7 +48,7 @@ fn should_create_account() -> Result<(), RejectResponse> {
             last_used: None,
             origin,
             name: Some(name),
-            is_default: None,
+            is_default: false,
         }
     );
     Ok(())
@@ -117,28 +117,28 @@ fn should_list_accounts() -> Result<(), RejectResponse> {
                 origin: origin.clone(),
                 last_used: None,
                 name: None,
-                is_default: None,
+                is_default: true,
             },
             AccountInfo {
                 account_number: first_created_account.account_number,
                 origin: origin.clone(),
                 last_used: None,
                 name: Some(name),
-                is_default: None,
+                is_default: false,
             },
             AccountInfo {
                 account_number: second_created_account.account_number,
                 origin: origin.clone(),
                 last_used: None,
                 name: Some(name_two),
-                is_default: None,
+                is_default: false,
             },
             AccountInfo {
                 account_number: third_created_account.account_number,
                 origin,
                 last_used: None,
                 name: Some(name_three),
-                is_default: None,
+                is_default: false,
             },
         ]
     );
@@ -171,7 +171,7 @@ fn should_list_default_account() -> Result<(), RejectResponse> {
             origin: origin.clone(),
             last_used: None,
             name: None,
-            is_default: None,
+            is_default: true,
         },]
     );
     Ok(())
@@ -252,21 +252,21 @@ fn should_list_only_own_accounts() -> Result<(), RejectResponse> {
                 origin: origin.clone(),
                 last_used: None,
                 name: None,
-                is_default: None,
+                is_default: true,
             },
             AccountInfo {
                 account_number: first_created_account.account_number,
                 origin: origin.clone(),
                 last_used: None,
                 name: Some(name),
-                is_default: None,
+                is_default: false,
             },
             AccountInfo {
                 account_number: second_created_account.account_number,
                 origin: origin.clone(),
                 last_used: None,
                 name: Some(name_two),
-                is_default: None,
+                is_default: false,
             },
         ]
     );
@@ -280,14 +280,14 @@ fn should_list_only_own_accounts() -> Result<(), RejectResponse> {
                 origin: origin.clone(),
                 last_used: None,
                 name: None,
-                is_default: None,
+                is_default: true,
             },
             AccountInfo {
                 account_number: another_identity_account.account_number,
                 origin,
                 last_used: None,
                 name: Some(name_three),
-                is_default: None,
+                is_default: false,
             },
         ]
     );
@@ -339,7 +339,7 @@ fn should_update_account() -> Result<(), RejectResponse> {
             last_used: None,
             origin,
             name: new_name,
-            is_default: None,
+            is_default: false,
         }
     );
     Ok(())
@@ -410,7 +410,7 @@ fn should_update_default_account() -> Result<(), RejectResponse> {
             origin: origin.clone(),
             last_used: None,
             name: None,
-            is_default: None,
+            is_default: true,
         },]
     );
 
@@ -437,7 +437,7 @@ fn should_update_default_account() -> Result<(), RejectResponse> {
             last_used: None,
             origin: origin.clone(),
             name: Some(name.clone()),
-            is_default: None,
+            is_default: true,
         }
     );
 
@@ -459,7 +459,7 @@ fn should_update_default_account() -> Result<(), RejectResponse> {
             origin,
             last_used: None,
             name: Some(name),
-            is_default: None,
+            is_default: true,
         },]
     );
 

--- a/src/internet_identity/tests/integration/accounts.rs
+++ b/src/internet_identity/tests/integration/accounts.rs
@@ -459,7 +459,9 @@ fn should_update_default_account() -> Result<(), RejectResponse> {
             origin,
             last_used: None,
             name: Some(name),
-            is_default: true,
+            // TODO[ID-363]: Expect that the `is_default` flag is persisted.
+            // Currently, this is just a mock value.
+            is_default: false,
         },]
     );
 

--- a/src/internet_identity/tests/integration/accounts.rs
+++ b/src/internet_identity/tests/integration/accounts.rs
@@ -47,7 +47,8 @@ fn should_create_account() -> Result<(), RejectResponse> {
             account_number: Some(1),
             last_used: None,
             origin,
-            name: Some(name)
+            name: Some(name),
+            is_default: None,
         }
     );
     Ok(())
@@ -115,25 +116,29 @@ fn should_list_accounts() -> Result<(), RejectResponse> {
                 account_number: None,
                 origin: origin.clone(),
                 last_used: None,
-                name: None
+                name: None,
+                is_default: None,
             },
             AccountInfo {
                 account_number: first_created_account.account_number,
                 origin: origin.clone(),
                 last_used: None,
-                name: Some(name)
+                name: Some(name),
+                is_default: None,
             },
             AccountInfo {
                 account_number: second_created_account.account_number,
                 origin: origin.clone(),
                 last_used: None,
-                name: Some(name_two)
+                name: Some(name_two),
+                is_default: None,
             },
             AccountInfo {
                 account_number: third_created_account.account_number,
                 origin,
                 last_used: None,
-                name: Some(name_three)
+                name: Some(name_three),
+                is_default: None,
             },
         ]
     );
@@ -165,7 +170,8 @@ fn should_list_default_account() -> Result<(), RejectResponse> {
             account_number: None,
             origin: origin.clone(),
             last_used: None,
-            name: None
+            name: None,
+            is_default: None,
         },]
     );
     Ok(())
@@ -245,19 +251,22 @@ fn should_list_only_own_accounts() -> Result<(), RejectResponse> {
                 account_number: None,
                 origin: origin.clone(),
                 last_used: None,
-                name: None
+                name: None,
+                is_default: None,
             },
             AccountInfo {
                 account_number: first_created_account.account_number,
                 origin: origin.clone(),
                 last_used: None,
-                name: Some(name)
+                name: Some(name),
+                is_default: None,
             },
             AccountInfo {
                 account_number: second_created_account.account_number,
                 origin: origin.clone(),
                 last_used: None,
-                name: Some(name_two)
+                name: Some(name_two),
+                is_default: None,
             },
         ]
     );
@@ -270,13 +279,15 @@ fn should_list_only_own_accounts() -> Result<(), RejectResponse> {
                 account_number: None,
                 origin: origin.clone(),
                 last_used: None,
-                name: None
+                name: None,
+                is_default: None,
             },
             AccountInfo {
                 account_number: another_identity_account.account_number,
                 origin,
                 last_used: None,
-                name: Some(name_three)
+                name: Some(name_three),
+                is_default: None,
             },
         ]
     );
@@ -327,7 +338,8 @@ fn should_update_account() -> Result<(), RejectResponse> {
             account_number: created_account.account_number,
             last_used: None,
             origin,
-            name: new_name
+            name: new_name,
+            is_default: None,
         }
     );
     Ok(())
@@ -397,7 +409,8 @@ fn should_update_default_account() -> Result<(), RejectResponse> {
             account_number: None,
             origin: origin.clone(),
             last_used: None,
-            name: None
+            name: None,
+            is_default: None,
         },]
     );
 
@@ -423,7 +436,8 @@ fn should_update_default_account() -> Result<(), RejectResponse> {
             account_number: Some(1),
             last_used: None,
             origin: origin.clone(),
-            name: Some(name.clone())
+            name: Some(name.clone()),
+            is_default: None,
         }
     );
 
@@ -444,7 +458,8 @@ fn should_update_default_account() -> Result<(), RejectResponse> {
             account_number: Some(1),
             origin,
             last_used: None,
-            name: Some(name)
+            name: Some(name),
+            is_default: None,
         },]
     );
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -344,6 +344,7 @@ pub struct AccountInfo {
     pub origin: FrontendHostname,
     pub last_used: Option<Timestamp>,
     pub name: Option<String>,
+    pub is_default: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -344,7 +344,7 @@ pub struct AccountInfo {
     pub origin: FrontendHostname,
     pub last_used: Option<Timestamp>,
     pub name: Option<String>,
-    pub is_default: Option<bool>,
+    pub is_default: bool,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
# Motivation

This is the first step towards supporting the new concept of default accounts. The FE needs a way to distinguish default and non-default accounts associates with a (identity, application) pair.

# Changes

Add the `is_default` to the Candid API and propagate it through the Rust types. 

The data isn't being stored yet, so most uses are just stubs with TODO references. In some trivial cases (and in testing), the uses are actually already set correctly, e.g., the first account is marked as the default, and the subsequent ones are marked as non-default. 

# Tests

Existing CI tests should suffice. 





<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


