### PR TITLE
feat: Setting and getting default accounts

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -483,7 +483,7 @@ export const idlFactory = ({ IDL }) => {
     'InternalCanisterError' : IDL.Text,
     'Unauthorized' : IDL.Principal,
     'NoSuchAccount' : IDL.Record({
-      'account_number' : IDL.Opt(AccountNumber),
+      'origin' : FrontendHostname,
       'anchor_number' : UserNumber,
     }),
   });

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -896,7 +896,7 @@ export type SetDefaultAccountError = {
   { 'Unauthorized' : Principal } |
   {
     'NoSuchAccount' : {
-      'account_number' : [] | [AccountNumber],
+      'origin' : FrontendHostname,
       'anchor_number' : UserNumber,
     }
   };

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -653,7 +653,7 @@ type SetDefaultAccountError = variant {
     };
     NoSuchAccount : record {
         anchor_number : UserNumber;
-        account_number : opt AccountNumber;
+        origin : FrontendHostname;
     };
 };
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1011,7 +1011,7 @@ service : (opt InternetIdentityInit) -> {
     get_default_account : (
         anchor_number : UserNumber,
         origin : FrontendHostname,
-    ) -> (variant { Ok : AccountInfo; Err: GetDefaultAccountError });
+    ) -> (variant { Ok : AccountInfo; Err: GetDefaultAccountError }) query;
 
     set_default_account : (
         anchor_number : UserNumber,

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -851,22 +851,18 @@ fn should_get_default_account_for_origin() {
         get_accounts_for_origin(anchor_number, &origin),
         vec![
             Account::synthetic(anchor_number, origin.clone()),
-            Account {
+            Account::new(
                 anchor_number,
-                origin: origin.clone(),
-                account_number: Some(1),
-                name: Some("Alice".to_string()),
-                last_used: None,
-                seed_from_anchor: None,
-            },
-            Account {
+                origin.clone(),
+                Some("Alice".to_string()),
+                Some(1)
+            ),
+            Account::new(
                 anchor_number,
-                origin: origin.clone(),
-                account_number: Some(2),
-                name: Some("Bob".to_string()),
-                last_used: None,
-                seed_from_anchor: None,
-            }
+                origin.clone(),
+                Some("Bob".to_string()),
+                Some(2)
+            ),
         ]
     );
 

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -996,7 +996,7 @@ fn should_get_default_account_for_origin() {
 }
 
 #[test]
-fn cannot_get_default_before_update_account_for_origin() {
+fn can_get_default_before_update_account_for_origin() {
     use crate::state::{storage_borrow_mut, storage_replace};
     use crate::storage::Storage;
     use ic_stable_structures::VectorMemory;
@@ -1011,7 +1011,7 @@ fn cannot_get_default_before_update_account_for_origin() {
 
     assert_eq!(
         result,
-        Err(GetDefaultAccountError::NoSuchOrigin { anchor_number })
+        Ok(Account::synthetic(anchor_number, origin.clone()).to_info())
     );
 }
 

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -54,7 +54,7 @@ fn try_read_account_info(
         storage.read_account(ReadAccountParams {
             account_number,
             anchor_number,
-            origin: &origin,
+            origin,
             known_app_num: Some(application_number),
         })
     }) else {

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -60,8 +60,7 @@ fn try_read_account_info(
     }) else {
         let account_str = account_number
             .map(|num| format!("#{}", num))
-            // The following case should not happen, as it is handled by `read_account` above.
-            // We include it here nonetheless for completeness.
+            // This can happen if update_account_for_origin was never called to init this account.
             .unwrap_or_else(|| "without a number".to_string());
 
         let message = format!(

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -391,28 +391,30 @@ fn update_account(
 #[update]
 fn get_default_account(
     anchor_number: AnchorNumber,
-    _origin: FrontendHostname,
+    origin: FrontendHostname,
 ) -> Result<AccountInfo, GetDefaultAccountError> {
     check_authorization(anchor_number)
         .map_err(|err| GetDefaultAccountError::Unauthorized(err.principal))?;
 
-    Err(GetDefaultAccountError::InternalCanisterError(
-        "Function get_default_account is not implemented yet.".to_string(),
-    ))
+    let default_account_info =
+        account_management::get_default_account_for_origin(anchor_number, origin)?;
+
+    Ok(default_account_info)
 }
 
 #[update]
 fn set_default_account(
     anchor_number: AnchorNumber,
-    _origin: FrontendHostname,
-    _account_number: Option<AccountNumber>,
+    origin: FrontendHostname,
+    account_number: Option<AccountNumber>,
 ) -> Result<AccountInfo, SetDefaultAccountError> {
     check_authorization(anchor_number)
         .map_err(|err| SetDefaultAccountError::Unauthorized(err.principal))?;
 
-    Err(SetDefaultAccountError::InternalCanisterError(
-        "Function set_default_account is not implemented yet.".to_string(),
-    ))
+    let default_account_info =
+        account_management::set_default_account_for_origin(anchor_number, origin, account_number)?;
+
+    Ok(default_account_info)
 }
 
 #[update]

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -388,7 +388,7 @@ fn update_account(
     }
 }
 
-#[update]
+#[query]
 fn get_default_account(
     anchor_number: AnchorNumber,
     origin: FrontendHostname,

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -1065,9 +1065,9 @@ impl<M: Memory + Clone> Storage<M> {
     ) -> Vec<Account> {
         check_frontend_length(origin);
         match self.lookup_application_number_with_origin(origin) {
-            None => vec![Account::new(anchor_number, origin.clone(), None, None)],
+            None => vec![Account::synthetic(anchor_number, origin.clone())],
             Some(app_num) => match self.lookup_account_references(anchor_number, app_num) {
-                None => vec![Account::new(anchor_number, origin.clone(), None, None)],
+                None => vec![Account::synthetic(anchor_number, origin.clone())],
                 Some(refs) => refs
                     .iter()
                     .filter_map(|acc_ref| {

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -91,8 +91,8 @@ impl Account {
             account_number,
             anchor_number,
             origin,
-            last_used: None,
             name,
+            last_used: None,
             seed_from_anchor: None,
         }
     }

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -65,7 +65,7 @@ pub struct Account {
     pub origin: FrontendHostname,
     pub last_used: Option<Timestamp>,
     pub name: Option<String>,
-    pub(crate) seed_from_anchor: Option<AnchorNumber>,
+    seed_from_anchor: Option<AnchorNumber>,
 }
 
 impl Account {

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -65,7 +65,7 @@ pub struct Account {
     pub origin: FrontendHostname,
     pub last_used: Option<Timestamp>,
     pub name: Option<String>,
-    seed_from_anchor: Option<AnchorNumber>,
+    pub(crate) seed_from_anchor: Option<AnchorNumber>,
 }
 
 impl Account {

--- a/src/internet_identity/src/storage/account.rs
+++ b/src/internet_identity/src/storage/account.rs
@@ -69,6 +69,18 @@ pub struct Account {
 }
 
 impl Account {
+    /// A default account that is not meant to be stored.
+    pub fn synthetic(anchor_number: AnchorNumber, origin: FrontendHostname) -> Self {
+        Self {
+            anchor_number,
+            origin,
+            account_number: None,
+            last_used: None,
+            name: None,
+            seed_from_anchor: None,
+        }
+    }
+
     pub fn new(
         anchor_number: AnchorNumber,
         origin: FrontendHostname,

--- a/src/internet_identity/src/storage/account/tests.rs
+++ b/src/internet_identity/src/storage/account/tests.rs
@@ -123,7 +123,7 @@ fn should_list_accounts() {
     };
     let expected_additional_account =
         Account::new(anchor_number, origin.clone(), Some(account_name), Some(1));
-    let expected_default_account = Account::new(anchor_number, origin.clone(), None, None);
+    let expected_default_account = Account::synthetic(anchor_number, origin.clone());
     storage.create_additional_account(new_account).unwrap();
 
     // 5. List accounts returns default account
@@ -238,7 +238,7 @@ fn should_update_default_account() {
 
     // 2. Default account exists withuot creating it
     let initial_accounts = storage.list_accounts(anchor_number, &origin);
-    let expected_unreserved_account = Account::new(anchor_number, origin.clone(), None, None);
+    let expected_unreserved_account = Account::synthetic(anchor_number, origin.clone());
     assert_eq!(initial_accounts, vec![expected_unreserved_account]);
 
     // 3. Update default account
@@ -525,7 +525,7 @@ fn should_read_default_account_with_empty_reference_list() {
     let default_account = storage.read_account(read_params).unwrap();
 
     // 4. Verify we get a synthetic default account
-    let expected_account = Account::new(anchor_number, origin, None, None);
+    let expected_account = Account::synthetic(anchor_number, origin.clone());
     assert_eq!(default_account, expected_account);
 }
 

--- a/src/internet_identity/src/storage/storable.rs
+++ b/src/internet_identity/src/storage/storable.rs
@@ -4,6 +4,7 @@ pub mod account_reference;
 pub mod account_reference_list;
 pub mod accounts_counter;
 pub mod anchor;
+pub mod anchor_application_config;
 pub mod anchor_number;
 pub mod anchor_number_list;
 pub mod application;

--- a/src/internet_identity/src/storage/storable/anchor_application_config.rs
+++ b/src/internet_identity/src/storage/storable/anchor_application_config.rs
@@ -1,0 +1,26 @@
+use crate::storage::storable::account_number::StorableAccountNumber;
+use ic_stable_structures::storable::Bound;
+use ic_stable_structures::Storable;
+use minicbor::{Decode, Encode};
+use std::borrow::Cow;
+
+#[derive(Encode, Decode, Default, Clone, Ord, Eq, PartialEq, PartialOrd)]
+#[cbor(map)]
+pub struct AnchorApplicationConfig {
+    #[n(0)]
+    pub default_account_number: Option<StorableAccountNumber>, // None is the unreserved default account
+}
+
+impl Storable for AnchorApplicationConfig {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        let mut buffer = Vec::new();
+        minicbor::encode(self, &mut buffer).expect("failed to encode AnchorApplicationConfig");
+        Cow::Owned(buffer)
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        minicbor::decode(&bytes).expect("failed to decode AnchorApplicationConfig")
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -433,7 +433,7 @@ pub struct DummyAuthConfig {
     pub prompt_for_index: bool,
 }
 
-#[derive(CandidType, Debug, Deserialize)]
+#[derive(CandidType, Debug, Deserialize, PartialEq)]
 pub enum GetDefaultAccountError {
     InternalCanisterError(String),
     Unauthorized(Principal),
@@ -441,7 +441,7 @@ pub enum GetDefaultAccountError {
     NoSuchOrigin { anchor_number: AnchorNumber },
 }
 
-#[derive(CandidType, Debug, Deserialize)]
+#[derive(CandidType, Debug, Deserialize, PartialEq)]
 pub enum SetDefaultAccountError {
     InternalCanisterError(String),
     Unauthorized(Principal),
@@ -451,6 +451,6 @@ pub enum SetDefaultAccountError {
     },
     NoSuchAccount {
         anchor_number: AnchorNumber,
-        account_number: Option<AccountNumber>, // None is the unreserved default account
+        origin: FrontendHostname,
     },
 }


### PR DESCRIPTION
# Motivation

This is the next step towards supporting the new concept of default accounts. The BE now allows authorized clients to set and get default accounts for each (anchor, origin).

# Changes

* Implemented `set_default_account` and `get_default_account`.
* `update_account_for_origin` initializes the default account in the `anchor_application_config` index while creating that account.

# Tests

## Coverage Summary
* Happy paths: Default retrieval, customization, reset, multi-origin
* Error cases: Non-existent anchor/origin/account
* Edge cases: Account state changes, operation sequencing 

## Details

### get_default_account_for_origin Tests

1. `should_get_default_account_for_origin` - Comprehensive integration test covering:
    * GET without SET (returns synthetic default)
    * SET to existing accounts + GET (customizes default)
    * SET to non-existent accounts + GET (SET fails, GET unchanged)
    * SET to None + GET (resets to synthetic default)
2. `can_get_default_before_update_account_for_origin` - Returns the synthetic account for uninitialized origins.
3. `should_get_updated_default_account_after_modification` - Returns updated default account with assigned account number after modification.
4. `should_fail_get_default_account_for_nonexistent_anchor` - Returns the synthetic account for non-existent anchors.
5. `should_get_default_account_for_different_origins` - Each origin has independent default accounts.

### set_default_account_for_origin Tests

Test scenarios:

✅ SET to existing accounts (succeeds)
✅ SET to non-existent accounts (fails with NoSuchAccount)
✅ SET to None (resets to synthetic default)
✅ State persistence across operations






<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->




