### PR TITLE
chore(fe): add missing translations across all languages

### DIFF
--- a/src/frontend/src/lib/locales/de.po
+++ b/src/frontend/src/lib/locales/de.po
@@ -23,28 +23,28 @@ msgid "{application} has moved to the new Internet Identity"
 msgstr "{application} ist zur neuen Internet Identity umgezogen"
 
 msgid "{attribute}:"
-msgstr ""
+msgstr "{attribute}:"
 
 msgid "{displayName} account"
-msgstr ""
+msgstr "{displayName}-Konto"
 
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
-msgstr ""
+msgstr "{domainInput} hat /.well-known/ii-openid-configuration nicht veröffentlicht (HTTP {0})."
 
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
-msgstr ""
+msgstr "Die /.well-known/ii-openid-configuration von {domainInput} ist fehlerhaft."
 
 msgid "{domainInput}'s SSO app doesn't allow the hybrid OAuth flow II requires. Ask the SSO admin to enable response_type \"id_token code\"."
-msgstr ""
+msgstr "Die SSO-App von {domainInput} erlaubt den hybriden OAuth-Flow nicht, den II benötigt. Bitten Sie den SSO-Administrator, response_type \"id_token code\" zu aktivieren."
 
 msgid "{domainInput}'s SSO denied the sign-in."
-msgstr ""
+msgstr "Das SSO von {domainInput} hat die Anmeldung abgelehnt."
 
 msgid "{domainInput}'s SSO returned \"{0}\": {1}"
-msgstr ""
+msgstr "Das SSO von {domainInput} hat \"{0}\" zurückgegeben: {1}"
 
 msgid "{domainInput}'s SSO returned error \"{0}\"."
-msgstr ""
+msgstr "Das SSO von {domainInput} hat den Fehler \"{0}\" zurückgegeben."
 
 msgid "{identityName} has been removed from this device."
 msgstr "{identityName} wurde von diesem Gerät entfernt."
@@ -56,13 +56,13 @@ msgid "{num, plural, one {# Passkey} other {# Passkeys}}"
 msgstr "{num, plural, one {# Passkey} other {# Passkeys}}"
 
 msgid "{providerName} {attribute}:"
-msgstr ""
+msgstr "{providerName} {attribute}:"
 
 msgid "{providerName} email:"
-msgstr ""
+msgstr "{providerName} E-Mail:"
 
 msgid "{providerName} name:"
-msgstr ""
+msgstr "{providerName} Name:"
 
 msgid "<0>Completely Redesigned Interface:</0> We've given Internet Identity a fresh, modern look and feel. The new design is intuitive and easier to navigate, ensuring a smoother user journey."
 msgstr "<0>Völlig überarbeitetes Interface:</0> Wir haben Internet Identity ein frisches, modernes Erscheinungsbild verliehen. Das neue Design ist intuitiv und einfacher zu bedienen, wodurch die Nutzerführung reibungsloser wird."
@@ -134,7 +134,7 @@ msgid "Advanced identity management"
 msgstr "Erweiterte Identitätsverwaltung"
 
 msgid "Allow to access this info"
-msgstr ""
+msgstr "Zugriff auf diese Informationen erlauben"
 
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
@@ -146,13 +146,13 @@ msgid "As you are currently signed in with this passkey, you will be signed out.
 msgstr "Da Sie derzeit mit diesem Passkey angemeldet sind, werden Sie abgemeldet."
 
 msgid "Attribute sharing failed"
-msgstr ""
+msgstr "Teilen der Attribute fehlgeschlagen"
 
 msgid "Authenticating..."
 msgstr "Authentifizierung..."
 
 msgid "Authentication failed"
-msgstr ""
+msgstr "Authentifizierung fehlgeschlagen"
 
 msgid "Authentication successful"
 msgstr "Authentifizierung erfolgreich"
@@ -161,7 +161,7 @@ msgid "Authorize new device"
 msgstr "Neues Gerät autorisieren"
 
 msgid "Back to sign-in options"
-msgstr ""
+msgstr "Zurück zu den Anmeldeoptionen"
 
 msgid "Before getting started, find a private place and have your recovery phrase ready. Keep it confidential to protect your identity."
 msgstr "Bevor Sie beginnen, suchen Sie sich einen privaten Ort und halten Sie Ihre Wiederherstellungsphrase bereit. Behandeln Sie diese vertraulich, um Ihre Identität zu schützen."
@@ -182,7 +182,7 @@ msgid "CAPTCHA characters"
 msgstr "CAPTCHA-Zeichen"
 
 msgid "Change"
-msgstr ""
+msgstr "Ändern"
 
 msgid "Characters are case-sensitive"
 msgstr "Groß- und Kleinschreibung beachten"
@@ -197,7 +197,7 @@ msgid "Checking your order"
 msgstr "Ihre Reihenfolge wird überprüft"
 
 msgid "Checking..."
-msgstr ""
+msgstr "Wird überprüft..."
 
 msgid "Choose an account"
 msgstr "Wählen Sie ein Konto aus"
@@ -212,7 +212,7 @@ msgid "Choose method to continue"
 msgstr "Methode wählen, um fortzufahren"
 
 msgid "Choose which details you'd like to share"
-msgstr ""
+msgstr "Wählen Sie aus, welche Details Sie teilen möchten"
 
 msgid "Clear all"
 msgstr "Alle löschen"
@@ -230,10 +230,10 @@ msgid "Code copied to clipboard"
 msgstr "Code in die Zwischenablage kopiert"
 
 msgid "Company domain"
-msgstr ""
+msgstr "Unternehmensdomain"
 
 msgid "company.domain.com"
-msgstr ""
+msgstr "unternehmen.domain.de"
 
 msgid "Complete set-up"
 msgstr "Einrichtung abschließen"
@@ -272,10 +272,10 @@ msgid "Continue with passkey"
 msgstr "Mit Passkey fortfahren"
 
 msgid "Continue with SSO"
-msgstr ""
+msgstr "Mit SSO fortfahren"
 
 msgid "Couldn't reach {domainInput}. Check the spelling and your network."
-msgstr ""
+msgstr "{domainInput} konnte nicht erreicht werden. Überprüfen Sie die Schreibweise und Ihre Netzwerkverbindung."
 
 msgid "Create account"
 msgstr "Konto erstellen"
@@ -320,7 +320,7 @@ msgid "Default"
 msgstr "Standard"
 
 msgid "Deny All"
-msgstr ""
+msgstr "Alle ablehnen"
 
 msgid "Discoverable passkeys"
 msgstr "Auffindbare Passkeys"
@@ -344,7 +344,7 @@ msgid "Edit account"
 msgstr "Konto bearbeiten"
 
 msgid "Email:"
-msgstr ""
+msgstr "E-Mail:"
 
 msgid "Enable multiple accounts"
 msgstr "Mehrere Konten aktivieren"
@@ -362,7 +362,7 @@ msgid "Enter recovery phrase"
 msgstr "Wiederherstellungsphrase eingeben"
 
 msgid "Enter your company domain"
-msgstr ""
+msgstr "Geben Sie Ihre Unternehmensdomain ein"
 
 msgid "Everything you need to know about Internet Identity, your private, secure, and easy way to log in to apps on the Internet Computer."
 msgstr "Alles, was Sie über Internet Identity wissen müssen – Ihre private, sichere und einfache Möglichkeit, sich bei Apps auf dem Internet Computer anzumelden."
@@ -534,7 +534,7 @@ msgid "Invalid code. Please check and try again."
 msgstr "Ungültiger Code. Bitte überprüfen und erneut versuchen."
 
 msgid "Invalid domain"
-msgstr ""
+msgstr "Ungültige Domain"
 
 msgid "Invalid recovery phrase"
 msgstr "Ungültige Wiederherstellungsphrase"
@@ -603,7 +603,7 @@ msgid "Link copied to clipboard"
 msgstr "Link in die Zwischenablage kopiert"
 
 msgid "Loading permissions"
-msgstr ""
+msgstr "Berechtigungen werden geladen"
 
 msgid "Locked legacy recovery phrase"
 msgstr "Gesperrte Legacy-Wiederherstellungsphrase"
@@ -669,7 +669,7 @@ msgid "Name your identity"
 msgstr "Benennen Sie Ihre Identität"
 
 msgid "Name:"
-msgstr ""
+msgstr "Name:"
 
 msgid "No data is shared with Google, Microsoft or Apple on which applications you log in with Internet Identity."
 msgstr "Es werden keine Daten an Google, Microsoft oder Apple darüber weitergegeben, bei welchen Anwendungen Sie sich mit Internet Identity anmelden."
@@ -840,7 +840,7 @@ msgid "Return to application"
 msgstr "Zur Anwendung zurückkehren"
 
 msgid "Review Permissions"
-msgstr ""
+msgstr "Berechtigungen prüfen"
 
 msgid "Right now"
 msgstr "Jetzt gerade"
@@ -879,10 +879,10 @@ msgid "Set as default sign-in"
 msgstr "Als Standardanmeldung festlegen"
 
 msgid "Several SSO sign-ins are in flight already. Wait a moment."
-msgstr ""
+msgstr "Es laufen bereits mehrere SSO-Anmeldungen. Bitte warten Sie einen Moment."
 
 msgid "Share {label}"
-msgstr ""
+msgstr "{label} teilen"
 
 msgid "Show all"
 msgstr "Alle anzeigen"
@@ -903,7 +903,7 @@ msgid "Sign in with another identity"
 msgstr "Mit einer anderen Identität anmelden"
 
 msgid "Sign in with your {displayName} account from any device."
-msgstr ""
+msgstr "Melden Sie sich von jedem Gerät aus mit Ihrem {displayName}-Konto an."
 
 msgid "Sign out"
 msgstr "Abmelden"
@@ -937,22 +937,22 @@ msgid "Something is wrong!"
 msgstr "Etwas stimmt nicht!"
 
 msgid "Something went wrong while creating your delegation. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Beim Erstellen Ihrer Delegation ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut; falls das Problem weiterhin besteht, kontaktieren Sie den Support."
 
 msgid "Something went wrong while sharing attributes. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Beim Teilen der Attribute ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut; falls das Problem weiterhin besteht, kontaktieren Sie den Support."
 
 msgid "Source code"
 msgstr "Quellcode"
 
 msgid "SSO"
-msgstr ""
+msgstr "SSO"
 
 msgid "SSO is not available for \"{domainInput}\" yet. Ask an II admin to register this domain."
-msgstr ""
+msgstr "SSO ist für \"{domainInput}\" noch nicht verfügbar. Bitten Sie einen II-Administrator, diese Domain zu registrieren."
 
 msgid "SSO sign-in for {domainInput} failed. Please try again."
-msgstr ""
+msgstr "Die SSO-Anmeldung für {domainInput} ist fehlgeschlagen. Bitte versuchen Sie es erneut."
 
 msgid "Start over"
 msgstr "Neu starten"
@@ -1033,7 +1033,7 @@ msgid "This app has moved to the new Internet Identity"
 msgstr "Diese App ist zur neuen Internet Identity umgezogen"
 
 msgid "This browser is not supported."
-msgstr ""
+msgstr "Dieser Browser wird nicht unterstützt."
 
 msgid "This identity has already been upgraded to the new experience."
 msgstr "Diese Identität wurde bereits auf die neue Version aktualisiert."
@@ -1048,7 +1048,7 @@ msgid "This passkey is no longer associated with any identity."
 msgstr "Dieser Passkey ist mit keiner Identität mehr verknüpft."
 
 msgid "This SSO is already linked to your identity."
-msgstr ""
+msgstr "Dieses SSO ist bereits mit Ihrer Identität verknüpft."
 
 msgid "This YubiKey has older firmware (5.1) that's incompatible."
 msgstr "Dieser YubiKey hat eine ältere Firmware (5.1), die inkompatibel ist."
@@ -1087,7 +1087,7 @@ msgid "To finish setting up your passkey, follow the instructions shown on your 
 msgstr "Um die Einrichtung Ihres Passkeys abzuschließen, folgen Sie den Anweisungen auf Ihrem <0>neuen Gerät</0>."
 
 msgid "Too many recent attempts for {domainInput}. Wait a few minutes."
-msgstr ""
+msgstr "Zu viele kürzliche Versuche für {domainInput}. Bitte warten Sie einige Minuten."
 
 msgid "Type each word in the correct order:"
 msgstr "Geben Sie jedes Wort in der richtigen Reihenfolge ein:"
@@ -1132,7 +1132,7 @@ msgid "Unsupported"
 msgstr "Nicht unterstützt"
 
 msgid "Unsupported browser"
-msgstr ""
+msgstr "Nicht unterstützter Browser"
 
 msgid "Unsupported Browser"
 msgstr "Nicht unterstützter Browser"

--- a/src/frontend/src/lib/locales/es.po
+++ b/src/frontend/src/lib/locales/es.po
@@ -23,28 +23,28 @@ msgid "{application} has moved to the new Internet Identity"
 msgstr "{application} se ha trasladado al nuevo Internet Identity"
 
 msgid "{attribute}:"
-msgstr ""
+msgstr "{attribute}:"
 
 msgid "{displayName} account"
-msgstr ""
+msgstr "Cuenta de {displayName}"
 
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
-msgstr ""
+msgstr "{domainInput} no publicó /.well-known/ii-openid-configuration (HTTP {0})."
 
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
-msgstr ""
+msgstr "El /.well-known/ii-openid-configuration de {domainInput} está mal formado."
 
 msgid "{domainInput}'s SSO app doesn't allow the hybrid OAuth flow II requires. Ask the SSO admin to enable response_type \"id_token code\"."
-msgstr ""
+msgstr "La app SSO de {domainInput} no permite el flujo OAuth híbrido que II requiere. Pide al administrador de SSO que habilite el response_type \"id_token code\"."
 
 msgid "{domainInput}'s SSO denied the sign-in."
-msgstr ""
+msgstr "El SSO de {domainInput} denegó el inicio de sesión."
 
 msgid "{domainInput}'s SSO returned \"{0}\": {1}"
-msgstr ""
+msgstr "El SSO de {domainInput} devolvió \"{0}\": {1}"
 
 msgid "{domainInput}'s SSO returned error \"{0}\"."
-msgstr ""
+msgstr "El SSO de {domainInput} devolvió el error \"{0}\"."
 
 msgid "{identityName} has been removed from this device."
 msgstr "{identityName} ha sido eliminada de este dispositivo."
@@ -56,13 +56,13 @@ msgid "{num, plural, one {# Passkey} other {# Passkeys}}"
 msgstr "{num, plural, one {# Passkey} other {# Passkeys}}"
 
 msgid "{providerName} {attribute}:"
-msgstr ""
+msgstr "{attribute} de {providerName}:"
 
 msgid "{providerName} email:"
-msgstr ""
+msgstr "Correo electrónico de {providerName}:"
 
 msgid "{providerName} name:"
-msgstr ""
+msgstr "Nombre de {providerName}:"
 
 msgid "<0>Completely Redesigned Interface:</0> We've given Internet Identity a fresh, modern look and feel. The new design is intuitive and easier to navigate, ensuring a smoother user journey."
 msgstr "<0>Interfaz completamente rediseñada:</0> Hemos dado a Internet Identity un aspecto fresco y moderno. El nuevo diseño es intuitivo y más fácil de navegar, garantizando una experiencia de usuario más fluida."
@@ -134,7 +134,7 @@ msgid "Advanced identity management"
 msgstr "Gestión avanzada de identidad"
 
 msgid "Allow to access this info"
-msgstr ""
+msgstr "Permitir el acceso a esta información"
 
 msgid "Are you sure?"
 msgstr "¿Estás seguro?"
@@ -146,13 +146,13 @@ msgid "As you are currently signed in with this passkey, you will be signed out.
 msgstr "Como has iniciado sesión con esta passkey, se cerrará la sesión."
 
 msgid "Attribute sharing failed"
-msgstr ""
+msgstr "Falló el intercambio de atributos"
 
 msgid "Authenticating..."
 msgstr "Autenticando..."
 
 msgid "Authentication failed"
-msgstr ""
+msgstr "Autenticación fallida"
 
 msgid "Authentication successful"
 msgstr "Autenticación correcta"
@@ -161,7 +161,7 @@ msgid "Authorize new device"
 msgstr "Autorizar nuevo dispositivo"
 
 msgid "Back to sign-in options"
-msgstr ""
+msgstr "Volver a las opciones de inicio de sesión"
 
 msgid "Before getting started, find a private place and have your recovery phrase ready. Keep it confidential to protect your identity."
 msgstr "Antes de empezar, busca un lugar privado y ten preparada tu frase de recuperación. Mantenla en secreto para proteger tu identidad."
@@ -182,7 +182,7 @@ msgid "CAPTCHA characters"
 msgstr "Caracteres del CAPTCHA"
 
 msgid "Change"
-msgstr ""
+msgstr "Cambiar"
 
 msgid "Characters are case-sensitive"
 msgstr "Distingue mayúsculas y minúsculas"
@@ -197,7 +197,7 @@ msgid "Checking your order"
 msgstr "Comprobando tu pedido"
 
 msgid "Checking..."
-msgstr ""
+msgstr "Comprobando..."
 
 msgid "Choose an account"
 msgstr "Elige una cuenta"
@@ -212,7 +212,7 @@ msgid "Choose method to continue"
 msgstr "Elige un método para continuar"
 
 msgid "Choose which details you'd like to share"
-msgstr ""
+msgstr "Elige qué datos quieres compartir"
 
 msgid "Clear all"
 msgstr "Borrar todo"
@@ -230,10 +230,10 @@ msgid "Code copied to clipboard"
 msgstr "Código copiado al portapapeles"
 
 msgid "Company domain"
-msgstr ""
+msgstr "Dominio de la empresa"
 
 msgid "company.domain.com"
-msgstr ""
+msgstr "empresa.dominio.com"
 
 msgid "Complete set-up"
 msgstr "Completar configuración"
@@ -272,10 +272,10 @@ msgid "Continue with passkey"
 msgstr "Continuar con passkey"
 
 msgid "Continue with SSO"
-msgstr ""
+msgstr "Continuar con SSO"
 
 msgid "Couldn't reach {domainInput}. Check the spelling and your network."
-msgstr ""
+msgstr "No se pudo conectar con {domainInput}. Comprueba la ortografía y tu red."
 
 msgid "Create account"
 msgstr "Crear cuenta"
@@ -320,7 +320,7 @@ msgid "Default"
 msgstr "Predeterminada"
 
 msgid "Deny All"
-msgstr ""
+msgstr "Denegar todo"
 
 msgid "Discoverable passkeys"
 msgstr "Passkeys detectables"
@@ -344,7 +344,7 @@ msgid "Edit account"
 msgstr "Editar cuenta"
 
 msgid "Email:"
-msgstr ""
+msgstr "Correo electrónico:"
 
 msgid "Enable multiple accounts"
 msgstr "Activar cuentas múltiples"
@@ -362,7 +362,7 @@ msgid "Enter recovery phrase"
 msgstr "Introduce la frase de recuperación"
 
 msgid "Enter your company domain"
-msgstr ""
+msgstr "Introduce el dominio de tu empresa"
 
 msgid "Everything you need to know about Internet Identity, your private, secure, and easy way to log in to apps on the Internet Computer."
 msgstr "Todo lo que necesitas saber sobre Internet Identity, tu forma privada, segura y sencilla de iniciar sesión en aplicaciones de Internet Computer."
@@ -534,7 +534,7 @@ msgid "Invalid code. Please check and try again."
 msgstr "Código inválido. Por favor, comprueba y vuelve a intentarlo."
 
 msgid "Invalid domain"
-msgstr ""
+msgstr "Dominio no válido"
 
 msgid "Invalid recovery phrase"
 msgstr "Frase de recuperación no válida"
@@ -603,7 +603,7 @@ msgid "Link copied to clipboard"
 msgstr "Enlace copiado al portapapeles"
 
 msgid "Loading permissions"
-msgstr ""
+msgstr "Cargando permisos"
 
 msgid "Locked legacy recovery phrase"
 msgstr "Frase de recuperación de legado bloqueada"
@@ -669,7 +669,7 @@ msgid "Name your identity"
 msgstr "Nombra tu identidad"
 
 msgid "Name:"
-msgstr ""
+msgstr "Nombre:"
 
 msgid "No data is shared with Google, Microsoft or Apple on which applications you log in with Internet Identity."
 msgstr "No se comparten datos con Google, Microsoft o Apple sobre en qué aplicaciones inicias sesión con Internet Identity."
@@ -840,7 +840,7 @@ msgid "Return to application"
 msgstr "Volver a la aplicación"
 
 msgid "Review Permissions"
-msgstr ""
+msgstr "Revisar permisos"
 
 msgid "Right now"
 msgstr "Ahora mismo"
@@ -879,10 +879,10 @@ msgid "Set as default sign-in"
 msgstr "Establecer como inicio de sesión predeterminado"
 
 msgid "Several SSO sign-ins are in flight already. Wait a moment."
-msgstr ""
+msgstr "Ya hay varios inicios de sesión SSO en curso. Espera un momento."
 
 msgid "Share {label}"
-msgstr ""
+msgstr "Compartir {label}"
 
 msgid "Show all"
 msgstr "Mostrar todo"
@@ -903,7 +903,7 @@ msgid "Sign in with another identity"
 msgstr "Iniciar sesión con otra identidad"
 
 msgid "Sign in with your {displayName} account from any device."
-msgstr ""
+msgstr "Inicia sesión con tu cuenta de {displayName} desde cualquier dispositivo."
 
 msgid "Sign out"
 msgstr "Cerrar sesión"
@@ -937,22 +937,22 @@ msgid "Something is wrong!"
 msgstr "¡Algo va mal!"
 
 msgid "Something went wrong while creating your delegation. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Algo salió mal al crear tu delegación. Por favor, inténtalo de nuevo; si el problema persiste, contacta con el soporte."
 
 msgid "Something went wrong while sharing attributes. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Algo salió mal al compartir los atributos. Por favor, inténtalo de nuevo; si el problema persiste, contacta con el soporte."
 
 msgid "Source code"
 msgstr "Código fuente"
 
 msgid "SSO"
-msgstr ""
+msgstr "SSO"
 
 msgid "SSO is not available for \"{domainInput}\" yet. Ask an II admin to register this domain."
-msgstr ""
+msgstr "SSO aún no está disponible para \"{domainInput}\". Pide a un administrador de II que registre este dominio."
 
 msgid "SSO sign-in for {domainInput} failed. Please try again."
-msgstr ""
+msgstr "Falló el inicio de sesión SSO para {domainInput}. Por favor, inténtalo de nuevo."
 
 msgid "Start over"
 msgstr "Empezar de nuevo"
@@ -1033,7 +1033,7 @@ msgid "This app has moved to the new Internet Identity"
 msgstr "Esta app se ha trasladado al nuevo Internet Identity"
 
 msgid "This browser is not supported."
-msgstr ""
+msgstr "Este navegador no es compatible."
 
 msgid "This identity has already been upgraded to the new experience."
 msgstr "Esta identidad ya ha sido actualizada a la nueva experiencia."
@@ -1048,7 +1048,7 @@ msgid "This passkey is no longer associated with any identity."
 msgstr "Esta passkey ya no está asociada a ninguna identidad."
 
 msgid "This SSO is already linked to your identity."
-msgstr ""
+msgstr "Este SSO ya está vinculado a tu identidad."
 
 msgid "This YubiKey has older firmware (5.1) that's incompatible."
 msgstr "Esta YubiKey tiene un firmware antiguo (5.1) que es incompatible."
@@ -1087,7 +1087,7 @@ msgid "To finish setting up your passkey, follow the instructions shown on your 
 msgstr "Para terminar de configurar tu passkey, sigue las instrucciones que aparecen en tu <0>nuevo dispositivo</0>."
 
 msgid "Too many recent attempts for {domainInput}. Wait a few minutes."
-msgstr ""
+msgstr "Demasiados intentos recientes para {domainInput}. Espera unos minutos."
 
 msgid "Type each word in the correct order:"
 msgstr "Escribe cada palabra en el orden correcto:"
@@ -1132,7 +1132,7 @@ msgid "Unsupported"
 msgstr "No compatible"
 
 msgid "Unsupported browser"
-msgstr ""
+msgstr "Navegador no compatible"
 
 msgid "Unsupported Browser"
 msgstr "Navegador no compatible"

--- a/src/frontend/src/lib/locales/fr.po
+++ b/src/frontend/src/lib/locales/fr.po
@@ -23,28 +23,28 @@ msgid "{application} has moved to the new Internet Identity"
 msgstr "{application} est passé à la nouvelle Internet Identity"
 
 msgid "{attribute}:"
-msgstr ""
+msgstr "{attribute} :"
 
 msgid "{displayName} account"
-msgstr ""
+msgstr "Compte {displayName}"
 
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
-msgstr ""
+msgstr "{domainInput} n’a pas publié /.well-known/ii-openid-configuration (HTTP {0})."
 
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
-msgstr ""
+msgstr "Le fichier /.well-known/ii-openid-configuration de {domainInput} est mal formé."
 
 msgid "{domainInput}'s SSO app doesn't allow the hybrid OAuth flow II requires. Ask the SSO admin to enable response_type \"id_token code\"."
-msgstr ""
+msgstr "L’application SSO de {domainInput} n’autorise pas le flux OAuth hybride requis par II. Demandez à l’administrateur SSO d’activer le response_type « id_token code »."
 
 msgid "{domainInput}'s SSO denied the sign-in."
-msgstr ""
+msgstr "Le SSO de {domainInput} a refusé la connexion."
 
 msgid "{domainInput}'s SSO returned \"{0}\": {1}"
-msgstr ""
+msgstr "Le SSO de {domainInput} a renvoyé « {0} » : {1}"
 
 msgid "{domainInput}'s SSO returned error \"{0}\"."
-msgstr ""
+msgstr "Le SSO de {domainInput} a renvoyé l’erreur « {0} »."
 
 msgid "{identityName} has been removed from this device."
 msgstr "{identityName} a été supprimée de cet appareil."
@@ -56,13 +56,13 @@ msgid "{num, plural, one {# Passkey} other {# Passkeys}}"
 msgstr "{num, plural, one {# passkey} other {# passkeys}}"
 
 msgid "{providerName} {attribute}:"
-msgstr ""
+msgstr "{attribute} {providerName} :"
 
 msgid "{providerName} email:"
-msgstr ""
+msgstr "Adresse e-mail {providerName} :"
 
 msgid "{providerName} name:"
-msgstr ""
+msgstr "Nom {providerName} :"
 
 msgid "<0>Completely Redesigned Interface:</0> We've given Internet Identity a fresh, modern look and feel. The new design is intuitive and easier to navigate, ensuring a smoother user journey."
 msgstr "<0>Interface entièrement repensée :</0> Nous avons donné à Internet Identity une apparence moderne et renouvelée. Le nouveau design est intuitif et plus facile à parcourir, garantissant une expérience utilisateur plus fluide."
@@ -134,7 +134,7 @@ msgid "Advanced identity management"
 msgstr "Gestion avancée de l’identité"
 
 msgid "Allow to access this info"
-msgstr ""
+msgstr "Autoriser l’accès à ces informations"
 
 msgid "Are you sure?"
 msgstr "Êtes-vous sûr ?"
@@ -146,13 +146,13 @@ msgid "As you are currently signed in with this passkey, you will be signed out.
 msgstr "Comme vous êtes actuellement connecté avec cette passkey, vous allez être déconnecté."
 
 msgid "Attribute sharing failed"
-msgstr ""
+msgstr "Échec du partage des attributs"
 
 msgid "Authenticating..."
 msgstr "Authentification en cours..."
 
 msgid "Authentication failed"
-msgstr ""
+msgstr "Échec de l’authentification"
 
 msgid "Authentication successful"
 msgstr "Authentification réussie"
@@ -161,7 +161,7 @@ msgid "Authorize new device"
 msgstr "Autoriser un nouvel appareil"
 
 msgid "Back to sign-in options"
-msgstr ""
+msgstr "Retour aux options de connexion"
 
 msgid "Before getting started, find a private place and have your recovery phrase ready. Keep it confidential to protect your identity."
 msgstr "Avant de commencer, trouvez un endroit privé et préparez votre phrase de récupération. Gardez-la confidentielle pour protéger votre identité."
@@ -182,7 +182,7 @@ msgid "CAPTCHA characters"
 msgstr "Caractères CAPTCHA"
 
 msgid "Change"
-msgstr ""
+msgstr "Modifier"
 
 msgid "Characters are case-sensitive"
 msgstr "Respectez les majuscules et minuscules"
@@ -197,7 +197,7 @@ msgid "Checking your order"
 msgstr "Vérification de votre ordre"
 
 msgid "Checking..."
-msgstr ""
+msgstr "Vérification..."
 
 msgid "Choose an account"
 msgstr "Choisissez un compte"
@@ -212,7 +212,7 @@ msgid "Choose method to continue"
 msgstr "Choisissez une méthode pour continuer"
 
 msgid "Choose which details you'd like to share"
-msgstr ""
+msgstr "Choisissez les informations que vous souhaitez partager"
 
 msgid "Clear all"
 msgstr "Tout effacer"
@@ -230,10 +230,10 @@ msgid "Code copied to clipboard"
 msgstr "Code copié dans le presse-papiers"
 
 msgid "Company domain"
-msgstr ""
+msgstr "Domaine de l’entreprise"
 
 msgid "company.domain.com"
-msgstr ""
+msgstr "entreprise.domaine.com"
 
 msgid "Complete set-up"
 msgstr "Configuration terminée"
@@ -272,10 +272,10 @@ msgid "Continue with passkey"
 msgstr "Continuer avec une passkey"
 
 msgid "Continue with SSO"
-msgstr ""
+msgstr "Continuer avec SSO"
 
 msgid "Couldn't reach {domainInput}. Check the spelling and your network."
-msgstr ""
+msgstr "Impossible de joindre {domainInput}. Vérifiez l’orthographe et votre réseau."
 
 msgid "Create account"
 msgstr "Créer un compte"
@@ -320,7 +320,7 @@ msgid "Default"
 msgstr "Par défaut"
 
 msgid "Deny All"
-msgstr ""
+msgstr "Tout refuser"
 
 msgid "Discoverable passkeys"
 msgstr "Passkeys découvrables"
@@ -344,7 +344,7 @@ msgid "Edit account"
 msgstr "Modifier le compte"
 
 msgid "Email:"
-msgstr ""
+msgstr "Adresse e-mail :"
 
 msgid "Enable multiple accounts"
 msgstr "Activer plusieurs comptes"
@@ -362,7 +362,7 @@ msgid "Enter recovery phrase"
 msgstr "Saisir la phrase de récupération"
 
 msgid "Enter your company domain"
-msgstr ""
+msgstr "Saisissez le domaine de votre entreprise"
 
 msgid "Everything you need to know about Internet Identity, your private, secure, and easy way to log in to apps on the Internet Computer."
 msgstr "Tout ce que vous devez savoir sur Internet Identity, votre moyen privé, sécurisé et facile de vous connecter à des applications sur l’Internet Computer."
@@ -534,7 +534,7 @@ msgid "Invalid code. Please check and try again."
 msgstr "Code invalide. Veuillez vérifier et réessayer."
 
 msgid "Invalid domain"
-msgstr ""
+msgstr "Domaine invalide"
 
 msgid "Invalid recovery phrase"
 msgstr "Phrase de récupération invalide"
@@ -603,7 +603,7 @@ msgid "Link copied to clipboard"
 msgstr "Lien copié dans le presse-papiers"
 
 msgid "Loading permissions"
-msgstr ""
+msgstr "Chargement des autorisations"
 
 msgid "Locked legacy recovery phrase"
 msgstr "Ancienne phrase de récupération verrouillée"
@@ -669,7 +669,7 @@ msgid "Name your identity"
 msgstr "Nommez votre identité"
 
 msgid "Name:"
-msgstr ""
+msgstr "Nom :"
 
 msgid "No data is shared with Google, Microsoft or Apple on which applications you log in with Internet Identity."
 msgstr "Aucune donnée n’est partagée avec Google, Microsoft ou Apple concernant les applications auxquelles vous vous connectez avec Internet Identity."
@@ -840,7 +840,7 @@ msgid "Return to application"
 msgstr "Retour à l’application"
 
 msgid "Review Permissions"
-msgstr ""
+msgstr "Vérifier les autorisations"
 
 msgid "Right now"
 msgstr "À l’instant"
@@ -879,10 +879,10 @@ msgid "Set as default sign-in"
 msgstr "Définir comme connexion par défaut"
 
 msgid "Several SSO sign-ins are in flight already. Wait a moment."
-msgstr ""
+msgstr "Plusieurs connexions SSO sont déjà en cours. Veuillez patienter un instant."
 
 msgid "Share {label}"
-msgstr ""
+msgstr "Partager {label}"
 
 msgid "Show all"
 msgstr "Tout afficher"
@@ -903,7 +903,7 @@ msgid "Sign in with another identity"
 msgstr "Se connecter avec une autre identité"
 
 msgid "Sign in with your {displayName} account from any device."
-msgstr ""
+msgstr "Connectez-vous avec votre compte {displayName} depuis n’importe quel appareil."
 
 msgid "Sign out"
 msgstr "Se déconnecter"
@@ -937,22 +937,22 @@ msgid "Something is wrong!"
 msgstr "Incorrect"
 
 msgid "Something went wrong while creating your delegation. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Une erreur est survenue lors de la création de votre délégation. Veuillez réessayer ; si le problème persiste, contactez le support."
 
 msgid "Something went wrong while sharing attributes. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Une erreur est survenue lors du partage des attributs. Veuillez réessayer ; si le problème persiste, contactez le support."
 
 msgid "Source code"
 msgstr "Code source"
 
 msgid "SSO"
-msgstr ""
+msgstr "SSO"
 
 msgid "SSO is not available for \"{domainInput}\" yet. Ask an II admin to register this domain."
-msgstr ""
+msgstr "Le SSO n’est pas encore disponible pour « {domainInput} ». Demandez à un administrateur II d’enregistrer ce domaine."
 
 msgid "SSO sign-in for {domainInput} failed. Please try again."
-msgstr ""
+msgstr "La connexion SSO pour {domainInput} a échoué. Veuillez réessayer."
 
 msgid "Start over"
 msgstr "Recommencer"
@@ -1033,7 +1033,7 @@ msgid "This app has moved to the new Internet Identity"
 msgstr "Cette application est passée à la nouvelle Internet Identity"
 
 msgid "This browser is not supported."
-msgstr ""
+msgstr "Ce navigateur n’est pas pris en charge."
 
 msgid "This identity has already been upgraded to the new experience."
 msgstr "Cette identité a déjà été mise à niveau vers la nouvelle expérience."
@@ -1048,7 +1048,7 @@ msgid "This passkey is no longer associated with any identity."
 msgstr "Cette passkey n’est plus associée à aucune identité."
 
 msgid "This SSO is already linked to your identity."
-msgstr ""
+msgstr "Ce SSO est déjà lié à votre identité."
 
 msgid "This YubiKey has older firmware (5.1) that's incompatible."
 msgstr "Cette YubiKey possède un micrologiciel plus ancien (5.1) qui est incompatible."
@@ -1087,7 +1087,7 @@ msgid "To finish setting up your passkey, follow the instructions shown on your 
 msgstr "Pour terminer la configuration de votre passkey, suivez les instructions affichées sur votre <0>nouvel appareil</0>."
 
 msgid "Too many recent attempts for {domainInput}. Wait a few minutes."
-msgstr ""
+msgstr "Trop de tentatives récentes pour {domainInput}. Veuillez patienter quelques minutes."
 
 msgid "Type each word in the correct order:"
 msgstr "Tapez chaque mot dans le bon ordre :"
@@ -1132,7 +1132,7 @@ msgid "Unsupported"
 msgstr "Non pris en charge"
 
 msgid "Unsupported browser"
-msgstr ""
+msgstr "Navigateur non pris en charge"
 
 msgid "Unsupported Browser"
 msgstr "Navigateur non pris en charge"

--- a/src/frontend/src/lib/locales/id.po
+++ b/src/frontend/src/lib/locales/id.po
@@ -23,28 +23,28 @@ msgid "{application} has moved to the new Internet Identity"
 msgstr "{application} telah pindah ke Internet Identity baru"
 
 msgid "{attribute}:"
-msgstr ""
+msgstr "{attribute}:"
 
 msgid "{displayName} account"
-msgstr ""
+msgstr "Akun {displayName}"
 
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
-msgstr ""
+msgstr "{domainInput} tidak mempublikasikan /.well-known/ii-openid-configuration (HTTP {0})."
 
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
-msgstr ""
+msgstr "/.well-known/ii-openid-configuration milik {domainInput} tidak valid."
 
 msgid "{domainInput}'s SSO app doesn't allow the hybrid OAuth flow II requires. Ask the SSO admin to enable response_type \"id_token code\"."
-msgstr ""
+msgstr "Aplikasi SSO milik {domainInput} tidak mengizinkan alur hybrid OAuth yang dibutuhkan II. Minta admin SSO untuk mengaktifkan response_type \"id_token code\"."
 
 msgid "{domainInput}'s SSO denied the sign-in."
-msgstr ""
+msgstr "SSO milik {domainInput} menolak proses masuk."
 
 msgid "{domainInput}'s SSO returned \"{0}\": {1}"
-msgstr ""
+msgstr "SSO milik {domainInput} mengembalikan \"{0}\": {1}"
 
 msgid "{domainInput}'s SSO returned error \"{0}\"."
-msgstr ""
+msgstr "SSO milik {domainInput} mengembalikan kesalahan \"{0}\"."
 
 msgid "{identityName} has been removed from this device."
 msgstr "{identityName} telah dihapus dari perangkat ini."
@@ -56,13 +56,13 @@ msgid "{num, plural, one {# Passkey} other {# Passkeys}}"
 msgstr "{num, plural, other {# Passkey}}"
 
 msgid "{providerName} {attribute}:"
-msgstr ""
+msgstr "{attribute} {providerName}:"
 
 msgid "{providerName} email:"
-msgstr ""
+msgstr "Email {providerName}:"
 
 msgid "{providerName} name:"
-msgstr ""
+msgstr "Nama {providerName}:"
 
 msgid "<0>Completely Redesigned Interface:</0> We've given Internet Identity a fresh, modern look and feel. The new design is intuitive and easier to navigate, ensuring a smoother user journey."
 msgstr "<0>Antarmuka yang Sepenuhnya Didesain Ulang:</0> Kami memberikan Internet Identity tampilan baru yang modern. Desain baru ini intuitif dan lebih mudah dinavigasi, sehingga pengalaman pengguna menjadi lebih lancar."
@@ -134,7 +134,7 @@ msgid "Advanced identity management"
 msgstr "Manajemen identitas tingkat lanjut"
 
 msgid "Allow to access this info"
-msgstr ""
+msgstr "Izinkan untuk mengakses info ini"
 
 msgid "Are you sure?"
 msgstr "Apakah Anda yakin?"
@@ -146,13 +146,13 @@ msgid "As you are currently signed in with this passkey, you will be signed out.
 msgstr "Karena Anda saat ini masuk dengan passkey ini, Anda akan keluar."
 
 msgid "Attribute sharing failed"
-msgstr ""
+msgstr "Berbagi atribut gagal"
 
 msgid "Authenticating..."
 msgstr "Mengautentikasi..."
 
 msgid "Authentication failed"
-msgstr ""
+msgstr "Autentikasi gagal"
 
 msgid "Authentication successful"
 msgstr "Autentikasi berhasil"
@@ -161,7 +161,7 @@ msgid "Authorize new device"
 msgstr "Otorisasi perangkat baru"
 
 msgid "Back to sign-in options"
-msgstr ""
+msgstr "Kembali ke opsi masuk"
 
 msgid "Before getting started, find a private place and have your recovery phrase ready. Keep it confidential to protect your identity."
 msgstr "Sebelum memulai, cari tempat yang privat dan siapkan frasa pemulihan Anda. Jaga kerahasiaannya untuk melindungi identitas Anda."
@@ -182,7 +182,7 @@ msgid "CAPTCHA characters"
 msgstr "Karakter CAPTCHA"
 
 msgid "Change"
-msgstr ""
+msgstr "Ubah"
 
 msgid "Characters are case-sensitive"
 msgstr "Karakter membedakan huruf besar/kecil"
@@ -197,7 +197,7 @@ msgid "Checking your order"
 msgstr "Memeriksa pesanan Anda"
 
 msgid "Checking..."
-msgstr ""
+msgstr "Memeriksa..."
 
 msgid "Choose an account"
 msgstr "Pilih akun"
@@ -212,7 +212,7 @@ msgid "Choose method to continue"
 msgstr "Pilih metode untuk melanjutkan"
 
 msgid "Choose which details you'd like to share"
-msgstr ""
+msgstr "Pilih detail yang ingin Anda bagikan"
 
 msgid "Clear all"
 msgstr "Hapus semua"
@@ -230,10 +230,10 @@ msgid "Code copied to clipboard"
 msgstr "Kode disalin ke papan klip"
 
 msgid "Company domain"
-msgstr ""
+msgstr "Domain perusahaan"
 
 msgid "company.domain.com"
-msgstr ""
+msgstr "company.domain.com"
 
 msgid "Complete set-up"
 msgstr "Selesaikan penyiapan"
@@ -272,10 +272,10 @@ msgid "Continue with passkey"
 msgstr "Lanjutkan dengan passkey"
 
 msgid "Continue with SSO"
-msgstr ""
+msgstr "Lanjutkan dengan SSO"
 
 msgid "Couldn't reach {domainInput}. Check the spelling and your network."
-msgstr ""
+msgstr "Tidak dapat menjangkau {domainInput}. Periksa ejaan dan jaringan Anda."
 
 msgid "Create account"
 msgstr "Buat akun"
@@ -320,7 +320,7 @@ msgid "Default"
 msgstr "Default"
 
 msgid "Deny All"
-msgstr ""
+msgstr "Tolak Semua"
 
 msgid "Discoverable passkeys"
 msgstr "Passkey yang dapat ditemukan"
@@ -344,7 +344,7 @@ msgid "Edit account"
 msgstr "Edit akun"
 
 msgid "Email:"
-msgstr ""
+msgstr "Email:"
 
 msgid "Enable multiple accounts"
 msgstr "Aktifkan banyak akun"
@@ -362,7 +362,7 @@ msgid "Enter recovery phrase"
 msgstr "Masukkan frasa pemulihan"
 
 msgid "Enter your company domain"
-msgstr ""
+msgstr "Masukkan domain perusahaan Anda"
 
 msgid "Everything you need to know about Internet Identity, your private, secure, and easy way to log in to apps on the Internet Computer."
 msgstr "Semua yang perlu Anda ketahui tentang Internet Identity, cara yang pribadi, aman, dan mudah untuk masuk ke aplikasi di Internet Computer."
@@ -534,7 +534,7 @@ msgid "Invalid code. Please check and try again."
 msgstr "Kode tidak valid. Silakan periksa dan coba lagi."
 
 msgid "Invalid domain"
-msgstr ""
+msgstr "Domain tidak valid"
 
 msgid "Invalid recovery phrase"
 msgstr "Frasa pemulihan tidak valid"
@@ -603,7 +603,7 @@ msgid "Link copied to clipboard"
 msgstr "Tautan disalin ke papan klip"
 
 msgid "Loading permissions"
-msgstr ""
+msgstr "Memuat izin"
 
 msgid "Locked legacy recovery phrase"
 msgstr "Frasa pemulihan lama terkunci"
@@ -669,7 +669,7 @@ msgid "Name your identity"
 msgstr "Beri nama identitas Anda"
 
 msgid "Name:"
-msgstr ""
+msgstr "Nama:"
 
 msgid "No data is shared with Google, Microsoft or Apple on which applications you log in with Internet Identity."
 msgstr "Tidak ada data yang dibagikan kepada Google, Microsoft, atau Apple mengenai aplikasi mana yang Anda masuk dengan Internet Identity."
@@ -840,7 +840,7 @@ msgid "Return to application"
 msgstr "Kembali ke aplikasi"
 
 msgid "Review Permissions"
-msgstr ""
+msgstr "Tinjau Izin"
 
 msgid "Right now"
 msgstr "Saat ini"
@@ -879,10 +879,10 @@ msgid "Set as default sign-in"
 msgstr "Atur sebagai metode masuk default"
 
 msgid "Several SSO sign-ins are in flight already. Wait a moment."
-msgstr ""
+msgstr "Beberapa proses masuk SSO sedang berlangsung. Tunggu sebentar."
 
 msgid "Share {label}"
-msgstr ""
+msgstr "Bagikan {label}"
 
 msgid "Show all"
 msgstr "Tampilkan semua"
@@ -903,7 +903,7 @@ msgid "Sign in with another identity"
 msgstr "Masuk dengan identitas lain"
 
 msgid "Sign in with your {displayName} account from any device."
-msgstr ""
+msgstr "Masuk dengan akun {displayName} Anda dari perangkat mana pun."
 
 msgid "Sign out"
 msgstr "Keluar"
@@ -937,22 +937,22 @@ msgid "Something is wrong!"
 msgstr "Ada yang salah!"
 
 msgid "Something went wrong while creating your delegation. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Terjadi kesalahan saat membuat delegasi Anda. Silakan coba lagi; jika masalah berlanjut, hubungi dukungan."
 
 msgid "Something went wrong while sharing attributes. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Terjadi kesalahan saat berbagi atribut. Silakan coba lagi; jika masalah berlanjut, hubungi dukungan."
 
 msgid "Source code"
 msgstr "Kode sumber"
 
 msgid "SSO"
-msgstr ""
+msgstr "SSO"
 
 msgid "SSO is not available for \"{domainInput}\" yet. Ask an II admin to register this domain."
-msgstr ""
+msgstr "SSO belum tersedia untuk \"{domainInput}\". Minta admin II untuk mendaftarkan domain ini."
 
 msgid "SSO sign-in for {domainInput} failed. Please try again."
-msgstr ""
+msgstr "Proses masuk SSO untuk {domainInput} gagal. Silakan coba lagi."
 
 msgid "Start over"
 msgstr "Mulai ulang"
@@ -1033,7 +1033,7 @@ msgid "This app has moved to the new Internet Identity"
 msgstr "Aplikasi ini telah pindah ke Internet Identity baru"
 
 msgid "This browser is not supported."
-msgstr ""
+msgstr "Peramban ini tidak didukung."
 
 msgid "This identity has already been upgraded to the new experience."
 msgstr "Identitas ini sudah ditingkatkan ke pengalaman baru."
@@ -1048,7 +1048,7 @@ msgid "This passkey is no longer associated with any identity."
 msgstr "Passkey ini tidak lagi dikaitkan dengan identitas apa pun."
 
 msgid "This SSO is already linked to your identity."
-msgstr ""
+msgstr "SSO ini sudah tertaut dengan identitas Anda."
 
 msgid "This YubiKey has older firmware (5.1) that's incompatible."
 msgstr "YubiKey ini memiliki firmware lama (5.1) yang tidak kompatibel."
@@ -1087,7 +1087,7 @@ msgid "To finish setting up your passkey, follow the instructions shown on your 
 msgstr "Untuk menyelesaikan pengaturan passkey Anda, ikuti instruksi yang ditampilkan di <0>perangkat baru</0> Anda."
 
 msgid "Too many recent attempts for {domainInput}. Wait a few minutes."
-msgstr ""
+msgstr "Terlalu banyak percobaan baru-baru ini untuk {domainInput}. Tunggu beberapa menit."
 
 msgid "Type each word in the correct order:"
 msgstr "Ketik setiap kata dalam urutan yang benar:"
@@ -1132,7 +1132,7 @@ msgid "Unsupported"
 msgstr "Tidak didukung"
 
 msgid "Unsupported browser"
-msgstr ""
+msgstr "Peramban tidak didukung"
 
 msgid "Unsupported Browser"
 msgstr "Peramban Tidak Didukung"

--- a/src/frontend/src/lib/locales/it.po
+++ b/src/frontend/src/lib/locales/it.po
@@ -23,28 +23,28 @@ msgid "{application} has moved to the new Internet Identity"
 msgstr "{application} si è spostata sulla nuova Internet Identity"
 
 msgid "{attribute}:"
-msgstr ""
+msgstr "{attribute}:"
 
 msgid "{displayName} account"
-msgstr ""
+msgstr "Account {displayName}"
 
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
-msgstr ""
+msgstr "{domainInput} non ha pubblicato /.well-known/ii-openid-configuration (HTTP {0})."
 
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
-msgstr ""
+msgstr "Il file /.well-known/ii-openid-configuration di {domainInput} è malformato."
 
 msgid "{domainInput}'s SSO app doesn't allow the hybrid OAuth flow II requires. Ask the SSO admin to enable response_type \"id_token code\"."
-msgstr ""
+msgstr "L'app SSO di {domainInput} non consente il flusso OAuth ibrido richiesto da II. Chiedi all'amministratore SSO di abilitare response_type \"id_token code\"."
 
 msgid "{domainInput}'s SSO denied the sign-in."
-msgstr ""
+msgstr "L'SSO di {domainInput} ha rifiutato l'accesso."
 
 msgid "{domainInput}'s SSO returned \"{0}\": {1}"
-msgstr ""
+msgstr "L'SSO di {domainInput} ha restituito \"{0}\": {1}"
 
 msgid "{domainInput}'s SSO returned error \"{0}\"."
-msgstr ""
+msgstr "L'SSO di {domainInput} ha restituito l'errore \"{0}\"."
 
 msgid "{identityName} has been removed from this device."
 msgstr "{identityName} è stata rimossa da questo dispositivo."
@@ -56,13 +56,13 @@ msgid "{num, plural, one {# Passkey} other {# Passkeys}}"
 msgstr "{num, plural, one {# passkey} other {# passkey}}"
 
 msgid "{providerName} {attribute}:"
-msgstr ""
+msgstr "{attribute} di {providerName}:"
 
 msgid "{providerName} email:"
-msgstr ""
+msgstr "Email di {providerName}:"
 
 msgid "{providerName} name:"
-msgstr ""
+msgstr "Nome di {providerName}:"
 
 msgid "<0>Completely Redesigned Interface:</0> We've given Internet Identity a fresh, modern look and feel. The new design is intuitive and easier to navigate, ensuring a smoother user journey."
 msgstr "<0>Interfaccia completamente riprogettata:</0> Abbiamo dato a Internet Identity un aspetto fresco e moderno. Il nuovo design è intuitivo e più facile da navigare, garantendo un'esperienza utente più fluida."
@@ -134,7 +134,7 @@ msgid "Advanced identity management"
 msgstr "Gestione avanzata dell'identità"
 
 msgid "Allow to access this info"
-msgstr ""
+msgstr "Consenti l'accesso a queste informazioni"
 
 msgid "Are you sure?"
 msgstr "Sei sicuro?"
@@ -146,13 +146,13 @@ msgid "As you are currently signed in with this passkey, you will be signed out.
 msgstr "Poiché sei attualmente connesso con questa passkey, verrai disconnesso."
 
 msgid "Attribute sharing failed"
-msgstr ""
+msgstr "Condivisione degli attributi non riuscita"
 
 msgid "Authenticating..."
 msgstr "Autenticazione in corso..."
 
 msgid "Authentication failed"
-msgstr ""
+msgstr "Autenticazione non riuscita"
 
 msgid "Authentication successful"
 msgstr "Autenticazione riuscita"
@@ -161,7 +161,7 @@ msgid "Authorize new device"
 msgstr "Autorizza nuovo dispositivo"
 
 msgid "Back to sign-in options"
-msgstr ""
+msgstr "Torna alle opzioni di accesso"
 
 msgid "Before getting started, find a private place and have your recovery phrase ready. Keep it confidential to protect your identity."
 msgstr "Prima di iniziare, trova un posto riservato e tieni pronta la tua frase di recupero. Mantienila nascosta per proteggere la tua identità."
@@ -182,7 +182,7 @@ msgid "CAPTCHA characters"
 msgstr "Caratteri CAPTCHA"
 
 msgid "Change"
-msgstr ""
+msgstr "Cambia"
 
 msgid "Characters are case-sensitive"
 msgstr "I caratteri fanno distinzione tra maiuscole e minuscole"
@@ -197,7 +197,7 @@ msgid "Checking your order"
 msgstr "Verifica del tuo ordine in corso"
 
 msgid "Checking..."
-msgstr ""
+msgstr "Verifica in corso..."
 
 msgid "Choose an account"
 msgstr "Scegli un account"
@@ -212,7 +212,7 @@ msgid "Choose method to continue"
 msgstr "Scegli il metodo per continuare"
 
 msgid "Choose which details you'd like to share"
-msgstr ""
+msgstr "Scegli quali dettagli vuoi condividere"
 
 msgid "Clear all"
 msgstr "Cancella tutto"
@@ -230,10 +230,10 @@ msgid "Code copied to clipboard"
 msgstr "Codice copiato negli appunti"
 
 msgid "Company domain"
-msgstr ""
+msgstr "Dominio aziendale"
 
 msgid "company.domain.com"
-msgstr ""
+msgstr "azienda.dominio.com"
 
 msgid "Complete set-up"
 msgstr "Completa la configurazione"
@@ -272,10 +272,10 @@ msgid "Continue with passkey"
 msgstr "Continua con passkey"
 
 msgid "Continue with SSO"
-msgstr ""
+msgstr "Continua con SSO"
 
 msgid "Couldn't reach {domainInput}. Check the spelling and your network."
-msgstr ""
+msgstr "Impossibile raggiungere {domainInput}. Controlla l'ortografia e la tua rete."
 
 msgid "Create account"
 msgstr "Crea account"
@@ -320,7 +320,7 @@ msgid "Default"
 msgstr "Predefinito"
 
 msgid "Deny All"
-msgstr ""
+msgstr "Nega tutto"
 
 msgid "Discoverable passkeys"
 msgstr "Passkey rilevabili"
@@ -344,7 +344,7 @@ msgid "Edit account"
 msgstr "Modifica account"
 
 msgid "Email:"
-msgstr ""
+msgstr "Email:"
 
 msgid "Enable multiple accounts"
 msgstr "Abilita account multipli"
@@ -362,7 +362,7 @@ msgid "Enter recovery phrase"
 msgstr "Inserisci la frase di recupero"
 
 msgid "Enter your company domain"
-msgstr ""
+msgstr "Inserisci il dominio della tua azienda"
 
 msgid "Everything you need to know about Internet Identity, your private, secure, and easy way to log in to apps on the Internet Computer."
 msgstr "Tutto ciò che devi sapere su Internet Identity: il metodo privato, sicuro e facile per accedere alle app su Internet Computer."
@@ -534,7 +534,7 @@ msgid "Invalid code. Please check and try again."
 msgstr "Codice non valido. Controlla e riprova."
 
 msgid "Invalid domain"
-msgstr ""
+msgstr "Dominio non valido"
 
 msgid "Invalid recovery phrase"
 msgstr "Frase di recupero non valida"
@@ -603,7 +603,7 @@ msgid "Link copied to clipboard"
 msgstr "Link copiato negli appunti"
 
 msgid "Loading permissions"
-msgstr ""
+msgstr "Caricamento autorizzazioni"
 
 msgid "Locked legacy recovery phrase"
 msgstr "Frase di recupero legacy bloccata"
@@ -669,7 +669,7 @@ msgid "Name your identity"
 msgstr "Dai un nome alla tua identità"
 
 msgid "Name:"
-msgstr ""
+msgstr "Nome:"
 
 msgid "No data is shared with Google, Microsoft or Apple on which applications you log in with Internet Identity."
 msgstr "Nessun dato relativo alle applicazioni a cui accedi con Internet Identity viene condiviso con Google, Microsoft o Apple."
@@ -840,7 +840,7 @@ msgid "Return to application"
 msgstr "Torna all'applicazione"
 
 msgid "Review Permissions"
-msgstr ""
+msgstr "Rivedi autorizzazioni"
 
 msgid "Right now"
 msgstr "Adesso"
@@ -879,10 +879,10 @@ msgid "Set as default sign-in"
 msgstr "Imposta come accesso predefinito"
 
 msgid "Several SSO sign-ins are in flight already. Wait a moment."
-msgstr ""
+msgstr "Sono già in corso diversi accessi SSO. Attendi un momento."
 
 msgid "Share {label}"
-msgstr ""
+msgstr "Condividi {label}"
 
 msgid "Show all"
 msgstr "Mostra tutto"
@@ -903,7 +903,7 @@ msgid "Sign in with another identity"
 msgstr "Accedi con un'altra identità"
 
 msgid "Sign in with your {displayName} account from any device."
-msgstr ""
+msgstr "Accedi con il tuo account {displayName} da qualsiasi dispositivo."
 
 msgid "Sign out"
 msgstr "Esci"
@@ -937,22 +937,22 @@ msgid "Something is wrong!"
 msgstr "Qualcosa non è corretto!"
 
 msgid "Something went wrong while creating your delegation. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Si è verificato un problema durante la creazione della tua delega. Riprova; se il problema persiste, contatta l'assistenza."
 
 msgid "Something went wrong while sharing attributes. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Si è verificato un problema durante la condivisione degli attributi. Riprova; se il problema persiste, contatta l'assistenza."
 
 msgid "Source code"
 msgstr "Codice sorgente"
 
 msgid "SSO"
-msgstr ""
+msgstr "SSO"
 
 msgid "SSO is not available for \"{domainInput}\" yet. Ask an II admin to register this domain."
-msgstr ""
+msgstr "L'SSO non è ancora disponibile per \"{domainInput}\". Chiedi a un amministratore II di registrare questo dominio."
 
 msgid "SSO sign-in for {domainInput} failed. Please try again."
-msgstr ""
+msgstr "L'accesso SSO per {domainInput} non è riuscito. Riprova."
 
 msgid "Start over"
 msgstr "Inizia da capo"
@@ -1033,7 +1033,7 @@ msgid "This app has moved to the new Internet Identity"
 msgstr "Questa app è stata spostata nella nuova Internet Identity"
 
 msgid "This browser is not supported."
-msgstr ""
+msgstr "Questo browser non è supportato."
 
 msgid "This identity has already been upgraded to the new experience."
 msgstr "Questa identità è già stata aggiornata alla nuova esperienza."
@@ -1048,7 +1048,7 @@ msgid "This passkey is no longer associated with any identity."
 msgstr "Questa passkey non è più associata ad alcuna identità."
 
 msgid "This SSO is already linked to your identity."
-msgstr ""
+msgstr "Questo SSO è già collegato alla tua identità."
 
 msgid "This YubiKey has older firmware (5.1) that's incompatible."
 msgstr "Questa YubiKey utilizza un firmware precedente (5.1) che è incompatibile."
@@ -1087,7 +1087,7 @@ msgid "To finish setting up your passkey, follow the instructions shown on your 
 msgstr "Per terminare la configurazione della tua passkey, segui le istruzioni mostrate sul tuo <0>nuovo dispositivo</0>."
 
 msgid "Too many recent attempts for {domainInput}. Wait a few minutes."
-msgstr ""
+msgstr "Troppi tentativi recenti per {domainInput}. Attendi qualche minuto."
 
 msgid "Type each word in the correct order:"
 msgstr "Digita ogni parola nell'ordine corretto:"
@@ -1132,7 +1132,7 @@ msgid "Unsupported"
 msgstr "Non supportato"
 
 msgid "Unsupported browser"
-msgstr ""
+msgstr "Browser non supportato"
 
 msgid "Unsupported Browser"
 msgstr "Browser non supportato"

--- a/src/frontend/src/lib/locales/nl.po
+++ b/src/frontend/src/lib/locales/nl.po
@@ -23,28 +23,28 @@ msgid "{application} has moved to the new Internet Identity"
 msgstr "{application} is overgegaan naar de nieuwe Internet Identity"
 
 msgid "{attribute}:"
-msgstr ""
+msgstr "{attribute}:"
 
 msgid "{displayName} account"
-msgstr ""
+msgstr "{displayName}-account"
 
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
-msgstr ""
+msgstr "{domainInput} heeft /.well-known/ii-openid-configuration niet gepubliceerd (HTTP {0})."
 
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
-msgstr ""
+msgstr "De /.well-known/ii-openid-configuration van {domainInput} is ongeldig."
 
 msgid "{domainInput}'s SSO app doesn't allow the hybrid OAuth flow II requires. Ask the SSO admin to enable response_type \"id_token code\"."
-msgstr ""
+msgstr "De SSO-app van {domainInput} staat de hybride OAuth-flow die II nodig heeft niet toe. Vraag de SSO-beheerder om response_type \"id_token code\" in te schakelen."
 
 msgid "{domainInput}'s SSO denied the sign-in."
-msgstr ""
+msgstr "De SSO van {domainInput} heeft de aanmelding geweigerd."
 
 msgid "{domainInput}'s SSO returned \"{0}\": {1}"
-msgstr ""
+msgstr "De SSO van {domainInput} gaf \"{0}\" terug: {1}"
 
 msgid "{domainInput}'s SSO returned error \"{0}\"."
-msgstr ""
+msgstr "De SSO van {domainInput} gaf de fout \"{0}\" terug."
 
 msgid "{identityName} has been removed from this device."
 msgstr "{identityName} is verwijderd van dit apparaat."
@@ -56,13 +56,13 @@ msgid "{num, plural, one {# Passkey} other {# Passkeys}}"
 msgstr "{num, plural, one {# Passkey} other {# Passkeys}}"
 
 msgid "{providerName} {attribute}:"
-msgstr ""
+msgstr "{providerName} {attribute}:"
 
 msgid "{providerName} email:"
-msgstr ""
+msgstr "{providerName} e-mailadres:"
 
 msgid "{providerName} name:"
-msgstr ""
+msgstr "{providerName} naam:"
 
 msgid "<0>Completely Redesigned Interface:</0> We've given Internet Identity a fresh, modern look and feel. The new design is intuitive and easier to navigate, ensuring a smoother user journey."
 msgstr "<0>Volledig Vernieuwde Interface:</0> We hebben Internet Identity een frisse, moderne uitstraling gegeven. Het nieuwe ontwerp is intuïtief en overzichtelijker, wat zorgt voor een soepelere gebruikerservaring."
@@ -134,7 +134,7 @@ msgid "Advanced identity management"
 msgstr "Geavanceerd identiteitsbeheer"
 
 msgid "Allow to access this info"
-msgstr ""
+msgstr "Toegang tot deze informatie toestaan"
 
 msgid "Are you sure?"
 msgstr "Weet u het zeker?"
@@ -146,13 +146,13 @@ msgid "As you are currently signed in with this passkey, you will be signed out.
 msgstr "Aangezien u momenteel bent ingelogd met deze passkey, wordt u uitgelogd."
 
 msgid "Attribute sharing failed"
-msgstr ""
+msgstr "Delen van attributen mislukt"
 
 msgid "Authenticating..."
 msgstr "Authenticeren..."
 
 msgid "Authentication failed"
-msgstr ""
+msgstr "Authenticatie mislukt"
 
 msgid "Authentication successful"
 msgstr "Authenticatie succesvol"
@@ -161,7 +161,7 @@ msgid "Authorize new device"
 msgstr "Autoriseer nieuw apparaat"
 
 msgid "Back to sign-in options"
-msgstr ""
+msgstr "Terug naar inlogopties"
 
 msgid "Before getting started, find a private place and have your recovery phrase ready. Keep it confidential to protect your identity."
 msgstr "Voordat u begint, zoek een privéplek en zorg dat u uw herstelzin bij de hand heeft. Houd deze vertrouwelijk om uw identiteit te beschermen."
@@ -182,7 +182,7 @@ msgid "CAPTCHA characters"
 msgstr "CAPTCHA-tekens"
 
 msgid "Change"
-msgstr ""
+msgstr "Wijzigen"
 
 msgid "Characters are case-sensitive"
 msgstr "Tekens zijn hoofdlettergevoelig"
@@ -197,7 +197,7 @@ msgid "Checking your order"
 msgstr "Uw bestelling controleren"
 
 msgid "Checking..."
-msgstr ""
+msgstr "Controleren..."
 
 msgid "Choose an account"
 msgstr "Kies een account"
@@ -212,7 +212,7 @@ msgid "Choose method to continue"
 msgstr "Kies methode om door te gaan"
 
 msgid "Choose which details you'd like to share"
-msgstr ""
+msgstr "Kies welke gegevens u wilt delen"
 
 msgid "Clear all"
 msgstr "Alles wissen"
@@ -230,10 +230,10 @@ msgid "Code copied to clipboard"
 msgstr "Code gekopieerd naar klembord"
 
 msgid "Company domain"
-msgstr ""
+msgstr "Bedrijfsdomein"
 
 msgid "company.domain.com"
-msgstr ""
+msgstr "bedrijf.domein.com"
 
 msgid "Complete set-up"
 msgstr "Instelling voltooien"
@@ -272,10 +272,10 @@ msgid "Continue with passkey"
 msgstr "Doorgaan met passkey"
 
 msgid "Continue with SSO"
-msgstr ""
+msgstr "Doorgaan met SSO"
 
 msgid "Couldn't reach {domainInput}. Check the spelling and your network."
-msgstr ""
+msgstr "Kon {domainInput} niet bereiken. Controleer de spelling en uw netwerk."
 
 msgid "Create account"
 msgstr "Account aanmaken"
@@ -320,7 +320,7 @@ msgid "Default"
 msgstr "Standaard"
 
 msgid "Deny All"
-msgstr ""
+msgstr "Alles weigeren"
 
 msgid "Discoverable passkeys"
 msgstr "Discoverable passkeys"
@@ -344,7 +344,7 @@ msgid "Edit account"
 msgstr "Account bewerken"
 
 msgid "Email:"
-msgstr ""
+msgstr "E-mailadres:"
 
 msgid "Enable multiple accounts"
 msgstr "Meerdere accounts inschakelen"
@@ -362,7 +362,7 @@ msgid "Enter recovery phrase"
 msgstr "Voer herstelzin in"
 
 msgid "Enter your company domain"
-msgstr ""
+msgstr "Voer uw bedrijfsdomein in"
 
 msgid "Everything you need to know about Internet Identity, your private, secure, and easy way to log in to apps on the Internet Computer."
 msgstr "Alles wat u moet weten over Internet Identity, uw veilige, privacyvriendelijke en gemakkelijke manier om in te loggen op Internet Computer-apps."
@@ -534,7 +534,7 @@ msgid "Invalid code. Please check and try again."
 msgstr "Ongeldige code. Controleer en probeer het opnieuw."
 
 msgid "Invalid domain"
-msgstr ""
+msgstr "Ongeldig domein"
 
 msgid "Invalid recovery phrase"
 msgstr "Ongeldige herstelzin"
@@ -603,7 +603,7 @@ msgid "Link copied to clipboard"
 msgstr "Link gekopieerd naar klembord"
 
 msgid "Loading permissions"
-msgstr ""
+msgstr "Machtigingen laden"
 
 msgid "Locked legacy recovery phrase"
 msgstr "Vergrendelde legacy-herstelzin"
@@ -669,7 +669,7 @@ msgid "Name your identity"
 msgstr "Geef uw identiteit een naam"
 
 msgid "Name:"
-msgstr ""
+msgstr "Naam:"
 
 msgid "No data is shared with Google, Microsoft or Apple on which applications you log in with Internet Identity."
 msgstr "Er worden geen gegevens gedeeld met Google, Microsoft of Apple over op welke applicaties u inlogt met Internet Identity."
@@ -840,7 +840,7 @@ msgid "Return to application"
 msgstr "Terug naar applicatie"
 
 msgid "Review Permissions"
-msgstr ""
+msgstr "Machtigingen controleren"
 
 msgid "Right now"
 msgstr "Op dit moment"
@@ -879,10 +879,10 @@ msgid "Set as default sign-in"
 msgstr "Instellen als standaard inlogmethode"
 
 msgid "Several SSO sign-ins are in flight already. Wait a moment."
-msgstr ""
+msgstr "Er zijn al meerdere SSO-aanmeldingen bezig. Een moment geduld."
 
 msgid "Share {label}"
-msgstr ""
+msgstr "{label} delen"
 
 msgid "Show all"
 msgstr "Alles tonen"
@@ -903,7 +903,7 @@ msgid "Sign in with another identity"
 msgstr "Inloggen met een andere identiteit"
 
 msgid "Sign in with your {displayName} account from any device."
-msgstr ""
+msgstr "Log in met uw {displayName}-account vanaf elk apparaat."
 
 msgid "Sign out"
 msgstr "Uitloggen"
@@ -937,22 +937,22 @@ msgid "Something is wrong!"
 msgstr "Er klopt iets niet!"
 
 msgid "Something went wrong while creating your delegation. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Er is iets misgegaan bij het aanmaken van uw delegatie. Probeer het opnieuw; als het probleem aanhoudt, neem dan contact op met ondersteuning."
 
 msgid "Something went wrong while sharing attributes. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Er is iets misgegaan bij het delen van attributen. Probeer het opnieuw; als het probleem aanhoudt, neem dan contact op met ondersteuning."
 
 msgid "Source code"
 msgstr "Broncode"
 
 msgid "SSO"
-msgstr ""
+msgstr "SSO"
 
 msgid "SSO is not available for \"{domainInput}\" yet. Ask an II admin to register this domain."
-msgstr ""
+msgstr "SSO is nog niet beschikbaar voor \"{domainInput}\". Vraag een II-beheerder om dit domein te registreren."
 
 msgid "SSO sign-in for {domainInput} failed. Please try again."
-msgstr ""
+msgstr "SSO-aanmelding voor {domainInput} is mislukt. Probeer het opnieuw."
 
 msgid "Start over"
 msgstr "Opnieuw beginnen"
@@ -1033,7 +1033,7 @@ msgid "This app has moved to the new Internet Identity"
 msgstr "Deze app is overgegaan naar de nieuwe Internet Identity"
 
 msgid "This browser is not supported."
-msgstr ""
+msgstr "Deze browser wordt niet ondersteund."
 
 msgid "This identity has already been upgraded to the new experience."
 msgstr "Deze identiteit is al geüpgraded naar de nieuwe ervaring."
@@ -1048,7 +1048,7 @@ msgid "This passkey is no longer associated with any identity."
 msgstr "Deze passkey is niet langer gekoppeld aan een identiteit."
 
 msgid "This SSO is already linked to your identity."
-msgstr ""
+msgstr "Deze SSO is al gekoppeld aan uw identiteit."
 
 msgid "This YubiKey has older firmware (5.1) that's incompatible."
 msgstr "Deze YubiKey heeft oudere firmware (5.1) die incompatibel is."
@@ -1087,7 +1087,7 @@ msgid "To finish setting up your passkey, follow the instructions shown on your 
 msgstr "Om uw passkey te voltooien, volgt u de instructies op uw <0>nieuwe apparaat</0>."
 
 msgid "Too many recent attempts for {domainInput}. Wait a few minutes."
-msgstr ""
+msgstr "Te veel recente pogingen voor {domainInput}. Wacht enkele minuten."
 
 msgid "Type each word in the correct order:"
 msgstr "Typ elk woord in de juiste volgorde:"
@@ -1132,7 +1132,7 @@ msgid "Unsupported"
 msgstr "Niet ondersteund"
 
 msgid "Unsupported browser"
-msgstr ""
+msgstr "Niet-ondersteunde browser"
 
 msgid "Unsupported Browser"
 msgstr "Niet-ondersteunde browser"

--- a/src/frontend/src/lib/locales/pl.po
+++ b/src/frontend/src/lib/locales/pl.po
@@ -23,28 +23,28 @@ msgid "{application} has moved to the new Internet Identity"
 msgstr "{application} został przeniesiony do nowej tożsamości internetowej"
 
 msgid "{attribute}:"
-msgstr ""
+msgstr "{attribute}:"
 
 msgid "{displayName} account"
-msgstr ""
+msgstr "Konto {displayName}"
 
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
-msgstr ""
+msgstr "{domainInput} nie opublikował /.well-known/ii-openid-configuration (HTTP {0})."
 
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
-msgstr ""
+msgstr "Plik /.well-known/ii-openid-configuration domeny {domainInput} jest nieprawidłowy."
 
 msgid "{domainInput}'s SSO app doesn't allow the hybrid OAuth flow II requires. Ask the SSO admin to enable response_type \"id_token code\"."
-msgstr ""
+msgstr "Aplikacja SSO domeny {domainInput} nie zezwala na hybrydowy przepływ OAuth wymagany przez II. Poproś administratora SSO o włączenie response_type \"id_token code\"."
 
 msgid "{domainInput}'s SSO denied the sign-in."
-msgstr ""
+msgstr "SSO domeny {domainInput} odrzuciło logowanie."
 
 msgid "{domainInput}'s SSO returned \"{0}\": {1}"
-msgstr ""
+msgstr "SSO domeny {domainInput} zwróciło \"{0}\": {1}"
 
 msgid "{domainInput}'s SSO returned error \"{0}\"."
-msgstr ""
+msgstr "SSO domeny {domainInput} zwróciło błąd \"{0}\"."
 
 msgid "{identityName} has been removed from this device."
 msgstr "{identityName} została usunięta z tego urządzenia."
@@ -56,13 +56,13 @@ msgid "{num, plural, one {# Passkey} other {# Passkeys}}"
 msgstr "{num, plural, one {# klucz dostępu} few {# klucze dostępu} other {# kluczy dostępu}}"
 
 msgid "{providerName} {attribute}:"
-msgstr ""
+msgstr "{providerName} {attribute}:"
 
 msgid "{providerName} email:"
-msgstr ""
+msgstr "Adres e-mail {providerName}:"
 
 msgid "{providerName} name:"
-msgstr ""
+msgstr "Nazwa {providerName}:"
 
 msgid "<0>Completely Redesigned Interface:</0> We've given Internet Identity a fresh, modern look and feel. The new design is intuitive and easier to navigate, ensuring a smoother user journey."
 msgstr "<0>Całkowicie przeprojektowany interfejs:</0> Nadaliśmy Internet Identity odświeżony, nowoczesny wygląd i charakter. Nowy projekt jest intuicyjny i łatwiejszy w nawigacji, zapewniając płynniejszą podróż użytkownika."
@@ -134,7 +134,7 @@ msgid "Advanced identity management"
 msgstr "Zaawansowane zarządzanie tożsamością"
 
 msgid "Allow to access this info"
-msgstr ""
+msgstr "Zezwól na dostęp do tych informacji"
 
 msgid "Are you sure?"
 msgstr "Czy na pewno?"
@@ -146,13 +146,13 @@ msgid "As you are currently signed in with this passkey, you will be signed out.
 msgstr "Ponieważ jesteś obecnie zalogowany/a przy użyciu tego klucza dostępu, zostaniesz wylogowany/a."
 
 msgid "Attribute sharing failed"
-msgstr ""
+msgstr "Udostępnianie atrybutów nie powiodło się"
 
 msgid "Authenticating..."
 msgstr "Uwierzytelnianie..."
 
 msgid "Authentication failed"
-msgstr ""
+msgstr "Uwierzytelnianie nie powiodło się"
 
 msgid "Authentication successful"
 msgstr "Uwierzytelnianie zakończone sukcesem"
@@ -161,7 +161,7 @@ msgid "Authorize new device"
 msgstr "Autoryzuj nowe urządzenie"
 
 msgid "Back to sign-in options"
-msgstr ""
+msgstr "Powrót do opcji logowania"
 
 msgid "Before getting started, find a private place and have your recovery phrase ready. Keep it confidential to protect your identity."
 msgstr "Zanim zaczniesz, znajdź ustronne miejsce i przygotuj swoją frazę odzyskiwania. Zachowaj ją w tajemnicy, aby chronić swoją tożsamość."
@@ -182,7 +182,7 @@ msgid "CAPTCHA characters"
 msgstr "Znaki CAPTCHA"
 
 msgid "Change"
-msgstr ""
+msgstr "Zmień"
 
 msgid "Characters are case-sensitive"
 msgstr "Znaki rozróżniają wielkość liter"
@@ -197,7 +197,7 @@ msgid "Checking your order"
 msgstr "Sprawdzanie Twojego zamówienia"
 
 msgid "Checking..."
-msgstr ""
+msgstr "Sprawdzanie..."
 
 msgid "Choose an account"
 msgstr "Wybierz konto"
@@ -212,7 +212,7 @@ msgid "Choose method to continue"
 msgstr "Wybierz metodę, aby kontynuować"
 
 msgid "Choose which details you'd like to share"
-msgstr ""
+msgstr "Wybierz, które dane chcesz udostępnić"
 
 msgid "Clear all"
 msgstr "Wyczyść wszystko"
@@ -230,10 +230,10 @@ msgid "Code copied to clipboard"
 msgstr "Kod skopiowany do schowka"
 
 msgid "Company domain"
-msgstr ""
+msgstr "Domena firmy"
 
 msgid "company.domain.com"
-msgstr ""
+msgstr "firma.domena.com"
 
 msgid "Complete set-up"
 msgstr "Zakończ konfigurację"
@@ -272,10 +272,10 @@ msgid "Continue with passkey"
 msgstr "Kontynuuj za pomocą klucza dostępu"
 
 msgid "Continue with SSO"
-msgstr ""
+msgstr "Kontynuuj z SSO"
 
 msgid "Couldn't reach {domainInput}. Check the spelling and your network."
-msgstr ""
+msgstr "Nie można połączyć się z {domainInput}. Sprawdź pisownię i swoje połączenie sieciowe."
 
 msgid "Create account"
 msgstr "Utwórz konto"
@@ -320,7 +320,7 @@ msgid "Default"
 msgstr "Domyślny"
 
 msgid "Deny All"
-msgstr ""
+msgstr "Odmów wszystkim"
 
 msgid "Discoverable passkeys"
 msgstr "Identyfikowalne klucze dostępu"
@@ -344,7 +344,7 @@ msgid "Edit account"
 msgstr "Edytuj konto"
 
 msgid "Email:"
-msgstr ""
+msgstr "Adres e-mail:"
 
 msgid "Enable multiple accounts"
 msgstr "Włącz wiele kont"
@@ -362,7 +362,7 @@ msgid "Enter recovery phrase"
 msgstr "Wpisz frazę odzyskiwania"
 
 msgid "Enter your company domain"
-msgstr ""
+msgstr "Wprowadź domenę swojej firmy"
 
 msgid "Everything you need to know about Internet Identity, your private, secure, and easy way to log in to apps on the Internet Computer."
 msgstr "Wszystko, co musisz wiedzieć o Internet Identity, Twoim prywatnym, bezpiecznym i łatwym sposobie logowania do aplikacji w Internet Computer."
@@ -534,7 +534,7 @@ msgid "Invalid code. Please check and try again."
 msgstr "Nieprawidłowy kod. Sprawdź i spróbuj ponownie."
 
 msgid "Invalid domain"
-msgstr ""
+msgstr "Nieprawidłowa domena"
 
 msgid "Invalid recovery phrase"
 msgstr "Nieprawidłowa fraza odzyskiwania"
@@ -603,7 +603,7 @@ msgid "Link copied to clipboard"
 msgstr "Link skopiowany do schowka"
 
 msgid "Loading permissions"
-msgstr ""
+msgstr "Ładowanie uprawnień"
 
 msgid "Locked legacy recovery phrase"
 msgstr "Zablokowana stara fraza odzyskiwania"
@@ -669,7 +669,7 @@ msgid "Name your identity"
 msgstr "Nazwij swoją tożsamość"
 
 msgid "Name:"
-msgstr ""
+msgstr "Nazwa:"
 
 msgid "No data is shared with Google, Microsoft or Apple on which applications you log in with Internet Identity."
 msgstr "Nie są udostępniane żadne dane Google, Microsoft ani Apple dotyczące aplikacji, w których logujesz się za pomocą Internet Identity."
@@ -840,7 +840,7 @@ msgid "Return to application"
 msgstr "Powrót do aplikacji"
 
 msgid "Review Permissions"
-msgstr ""
+msgstr "Przejrzyj uprawnienia"
 
 msgid "Right now"
 msgstr "Teraz"
@@ -879,10 +879,10 @@ msgid "Set as default sign-in"
 msgstr "Ustaw jako domyślne logowanie"
 
 msgid "Several SSO sign-ins are in flight already. Wait a moment."
-msgstr ""
+msgstr "Kilka logowań SSO jest już w toku. Poczekaj chwilę."
 
 msgid "Share {label}"
-msgstr ""
+msgstr "Udostępnij {label}"
 
 msgid "Show all"
 msgstr "Pokaż wszystkie"
@@ -903,7 +903,7 @@ msgid "Sign in with another identity"
 msgstr "Zaloguj się z inną tożsamością"
 
 msgid "Sign in with your {displayName} account from any device."
-msgstr ""
+msgstr "Zaloguj się przy użyciu swojego konta {displayName} z dowolnego urządzenia."
 
 msgid "Sign out"
 msgstr "Wyloguj się"
@@ -937,22 +937,22 @@ msgid "Something is wrong!"
 msgstr "Coś jest nie tak!"
 
 msgid "Something went wrong while creating your delegation. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Coś poszło nie tak podczas tworzenia delegacji. Spróbuj ponownie; jeśli problem będzie się powtarzał, skontaktuj się z pomocą techniczną."
 
 msgid "Something went wrong while sharing attributes. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Coś poszło nie tak podczas udostępniania atrybutów. Spróbuj ponownie; jeśli problem będzie się powtarzał, skontaktuj się z pomocą techniczną."
 
 msgid "Source code"
 msgstr "Kod źródłowy"
 
 msgid "SSO"
-msgstr ""
+msgstr "SSO"
 
 msgid "SSO is not available for \"{domainInput}\" yet. Ask an II admin to register this domain."
-msgstr ""
+msgstr "SSO nie jest jeszcze dostępne dla \"{domainInput}\". Poproś administratora II o zarejestrowanie tej domeny."
 
 msgid "SSO sign-in for {domainInput} failed. Please try again."
-msgstr ""
+msgstr "Logowanie SSO dla {domainInput} nie powiodło się. Spróbuj ponownie."
 
 msgid "Start over"
 msgstr "Zacznij od nowa"
@@ -1033,7 +1033,7 @@ msgid "This app has moved to the new Internet Identity"
 msgstr "Ta aplikacja została przeniesiona do nowego Internet Identity"
 
 msgid "This browser is not supported."
-msgstr ""
+msgstr "Ta przeglądarka nie jest obsługiwana."
 
 msgid "This identity has already been upgraded to the new experience."
 msgstr "Ta tożsamość została już zaktualizowana do nowego doświadczenia."
@@ -1048,7 +1048,7 @@ msgid "This passkey is no longer associated with any identity."
 msgstr "Ten klucz dostępu nie jest już powiązany z żadną tożsamością."
 
 msgid "This SSO is already linked to your identity."
-msgstr ""
+msgstr "To SSO jest już powiązane z Twoją tożsamością."
 
 msgid "This YubiKey has older firmware (5.1) that's incompatible."
 msgstr "Ten YubiKey ma starsze oprogramowanie układowe (5.1), które jest niekompatybilne."
@@ -1087,7 +1087,7 @@ msgid "To finish setting up your passkey, follow the instructions shown on your 
 msgstr "Aby dokończyć konfigurowanie klucza dostępu, postępuj zgodnie z instrukcjami wyświetlanymi na <0>nowym urządzeniu</0>."
 
 msgid "Too many recent attempts for {domainInput}. Wait a few minutes."
-msgstr ""
+msgstr "Zbyt wiele ostatnich prób dla {domainInput}. Poczekaj kilka minut."
 
 msgid "Type each word in the correct order:"
 msgstr "Wpisz każde słowo we właściwej kolejności:"
@@ -1132,7 +1132,7 @@ msgid "Unsupported"
 msgstr "Nieobsługiwane"
 
 msgid "Unsupported browser"
-msgstr ""
+msgstr "Nieobsługiwana przeglądarka"
 
 msgid "Unsupported Browser"
 msgstr "Nieobsługiwana przeglądarka"

--- a/src/frontend/src/lib/locales/ru.po
+++ b/src/frontend/src/lib/locales/ru.po
@@ -23,28 +23,28 @@ msgid "{application} has moved to the new Internet Identity"
 msgstr "приложение {application} переехало на новую версию Internet Identity"
 
 msgid "{attribute}:"
-msgstr ""
+msgstr "{attribute}:"
 
 msgid "{displayName} account"
-msgstr ""
+msgstr "Аккаунт {displayName}"
 
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
-msgstr ""
+msgstr "Домен {domainInput} не опубликовал /.well-known/ii-openid-configuration (HTTP {0})."
 
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
-msgstr ""
+msgstr "Файл /.well-known/ii-openid-configuration домена {domainInput} имеет неверный формат."
 
 msgid "{domainInput}'s SSO app doesn't allow the hybrid OAuth flow II requires. Ask the SSO admin to enable response_type \"id_token code\"."
-msgstr ""
+msgstr "SSO-приложение домена {domainInput} не поддерживает гибридный OAuth-поток, необходимый II. Попросите администратора SSO включить response_type «id_token code»."
 
 msgid "{domainInput}'s SSO denied the sign-in."
-msgstr ""
+msgstr "SSO домена {domainInput} отклонил вход."
 
 msgid "{domainInput}'s SSO returned \"{0}\": {1}"
-msgstr ""
+msgstr "SSO домена {domainInput} вернул «{0}»: {1}"
 
 msgid "{domainInput}'s SSO returned error \"{0}\"."
-msgstr ""
+msgstr "SSO домена {domainInput} вернул ошибку «{0}»."
 
 msgid "{identityName} has been removed from this device."
 msgstr "Данные {identityName} были удалены с этого устройства."
@@ -56,13 +56,13 @@ msgid "{num, plural, one {# Passkey} other {# Passkeys}}"
 msgstr "{num, plural, one {# ключ доступа} few {# ключа доступа} many {# ключей доступа} other {# ключей доступа}}"
 
 msgid "{providerName} {attribute}:"
-msgstr ""
+msgstr "{providerName} {attribute}:"
 
 msgid "{providerName} email:"
-msgstr ""
+msgstr "Email {providerName}:"
 
 msgid "{providerName} name:"
-msgstr ""
+msgstr "Имя {providerName}:"
 
 msgid "<0>Completely Redesigned Interface:</0> We've given Internet Identity a fresh, modern look and feel. The new design is intuitive and easier to navigate, ensuring a smoother user journey."
 msgstr "<0>Полностью обновлённый интерфейс:</0> Мы придали Internet Identity свежий, современный вид. Новый дизайн интуитивно понятен и удобен в навигации, что делает работу с сервисом приятнее."
@@ -134,7 +134,7 @@ msgid "Advanced identity management"
 msgstr "Контроль над доступом"
 
 msgid "Allow to access this info"
-msgstr ""
+msgstr "Разрешить доступ к этим данным"
 
 msgid "Are you sure?"
 msgstr "Вы уверены?"
@@ -146,13 +146,13 @@ msgid "As you are currently signed in with this passkey, you will be signed out.
 msgstr "Поскольку вы в данный момент вошли в систему с этим ключом доступа, вы будете выведены из системы."
 
 msgid "Attribute sharing failed"
-msgstr ""
+msgstr "Не удалось передать атрибуты"
 
 msgid "Authenticating..."
 msgstr "Аутентификация..."
 
 msgid "Authentication failed"
-msgstr ""
+msgstr "Ошибка аутентификации"
 
 msgid "Authentication successful"
 msgstr "Аутентификация прошла успешно"
@@ -161,7 +161,7 @@ msgid "Authorize new device"
 msgstr "Авторизовать новое устройство"
 
 msgid "Back to sign-in options"
-msgstr ""
+msgstr "Назад к способам входа"
 
 msgid "Before getting started, find a private place and have your recovery phrase ready. Keep it confidential to protect your identity."
 msgstr "Подготовьте резервную фразу и держите её в секрете. Убедитесь, что никто не видит ваш экран."
@@ -182,7 +182,7 @@ msgid "CAPTCHA characters"
 msgstr "Символы CAPTCHA"
 
 msgid "Change"
-msgstr ""
+msgstr "Изменить"
 
 msgid "Characters are case-sensitive"
 msgstr "Символы чувствительны к регистру"
@@ -197,7 +197,7 @@ msgid "Checking your order"
 msgstr "Проверка порядка слов"
 
 msgid "Checking..."
-msgstr ""
+msgstr "Проверка..."
 
 msgid "Choose an account"
 msgstr "Выберите аккаунт"
@@ -212,7 +212,7 @@ msgid "Choose method to continue"
 msgstr "Выберите способ входа"
 
 msgid "Choose which details you'd like to share"
-msgstr ""
+msgstr "Выберите, какими данными вы хотите поделиться"
 
 msgid "Clear all"
 msgstr "Очистить все"
@@ -230,10 +230,10 @@ msgid "Code copied to clipboard"
 msgstr "Код скопирован в буфер обмена"
 
 msgid "Company domain"
-msgstr ""
+msgstr "Домен компании"
 
 msgid "company.domain.com"
-msgstr ""
+msgstr "company.domain.com"
 
 msgid "Complete set-up"
 msgstr "Завершить настройку"
@@ -272,10 +272,10 @@ msgid "Continue with passkey"
 msgstr "Войти с ключом доступа"
 
 msgid "Continue with SSO"
-msgstr ""
+msgstr "Продолжить с SSO"
 
 msgid "Couldn't reach {domainInput}. Check the spelling and your network."
-msgstr ""
+msgstr "Не удалось связаться с {domainInput}. Проверьте написание и подключение к сети."
 
 msgid "Create account"
 msgstr "Создать аккаунт"
@@ -320,7 +320,7 @@ msgid "Default"
 msgstr "По умолчанию"
 
 msgid "Deny All"
-msgstr ""
+msgstr "Отклонить все"
 
 msgid "Discoverable passkeys"
 msgstr "Вход без паролей"
@@ -344,7 +344,7 @@ msgid "Edit account"
 msgstr "Редактировать аккаунт"
 
 msgid "Email:"
-msgstr ""
+msgstr "Email:"
 
 msgid "Enable multiple accounts"
 msgstr "Включить несколько аккаунтов"
@@ -362,7 +362,7 @@ msgid "Enter recovery phrase"
 msgstr "Введите резервную фразу"
 
 msgid "Enter your company domain"
-msgstr ""
+msgstr "Введите домен вашей компании"
 
 msgid "Everything you need to know about Internet Identity, your private, secure, and easy way to log in to apps on the Internet Computer."
 msgstr "Всё, что нужно знать об Internet Identity — вашем приватном, безопасном и простом способе входа в приложения на Internet Computer."
@@ -534,7 +534,7 @@ msgid "Invalid code. Please check and try again."
 msgstr "Неверный код. Пожалуйста, проверьте и попробуйте снова."
 
 msgid "Invalid domain"
-msgstr ""
+msgstr "Недопустимый домен"
 
 msgid "Invalid recovery phrase"
 msgstr "Неверная резервная фраза"
@@ -603,7 +603,7 @@ msgid "Link copied to clipboard"
 msgstr "Ссылка скопирована в буфер обмена"
 
 msgid "Loading permissions"
-msgstr ""
+msgstr "Загрузка разрешений"
 
 msgid "Locked legacy recovery phrase"
 msgstr "Заблокированная устаревшая резервная фраза"
@@ -669,7 +669,7 @@ msgid "Name your identity"
 msgstr "Придумайте имя"
 
 msgid "Name:"
-msgstr ""
+msgstr "Имя:"
 
 msgid "No data is shared with Google, Microsoft or Apple on which applications you log in with Internet Identity."
 msgstr "Никакие данные о том, в какие приложения вы входите с помощью Internet Identity, не передаются Google, Microsoft или Apple."
@@ -840,7 +840,7 @@ msgid "Return to application"
 msgstr "Вернуться к приложению"
 
 msgid "Review Permissions"
-msgstr ""
+msgstr "Проверить разрешения"
 
 msgid "Right now"
 msgstr "Прямо сейчас"
@@ -879,10 +879,10 @@ msgid "Set as default sign-in"
 msgstr "Установить как вход по умолчанию"
 
 msgid "Several SSO sign-ins are in flight already. Wait a moment."
-msgstr ""
+msgstr "Уже выполняется несколько SSO-входов. Подождите немного."
 
 msgid "Share {label}"
-msgstr ""
+msgstr "Поделиться: {label}"
 
 msgid "Show all"
 msgstr "Показать все"
@@ -903,7 +903,7 @@ msgid "Sign in with another identity"
 msgstr "Войти с другой учётной записью"
 
 msgid "Sign in with your {displayName} account from any device."
-msgstr ""
+msgstr "Входите со своего аккаунта {displayName} с любого устройства."
 
 msgid "Sign out"
 msgstr "Выйти"
@@ -937,22 +937,22 @@ msgid "Something is wrong!"
 msgstr "Что-то не так!"
 
 msgid "Something went wrong while creating your delegation. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Что-то пошло не так при создании делегирования. Пожалуйста, попробуйте снова; если проблема сохраняется, обратитесь в службу поддержки."
 
 msgid "Something went wrong while sharing attributes. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Что-то пошло не так при передаче атрибутов. Пожалуйста, попробуйте снова; если проблема сохраняется, обратитесь в службу поддержки."
 
 msgid "Source code"
 msgstr "Исходный код"
 
 msgid "SSO"
-msgstr ""
+msgstr "SSO"
 
 msgid "SSO is not available for \"{domainInput}\" yet. Ask an II admin to register this domain."
-msgstr ""
+msgstr "SSO для «{domainInput}» пока недоступен. Попросите администратора II зарегистрировать этот домен."
 
 msgid "SSO sign-in for {domainInput} failed. Please try again."
-msgstr ""
+msgstr "Не удалось выполнить вход через SSO для {domainInput}. Пожалуйста, попробуйте снова."
 
 msgid "Start over"
 msgstr "Начать заново"
@@ -1033,7 +1033,7 @@ msgid "This app has moved to the new Internet Identity"
 msgstr "Это приложение переехало на новую версию Internet Identity"
 
 msgid "This browser is not supported."
-msgstr ""
+msgstr "Этот браузер не поддерживается."
 
 msgid "This identity has already been upgraded to the new experience."
 msgstr "Эта учётная запись уже была обновлена до нового интерфейса."
@@ -1048,7 +1048,7 @@ msgid "This passkey is no longer associated with any identity."
 msgstr "Этот ключ доступа больше не связан ни с одной учётной записью."
 
 msgid "This SSO is already linked to your identity."
-msgstr ""
+msgstr "Этот SSO уже привязан к вашей учётной записи."
 
 msgid "This YubiKey has older firmware (5.1) that's incompatible."
 msgstr "Этот YubiKey имеет старую прошивку (5.1), которая несовместима."
@@ -1087,7 +1087,7 @@ msgid "To finish setting up your passkey, follow the instructions shown on your 
 msgstr "Чтобы завершить настройку вашего ключа доступа, следуйте инструкциям, показанным на вашем <0>новом устройстве</0>."
 
 msgid "Too many recent attempts for {domainInput}. Wait a few minutes."
-msgstr ""
+msgstr "Слишком много недавних попыток для {domainInput}. Подождите несколько минут."
 
 msgid "Type each word in the correct order:"
 msgstr "Введите каждое слово в правильном порядке:"
@@ -1132,7 +1132,7 @@ msgid "Unsupported"
 msgstr "Не поддерживается"
 
 msgid "Unsupported browser"
-msgstr ""
+msgstr "Неподдерживаемый браузер"
 
 msgid "Unsupported Browser"
 msgstr "Неподдерживаемый браузер"

--- a/src/frontend/src/lib/locales/uk.po
+++ b/src/frontend/src/lib/locales/uk.po
@@ -23,28 +23,28 @@ msgid "{application} has moved to the new Internet Identity"
 msgstr "{application} перейшов до нової версії Internet Identity"
 
 msgid "{attribute}:"
-msgstr ""
+msgstr "{attribute}:"
 
 msgid "{displayName} account"
-msgstr ""
+msgstr "Обліковий запис {displayName}"
 
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
-msgstr ""
+msgstr "{domainInput} не опублікував /.well-known/ii-openid-configuration (HTTP {0})."
 
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
-msgstr ""
+msgstr "Файл /.well-known/ii-openid-configuration домену {domainInput} має неправильний формат."
 
 msgid "{domainInput}'s SSO app doesn't allow the hybrid OAuth flow II requires. Ask the SSO admin to enable response_type \"id_token code\"."
-msgstr ""
+msgstr "SSO-застосунок домену {domainInput} не дозволяє гібридний потік OAuth, необхідний для II. Попросіть адміністратора SSO увімкнути response_type \"id_token code\"."
 
 msgid "{domainInput}'s SSO denied the sign-in."
-msgstr ""
+msgstr "SSO домену {domainInput} відхилив вхід."
 
 msgid "{domainInput}'s SSO returned \"{0}\": {1}"
-msgstr ""
+msgstr "SSO домену {domainInput} повернув \"{0}\": {1}"
 
 msgid "{domainInput}'s SSO returned error \"{0}\"."
-msgstr ""
+msgstr "SSO домену {domainInput} повернув помилку \"{0}\"."
 
 msgid "{identityName} has been removed from this device."
 msgstr "{identityName} було видалено з цього пристрою."
@@ -56,13 +56,13 @@ msgid "{num, plural, one {# Passkey} other {# Passkeys}}"
 msgstr "{num, plural, one {# ключ доступу} few {# ключі доступу} many {# ключів доступу} other {# ключів доступу}}"
 
 msgid "{providerName} {attribute}:"
-msgstr ""
+msgstr "{providerName} {attribute}:"
 
 msgid "{providerName} email:"
-msgstr ""
+msgstr "Електронна пошта {providerName}:"
 
 msgid "{providerName} name:"
-msgstr ""
+msgstr "Ім'я {providerName}:"
 
 msgid "<0>Completely Redesigned Interface:</0> We've given Internet Identity a fresh, modern look and feel. The new design is intuitive and easier to navigate, ensuring a smoother user journey."
 msgstr "<0>Повністю перероблений інтерфейс:</0> Ми надали Internet Identity свіжого, сучасного вигляду. Новий дизайн інтуїтивний і простіший для навігації, що забезпечує більш плавний користувацький досвід."
@@ -134,7 +134,7 @@ msgid "Advanced identity management"
 msgstr "Розширене керування ідентифікатором"
 
 msgid "Allow to access this info"
-msgstr ""
+msgstr "Дозволити доступ до цієї інформації"
 
 msgid "Are you sure?"
 msgstr "Ви впевнені?"
@@ -146,13 +146,13 @@ msgid "As you are currently signed in with this passkey, you will be signed out.
 msgstr "Оскільки ви наразі увійшли з цим ключем доступу, вас буде виведено з нього."
 
 msgid "Attribute sharing failed"
-msgstr ""
+msgstr "Не вдалося поділитися атрибутами"
 
 msgid "Authenticating..."
 msgstr "Автентифікація..."
 
 msgid "Authentication failed"
-msgstr ""
+msgstr "Автентифікацію не вдалося виконати"
 
 msgid "Authentication successful"
 msgstr "Автентифікацію успішно виконано"
@@ -161,7 +161,7 @@ msgid "Authorize new device"
 msgstr "Авторизувати новий пристрій"
 
 msgid "Back to sign-in options"
-msgstr ""
+msgstr "Повернутися до варіантів входу"
 
 msgid "Before getting started, find a private place and have your recovery phrase ready. Keep it confidential to protect your identity."
 msgstr "Перш ніж розпочати, знайдіть приватне місце та підготуйте свою фразу відновлення. Зберігайте її конфіденційно, щоб захистити свій ідентифікатор."
@@ -182,7 +182,7 @@ msgid "CAPTCHA characters"
 msgstr "Символи CAPTCHA"
 
 msgid "Change"
-msgstr ""
+msgstr "Змінити"
 
 msgid "Characters are case-sensitive"
 msgstr "Символи чутливі до регістру"
@@ -197,7 +197,7 @@ msgid "Checking your order"
 msgstr "Перевірка вашого замовлення"
 
 msgid "Checking..."
-msgstr ""
+msgstr "Перевірка..."
 
 msgid "Choose an account"
 msgstr "Виберіть обліковий запис"
@@ -212,7 +212,7 @@ msgid "Choose method to continue"
 msgstr "Виберіть метод для продовження"
 
 msgid "Choose which details you'd like to share"
-msgstr ""
+msgstr "Виберіть, якими даними ви хочете поділитися"
 
 msgid "Clear all"
 msgstr "Очистити все"
@@ -230,10 +230,10 @@ msgid "Code copied to clipboard"
 msgstr "Код скопійовано до буфера обміну"
 
 msgid "Company domain"
-msgstr ""
+msgstr "Домен компанії"
 
 msgid "company.domain.com"
-msgstr ""
+msgstr "company.domain.com"
 
 msgid "Complete set-up"
 msgstr "Завершити налаштування"
@@ -272,10 +272,10 @@ msgid "Continue with passkey"
 msgstr "Продовжити з ключем доступу"
 
 msgid "Continue with SSO"
-msgstr ""
+msgstr "Продовжити з SSO"
 
 msgid "Couldn't reach {domainInput}. Check the spelling and your network."
-msgstr ""
+msgstr "Не вдалося підключитися до {domainInput}. Перевірте правильність написання та своє з'єднання."
 
 msgid "Create account"
 msgstr "Створити обліковий запис"
@@ -320,7 +320,7 @@ msgid "Default"
 msgstr "За замовчуванням"
 
 msgid "Deny All"
-msgstr ""
+msgstr "Відхилити все"
 
 msgid "Discoverable passkeys"
 msgstr "Виявлювані ключі доступу"
@@ -344,7 +344,7 @@ msgid "Edit account"
 msgstr "Редагувати обліковий запис"
 
 msgid "Email:"
-msgstr ""
+msgstr "Електронна пошта:"
 
 msgid "Enable multiple accounts"
 msgstr "Увімкнути кілька облікових записів"
@@ -362,7 +362,7 @@ msgid "Enter recovery phrase"
 msgstr "Введіть фразу відновлення"
 
 msgid "Enter your company domain"
-msgstr ""
+msgstr "Введіть домен вашої компанії"
 
 msgid "Everything you need to know about Internet Identity, your private, secure, and easy way to log in to apps on the Internet Computer."
 msgstr "Усе, що потрібно знати про Internet Identity — ваш приватний, безпечний та простий спосіб входу в застосунки на Internet Computer."
@@ -534,7 +534,7 @@ msgid "Invalid code. Please check and try again."
 msgstr "Недійсний код. Будь ласка, перевірте та спробуйте ще раз."
 
 msgid "Invalid domain"
-msgstr ""
+msgstr "Недійсний домен"
 
 msgid "Invalid recovery phrase"
 msgstr "Неправильна фраза відновлення"
@@ -603,7 +603,7 @@ msgid "Link copied to clipboard"
 msgstr "Посилання скопійовано в буфер обміну"
 
 msgid "Loading permissions"
-msgstr ""
+msgstr "Завантаження дозволів"
 
 msgid "Locked legacy recovery phrase"
 msgstr "Заблокована застаріла фраза відновлення"
@@ -669,7 +669,7 @@ msgid "Name your identity"
 msgstr "Назвіть свій ідентифікатор"
 
 msgid "Name:"
-msgstr ""
+msgstr "Ім'я:"
 
 msgid "No data is shared with Google, Microsoft or Apple on which applications you log in with Internet Identity."
 msgstr "Жодні дані про те, в які застосунки ви входите через Internet Identity, не передаються Google, Microsoft чи Apple."
@@ -840,7 +840,7 @@ msgid "Return to application"
 msgstr "Повернутися до застосунку"
 
 msgid "Review Permissions"
-msgstr ""
+msgstr "Переглянути дозволи"
 
 msgid "Right now"
 msgstr "Зараз"
@@ -879,10 +879,10 @@ msgid "Set as default sign-in"
 msgstr "Встановити як вхід за замовчуванням"
 
 msgid "Several SSO sign-ins are in flight already. Wait a moment."
-msgstr ""
+msgstr "Декілька входів через SSO вже виконуються. Зачекайте трохи."
 
 msgid "Share {label}"
-msgstr ""
+msgstr "Поділитися {label}"
 
 msgid "Show all"
 msgstr "Показати все"
@@ -903,7 +903,7 @@ msgid "Sign in with another identity"
 msgstr "Увійти з іншим ідентифікатором"
 
 msgid "Sign in with your {displayName} account from any device."
-msgstr ""
+msgstr "Увійдіть зі своїм обліковим записом {displayName} з будь-якого пристрою."
 
 msgid "Sign out"
 msgstr "Вийти"
@@ -937,22 +937,22 @@ msgid "Something is wrong!"
 msgstr "Щось не так!"
 
 msgid "Something went wrong while creating your delegation. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Під час створення вашого делегування щось пішло не так. Будь ласка, спробуйте ще раз; якщо проблема не зникне, зверніться до служби підтримки."
 
 msgid "Something went wrong while sharing attributes. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "Під час спільного використання атрибутів щось пішло не так. Будь ласка, спробуйте ще раз; якщо проблема не зникне, зверніться до служби підтримки."
 
 msgid "Source code"
 msgstr "Вихідний код"
 
 msgid "SSO"
-msgstr ""
+msgstr "SSO"
 
 msgid "SSO is not available for \"{domainInput}\" yet. Ask an II admin to register this domain."
-msgstr ""
+msgstr "SSO ще недоступний для \"{domainInput}\". Попросіть адміністратора II зареєструвати цей домен."
 
 msgid "SSO sign-in for {domainInput} failed. Please try again."
-msgstr ""
+msgstr "Не вдалося увійти через SSO для {domainInput}. Будь ласка, спробуйте ще раз."
 
 msgid "Start over"
 msgstr "Почати спочатку"
@@ -1033,7 +1033,7 @@ msgid "This app has moved to the new Internet Identity"
 msgstr "Цей застосунок перейшов до нової версії Internet Identity"
 
 msgid "This browser is not supported."
-msgstr ""
+msgstr "Цей браузер не підтримується."
 
 msgid "This identity has already been upgraded to the new experience."
 msgstr "Цей ідентифікатор вже оновлено до нового інтерфейсу."
@@ -1048,7 +1048,7 @@ msgid "This passkey is no longer associated with any identity."
 msgstr "Цей ключ доступу більше не пов'язаний з жодним ідентифікатором."
 
 msgid "This SSO is already linked to your identity."
-msgstr ""
+msgstr "Цей SSO вже пов'язаний з вашим ідентифікатором."
 
 msgid "This YubiKey has older firmware (5.1) that's incompatible."
 msgstr "Цей YubiKey має старішу прошивку (5.1), яка несумісна."
@@ -1087,7 +1087,7 @@ msgid "To finish setting up your passkey, follow the instructions shown on your 
 msgstr "Щоб завершити налаштування вашого ключа доступу, дотримуйтесь інструкцій, показаних на вашому <0>новому пристрої</0>."
 
 msgid "Too many recent attempts for {domainInput}. Wait a few minutes."
-msgstr ""
+msgstr "Забагато нещодавніх спроб для {domainInput}. Зачекайте кілька хвилин."
 
 msgid "Type each word in the correct order:"
 msgstr "Введіть кожне слово у правильному порядку:"
@@ -1132,7 +1132,7 @@ msgid "Unsupported"
 msgstr "Не підтримується"
 
 msgid "Unsupported browser"
-msgstr ""
+msgstr "Непідтримуваний браузер"
 
 msgid "Unsupported Browser"
 msgstr "Непідтримуваний браузер"

--- a/src/frontend/src/lib/locales/ur.po
+++ b/src/frontend/src/lib/locales/ur.po
@@ -23,28 +23,28 @@ msgid "{application} has moved to the new Internet Identity"
 msgstr "{application} نئی Internet Identity پر منتقل ہو گئی ہے"
 
 msgid "{attribute}:"
-msgstr ""
+msgstr "{attribute}:"
 
 msgid "{displayName} account"
-msgstr ""
+msgstr "{displayName} اکاؤنٹ"
 
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
-msgstr ""
+msgstr "{domainInput} نے /.well-known/ii-openid-configuration شائع نہیں کیا (HTTP {0})۔"
 
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
-msgstr ""
+msgstr "{domainInput} کی /.well-known/ii-openid-configuration درست شکل میں نہیں ہے۔"
 
 msgid "{domainInput}'s SSO app doesn't allow the hybrid OAuth flow II requires. Ask the SSO admin to enable response_type \"id_token code\"."
-msgstr ""
+msgstr "{domainInput} کی SSO ایپ اس ہائبرڈ OAuth فلو کی اجازت نہیں دیتی جس کی II کو ضرورت ہے۔ SSO ایڈمن سے کہیں کہ response_type \"id_token code\" فعال کریں۔"
 
 msgid "{domainInput}'s SSO denied the sign-in."
-msgstr ""
+msgstr "{domainInput} کی SSO نے سائن اِن مسترد کر دیا۔"
 
 msgid "{domainInput}'s SSO returned \"{0}\": {1}"
-msgstr ""
+msgstr "{domainInput} کی SSO نے \"{0}\" واپس کیا: {1}"
 
 msgid "{domainInput}'s SSO returned error \"{0}\"."
-msgstr ""
+msgstr "{domainInput} کی SSO نے ایرر \"{0}\" واپس کیا۔"
 
 msgid "{identityName} has been removed from this device."
 msgstr "{identityName} کو اس آلے سے ہٹا دیا گیا ہے۔"
@@ -56,13 +56,13 @@ msgid "{num, plural, one {# Passkey} other {# Passkeys}}"
 msgstr "{num, plural, one {# پاس کی} other {# پاس کیز}}"
 
 msgid "{providerName} {attribute}:"
-msgstr ""
+msgstr "{providerName} {attribute}:"
 
 msgid "{providerName} email:"
-msgstr ""
+msgstr "{providerName} ای میل:"
 
 msgid "{providerName} name:"
-msgstr ""
+msgstr "{providerName} نام:"
 
 msgid "<0>Completely Redesigned Interface:</0> We've given Internet Identity a fresh, modern look and feel. The new design is intuitive and easier to navigate, ensuring a smoother user journey."
 msgstr "<0>بالکل نئے سرے سے ڈیزائن کیا گیا انٹرفیس:</0> ہم نے Internet Identity کو نیا، جدید انداز اور احساس دیا ہے۔ نیا ڈیزائن بدیہی ہے اور نیویگییشن کو مزید آسان بناتا ہے، جس سے صارف کے سفر میں زیادہ روانی یقینی ہوتی ہے۔"
@@ -134,7 +134,7 @@ msgid "Advanced identity management"
 msgstr "جدید شناختی نظم و نسق"
 
 msgid "Allow to access this info"
-msgstr ""
+msgstr "اس معلومات تک رسائی کی اجازت دیں"
 
 msgid "Are you sure?"
 msgstr "کیا آپ کو یقین ہے؟"
@@ -146,13 +146,13 @@ msgid "As you are currently signed in with this passkey, you will be signed out.
 msgstr "چونکہ آپ فی الحال اس پاس کی سے سائن اِن ہیں، اس لیے آپ کو سائن آؤٹ کر دیا جائے گا۔"
 
 msgid "Attribute sharing failed"
-msgstr ""
+msgstr "ایٹریبیوٹس شیئر کرنا ناکام ہو گیا"
 
 msgid "Authenticating..."
 msgstr "تصدیق ہو رہی ہے..."
 
 msgid "Authentication failed"
-msgstr ""
+msgstr "تصدیق ناکام ہو گئی"
 
 msgid "Authentication successful"
 msgstr "تصدیق کامیاب رہی"
@@ -161,7 +161,7 @@ msgid "Authorize new device"
 msgstr "نئے آلے کی توثیق کریں"
 
 msgid "Back to sign-in options"
-msgstr ""
+msgstr "سائن اِن کے آپشنز پر واپس جائیں"
 
 msgid "Before getting started, find a private place and have your recovery phrase ready. Keep it confidential to protect your identity."
 msgstr "شروع کرنے سے پہلے کسی نجی جگہ پر جائیں اور اپنا ریکوری فریز تیار رکھیں۔ اپنی شناخت کے تحفظ کے لیے اسے خفیہ رکھیں۔"
@@ -182,7 +182,7 @@ msgid "CAPTCHA characters"
 msgstr "CAPTCHA حروف"
 
 msgid "Change"
-msgstr ""
+msgstr "تبدیل کریں"
 
 msgid "Characters are case-sensitive"
 msgstr "حروف بڑے اور چھوٹے ہونے کے لحاظ سے حساس ہوتے ہیں"
@@ -197,7 +197,7 @@ msgid "Checking your order"
 msgstr "آپ کے آرڈر کی جانچ ہو رہی ہے"
 
 msgid "Checking..."
-msgstr ""
+msgstr "جانچ ہو رہی ہے..."
 
 msgid "Choose an account"
 msgstr "اکاؤنٹ منتخب کریں"
@@ -212,7 +212,7 @@ msgid "Choose method to continue"
 msgstr "جاری رکھنے کے لیے طریقہ منتخب کریں"
 
 msgid "Choose which details you'd like to share"
-msgstr ""
+msgstr "منتخب کریں کہ آپ کون سی تفصیلات شیئر کرنا چاہتے ہیں"
 
 msgid "Clear all"
 msgstr "سب صاف کریں"
@@ -230,10 +230,10 @@ msgid "Code copied to clipboard"
 msgstr "کوڈ کلپ بورڈ پر کاپی ہو گیا"
 
 msgid "Company domain"
-msgstr ""
+msgstr "کمپنی کا ڈومین"
 
 msgid "company.domain.com"
-msgstr ""
+msgstr "company.domain.com"
 
 msgid "Complete set-up"
 msgstr "سیٹ اپ مکمل کریں"
@@ -272,10 +272,10 @@ msgid "Continue with passkey"
 msgstr "پاس کی کے ساتھ جاری رکھیں"
 
 msgid "Continue with SSO"
-msgstr ""
+msgstr "SSO کے ساتھ جاری رکھیں"
 
 msgid "Couldn't reach {domainInput}. Check the spelling and your network."
-msgstr ""
+msgstr "{domainInput} تک نہیں پہنچا جا سکا۔ سپیلنگ اور اپنا نیٹ ورک چیک کریں۔"
 
 msgid "Create account"
 msgstr "اکاؤنٹ بنائیں"
@@ -320,7 +320,7 @@ msgid "Default"
 msgstr "ڈیفالٹ"
 
 msgid "Deny All"
-msgstr ""
+msgstr "سب کو مسترد کریں"
 
 msgid "Discoverable passkeys"
 msgstr "قابلِ دریافت پاس کیز"
@@ -344,7 +344,7 @@ msgid "Edit account"
 msgstr "اکاؤنٹ میں ترمیم کریں"
 
 msgid "Email:"
-msgstr ""
+msgstr "ای میل:"
 
 msgid "Enable multiple accounts"
 msgstr "متعدد اکاؤنٹس فعال کریں"
@@ -362,7 +362,7 @@ msgid "Enter recovery phrase"
 msgstr "ریکوری فریز درج کریں"
 
 msgid "Enter your company domain"
-msgstr ""
+msgstr "اپنی کمپنی کا ڈومین درج کریں"
 
 msgid "Everything you need to know about Internet Identity, your private, secure, and easy way to log in to apps on the Internet Computer."
 msgstr "Internet Identity کے بارے میں وہ سب کچھ جو آپ کو جاننا چاہیے — انٹرنیٹ کمپیوٹر کی ایپس میں لاگ اِن کا نجی، محفوظ اور آسان طریقہ۔"
@@ -534,7 +534,7 @@ msgid "Invalid code. Please check and try again."
 msgstr "غلط کوڈ۔ براہِ کرم چیک کریں اور دوبارہ کوشش کریں"
 
 msgid "Invalid domain"
-msgstr ""
+msgstr "غلط ڈومین"
 
 msgid "Invalid recovery phrase"
 msgstr "غلط ریکوری فریز"
@@ -603,7 +603,7 @@ msgid "Link copied to clipboard"
 msgstr "لنک کلپ بورڈ پر کاپی ہو گیا"
 
 msgid "Loading permissions"
-msgstr ""
+msgstr "اجازتیں لوڈ ہو رہی ہیں"
 
 msgid "Locked legacy recovery phrase"
 msgstr "مقفل پرانا ریکوری فریز"
@@ -669,7 +669,7 @@ msgid "Name your identity"
 msgstr "اپنی شناخت کا نام رکھیں"
 
 msgid "Name:"
-msgstr ""
+msgstr "نام:"
 
 msgid "No data is shared with Google, Microsoft or Apple on which applications you log in with Internet Identity."
 msgstr "Google، Microsoft یا Apple کے ساتھ یہ معلومات شیئر نہیں کی جاتیں کہ آپ Internet Identity کے ذریعے کن ایپلیکیشنز میں لاگ اِن کرتے ہیں۔"
@@ -840,7 +840,7 @@ msgid "Return to application"
 msgstr "ایپلی کیشن پر واپس جائیں"
 
 msgid "Review Permissions"
-msgstr ""
+msgstr "اجازتوں کا جائزہ لیں"
 
 msgid "Right now"
 msgstr "ابھی"
@@ -879,10 +879,10 @@ msgid "Set as default sign-in"
 msgstr "ڈیفالٹ سائن اِن کے طور پر سیٹ کریں"
 
 msgid "Several SSO sign-ins are in flight already. Wait a moment."
-msgstr ""
+msgstr "متعدد SSO سائن اِن پہلے ہی جاری ہیں۔ ایک لمحہ انتظار کریں۔"
 
 msgid "Share {label}"
-msgstr ""
+msgstr "{label} شیئر کریں"
 
 msgid "Show all"
 msgstr "سب دکھائیں"
@@ -903,7 +903,7 @@ msgid "Sign in with another identity"
 msgstr "دوسری شناخت کے ساتھ سائن اِن کریں"
 
 msgid "Sign in with your {displayName} account from any device."
-msgstr ""
+msgstr "اپنے {displayName} اکاؤنٹ سے کسی بھی آلے سے سائن اِن کریں۔"
 
 msgid "Sign out"
 msgstr "سائن آؤٹ"
@@ -937,22 +937,22 @@ msgid "Something is wrong!"
 msgstr "کچھ غلط ہے!"
 
 msgid "Something went wrong while creating your delegation. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "آپ کی ڈیلیگیشن بناتے وقت کچھ غلط ہو گیا۔ براہ کرم دوبارہ کوشش کریں؛ اگر مسئلہ برقرار رہے تو سپورٹ سے رابطہ کریں۔"
 
 msgid "Something went wrong while sharing attributes. Please try again; if the issue persists, contact support."
-msgstr ""
+msgstr "ایٹریبیوٹس شیئر کرتے وقت کچھ غلط ہو گیا۔ براہ کرم دوبارہ کوشش کریں؛ اگر مسئلہ برقرار رہے تو سپورٹ سے رابطہ کریں۔"
 
 msgid "Source code"
 msgstr "سورس کوڈ"
 
 msgid "SSO"
-msgstr ""
+msgstr "SSO"
 
 msgid "SSO is not available for \"{domainInput}\" yet. Ask an II admin to register this domain."
-msgstr ""
+msgstr "SSO ابھی \"{domainInput}\" کے لیے دستیاب نہیں ہے۔ اس ڈومین کو رجسٹر کرنے کے لیے II ایڈمن سے کہیں۔"
 
 msgid "SSO sign-in for {domainInput} failed. Please try again."
-msgstr ""
+msgstr "{domainInput} کے لیے SSO سائن اِن ناکام ہو گیا۔ براہ کرم دوبارہ کوشش کریں۔"
 
 msgid "Start over"
 msgstr "دوبارہ شروع کریں"
@@ -1033,7 +1033,7 @@ msgid "This app has moved to the new Internet Identity"
 msgstr "یہ ایپ نئی Internet Identity پر منتقل ہو گئی ہے"
 
 msgid "This browser is not supported."
-msgstr ""
+msgstr "یہ براؤزر معاون نہیں ہے۔"
 
 msgid "This identity has already been upgraded to the new experience."
 msgstr "یہ شناخت پہلے ہی نئے تجربے پر اپ گریڈ ہو چکی ہے۔"
@@ -1048,7 +1048,7 @@ msgid "This passkey is no longer associated with any identity."
 msgstr "یہ پاس کی اب کسی شناخت سے منسلک نہیں ہے۔"
 
 msgid "This SSO is already linked to your identity."
-msgstr ""
+msgstr "یہ SSO پہلے ہی آپ کی شناخت سے منسلک ہے۔"
 
 msgid "This YubiKey has older firmware (5.1) that's incompatible."
 msgstr "اس YubiKey کا فرم ویئر پرانا (5.1) ہے اور یہ اس سسٹم کے ساتھ مطابقت نہیں رکھتا۔"
@@ -1087,7 +1087,7 @@ msgid "To finish setting up your passkey, follow the instructions shown on your 
 msgstr "اپنی پاس کی سیٹ اپ مکمل کرنے کے لیے، اپنی <0>نئی ڈیوائس</0> پر دکھائی گئی ہدایات پر عمل کریں۔"
 
 msgid "Too many recent attempts for {domainInput}. Wait a few minutes."
-msgstr ""
+msgstr "{domainInput} کے لیے حالیہ کوششیں بہت زیادہ ہیں۔ چند منٹ انتظار کریں۔"
 
 msgid "Type each word in the correct order:"
 msgstr "ہر لفظ درست ترتیب میں درج کریں:"
@@ -1132,7 +1132,7 @@ msgid "Unsupported"
 msgstr "غیر معاون"
 
 msgid "Unsupported browser"
-msgstr ""
+msgstr "غیر معاون براؤزر"
 
 msgid "Unsupported Browser"
 msgstr "آپ کا براؤزر اس سروس کو سپورٹ نہیں کرتا"


### PR DESCRIPTION
Several recently-added strings — primarily SSO sign-in, attribute sharing, and related error messages — were untranslated in every non-English language file, so users in those locales would have seen the English source text in the UI.

# Changes

- Translated 41 missing entries across `de.po`, `es.po`, `fr.po`, `id.po`, `it.po`, `nl.po`, `pl.po`, `ru.po`, `uk.po`, `ur.po` (410 strings total).
- Style and terminology kept consistent with each file's existing translations; brand names (Internet Identity, SSO, II, OAuth) left untranslated; variables and tags preserved.

This PR is a one-off catch-up. Future runs will be handled per-language by the automation in #3796 once it lands.