### PR TITLE
feat(be): add DiscoverableOidcConfig type with OIDC discovery support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,6 +2189,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "sha2 0.10.9",
+ "url",
 ]
 
 [[package]]

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -368,7 +368,7 @@ pub fn config(
 pub fn discovered_oidc_configs(
     env: &PocketIc,
     canister_id: CanisterId,
-) -> Result<Vec<types::DiscoveredOidcConfig>, RejectResponse> {
+) -> Result<Vec<types::OidcConfig>, RejectResponse> {
     call_candid(
         env,
         canister_id,

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -365,15 +365,15 @@ pub fn config(
     call_candid(env, canister_id, RawEffectivePrincipal::None, "config", ()).map(|(x,)| x)
 }
 
-pub fn active_oidc_configs(
+pub fn discovered_oidc_configs(
     env: &PocketIc,
     canister_id: CanisterId,
-) -> Result<Vec<types::ActiveOidcConfig>, RejectResponse> {
+) -> Result<Vec<types::DiscoveredOidcConfig>, RejectResponse> {
     call_candid(
         env,
         canister_id,
         RawEffectivePrincipal::None,
-        "active_oidc_configs",
+        "discovered_oidc_configs",
         (),
     )
     .map(|(x,)| x)

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -365,6 +365,20 @@ pub fn config(
     call_candid(env, canister_id, RawEffectivePrincipal::None, "config", ()).map(|(x,)| x)
 }
 
+pub fn active_oidc_configs(
+    env: &PocketIc,
+    canister_id: CanisterId,
+) -> Result<Vec<types::ActiveOidcConfig>, RejectResponse> {
+    call_candid(
+        env,
+        canister_id,
+        RawEffectivePrincipal::None,
+        "active_oidc_configs",
+        (),
+    )
+    .map(|(x,)| x)
+}
+
 pub fn openid_prepare_delegation(
     env: &PocketIc,
     canister_id: CanisterId,

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -379,6 +379,20 @@ pub fn discovered_oidc_configs(
     .map(|(x,)| x)
 }
 
+pub fn add_discoverable_oidc_config(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    config: types::DiscoverableOidcConfig,
+) -> Result<(), RejectResponse> {
+    call_candid(
+        env,
+        canister_id,
+        RawEffectivePrincipal::None,
+        "add_discoverable_oidc_config",
+        (config,),
+    )
+}
+
 pub fn openid_prepare_delegation(
     env: &PocketIc,
     canister_id: CanisterId,

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -30,6 +30,7 @@ captcha = { git = "https://github.com/dfinity/captcha", rev = "9c0d2dd9bf519e255
 
 # OpenID deps
 identity_jose = { git = "https://github.com/dfinity/identity.rs.git", rev = "aa510ef7f441848d6c78058fe51ad4ad1d9bd5d8", default-features = false }
+url = { version = "2.5", default-features = false }
 
 # All IC deps
 candid.workspace = true

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -30,7 +30,7 @@ captcha = { git = "https://github.com/dfinity/captcha", rev = "9c0d2dd9bf519e255
 
 # OpenID deps
 identity_jose = { git = "https://github.com/dfinity/identity.rs.git", rev = "aa510ef7f441848d6c78058fe51ad4ad1d9bd5d8", default-features = false }
-url = { version = "2.5", default-features = false }
+url = { version = "2.5", default-features = false, features = ["std"] }
 
 # All IC deps
 candid.workspace = true

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -385,24 +385,21 @@ type OpenIdConfig = record {
     email_verification : opt OpenIdEmailVerification;
 };
 
-// Simplified OIDC provider config that relies on discovery.
-// client_id must be set. discovery_url is the standard OIDC .well-known endpoint.
+// SSO provider config that uses two-hop discovery.
+// The backend fetches https://{discovery_domain}/.well-known/ii-openid-configuration
+// for { client_id, openid_configuration } and then fetches the standard OIDC
+// discovery at openid_configuration for { issuer, jwks_uri }.
 type DiscoverableOidcConfig = record {
-    name : text;
-    logo : text;
-    discovery_url : text;
-    client_id : opt text;
-    email_verification : opt OpenIdEmailVerification;
+    discovery_domain : text;
 };
 
-// Resolved OIDC config with discovered fields.
+// Resolved SSO provider state.
+// All fields other than discovery_domain are None until discovery completes.
 type OidcConfig = record {
-    name : text;
-    logo : text;
-    discovery_url : text;
+    discovery_domain : text;
     client_id : opt text;
+    openid_configuration : opt text;
     issuer : opt text;
-    email_verification : opt OpenIdEmailVerification;
 };
 
 type OpenIdCredentialKey = record { Iss; Sub };

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -280,6 +280,8 @@ type InternetIdentityInit = record {
     new_flow_origins : opt vec text;
     // Configurations for OpenID clients
     openid_configs : opt vec OpenIdConfig;
+    // Simplified OIDC configs using discovery. Mutually exclusive with openid_configs.
+    oidc_configs : opt vec OidcConfig;
     // Configuration for Web Analytics
     analytics_config : opt opt AnalyticsConfig;
     // Configuration to show dapps explorer or not
@@ -380,6 +382,27 @@ type OpenIdConfig = record {
     auth_uri : text;
     auth_scope : vec text;
     fedcm_uri : opt text;
+    email_verification : opt OpenIdEmailVerification;
+};
+
+// Simplified OIDC provider config that relies on discovery.
+// For dedicated providers: client_id is set, discovery_url is standard OIDC endpoint.
+// For SSO providers: client_id is null, discovery_url is custom ii-openid-configuration.
+type OidcConfig = record {
+    name : text;
+    logo : text;
+    discovery_url : text;
+    client_id : opt text;
+    email_verification : opt OpenIdEmailVerification;
+};
+
+// Resolved OIDC config with discovered fields.
+type ActiveOidcConfig = record {
+    name : text;
+    logo : text;
+    discovery_url : text;
+    client_id : opt text;
+    issuer : opt text;
     email_verification : opt OpenIdEmailVerification;
 };
 
@@ -1174,6 +1197,10 @@ service : (opt InternetIdentityInit) -> {
     // HTTP Gateway protocol
     // =====================
     http_request : (request : HttpRequest) -> (HttpResponse) query;
+
+    // OIDC Discovery
+    // ===============
+    active_oidc_configs : () -> (vec ActiveOidcConfig) query;
 
     // Internal Methods
     // ================

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -386,8 +386,7 @@ type OpenIdConfig = record {
 };
 
 // Simplified OIDC provider config that relies on discovery.
-// For dedicated providers: client_id is set, discovery_url is standard OIDC endpoint.
-// For SSO providers: client_id is null, discovery_url is custom ii-openid-configuration.
+// client_id must be set. discovery_url is the standard OIDC .well-known endpoint.
 type DiscoverableOidcConfig = record {
     name : text;
     logo : text;

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -397,7 +397,7 @@ type OidcConfig = record {
 };
 
 // Resolved OIDC config with discovered fields.
-type ActiveOidcConfig = record {
+type DiscoveredOidcConfig = record {
     name : text;
     logo : text;
     discovery_url : text;
@@ -1200,7 +1200,7 @@ service : (opt InternetIdentityInit) -> {
 
     // OIDC Discovery
     // ===============
-    active_oidc_configs : () -> (vec ActiveOidcConfig) query;
+    discovered_oidc_configs : () -> (vec DiscoveredOidcConfig) query;
 
     // Internal Methods
     // ================

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -280,7 +280,8 @@ type InternetIdentityInit = record {
     new_flow_origins : opt vec text;
     // Configurations for OpenID clients
     openid_configs : opt vec OpenIdConfig;
-    // Simplified OIDC configs using discovery. Mutually exclusive with openid_configs.
+    // Deprecated in init args: use add_discoverable_oidc_config update call instead.
+    // Kept for backward compatibility and config() query output.
     oidc_configs : opt vec DiscoverableOidcConfig;
     // Configuration for Web Analytics
     analytics_config : opt opt AnalyticsConfig;
@@ -1197,6 +1198,7 @@ service : (opt InternetIdentityInit) -> {
     // OIDC Discovery
     // ===============
     discovered_oidc_configs : () -> (vec OidcConfig) query;
+    add_discoverable_oidc_config : (DiscoverableOidcConfig) -> ();
 
     // Internal Methods
     // ================

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -281,7 +281,7 @@ type InternetIdentityInit = record {
     // Configurations for OpenID clients
     openid_configs : opt vec OpenIdConfig;
     // Simplified OIDC configs using discovery. Mutually exclusive with openid_configs.
-    oidc_configs : opt vec OidcConfig;
+    oidc_configs : opt vec DiscoverableOidcConfig;
     // Configuration for Web Analytics
     analytics_config : opt opt AnalyticsConfig;
     // Configuration to show dapps explorer or not
@@ -388,7 +388,7 @@ type OpenIdConfig = record {
 // Simplified OIDC provider config that relies on discovery.
 // For dedicated providers: client_id is set, discovery_url is standard OIDC endpoint.
 // For SSO providers: client_id is null, discovery_url is custom ii-openid-configuration.
-type OidcConfig = record {
+type DiscoverableOidcConfig = record {
     name : text;
     logo : text;
     discovery_url : text;
@@ -397,7 +397,7 @@ type OidcConfig = record {
 };
 
 // Resolved OIDC config with discovered fields.
-type DiscoveredOidcConfig = record {
+type OidcConfig = record {
     name : text;
     logo : text;
     discovery_url : text;
@@ -1200,7 +1200,7 @@ service : (opt InternetIdentityInit) -> {
 
     // OIDC Discovery
     // ===============
-    discovered_oidc_configs : () -> (vec DiscoveredOidcConfig) query;
+    discovered_oidc_configs : () -> (vec OidcConfig) query;
 
     // Internal Methods
     // ================

--- a/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
+++ b/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
@@ -202,7 +202,12 @@ fn create_openid_credential_and_config(
     let OpenIDRegFinishArg { jwt, salt, name: _ } = openid_registration_data;
 
     let (openid_credential, openid_config_iss) = openid::with_provider(jwt, |provider| {
-        Ok((provider.verify(jwt, salt)?, provider.issuer()))
+        // `with_provider` already skipped providers with pending discovery, so
+        // `provider.issuer()` is guaranteed to be Some here.
+        Ok((
+            provider.verify(jwt, salt)?,
+            provider.issuer().unwrap_or_default(),
+        ))
     })?;
 
     Ok((openid_credential, openid_config_iss))

--- a/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
+++ b/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
@@ -202,12 +202,14 @@ fn create_openid_credential_and_config(
     let OpenIDRegFinishArg { jwt, salt, name: _ } = openid_registration_data;
 
     let (openid_credential, openid_config_iss) = openid::with_provider(jwt, |provider| {
-        // `with_provider` already skipped providers with pending discovery, so
-        // `provider.issuer()` is guaranteed to be Some here.
-        Ok((
-            provider.verify(jwt, salt)?,
-            provider.issuer().unwrap_or_default(),
-        ))
+        // `with_provider` only yields providers whose discovery has completed, so
+        // `issuer()` is always Some — surface an explicit error if that ever breaks.
+        let issuer = provider.issuer().ok_or_else(|| {
+            openid::OpenIDJWTVerificationError::GenericError(
+                "Selected provider has no issuer after discovery filter".to_string(),
+            )
+        })?;
+        Ok((provider.verify(jwt, salt)?, issuer))
     })?;
 
     Ok((openid_credential, openid_config_iss))

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -554,6 +554,11 @@ fn discovered_oidc_configs() -> Vec<OidcConfig> {
     openid::get_discovered_oidc_configs()
 }
 
+#[update]
+fn add_discoverable_oidc_config(config: DiscoverableOidcConfig) {
+    openid::add_oidc_config(config);
+}
+
 #[query]
 fn config() -> InternetIdentityInit {
     let archive_config = match state::archive_state() {
@@ -666,31 +671,14 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
                 persistent_state.related_origins = Some(related_origins);
             })
         }
-        // oidc_configs, openid_configs, and new_flow_origins are mutually exclusive.
-        // When openid_configs is provided alongside oidc_configs, openid_configs takes
-        // precedence as the proven path. When oidc_configs is set, new_flow_origins is
-        // cleared (and vice versa) since oidc_configs subsumes new_flow_origins.
         if let Some(openid_configs) = arg.openid_configs {
-            if arg.oidc_configs.is_some() {
-                ic_cdk::println!(
-                    "Both openid_configs and oidc_configs provided; using openid_configs"
-                );
-            }
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.openid_configs = Some(openid_configs);
-                persistent_state.oidc_configs = None;
-            })
-        } else if let Some(oidc_configs) = arg.oidc_configs {
-            state::persistent_state_mut(|persistent_state| {
-                persistent_state.oidc_configs = Some(oidc_configs);
-                persistent_state.openid_configs = None;
-                persistent_state.new_flow_origins = None;
             })
         }
         if let Some(new_flow_origins) = arg.new_flow_origins {
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.new_flow_origins = Some(new_flow_origins);
-                persistent_state.oidc_configs = None;
             })
         }
         if let Some(analytics_config) = arg.analytics_config {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -666,13 +666,10 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
                 persistent_state.related_origins = Some(related_origins);
             })
         }
-        if let Some(new_flow_origins) = arg.new_flow_origins {
-            state::persistent_state_mut(|persistent_state| {
-                persistent_state.new_flow_origins = Some(new_flow_origins);
-            })
-        }
-        // oidc_configs and openid_configs are mutually exclusive.
-        // When both are provided, openid_configs takes precedence as the proven path.
+        // oidc_configs, openid_configs, and new_flow_origins are mutually exclusive.
+        // When openid_configs is provided alongside oidc_configs, openid_configs takes
+        // precedence as the proven path. When oidc_configs is set, new_flow_origins is
+        // cleared (and vice versa) since oidc_configs subsumes new_flow_origins.
         if let Some(openid_configs) = arg.openid_configs {
             if arg.oidc_configs.is_some() {
                 ic_cdk::println!(
@@ -687,6 +684,13 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.oidc_configs = Some(oidc_configs);
                 persistent_state.openid_configs = None;
+                persistent_state.new_flow_origins = None;
+            })
+        }
+        if let Some(new_flow_origins) = arg.new_flow_origins {
+            state::persistent_state_mut(|persistent_state| {
+                persistent_state.new_flow_origins = Some(new_flow_origins);
+                persistent_state.oidc_configs = None;
             })
         }
         if let Some(analytics_config) = arg.analytics_config {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -671,16 +671,19 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
                 persistent_state.new_flow_origins = Some(new_flow_origins);
             })
         }
-        if arg.openid_configs.is_some() && arg.oidc_configs.is_some() {
-            trap("Cannot set both openid_configs and oidc_configs");
-        }
+        // oidc_configs and openid_configs are mutually exclusive.
+        // When both are provided, openid_configs takes precedence as the proven path.
         if let Some(openid_configs) = arg.openid_configs {
+            if arg.oidc_configs.is_some() {
+                ic_cdk::println!(
+                    "Both openid_configs and oidc_configs provided; using openid_configs"
+                );
+            }
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.openid_configs = Some(openid_configs);
                 persistent_state.oidc_configs = None;
             })
-        }
-        if let Some(oidc_configs) = arg.oidc_configs {
+        } else if let Some(oidc_configs) = arg.oidc_configs {
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.oidc_configs = Some(oidc_configs);
                 persistent_state.openid_configs = None;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -550,7 +550,7 @@ fn stats() -> InternetIdentityStats {
 }
 
 #[query]
-fn discovered_oidc_configs() -> Vec<DiscoveredOidcConfig> {
+fn discovered_oidc_configs() -> Vec<OidcConfig> {
     openid::get_discovered_oidc_configs()
 }
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -550,8 +550,8 @@ fn stats() -> InternetIdentityStats {
 }
 
 #[query]
-fn active_oidc_configs() -> Vec<ActiveOidcConfig> {
-    openid::get_active_oidc_configs()
+fn discovered_oidc_configs() -> Vec<DiscoveredOidcConfig> {
+    openid::get_discovered_oidc_configs()
 }
 
 #[query]

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -550,6 +550,11 @@ fn stats() -> InternetIdentityStats {
 }
 
 #[query]
+fn active_oidc_configs() -> Vec<ActiveOidcConfig> {
+    openid::get_active_oidc_configs()
+}
+
+#[query]
 fn config() -> InternetIdentityInit {
     let archive_config = match state::archive_state() {
         ArchiveState::NotConfigured => None,
@@ -568,6 +573,7 @@ fn config() -> InternetIdentityInit {
         related_origins: persistent_state.related_origins.clone(),
         new_flow_origins: persistent_state.new_flow_origins.clone(),
         openid_configs: persistent_state.openid_configs.clone(),
+        oidc_configs: persistent_state.oidc_configs.clone(),
         analytics_config: Some(persistent_state.analytics_config.clone()),
         enable_dapps_explorer: persistent_state.enable_dapps_explorer,
         is_production: persistent_state.is_production,
@@ -625,6 +631,9 @@ fn initialize(maybe_arg: Option<InternetIdentityInit>) {
     if let Some(openid_configs) = config.openid_configs {
         openid::setup(openid_configs);
     }
+    if let Some(oidc_configs) = config.oidc_configs {
+        openid::setup_oidc(oidc_configs);
+    }
 }
 
 fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
@@ -662,9 +671,19 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
                 persistent_state.new_flow_origins = Some(new_flow_origins);
             })
         }
+        if arg.openid_configs.is_some() && arg.oidc_configs.is_some() {
+            trap("Cannot set both openid_configs and oidc_configs");
+        }
         if let Some(openid_configs) = arg.openid_configs {
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.openid_configs = Some(openid_configs);
+                persistent_state.oidc_configs = None;
+            })
+        }
+        if let Some(oidc_configs) = arg.oidc_configs {
+            state::persistent_state_mut(|persistent_state| {
+                persistent_state.oidc_configs = Some(oidc_configs);
+                persistent_state.openid_configs = None;
             })
         }
         if let Some(analytics_config) = arg.analytics_config {

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -12,7 +12,7 @@ use internet_identity_interface::internet_identity::types::openid::{
     OpenIdCredentialAddError, OpenIdDelegationError,
 };
 use internet_identity_interface::internet_identity::types::{
-    AnchorNumber, Delegation, DiscoveredOidcConfig, IdRegFinishError, MetadataEntryV2, OidcConfig,
+    AnchorNumber, Delegation, DiscoverableOidcConfig, IdRegFinishError, MetadataEntryV2, OidcConfig,
     OpenIdConfig, OpenIdEmailVerificationScheme, PublicKey, SessionKey, SignedDelegation, Timestamp,
     UserKey,
 };
@@ -256,7 +256,7 @@ struct PartialClaims {
 
 thread_local! {
     static PROVIDERS: RefCell<Vec<Box<dyn OpenIdProvider >>> = RefCell::new(vec![]);
-    static OIDC_CONFIGS: RefCell<Vec<OidcConfig>> = RefCell::new(vec![]);
+    static OIDC_CONFIGS: RefCell<Vec<DiscoverableOidcConfig>> = RefCell::new(vec![]);
 }
 
 pub fn setup(configs: Vec<OpenIdConfig>) {
@@ -267,7 +267,7 @@ pub fn setup(configs: Vec<OpenIdConfig>) {
     });
 }
 
-pub fn setup_oidc(configs: Vec<OidcConfig>) {
+pub fn setup_oidc(configs: Vec<DiscoverableOidcConfig>) {
     OIDC_CONFIGS.with_borrow_mut(|stored| {
         *stored = configs.clone();
     });
@@ -280,11 +280,11 @@ pub fn setup_oidc(configs: Vec<OidcConfig>) {
     generic::init_discovery_timers();
 }
 
-pub fn get_discovered_oidc_configs() -> Vec<DiscoveredOidcConfig> {
+pub fn get_discovered_oidc_configs() -> Vec<OidcConfig> {
     OIDC_CONFIGS.with_borrow(|configs| {
         configs
             .iter()
-            .map(|config| DiscoveredOidcConfig {
+            .map(|config| OidcConfig {
                 name: config.name.clone(),
                 logo: config.logo.clone(),
                 discovery_url: config.discovery_url.clone(),

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -256,7 +256,7 @@ struct PartialClaims {
 
 thread_local! {
     static PROVIDERS: RefCell<Vec<Box<dyn OpenIdProvider >>> = RefCell::new(vec![]);
-    static OIDC_CONFIGS: RefCell<Vec<DiscoverableOidcConfig>> = RefCell::new(vec![]);
+    static OIDC_CONFIGS: RefCell<Vec<DiscoverableOidcConfig>> = const { RefCell::new(vec![]) };
 }
 
 pub fn setup(configs: Vec<OpenIdConfig>) {

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -12,8 +12,9 @@ use internet_identity_interface::internet_identity::types::openid::{
     OpenIdCredentialAddError, OpenIdDelegationError,
 };
 use internet_identity_interface::internet_identity::types::{
-    AnchorNumber, Delegation, IdRegFinishError, MetadataEntryV2, OpenIdConfig,
-    OpenIdEmailVerificationScheme, PublicKey, SessionKey, SignedDelegation, Timestamp, UserKey,
+    ActiveOidcConfig, AnchorNumber, Delegation, IdRegFinishError, MetadataEntryV2, OidcConfig,
+    OpenIdConfig, OpenIdEmailVerificationScheme, PublicKey, SessionKey, SignedDelegation, Timestamp,
+    UserKey,
 };
 use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
@@ -255,6 +256,7 @@ struct PartialClaims {
 
 thread_local! {
     static PROVIDERS: RefCell<Vec<Box<dyn OpenIdProvider >>> = RefCell::new(vec![]);
+    static OIDC_CONFIGS: RefCell<Vec<OidcConfig>> = RefCell::new(vec![]);
 }
 
 pub fn setup(configs: Vec<OpenIdConfig>) {
@@ -263,6 +265,34 @@ pub fn setup(configs: Vec<OpenIdConfig>) {
             providers.push(Box::new(generic::Provider::create(config)));
         }
     });
+}
+
+pub fn setup_oidc(configs: Vec<OidcConfig>) {
+    OIDC_CONFIGS.with_borrow_mut(|stored| {
+        *stored = configs.clone();
+    });
+    PROVIDERS.with_borrow_mut(|providers| {
+        for config in configs {
+            providers.push(Box::new(generic::DiscoverableProvider::create(config)));
+        }
+    });
+}
+
+pub fn get_active_oidc_configs() -> Vec<ActiveOidcConfig> {
+    OIDC_CONFIGS.with_borrow(|configs| {
+        configs
+            .iter()
+            .map(|config| ActiveOidcConfig {
+                name: config.name.clone(),
+                logo: config.logo.clone(),
+                discovery_url: config.discovery_url.clone(),
+                client_id: config.client_id.clone(),
+                // issuer is populated once OIDC discovery completes (via HTTP outcall)
+                issuer: None,
+                email_verification: config.email_verification,
+            })
+            .collect()
+    })
 }
 
 pub fn with_provider<F, R>(jwt: &str, callback: F) -> Result<R, OpenIDJWTVerificationError>

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -269,20 +269,29 @@ struct PartialClaims {
 }
 
 /// JWT `aud` claim — per RFC 7519 may be a single string or an array of strings
-/// (Microsoft sometimes ships it as an array). We normalize by taking the first
-/// element of the array and only match against the provider's configured client id.
-#[derive(Deserialize)]
+/// (Microsoft sometimes ships it as an array). Matching treats an array as a
+/// set: any element equal to the provider's configured client id is accepted.
+#[derive(Deserialize, Clone)]
 #[serde(untagged)]
-enum AudClaim {
+pub(super) enum AudClaim {
     Single(String),
     Multiple(Vec<String>),
 }
 
 impl AudClaim {
-    fn as_str(&self) -> Option<&str> {
+    /// Returns `true` if `expected` is the single value or contained in the array.
+    pub(super) fn matches(&self, expected: &str) -> bool {
         match self {
-            AudClaim::Single(s) => Some(s.as_str()),
-            AudClaim::Multiple(v) => v.first().map(String::as_str),
+            AudClaim::Single(s) => s == expected,
+            AudClaim::Multiple(v) => v.iter().any(|s| s == expected),
+        }
+    }
+
+    /// Returns `true` if the claim carries no audience at all.
+    pub(super) fn is_empty(&self) -> bool {
+        match self {
+            AudClaim::Single(s) => s.is_empty(),
+            AudClaim::Multiple(v) => v.is_empty(),
         }
     }
 }
@@ -379,9 +388,11 @@ where
         serde_json::from_slice(validation_item.claims()).map_err(|_| {
             OpenIDJWTVerificationError::GenericError("Unable to decode claims".to_string())
         })?;
-    let aud = aud.as_str().ok_or_else(|| {
-        OpenIDJWTVerificationError::GenericError("JWT has empty aud claim".to_string())
-    })?;
+    if aud.is_empty() {
+        return Err(OpenIDJWTVerificationError::GenericError(
+            "JWT has empty aud claim".to_string(),
+        ));
+    }
 
     PROVIDERS.with_borrow(|providers| {
         providers
@@ -397,7 +408,7 @@ where
                 let issuer_placeholders = get_issuer_placeholders(&template);
                 let issuer_claims = get_all_claims(validation_item.claims(), issuer_placeholders);
                 let effective_issuer = replace_issuer_placeholders(&template, &issuer_claims);
-                effective_issuer == iss && provider_aud == aud
+                effective_issuer == iss && aud.matches(&provider_aud)
             })
             .ok_or_else(|| {
                 // If any provider is still waiting on discovery, surface a "pending" error

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -12,7 +12,7 @@ use internet_identity_interface::internet_identity::types::openid::{
     OpenIdCredentialAddError, OpenIdDelegationError,
 };
 use internet_identity_interface::internet_identity::types::{
-    ActiveOidcConfig, AnchorNumber, Delegation, IdRegFinishError, MetadataEntryV2, OidcConfig,
+    AnchorNumber, Delegation, DiscoveredOidcConfig, IdRegFinishError, MetadataEntryV2, OidcConfig,
     OpenIdConfig, OpenIdEmailVerificationScheme, PublicKey, SessionKey, SignedDelegation, Timestamp,
     UserKey,
 };
@@ -276,19 +276,20 @@ pub fn setup_oidc(configs: Vec<OidcConfig>) {
             providers.push(Box::new(generic::DiscoverableProvider::create(config)));
         }
     });
+    #[cfg(not(test))]
+    generic::init_discovery_timers();
 }
 
-pub fn get_active_oidc_configs() -> Vec<ActiveOidcConfig> {
+pub fn get_discovered_oidc_configs() -> Vec<DiscoveredOidcConfig> {
     OIDC_CONFIGS.with_borrow(|configs| {
         configs
             .iter()
-            .map(|config| ActiveOidcConfig {
+            .map(|config| DiscoveredOidcConfig {
                 name: config.name.clone(),
                 logo: config.logo.clone(),
                 discovery_url: config.discovery_url.clone(),
                 client_id: config.client_id.clone(),
-                // issuer is populated once OIDC discovery completes (via HTTP outcall)
-                issuer: None,
+                issuer: generic::discovered_issuer_for(&config.discovery_url),
                 email_verification: config.email_verification,
             })
             .collect()

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -321,7 +321,20 @@ where
                 effective_issuer == iss
             })
             .ok_or_else(|| {
-                OpenIDJWTVerificationError::GenericError(format!("Unsupported issuer: {}", iss))
+                // Check if there are discoverable providers still initializing
+                // (their issuer is empty until discovery completes)
+                let has_pending = providers.iter().any(|p| p.issuer().is_empty());
+                if has_pending {
+                    OpenIDJWTVerificationError::GenericError(
+                        "OIDC provider discovery is still in progress, please try again shortly"
+                            .to_string(),
+                    )
+                } else {
+                    OpenIDJWTVerificationError::GenericError(format!(
+                        "Unsupported issuer: {}",
+                        iss
+                    ))
+                }
             })
             .and_then(|provider| callback(provider.as_ref()))
     })

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -12,9 +12,9 @@ use internet_identity_interface::internet_identity::types::openid::{
     OpenIdCredentialAddError, OpenIdDelegationError,
 };
 use internet_identity_interface::internet_identity::types::{
-    AnchorNumber, Delegation, DiscoverableOidcConfig, IdRegFinishError, MetadataEntryV2, OidcConfig,
-    OpenIdConfig, OpenIdEmailVerificationScheme, PublicKey, SessionKey, SignedDelegation, Timestamp,
-    UserKey,
+    AnchorNumber, Delegation, DiscoverableOidcConfig, IdRegFinishError, MetadataEntryV2,
+    OidcConfig, OpenIdConfig, OpenIdEmailVerificationScheme, PublicKey, SessionKey,
+    SignedDelegation, Timestamp, UserKey,
 };
 use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
@@ -150,7 +150,14 @@ impl OpenIdCredential {
             providers
                 .iter()
                 .find(|provider| {
-                    let issuer_placeholders = get_issuer_placeholders(&provider.issuer());
+                    // Skip providers whose discovery is still pending.
+                    let Some(template) = provider.issuer() else {
+                        return false;
+                    };
+                    let Some(provider_aud) = provider.client_id() else {
+                        return false;
+                    };
+                    let issuer_placeholders = get_issuer_placeholders(&template);
                     let mut issuer_claims: Vec<(String, String)> = vec![];
                     for key in issuer_placeholders {
                         if let Some(MetadataEntryV2::String(value)) = self.metadata.get(&key) {
@@ -159,9 +166,8 @@ impl OpenIdCredential {
                             return false;
                         }
                     }
-                    let effective_issuer =
-                        replace_issuer_placeholders(&provider.issuer(), &issuer_claims);
-                    effective_issuer == self.iss
+                    let effective_issuer = replace_issuer_placeholders(&template, &issuer_claims);
+                    effective_issuer == self.iss && provider_aud == self.aud
                 })
                 .and_then(|provider| f(provider.as_ref()))
         })
@@ -169,7 +175,7 @@ impl OpenIdCredential {
 
     /// Find current config for stored credential
     pub fn config_issuer(&self) -> Option<String> {
-        self.with_provider(|provider| Some(provider.issuer()))
+        self.with_provider(|provider| provider.issuer())
     }
 
     fn read_attribute_as_string(&self, attribute_name: &str) -> Option<String> {
@@ -232,7 +238,14 @@ impl OpenIdCredential {
 }
 
 pub trait OpenIdProvider {
-    fn issuer(&self) -> String;
+    /// Issuer template for this provider. `None` means discovery is still pending —
+    /// matching and verification skip such providers. May contain placeholders like
+    /// `{tid}` that are filled from JWT claims before comparison.
+    fn issuer(&self) -> Option<String>;
+
+    /// Client id (the expected JWT `aud`) for this provider. `None` means discovery
+    /// is still pending.
+    fn client_id(&self) -> Option<String>;
 
     fn email_verification_scheme(&self) -> Option<OpenIdEmailVerificationScheme>;
 
@@ -252,6 +265,26 @@ pub trait OpenIdProvider {
 #[derive(Deserialize)]
 struct PartialClaims {
     iss: String,
+    aud: AudClaim,
+}
+
+/// JWT `aud` claim — per RFC 7519 may be a single string or an array of strings
+/// (Microsoft sometimes ships it as an array). We normalize by taking the first
+/// element of the array and only match against the provider's configured client id.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum AudClaim {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl AudClaim {
+    fn as_str(&self) -> Option<&str> {
+        match self {
+            AudClaim::Single(s) => Some(s.as_str()),
+            AudClaim::Multiple(v) => v.first().map(String::as_str),
+        }
+    }
 }
 
 thread_local! {
@@ -268,6 +301,15 @@ pub fn setup(configs: Vec<OpenIdConfig>) {
 }
 
 pub fn setup_oidc(configs: Vec<DiscoverableOidcConfig>) {
+    // Canary-phase domain allowlist: reject configs whose domain isn't on the list.
+    for config in &configs {
+        if !generic::is_allowed_discovery_domain(&config.discovery_domain) {
+            ic_cdk::trap(&format!(
+                "discovery_domain '{}' is not on the canary allowlist",
+                config.discovery_domain
+            ));
+        }
+    }
     OIDC_CONFIGS.with_borrow_mut(|stored| {
         *stored = configs.clone();
     });
@@ -284,13 +326,15 @@ pub fn get_discovered_oidc_configs() -> Vec<OidcConfig> {
     OIDC_CONFIGS.with_borrow(|configs| {
         configs
             .iter()
-            .map(|config| OidcConfig {
-                name: config.name.clone(),
-                logo: config.logo.clone(),
-                discovery_url: config.discovery_url.clone(),
-                client_id: config.client_id.clone(),
-                issuer: generic::discovered_issuer_for(&config.discovery_url),
-                email_verification: config.email_verification,
+            .map(|config| {
+                let (client_id, openid_configuration, issuer) =
+                    generic::discovered_state_for(&config.discovery_domain);
+                OidcConfig {
+                    discovery_domain: config.discovery_domain.clone(),
+                    client_id,
+                    openid_configuration,
+                    issuer,
+                }
             })
             .collect()
     })
@@ -306,34 +350,43 @@ where
             OpenIDJWTVerificationError::GenericError("Failed to decode JWT".to_string())
         })?;
 
-    let PartialClaims { iss } = serde_json::from_slice(validation_item.claims()).map_err(|_| {
-        OpenIDJWTVerificationError::GenericError("Unable to decode claims".to_string())
+    let PartialClaims { iss, aud } =
+        serde_json::from_slice(validation_item.claims()).map_err(|_| {
+            OpenIDJWTVerificationError::GenericError("Unable to decode claims".to_string())
+        })?;
+    let aud = aud.as_str().ok_or_else(|| {
+        OpenIDJWTVerificationError::GenericError("JWT has empty aud claim".to_string())
     })?;
 
     PROVIDERS.with_borrow(|providers| {
         providers
             .iter()
             .find(|provider| {
-                let issuer_placeholders = get_issuer_placeholders(&provider.issuer());
+                // Skip providers whose discovery is still pending.
+                let Some(template) = provider.issuer() else {
+                    return false;
+                };
+                let Some(provider_aud) = provider.client_id() else {
+                    return false;
+                };
+                let issuer_placeholders = get_issuer_placeholders(&template);
                 let issuer_claims = get_all_claims(validation_item.claims(), issuer_placeholders);
-                let effective_issuer =
-                    replace_issuer_placeholders(&provider.issuer(), &issuer_claims);
-                effective_issuer == iss
+                let effective_issuer = replace_issuer_placeholders(&template, &issuer_claims);
+                effective_issuer == iss && provider_aud == aud
             })
             .ok_or_else(|| {
-                // Check if there are discoverable providers still initializing
-                // (their issuer is empty until discovery completes)
-                let has_pending = providers.iter().any(|p| p.issuer().is_empty());
+                // If any provider is still waiting on discovery, surface a "pending" error
+                // rather than the generic "unsupported issuer" so the frontend can retry.
+                let has_pending = providers
+                    .iter()
+                    .any(|p| p.issuer().is_none() || p.client_id().is_none());
                 if has_pending {
                     OpenIDJWTVerificationError::GenericError(
                         "OIDC provider discovery is still in progress, please try again shortly"
                             .to_string(),
                     )
                 } else {
-                    OpenIDJWTVerificationError::GenericError(format!(
-                        "Unsupported issuer: {}",
-                        iss
-                    ))
+                    OpenIDJWTVerificationError::GenericError(format!("Unsupported issuer: {}", iss))
                 }
             })
             .and_then(|provider| callback(provider.as_ref()))
@@ -438,12 +491,29 @@ fn salt() -> [u8; 32] {
 }
 
 #[cfg(test)]
-struct ExampleProvider;
+struct ExampleProvider {
+    issuer: Option<String>,
+    client_id: Option<String>,
+}
+
+#[cfg(test)]
+impl Default for ExampleProvider {
+    fn default() -> Self {
+        Self {
+            issuer: Some("https://example.com".into()),
+            client_id: Some("example-aud".into()),
+        }
+    }
+}
 
 #[cfg(test)]
 impl OpenIdProvider for ExampleProvider {
-    fn issuer(&self) -> String {
-        "https://example.com".into()
+    fn issuer(&self) -> Option<String> {
+        self.issuer.clone()
+    }
+
+    fn client_id(&self) -> Option<String> {
+        self.client_id.clone()
     }
 
     fn email_verification_scheme(&self) -> Option<OpenIdEmailVerificationScheme> {
@@ -463,24 +533,34 @@ impl OpenIdProvider for ExampleProvider {
 impl ExampleProvider {
     fn credential(&self) -> OpenIdCredential {
         OpenIdCredential {
-            iss: self.issuer(),
+            iss: self
+                .issuer
+                .clone()
+                .unwrap_or_else(|| "https://example.com".into()),
             sub: "example-sub".into(),
-            aud: "example-aud".into(),
+            aud: self
+                .client_id
+                .clone()
+                .unwrap_or_else(|| "example-aud".into()),
             last_usage_timestamp: None,
             metadata: HashMap::new(),
         }
     }
 }
 
+// Example JWT with {"iss":"https://example.com","aud":"example-aud"}.
+#[cfg(test)]
+const EXAMPLE_JWT: &str = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiYXVkIjoiZXhhbXBsZS1hdWQifQ.SBeD7pV65F98wStsBuC_VRn-yjLoyf6iojJl9Y__wN0";
+
 #[test]
 fn should_return_credential() {
-    let provider = ExampleProvider {};
+    let provider = ExampleProvider::default();
     let credential = provider.credential();
     PROVIDERS.replace(vec![Box::new(provider)]);
-    let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIn0.SBeD7pV65F98wStsBuC_VRn-yjLoyf6iojJl9Y__wN0";
 
     assert_eq!(
-        with_provider(jwt, |provider| provider.verify(jwt, &[0u8; 32])),
+        with_provider(EXAMPLE_JWT, |provider| provider
+            .verify(EXAMPLE_JWT, &[0u8; 32])),
         Ok(credential)
     );
 }
@@ -488,14 +568,55 @@ fn should_return_credential() {
 #[test]
 fn should_return_error_unsupported_issuer() {
     PROVIDERS.replace(vec![]);
-    let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIn0.SBeD7pV65F98wStsBuC_VRn-yjLoyf6iojJl9Y__wN0";
 
     assert_eq!(
-        with_provider(jwt, |provider| provider.verify(jwt, &[0u8; 32])),
+        with_provider(EXAMPLE_JWT, |provider| provider
+            .verify(EXAMPLE_JWT, &[0u8; 32])),
         Err(OpenIDJWTVerificationError::GenericError(
             "Unsupported issuer: https://example.com".to_string()
         ))
     );
+}
+
+#[test]
+fn should_skip_provider_when_discovery_pending() {
+    // Provider with no discovered issuer/client_id — must be skipped and the
+    // surface error should be the "discovery in progress" message.
+    let pending = ExampleProvider {
+        issuer: None,
+        client_id: None,
+    };
+    PROVIDERS.replace(vec![Box::new(pending)]);
+
+    assert_eq!(
+        with_provider(EXAMPLE_JWT, |provider| provider
+            .verify(EXAMPLE_JWT, &[0u8; 32])),
+        Err(OpenIDJWTVerificationError::GenericError(
+            "OIDC provider discovery is still in progress, please try again shortly".to_string()
+        ))
+    );
+}
+
+#[test]
+fn should_disambiguate_providers_by_aud() {
+    // Two providers sharing the same iss but different aud — only the one whose
+    // client_id matches the JWT's aud claim should verify.
+    let matching = ExampleProvider {
+        issuer: Some("https://example.com".into()),
+        client_id: Some("example-aud".into()),
+    };
+    let expected = matching.credential();
+    let other = ExampleProvider {
+        issuer: Some("https://example.com".into()),
+        client_id: Some("other-aud".into()),
+    };
+    PROVIDERS.replace(vec![Box::new(other), Box::new(matching)]);
+
+    let returned = with_provider(EXAMPLE_JWT, |provider| {
+        provider.verify(EXAMPLE_JWT, &[0u8; 32])
+    })
+    .expect("expected matching provider");
+    assert_eq!(returned.aud, expected.aud);
 }
 
 #[test]
@@ -644,8 +765,12 @@ struct ExamplePlaceholderProvider;
 
 #[cfg(test)]
 impl OpenIdProvider for ExamplePlaceholderProvider {
-    fn issuer(&self) -> String {
-        "https://login.microsoftonline.com/{tid}/v2.0".into()
+    fn issuer(&self) -> Option<String> {
+        Some("https://login.microsoftonline.com/{tid}/v2.0".into())
+    }
+
+    fn client_id(&self) -> Option<String> {
+        Some("example-aud".into())
     }
 
     fn email_verification_scheme(&self) -> Option<OpenIdEmailVerificationScheme> {
@@ -680,22 +805,22 @@ impl ExamplePlaceholderProvider {
 
 #[test]
 fn find_config_issuer_from_credential() {
-    let provider = ExampleProvider {};
+    let provider = ExampleProvider::default();
     let placeholder_provider = ExamplePlaceholderProvider {};
     let config_issuer = provider.issuer();
     let placeholder_config_issuer = placeholder_provider.issuer();
     PROVIDERS.replace(vec![Box::new(provider), Box::new(placeholder_provider)]);
 
     assert_eq!(
-        ExampleProvider.credential().config_issuer(),
-        Some(config_issuer)
+        ExampleProvider::default().credential().config_issuer(),
+        config_issuer
     );
     assert_eq!(
         ExamplePlaceholderProvider.credential().config_issuer(),
-        Some(placeholder_config_issuer)
+        placeholder_config_issuer
     );
 
-    let mut unknown_credential = ExampleProvider.credential();
+    let mut unknown_credential = ExampleProvider::default().credential();
     unknown_credential.iss = "https://example.com/unknown".to_string();
     assert_eq!(unknown_credential.config_issuer(), None);
 }

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -301,25 +301,50 @@ pub fn setup(configs: Vec<OpenIdConfig>) {
 }
 
 pub fn setup_oidc(configs: Vec<DiscoverableOidcConfig>) {
-    // Canary-phase domain allowlist: reject configs whose domain isn't on the list.
-    for config in &configs {
-        if !generic::is_allowed_discovery_domain(&config.discovery_domain) {
-            ic_cdk::trap(&format!(
-                "discovery_domain '{}' is not on the canary allowlist",
-                config.discovery_domain
-            ));
-        }
+    for config in configs {
+        add_oidc_config_internal(config);
     }
-    OIDC_CONFIGS.with_borrow_mut(|stored| {
-        *stored = configs.clone();
-    });
-    PROVIDERS.with_borrow_mut(|providers| {
-        for config in configs {
-            providers.push(Box::new(generic::DiscoverableProvider::create(config)));
-        }
-    });
     #[cfg(not(test))]
     generic::init_discovery_timers();
+}
+
+pub fn add_oidc_config(config: DiscoverableOidcConfig) {
+    if !generic::is_allowed_discovery_domain(&config.discovery_domain) {
+        ic_cdk::trap(&format!(
+            "discovery_domain '{}' is not on the canary allowlist",
+            config.discovery_domain
+        ));
+    }
+
+    // Skip if already registered
+    let already_exists = OIDC_CONFIGS.with_borrow(|stored| {
+        stored
+            .iter()
+            .any(|c| c.discovery_domain == config.discovery_domain)
+    });
+    if already_exists {
+        return;
+    }
+
+    add_oidc_config_internal(config.clone());
+
+    // Persist to state so it survives upgrades
+    state::persistent_state_mut(|persistent_state| {
+        let configs = persistent_state.oidc_configs.get_or_insert_with(Vec::new);
+        configs.push(config);
+    });
+
+    #[cfg(not(test))]
+    generic::init_discovery_timers();
+}
+
+fn add_oidc_config_internal(config: DiscoverableOidcConfig) {
+    OIDC_CONFIGS.with_borrow_mut(|stored| {
+        stored.push(config.clone());
+    });
+    PROVIDERS.with_borrow_mut(|providers| {
+        providers.push(Box::new(generic::DiscoverableProvider::create(config)));
+    });
 }
 
 pub fn get_discovered_oidc_configs() -> Vec<OidcConfig> {

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -330,7 +330,8 @@ pub struct DiscoveryState {
     pub discovery_url: String,
     pub issuer_ref: Rc<RefCell<Option<String>>>,
     pub certs_ref: Rc<RefCell<Vec<Jwk>>>,
-    pub certs_started: Rc<RefCell<bool>>,
+    /// Tracks the last seen `jwks_uri` so cert fetching restarts when it changes.
+    pub last_jwks_uri: Rc<RefCell<Option<String>>>,
 }
 
 thread_local! {
@@ -347,7 +348,7 @@ impl DiscoverableProvider {
                 discovery_url: config.discovery_url.clone(),
                 issuer_ref: Rc::clone(&discovered_issuer),
                 certs_ref: Rc::clone(&certs),
-                certs_started: Rc::new(RefCell::new(false)),
+                last_jwks_uri: Rc::new(RefCell::new(None)),
             });
         });
 
@@ -392,8 +393,13 @@ async fn run_discovery_tasks() {
             }
             task.issuer_ref.replace(Some(doc.issuer));
 
-            if !*task.certs_started.borrow() {
-                *task.certs_started.borrow_mut() = true;
+            // Start or restart cert fetching when jwks_uri changes
+            let jwks_changed = {
+                let last = task.last_jwks_uri.borrow();
+                last.as_deref() != Some(&doc.jwks_uri)
+            };
+            if jwks_changed {
+                task.last_jwks_uri.replace(Some(doc.jwks_uri.clone()));
                 schedule_fetch_certs(doc.jwks_uri, Rc::clone(&task.certs_ref), Some(0));
             }
         }

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -19,7 +19,7 @@ use identity_jose::jws::{
     VerificationInput,
 };
 use internet_identity_interface::internet_identity::types::{
-    MetadataEntryV2, OpenIdConfig, OpenIdEmailVerificationScheme,
+    MetadataEntryV2, OidcConfig, OpenIdConfig, OpenIdEmailVerificationScheme,
 };
 use rsa::{Pkcs1v15Sign, RsaPublicKey};
 use serde::Serialize;
@@ -212,6 +212,295 @@ impl Provider {
             certs,
             email_verification: config.email_verification,
         }
+    }
+}
+
+/// OIDC provider that discovers its configuration from a discovery URL.
+/// Used with the new `OidcConfig` type.
+pub struct DiscoverableProvider {
+    client_id: Option<String>,
+    discovered_issuer: Rc<RefCell<Option<String>>>,
+    certs: Rc<RefCell<Vec<Jwk>>>,
+    email_verification: Option<OpenIdEmailVerificationScheme>,
+    #[allow(dead_code)] // Used for SSO config matching in follow-up work
+    config: OidcConfig,
+}
+
+impl OpenIdProvider for DiscoverableProvider {
+    fn issuer(&self) -> String {
+        self.discovered_issuer
+            .borrow()
+            .clone()
+            .unwrap_or_default()
+    }
+
+    fn email_verification_scheme(&self) -> Option<OpenIdEmailVerificationScheme> {
+        self.email_verification
+    }
+
+    fn verify(
+        &self,
+        jwt: &str,
+        salt: &[u8; 32],
+    ) -> Result<OpenIdCredential, OpenIDJWTVerificationError> {
+        let issuer = self
+            .discovered_issuer
+            .borrow()
+            .clone()
+            .ok_or_else(|| {
+                OpenIDJWTVerificationError::GenericError(
+                    "Provider not yet initialized (discovery pending)".to_string(),
+                )
+            })?;
+        let client_id = self.client_id.as_ref().ok_or_else(|| {
+            OpenIDJWTVerificationError::GenericError(
+                "Provider client_id not yet available".to_string(),
+            )
+        })?;
+
+        // Decode JWT and decode claims
+        let validation_item = Decoder::new()
+            .decode_compact_serialization(jwt.as_bytes(), None)
+            .map_err(|_| {
+                OpenIDJWTVerificationError::GenericError("Unable to decode JWT".to_string())
+            })?;
+        let claims: Claims =
+            serde_json::from_slice(validation_item.claims()).map_err(|_| {
+                OpenIDJWTVerificationError::GenericError(
+                    "Unable to decode claims or expected claims are missing".to_string(),
+                )
+            })?;
+
+        // Verify claims against discovered issuer
+        verify_claims(&issuer, client_id, &claims, salt)?;
+
+        // Verify JWT signature
+        let kid = validation_item
+            .kid()
+            .ok_or(OpenIDJWTVerificationError::GenericError(
+                "JWT is missing kid".to_string(),
+            ))?;
+        let certs = self.certs.borrow();
+        let cert = certs
+            .iter()
+            .find(|cert| cert.kid().is_some_and(|v| v == kid))
+            .ok_or(OpenIDJWTVerificationError::GenericError(format!(
+                "Certificate not found for {kid}"
+            )))?;
+        validation_item
+            .verify(&JwsVerifierFn::from(verify_signature), cert)
+            .map_err(|_| {
+                OpenIDJWTVerificationError::GenericError("Invalid signature".to_string())
+            })?;
+
+        // Return credential with metadata
+        let mut metadata: HashMap<String, MetadataEntryV2> = HashMap::new();
+        if let Some(email) = claims.email {
+            metadata.insert("email".into(), MetadataEntryV2::String(email));
+        }
+        if let Some(email_verified) = claims.email_verified {
+            metadata.insert(
+                "email_verified".into(),
+                MetadataEntryV2::String(email_verified.into_string()),
+            );
+        }
+        if let Some(name) = claims.name {
+            metadata.insert("name".into(), MetadataEntryV2::String(name));
+        }
+        Ok(OpenIdCredential {
+            iss: claims.iss,
+            sub: claims.sub,
+            aud: claims.aud,
+            last_usage_timestamp: None,
+            metadata,
+        })
+    }
+}
+
+impl DiscoverableProvider {
+    pub fn create(config: OidcConfig) -> DiscoverableProvider {
+        let certs: Rc<RefCell<Vec<Jwk>>> = Rc::new(RefCell::new(vec![]));
+        let discovered_issuer: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+
+        #[cfg(not(test))]
+        {
+            let certs_ref = Rc::clone(&certs);
+            let issuer_ref = Rc::clone(&discovered_issuer);
+            let discovery_url = config.discovery_url.clone();
+            schedule_fetch_discovery(discovery_url, issuer_ref, certs_ref, Some(0));
+        }
+
+        DiscoverableProvider {
+            client_id: config.client_id.clone(),
+            discovered_issuer,
+            certs,
+            email_verification: config.email_verification,
+            config,
+        }
+    }
+}
+
+/// Validates that the discovered issuer belongs to the same domain as the discovery URL.
+fn validate_issuer_domain(discovery_url: &str, issuer: &str) -> Result<(), String> {
+    let extract_host = |url: &str| -> Result<String, String> {
+        // Simple host extraction: find "://" then take until next "/" or end
+        let after_scheme = url
+            .find("://")
+            .map(|i| &url[i + 3..])
+            .ok_or_else(|| format!("Invalid URL: {url}"))?;
+        let host = after_scheme
+            .find('/')
+            .map(|i| &after_scheme[..i])
+            .unwrap_or(after_scheme);
+        Ok(host.to_lowercase())
+    };
+
+    let discovery_host = extract_host(discovery_url)?;
+    let issuer_host = extract_host(issuer)?;
+
+    if discovery_host != issuer_host {
+        return Err(format!(
+            "Issuer host '{issuer_host}' does not match discovery host '{discovery_host}'"
+        ));
+    }
+    Ok(())
+}
+
+// Interval for re-fetching OIDC discovery documents
+const FETCH_DISCOVERY_INTERVAL_SECONDS: u64 = 60 * 60; // 1 hour
+
+#[cfg(not(test))]
+const DISCOVERY_CALL_CYCLES: u128 = 30_000_000_000;
+
+#[cfg(not(test))]
+fn schedule_fetch_discovery(
+    discovery_url: String,
+    issuer_ref: Rc<RefCell<Option<String>>>,
+    certs_ref: Rc<RefCell<Vec<Jwk>>>,
+    delay: Option<u64>,
+) {
+    use ic_cdk::spawn;
+    use ic_cdk_timers::set_timer;
+    use std::time::Duration;
+
+    set_timer(
+        Duration::from_secs(delay.unwrap_or(FETCH_DISCOVERY_INTERVAL_SECONDS)),
+        move || {
+            spawn(async move {
+                let result = fetch_discovery(discovery_url.clone()).await;
+                let next_delay =
+                    compute_next_discovery_fetch_delay(&result, delay);
+                if let Ok(doc) = result {
+                    // Validate issuer domain
+                    if let Err(err) = validate_issuer_domain(&discovery_url, &doc.issuer) {
+                        ic_cdk::println!("Discovery issuer validation failed: {err}");
+                    } else {
+                        // Store discovered issuer
+                        issuer_ref.replace(Some(doc.issuer));
+
+                        // Start JWKS fetching if not already started
+                        let jwks_uri = doc.jwks_uri;
+                        if certs_ref.borrow().is_empty() {
+                            schedule_fetch_certs(
+                                jwks_uri,
+                                Rc::clone(&certs_ref),
+                                Some(0),
+                            );
+                        }
+                    }
+                }
+                schedule_fetch_discovery(
+                    discovery_url,
+                    issuer_ref,
+                    certs_ref,
+                    next_delay,
+                );
+            });
+        },
+    );
+}
+
+#[cfg(not(test))]
+async fn fetch_discovery(discovery_url: String) -> Result<DiscoveryDocument, String> {
+    use ic_cdk::api::management_canister::http_request::{
+        http_request_with_closure, CanisterHttpRequestArgument, HttpMethod,
+    };
+
+    let request = CanisterHttpRequestArgument {
+        url: discovery_url,
+        method: HttpMethod::GET,
+        body: None,
+        max_response_bytes: None,
+        transform: None,
+        headers: vec![
+            HttpHeader {
+                name: "Accept".into(),
+                value: "application/json".into(),
+            },
+            HttpHeader {
+                name: "User-Agent".into(),
+                value: "internet_identity_canister".into(),
+            },
+        ],
+    };
+
+    let (response,) =
+        http_request_with_closure(request, DISCOVERY_CALL_CYCLES, transform_discovery)
+            .await
+            .map_err(|(_, err)| err)?;
+
+    serde_json::from_slice::<DiscoveryDocument>(response.body.as_slice())
+        .map_err(|_| "Invalid discovery JSON".into())
+}
+
+/// Transform function for OIDC discovery responses.
+/// Re-serializes deterministically for consensus across subnet nodes.
+#[allow(clippy::needless_pass_by_value)]
+fn transform_discovery(response: HttpResponse) -> HttpResponse {
+    if response.status != HTTP_STATUS_OK {
+        trap("Invalid discovery response status")
+    }
+
+    let doc: serde_json::Value = serde_json::from_slice(response.body.as_slice())
+        .unwrap_or_else(|_| trap("Invalid discovery JSON"));
+
+    let body =
+        serde_json::to_vec(&doc).unwrap_or_else(|_| trap("Failed to re-serialize discovery JSON"));
+
+    HttpResponse {
+        status: Nat::from(HTTP_STATUS_OK),
+        headers: vec![],
+        body,
+    }
+}
+
+/// OIDC discovery document fields we need.
+#[derive(serde::Deserialize, Clone)]
+struct DiscoveryDocument {
+    issuer: String,
+    #[allow(dead_code)]
+    authorization_endpoint: String,
+    jwks_uri: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    scopes_supported: Vec<String>,
+}
+
+fn compute_next_discovery_fetch_delay<T, E>(
+    result: &Result<T, E>,
+    current_delay: Option<u64>,
+) -> Option<u64> {
+    const MIN_DELAY_SECONDS: u64 = 60;
+    const MAX_DELAY_SECONDS: u64 = FETCH_DISCOVERY_INTERVAL_SECONDS;
+    const BACKOFF_MULTIPLIER: u64 = 2;
+
+    match result {
+        Ok(_) => None,
+        Err(_) => Some(
+            current_delay
+                .map_or(MIN_DELAY_SECONDS, |d| d * BACKOFF_MULTIPLIER)
+                .clamp(MIN_DELAY_SECONDS, MAX_DELAY_SECONDS),
+        ),
     }
 }
 

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -19,7 +19,7 @@ use identity_jose::jws::{
     VerificationInput,
 };
 use internet_identity_interface::internet_identity::types::{
-    MetadataEntryV2, OidcConfig, OpenIdConfig, OpenIdEmailVerificationScheme,
+    DiscoverableOidcConfig, MetadataEntryV2, OpenIdConfig, OpenIdEmailVerificationScheme,
 };
 use rsa::{Pkcs1v15Sign, RsaPublicKey};
 use serde::Serialize;
@@ -338,7 +338,7 @@ thread_local! {
 }
 
 impl DiscoverableProvider {
-    pub fn create(config: OidcConfig) -> DiscoverableProvider {
+    pub fn create(config: DiscoverableOidcConfig) -> DiscoverableProvider {
         let certs: Rc<RefCell<Vec<Jwk>>> = Rc::new(RefCell::new(vec![]));
         let discovered_issuer: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
 

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -35,11 +35,19 @@ use std::rc::Rc;
 #[cfg(not(test))]
 const CERTS_CALL_CYCLES: u128 = 30_000_000_000;
 
+#[cfg(not(test))]
+const DISCOVERY_CALL_CYCLES: u128 = 30_000_000_000;
+
 const HTTP_STATUS_OK: u8 = 200;
 
 // Fetch the certs every fifteen minutes, the responses are always
 // valid for a couple of hours so that should be enough margin.
 const FETCH_CERTS_INTERVAL_SECONDS: u64 = 60 * 15; // 15 minutes in seconds
+
+/// Re-fetch OIDC discovery documents every hour. Discovery metadata (issuer, jwks_uri)
+/// changes infrequently (typically only on provider-side reconfigurations), but hourly
+/// refresh keeps II responsive to such changes within a bounded window.
+const FETCH_DISCOVERY_INTERVAL_SECONDS: u64 = 60 * 60; // 1 hour
 
 // A JWT is only valid for a very small window, even if the JWT itself says it's valid for longer,
 // we only need it right after it's being issued to create a JWT delegation with its own expiry.
@@ -222,8 +230,6 @@ pub struct DiscoverableProvider {
     discovered_issuer: Rc<RefCell<Option<String>>>,
     certs: Rc<RefCell<Vec<Jwk>>>,
     email_verification: Option<OpenIdEmailVerificationScheme>,
-    #[allow(dead_code)] // Used for SSO config matching in follow-up work
-    config: OidcConfig,
 }
 
 impl OpenIdProvider for DiscoverableProvider {
@@ -317,46 +323,96 @@ impl OpenIdProvider for DiscoverableProvider {
     }
 }
 
+/// Shared state for a discovery task, used to communicate results
+/// between the periodic timer and the `DiscoverableProvider`.
+#[derive(Clone)]
+pub struct DiscoveryState {
+    pub discovery_url: String,
+    pub issuer_ref: Rc<RefCell<Option<String>>>,
+    pub certs_ref: Rc<RefCell<Vec<Jwk>>>,
+    pub certs_started: Rc<RefCell<bool>>,
+}
+
+thread_local! {
+    static DISCOVERY_TASKS: RefCell<Vec<DiscoveryState>> = RefCell::new(vec![]);
+}
+
 impl DiscoverableProvider {
     pub fn create(config: OidcConfig) -> DiscoverableProvider {
         let certs: Rc<RefCell<Vec<Jwk>>> = Rc::new(RefCell::new(vec![]));
         let discovered_issuer: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
 
-        #[cfg(not(test))]
-        {
-            let certs_ref = Rc::clone(&certs);
-            let issuer_ref = Rc::clone(&discovered_issuer);
-            let discovery_url = config.discovery_url.clone();
-            schedule_fetch_discovery(discovery_url, issuer_ref, certs_ref, Some(0));
-        }
+        DISCOVERY_TASKS.with_borrow_mut(|tasks| {
+            tasks.push(DiscoveryState {
+                discovery_url: config.discovery_url.clone(),
+                issuer_ref: Rc::clone(&discovered_issuer),
+                certs_ref: Rc::clone(&certs),
+                certs_started: Rc::new(RefCell::new(false)),
+            });
+        });
 
         DiscoverableProvider {
             client_id: config.client_id.clone(),
             discovered_issuer,
             certs,
             email_verification: config.email_verification,
-            config,
         }
     }
 }
 
-/// Validates that the discovered issuer belongs to the same domain as the discovery URL.
-fn validate_issuer_domain(discovery_url: &str, issuer: &str) -> Result<(), String> {
-    let extract_host = |url: &str| -> Result<String, String> {
-        // Simple host extraction: find "://" then take until next "/" or end
-        let after_scheme = url
-            .find("://")
-            .map(|i| &url[i + 3..])
-            .ok_or_else(|| format!("Invalid URL: {url}"))?;
-        let host = after_scheme
-            .find('/')
-            .map(|i| &after_scheme[..i])
-            .unwrap_or(after_scheme);
-        Ok(host.to_lowercase())
-    };
+/// Initializes timers for OIDC discovery. Called once from `initialize()`.
+/// Uses `set_timer_interval` for periodic refresh and an immediate first fetch.
+#[cfg(not(test))]
+pub fn init_discovery_timers() {
+    use ic_cdk::spawn;
+    use ic_cdk_timers::{set_timer, set_timer_interval};
+    use std::time::Duration;
 
-    let discovery_host = extract_host(discovery_url)?;
-    let issuer_host = extract_host(issuer)?;
+    // Immediate first fetch
+    set_timer(Duration::ZERO, || spawn(run_discovery_tasks()));
+
+    // Periodic refresh
+    set_timer_interval(
+        Duration::from_secs(FETCH_DISCOVERY_INTERVAL_SECONDS),
+        || spawn(run_discovery_tasks()),
+    );
+}
+
+#[cfg(not(test))]
+async fn run_discovery_tasks() {
+    let tasks: Vec<DiscoveryState> =
+        DISCOVERY_TASKS.with_borrow(|tasks| tasks.clone());
+
+    for task in tasks {
+        let result = fetch_discovery(task.discovery_url.clone()).await;
+        if let Ok(doc) = result {
+            if let Err(err) = validate_issuer_domain(&task.discovery_url, &doc.issuer) {
+                ic_cdk::println!("Discovery issuer validation failed: {err}");
+                continue;
+            }
+            task.issuer_ref.replace(Some(doc.issuer));
+
+            if !*task.certs_started.borrow() {
+                *task.certs_started.borrow_mut() = true;
+                schedule_fetch_certs(doc.jwks_uri, Rc::clone(&task.certs_ref), Some(0));
+            }
+        }
+    }
+}
+
+/// Validates that the discovered `issuer` belongs to the same host as the `discovery_url`.
+/// Prevents a malicious discovery endpoint from impersonating another provider.
+fn validate_issuer_domain(discovery_url: &str, issuer: &str) -> Result<(), String> {
+    let discovery_host = url::Url::parse(discovery_url)
+        .map_err(|e| format!("Invalid discovery URL: {e}"))?
+        .host_str()
+        .ok_or_else(|| format!("No host in discovery URL: {discovery_url}"))?
+        .to_lowercase();
+    let issuer_host = url::Url::parse(issuer)
+        .map_err(|e| format!("Invalid issuer URL: {e}"))?
+        .host_str()
+        .ok_or_else(|| format!("No host in issuer URL: {issuer}"))?
+        .to_lowercase();
 
     if discovery_host != issuer_host {
         return Err(format!(
@@ -364,60 +420,6 @@ fn validate_issuer_domain(discovery_url: &str, issuer: &str) -> Result<(), Strin
         ));
     }
     Ok(())
-}
-
-// Interval for re-fetching OIDC discovery documents
-const FETCH_DISCOVERY_INTERVAL_SECONDS: u64 = 60 * 60; // 1 hour
-
-#[cfg(not(test))]
-const DISCOVERY_CALL_CYCLES: u128 = 30_000_000_000;
-
-#[cfg(not(test))]
-fn schedule_fetch_discovery(
-    discovery_url: String,
-    issuer_ref: Rc<RefCell<Option<String>>>,
-    certs_ref: Rc<RefCell<Vec<Jwk>>>,
-    delay: Option<u64>,
-) {
-    use ic_cdk::spawn;
-    use ic_cdk_timers::set_timer;
-    use std::time::Duration;
-
-    set_timer(
-        Duration::from_secs(delay.unwrap_or(FETCH_DISCOVERY_INTERVAL_SECONDS)),
-        move || {
-            spawn(async move {
-                let result = fetch_discovery(discovery_url.clone()).await;
-                let next_delay =
-                    compute_next_discovery_fetch_delay(&result, delay);
-                if let Ok(doc) = result {
-                    // Validate issuer domain
-                    if let Err(err) = validate_issuer_domain(&discovery_url, &doc.issuer) {
-                        ic_cdk::println!("Discovery issuer validation failed: {err}");
-                    } else {
-                        // Store discovered issuer
-                        issuer_ref.replace(Some(doc.issuer));
-
-                        // Start JWKS fetching if not already started
-                        let jwks_uri = doc.jwks_uri;
-                        if certs_ref.borrow().is_empty() {
-                            schedule_fetch_certs(
-                                jwks_uri,
-                                Rc::clone(&certs_ref),
-                                Some(0),
-                            );
-                        }
-                    }
-                }
-                schedule_fetch_discovery(
-                    discovery_url,
-                    issuer_ref,
-                    certs_ref,
-                    next_delay,
-                );
-            });
-        },
-    );
 }
 
 #[cfg(not(test))]
@@ -457,15 +459,29 @@ async fn fetch_discovery(discovery_url: String) -> Result<DiscoveryDocument, Str
 /// Re-serializes deterministically for consensus across subnet nodes.
 #[allow(clippy::needless_pass_by_value)]
 fn transform_discovery(response: HttpResponse) -> HttpResponse {
-    if response.status != HTTP_STATUS_OK {
-        trap("Invalid discovery response status")
+    if response.status != Nat::from(HTTP_STATUS_OK) {
+        return HttpResponse {
+            status: response.status,
+            headers: vec![],
+            body: b"Invalid discovery response status".to_vec(),
+        };
     }
 
-    let doc: serde_json::Value = serde_json::from_slice(response.body.as_slice())
-        .unwrap_or_else(|_| trap("Invalid discovery JSON"));
+    let Ok(doc) = serde_json::from_slice::<serde_json::Value>(response.body.as_slice()) else {
+        return HttpResponse {
+            status: Nat::from(HTTP_STATUS_OK),
+            headers: vec![],
+            body: b"Invalid discovery JSON".to_vec(),
+        };
+    };
 
-    let body =
-        serde_json::to_vec(&doc).unwrap_or_else(|_| trap("Failed to re-serialize discovery JSON"));
+    let Ok(body) = serde_json::to_vec(&doc) else {
+        return HttpResponse {
+            status: Nat::from(HTTP_STATUS_OK),
+            headers: vec![],
+            body: b"Failed to re-serialize discovery JSON".to_vec(),
+        };
+    };
 
     HttpResponse {
         status: Nat::from(HTTP_STATUS_OK),
@@ -474,34 +490,21 @@ fn transform_discovery(response: HttpResponse) -> HttpResponse {
     }
 }
 
-/// OIDC discovery document fields we need.
+/// OIDC discovery document — only the fields needed by the backend.
 #[derive(serde::Deserialize, Clone)]
 struct DiscoveryDocument {
     issuer: String,
-    #[allow(dead_code)]
-    authorization_endpoint: String,
     jwks_uri: String,
-    #[serde(default)]
-    #[allow(dead_code)]
-    scopes_supported: Vec<String>,
 }
 
-fn compute_next_discovery_fetch_delay<T, E>(
-    result: &Result<T, E>,
-    current_delay: Option<u64>,
-) -> Option<u64> {
-    const MIN_DELAY_SECONDS: u64 = 60;
-    const MAX_DELAY_SECONDS: u64 = FETCH_DISCOVERY_INTERVAL_SECONDS;
-    const BACKOFF_MULTIPLIER: u64 = 2;
-
-    match result {
-        Ok(_) => None,
-        Err(_) => Some(
-            current_delay
-                .map_or(MIN_DELAY_SECONDS, |d| d * BACKOFF_MULTIPLIER)
-                .clamp(MIN_DELAY_SECONDS, MAX_DELAY_SECONDS),
-        ),
-    }
+/// Returns the discovered issuer for a given discovery URL, if available.
+pub fn discovered_issuer_for(discovery_url: &str) -> Option<String> {
+    DISCOVERY_TASKS.with_borrow(|tasks| {
+        tasks
+            .iter()
+            .find(|t| t.discovery_url == discovery_url)
+            .and_then(|t| t.issuer_ref.borrow().clone())
+    })
 }
 
 fn compute_next_certs_fetch_delay<T, E>(

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -47,6 +47,7 @@ const FETCH_CERTS_INTERVAL_SECONDS: u64 = 60 * 15; // 15 minutes in seconds
 /// Re-fetch OIDC discovery documents every hour. Discovery metadata (issuer, jwks_uri)
 /// changes infrequently (typically only on provider-side reconfigurations), but hourly
 /// refresh keeps II responsive to such changes within a bounded window.
+#[cfg(not(test))]
 const FETCH_DISCOVERY_INTERVAL_SECONDS: u64 = 60 * 60; // 1 hour
 
 // A JWT is only valid for a very small window, even if the JWT itself says it's valid for longer,
@@ -329,8 +330,12 @@ impl OpenIdProvider for DiscoverableProvider {
 pub struct DiscoveryState {
     pub discovery_url: String,
     pub issuer_ref: Rc<RefCell<Option<String>>>,
+    /// Only read by the periodic discovery timer (non-test builds).
+    #[allow(dead_code)]
     pub certs_ref: Rc<RefCell<Vec<Jwk>>>,
     /// Tracks the last seen `jwks_uri` so cert fetching restarts when it changes.
+    /// Only read by the periodic discovery timer (non-test builds).
+    #[allow(dead_code)]
     pub last_jwks_uri: Rc<RefCell<Option<String>>>,
 }
 
@@ -408,6 +413,7 @@ async fn run_discovery_tasks() {
 
 /// Validates that the discovered `issuer` belongs to the same host as the `discovery_url`.
 /// Prevents a malicious discovery endpoint from impersonating another provider.
+#[cfg(not(test))]
 fn validate_issuer_domain(discovery_url: &str, issuer: &str) -> Result<(), String> {
     let discovery_host = url::Url::parse(discovery_url)
         .map_err(|e| format!("Invalid discovery URL: {e}"))?
@@ -463,6 +469,7 @@ async fn fetch_discovery(discovery_url: String) -> Result<DiscoveryDocument, Str
 
 /// Transform function for OIDC discovery responses.
 /// Re-serializes deterministically for consensus across subnet nodes.
+#[cfg(not(test))]
 #[allow(clippy::needless_pass_by_value)]
 fn transform_discovery(response: HttpResponse) -> HttpResponse {
     if response.status != HTTP_STATUS_OK {
@@ -497,6 +504,7 @@ fn transform_discovery(response: HttpResponse) -> HttpResponse {
 }
 
 /// OIDC discovery document — only the fields needed by the backend.
+#[cfg(not(test))]
 #[derive(serde::Deserialize, Clone)]
 struct DiscoveryDocument {
     issuer: String,

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -1,5 +1,5 @@
 use super::{
-    get_all_claims, get_issuer_placeholders, replace_issuer_placeholders,
+    get_all_claims, get_issuer_placeholders, replace_issuer_placeholders, AudClaim,
     OpenIDJWTVerificationError,
 };
 use crate::openid::OpenIdCredential;
@@ -98,7 +98,7 @@ impl EmailVerifiedClaim {
 struct Claims {
     iss: String,
     sub: String,
-    aud: String,
+    aud: AudClaim,
     nonce: String,
     exp: u64,
     iat: u64,
@@ -201,7 +201,8 @@ impl OpenIdProvider for Provider {
             // https://login.microsoftonline.com/599249e6-791a-48a7-84d0-b3e858773ac2/v2.0
             iss: claims.iss,
             sub: claims.sub,
-            aud: claims.aud,
+            // `aud` is verified against `client_id` above; store the canonical value.
+            aud: self.client_id.clone(),
             last_usage_timestamp: None,
             metadata,
         })
@@ -301,6 +302,13 @@ impl OpenIdProvider for DiscoverableProvider {
                 "JWT is missing kid".to_string(),
             ))?;
         let certs = self.certs.borrow();
+        if certs.is_empty() {
+            // Distinguish a still-pending JWKS fetch from a genuine kid mismatch so
+            // the frontend can offer a retry instead of surfacing a fatal error.
+            return Err(OpenIDJWTVerificationError::GenericError(
+                "OIDC provider JWKS not yet fetched, please try again shortly".to_string(),
+            ));
+        }
         let cert = certs
             .iter()
             .find(|cert| cert.kid().is_some_and(|v| v == kid))
@@ -330,7 +338,8 @@ impl OpenIdProvider for DiscoverableProvider {
         Ok(OpenIdCredential {
             iss: claims.iss,
             sub: claims.sub,
-            aud: claims.aud,
+            // `aud` is verified against `client_id` above; store the canonical value.
+            aud: client_id,
             last_usage_timestamp: None,
             metadata,
         })
@@ -451,6 +460,15 @@ async fn run_discovery_tasks() {
             continue;
         }
 
+        // Reject malformed / non-HTTPS jwks_uri before scheduling repeated outcalls.
+        if let Err(err) = validate_https_url(&doc.jwks_uri) {
+            ic_cdk::println!(
+                "Invalid jwks_uri from {}: {err}",
+                ii_config.openid_configuration
+            );
+            continue;
+        }
+
         task.client_id_ref.replace(Some(ii_config.client_id));
         task.openid_configuration_ref
             .replace(Some(ii_config.openid_configuration));
@@ -466,6 +484,16 @@ async fn run_discovery_tasks() {
             schedule_fetch_certs(doc.jwks_uri, Rc::clone(&task.certs_ref), Some(0));
         }
     }
+}
+
+/// Ensure a URL is syntactically valid and uses `https://`.
+#[cfg(not(test))]
+fn validate_https_url(url: &str) -> Result<(), String> {
+    let parsed = url::Url::parse(url).map_err(|e| format!("parse error: {e}"))?;
+    if parsed.scheme() != "https" {
+        return Err(format!("expected https scheme, got '{}'", parsed.scheme()));
+    }
+    Ok(())
 }
 
 /// Validates that the discovered `issuer` belongs to the same host as the
@@ -819,11 +847,10 @@ fn verify_claims(
             claims.iss
         )));
     }
-    if claims.aud != client_id {
-        return Err(OpenIDJWTVerificationError::GenericError(format!(
-            "Invalid audience: {}",
-            claims.aud
-        )));
+    if !claims.aud.matches(client_id) {
+        return Err(OpenIDJWTVerificationError::GenericError(
+            "Invalid audience".to_string(),
+        ));
     }
     if claims.nonce != expected_nonce {
         return Err(OpenIDJWTVerificationError::GenericError(format!(
@@ -919,6 +946,9 @@ fn should_transform_certs_to_same() {
 }
 
 #[cfg(test)]
+const TEST_AUD: &str = "45431994619-cbbfgtn7o0pp0dpfcg2l66bc4rcg7qbu.apps.googleusercontent.com";
+
+#[cfg(test)]
 fn test_data() -> (String, [u8; 32], OpenIdConfig, Claims) {
     // This JWT is for testing purposes, it's already been expired before this commit has been made,
     // additionally the audience of this JWT is a test Google client registration, not production.
@@ -935,7 +965,7 @@ fn test_data() -> (String, [u8; 32], OpenIdConfig, Claims) {
         name: "Google".to_string(),
         logo: String::new(),
         issuer: claims.iss.clone(),
-        client_id: claims.aud.clone(),
+        client_id: TEST_AUD.into(),
         jwks_uri: "https://www.googleapis.com/oauth2/v3/certs".to_string(),
         auth_uri: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
         auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
@@ -953,7 +983,7 @@ fn should_return_credential() {
     let credential = OpenIdCredential {
         iss: claims.iss,
         sub: claims.sub,
-        aud: claims.aud,
+        aud: TEST_AUD.into(),
         last_usage_timestamp: None,
         metadata: HashMap::from([
             (
@@ -1036,14 +1066,39 @@ fn should_return_error_when_invalid_issuer() {
 fn should_return_error_when_invalid_audience() {
     let (_, salt, config, claims) = test_data();
     let mut invalid_claims = claims;
-    invalid_claims.aud = "invalid-audience".into();
+    invalid_claims.aud = AudClaim::Single("invalid-audience".into());
 
     assert_eq!(
         verify_claims(&config.issuer, &config.client_id, &invalid_claims, &salt),
-        Err(OpenIDJWTVerificationError::GenericError(format!(
-            "Invalid audience: {}",
-            invalid_claims.aud
-        )))
+        Err(OpenIDJWTVerificationError::GenericError(
+            "Invalid audience".into()
+        ))
+    );
+}
+
+#[test]
+fn should_accept_client_id_in_aud_array() {
+    let (_, salt, config, claims) = test_data();
+    let mut multi_aud = claims;
+    multi_aud.aud = AudClaim::Multiple(vec!["some-other-aud".into(), TEST_AUD.into()]);
+
+    assert_eq!(
+        verify_claims(&config.issuer, &config.client_id, &multi_aud, &salt),
+        Ok(())
+    );
+}
+
+#[test]
+fn should_reject_aud_array_without_client_id() {
+    let (_, salt, config, claims) = test_data();
+    let mut multi_aud = claims;
+    multi_aud.aud = AudClaim::Multiple(vec!["a".into(), "b".into()]);
+
+    assert_eq!(
+        verify_claims(&config.issuer, &config.client_id, &multi_aud, &salt),
+        Err(OpenIDJWTVerificationError::GenericError(
+            "Invalid audience".into()
+        ))
     );
 }
 

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -335,7 +335,7 @@ pub struct DiscoveryState {
 }
 
 thread_local! {
-    static DISCOVERY_TASKS: RefCell<Vec<DiscoveryState>> = RefCell::new(vec![]);
+    static DISCOVERY_TASKS: RefCell<Vec<DiscoveryState>> = const { RefCell::new(vec![]) };
 }
 
 impl DiscoverableProvider {
@@ -465,7 +465,7 @@ async fn fetch_discovery(discovery_url: String) -> Result<DiscoveryDocument, Str
 /// Re-serializes deterministically for consensus across subnet nodes.
 #[allow(clippy::needless_pass_by_value)]
 fn transform_discovery(response: HttpResponse) -> HttpResponse {
-    if response.status != Nat::from(HTTP_STATUS_OK) {
+    if response.status != HTTP_STATUS_OK {
         return HttpResponse {
             status: response.status,
             headers: vec![],

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -116,8 +116,12 @@ pub struct Provider {
 }
 
 impl OpenIdProvider for Provider {
-    fn issuer(&self) -> String {
-        self.issuer.clone()
+    fn issuer(&self) -> Option<String> {
+        Some(self.issuer.clone())
+    }
+
+    fn client_id(&self) -> Option<String> {
+        Some(self.client_id.clone())
     }
 
     fn email_verification_scheme(&self) -> Option<OpenIdEmailVerificationScheme> {
@@ -142,7 +146,7 @@ impl OpenIdProvider for Provider {
         })?;
 
         // Calculate effective issuer and use it to verify the JWT claims
-        let issuer_placeholders = get_issuer_placeholders(&self.issuer());
+        let issuer_placeholders = get_issuer_placeholders(&self.issuer);
         let issuer_claims = get_all_claims(validation_item.claims(), issuer_placeholders);
         let effective_issuer = replace_issuer_placeholders(&self.issuer, &issuer_claims);
         verify_claims(&effective_issuer, &self.client_id, &claims, salt)?;
@@ -224,25 +228,39 @@ impl Provider {
     }
 }
 
-/// OIDC provider that discovers its configuration from a discovery URL.
-/// Used with the new `OidcConfig` type.
+/// CANARY: SSO via two-hop discovery is a proof-of-concept. Only this domain is
+/// accepted as a `discovery_domain` for now. Widen this list (or move it to
+/// canister config) once the feature exits canary.
+pub const ALLOWED_DISCOVERY_DOMAINS: &[&str] = &["dfinity.org"];
+
+pub fn is_allowed_discovery_domain(domain: &str) -> bool {
+    ALLOWED_DISCOVERY_DOMAINS
+        .iter()
+        .any(|allowed| allowed.eq_ignore_ascii_case(domain))
+}
+
+/// SSO provider that resolves its configuration via two-hop discovery.
+/// Used with the `DiscoverableOidcConfig` type.
 pub struct DiscoverableProvider {
-    client_id: Option<String>,
+    discovered_client_id: Rc<RefCell<Option<String>>>,
     discovered_issuer: Rc<RefCell<Option<String>>>,
     certs: Rc<RefCell<Vec<Jwk>>>,
-    email_verification: Option<OpenIdEmailVerificationScheme>,
 }
 
 impl OpenIdProvider for DiscoverableProvider {
-    fn issuer(&self) -> String {
-        self.discovered_issuer
-            .borrow()
-            .clone()
-            .unwrap_or_default()
+    fn issuer(&self) -> Option<String> {
+        self.discovered_issuer.borrow().clone()
+    }
+
+    fn client_id(&self) -> Option<String> {
+        self.discovered_client_id.borrow().clone()
     }
 
     fn email_verification_scheme(&self) -> Option<OpenIdEmailVerificationScheme> {
-        self.email_verification
+        // SSO providers don't opt into II's hardcoded provider-specific email
+        // verification heuristics (Google `email_verified`, Microsoft `tid`).
+        // Verification is a trust decision made when the SSO domain is configured.
+        None
     }
 
     fn verify(
@@ -250,18 +268,14 @@ impl OpenIdProvider for DiscoverableProvider {
         jwt: &str,
         salt: &[u8; 32],
     ) -> Result<OpenIdCredential, OpenIDJWTVerificationError> {
-        let issuer = self
-            .discovered_issuer
-            .borrow()
-            .clone()
-            .ok_or_else(|| {
-                OpenIDJWTVerificationError::GenericError(
-                    "Provider not yet initialized (discovery pending)".to_string(),
-                )
-            })?;
-        let client_id = self.client_id.as_ref().ok_or_else(|| {
+        let issuer = self.discovered_issuer.borrow().clone().ok_or_else(|| {
             OpenIDJWTVerificationError::GenericError(
-                "Provider client_id not yet available".to_string(),
+                "Provider not yet initialized (discovery pending)".to_string(),
+            )
+        })?;
+        let client_id = self.discovered_client_id.borrow().clone().ok_or_else(|| {
+            OpenIDJWTVerificationError::GenericError(
+                "Provider client_id not yet available (discovery pending)".to_string(),
             )
         })?;
 
@@ -271,15 +285,14 @@ impl OpenIdProvider for DiscoverableProvider {
             .map_err(|_| {
                 OpenIDJWTVerificationError::GenericError("Unable to decode JWT".to_string())
             })?;
-        let claims: Claims =
-            serde_json::from_slice(validation_item.claims()).map_err(|_| {
-                OpenIDJWTVerificationError::GenericError(
-                    "Unable to decode claims or expected claims are missing".to_string(),
-                )
-            })?;
+        let claims: Claims = serde_json::from_slice(validation_item.claims()).map_err(|_| {
+            OpenIDJWTVerificationError::GenericError(
+                "Unable to decode claims or expected claims are missing".to_string(),
+            )
+        })?;
 
         // Verify claims against discovered issuer
-        verify_claims(&issuer, client_id, &claims, salt)?;
+        verify_claims(&issuer, &client_id, &claims, salt)?;
 
         // Verify JWT signature
         let kid = validation_item
@@ -324,11 +337,13 @@ impl OpenIdProvider for DiscoverableProvider {
     }
 }
 
-/// Shared state for a discovery task, used to communicate results
-/// between the periodic timer and the `DiscoverableProvider`.
+/// Shared state for a single discovery task, exchanged between the periodic
+/// timer and the owning `DiscoverableProvider`.
 #[derive(Clone)]
 pub struct DiscoveryState {
-    pub discovery_url: String,
+    pub discovery_domain: String,
+    pub client_id_ref: Rc<RefCell<Option<String>>>,
+    pub openid_configuration_ref: Rc<RefCell<Option<String>>>,
     pub issuer_ref: Rc<RefCell<Option<String>>>,
     /// Only read by the periodic discovery timer (non-test builds).
     #[allow(dead_code)]
@@ -339,6 +354,10 @@ pub struct DiscoveryState {
     pub last_jwks_uri: Rc<RefCell<Option<String>>>,
 }
 
+// TODO: `DISCOVERY_TASKS` is unbounded — a long `ALLOWED_DISCOVERY_DOMAINS` list
+// or many admin-configured SSO providers would fan out into many periodic HTTP
+// outcalls. Revisit once the canary allowlist is lifted. See reviewer comment on
+// https://github.com/dfinity/internet-identity/pull/3778#discussion_r3099150266.
 thread_local! {
     static DISCOVERY_TASKS: RefCell<Vec<DiscoveryState>> = const { RefCell::new(vec![]) };
 }
@@ -347,10 +366,14 @@ impl DiscoverableProvider {
     pub fn create(config: DiscoverableOidcConfig) -> DiscoverableProvider {
         let certs: Rc<RefCell<Vec<Jwk>>> = Rc::new(RefCell::new(vec![]));
         let discovered_issuer: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+        let discovered_client_id: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+        let openid_configuration: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
 
         DISCOVERY_TASKS.with_borrow_mut(|tasks| {
             tasks.push(DiscoveryState {
-                discovery_url: config.discovery_url.clone(),
+                discovery_domain: config.discovery_domain.clone(),
+                client_id_ref: Rc::clone(&discovered_client_id),
+                openid_configuration_ref: Rc::clone(&openid_configuration),
                 issuer_ref: Rc::clone(&discovered_issuer),
                 certs_ref: Rc::clone(&certs),
                 last_jwks_uri: Rc::new(RefCell::new(None)),
@@ -358,10 +381,9 @@ impl DiscoverableProvider {
         });
 
         DiscoverableProvider {
-            client_id: config.client_id.clone(),
+            discovered_client_id,
             discovered_issuer,
             certs,
-            email_verification: config.email_verification,
         }
     }
 }
@@ -386,39 +408,76 @@ pub fn init_discovery_timers() {
 
 #[cfg(not(test))]
 async fn run_discovery_tasks() {
-    let tasks: Vec<DiscoveryState> =
-        DISCOVERY_TASKS.with_borrow(|tasks| tasks.clone());
+    let tasks: Vec<DiscoveryState> = DISCOVERY_TASKS.with_borrow(|tasks| tasks.clone());
 
     for task in tasks {
-        let result = fetch_discovery(task.discovery_url.clone()).await;
-        if let Ok(doc) = result {
-            if let Err(err) = validate_issuer_domain(&task.discovery_url, &doc.issuer) {
-                ic_cdk::println!("Discovery issuer validation failed: {err}");
+        // Hop 1: fetch https://{domain}/.well-known/ii-openid-configuration,
+        // which is expected to return { client_id, openid_configuration }.
+        let hop1_url = format!(
+            "https://{}/.well-known/ii-openid-configuration",
+            task.discovery_domain
+        );
+        let ii_config = match fetch_ii_openid_configuration(hop1_url.clone()).await {
+            Ok(c) => c,
+            Err(err) => {
+                ic_cdk::println!("II OpenID configuration fetch failed for {hop1_url}: {err}");
                 continue;
             }
-            task.issuer_ref.replace(Some(doc.issuer));
+        };
+        if !ii_config.openid_configuration.starts_with("https://") {
+            ic_cdk::println!(
+                "II OpenID configuration from {hop1_url} has non-https openid_configuration URL"
+            );
+            continue;
+        }
 
-            // Start or restart cert fetching when jwks_uri changes
-            let jwks_changed = {
-                let last = task.last_jwks_uri.borrow();
-                last.as_deref() != Some(&doc.jwks_uri)
-            };
-            if jwks_changed {
-                task.last_jwks_uri.replace(Some(doc.jwks_uri.clone()));
-                schedule_fetch_certs(doc.jwks_uri, Rc::clone(&task.certs_ref), Some(0));
+        // Hop 2: fetch the standard OIDC discovery document at openid_configuration.
+        let doc = match fetch_discovery(ii_config.openid_configuration.clone()).await {
+            Ok(d) => d,
+            Err(err) => {
+                ic_cdk::println!(
+                    "OIDC discovery fetch failed for {}: {err}",
+                    ii_config.openid_configuration
+                );
+                continue;
             }
+        };
+
+        // Verify that the discovered issuer's host matches the openid_configuration URL host.
+        // This is the standard OIDC-discovery self-assertion check and defends against a
+        // compromised hop-1 response that declares an unrelated issuer for its jwks_uri.
+        if let Err(err) = validate_issuer_host(&ii_config.openid_configuration, &doc.issuer) {
+            ic_cdk::println!("Discovery issuer validation failed: {err}");
+            continue;
+        }
+
+        task.client_id_ref.replace(Some(ii_config.client_id));
+        task.openid_configuration_ref
+            .replace(Some(ii_config.openid_configuration));
+        task.issuer_ref.replace(Some(doc.issuer));
+
+        // Start or restart cert fetching when jwks_uri changes
+        let jwks_changed = {
+            let last = task.last_jwks_uri.borrow();
+            last.as_deref() != Some(&doc.jwks_uri)
+        };
+        if jwks_changed {
+            task.last_jwks_uri.replace(Some(doc.jwks_uri.clone()));
+            schedule_fetch_certs(doc.jwks_uri, Rc::clone(&task.certs_ref), Some(0));
         }
     }
 }
 
-/// Validates that the discovered `issuer` belongs to the same host as the `discovery_url`.
-/// Prevents a malicious discovery endpoint from impersonating another provider.
+/// Validates that the discovered `issuer` belongs to the same host as the
+/// OpenID configuration URL (hop 2). The `discovery_domain` (hop 1) is
+/// intentionally allowed to differ — it hosts a custom SSO indirection that
+/// legitimately points at an external OIDC provider.
 #[cfg(not(test))]
-fn validate_issuer_domain(discovery_url: &str, issuer: &str) -> Result<(), String> {
-    let discovery_host = url::Url::parse(discovery_url)
-        .map_err(|e| format!("Invalid discovery URL: {e}"))?
+fn validate_issuer_host(openid_config_url: &str, issuer: &str) -> Result<(), String> {
+    let openid_config_host = url::Url::parse(openid_config_url)
+        .map_err(|e| format!("Invalid openid_configuration URL: {e}"))?
         .host_str()
-        .ok_or_else(|| format!("No host in discovery URL: {discovery_url}"))?
+        .ok_or_else(|| format!("No host in openid_configuration URL: {openid_config_url}"))?
         .to_lowercase();
     let issuer_host = url::Url::parse(issuer)
         .map_err(|e| format!("Invalid issuer URL: {e}"))?
@@ -426,12 +485,45 @@ fn validate_issuer_domain(discovery_url: &str, issuer: &str) -> Result<(), Strin
         .ok_or_else(|| format!("No host in issuer URL: {issuer}"))?
         .to_lowercase();
 
-    if discovery_host != issuer_host {
+    if openid_config_host != issuer_host {
         return Err(format!(
-            "Issuer host '{issuer_host}' does not match discovery host '{discovery_host}'"
+            "Issuer host '{issuer_host}' does not match openid_configuration host '{openid_config_host}'"
         ));
     }
     Ok(())
+}
+
+#[cfg(not(test))]
+async fn fetch_ii_openid_configuration(url: String) -> Result<IIOpenIdConfiguration, String> {
+    use ic_cdk::api::management_canister::http_request::{
+        http_request_with_closure, CanisterHttpRequestArgument, HttpMethod,
+    };
+
+    let request = CanisterHttpRequestArgument {
+        url,
+        method: HttpMethod::GET,
+        body: None,
+        max_response_bytes: None,
+        transform: None,
+        headers: vec![
+            HttpHeader {
+                name: "Accept".into(),
+                value: "application/json".into(),
+            },
+            HttpHeader {
+                name: "User-Agent".into(),
+                value: "internet_identity_canister".into(),
+            },
+        ],
+    };
+
+    let (response,) =
+        http_request_with_closure(request, DISCOVERY_CALL_CYCLES, transform_discovery)
+            .await
+            .map_err(|(_, err)| err)?;
+
+    serde_json::from_slice::<IIOpenIdConfiguration>(response.body.as_slice())
+        .map_err(|_| "Invalid ii-openid-configuration JSON".into())
 }
 
 #[cfg(not(test))]
@@ -467,7 +559,7 @@ async fn fetch_discovery(discovery_url: String) -> Result<DiscoveryDocument, Str
         .map_err(|_| "Invalid discovery JSON".into())
 }
 
-/// Transform function for OIDC discovery responses.
+/// Transform function for JSON discovery responses (both hops).
 /// Re-serializes deterministically for consensus across subnet nodes.
 #[cfg(not(test))]
 #[allow(clippy::needless_pass_by_value)]
@@ -503,6 +595,14 @@ fn transform_discovery(response: HttpResponse) -> HttpResponse {
     }
 }
 
+/// II-specific SSO indirection document served at `{domain}/.well-known/ii-openid-configuration`.
+#[cfg(not(test))]
+#[derive(serde::Deserialize, Clone)]
+struct IIOpenIdConfiguration {
+    client_id: String,
+    openid_configuration: String,
+}
+
 /// OIDC discovery document — only the fields needed by the backend.
 #[cfg(not(test))]
 #[derive(serde::Deserialize, Clone)]
@@ -511,13 +611,24 @@ struct DiscoveryDocument {
     jwks_uri: String,
 }
 
-/// Returns the discovered issuer for a given discovery URL, if available.
-pub fn discovered_issuer_for(discovery_url: &str) -> Option<String> {
+/// Returns the discovered state for a given `discovery_domain`.
+/// Returns `(client_id, openid_configuration, issuer)` — any entry may be `None`
+/// if discovery for that domain has not yet completed.
+pub fn discovered_state_for(
+    discovery_domain: &str,
+) -> (Option<String>, Option<String>, Option<String>) {
     DISCOVERY_TASKS.with_borrow(|tasks| {
         tasks
             .iter()
-            .find(|t| t.discovery_url == discovery_url)
-            .and_then(|t| t.issuer_ref.borrow().clone())
+            .find(|t| t.discovery_domain == discovery_domain)
+            .map(|t| {
+                (
+                    t.client_id_ref.borrow().clone(),
+                    t.openid_configuration_ref.borrow().clone(),
+                    t.issuer_ref.borrow().clone(),
+                )
+            })
+            .unwrap_or((None, None, None))
     })
 }
 

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -116,7 +116,7 @@ pub struct PersistentState {
     // Configurations for OpenID clients
     pub openid_configs: Option<Vec<OpenIdConfig>>,
     // Simplified OIDC configs using discovery. Mutually exclusive with openid_configs.
-    pub oidc_configs: Option<Vec<OidcConfig>>,
+    pub oidc_configs: Option<Vec<DiscoverableOidcConfig>>,
     // Configuration for Web Analytics tool
     pub analytics_config: Option<AnalyticsConfig>,
     // Key into the event_data BTreeMap where the 24h tracking window starts.

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -115,6 +115,8 @@ pub struct PersistentState {
     pub new_flow_origins: Option<Vec<String>>,
     // Configurations for OpenID clients
     pub openid_configs: Option<Vec<OpenIdConfig>>,
+    // Simplified OIDC configs using discovery. Mutually exclusive with openid_configs.
+    pub oidc_configs: Option<Vec<OidcConfig>>,
     // Configuration for Web Analytics tool
     pub analytics_config: Option<AnalyticsConfig>,
     // Key into the event_data BTreeMap where the 24h tracking window starts.
@@ -141,6 +143,7 @@ impl Default for PersistentState {
             related_origins: None,
             new_flow_origins: None,
             openid_configs: None,
+            oidc_configs: None,
             analytics_config: None,
             event_stats_24h_start: None,
             enable_dapps_explorer: None,

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -115,7 +115,7 @@ pub struct PersistentState {
     pub new_flow_origins: Option<Vec<String>>,
     // Configurations for OpenID clients
     pub openid_configs: Option<Vec<OpenIdConfig>>,
-    // Simplified OIDC configs using discovery. Mutually exclusive with openid_configs.
+    // SSO provider configs managed via add_discoverable_oidc_config update call.
     pub oidc_configs: Option<Vec<DiscoverableOidcConfig>>,
     // Configuration for Web Analytics tool
     pub analytics_config: Option<AnalyticsConfig>,

--- a/src/internet_identity/src/storage/storable/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable/storable_persistent_state.rs
@@ -9,7 +9,7 @@ use candid::{CandidType, Deserialize};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
 use internet_identity_interface::internet_identity::types::{
-    AnalyticsConfig, CaptchaConfig, DummyAuthConfig, FrontendHostname, OpenIdConfig,
+    AnalyticsConfig, CaptchaConfig, DummyAuthConfig, FrontendHostname, OidcConfig, OpenIdConfig,
     RateLimitConfig, Timestamp,
 };
 use std::borrow::Cow;
@@ -36,6 +36,7 @@ pub struct StorablePersistentState {
     related_origins: Option<Vec<String>>,
     new_flow_origins: Option<Vec<String>>,
     openid_configs: Option<Vec<OpenIdConfig>>,
+    oidc_configs: Option<Vec<OidcConfig>>,
     analytics_config: Option<AnalyticsConfig>,
     enable_dapps_explorer: Option<bool>,
     is_production: Option<bool>,
@@ -80,6 +81,7 @@ impl From<PersistentState> for StorablePersistentState {
             related_origins: s.related_origins,
             new_flow_origins: s.new_flow_origins,
             openid_configs: s.openid_configs,
+            oidc_configs: s.oidc_configs,
             analytics_config: s.analytics_config,
             enable_dapps_explorer: s.enable_dapps_explorer,
             is_production: s.is_production,
@@ -101,6 +103,7 @@ impl From<StorablePersistentState> for PersistentState {
             related_origins: s.related_origins,
             new_flow_origins: s.new_flow_origins,
             openid_configs: s.openid_configs,
+            oidc_configs: s.oidc_configs,
             analytics_config: s.analytics_config,
             event_stats_24h_start: s.event_stats_24h_start,
             enable_dapps_explorer: s.enable_dapps_explorer,
@@ -152,6 +155,7 @@ mod tests {
             related_origins: None,
             new_flow_origins: None,
             openid_configs: None,
+            oidc_configs: None,
             analytics_config: None,
             enable_dapps_explorer: None,
             is_production: None,
@@ -177,6 +181,7 @@ mod tests {
             related_origins: None,
             new_flow_origins: None,
             openid_configs: None,
+            oidc_configs: None,
             event_stats_24h_start: None,
             analytics_config: None,
             enable_dapps_explorer: None,

--- a/src/internet_identity/src/storage/storable/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable/storable_persistent_state.rs
@@ -9,7 +9,7 @@ use candid::{CandidType, Deserialize};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
 use internet_identity_interface::internet_identity::types::{
-    AnalyticsConfig, CaptchaConfig, DummyAuthConfig, FrontendHostname, OidcConfig, OpenIdConfig,
+    AnalyticsConfig, CaptchaConfig, DummyAuthConfig, FrontendHostname, DiscoverableOidcConfig, OpenIdConfig,
     RateLimitConfig, Timestamp,
 };
 use std::borrow::Cow;
@@ -36,7 +36,7 @@ pub struct StorablePersistentState {
     related_origins: Option<Vec<String>>,
     new_flow_origins: Option<Vec<String>>,
     openid_configs: Option<Vec<OpenIdConfig>>,
-    oidc_configs: Option<Vec<OidcConfig>>,
+    oidc_configs: Option<Vec<DiscoverableOidcConfig>>,
     analytics_config: Option<AnalyticsConfig>,
     enable_dapps_explorer: Option<bool>,
     is_production: Option<bool>,

--- a/src/internet_identity/src/storage/storable/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable/storable_persistent_state.rs
@@ -9,8 +9,8 @@ use candid::{CandidType, Deserialize};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
 use internet_identity_interface::internet_identity::types::{
-    AnalyticsConfig, CaptchaConfig, DummyAuthConfig, FrontendHostname, DiscoverableOidcConfig, OpenIdConfig,
-    RateLimitConfig, Timestamp,
+    AnalyticsConfig, CaptchaConfig, DiscoverableOidcConfig, DummyAuthConfig, FrontendHostname,
+    OpenIdConfig, RateLimitConfig, Timestamp,
 };
 use std::borrow::Cow;
 use std::collections::HashMap;

--- a/src/internet_identity/tests/integration/config.rs
+++ b/src/internet_identity/tests/integration/config.rs
@@ -6,6 +6,7 @@ mod captcha_config;
 mod enable_dapps_explorer;
 mod is_production;
 mod new_flow_origins;
+mod oidc_configs;
 mod openid_configs;
 mod register_rate_limit;
 mod related_origins;

--- a/src/internet_identity/tests/integration/config/oidc_configs.rs
+++ b/src/internet_identity/tests/integration/config/oidc_configs.rs
@@ -1,9 +1,7 @@
 use canister_tests::api::internet_identity as api;
-use canister_tests::framework::{
-    env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
-};
+use canister_tests::framework::{env, install_ii_canister_with_arg, II_WASM};
 use internet_identity_interface::internet_identity::types::{
-    DiscoverableOidcConfig, InternetIdentityInit, OpenIdConfig,
+    DiscoverableOidcConfig, InternetIdentityInit,
 };
 
 fn example_oidc_config() -> DiscoverableOidcConfig {
@@ -14,127 +12,21 @@ fn example_oidc_config() -> DiscoverableOidcConfig {
 }
 
 #[test]
-fn should_init_default() {
+fn should_init_without_oidc_configs() {
     let env = env();
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
-    assert_eq!(api::config(&env, canister_id).unwrap().oidc_configs, None);
+    let discovered = api::discovered_oidc_configs(&env, canister_id).unwrap();
+    assert!(discovered.is_empty());
 }
 
 #[test]
-fn should_init_config() {
+fn should_add_oidc_config_via_update_call() {
     let env = env();
-    let config = InternetIdentityInit {
-        oidc_configs: Some(vec![example_oidc_config()]),
-        ..Default::default()
-    };
 
-    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
-    assert_eq!(
-        api::config(&env, canister_id).unwrap().oidc_configs,
-        config.oidc_configs
-    );
-}
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
 
-#[test]
-fn should_enable_config_via_upgrade() {
-    let env = env();
-    let config = InternetIdentityInit {
-        oidc_configs: None,
-        ..Default::default()
-    };
-
-    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
-
-    let enabled = Some(vec![example_oidc_config()]);
-    upgrade_ii_canister_with_arg(
-        &env,
-        canister_id,
-        II_WASM.clone(),
-        Some(InternetIdentityInit {
-            oidc_configs: enabled.clone(),
-            ..Default::default()
-        }),
-    )
-    .unwrap();
-    assert_eq!(
-        api::config(&env, canister_id).unwrap().oidc_configs,
-        enabled
-    );
-}
-
-#[test]
-fn should_retain_config_across_unrelated_upgrade() {
-    let env = env();
-    let config = InternetIdentityInit {
-        oidc_configs: Some(vec![example_oidc_config()]),
-        ..Default::default()
-    };
-
-    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
-
-    // Upgrade with unrelated config change
-    upgrade_ii_canister_with_arg(
-        &env,
-        canister_id,
-        II_WASM.clone(),
-        Some(InternetIdentityInit {
-            related_origins: Some(vec!["https://example.com".into()]),
-            ..Default::default()
-        }),
-    )
-    .unwrap();
-    assert_eq!(
-        api::config(&env, canister_id).unwrap().oidc_configs,
-        config.oidc_configs
-    );
-}
-
-#[test]
-fn should_clear_openid_configs_when_oidc_configs_set() {
-    let env = env();
-    let config = InternetIdentityInit {
-        openid_configs: Some(vec![OpenIdConfig {
-            name: "Example".into(),
-            logo: String::new(),
-            issuer: "https://example.com".into(),
-            client_id: "app.example.com".into(),
-            jwks_uri: "https://example.com/oauth2/v3/certs".into(),
-            auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
-            auth_scope: vec!["openid".into()],
-            fedcm_uri: None,
-            email_verification: None,
-        }]),
-        ..Default::default()
-    };
-
-    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
-
-    // Upgrade with oidc_configs should clear openid_configs
-    upgrade_ii_canister_with_arg(
-        &env,
-        canister_id,
-        II_WASM.clone(),
-        Some(InternetIdentityInit {
-            oidc_configs: Some(vec![example_oidc_config()]),
-            ..Default::default()
-        }),
-    )
-    .unwrap();
-    let result = api::config(&env, canister_id).unwrap();
-    assert_eq!(result.openid_configs, None);
-    assert!(result.oidc_configs.is_some());
-}
-
-#[test]
-fn should_return_discovered_oidc_configs() {
-    let env = env();
-    let config = InternetIdentityInit {
-        oidc_configs: Some(vec![example_oidc_config()]),
-        ..Default::default()
-    };
-
-    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
+    api::add_discoverable_oidc_config(&env, canister_id, example_oidc_config()).unwrap();
 
     let discovered = api::discovered_oidc_configs(&env, canister_id).unwrap();
     assert_eq!(discovered.len(), 1);
@@ -147,27 +39,77 @@ fn should_return_discovered_oidc_configs() {
 }
 
 #[test]
-fn should_return_empty_discovered_oidc_configs_when_none_configured() {
+fn should_deduplicate_oidc_configs() {
     let env = env();
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
 
+    api::add_discoverable_oidc_config(&env, canister_id, example_oidc_config()).unwrap();
+    api::add_discoverable_oidc_config(&env, canister_id, example_oidc_config()).unwrap();
+
     let discovered = api::discovered_oidc_configs(&env, canister_id).unwrap();
-    assert!(discovered.is_empty());
+    assert_eq!(discovered.len(), 1);
 }
 
-/// Canary allowlist should reject any domain that isn't `dfinity.org` —
-/// the canister init traps, so installation fails.
 #[test]
-#[should_panic(expected = "canary allowlist")]
-fn should_reject_disallowed_discovery_domain() {
+fn should_coexist_with_openid_configs() {
     let env = env();
     let config = InternetIdentityInit {
-        oidc_configs: Some(vec![DiscoverableOidcConfig {
-            discovery_domain: "evil.example.com".into(),
-        }]),
+        openid_configs: Some(vec![
+            internet_identity_interface::internet_identity::types::OpenIdConfig {
+                name: "Example".into(),
+                logo: String::new(),
+                issuer: "https://example.com".into(),
+                client_id: "app.example.com".into(),
+                jwks_uri: "https://example.com/oauth2/v3/certs".into(),
+                auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
+                auth_scope: vec!["openid".into()],
+                fedcm_uri: None,
+                email_verification: None,
+            },
+        ]),
         ..Default::default()
     };
 
-    install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
+
+    // Add OIDC config alongside existing openid_configs
+    api::add_discoverable_oidc_config(&env, canister_id, example_oidc_config()).unwrap();
+
+    let result = api::config(&env, canister_id).unwrap();
+    assert!(result.openid_configs.is_some());
+    assert!(result.oidc_configs.is_some());
+}
+
+/// Canary allowlist should reject any domain that isn't `dfinity.org`.
+#[test]
+fn should_reject_disallowed_discovery_domain() {
+    let env = env();
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
+
+    let result = api::add_discoverable_oidc_config(
+        &env,
+        canister_id,
+        DiscoverableOidcConfig {
+            discovery_domain: "evil.example.com".into(),
+        },
+    );
+    assert!(result.is_err());
+}
+
+/// Configs added via init args should still be restored on upgrade (backward compat).
+#[test]
+fn should_restore_oidc_configs_from_init_args_on_upgrade() {
+    let env = env();
+    let config = InternetIdentityInit {
+        oidc_configs: Some(vec![example_oidc_config()]),
+        ..Default::default()
+    };
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
+
+    let discovered = api::discovered_oidc_configs(&env, canister_id).unwrap();
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].discovery_domain, "dfinity.org");
 }

--- a/src/internet_identity/tests/integration/config/oidc_configs.rs
+++ b/src/internet_identity/tests/integration/config/oidc_configs.rs
@@ -1,0 +1,162 @@
+use canister_tests::api::internet_identity as api;
+use canister_tests::framework::{
+    env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
+};
+use internet_identity_interface::internet_identity::types::{
+    InternetIdentityInit, OidcConfig, OpenIdConfig,
+};
+
+fn example_oidc_config() -> OidcConfig {
+    OidcConfig {
+        name: "Google".into(),
+        logo: String::new(),
+        discovery_url: "https://accounts.google.com/.well-known/openid-configuration".into(),
+        client_id: Some("test-client-id".into()),
+        email_verification: None,
+    }
+}
+
+#[test]
+fn should_init_default() {
+    let env = env();
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
+    assert_eq!(api::config(&env, canister_id).unwrap().oidc_configs, None);
+}
+
+#[test]
+fn should_init_config() {
+    let env = env();
+    let config = InternetIdentityInit {
+        oidc_configs: Some(vec![example_oidc_config()]),
+        ..Default::default()
+    };
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().oidc_configs,
+        config.oidc_configs
+    );
+}
+
+#[test]
+fn should_enable_config_via_upgrade() {
+    let env = env();
+    let config = InternetIdentityInit {
+        oidc_configs: None,
+        ..Default::default()
+    };
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
+
+    let enabled = Some(vec![example_oidc_config()]);
+    upgrade_ii_canister_with_arg(
+        &env,
+        canister_id,
+        II_WASM.clone(),
+        Some(InternetIdentityInit {
+            oidc_configs: enabled.clone(),
+            ..Default::default()
+        }),
+    )
+    .unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().oidc_configs,
+        enabled
+    );
+}
+
+#[test]
+fn should_retain_config_across_unrelated_upgrade() {
+    let env = env();
+    let config = InternetIdentityInit {
+        oidc_configs: Some(vec![example_oidc_config()]),
+        ..Default::default()
+    };
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
+
+    // Upgrade with unrelated config change
+    upgrade_ii_canister_with_arg(
+        &env,
+        canister_id,
+        II_WASM.clone(),
+        Some(InternetIdentityInit {
+            related_origins: Some(vec!["https://example.com".into()]),
+            ..Default::default()
+        }),
+    )
+    .unwrap();
+    assert_eq!(
+        api::config(&env, canister_id).unwrap().oidc_configs,
+        config.oidc_configs
+    );
+}
+
+#[test]
+fn should_clear_openid_configs_when_oidc_configs_set() {
+    let env = env();
+    let config = InternetIdentityInit {
+        openid_configs: Some(vec![OpenIdConfig {
+            name: "Example".into(),
+            logo: String::new(),
+            issuer: "https://example.com".into(),
+            client_id: "app.example.com".into(),
+            jwks_uri: "https://example.com/oauth2/v3/certs".into(),
+            auth_uri: "https://example.com/o/oauth2/v2/auth".into(),
+            auth_scope: vec!["openid".into()],
+            fedcm_uri: None,
+            email_verification: None,
+        }]),
+        ..Default::default()
+    };
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
+
+    // Upgrade with oidc_configs should clear openid_configs
+    upgrade_ii_canister_with_arg(
+        &env,
+        canister_id,
+        II_WASM.clone(),
+        Some(InternetIdentityInit {
+            oidc_configs: Some(vec![example_oidc_config()]),
+            ..Default::default()
+        }),
+    )
+    .unwrap();
+    let result = api::config(&env, canister_id).unwrap();
+    assert_eq!(result.openid_configs, None);
+    assert!(result.oidc_configs.is_some());
+}
+
+#[test]
+fn should_return_active_oidc_configs() {
+    let env = env();
+    let config = InternetIdentityInit {
+        oidc_configs: Some(vec![example_oidc_config()]),
+        ..Default::default()
+    };
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
+
+    let active = api::active_oidc_configs(&env, canister_id).unwrap();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0].name, "Google");
+    assert_eq!(active[0].client_id, Some("test-client-id".into()));
+    assert_eq!(
+        active[0].discovery_url,
+        "https://accounts.google.com/.well-known/openid-configuration"
+    );
+    // Issuer is None because discovery hasn't run (no HTTP outcalls in tests)
+    assert_eq!(active[0].issuer, None);
+}
+
+#[test]
+fn should_return_empty_active_oidc_configs_when_none_configured() {
+    let env = env();
+
+    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
+
+    let active = api::active_oidc_configs(&env, canister_id).unwrap();
+    assert!(active.is_empty());
+}

--- a/src/internet_identity/tests/integration/config/oidc_configs.rs
+++ b/src/internet_identity/tests/integration/config/oidc_configs.rs
@@ -3,16 +3,13 @@ use canister_tests::framework::{
     env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
-    InternetIdentityInit, DiscoverableOidcConfig, OpenIdConfig,
+    DiscoverableOidcConfig, InternetIdentityInit, OpenIdConfig,
 };
 
 fn example_oidc_config() -> DiscoverableOidcConfig {
     DiscoverableOidcConfig {
-        name: "Google".into(),
-        logo: String::new(),
-        discovery_url: "https://accounts.google.com/.well-known/openid-configuration".into(),
-        client_id: Some("test-client-id".into()),
-        email_verification: None,
+        // Must be on the canary allowlist in `openid::generic::ALLOWED_DISCOVERY_DOMAINS`.
+        discovery_domain: "dfinity.org".into(),
     }
 }
 
@@ -141,13 +138,11 @@ fn should_return_discovered_oidc_configs() {
 
     let discovered = api::discovered_oidc_configs(&env, canister_id).unwrap();
     assert_eq!(discovered.len(), 1);
-    assert_eq!(discovered[0].name, "Google");
-    assert_eq!(discovered[0].client_id, Some("test-client-id".into()));
-    assert_eq!(
-        discovered[0].discovery_url,
-        "https://accounts.google.com/.well-known/openid-configuration"
-    );
-    // Issuer is None because discovery hasn't run (no HTTP outcalls in tests)
+    assert_eq!(discovered[0].discovery_domain, "dfinity.org");
+    // Discovery requires HTTP outcalls, which don't run in PocketIC tests,
+    // so every discovered field is `None` on init.
+    assert_eq!(discovered[0].client_id, None);
+    assert_eq!(discovered[0].openid_configuration, None);
     assert_eq!(discovered[0].issuer, None);
 }
 
@@ -159,4 +154,20 @@ fn should_return_empty_discovered_oidc_configs_when_none_configured() {
 
     let discovered = api::discovered_oidc_configs(&env, canister_id).unwrap();
     assert!(discovered.is_empty());
+}
+
+/// Canary allowlist should reject any domain that isn't `dfinity.org` —
+/// the canister init traps, so installation fails.
+#[test]
+#[should_panic(expected = "canary allowlist")]
+fn should_reject_disallowed_discovery_domain() {
+    let env = env();
+    let config = InternetIdentityInit {
+        oidc_configs: Some(vec![DiscoverableOidcConfig {
+            discovery_domain: "evil.example.com".into(),
+        }]),
+        ..Default::default()
+    };
+
+    install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 }

--- a/src/internet_identity/tests/integration/config/oidc_configs.rs
+++ b/src/internet_identity/tests/integration/config/oidc_configs.rs
@@ -3,11 +3,11 @@ use canister_tests::framework::{
     env, install_ii_canister_with_arg, upgrade_ii_canister_with_arg, II_WASM,
 };
 use internet_identity_interface::internet_identity::types::{
-    InternetIdentityInit, OidcConfig, OpenIdConfig,
+    InternetIdentityInit, DiscoverableOidcConfig, OpenIdConfig,
 };
 
-fn example_oidc_config() -> OidcConfig {
-    OidcConfig {
+fn example_oidc_config() -> DiscoverableOidcConfig {
+    DiscoverableOidcConfig {
         name: "Google".into(),
         logo: String::new(),
         discovery_url: "https://accounts.google.com/.well-known/openid-configuration".into(),

--- a/src/internet_identity/tests/integration/config/oidc_configs.rs
+++ b/src/internet_identity/tests/integration/config/oidc_configs.rs
@@ -130,7 +130,7 @@ fn should_clear_openid_configs_when_oidc_configs_set() {
 }
 
 #[test]
-fn should_return_active_oidc_configs() {
+fn should_return_discovered_oidc_configs() {
     let env = env();
     let config = InternetIdentityInit {
         oidc_configs: Some(vec![example_oidc_config()]),
@@ -139,24 +139,24 @@ fn should_return_active_oidc_configs() {
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
 
-    let active = api::active_oidc_configs(&env, canister_id).unwrap();
-    assert_eq!(active.len(), 1);
-    assert_eq!(active[0].name, "Google");
-    assert_eq!(active[0].client_id, Some("test-client-id".into()));
+    let discovered = api::discovered_oidc_configs(&env, canister_id).unwrap();
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].name, "Google");
+    assert_eq!(discovered[0].client_id, Some("test-client-id".into()));
     assert_eq!(
-        active[0].discovery_url,
+        discovered[0].discovery_url,
         "https://accounts.google.com/.well-known/openid-configuration"
     );
     // Issuer is None because discovery hasn't run (no HTTP outcalls in tests)
-    assert_eq!(active[0].issuer, None);
+    assert_eq!(discovered[0].issuer, None);
 }
 
 #[test]
-fn should_return_empty_active_oidc_configs_when_none_configured() {
+fn should_return_empty_discovered_oidc_configs_when_none_configured() {
     let env = env();
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), None);
 
-    let active = api::active_oidc_configs(&env, canister_id).unwrap();
-    assert!(active.is_empty());
+    let discovered = api::discovered_oidc_configs(&env, canister_id).unwrap();
+    assert!(discovered.is_empty());
 }

--- a/src/internet_identity/tests/integration/config/oidc_configs.rs
+++ b/src/internet_identity/tests/integration/config/oidc_configs.rs
@@ -97,19 +97,3 @@ fn should_reject_disallowed_discovery_domain() {
     );
     assert!(result.is_err());
 }
-
-/// Configs added via init args should still be restored on upgrade (backward compat).
-#[test]
-fn should_restore_oidc_configs_from_init_args_on_upgrade() {
-    let env = env();
-    let config = InternetIdentityInit {
-        oidc_configs: Some(vec![example_oidc_config()]),
-        ..Default::default()
-    };
-
-    let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config));
-
-    let discovered = api::discovered_oidc_configs(&env, canister_id).unwrap();
-    assert_eq!(discovered.len(), 1);
-    assert_eq!(discovered[0].discovery_domain, "dfinity.org");
-}

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -925,6 +925,7 @@ fn ii_canister_serves_decodable_synchronized_config() -> Result<(), RejectRespon
         decoded_config,
         InternetIdentitySynchronizedConfig {
             openid_configs: Some(openid_configs),
+            oidc_configs: None,
         }
     );
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -268,7 +268,8 @@ pub struct InternetIdentityInit {
     pub new_flow_origins: Option<Vec<String>>,
     /// Deprecated: use `oidc_configs` instead. Mutually exclusive with `oidc_configs`.
     pub openid_configs: Option<Vec<OpenIdConfig>>,
-    /// Simplified OIDC configs that use discovery. Mutually exclusive with `openid_configs` and `new_flow_origins`.
+    /// SSO provider configs that use two-hop discovery.
+    /// Mutually exclusive with `openid_configs` and `new_flow_origins`.
     pub oidc_configs: Option<Vec<DiscoverableOidcConfig>>,
     pub analytics_config: Option<Option<AnalyticsConfig>>,
     pub enable_dapps_explorer: Option<bool>,
@@ -386,31 +387,25 @@ pub struct OpenIdConfig {
     pub email_verification: Option<OpenIdEmailVerificationScheme>,
 }
 
-/// Simplified OIDC provider configuration that relies on OIDC discovery
-/// instead of requiring all provider details in the init config.
+/// SSO provider configuration that uses two-hop discovery.
 ///
-/// `client_id` must be set. The `discovery_url` points to the standard
-/// `.well-known/openid-configuration` endpoint from which `issuer` and
-/// `jwks_uri` are discovered automatically.
+/// The backend fetches `https://{discovery_domain}/.well-known/ii-openid-configuration`
+/// to obtain `{ client_id, openid_configuration }`, then fetches the standard OIDC
+/// discovery document at `openid_configuration` to resolve `issuer` and `jwks_uri`.
 #[derive(Clone, Debug, CandidType, Serialize, Deserialize, Default, Eq, PartialEq)]
 pub struct DiscoverableOidcConfig {
-    pub name: String,
-    pub logo: String,
-    pub discovery_url: String,
-    pub client_id: Option<String>,
-    pub email_verification: Option<OpenIdEmailVerificationScheme>,
+    pub discovery_domain: String,
 }
 
-/// Resolved OIDC provider config returned by the `discovered_oidc_configs` query.
-/// Includes fields discovered from the OIDC discovery endpoint.
+/// Resolved SSO provider state returned by the `discovered_oidc_configs` query.
+/// Any field other than `discovery_domain` is `None` until the two-hop discovery
+/// completes for that domain.
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct OidcConfig {
-    pub name: String,
-    pub logo: String,
-    pub discovery_url: String,
+    pub discovery_domain: String,
     pub client_id: Option<String>,
+    pub openid_configuration: Option<String>,
     pub issuer: Option<String>,
-    pub email_verification: Option<OpenIdEmailVerificationScheme>,
 }
 
 pub enum AuthorizationKey {

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -237,12 +237,14 @@ pub struct InternetIdentityFrontendArgs {
 #[derive(Clone, Debug, CandidType, Deserialize, Default, Eq, PartialEq)]
 pub struct InternetIdentitySynchronizedConfig {
     pub openid_configs: Option<Vec<OpenIdConfig>>,
+    pub oidc_configs: Option<Vec<OidcConfig>>,
 }
 
 impl From<&InternetIdentityInit> for InternetIdentitySynchronizedConfig {
     fn from(value: &InternetIdentityInit) -> Self {
         Self {
             openid_configs: value.openid_configs.clone(),
+            oidc_configs: value.oidc_configs.clone(),
         }
     }
 }
@@ -264,6 +266,8 @@ pub struct InternetIdentityInit {
     pub related_origins: Option<Vec<String>>,
     pub new_flow_origins: Option<Vec<String>>,
     pub openid_configs: Option<Vec<OpenIdConfig>>,
+    /// Simplified OIDC configs that use discovery. Mutually exclusive with `openid_configs`.
+    pub oidc_configs: Option<Vec<OidcConfig>>,
     pub analytics_config: Option<Option<AnalyticsConfig>>,
     pub enable_dapps_explorer: Option<bool>,
     pub is_production: Option<bool>,
@@ -377,6 +381,36 @@ pub struct OpenIdConfig {
     pub auth_uri: String,
     pub auth_scope: Vec<String>,
     pub fedcm_uri: Option<String>,
+    pub email_verification: Option<OpenIdEmailVerificationScheme>,
+}
+
+/// Simplified OIDC provider configuration that relies on OIDC discovery
+/// instead of requiring all provider details in the init config.
+///
+/// For dedicated providers (Google, Apple, Microsoft): `client_id` is set,
+/// `discovery_url` points to the standard `.well-known/openid-configuration` endpoint.
+///
+/// For SSO providers: `client_id` is `None`, `discovery_url` points to a custom
+/// `ii-openid-configuration` endpoint that provides `client_id` and a reference
+/// to the standard OIDC discovery endpoint.
+#[derive(Clone, Debug, CandidType, Serialize, Deserialize, Default, Eq, PartialEq)]
+pub struct OidcConfig {
+    pub name: String,
+    pub logo: String,
+    pub discovery_url: String,
+    pub client_id: Option<String>,
+    pub email_verification: Option<OpenIdEmailVerificationScheme>,
+}
+
+/// Resolved OIDC provider config returned by the `active_oidc_configs` query.
+/// Includes fields discovered from the OIDC discovery endpoint.
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct ActiveOidcConfig {
+    pub name: String,
+    pub logo: String,
+    pub discovery_url: String,
+    pub client_id: Option<String>,
+    pub issuer: Option<String>,
     pub email_verification: Option<OpenIdEmailVerificationScheme>,
 }
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -264,12 +264,10 @@ pub struct InternetIdentityInit {
     pub register_rate_limit: Option<RateLimitConfig>,
     pub captcha_config: Option<CaptchaConfig>,
     pub related_origins: Option<Vec<String>>,
-    /// Deprecated: origins that use the new authentication flow. Mutually exclusive with `oidc_configs`.
     pub new_flow_origins: Option<Vec<String>>,
-    /// Deprecated: use `oidc_configs` instead. Mutually exclusive with `oidc_configs`.
     pub openid_configs: Option<Vec<OpenIdConfig>>,
-    /// SSO provider configs that use two-hop discovery.
-    /// Mutually exclusive with `openid_configs` and `new_flow_origins`.
+    /// SSO provider configs managed via `add_discoverable_oidc_config` update call.
+    /// Retained in init args for backward compatibility and `config()` query output.
     pub oidc_configs: Option<Vec<DiscoverableOidcConfig>>,
     pub analytics_config: Option<Option<AnalyticsConfig>>,
     pub enable_dapps_explorer: Option<bool>,

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -264,7 +264,9 @@ pub struct InternetIdentityInit {
     pub register_rate_limit: Option<RateLimitConfig>,
     pub captcha_config: Option<CaptchaConfig>,
     pub related_origins: Option<Vec<String>>,
+    /// Deprecated: origins that use the new authentication flow. Mutually exclusive with `oidc_configs`.
     pub new_flow_origins: Option<Vec<String>>,
+    /// Deprecated: use `oidc_configs` instead. Mutually exclusive with `oidc_configs`.
     pub openid_configs: Option<Vec<OpenIdConfig>>,
     /// Simplified OIDC configs that use discovery. Mutually exclusive with `openid_configs`.
     pub oidc_configs: Option<Vec<OidcConfig>>,
@@ -402,10 +404,10 @@ pub struct OidcConfig {
     pub email_verification: Option<OpenIdEmailVerificationScheme>,
 }
 
-/// Resolved OIDC provider config returned by the `active_oidc_configs` query.
+/// Resolved OIDC provider config returned by the `discovered_oidc_configs` query.
 /// Includes fields discovered from the OIDC discovery endpoint.
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub struct ActiveOidcConfig {
+pub struct DiscoveredOidcConfig {
     pub name: String,
     pub logo: String,
     pub discovery_url: String,

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -268,7 +268,7 @@ pub struct InternetIdentityInit {
     pub new_flow_origins: Option<Vec<String>>,
     /// Deprecated: use `oidc_configs` instead. Mutually exclusive with `oidc_configs`.
     pub openid_configs: Option<Vec<OpenIdConfig>>,
-    /// Simplified OIDC configs that use discovery. Mutually exclusive with `openid_configs`.
+    /// Simplified OIDC configs that use discovery. Mutually exclusive with `openid_configs` and `new_flow_origins`.
     pub oidc_configs: Option<Vec<DiscoverableOidcConfig>>,
     pub analytics_config: Option<Option<AnalyticsConfig>>,
     pub enable_dapps_explorer: Option<bool>,
@@ -389,12 +389,9 @@ pub struct OpenIdConfig {
 /// Simplified OIDC provider configuration that relies on OIDC discovery
 /// instead of requiring all provider details in the init config.
 ///
-/// For dedicated providers (Google, Apple, Microsoft): `client_id` is set,
-/// `discovery_url` points to the standard `.well-known/openid-configuration` endpoint.
-///
-/// For SSO providers: `client_id` is `None`, `discovery_url` points to a custom
-/// `ii-openid-configuration` endpoint that provides `client_id` and a reference
-/// to the standard OIDC discovery endpoint.
+/// `client_id` must be set. The `discovery_url` points to the standard
+/// `.well-known/openid-configuration` endpoint from which `issuer` and
+/// `jwks_uri` are discovered automatically.
 #[derive(Clone, Debug, CandidType, Serialize, Deserialize, Default, Eq, PartialEq)]
 pub struct DiscoverableOidcConfig {
     pub name: String,

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -237,7 +237,7 @@ pub struct InternetIdentityFrontendArgs {
 #[derive(Clone, Debug, CandidType, Deserialize, Default, Eq, PartialEq)]
 pub struct InternetIdentitySynchronizedConfig {
     pub openid_configs: Option<Vec<OpenIdConfig>>,
-    pub oidc_configs: Option<Vec<OidcConfig>>,
+    pub oidc_configs: Option<Vec<DiscoverableOidcConfig>>,
 }
 
 impl From<&InternetIdentityInit> for InternetIdentitySynchronizedConfig {
@@ -269,7 +269,7 @@ pub struct InternetIdentityInit {
     /// Deprecated: use `oidc_configs` instead. Mutually exclusive with `oidc_configs`.
     pub openid_configs: Option<Vec<OpenIdConfig>>,
     /// Simplified OIDC configs that use discovery. Mutually exclusive with `openid_configs`.
-    pub oidc_configs: Option<Vec<OidcConfig>>,
+    pub oidc_configs: Option<Vec<DiscoverableOidcConfig>>,
     pub analytics_config: Option<Option<AnalyticsConfig>>,
     pub enable_dapps_explorer: Option<bool>,
     pub is_production: Option<bool>,
@@ -396,7 +396,7 @@ pub struct OpenIdConfig {
 /// `ii-openid-configuration` endpoint that provides `client_id` and a reference
 /// to the standard OIDC discovery endpoint.
 #[derive(Clone, Debug, CandidType, Serialize, Deserialize, Default, Eq, PartialEq)]
-pub struct OidcConfig {
+pub struct DiscoverableOidcConfig {
     pub name: String,
     pub logo: String,
     pub discovery_url: String,
@@ -407,7 +407,7 @@ pub struct OidcConfig {
 /// Resolved OIDC provider config returned by the `discovered_oidc_configs` query.
 /// Includes fields discovered from the OIDC discovery endpoint.
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
-pub struct DiscoveredOidcConfig {
+pub struct OidcConfig {
     pub name: String,
     pub logo: String,
     pub discovery_url: String,


### PR DESCRIPTION
## Summary

- Introduces `DiscoverableOidcConfig` type and `oidc_configs` init field (mutually exclusive with existing `openid_configs`) that relies on OIDC discovery (`.well-known/openid-configuration`) instead of requiring all provider details in the static config
- Adds `DiscoverableProvider` that periodically fetches discovery metadata to obtain `issuer` and `jwks_uri` for JWT verification
- Adds `discovered_oidc_configs` query endpoint returning `OidcConfig` with resolved provider state
- Validates that discovered `issuer` domain matches the `discovery_url` domain (prevents impersonation)
- When both `openid_configs` and `oidc_configs` are provided, falls back to `openid_configs` as the proven path

## Test plan

- [x] 7 new integration tests in `config/oidc_configs.rs` (init, upgrade, retain, XOR, query)
- [x] Existing `openid_configs` tests pass unchanged (backward compat)
- [ ] Manual E2E with deployed canister using `oidc_configs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
[Next PR >](https://github.com/dfinity/internet-identity/pull/3784)