### PR TITLE
Restrict wave animation to the landing page

### DIFF
--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -66,15 +66,19 @@
     },
   ];
 
-  onMount(async () => {
-    setTimeout(
-      async () =>
-        await triggerDropWaveAnimation({ containerHeight: "h-[640px]" }),
-    );
-  });
-
-  onDestroy(() => {
-    void clearDropWaveAnimation();
+  // Only trigger the drop wave animation 100ms after the page has loaded,
+  // so we can cancel it if navigated to another route in that time window.
+  onMount(() => {
+    let cancelled = false;
+    setTimeout(() => {
+      if (!cancelled) {
+        void triggerDropWaveAnimation({ containerHeight: "h-[640px]" });
+      }
+    }, 100);
+    return () => {
+      cancelled = true;
+      void clearDropWaveAnimation();
+    };
   });
 </script>
 


### PR DESCRIPTION
Restrict wave animation to the landing page

# Changes

- Updated landing page to avoid triggering the wave animation when navigating to another page (e.g. /#authorize).

# Tests

- The issue only happens though the SSG landing page, so had to verify on a local production build instead of dev build.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
