### PR TITLE
Automatically flip popover if it doesn't fit in viewport e.g. select dropdown on mobile.

### DIFF
--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -121,7 +121,9 @@
         }[finalDirection];
       }
 
-      if (tracking) requestAnimationFrame(track);
+      if (tracking) {
+        requestAnimationFrame(track);
+      }
     };
 
     requestAnimationFrame(track);


### PR DESCRIPTION
Automatically flip popover if it doesn't fit in viewport e.g. select dropdown on mobile.

# Tests

Verified that all existing usages of the popover component aren't affected.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

