### PR TITLE
feat(fe): warn when removing second-to-last access method

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/+page.svelte
@@ -314,6 +314,7 @@
           $authenticatedStore,
           removingAccessMethod,
         )}
+        isLastRemainingAfterRemoval={accessMethods.length === 2}
       />
     {/if}
     {#if "openid" in removingAccessMethod}
@@ -328,6 +329,7 @@
           $authenticatedStore,
           removingAccessMethod,
         )}
+        isLastRemainingAfterRemoval={accessMethods.length === 2}
       />
     {/if}
   </Dialog>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/RemoveOpenIdCredential.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/RemoveOpenIdCredential.svelte
@@ -11,6 +11,7 @@
     onCancel: () => void;
     providerName: string;
     isCurrentAccessMethod?: boolean;
+    isLastRemainingAfterRemoval?: boolean;
   }
 
   const {
@@ -18,6 +19,7 @@
     onCancel,
     providerName: name,
     isCurrentAccessMethod,
+    isLastRemainingAfterRemoval = false,
   }: Props = $props();
 
   let isRemoving = $state(false);
@@ -58,6 +60,14 @@
           account.
         </Trans>
       </p>
+      {#if isLastRemainingAfterRemoval}
+        <p>
+          <Trans>
+            This will leave you with only one access method. If you lose access
+            to it, you may be permanently locked out of your identity.
+          </Trans>
+        </p>
+      {/if}
       {#if isCurrentAccessMethod}
         <p>
           <Trans>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/RemovePasskey.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/RemovePasskey.svelte
@@ -10,9 +10,15 @@
     onRemove: () => Promise<void>;
     onCancel: () => void;
     isCurrentAccessMethod?: boolean;
+    isLastRemainingAfterRemoval?: boolean;
   }
 
-  const { onRemove, onCancel, isCurrentAccessMethod = false }: Props = $props();
+  const {
+    onRemove,
+    onCancel,
+    isCurrentAccessMethod = false,
+    isLastRemainingAfterRemoval = false,
+  }: Props = $props();
 
   let isRemoving = $state(false);
 
@@ -49,6 +55,14 @@
       <p>
         <Trans>It won't be removed from your device or password manager.</Trans>
       </p>
+      {#if isLastRemainingAfterRemoval}
+        <p>
+          <Trans>
+            This will leave you with only one access method. If you lose access
+            to it, you may be permanently locked out of your identity.
+          </Trans>
+        </p>
+      {/if}
       {#if isCurrentAccessMethod}
         <p>
           <Trans>


### PR DESCRIPTION
## Summary

- When a user has exactly 2 access methods and removes one, the confirmation dialog now warns that they will be left with only one access method and may be permanently locked out
- Applies to both passkey removal and OpenID credential unlinking
- The existing guard that hides the remove option for the last remaining access method is unchanged

The warning text: *"This will leave you with only one access method. If you lose access to it, you may be permanently locked out of your identity."*

Addresses #897

## Test plan

- [ ] With 3+ access methods: remove one — no extra warning shown
- [ ] With exactly 2 access methods: remove one — lockout warning appears in the confirmation dialog
- [ ] With 1 access method: remove option is hidden (existing behavior, unchanged)
- [ ] Warning appears for both passkey removal and OpenID credential unlinking

🤖 Generated with [Claude Code](https://claude.com/claude-code)