### PR TITLE
Double passkeys limit in dashboard

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/+page.svelte
@@ -39,7 +39,7 @@
   import { ConfirmAccessMethodWizard } from "$lib/components/wizards/confirmAccessMethod";
   import { toaster } from "$lib/components/utils/toaster";
 
-  const MAX_PASSKEYS = 8;
+  const MAX_PASSKEYS = 16;
 
   const { data }: PageProps = $props();
 

--- a/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
+++ b/src/frontend/tests/e2e-playwright/dashboard/addPasskeys.spec.ts
@@ -267,7 +267,7 @@ test("User can add a new passkey and use it with cached identity without clearin
   await newPage.close();
 });
 
-test("User can log into the dashboard and add up to 7 additional passkeys", async ({
+test("User can log into the dashboard and add up to 15 additional passkeys", async ({
   page,
 }) => {
   const auth = dummyAuth();
@@ -297,15 +297,15 @@ test("User can log into the dashboard and add up to 7 additional passkeys", asyn
     page.getByRole("listitem").filter({ hasText: "Passkey" }),
   ).toHaveCount(1);
 
-  // Add 7 more passkeys
-  for (let i = 0; i < 7; i++) {
+  // Add 15 more passkeys
+  for (let i = 0; i < 15; i++) {
     await addPasskeyCurrentDevice(page, dummyAuth());
   }
 
-  // Verify we have 8 passkeys
+  // Verify we have 16 passkeys
   await expect(
     page.getByRole("listitem").filter({ hasText: "Passkey" }),
-  ).toHaveCount(8);
+  ).toHaveCount(16);
 
   // Verify we cannot add more passkeys
   await page.getByRole("button", { name: "Add new" }).click();


### PR DESCRIPTION
Now that the limit has been doubled in the canister, also double the passkeys limit in the dashboard.

# Changes

- Increase limit constant from `8` to `16`.
- Adjust e2e test for this new limit.
