### PR TITLE
Fix disabled tertiary button and add utility to avoid page jumps when inputs are focused on mobile.

### DIFF
--- a/src/frontend/src/lib/app.css
+++ b/src/frontend/src/lib/app.css
@@ -1,4 +1,5 @@
 @import "tailwindcss" source("../");
+@import "./styles/fixes.css";
 @import "./styles/button.css";
 
 @plugin "@tailwindcss/forms";

--- a/src/frontend/src/lib/styles/button.css
+++ b/src/frontend/src/lib/styles/button.css
@@ -16,7 +16,7 @@
 }
 
 /* ------------------------------------------- */
-/* Primary Variant                              */
+/* Primary Variant                             */
 /* ------------------------------------------- */
 @utility btn-primary {
   /* Base */
@@ -30,7 +30,7 @@
 }
 
 /* ------------------------------------------- */
-/* Secondary Variant                            */
+/* Secondary Variant                           */
 /* ------------------------------------------- */
 @utility btn-secondary {
   /* Base */
@@ -44,7 +44,7 @@
 }
 
 /* ------------------------------------------- */
-/* Tertiary Variant                              */
+/* Tertiary Variant                            */
 /* ------------------------------------------- */
 @utility btn-tertiary {
   /* Base */
@@ -54,11 +54,11 @@
   @apply hover:not-disabled:bg-bg-primary_hover;
 
   /* Disabled */
-  @apply disabled:text-fg-disabled;
+  @apply disabled:text-fg-disabled disabled:bg-transparent;
 }
 
 /* ------------------------------------------- */
-/* Sizes                                        */
+/* Sizes                                       */
 /* ------------------------------------------- */
 @utility btn-sm {
   @apply h-9 gap-1.5 px-3 text-sm;
@@ -78,6 +78,7 @@
 
 @utility btn-icon {
   @apply aspect-square !gap-0 !p-0;
+  @apply [&_>_span]:sr-only;
 }
 
 /* ------------------------------------------- */

--- a/src/frontend/src/lib/styles/fixes.css
+++ b/src/frontend/src/lib/styles/fixes.css
@@ -1,0 +1,18 @@
+/* Below is a workaround for iOS that avoids the browser from scrolling
+   the input to the center of the screen which breaks e.g. bottom sheets. */
+@keyframes input-scroll-animation {
+  0% {
+    transform: translateY(-9999px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@utility input-noscroll {
+  will-change: transform;
+
+  &:focus {
+    animation: input-scroll-animation 1ms forwards;
+  }
+}


### PR DESCRIPTION
Fix disabled tertiary button, hide label on icon only variants and add utility to avoid page jumps when inputs are focused on mobile.
