### PR TITLE
Add auth method to authentication state.

### DIFF
--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -244,6 +244,10 @@ export class MigrationFlow {
       await authenticationStore.set({
         identity,
         identityNumber,
+        // Credential ID is currently missing, so we assign a dummy value.
+        // This placeholder will be replaced with the newly created passkey
+        // anyway once the user has completed the whole migration process.
+        authMethod: { passkey: { credentialId: new Uint8Array() } },
       });
       upgradeIdentityFunnel.trigger(
         UpgradeIdentityEvents.AuthenticationSuccessful,

--- a/src/frontend/src/lib/flows/registerAccessMethodFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/registerAccessMethodFlow.svelte.ts
@@ -125,18 +125,20 @@ export class RegisterAccessMethodFlow {
       ])
       .then(throwCanisterError);
     const identity = await authenticateWithSession({ session });
+    const authMethod = {
+      passkey: {
+        credentialId: new Uint8Array(credentialId),
+      },
+    };
     await authenticationStore.set({
       identity,
       identityNumber: this.#identityNumber,
+      authMethod,
     });
     lastUsedIdentitiesStore.addLastUsedIdentity({
       identityNumber: this.#identityNumber,
       name,
-      authMethod: {
-        passkey: {
-          credentialId: new Uint8Array(credentialId),
-        },
-      },
+      authMethod,
       createdAtMillis: this.#createdAtMillis,
     });
     return this.#identityNumber;

--- a/src/frontend/src/lib/stores/authentication.store.ts
+++ b/src/frontend/src/lib/stores/authentication.store.ts
@@ -19,6 +19,9 @@ export interface Authenticated {
   identity: DelegationIdentity;
   agent: HttpAgent;
   actor: ActorSubclass<_SERVICE>;
+  authMethod:
+    | { passkey: { credentialId: Uint8Array } }
+    | { openid: { iss: string; sub: string } };
 }
 
 type AuthenticationStore = Readable<Authenticated | undefined> & {


### PR DESCRIPTION
Add auth method to authentication state, this will be used in the dashboard to indicate which access method is currently in use.

The last used identity store data could also be used for this purpose but isn't reliable since it's value could change by signing in on other tabs/windows due to it being tied to local storage.

# Changes

- Add authMethod property to authentication store state.
- Update flows to pass auth method into authentication store.
- Remove unused `confirmationCode` from authFlow.

# Tests

Verified authentication flows still work as expected and correct auth method value is present when expected.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
