### PR TITLE
fix(scripts): query workflow runs by branch name instead of pull_requests field

### DIFF
--- a/scripts/deploy-pr-to-beta
+++ b/scripts/deploy-pr-to-beta
@@ -197,12 +197,15 @@ AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
 
 echo "Fetching workflow runs for PR #$PR_NUMBER..."
 
-# Fetch the most recent workflow run for this PR (regardless of overall conclusion)
+# Get the branch name for this PR
+BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName -q '.headRefName')
+
+# Fetch the most recent workflow run for this PR's branch
 RUN_ID=$(curl -sf -H "$AUTH_HEADER" \
-    "https://api.github.com/repos/$REPO/actions/runs?event=push&per_page=100" \
-    | jq -r --arg PR "$PR_NUMBER" --arg WF "$WORKFLOW_FILE" '
+    "https://api.github.com/repos/$REPO/actions/runs?per_page=100" \
+    | jq -r --arg BRANCH "$BRANCH" --arg WF "$WORKFLOW_FILE" '
         [.workflow_runs[]
-            | select(.pull_requests[]?.number == ($PR|tonumber))
+            | select(.head_branch == $BRANCH)
             | select(.path == (".github/workflows/" + $WF))
         ]
         | sort_by(.run_number)


### PR DESCRIPTION
The `pull_requests` field in the GitHub API's workflow runs endpoint is often empty for recent runs, causing `deploy-pr-to-beta` to fail to locate the workflow run. 

Query by the PR's head branch name instead, which is reliably populated.

## Test plan
- [x] Verified fix resolves the issue for PR #3784
- [x] Script now successfully finds canister-tests.yml workflow runs