### PR TITLE
feat: Add default account API

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -635,6 +635,28 @@ type AccountDelegationError = variant {
     NoSuchDelegation;
 };
 
+type GetDefaultAccountError = variant {
+    InternalCanisterError : text;
+    Unauthorized : principal;
+    NoSuchAnchor;
+    NoSuchOrigin : record {
+        anchor_number : UserNumber;
+    };
+};
+
+type SetDefaultAccountError = variant {
+    InternalCanisterError : text;
+    Unauthorized : principal;
+    NoSuchAnchor;
+    NoSuchOrigin : record {
+        anchor_number : UserNumber;
+    };
+    NoSuchAccount : record {
+        anchor_number : UserNumber;
+        account_number : opt AccountNumber;
+    };
+};
+
 type PrepareAccountDelegation = record {
     user_key : UserKey;
     expiration : Timestamp;
@@ -985,4 +1007,15 @@ service : (opt InternetIdentityInit) -> {
         session_key : SessionKey,
         expiration : Timestamp
     ) -> (variant { Ok : SignedDelegation; Err : AccountDelegationError }) query;
+
+    get_default_account : (
+        anchor_number : UserNumber,
+        origin : FrontendHostname,
+    ) -> (variant { Ok : AccountInfo; Err: GetDefaultAccountError });
+
+    set_default_account : (
+        anchor_number : UserNumber,
+        origin : FrontendHostname,
+        account_number : opt AccountNumber;
+    ) -> (variant { Ok : AccountInfo; Err: SetDefaultAccountError });
 };

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -389,6 +389,32 @@ fn update_account(
 }
 
 #[update]
+fn get_default_account(
+    anchor_number: AnchorNumber,
+    _origin: FrontendHostname,
+) -> Result<AccountInfo, GetDefaultAccountError> {
+    check_authorization(anchor_number)
+        .map_err(|err| GetDefaultAccountError::Unauthorized(err.principal))?;
+
+    Err(GetDefaultAccountError::InternalCanisterError(
+        "Function get_default_account is not implemented yet.".to_string(),
+    ))
+}
+
+#[update]
+fn set_default_account(
+    anchor_number: AnchorNumber,
+    _origin: FrontendHostname,
+) -> Result<AccountInfo, SetDefaultAccountError> {
+    check_authorization(anchor_number)
+        .map_err(|err| SetDefaultAccountError::Unauthorized(err.principal))?;
+
+    Err(SetDefaultAccountError::InternalCanisterError(
+        "Function set_default_account is not implemented yet.".to_string(),
+    ))
+}
+
+#[update]
 async fn prepare_account_delegation(
     anchor_number: AnchorNumber,
     origin: FrontendHostname,

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -432,3 +432,25 @@ pub enum AccountNameValidationError {
 pub struct DummyAuthConfig {
     pub prompt_for_index: bool,
 }
+
+#[derive(CandidType, Debug, Deserialize)]
+pub enum GetDefaultAccountError {
+    InternalCanisterError(String),
+    Unauthorized(Principal),
+    NoSuchAnchor,
+    NoSuchOrigin { anchor_number: AnchorNumber },
+}
+
+#[derive(CandidType, Debug, Deserialize)]
+pub enum SetDefaultAccountError {
+    InternalCanisterError(String),
+    Unauthorized(Principal),
+    NoSuchAnchor,
+    NoSuchOrigin {
+        anchor_number: AnchorNumber,
+    },
+    NoSuchAccount {
+        anchor_number: AnchorNumber,
+        account_number: Option<AccountNumber>, // None is the unreserved default account
+    },
+}


### PR DESCRIPTION
# Motivation

This is the first step towards supporting the new concept of default accounts. The FE needs a way to get the default account associated with an (identity, application) pair.

# Changes

Added `set_default_account` and `get_default_account`. These function are not implemented yet, i.e., calling them will always result in an error.

# Tests

Existing CI tests should suffice.