### PR TITLE
fix(fe): drop unnecessary LastUsedIdentity schema bump

### DIFF
--- a/src/frontend/src/lib/stores/last-used-identities.store.ts
+++ b/src/frontend/src/lib/stores/last-used-identities.store.ts
@@ -92,7 +92,7 @@ export const initLastUsedIdentitiesStore = (): LastUsedIdentitiesStore => {
   const lastUsedStore = writableStored<LastUsedIdentities>({
     key: storeLocalStorageKey.LastUsedIdentities,
     defaultValue: {},
-    version: 5,
+    version: 4,
   });
   const selectedStore = writable<bigint | undefined>(
     Object.values(get(lastUsedStore)).sort(


### PR DESCRIPTION
The schema bump from `version: 4` to `version: 5` in #3814 wipes every user's locally-stored last-used identity list on first load — but the change that triggered the bump (a new `sso` variant on `authMethod`) is purely additive:

- Existing `passkey` and `openid` shapes are unchanged.
- Every consumer (`authLastUsedFlow`, `ManageIdentities`, `IdentitySwitcher`, `IdentityListItem`, `IdentityAvatar`) uses `"X" in authMethod` discrimination with `if`/`else if` fallthrough — there are no exhaustive switches that would throw on a v4 entry.

So v4 entries continue to parse and route through the existing branches; they just never enter the new `sso` branch (which is correct — they aren't sso). Reverting to `version: 4` keeps everyone's last-used list intact.

# Changes

- `LastUsedIdentities` store version: `5` → `4`