### PR TITLE
Add behavior when entering recovery words

### DIFF
--- a/src/frontend/src/routes/(new-styling)/recovery-phrase/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/recovery-phrase/+page.svelte
@@ -239,7 +239,6 @@
                 oninput={(event) => {
                   const target = event.currentTarget as HTMLInputElement;
                   word.value = target.value.toLowerCase();
-                  target.value = word.value;
                 }}
                 onkeydown={(e) => handleKeyDownInput(e, i)}
                 onpaste={(e) => handlePaste(e, i)}


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

Improve the user experience during entering the recovery phrase.

# Changes

This pull request enhances the recovery phrase entry page by improving user privacy and usability. The main changes introduce per-word and global visibility toggling for recovery phrase inputs, enforce lowercase input, and add a "Clear all" option. These updates help protect sensitive information from shoulder surfing and password managers, while making the input process smoother and more intuitive.

**Recovery phrase input privacy and usability improvements:**

* Added a `showContent` property to each recovery word and a global `showAll` state to control visibility of word inputs. Inputs are now masked by default (type `password`), and can be revealed individually (on focus) or all at once via a "Show all"/"Hide all" toggle.
* Added a "Clear all" button that resets all recovery phrase fields, validity, and visibility, and focuses the first input.
* Enforced lowercase for all input and pasted recovery words to ensure consistency and prevent accidental mismatches.
* Added attributes to input fields to discourage password managers from interfering (e.g., `data-lpignore`, `autocomplete="off"`, etc.).

# Tests

Tested locally, see videos attached.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

