### PR TITLE
chore: default captcha config to CaptchaDisabled

### DIFF
--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -26,8 +26,8 @@ mod temp_keys;
 
 /// Default captcha config
 pub const DEFAULT_CAPTCHA_CONFIG: CaptchaConfig = CaptchaConfig {
-    max_unsolved_captchas: 500,
-    captcha_trigger: CaptchaTrigger::Static(StaticCaptchaTrigger::CaptchaEnabled),
+    max_unsolved_captchas: 50,
+    captcha_trigger: CaptchaTrigger::Static(StaticCaptchaTrigger::CaptchaDisabled),
 };
 
 /// Default registration rate limit config.

--- a/src/internet_identity/tests/integration/config/captcha_config.rs
+++ b/src/internet_identity/tests/integration/config/captcha_config.rs
@@ -16,8 +16,8 @@ fn should_init_default() {
     assert_eq!(
         api::config(&env, canister_id).unwrap().captcha_config,
         Some(CaptchaConfig {
-            max_unsolved_captchas: 500,
-            captcha_trigger: Static(CaptchaEnabled)
+            max_unsolved_captchas: 50,
+            captcha_trigger: Static(CaptchaDisabled)
         })
     );
 }


### PR DESCRIPTION
## Summary
- Change `DEFAULT_CAPTCHA_CONFIG` so that when the canister is installed with `(null)` as the argument, the captcha is disabled by default (`max_unsolved_captchas=50`, `CaptchaDisabled`), matching the dev wasm behavior.
- Update the `should_init_default` integration test to expect the new defaults.

## Test plan
- [ ] Verify `should_init_default` test passes with the updated expected values
- [ ] Confirm production canister installed with `(null)` arg defaults to `CaptchaDisabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)