### PR TITLE
Change copy in passkey screen

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte
@@ -3,7 +3,6 @@
   import Button from "$lib/components/ui/Button.svelte";
   import PasskeyIllustration from "$lib/components/illustrations/PasskeyIllustration.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
-  import { AUTH_FLOW_UPDATES } from "$lib/state/featureFlags";
   import { waitFor } from "$lib/utils/utils";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import { HelpCircleIcon } from "@lucide/svelte";
@@ -48,11 +47,7 @@
 </div>
 <div class="flex flex-col gap-3">
   <Button onclick={setupNew} size="lg" disabled={isAuthenticating}>
-    {#if $AUTH_FLOW_UPDATES}
-      Create new identity
-    {:else}
-      Set up a new Passkey
-    {/if}
+    Create new identity
   </Button>
   <Tooltip
     label="Interaction canceled. Please try again."
@@ -69,13 +64,7 @@
         <ProgressRing />
         <span>Authenticating...</span>
       {:else}
-        <span>
-          {#if $AUTH_FLOW_UPDATES}
-            Use existing identity
-          {:else}
-            Use an existing Passkey
-          {/if}
-        </span>
+        <span>Use existing identity</span>
       {/if}
     </Button>
   </Tooltip>

--- a/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/alternativeOrigins.spec.ts
@@ -104,7 +104,7 @@ test("Should issue delegation when derivationOrigin is properly configured in /.
 
   // Create a new identity in II
   await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
-  await authPage.getByRole("button", { name: "Set up a new Passkey" }).click();
+  await authPage.getByRole("button", { name: "Create new identity" }).click();
   await authPage.getByLabel("Identity name").fill("John Doe");
   const auth = dummyAuth();
   auth(authPage);
@@ -241,7 +241,7 @@ test("Should issue the same principal to nice url and canonical url", async ({
   await authPage1
     .getByRole("button", { name: "Continue with Passkey" })
     .click();
-  await authPage1.getByRole("button", { name: "Set up a new Passkey" }).click();
+  await authPage1.getByRole("button", { name: "Create new identity" }).click();
   await authPage1.getByLabel("Identity name").fill("Test User");
   auth(authPage1);
   await authPage1.getByRole("button", { name: "Create Passkey" }).click();

--- a/src/frontend/tests/e2e-playwright/authorize/continue.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/continue.spec.ts
@@ -60,7 +60,7 @@ test("Authorize by signing in with a different passkey", async ({ page }) => {
       .click();
     auth1(authPage);
     await authPage
-      .getByRole("button", { name: "Use an existing Passkey" })
+      .getByRole("button", { name: "Use existing identity" })
       .click();
     await authPage.getByRole("button", { name: "Primary account" }).click();
   });

--- a/src/frontend/tests/e2e-playwright/authorize/delegationTtl.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/delegationTtl.spec.ts
@@ -18,7 +18,7 @@ test("Delegation maxTimeToLive: 1 min", async ({ page }) => {
 
   // Create new identity and authenticate
   await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
-  await authPage.getByRole("button", { name: "Set up a new Passkey" }).click();
+  await authPage.getByRole("button", { name: "Create new identity" }).click();
   await authPage.getByLabel("Identity name").fill("Test User");
   auth(authPage);
   await authPage.getByRole("button", { name: "Create Passkey" }).click();
@@ -53,7 +53,7 @@ test("Delegation maxTimeToLive: 1 day", async ({ page }) => {
 
   // Create new identity and authenticate
   await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
-  await authPage.getByRole("button", { name: "Set up a new Passkey" }).click();
+  await authPage.getByRole("button", { name: "Create new identity" }).click();
   await authPage.getByLabel("Identity name").fill("Test User");
   auth(authPage);
   await authPage.getByRole("button", { name: "Create Passkey" }).click();
@@ -87,7 +87,7 @@ test("Delegation maxTimeToLive: 2 months", async ({ page }) => {
 
   // Create new identity and authenticate
   await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
-  await authPage.getByRole("button", { name: "Set up a new Passkey" }).click();
+  await authPage.getByRole("button", { name: "Create new identity" }).click();
   await authPage.getByLabel("Identity name").fill("Test User");
   auth(authPage);
   await authPage.getByRole("button", { name: "Create Passkey" }).click();

--- a/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/authorize/index.spec.ts
@@ -19,9 +19,7 @@ test("Authorize by registering a new passkey", async ({ page }) => {
     await authPage
       .getByRole("button", { name: "Continue with Passkey" })
       .click();
-    await authPage
-      .getByRole("button", { name: "Set up a new Passkey" })
-      .click();
+    await authPage.getByRole("button", { name: "Create new identity" }).click();
     await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
     auth(authPage);
     await authPage.getByRole("button", { name: "Create Passkey" }).click();
@@ -38,7 +36,7 @@ test("Authorize by signing in with an existing passkey", async ({ page }) => {
       .click();
     auth(authPage);
     await authPage
-      .getByRole("button", { name: "Use an existing Passkey" })
+      .getByRole("button", { name: "Use existing identity" })
       .click();
     await authPage.getByRole("button", { name: "Primary account" }).click();
   });
@@ -65,7 +63,9 @@ test("Authorize by signing in from another device", async ({
       .click();
     cancelDummyAuth(authPage);
     await authPage
-      .getByRole("button", { name: "Use an existing Passkey" })
+      .getByRole("button", {
+        name: "Use existing identity",
+      })
       .click();
     await authPage
       .getByRole("heading", {
@@ -179,9 +179,7 @@ test("App logo appears when app is known", async ({ page }) => {
     await authPage
       .getByRole("button", { name: "Continue with Passkey" })
       .click();
-    await authPage
-      .getByRole("button", { name: "Set up a new Passkey" })
-      .click();
+    await authPage.getByRole("button", { name: "Create new identity" }).click();
     await authPage.getByLabel("Identity name").fill("John Doe");
     auth(authPage);
     await authPage.getByRole("button", { name: "Create Passkey" }).click();
@@ -202,7 +200,7 @@ test("App logo doesn't appear when app is not known", async ({ page }) => {
         .getByRole("button", { name: "Continue with Passkey" })
         .click();
       await authPage
-        .getByRole("button", { name: "Set up a new Passkey" })
+        .getByRole("button", { name: "Create new identity" })
         .click();
       await authPage.getByLabel("Identity name").fill("John Doe");
       auth(authPage);

--- a/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
@@ -25,7 +25,7 @@ test("User can log into the dashboard and add a new passkey from the same device
   await page.getByRole("link", { name: "Manage Identity" }).click();
   await page.getByRole("button", { name: "Continue with Passkey" }).click();
   auth(page);
-  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
 
   // Verify we're at the dashboard and have one passkey
   await page.waitForURL(II_URL + "/manage");
@@ -54,9 +54,7 @@ test("User can log into the dashboard and add a new passkey from the same device
   await newPage.getByRole("link", { name: "Manage Identity" }).click();
   await newPage.getByRole("button", { name: "Continue with Passkey" }).click();
   auth2(newPage);
-  await newPage
-    .getByRole("button", { name: "Use an existing Passkey" })
-    .click();
+  await newPage.getByRole("button", { name: "Use existing identity" }).click();
 
   await expect(
     newPage.getByText("Chrome").locator("..").getByLabel("Current Passkey"),
@@ -84,7 +82,7 @@ test("User can log in the dashboard and add a new passkey from another device", 
   await page.getByRole("link", { name: "Manage Identity" }).click();
   await page.getByRole("button", { name: "Continue with Passkey" }).click();
   auth(page);
-  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
 
   // Verify we're at the dashboard and have one passkey
   await page.waitForURL(II_URL + "/manage");

--- a/src/frontend/tests/e2e-playwright/dashboard/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/index.spec.ts
@@ -14,7 +14,7 @@ test.describe("Dashboard Navigation", () => {
     await page.getByRole("link", { name: "Manage Identity" }).click();
     await page.getByRole("button", { name: "Continue with Passkey" }).click();
     auth(page);
-    await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+    await page.getByRole("button", { name: "Use existing identity" }).click();
 
     // Verify we're at the dashboard
     await page.waitForURL(II_URL + "/manage");

--- a/src/frontend/tests/e2e-playwright/dashboard/migration.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/migration.spec.ts
@@ -107,7 +107,7 @@ test.describe("Migration", () => {
     await page.getByRole("link", { name: "Manage Identity" }).click();
     await page.getByRole("button", { name: "Continue with Passkey" }).click();
     auth(page);
-    await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+    await page.getByRole("button", { name: "Use existing identity" }).click();
     await page.waitForURL(II_URL + "/manage");
     await expect(
       page.getByRole("heading", {

--- a/src/frontend/tests/e2e-playwright/dashboard/removePasskey.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/removePasskey.spec.ts
@@ -22,7 +22,7 @@ test("User can remove a passkey when they have multiple access methods", async (
   await page.getByRole("link", { name: "Manage Identity" }).click();
   await page.getByRole("button", { name: "Continue with Passkey" }).click();
   auth(page);
-  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
 
   // Verify we're at the dashboard and have one passkey
   await page.waitForURL(II_URL + "/manage");
@@ -97,7 +97,7 @@ test("User cannot remove passkey if they only have one access method", async ({
   await page.getByRole("link", { name: "Manage Identity" }).click();
   await page.getByRole("button", { name: "Continue with Passkey" }).click();
   auth(page);
-  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
 
   // Verify we're at the dashboard and have one passkey
   await page.waitForURL(II_URL + "/manage");
@@ -123,7 +123,7 @@ test("User is logged out after removing the passkey they used to authenticate", 
   await page.getByRole("link", { name: "Manage Identity" }).click();
   await page.getByRole("button", { name: "Continue with Passkey" }).click();
   auth(page);
-  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
 
   // Verify we're at the dashboard and have one passkey
   await page.waitForURL(II_URL + "/manage");
@@ -194,7 +194,7 @@ test("User can cancel passkey removal", async ({ page }) => {
   await page.getByRole("link", { name: "Manage Identity" }).click();
   await page.getByRole("button", { name: "Continue with Passkey" }).click();
   auth(page);
-  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
 
   // Verify we're at the dashboard and have one passkey
   await page.waitForURL(II_URL + "/manage");

--- a/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/renamePasskeys.spec.ts
@@ -22,7 +22,7 @@ test("User can rename the current passkey used for authentication", async ({
   await page.getByRole("link", { name: "Manage Identity" }).click();
   await page.getByRole("button", { name: "Continue with Passkey" }).click();
   auth(page);
-  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
 
   // Verify we're at the dashboard and have one passkey
   await page.waitForURL(II_URL + "/manage");
@@ -69,7 +69,7 @@ test("User can rename a newly added passkey from the same device", async ({
   await page.getByRole("link", { name: "Manage Identity" }).click();
   await page.getByRole("button", { name: "Continue with Passkey" }).click();
   auth(page);
-  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
 
   // Verify we're at the dashboard and have one passkey
   await page.waitForURL(II_URL + "/manage");
@@ -111,7 +111,7 @@ test("User cannot rename passkey to an empty name nor is it renamed on cancel", 
   await page.getByRole("link", { name: "Manage Identity" }).click();
   await page.getByRole("button", { name: "Continue with Passkey" }).click();
   auth(page);
-  await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+  await page.getByRole("button", { name: "Use existing identity" }).click();
 
   // Verify we're at the dashboard and have one passkey
   await page.waitForURL(II_URL + "/manage");

--- a/src/frontend/tests/e2e-playwright/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/index.spec.ts
@@ -18,7 +18,7 @@ test.describe("First visit", () => {
     await page.goto(II_URL);
     await page.getByRole("link", { name: "Manage Identity" }).click();
     await page.getByRole("button", { name: "Continue with Passkey" }).click();
-    await page.getByRole("button", { name: "Set up a new Passkey" }).click();
+    await page.getByRole("button", { name: "Create new identity" }).click();
     await page.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
     auth(page);
     await page.getByRole("button", { name: "Create Passkey" }).click();
@@ -41,7 +41,7 @@ test.describe("First visit", () => {
     await page.getByRole("link", { name: "Manage Identity" }).click();
     await page.getByRole("button", { name: "Continue with Passkey" }).click();
     auth(page);
-    await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+    await page.getByRole("button", { name: "Use existing identity" }).click();
     await page.waitForURL(II_URL + "/manage");
     await expect(
       page.getByRole("heading", {
@@ -73,7 +73,7 @@ test.describe("First visit", () => {
       .click();
     cancelDummyAuth(newDevicePage);
     await newDevicePage
-      .getByRole("button", { name: "Use an existing Passkey" })
+      .getByRole("button", { name: "Use existing identity" })
       .click();
     await newDevicePage
       .getByRole("heading", {
@@ -267,7 +267,7 @@ test.describe("Last used identities listed", () => {
     await page.getByRole("button", { name: "Use another identity" }).click();
     await page.getByRole("button", { name: "Continue with Passkey" }).click();
     auth(page);
-    await page.getByRole("button", { name: "Use an existing Passkey" }).click();
+    await page.getByRole("button", { name: "Use existing identity" }).click();
     await page.waitForURL(II_URL + "/manage");
     await expect(
       page.getByRole("heading", {
@@ -286,7 +286,7 @@ test.describe("Last used identities listed", () => {
     await page.getByRole("link", { name: "Manage Identity" }).click();
     await page.getByRole("button", { name: "Use another identity" }).click();
     await page.getByRole("button", { name: "Continue with Passkey" }).click();
-    await page.getByRole("button", { name: "Set up a new Passkey" }).click();
+    await page.getByRole("button", { name: "Create new identity" }).click();
     await page.getByLabel("Identity name").fill(SECONDARY_USER_NAME);
     auth(page);
     await page.getByRole("button", { name: "Create Passkey" }).click();

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -114,7 +114,7 @@ export const createNewIdentityInII = async (
 
   // Create passkey identity
   await page.getByRole("button", { name: "Continue with Passkey" }).click();
-  await page.getByRole("button", { name: "Set up a new Passkey" }).click();
+  await page.getByRole("button", { name: "Create new identity" }).click();
   await page.getByLabel("Identity name").fill(name);
   dummyAuth(page);
   await page.getByRole("button", { name: "Create Passkey" }).click();


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Improve the user experience during the passkey flow.

# Changes

* Enable the new copy in the SetupOrUseExistingPasskey.svelte file.
* Change the text of the button to be clicked in e2e tests.

# Tests

See screenshot attached.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
