### PR TITLE
docs: update Node.js version requirement in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -12,7 +12,7 @@ The build requires the following dependencies:
 - Rustup with target `wasm32-unknown-unknown` (see [rustup instructions](https://rust-lang.github.io/rustup/cross-compilation.html)), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
 - CMake
 - [`ic-wasm`](https://github.com/dfinity/ic-wasm), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
-- Node.js v16+
+- Node.js v24+ (see `.nvmrc` for the exact version)
 
 ## Running Locally
 


### PR DESCRIPTION
## Summary

The Node.js prerequisite listed in `HACKING.md` says **v16+**, but the project
actually requires **Node.js v24** — see `.nvmrc` (pinned at `24.15.0`) and
`package.json` (`engines.node: ">=24.0.0 <25.0.0"`).

This one-line fix updates the documented requirement to match reality so that
new contributors don't waste time with an unsupported Node version.

## Changes

- `HACKING.md` line 15: `Node.js v16+` → `Node.js v24+ (see .nvmrc for the exact version)`