### PR TITLE
feat: Add new API function `lookup_caller_identity_by_recovery_phrase`

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -734,6 +734,11 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Opt(IdentityNumber)],
         ['query'],
       ),
+    'lookup_caller_identity_by_recovery_phrase' : IDL.Func(
+        [],
+        [IDL.Opt(IdentityNumber)],
+        ['query'],
+      ),
     'lookup_device_key' : IDL.Func(
         [IDL.Vec(IDL.Nat8)],
         [IDL.Opt(DeviceKeyWithAnchor)],

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1212,6 +1212,10 @@ export interface _SERVICE {
     [RegistrationId],
     [] | [IdentityNumber]
   >,
+  'lookup_caller_identity_by_recovery_phrase' : ActorMethod<
+    [],
+    [] | [IdentityNumber]
+  >,
   /**
    * Discoverable passkeys protocol
    */

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1014,4 +1014,7 @@ service : (opt InternetIdentityInit) -> {
         origin : FrontendHostname,
         account_number : opt AccountNumber
     ) -> (variant { Ok : AccountInfo; Err: SetDefaultAccountError });
+
+    // Looks up identity number when called with a recovery phrase
+    lookup_caller_identity_by_recovery_phrase : () -> (opt IdentityNumber) query;
 };

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -271,6 +271,12 @@ fn get_anchor_credentials(anchor_number: AnchorNumber) -> AnchorCredentials {
 }
 
 #[query]
+fn lookup_caller_identity_by_recovery_phrase() -> Option<IdentityNumber> {
+    // TODO: Implement this function
+    None
+}
+
+#[query]
 fn lookup_device_key(credential_id: CredentialId) -> Option<DeviceKeyWithAnchor> {
     anchor_management::lookup_device_key_with_credential_id(&credential_id)
 }


### PR DESCRIPTION
# Motivation

Enable recovery phrases for id.ai

| [Next PR](https://github.com/dfinity/internet-identity/pull/3487) >

# Changes

Just adding the function to agree on the API shape.



<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->


