### PR TITLE
chore(fe): fix German Undo translation per reviewer feedback

### DIFF
--- a/src/frontend/src/lib/locales/de.po
+++ b/src/frontend/src/lib/locales/de.po
@@ -1004,7 +1004,7 @@ msgid "Understanding Internet Identity"
 msgstr "Internet Identity verstehen"
 
 msgid "Undo"
-msgstr "Rückgängig"
+msgstr "Rückgängig machen"
 
 msgid "Unexpected error"
 msgstr "Unerwarteter Fehler"


### PR DESCRIPTION
# Motivation

The "Undo" button was translated as "Rückgängig" in German, which is incomplete as a standalone button label. Per reviewer feedback from @marc0olo on #3743, this updates it to "Rückgängig machen" — the standard German UI convention for undo actions.

# Changes

- Updated the German translation for "Undo" from "Rückgängig" to "Rückgängig machen" in `de.po`.