### PR TITLE
Add user agent and is telegram to test app

### DIFF
--- a/demos/test-app/src/index.html
+++ b/demos/test-app/src/index.html
@@ -160,6 +160,11 @@
         <div id="messages"></div>
       </section>
       <section id="root-vc-flow"></section>
+      <section>
+        <h1>User Agent</h1>
+        <p id="userAgent"></p>
+        <p>Is telegram? <span id="isTelegram"></span></p>
+      </section>
     </main>
   </body>
 </html>

--- a/demos/test-app/src/index.tsx
+++ b/demos/test-app/src/index.tsx
@@ -243,7 +243,29 @@ const readCanisterId = (): string => {
   return canIdEl.dataset.canisterId!;
 };
 
+// Not entirely reliable, it fails on Android
+function isTgInAppBrowser() {
+  if (typeof window === "undefined") return false;
+
+  // Telegram's webview bridge in mobile apps (Android & iOS)
+  const hasBridge =
+    typeof (window as any).TelegramWebviewProxy === "object" ||
+    typeof (window as any).TelegramWebviewProxyProto === "object";
+
+  // Useful but not guaranteed on iOS; often present on Android
+  const ua = navigator.userAgent || "";
+  const hasUA = /\bTelegram(?:Android|-Android)?\b/i.test(ua);
+
+  return hasBridge || hasUA;
+}
+
 const init = async () => {
+  const userAgentElement = document.getElementById("userAgent") as HTMLElement;
+  userAgentElement.innerText = navigator.userAgent;
+  const isTelegramElement = document.getElementById(
+    "isTelegram",
+  ) as HTMLElement;
+  isTelegramElement.innerText = isTgInAppBrowser() ? "Yes" : "No";
   signInBtn.onclick = async () => {
     const maxTimeToLive_ = BigInt(maxTimeToLiveEl.value);
     // The default max TTL set in the @icp-sdk/auth/client library
@@ -381,7 +403,7 @@ const init = async () => {
   await updateAlternativeOriginsView();
 };
 
-init();
+window.addEventListener("DOMContentLoaded", init);
 
 whoamiBtn.addEventListener("click", async () => {
   const canisterId = Principal.fromText(readCanisterId());


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Make debugging in certain environments like twitter or telegram easier.

A new section is added to the test app to show the user agent and whether the code detects it's in a telegram webview or not.

# Changes

* Added a new section to the `index.html` UI to display the user's browser user agent and whether the app is running in Telegram's in-app browser.
* Implemented the `isTgInAppBrowser` function in `index.tsx` to detect Telegram's in-app browser using both the presence of webview bridge objects and user agent string matching.
* Updated the initialization logic to populate the new UI elements with the user agent and Telegram detection result.
* Changed app initialization to run on the `DOMContentLoaded` event instead of immediately, ensuring the UI elements exist before being accessed.

# Tests

[Deployed to mainnet](https://vt36r-2qaaa-aaaad-aad5a-cai.icp0.io/)

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
