### PR TITLE
Update toggle design and color tokens

### DIFF
--- a/src/frontend/src/lib/app.css
+++ b/src/frontend/src/lib/app.css
@@ -172,8 +172,8 @@ a:not(:disabled) {
   --bg-secondary_alt: var(--color-surface-light-100);
   --bg-secondary_hover: var(--color-surface-light-100);
   --bg-tertiary: var(--color-surface-light-200);
-  --bg-quaternary: var(--color-surface-light-200);
-  --bg-quaternary_hover: var(--color-surface-light-100);
+  --bg-quaternary: var(--color-surface-light-300);
+  --bg-quaternary_hover: var(--color-surface-light-200);
   --bg-active: var(--color-surface-light-50);
   --bg-disabled: var(--color-surface-light-200);
   --bg-disabled_subtle: var(--color-surface-light-50);
@@ -266,8 +266,8 @@ a:not(:disabled) {
     --bg-secondary_alt: var(--color-surface-dark-800);
     --bg-secondary_hover: var(--color-surface-dark-800);
     --bg-tertiary: var(--color-surface-dark-800);
-    --bg-quaternary: var(--color-surface-dark-600);
-    --bg-quaternary_hover: var(--color-surface-dark-500);
+    --bg-quaternary: var(--color-surface-dark-700);
+    --bg-quaternary_hover: var(--color-surface-dark-600);
     --bg-active: var(--color-surface-dark-800);
     --bg-disabled: var(--color-surface-dark-700);
     --bg-disabled_subtle: var(--color-surface-dark-900);

--- a/src/frontend/src/lib/components/ui/Toggle.svelte
+++ b/src/frontend/src/lib/components/ui/Toggle.svelte
@@ -37,11 +37,11 @@
   <div
     class={[
       "shrink-0 cursor-pointer rounded-full p-0.5 transition-colors duration-200",
-      "bg-bg-tertiary dark:bg-bg-quaternary/60",
-      "peer-checked:bg-bg-brand-solid dark:peer-checked:bg-fg-tertiary",
-      "after:block after:rounded-full after:bg-white after:shadow-xs after:transition-transform after:duration-200",
-      "peer-checked:after:translate-x-[100%]",
-      "peer-disabled:bg-bg-disabled peer-disabled:after:bg-surface-light-50  dark:peer-disabled:after:bg-surface-dark-400",
+      "bg-bg-quaternary",
+      "peer-checked:bg-bg-brand-solid peer-checked:hover:bg-bg-brand-solid",
+      "after:block after:rounded-full after:bg-white after:shadow-sm after:transition-transform after:duration-200",
+      "dark:peer-checked:after:bg-fg-primary-inversed peer-checked:after:translate-x-[100%]",
+      "peer-disabled:bg-bg-disabled peer-disabled:after:bg-surface-light-50  dark:peer-disabled:after:bg-surface-dark-600",
       "peer-focus-visible:ring-focus-ring peer-focus-visible:ring-offset-bg-primary outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-offset-2",
       {
         sm: "h-5 w-9 after:size-4",


### PR DESCRIPTION
Update toggle design and color tokens

# Tests

Verified that toggle looks according to design in both light and dark mode.

<img width="285" height="131" alt="image" src="https://github.com/user-attachments/assets/a9a67af7-f502-44cd-a939-f5b923d5e284" />
<img width="272" height="133" alt="image" src="https://github.com/user-attachments/assets/b89a8866-2fc0-4901-8d55-99757544b163" />
<img width="291" height="171" alt="image" src="https://github.com/user-attachments/assets/b34275cd-8657-4a2a-acdc-92703fe1431c" />
<img width="283" height="133" alt="image" src="https://github.com/user-attachments/assets/9d24f849-b433-45ea-b01b-cd1e1ec3eed8" />

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
