### PR TITLE
docs: use id.ai as the canonical Internet Identity URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://identity.internetcomputer.org" target="_blank" rel="noopener noreferrer"><img width="600" src="./ii-logo.png" alt="Internet Identity"/></a></p>
+<p align="center"><a href="https://id.ai" target="_blank" rel="noopener noreferrer"><img width="600" src="./ii-logo.png" alt="Internet Identity"/></a></p>
 
 <p align="center">
     <a href="https://github.com/dfinity/internet-identity/actions/workflows/canister-tests.yml"><img src="https://github.com/dfinity/internet-identity/actions/workflows/canister-tests.yml/badge.svg" alt="Canister Tests" /></a>
@@ -8,12 +8,12 @@
 </p>
 
 <p align="center">
-    🔗 <a href="https://identity.internetcomputer.org">https://identity.internetcomputer.org</a> • 📜 <a href="https://internetcomputer.org/docs/current/references/ii-spec">Specification</a> <br/> ― <br/>📚 <a href="https://forum.dfinity.org/c/internet-identity/32">Forum</a> • 🚑 <a href="https://github.com/dfinity/internet-identity/issues/new">Report an Issue</a> • 📞 <a href="https://discord.internetcomputer.org">Discord</a>
+    🔗 <a href="https://id.ai">https://id.ai</a> • 📜 <a href="https://internetcomputer.org/docs/current/references/ii-spec">Specification</a> <br/> ― <br/>📚 <a href="https://forum.dfinity.org/c/internet-identity/32">Forum</a> • 🚑 <a href="https://github.com/dfinity/internet-identity/issues/new">Report an Issue</a> • 📞 <a href="https://discord.internetcomputer.org">Discord</a>
 </p>
 
 ---
 
-Internet Identity is an authentication and identity service for the [Internet Computer][ic]. It enables hundreds of thousands of users to securely log in to dapps such as [OISY](https://oisy.com), [Caffeine](https://caffeine.ai), [NNS Dapp](https://nns.internetcomputer.org), [OpenChat](https://oc.app), and [many more](https://identity.internetcomputer.org).
+Internet Identity is an authentication and identity service for the [Internet Computer][ic]. It enables hundreds of thousands of users to securely log in to dapps such as [OISY](https://oisy.com), [Caffeine](https://caffeine.ai), [NNS Dapp](https://nns.internetcomputer.org), [OpenChat](https://oc.app), and [many more](https://id.ai).
 
 Internet Identity is:
 

--- a/docs/ii-spec.mdx
+++ b/docs/ii-spec.mdx
@@ -71,7 +71,7 @@ Just for background: At launch this meant we relied on the trustworthiness of th
 
 ## Identity design and data model
 
-The Internet Computer serves this frontend under hostnames `https://identity.internetcomputer.org` (official) and `https://identity.ic0.app` (legacy).
+The Internet Computer serves this frontend under the hostname `https://id.ai` (official), with `https://identity.internetcomputer.org` and `https://identity.ic0.app` as legacy aliases.
 
 The canister maintains a salt (in the following the `salt`), a 32 byte long blob that is obtained via the Internet Computer's source of secure randomness.
 
@@ -137,7 +137,7 @@ sequenceDiagram
 
 2.  It installs a `message` event handler on its own `window`.
 
-3.  It loads the url `https://identity.internetcomputer.org/#authorize` in a separate tab. Let `identityWindow` be the `Window` object returned from this.
+3.  It loads the url `https://id.ai/#authorize` in a separate tab. Let `identityWindow` be the `Window` object returned from this.
 
 4.  In the `identityWindow`, the user logs in, and the `identityWindow` invokes
 
@@ -156,7 +156,7 @@ sequenceDiagram
 5.  The client application, after receiving the `InternetIdentityReady`, invokes
 
     ```ts
-    identityWindow.postMessage(msg, "https://identity.internetcomputer.org");
+    identityWindow.postMessage(msg, "https://id.ai");
     ```
 
     where `msg` is a value of type
@@ -186,7 +186,7 @@ sequenceDiagram
 
 6.  Now the client application window expects a message back, with data `event`.
 
-7.  If `event.origin` is not either `"https://identity.ic0.app"` or `"https://identity.internetcomputer.org"` (depending on which endpoint you are using), ignore this message.
+7.  If `event.origin` is not one of `"https://id.ai"`, `"https://identity.internetcomputer.org"`, or `"https://identity.ic0.app"`, ignore this message.
 
 8.  The `event.data` value is a JS object with the following type:
 
@@ -332,7 +332,7 @@ To prevent misuse of this feature, the number of alternative origins _must not_ 
 :::
 
 :::note
-In order to allow Internet Identity to read the path `/.well-known/ii-alternative-origins`, the CORS response header [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) must be set and allow the Internet Identity origin `https://identity.internetcomputer.org`.
+In order to allow Internet Identity to read the path `/.well-known/ii-alternative-origins`, the CORS response header [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) must be set and allow the Internet Identity origin `https://id.ai`.
 :::
 
 ## The Internet Identity Service Backend interface
@@ -347,7 +347,7 @@ Note that the interface is split into 4 categories:
     - The aim of the API v2 is to introduce changes that cannot be made without breaking existing clients of the legacy API. While the API v2 has feature parity with the legacy API, the desired changes are not fully implemented yet:
       - Methods should return proper results with meaningful errors.
       - Adding explicit WebAuthn signatures to security critical operations.
-- HTTP gateway protocol, required to serve `https://identity.internetcomputer.org`.
+- HTTP gateway protocol, required to serve `https://id.ai`.
 - Auth protocol, for creating signed delegations.
 - Verifiable credentials protocol, for creating id alias credentials.
 - Internal methods, not intended to be called by external clients.

--- a/docs/ii-spec.mdx
+++ b/docs/ii-spec.mdx
@@ -332,7 +332,7 @@ To prevent misuse of this feature, the number of alternative origins _must not_ 
 :::
 
 :::note
-In order to allow Internet Identity to read the path `/.well-known/ii-alternative-origins`, the CORS response header [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) must be set and allow the Internet Identity origin `https://id.ai`.
+In order to allow Internet Identity to read the path `/.well-known/ii-alternative-origins`, the CORS response header [`Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) must be set and allow the Internet Identity origin being used, for example `https://id.ai`, `https://identity.internetcomputer.org`, or `https://identity.ic0.app`.
 :::
 
 ## The Internet Identity Service Backend interface


### PR DESCRIPTION
## Summary

Internet Identity's canonical user-facing URL is now `https://id.ai`. This PR updates the documentation (`README.md` and `docs/ii-spec.mdx`) to point readers to `id.ai` instead of the legacy `identity.internetcomputer.org` and `identity.ic0.app` URLs.

## Changes

- **README.md**: Update the header link, the prominent URL in the links bar, and the "many more" link to point to `https://id.ai`.
- **docs/ii-spec.mdx**: Update the canonical hostname description, the client authentication protocol URLs (`#authorize` endpoint, `postMessage` target origin), the CORS `Access-Control-Allow-Origin` guidance, and the HTTP gateway protocol reference to use `https://id.ai`. Legacy URLs are preserved only where needed for backward-compatibility context (origin validation lists, alias descriptions).

## What is NOT changed

- Code files (`.ts`, `.rs`, config, CI) — docs-only.
- Historical references (changelogs, security advisories).
- Canister-as-a-service URLs (e.g., canister ID on `ic0.app`).
- The `HACKING.md` `dfx canister install` command, which references `identity.ic0.app` in a `related_origins` config value.

Consistent with the framing already used in `HACKING.md` and `frontend_proposal.md`, which reference `id.ai`.