### PR TITLE
docs: update Node.js version requirement in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -12,7 +12,7 @@ The build requires the following dependencies:
 - Rustup with target `wasm32-unknown-unknown` (see [rustup instructions](https://rust-lang.github.io/rustup/cross-compilation.html)), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
 - CMake
 - [`ic-wasm`](https://github.com/dfinity/ic-wasm), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
-- Node.js v24+ (see `.nvmrc` for the exact version)
+- Node.js v24.x (see `.nvmrc` for the exact version)
 
 ## Running Locally
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -12,7 +12,7 @@ The build requires the following dependencies:
 - Rustup with target `wasm32-unknown-unknown` (see [rustup instructions](https://rust-lang.github.io/rustup/cross-compilation.html)), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
 - CMake
 - [`ic-wasm`](https://github.com/dfinity/ic-wasm), which can be installed by running [./scripts/bootstrap](./scripts/bootstrap)
-- Node.js v16+
+- Node.js v24+ (see `.nvmrc` for the exact version)
 
 ## Running Locally
 


### PR DESCRIPTION
## Summary

`HACKING.md` lists **Node.js v16+** as a build prerequisite, but the project
actually requires **Node.js v24**:

| Source | Value |
|---|---|
| `.nvmrc` | `24.15.0` |
| `package.json` engines | `>=24.0.0 <25.0.0` |

New contributors following the current docs would install a Node version
that's eight major versions behind and incompatible with the project.

## Changes

- `HACKING.md` line 15: `Node.js v16+` → `Node.js v24+ (see .nvmrc for the exact version)`

This is a one-line documentation fix with no code changes.