### PR TITLE
Allow upgrading with any valid passkey (authentication or recovery).

### DIFF
--- a/src/frontend/src/lib/flows/migrationFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/migrationFlow.svelte.ts
@@ -166,7 +166,8 @@ export class MigrationFlow {
   ): Promise<Omit<DeviceData, "alias">[]> => {
     const actor = await get(sessionStore).actor;
     const allDevices = await actor.lookup(userNumber);
-    return allDevices.filter((device) => "authentication" in device.purpose);
+    // Attempt to authenticate with any device that has a credential id
+    return allDevices.filter((device) => device.credential_id[0] !== undefined);
   };
 
   #authenticate = async ({


### PR DESCRIPTION
Allow upgrading with any valid passkey (authentication or recovery).

# Changes

- Replace authentication purpose filter with more broad credential id filter in upgrade flow.

# Tests

Verified that recovery passkeys can be used to upgrade after this change while existing passkeys also still work.
