### PR TITLE
fix: improve error recovery during identity switching

### DIFF
--- a/src/frontend/src/lib/stores/authorization.store.ts
+++ b/src/frontend/src/lib/stores/authorization.store.ts
@@ -70,45 +70,53 @@ export const authorizationStore: AuthorizationStore = {
       ...context,
       isAuthenticating: true,
     });
-    const { identityNumber, actor } = get(authenticatedStore);
-    const artificialDelayPromise = waitFor(
-      features.DUMMY_AUTH ||
-        frontendCanisterConfig.dummy_auth[0]?.[0] !== undefined
-        ? 0
-        : (artificialDelay ?? 0),
-    );
-    const accountNumber = await accountNumberMaybePromise;
-    const { user_key, expiration } = await actor
-      .prepare_account_delegation(
-        identityNumber,
-        context.effectiveOrigin,
-        accountNumber !== undefined ? [accountNumber] : [],
-        context.authRequest.sessionPublicKey,
-        context.authRequest.maxTimeToLive !== undefined
-          ? [context.authRequest.maxTimeToLive]
-          : [],
-      )
-      .then(throwCanisterError);
-    const delegationChain = await retryFor(5, () =>
-      actor
-        .get_account_delegation(
+    try {
+      const { identityNumber, actor } = get(authenticatedStore);
+      const artificialDelayPromise = waitFor(
+        features.DUMMY_AUTH ||
+          frontendCanisterConfig.dummy_auth[0]?.[0] !== undefined
+          ? 0
+          : (artificialDelay ?? 0),
+      );
+      const accountNumber = await accountNumberMaybePromise;
+      const { user_key, expiration } = await actor
+        .prepare_account_delegation(
           identityNumber,
           context.effectiveOrigin,
           accountNumber !== undefined ? [accountNumber] : [],
           context.authRequest.sessionPublicKey,
-          expiration,
+          context.authRequest.maxTimeToLive !== undefined
+            ? [context.authRequest.maxTimeToLive]
+            : [],
         )
-        .then(throwCanisterError)
-        .then(transformSignedDelegation)
-        .then((delegation) =>
-          DelegationChain.fromDelegations(
-            [delegation],
-            new Uint8Array(user_key),
+        .then(throwCanisterError);
+      const delegationChain = await retryFor(5, () =>
+        actor
+          .get_account_delegation(
+            identityNumber,
+            context.effectiveOrigin,
+            accountNumber !== undefined ? [accountNumber] : [],
+            context.authRequest.sessionPublicKey,
+            expiration,
+          )
+          .then(throwCanisterError)
+          .then(transformSignedDelegation)
+          .then((delegation) =>
+            DelegationChain.fromDelegations(
+              [delegation],
+              new Uint8Array(user_key),
+            ),
           ),
-        ),
-    );
-    await artificialDelayPromise;
-    return { requestId: context.requestId, delegationChain };
+      );
+      await artificialDelayPromise;
+      return { requestId: context.requestId, delegationChain };
+    } catch (error) {
+      internalStore.set({
+        ...context,
+        isAuthenticating: false,
+      });
+      throw error;
+    }
   },
 };
 

--- a/src/frontend/src/lib/stores/session.store.test.ts
+++ b/src/frontend/src/lib/stores/session.store.test.ts
@@ -36,7 +36,7 @@ describe("sessionStore", () => {
       agentOptions: {},
     });
     const session = get(sessionStore);
-    sessionStore.reset();
+    await sessionStore.reset();
     const session2 = get(sessionStore);
 
     // Make sure session identity is not anonymous

--- a/src/frontend/src/lib/stores/session.store.ts
+++ b/src/frontend/src/lib/stores/session.store.ts
@@ -33,7 +33,7 @@ type SessionStore = Readable<Session> & {
     canisterId: Principal;
     agentOptions: HttpAgentOptions;
   }) => Promise<void>;
-  reset: () => void;
+  reset: () => Promise<void>;
 };
 
 const STORAGE_KEY = "ii-session";
@@ -97,17 +97,14 @@ const readSession = async (): Promise<SessionData | undefined> => {
 };
 
 let preCreatedSession: CreatedSession | undefined = undefined;
-const nextSession = (): CreatedSession => {
-  // Consume the pre-created session by assigning it to a local variable
-  // and clearing it afterwards. This ensures that if nextSession is called
-  // again before the background creation completes, it will throw an error.
-  const session = preCreatedSession;
+const nextSession = async (): Promise<CreatedSession> => {
+  // Consume the pre-created session if available (fast synchronous path).
+  // If not yet ready (e.g. rapid consecutive resets), fall back to creating
+  // a new session on demand (slower async path).
+  const session = preCreatedSession ?? (await createSession());
   preCreatedSession = undefined;
-  if (session === undefined) {
-    throw new Error("No pre-created session available");
-  }
   void (async () => {
-    // Pre-create the next session in the background to make reset synchronous
+    // Pre-create the next session in the background
     preCreatedSession = await createSession();
   })();
   return session;
@@ -143,8 +140,8 @@ export const sessionStore: SessionStore = {
     }
     return session;
   }).subscribe,
-  reset: () => {
-    const session = nextSession();
+  reset: async () => {
+    const session = await nextSession();
     session.persist();
     const { identity, nonce, salt } = session.data;
     internalStore.update((session) => {

--- a/src/frontend/src/routes/(new-styling)/(channel)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/(channel)/authorize/+layout.svelte
@@ -54,7 +54,7 @@
       isAuthenticating = true;
       if ($authenticationStore?.identityNumber !== identityNumber) {
         // Sign in if not authenticated with this identity yet
-        sessionStore.reset();
+        await sessionStore.reset();
         await authLastUsedFlow.authenticate(
           $lastUsedIdentitiesStore.identities[`${identityNumber}`],
         );

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -67,7 +67,7 @@
       isAuthenticating = true;
       if ($authenticationStore?.identityNumber !== identityNumber) {
         // Switch sign in if not authenticated with this identity yet
-        sessionStore.reset();
+        await sessionStore.reset();
         await authLastUsedFlow.authenticate(
           $lastUsedIdentitiesStore.identities[`${identityNumber}`],
         );

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/+page.svelte
@@ -195,7 +195,7 @@
         lastUsedIdentitiesStore.removeIdentity(
           $authenticatedStore.identityNumber,
         );
-        sessionStore.reset();
+        await sessionStore.reset();
         location.replace("/login");
         return;
       }

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -88,7 +88,7 @@
       isAuthenticating = true;
       if ($authenticationStore?.identityNumber !== identityNumber) {
         // Sign in if not authenticated with this identity yet
-        sessionStore.reset();
+        await sessionStore.reset();
         await authLastUsedFlow.authenticate(
           $lastUsedIdentitiesStore.identities[`${identityNumber}`],
         );
@@ -210,7 +210,7 @@
       handleConfirmSignOut();
       return;
     }
-    sessionStore.reset();
+    await sessionStore.reset();
     await authLastUsedFlow.authenticate(lastUsedIdentity);
     isReauthDialogOpen = false;
   };


### PR DESCRIPTION
## Summary

- Reset `isAuthenticating` flag on error in `authorizationStore.authorize()` to prevent stuck spinner UI
- Make `sessionStore.reset()` resilient to rapid consecutive calls instead of crashing

## Problem

Two error-recovery issues surface when identity switching fails (e.g. due to a lost PostMessage channel or network error):

1. **Stuck UI spinner:** `authorizationStore.authorize()` sets `isAuthenticating: true` but has no error-path reset. If the call throws, the authorization layout renders a perpetual "Redirecting to the app" spinner that after 10 seconds shows a misleading "Authentication successful" dialog.

2. **Crash on rapid retry:** `sessionStore.reset()` consumes a pre-created session and starts creating the next one in the background. If the user retries before background creation completes, `nextSession()` throws `"No pre-created session available"`, crashing the retry.

## Changes

| File | Change |
|------|--------|
| `authorization.store.ts` | Wrap `authorize()` body in try/catch; reset `isAuthenticating: false` on error before re-throwing |
| `session.store.ts` | Make `nextSession()` async; fall back to `createSession()` when pre-created session unavailable |
| `session.store.test.ts` | Await `reset()` call |
| 4 route files | Add `await` to `sessionStore.reset()` calls |

## Test plan

- [ ] `session.store.test.ts` passes with async reset
- [ ] Manual: trigger authorization error during identity switch → UI returns to identity picker (no stuck spinner)
- [ ] Manual: rapidly switch identities twice in quick succession → no crash on second attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)