### PR TITLE
ci: add pull_request trigger to enable CI on fork PRs

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -5,6 +5,7 @@ name: Canister tests
 
 on:
   push:
+  pull_request:
 
 jobs:
   #####################

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -693,6 +693,7 @@ jobs:
   # This prepares all the files necessary for a release (all flavors of Wasm, release notes).
   # On release tags, a new release is created and the assets are uploaded.
   release:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs:
       [

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # set a PAT so that add-and-commit can trigger CI runs
-          token: ${{ secrets.GIX_BOT_PAT }}
+          token: ${{ secrets.GIX_BOT_PAT || github.token }}
       - uses: ./.github/actions/setup-node
       - run: npm ci
       - name: Run tsc

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -38,8 +38,9 @@ jobs:
           done < <(jq <src/frontend/src/flows/dappsExplorer/dapps.json -cMr '.[] | .logo' )
       - name: Commit type interfaces
         uses: EndBug/add-and-commit@v9
-        # We don't want to commit automatic changes to main
-        if: ${{ github.ref != 'refs/heads/main' }}
+        # We don't want to commit automatic changes to main, and we can't
+        # push to fork PRs (read-only token).
+        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
         with:
           add: |
             src/frontend/generated

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -2,6 +2,7 @@ name: Frontend checks and lints
 
 on:
   push:
+  pull_request:
 
 jobs:
   frontend-checks:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@ name: Rust
 
 on:
   push:
+  pull_request:
 
 jobs:
   cargo-fmt:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           # set a PAT so that add-and-commit can trigger
           # CI runs
-          token: ${{ secrets.GIX_BOT_PAT }}
+          token: ${{ secrets.GIX_BOT_PAT || github.token }}
       - uses: ./.github/actions/bootstrap
 
       - name: Cargo fmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,8 +29,9 @@ jobs:
 
       - name: Commit Formatting changes
         uses: EndBug/add-and-commit@v9
-        # We don't want to commit formatting changes to main
-        if: ${{ github.ref != 'refs/heads/main' }}
+        # We don't want to commit formatting changes to main, and we can't
+        # push to fork PRs (read-only token).
+        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
         with:
           add: "**/*.rs"
           default_author: github_actions


### PR DESCRIPTION
## Summary

- Add `pull_request` trigger to `canister-tests.yml`, `frontend-checks.yml`, and `rust.yml`
- Currently these workflows only trigger on `push`, so fork PRs never get CI checks
- With `pull_request` added, maintainers see an "Approve and run" button to trigger CI on external contributions

## Notes

- Some jobs reference `secrets.GIX_BOT_PAT`, which is not available to `pull_request` runs from forks. Steps that depend on this token (e.g., auto-commit formatting fixes) will be skipped or fail on fork PRs, but the core checks (build, test, lint) should still work.
- The repo setting at **Settings > Actions > General > Fork pull request workflows** controls which contributors require approval.