### PR TITLE
test: Adjust `sync_anchor_indices_migration` test to reflect the recent bug fix

### DIFF
--- a/src/internet_identity/tests/integration/upgrade.rs
+++ b/src/internet_identity/tests/integration/upgrade.rs
@@ -9,7 +9,6 @@ use canister_tests::api::internet_identity::api_v2::create_account;
 use canister_tests::api::internet_identity::api_v2::get_accounts;
 use canister_tests::flows;
 use canister_tests::framework::*;
-use internet_identity_interface::internet_identity::authn_method;
 use internet_identity_interface::internet_identity::types::*;
 use pocket_ic::ErrorCode::CanisterCalledTrap;
 use pocket_ic::RejectResponse;


### PR DESCRIPTION
# Motivation

Context. The migration has been patched to gracefully handle anchor memory corruption, and the canister has been fixed to not allocate new dangling anchors. Now the integration test needs to be adjuster to reflect that there is no way to introduce this issue using the latest canister version.

# Changes

* No longer attempt to allocate dangling anchors in `sync_anchor_indices_migration`.

# Tests

* The test in question (`sync_anchor_indices_migration`) has been adjusted accordingly.