### PR TITLE
Change referrer policy test app

### DIFF
--- a/demos/test-app/lib.rs
+++ b/demos/test-app/lib.rs
@@ -143,7 +143,10 @@ fn not_found_response(path: &str) -> HttpResponse {
 }
 
 fn static_headers() -> Vec<HeaderField> {
-    vec![("Access-Control-Allow-Origin".to_string(), "*".to_string())]
+    vec![
+        ("Access-Control-Allow-Origin".to_string(), "*".to_string()),
+        ("Referrer-Policy".to_string(), "strict-origin-when-cross-origin".to_string()),
+    ]
 }
 
 // Assets


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Change the referrer policy for the test app to share the referrer. The referrer is used to test the orphan error case.

# Changes

* Set `Referrer-Policy` to `strict-origin-when-cross-origin` in test app

# Tests

Test app in mainnet has been updated and now it shares the referrer.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
