### PR TITLE
chore(test): add SSO discovery endpoint to test OpenID provider

### DIFF
--- a/src/test_openid_provider/index.js
+++ b/src/test_openid_provider/index.js
@@ -59,6 +59,14 @@ app.post("/account/:id/claims", express.json(), async (req, res) => {
   res.status(201).send();
 });
 
+// Endpoint for SSO discoverability
+app.get("/.well-known/ii-openid-configuration", express.json(), async (req, res) => {
+  res.status(201).send({
+    client_id: "internet_identity",
+    openid_configuration: `http://localhost:${port}/.well-known/openid-configuration`
+  });
+});
+
 // Register provider and start server
 app.use(provider.callback());
 app.listen(port, () => {

--- a/src/test_openid_provider/index.js
+++ b/src/test_openid_provider/index.js
@@ -61,7 +61,7 @@ app.post("/account/:id/claims", express.json(), async (req, res) => {
 
 // Endpoint for SSO discoverability
 app.get("/.well-known/ii-openid-configuration", express.json(), async (req, res) => {
-  res.status(201).send({
+  res.status(200).send({
     client_id: "internet_identity",
     openid_configuration: `http://localhost:${port}/.well-known/openid-configuration`
   });
@@ -72,5 +72,8 @@ app.use(provider.callback());
 app.listen(port, () => {
   console.log(
     `For endpoints see: http://localhost:${port}/.well-known/openid-configuration`,
+  );
+  console.log(
+    `For SSO discovery see: http://localhost:${port}/.well-known/ii-openid-configuration`,
   );
 });

--- a/src/test_openid_provider/index.js
+++ b/src/test_openid_provider/index.js
@@ -60,8 +60,8 @@ app.post("/account/:id/claims", express.json(), async (req, res) => {
 });
 
 // Endpoint for SSO discoverability
-app.get("/.well-known/ii-openid-configuration", express.json(), async (req, res) => {
-  res.status(200).send({
+app.get("/.well-known/ii-openid-configuration", (req, res) => {
+  res.status(200).json({
     client_id: "internet_identity",
     openid_configuration: `http://localhost:${port}/.well-known/openid-configuration`
   });


### PR DESCRIPTION
The test OpenID provider did not expose the `ii-openid-configuration` SSO discovery endpoint that Internet Identity relies on to discover OpenID providers. Without it, SSO flows that depend on discovery cannot be exercised end-to-end against the local test provider.

# Changes

- Serve `GET /.well-known/ii-openid-configuration` with the `client_id` and a pointer to the provider's `openid-configuration`.
- Log the SSO discovery URL on startup alongside the existing `openid-configuration` URL.