### PR TITLE
Fix 1Password overlay, move it to the top layer whenever it appears.

### DIFF
--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
       if (!(element instanceof HTMLElement)) {
         return;
       }
-      // Move 1Password to top layer
+      // Move 1Password to the top layer
       element.setAttribute("popover", "manual");
       element.showPopover();
     }).observe(document.documentElement, {


### PR DESCRIPTION
Fix 1Password overlay, move it to the top layer whenever it appears.

# Changes

- Add mutation observer to root layout that detects a password manager overlay and moves it to the top layer.
