### PR TITLE
Dark logo variant in Safari

### DIFF
--- a/src/frontend/src/lib/stores/authorization.store.ts
+++ b/src/frontend/src/lib/stores/authorization.store.ts
@@ -199,7 +199,6 @@ export const authorizationContextStore: Readable<AuthorizationContext> =
     if (isNullish(context)) {
       throw new Error("Authorization context is not available yet");
     }
-    context.requestOrigin = "https://caffeine.ai";
     return context;
   });
 


### PR DESCRIPTION
Since Safari seems to communicate light mode to SVG images rendered in an `<img>` tag even though the browser is in dark mode, the media query CSS has been removed from the dark logo SVG.