### PR TITLE
feat(be): use semantically correct ICRC-3 types for certified attribute values

### DIFF
--- a/demos/test-app/src/auth.ts
+++ b/demos/test-app/src/auth.ts
@@ -46,6 +46,7 @@ export const authWithII = async ({
   useIcrc25,
   requestAttributes,
   useIcrc3Attributes,
+  icrc3Nonce,
 }: {
   url: string;
   maxTimeToLive?: bigint;
@@ -56,6 +57,7 @@ export const authWithII = async ({
   useIcrc25?: boolean;
   requestAttributes?: string[];
   useIcrc3Attributes?: boolean;
+  icrc3Nonce?: Uint8Array;
 }): Promise<{
   identity: DelegationIdentity;
   authnMethod: string;
@@ -111,7 +113,7 @@ export const authWithII = async ({
             })
         : Promise.resolve(undefined);
 
-    const nonce = crypto.getRandomValues(new Uint8Array(32));
+    const nonce = icrc3Nonce ?? crypto.getRandomValues(new Uint8Array(32));
     const icrc3AttributesPromise =
       hasAttributes && useIcrc3Attributes
         ? signer

--- a/demos/test-app/src/index.html
+++ b/demos/test-app/src/index.html
@@ -87,6 +87,12 @@
           <input type="checkbox" id="useIcrc3Attributes" />
         </div>
         <div>
+          <label for="icrc3Nonce" style="display: inline-block; width: 200px"
+            >ICRC-3 nonce (base64):</label
+          >
+          <input type="text" id="icrc3Nonce" />
+        </div>
+        <div>
           <label
             for="requestAttributes"
             style="display: inline-block; width: 200px"

--- a/demos/test-app/src/index.tsx
+++ b/demos/test-app/src/index.tsx
@@ -86,6 +86,7 @@ const useIcrc25El = document.getElementById("useIcrc25") as HTMLInputElement;
 const useIcrc3AttributesEl = document.getElementById(
   "useIcrc3Attributes",
 ) as HTMLInputElement;
+const icrc3NonceEl = document.getElementById("icrc3Nonce") as HTMLInputElement;
 const requestAttributesEl = document.getElementById(
   "requestAttributes",
 ) as HTMLInputElement;
@@ -337,6 +338,11 @@ const init = async () => {
         autoSelectionPrincipal,
         useIcrc25: useIcrc25El.checked,
         useIcrc3Attributes: useIcrc3AttributesEl.checked,
+        icrc3Nonce:
+          icrc3NonceEl.value.trim() !== ""
+            ? // @ts-ignore Not known in TS types yet but supported in all browsers
+              Uint8Array.fromBase64(icrc3NonceEl.value.trim())
+            : undefined,
         requestAttributes: requestAttributesEl.value
           .split("\n")
           .map((s) => s.trim())

--- a/src/frontend/tests/e2e-playwright/fixtures/authorize.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/authorize.ts
@@ -1,5 +1,6 @@
 import { Principal } from "@icp-sdk/core/principal";
 import { test as base, expect, type Page } from "@playwright/test";
+import { toBase64 } from "../utils";
 
 export type AuthorizeConfig = {
   testAppURL: string;
@@ -12,7 +13,7 @@ export type AuthorizeConfig = {
       openid?: string;
       attributes?: string[];
       useIcrc3Attributes?: boolean;
-      icrc3Nonce?: string;
+      icrc3Nonce?: Uint8Array;
     }
 );
 
@@ -75,7 +76,7 @@ export const test = base.extend<{
       ) {
         await testAppPage
           .getByRole("textbox", { name: "ICRC-3 nonce (base64):" })
-          .fill(authorizeConfig.icrc3Nonce);
+          .fill(toBase64(authorizeConfig.icrc3Nonce));
       }
       if (
         "attributes" in authorizeConfig &&

--- a/src/frontend/tests/e2e-playwright/fixtures/authorize.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/authorize.ts
@@ -12,6 +12,7 @@ export type AuthorizeConfig = {
       openid?: string;
       attributes?: string[];
       useIcrc3Attributes?: boolean;
+      icrc3Nonce?: string;
     }
 );
 
@@ -67,6 +68,14 @@ export const test = base.extend<{
         await testAppPage
           .getByRole("checkbox", { name: "Use ICRC-3 attributes:" })
           .setChecked(true);
+      }
+      if (
+        "icrc3Nonce" in authorizeConfig &&
+        authorizeConfig.icrc3Nonce !== undefined
+      ) {
+        await testAppPage
+          .getByRole("textbox", { name: "ICRC-3 nonce (base64):" })
+          .fill(authorizeConfig.icrc3Nonce);
       }
       if (
         "attributes" in authorizeConfig &&

--- a/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
@@ -152,7 +152,11 @@ test.describe("Authorize with direct OpenID", () => {
 
   test.describe("with app-supplied nonce", () => {
     const name = "John Doe";
-    const knownNonce = crypto.getRandomValues(new Uint8Array(32));
+    // prettier-ignore
+    const knownNonce = new Uint8Array([
+      80, 48, 222, 48, 28, 157, 149, 134, 236, 61, 19, 71, 200, 105, 53, 187,
+      44, 126, 9, 241, 76, 103, 217, 148, 12, 55, 90, 181, 33, 208, 99, 7,
+    ]);
 
     test.use({
       openIdConfig: {

--- a/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
@@ -27,7 +27,7 @@ Icrc3Value.fill(
   }),
 );
 
-function decodeIcrc3BlobEntries(base64Data: string): Record<string, string> {
+function decodeIcrc3TextEntries(base64Data: string): Record<string, string> {
   const dataBytes = fromBase64(base64Data);
   const { Map: map } = IDL.decode([Icrc3Value], dataBytes)[0] as {
     Map: [string, Icrc3Value][];
@@ -35,12 +35,9 @@ function decodeIcrc3BlobEntries(base64Data: string): Record<string, string> {
   return Object.fromEntries(
     map
       .filter(
-        (entry): entry is [string, { Blob: number[] }] => "Blob" in entry[1],
+        (entry): entry is [string, { Text: string }] => "Text" in entry[1],
       )
-      .map(([key, { Blob: blob }]) => [
-        key,
-        new TextDecoder().decode(new Uint8Array(blob)),
-      ]),
+      .map(([key, { Text: text }]) => [key, text]),
   );
 }
 
@@ -111,7 +108,7 @@ test.describe("Authorize with direct OpenID", () => {
 
       expect(authorizedIcrc3Attributes.signature.length).toBeGreaterThan(0);
 
-      const blobEntries = decodeIcrc3BlobEntries(
+      const blobEntries = decodeIcrc3TextEntries(
         authorizedIcrc3Attributes.data,
       );
       expect(blobEntries).toMatchObject({
@@ -195,7 +192,7 @@ test.describe("Authorize with direct OpenID", () => {
         return;
       }
 
-      const blobEntries = decodeIcrc3BlobEntries(
+      const blobEntries = decodeIcrc3TextEntries(
         authorizedIcrc3Attributes.data,
       );
       // Only the name from the default provider should be present via implicit consent.
@@ -249,7 +246,7 @@ test.describe("Authorize with direct OpenID", () => {
         return;
       }
 
-      const blobEntries = decodeIcrc3BlobEntries(
+      const blobEntries = decodeIcrc3TextEntries(
         authorizedIcrc3Attributes.data,
       );
       expect(

--- a/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
@@ -5,7 +5,7 @@ import {
   ALTERNATE_OPENID_PORT,
   DEFAULT_OPENID_PORT,
 } from "../../fixtures/openid";
-import { fromBase64, toBase64, II_URL } from "../../utils";
+import { fromBase64, II_URL } from "../../utils";
 
 type Icrc3Value =
   | { Nat: bigint }
@@ -152,8 +152,7 @@ test.describe("Authorize with direct OpenID", () => {
 
   test.describe("with app-supplied nonce", () => {
     const name = "John Doe";
-    const knownNonce = new Uint8Array(32).fill(42);
-    const knownNonceBase64 = toBase64(knownNonce);
+    const knownNonce = crypto.getRandomValues(new Uint8Array(32));
 
     test.use({
       openIdConfig: {
@@ -168,7 +167,7 @@ test.describe("Authorize with direct OpenID", () => {
         protocol: "icrc25",
         openid: `http://localhost:${DEFAULT_OPENID_PORT}`,
         useIcrc3Attributes: true,
-        icrc3Nonce: knownNonceBase64,
+        icrc3Nonce: knownNonce,
         attributes: [`openid:http://localhost:${DEFAULT_OPENID_PORT}:name`],
       },
     });

--- a/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
@@ -5,7 +5,7 @@ import {
   ALTERNATE_OPENID_PORT,
   DEFAULT_OPENID_PORT,
 } from "../../fixtures/openid";
-import { fromBase64, II_URL } from "../../utils";
+import { fromBase64, toBase64, II_URL } from "../../utils";
 
 type Icrc3Value =
   | { Nat: bigint }
@@ -142,6 +142,55 @@ test.describe("Authorize with direct OpenID", () => {
     });
 
     test("should return attributes", async ({
+      authorizePage,
+      signInWithOpenId,
+      openIdUsers,
+    }) => {
+      await signInWithOpenId(authorizePage.page, openIdUsers[0].id);
+    });
+  });
+
+  test.describe("with app-supplied nonce", () => {
+    const name = "John Doe";
+    const knownNonce = new Uint8Array(32).fill(42);
+    const knownNonceBase64 = toBase64(knownNonce);
+
+    test.use({
+      openIdConfig: {
+        defaultPort: DEFAULT_OPENID_PORT,
+        createUsers: [
+          {
+            claims: { name },
+          },
+        ],
+      },
+      authorizeConfig: {
+        protocol: "icrc25",
+        openid: `http://localhost:${DEFAULT_OPENID_PORT}`,
+        useIcrc3Attributes: true,
+        icrc3Nonce: knownNonceBase64,
+        attributes: [`openid:http://localhost:${DEFAULT_OPENID_PORT}:name`],
+      },
+    });
+
+    test.afterEach(({ authorizedPrincipal, authorizedIcrc3Attributes }) => {
+      expect(authorizedPrincipal?.isAnonymous()).toBe(false);
+      expect(authorizedIcrc3Attributes).toBeDefined();
+      if (authorizedIcrc3Attributes === undefined) {
+        return;
+      }
+
+      const map = decodeIcrc3Map(authorizedIcrc3Attributes.data);
+
+      // Verify the nonce in the ICRC-3 map matches the one we supplied
+      expect(map["implicit:nonce"]).toHaveProperty("Blob");
+      const { Blob: nonceBlob } = map["implicit:nonce"] as {
+        Blob: number[];
+      };
+      expect(nonceBlob).toEqual(Array.from(knownNonce));
+    });
+
+    test("should include the app-supplied nonce", async ({
       authorizePage,
       signInWithOpenId,
       openIdUsers,

--- a/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
@@ -190,7 +190,7 @@ test.describe("Authorize with direct OpenID", () => {
       const { Blob: nonceBlob } = map["implicit:nonce"] as {
         Blob: number[];
       };
-      expect(nonceBlob).toEqual(Array.from(knownNonce));
+      expect(Array.from(nonceBlob)).toEqual(Array.from(knownNonce));
     });
 
     test("should include the app-supplied nonce", async ({

--- a/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/openid.spec.ts
@@ -27,13 +27,17 @@ Icrc3Value.fill(
   }),
 );
 
-function decodeIcrc3TextEntries(base64Data: string): Record<string, string> {
+function decodeIcrc3Map(base64Data: string): Record<string, Icrc3Value> {
   const dataBytes = fromBase64(base64Data);
   const { Map: map } = IDL.decode([Icrc3Value], dataBytes)[0] as {
     Map: [string, Icrc3Value][];
   };
+  return Object.fromEntries(map);
+}
+
+function decodeIcrc3TextEntries(base64Data: string): Record<string, string> {
   return Object.fromEntries(
-    map
+    Object.entries(decodeIcrc3Map(base64Data))
       .filter(
         (entry): entry is [string, { Text: string }] => "Text" in entry[1],
       )
@@ -108,13 +112,33 @@ test.describe("Authorize with direct OpenID", () => {
 
       expect(authorizedIcrc3Attributes.signature.length).toBeGreaterThan(0);
 
-      const blobEntries = decodeIcrc3TextEntries(
+      const map = decodeIcrc3Map(authorizedIcrc3Attributes.data);
+
+      // Verify user attributes are Text
+      const textEntries = decodeIcrc3TextEntries(
         authorizedIcrc3Attributes.data,
       );
-      expect(blobEntries).toMatchObject({
+      expect(textEntries).toMatchObject({
         [`openid:http://localhost:${DEFAULT_OPENID_PORT}:name`]: name,
         [`openid:http://localhost:${DEFAULT_OPENID_PORT}:email`]: email,
       });
+
+      // Verify implicit:origin is Text
+      expect(map["implicit:origin"]).toHaveProperty("Text");
+
+      // Verify implicit:nonce is a 32-byte Blob
+      expect(map["implicit:nonce"]).toHaveProperty("Blob");
+      const { Blob: nonceBlob } = map["implicit:nonce"] as {
+        Blob: number[];
+      };
+      expect(nonceBlob).toHaveLength(32);
+
+      // Verify implicit:issued_at_timestamp_ns is a Nat
+      expect(map["implicit:issued_at_timestamp_ns"]).toHaveProperty("Nat");
+      const { Nat: timestamp } = map["implicit:issued_at_timestamp_ns"] as {
+        Nat: bigint;
+      };
+      expect(timestamp).toBeGreaterThan(BigInt(0));
     });
 
     test("should return attributes", async ({

--- a/src/internet_identity/src/attributes.rs
+++ b/src/internet_identity/src/attributes.rs
@@ -237,12 +237,12 @@ pub const ICRC3_ATTRIBUTES_CERTIFICATION_DOMAIN: &[u8] = b"ic-sender-info";
 
 /// Builds a Candid-encoded ICRC-3 Value map from certified key-value pairs.
 /// The pairs are (certified_key, value) where certified_key may have scope omitted.
-fn icrc3_attribute_message(certified_pairs: &BTreeMap<String, Vec<u8>>) -> Vec<u8> {
+fn icrc3_attribute_message(certified_pairs: &BTreeMap<String, Icrc3Value>) -> Vec<u8> {
     use candid::Encode;
 
     let map_entries: Vec<(String, Icrc3Value)> = certified_pairs
         .iter()
-        .map(|(key, value)| (key.clone(), Icrc3Value::Blob(value.clone())))
+        .map(|(key, value)| (key.clone(), value.clone()))
         .collect();
 
     let value = Icrc3Value::Map(map_entries);
@@ -266,7 +266,7 @@ impl Anchor {
         issued_at_timestamp_ns: u64,
         account: Account,
     ) -> Result<Vec<u8>, PrepareIcrc3AttributeError> {
-        let mut certified_pairs = BTreeMap::new();
+        let mut certified_pairs: BTreeMap<String, Icrc3Value> = BTreeMap::new();
 
         for spec in &attribute_specs {
             let Some(AttributeScope::OpenId { issuer }) = &spec.key.scope else {
@@ -310,15 +310,15 @@ impl Anchor {
             if let std::collections::btree_map::Entry::Vacant(entry) =
                 certified_pairs.entry(certified_key)
             {
-                entry.insert(stored.into_bytes());
+                entry.insert(Icrc3Value::Text(stored));
             }
         }
 
-        certified_pairs.insert("implicit:nonce".to_string(), nonce);
-        certified_pairs.insert("implicit:origin".to_string(), origin.into_bytes());
+        certified_pairs.insert("implicit:nonce".to_string(), Icrc3Value::Blob(nonce));
+        certified_pairs.insert("implicit:origin".to_string(), Icrc3Value::Text(origin));
         certified_pairs.insert(
             "implicit:issued_at_timestamp_ns".to_string(),
-            issued_at_timestamp_ns.to_string().into_bytes(),
+            Icrc3Value::Nat(candid::Nat::from(issued_at_timestamp_ns)),
         );
 
         let message = icrc3_attribute_message(&certified_pairs);
@@ -1535,11 +1535,14 @@ mod tests {
             let mut scoped_pairs = BTreeMap::new();
             scoped_pairs.insert(
                 format!("openid:{}:email", GOOGLE_ISSUER),
-                "user@example.com".as_bytes().to_vec(),
+                Icrc3Value::Text("user@example.com".to_string()),
             );
 
             let mut unscoped_pairs = BTreeMap::new();
-            unscoped_pairs.insert("email".to_string(), "user@example.com".as_bytes().to_vec());
+            unscoped_pairs.insert(
+                "email".to_string(),
+                Icrc3Value::Text("user@example.com".to_string()),
+            );
 
             let scoped_msg = icrc3_attribute_message(&scoped_pairs);
             let unscoped_msg = icrc3_attribute_message(&unscoped_pairs);
@@ -1554,8 +1557,14 @@ mod tests {
         #[test]
         fn should_produce_deterministic_encoding() {
             let mut pairs = BTreeMap::new();
-            pairs.insert("email".to_string(), "user@example.com".as_bytes().to_vec());
-            pairs.insert("name".to_string(), "Example User".as_bytes().to_vec());
+            pairs.insert(
+                "email".to_string(),
+                Icrc3Value::Text("user@example.com".to_string()),
+            );
+            pairs.insert(
+                "name".to_string(),
+                Icrc3Value::Text("Example User".to_string()),
+            );
 
             let msg1 = icrc3_attribute_message(&pairs);
             let msg2 = icrc3_attribute_message(&pairs);
@@ -1565,8 +1574,14 @@ mod tests {
         #[test]
         fn should_produce_decodable_icrc3_value() {
             let mut pairs = BTreeMap::new();
-            pairs.insert("email".to_string(), "user@example.com".as_bytes().to_vec());
-            pairs.insert("name".to_string(), "Example User".as_bytes().to_vec());
+            pairs.insert(
+                "email".to_string(),
+                Icrc3Value::Text("user@example.com".to_string()),
+            );
+            pairs.insert(
+                "name".to_string(),
+                Icrc3Value::Text("Example User".to_string()),
+            );
 
             let msg = icrc3_attribute_message(&pairs);
             let decoded: Icrc3Value =
@@ -1577,7 +1592,15 @@ mod tests {
                     pretty_assert_eq!(entries.len(), 2);
                     // BTreeMap ordering: email < name
                     pretty_assert_eq!(entries[0].0, "email");
+                    pretty_assert_eq!(
+                        entries[0].1,
+                        Icrc3Value::Text("user@example.com".to_string())
+                    );
                     pretty_assert_eq!(entries[1].0, "name");
+                    pretty_assert_eq!(
+                        entries[1].1,
+                        Icrc3Value::Text("Example User".to_string())
+                    );
                 }
                 other => panic!("Expected Map, got {:?}", other),
             }

--- a/src/internet_identity/src/attributes.rs
+++ b/src/internet_identity/src/attributes.rs
@@ -1597,10 +1597,7 @@ mod tests {
                         Icrc3Value::Text("user@example.com".to_string())
                     );
                     pretty_assert_eq!(entries[1].0, "name");
-                    pretty_assert_eq!(
-                        entries[1].1,
-                        Icrc3Value::Text("Example User".to_string())
-                    );
+                    pretty_assert_eq!(entries[1].1, Icrc3Value::Text("Example User".to_string()));
                 }
                 other => panic!("Expected Map, got {:?}", other),
             }

--- a/src/internet_identity/src/attributes.rs
+++ b/src/internet_identity/src/attributes.rs
@@ -1860,10 +1860,7 @@ mod tests {
                         Icrc3Value::Text("user@example.com".to_string())
                     );
                     pretty_assert_eq!(entries[1].0, "name");
-                    pretty_assert_eq!(
-                        entries[1].1,
-                        Icrc3Value::Text("Example User".to_string())
-                    );
+                    pretty_assert_eq!(entries[1].1, Icrc3Value::Text("Example User".to_string()));
                 }
                 other => panic!("Expected Map, got {:?}", other),
             }

--- a/src/internet_identity/src/attributes.rs
+++ b/src/internet_identity/src/attributes.rs
@@ -267,6 +267,7 @@ impl Anchor {
         account: Account,
     ) -> Result<Vec<u8>, PrepareIcrc3AttributeError> {
         let mut certified_pairs: BTreeMap<String, Icrc3Value> = BTreeMap::new();
+        let mut problems = Vec::new();
 
         for spec in &attribute_specs {
             match &spec.key.scope {
@@ -299,9 +300,8 @@ impl Anchor {
                     if let Some(ref expected_value) = spec.value {
                         if expected_value.as_slice() != stored.as_bytes() {
                             problems.push(format!(
-                                "Attribute value mismatch for {}: provided value does not match stored value (stored {} bytes)",
-                                spec.key,
-                                stored.len()
+                                "Attribute value mismatch for {}: provided value does not match stored value",
+                                spec.key
                             ));
                             continue;
                         }
@@ -323,7 +323,7 @@ impl Anchor {
                             ));
                         }
                         std::collections::btree_map::Entry::Vacant(entry) => {
-                            entry.insert(stored.into_bytes());
+                            entry.insert(Icrc3Value::Text(stored));
                         }
                     }
                 }
@@ -336,19 +336,8 @@ impl Anchor {
             }
         }
 
-            // Compute the certified key.
-            let certified_key = if spec.omit_scope {
-                spec.key.attribute_name.to_string()
-            } else {
-                spec.key.to_string()
-            };
-
-            // Skip duplicates silently.
-            if let std::collections::btree_map::Entry::Vacant(entry) =
-                certified_pairs.entry(certified_key)
-            {
-                entry.insert(Icrc3Value::Text(stored));
-            }
+        if !problems.is_empty() {
+            return Err(PrepareIcrc3AttributeError::AttributeMismatch { problems });
         }
 
         certified_pairs.insert("implicit:nonce".to_string(), Icrc3Value::Blob(nonce));

--- a/src/internet_identity/src/attributes.rs
+++ b/src/internet_identity/src/attributes.rs
@@ -237,12 +237,12 @@ pub const ICRC3_ATTRIBUTES_CERTIFICATION_DOMAIN: &[u8] = b"ic-sender-info";
 
 /// Builds a Candid-encoded ICRC-3 Value map from certified key-value pairs.
 /// The pairs are (certified_key, value) where certified_key may have scope omitted.
-fn icrc3_attribute_message(certified_pairs: &BTreeMap<String, Vec<u8>>) -> Vec<u8> {
+fn icrc3_attribute_message(certified_pairs: &BTreeMap<String, Icrc3Value>) -> Vec<u8> {
     use candid::Encode;
 
     let map_entries: Vec<(String, Icrc3Value)> = certified_pairs
         .iter()
-        .map(|(key, value)| (key.clone(), Icrc3Value::Blob(value.clone())))
+        .map(|(key, value)| (key.clone(), value.clone()))
         .collect();
 
     let value = Icrc3Value::Map(map_entries);
@@ -266,8 +266,7 @@ impl Anchor {
         issued_at_timestamp_ns: u64,
         account: Account,
     ) -> Result<Vec<u8>, PrepareIcrc3AttributeError> {
-        let mut certified_pairs = BTreeMap::new();
-        let mut problems = Vec::new();
+        let mut certified_pairs: BTreeMap<String, Icrc3Value> = BTreeMap::new();
 
         for spec in &attribute_specs {
             match &spec.key.scope {
@@ -337,15 +336,26 @@ impl Anchor {
             }
         }
 
-        if !problems.is_empty() {
-            return Err(PrepareIcrc3AttributeError::AttributeMismatch { problems });
+            // Compute the certified key.
+            let certified_key = if spec.omit_scope {
+                spec.key.attribute_name.to_string()
+            } else {
+                spec.key.to_string()
+            };
+
+            // Skip duplicates silently.
+            if let std::collections::btree_map::Entry::Vacant(entry) =
+                certified_pairs.entry(certified_key)
+            {
+                entry.insert(Icrc3Value::Text(stored));
+            }
         }
 
-        certified_pairs.insert("implicit:nonce".to_string(), nonce);
-        certified_pairs.insert("implicit:origin".to_string(), origin.into_bytes());
+        certified_pairs.insert("implicit:nonce".to_string(), Icrc3Value::Blob(nonce));
+        certified_pairs.insert("implicit:origin".to_string(), Icrc3Value::Text(origin));
         certified_pairs.insert(
             "implicit:issued_at_timestamp_ns".to_string(),
-            issued_at_timestamp_ns.to_string().into_bytes(),
+            Icrc3Value::Nat(candid::Nat::from(issued_at_timestamp_ns)),
         );
 
         let message = icrc3_attribute_message(&certified_pairs);
@@ -1788,11 +1798,14 @@ mod tests {
             let mut scoped_pairs = BTreeMap::new();
             scoped_pairs.insert(
                 format!("openid:{}:email", GOOGLE_ISSUER),
-                "user@example.com".as_bytes().to_vec(),
+                Icrc3Value::Text("user@example.com".to_string()),
             );
 
             let mut unscoped_pairs = BTreeMap::new();
-            unscoped_pairs.insert("email".to_string(), "user@example.com".as_bytes().to_vec());
+            unscoped_pairs.insert(
+                "email".to_string(),
+                Icrc3Value::Text("user@example.com".to_string()),
+            );
 
             let scoped_msg = icrc3_attribute_message(&scoped_pairs);
             let unscoped_msg = icrc3_attribute_message(&unscoped_pairs);
@@ -1807,8 +1820,14 @@ mod tests {
         #[test]
         fn should_produce_deterministic_encoding() {
             let mut pairs = BTreeMap::new();
-            pairs.insert("email".to_string(), "user@example.com".as_bytes().to_vec());
-            pairs.insert("name".to_string(), "Example User".as_bytes().to_vec());
+            pairs.insert(
+                "email".to_string(),
+                Icrc3Value::Text("user@example.com".to_string()),
+            );
+            pairs.insert(
+                "name".to_string(),
+                Icrc3Value::Text("Example User".to_string()),
+            );
 
             let msg1 = icrc3_attribute_message(&pairs);
             let msg2 = icrc3_attribute_message(&pairs);
@@ -1818,8 +1837,14 @@ mod tests {
         #[test]
         fn should_produce_decodable_icrc3_value() {
             let mut pairs = BTreeMap::new();
-            pairs.insert("email".to_string(), "user@example.com".as_bytes().to_vec());
-            pairs.insert("name".to_string(), "Example User".as_bytes().to_vec());
+            pairs.insert(
+                "email".to_string(),
+                Icrc3Value::Text("user@example.com".to_string()),
+            );
+            pairs.insert(
+                "name".to_string(),
+                Icrc3Value::Text("Example User".to_string()),
+            );
 
             let msg = icrc3_attribute_message(&pairs);
             let decoded: Icrc3Value =
@@ -1830,7 +1855,15 @@ mod tests {
                     pretty_assert_eq!(entries.len(), 2);
                     // BTreeMap ordering: email < name
                     pretty_assert_eq!(entries[0].0, "email");
+                    pretty_assert_eq!(
+                        entries[0].1,
+                        Icrc3Value::Text("user@example.com".to_string())
+                    );
                     pretty_assert_eq!(entries[1].0, "name");
+                    pretty_assert_eq!(
+                        entries[1].1,
+                        Icrc3Value::Text("Example User".to_string())
+                    );
                 }
                 other => panic!("Expected Map, got {:?}", other),
             }

--- a/src/internet_identity/tests/integration/attributes.rs
+++ b/src/internet_identity/tests/integration/attributes.rs
@@ -7,7 +7,7 @@ use ic_canister_sig_creation::extract_raw_canister_sig_pk_from_der;
 use internet_identity_interface::internet_identity::types::attributes::{
     AttributeSpec, CertifiedAttribute, CertifiedAttributes, GetAttributesRequest,
     GetIcrc3AttributeError, GetIcrc3AttributeRequest, ListAvailableAttributesRequest,
-    PrepareAttributeRequest, PrepareIcrc3AttributeRequest,
+    PrepareAttributeRequest, PrepareIcrc3AttributeError, PrepareIcrc3AttributeRequest,
 };
 use internet_identity_interface::internet_identity::types::{
     GetDelegationResponse, OpenIdConfig, SignedDelegation,
@@ -842,4 +842,57 @@ fn should_list_all_available_attributes() {
         "Expected at least 2 attributes, got {}",
         result.len()
     );
+}
+
+#[test]
+fn should_return_error_for_unavailable_icrc3_attributes() {
+    let (env, canister_id, principal, identity_number) = setup_icrc3_test_env();
+    let origin = "https://some-dapp.com";
+
+    // Request unavailable verified_email and unknown issuer alongside available email
+    let prepare_request = PrepareIcrc3AttributeRequest {
+        identity_number,
+        origin: origin.to_string(),
+        account_number: None,
+        attributes: vec![
+            AttributeSpec {
+                key: "openid:https://accounts.google.com:email".into(),
+                value: None,
+                omit_scope: false,
+            },
+            // The test user has no verified_email
+            AttributeSpec {
+                key: "openid:https://accounts.google.com:verified_email".into(),
+                value: None,
+                omit_scope: false,
+            },
+            // Unknown issuer
+            AttributeSpec {
+                key: "openid:https://unknown-issuer.com:email".into(),
+                value: None,
+                omit_scope: false,
+            },
+        ],
+        nonce: vec![0u8; 32],
+    };
+
+    let result = api::prepare_icrc3_attributes(&env, canister_id, principal, prepare_request)
+        .expect("failed to call prepare_icrc3_attributes");
+
+    match result {
+        Err(PrepareIcrc3AttributeError::AttributeMismatch { problems }) => {
+            assert_eq!(problems.len(), 2, "Expected 2 problems, got {:?}", problems);
+            assert!(
+                problems.iter().any(|p| p.contains("verified_email")),
+                "Expected a problem about verified_email, got {:?}",
+                problems
+            );
+            assert!(
+                problems.iter().any(|p| p.contains("unknown-issuer.com")),
+                "Expected a problem about unknown issuer, got {:?}",
+                problems
+            );
+        }
+        other => panic!("Expected AttributeMismatch error, got {:?}", other),
+    }
 }

--- a/src/internet_identity/tests/integration/attributes.rs
+++ b/src/internet_identity/tests/integration/attributes.rs
@@ -713,7 +713,11 @@ fn should_certify_icrc3_attributes_mixed_omit_scope() {
                 .expect("Expected 'implicit:issued_at_timestamp_ns' key in message map");
             match &timestamp_entry.1 {
                 Icrc3Value::Nat(nat) => {
-                    let ts: u64 = nat.0.clone().try_into().expect("timestamp should fit in u64");
+                    let ts: u64 = nat
+                        .0
+                        .clone()
+                        .try_into()
+                        .expect("timestamp should fit in u64");
                     assert!(
                         ts >= time_before && ts <= time_after,
                         "Timestamp {} should be between {} and {}",

--- a/src/internet_identity/tests/integration/attributes.rs
+++ b/src/internet_identity/tests/integration/attributes.rs
@@ -696,27 +696,24 @@ fn should_certify_icrc3_attributes_mixed_omit_scope() {
                 Icrc3Value::Blob(nonce.clone()),
                 "Nonce value in certified message does not match the provided nonce"
             );
-            // origin should be included
+            // origin should be included as Text
             let origin_entry = entries
                 .iter()
                 .find(|(k, _)| k == "implicit:origin")
                 .expect("Expected 'implicit:origin' key in message map");
             assert_eq!(
                 origin_entry.1,
-                Icrc3Value::Blob(origin.as_bytes().to_vec()),
+                Icrc3Value::Text(origin.to_string()),
                 "Origin value does not match"
             );
-            // issued_at_timestamp_ns should fall within the time window of the call
+            // issued_at_timestamp_ns should be a Nat within the time window of the call
             let timestamp_entry = entries
                 .iter()
                 .find(|(k, _)| k == "implicit:issued_at_timestamp_ns")
                 .expect("Expected 'implicit:issued_at_timestamp_ns' key in message map");
             match &timestamp_entry.1 {
-                Icrc3Value::Blob(bytes) => {
-                    let ts: u64 = std::str::from_utf8(bytes)
-                        .expect("timestamp should be valid UTF-8")
-                        .parse()
-                        .expect("timestamp should be a valid u64");
+                Icrc3Value::Nat(nat) => {
+                    let ts: u64 = nat.0.clone().try_into().expect("timestamp should fit in u64");
                     assert!(
                         ts >= time_before && ts <= time_after,
                         "Timestamp {} should be between {} and {}",
@@ -725,7 +722,7 @@ fn should_certify_icrc3_attributes_mixed_omit_scope() {
                         time_after
                     );
                 }
-                other => panic!("Expected Blob for timestamp, got {:?}", other),
+                other => panic!("Expected Nat for timestamp, got {:?}", other),
             }
         }
         other => panic!("Expected Map, got {:?}", other),


### PR DESCRIPTION
Certified attribute values were encoded as raw bytes (`Blob`) regardless of their semantic type. This changes the ICRC-3 attribute message to use the correct types: `Text` for string values (email, name), `Blob` for binary data (nonce), and `Nat` for timestamps.

# Changes

- `prepare_icrc3_attributes` now produces `Icrc3Value::Text` for attribute values, `Icrc3Value::Blob` for nonce, and `Icrc3Value::Nat` for timestamps instead of encoding everything as `Blob`.
- `icrc3_attribute_message` accepts `BTreeMap<String, Icrc3Value>` instead of `BTreeMap<String, Vec<u8>>`.
- E2e tests updated to verify correct ICRC-3 Value types in the decoded attribute map.

---

<div align="left">← Previous: dfinity/internet-identity#3768</div>
<div align="right">Next: dfinity/internet-identity#3791 →</div>