### PR TITLE
feat: Support II origins with up to 100 bytes

### DIFF
--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -1085,7 +1085,7 @@ fn check_device_invariants(device: &Device) -> Result<(), AnchorError> {
 }
 
 fn check_device_limits(device: &Device) -> Result<(), AnchorError> {
-    const ORIGIN_LEN_LIMIT: usize = 50;
+    const ORIGIN_LEN_LIMIT: usize = 100;
     const ALIAS_LEN_LIMIT: usize = 64;
     const PK_LEN_LIMIT: usize = 300;
     const CREDENTIAL_ID_LEN_LIMIT: usize = 350;


### PR DESCRIPTION
# Motivation

The current limit for an II passkey origin is 50 bytes. However, II origins may have more than 50 bytes, e.g., if the II canister is installed onto a dynamic testnet. Thus, we need bump the limit to enable II-powered testnets.

# Changes

* Bump `internet_identity::storage::anchor::ORIGIN_LEN_LIMIT` to 100.