### PR TITLE
Exclude callback from redirect

### DIFF
--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -22,7 +22,9 @@
       // Don't redirect if we're visiting self-service
       window.location.pathname !== "/self-service" &&
       // Don't redirect if we're visiting webauthn iframe used for migration
-      window.location.pathname !== "/iframe/webauthn"
+      window.location.pathname !== "/iframe/webauthn" &&
+      // Don't redirect if we're visiting callback used for OpenID flows
+      window.location.pathname !== "/callback"
     ) {
       window.location.replace(
         primaryOrigin +


### PR DESCRIPTION
Exclude `/callback` from redirect to avoid breaking domain specific state in the direct OpenID authentication flow.

# Changes

- Add `/callback` to redirect exclude condition

# Tests

Verified that direct OpenID authentication flow is now working as expected.
