### PR TITLE
Simplify dfx pull args

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -104,6 +104,15 @@ then
     echo; echo
 fi
 
+init_arg() {
+	local init_arg
+	init_arg=$(cat <<'EOF'
+(opt record { fetch_root_key = opt true; captcha_config = opt record { max_unsolved_captchas = 50:nat64; captcha_trigger = variant { Static = variant { CaptchaDisabled } } };})
+EOF
+)
+	printf '%s\n' "$init_arg"
+}
+
 # Builds a single canister
 # build_canister CANISTER EXTRA_BUILD_ARGS...
 # CANISTER: possible values: [internet_identity, archive]
@@ -162,14 +171,14 @@ function build_canister() {
           # of the build (for caching & integrity checking)
           IFS=,
           read -r -a version_parts <<< "$II_VERSION"
-          release="release-2026-01-14" # Hardcode release for now
+          release="${version_parts[1]}"
           if [ -n "$release" ]
           then
               asset_name="internet_identity_production.wasm.gz"
               wasm_url="https://github.com/dfinity/internet-identity/releases/download/$release/$asset_name"
               wasm_hash_url="https://github.com/dfinity/internet-identity/releases/download/$release/$asset_name.sha256"
 
-              init_arg="(opt record { fetch_root_key = opt true; captcha_config = opt record { max_unsolved_captchas = 50:nat64; captcha_trigger = variant { Static = variant { CaptchaDisabled } } };})"
+              init_arg=$(init_arg)
               init_guide="Use '(null)' for sensible defaults. See the candid interface for more details."
               metadata_json=$(echo '{}' | jq -cMr \
                   --arg wasm_url "$wasm_url" \
@@ -178,7 +187,6 @@ function build_canister() {
                   --arg init_guide "$init_guide" \
                   '. | .pullable = { wasm_url: $wasm_url, wasm_hash_url: $wasm_hash_url, dependencies: [], init_arg: $init_arg, init_guide: $init_guide} ')
               ic-wasm "$canister.wasm" -o "$canister.wasm" metadata dfx -d "$metadata_json" -v public
-              pwd
           fi
 
         fi


### PR DESCRIPTION
Simplify dfx pull args

# Changes

- Remove `openid_configs` from dfx pull init args for now since both Google and Microsoft don't seem to support localhost subdomains.
- Add `fetch_root_key` to dfx pull init args to make production wasm frontend work locally.
- Inline dfx pull init args again since they're no longer long enough to require a separate function.

# Tests

Manually tested with a test release and dfx to verify that dfx pull now creates a local working instance of the new II.
