### PR TITLE
feat: Implement `lookup_caller_identity_by_recovery_phrase`

### DIFF
--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -2,13 +2,14 @@ use crate::archive::{archive_operation, device_diff};
 use crate::openid::{OpenIdCredential, OpenIdCredentialKey};
 use crate::storage::anchor::{Anchor, AnchorError, Device};
 use crate::{state, stats::activity_stats};
+use candid::Principal;
 use ic_cdk::api::time;
 use ic_cdk::{caller, trap};
 use internet_identity_interface::archive::types::{DeviceDataWithoutAlias, Operation};
 use internet_identity_interface::internet_identity::types::openid::OpenIdCredentialData;
 use internet_identity_interface::internet_identity::types::{
     AnchorNumber, AuthorizationKey, CredentialId, DeviceData, DeviceKey, DeviceKeyWithAnchor,
-    DeviceWithUsage, IdentityAnchorInfo, IdentityPropertiesReplace, MetadataEntry,
+    DeviceWithUsage, IdentityAnchorInfo, IdentityNumber, IdentityPropertiesReplace, MetadataEntry,
 };
 use state::storage_borrow;
 use std::collections::HashMap;
@@ -235,6 +236,11 @@ pub fn lookup_device_key_with_credential_id(
         pubkey: device.pubkey.clone(),
         anchor_number,
     })
+}
+
+/// Lookup `IdentityNumber` for the given caller `Principal` used as recovery phrase.
+pub fn lookup_caller_identity_by_recovery_phrase(caller: Principal) -> Option<IdentityNumber> {
+    storage_borrow(|storage| storage.lookup_anchor_with_recovery_phrase_principal(caller))
 }
 
 /// Set `name` of the given anchor.

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -321,9 +321,8 @@ fn get_anchor_credentials(anchor_number: AnchorNumber) -> AnchorCredentials {
 
 #[query]
 fn lookup_caller_identity_by_recovery_phrase() -> Option<IdentityNumber> {
-    // TODO: Implement this function after the `lookup_anchor_with_recovery_phrase_principal_memory`
-    // TODO: index is initialized with existing user data.
-    None
+    let caller = caller();
+    anchor_management::lookup_caller_identity_by_recovery_phrase(caller)
 }
 
 #[query]

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -702,7 +702,15 @@ impl<M: Memory + Clone> Storage<M> {
         anchor_numbers.first().copied()
     }
 
-    pub(crate) fn sync_anchor_with_recovery_phrase_principal_index(
+    pub fn lookup_anchor_with_recovery_phrase_principal(
+        &self,
+        key: Principal,
+    ) -> Option<AnchorNumber> {
+        self.lookup_anchor_with_recovery_phrase_principal_memory
+            .get(&key)
+    }
+
+    fn sync_anchor_with_recovery_phrase_principal_index(
         &mut self,
         anchor_number: AnchorNumber,
         previous_devices: &[Device],

--- a/src/internet_identity/tests/integration/upgrade.rs
+++ b/src/internet_identity/tests/integration/upgrade.rs
@@ -418,4 +418,37 @@ fn test_sync_anchor_indices_migration() {
 
         assert_eq!(count_recovery_phrases, NUM_ANCHORS as u64);
     }
+
+    // smoke test
+    for (label, sender, expected_anchor_number) in [
+        (
+            "Anonymous user should not get any anchor number",
+            Principal::anonymous(),
+            None,
+        ),
+        (
+            "User with pub-key-0 should get anchor number 10000",
+            Principal::self_authenticating("pub-key-0"),
+            Some(10_000),
+        ),
+    ] {
+        let payload = candid::encode_one(()).unwrap();
+
+        let data = env
+            .update_call(
+                canister_id,
+                sender,
+                "lookup_caller_identity_by_recovery_phrase",
+                payload,
+            )
+            .unwrap();
+
+        let observed_anchor_number: Option<u64> = candid::decode_one(&data).unwrap();
+
+        assert_eq!(
+            observed_anchor_number, expected_anchor_number,
+            "failed for {}",
+            label
+        );
+    }
 }


### PR DESCRIPTION
# Motivation

This PR implements the `lookup_caller_identity_by_recovery_phraseba` backend function that enables recovery phrases without needing users to provide their Identity anchor number, which is an internal implementation detail in id.ai.

< [Previous PR](https://github.com/dfinity/internet-identity/pull/3490) |

# Changes

Straightforward implementation for `lookup_caller_identity_by_recovery_phraseba`.

# Tests

Extended `test_recovery_phrase_migration` to demo how this function can be used.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

