### PR TITLE
Enable new Upgrade CTA

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -133,30 +133,15 @@
         </Button>
       </Tooltip>
     {/if}
-    {#if $AUTH_FLOW_UPDATES}
-      <div class="border-border-tertiary border-t"></div>
-      <div class="flex flex-row items-center justify-between gap-4">
-        <p class="text-text-secondary text-sm">
-          Still have an identity number?
-        </p>
-        <button
-          onclick={migrate}
-          class="text-text-primary text-sm font-semibold outline-0 hover:underline focus-visible:underline"
-        >
-          Upgrade
-        </button>
-      </div>
-    {:else}
-      <Button
+    <div class="border-border-tertiary border-t"></div>
+    <div class="flex flex-row items-center justify-between gap-4">
+      <p class="text-text-secondary text-sm">Still have an identity number?</p>
+      <button
         onclick={migrate}
-        variant="tertiary"
-        size="xl"
-        disabled={!supportsPasskeys ||
-          nonNullish(authenticatingProviderId) ||
-          isGoogleAuthenticating}
+        class="text-text-primary text-sm font-semibold outline-0 hover:underline focus-visible:underline"
       >
-        Upgrade from legacy identity
-      </Button>
-    {/if}
+        Upgrade
+      </button>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Enable the changes in the Upgrade from legacy identity CTA for all users.

# Changes

* Removed the conditional block that displayed either a legacy upgrade button or a new upgrade option based on the `$AUTH_FLOW_UPDATES` variable, ensuring a single upgrade UI is shown to all users.
* Streamlined the upgrade prompt and button presentation for users with an identity number, making the interface clearer and more consistent.

# Tests

Tested locally with mobile, desktop and light and dark mode.
