### PR TITLE
chore(scripts): refactor deploy-{pr,local}-to-beta with shared library

### DIFF
--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -1,0 +1,596 @@
+#!/usr/bin/env bash
+# Shared helpers for deploy-pr-to-beta and deploy-local-to-beta.
+#
+# Responsibilities:
+# - CLI arg parsing for staging selection (-sa/-sb/-sc/--staging custom),
+#   end selection (-fe/-be/--end), dry-run, no-checks, and (for the local
+#   script) the rebuild flags.
+# - Reachability + consistency checks against the selected staging canisters.
+# - Interactive prompting for the small set of install-arg fields we actually
+#   want humans to make decisions about (dev_csp / dummy_auth / analytics_config)
+#   — everything else is derived from the four shared values (BE_ID, FE_ID,
+#   BE_URL, FE_URL) or left opaque via opt null to preserve prior state.
+# - Install-arg builders that emit Candid text for each canister.
+# - A dfx install runner that honours --dry-run.
+#
+# Globals set by parse_common_args (and expected by later helpers):
+#   STAGING_NAME       : "a" | "b" | "c" | "custom"
+#   BE_ID, FE_ID       : principals (text form)
+#   BE_URL, FE_URL     : https://... URLs
+#   DEPLOY_FE          : true | false
+#   DEPLOY_BE          : true | false
+#   REBUILD_FE         : true | false  (deploy-local-to-beta only)
+#   REBUILD_BE         : true | false  (deploy-local-to-beta only)
+#   DRY_RUN            : true | false
+#   NO_CHECKS          : true | false
+#   REMAINING_ARGS[]   : leftover positional args (deploy-pr-to-beta reads PR#)
+
+readonly WALLET_CANISTER_ID="cvthj-wyaaa-aaaad-aaaaq-cai"
+readonly IC_NETWORK="ic"
+
+# -------------------------
+# Staging environments
+# -------------------------
+staging_be_id() {
+    case "$1" in
+        a) echo "fgte5-ciaaa-aaaad-aaatq-cai" ;;
+        b) echo "jqajs-xiaaa-aaaad-aab5q-cai" ;;
+        c) echo "y2aaj-miaaa-aaaad-aacxq-cai" ;;
+        *) return 1 ;;
+    esac
+}
+staging_fe_id() {
+    case "$1" in
+        a) echo "gjxif-ryaaa-aaaad-ae4ka-cai" ;;
+        b) echo "uhh2r-oyaaa-aaaad-agbva-cai" ;;
+        c) echo "uag4f-daaaa-aaaad-agbvq-cai" ;;
+        *) return 1 ;;
+    esac
+}
+
+# Default public URL for any IC canister.
+canister_default_url() {
+    echo "https://$1.icp0.io"
+}
+
+# -------------------------
+# Interactive / CI detection
+# -------------------------
+# True if a user terminal is attached (we can prompt), false in CI / piped.
+#
+# We check whether `/dev/tty` is openable rather than `[ -t 0/1 ]` because
+# prompt_default is typically called inside `$(...)` to capture the answer;
+# inside that subshell stdout is a pipe (not a tty) even when the user is
+# sitting at a real terminal. `/dev/tty` stays accessible regardless, as
+# long as the process has a controlling terminal — which is exactly the
+# condition that makes prompting safe.
+is_interactive() {
+    [ -r /dev/tty ] && [ -w /dev/tty ]
+}
+
+# Emit an error that explains this script needs a human.
+die_non_interactive() {
+    local reason="$1"
+    echo "Error: non-interactive invocation but $reason" >&2
+    echo "       These scripts are intended to be run from a terminal. For CI-like" >&2
+    echo "       use, run them locally and set --no-checks to skip reachability /" >&2
+    echo "       consistency prompts; the FE install-arg prompts have no bypass." >&2
+    exit 1
+}
+
+# Interactive y/N prompt. Returns 0 on yes, 1 on no. Errors out when stdin
+# isn't a tty (so CI fails loudly instead of hanging).
+confirm_yn() {
+    local prompt="$1"
+    if ! is_interactive; then
+        die_non_interactive "a [y/N] confirmation is required: $prompt"
+    fi
+    local reply
+    read -r -p "$prompt [y/N]: " reply </dev/tty
+    [[ "$reply" =~ ^[Yy] ]]
+}
+
+# Prompt with a default; empty input keeps the default. Prints the chosen
+# value on stdout.
+prompt_default() {
+    local label="$1"
+    local default="$2"
+    if ! is_interactive; then
+        die_non_interactive "prompt '$label' requires input"
+    fi
+    local reply
+    read -r -p "  $label [$default]: " reply </dev/tty >&2
+    if [ -z "$reply" ]; then
+        echo "$default"
+    else
+        echo "$reply"
+    fi
+}
+
+# -------------------------
+# CLI arg parsing shared between both deploy scripts.
+#
+# Arguments with no space (e.g. --end=front) are not supported — we expect
+# the forms documented in print_common_usage below.
+# -------------------------
+print_common_usage() {
+    cat <<'EOF'
+Common options:
+  --staging-a, -sa          Use Staging A
+  --staging-b, -sb          Use Staging B
+  --staging-c, -sc          Use Staging C
+  --staging custom          Prompt for a custom (BE_ID, FE_ID, BE_URL, FE_URL) quad
+  --end <front|back>        Which end(s) to deploy (can be repeated)
+  -fe                       Shortcut for --end front
+  -be                       Shortcut for --end back
+  --dry-run                 Print dfx install commands instead of running them
+  --no-checks               Skip reachability and consistency checks
+  -h, --help                Show this help
+EOF
+}
+
+# Fills the globals listed in the file header. Any arguments not consumed
+# (e.g. a PR number) are left in REMAINING_ARGS.
+parse_common_args() {
+    STAGING_NAME=""
+    BE_ID=""
+    FE_ID=""
+    BE_URL=""
+    FE_URL=""
+    DEPLOY_FE=false
+    DEPLOY_BE=false
+    REBUILD_FE=false
+    REBUILD_BE=false
+    DRY_RUN=false
+    NO_CHECKS=false
+    REMAINING_ARGS=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                # Caller prints its own usage; re-raise.
+                return 2
+                ;;
+            -sa|--staging-a)
+                STAGING_NAME="a"
+                shift
+                ;;
+            -sb|--staging-b)
+                STAGING_NAME="b"
+                shift
+                ;;
+            -sc|--staging-c)
+                STAGING_NAME="c"
+                shift
+                ;;
+            --staging)
+                shift
+                if [ $# -eq 0 ]; then
+                    echo "Error: --staging requires an argument (a|b|c|custom)" >&2
+                    return 1
+                fi
+                case "$1" in
+                    a|b|c)   STAGING_NAME="$1" ;;
+                    custom)  STAGING_NAME="custom" ;;
+                    *)
+                        echo "Error: --staging value must be a|b|c|custom, got '$1'" >&2
+                        return 1
+                        ;;
+                esac
+                shift
+                ;;
+            --end)
+                shift
+                if [ $# -eq 0 ]; then
+                    echo "Error: --end requires an argument (front or back)" >&2
+                    return 1
+                fi
+                case "$1" in
+                    front) DEPLOY_FE=true ;;
+                    back)  DEPLOY_BE=true ;;
+                    *)
+                        echo "Error: --end value must be 'front' or 'back', got '$1'" >&2
+                        return 1
+                        ;;
+                esac
+                shift
+                ;;
+            -fe)
+                DEPLOY_FE=true
+                shift
+                ;;
+            -be)
+                DEPLOY_BE=true
+                shift
+                ;;
+            -rfe)
+                REBUILD_FE=true
+                shift
+                ;;
+            -rbe)
+                REBUILD_BE=true
+                shift
+                ;;
+            --rebuild)
+                shift
+                # Consume one or more subsequent values in {fe, be, front, back}
+                # until anything else.
+                if [ $# -eq 0 ]; then
+                    echo "Error: --rebuild requires at least one of {fe, be}" >&2
+                    return 1
+                fi
+                while [[ $# -gt 0 ]]; do
+                    case "$1" in
+                        fe|front) REBUILD_FE=true; shift ;;
+                        be|back)  REBUILD_BE=true; shift ;;
+                        *) break ;;
+                    esac
+                done
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --no-checks)
+                NO_CHECKS=true
+                shift
+                ;;
+            --)
+                shift
+                REMAINING_ARGS+=("$@")
+                break
+                ;;
+            -*)
+                echo "Unknown option: $1" >&2
+                return 1
+                ;;
+            *)
+                REMAINING_ARGS+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "$STAGING_NAME" ]; then
+        echo "Error: staging must be specified (use -sa/-sb/-sc or --staging custom)" >&2
+        return 1
+    fi
+    if [ "$DEPLOY_FE" = false ] && [ "$DEPLOY_BE" = false ]; then
+        echo "Error: --end must be specified (use -fe/-be or --end front/back)" >&2
+        return 1
+    fi
+    return 0
+}
+
+# Populate BE_ID/FE_ID/BE_URL/FE_URL from STAGING_NAME. For known stagings we
+# fill the canonical ids/URLs directly; for `custom` we prompt.
+resolve_staging_config() {
+    case "$STAGING_NAME" in
+        a|b|c)
+            BE_ID="$(staging_be_id "$STAGING_NAME")"
+            FE_ID="$(staging_fe_id "$STAGING_NAME")"
+            BE_URL="$(canister_default_url "$BE_ID")"
+            FE_URL="$(canister_default_url "$FE_ID")"
+            ;;
+        custom)
+            echo "Custom staging: please provide the four canister coordinates." >&2
+            BE_ID="$(prompt_default "Backend canister id" "")"
+            FE_ID="$(prompt_default "Frontend canister id" "")"
+            BE_URL="$(prompt_default "Backend canister URL" "$(canister_default_url "$BE_ID")")"
+            FE_URL="$(prompt_default "Frontend canister URL" "$(canister_default_url "$FE_ID")")"
+            [ -n "$BE_ID" ] || { echo "Error: Backend canister id cannot be empty" >&2; exit 1; }
+            [ -n "$FE_ID" ] || { echo "Error: Frontend canister id cannot be empty" >&2; exit 1; }
+            [ -n "$BE_URL" ] || { echo "Error: Backend canister URL cannot be empty" >&2; exit 1; }
+            [ -n "$FE_URL" ] || { echo "Error: Frontend canister URL cannot be empty" >&2; exit 1; }
+            ;;
+        *)
+            echo "Error: unknown STAGING_NAME='$STAGING_NAME'" >&2
+            exit 1
+            ;;
+    esac
+}
+
+# -------------------------
+# Reachability checks
+# -------------------------
+# Verify the frontend URL serves II-frontend HTML. The HTML injects
+# `data-canister-id` with the BACKEND canister id (configured on the FE via
+# its `backend_canister_id` init arg) — we just check the attribute is
+# present here; consistency between its value and our BE_ID is checked
+# separately in `run_consistency_checks`.
+check_fe_reachable() {
+    local url="$1"
+    echo "  Fetching $url ..." >&2
+    local body
+    if ! body=$(curl -fsSL --max-time 15 "$url" 2>/dev/null); then
+        echo "  Error: could not fetch $url" >&2
+        return 1
+    fi
+    if ! echo "$body" | grep -q 'data-canister-id="'; then
+        echo "  Error: $url did not expose a data-canister-id attribute" >&2
+        echo "         (likely not an II frontend canister at this URL)" >&2
+        return 1
+    fi
+    local injected
+    injected=$(echo "$body" | grep -oE 'data-canister-id="[^"]+"' \
+        | head -n1 | sed -E 's/data-canister-id="([^"]+)"/\1/')
+    echo "  OK — $url is an II frontend (advertises backend $injected)" >&2
+    return 0
+}
+
+# Verify the backend URL serves `/.config.did.bin` with a non-empty body.
+# If `didc` is available, additionally check the blob decodes as Candid.
+#
+# Uses explicit cleanup rather than `trap ... RETURN` — the RETURN trap isn't
+# auto-restored, so a trap set inside a function keeps firing on every
+# subsequent function return elsewhere in the script.
+check_be_reachable() {
+    local url="$1"
+    local expected_id="$2"
+    local config_url="${url}/.config.did.bin"
+    echo "  Fetching $config_url ..." >&2
+    local tmp
+    tmp=$(mktemp)
+    local status rc=0
+    status=$(curl -sSL --max-time 15 -o "$tmp" -w '%{http_code}' "$config_url" 2>/dev/null || echo "000")
+    if [ "$status" != "200" ]; then
+        echo "  Error: $config_url returned HTTP $status" >&2
+        rc=1
+    elif [ ! -s "$tmp" ]; then
+        echo "  Error: $config_url returned an empty body" >&2
+        rc=1
+    elif command -v didc >/dev/null 2>&1; then
+        if ! didc decode "$(xxd -p "$tmp" | tr -d '\n')" >/dev/null 2>&1; then
+            echo "  Error: $config_url did not decode as Candid" >&2
+            rc=1
+        else
+            echo "  OK — $config_url returns valid Candid (canister $expected_id)" >&2
+        fi
+    else
+        echo "  OK — $config_url returns HTTP 200 ($(wc -c <"$tmp" | tr -d ' ') bytes)." >&2
+        echo "       (install didc to additionally verify the body decodes as Candid)" >&2
+    fi
+    rm -f "$tmp"
+    return $rc
+}
+
+run_reachability_checks() {
+    if [ "$NO_CHECKS" = true ]; then
+        echo "Skipping reachability checks (--no-checks)." >&2
+        return 0
+    fi
+    echo "Running reachability checks..." >&2
+    if [ "$DEPLOY_FE" = true ]; then
+        check_fe_reachable "$FE_URL" || {
+            echo "  Hint: pass --no-checks to bypass, or double-check FE_URL." >&2
+            return 1
+        }
+    fi
+    if [ "$DEPLOY_BE" = true ]; then
+        check_be_reachable "$BE_URL" "$BE_ID" || {
+            echo "  Hint: pass --no-checks to bypass, or double-check BE_URL/BE_ID." >&2
+            return 1
+        }
+    fi
+    return 0
+}
+
+# -------------------------
+# Consistency check: FE's injected data-canister-id should equal our BE_ID
+# (the FE canister points at the intended backend). This catches the
+# "Staging C FE pointing at Staging B backend" misconfiguration we hit
+# in the wild.
+# -------------------------
+run_consistency_checks() {
+    if [ "$NO_CHECKS" = true ]; then
+        echo "Skipping consistency checks (--no-checks)." >&2
+        return 0
+    fi
+    # Only useful when deploying either end against a known staging.
+    if [ "$STAGING_NAME" = "custom" ]; then
+        echo "Consistency check skipped (custom staging has no expected baseline)." >&2
+        return 0
+    fi
+    echo "Running consistency checks..." >&2
+    local html
+    if ! html=$(curl -fsSL --max-time 15 "$FE_URL" 2>/dev/null); then
+        echo "  Warning: could not fetch $FE_URL to verify FE → BE wiring." >&2
+        return 0
+    fi
+    local injected_be_id
+    injected_be_id=$(echo "$html" | grep -oE 'data-canister-id="[^"]+"' \
+        | head -n1 \
+        | sed -E 's/data-canister-id="([^"]+)"/\1/') || true
+    if [ -z "$injected_be_id" ]; then
+        echo "  Warning: $FE_URL did not expose data-canister-id; skipping consistency check." >&2
+        return 0
+    fi
+    if [ "$injected_be_id" = "$BE_ID" ]; then
+        echo "  OK — FE $FE_ID is wired to BE $BE_ID." >&2
+        return 0
+    fi
+    echo "" >&2
+    echo "  INCONSISTENCY:" >&2
+    echo "    $FE_URL currently points at backend $injected_be_id" >&2
+    echo "    but this deploy would use $BE_ID for Staging $STAGING_NAME." >&2
+    echo "    Deploying the FE (with its updated backend_canister_id) will realign them," >&2
+    echo "    but anything calling the live FE until then will keep hitting the old BE." >&2
+    echo "" >&2
+    if ! confirm_yn "Continue anyway?"; then
+        echo "Aborted by user." >&2
+        exit 1
+    fi
+    return 0
+}
+
+# Extract a Candid record field's text value (including multi-line nested
+# values) from the FE canister's /.config output. Returns empty if absent.
+#
+# Copied from scripts/frontend-arg-helpers.bash (where it's battle-tested) so
+# we don't have to source the whole helper.
+_parse_candid_field() {
+    local field="$1" config="$2"
+    awk -v field="$field" '
+        BEGIN { found=0; depth=0; val="" }
+        !found && $0 ~ field" = " {
+            found=1
+            sub(".*"field" = ", "")
+        }
+        found {
+            val = (val == "" ? $0 : val "\n" $0)
+            depth += gsub(/[{(]/, "&")
+            depth -= gsub(/[})]/, "&")
+            if (depth <= 0) {
+                sub(/;[[:space:]]*$/, "", val)
+                print val
+                exit
+            }
+        }
+    ' <<< "$config"
+}
+
+# -------------------------
+# Per-FE interactive prompts for the small set of fields that aren't derived
+# from the shared quad (dev_csp, dummy_auth, analytics_config). fetch_root_key
+# is auto-selected by network.
+#
+# Fetches the FE canister's current `/.config` so each prompt offers the
+# currently-stored value as its default. Sending `null` on upgrade actively
+# resets these fields on the canister — it is NOT a no-op — so using the
+# current values as defaults preserves behavior when the user just hits
+# Enter.
+# -------------------------
+prompt_fe_extra_args() {
+    # Mainnet is the only target we currently support → fetch_root_key false.
+    if [ "$IC_NETWORK" = "ic" ]; then
+        FETCH_ROOT_KEY_ARG="opt false"
+    else
+        FETCH_ROOT_KEY_ARG="opt true"
+    fi
+
+    # Fetch the current FE config so prompt defaults reflect actual state.
+    local config_url="${FE_URL}/.config"
+    local raw_config=""
+    echo "" >&2
+    echo "Fetching current FE config from $config_url ..." >&2
+    raw_config=$(curl --connect-timeout 10 --max-time 30 -sfL "$config_url" 2>/dev/null || true)
+
+    local dev_csp_default="null"
+    local dummy_auth_default="null"
+    local analytics_default="null"
+
+    if [ -n "$raw_config" ]; then
+        local parsed
+        parsed=$(_parse_candid_field "dev_csp" "$raw_config");          [ -n "$parsed" ] && dev_csp_default="$parsed"
+        parsed=$(_parse_candid_field "dummy_auth" "$raw_config");       [ -n "$parsed" ] && dummy_auth_default="$parsed"
+        parsed=$(_parse_candid_field "analytics_config" "$raw_config"); [ -n "$parsed" ] && analytics_default="$parsed"
+    else
+        echo "  Warning: could not fetch current config; defaulting all three fields to null." >&2
+        echo "           (This will reset them on the canister if you hit Enter through.)" >&2
+    fi
+
+    echo "" >&2
+    echo "Frontend-only install-arg prompts (hit Enter to keep current value):" >&2
+
+    DEV_CSP_ARG=$(prompt_default "dev_csp (opt bool)" "$dev_csp_default")
+    DUMMY_AUTH_ARG=$(prompt_default "dummy_auth (opt opt DummyAuthConfig)" "$dummy_auth_default")
+    ANALYTICS_ARG=$(prompt_default "analytics_config (opt opt AnalyticsConfig)" "$analytics_default")
+}
+
+# -------------------------
+# Candid install-arg builders
+# -------------------------
+
+# Build the FE install arg. The FE init type is a REQUIRED record (not opt),
+# so every required field is present; the optional ones we don't know are
+# left as `null`.
+#
+# Output: Candid text on stdout.
+build_fe_install_arg() {
+    cat <<EOF
+(
+  record {
+    backend_canister_id = principal "$BE_ID";
+    backend_origin = "$BE_URL";
+    related_origins = opt vec { "$FE_URL" };
+    fetch_root_key = $FETCH_ROOT_KEY_ARG;
+    dev_csp = $DEV_CSP_ARG;
+    dummy_auth = $DUMMY_AUTH_ARG;
+    analytics_config = $ANALYTICS_ARG;
+  }
+)
+EOF
+}
+
+# Build the BE install arg. The BE init type is `opt InternetIdentityInit`
+# where every field is itself `opt` and "absent" = preserve previous value,
+# so we only set the fields that follow from the shared quad (BE_ID, BE_URL,
+# FE_URL). Everything else stays untouched on upgrade.
+#
+# Output: Candid text on stdout.
+build_be_install_arg() {
+    cat <<EOF
+(
+  opt record {
+    backend_canister_id = opt principal "$BE_ID";
+    backend_origin = opt "$BE_URL";
+    related_origins = opt vec { "$FE_URL" };
+  }
+)
+EOF
+}
+
+# -------------------------
+# dfx install runner (honours DRY_RUN)
+# -------------------------
+# Args: <canister_id> <wasm_path> <install_arg_candid_text>
+run_dfx_install() {
+    local canister_id="$1"
+    local wasm_path="$2"
+    local install_arg="$3"
+
+    if [ ! -f "$wasm_path" ]; then
+        echo "Error: wasm not found at $wasm_path" >&2
+        return 1
+    fi
+
+    local cmd=(
+        dfx canister
+            --network "$IC_NETWORK"
+            --wallet "$WALLET_CANISTER_ID"
+            install "$canister_id"
+            --mode upgrade
+            --wasm "$wasm_path"
+            --argument "$install_arg"
+    )
+
+    if [ "$DRY_RUN" = true ]; then
+        echo ""
+        echo "[dry-run] Would run:"
+        # Quote each arg so the printout is copy-pasteable.
+        printf '  %q' "${cmd[@]}"; echo
+        return 0
+    fi
+
+    echo "Upgrading canister $canister_id ..."
+    "${cmd[@]}"
+    echo "Upgrade of $canister_id complete."
+}
+
+# -------------------------
+# Banner / status summary
+# -------------------------
+print_deployment_summary() {
+    echo ""
+    echo "======== Deployment plan ========"
+    echo "  Staging:    $STAGING_NAME"
+    echo "  BE_ID:      $BE_ID"
+    echo "  BE_URL:     $BE_URL"
+    echo "  FE_ID:      $FE_ID"
+    echo "  FE_URL:     $FE_URL"
+    echo "  Deploy FE:  $DEPLOY_FE"
+    echo "  Deploy BE:  $DEPLOY_BE"
+    echo "  Dry run:    $DRY_RUN"
+    echo "  No checks:  $NO_CHECKS"
+    echo "================================="
+}

--- a/scripts/deploy-local-to-beta
+++ b/scripts/deploy-local-to-beta
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./deploy-local-to-beta [-sa|-sb|-sc|--staging custom] (-fe|-be) [options]
+#
+# Deploy LOCALLY-BUILT artifacts to a staging canister. Builds the wasm.gz
+# files with `scripts/build` (on-demand, per `-rfe`/`-rbe`) and runs the
+# resulting artifacts through `dfx canister install`.
+
+print_usage() {
+    cat <<EOF
+Usage: $0 [-sa|-sb|-sc|--staging custom] (-fe|-be) [-rfe] [-rbe] [--dry-run] [--no-checks]
+
+Deploys wasm.gz files built from your local working tree. Prompts for the
+small set of install-arg fields that can vary (dev_csp, dummy_auth,
+analytics_config) and derives the rest from the (BE_ID, FE_ID, BE_URL,
+FE_URL) quad — known for -sa/-sb/-sc, prompted for --staging custom.
+
+Rebuild flags (default: reuse existing wasm.gz at repo root):
+  --rebuild fe [be]       Rebuild the listed ends before deploying
+  -rfe                    Shortcut for --rebuild fe
+  -rbe                    Shortcut for --rebuild be
+
+EOF
+    print_common_usage
+    cat <<EOF
+
+Artifacts expected at the repo root (produced by \`scripts/build\`):
+  Backend  → internet_identity.wasm.gz
+  Frontend → internet_identity_frontend.wasm.gz
+EOF
+}
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$SCRIPTS_DIR/.."
+
+# shellcheck source=deploy-common.bash
+source "$SCRIPTS_DIR/deploy-common.bash"
+
+# -------------------------
+# CLI
+# -------------------------
+parse_common_args "$@" || { rc=$?; if [ "$rc" -eq 2 ]; then print_usage; exit 0; fi; print_usage; exit 1; }
+
+if [ "${#REMAINING_ARGS[@]}" -gt 0 ]; then
+    # deploy-local-to-beta does NOT accept a PR number — noop it with a note.
+    echo "Note: ignoring unexpected positional args: ${REMAINING_ARGS[*]}" >&2
+    echo "       (deploy-local-to-beta does not take a PR number — your working tree is deployed as-is)" >&2
+fi
+
+resolve_staging_config
+print_deployment_summary
+
+# -------------------------
+# `scripts/build` pins `ic-wasm 0.8.5`. If a newer `ic-wasm` shadows it on
+# PATH (e.g. from node_modules/.bin or nvm's node bin dir), prepend the
+# cargo-installed version so the pin wins.
+# -------------------------
+if [ -x "$HOME/.cargo/bin/ic-wasm" ]; then
+    PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+# -------------------------
+# Build (per rebuild flags)
+# -------------------------
+BUILD_FLAGS=()
+if [ "$DEPLOY_BE" = true ] && [ "$REBUILD_BE" = true ]; then
+    BUILD_FLAGS+=(--internet-identity)
+fi
+if [ "$DEPLOY_FE" = true ] && [ "$REBUILD_FE" = true ]; then
+    BUILD_FLAGS+=(--frontend)
+fi
+
+if [ "${#BUILD_FLAGS[@]}" -gt 0 ]; then
+    echo ""
+    echo "Running ./scripts/build ${BUILD_FLAGS[*]} ..."
+    "$SCRIPTS_DIR/build" "${BUILD_FLAGS[@]}"
+else
+    echo ""
+    echo "No rebuild requested — reusing existing wasm.gz at $ROOT_DIR" \
+         "(pass -rfe / -rbe to rebuild)."
+fi
+
+# -------------------------
+# Reachability + consistency
+# -------------------------
+run_reachability_checks || exit 1
+run_consistency_checks
+
+# -------------------------
+# Prompt for FE extras (only if deploying FE)
+# -------------------------
+if [ "$DEPLOY_FE" = true ]; then
+    prompt_fe_extra_args
+fi
+
+# -------------------------
+# Deploy (honours --dry-run)
+# -------------------------
+if [ "$DEPLOY_BE" = true ]; then
+    BE_WASM="$ROOT_DIR/internet_identity.wasm.gz"
+    echo ""
+    echo "=== Deploying backend to $BE_ID ==="
+    run_dfx_install "$BE_ID" "$BE_WASM" "$(build_be_install_arg)"
+fi
+
+if [ "$DEPLOY_FE" = true ]; then
+    FE_WASM="$ROOT_DIR/internet_identity_frontend.wasm.gz"
+    echo ""
+    echo "=== Deploying frontend to $FE_ID ==="
+    run_dfx_install "$FE_ID" "$FE_WASM" "$(build_fe_install_arg)"
+fi
+
+echo ""
+echo "All deployments complete."

--- a/scripts/deploy-pr-to-beta
+++ b/scripts/deploy-pr-to-beta
@@ -1,227 +1,109 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: ./deploy-pr-to-beta [--staging-a|-sa | --staging-b|-sb | --staging-c|-sc | --staging <CANISTER_ID>] --end <front|back> <PR_NUMBER>
+# Usage: ./deploy-pr-to-beta [-sa|-sb|-sc|--staging custom] (-fe|-be) [options] <PR_NUMBER>
+#
+# Deploy CI-built artifacts from a pull request's canister-tests.yml run to
+# a staging canister. The PR's workflow run artifacts are fetched first —
+# before we ask the user any install-arg questions — so we can fail fast if
+# CI hasn't produced usable WASMs.
 
 print_usage() {
     cat <<EOF
-Usage: $0 [--staging-a|-sa | --staging-b|-sb | --staging-c|-sc | --staging <CANISTER_ID>] --end <front|back> <PR_NUMBER>
+Usage: $0 [-sa|-sb|-sc|--staging custom] (-fe|-be) [--dry-run] [--no-checks] <PR_NUMBER>
 
-Select which staging canister to upgrade and which end(s) to deploy.
+Download CI-built wasm.gz files from the most recent canister-tests.yml run
+for <PR_NUMBER> and upgrade the selected staging canister(s) to them.
 
-Options:
-  --staging-a, -sa        Use Staging A (backend: fgte5-ciaaa-aaaad-aaatq-cai, frontend: gjxif-ryaaa-aaaad-ae4ka-cai)
-  --staging-b, -sb        Use Staging B (backend: jqajs-xiaaa-aaaad-aab5q-cai, frontend: uhh2r-oyaaa-aaaad-agbva-cai)
-  --staging-c, -sc        Use Staging C (backend: y2aaj-miaaa-aaaad-aacxq-cai, frontend: uag4f-daaaa-aaaad-agbvq-cai)
-  --staging <CANISTER_ID> Use the provided canister id
-  --end <front|back>      Which end(s) to deploy (can be specified multiple times)
-  -fe                     Shortcut for --end front
-  -be                     Shortcut for --end back
-  -h, --help              Show this help
+EOF
+    print_common_usage
+    cat <<EOF
+
+Artifacts fetched (named per the CI workflow):
+  Backend  → internet_identity_backend.wasm.gz
+  Frontend → docker-build-internet_identity_frontend job's
+             internet_identity_frontend.wasm.gz artifact
 EOF
 }
-
-PR_NUMBER=""
-STAGING_CANISTER_ID=""
-STAGING_NAME=""
-DEPLOY_FRONT=false
-DEPLOY_BACK=false
-
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        -h|--help)
-            print_usage
-            exit 0
-            ;;
-        -sa|--staging-a)
-            STAGING_CANISTER_ID="fgte5-ciaaa-aaaad-aaatq-cai"
-            STAGING_NAME="a"
-            shift
-            ;;
-        -sb|--staging-b)
-            STAGING_CANISTER_ID="jqajs-xiaaa-aaaad-aab5q-cai"
-            STAGING_NAME="b"
-            shift
-            ;;
-        -sc|--staging-c)
-            STAGING_CANISTER_ID="y2aaj-miaaa-aaaad-aacxq-cai"
-            STAGING_NAME="c"
-            shift
-            ;;
-        --staging)
-            shift
-            if [ $# -eq 0 ]; then
-                echo "Error: --staging requires an argument" >&2
-                print_usage
-                exit 1
-            fi
-            STAGING_CANISTER_ID="$1"
-            STAGING_NAME="custom"
-            shift
-            ;;
-        --end)
-            shift
-            if [ $# -eq 0 ]; then
-                echo "Error: --end requires an argument (front or back)" >&2
-                print_usage
-                exit 1
-            fi
-            case "$1" in
-                front) DEPLOY_FRONT=true ;;
-                back)  DEPLOY_BACK=true ;;
-                *)
-                    echo "Error: --end value must be 'front' or 'back', got '$1'" >&2
-                    print_usage
-                    exit 1
-                    ;;
-            esac
-            shift
-            ;;
-        -fe)
-            DEPLOY_FRONT=true
-            shift
-            ;;
-        -be)
-            DEPLOY_BACK=true
-            shift
-            ;;
-        --)
-            shift
-            break
-            ;;
-        -*)
-            echo "Unknown option: $1" >&2
-            print_usage
-            exit 1
-            ;;
-        *)
-            if [ -z "$PR_NUMBER" ]; then
-                PR_NUMBER="$1"
-                shift
-            else
-                echo "Unexpected argument: $1" >&2
-                print_usage
-                exit 1
-            fi
-            ;;
-    esac
-done
-
-if [ -z "$PR_NUMBER" ]; then
-    echo "Error: PR number is required" >&2
-    print_usage
-    exit 1
-fi
-
-if [ -z "$STAGING_CANISTER_ID" ]; then
-    echo "Error: staging must be specified (use --staging-a/-sa, --staging-b/-sb, --staging-c/-sc, or --staging <CANISTER_ID>)" >&2
-    print_usage
-    exit 1
-fi
-
-if [ "$DEPLOY_FRONT" = false ] && [ "$DEPLOY_BACK" = false ]; then
-    echo "Error: --end must be specified (use --end front, --end back, -fe, or -be)" >&2
-    print_usage
-    exit 1
-fi
-
-if [ "$DEPLOY_FRONT" = true ] && [ "$STAGING_NAME" != "a" ] && [ "$STAGING_NAME" != "b" ] && [ "$STAGING_NAME" != "c" ]; then
-    echo "Error: Frontend deployment is only supported for Staging A, B, and C. Use --staging-a/-sa, --staging-b/-sb, or --staging-c/-sc." >&2
-    exit 1
-fi
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 cd "$ROOT_DIR"
 
-REPO="dfinity/internet-identity"
-WORKFLOW_FILE="canister-tests.yml"
-WALLET_CANISTER_ID="cvthj-wyaaa-aaaad-aaaaq-cai"
-
-# Map staging environment to its frontend canister ID
-case "$STAGING_NAME" in
-    a) FRONTEND_CANISTER_ID="gjxif-ryaaa-aaaad-ae4ka-cai" ;;
-    b) FRONTEND_CANISTER_ID="uhh2r-oyaaa-aaaad-agbva-cai" ;;
-    c) FRONTEND_CANISTER_ID="uag4f-daaaa-aaaad-agbvq-cai" ;;
-    *) FRONTEND_CANISTER_ID="" ;;
-esac
-
-source "$SCRIPTS_DIR/frontend-arg-helpers.bash"
+# shellcheck source=deploy-common.bash
+source "$SCRIPTS_DIR/deploy-common.bash"
 
 # -------------------------
-# Prompt for frontend install args if deploying frontend
+# CLI
 # -------------------------
-FRONTEND_INSTALL_ARG=""
-if [ "$DEPLOY_FRONT" = true ]; then
-    build_frontend_install_arg "$FRONTEND_CANISTER_ID"
-fi
+parse_common_args "$@" || { rc=$?; if [ "$rc" -eq 2 ]; then print_usage; exit 0; fi; print_usage; exit 1; }
 
-# Build the list of (artifact, canister, job_pattern, job_filter) tuples to deploy.
-# job_pattern and job_filter are substrings matched against the job name, so the script
-# is resilient to changes in matrix keys/order or GitHub's display-name formatting.
-DEPLOYMENTS=()
-if [ "$DEPLOY_BACK" = true ]; then
-    DEPLOYMENTS+=("internet_identity_backend.wasm.gz:$STAGING_CANISTER_ID:docker-build-internet_identity:internet_identity_backend.wasm.gz")
-fi
-if [ "$DEPLOY_FRONT" = true ]; then
-    DEPLOYMENTS+=("internet_identity_frontend.wasm.gz:$FRONTEND_CANISTER_ID:docker-build-internet_identity_frontend:docker-build-internet_identity_frontend")
-fi
-
-# -------------------------
-# Cleanup handler
-# -------------------------
-cleanup() {
-    echo "Cleaning up temporary files..."
-    for pair in "${DEPLOYMENTS[@]}"; do
-        artifact="${pair%%:*}"
-        rm -f "$ROOT_DIR/$artifact.zip"
-        rm -f "$ROOT_DIR/$artifact"
-    done
-}
-trap cleanup EXIT
-# -------------------------
-
-# Get GitHub token from gh CLI
-if command -v gh >/dev/null 2>&1; then
-    GITHUB_TOKEN="$(gh auth token)"
-    if [ -z "$GITHUB_TOKEN" ]; then
-        echo "Error: gh CLI is not authenticated or token unavailable."
-        exit 1
-    fi
+# This script does require a PR number as a positional argument.
+PR_NUMBER=""
+if [ "${#REMAINING_ARGS[@]}" -eq 1 ]; then
+    PR_NUMBER="${REMAINING_ARGS[0]}"
+elif [ "${#REMAINING_ARGS[@]}" -gt 1 ]; then
+    echo "Error: expected a single PR number, got: ${REMAINING_ARGS[*]}" >&2
+    print_usage
+    exit 1
 else
-    echo "Error: gh CLI not found. Install and authenticate to access private workflows."
+    echo "Error: PR number is required" >&2
+    print_usage
     exit 1
 fi
 
+resolve_staging_config
+print_deployment_summary
+
+REPO="dfinity/internet-identity"
+WORKFLOW_FILE="canister-tests.yml"
+
+# -------------------------
+# Fetch CI artifacts FIRST, before asking the user any interactive questions.
+# Failing fast here avoids wasting the user's time on prompts when the
+# underlying CI run doesn't exist or isn't green.
+# -------------------------
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh CLI not found. Install and authenticate to access private workflows." >&2
+    exit 1
+fi
+GITHUB_TOKEN="$(gh auth token)"
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "Error: gh CLI is not authenticated or token unavailable." >&2
+    exit 1
+fi
 AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
 
-echo "Fetching workflow runs for PR #$PR_NUMBER..."
+echo ""
+echo "Resolving PR #$PR_NUMBER head branch..."
+BRANCH=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName -q '.headRefName' || true)
+if [ -z "$BRANCH" ] || [ "$BRANCH" = "null" ]; then
+    echo "Error: could not determine head branch for PR #$PR_NUMBER in $REPO" >&2
+    exit 1
+fi
+echo "  PR #$PR_NUMBER → branch '$BRANCH'"
 
-# Get the branch name for this PR
-BRANCH=$(gh pr view "$PR_NUMBER" --json headRefName -q '.headRefName')
-
-# Fetch the most recent workflow run for this PR's branch
+echo "Fetching workflow runs for branch '$BRANCH'..."
 RUN_ID=$(curl -sf -H "$AUTH_HEADER" \
-    "https://api.github.com/repos/$REPO/actions/runs?per_page=100" \
-    | jq -r --arg BRANCH "$BRANCH" --arg WF "$WORKFLOW_FILE" '
+    "https://api.github.com/repos/$REPO/actions/runs?event=push&branch=$BRANCH&per_page=100" \
+    | jq -r --arg WF "$WORKFLOW_FILE" '
         [.workflow_runs[]
-            | select(.head_branch == $BRANCH)
             | select(.path == (".github/workflows/" + $WF))
         ]
         | sort_by(.run_number)
         | reverse
         | .[0].id
-    ')
+    ' || true)
 
 if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-    echo "Error: No canister-tests.yml workflow run found for PR #$PR_NUMBER"
+    echo "Error: No canister-tests.yml workflow run found for branch '$BRANCH'" >&2
     exit 1
 fi
+echo "  Workflow run: $RUN_ID"
 
-echo "Found workflow run ID: $RUN_ID"
-
-# Fetch all jobs for this run, paginating to collect every page.
-echo "Fetching jobs for workflow run..."
+# Collect all jobs for this run so we can validate each required build before
+# we start asking the user anything.
+echo "Fetching jobs for workflow run $RUN_ID..."
 JOBS_JSON='{"jobs":[]}'
 PAGE=1
 while true; do
@@ -239,22 +121,32 @@ while true; do
     PAGE=$((PAGE + 1))
 done
 
-TOTAL_JOBS=$(echo "$JOBS_JSON" | jq '.jobs | length')
-echo "Fetched $TOTAL_JOBS jobs."
+# Build the list of (artifact_name, canister_id, job_pattern, job_filter)
+# for the selected ends. job_pattern/job_filter are substrings matched
+# against the job name (resilient to matrix reordering / display-name
+# changes).
+ARTIFACTS=()
+if [ "$DEPLOY_BE" = true ]; then
+    ARTIFACTS+=("internet_identity_backend.wasm.gz:$BE_ID:docker-build-internet_identity:internet_identity_backend.wasm.gz")
+fi
+if [ "$DEPLOY_FE" = true ]; then
+    ARTIFACTS+=("internet_identity_frontend.wasm.gz:$FE_ID:docker-build-internet_identity_frontend:docker-build-internet_identity_frontend")
+fi
 
-for tuple in "${DEPLOYMENTS[@]}"; do
+# Validate each required job succeeded AND fetch the artifact URL for each,
+# failing fast on any problem before we prompt the user.
+echo ""
+echo "Validating CI artifacts..."
+
+declare -A ARTIFACT_URL_BY_NAME=()
+for tuple in "${ARTIFACTS[@]}"; do
     ARTIFACT_NAME="${tuple%%:*}"
-    remainder="${tuple#*:}"
-    CANISTER_ID="${remainder%%:*}"
-    remainder="${remainder#*:}"
-    JOB_PATTERN="${remainder%%:*}"
-    JOB_FILTER="${remainder#*:}"
-    ZIP_FILE="$ARTIFACT_NAME.zip"
+    rest="${tuple#*:}"
+    # canister_id is the second field — skip it here, it's used later.
+    rest="${rest#*:}"
+    JOB_PATTERN="${rest%%:*}"
+    JOB_FILTER="${rest#*:}"
 
-    echo ""
-    echo "=== Deploying $ARTIFACT_NAME to canister $CANISTER_ID ==="
-
-    # Find matching jobs by substring (resilient to matrix key/order changes)
     MATCHING_JOBS=$(echo "$JOBS_JSON" | jq -c \
         --arg PAT "$JOB_PATTERN" --arg FIL "$JOB_FILTER" '
         .jobs | map(select(.name | contains($PAT) and contains($FIL)))
@@ -262,15 +154,14 @@ for tuple in "${DEPLOYMENTS[@]}"; do
     MATCH_COUNT=$(echo "$MATCHING_JOBS" | jq 'length')
 
     if [ "$MATCH_COUNT" -eq 0 ]; then
-        echo "Error: No job matching '$JOB_PATTERN' + '$JOB_FILTER' found."
-        echo "Available jobs:"
-        echo "$JOBS_JSON" | jq -r '.jobs[] | "  - \(.name) (\(.status)/\(.conclusion))"'
+        echo "Error: No job matching '$JOB_PATTERN' + '$JOB_FILTER' found." >&2
+        echo "Available jobs:" >&2
+        echo "$JOBS_JSON" | jq -r '.jobs[] | "  - \(.name) (\(.status)/\(.conclusion))"' >&2
         exit 1
     fi
-
     if [ "$MATCH_COUNT" -gt 1 ]; then
-        echo "Error: Multiple jobs match '$JOB_PATTERN' + '$JOB_FILTER':"
-        echo "$MATCHING_JOBS" | jq -r '.[] | "  - \(.name) (\(.status)/\(.conclusion))"'
+        echo "Error: Multiple jobs match '$JOB_PATTERN' + '$JOB_FILTER':" >&2
+        echo "$MATCHING_JOBS" | jq -r '.[] | "  - \(.name) (\(.status)/\(.conclusion))"' >&2
         exit 1
     fi
 
@@ -279,59 +170,98 @@ for tuple in "${DEPLOYMENTS[@]}"; do
     JOB_CONCLUSION=$(echo "$MATCHING_JOBS" | jq -r '.[0].conclusion')
 
     if [ "$JOB_STATE" = "queued" ] || [ "$JOB_STATE" = "in_progress" ]; then
-        echo "Error: Required job '$JOB_NAME' has not completed yet (status: $JOB_STATE)"
+        echo "Error: Required job '$JOB_NAME' has not completed yet (status: $JOB_STATE)" >&2
         exit 1
     fi
-
     if [ "$JOB_CONCLUSION" != "success" ]; then
-        echo "Error: Required job '$JOB_NAME' did not succeed (conclusion: $JOB_CONCLUSION)"
+        echo "Error: Required job '$JOB_NAME' did not succeed (conclusion: $JOB_CONCLUSION)" >&2
         exit 1
     fi
 
-    echo "Required job '$JOB_NAME' succeeded."
-
-    echo "Fetching artifact list..."
     ARTIFACT_URL=$(curl -sf -H "$AUTH_HEADER" \
         "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/artifacts?per_page=100" \
         | jq -r --arg ART "$ARTIFACT_NAME" '
             .artifacts[] | select(.name == $ART) | .archive_download_url
         ')
-
     if [ -z "$ARTIFACT_URL" ] || [ "$ARTIFACT_URL" = "null" ]; then
-        echo "Error: Artifact not found: $ARTIFACT_NAME"
+        echo "Error: Artifact '$ARTIFACT_NAME' not found on run $RUN_ID" >&2
         exit 1
     fi
 
-    echo "Downloading artifact $ARTIFACT_NAME..."
-    curl -sfL -H "$AUTH_HEADER" -o "$ZIP_FILE" "$ARTIFACT_URL"
-
-    echo "Extracting ZIP..."
-    unzip -o "$ZIP_FILE" -d "$ROOT_DIR" >/dev/null
-
-    if [ ! -f "$ROOT_DIR/$ARTIFACT_NAME" ]; then
-        echo "Error: Extracted file not found: $ARTIFACT_NAME"
-        exit 1
-    fi
-
-    echo "Artifact extracted: $ARTIFACT_NAME"
-
-    # Build the install command with optional --argument for frontend
-    INSTALL_ARGS=()
-    if [ "$ARTIFACT_NAME" = "internet_identity_frontend.wasm.gz" ] && [ -n "$FRONTEND_INSTALL_ARG" ]; then
-        INSTALL_ARGS+=(--argument-type raw --argument "$FRONTEND_INSTALL_ARG")
-    fi
-
-    echo "Upgrading canister $CANISTER_ID..."
-    dfx canister \
-        --network ic \
-        --wallet "$WALLET_CANISTER_ID" \
-        install "$CANISTER_ID" \
-        --mode upgrade \
-        --wasm "$ROOT_DIR/$ARTIFACT_NAME" \
-        ${INSTALL_ARGS[@]+"${INSTALL_ARGS[@]}"}
-
-    echo "Upgrade of $CANISTER_ID complete."
+    ARTIFACT_URL_BY_NAME["$ARTIFACT_NAME"]="$ARTIFACT_URL"
+    echo "  OK — '$JOB_NAME' succeeded; artifact '$ARTIFACT_NAME' available."
 done
+
+# -------------------------
+# Download CI artifacts into a dedicated temp directory rather than the
+# repo root — the CI artifact names collide with names produced by
+# `scripts/build` locally (e.g. `internet_identity_frontend.wasm.gz`), so
+# extracting into the repo root would overwrite and then (via cleanup)
+# delete the developer's local build outputs. The temp dir is wiped on
+# EXIT regardless of outcome.
+# -------------------------
+ARTIFACT_DIR=$(mktemp -d -t ii-deploy-pr.XXXXXX)
+cleanup() {
+    if [ -n "$ARTIFACT_DIR" ] && [ -d "$ARTIFACT_DIR" ]; then
+        echo "Cleaning up downloaded artifacts (in $ARTIFACT_DIR)..." >&2
+        rm -rf "$ARTIFACT_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# -------------------------
+# Download + extract each artifact
+# -------------------------
+echo ""
+echo "Downloading CI artifacts to $ARTIFACT_DIR..."
+for tuple in "${ARTIFACTS[@]}"; do
+    ARTIFACT_NAME="${tuple%%:*}"
+    ARTIFACT_URL="${ARTIFACT_URL_BY_NAME[$ARTIFACT_NAME]}"
+    ZIP_FILE="$ARTIFACT_DIR/$ARTIFACT_NAME.zip"
+
+    echo "  Downloading $ARTIFACT_NAME..."
+    curl -sfL -H "$AUTH_HEADER" -o "$ZIP_FILE" "$ARTIFACT_URL"
+    unzip -o "$ZIP_FILE" -d "$ARTIFACT_DIR" >/dev/null
+    if [ ! -f "$ARTIFACT_DIR/$ARTIFACT_NAME" ]; then
+        echo "Error: Extracted file not found: $ARTIFACT_DIR/$ARTIFACT_NAME" >&2
+        exit 1
+    fi
+    echo "  Extracted: $ARTIFACT_DIR/$ARTIFACT_NAME"
+done
+
+# -------------------------
+# Reachability + consistency
+# -------------------------
+run_reachability_checks || exit 1
+run_consistency_checks
+
+# -------------------------
+# Now — after CI artifacts are verified AND on disk — prompt for FE extras.
+# -------------------------
+if [ "$DEPLOY_FE" = true ]; then
+    prompt_fe_extra_args
+fi
+
+# -------------------------
+# Deploy (honours --dry-run)
+# -------------------------
+if [ "$DEPLOY_BE" = true ]; then
+    echo ""
+    echo "=== Deploying backend (PR #$PR_NUMBER, run $RUN_ID) to $BE_ID ==="
+    run_dfx_install \
+        "$BE_ID" \
+        "$ARTIFACT_DIR/internet_identity_backend.wasm.gz" \
+        "$(build_be_install_arg)"
+fi
+
+if [ "$DEPLOY_FE" = true ]; then
+    echo ""
+    echo "=== Deploying frontend (PR #$PR_NUMBER, run $RUN_ID) to $FE_ID ==="
+    run_dfx_install \
+        "$FE_ID" \
+        "$ARTIFACT_DIR/internet_identity_frontend.wasm.gz" \
+        "$(build_fe_install_arg)"
+fi
 
 echo ""
 echo "All deployments complete."


### PR DESCRIPTION
`deploy-pr-to-beta` and `deploy-local-to-beta` had accumulated copy-pasted CLI parsing, staging config, and `dfx install` glue. The install-arg handling in particular prompted the user for every field in `InternetIdentityFrontendInit` without enforcing any consistency between the frontend's `backend_canister_id` / `backend_origin` / `related_origins` and the selected staging — which is how we ended up shipping a frontend on Staging C that pointed at Staging B's backend (canister `jqajs-...` instead of `y2aaj-...`) and spent a session debugging the `Canister has no update method 'add_discoverable_oidc_config'` error.

Factored out into a shared library and added explicit per-end build controls, reachability / consistency checks, and dry-run support.

# Changes

## New: `scripts/deploy-common.bash`

Shared library sourced by both deploy scripts. Responsibilities:

- Staging-letter → canister-id/URL lookups.
- `parse_common_args`: single parser for `-sa/-sb/-sc` / `--staging custom`, `-fe/-be` / `--end`, `-rfe/-rbe` / `--rebuild fe be`, `--dry-run`, `--no-checks`.
- `resolve_staging_config`: fills the shared quad `(BE_ID, FE_ID, BE_URL, FE_URL)` — baked in for A/B/C, prompted for `custom`.
- `is_interactive` / `die_non_interactive`: prompts fail loudly when `/dev/tty` isn't openable (CI) instead of hanging. Uses `/dev/tty` rather than `[ -t 0/1 ]` so it behaves correctly inside `$(...)` subshells (which `prompt_default` is always called from).
- `check_fe_reachable` / `check_be_reachable`: best-effort HTTP probes. FE check confirms the URL serves an II frontend (has `data-canister-id="..."` attribute); BE check fetches `/.config.did.bin` and validates it decodes as Candid when `didc` is available.
- `run_consistency_checks`: compares the FE's injected `data-canister-id` against the expected `BE_ID` for the staging and interactively prompts to override on mismatch. This is the check that would have caught the Staging C → Staging B misconfig.
- `prompt_fe_extra_args`: interactive prompts for the small set of FE-only fields that don't follow from the shared quad (`dev_csp`, `dummy_auth`, `analytics_config`). `fetch_root_key` is auto-set to `opt false` for mainnet.
- `build_fe_install_arg` / `build_be_install_arg`: emit Candid install args. FE arg is a required record (non-opt). BE arg is a tight `opt record { backend_canister_id; backend_origin; related_origins; }` — every other field is left `opt null` so the upgrade preserves existing state.
- `run_dfx_install`: one entry point that either runs or prints the `dfx canister install` command based on `DRY_RUN`.

## Refactored: `scripts/deploy-local-to-beta`

Thin wrapper around the common lib.

- Does **not** accept a PR number anymore (it deploys your working tree).
- Rebuild is opt-in per end: `-rfe` / `-rbe` / `--rebuild fe be`. Default is to reuse existing `wasm.gz` files at the repo root.
- Prepends `~/.cargo/bin` to `PATH` when present so `scripts/build`'s pinned `ic-wasm 0.8.5` wins over newer versions installed elsewhere (e.g. via nvm's node `bin` dir).

## Refactored: `scripts/deploy-pr-to-beta`

Thin wrapper around the common lib.

- CI artifact validation (workflow run exists, required jobs succeeded, artifact URLs resolvable) is performed **before** the FE extra-args prompts, so we fail fast on missing/broken CI runs instead of wasting the user's time at the prompts.
- `--dry-run` prints the `dfx canister install` command after the artifacts have been downloaded and extracted, so the exact command (including `--argument`) is copy-pasteable.

## Not changed

`scripts/frontend-arg-helpers.bash` is untouched — still sourced by `scripts/make-upgrade-proposal`, which has a different prompt model and isn't in scope here.

# Tests

Both scripts shellcheck clean (only `SC1091 info` for the sourced lib, same as the prior `frontend-arg-helpers.bash`).

Manually verified:

- `-sa/-sb/-sc` resolution → correct canister ids / URLs.
- `--staging custom` → prompts for all four values.
- `--dry-run` → prints the exact `dfx canister install` command that would run, with both install args formatted correctly.
- Reachability check against Staging C: FE HTML probe OK, BE `/.config.did.bin` decodes as Candid (when `didc` is installed).
- Consistency check against Staging C: would have caught the Staging C → Staging B misconfig (FE injected `data-canister-id` vs. expected `BE_ID`).
- Error paths: missing `--staging`, missing `--end`, unexpected positional args, non-interactive prompt attempt (errors out with a clear message).
