### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -15,16 +15,16 @@ jobs:
   docker-build-base:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # We use buildx and its GitHub Actions caching support `type=gha`. For
       # more information, see
       # https://github.com/docker/build-push-action/issues/539
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build base Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: Dockerfile
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-base
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Infer version
         id: version
@@ -51,10 +51,10 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build internet_identity_backend.wasm.gz
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: Dockerfile
@@ -68,7 +68,7 @@ jobs:
       - run: mv out/internet_identity.wasm.gz internet_identity_backend.wasm.gz
       - run: sha256sum internet_identity_backend.wasm.gz
       - name: "Upload internet_identity_backend.wasm.gz"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           # name is the name used to display and retrieve the artifact
           name: internet_identity_backend.wasm.gz
@@ -80,13 +80,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-base
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build Archive Canister
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: Dockerfile
@@ -98,7 +98,7 @@ jobs:
       - run: mv out/archive.wasm.gz archive.wasm.gz
       - run: sha256sum archive.wasm.gz
       - name: "Upload archive.wasm.gz"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           # name is the name used to display and retrieve the artifact
           name: archive.wasm.gz
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-base
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Infer version
         id: version
@@ -120,10 +120,10 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build internet_identity_frontend.wasm.gz
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: Dockerfile
@@ -137,7 +137,7 @@ jobs:
       - run: mv out/internet_identity_frontend.wasm.gz internet_identity_frontend.wasm.gz
       - run: sha256sum internet_identity_frontend.wasm.gz
       - name: "Upload internet_identity_frontend.wasm.gz"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           # name is the name used to display and retrieve the artifact
           name: internet_identity_frontend.wasm.gz
@@ -149,9 +149,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: docker-build-internet_identity
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: "Download wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: internet_identity_backend.wasm.gz
           path: .
@@ -175,8 +175,8 @@ jobs:
   vc_demo_issuer-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -192,7 +192,7 @@ jobs:
       - run: sha256sum vc_demo_issuer.wasm.gz
         working-directory: demos/vc_issuer
       - name: "Upload VC issuer"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           # name is the name used to display and retrieve the artifact
           name: vc_demo_issuer.wasm.gz
@@ -203,8 +203,8 @@ jobs:
   test-app-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -218,7 +218,7 @@ jobs:
         working-directory: demos/test-app
         run: ./build.sh
       - name: "Upload test app"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           # name is the name used to display and retrieve the artifact
           name: test_app.wasm
@@ -234,8 +234,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [docker-build-internet_identity, vc_demo_issuer-build]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -244,18 +244,18 @@ jobs:
           key: ${{ runner.os }}-cargo-vc-tests-${{ hashFiles('demos/vc_issuer/Cargo.lock', 'rust-toolchain.toml') }}
       - uses: ./.github/actions/bootstrap
       - name: "Download VC issuer wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: vc_demo_issuer.wasm.gz
           path: demos/vc_issuer
       - name: "Download II wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: internet_identity_backend.wasm.gz
           path: .
       - run: mv internet_identity_backend.wasm.gz internet_identity.wasm.gz
       - name: Install PocketIC server
-        uses: dfinity/pocketic@main
+        uses: dfinity/pocketic@20c33db1aa87cc6ece50857ac632c37acf5e0322 # main
         with:
           pocket-ic-server-version: "9.0.3"
       - name: "Run VC issuer canister tests"
@@ -279,13 +279,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # Attempt to restore the pre-built test binaries from cache.
       # The test binaries are only dependent on rust code, because the front-end code is bundled in the `wasm` file
       # that is loaded by the test binaries.
       # If the binary can be restored from cache, we skip the build step, including even setting up the toolchain etc.
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: cache-test-archive
         with:
           path: /tmp/test-archive
@@ -294,7 +294,7 @@ jobs:
       - uses: ./.github/actions/bootstrap
         if: steps.cache-test-archive.outputs.cache-hit != 'true'
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         if: steps.cache-test-archive.outputs.cache-hit != 'true'
         with:
           path: |
@@ -333,7 +333,7 @@ jobs:
           mv /tmp/test-archive/canister-tests-${{ matrix.os }}.tar.zst .
 
       - name: "Upload canister test archive"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           # name is the name used to display and retrieve the artifact
           name: canister-tests-${{ matrix.os }}.tar.zst
@@ -355,7 +355,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         partition: ["1/3", "2/3", "3/3"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download nextest
         run: |
@@ -363,29 +363,29 @@ jobs:
           curl -LsSf https://get.nexte.st/latest/${{ matrix.os == 'macos-latest' && 'mac' || 'linux' }}  | tar zxf -
 
       - name: "Download nextest test archive"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: canister-tests-${{ matrix.os }}.tar.zst
           path: .
       - name: Install PocketIC server
-        uses: dfinity/pocketic@main
+        uses: dfinity/pocketic@20c33db1aa87cc6ece50857ac632c37acf5e0322 # main
         with:
           pocket-ic-server-version: "9.0.3"
 
       - name: "Download II wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: internet_identity_backend.wasm.gz
           path: .
 
       - name: "Download archive wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: archive.wasm.gz
           path: .
 
       - name: "Download II frontend wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: internet_identity_frontend.wasm.gz
           path: .
@@ -415,8 +415,8 @@ jobs:
     needs: [docker-build-internet_identity, docker-build-archive]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: cache
         with:
           path: |
@@ -425,13 +425,13 @@ jobs:
           key: ${{ runner.os }}-test-canisters-script-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock', '.node-version', 'package-lock.json') }}
 
       - name: "Download II wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: internet_identity_backend.wasm.gz
           path: .
 
       - name: "Download archive wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: archive.wasm.gz
           path: .
@@ -482,7 +482,7 @@ jobs:
       # OpenID provider instance ports (see /src/test_openid_provider)
       openid_providers: "11105 11106"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-node
 
       - name: Install npm deps
@@ -514,19 +514,19 @@ jobs:
         run: dfx start --background --artificial-delay 0
 
       - name: "Download II backend wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: internet_identity_backend.wasm.gz
           path: .
 
       - name: "Download II frontend wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: internet_identity_frontend.wasm.gz
           path: .
 
       - name: "Download test app wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: test_app.wasm
           path: demos/test-app
@@ -578,7 +578,7 @@ jobs:
 
       - name: Archive dev server logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dev-server-logs-${{ env.artifact_suffix }}
           path: dev-server-logs.txt
@@ -586,7 +586,7 @@ jobs:
 
       - name: Archive playwright reports
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report-${{ env.artifact_suffix }}
           path: playwright-report/
@@ -612,18 +612,18 @@ jobs:
         vc_demo_issuer-build,
       ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365
 
       - name: "Download II wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: internet_identity_backend.wasm.gz
           path: .
 
       - name: "Download archive wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: archive.wasm.gz
           path: .
@@ -649,7 +649,7 @@ jobs:
             y2aaj-miaaa-aaaad-aacxq-cai
 
       - name: "Download test app wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: test_app.wasm
           path: .
@@ -664,7 +664,7 @@ jobs:
             vt36r-2qaaa-aaaad-aad5a-cai
 
       - name: "Download VC issuer wasm"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: vc_demo_issuer.wasm.gz
           path: .
@@ -702,34 +702,34 @@ jobs:
       ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Download backend build"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: internet_identity_backend.wasm.gz
           path: .
 
       - name: "Download archive"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: archive.wasm.gz
           path: .
 
       - name: "Download frontend"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: internet_identity_frontend.wasm.gz
           path: .
 
       - name: "Download issuer"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: vc_demo_issuer.wasm.gz
           path: .
 
       - name: "Get GHA job IDs"
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         id: pipeline-jobs
         with:
           script: |
@@ -745,7 +745,7 @@ jobs:
               });
 
       - name: "Get latest release"
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         id: latest-release-tag
         with:
           result-encoding: string
@@ -757,7 +757,7 @@ jobs:
       # listing contributions since).
       # https://github.com/github/feedback/discussions/5975
       - name: "Generate CHANGELOG"
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         id: changelog
         with:
           result-encoding: string
@@ -840,7 +840,7 @@ jobs:
 
       # Create app token (needed to create pull request)
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -848,7 +848,7 @@ jobs:
 
       # Checkout project
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -900,7 +900,7 @@ jobs:
   sig-verifier-js:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-node
       - run: npm ci
       - name: Build sig-verifier

--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -17,10 +17,10 @@ jobs:
       testnet_app_canister_id: jlfvx-nqaaa-aaaad-aab7a-cai
       wallet_canister_id: cvthj-wyaaa-aaaad-aaaaq-cai
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Download build for Release Candidate"
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             // Find all artifacts for the backend build, and filter for non-expired main artifacts

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -7,7 +7,7 @@ jobs:
   frontend-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # set a PAT so that add-and-commit can trigger CI runs
           token: ${{ secrets.GIX_BOT_PAT }}
@@ -36,7 +36,7 @@ jobs:
             fi
           done < <(jq <src/frontend/src/flows/dappsExplorer/dapps.json -cMr '.[] | .logo' )
       - name: Commit type interfaces
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         # We don't want to commit automatic changes to main
         if: ${{ github.ref != 'refs/heads/main' }}
         with:

--- a/.github/workflows/pr-review-requested.yml
+++ b/.github/workflows/pr-review-requested.yml
@@ -15,7 +15,7 @@ jobs:
       github.event.pull_request.author_association == 'COLLABORATOR'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "refs/tags/${{ needs.latest-release.outputs.ref }}"
 
@@ -88,7 +88,7 @@ jobs:
         # was minimal, so we will skip them for now until there is a reliable way to run docker images on macos runners.
         os: [ubuntu-22.04, ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: "refs/tags/${{ needs.latest-release.outputs.ref }}"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
   cargo-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # set a PAT so that add-and-commit can trigger
           # CI runs
@@ -27,7 +27,7 @@ jobs:
           cargo fmt
 
       - name: Commit Formatting changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         # We don't want to commit formatting changes to main
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
@@ -38,7 +38,7 @@ jobs:
   cargo-clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/bootstrap
 
       - name: Create dummy assets
@@ -71,7 +71,7 @@ jobs:
   check-lockfile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/bootstrap
 
         # fails if lockfile is out of date

--- a/.github/workflows/update-dapps.yml
+++ b/.github/workflows/update-dapps.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get update && sudo apt-get install -y imagemagick
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/setup-node
       - run: npm ci
 
@@ -28,7 +28,7 @@ jobs:
       # If the dapps changed, create a PR.
       # This action creates a PR only if there are changes.
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main

--- a/.github/workflows/update-dfx.yml
+++ b/.github/workflows/update-dfx.yml
@@ -12,7 +12,7 @@ jobs:
   dfx-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
         # First, check dfx releases (on the SDK repo) for a new version.
       - name: Check new dfx version
@@ -40,7 +40,7 @@ jobs:
         # If the dfx.json was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -11,7 +11,7 @@ jobs:
   didc-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
         # First, check didc releases (on the candid repo) for a new version.
       - name: Check new didc version
@@ -39,7 +39,7 @@ jobs:
         # If the .didc-release was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main

--- a/.github/workflows/update-node.yml
+++ b/.github/workflows/update-node.yml
@@ -11,7 +11,7 @@ jobs:
   node-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
         # First, check node's releases for a new version.
       - name: Check new node version
@@ -42,7 +42,7 @@ jobs:
         # If the .node-version was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main

--- a/.github/workflows/update-passkey-aaguid.yml
+++ b/.github/workflows/update-passkey-aaguid.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       # Create app token (needed to create pull request)
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
@@ -21,7 +21,7 @@ jobs:
 
       # Checkout project
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -11,7 +11,7 @@ jobs:
   rust-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
         # First, check rust GitHub releases for a new version. We assume that the
         # latest version's tag name is the version.
@@ -48,7 +48,7 @@ jobs:
         # If the rust-toolchain was updated, create a PR.
       - name: Create Pull Request
         if: ${{ steps.update.outputs.updated == '1' }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `docker/setup-buildx-action@v3` -> `docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0`
  - Version: v3.12.0 | Latest: v4.0.0 | Release age: 35d
  - Commit: https://github.com/docker/setup-buildx-action/commit/8d2750c68a42422c14e847fe6c8ac0403b4cbd6f

- `docker/build-push-action@v5` -> `docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0`
  - Version: v5.4.0 | Latest: v7.0.0 | Release age: 34d
  - Commit: https://github.com/docker/build-push-action/commit/ca052bb54ab0790a636c9b5f226502c73d547a25

- `actions/upload-artifact@v4` -> `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
  - Version: v4.6.2 | Latest: v3.2.2 | Release age: 22d
  - Commit: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02

- `actions/download-artifact@v4` -> `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0`
  - Version: v4.3.0 | Latest: v3.1.0-node20 | Release age: 22d
  - Commit: https://github.com/actions/download-artifact/commit/d3f86a106a0bac45b974a628896c90dbdf5c8093
  - Warnings: 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `actions/cache@v4` -> `actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0`
  - Version: v4.3.0 | Latest: v5.0.4 | Release age: 21d
  - Commit: https://github.com/actions/cache/commit/0057852bfaa89a56745cba8c7296529d2fc39830

- `dfinity/pocketic@main` -> `dfinity/pocketic@20c33db1aa87cc6ece50857ac632c37acf5e0322 # main`
  - Version: main | Latest: 13.0.0 | Release age: 16d
  - Commit: https://github.com/dfinity/pocketic/commit/20c33db1aa87cc6ece50857ac632c37acf5e0322

- `actions/github-script@v7` -> `actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0`
  - Version: v7.1.0 | Latest: v8 | Release age: 216d
  - Commit: https://github.com/actions/github-script/commit/f28e40c7f34bde8b3046d885e986cb6290c5673b

- `actions/create-github-app-token@v1` -> `actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0`
  - Version: v1.12.0 | Latest: v3.0.0 | Release age: 26d
  - Commit: https://github.com/actions/create-github-app-token/commit/d72941d797fd3113feb6b93fd0dec494b13a2547

- `EndBug/add-and-commit@v9` -> `EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4`
  - Version: v9.1.4 | Latest: v10.0.0 | Release age: 17d
  - Commit: https://github.com/EndBug/add-and-commit/commit/a94899bca583c204427a224a7af87c02f9b325d5

- `peter-evans/create-pull-request@v6` -> `peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0`
  - Version: v6.1.0 | Latest: v8.1.0 | Release age: 77d
  - Commit: https://github.com/peter-evans/create-pull-request/commit/c5a7806660adbe173f04e3e038b0ccdcd758773c


### Files modified

- `.github/workflows/canister-tests.yml`
- `.github/workflows/deploy-rc.yml`
- `.github/workflows/frontend-checks.yml`
- `.github/workflows/pr-review-requested.yml`
- `.github/workflows/release-build-check.yml`
- `.github/workflows/rust.yml`
- `.github/workflows/update-dapps.yml`
- `.github/workflows/update-dfx.yml`
- `.github/workflows/update-didc.yml`
- `.github/workflows/update-node.yml`
- `.github/workflows/update-passkey-aaguid.yml`
- `.github/workflows/update-rust.yml`

### Security warnings

- 1 security advisory(ies) found
- Action has 1 known advisory(ies)