### PR TITLE
Manually close transport channel in test app

### DIFF
--- a/demos/test-app/src/auth.ts
+++ b/demos/test-app/src/auth.ts
@@ -57,7 +57,11 @@ export const authWithII = async ({
   // Authenticate with signer-js instead if we use the ICRC-25 protocol
   if (useIcrc25) {
     const transport = new PostMessageTransport({ url: url_ });
-    const signer = new Signer({ transport, derivationOrigin });
+    const signer = new Signer({
+      transport,
+      derivationOrigin,
+      autoCloseTransportChannel: false,
+    });
     const attributesRequestId = window.crypto.randomUUID();
     const attributesPromise =
       requestAttributes !== undefined && requestAttributes.length > 0
@@ -104,6 +108,7 @@ export const authWithII = async ({
       delegationPromise,
       attributesPromise,
     ]);
+    await signer.closeChannel();
     return {
       identity: DelegationIdentity.fromDelegation(
         sessionIdentity,

--- a/demos/test-app/src/index.tsx
+++ b/demos/test-app/src/index.tsx
@@ -312,7 +312,7 @@ const init = async () => {
         autoSelectionPrincipal,
         useIcrc25: useIcrc25El.checked,
         requestAttributes: requestAttributesEl.value
-          .split(",")
+          .split("\n")
           .map((s) => s.trim())
           .filter((s) => s.length > 0),
       });


### PR DESCRIPTION
Manually close transport channel in test app

# Changes

- Set `autoCloseTransportChannel` option to `false`.
- Manually call `signer.closeChannel()` instead.
- Split multiple attributes from test app input by new line instead of comma.
