### PR TITLE
Add svelte-check to check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run extract && tsc --noEmit && vite build",
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",
-    "check": "tsc --project ./tsconfig.all.json --noEmit",
+    "check": "tsc --project ./tsconfig.all.json --noEmit && svelte-check check",
     "check:showcase": "astro check --root ./src/showcase --tsconfig ../../tsconfig.all.json",
     "watch": "npm run check -- --watch",
     "opts": "TS_NODE_PROJECT=tsconfig.base.json NODE_OPTIONS='--loader ts-node/esm --experimental-specifier-resolution=node' \"$@\"",


### PR DESCRIPTION
# Motivation

Do not ship type errors to mainnet.

# Changes

* Add `svelte-check check` to the `npm run check` script.

# Tests

* Tested by adding a type error in one Svelte component and getting the fail on `npm run check`.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
