### PR TITLE
chore(release): polish release flow - auto-detect archive, capture proposal IDs, fix try-it-out

### DIFF
--- a/.github/actions/release/run.sh
+++ b/.github/actions/release/run.sh
@@ -13,6 +13,15 @@ cat > "$section_intro" << EOF
 This is Internet Identity release [$RELEASE_TAG](https://github.com/dfinity/internet-identity/releases/tag/$RELEASE_TAG) for commit [$GITHUB_SHA](https://github.com/dfinity/internet-identity/commit/$GITHUB_SHA).
 EOF
 
+# "Try it out" section so readers (and downstream forum/proposal tooling) can
+# reach staging and the test application without hunting for links.
+section_try_it_out=$(mktemp)
+cat > "$section_try_it_out" <<EOF
+## Try it out
+* Staging: https://beta.id.ai
+* Testing application: https://try.id.ai
+EOF
+
 # Starting the artifacts section where we add the shas of all input assets
 section_build_flavors=$(mktemp)
 
@@ -37,7 +46,8 @@ git pull # to ensure you have the latest changes.
 git checkout $GITHUB_SHA
 ./scripts/verify-hash \
     --ii-hash $(shasum -a 256 "internet_identity_backend.wasm.gz" | cut -d ' ' -f1) \
-    --iife-hash $(shasum -a 256 internet_identity_frontend.wasm.gz | cut -d ' ' -f1)
+    --iife-hash $(shasum -a 256 "internet_identity_frontend.wasm.gz" | cut -d ' ' -f1) \
+    --archive-hash $(shasum -a 256 "archive.wasm.gz" | cut -d ' ' -f1)
 \`\`\`
 
 Make sure to compare the hashes also with the proposal payload when verifying canister upgrade proposals.
@@ -177,6 +187,7 @@ fi
 body=$(mktemp)
 >&2 echo "Using '$body' for body"
 cat "$section_intro" >> "$body" && echo >> "$body" && rm "$section_intro"
+cat "$section_try_it_out" >> "$body" && echo >> "$body" && rm "$section_try_it_out"
 cat "$section_changelog" >> "$body" && echo >> "$body" && rm "$section_changelog"
 cat "$section_build_flavors" >> "$body" && echo >> "$body" && rm "$section_build_flavors"
 cat "$section_wasm_verification" >> "$body" && echo >> "$body" && rm "$section_wasm_verification"

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -354,17 +354,18 @@ detect_archive_hash_change() {
 
   local prev_archive
   prev_archive=$(mktemp)
-  trap 'rm -f "$prev_archive"' RETURN
 
   if ! curl -fsSL "https://github.com/dfinity/internet-identity/releases/download/${prev_release_tag}/archive.wasm.gz" -o "$prev_archive"; then
+    rm -f "$prev_archive"
     echo "Could not download ${prev_release_tag}/archive.wasm.gz; treating archive as changed." >&2
     echo "true"
     return
   fi
 
   local prev_sha curr_sha
-  prev_sha=$(shasum -a 256 "$prev_archive" | awk '{print $1}')
-  curr_sha=$(shasum -a 256 ./archive.wasm.gz | awk '{print $1}')
+  prev_sha=$(sha256 "$prev_archive")
+  curr_sha=$(sha256 ./archive.wasm.gz)
+  rm -f "$prev_archive"
   echo "Previous archive (${prev_release_tag}): $prev_sha" >&2
   echo "Current archive:                        $curr_sha" >&2
 
@@ -798,10 +799,15 @@ parse_proposal_id() {
   # reads "proposal proposal N". Matching the doubled form avoids
   # false positives from other numeric output on the same stream.
   # See dfinity/nns-dapp scripts/nns-dapp/release for the same pattern.
+  #
+  # Uses bash's regex match (no external pipeline) to keep behavior
+  # predictable under `set -eo pipefail`.
   local output="$1" label="$2"
-  local id
-  id=$(echo "$output" | grep -oE 'proposal proposal [0-9]+' | head -1 | awk '{print $3}')
-  if [ -z "$id" ] || ! [[ "$id" =~ ^[0-9]+$ ]]; then
+  local id=""
+  if [[ "$output" =~ proposal[[:space:]]+proposal[[:space:]]+([0-9]+) ]]; then
+    id="${BASH_REMATCH[1]}"
+  fi
+  if [ -z "$id" ]; then
     echo "ERROR: could not parse ${label} from ic-admin output." >&2
     echo "       Run the command manually and record the proposal number in the checklist file." >&2
     return 1

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -318,15 +318,36 @@ update_release_text() {
   echo "Please review: https://github.com/dfinity/internet-identity/releases/tag/$TAG_NAME"
 }
 
+# Resolve a proposal-backend-*/proposal-frontend-* tag to the release-* tag
+# pointing at the same commit. GitHub releases are only published for
+# release-* tags, so looking up wasm artifacts requires going through the
+# matching release tag. Mirrors the helper of the same name in
+# .github/actions/release/run.sh.
+resolve_release_tag() {
+  local proposal_tag="$1"
+  local commit
+  commit=$(git rev-parse "$proposal_tag" 2>/dev/null) || { echo ""; return; }
+  git tag --points-at "$commit" | grep "^release-" | sort | head -1 || true
+}
+
 detect_archive_hash_change() {
-  # Compare local archive.wasm.gz sha256 against the previous
-  # proposal-backend-*'s archive.wasm.gz. Emits "true" or "false" on stdout.
-  # Falls back to "true" if the previous archive cannot be fetched, so the
-  # BE proposal includes the archive hash in the conservative case.
-  local prev_tag
-  prev_tag=$(git tag -l "proposal-backend-*" | sort -V | tail -1)
-  if [ -z "$prev_tag" ]; then
+  # Compare local archive.wasm.gz sha256 against the archive attached to the
+  # release that corresponds to the previous proposal-backend-*. Emits "true"
+  # or "false" on stdout. Falls back to "true" if the previous archive can't
+  # be fetched, so the BE proposal includes the archive hash in the
+  # conservative case.
+  local prev_proposal_tag
+  prev_proposal_tag=$(git tag -l "proposal-backend-*" | sort -V | tail -1)
+  if [ -z "$prev_proposal_tag" ]; then
     echo "No previous proposal-backend-* tag found; treating archive as changed." >&2
+    echo "true"
+    return
+  fi
+
+  local prev_release_tag
+  prev_release_tag=$(resolve_release_tag "$prev_proposal_tag")
+  if [ -z "$prev_release_tag" ]; then
+    echo "Could not resolve ${prev_proposal_tag} to a release-* tag; treating archive as changed." >&2
     echo "true"
     return
   fi
@@ -335,8 +356,8 @@ detect_archive_hash_change() {
   prev_archive=$(mktemp)
   trap 'rm -f "$prev_archive"' RETURN
 
-  if ! curl -fsSL "https://github.com/dfinity/internet-identity/releases/download/${prev_tag}/archive.wasm.gz" -o "$prev_archive"; then
-    echo "Could not download ${prev_tag}/archive.wasm.gz; treating archive as changed." >&2
+  if ! curl -fsSL "https://github.com/dfinity/internet-identity/releases/download/${prev_release_tag}/archive.wasm.gz" -o "$prev_archive"; then
+    echo "Could not download ${prev_release_tag}/archive.wasm.gz; treating archive as changed." >&2
     echo "true"
     return
   fi
@@ -344,8 +365,8 @@ detect_archive_hash_change() {
   local prev_sha curr_sha
   prev_sha=$(shasum -a 256 "$prev_archive" | awk '{print $1}')
   curr_sha=$(shasum -a 256 ./archive.wasm.gz | awk '{print $1}')
-  echo "Previous archive (${prev_tag}): $prev_sha" >&2
-  echo "Current archive:                $curr_sha" >&2
+  echo "Previous archive (${prev_release_tag}): $prev_sha" >&2
+  echo "Current archive:                        $curr_sha" >&2
 
   if [ "$prev_sha" = "$curr_sha" ]; then
     echo "false"

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -55,7 +55,7 @@ NOT_MOCKED_COMMANDS=(
   echo
   printf
   update_release_text
-  wait_for_archive_canister_hash
+  detect_archive_hash_change
   download_wasms
   request_verification_command
   deploy_release_candidate
@@ -318,12 +318,40 @@ update_release_text() {
   echo "Please review: https://github.com/dfinity/internet-identity/releases/tag/$TAG_NAME"
 }
 
-wait_for_archive_canister_hash() {
-  echo "Go to the release page"
-  echo "Compare the hashes of archive canisters from the previous release and this one"
-  echo "If they are different, we need a new canister"
-  echo "Update the release page verify command: \"scripts/verify-hash\""
-  echo "Release page: https://github.com/dfinity/internet-identity/releases/tag/$TAG_NAME"
+detect_archive_hash_change() {
+  # Compare local archive.wasm.gz sha256 against the previous
+  # proposal-backend-*'s archive.wasm.gz. Emits "true" or "false" on stdout.
+  # Falls back to "true" if the previous archive cannot be fetched, so the
+  # BE proposal includes the archive hash in the conservative case.
+  local prev_tag
+  prev_tag=$(git tag -l "proposal-backend-*" | sort -V | tail -1)
+  if [ -z "$prev_tag" ]; then
+    echo "No previous proposal-backend-* tag found; treating archive as changed." >&2
+    echo "true"
+    return
+  fi
+
+  local prev_archive
+  prev_archive=$(mktemp)
+  trap 'rm -f "$prev_archive"' RETURN
+
+  if ! curl -fsSL "https://github.com/dfinity/internet-identity/releases/download/${prev_tag}/archive.wasm.gz" -o "$prev_archive"; then
+    echo "Could not download ${prev_tag}/archive.wasm.gz; treating archive as changed." >&2
+    echo "true"
+    return
+  fi
+
+  local prev_sha curr_sha
+  prev_sha=$(shasum -a 256 "$prev_archive" | awk '{print $1}')
+  curr_sha=$(shasum -a 256 ./archive.wasm.gz | awk '{print $1}')
+  echo "Previous archive (${prev_tag}): $prev_sha" >&2
+  echo "Current archive:                $curr_sha" >&2
+
+  if [ "$prev_sha" = "$curr_sha" ]; then
+    echo "false"
+  else
+    echo "true"
+  fi
 }
 
 download_wasms() {
@@ -535,6 +563,18 @@ append_proposal_argument() {
   if should_upgrade_backend "$upgrade_type"; then
     ARGUMENTS="$(cat args.txt)"
     II_WASM_SHA=$(sha256sum "internet_identity.wasm.gz" | awk '{print $1}')
+    ARCHIVE_WASM_SHA=$(sha256sum "archive.wasm.gz" | awk '{print $1}')
+    local archive_changed
+    archive_changed=$(checklist_must_get "Archive changed")
+
+    # BE proposal verify command: always --ii-hash; add --archive-hash only
+    # when the archive wasm differs from the previous proposal-backend-*.
+    local verify_cmd
+    if [ "$archive_changed" = "true" ]; then
+      verify_cmd=$(printf './scripts/verify-hash \\\n    --ii-hash %s \\\n    --archive-hash %s' "$II_WASM_SHA" "$ARCHIVE_WASM_SHA")
+    else
+      verify_cmd="./scripts/verify-hash --ii-hash ${II_WASM_SHA}"
+    fi
 
     # Remove previously appended sections (idempotent on re-run)
     sed -i.bak '/^## Backend Argument Verification/,$d' backend_proposal.md && rm -f backend_proposal.md.bak
@@ -549,7 +589,7 @@ To build the wasm modules yourself and verify their hashes, run the following co
 \`\`\`
 git pull  # to ensure you have the latest changes.
 git checkout ${git_commit}
-./scripts/verify-hash --ii-hash ${II_WASM_SHA}
+${verify_cmd}
 \`\`\`
 
 ## Backend Argument Verification
@@ -729,52 +769,82 @@ dry_run_proposal() {
   fi
 }
 
-make_proposal() {
-  local upgrade_type="$(checklist_must_get 'Upgrade type')"
-  
-  if should_upgrade_backend "$upgrade_type"; then
-    echo "=== Creating Backend Proposal ==="
-    # Download again the release tag wasm to check the hash along the latest downloaded before.
-    curl -fsSL https://github.com/dfinity/internet-identity/releases/download/$TAG_NAME/internet_identity_production.wasm.gz -o internet_identity-$TAG_NAME.wasm.gz
-    # Read again the arguments to check the hash along the mainnet_arg.bin file sent in the proposal.
-    ic-admin \
-      --use-hsm \
-      --key-id "01" \
-      --slot 0 \
-      --pin "$(read -p 'HSM PIN? '; echo "$REPLY")" \
-      --nns-url "https://ic0.app" \
-      propose-to-change-nns-canister \
-      --proposer "$(read -p 'NEURON ID? '; echo "$REPLY")" \
-      --canister-id rdmx6-jaaaa-aaaaa-aaadq-cai \
-      --mode upgrade \
-      --wasm-module-path ./internet_identity.wasm.gz \
-      --wasm-module-sha256 "$(sha256 internet_identity-$TAG_NAME.wasm.gz)" \
-      --arg mainnet_arg.bin \
-      --arg-sha256 "$(compute_sha256sum_for_args args.txt)" \
-      --summary-file ./backend_proposal.md \
-      --proposal-title "Upgrade Internet Identity Backend Canister to $(git rev-parse --short "$TAG_NAME")"
+parse_proposal_id() {
+  # Parse an NNS proposal ID from captured ic-admin stdout. The
+  # propose-to-change-nns-canister subcommand prints the ID via
+  # propose_action_from_command as "proposal {proposal_id}", and
+  # ProposalId's Display impl is itself "proposal N", so the line
+  # reads "proposal proposal N". Matching the doubled form avoids
+  # false positives from other numeric output on the same stream.
+  # See dfinity/nns-dapp scripts/nns-dapp/release for the same pattern.
+  local output="$1" label="$2"
+  local id
+  id=$(echo "$output" | grep -oE 'proposal proposal [0-9]+' | head -1 | awk '{print $3}')
+  if [ -z "$id" ] || ! [[ "$id" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: could not parse ${label} from ic-admin output." >&2
+    echo "       Run the command manually and record the proposal number in the checklist file." >&2
+    return 1
   fi
+  # NNS proposal numbers are in the hundreds of thousands. Anything
+  # noticeably smaller almost certainly came from a false-positive
+  # match — refuse to record it as a proposal ID.
+  if [ "$id" -lt 100000 ]; then
+    echo "ERROR: parsed ${label} '${id}' looks wrong (expected >= 100000)." >&2
+    return 1
+  fi
+  echo "$id"
+}
 
-  if should_upgrade_frontend "$upgrade_type"; then
-    echo "=== Creating Frontend Proposal ==="
-    curl -fsSL https://github.com/dfinity/internet-identity/releases/download/$TAG_NAME/internet_identity_frontend.wasm.gz -o internet_identity_frontend-$TAG_NAME.wasm.gz
-    ic-admin \
-      --use-hsm \
-      --key-id "01" \
-      --slot 0 \
-      --pin "$(read -p 'HSM PIN? '; echo "$REPLY")" \
-      --nns-url "https://ic0.app" \
-      propose-to-change-nns-canister \
-      --proposer "$(read -p 'NEURON ID? '; echo "$REPLY")" \
-      --canister-id uqzsh-gqaaa-aaaaq-qaada-cai \
-      --mode upgrade \
-      --wasm-module-path ./internet_identity_frontend.wasm.gz \
-      --wasm-module-sha256 "$(sha256 internet_identity_frontend-$TAG_NAME.wasm.gz)" \
-      --arg mainnet_frontend_arg.bin \
-      --arg-sha256 "$(compute_sha256sum_for_frontend_args frontend_args.txt)" \
-      --summary-file ./frontend_proposal.md \
-      --proposal-title "Upgrade Internet Identity Frontend Canister to $(git rev-parse --short "$TAG_NAME")"
-  fi
+make_backend_proposal() {
+  echo "=== Creating Backend Proposal ===" >&2
+  # Download again the release tag wasm to check the hash along the latest downloaded before.
+  curl -fsSL https://github.com/dfinity/internet-identity/releases/download/$TAG_NAME/internet_identity_production.wasm.gz -o internet_identity-$TAG_NAME.wasm.gz >&2
+  # Read again the arguments to check the hash along the mainnet_arg.bin file sent in the proposal.
+  local output
+  # shellcheck disable=SC2312
+  output=$(ic-admin \
+    --use-hsm \
+    --key-id "01" \
+    --slot 0 \
+    --pin "$(read -p 'HSM PIN? '; echo "$REPLY")" \
+    --nns-url "https://ic0.app" \
+    propose-to-change-nns-canister \
+    --proposer "$(read -p 'NEURON ID? '; echo "$REPLY")" \
+    --canister-id rdmx6-jaaaa-aaaaa-aaadq-cai \
+    --mode upgrade \
+    --wasm-module-path ./internet_identity.wasm.gz \
+    --wasm-module-sha256 "$(sha256 internet_identity-$TAG_NAME.wasm.gz)" \
+    --arg mainnet_arg.bin \
+    --arg-sha256 "$(compute_sha256sum_for_args args.txt)" \
+    --summary-file ./backend_proposal.md \
+    --proposal-title "Upgrade Internet Identity Backend Canister to $(git rev-parse --short "$TAG_NAME")" \
+    2>&1 | tee /dev/tty)
+  parse_proposal_id "$output" "backend proposal number"
+}
+
+make_frontend_proposal() {
+  echo "=== Creating Frontend Proposal ===" >&2
+  curl -fsSL https://github.com/dfinity/internet-identity/releases/download/$TAG_NAME/internet_identity_frontend.wasm.gz -o internet_identity_frontend-$TAG_NAME.wasm.gz >&2
+  local output
+  # shellcheck disable=SC2312
+  output=$(ic-admin \
+    --use-hsm \
+    --key-id "01" \
+    --slot 0 \
+    --pin "$(read -p 'HSM PIN? '; echo "$REPLY")" \
+    --nns-url "https://ic0.app" \
+    propose-to-change-nns-canister \
+    --proposer "$(read -p 'NEURON ID? '; echo "$REPLY")" \
+    --canister-id uqzsh-gqaaa-aaaaq-qaada-cai \
+    --mode upgrade \
+    --wasm-module-path ./internet_identity_frontend.wasm.gz \
+    --wasm-module-sha256 "$(sha256 internet_identity_frontend-$TAG_NAME.wasm.gz)" \
+    --arg mainnet_frontend_arg.bin \
+    --arg-sha256 "$(compute_sha256sum_for_frontend_args frontend_args.txt)" \
+    --summary-file ./frontend_proposal.md \
+    --proposal-title "Upgrade Internet Identity Frontend Canister to $(git rev-parse --short "$TAG_NAME")" \
+    2>&1 | tee /dev/tty)
+  parse_proposal_id "$output" "frontend proposal number"
 }
 
 tag_proposal() {
@@ -850,23 +920,11 @@ create_forum_post() {
     proposals_text="Proposals ${linked_nums[0]} and ${linked_nums[1]}"
   fi
 
-  # Replace the default "This is Internet Identity release ..." line with the proposals version
+  # Replace the default "This is Internet Identity release ..." line with the proposals version.
+  # The release body already carries a "## Try it out" section (added by
+  # .github/actions/release/run.sh), so no extra insertion is needed here.
   local body
   body=$(echo "$release_body" | sed "s|This is Internet Identity release \(.*\) for commit \(.*\)\.|${proposals_text} to upgrade Internet Identity to \1 for commit \2.|")
-
-  # Insert "Try it out" section right before "## What's Changed"
-  local try_it_out
-  try_it_out="## Try it out
-* Staging: https://beta.id.ai
-* Testing application: https://try.id.ai
-
-"
-  local whats_changed_marker="## What's Changed"
-  if [[ "$body" != *"$whats_changed_marker"* ]]; then
-    echo "Error: could not find '## What's Changed' section in release body to insert 'Try it out' section." >&2
-    exit 1
-  fi
-  body="${body/$whats_changed_marker/${try_it_out}${whats_changed_marker}}"
 
   # URL-encode title and body for the Discourse new-topic URL
   local encoded_title encoded_body
@@ -912,15 +970,15 @@ record "New tag pushed" git push "$REPO_HTTPS_URL" $TAG_NAME
 confirm_cmd wait_for_release
 confirm_manual "Review release page update" update_release_text
 
-if should_upgrade_backend "$UPGRADE_TYPE"; then
-  confirm_manual "Add archive canister if needed" wait_for_archive_canister_hash
-fi
-
 confirm_cmd download_wasms
 
 if should_upgrade_backend "$UPGRADE_TYPE"; then
   record "II WASM hash" sha256 internet_identity.wasm.gz
   record "Archive WASM hash" sha256 archive.wasm.gz
+  # Auto-detect whether the archive wasm differs from the previous
+  # proposal-backend-* release. The BE proposal's verify-hash command
+  # includes --archive-hash only when this says "true".
+  record "Archive changed" detect_archive_hash_change
 fi
 
 if should_upgrade_frontend "$UPGRADE_TYPE"; then
@@ -955,14 +1013,15 @@ confirm_manual "Confirm proposal arguments" confirm_proposal_arguments
 confirm_manual "Share proposal contents on Slack" share_proposal
 confirm_cmd dry_run_proposal
 confirm_manual "Review proposal" echo "Review the proposal above"
-confirm_cmd make_proposal
 
+# Proposal numbers are parsed from ic-admin's stdout rather than asked from
+# the user: on success it prints "proposal proposal N" (see parse_proposal_id).
 if should_upgrade_backend "$UPGRADE_TYPE"; then
-  record "Backend proposal number" bash -c 'read -p "Enter backend proposal number: " num; echo "$num"'
+  record "Backend proposal number" make_backend_proposal
 fi
 
 if should_upgrade_frontend "$UPGRADE_TYPE"; then
-  record "Frontend proposal number" bash -c 'read -p "Enter frontend proposal number: " num; echo "$num"'
+  record "Frontend proposal number" make_frontend_proposal
 fi
 
 confirm_cmd tag_proposal

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -845,7 +845,7 @@ make_backend_proposal() {
     --arg-sha256 "$(compute_sha256sum_for_args args.txt)" \
     --summary-file ./backend_proposal.md \
     --proposal-title "Upgrade Internet Identity Backend Canister to $(git rev-parse --short "$TAG_NAME")" \
-    2>&1 | tee /dev/tty)
+    2>&1 | tee /dev/stderr)
   parse_proposal_id "$output" "backend proposal number"
 }
 
@@ -870,7 +870,7 @@ make_frontend_proposal() {
     --arg-sha256 "$(compute_sha256sum_for_frontend_args frontend_args.txt)" \
     --summary-file ./frontend_proposal.md \
     --proposal-title "Upgrade Internet Identity Frontend Canister to $(git rev-parse --short "$TAG_NAME")" \
-    2>&1 | tee /dev/tty)
+    2>&1 | tee /dev/stderr)
   parse_proposal_id "$output" "frontend proposal number"
 }
 

--- a/scripts/verify-hash
+++ b/scripts/verify-hash
@@ -122,18 +122,25 @@ verify() {
   exit 1
 }
 
+# Build every requested canister in a single docker-build invocation.
+# scripts/docker-build accepts any combination of --internet-identity /
+# --frontend / --archive and builds just the ones requested.
+build_args=()
+[ -n "$expected_ii_hash" ] && build_args+=("--internet-identity")
+[ -n "$expected_iife_hash" ] && build_args+=("--frontend")
+[ -n "$expected_archive_hash" ] && build_args+=("--archive")
+
+./scripts/docker-build "${build_args[@]}"
+
 if [ -n "$expected_ii_hash" ]; then
-  ./scripts/docker-build
   verify "II backend" "$expected_ii_hash" ./internet_identity.wasm.gz
 fi
 
 if [ -n "$expected_iife_hash" ]; then
-  ./scripts/docker-build --frontend
   verify "II frontend" "$expected_iife_hash" ./internet_identity_frontend.wasm.gz
 fi
 
 if [ -n "$expected_archive_hash" ]; then
-  ./scripts/docker-build --archive
   verify "archive" "$expected_archive_hash" ./archive.wasm.gz
 fi
 

--- a/scripts/verify-hash
+++ b/scripts/verify-hash
@@ -37,26 +37,30 @@ print_green() {
 #########
 
 function title() {
-    echo "Verifies the hash of the II and archive wasm files"
+    echo "Verifies the hashes of the II, frontend, and archive wasm files"
 }
 
 function usage() {
     cat << EOF
 
 Usage:
-  $0 --ii-hash II_HASH [--iife-hash IIFE_HASH] [--archive-hash ARCHIVE_HASH]
+  $0 [--ii-hash II_HASH] [--iife-hash IIFE_HASH] [--archive-hash ARCHIVE_HASH]
+
+At least one of --ii-hash, --iife-hash, --archive-hash must be provided.
 
 Options:
-  --ii-hash HASH                  Expected II SHA256 hash of the II wasm.
-  --iife-hash HASH                Optional II frontend hash, if the frontend needs to be verified as well.
-  --archive-hash ARCHIVE_HASH     Optional archive hash, if the archive needs to be verified as well.
+  --ii-hash HASH                  Expected SHA256 hash of the II backend wasm.
+  --iife-hash HASH                Expected SHA256 hash of the II frontend wasm.
+  --archive-hash HASH             Expected SHA256 hash of the archive wasm.
 EOF
 }
 
 function help() {
     cat << EOF
 
-Builds the II canister (and optionally also the frontend and archive) and compares the hash of the built wasm with the expected hash.
+Builds each canister for which a hash is provided and compares the hash of the
+built wasm with the expected hash. Canisters with no hash are skipped, so this
+script can verify the backend, frontend, and archive independently or together.
 EOF
 }
 
@@ -96,71 +100,42 @@ do
     esac
 done
 
-if [ -z "$expected_ii_hash" ]
-then
-    echo no II hash provided
+if [ -z "$expected_ii_hash" ] && [ -z "$expected_iife_hash" ] && [ -z "$expected_archive_hash" ]; then
+    echo "Error: no hash provided. Pass at least one of --ii-hash, --iife-hash, --archive-hash." >&2
     usage
     exit 1
 fi
 
-# Run the build
-./scripts/docker-build
-prod_build_sha256="$(shasum -a 256 ./internet_identity.wasm.gz | cut -d ' ' -f1)"
+matches=()
 
-ii_match=false
-iife_match=false
-archive_match=false
-
-if [ "$prod_build_sha256" == "$expected_ii_hash" ]
-then
-  ii_match=true
-else
-  print_red "sha mismatch: $prod_build_sha256 /= $expected_ii_hash"
+verify() {
+  local label="$1" expected="$2" wasm_path="$3"
+  local actual
+  actual="$(shasum -a 256 "$wasm_path" | cut -d ' ' -f1)"
+  if [ "$actual" = "$expected" ]; then
+    matches+=("$(basename "$wasm_path") sha256 matches expected hash $expected")
+    return
+  fi
+  print_red "sha mismatch for $label: $actual /= $expected"
+  # On mismatch, still report anything that matched before we abort.
+  for m in "${matches[@]}"; do print_green "$m"; done
   exit 1
+}
+
+if [ -n "$expected_ii_hash" ]; then
+  ./scripts/docker-build
+  verify "II backend" "$expected_ii_hash" ./internet_identity.wasm.gz
 fi
 
-if [ -n "$expected_iife_hash" ]
-then
+if [ -n "$expected_iife_hash" ]; then
   ./scripts/docker-build --frontend
-  iife_sha256="$(shasum -a 256 ./internet_identity_frontend.wasm.gz | cut -d ' ' -f1)"
-  if [ "$iife_sha256" == "$expected_iife_hash" ]
-  then
-    iife_match=true
-  else
-    print_red "sha mismatch: $iife_sha256 /= $expected_iife_hash"
-    if $ii_match; then
-      print_green "internet_identity.wasm.gz sha256 matches expected hash $expected_ii_hash"
-    fi
-    exit 1
-  fi
+  verify "II frontend" "$expected_iife_hash" ./internet_identity_frontend.wasm.gz
 fi
 
-if [ -n "$expected_archive_hash" ]
-then
+if [ -n "$expected_archive_hash" ]; then
   ./scripts/docker-build --archive
-  archive_sha256="$(shasum -a 256 ./archive.wasm.gz | cut -d ' ' -f1)"
-  if [ "$archive_sha256" == "$expected_archive_hash" ]
-  then
-    archive_match=true
-  else
-    print_red "sha mismatch: $archive_sha256 /= $expected_archive_hash"
-    if $ii_match; then
-      print_green "internet_identity.wasm.gz sha256 matches expected hash $expected_ii_hash"
-    fi
-    exit 1
-  fi
+  verify "archive" "$expected_archive_hash" ./archive.wasm.gz
 fi
 
-if $ii_match; then
-  print_green "internet_identity.wasm.gz sha256 matches expected hash $expected_ii_hash"
-fi
-
-if $iife_match; then
-  print_green "internet_identity_frontend.wasm.gz sha256 matches expected hash $expected_iife_hash"
-fi
-
-if $archive_match; then
-  print_green "archive.wasm.gz sha256 matches expected hash $expected_archive_hash"
-fi
-
+for m in "${matches[@]}"; do print_green "$m"; done
 print_green "Wasm verification successful!"


### PR DESCRIPTION
## Summary

Close gaps in the release SOP so running `./scripts/make-upgrade-proposal` takes the release engineer from a fresh tag to submitted proposals without pauses to patch around missing sections or ferry values between steps.

## Changes

- **Release body now carries `## Try it out`** (staging + testing app URLs) and the full verify-hash command includes `--archive-hash`. Downstream forum post picks up the section for free. Replaces a brittle bash-level insertion in `create_forum_post` that silently failed — the section wasn't actually making it into the post.
- **Archive change auto-detected.** New `detect_archive_hash_change` resolves the previous `proposal-backend-*` tag to its matching `release-*` (via `resolve_release_tag`, mirroring the helper in `.github/actions/release/run.sh`), downloads that release's `archive.wasm.gz`, and compares sha256 against the current one. Falls back to "changed" if the previous archive can't be fetched. Replaces the manual "compare hashes and update the release page" prompt.
- **Per-proposal verify-hash commands.** Backend proposal emits `--ii-hash X` (plus `--archive-hash Y` iff the archive changed). Frontend proposal emits `--iife-hash Z` only. The release page keeps the canonical full command for anyone verifying the entire release.
- **Proposal numbers parsed from `ic-admin` stdout.** Matches `proposal proposal N` (the doubled prefix emitted by `propose_action_from_command` — same pattern as `dfinity/nns-dapp`'s release-sop), with validation that the ID is numeric and ≥ 100000 to guard against false-positive matches on neuron IDs or other numeric output. Removes the two `read -p` prompts.
- **`./scripts/verify-hash` accepts any combination of flags.** `--ii-hash` is no longer required; at least one of the three must be provided. All requested targets are built in a single `./scripts/docker-build` invocation, so frontend-only releases and standalone archive verification now work without redundant builds.

## Tests

No automated tests added (the repo has no bash test harness). Manually exercised:

- `bash -n` on all three scripts.
- `parse_proposal_id` on happy path, no-match, too-small ID, empty input, and multiple matches.
- `resolve_release_tag` against the existing `proposal-backend-141500` tag (resolves to `release-2026-04-21`) and a nonexistent tag (returns empty).
- `detect_archive_hash_change` no-previous-tag fallback in an empty git repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)