### PR TITLE
feat(fe): make last-used sign-in work for SSO accounts

### DIFF
--- a/src/frontend/src/lib/components/ui/AuthMethodBadge.svelte
+++ b/src/frontend/src/lib/components/ui/AuthMethodBadge.svelte
@@ -1,12 +1,22 @@
 <script lang="ts">
   import PasskeyIcon from "../icons/PasskeyIcon.svelte";
+  import SsoIcon from "../icons/SsoIcon.svelte";
+
+  // Discriminated union: each auth method draws something different and
+  // each carries different (or no) extra data. A flat `logo + isSso`
+  // pair would let a caller accidentally pass both — the union prevents
+  // that statically.
+  export type AuthMethodBadgeVariant =
+    | { type: "passkey" }
+    | { type: "openid"; logo?: string }
+    | { type: "sso" };
 
   type Props = {
-    logo: string | undefined;
+    variant: AuthMethodBadgeVariant;
     size: "sm" | "lg";
   };
 
-  let { logo, size }: Props = $props();
+  let { variant, size }: Props = $props();
 </script>
 
 <span
@@ -17,11 +27,15 @@
       : "-inset-e-1.25 -bottom-1.25 size-5",
   ]}
 >
-  {#if logo !== undefined}
+  {#if variant.type === "sso"}
+    <SsoIcon
+      class={["text-fg-tertiary", size === "lg" ? "size-4.25!" : "size-3!"]}
+    />
+  {:else if variant.type === "openid" && variant.logo !== undefined}
     <span
       class={["text-fg-tertiary", size === "lg" ? "size-4.25" : "size-3.25"]}
     >
-      {@html logo}
+      {@html variant.logo}
     </span>
   {:else}
     <PasskeyIcon

--- a/src/frontend/src/lib/components/ui/AuthMethodBadge.svelte
+++ b/src/frontend/src/lib/components/ui/AuthMethodBadge.svelte
@@ -2,10 +2,6 @@
   import PasskeyIcon from "../icons/PasskeyIcon.svelte";
   import SsoIcon from "../icons/SsoIcon.svelte";
 
-  // Discriminated union: each auth method draws something different and
-  // each carries different (or no) extra data. A flat `logo + isSso`
-  // pair would let a caller accidentally pass both — the union prevents
-  // that statically.
   export type AuthMethodBadgeVariant =
     | { type: "passkey" }
     | { type: "openid"; logo?: string }

--- a/src/frontend/src/lib/components/ui/IdentityAvatar.svelte
+++ b/src/frontend/src/lib/components/ui/IdentityAvatar.svelte
@@ -3,7 +3,9 @@
   import { openIdLogo } from "$lib/utils/openID";
   import { UserIcon } from "@lucide/svelte";
   import Avatar from "./Avatar.svelte";
-  import AuthMethodBadge from "./AuthMethodBadge.svelte";
+  import AuthMethodBadge, {
+    type AuthMethodBadgeVariant,
+  } from "./AuthMethodBadge.svelte";
 
   type Props = {
     identity: LastUsedIdentity;
@@ -12,22 +14,28 @@
 
   let { identity, size }: Props = $props();
 
-  const logo = $derived(
-    "openid" in identity.authMethod &&
-      identity.authMethod.openid.metadata !== undefined
-      ? openIdLogo(
-          identity.authMethod.openid.iss,
-          // `aud` not currently tracked on `LastUsedIdentity` (see
-          // #3795) — issuer-only fallback in `findConfig` is correct
-          // for direct providers, imprecise for SSO until that's
-          // fixed. `ssoDomain` is unknown here for the same reason,
-          // so SSO-linked last-used identities render with the
-          // underlying IdP's logo.
-          undefined,
-          identity.authMethod.openid.metadata,
-          undefined,
-        )
-      : undefined,
+  // SSO entries get their own badge — never the underlying IdP's logo —
+  // so the row UX matches what the user picked.
+  const variant = $derived<AuthMethodBadgeVariant>(
+    "sso" in identity.authMethod
+      ? { type: "sso" }
+      : "openid" in identity.authMethod
+        ? {
+            type: "openid",
+            logo:
+              identity.authMethod.openid.metadata !== undefined
+                ? openIdLogo(
+                    identity.authMethod.openid.iss,
+                    // `aud` not currently tracked on `LastUsedIdentity`
+                    // (see #3795) — issuer-only fallback in `findConfig`
+                    // is correct for direct providers.
+                    undefined,
+                    identity.authMethod.openid.metadata,
+                    undefined,
+                  )
+                : undefined,
+          }
+        : { type: "passkey" },
   );
 </script>
 
@@ -35,5 +43,5 @@
   <Avatar {size}>
     <UserIcon class={size === "lg" ? "size-6" : "size-5"} />
   </Avatar>
-  <AuthMethodBadge {logo} {size} />
+  <AuthMethodBadge {variant} {size} />
 </div>

--- a/src/frontend/src/lib/components/ui/IdentityListItem.svelte
+++ b/src/frontend/src/lib/components/ui/IdentityListItem.svelte
@@ -25,6 +25,9 @@
         >{getMetadataString(identity.authMethod.openid.metadata, "email") ??
           $t`Hidden email`}</span
       >
+    {:else if "sso" in identity.authMethod}
+      {@const sso = identity.authMethod.sso}
+      <span>{sso.email ?? sso.name ?? sso.domain}</span>
     {:else}
       <span>
         {$t`Passkey`}

--- a/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
+++ b/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
@@ -128,6 +128,9 @@
             "email",
           ) ?? $t`Hidden email`}</span
         >
+      {:else if "sso" in selectedIdentity.authMethod}
+        {@const sso = selectedIdentity.authMethod.sso}
+        <span>{sso.email ?? sso.name ?? sso.domain}</span>
       {/if}
     </p>
     {#if onSignOut !== undefined}

--- a/src/frontend/src/lib/components/ui/ManageIdentities.svelte
+++ b/src/frontend/src/lib/components/ui/ManageIdentities.svelte
@@ -39,25 +39,22 @@
 </script>
 
 {#snippet removeConfirmation(identity: LastUsedIdentity)}
-  {@const openIdProvider =
-    "openid" in identity.authMethod &&
-    identity.authMethod.openid.metadata !== undefined
-      ? openIdName(
-          identity.authMethod.openid.iss,
-          // `aud` not tracked on `LastUsedIdentity`; see #3795. Fall
-          // through to issuer-only `findConfig` — correct for direct
-          // providers. SSO entries take the `"sso" in authMethod`
-          // branch below instead.
-          undefined,
-          identity.authMethod.openid.metadata,
-          undefined,
-          undefined,
-        )
-      : undefined}
-  {@const ssoProvider =
+  {@const provider =
     "sso" in identity.authMethod
       ? (identity.authMethod.sso.name ?? identity.authMethod.sso.domain)
-      : undefined}
+      : "openid" in identity.authMethod &&
+          identity.authMethod.openid.metadata !== undefined
+        ? openIdName(
+            identity.authMethod.openid.iss,
+            // `aud` not tracked on `LastUsedIdentity`; see #3795. Fall
+            // through to issuer-only `findConfig` — correct for direct
+            // providers. SSO entries take the branch above.
+            undefined,
+            identity.authMethod.openid.metadata,
+            undefined,
+            undefined,
+          )
+        : undefined}
   <div class="flex flex-col gap-8">
     <div class="flex flex-col gap-4">
       <FeaturedIcon size="lg">
@@ -68,14 +65,9 @@
           {$t`Remove from this device`}
         </h2>
         <p class="text-text-tertiary text-base">
-          {#if ssoProvider !== undefined}
+          {#if provider !== undefined}
             <Trans>
-              You can add it back anytime by signing in with the same {ssoProvider}
-              SSO.
-            </Trans>
-          {:else if openIdProvider !== undefined}
-            <Trans>
-              You can add it back anytime by signing in with the same {openIdProvider}
+              You can add it back anytime by signing in with the same {provider}
               account.
             </Trans>
           {:else}

--- a/src/frontend/src/lib/components/ui/ManageIdentities.svelte
+++ b/src/frontend/src/lib/components/ui/ManageIdentities.svelte
@@ -44,15 +44,19 @@
     identity.authMethod.openid.metadata !== undefined
       ? openIdName(
           identity.authMethod.openid.iss,
-          // `aud`, `ssoName`, `ssoDomain` not tracked on
-          // `LastUsedIdentity`; see #3795. Fall through to issuer-only
-          // `findConfig` — correct for direct providers, imprecise for
-          // SSO until that's fixed.
+          // `aud` not tracked on `LastUsedIdentity`; see #3795. Fall
+          // through to issuer-only `findConfig` — correct for direct
+          // providers. SSO entries take the `"sso" in authMethod`
+          // branch below instead.
           undefined,
           identity.authMethod.openid.metadata,
           undefined,
           undefined,
         )
+      : undefined}
+  {@const ssoProvider =
+    "sso" in identity.authMethod
+      ? (identity.authMethod.sso.name ?? identity.authMethod.sso.domain)
       : undefined}
   <div class="flex flex-col gap-8">
     <div class="flex flex-col gap-4">
@@ -64,7 +68,12 @@
           {$t`Remove from this device`}
         </h2>
         <p class="text-text-tertiary text-base">
-          {#if openIdProvider !== undefined}
+          {#if ssoProvider !== undefined}
+            <Trans>
+              You can add it back anytime by signing in with the same {ssoProvider}
+              SSO.
+            </Trans>
+          {:else if openIdProvider !== undefined}
             <Trans>
               You can add it back anytime by signing in with the same {openIdProvider}
               account.

--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -39,6 +39,12 @@
   let isContinueFromAnotherDeviceVisible = $state(false);
   let isAuthenticating = $state(false);
   let isUpgrading = $state(false);
+  // True while a deferred SSO registration is awaiting the name-entry view
+  // (`setupNewIdentity`). Used by `handleCompleteOpenIdRegistration` to
+  // dispatch to `completeSsoRegistration` instead of the direct-provider
+  // counterpart. Plain `let` (no `$state`) — only read inside async event
+  // handlers, never in the template, so reactivity isn't needed.
+  let pendingSsoRegistration = false;
 
   const handleContinueWithExistingPasskey = async (): Promise<
     void | "cancelled"
@@ -84,6 +90,10 @@
         await onSignIn(result.identityNumber);
       } else if (result.name !== undefined) {
         await onSignUp(await authFlow.completeOpenIdRegistration(result.name));
+      } else {
+        // Deferred direct-OpenID sign-up: ensure the SSO flag is clear so
+        // the name-entry view dispatches to `completeOpenIdRegistration`.
+        pendingSsoRegistration = false;
       }
     } catch (error) {
       if (isOpenIdCancelError(error)) {
@@ -104,9 +114,12 @@
       if (authResult.type === "signIn") {
         await onSignIn(authResult.identityNumber);
       } else if (authResult.name !== undefined) {
-        await onSignUp(
-          await authFlow.completeOpenIdRegistration(authResult.name),
-        );
+        await onSignUp(await authFlow.completeSsoRegistration(authResult.name));
+      } else {
+        // The SSO IdP didn't supply a name — the wizard now drives the
+        // user to `setupNewIdentity`. Mark the deferred completion as
+        // SSO so the name-entry callback dispatches to the SSO path.
+        pendingSsoRegistration = true;
       }
     } catch (error) {
       if (isOpenIdCancelError(error)) {
@@ -123,7 +136,12 @@
   ): Promise<void> => {
     try {
       isAuthenticating = true;
-      await onSignUp(await authFlow.completeOpenIdRegistration(name));
+      if (pendingSsoRegistration) {
+        await onSignUp(await authFlow.completeSsoRegistration(name));
+        pendingSsoRegistration = false;
+      } else {
+        await onSignUp(await authFlow.completeOpenIdRegistration(name));
+      }
     } catch (error) {
       onError(error); // Propagate unhandled errors to parent component
     } finally {
@@ -189,6 +207,7 @@
           if (isAuthenticating) {
             return;
           }
+          pendingSsoRegistration = false;
           authFlow.chooseMethod();
         }}
       >

--- a/src/frontend/src/lib/flows/authFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.ts
@@ -22,6 +22,7 @@ import { passkeyAuthnMethodData } from "$lib/utils/authnMethodData";
 import { isCanisterError, throwCanisterError } from "$lib/utils/utils";
 import {
   CheckCaptchaError,
+  IdentityAnchorInfo,
   IdRegFinishError,
   IdRegStartError,
   OpenIdDelegationError,
@@ -60,6 +61,14 @@ export class AuthFlow {
   #name = $state<string>();
   #jwt = $state<string>();
   #configIssuer = $state<string>();
+  // SSO sign-up state: kept separate from the direct-provider `#jwt` /
+  // `#configIssuer` pair so `completeSsoRegistration` (the SSO-specific
+  // counterpart to `completeOpenIdRegistration`) can reconstruct the
+  // `sso` LastUsedIdentity entry without leaking SSO awareness into the
+  // direct-provider methods.
+  #ssoJwt = $state<string>();
+  #ssoDomain = $state<string>();
+  #ssoName = $state<string>();
 
   get view() {
     return this.#view;
@@ -109,26 +118,53 @@ export class AuthFlow {
         type: "signUp";
       }
   > => {
-    const { clientId, discovery } = ssoResult;
+    const { clientId, discovery, domain, name: ssoName } = ssoResult;
+    authenticationV2Funnel.addProperties({ provider: "SSO" });
+    const result = await this.#openIdJwtSignIn({
+      clientId,
+      authURL: discovery.authorization_endpoint,
+      authScope: selectAuthScopes(discovery.scopes_supported).join(" "),
+    });
+    if (result.type === "signIn") {
+      if (this.#options.trackLastUsed) {
+        // `email` is purely for display fallback in the identity row
+        // (email → name → domain); decoded fresh from the JWT here so
+        // the sso variant doesn't need to remember `iss`/`sub`.
+        const { email } = decodeJWT(result.jwt);
+        lastUsedIdentitiesStore.addLastUsedIdentity({
+          identityNumber: result.identityNumber,
+          name: result.info.name[0],
+          authMethod: {
+            sso: {
+              domain,
+              name: ssoName,
+              email,
+              loginHint: result.loginHint,
+            },
+          },
+          createdAtMillis: result.info.created_at.map(nanosToMillis)[0],
+        });
+      }
+      return { identityNumber: result.identityNumber, type: "signIn" };
+    }
+    this.#ssoJwt = result.jwt;
+    this.#ssoDomain = domain;
+    this.#ssoName = ssoName;
+    return { name: result.suggestedName, type: "signUp" };
+  };
 
-    // Build a synthetic OpenIdConfig from SSO discovery result. The
-    // canister identifies the matching DiscoverableProvider by (iss,
-    // aud) and stamps `sso_domain` (+ optional `sso_name`) onto the
-    // credential when it verifies the JWT — the FE doesn't need to
-    // remember anything about this flow locally.
-    const syntheticConfig: OpenIdConfig = {
-      auth_uri: discovery.authorization_endpoint,
-      jwks_uri: "",
-      logo: "",
-      name: "SSO",
-      fedcm_uri: [],
-      email_verification: [],
-      issuer: discovery.issuer,
-      auth_scope: selectAuthScopes(discovery.scopes_supported),
-      client_id: clientId,
-    };
-
-    return await this.continueWithOpenId(syntheticConfig);
+  completeSsoRegistration = async (name: string): Promise<bigint> => {
+    if (this.#ssoJwt === undefined || this.#ssoDomain === undefined) {
+      throw new Error("SSO JWT or domain is missing");
+    }
+    authenticationV2Funnel.trigger(AuthenticationV2Events.RegisterWithOpenID);
+    await this.#startRegistration();
+    return this.#registerWithSso(
+      this.#ssoJwt,
+      name,
+      this.#ssoDomain,
+      this.#ssoName,
+    );
   };
 
   continueWithExistingPasskey = async (): Promise<bigint> => {
@@ -194,19 +230,70 @@ export class AuthFlow {
         type: "signUp";
       }
   > => {
+    authenticationV2Funnel.addProperties({ provider: config.name });
+    const result = await this.#openIdJwtSignIn(
+      {
+        clientId: config.client_id,
+        authURL: config.auth_uri,
+        authScope: config.auth_scope.join(" "),
+        configURL: config.fedcm_uri?.[0],
+      },
+      existingJwt,
+    );
+    if (result.type === "signIn") {
+      if (this.#options.trackLastUsed) {
+        const authnMethod = result.info.openid_credentials[0]?.find(
+          (method) => method.iss === result.iss,
+        );
+        lastUsedIdentitiesStore.addLastUsedIdentity({
+          identityNumber: result.identityNumber,
+          name: result.info.name[0],
+          authMethod: {
+            openid: {
+              iss: result.iss,
+              sub: result.sub,
+              loginHint: result.loginHint,
+              metadata: authnMethod?.metadata,
+            },
+          },
+          createdAtMillis: result.info.created_at.map(nanosToMillis)[0],
+        });
+      }
+      return { identityNumber: result.identityNumber, type: "signIn" };
+    }
+    this.#jwt = result.jwt;
+    this.#configIssuer = config.issuer;
+    return { name: result.suggestedName, type: "signUp" };
+  };
+
+  // Shared core for `continueWithOpenId` / `continueWithSso`. Acquires the
+  // JWT (skipped when one is supplied), authenticates with II, and either
+  // returns sign-in details (with anchor info) or signals that registration
+  // is needed. Knows nothing about how either caller persists LastUsedIdentity
+  // — that's the caller's responsibility, so the OpenID and SSO variants
+  // don't bleed into each other.
+  #openIdJwtSignIn = async (
+    requestConfig: RequestConfig,
+    existingJwt?: string,
+  ): Promise<
+    | {
+        type: "signIn";
+        jwt: string;
+        iss: string;
+        sub: string;
+        loginHint?: string;
+        identityNumber: bigint;
+        info: IdentityAnchorInfo;
+      }
+    | {
+        type: "signUp";
+        jwt: string;
+        suggestedName?: string;
+      }
+  > => {
     let jwt: string | undefined = existingJwt;
-    // Convert OpenIdConfig to RequestConfig
-    const requestConfig: RequestConfig = {
-      clientId: config.client_id,
-      authURL: config.auth_uri,
-      authScope: config.auth_scope.join(" "),
-      configURL: config.fedcm_uri?.[0],
-    };
-    authenticationV2Funnel.addProperties({
-      provider: config.name,
-    });
     if (jwt === undefined) {
-      // Create two try-catch blocks to avoid double-triggering the analytics.
+      // Two try-catch blocks to avoid double-triggering the analytics.
       try {
         this.#systemOverlay = true;
         jwt = await requestJWT(requestConfig, {
@@ -218,7 +305,7 @@ export class AuthFlow {
         throw error;
       } finally {
         this.#systemOverlay = false;
-        // Moved after `requestJWT` to avoid Safari from blocking the popup.
+        // Moved after `requestJWT` to avoid Safari blocking the popup.
         authenticationV2Funnel.trigger(
           AuthenticationV2Events.ContinueWithOpenID,
         );
@@ -231,10 +318,6 @@ export class AuthFlow {
         session: get(sessionStore),
         jwt,
       });
-      // If the previous call succeeds, it means the OpenID user already exists in II.
-      // Therefore, they are logging in.
-      // If the call fails, it means the OpenID user does not exist in II.
-      // In that case, we register them.
       authenticationV2Funnel.trigger(AuthenticationV2Events.LoginWithOpenID);
       await authenticationStore.set({
         identity,
@@ -243,37 +326,28 @@ export class AuthFlow {
       });
       const info =
         await get(authenticatedStore).actor.get_anchor_info(identityNumber);
-      const authnMethod = info.openid_credentials[0]?.find(
-        (method) => method.iss === iss,
-      );
-      if (this.#options.trackLastUsed) {
-        lastUsedIdentitiesStore.addLastUsedIdentity({
-          identityNumber,
-          name: info.name[0],
-          authMethod: {
-            openid: { iss, sub, loginHint, metadata: authnMethod?.metadata },
-          },
-          createdAtMillis: info.created_at.map(nanosToMillis)[0],
-        });
-      }
-      return { identityNumber, type: "signIn" };
+      return {
+        type: "signIn",
+        jwt,
+        iss,
+        sub,
+        loginHint,
+        identityNumber,
+        info,
+      };
     } catch (error) {
       if (
         isCanisterError<OpenIdDelegationError>(error) &&
-        error.type === "NoSuchAnchor" &&
-        jwt !== undefined
+        error.type === "NoSuchAnchor"
       ) {
-        this.#jwt = jwt;
-        this.#configIssuer = config.issuer;
         const { name } = decodeJWT(jwt);
         authenticationV2Funnel.trigger(
           AuthenticationV2Events.RegisterWithOpenID,
         );
         if (name === undefined) {
-          // Show enter name screen to complete registration,
           this.#view = "setupNewIdentity";
         }
-        return { name, type: "signUp" };
+        return { type: "signUp", jwt, suggestedName: name };
       }
       throw error;
     }
@@ -416,6 +490,80 @@ export class AuthFlow {
     name: string,
     configIssuer: string,
   ): Promise<bigint> => {
+    const result = await this.#openIdRegistrationCommit(jwt, name);
+    if (this.#options.trackLastUsed) {
+      const { name: jwtName, email, ...restJWTClaims } = result.decodedJwt;
+      const metadata: MetadataMapV2 = [];
+      if (jwtName !== undefined) {
+        metadata.push(["name", { String: jwtName }]);
+      }
+      if (email !== undefined) {
+        metadata.push(["email", { String: email }]);
+      }
+      extractIssuerTemplateClaims(configIssuer).forEach((key) => {
+        if (restJWTClaims[key] !== undefined) {
+          metadata.push([key, { String: restJWTClaims[key] }]);
+        }
+      });
+      lastUsedIdentitiesStore.addLastUsedIdentity({
+        identityNumber: result.identityNumber,
+        name,
+        authMethod: {
+          openid: {
+            iss: result.iss,
+            sub: result.sub,
+            loginHint: result.loginHint,
+            metadata,
+          },
+        },
+        createdAtMillis: Date.now(),
+      });
+    }
+    return result.identityNumber;
+  };
+
+  #registerWithSso = async (
+    jwt: string,
+    name: string,
+    domain: string,
+    ssoName: string | undefined,
+  ): Promise<bigint> => {
+    const result = await this.#openIdRegistrationCommit(jwt, name);
+    if (this.#options.trackLastUsed) {
+      // See `continueWithSso`: email is kept only for the identity-row
+      // display fallback chain (email → name → domain).
+      lastUsedIdentitiesStore.addLastUsedIdentity({
+        identityNumber: result.identityNumber,
+        name,
+        authMethod: {
+          sso: {
+            domain,
+            name: ssoName,
+            email: result.decodedJwt.email,
+            loginHint: result.loginHint,
+          },
+        },
+        createdAtMillis: Date.now(),
+      });
+    }
+    return result.identityNumber;
+  };
+
+  // Shared core for `#registerWithOpenId` / `#registerWithSso`. Calls the
+  // canister-side `openid_identity_registration_finish` (with captcha-retry
+  // recursion), authenticates with the resulting delegation, and returns
+  // the credential identifiers + decoded JWT — leaving LastUsedIdentity
+  // recording to the variant-specific callers.
+  #openIdRegistrationCommit = async (
+    jwt: string,
+    name: string,
+  ): Promise<{
+    iss: string;
+    sub: string;
+    loginHint?: string;
+    identityNumber: bigint;
+    decodedJwt: ReturnType<typeof decodeJWT>;
+  }> => {
     try {
       await get(sessionStore)
         .actor.openid_identity_registration_finish({
@@ -424,14 +572,8 @@ export class AuthFlow {
           name,
         })
         .then(throwCanisterError);
-      const {
-        iss,
-        sub,
-        loginHint,
-        name: jwtName,
-        email,
-        ...restJWTClaims
-      } = decodeJWT(jwt);
+      const decodedJwt = decodeJWT(jwt);
+      const { iss, sub, loginHint } = decodedJwt;
       const { identity, identityNumber } = await authenticateWithJWT({
         canisterId,
         session: get(sessionStore),
@@ -445,28 +587,8 @@ export class AuthFlow {
         identityNumber,
         authMethod: { openid: { iss, sub } },
       });
-      const metadata: MetadataMapV2 = [];
-      if (jwtName !== undefined) {
-        metadata.push(["name", { String: jwtName }]);
-      }
-      if (email !== undefined) {
-        metadata.push(["email", { String: email }]);
-      }
-      extractIssuerTemplateClaims(configIssuer).forEach((key) => {
-        if (restJWTClaims[key] !== undefined) {
-          metadata.push([key, { String: restJWTClaims[key] }]);
-        }
-      });
-      if (this.#options.trackLastUsed) {
-        lastUsedIdentitiesStore.addLastUsedIdentity({
-          identityNumber,
-          name,
-          authMethod: { openid: { iss, sub, loginHint, metadata } },
-          createdAtMillis: Date.now(),
-        });
-      }
       this.#captcha = undefined;
-      return identityNumber;
+      return { iss, sub, loginHint, identityNumber, decodedJwt };
     } catch (error) {
       if (
         isCanisterError<IdRegFinishError>(error) &&
@@ -477,7 +599,7 @@ export class AuthFlow {
           await this.#solveCaptcha(
             `data:image/png;base64,${nextStep.CheckCaptcha.captcha_png_base64}`,
           );
-          return this.#registerWithOpenId(jwt, name, configIssuer);
+          return this.#openIdRegistrationCommit(jwt, name);
         }
       }
       throw error;

--- a/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
@@ -8,7 +8,14 @@ import {
   lastUsedIdentitiesStore,
   type LastUsedIdentity,
 } from "$lib/stores/last-used-identities.store";
-import { decodeJWT, findConfig, requestJWT } from "$lib/utils/openID";
+import {
+  decodeJWT,
+  findConfig,
+  requestJWT,
+  requestWithPopup,
+  selectAuthScopes,
+} from "$lib/utils/openID";
+import { discoverSsoConfig } from "$lib/utils/ssoDiscovery";
 import { get } from "svelte/store";
 import { sessionStore } from "$lib/stores/session.store";
 import { fetchIdentityCredentials } from "$lib/utils/fetchCredentials";
@@ -98,6 +105,52 @@ export class AuthLastUsedFlow {
         authenticationV2Funnel.addProperties({
           provider: config.name,
         });
+        authenticationV2Funnel.trigger(AuthenticationV2Events.ContinueAsOpenID);
+      } else if ("sso" in lastUsedIdentity.authMethod) {
+        this.systemOverlay = true;
+        // SSO providers aren't in the static `openid_configs` list — the
+        // canister only knows the discovery domain. Re-run the FE-side
+        // two-hop chain so the request config is rebuilt from a fresh
+        // provider discovery doc. No `add_discoverable_oidc_config` call
+        // here: the only way to have a stored `sso` LastUsedIdentity is
+        // to have completed an initial sign-up that already registered
+        // the domain canister-side, and the canister persists those
+        // registrations across upgrades.
+        //
+        // Calling `requestWithPopup` directly (rather than `requestJWT`)
+        // with a `Promise<RequestConfig>` so the popup opens synchronously
+        // in the same task as the user click — discovery resolves while
+        // the popup shows about:blank, then navigates to the IdP. Awaiting
+        // discovery before `window.open` would let Safari block the popup.
+        const { domain, loginHint } = lastUsedIdentity.authMethod.sso;
+        const jwt = await requestWithPopup(
+          discoverSsoConfig(domain).then((ssoResult) => ({
+            clientId: ssoResult.clientId,
+            authURL: ssoResult.discovery.authorization_endpoint,
+            authScope: selectAuthScopes(
+              ssoResult.discovery.scopes_supported,
+            ).join(" "),
+          })),
+          {
+            nonce: get(sessionStore).nonce,
+            mediation: "optional",
+            loginHint,
+          },
+        );
+        const { iss, sub } = decodeJWT(jwt);
+        this.systemOverlay = false;
+        const { identity, identityNumber } = await authenticateWithJWT({
+          canisterId,
+          session: get(sessionStore),
+          jwt,
+        });
+        await authenticationStore.set({
+          identity,
+          identityNumber,
+          authMethod: { openid: { iss, sub } },
+        });
+        lastUsedIdentitiesStore.addLastUsedIdentity(lastUsedIdentity);
+        authenticationV2Funnel.addProperties({ provider: "SSO" });
         authenticationV2Funnel.trigger(AuthenticationV2Events.ContinueAsOpenID);
       } else {
         throw new Error("Unrecognized authentication method");

--- a/src/frontend/src/lib/locales/de.po
+++ b/src/frontend/src/lib/locales/de.po
@@ -1251,6 +1251,9 @@ msgstr "Sie aktualisieren die ID <0>{identityNumber}</0>"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "Sie können sie jederzeit wieder hinzufügen, indem Sie sich mit demselben {openIdProvider}-Konto anmelden."
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr ""
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Sie können sie jederzeit wieder hinzufügen, indem Sie sich mit demselben Passkey anmelden."
 

--- a/src/frontend/src/lib/locales/de.po
+++ b/src/frontend/src/lib/locales/de.po
@@ -1248,10 +1248,7 @@ msgstr "Sie haben bereits ein {name}-Konto verknüpft"
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Sie aktualisieren die ID <0>{identityNumber}</0>"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "Sie können sie jederzeit wieder hinzufügen, indem Sie sich mit demselben {openIdProvider}-Konto anmelden."
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
 msgstr ""
 
 msgid "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/de.po
+++ b/src/frontend/src/lib/locales/de.po
@@ -1249,7 +1249,7 @@ msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Sie aktualisieren die ID <0>{identityNumber}</0>"
 
 msgid "You can add it back anytime by signing in with the same {provider} account."
-msgstr ""
+msgstr "Sie können sie jederzeit wieder hinzufügen, indem Sie sich mit demselben {provider}-Konto anmelden."
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Sie können sie jederzeit wieder hinzufügen, indem Sie sich mit demselben Passkey anmelden."

--- a/src/frontend/src/lib/locales/en.po
+++ b/src/frontend/src/lib/locales/en.po
@@ -1251,6 +1251,9 @@ msgstr "You are upgrading ID <0>{identityNumber}</0>"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "You can add it back anytime by signing in with the same {openIdProvider} account."
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "You can add it back anytime by signing in with the same passkey."
 

--- a/src/frontend/src/lib/locales/en.po
+++ b/src/frontend/src/lib/locales/en.po
@@ -1248,11 +1248,8 @@ msgstr "You already have a {name} account linked"
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "You are upgrading ID <0>{identityNumber}</0>"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "You can add it back anytime by signing in with the same {openIdProvider} account."
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
-msgstr "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
+msgstr "You can add it back anytime by signing in with the same {provider} account."
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/es.po
+++ b/src/frontend/src/lib/locales/es.po
@@ -1248,10 +1248,7 @@ msgstr "Ya tienes una cuenta de {name} vinculada"
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Estás actualizando el ID <0>{identityNumber}</0>"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "Puedes volver a añadirla en cualquier momento iniciando sesión con la misma cuenta de {openIdProvider}."
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
 msgstr ""
 
 msgid "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/es.po
+++ b/src/frontend/src/lib/locales/es.po
@@ -1249,7 +1249,7 @@ msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Estás actualizando el ID <0>{identityNumber}</0>"
 
 msgid "You can add it back anytime by signing in with the same {provider} account."
-msgstr ""
+msgstr "Puedes volver a añadirla en cualquier momento iniciando sesión con la misma cuenta de {provider}."
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Puedes volver a añadirla en cualquier momento iniciando sesión con la misma passkey."

--- a/src/frontend/src/lib/locales/es.po
+++ b/src/frontend/src/lib/locales/es.po
@@ -1251,6 +1251,9 @@ msgstr "Estás actualizando el ID <0>{identityNumber}</0>"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "Puedes volver a añadirla en cualquier momento iniciando sesión con la misma cuenta de {openIdProvider}."
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr ""
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Puedes volver a añadirla en cualquier momento iniciando sesión con la misma passkey."
 

--- a/src/frontend/src/lib/locales/fr.po
+++ b/src/frontend/src/lib/locales/fr.po
@@ -1251,6 +1251,9 @@ msgstr "Vous mettez à niveau l’ID <0>{identityNumber}</0>"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "Vous pouvez la rajouter à tout moment en vous reconnectant avec le même compte {openIdProvider}."
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr ""
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Vous pouvez la rajouter à tout moment en vous reconnectant avec la même passkey."
 

--- a/src/frontend/src/lib/locales/fr.po
+++ b/src/frontend/src/lib/locales/fr.po
@@ -1248,10 +1248,7 @@ msgstr "Vous avez déjà un compte {name} lié"
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Vous mettez à niveau l’ID <0>{identityNumber}</0>"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "Vous pouvez la rajouter à tout moment en vous reconnectant avec le même compte {openIdProvider}."
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
 msgstr ""
 
 msgid "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/fr.po
+++ b/src/frontend/src/lib/locales/fr.po
@@ -1249,7 +1249,7 @@ msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Vous mettez à niveau l’ID <0>{identityNumber}</0>"
 
 msgid "You can add it back anytime by signing in with the same {provider} account."
-msgstr ""
+msgstr "Vous pouvez la rajouter à tout moment en vous reconnectant avec le même compte {provider}."
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Vous pouvez la rajouter à tout moment en vous reconnectant avec la même passkey."

--- a/src/frontend/src/lib/locales/id.po
+++ b/src/frontend/src/lib/locales/id.po
@@ -1251,6 +1251,9 @@ msgstr "Anda sedang meningkatkan ID <0>{identityNumber}</0>"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "Anda dapat menambahkannya kembali kapan saja dengan masuk menggunakan akun {openIdProvider} yang sama."
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr ""
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Anda dapat menambahkannya kembali kapan saja dengan masuk menggunakan passkey yang sama."
 

--- a/src/frontend/src/lib/locales/id.po
+++ b/src/frontend/src/lib/locales/id.po
@@ -1249,7 +1249,7 @@ msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Anda sedang meningkatkan ID <0>{identityNumber}</0>"
 
 msgid "You can add it back anytime by signing in with the same {provider} account."
-msgstr ""
+msgstr "Anda dapat menambahkannya kembali kapan saja dengan masuk menggunakan akun {provider} yang sama."
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Anda dapat menambahkannya kembali kapan saja dengan masuk menggunakan passkey yang sama."

--- a/src/frontend/src/lib/locales/id.po
+++ b/src/frontend/src/lib/locales/id.po
@@ -1248,10 +1248,7 @@ msgstr "Anda sudah memiliki akun {name} yang tertaut"
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Anda sedang meningkatkan ID <0>{identityNumber}</0>"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "Anda dapat menambahkannya kembali kapan saja dengan masuk menggunakan akun {openIdProvider} yang sama."
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
 msgstr ""
 
 msgid "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/it.po
+++ b/src/frontend/src/lib/locales/it.po
@@ -1248,10 +1248,7 @@ msgstr "Hai già un account {name} collegato"
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Stai aggiornando l'ID <0>{identityNumber}</0>"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "Puoi aggiungerla di nuovo in qualsiasi momento accedendo con lo stesso account {openIdProvider}."
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
 msgstr ""
 
 msgid "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/it.po
+++ b/src/frontend/src/lib/locales/it.po
@@ -1249,7 +1249,7 @@ msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Stai aggiornando l'ID <0>{identityNumber}</0>"
 
 msgid "You can add it back anytime by signing in with the same {provider} account."
-msgstr ""
+msgstr "Puoi aggiungerla di nuovo in qualsiasi momento accedendo con lo stesso account {provider}."
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Puoi aggiungerla di nuovo in qualsiasi momento accedendo con la stessa passkey."

--- a/src/frontend/src/lib/locales/it.po
+++ b/src/frontend/src/lib/locales/it.po
@@ -1251,6 +1251,9 @@ msgstr "Stai aggiornando l'ID <0>{identityNumber}</0>"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "Puoi aggiungerla di nuovo in qualsiasi momento accedendo con lo stesso account {openIdProvider}."
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr ""
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Puoi aggiungerla di nuovo in qualsiasi momento accedendo con la stessa passkey."
 

--- a/src/frontend/src/lib/locales/nl.po
+++ b/src/frontend/src/lib/locales/nl.po
@@ -1248,10 +1248,7 @@ msgstr "U heeft al een {name}-account gekoppeld"
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "U upgrade ID <0>{identityNumber}</0>"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "U kunt het op elk moment weer toevoegen door in te loggen met hetzelfde {openIdProvider}-account."
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
 msgstr ""
 
 msgid "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/nl.po
+++ b/src/frontend/src/lib/locales/nl.po
@@ -1251,6 +1251,9 @@ msgstr "U upgrade ID <0>{identityNumber}</0>"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "U kunt het op elk moment weer toevoegen door in te loggen met hetzelfde {openIdProvider}-account."
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr ""
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "U kunt het op elk moment weer toevoegen door in te loggen met dezelfde passkey."
 

--- a/src/frontend/src/lib/locales/nl.po
+++ b/src/frontend/src/lib/locales/nl.po
@@ -1249,7 +1249,7 @@ msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "U upgrade ID <0>{identityNumber}</0>"
 
 msgid "You can add it back anytime by signing in with the same {provider} account."
-msgstr ""
+msgstr "U kunt het op elk moment weer toevoegen door in te loggen met hetzelfde {provider}-account."
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "U kunt het op elk moment weer toevoegen door in te loggen met dezelfde passkey."

--- a/src/frontend/src/lib/locales/pl.po
+++ b/src/frontend/src/lib/locales/pl.po
@@ -1248,10 +1248,7 @@ msgstr "Masz już połączone konto {name}"
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Aktualizujesz ID <0>{identityNumber}</0>"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "Możesz ją dodać z powrotem w dowolnym momencie, logując się tym samym kontem {openIdProvider}."
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
 msgstr ""
 
 msgid "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/pl.po
+++ b/src/frontend/src/lib/locales/pl.po
@@ -1251,6 +1251,9 @@ msgstr "Aktualizujesz ID <0>{identityNumber}</0>"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "Możesz ją dodać z powrotem w dowolnym momencie, logując się tym samym kontem {openIdProvider}."
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr ""
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Możesz ją dodać z powrotem w dowolnym momencie, logując się tym samym kluczem dostępu."
 

--- a/src/frontend/src/lib/locales/pl.po
+++ b/src/frontend/src/lib/locales/pl.po
@@ -1249,7 +1249,7 @@ msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Aktualizujesz ID <0>{identityNumber}</0>"
 
 msgid "You can add it back anytime by signing in with the same {provider} account."
-msgstr ""
+msgstr "Możesz ją dodać z powrotem w dowolnym momencie, logując się tym samym kontem {provider}."
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Możesz ją dodać z powrotem w dowolnym momencie, logując się tym samym kluczem dostępu."

--- a/src/frontend/src/lib/locales/ru.po
+++ b/src/frontend/src/lib/locales/ru.po
@@ -1251,6 +1251,9 @@ msgstr "Вы обновляете ID <0>{identityNumber}</0>"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "Всегда можно вернуть, снова войдя с тем же аккаунтом {openIdProvider}."
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr ""
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Всегда можно вернуть, снова войдя с тем же ключом доступа."
 

--- a/src/frontend/src/lib/locales/ru.po
+++ b/src/frontend/src/lib/locales/ru.po
@@ -1249,7 +1249,7 @@ msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Вы обновляете ID <0>{identityNumber}</0>"
 
 msgid "You can add it back anytime by signing in with the same {provider} account."
-msgstr ""
+msgstr "Всегда можно вернуть, снова войдя с тем же аккаунтом {provider}."
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Всегда можно вернуть, снова войдя с тем же ключом доступа."

--- a/src/frontend/src/lib/locales/ru.po
+++ b/src/frontend/src/lib/locales/ru.po
@@ -1248,10 +1248,7 @@ msgstr "У вас уже есть связанный аккаунт {name}"
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Вы обновляете ID <0>{identityNumber}</0>"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "Всегда можно вернуть, снова войдя с тем же аккаунтом {openIdProvider}."
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
 msgstr ""
 
 msgid "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/uk.po
+++ b/src/frontend/src/lib/locales/uk.po
@@ -1248,10 +1248,7 @@ msgstr "Ви вже маєте пов'язаний обліковий запис
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Ви оновлюєте ID <0>{identityNumber}</0>"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "Ви можете додати її знову будь-коли, увійшовши з тим самим обліковим записом {openIdProvider}."
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
 msgstr ""
 
 msgid "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/uk.po
+++ b/src/frontend/src/lib/locales/uk.po
@@ -1251,6 +1251,9 @@ msgstr "Ви оновлюєте ID <0>{identityNumber}</0>"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "Ви можете додати її знову будь-коли, увійшовши з тим самим обліковим записом {openIdProvider}."
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr ""
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Ви можете додати її знову будь-коли, увійшовши з тим самим ключем доступу."
 

--- a/src/frontend/src/lib/locales/uk.po
+++ b/src/frontend/src/lib/locales/uk.po
@@ -1249,7 +1249,7 @@ msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "Ви оновлюєте ID <0>{identityNumber}</0>"
 
 msgid "You can add it back anytime by signing in with the same {provider} account."
-msgstr ""
+msgstr "Ви можете додати її знову будь-коли, увійшовши з тим самим обліковим записом {provider}."
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "Ви можете додати її знову будь-коли, увійшовши з тим самим ключем доступу."

--- a/src/frontend/src/lib/locales/ur.po
+++ b/src/frontend/src/lib/locales/ur.po
@@ -1249,7 +1249,7 @@ msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "آپ ID <0>{identityNumber}</0> کو اپ گریڈ کر رہے ہیں"
 
 msgid "You can add it back anytime by signing in with the same {provider} account."
-msgstr ""
+msgstr "آپ اسی {provider} اکاؤنٹ سے سائن اِن کر کے اسے کسی بھی وقت واپس شامل کر سکتے ہیں۔"
 
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "آپ اسی پاس کی سے سائن اِن کر کے اسے کسی بھی وقت واپس شامل کر سکتے ہیں۔"

--- a/src/frontend/src/lib/locales/ur.po
+++ b/src/frontend/src/lib/locales/ur.po
@@ -1248,10 +1248,7 @@ msgstr "آپ کا پہلے ہی ایک {name} اکاؤنٹ منسلک ہے"
 msgid "You are upgrading ID <0>{identityNumber}</0>"
 msgstr "آپ ID <0>{identityNumber}</0> کو اپ گریڈ کر رہے ہیں"
 
-msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
-msgstr "آپ اسی {openIdProvider} اکاؤنٹ سے سائن اِن کر کے اسے کسی بھی وقت واپس شامل کر سکتے ہیں۔"
-
-msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgid "You can add it back anytime by signing in with the same {provider} account."
 msgstr ""
 
 msgid "You can add it back anytime by signing in with the same passkey."

--- a/src/frontend/src/lib/locales/ur.po
+++ b/src/frontend/src/lib/locales/ur.po
@@ -1251,6 +1251,9 @@ msgstr "آپ ID <0>{identityNumber}</0> کو اپ گریڈ کر رہے ہیں"
 msgid "You can add it back anytime by signing in with the same {openIdProvider} account."
 msgstr "آپ اسی {openIdProvider} اکاؤنٹ سے سائن اِن کر کے اسے کسی بھی وقت واپس شامل کر سکتے ہیں۔"
 
+msgid "You can add it back anytime by signing in with the same {ssoProvider} SSO."
+msgstr ""
+
 msgid "You can add it back anytime by signing in with the same passkey."
 msgstr "آپ اسی پاس کی سے سائن اِن کر کے اسے کسی بھی وقت واپس شامل کر سکتے ہیں۔"
 

--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -31,6 +31,23 @@ export type LastUsedIdentity = {
           loginHint?: string;
           metadata?: MetadataMapV2;
         };
+      }
+    | {
+        // SSO credentials are resolved via the two-hop discovery chain
+        // (`add_discoverable_oidc_config` + `discoverSsoConfig`), not via
+        // the static `openid_configs` list — so we only need the discovery
+        // domain (and the optional friendly name from hop 1) to rebuild
+        // the request config at sign-in time. `iss`/`sub` aren't stored
+        // because a fresh JWT gives us new ones on every re-auth.
+        // `email` (when the IdP publishes one) is kept purely for the
+        // identity row's secondary text — display fallback is
+        // email → name → domain.
+        sso: {
+          domain: string;
+          name?: string;
+          email?: string;
+          loginHint?: string;
+        };
       };
   accounts?: LastUsedAccounts;
   lastUsedTimestampMillis: number;
@@ -75,7 +92,7 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
   const lastUsedStore = writableStored<LastUsedIdentities>({
     key: storeLocalStorageKey.LastUsedIdentities,
     defaultValue: {},
-    version: 4,
+    version: 5,
   });
   const selectedStore = writable<bigint | undefined>(
     Object.values(get(lastUsedStore)).sort(

--- a/src/frontend/src/lib/utils/openID.ts
+++ b/src/frontend/src/lib/utils/openID.ts
@@ -195,15 +195,40 @@ export const extractIdTokenFromCallback = (
 };
 
 /**
- * Request JWT through redirect flow in a popup
- * @param config of the OpenID provider
- * @param options for the JWT request
+ * Request JWT through the redirect flow in a popup.
+ *
+ * Accepts either:
+ * - A `RequestConfig`: redirect URL is built synchronously and the popup
+ *   navigates straight to the IdP. Used by the standard flows where the
+ *   provider config is already in hand at click time.
+ * - A `Promise<RequestConfig>`: popup is opened to `about:blank`
+ *   synchronously (so the user-activation token is consumed before any
+ *   `await` — Safari blocks `window.open` after one), then navigated to
+ *   the IdP once the config resolves. Used by callers that need an async
+ *   step (e.g. SSO two-hop discovery) before the URL is known.
  */
-const requestWithPopup = async (
-  config: Omit<RequestConfig, "configURL">,
+export const requestWithPopup = async (
+  configOrPromise:
+    | Omit<RequestConfig, "configURL">
+    | Promise<Omit<RequestConfig, "configURL">>,
   options: RequestOptions,
 ): Promise<string> => {
-  const redirectURL = createRedirectURL(config, options);
+  if (configOrPromise instanceof Promise) {
+    // Capture the redirect URL's `state` from inside the promise chain so
+    // we can verify it against the callback once the popup posts back.
+    let capturedState: string | undefined;
+    const urlPromise = configOrPromise.then((config) => {
+      const redirectURL = createRedirectURL(config, options);
+      capturedState = redirectURL.searchParams.get("state") ?? undefined;
+      return redirectURL.href;
+    });
+    const callback = await redirectInPopup(urlPromise);
+    if (capturedState === undefined) {
+      throw new Error("Missing state in redirect URL");
+    }
+    return extractIdTokenFromCallback(callback, capturedState);
+  }
+  const redirectURL = createRedirectURL(configOrPromise, options);
   const callback = await redirectInPopup(redirectURL.href);
   const expectedState = redirectURL.searchParams.get("state");
   if (expectedState === null) {

--- a/src/frontend/src/routes/(new-styling)/callback/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/callback/utils.ts
@@ -3,13 +3,35 @@ export const REDIRECT_CALLBACK_PATH = "/callback";
 
 export class CallbackPopupClosedError extends Error {}
 
-export const redirectInPopup = (url: string): Promise<string> => {
+/**
+ * Open a popup that round-trips through an OAuth provider and resolves with
+ * the callback URL.
+ *
+ * Accepts either:
+ * - A `string` URL: navigated to immediately. Used by the synchronous flows
+ *   where the redirect URL is known at click time.
+ * - A `Promise<string>`: the popup is opened to `about:blank` first
+ *   (synchronously, to consume the user-activation token before any
+ *   `await` — Safari blocks `window.open` after an awaited Promise),
+ *   then navigated once the URL resolves. Used for flows that need an
+ *   async step (e.g. SSO two-hop discovery) before the redirect URL is
+ *   known. If the promise rejects, the popup is closed and the outer
+ *   promise rejects with the same error.
+ */
+export const redirectInPopup = (
+  url: string | Promise<string>,
+): Promise<string> => {
   const width = 500;
   const height = 600;
   const left = (window.innerWidth - width) / 2 + window.screenX;
   const top = (window.innerHeight - height) / 2 + window.screenY;
+  // For deferred URLs, open about:blank synchronously so we don't lose
+  // the user-activation token — same-origin (inherited), so we can later
+  // navigate via `redirectWindow.location.href = ...` even though we'll
+  // end up on a cross-origin IdP.
+  const initialUrl = typeof url === "string" ? url : "about:blank";
   const redirectWindow = window.open(
-    url,
+    initialUrl,
     "_blank",
     `width=${width},height=${height},left=${left},top=${top}`,
   );
@@ -44,6 +66,23 @@ export const redirectInPopup = (url: string): Promise<string> => {
       cleanup();
       resolve(event.data);
     });
+
+    if (typeof url !== "string") {
+      url.then(
+        (resolvedUrl) => {
+          // The user may have closed the popup or the close-poller may have
+          // already rejected during the await — `closed` covers both.
+          if (redirectWindow.closed) {
+            return;
+          }
+          redirectWindow.location.href = resolvedUrl;
+        },
+        (error: unknown) => {
+          cleanup();
+          reject(error);
+        },
+      );
+    }
   });
 };
 

--- a/src/frontend/tests/e2e-playwright/routes/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/index.spec.ts
@@ -313,6 +313,135 @@ test.describe("First visit", () => {
       ).toBeVisible();
     });
   });
+
+  // Sign-in (not sign-up) tests: the OpenID/SSO user already exists in II
+  // because we go through the sign-up flow first, then clear localStorage
+  // so the next attempt looks like a "first visit" (no last-used row).
+  // The canister recognises the (iss, sub) tuple from the JWT and signs
+  // the user in directly — no name prompt.
+  test.describe("OpenID existing user", () => {
+    const name = "John Doe";
+
+    test.use({
+      openIdConfig: {
+        createUsers: [
+          {
+            claims: { name },
+          },
+        ],
+      },
+    });
+
+    test("Sign in with OpenID", async ({
+      page,
+      managePage,
+      signInWithOpenId,
+      openIdUsers,
+    }) => {
+      // Sign up first so the user exists in II.
+      await page.goto(II_URL);
+      await page.getByRole("button", { name: "Sign in" }).click();
+      const signUpPopupPromise = page.context().waitForEvent("page");
+      await page
+        .getByRole("button", { name: openIdUsers[0].issuer.name })
+        .click();
+      const signUpPopup = await signUpPopupPromise;
+      const signUpClosePromise = signUpPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(signUpPopup, openIdUsers[0].id);
+      await signUpClosePromise;
+      await page.waitForURL(II_URL + "/manage");
+
+      // Wipe localStorage AND IdP cookies so the second flow is fully
+      // fresh: no last-used row on the landing page, and the IdP can't
+      // silently reuse the sign-up session and skip the login prompt.
+      await managePage.signOut();
+      await page.evaluate(() => window.localStorage.clear());
+      await page.context().clearCookies();
+      await page.goto(II_URL);
+
+      // Sign in via OpenID — same (iss, sub), so we should jump straight
+      // to /manage without a name prompt.
+      await page.getByRole("button", { name: "Sign in" }).click();
+      const signInPopupPromise = page.context().waitForEvent("page");
+      await page
+        .getByRole("button", { name: openIdUsers[0].issuer.name })
+        .click();
+      const signInPopup = await signInPopupPromise;
+      const signInClosePromise = signInPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(signInPopup, openIdUsers[0].id);
+      await signInClosePromise;
+
+      await page.waitForURL(II_URL + "/manage");
+      await expect(
+        page.getByRole("heading", {
+          name: new RegExp(`Welcome, ${name}!`),
+        }),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("SSO existing user", () => {
+    const name = "John Doe";
+
+    test.use({
+      openIdConfig: {
+        defaultPort: SSO_OPENID_PORT,
+        createUsers: [
+          {
+            claims: { name },
+          },
+        ],
+      },
+    });
+
+    test("Sign in with SSO", async ({
+      page,
+      managePage,
+      openSsoPopup,
+      signInWithOpenId,
+      openIdUsers,
+    }) => {
+      // Sign up first so the user exists in II.
+      await page.goto(II_URL);
+      await page.getByRole("button", { name: "Sign in" }).click();
+      const signUpPopup = await openSsoPopup(page);
+      const signUpClosePromise = signUpPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(signUpPopup, openIdUsers[0].id);
+      await signUpClosePromise;
+      await page.waitForURL(II_URL + "/manage");
+
+      // Wipe localStorage AND IdP cookies so the second flow is fully
+      // fresh: no last-used row on the landing page, and the IdP can't
+      // silently reuse the sign-up session and skip the login prompt.
+      await managePage.signOut();
+      await page.evaluate(() => window.localStorage.clear());
+      await page.context().clearCookies();
+      await page.goto(II_URL);
+
+      // Sign in via SSO — the user already exists in II so we should
+      // jump straight to /manage without a name prompt.
+      await page.getByRole("button", { name: "Sign in" }).click();
+      const signInPopup = await openSsoPopup(page);
+      const signInClosePromise = signInPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(signInPopup, openIdUsers[0].id);
+      await signInClosePromise;
+
+      await page.waitForURL(II_URL + "/manage");
+      await expect(
+        page.getByRole("heading", {
+          name: new RegExp(`Welcome, ${name}!`),
+        }),
+      ).toBeVisible();
+    });
+  });
 });
 
 test.describe("Last used identities listed", () => {
@@ -381,5 +510,128 @@ test.describe("Last used identities listed", () => {
     await page.getByLabel("Identity name").fill(SECONDARY_USER_NAME);
     await page.getByRole("button", { name: "Create identity" }).click();
     await managePage.assertVisible();
+  });
+
+  // Last-used sign-in for OpenID / SSO: sign up first to populate the
+  // last-used row, sign out, then click "Manage your Internet Identity"
+  // to drive `AuthLastUsedFlow.authenticate` for the matching variant.
+  test.describe("OpenID last used identity", () => {
+    const name = "John Doe";
+
+    test.use({
+      openIdConfig: {
+        createUsers: [
+          {
+            claims: { name },
+          },
+        ],
+      },
+    });
+
+    test("Sign in with last used OpenID identity", async ({
+      page,
+      managePage,
+      signInWithOpenId,
+      openIdUsers,
+    }) => {
+      // Sign up first to populate the last-used entry.
+      await page.goto(II_URL);
+      await page.getByRole("button", { name: "Sign in" }).click();
+      const signUpPopupPromise = page.context().waitForEvent("page");
+      await page
+        .getByRole("button", { name: openIdUsers[0].issuer.name })
+        .click();
+      const signUpPopup = await signUpPopupPromise;
+      const signUpClosePromise = signUpPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(signUpPopup, openIdUsers[0].id);
+      await signUpClosePromise;
+      await page.waitForURL(II_URL + "/manage");
+
+      // Sign out (keeps the last-used entry) and clear IdP cookies so the
+      // re-auth popup actually shows the login UI rather than silently
+      // reusing the sign-up session.
+      await managePage.signOut();
+      await page.context().clearCookies();
+      await page.getByRole("button", { name: "Switch identity" }).click();
+      const signInPopupPromise = page.context().waitForEvent("page");
+      await page
+        .getByRole("button", { name: "Manage your Internet Identity" })
+        .click();
+      const signInPopup = await signInPopupPromise;
+      const signInClosePromise = signInPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(signInPopup, openIdUsers[0].id);
+      await signInClosePromise;
+
+      await page.waitForURL(II_URL + "/manage");
+      await expect(
+        page.getByRole("heading", {
+          name: new RegExp(`Welcome, ${name}!`),
+        }),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("SSO last used identity", () => {
+    const name = "John Doe";
+
+    test.use({
+      openIdConfig: {
+        defaultPort: SSO_OPENID_PORT,
+        createUsers: [
+          {
+            claims: { name },
+          },
+        ],
+      },
+    });
+
+    test("Sign in with last used SSO identity", async ({
+      page,
+      managePage,
+      openSsoPopup,
+      signInWithOpenId,
+      openIdUsers,
+    }) => {
+      // Sign up first to populate the last-used SSO entry.
+      await page.goto(II_URL);
+      await page.getByRole("button", { name: "Sign in" }).click();
+      const signUpPopup = await openSsoPopup(page);
+      const signUpClosePromise = signUpPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(signUpPopup, openIdUsers[0].id);
+      await signUpClosePromise;
+      await page.waitForURL(II_URL + "/manage");
+
+      // Sign out and clear IdP cookies so the re-auth popup actually
+      // shows the login UI rather than silently reusing the sign-up
+      // session, then trigger the last-used SSO path. The popup opens
+      // synchronously to about:blank (so Safari doesn't block it), then
+      // discoverSsoConfig resolves and the popup navigates to the IdP.
+      await managePage.signOut();
+      await page.context().clearCookies();
+      await page.getByRole("button", { name: "Switch identity" }).click();
+      const signInPopupPromise = page.context().waitForEvent("page");
+      await page
+        .getByRole("button", { name: "Manage your Internet Identity" })
+        .click();
+      const signInPopup = await signInPopupPromise;
+      const signInClosePromise = signInPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(signInPopup, openIdUsers[0].id);
+      await signInClosePromise;
+
+      await page.waitForURL(II_URL + "/manage");
+      await expect(
+        page.getByRole("heading", {
+          name: new RegExp(`Welcome, ${name}!`),
+        }),
+      ).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Last-used SSO entries fell back to a direct-provider lookup that doesn't cover SSO providers, so re-signing in via the row threw _\"OpenID authentication is not available for this account.\"_

This PR adds:

- A dedicated \`sso\` \`LastUsedIdentity\` variant that stores the discovery domain (and friendly name + email for the row's secondary text), so the last-used flow re-runs the two-hop discovery chain instead of trying to find the provider in \`openid_configs\`.
- Parallel \`continueWithSso\` / \`completeSsoRegistration\` paths in \`AuthFlow\` so the SSO flow no longer pretends to be a direct-OpenID flow with a synthetic config. The shared JWT-flow / registration-finish primitives stay private and don't leak SSO awareness back into the OpenID methods (or vice versa).
- A \`requestWithPopup(Promise<RequestConfig>)\` overload that opens the popup to \`about:blank\` synchronously (so Safari keeps the user-activation token), runs the two-hop discovery while the popup shows blank, then navigates the popup to the IdP. The direct-OpenID synchronous popup path is unchanged.
- UI updates so identity rows render the SSO icon (not the underlying IdP's logo) and use an \`email -> name -> domain\` fallback for the secondary line; the \"remove from device\" dialog gets an SSO-specific message. \`AuthMethodBadge\` now takes a discriminated variant union so callers can't accidentally combine an IdP logo with the SSO fallback.
- A schema bump (\`writableStored\` version 4 -> 5) for \`LastUsedIdentity\` since the \`sso\` variant is new — existing entries get reset on first load.

## Tests

- New e2e tests in [routes/index.spec.ts](https://github.com/dfinity/internet-identity/blob/main/src/frontend/tests/e2e-playwright/routes/index.spec.ts) covering first-visit and last-used sign-in via both direct OpenID and SSO (4 tests added; all 13 tests in the file pass locally).