### PR TITLE
ci: stop running CI twice on internal PRs

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -5,6 +5,8 @@ name: Canister tests
 
 on:
   push:
+    branches: [main]
+    tags: ['release-*']
   pull_request:
 
 jobs:

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     tags: ['release-*']
   pull_request:
+  merge_group:
 
 jobs:
   #####################

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -2,6 +2,7 @@ name: Frontend checks and lints
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:
@@ -38,9 +39,9 @@ jobs:
           done < <(jq <src/frontend/src/flows/dappsExplorer/dapps.json -cMr '.[] | .logo' )
       - name: Commit type interfaces
         uses: EndBug/add-and-commit@v9
-        # We don't want to commit automatic changes to main, and we can't
-        # push to fork PRs (read-only token).
-        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+        # Push only fires on `main` now, so this is inert. Preserved for
+        # reference; re-enable by gating on a suitable event.
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/main' }}
         with:
           add: |
             src/frontend/generated

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 jobs:
   frontend-checks:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 jobs:
   cargo-fmt:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@ name: Rust
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:
@@ -29,9 +30,9 @@ jobs:
 
       - name: Commit Formatting changes
         uses: EndBug/add-and-commit@v9
-        # We don't want to commit formatting changes to main, and we can't
-        # push to fork PRs (read-only token).
-        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
+        # Push only fires on `main` and release tags now, so this is inert.
+        # Preserved for reference; re-enable by gating on a suitable event.
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/main' }}
         with:
           add: "**/*.rs"
           default_author: github_actions


### PR DESCRIPTION
Since https://github.com/dfinity/internet-identity/pull/3782 added a `pull_request` trigger, every commit on an internal PR branch fires **both** `push` and `pull_request`, running every CI job twice. This PR scopes the `push` trigger so PR branches fire only `pull_request`, eliminating the duplicate runs.

## Changes

- [canister-tests.yml](.github/workflows/canister-tests.yml): `push` → `branches: [main]` + `tags: ['release-*']`
- [frontend-checks.yml](.github/workflows/frontend-checks.yml): `push` → `branches: [main]`
- [rust.yml](.github/workflows/rust.yml): `push` → `branches: [main]`

## When each trigger fires after this change

| Scenario | `push` | `pull_request` |
|---|---|---|
| Push to internal PR branch | — | ✓ |
| Push to fork PR branch | — | ✓ |
| Merge to `main` | ✓ | — |
| Push release tag (`release-*`) | ✓ (canister-tests only) | — |

Release flow, main-branch post-merge CI, and fork PR CI are preserved.

## Caveat — auto-commit formatting

The `cargo-fmt` auto-commit in `rust.yml` and the `Commit type interfaces` step in `frontend-checks.yml` were previously gated on `push` to non-`main` branches. Since `push` no longer fires on feature branches, these steps are now inert. The conditions have been tightened so they cannot spuriously fire on tag pushes. Re-enabling them for same-repo PRs is possible but requires adjusting the `checkout` ref and token handling, which is out of scope here — please run `cargo fmt` / `npm run generate` locally until that follow-up lands.