### PR TITLE
Fetch default account during authorization

### DIFF
--- a/src/frontend/src/routes/(new-styling)/authorize/(panel)/continue/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/(panel)/continue/+page.svelte
@@ -85,16 +85,16 @@
       if (!$isAuthenticatedStore) {
         await authLastUsedFlow.authenticate($lastUsedIdentitiesStore.selected!);
       }
-      if (defaultAccountNumber === null) {
-        const { identityNumber, actor } = $authenticationStore!;
-        const { effectiveOrigin } = $authorizationContextStore;
-        defaultAccountNumber = (
-          await actor
-            .get_default_account(identityNumber, effectiveOrigin)
-            .then(throwCanisterError)
-        ).account_number[0];
-      }
-      await authorizationStore.authorize(defaultAccountNumber);
+      const { identityNumber, actor } = $authenticationStore!;
+      const { effectiveOrigin } = $authorizationContextStore;
+      await authorizationStore.authorize(
+        defaultAccountNumber === null
+          ? actor
+              .get_default_account(identityNumber, effectiveOrigin)
+              .then(throwCanisterError)
+              .then((account) => account.account_number[0])
+          : defaultAccountNumber,
+      );
     } catch (error) {
       handleError(error);
     }


### PR DESCRIPTION
Fetch default account during authorization, this avoid the visible delay after clicking "Continue".

# Changes

- Update authorization store to accept `Promise<bigint | undefined>` besides `bigint | undefined` as account number.
- Use the above to fetch account number during authorization so that the "Redirecting to app..." screen can be shown immediately.

# Tests

Verified that authorization works as expected and there's no more visible delay.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
