### PR TITLE
Landing page FAQ improvements and fixes

### DIFF
--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -181,11 +181,11 @@
         // Toggle summary icons
         "[&_details:not(:open)_summary_svg:first-child]:hidden [&_details:open_summary_svg:last-child]:hidden",
         // Paragraph styling and spacing
-        "[&_p]:text-base [&_p]:text-text-secondary [&_p]:mb-4",
+        "[&_p]:text-text-secondary [&_p]:mb-4 [&_p]:text-base",
         // Paragraph + list spacing
         "[&_ul]:mb-4",
         // List styling and spacing
-        "[&_li]:text-base [&_li]:text-text-secondary [&_li_+_li]:mt-4",
+        "[&_li]:text-text-secondary [&_li]:text-base [&_li_+_li]:mt-4",
       ]}
     >
       <details>


### PR DESCRIPTION
Landing page FAQ improvements and fixes.

# Changes

- Fix FAQ accordion icons (swap + and - around).
- Increase FAQ accordion click target size.
   - previously you could only click on or above the title, now the whole row is clickable.
- Increase spacing between FAQ accordion titles and content slightly so it feels less cramped.

# Tests

Double checked things work as expected on both desktop and mobile.

<img width="670" height="455" alt="image" src="https://github.com/user-attachments/assets/bbd52936-3a3c-4f18-a012-153e94f79451" />



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

