### PR TITLE
Instance check instead of cast

### DIFF
--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -108,7 +108,10 @@
     onintrostart={() => popoverRef?.showPopover()}
     onoutrostart={() => popoverRef?.hidePopover()}
     onfocusout={(e) => {
-      if (!popoverRef?.contains(e.relatedTarget as Node)) {
+      if (
+        !(e.relatedTarget instanceof Node) ||
+        !popoverRef?.contains(e.relatedTarget)
+      ) {
         anchorRef?.querySelector("button")?.focus();
         onClose?.();
       }


### PR DESCRIPTION
Instance check instead of cast, avoids possibly casting `null` to `Node` which could result in errors. 

Additionally, it handles cases where focus is lost without a new focus target and lastly this PR solves the IDE errors I was getting on my end, apparently not every IDE likes TS code within svelte event handlers.
<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
