### PR TITLE
Show error style on invalid spelling recovery word

### DIFF
--- a/src/frontend/src/routes/(new-styling)/recovery-phrase/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/recovery-phrase/+page.svelte
@@ -47,7 +47,6 @@
   };
 
   const handleKeyDownInput = (event: KeyboardEvent, currentIndex: number) => {
-    console.log("in da handleKeyDownInput");
     const currentWord = words[currentIndex];
     // Reset validity state when typing
     if (currentWord && event.key !== "Enter") {


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Provide feedback to the user when they make a mistake in a specific word while entering the recovery phrase.

# Changes

* Added BIP39 English word list validation: Each recovery word is now checked against the official BIP39 English word list to ensure correct spelling. The `RecoveryWord` type was updated to include an `isValid` flag, and the validation logic was implemented in the new `validateWord` function.
* Updated submission logic: The recovery phrase can only be submitted if all words are present and valid, preventing accidental submission of incorrect phrases. All words are validated before submission.
* Improved input handling: Words are trimmed on paste and entry, and their validity state is reset when typing, providing a smoother and more accurate user experience.
* Enhanced UI feedback: Invalid words are visually highlighted with error styles, and a tooltip with an info icon appears to inform the user of incorrect spelling. Input fields and word indices update their border and text color based on validity.

# Tests

Tested locally. See videos attached.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

