### PR TITLE
Certify dapp's actual origin in implicit:origin (icp0.io kept, not remapped)

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -539,6 +539,7 @@ export const idlFactory = ({ IDL }) => {
     'omit_scope' : IDL.Bool,
   });
   const PrepareIcrc3AttributeRequest = IDL.Record({
+    'unmapped_origin' : IDL.Opt(FrontendHostname),
     'origin' : FrontendHostname,
     'account_number' : IDL.Opt(AccountNumber),
     'attributes' : IDL.Vec(AttributeSpec),

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1037,7 +1037,19 @@ export type PrepareIcrc3AttributeError = { 'AuthorizationError' : Principal } |
   { 'AttributeMismatch' : { 'problems' : Array<string> } };
 export interface PrepareIcrc3AttributeRequest {
   /**
-   * Origin of the relying party in the attribute sharing flow.
+   * The relying party's actual origin, before the legacy `icp0.io →
+   * ic0.app` remap that `origin` may have gone through. When set, this
+   * value is what gets certified as `implicit:origin` instead of `origin`,
+   * so that an RP signed in via the icp0.io domain sees its real origin
+   * in the certified message. The canister verifies that mapping
+   * `unmapped_origin` through the same legacy remap yields `origin`,
+   * so an RP can't certify an arbitrary value here.
+   */
+  'unmapped_origin' : [] | [FrontendHostname],
+  /**
+   * Origin of the relying party in the attribute sharing flow. May have
+   * been remapped from `<sub>.icp0.io` to `<sub>.ic0.app` for principal
+   * stability — see `unmapped_origin`.
    */
   'origin' : FrontendHostname,
   /**

--- a/src/frontend/src/lib/stores/channelHandlers/attributes.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/attributes.ts
@@ -264,11 +264,16 @@ export const handleLegacyAttributes =
 /**
  * Everything the consent handler needs to drive the consent UI and, once
  * the user agrees, certify + send. Built by `resolveConsentPipeline`.
+ *
+ * `origin` is the legacy-remapped value used for principal derivation.
+ * `unmappedOrigin` is the dapp's actual origin (icp0.io, custom domain,
+ * etc.) and is what the canister will certify as `implicit:origin`.
  */
 type ConsentPipeline = {
   accountNumberPromise: Promise<bigint | undefined>;
   authenticated: Authenticated;
   origin: string;
+  unmappedOrigin: string;
   groups: AttributeGroup[];
 };
 
@@ -300,7 +305,8 @@ const resolveConsentPipeline = async (params: {
       return null;
     }
 
-    const origin = remapToLegacyDomain(derivationOrigin ?? channel.origin);
+    const unmappedOrigin = derivationOrigin ?? channel.origin;
+    const origin = remapToLegacyDomain(unmappedOrigin);
 
     // TODO: pass `[requestedKeys]` once the canister silently drops unknown
     // keys. Today it errors on anything it doesn't recognise, which would
@@ -320,6 +326,7 @@ const resolveConsentPipeline = async (params: {
       accountNumberPromise,
       authenticated,
       origin,
+      unmappedOrigin,
       groups: resolveAttributeGroups(requestedKeys, available),
     };
   } catch (error) {
@@ -344,6 +351,7 @@ const certifyAndSend = async (params: {
   authenticated: { identityNumber: bigint; actor: Authenticated["actor"] };
   accountNumber: bigint | undefined;
   origin: string;
+  unmappedOrigin: string;
   attributeSpecs: Array<{
     key: string;
     value: [] | [Uint8Array];
@@ -358,12 +366,14 @@ const certifyAndSend = async (params: {
     authenticated,
     accountNumber,
     origin,
+    unmappedOrigin,
     attributeSpecs,
   } = params;
   try {
     const { message } = await authenticated.actor
       .prepare_icrc3_attributes({
         origin,
+        unmapped_origin: [unmappedOrigin],
         account_number: accountNumber !== undefined ? [accountNumber] : [],
         identity_number: authenticated.identityNumber,
         attributes: attributeSpecs,
@@ -447,9 +457,9 @@ export const handleIcrc3OneClickOpenIdAttributes =
         return;
       }
 
-      const origin = remapToLegacyDomain(
-        paramsResult.data.icrc95DerivationOrigin ?? channel.origin,
-      );
+      const unmappedOrigin =
+        paramsResult.data.icrc95DerivationOrigin ?? channel.origin;
+      const origin = remapToLegacyDomain(unmappedOrigin);
 
       // Filter to keys the canister actually has — the user may not have
       // granted every claim in the allowlist (e.g. missing verified_email).
@@ -480,6 +490,7 @@ export const handleIcrc3OneClickOpenIdAttributes =
         authenticated,
         accountNumber,
         origin,
+        unmappedOrigin,
         attributeSpecs,
       });
     } catch (error) {
@@ -536,9 +547,9 @@ export const handleIcrc3OneClickSsoAttributes =
         return;
       }
 
-      const origin = remapToLegacyDomain(
-        paramsResult.data.icrc95DerivationOrigin ?? channel.origin,
-      );
+      const unmappedOrigin =
+        paramsResult.data.icrc95DerivationOrigin ?? channel.origin;
+      const origin = remapToLegacyDomain(unmappedOrigin);
 
       // Filter to keys the canister actually has — the user may have
       // signed in with a subset of the allowlist (e.g. no email claim).
@@ -569,6 +580,7 @@ export const handleIcrc3OneClickSsoAttributes =
         authenticated,
         accountNumber,
         origin,
+        unmappedOrigin,
         attributeSpecs,
       });
     } catch (error) {
@@ -682,6 +694,7 @@ export const handleIcrc3ConsentAttributes =
           authenticated: pipeline.authenticated,
           accountNumber,
           origin: pipeline.origin,
+          unmappedOrigin: pipeline.unmappedOrigin,
           attributeSpecs,
         });
       } finally {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -999,8 +999,19 @@ type PrepareIcrc3AttributeRequest = record {
     // Identity for which the attributes should be prepared.
     identity_number : IdentityNumber;
 
-    // Origin of the relying party in the attribute sharing flow.
+    // Origin of the relying party in the attribute sharing flow. May have
+    // been remapped from `<sub>.icp0.io` to `<sub>.ic0.app` for principal
+    // stability — see `unmapped_origin`.
     origin : FrontendHostname;
+
+    // The relying party's actual origin, before the legacy `icp0.io →
+    // ic0.app` remap that `origin` may have gone through. When set, this
+    // value is what gets certified as `implicit:origin` instead of `origin`,
+    // so that an RP signed in via the icp0.io domain sees its real origin
+    // in the certified message. The canister verifies that mapping
+    // `unmapped_origin` through the same legacy remap yields `origin`,
+    // so an RP can't certify an arbitrary value here.
+    unmapped_origin : opt FrontendHostname;
 
     // II account for the relying party.
     account_number : opt AccountNumber;

--- a/src/internet_identity/src/attributes.rs
+++ b/src/internet_identity/src/attributes.rs
@@ -286,6 +286,13 @@ impl Anchor {
         attribute_specs: Vec<ValidatedAttributeSpec>,
         nonce: Vec<u8>,
         origin: String,
+        // The relying party's actual origin, before the legacy `icp0.io →
+        // ic0.app` remap that `origin` may have gone through for principal
+        // stability. The validator (`ValidatedPrepareIcrc3AttributeRequest`)
+        // has already verified that `unmapped_origin` maps to `origin` under
+        // the same remap, so it's safe to certify here as `implicit:origin`.
+        // When `None`, falls back to `origin`.
+        unmapped_origin: Option<String>,
         issued_at_timestamp_ns: u64,
         account: Account,
     ) -> Result<Vec<u8>, PrepareIcrc3AttributeError> {
@@ -431,7 +438,10 @@ impl Anchor {
         }
 
         certified_pairs.insert("implicit:nonce".to_string(), Icrc3Value::Blob(nonce));
-        certified_pairs.insert("implicit:origin".to_string(), Icrc3Value::Text(origin));
+        certified_pairs.insert(
+            "implicit:origin".to_string(),
+            Icrc3Value::Text(unmapped_origin.unwrap_or(origin)),
+        );
         certified_pairs.insert(
             "implicit:issued_at_timestamp_ns".to_string(),
             Icrc3Value::Nat(candid::Nat::from(issued_at_timestamp_ns)),
@@ -1783,6 +1793,7 @@ mod tests {
                 ],
                 vec![0u8; 32],
                 "https://dapp.com".to_string(),
+                None,
                 1_000_000_000,
                 account,
             );
@@ -1820,6 +1831,7 @@ mod tests {
                 }],
                 vec![0u8; 32],
                 "https://dapp.com".to_string(),
+                None,
                 1_000_000_000,
                 account,
             );
@@ -1853,6 +1865,7 @@ mod tests {
                 }],
                 vec![0u8; 32],
                 "https://dapp.com".to_string(),
+                None,
                 1_000_000_000,
                 account,
             );
@@ -1883,6 +1896,7 @@ mod tests {
                 ],
                 vec![0u8; 32],
                 "https://dapp.com".to_string(),
+                None,
                 1_000_000_000,
                 account,
             );
@@ -2310,6 +2324,7 @@ mod tests {
                 vec![verified_spec],
                 vec![0u8; 32],
                 "https://rp.example".to_string(),
+                None,
                 1_000_000_000,
                 account,
             );
@@ -2359,6 +2374,7 @@ mod tests {
                 vec![openid_spec],
                 vec![0u8; 32],
                 "https://rp.example".to_string(),
+                None,
                 1_000_000_000,
                 account,
             );

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1465,6 +1465,7 @@ mod attribute_sharing {
         let ValidatedPrepareIcrc3AttributeRequest {
             identity_number,
             origin,
+            unmapped_origin,
             account_number,
             attributes,
             nonce,
@@ -1486,6 +1487,7 @@ mod attribute_sharing {
             attributes,
             nonce,
             origin,
+            unmapped_origin,
             issued_at_timestamp_ns,
             account,
         )?;

--- a/src/internet_identity/tests/integration/attributes.rs
+++ b/src/internet_identity/tests/integration/attributes.rs
@@ -599,6 +599,7 @@ fn should_get_icrc3_certified_attributes() {
         identity_number,
         origin: origin.to_string(),
         account_number: None,
+        unmapped_origin: None,
         attributes: vec![
             AttributeSpec {
                 key: "openid:https://accounts.google.com:email".into(),
@@ -752,6 +753,7 @@ fn should_certify_icrc3_attributes_mixed_omit_scope() {
         identity_number,
         origin: origin.to_string(),
         account_number: None,
+        unmapped_origin: None,
         attributes: vec![
             AttributeSpec {
                 key: "openid:https://accounts.google.com:email".into(),
@@ -893,6 +895,7 @@ fn should_return_no_such_signature_for_unknown_message() {
         identity_number,
         origin: origin.to_string(),
         account_number: None,
+        unmapped_origin: None,
         attributes: vec![AttributeSpec {
             key: "openid:https://accounts.google.com:email".into(),
             value: None,
@@ -1123,6 +1126,7 @@ fn icrc3_test_vectors() {
             identity_number,
             origin: origin.to_string(),
             account_number: None,
+            unmapped_origin: None,
             attributes: attributes.clone(),
             nonce: nonce.clone(),
         };
@@ -1514,6 +1518,7 @@ fn should_return_error_for_unavailable_icrc3_attributes() {
         identity_number,
         origin: origin.to_string(),
         account_number: None,
+        unmapped_origin: None,
         attributes: vec![
             AttributeSpec {
                 key: "openid:https://accounts.google.com:email".into(),

--- a/src/internet_identity_interface/src/internet_identity/types/attributes.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/attributes.rs
@@ -19,6 +19,40 @@ pub const OPENID_ISSUER_MAX_BYTES: usize = 1024;
 /// fully-qualified DNS name, only a reasonable cap.
 pub const SSO_DOMAIN_MAX_BYTES: usize = 253;
 
+/// Mirror of the frontend's `remapToLegacyDomain`: the frontend rewrites
+/// `https://<sub>.icp0.io` to `https://<sub>.ic0.app` before deriving a
+/// principal so users get the same principal across the two domains. The
+/// canister needs the same transformation to verify that an `unmapped_origin`
+/// supplied alongside the (legacy-mapped) `origin` is just the icp0.io form
+/// of the same site, not a different origin sneaking into the certified
+/// `implicit:origin`.
+///
+/// The accepted shape — `<subdomain>(.raw)?` containing only ASCII word
+/// characters or `-` — matches the regex `^https://([\w-]+(?:\.raw)?)\.icp0\.io$`
+/// used in the frontend.
+pub fn remap_to_legacy_domain(origin: &str) -> String {
+    const PREFIX: &str = "https://";
+    const ICP0_SUFFIX: &str = ".icp0.io";
+
+    let Some(rest) = origin.strip_prefix(PREFIX) else {
+        return origin.to_string();
+    };
+    let Some(subdomain) = rest.strip_suffix(ICP0_SUFFIX) else {
+        return origin.to_string();
+    };
+
+    let base = subdomain.strip_suffix(".raw").unwrap_or(subdomain);
+    let valid = !base.is_empty()
+        && base
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if !valid {
+        return origin.to_string();
+    }
+
+    format!("{PREFIX}{subdomain}.ic0.app")
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, CandidType, Serialize)]
 pub enum AttributeName {
     Email,
@@ -606,6 +640,12 @@ pub const ICRC3_NONCE_BYTES: usize = 32;
 pub struct PrepareIcrc3AttributeRequest {
     pub identity_number: AnchorNumber,
     pub origin: FrontendHostname,
+    /// The relying party's actual origin, before the legacy `icp0.io → ic0.app`
+    /// remap that `origin` may have gone through for principal stability. When
+    /// provided, this value is what gets certified as `implicit:origin`. The
+    /// canister verifies that mapping `unmapped_origin` through the same legacy
+    /// remap yields `origin`, so an RP can't certify an arbitrary value here.
+    pub unmapped_origin: Option<FrontendHostname>,
     pub account_number: Option<AccountNumber>,
     pub attributes: Vec<AttributeSpec>,
     pub nonce: Vec<u8>,
@@ -615,6 +655,7 @@ pub struct PrepareIcrc3AttributeRequest {
 pub struct ValidatedPrepareIcrc3AttributeRequest {
     pub identity_number: AnchorNumber,
     pub origin: FrontendHostname,
+    pub unmapped_origin: Option<FrontendHostname>,
     pub account_number: Option<AccountNumber>,
     pub attributes: Vec<ValidatedAttributeSpec>,
     pub nonce: Vec<u8>,
@@ -627,6 +668,7 @@ impl TryFrom<PrepareIcrc3AttributeRequest> for ValidatedPrepareIcrc3AttributeReq
         let PrepareIcrc3AttributeRequest {
             identity_number,
             origin,
+            unmapped_origin,
             account_number,
             attributes: unparsed_attributes,
             nonce,
@@ -648,6 +690,21 @@ impl TryFrom<PrepareIcrc3AttributeRequest> for ValidatedPrepareIcrc3AttributeReq
                 origin.len(),
                 FRONTEND_HOSTNAME_MAX_BYTES
             ));
+        }
+
+        if let Some(ref unmapped) = unmapped_origin {
+            if unmapped.len() > FRONTEND_HOSTNAME_MAX_BYTES {
+                problems.push(format!(
+                    "Unmapped origin length {} exceeds limit of {} bytes",
+                    unmapped.len(),
+                    FRONTEND_HOSTNAME_MAX_BYTES
+                ));
+            } else if remap_to_legacy_domain(unmapped) != origin {
+                problems.push(format!(
+                    "Unmapped origin {} is not related to origin {}",
+                    unmapped, origin
+                ));
+            }
         }
 
         if unparsed_attributes.len() > MAX_ATTRIBUTES_PER_REQUEST {
@@ -694,6 +751,7 @@ impl TryFrom<PrepareIcrc3AttributeRequest> for ValidatedPrepareIcrc3AttributeReq
         Ok(Self {
             identity_number,
             origin,
+            unmapped_origin,
             account_number,
             attributes,
             nonce,
@@ -1828,6 +1886,7 @@ mod tests {
                         identity_number: 123,
                         origin: "example.com".to_string(),
                         account_number: None,
+                        unmapped_origin: None,
                         attributes: vec![make_spec(
                             "openid:https://google.com:email",
                             Some(b"user@example.com"),
@@ -1843,6 +1902,7 @@ mod tests {
                         identity_number: 123,
                         origin: "example.com".to_string(),
                         account_number: None,
+                        unmapped_origin: None,
                         attributes: vec![make_spec("openid:https://google.com:email", None, false)],
                         nonce: vec![0u8; 32],
                     },
@@ -1854,6 +1914,7 @@ mod tests {
                         identity_number: 123,
                         origin: "example.com".to_string(),
                         account_number: None,
+                        unmapped_origin: None,
                         attributes: vec![make_spec("openid:https://google.com:email", None, true)],
                         nonce: vec![0u8; 32],
                     },
@@ -1865,6 +1926,7 @@ mod tests {
                         identity_number: 123,
                         origin: "example.com".to_string(),
                         account_number: Some(42),
+                        unmapped_origin: None,
                         attributes: vec![
                             make_spec(
                                 "openid:https://google.com:email",
@@ -1883,6 +1945,7 @@ mod tests {
                         identity_number: 123,
                         origin: "example.com".to_string(),
                         account_number: None,
+                        unmapped_origin: None,
                         attributes: vec![],
                         nonce: vec![0u8; 32],
                     },
@@ -1908,6 +1971,7 @@ mod tests {
                 identity_number: 123,
                 origin: "example.com".to_string(),
                 account_number: None,
+                unmapped_origin: None,
                 attributes: vec![
                     make_spec("openid:https://google.com:email", None, true),
                     make_spec("openid:https://google.com:name", None, false),
@@ -1925,6 +1989,7 @@ mod tests {
                 identity_number: 123,
                 origin: "example.com".to_string(),
                 account_number: None,
+                unmapped_origin: None,
                 attributes: vec![
                     make_spec(
                         "openid:https://google.com:email",
@@ -1955,6 +2020,7 @@ mod tests {
                         identity_number: 123,
                         origin: long_origin.clone(),
                         account_number: None,
+                        unmapped_origin: None,
                         attributes: vec![],
                         nonce: vec![0u8; 32],
                     },
@@ -1970,6 +2036,7 @@ mod tests {
                         identity_number: 123,
                         origin: "example.com".to_string(),
                         account_number: None,
+                        unmapped_origin: None,
                         attributes: (0..=MAX_ATTRIBUTES_PER_REQUEST)
                             .map(|_| make_spec("openid:https://google.com:email", None, false))
                             .collect(),
@@ -1987,6 +2054,7 @@ mod tests {
                         identity_number: 123,
                         origin: "example.com".to_string(),
                         account_number: None,
+                        unmapped_origin: None,
                         attributes: vec![make_spec("invalid_key", None, false)],
                         nonce: vec![0u8; 32],
                     },
@@ -1998,6 +2066,7 @@ mod tests {
                         identity_number: 123,
                         origin: "example.com".to_string(),
                         account_number: None,
+                        unmapped_origin: None,
                         attributes: vec![AttributeSpec {
                             key: "openid:https://google.com:email".to_string(),
                             value: Some(long_value.clone()),
@@ -2017,6 +2086,7 @@ mod tests {
                         identity_number: 123,
                         origin: long_origin.clone(),
                         account_number: None,
+                        unmapped_origin: None,
                         attributes: vec![make_spec("bad_key", None, false)],
                         nonce: vec![0u8; 32],
                     },
@@ -2053,6 +2123,158 @@ mod tests {
                     other => panic!("Expected validation error for {}, got {:?}", label, other),
                 }
             }
+        }
+
+        #[test]
+        fn test_unmapped_origin_accepted_when_remap_matches_origin() {
+            let request = PrepareIcrc3AttributeRequest {
+                identity_number: 123,
+                origin: "https://foo.ic0.app".to_string(),
+                unmapped_origin: Some("https://foo.icp0.io".to_string()),
+                account_number: None,
+                attributes: vec![],
+                nonce: vec![0u8; 32],
+            };
+            let validated =
+                ValidatedPrepareIcrc3AttributeRequest::try_from(request).expect("should validate");
+            pretty_assert_eq!(
+                validated.unmapped_origin,
+                Some("https://foo.icp0.io".to_string())
+            );
+        }
+
+        #[test]
+        fn test_unmapped_origin_accepted_when_equal_to_origin() {
+            // For non-icp0.io origins, the frontend's remap is a no-op, so
+            // `unmapped_origin == origin` is the expected case.
+            let request = PrepareIcrc3AttributeRequest {
+                identity_number: 123,
+                origin: "https://example.com".to_string(),
+                unmapped_origin: Some("https://example.com".to_string()),
+                account_number: None,
+                attributes: vec![],
+                nonce: vec![0u8; 32],
+            };
+            ValidatedPrepareIcrc3AttributeRequest::try_from(request).expect("should validate");
+        }
+
+        #[test]
+        fn test_unmapped_origin_rejected_when_unrelated_to_origin() {
+            let request = PrepareIcrc3AttributeRequest {
+                identity_number: 123,
+                origin: "https://foo.ic0.app".to_string(),
+                unmapped_origin: Some("https://evil.com".to_string()),
+                account_number: None,
+                attributes: vec![],
+                nonce: vec![0u8; 32],
+            };
+            let err = ValidatedPrepareIcrc3AttributeRequest::try_from(request).unwrap_err();
+            match err {
+                PrepareIcrc3AttributeError::ValidationError { problems } => {
+                    assert!(
+                        problems
+                            .iter()
+                            .any(|p| p.contains("not related to origin")),
+                        "expected 'not related to origin' problem, got {:?}",
+                        problems
+                    );
+                }
+                other => panic!("Expected ValidationError, got {:?}", other),
+            }
+        }
+
+        #[test]
+        fn test_unmapped_origin_too_long_rejected() {
+            let long = format!("https://{}.com", "x".repeat(FRONTEND_HOSTNAME_MAX_BYTES));
+            let request = PrepareIcrc3AttributeRequest {
+                identity_number: 123,
+                origin: "https://example.com".to_string(),
+                unmapped_origin: Some(long.clone()),
+                account_number: None,
+                attributes: vec![],
+                nonce: vec![0u8; 32],
+            };
+            let err = ValidatedPrepareIcrc3AttributeRequest::try_from(request).unwrap_err();
+            match err {
+                PrepareIcrc3AttributeError::ValidationError { problems } => {
+                    assert!(
+                        problems
+                            .iter()
+                            .any(|p| p.contains("Unmapped origin length")),
+                        "expected length problem, got {:?}",
+                        problems
+                    );
+                }
+                other => panic!("Expected ValidationError, got {:?}", other),
+            }
+        }
+
+        #[test]
+        fn test_unmapped_origin_none_is_accepted() {
+            let request = PrepareIcrc3AttributeRequest {
+                identity_number: 123,
+                origin: "https://foo.ic0.app".to_string(),
+                unmapped_origin: None,
+                account_number: None,
+                attributes: vec![],
+                nonce: vec![0u8; 32],
+            };
+            let validated =
+                ValidatedPrepareIcrc3AttributeRequest::try_from(request).expect("should validate");
+            assert!(validated.unmapped_origin.is_none());
+        }
+    }
+
+    mod remap_to_legacy_domain_tests {
+        use super::*;
+
+        #[test]
+        fn maps_icp0_io_subdomain_to_ic0_app() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://foo.icp0.io"),
+                "https://foo.ic0.app"
+            );
+        }
+
+        #[test]
+        fn maps_raw_subdomain() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://foo.raw.icp0.io"),
+                "https://foo.raw.ic0.app"
+            );
+        }
+
+        #[test]
+        fn allows_underscore_and_hyphen_in_subdomain() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://my-app_1.icp0.io"),
+                "https://my-app_1.ic0.app"
+            );
+        }
+
+        #[test]
+        fn leaves_non_icp0_origin_unchanged() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://example.com"),
+                "https://example.com"
+            );
+        }
+
+        #[test]
+        fn rejects_extra_subdomain_levels() {
+            // `foo.bar` is not `[\w-]+(?:\.raw)?`, so the input passes through.
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://foo.bar.icp0.io"),
+                "https://foo.bar.icp0.io"
+            );
+        }
+
+        #[test]
+        fn rejects_http_scheme() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("http://foo.icp0.io"),
+                "http://foo.icp0.io"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

The frontend rewrites `<sub>.icp0.io` to `<sub>.ic0.app` before sending the origin to the canister so users get a stable principal across both domains. As a side effect an RP signed in via `icp0.io` saw the `ic0.app` form in the certified `implicit:origin`, so the certified origin didn't reflect where the user actually authenticated.

The frontend now also passes the **unmapped** origin alongside the legacy-remapped one. The canister verifies the two are related (running the same legacy remap on `unmapped_origin` must yield `origin`) and certifies `unmapped_origin` as `implicit:origin` when present, falling back to `origin` for backwards compatibility.

- New optional `unmapped_origin : opt FrontendHostname` on `PrepareIcrc3AttributeRequest`.
- Canister-side `remap_to_legacy_domain` mirrors the frontend regex (`https://<sub>(.raw)?.icp0.io` → `https://<sub>(.raw)?.ic0.app`); rejects `unmapped_origin` if the relationship doesn't hold or it exceeds the hostname limit.
- Frontend channel handlers (`handleIcrc3OneClickOpenIdAttributes`, `handleIcrc3OneClickSsoAttributes`, `handleIcrc3ConsentAttributes`) compute the unmapped origin once, then pass both fields through `certifyAndSend`.

## Tests

- Added unit tests for the new validation (accepted when remap matches / equal / `None`; rejected when unrelated or too long).
- Added unit tests for the new `remap_to_legacy_domain` helper covering the icp0.io→ic0.app mapping, `.raw` subdomains, allowed characters, and rejected shapes (extra subdomain levels, `http://`).