### PR TITLE
Use classes instead of component for buttons.

### DIFF
--- a/src/frontend/src/lib/app.css
+++ b/src/frontend/src/lib/app.css
@@ -1,4 +1,5 @@
 @import "tailwindcss" source("../");
+@import "./styles/button.css";
 
 @plugin "@tailwindcss/forms";
 

--- a/src/frontend/src/lib/components/ui/Button.svelte
+++ b/src/frontend/src/lib/components/ui/Button.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  // TODO: Deprecate this component, use classes directly on <button> and <a>
   import ButtonOrAnchor from "$lib/components/utils/ButtonOrAnchor.svelte";
   import type {
     HTMLAnchorAttributes,
@@ -33,45 +34,20 @@
   bind:element
   {...props}
   class={[
-    "box-border flex items-center justify-center justify-self-start rounded-md font-semibold whitespace-nowrap opacity-100 not-disabled:cursor-pointer",
+    "btn",
     {
-      primary: [
-        danger
-          ? "bg-bg-error-solid text-white"
-          : "bg-bg-brand-solid text-text-primary-inversed",
-        danger
-          ? "not-disabled:hover:bg-bg-error-solid_hover"
-          : "not-disabled:hover:bg-bg-brand-solid_hover",
-        "disabled:bg-bg-disabled disabled:text-fg-disabled",
-      ],
-      secondary: [
-        "bg-bg-primary border",
-        danger
-          ? "border-border-error_subtle text-text-error-primary"
-          : "border-border-secondary text-fg-primary",
-        danger
-          ? "not-disabled:hover:bg-bg-error-primary text-text-error-primary_hover"
-          : "not-disabled:hover:bg-bg-primary_hover",
-        "disabled:border-border-disabled disabled:text-fg-disabled",
-      ],
-      tertiary: [
-        danger ? "text-text-error-primary" : "text-fg-primary",
-        danger
-          ? "not-disabled:hover:bg-bg-error-primary text-text-error-primary_hover"
-          : "not-disabled:hover:bg-bg-primary_hover",
-        "disabled:text-fg-disabled",
-      ],
+      primary: "btn-primary",
+      secondary: "btn-secondary",
+      tertiary: "btn-tertiary",
     }[variant],
-    "focus-visible:ring-offset-bg-primary outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-    danger
-      ? "focus-visible:ring-focus-ring-error"
-      : "focus-visible:ring-focus-ring",
     {
-      sm: iconOnly ? "size-9" : "h-9 gap-1.5 px-3 text-sm",
-      md: iconOnly ? "size-10" : "h-10 gap-1.5 px-3.5 text-sm",
-      lg: iconOnly ? "size-11" : "h-11 gap-2.5 px-4 text-base",
-      xl: iconOnly ? "size-12" : "h-12 gap-2.5 px-4.5 text-base",
+      sm: "btn-sm",
+      md: "btn-md",
+      lg: "btn-lg",
+      xl: "btn-xl",
     }[size],
+    danger && "btn-danger",
+    iconOnly && "btn-icon",
     className,
   ]}
 >

--- a/src/frontend/src/lib/styles/button.css
+++ b/src/frontend/src/lib/styles/button.css
@@ -1,0 +1,111 @@
+/* ------------------------------------------- */
+/* Base Button                                 */
+/* ------------------------------------------- */
+@utility btn {
+  /* Base */
+  @apply box-border flex items-center justify-center justify-self-start;
+  @apply rounded-md font-semibold whitespace-nowrap opacity-100;
+  @apply not-disabled:cursor-pointer;
+
+  /* Focus */
+  @apply outline-none focus-visible:ring-2 focus-visible:ring-offset-2;
+  @apply focus-visible:ring-offset-bg-primary focus-visible:ring-focus-ring;
+
+  /* Defaults */
+  @apply btn-primary btn-md;
+}
+
+/* ------------------------------------------- */
+/* Primary Variant                              */
+/* ------------------------------------------- */
+@utility btn-primary {
+  /* Base */
+  @apply bg-bg-brand-solid text-text-primary-inversed;
+
+  /* Hover */
+  @apply hover:not-disabled:bg-bg-brand-solid_hover;
+
+  /* Disabled */
+  @apply disabled:bg-bg-disabled disabled:text-fg-disabled;
+}
+
+/* ------------------------------------------- */
+/* Secondary Variant                            */
+/* ------------------------------------------- */
+@utility btn-secondary {
+  /* Base */
+  @apply bg-bg-primary border-border-secondary text-fg-primary border;
+
+  /* Hover */
+  @apply hover:not-disabled:bg-bg-primary_hover;
+
+  /* Disabled */
+  @apply disabled:border-border-disabled disabled:text-fg-disabled;
+}
+
+/* ------------------------------------------- */
+/* Tertiary Variant                              */
+/* ------------------------------------------- */
+@utility btn-tertiary {
+  /* Base */
+  @apply text-fg-primary bg-transparent;
+
+  /* Hover */
+  @apply hover:not-disabled:bg-bg-primary_hover;
+
+  /* Disabled */
+  @apply disabled:text-fg-disabled;
+}
+
+/* ------------------------------------------- */
+/* Sizes                                        */
+/* ------------------------------------------- */
+@utility btn-sm {
+  @apply h-9 gap-1.5 px-3 text-sm;
+}
+
+@utility btn-md {
+  @apply h-10 gap-1.5 px-3.5 text-sm;
+}
+
+@utility btn-lg {
+  @apply h-11 gap-2.5 px-4 text-base;
+}
+
+@utility btn-xl {
+  @apply h-12 gap-2.5 px-4.5 text-base;
+}
+
+@utility btn-icon {
+  @apply aspect-square !gap-0 !p-0;
+}
+
+/* ------------------------------------------- */
+/* Danger Variants                             */
+/* ------------------------------------------- */
+@utility btn-danger {
+  @apply focus-visible:ring-focus-ring-error;
+
+  /* Defaults */
+  @apply bg-bg-error-solid text-white;
+  @apply hover:not-disabled:bg-bg-error-solid_hover;
+  @apply disabled:bg-bg-disabled disabled:text-fg-disabled;
+}
+
+.btn-primary.btn-danger {
+  @apply bg-bg-error-solid text-white;
+  @apply hover:not-disabled:bg-bg-error-solid_hover;
+  @apply disabled:bg-bg-disabled disabled:text-fg-disabled;
+}
+
+.btn-secondary.btn-danger {
+  @apply border-border-error_subtle bg-bg-primary text-text-error-primary border;
+  @apply hover:not-disabled:bg-bg-error-primary hover:not-disabled:text-text-error-primary_hover;
+  @apply disabled:border-border-disabled disabled:text-fg-disabled;
+}
+
+.btn-tertiary.btn-danger {
+  @apply text-text-error-primary;
+  @apply hover:not-disabled:bg-bg-error-primary hover:not-disabled:text-text-error-primary_hover;
+  @apply disabled:text-fg-disabled;
+}


### PR DESCRIPTION
Use classes instead of component for buttons.

# Changes

- Create `styles/button.css` with `btn` utility classes.
- Use these new utility classes in `Button` component
- Next up: deprecate the `Button` component, use the utility classes directly on `<button>` and `<a>`.

# Tests

Manually verified that all buttons on various pages are unchanged.

<!-- SCREENSHOTS REPORT START -->
<hr/><details><summary>🟡 Some screens were changed</summary><img src="https://raw.githubusercontent.com/dfinity/internet-identity/image-dumpster/objs/217496e0c/desktop/showSpinner.png" width="250"></details>
<!-- SCREENSHOTS REPORT STOP -->
