### PR TITLE
Reset session store when logged out due to removing current access method.

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+page.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-  import identityInfo from "$lib/stores/identity-info.state.svelte";
-  import PlaceHolder from "$lib/components/ui/PlaceHolder.svelte";
   import IdentityInfoPanel from "$lib/components/views/IdentityInfoPanel.svelte";
-  import { fade } from "svelte/transition";
   import type { PageProps } from "./$types";
   import { afterNavigate, invalidateAll, replaceState } from "$app/navigation";
   import { page } from "$app/state";

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/+page.svelte
@@ -32,6 +32,7 @@
     toKey,
     isCurrentAccessMethod,
   } from "./utils";
+  import { sessionStore } from "$lib/stores/session.store";
 
   const MAX_PASSKEYS = 8;
 
@@ -133,6 +134,7 @@
         lastUsedIdentitiesStore.removeIdentity(
           $authenticatedStore.identityNumber,
         );
+        await sessionStore.reset();
         location.replace("/login");
         return;
       }


### PR DESCRIPTION
# Changes

- Make sure to call `sessionStore.reset()` on logout due to removing current access method.
- Remove unused imports.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
