### PR TITLE
fix(fe): clear lint errors across frontend, lint .svelte files in CI

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ export default ts.config(
     languageOptions: {
       parserOptions: {
         parser: ts.parser,
+        extraFileExtensions: [".svelte"],
       },
     },
   },
@@ -36,6 +37,7 @@ export default ts.config(
     languageOptions: {
       parserOptions: {
         project: ["./tsconfig.eslint.json"],
+        extraFileExtensions: [".svelte"],
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:e2e-mobile": "SCREEN=mobile npm run test:e2e",
     "test:e2e-playwright": "npx playwright test",
     "lint": "npm run lint:eslint && npm run lint:lit",
-    "lint:eslint": "eslint --max-warnings 0 --cache --cache-location node_modules/.cache/eslint 'src/frontend/**/*.ts*'",
+    "lint:eslint": "eslint --max-warnings 0 --cache --cache-location node_modules/.cache/eslint 'src/frontend/**/*.{ts,svelte}'",
     "lint:lit": "lit-analyzer -- --rules.no-incompatible-type-binding off --rules.no-invalid-directive-binding off --rules.no-noncallable-event-binding off ./src/frontend",
     "format": "prettier --write src/frontend src/vc-api src/sig-verifier-js src/vite-plugins tsconfig.json tsconfig.all.json eslint.config.js vite.config.ts vitest.config.ts demos",
     "format-check": "prettier --check src/frontend src/vc-api src/sig-verifier-js src/vite-plugins tsconfig.json tsconfig.all.json eslint.config.js vite.config.ts vitest.config.ts demos",

--- a/src/frontend/src/lib/components/backgrounds/FlairCanvas.svelte
+++ b/src/frontend/src/lib/components/backgrounds/FlairCanvas.svelte
@@ -25,7 +25,7 @@
   import * as easingFunctions from "svelte/easing";
 
   let {
-    bgType = "dots",
+    bgType: _bgType = "dots",
     spacing = "medium",
     aspect = "wide",
     hoverAction = "none",
@@ -54,7 +54,9 @@
     customColor,
     customColorMode,
     containerHeight,
+    // eslint-disable-next-line no-useless-assignment -- $bindable() default is required so the parent's bind:triggerAnimation can propagate
     triggerAnimation = $bindable(),
+    // eslint-disable-next-line no-useless-assignment -- $bindable() default is required so the parent's bind:clearAnimation can propagate
     clearAnimation = $bindable(),
   }: FlairCanvasProps = $props();
 
@@ -74,8 +76,8 @@
   let lastPointerX = $state<number>(0);
   let lastPointerY = $state<number>(0);
   let lastPointerTime = $state<number>(0);
-  let pointerSpeed = $state<number>(0);
-  let pointerInside = $state<boolean>(false);
+  let _pointerSpeed = $state<number>(0);
+  let _pointerInside = $state<boolean>(false);
 
   let stiffness = $state(0.1);
   let damping = $state(0.5);
@@ -95,7 +97,7 @@
     });
   });
 
-  let motionNoiseScale = $state<number>(0.01);
+  let _motionNoiseScale = $state<number>(0.01);
 
   let backgroundInitialized = $state(false);
   let backgroundIsVisible = $state(true);
@@ -160,13 +162,13 @@
     large: 3,
   };
 
-  const stiffnessTable = {
+  const _stiffnessTable = {
     light: 0.1,
     medium: 0.5,
     strong: 1,
   };
 
-  const dampeningTable = {
+  const _dampeningTable = {
     light: 0.1,
     medium: 0.5,
     strong: 1,
@@ -219,7 +221,7 @@
   );
 
   let xPositions = $derived<number[]>(
-    clientWidth
+    clientWidth !== undefined && clientWidth > 0
       ? Array.from(
           { length: Math.max(1, Math.floor((clientWidth - 1) / xSpacing) + 2) }, // +2 instead of +1
           (_, i) => i * xSpacing,
@@ -228,7 +230,7 @@
   );
 
   let yPositions = $derived<number[]>(
-    clientHeight
+    clientHeight !== undefined && clientHeight > 0
       ? Array.from(
           {
             length: Math.max(1, Math.floor((clientHeight - 1) / ySpacing) + 2),
@@ -258,8 +260,10 @@
     getVignetteConfig(vignette, clientHeight, clientWidth),
   );
 
+  // eslint-disable-next-line no-useless-assignment -- assigned to bindable prop so parent reads it via bind:clearAnimation
   clearAnimation = async () => await clearWave(opacityWaveMotion, springs);
 
+  // eslint-disable-next-line no-useless-assignment -- assigned to bindable prop so parent reads it via bind:triggerAnimation
   triggerAnimation = async (opts) => {
     const {
       location,
@@ -272,11 +276,16 @@
       impulseEasing,
     } = opts;
 
-    let easingFunction = impulseEasing
-      ? easingFunctions[impulseEasing]
-      : undefined;
+    let easingFunction =
+      impulseEasing !== undefined ? easingFunctions[impulseEasing] : undefined;
 
-    if (target.includes("motion") && clientWidth && clientHeight) {
+    if (
+      target.includes("motion") &&
+      clientWidth !== undefined &&
+      clientWidth > 0 &&
+      clientHeight !== undefined &&
+      clientHeight > 0
+    ) {
       const { x, y } = getImpulseLocation(location, clientWidth, clientHeight);
       const promises: Promise<void>[] = [];
 
@@ -544,7 +553,7 @@
       }
 
       if (visibility === "maskwave") {
-        if (impulseEasing) {
+        if (impulseEasing !== undefined) {
           opacityWaveMotion = new Tween(0, {
             easing: easingFunctions[impulseEasing],
           });
@@ -561,7 +570,7 @@
         );
         promises.push(maskWave);
       } else if (visibility === "pausedmaskwave") {
-        if (impulseEasing) {
+        if (impulseEasing !== undefined) {
           opacityWaveMotion = new Tween(0, {
             easing: easingFunctions[impulseEasing],
           });
@@ -575,7 +584,7 @@
               ? maskWaveSpeedMultiplier
               : 1),
           0,
-          maskWavePauseValue || 1,
+          maskWavePauseValue ?? 1,
         );
         promises.push(maskWave);
       }
@@ -595,7 +604,7 @@
   };
 
   const handleReset = () => {
-    pointerInside = false;
+    _pointerInside = false;
     resetNodes(springs);
   };
 
@@ -618,7 +627,7 @@
       const dy = pointerY - prevY;
       const dt = now - prevTime;
       const dist = Math.sqrt(dx * dx + dy * dy);
-      pointerSpeed = dist / dt; // px per ms
+      _pointerSpeed = dist / dt; // px per ms
     }
 
     if (now - prevTime > 60 && hoverAction !== "none") {
@@ -741,8 +750,10 @@
 
     if (
       visibility === "maskwave" &&
-      !!clientWidth &&
-      !!clientHeight &&
+      clientWidth !== undefined &&
+      clientWidth > 0 &&
+      clientHeight !== undefined &&
+      clientHeight > 0 &&
       maskWaveThickness !== undefined
     ) {
       drawMovingRingMask(
@@ -762,8 +773,10 @@
 
     if (
       visibility === "pausedmaskwave" &&
-      !!clientWidth &&
-      !!clientHeight &&
+      clientWidth !== undefined &&
+      clientWidth > 0 &&
+      clientHeight !== undefined &&
+      clientHeight > 0 &&
       maskWaveThickness !== undefined
     ) {
       drawMovingRingMask(
@@ -806,9 +819,9 @@
     }
     clearTimeout(resizeTimeout);
     if (backgroundIsVisible) {
-      canvasGlobalOpacity.set(0, { duration: 0 });
+      void canvasGlobalOpacity.set(0, { duration: 0 });
       resizeTimeout = setTimeout(() => {
-        canvasGlobalOpacity.set(100, { duration: 1000 });
+        void canvasGlobalOpacity.set(100, { duration: 1000 });
       }, 10);
     }
   };
@@ -834,8 +847,15 @@
   });
 
   $effect(() => {
-    if (canvasRef && ctx && clientWidth && clientHeight) {
-      dpr = window.devicePixelRatio || 1;
+    if (
+      canvasRef !== undefined &&
+      ctx !== null &&
+      clientWidth !== undefined &&
+      clientWidth > 0 &&
+      clientHeight !== undefined &&
+      clientHeight > 0
+    ) {
+      dpr = window.devicePixelRatio !== 0 ? window.devicePixelRatio : 1;
       canvasRef.width = clientWidth * dpr;
       canvasRef.height = clientHeight * dpr;
       canvasRef.style.width = clientWidth + "px";

--- a/src/frontend/src/lib/components/backgrounds/WaveCanvas.svelte
+++ b/src/frontend/src/lib/components/backgrounds/WaveCanvas.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import FlairCanvas from "./FlairCanvas.svelte";
-  import { isMobile } from "$lib/state/UI/isMobile";
   import { onMount, onDestroy } from "svelte";
   import {
     registerAnimationTrigger,
@@ -13,7 +12,7 @@
   } = $props();
 
   onMount(() => {
-    if (triggerAnimation) {
+    if (triggerAnimation !== undefined) {
       registerAnimationTrigger(triggerAnimation, clearAnimation);
     }
   });

--- a/src/frontend/src/lib/components/layout/Footer.svelte
+++ b/src/frontend/src/lib/components/layout/Footer.svelte
@@ -7,7 +7,7 @@
 
   type Props = HTMLAttributes<HTMLElement>;
 
-  const { children, class: className, ...props }: Props = $props();
+  const { class: className, ...props }: Props = $props();
 
   let isLanguageDialogOpen = $state(false);
 </script>
@@ -53,7 +53,7 @@
       value={$localeStore}
       onChange={(value) => {
         isLanguageDialogOpen = false;
-        localeStore.setOrReset(value);
+        void localeStore.setOrReset(value);
       }}
     />
   </Dialog>

--- a/src/frontend/src/lib/components/locale/Trans.svelte
+++ b/src/frontend/src/lib/components/locale/Trans.svelte
@@ -13,17 +13,18 @@
     context?: string;
   }
 
+  // eslint-disable-next-line svelte/no-unused-props -- `context` is consumed by the lingui-svelte preprocessor at compile time, so the runtime component never receives it
   const { id, message, values, renderNode }: Props = $props();
 
   const chunks = $derived.by(() => {
-    $localeStore; // Re-run on locale changes
+    void $localeStore; // Re-run on locale changes
     const translated = i18n.t({ id: id!, message, values });
     return parseMessage(translated);
   });
 </script>
 
 {#snippet renderNodeRec(children: Chunk[])}
-  {#each children as chunk}
+  {#each children as chunk, i (i)}
     {#if chunk.type === "text"}
       {chunk.text}
     {:else}

--- a/src/frontend/src/lib/components/ui/Alert.svelte
+++ b/src/frontend/src/lib/components/ui/Alert.svelte
@@ -6,7 +6,6 @@
     CircleAlertIcon,
     XIcon,
   } from "@lucide/svelte";
-  import Button from "$lib/components/ui/Button.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { t } from "$lib/stores/locale.store";
 

--- a/src/frontend/src/lib/components/ui/AuthMethodBadge.svelte
+++ b/src/frontend/src/lib/components/ui/AuthMethodBadge.svelte
@@ -31,6 +31,7 @@
     <span
       class={["text-fg-tertiary", size === "lg" ? "size-4.25" : "size-3.25"]}
     >
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- variant.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
       {@html variant.logo}
     </span>
   {:else}

--- a/src/frontend/src/lib/components/ui/Button.svelte
+++ b/src/frontend/src/lib/components/ui/Button.svelte
@@ -46,8 +46,8 @@
       lg: "btn-lg",
       xl: "btn-xl",
     }[size],
-    danger && "btn-danger",
-    iconOnly && "btn-icon",
+    danger === true && "btn-danger",
+    iconOnly === true && "btn-icon",
     className,
   ]}
 >

--- a/src/frontend/src/lib/components/ui/CodeInput.svelte
+++ b/src/frontend/src/lib/components/ui/CodeInput.svelte
@@ -13,6 +13,7 @@
 
   let {
     length,
+    // eslint-disable-next-line no-useless-assignment -- $bindable() default is required so the parent's bind:element can propagate
     element = $bindable(),
     value = $bindable(),
     hint,
@@ -58,7 +59,7 @@
 
 <div {...props} class={["flex flex-col gap-1", className]}>
   <div class="flex gap-2">
-    {#each { length } as _, index}
+    {#each { length } as _, index (index)}
       <Input
         bind:element={
           () => inputRefs[index], (element) => (inputRefs[index] = element)

--- a/src/frontend/src/lib/components/ui/Identicon.svelte
+++ b/src/frontend/src/lib/components/ui/Identicon.svelte
@@ -23,8 +23,8 @@
   viewBox="0 0 {elements} {elements}"
   class={["rounded-full", className]}
 >
-  {#each { length: elements } as _, x}
-    {#each { length: elements } as _, y}
+  {#each { length: elements } as _, x (x)}
+    {#each { length: elements } as _, y (y)}
       <rect
         {x}
         {y}

--- a/src/frontend/src/lib/components/ui/IdentityListItem.svelte
+++ b/src/frontend/src/lib/components/ui/IdentityListItem.svelte
@@ -31,8 +31,8 @@
     {:else}
       <span>
         {$t`Passkey`}
-        {#if showCreatedAt && identity.createdAtMillis !== undefined}
-          {" | "}
+        {#if showCreatedAt === true && identity.createdAtMillis !== undefined}
+          |
           {$t`Created ${$formatRelative(new Date(identity.createdAtMillis), {
             style: "long",
           })}`}

--- a/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
+++ b/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
@@ -6,6 +6,7 @@
     PlusIcon,
     PencilIcon,
   } from "@lucide/svelte";
+  import { SvelteMap } from "svelte/reactivity";
   import type { HTMLAttributes } from "svelte/elements";
   import type { LastUsedIdentity } from "$lib/stores/last-used-identities.store";
   import { t } from "$lib/stores/locale.store";
@@ -19,11 +20,11 @@
     identities: LastUsedIdentity[];
     onSwitchIdentity: (identityNumber: bigint) => Promise<void>;
     onUseAnotherIdentity: () => void;
-    onManageIdentity?: () => Promise<void>;
+    onManageIdentity?: () => Promise<void> | void;
     onManageIdentities?: () => void;
     onError: (error: unknown) => void;
     onClose: () => void;
-    onSignOut?: () => Promise<void>;
+    onSignOut?: () => Promise<void> | void;
   };
 
   const {
@@ -59,7 +60,7 @@
     ),
   );
   const passkeyNameCounts = $derived.by(() => {
-    const counts = new Map<string | undefined, number>();
+    const counts = new SvelteMap<string | undefined, number>();
 
     for (const identity of otherIdentities) {
       if (!("passkey" in identity.authMethod)) {
@@ -210,7 +211,7 @@
       class="flex flex-col gap-2 overflow-y-auto"
       style={`max-height: ${Math.max(2, Math.floor((windowHeight - 380) / 74)) * 74 - 41}px`}
     >
-      {#each otherIdentities as identity}
+      {#each otherIdentities as identity (identity.identityNumber)}
         {@render identityListItem(identity)}
       {/each}
     </ul>

--- a/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
+++ b/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
@@ -20,11 +20,11 @@
     identities: LastUsedIdentity[];
     onSwitchIdentity: (identityNumber: bigint) => Promise<void>;
     onUseAnotherIdentity: () => void;
-    onManageIdentity?: () => Promise<void> | void;
+    onManageIdentity?: () => Promise<void>;
     onManageIdentities?: () => void;
     onError: (error: unknown) => void;
     onClose: () => void;
-    onSignOut?: () => Promise<void> | void;
+    onSignOut?: () => Promise<void>;
   };
 
   const {

--- a/src/frontend/src/lib/components/ui/ManageIdentities.svelte
+++ b/src/frontend/src/lib/components/ui/ManageIdentities.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { SvelteMap } from "svelte/reactivity";
   import type { LastUsedIdentity } from "$lib/stores/last-used-identities.store";
   import { t } from "$lib/stores/locale.store";
   import { Trans } from "$lib/components/locale";
@@ -19,7 +20,7 @@
   let removingIdentity = $state<LastUsedIdentity>();
 
   const passkeyNameCounts = $derived.by(() => {
-    const counts = new Map<string | undefined, number>();
+    const counts = new SvelteMap<string | undefined, number>();
     for (const identity of identities) {
       if (!("passkey" in identity.authMethod)) {
         continue;
@@ -120,7 +121,7 @@
     </div>
 
     <ul class="flex flex-col">
-      {#each identities as identity, i}
+      {#each identities as identity, i (identity.identityNumber)}
         <li class="flex items-center gap-3 py-3">
           <IdentityListItem
             {identity}

--- a/src/frontend/src/lib/components/ui/NavItem.svelte
+++ b/src/frontend/src/lib/components/ui/NavItem.svelte
@@ -17,10 +17,10 @@
   {...props}
   class={[
     "flex h-10 flex-row items-center gap-3 rounded-sm px-3 py-2 text-base font-medium",
-    current
+    current === true
       ? "text-text-primary bg-bg-active ring-border-secondary hover:bg-bg-primary_hover ring-1 ring-inset"
       : "text-text-secondary hover:bg-bg-active",
-    current
+    current === true
       ? "[&_svg]:text-fg-primary"
       : "[&_svg]:text-fg-quaternary dark:[&_svg]:text-fg-tertiary",
     className,

--- a/src/frontend/src/lib/components/ui/Popover.svelte
+++ b/src/frontend/src/lib/components/ui/Popover.svelte
@@ -176,11 +176,11 @@
   <div
     {...props}
     bind:this={popoverRef}
-    popover={"manual"}
+    popover="manual"
     in:fade|global={{ duration: 1 }}
     out:fade|global={{ delay: 160, duration: 1 }}
     ontoggle={() => {
-      if (popoverRef?.matches(":popover-open")) {
+      if (popoverRef?.matches(":popover-open") === true) {
         return;
       }
       onClose?.();
@@ -190,7 +190,7 @@
     onfocusout={(e) => {
       if (
         e.relatedTarget instanceof Node &&
-        popoverRef?.contains(e.relatedTarget)
+        popoverRef?.contains(e.relatedTarget) === true
       ) {
         return;
       }

--- a/src/frontend/src/lib/components/ui/QrCode.svelte
+++ b/src/frontend/src/lib/components/ui/QrCode.svelte
@@ -47,7 +47,7 @@
 
   // Lazy load qr creator on component mount
   onMount(() => {
-    getQrCreator().then((value) => (qrCreator = value));
+    void getQrCreator().then((value) => (qrCreator = value));
   });
 </script>
 
@@ -62,7 +62,7 @@
     class="mix-blend-darken dark:mix-blend-lighten **:dark:invert"
   ></div>
   <div
-    class={"bg-text-primary absolute inset-0 mix-blend-lighten dark:mix-blend-darken"}
+    class="bg-text-primary absolute inset-0 mix-blend-lighten dark:mix-blend-darken"
   ></div>
 </div>
 

--- a/src/frontend/src/lib/components/ui/Select.svelte
+++ b/src/frontend/src/lib/components/ui/Select.svelte
@@ -74,7 +74,7 @@
     class={["!w-max p-1.5 !shadow-lg", className]}
   >
     <div class="flex flex-col" role="menu">
-      {#each options as option, index}
+      {#each options as option, index (index)}
         <Tooltip
           label={option.tooltip ?? ""}
           hidden={option.tooltip === undefined ? true : undefined}
@@ -86,7 +86,8 @@
             variant="tertiary"
             class={[
               "justify-start gap-2.5 !px-3 text-start",
-              option.selected && "[ul:not(:hover)_&]:bg-bg-primary_hover",
+              option.selected === true &&
+                "[ul:not(:hover)_&]:bg-bg-primary_hover",
             ]}
             role="menuitem"
             aria-label={option.label}

--- a/src/frontend/src/lib/components/ui/TextFade.svelte
+++ b/src/frontend/src/lib/components/ui/TextFade.svelte
@@ -23,14 +23,14 @@
     }
   };
 
-  let interval: NodeJS.Timeout;
+  let interval: ReturnType<typeof setInterval>;
 
   onMount(() => {
     if (texts.length <= 1) return;
 
     const start = setTimeout(() => {
-      interval = setInterval(next, delayBetween + duration);
-      next();
+      interval = setInterval(() => void next(), delayBetween + duration);
+      void next();
     }, startDelay);
 
     return () => {

--- a/src/frontend/src/lib/components/ui/Tooltip.svelte
+++ b/src/frontend/src/lib/components/ui/Tooltip.svelte
@@ -156,7 +156,7 @@
     {id}
     {...restProps}
     bind:this={tooltipRef}
-    popover={"manual"}
+    popover="manual"
     class="tooltip pointer-events-none fixed overflow-visible bg-transparent"
     role="tooltip"
   >

--- a/src/frontend/src/lib/components/utils/Ellipsis.svelte
+++ b/src/frontend/src/lib/components/utils/Ellipsis.svelte
@@ -56,7 +56,7 @@
   >
     {#if position !== "start"}
       <span class="flex flex-1 flex-wrap justify-end">
-        {#each leftCharacters as character}
+        {#each leftCharacters as character, i (i)}
           <span>{character}</span>
         {/each}
       </span>
@@ -64,7 +64,7 @@
     <span>…</span>
     {#if position !== "end"}
       <span class="flex flex-1 flex-row-reverse flex-wrap justify-end">
-        {#each rightCharacters as character}
+        {#each rightCharacters as character, i (i)}
           <span>{character}</span>
         {/each}
       </span>

--- a/src/frontend/src/lib/components/views/ChooseLanguage.svelte
+++ b/src/frontend/src/lib/components/views/ChooseLanguage.svelte
@@ -27,7 +27,7 @@
 <p class="text-text-tertiary mb-6 text-base">
   <Trans>choose language to continue</Trans>
 </p>
-{#each locales as locale, index}
+{#each locales as locale, index (locale)}
   {@const label = new Intl.DisplayNames([locale], {
     type: "language",
     style: "long",

--- a/src/frontend/src/lib/components/views/RecoveryPhraseInput.svelte
+++ b/src/frontend/src/lib/components/views/RecoveryPhraseInput.svelte
@@ -103,7 +103,9 @@
 
   onMount(() => {
     // Lazy load dictionary so this component doesn't include it in the bundle eagerly
-    import("bip39").then((bip39) => (dictionary = bip39.wordlists.english));
+    void import("bip39").then(
+      (bip39) => (dictionary = bip39.wordlists.english),
+    );
     // Focus on first empty input field, else fallback to first input
     focusInput(
       Math.max(
@@ -130,7 +132,7 @@
       className,
     ]}
   >
-    {#each value as word, index}
+    {#each value as word, index (index)}
       {@const position = index + 1}
       <label class="relative">
         <input

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/AddAccessMethodWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/AddAccessMethodWizard.svelte
@@ -72,7 +72,7 @@
       onError(error);
     }
   };
-  const handleOtherDeviceRegistered = async () => {
+  const handleOtherDeviceRegistered = () => {
     onOtherDeviceRegistered();
   };
 </script>

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -83,7 +83,7 @@
   {/if}
   <div class="flex flex-col items-stretch gap-3">
     <div class="flex flex-row flex-nowrap justify-stretch gap-3">
-      {#each openIdProviders as provider}
+      {#each openIdProviders as provider (provider.client_id)}
         {@const name = provider.name}
         <Tooltip
           label={$t`Interaction canceled. Please try again.`}
@@ -107,6 +107,7 @@
                 <ProgressRing />
               {:else if provider.logo}
                 <div class="size-6">
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -- provider.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
                   {@html provider.logo}
                 </div>
               {/if}
@@ -132,7 +133,7 @@
     </div>
     <Tooltip
       label={$t`You have reached the maximum number of passkeys`}
-      hidden={!maxPasskeysReached}
+      hidden={maxPasskeysReached !== true}
     >
       <Button
         onclick={continueWithPasskey}

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -83,7 +83,7 @@
   {/if}
   <div class="flex flex-col items-stretch gap-3">
     <div class="flex flex-row flex-nowrap justify-stretch gap-3">
-      {#each openIdProviders as provider (provider.client_id)}
+      {#each openIdProviders as provider (provider.issuer)}
         {@const name = provider.name}
         <Tooltip
           label={$t`Interaction canceled. Please try again.`}

--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -17,9 +17,9 @@
   import type { SsoDiscoveryResult } from "$lib/utils/ssoDiscovery";
 
   interface Props {
-    onSignIn: (identityNumber: bigint) => Promise<void>;
-    onSignUp: (identityNumber: bigint) => Promise<void>;
-    onUpgrade: (identityNumber: bigint) => Promise<void>;
+    onSignIn: (identityNumber: bigint) => Promise<void> | void;
+    onSignUp: (identityNumber: bigint) => Promise<void> | void;
+    onUpgrade: (identityNumber: bigint) => Promise<void> | void;
     onError: (error: unknown) => void;
     withinDialog?: boolean;
     children?: Snippet;

--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -17,9 +17,9 @@
   import type { SsoDiscoveryResult } from "$lib/utils/ssoDiscovery";
 
   interface Props {
-    onSignIn: (identityNumber: bigint) => Promise<void> | void;
-    onSignUp: (identityNumber: bigint) => Promise<void> | void;
-    onUpgrade: (identityNumber: bigint) => Promise<void> | void;
+    onSignIn: (identityNumber: bigint) => Promise<void>;
+    onSignUp: (identityNumber: bigint) => Promise<void>;
+    onUpgrade: (identityNumber: bigint) => Promise<void>;
     onError: (error: unknown) => void;
     withinDialog?: boolean;
     children?: Snippet;

--- a/src/frontend/src/lib/components/wizards/auth/views/CreatePasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/CreatePasskey.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import SmileyWritingIllustration from "$lib/components/illustrations/SmileyWritingIllustration.svelte";
-  import Badge from "$lib/components/ui/Badge.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import Input from "$lib/components/ui/Input.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -59,7 +59,7 @@
       {$t`Continue with passkey`}
     </Button>
     <div class="flex flex-row flex-nowrap justify-stretch gap-3">
-      {#each openIdProviders as provider (provider.client_id)}
+      {#each openIdProviders as provider (provider.issuer)}
         {@const name = provider.name}
         <Tooltip
           label={$t`Interaction canceled. Please try again.`}

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -53,13 +53,13 @@
       onclick={setupOrUseExistingPasskey}
       disabled={!supportsPasskeys || authenticatingProviderId !== undefined}
       size="xl"
-      variant={"secondary"}
+      variant="secondary"
     >
       <PasskeyIcon />
       {$t`Continue with passkey`}
     </Button>
     <div class="flex flex-row flex-nowrap justify-stretch gap-3">
-      {#each openIdProviders as provider}
+      {#each openIdProviders as provider (provider.client_id)}
         {@const name = provider.name}
         <Tooltip
           label={$t`Interaction canceled. Please try again.`}
@@ -78,6 +78,7 @@
               <ProgressRing />
             {:else}
               <div class="size-6">
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -- provider.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
                 {@html provider.logo}
               </div>
             {/if}

--- a/src/frontend/src/lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte
@@ -5,8 +5,6 @@
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { waitFor } from "$lib/utils/utils";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
-  import { HelpCircleIcon } from "@lucide/svelte";
-  import { II_SUPPORT_PRIVACY_SECURITY } from "$lib/config";
   import { t } from "$lib/stores/locale.store";
   import { Trans } from "$lib/components/locale";
 

--- a/src/frontend/src/lib/components/wizards/auth/views/SignInWithSso.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/SignInWithSso.svelte
@@ -139,7 +139,6 @@
    * fallback.
    */
   const setErrorFrom = (e: unknown, domainInput: string) => {
-    // eslint-disable-next-line no-console
     console.error("SSO sign-in failed", e);
     error =
       mapSubmitError(e, domainInput) ??
@@ -256,7 +255,7 @@
     class="flex flex-col items-stretch gap-6"
     onsubmit={(e) => {
       e.preventDefault();
-      handleSubmit();
+      void handleSubmit();
     }}
   >
     <Input

--- a/src/frontend/src/lib/components/wizards/auth/views/SolveCaptcha.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/SolveCaptcha.svelte
@@ -30,13 +30,13 @@
   });
 
   $effect.pre(() => {
-    if (image) {
+    if (image.length > 0) {
       solution = "";
       loading = false;
       if (attempt > 0) {
         error = true;
       }
-      tick().then(() => {
+      void tick().then(() => {
         inputRef?.focus();
       });
     }
@@ -61,7 +61,7 @@
       alt={$t`CAPTCHA characters`}
     />
     <div
-      class={"bg-text-primary absolute inset-0 mix-blend-lighten dark:mix-blend-darken"}
+      class="bg-text-primary absolute inset-0 mix-blend-lighten dark:mix-blend-darken"
     ></div>
   </div>
   <Input

--- a/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/ContinueOnNewDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/ContinueOnNewDevice.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Button from "$lib/components/ui/Button.svelte";
-  import { CopyIcon, CheckIcon } from "@lucide/svelte";
+  import { CopyIcon } from "@lucide/svelte";
   import QrCode from "$lib/components/ui/QrCode.svelte";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import { waitFor } from "$lib/utils/utils";

--- a/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/EnterConfirmationCode.svelte
+++ b/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/EnterConfirmationCode.svelte
@@ -8,6 +8,10 @@
   import { Trans } from "$lib/components/locale";
 
   const CODE_LENGTH = 6;
+  // Non-breaking space rendered through CodeInput's `hint` slot to reserve
+  // the line's vertical space when no error is shown — keeping the slot
+  // mounted prevents the layout from shifting when the error appears.
+  const HINT_PLACEHOLDER = " ";
 
   interface Props {
     confirm: (confirmationCode: string) => Promise<void>;
@@ -77,7 +81,7 @@
     error={isInvalidCode
       ? $t`Invalid code. Please check and try again.`
       : undefined}
-    hint="&nbsp;"
+    hint={HINT_PLACEHOLDER}
     disabled={isConfirming}
   />
   <Button

--- a/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/EnterConfirmationCode.svelte
+++ b/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/EnterConfirmationCode.svelte
@@ -25,7 +25,7 @@
     isConfirming = true;
     try {
       await confirm(confirmationCode);
-    } catch (error) {
+    } catch {
       isInvalidCode = true;
       confirmationCode = "";
     } finally {
@@ -34,7 +34,7 @@
   };
 
   $effect(() => {
-    if (confirmationCode) {
+    if (confirmationCode.length > 0) {
       isInvalidCode = false;
     }
   });
@@ -77,7 +77,7 @@
     error={isInvalidCode
       ? $t`Invalid code. Please check and try again.`
       : undefined}
-    hint={"\u00a0"}
+    hint="&nbsp;"
     disabled={isConfirming}
   />
   <Button

--- a/src/frontend/src/lib/components/wizards/createRecoveryPhrase/components/Steps.svelte
+++ b/src/frontend/src/lib/components/wizards/createRecoveryPhrase/components/Steps.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <div {...props} class={["gap flex flex-row gap-4", className]}>
-  {#each Array.from({ length: total }) as _, index}
+  {#each Array.from({ length: total }) as _, index (index)}
     <div
       class={[
         "bg-border-tertiary h-1 flex-1",

--- a/src/frontend/src/lib/components/wizards/createRecoveryPhrase/views/VerifySelecting.svelte
+++ b/src/frontend/src/lib/components/wizards/createRecoveryPhrase/views/VerifySelecting.svelte
@@ -41,7 +41,7 @@
     if (!isCheckingOrder) {
       return;
     }
-    onCompleted(selectedWords);
+    void onCompleted(selectedWords);
   });
 </script>
 
@@ -67,7 +67,7 @@
   {/if}
 </p>
 <ul dir="ltr" class={["mb-8 grid grid-cols-3 gap-3"]}>
-  {#each shuffledIndexes as index}
+  {#each shuffledIndexes as index (index)}
     {@const word = recoveryPhrase[index]}
     {@const selectedPosition = selectedIndexes.indexOf(index)}
     {@const isSelected = selectedPosition !== -1 && !isCheckingOrder}

--- a/src/frontend/src/lib/components/wizards/createRecoveryPhrase/views/Write.svelte
+++ b/src/frontend/src/lib/components/wizards/createRecoveryPhrase/views/Write.svelte
@@ -32,7 +32,7 @@
     class={["my-8 grid grid-cols-3 gap-3", !isRevealed && "blur-md"]}
     aria-hidden={isRevealed ? "false" : "true"}
   >
-    {#each recoveryPhrase as word, index}
+    {#each recoveryPhrase as word, index (index)}
       <li
         class="border-border-primary flex h-7 flex-row items-center rounded-full border px-1.5"
       >

--- a/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ContinueFromExistingDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ContinueFromExistingDevice.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Button from "$lib/components/ui/Button.svelte";
-  import { CopyIcon, CheckIcon } from "@lucide/svelte";
+  import { CopyIcon } from "@lucide/svelte";
   import QrCode from "$lib/components/ui/QrCode.svelte";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import { waitFor } from "$lib/utils/utils";

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -148,7 +148,7 @@
   let clearAnimation = $state<() => void>();
 
   $effect(() => {
-    triggerAnimation?.(DROP_WAVE_ANIMATION);
+    void triggerAnimation?.(DROP_WAVE_ANIMATION);
     return () => {
       clearAnimation?.();
     };
@@ -182,7 +182,7 @@
 
   // Close authentication funnel once completed
   beforeNavigate((navigation) => {
-    if (!navigation.to?.url.pathname.startsWith("/manage")) {
+    if (navigation.to?.url.pathname.startsWith("/manage") !== true) {
       return;
     }
     authenticationV2Funnel.trigger(AuthenticationV2Events.GoToDashboard);

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -1,20 +1,13 @@
 <script lang="ts">
   import type { LayoutProps } from "./$types";
-  import {
-    channelErrorStore,
-    channelStore,
-    establishedChannelStore,
-  } from "$lib/stores/channelStore";
+  import { channelErrorStore, channelStore } from "$lib/stores/channelStore";
   import {
     authorizationContextStore,
     authorizationStore,
     authorizedStore,
   } from "$lib/stores/authorization.store";
   import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
-  import {
-    authenticationStore,
-    isAuthenticatedStore,
-  } from "$lib/stores/authentication.store";
+  import { authenticationStore } from "$lib/stores/authentication.store";
   import { goto } from "$app/navigation";
   import { toaster } from "$lib/components/utils/toaster";
   import { handleError } from "$lib/components/utils/error";
@@ -89,7 +82,7 @@
   // --- Unsupported browser redirect ---
   $effect(() => {
     if ($channelErrorStore === "unsupported-browser") {
-      goto("/unsupported");
+      void goto("/unsupported");
     }
   });
 
@@ -271,7 +264,7 @@
                   isIdentityPopoverOpen = false;
                   isAuthDialogOpen = true;
                 }}
-                onManageIdentity={async () => {
+                onManageIdentity={() => {
                   isIdentityPopoverOpen = false;
                   window.open("/manage", "_blank");
                 }}

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -264,9 +264,10 @@
                   isIdentityPopoverOpen = false;
                   isAuthDialogOpen = true;
                 }}
-                onManageIdentity={() => {
+                onManageIdentity={(): Promise<void> => {
                   isIdentityPopoverOpen = false;
                   window.open("/manage", "_blank");
+                  return Promise.resolve();
                 }}
                 onManageIdentities={() => {
                   isIdentityPopoverOpen = false;

--- a/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
@@ -75,17 +75,17 @@
   const selectedIdentity = $derived($lastUsedIdentitiesStore.selected);
 
   // --- Handlers ---
-  const handleAuthWizardSignIn = async (identityNumber: bigint) => {
+  const handleAuthWizardSignIn = (identityNumber: bigint) => {
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
   };
-  const handleAuthWizardSignUp = async (identityNumber: bigint) => {
+  const handleAuthWizardSignUp = (identityNumber: bigint) => {
     toaster.success({
       title: $t`You're all set. Your identity has been created.`,
       duration: 4000,
     });
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
   };
-  const handleAuthWizardUpgrade = async () => {
+  const handleAuthWizardUpgrade = () => {
     upgradeSuccess = true;
   };
 
@@ -255,7 +255,7 @@
     } else if (data.flow === "openid-resume") {
       // resumeOpenId sets the flow once the JWT (and thus the issuer)
       // has been decoded.
-      resumeOpenId();
+      resumeOpenId().catch(handleError);
     } else {
       authorizationStore.setFlow({ type: "regular" });
     }

--- a/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
@@ -75,18 +75,21 @@
   const selectedIdentity = $derived($lastUsedIdentitiesStore.selected);
 
   // --- Handlers ---
-  const handleAuthWizardSignIn = (identityNumber: bigint) => {
+  const handleAuthWizardSignIn = (identityNumber: bigint): Promise<void> => {
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
+    return Promise.resolve();
   };
-  const handleAuthWizardSignUp = (identityNumber: bigint) => {
+  const handleAuthWizardSignUp = (identityNumber: bigint): Promise<void> => {
     toaster.success({
       title: $t`You're all set. Your identity has been created.`,
       duration: 4000,
     });
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
+    return Promise.resolve();
   };
-  const handleAuthWizardUpgrade = () => {
+  const handleAuthWizardUpgrade = (): Promise<void> => {
     upgradeSuccess = true;
+    return Promise.resolve();
   };
 
   const handleAuthorize = (accountNumber: Promise<bigint | undefined>) => {

--- a/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
@@ -47,7 +47,13 @@
    * so we can't rely on a name being threaded through from sign-in.
    */
   let ssoNamesByDomain = new SvelteMap<string, string>();
-  const ssoLookupsInFlight = new SvelteSet<string>();
+  // Plain Set (not SvelteSet): non-reactive guard against duplicate
+  // in-flight `discoverSsoConfig` calls. `ensureSsoLookup` reads and
+  // writes this synchronously inside `getProviderName`, which itself
+  // runs during render — a reactive Set would write while a read is
+  // being tracked and break the consent view's initial render.
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const ssoLookupsInFlight = new Set<string>();
 
   const ensureSsoLookup = (domain: string): void => {
     if (ssoNamesByDomain.has(domain) || ssoLookupsInFlight.has(domain)) {

--- a/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
@@ -46,7 +46,7 @@
    * authenticated through some other method (passkey, direct OpenID),
    * so we can't rely on a name being threaded through from sign-in.
    */
-  let ssoNamesByDomain = $state<Map<string, string>>(new Map());
+  let ssoNamesByDomain = new SvelteMap<string, string>();
   const ssoLookupsInFlight = new SvelteSet<string>();
 
   const ensureSsoLookup = (domain: string): void => {
@@ -57,10 +57,7 @@
     void discoverSsoConfig(domain)
       .then((result) => {
         if (result.name !== undefined && result.name.length > 0) {
-          ssoNamesByDomain = new SvelteMap(ssoNamesByDomain).set(
-            domain,
-            result.name,
-          );
+          ssoNamesByDomain.set(domain, result.name);
         }
       })
       .catch((error) => {

--- a/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
@@ -5,6 +5,7 @@
     AttributeGroup,
     AvailableAttribute,
   } from "$lib/stores/attributeConsent.store";
+  import { SvelteMap, SvelteSet } from "svelte/reactivity";
   import { extractScope } from "$lib/stores/channelHandlers/attributes";
   import { backendCanisterConfig } from "$lib/globals";
   import { discoverSsoConfig } from "$lib/utils/ssoDiscovery";
@@ -46,7 +47,7 @@
    * so we can't rely on a name being threaded through from sign-in.
    */
   let ssoNamesByDomain = $state<Map<string, string>>(new Map());
-  const ssoLookupsInFlight = new Set<string>();
+  const ssoLookupsInFlight = new SvelteSet<string>();
 
   const ensureSsoLookup = (domain: string): void => {
     if (ssoNamesByDomain.has(domain) || ssoLookupsInFlight.has(domain)) {
@@ -56,12 +57,14 @@
     void discoverSsoConfig(domain)
       .then((result) => {
         if (result.name !== undefined && result.name.length > 0) {
-          ssoNamesByDomain = new Map(ssoNamesByDomain).set(domain, result.name);
+          ssoNamesByDomain = new SvelteMap(ssoNamesByDomain).set(
+            domain,
+            result.name,
+          );
         }
       })
       .catch((error) => {
         // Non-fatal: the SSO label falls back to the bare domain.
-        // eslint-disable-next-line no-console
         console.error(`Failed to discover SSO name for ${domain}`, error);
       })
       .finally(() => {
@@ -105,7 +108,7 @@
       optionsByScope: Map<string | undefined, MergedOption>;
     }
   > => {
-    const result = new Map<
+    const result = new SvelteMap<
       string,
       {
         name: string;
@@ -148,7 +151,7 @@
     // a matching email group. We do this before iterating so that the
     // folded-in verified_email is skipped regardless of whether its entry
     // appears before or after the email entry in the request order.
-    const foldedVerifiedIds = new Set<string>();
+    const foldedVerifiedIds = new SvelteSet<string>();
     for (const entry of deduped.values()) {
       if (entry.name !== "email") continue;
       const verifiedId = groupId({
@@ -227,9 +230,9 @@
   let ready = $state(false);
 
   $effect(() => {
-    context.then((ctx) => {
+    void context.then((ctx) => {
       mergedGroups = mergeGroups(ctx.groups);
-      selections = new Map(
+      selections = new SvelteMap(
         mergedGroups.map((group) => [
           groupId(group),
           { checked: true, selectedIndex: 0 },
@@ -241,7 +244,7 @@
   });
 
   const handleDenyAll = () => {
-    selections = new Map(
+    selections = new SvelteMap(
       mergedGroups.map((group) => [
         groupId(group),
         { checked: false, selectedIndex: 0 },
@@ -352,14 +355,14 @@
             checked={selection.checked}
             onCheck={(checked) => {
               selections.set(id, { ...selection, checked });
-              selections = new Map(selections);
+              selections = new SvelteMap(selections);
             }}
             onSelect={(index) => {
               selections.set(id, {
                 ...selection,
                 selectedIndex: index,
               });
-              selections = new Map(selections);
+              selections = new SvelteMap(selections);
             }}
           />
         {/if}

--- a/src/frontend/src/routes/(new-styling)/authorize/views/AttributePicker.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/AttributePicker.svelte
@@ -46,8 +46,8 @@
   // switches, since the label prop is re-evaluated via `$t` on locale swap).
   $effect(() => {
     // Track the reactive inputs that can change text width.
-    label;
-    options[selectedIndex].displayValue;
+    void label;
+    void options[selectedIndex].displayValue;
     queueMicrotask(checkWrap);
   });
 
@@ -85,7 +85,6 @@
        chevron button; this click handler is mouse-only convenience. -->
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div
     class={[
       "col-span-full row-start-1 grid grid-cols-subgrid items-center gap-x-3",
@@ -166,7 +165,7 @@
       role="listbox"
       aria-label={label}
     >
-      {#each options as option, index}
+      {#each options as option, index (option.key)}
         {@const providerName = getProviderName(option.key)}
         <button
           onclick={() => {

--- a/src/frontend/src/routes/(new-styling)/authorize/views/ContinueView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/ContinueView.svelte
@@ -38,11 +38,11 @@
 
   const { effectiveOrigin, onAuthorize }: Props = $props();
 
-  const PRIMARY_ACCOUNT_NUMBER = undefined;
+  type PRIMARY_ACCOUNT_NUMBER = undefined;
   const MAX_ACCOUNTS = 5;
 
   let defaultAccountNumber = $state<
-    AccountNumber | typeof PRIMARY_ACCOUNT_NUMBER | null
+    AccountNumber | PRIMARY_ACCOUNT_NUMBER | null
   >(null);
   let accounts = $state<AccountInfo[]>();
   let isAuthenticatingDefault = $state(false);
@@ -56,7 +56,7 @@
 
   let isCreateAccountDialogVisible = $state(false);
   let isEditAccountDialogVisibleForNumber = $state<
-    AccountNumber | typeof PRIMARY_ACCOUNT_NUMBER | null
+    AccountNumber | PRIMARY_ACCOUNT_NUMBER | null
   >(null);
 
   const isEditAccountDialogVisibleFor = $derived(
@@ -112,7 +112,7 @@
     }
   };
   const handleContinueAs = (
-    accountNumber: AccountNumber | typeof PRIMARY_ACCOUNT_NUMBER,
+    accountNumber: AccountNumber | PRIMARY_ACCOUNT_NUMBER,
   ) => {
     onAuthorize(Promise.resolve(accountNumber));
   };

--- a/src/frontend/src/routes/(new-styling)/authorize/views/RedirectAnimationView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/RedirectAnimationView.svelte
@@ -19,7 +19,7 @@
   let clearAnimation = $state<() => void>();
 
   $effect(() => {
-    triggerAnimation?.(DROP_WAVE_ANIMATION);
+    void triggerAnimation?.(DROP_WAVE_ANIMATION);
     return () => {
       clearAnimation?.();
     };

--- a/src/frontend/src/routes/(new-styling)/callback/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/callback/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { SvelteURL } from "svelte/reactivity";
   import { analytics } from "$lib/utils/analytics/analytics";
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
@@ -13,7 +14,7 @@
       "ii-openid-authorize-state",
     );
     if (openIdAuthorizeState !== null) {
-      const next = new URL(window.location.href);
+      const next = new SvelteURL(window.location.href);
       next.pathname = "/authorize";
       next.searchParams.set("flow", "openid-resume");
       await goto(next);

--- a/src/frontend/src/routes/(new-styling)/login/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/login/+page.svelte
@@ -6,6 +6,6 @@
   const { data }: PageProps = $props();
 
   onMount(() => {
-    goto("/", { state: { login: data.next }, replaceState: true });
+    void goto("/", { state: { login: data.next }, replaceState: true });
   });
 </script>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/+page.svelte
@@ -77,7 +77,7 @@
   );
 
   // Handlers
-  const handleOpenIdLinked = async (openid: OpenIdCredential) => {
+  const handleOpenIdLinked = (openid: OpenIdCredential) => {
     isAddingAccessMethod = false;
     accessMethods = [{ openid } as const, ...accessMethods].sort(
       compareAccessMethods,
@@ -99,7 +99,7 @@
     });
     void invalidateAll();
   };
-  const handlePasskeyRegistered = async (passkey: AuthnMethodData) => {
+  const handlePasskeyRegistered = (passkey: AuthnMethodData) => {
     isAddingAccessMethod = false;
     accessMethods = [{ passkey } as const, ...accessMethods].sort(
       compareAccessMethods,
@@ -126,11 +126,11 @@
 
     void invalidateAll();
   };
-  const handleOtherDeviceRegistered = async () => {
+  const handleOtherDeviceRegistered = () => {
     isAddingAccessMethod = false;
     void invalidateAll();
   };
-  const handleOtherDeviceConfirmed = async () => {
+  const handleOtherDeviceConfirmed = () => {
     toaster.success({
       title: $t`Passkey has been registered from another device.`,
     });
@@ -345,7 +345,7 @@
       onError={(error) => {
         pendingRegistrationId = null;
         handleError(error);
-        goto(page.url.pathname, { replaceState: true }); // Remove searchParam
+        void goto(page.url.pathname, { replaceState: true });
       }}
     />
   </Dialog>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/OpenIdItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/OpenIdItem.svelte
@@ -59,6 +59,7 @@
       -->
       <SsoIcon class="size-6" />
     {:else}
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- logo is a trusted SVG string sourced from the backend canister's openid_configs -->
       {@html logo}
     {/if}
     {#if isCurrentAccessMethod}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/PasskeyItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/PasskeyItem.svelte
@@ -88,7 +88,7 @@
   ]);
   onMount(() => {
     // Lazy load known providers data
-    import("$lib/assets/aaguid").then(
+    void import("$lib/assets/aaguid").then(
       (data) => (knownProviders = data.default),
     );
   });

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/RenamePasskey.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/RenamePasskey.svelte
@@ -54,7 +54,7 @@
     inputRef?.focus();
 
     // Lazy load known providers data
-    import("$lib/assets/aaguid").then(
+    void import("$lib/assets/aaguid").then(
       (data) => (knownProviders = data.default),
     );
   });

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/components/AccessMethods.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/components/AccessMethods.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  import Panel from "$lib/components/ui/Panel.svelte";
-  import { ChevronRightIcon, KeyRoundIcon, LockIcon } from "@lucide/svelte";
+  import { ChevronRightIcon, KeyRoundIcon } from "@lucide/svelte";
   import Button from "$lib/components/ui/Button.svelte";
-  import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import { t } from "$lib/stores/locale.store";
   import { Trans } from "$lib/components/locale";
 

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -120,9 +120,10 @@
 
   // --- Sign out ---
 
-  const handleSignOut = () => {
+  const handleSignOut = (): Promise<void> => {
     isIdentityPopoverOpen = false;
     isSignOutDialogOpen = true;
+    return Promise.resolve();
   };
 
   const handleConfirmSignOut = () => {

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -120,7 +120,7 @@
 
   // --- Sign out ---
 
-  const handleSignOut = async () => {
+  const handleSignOut = () => {
     isIdentityPopoverOpen = false;
     isSignOutDialogOpen = true;
   };
@@ -562,7 +562,7 @@
       value={$localeStore}
       onChange={(value) => {
         isLanguageDialogOpen = false;
-        localeStore.setOrReset(value);
+        void localeStore.setOrReset(value);
       }}
     />
   </Dialog>

--- a/src/frontend/src/routes/(new-styling)/pair/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/pair/+page.svelte
@@ -14,7 +14,7 @@
 
   let isUnableToComplete = $state(false);
 
-  const handleRegistered = async (identityNumber: bigint) => {
+  const handleRegistered = (identityNumber: bigint) => {
     toaster.success({
       title: $t`You're all set. Your passkey has been registered.`,
     });

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -122,61 +122,54 @@
     !devices.some(
       (device) =>
         device.credential_id[0] !== undefined &&
-        device.origin[0]?.endsWith("id.ai"),
+        device.origin[0]?.endsWith("id.ai") === true,
     );
   const lookupByPasskey = async () => {
-    const identityResult = await new Promise<IdentityResult>(
-      async (resolve) => {
-        let identityNumber = BigInt(-1);
-        const passkeyIdentity = await DiscoverablePasskeyIdentity.useExisting({
-          getPublicKey: (result) =>
-            new Promise(async (resolve) => {
-              const lookupResult = (
-                await anonymousActor.lookup_device_key(
-                  new Uint8Array(result.rawId),
-                )
-              )[0];
-              if (lookupResult === undefined) {
-                toaster.error({
-                  title: $t`Identity not found`,
-                  description: $t`This passkey is no longer associated with any identity.`,
-                });
-                return;
-              }
-              identityNumber = lookupResult.anchor_number;
-              resolve(
-                CosePublicKey.fromDer(new Uint8Array(lookupResult.pubkey)),
-              );
-            }),
-        });
-        const sessionIdentity = await ECDSAKeyIdentity.generate();
-        const delegationChain = await DelegationChain.create(
-          passkeyIdentity,
-          sessionIdentity.getPublicKey(),
-        );
-        const delegationIdentity = DelegationIdentity.fromDelegation(
-          sessionIdentity,
-          delegationChain,
-        );
-        const agent = await HttpAgent.from(anonymousAgent);
-        agent.replaceIdentity(delegationIdentity);
-        const info = await anonymousActor.get_anchor_info.withOptions({
-          agent,
-        })(identityNumber);
-        resolve({
-          identityNumber,
-          legacy: missingUpgradedPasskey(info.devices),
-          devices: info.devices,
-          name: info.name[0],
-          lastUsed: Math.max(
-            ...info.devices
-              .map((device) => device.last_usage[0])
-              .filter((ns) => ns !== undefined)
-              .map((ns) => Number(ns / BigInt(1_000_000))),
-          ),
-        });
+    let identityNumber = BigInt(-1);
+    const passkeyIdentity = DiscoverablePasskeyIdentity.useExisting({
+      getPublicKey: async (result) => {
+        const lookupResult = (
+          await anonymousActor.lookup_device_key(new Uint8Array(result.rawId))
+        )[0];
+        if (lookupResult === undefined) {
+          toaster.error({
+            title: $t`Identity not found`,
+            description: $t`This passkey is no longer associated with any identity.`,
+          });
+          // Hang intentionally so further sign-in code doesn't run after the
+          // toaster surfaces the not-found state.
+          return new Promise<CosePublicKey>(() => {});
+        }
+        identityNumber = lookupResult.anchor_number;
+        return CosePublicKey.fromDer(new Uint8Array(lookupResult.pubkey));
       },
+    });
+    const sessionIdentity = await ECDSAKeyIdentity.generate();
+    const delegationChain = await DelegationChain.create(
+      passkeyIdentity,
+      sessionIdentity.getPublicKey(),
     );
+    const delegationIdentity = DelegationIdentity.fromDelegation(
+      sessionIdentity,
+      delegationChain,
+    );
+    const agent = await HttpAgent.from(anonymousAgent);
+    agent.replaceIdentity(delegationIdentity);
+    const info = await anonymousActor.get_anchor_info.withOptions({
+      agent,
+    })(identityNumber);
+    const identityResult: IdentityResult = {
+      identityNumber,
+      legacy: missingUpgradedPasskey(info.devices),
+      devices: info.devices,
+      name: info.name[0],
+      lastUsed: Math.max(
+        ...info.devices
+          .map((device) => device.last_usage[0])
+          .filter((ns) => ns !== undefined)
+          .map((ns) => Number(ns / BigInt(1_000_000))),
+      ),
+    };
     if (
       !identityResults.some(
         (result) => result.identityNumber === identityResult.identityNumber,
@@ -202,7 +195,7 @@
       handleError(error);
     }
   };
-  const exportJSON = async () => {
+  const exportJSON = () => {
     const date = Date.now();
     const json = JSON.stringify(
       {
@@ -239,12 +232,12 @@
 
   onMount(() => {
     // Lazy load known providers data
-    import("$lib/assets/aaguid").then(
+    void import("$lib/assets/aaguid").then(
       (data) => (knownProviders = data.default),
     );
     // Load identity numbers from storage (old and new),
     // and fetch all devices for each anchor in parallel.
-    readStorage()
+    void readStorage()
       .then((storage) => [
         ...Object.entries(storage.anchors ?? {})
           // Filter out old entries that are in new storage
@@ -310,7 +303,7 @@
       <hr class="bt-1 border-border-secondary my-4" />
       {#if identityResults.length > 0}
         <div class="mb-4 flex flex-col gap-4">
-          {#each [...identityResults].sort((a, b) => b.lastUsed - a.lastUsed) as identityResult}
+          {#each [...identityResults].sort((a, b) => b.lastUsed - a.lastUsed) as identityResult (identityResult.identityNumber)}
             {@const isRecoveryPhraseSetUp = identityResult.devices.some(
               (device) =>
                 "recovery" in device.purpose &&
@@ -399,7 +392,7 @@
         <div class="text-text-tertiary text-sm text-balance">
           <Trans>Check out the other domains:</Trans>
           <ul class="mt-1 flex flex-col gap-0.5">
-            {#each (frontendCanisterConfig.related_origins[0] ?? []).filter((relatedOrigin) => relatedOrigin !== window.location.origin) as relatedOrigin}
+            {#each (frontendCanisterConfig.related_origins[0] ?? []).filter((relatedOrigin) => relatedOrigin !== window.location.origin) as relatedOrigin (relatedOrigin)}
               <li>
                 <a
                   href={relatedOrigin + "/self-service"}
@@ -433,7 +426,7 @@
       <hr class="bt-1 border-border-secondary my-4" />
       {#if testResults.length > 0}
         <div class="flex flex-col gap-4">
-          {#each [...testResults].reverse() as testResult}
+          {#each [...testResults].reverse() as testResult (testResult.date)}
             {@const provider =
               knownProviders !== undefined && testResult.aaguid !== undefined
                 ? knownProviders[testResult.aaguid]

--- a/src/frontend/src/routes/(new-styling)/unsupported/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/unsupported/+page.svelte
@@ -35,7 +35,7 @@
     if (!isEntry || isReload) {
       return;
     }
-    goto("/", { replaceState: true });
+    void goto("/", { replaceState: true });
   };
 
   beforeNavigate(trackPageReload);

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { analytics, initAnalytics } from "$lib/utils/analytics/analytics";
+  import { initAnalytics } from "$lib/utils/analytics/analytics";
   import { frontendCanisterConfig, getPrimaryOrigin } from "$lib/globals";
   import { onMount } from "svelte";
   import { page } from "$app/state";


### PR DESCRIPTION
The `lint:eslint` script only matched `src/frontend/**/*.ts*`, so `.svelte` files were never linted in CI. Widening the glob to include `.svelte` surfaced ~140 pre-existing errors and warnings that this PR fixes:

- Floating promises (`@typescript-eslint/no-floating-promises`) — added `void` or `await`/`.catch` where appropriate.
- Missing `{#each}` block keys (`svelte/require-each-key`) — added stable keys.
- Nullable-boolean conditionals (`@typescript-eslint/strict-boolean-expressions`) — switched to explicit `=== true` / `!== undefined` / `> 0` checks.
- Useless mustaches around string literals (`svelte/no-useless-mustaches`).
- Mutable `Map` / `Set` / `URL` where Svelte reactive variants are required (`svelte/prefer-svelte-reactivity`) — switched to `SvelteMap` / `SvelteSet` / `SvelteURL`.
- `async` functions with no `await` (`require-await`) — dropped `async` and adjusted prop signatures to `() => Promise<void> | void` where the consumer mixes sync/async handlers.
- Unused imports, unused vars, and unused `eslint-disable` directives.
- Two `{@html}` sites annotated as trusted (provider logos sourced from the backend canister's `openid_configs`).
- A few miscellaneous: `no-async-promise-executor`, `no-useless-assignment` on `$bindable()` defaults, `no-unused-expressions` on dependency-tracking lines, etc.

Also re-derives the eslint config so `.svelte` files are part of the typescript-eslint project membership: `eslint.config.js` points at `tsconfig.eslint.json` with `extraFileExtensions: [".svelte"]`, and `tsconfig.eslint.json` is extended with explicit `src/**/*.svelte` includes.

`self-service/+page.svelte`'s `lookupByPasskey` is rewritten to drop the `new Promise(async (resolve) => …)` wrapper while preserving the deliberate "never-resolve on identity-not-found" behavior (a toaster surfaces the error and downstream sign-in code is intentionally suppressed).