### PR TITLE
fix: Record anchors operation outcome only if it succeeds

### DIFF
--- a/src/internet_identity/src/authz_utils.rs
+++ b/src/internet_identity/src/authz_utils.rs
@@ -79,19 +79,15 @@ where
 
     anchor_management::activity_bookkeeping(&mut anchor, &authorization_key);
 
-    let result = op(&mut anchor);
+    let (ret, operation) = op(&mut anchor)?;
 
     // write back anchor
     state::storage_borrow_mut(|storage| storage.update(anchor))
         .map_err(|err| E::from(IdentityUpdateError::StorageError(anchor_number, err)))?;
 
-    match result {
-        Ok((ret, operation)) => {
-            post_operation_bookkeeping(anchor_number, operation);
-            Ok(ret)
-        }
-        Err(err) => Err(err),
-    }
+    post_operation_bookkeeping(anchor_number, operation);
+
+    Ok(ret)
 }
 
 /// Checks if the caller is authorized to operate on the anchor provided and returns a reference to the public key of the authentication method used (device or openid).


### PR DESCRIPTION
<!-- Make sure you talk to us before submitting changes. See CONTRIBUTING.md. -->

# Motivation

There's been a subtle issue with `anchor_operation_with_authz_check` that could lead to inconsistent state being recorded in case the inner operation fails half-way through mutating some anchor fields. We sole this by recording anchors back into the storage only after all anchor-mutating operations have succeeded.

# Changes

* Do not call `storage.update(anchor)` if `op(&mut anchor)` returns an error.

# Tests

* Existing tests should suffice for this PR.

<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->
