### PR TITLE
feat: replace dev_csp compile-time feature with init arg for frontend canister

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -4,7 +4,7 @@
       "type": "custom",
       "candid": "src/internet_identity_frontend/internet_identity_frontend.did",
       "wasm": "internet_identity_frontend.wasm.gz",
-      "build": "bash -c 'II_DEV_CSP=1 II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=${II_DUMMY_CAPTCHA:-1} scripts/build --frontend'",
+      "build": "bash -c 'II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=${II_DUMMY_CAPTCHA:-1} scripts/build --frontend'",
       "init_arg_file": "src/internet_identity_frontend/local_test_arg.did",
       "shrink": false
     },

--- a/scripts/build
+++ b/scripts/build
@@ -318,13 +318,6 @@ function build_internet_identity_frontend() {
   # WARNING: this MUST be opt-in, because we DO NOT want this in production.
   extra_build_args=()
 
-  # This enables the "dev_csp" feature which weakens the content security policy to facilitate development.
-  # WARNING: this MUST be opt-in, because we DO NOT want this in production.
-  if [ "${II_DEV_CSP:-}" == "1" ]
-  then
-      echo "USING DEV CONTENT SECURITY POLICY"
-      extra_build_args+=( --features dev_csp )
-  fi
   # XXX: for bash > 4.4, empty arrays are considered unset, so do some substitution
   build_canister "internet_identity_frontend" ${extra_build_args[@]+"${extra_build_args[@]}"}
 }

--- a/src/internet_identity_frontend/Cargo.toml
+++ b/src/internet_identity_frontend/Cargo.toml
@@ -30,9 +30,4 @@ ic-cdk-timers.workspace = true
 [dev-dependencies]
 candid_parser.workspace = true
 
-[features]
-# The dev_csp feature weakens the CSP in order to facilitate development with a locally deployed II instance.
-# In particular, this allows
-# * accessing II using http instead of https
-# * II to connect to localhost both on http and https, which is useful when developing a vc issuer
-dev_csp = []
+

--- a/src/internet_identity_frontend/internet_identity_frontend.did
+++ b/src/internet_identity_frontend/internet_identity_frontend.did
@@ -54,6 +54,7 @@ type InternetIdentityFrontendInit = record {
     fetch_root_key : opt bool;
     analytics_config : opt opt AnalyticsConfig;
     dummy_auth : opt opt DummyAuthConfig;
+    dev_csp : opt bool;
 };
 
 service : (InternetIdentityFrontendInit) -> {

--- a/src/internet_identity_frontend/local_test_arg.did
+++ b/src/internet_identity_frontend/local_test_arg.did
@@ -8,5 +8,6 @@
     fetch_root_key = null;
     analytics_config = null;
     dummy_auth = null;
+    dev_csp = opt true;
   },
 )

--- a/src/internet_identity_frontend/src/main.rs
+++ b/src/internet_identity_frontend/src/main.rs
@@ -38,6 +38,7 @@ fn post_upgrade(args: InternetIdentityFrontendArgs) {
 fn certify_all_assets(args: InternetIdentityFrontendArgs) {
     let static_assets = get_static_assets(&args);
     let related_origins = args.related_origins.as_ref();
+    let dev_csp = args.dev_csp.unwrap_or(false);
 
     // 2. Extract integrity hashes for inline scripts from HTML files
     let integrity_hashes = static_assets
@@ -84,6 +85,7 @@ fn certify_all_assets(args: InternetIdentityFrontendArgs) {
                         headers: get_asset_headers(
                             integrity_hashes.clone(),
                             related_origins,
+                            dev_csp,
                             vec![(
                                 "cache-control".to_string(),
                                 NO_CACHE_ASSET_CACHE_CONTROL.to_string(),
@@ -120,6 +122,7 @@ fn certify_all_assets(args: InternetIdentityFrontendArgs) {
                         headers: get_asset_headers(
                             integrity_hashes.clone(),
                             related_origins,
+                            dev_csp,
                             vec![headers],
                         ),
                         fallback_for: vec![],
@@ -144,6 +147,7 @@ fn certify_all_assets(args: InternetIdentityFrontendArgs) {
 fn get_asset_headers(
     integrity_hashes: Vec<String>,
     related_origins: Option<&Vec<String>>,
+    dev_csp: bool,
     additional_headers: Vec<HeaderField>,
 ) -> Vec<HeaderField> {
     let credentials_allowlist = if let Some(related_origins) = related_origins {
@@ -176,7 +180,7 @@ fn get_asset_headers(
         // Comprehensive policy to prevent XSS attacks and data injection
         (
             "Content-Security-Policy".to_string(),
-            get_content_security_policy(integrity_hashes, related_origins),
+            get_content_security_policy(integrity_hashes, related_origins, dev_csp),
         ),
         // Strict-Transport-Security (HSTS)
         // Forces browsers to use HTTPS for all future requests to this domain
@@ -279,12 +283,14 @@ fn get_asset_headers(
 fn get_content_security_policy(
     integrity_hashes: Vec<String>,
     related_origins: Option<&Vec<String>>,
+    dev_csp: bool,
 ) -> String {
-    let connect_src = "'self' https:";
-
-    // Allow connecting via http for development purposes
-    #[cfg(feature = "dev_csp")]
-    let connect_src = format!("{connect_src} http:");
+    let connect_src = if dev_csp {
+        // Allow connecting via http for development purposes
+        "'self' https: http:".to_string()
+    } else {
+        "'self' https:".to_string()
+    };
 
     // Build script-src with integrity hashes if provided
     let script_src = if integrity_hashes.is_empty() {
@@ -326,10 +332,11 @@ fn get_content_security_policy(
 
     // For production builds, upgrade all HTTP connections to HTTPS
     // Omitted in dev builds to allow localhost development
-    #[cfg(not(feature = "dev_csp"))]
-    let csp = format!("{csp}upgrade-insecure-requests;");
-
-    csp
+    if !dev_csp {
+        format!("{csp}upgrade-insecure-requests;")
+    } else {
+        csp
+    }
 }
 
 /// Gets the static assets with HTML fixup and well-known endpoints

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -219,6 +219,11 @@ pub struct InternetIdentityFrontendArgs {
     pub fetch_root_key: Option<bool>,
     pub analytics_config: Option<Option<AnalyticsConfig>>,
     pub dummy_auth: Option<Option<DummyAuthConfig>>,
+    /// Weakens the Content Security Policy to facilitate local development over HTTP.
+    /// When enabled:
+    /// * allows accessing II using http instead of https
+    /// * allows II to connect to localhost on both http and https
+    pub dev_csp: Option<bool>,
 }
 
 impl From<InternetIdentityFrontendArgs> for InternetIdentityInit {
@@ -230,6 +235,7 @@ impl From<InternetIdentityFrontendArgs> for InternetIdentityInit {
             analytics_config,
             dummy_auth,
             related_origins,
+            dev_csp: _,
         } = value;
 
         Self {


### PR DESCRIPTION
# Motivation

Replace the compile-time `dev_csp` Cargo feature flag on `internet_identity_frontend` with a runtime `dev_csp: opt bool`
installation argument.

Previously, building the frontend with a relaxed Content Security Policy (allowing HTTP connections for local development) required compiling a separate wasm with `--features dev_csp`. This meant release builds could not be reused for local testing without rebuilding.

Now, the same wasm binary can serve both production and development by passing `dev_csp = opt true` in the canister init arg. When enabled:
- `connect-src` allows `http:` in addition to `https:`
- `upgrade-insecure-requests` directive is omitted

When omitted or set to `false`, the strict production CSP is used.

# Changes
- Add `dev_csp: Option<bool>` to `InternetIdentityFrontendArgs` (Rust)
- Add `dev_csp : opt bool` to `InternetIdentityFrontendInit` (Candid)
- Replace `#[cfg(feature = "dev_csp")]` checks in `main.rs` with
  runtime boolean threaded through the CSP construction
- Remove `[features]` section from frontend `Cargo.toml`
- Remove `II_DEV_CSP` handling from `scripts/build` for frontend
- Remove `II_DEV_CSP=1` from frontend build command in `dfx.json`
- Add `dev_csp = opt true` to `local_test_arg.did`

| [Next PR](https://github.com/dfinity/internet-identity/pull/3685) >