### PR TITLE
fix: prevent PostMessage channel disconnect during identity switching in Chrome

### DIFF
--- a/src/frontend/src/lib/utils/transport/postMessage.ts
+++ b/src/frontend/src/lib/utils/transport/postMessage.ts
@@ -9,7 +9,11 @@ import {
 import { HeartbeatServer } from "./heartBeat";
 
 const ESTABLISH_TIMEOUT_MS = 10000;
-const DISCONNECT_TIMEOUT_MS = 10000;
+// Chrome aggressively throttles timers in background tabs (up to 1 wake-up
+// per minute after 5 minutes hidden). A 30-second timeout gives the relying
+// party's ICRC-29 heartbeat enough margin to survive throttling while still
+// detecting genuine disconnects in a reasonable time frame.
+const DISCONNECT_TIMEOUT_MS = 30000;
 
 export class PostMessageUnsupportedError extends Error {}
 

--- a/src/frontend/src/routes/(new-styling)/(channel)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/(channel)/authorize/+layout.svelte
@@ -126,6 +126,11 @@
   };
   const authorizeDefault = async () => {
     try {
+      if ($establishedChannelStore.closed) {
+        throw new Error(
+          "Connection to the application was lost. Please try again.",
+        );
+      }
       const { identityNumber, actor } = $authenticationStore!;
       const { effectiveOrigin } = $authorizationContextStore;
       const accountNumber = actor


### PR DESCRIPTION
## Summary

- Increase `DISCONNECT_TIMEOUT_MS` from 10s to 30s to survive Chrome's aggressive background-tab timer throttling
- Add channel health check in `authorizeDefault()` before attempting delegation, providing a clear error message if the connection was already lost

## Problem

Users experience a transient "try again" error in Chrome when switching identities during authorization ([forum report](https://forum.dfinity.org/t/chrome-try-again-error-when-switching-identities-on-id-ai/67215)). The error appears on the first attempt but succeeds on retry.

**Root cause:** When the II popup is in the foreground, the relying party tab moves to the background. Chrome throttles background-tab JavaScript timers (up to 1 wake-up/minute after 5 min hidden). This delays the relying party's ICRC-29 heartbeat requests beyond the 10-second `DISCONNECT_TIMEOUT_MS`, causing the `HeartbeatServer` to fire `onDisconnect` and close the PostMessage channel mid-flow.

On retry, it works because the user just interacted with the dApp tab (to click "try again"), so Chrome un-throttles its timers and the fresh channel establishes correctly.

## Changes

| File | Change |
|------|--------|
| `src/frontend/src/lib/utils/transport/postMessage.ts` | `DISCONNECT_TIMEOUT_MS`: 10000 → 30000 |
| `src/frontend/src/routes/(new-styling)/(channel)/authorize/+layout.svelte` | Early `closed` check before `authorize()` call |

## Test plan

- [ ] Verify existing unit tests pass
- [ ] Manual: open dApp → authenticate with identity A → wait ~15s → switch to identity B → confirm no error
- [ ] Manual: rapidly switch identities — no crash or stale UI state

🤖 Generated with [Claude Code](https://claude.com/claude-code)