### PR TITLE
Add type check for "navigator"

### DIFF
--- a/src/frontend/src/lib/stores/locale.store.ts
+++ b/src/frontend/src/lib/stores/locale.store.ts
@@ -16,7 +16,9 @@ export const locales = derived(ENABLE_ALL_LOCALES, () =>
 
 export const browserLocales = building
   ? [get(locales)[0]] // Fallback during SSG
-  : (navigator.languages ?? [navigator.language ?? availableLocales[0]]);
+  : "navigator" in globalThis
+    ? (navigator.languages ?? [navigator.language ?? availableLocales[0]])
+    : [get(locales)[0]]; // Fallback if no navigator available
 export const availableBrowserLocale =
   // Exact match
   browserLocales.find((ul) => get(locales).includes(ul)) ??


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Following error is thrown when running `npm run dev` in my machine: "ReferenceError: navigator is not defined".

The problem comes from `locale.store.ts`, which doesn't check that `navigator` is present in the global scope.

This doesn't seem to happen in all computers... However, the check shouldn't cause any damage and should only fix the problem.

# Changes

* Improved browser locale detection by checking for the existence of `navigator` in `globalThis` before accessing its properties, preventing runtime errors in environments where `navigator` is undefined.

# Tests

Tested locally.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
