### PR TITLE
fix(scripts): use dfx for wallet-routed staging upgrades in release SOP

### DIFF
--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -435,26 +435,30 @@ prepare_staging_frontend_argument() {
 
 deploy_staging_backend() {
   echo "Deploying II backend release candidate to staging"
-  icp canister \
+  # icp-cli's --proxy expects a custom proxy canister exposing a `proxy`
+  # method, which is NOT what a dfx wallet canister implements. Use dfx
+  # here so wallet_call routing keeps working against the existing wallet.
+  dfx canister \
+    --network ic \
+    --wallet cvthj-wyaaa-aaaad-aaaaq-cai \
     install "$STAGING_BACKEND_CANISTER_ID" \
-    -e ic \
-    --proxy cvthj-wyaaa-aaaad-aaaaq-cai \
       --mode upgrade \
       --wasm ./internet_identity.wasm.gz \
-      --args-format bin \
-      --args "$(cat ./staging_icp_arg.bin)"
+      --argument-type raw \
+      --argument "$(cat ./staging_icp_arg.bin)"
 }
 
 deploy_staging_frontend() {
   echo "Deploying II frontend release candidate to staging"
-  icp canister \
+  # See deploy_staging_backend: dfx is used here for wallet-routed upgrades.
+  dfx canister \
+    --network ic \
+    --wallet cvthj-wyaaa-aaaad-aaaaq-cai \
     install "$STAGING_FRONTEND_CANISTER_ID" \
-    -e ic \
-    --proxy cvthj-wyaaa-aaaad-aaaaq-cai \
       --mode upgrade \
       --wasm ./internet_identity_frontend.wasm.gz \
-      --args-format bin \
-      --args "$(cat ./staging_icp_frontend_arg.bin)"
+      --argument-type raw \
+      --argument "$(cat ./staging_icp_frontend_arg.bin)"
 }
 
 test_release_candidate() {


### PR DESCRIPTION
## Summary

The recent dfx -> icp-cli migration mapped \`--wallet\` to \`--proxy\` per the [migration guide](https://cli.internetcomputer.org/0.2/migration/from-dfx.md), but those flags aren't equivalent:

- icp-cli's \`--proxy\` calls a \`proxy\` method on a custom proxy canister.
- A dfx wallet canister exposes \`wallet_call\` / \`wallet_call128\`.

So pointing \`icp canister install --proxy\` at the existing II wallet (\`cvthj-wyaaa-aaaad-aaaaq-cai\`) traps with _\"Canister has no update method 'proxy'\"_, which breaks the staging deploy step of the release SOP — running \`scripts/make-upgrade-proposal\` fails before any proposal is created.

icp-cli has no equivalent for the dfx wallet's \`wallet_call\`, so this PR falls back to dfx for the two staging deploy functions only. The rest of the script stays on icp-cli.