### PR TITLE
chore: Avoid hard codeing /.well-known/ic-domains

### DIFF
--- a/src/internet_identity/src/assets.rs
+++ b/src/internet_identity/src/assets.rs
@@ -97,6 +97,9 @@ pub fn get_static_assets(config: &InternetIdentityInit) -> Vec<Asset> {
             .related_origins
             .clone()
             .unwrap_or_default()
+            .into_iter()
+            .map(|origin| origin.replace("https://", ""))
+            .collect::<Vec<_>>()
             .join("\n")
             .into_bytes(),
         encoding: ContentEncoding::Identity,

--- a/src/internet_identity_frontend/src/main.rs
+++ b/src/internet_identity_frontend/src/main.rs
@@ -328,6 +328,9 @@ fn get_static_assets(config: &InternetIdentityFrontendArgs) -> Vec<AssetUtilAsse
             .related_origins
             .clone()
             .unwrap_or_default()
+            .into_iter()
+            .map(|origin| origin.replace("https://", ""))
+            .collect::<Vec<_>>()
             .join("\n")
             .into_bytes(),
         encoding: ContentEncoding::Identity,


### PR DESCRIPTION
# Motivation

The domains specified in /.well-known/ic-domains of the II canisters should not be hard coded but should instead depend on the canister config.

# Changes

Set /.well-known/ic-domains to all the domains from `related_origins`.