### PR TITLE
Add created timestamp to identity switcher

### DIFF
--- a/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
+++ b/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
@@ -82,7 +82,7 @@
             </div>
             <div class="text-text-tertiary font-normal" aria-hidden="true">
               {#if nonNullish(date)}
-                <span>{$t`${name} | Created`} {date}</span>
+                <span>{$t`${name} | Created ${date}`}</span>
               {:else}
                 <span>{name}</span>
               {/if}

--- a/src/frontend/src/lib/locales/de.po
+++ b/src/frontend/src/lib/locales/de.po
@@ -18,7 +18,7 @@ msgid "{MAX_ACCOUNTS, plural, one {You have reached the maximum of # account for
 msgstr ""
 
 #: src/frontend/src/lib/components/ui/IdentitySwitcher.svelte:85
-msgid "{name} | Created"
+msgid "{name} | Created {date}"
 msgstr ""
 
 #: src/frontend/src/routes/(new-styling)/callback/+page.svelte:103

--- a/src/frontend/src/lib/locales/en.po
+++ b/src/frontend/src/lib/locales/en.po
@@ -18,8 +18,8 @@ msgid "{MAX_ACCOUNTS, plural, one {You have reached the maximum of # account for
 msgstr "{MAX_ACCOUNTS, plural, one {You have reached the maximum of # account for a single app.} other {You have reached the maximum of # accounts for a single app.}}"
 
 #: src/frontend/src/lib/components/ui/IdentitySwitcher.svelte:85
-msgid "{name} | Created"
-msgstr "{name} | Created"
+msgid "{name} | Created {date}"
+msgstr "{name} | Created {date}"
 
 #: src/frontend/src/routes/(new-styling)/callback/+page.svelte:103
 msgid "{name} logo"

--- a/src/frontend/src/lib/locales/es.po
+++ b/src/frontend/src/lib/locales/es.po
@@ -18,7 +18,7 @@ msgid "{MAX_ACCOUNTS, plural, one {You have reached the maximum of # account for
 msgstr ""
 
 #: src/frontend/src/lib/components/ui/IdentitySwitcher.svelte:85
-msgid "{name} | Created"
+msgid "{name} | Created {date}"
 msgstr ""
 
 #: src/frontend/src/routes/(new-styling)/callback/+page.svelte:103

--- a/src/frontend/src/lib/locales/id.po
+++ b/src/frontend/src/lib/locales/id.po
@@ -18,7 +18,7 @@ msgid "{MAX_ACCOUNTS, plural, one {You have reached the maximum of # account for
 msgstr ""
 
 #: src/frontend/src/lib/components/ui/IdentitySwitcher.svelte:85
-msgid "{name} | Created"
+msgid "{name} | Created {date}"
 msgstr ""
 
 #: src/frontend/src/routes/(new-styling)/callback/+page.svelte:103


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Enhance the identification of identities.

In this PR, we add the created timestamp (if present) in the identity switcher.

# Changes

* Updated the identity details display to show the creation date (formatted as short date) next to the identity type, if `createdAtMillis` is present.
* Improved the layout of secondary identity information for better readability.

# Tests

Tested locally, see screenshots attached.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

