### PR TITLE
Fix dark dapp logo in direct OpenID flow

### DIFF
--- a/src/frontend/src/routes/(new-styling)/(resuming-channel)/resume-openid-authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/(resuming-channel)/resume-openid-authorize/+page.svelte
@@ -164,10 +164,9 @@
 
 <div class="flex min-h-[100dvh] flex-col items-center justify-center px-8">
   {#if dapp?.logoSrc !== undefined}
-    {@const name = dapp?.name ?? $authorizationContextStore.requestOrigin}
     <img
       src={dapp.logoSrc}
-      alt={$t`${name} logo`}
+      alt={$t`${dapp.name} logo`}
       class={[
         "mb-10 h-16 max-w-50 object-contain",
         dapp.logoDarkSrc !== undefined && "dark:hidden",
@@ -176,7 +175,7 @@
     {#if dapp.logoDarkSrc !== undefined}
       <img
         src={dapp.logoDarkSrc}
-        alt={$t`${name} logo`}
+        alt={$t`${dapp.name} logo`}
         class="mb-10 hidden h-16 max-w-50 object-contain dark:block"
         aria-hidden="true"
       />


### PR DESCRIPTION
Fix dark dapp logo in direct OpenID flow

# Changes

- Apply same fix as previously seen in `AuthorizeHeader` component to direct OpenID page.
