### PR TITLE
Styling improvements

### DIFF
--- a/src/frontend/src/lib/components/layout/Header.svelte
+++ b/src/frontend/src/lib/components/layout/Header.svelte
@@ -14,7 +14,7 @@
   <div class="flex h-16 flex-1 items-center gap-4">
     <a href="/" class="flex items-center gap-4">
       <Logo class="text-fg-primary h-5.5" />
-      <h1 class="text-md text-text-primary hidden font-semibold sm:block">
+      <h1 class="text-text-primary hidden text-base font-semibold sm:block">
         Internet Identity
       </h1>
     </a>

--- a/src/frontend/src/lib/components/layout/LandingHeader.svelte
+++ b/src/frontend/src/lib/components/layout/LandingHeader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { HTMLAttributes } from "svelte/elements";
   import Logo from "$lib/components/ui/Logo.svelte";
+
   type Props = HTMLAttributes<HTMLElement>;
   const { children, class: className, ...props }: Props = $props();
 </script>
@@ -11,7 +12,7 @@
 >
   <div class="flex min-h-16 flex-1 items-center gap-4">
     <Logo class="text-fg-primary h-5.5" />
-    <h1 class="text-md text-text-primary hidden font-semibold sm:block">
+    <h1 class="text-text-primary hidden text-base font-semibold sm:block">
       Internet Identity
     </h1>
   </div>

--- a/src/frontend/src/lib/components/ui/Avatar.svelte
+++ b/src/frontend/src/lib/components/ui/Avatar.svelte
@@ -15,8 +15,8 @@
     {
       sm: "size-8 text-sm",
       md: "size-10 text-sm",
-      lg: "text-md size-12",
-      xl: "text-md size-14",
+      lg: "size-12 text-base",
+      xl: "size-14 text-base",
     }[size],
     className,
   ]}

--- a/src/frontend/src/lib/components/ui/Button.svelte
+++ b/src/frontend/src/lib/components/ui/Button.svelte
@@ -69,8 +69,8 @@
     {
       sm: iconOnly ? "size-9" : "h-9 gap-1.5 px-3 text-sm",
       md: iconOnly ? "size-10" : "h-10 gap-1.5 px-3.5 text-sm",
-      lg: iconOnly ? "size-11" : "text-md h-11 gap-2.5 px-4",
-      xl: iconOnly ? "size-12" : "text-md h-12 gap-2.5 px-4.5",
+      lg: iconOnly ? "size-11" : "h-11 gap-2.5 px-4 text-base",
+      xl: iconOnly ? "size-12" : "h-12 gap-2.5 px-4.5 text-base",
     }[size],
     className,
   ]}

--- a/src/frontend/src/lib/components/ui/Checkbox.svelte
+++ b/src/frontend/src/lib/components/ui/Checkbox.svelte
@@ -25,7 +25,7 @@
 
 <label
   class={[
-    "flex w-max flex-row items-start",
+    "flex w-max max-w-full flex-row items-start",
     { sm: "gap-2", md: "gap-3" }[size],
     className,
   ]}
@@ -38,7 +38,7 @@
   />
   <div
     class={[
-      "relative flex items-center justify-center rounded-sm border",
+      "relative flex shrink-0 items-center justify-center rounded-sm border",
       "border-border-primary text-fg-primary-inversed bg-bg-primary",
       "hover:bg-bg-primary_hover",
       "peer-checked:bg-bg-brand-solid peer-checked:hover:bg-bg-brand-solid_hover peer-checked:border-none",
@@ -48,6 +48,7 @@
         sm: "size-4",
         md: "size-5",
       }[size],
+      (nonNullish(label) || nonNullish(hint)) && "mt-0.5",
       className,
     ]}
   >
@@ -73,7 +74,7 @@
         <p
           class={[
             "text-text-secondary font-medium select-none",
-            { sm: "text-sm", md: "text-md" }[size],
+            { sm: "text-sm", md: "text-base" }[size],
           ]}
         >
           {label}
@@ -83,7 +84,7 @@
         <p
           class={[
             "text-text-tertiary select-none",
-            { sm: "text-sm", md: "text-md" }[size],
+            { sm: "text-sm", md: "text-base" }[size],
           ]}
         >
           {hint}

--- a/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
+++ b/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
@@ -41,7 +41,7 @@
 </script>
 
 <div class="mb-4 flex items-center">
-  <h2 class="text-text-primary text-md font-medium">{$t`Switch identity`}</h2>
+  <h2 class="text-text-primary text-base font-medium">{$t`Switch identity`}</h2>
   {#if nonNullish(onClose)}
     <Button
       onclick={onClose}

--- a/src/frontend/src/lib/components/ui/Input.svelte
+++ b/src/frontend/src/lib/components/ui/Input.svelte
@@ -43,7 +43,7 @@
       bind:value
       {...restProps}
       class={[
-        "text-md bg-bg-primary text-text-primary placeholder:text-text-placeholder flex-1 rounded-lg border border-none p-0 opacity-100 ring outline-none ring-inset not-dark:shadow-xs",
+        "bg-bg-primary text-text-primary placeholder:text-text-placeholder flex-1 rounded-lg border border-none p-0 text-base opacity-100 ring outline-none ring-inset not-dark:shadow-xs",
         errorBorder ? "ring-border-error_subtle" : "ring-border-secondary",
         "focus:ring-2",
         errorBorder ? "focus:ring-border-error" : "focus:ring-border-brand",

--- a/src/frontend/src/lib/components/ui/SideBar.svelte
+++ b/src/frontend/src/lib/components/ui/SideBar.svelte
@@ -11,7 +11,7 @@
 >
   <div class="mb-6 flex flex-1 items-center gap-4 px-3">
     <Logo class="text-fg-primary h-5.5" />
-    <h1 class="text-md text-text-primary font-semibold sm:block">
+    <h1 class="text-text-primary text-base font-semibold sm:block">
       Internet Identity <span class="font-medium">Hub</span>
     </h1>
   </div>

--- a/src/frontend/src/lib/components/ui/Toggle.svelte
+++ b/src/frontend/src/lib/components/ui/Toggle.svelte
@@ -22,7 +22,7 @@
 
 <label
   class={[
-    "flex w-max flex-row items-start",
+    "flex w-max max-w-full flex-row items-start",
     { sm: "gap-2", md: "gap-3" }[size],
     className,
   ]}
@@ -36,11 +36,10 @@
   />
   <div
     class={[
-      "cursor-pointer rounded-full p-0.5 transition-colors duration-200",
-      "bg-bg-tertiary",
-      "peer-checked:bg-bg-brand-solid dark:peer-checked:bg-bg-quaternary",
-      "peer-checked:hover:bg-bg-brand-solid_hover dark:peer-checked:hover:bg-bg-quaternary_hover",
-      "after:block after:rounded-full after:bg-white after:shadow-sm after:transition-transform after:duration-200",
+      "shrink-0 cursor-pointer rounded-full p-0.5 transition-colors duration-200",
+      "bg-bg-tertiary dark:bg-bg-quaternary/60",
+      "peer-checked:bg-bg-brand-solid dark:peer-checked:bg-fg-tertiary",
+      "after:block after:rounded-full after:bg-white after:shadow-xs after:transition-transform after:duration-200",
       "peer-checked:after:translate-x-[100%]",
       "peer-disabled:bg-bg-disabled peer-disabled:after:bg-surface-light-50  dark:peer-disabled:after:bg-surface-dark-400",
       "peer-focus-visible:ring-focus-ring peer-focus-visible:ring-offset-bg-primary outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-offset-2",
@@ -56,7 +55,7 @@
         <p
           class={[
             "text-text-secondary font-medium select-none",
-            { sm: "text-sm", md: "text-md" }[size],
+            { sm: "text-sm", md: "text-base" }[size],
           ]}
         >
           {label}
@@ -66,7 +65,7 @@
         <p
           class={[
             "text-text-tertiary select-none",
-            { sm: "text-sm", md: "text-md" }[size],
+            { sm: "text-sm", md: "text-base" }[size],
           ]}
         >
           {hint}

--- a/src/frontend/src/lib/components/views/AuthorizeError.svelte
+++ b/src/frontend/src/lib/components/views/AuthorizeError.svelte
@@ -33,7 +33,7 @@
       <CircleAlertIcon class="size-6" />
     </FeaturedIcon>
     <h1 class="text-text-primary mb-3 text-2xl font-medium">{title}</h1>
-    <p class="text-md text-text-tertiary mb-6 font-medium">{description}</p>
+    <p class="text-text-tertiary mb-6 text-base font-medium">{description}</p>
     <Button onclick={() => window.close()} variant="secondary">
       <RotateCcwIcon class="size-4" />
       <span>{$t`Return to app`}</span>
@@ -47,7 +47,7 @@
     <h1 class="text-text-primary mb-3 text-2xl font-medium">
       {$t`Authentication successful`}
     </h1>
-    <p class="text-md text-text-tertiary mb-6 font-medium">
+    <p class="text-text-tertiary mb-6 text-base font-medium">
       {$t`You may close this page.`}
     </p>
     <Button onclick={() => window.close()} variant="secondary">

--- a/src/frontend/src/lib/components/views/EditAccount.svelte
+++ b/src/frontend/src/lib/components/views/EditAccount.svelte
@@ -63,7 +63,7 @@
     <h1 class="text-text-primary mb-3 text-2xl font-medium">
       {isNullish(account) ? $t`Name account` : $t`Edit account`}
     </h1>
-    <p class="text-md text-text-tertiary mb-6 font-medium">
+    <p class="text-text-tertiary mb-6 text-base font-medium">
       {isNullish(account)
         ? $t`You can edit this account later. Label it by use (e.g. 'Work' or 'Demo').`
         : $t`Rename or make this your default sign-in`}

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -59,7 +59,9 @@
   <h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
     Add access method
   </h1>
-  <p class="text-md text-text-tertiary font-medium text-balance sm:text-center">
+  <p
+    class="text-text-tertiary text-base font-medium text-balance sm:text-center"
+  >
     Add another way to sign in with a passkey or third-party account for secure
     access.
   </p>

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddPasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddPasskey.svelte
@@ -33,7 +33,9 @@
       Add a passkey
     {/if}
   </h1>
-  <p class="text-md text-text-tertiary font-medium text-balance sm:text-center">
+  <p
+    class="text-text-tertiary text-base font-medium text-balance sm:text-center"
+  >
     With passkeys, you can now use your fingerprint, face, or screen lock to
     quickly and securely confirm it’s really you.
   </p>

--- a/src/frontend/src/lib/components/wizards/auth/views/CreateIdentity.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/CreateIdentity.svelte
@@ -40,7 +40,7 @@
         {$t`What's your name?`}
       </h1>
       <p
-        class="text-md text-text-tertiary font-medium text-balance sm:text-center"
+        class="text-text-tertiary text-base font-medium text-balance sm:text-center"
       >
         <Trans>
           Give your identity a clear, simple, and memorable name you'll easily

--- a/src/frontend/src/lib/components/wizards/auth/views/CreatePasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/CreatePasskey.svelte
@@ -60,7 +60,7 @@
         {$t`Name your identity`}
       </h1>
       <p
-        class="text-md text-text-tertiary font-medium text-balance sm:text-center"
+        class="text-text-tertiary text-base font-medium text-balance sm:text-center"
       >
         <Trans>
           Internet Identity <b>does not</b> store your biometric data. It stays on

--- a/src/frontend/src/lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte
@@ -39,7 +39,9 @@
     {$t`Simplify your sign-in`}
   </h1>
 
-  <p class="text-md text-text-tertiary font-medium text-balance sm:text-center">
+  <p
+    class="text-text-tertiary text-base font-medium text-balance sm:text-center"
+  >
     <Trans>
       Create an identity with a passkey, using biometrics or a security key.
       Your data never leaves your device.

--- a/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/ContinueOnNewDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/ContinueOnNewDevice.svelte
@@ -29,7 +29,7 @@
       {$t`Continue on another device`}
     </h1>
     <p
-      class="text-md text-text-tertiary font-medium text-balance sm:text-center"
+      class="text-text-tertiary text-base font-medium text-balance sm:text-center"
     >
       <Trans>
         Scan the above QR code with your

--- a/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/EnterConfirmationCode.svelte
+++ b/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/EnterConfirmationCode.svelte
@@ -53,18 +53,18 @@
   <h1 class="text-text-primary mb-3 text-2xl font-medium">
     {$t`Authorize new device`}
   </h1>
-  <p class="text-md text-text-tertiary mb-4 font-medium">
+  <p class="text-text-tertiary mb-4 text-base font-medium">
     <Trans>
       You're about to sign in on a <b class="text-text-primary">new device</b>.
     </Trans>
   </p>
-  <p class="text-md text-text-tertiary mb-4 font-medium">
+  <p class="text-text-tertiary mb-4 text-base font-medium">
     <Trans>
       Only enter the code from that device if you initiated this process
       <b class="text-text-primary">yourself</b>.
     </Trans>
   </p>
-  <p class="text-md text-text-tertiary mb-8 font-medium">
+  <p class="text-text-tertiary mb-8 text-base font-medium">
     <Trans>
       <b class="text-text-primary">Never</b> enter a code from another source.
     </Trans>

--- a/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/FinishOnNewDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/FinishOnNewDevice.svelte
@@ -9,7 +9,7 @@
   <h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
     {$t`Continue on your new device`}
   </h1>
-  <p class="text-md text-text-tertiary font-medium sm:text-center">
+  <p class="text-text-tertiary text-base font-medium sm:text-center">
     <Trans>
       To finish setting up your passkey, follow the instructions shown on your
       <b class="text-text-primary">new device</b>.

--- a/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/WaitingForNewDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/WaitingForNewDevice.svelte
@@ -11,7 +11,9 @@
   <h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
     {$t`Waiting for your new device`}
   </h1>
-  <p class="text-md text-text-tertiary font-medium text-balance sm:text-center">
+  <p
+    class="text-text-tertiary text-base font-medium text-balance sm:text-center"
+  >
     <Trans>
       The <b class="text-text-primary">new device</b> is preparing to continue.
     </Trans>

--- a/src/frontend/src/lib/components/wizards/migration/views/AlreadyMigrated.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/views/AlreadyMigrated.svelte
@@ -31,14 +31,14 @@
         {$t`Identity already upgraded`}
       </h1>
       <p
-        class="text-md text-text-tertiary mb-4 font-medium text-balance sm:text-center"
+        class="text-text-tertiary mb-4 text-base font-medium text-balance sm:text-center"
       >
         <Trans>
           This identity has already been upgraded to the new experience.
         </Trans>
       </p>
       <p
-        class="text-md text-text-tertiary font-medium text-balance sm:text-center"
+        class="text-text-tertiary text-base font-medium text-balance sm:text-center"
       >
         <Trans>
           You can continue with

--- a/src/frontend/src/lib/components/wizards/migration/views/EnterIdentityNumber.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/views/EnterIdentityNumber.svelte
@@ -58,7 +58,7 @@
         {$t`Let's get started`}
       </h1>
       <p
-        class="text-md text-text-tertiary font-medium text-balance sm:text-center"
+        class="text-text-tertiary text-base font-medium text-balance sm:text-center"
       >
         <Trans>
           Upgrade your existing identity to the new experience in a few steps.

--- a/src/frontend/src/lib/components/wizards/migration/views/UpgradePasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/migration/views/UpgradePasskey.svelte
@@ -59,7 +59,7 @@
         {$t`Name your identity`}
       </h1>
       <p
-        class="text-md text-text-tertiary font-medium text-balance sm:text-center"
+        class="text-text-tertiary text-base font-medium text-balance sm:text-center"
       >
         <Trans>
           Internet Identity <b>does not</b> store your biometric data. It stays on

--- a/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ConfirmThisDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ConfirmThisDevice.svelte
@@ -33,7 +33,7 @@
   {$t`Confirm this device`}
 </h1>
 <p
-  class="text-md text-text-tertiary mb-8 font-medium sm:text-center sm:text-balance"
+  class="text-text-tertiary mb-8 text-base font-medium sm:text-center sm:text-balance"
 >
   <Trans>
     To confirm it's you, enter below code on your

--- a/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ConfirmYourSignIn.svelte
+++ b/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ConfirmYourSignIn.svelte
@@ -29,7 +29,7 @@
 <h1 class="text-text-primary mb-3 text-2xl font-medium">
   {$t`Confirm your sign-in`}
 </h1>
-<p class="text-md text-text-tertiary mb-4 font-medium text-balance">
+<p class="text-text-tertiary mb-4 text-base font-medium text-balance">
   {#if nonNullish(name)}
     <Trans>
       You're signing in as <b class="text-text-primary">{name}</b>.
@@ -38,7 +38,7 @@
     <Trans>You're about to sign in.</Trans>
   {/if}
 </p>
-<p class="text-md text-text-tertiary mb-8 font-medium text-balance">
+<p class="text-text-tertiary mb-8 text-base font-medium text-balance">
   <Trans>
     To continue, create a passkey to secure your identity and simplify future
     sign-ins.

--- a/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ContinueFromExistingDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ContinueFromExistingDevice.svelte
@@ -29,7 +29,7 @@
       {$t`Can't find your identity?`}
     </h1>
     <p
-      class="text-md text-text-tertiary font-medium text-balance sm:text-center"
+      class="text-text-tertiary text-base font-medium text-balance sm:text-center"
     >
       <Trans>
         Use a device that already holds your identity to scan or open the URL.

--- a/src/frontend/src/lib/components/wizards/registerAccessMethod/views/WaitingForExistingDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/registerAccessMethod/views/WaitingForExistingDevice.svelte
@@ -11,7 +11,9 @@
   <h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
     {$t`Waiting for your existing device`}
   </h1>
-  <p class="text-md text-text-tertiary font-medium text-balance sm:text-center">
+  <p
+    class="text-text-tertiary text-base font-medium text-balance sm:text-center"
+  >
     <Trans>
       The <b class="text-text-primary">existing device</b> is preparing to continue.
     </Trans>

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -181,11 +181,11 @@
         // Toggle summary icons
         "[&_details:not(:open)_summary_svg:last-child]:hidden [&_details:open_summary_svg:first-child]:hidden",
         // Paragraph styling and spacing
-        "[&_p]:text-text-md [&_p]:text-text-secondary [&_p_+_p]:mt-4",
+        "[&_p]:text-text-base [&_p]:text-text-secondary [&_p_+_p]:mt-4",
         // Paragraph + list spacing
         "[&_p_+_ul]:mt-4",
         // List styling and spacing
-        "[&_li]:text-text-md [&_li]:text-text-secondary [&_li_+_li]:mt-4",
+        "[&_li]:text-text-base [&_li]:text-text-secondary [&_li_+_li]:mt-4",
       ]}
     >
       <details>

--- a/src/frontend/src/routes/(new-styling)/authorize/upgrade-success/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/upgrade-success/+page.svelte
@@ -42,7 +42,9 @@
     <h1 class="text-text-primary mb-3 text-center text-2xl font-medium">
       {$t`Identity upgraded!`}
     </h1>
-    <p class="text-md text-text-tertiary text-center font-medium text-balance">
+    <p
+      class="text-text-tertiary text-center text-base font-medium text-balance"
+    >
       <Trans>
         You no longer need to remember your identity number and can use your
         fingerprint, face or screen lock instead.

--- a/src/frontend/src/routes/(new-styling)/callback/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/callback/+page.svelte
@@ -111,7 +111,7 @@
     <div class="bg-bg-quaternary my-6 h-0.5 w-full max-w-74 rounded-full">
       <div class="bg-fg-brand-primary animate-grow h-full rounded-full"></div>
     </div>
-    <p class="text-text-secondary text-md">
+    <p class="text-text-secondary text-base">
       {$t`Powered by Internet Identity`}
     </p>
     <Button

--- a/src/frontend/src/routes/(new-styling)/direct-authorize-protocol/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/direct-authorize-protocol/+page.svelte
@@ -62,7 +62,7 @@
     <h1 class="text-text-primary mb-3 text-2xl font-medium">
       {$t`Something went wrong`}
     </h1>
-    <p class="text-md text-text-tertiary mb-6 font-medium">
+    <p class="text-text-tertiary mb-6 text-base font-medium">
       <Trans>
         It seems like the connection with the service could not be established.
         Try a different browser; if the issue persists, contact support.

--- a/src/frontend/src/routes/(new-styling)/pair/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/pair/+page.svelte
@@ -48,7 +48,7 @@
     <h1 class="text-text-primary mb-3 text-2xl font-medium">
       {$t`Unable to complete setup`}
     </h1>
-    <p class="text-md text-text-tertiary font-medium">
+    <p class="text-text-tertiary text-base font-medium">
       <Trans>
         Please go back to your <b class="text-text-primary">existing device</b>
         and choose <b class="text-text-primary">Start over</b> to try again.

--- a/src/frontend/src/routes/(new-styling)/unsupported/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/unsupported/+page.svelte
@@ -31,7 +31,7 @@
             <strong>{$t`To continue:`}</strong>
           </p>
           <ol
-            class="text-md text-text-tertiary mb-5 list-decimal space-y-2 pl-6 text-left font-medium"
+            class="text-text-tertiary mb-5 list-decimal space-y-2 pl-6 text-left text-base font-medium"
           >
             <li>{$t`Long-press the link that opened this page.`}</li>
             <li>


### PR DESCRIPTION
Styling improvements

# Changes

- Replace `text-md` with `text-base`, the first didn't actually exist in tailwind, the later should have been used. Most elements use the base font-size by default, but not all. This change should make sure the correct font size is used as was intended.
- Make sure `Checkbox` and `Toggle` labels are wrapped if they're too long.
- Increase `Toggle` background color contrast in dark mode slightly.
- Fix `Checkbox` label vertical alignment.

# Tests

Verified that these changes did not break any UI related to the updated files.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
