### PR TITLE
Redirect to landing page when unsupported page is visited directly.

### DIFF
--- a/src/frontend/src/routes/(new-styling)/unsupported/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/unsupported/+page.svelte
@@ -4,7 +4,7 @@
   import { afterNavigate, beforeNavigate, goto } from "$app/navigation";
   import type { AfterNavigate, BeforeNavigate } from "@sveltejs/kit";
 
-  const SESSION_KEY = "ii-unsupported-page-reloaded";
+  const PAGE_RELOADED_KEY = "ii-unsupported-page-reloaded";
 
   const isX = /\bTwitter/i.test(navigator.userAgent);
 
@@ -20,7 +20,7 @@
     if (!isReloadOrClose) {
       return;
     }
-    sessionStorage.setItem(SESSION_KEY, "true");
+    sessionStorage.setItem(PAGE_RELOADED_KEY, "true");
   };
   /**
    * Redirect to landing page when this page is visited directly,
@@ -28,9 +28,9 @@
    */
   const redirectOnEntryExceptReload = (navigation: AfterNavigate) => {
     const isEntry = navigation.type === "enter";
-    const isReload = sessionStorage.getItem(SESSION_KEY) === "true";
+    const isReload = sessionStorage.getItem(PAGE_RELOADED_KEY) === "true";
 
-    sessionStorage.removeItem(SESSION_KEY); // Always cleanup after it's read
+    sessionStorage.removeItem(PAGE_RELOADED_KEY); // Always cleanup after it's read
 
     if (!isEntry || isReload) {
       return;


### PR DESCRIPTION
Redirect to landing page when this page is visited directly. Reloading the unsupported page either manually or automatically due to inactivity, does not result in a redirect.

# Changes

- Updated unsupported page with `beforeNavigate` and `afterNavigate` hooks.

# Tests

Manually verified the page behaves as expected, visiting `/#authorize` still redirects to `/unsupported` and is out of scope for this PR.


<!-- SCREENSHOTS REPORT START -->

<!-- SCREENSHOTS REPORT STOP -->

