### PR TITLE
fix(scripts): unbreak deploy-pr-to-beta and deploy-local-to-beta

### DIFF
--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -541,8 +541,15 @@ EOF
 }
 
 # -------------------------
-# icp install runner (honours DRY_RUN)
+# Wallet-proxied install runner (honours DRY_RUN)
 # -------------------------
+# Falls back to dfx for the actual upgrade because the staging canisters
+# are controlled by a dfx wallet (`cvthj-wyaaa-aaaad-aaaaq-cai`) that
+# routes via `wallet_call`. icp-cli's `--proxy` expects a custom proxy
+# canister exposing a `proxy` method instead, so pointing it at the
+# wallet trips `Canister has no update method 'proxy'`. See PR #3815
+# where the same pattern was applied to `make-upgrade-proposal`.
+#
 # Args: <canister_id> <wasm_path> <install_arg_candid_text>
 run_icp_install() {
     local canister_id="$1"
@@ -554,24 +561,14 @@ run_icp_install() {
         return 1
     fi
 
-    # `icp canister install` loads `icp.yaml`, which references
-    # `init_args.path: src/internet_identity_frontend/local_test_arg.did` —
-    # a gitignored file rendered from the `.template` by
-    # `scripts/render-local-init-args`. On a fresh checkout (CI artifacts,
-    # someone who's never run `icp deploy` locally, etc.) the file doesn't
-    # exist and the project fails to load. Render a stub up-front so the
-    # install can always parse the project; we override init args via
-    # `--args` below, so the stub's content is never read.
-    "$SCRIPTS_DIR/render-local-init-args" >/dev/null
-
     local cmd=(
-        icp canister
+        dfx canister
+            --network "$IC_NETWORK"
+            --wallet "$WALLET_CANISTER_ID"
             install "$canister_id"
-            -e "$IC_NETWORK"
-            --proxy "$WALLET_CANISTER_ID"
             --mode upgrade
             --wasm "$wasm_path"
-            --args "$install_arg"
+            --argument "$install_arg"
     )
 
     if [ "$DRY_RUN" = true ]; then

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -554,6 +554,16 @@ run_icp_install() {
         return 1
     fi
 
+    # `icp canister install` loads `icp.yaml`, which references
+    # `init_args.path: src/internet_identity_frontend/local_test_arg.did` —
+    # a gitignored file rendered from the `.template` by
+    # `scripts/render-local-init-args`. On a fresh checkout (CI artifacts,
+    # someone who's never run `icp deploy` locally, etc.) the file doesn't
+    # exist and the project fails to load. Render a stub up-front so the
+    # install can always parse the project; we override init args via
+    # `--args` below, so the stub's content is never read.
+    "$SCRIPTS_DIR/render-local-init-args" >/dev/null
+
     local cmd=(
         icp canister
             install "$canister_id"

--- a/scripts/deploy-pr-to-beta
+++ b/scripts/deploy-pr-to-beta
@@ -84,8 +84,13 @@ fi
 echo "  PR #$PR_NUMBER → branch '$BRANCH'"
 
 echo "Fetching workflow runs for branch '$BRANCH'..."
+# `canister-tests.yml` only triggers on `push` for `main` and release tags;
+# every other branch goes through the `pull_request` event. Filtering the
+# API call by `event=push` therefore returns nothing for PR branches —
+# leave the event open and let the jq filter below pick the right
+# workflow by path, regardless of trigger.
 RUN_ID=$(curl -sf -H "$AUTH_HEADER" \
-    "https://api.github.com/repos/$REPO/actions/runs?event=push&branch=$BRANCH&per_page=100" \
+    "https://api.github.com/repos/$REPO/actions/runs?branch=$BRANCH&per_page=100" \
     | jq -r --arg WF "$WORKFLOW_FILE" '
         [.workflow_runs[]
             | select(.path == (".github/workflows/" + $WF))

--- a/scripts/render-local-init-args
+++ b/scripts/render-local-init-args
@@ -14,9 +14,14 @@
 
 set -euo pipefail
 
-template="src/internet_identity_frontend/local_test_arg.did.template"
-output="src/internet_identity_frontend/local_test_arg.did"
-mappings=".icp/cache/mappings/local.ids.json"
+# Resolve paths relative to the repo root (this script's parent) so the
+# script works regardless of the caller's cwd — both `icp deploy`
+# (which invokes us from the project root) and the deploy helpers in
+# `scripts/deploy-*-to-beta` (which may not cd) end up in the right place.
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+template="$ROOT_DIR/src/internet_identity_frontend/local_test_arg.did.template"
+output="$ROOT_DIR/src/internet_identity_frontend/local_test_arg.did"
+mappings="$ROOT_DIR/.icp/cache/mappings/local.ids.json"
 
 if [ ! -f "$template" ]; then
   echo "error: $template not found" >&2


### PR DESCRIPTION
`scripts/deploy-pr-to-beta` and `scripts/deploy-local-to-beta` are both broken on the current main — three independent bugs hit in sequence when running an end-to-end deploy.

## Bugs fixed

1. **Workflow lookup misses every PR branch.** `deploy-pr-to-beta <PR>` exits with `Error: No canister-tests.yml workflow run found for branch '<branch>'` because it queries `actions/runs?event=push&branch=<branch>`. [`canister-tests.yml`](.github/workflows/canister-tests.yml) only triggers on `push` for `main` and `release-*` tags — every PR branch only ever produces `pull_request` runs, so the API filter returns an empty list and the script bails before fetching any artifacts.
2. **`render-local-init-args` is cwd-dependent.** The script uses relative paths for its template / output / mappings, so a caller that doesn't first `cd` into the repo root sees `error: src/internet_identity_frontend/local_test_arg.did.template not found`.
3. **icp-cli `--proxy` doesn't speak `wallet_call`.** Once artifacts are fetched, the install step fails with `Canister has no update method 'proxy'`. icp-cli's `--proxy` expects a custom proxy canister exposing a `proxy` method, but the staging canisters are controlled by a dfx wallet that routes via `wallet_call`.

## Fix

- Drop the `event=push` filter from the workflow-run lookup. The existing jq path-filter already selects the right workflow by file path, so leaving the event open lets `pull_request` runs through. Main keeps working — push runs still show up.
- Resolve `render-local-init-args`'s paths relative to the script's own location instead of the caller's cwd, so it works regardless of where it's invoked from (`icp deploy` build steps, the deploy helpers, CI).
- Switch `run_icp_install` to `dfx canister install --network ic --wallet <wallet> ...` for the actual upgrade. Same pattern as #3815 (which fixed `make-upgrade-proposal`); the rest of the deploy scripts stay on icp-cli.

## Tests

- [x] Reproduced each failure in sequence against PR #3823 on the current main, then confirmed the patched scripts proceed past each.
- [x] Ran `scripts/render-local-init-args` from `/tmp` to confirm cwd-independent path resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)