### PR TITLE
build(local): bootstrap frontend init_args before icp commands

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,3 +25,6 @@ Dockerfile
 scripts/
 !scripts/build
 !scripts/bootstrap
+# Needed by the `postinstall` hook in package.json — it renders the
+# frontend canister's local init args before any `icp` command runs.
+!scripts/render-local-init-args

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -530,11 +530,12 @@ jobs:
             npm start --prefix ./src/test_openid_provider -- "$port" | tee -a "test-openid-provider-${port}-logs.txt" &
           done
 
-      # Render `src/internet_identity_frontend/local_test_arg.did` from
-      # the gitignored template so `icp.yaml`'s `init_args.path` resolves
-      # when icp-cli loads the project. CI overrides init args via
-      # `--args` at install time, so the rendered placeholder content is
-      # never parsed.
+      # Render the frontend canister's init_args file from the template
+      # so `icp.yaml`'s `init_args.path` resolves when icp-cli loads the
+      # project. Locally this happens via the `postinstall` npm hook; in
+      # CI we invoke it explicitly because not every job runs `npm
+      # install` before `icp`. CI overrides init args via `--args` at
+      # install time, so the rendered placeholder content is never parsed.
       - name: "Render frontend init_args stub"
         run: scripts/render-local-init-args
 
@@ -668,11 +669,10 @@ jobs:
           name: archive.wasm.gz
           path: .
 
-      # Render `src/internet_identity_frontend/local_test_arg.did` from
-      # the gitignored template so `icp.yaml`'s `init_args.path` resolves
-      # when icp-cli loads the project. This deploy targets mainnet via
-      # `--args` overrides, so the rendered placeholder content is never
-      # parsed.
+      # Render the frontend canister's init_args file from the template
+      # so `icp.yaml`'s `init_args.path` resolves when icp-cli loads the
+      # project. This deploy targets mainnet via `--args` overrides, so
+      # the rendered placeholder content is never parsed.
       - name: "Render frontend init_args stub"
         run: scripts/render-local-init-args
 

--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -61,11 +61,10 @@ jobs:
       - name: Install icp-cli
         run: npm install -g @icp-sdk/icp-cli@$(cat .icp-cli-version | tr -d '[:space:]')
 
-      # Render `src/internet_identity_frontend/local_test_arg.did` from
-      # the gitignored template so `icp.yaml`'s `init_args.path` resolves
-      # when icp-cli loads the project. This deploy targets mainnet via
-      # `--args` overrides, so the rendered placeholder content is never
-      # parsed.
+      # Render the frontend canister's init_args file from the template
+      # so `icp.yaml`'s `init_args.path` resolves when icp-cli loads the
+      # project. This deploy targets mainnet via `--args` overrides, so
+      # the rendered placeholder content is never parsed.
       - name: "Render frontend init_args stub"
         run: scripts/render-local-init-args
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@
 # icp-cli temporary files
 .icp/
 
-# Rendered from local_test_arg.did.template by scripts/render-local-init-args
-src/internet_identity_frontend/local_test_arg.did
-
 # frontend code
 node_modules/
 dist/

--- a/icp.yaml
+++ b/icp.yaml
@@ -10,7 +10,7 @@ canisters:
             - "II_FETCH_ROOT_KEY=1 scripts/build --frontend"
             - "cp internet_identity_frontend.wasm.gz \"$ICP_WASM_OUTPUT_PATH\""
     init_args:
-      path: src/internet_identity_frontend/local_test_arg.did
+      path: .icp/cache/init-args/internet_identity_frontend.did
 
   - name: internet_identity
     build:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "host": "II_FETCH_ROOT_KEY=1 II_DUMMY_CAPTCHA=1 vite --host",
     "build": "npm run extract && tsc --noEmit && vite build",
     "preview": "vite preview",
+    "postinstall": "scripts/render-local-init-args",
     "prepare": "svelte-kit sync || echo ''",
     "check": "tsc --project ./tsconfig.all.json --noEmit && svelte-check check",
     "watch": "npm run check -- --watch",

--- a/scripts/render-local-init-args
+++ b/scripts/render-local-init-args
@@ -2,10 +2,13 @@
 # Render the frontend canister's local init args by substituting the local
 # canister IDs (assigned by icp-cli) into the .template file.
 #
-# Invoked from the `internet_identity_frontend` build step in icp.yaml so
-# `icp deploy` "just works" without the user needing to edit the .did file
-# whenever icp-cli hands out new principals (which it does whenever the
-# local network is recreated). The rendered file is git-ignored.
+# Output lives under `.icp/cache/` (gitignored) so `icp deploy` re-renders
+# never dirty the working tree. Invoked from:
+#   - `npm install` (postinstall hook) so a fresh clone has a valid file
+#     before any `icp` command runs and `icp.yaml`'s `init_args.path`
+#     resolves on project load.
+#   - The `internet_identity_frontend` build step in `icp.yaml` so deploys
+#     pick up the real local IDs once they've been assigned.
 #
 # First-time deploy on a fresh network: this script calls
 # `icp canister create` for each canister it depends on so the IDs file
@@ -20,7 +23,7 @@ set -euo pipefail
 # `scripts/deploy-*-to-beta` (which may not cd) end up in the right place.
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 template="$ROOT_DIR/src/internet_identity_frontend/local_test_arg.did.template"
-output="$ROOT_DIR/src/internet_identity_frontend/local_test_arg.did"
+output="$ROOT_DIR/.icp/cache/init-args/internet_identity_frontend.did"
 mappings="$ROOT_DIR/.icp/cache/mappings/local.ids.json"
 
 if [ ! -f "$template" ]; then
@@ -51,6 +54,7 @@ if [ -f "$mappings" ]; then
   iif_id=$(jq -er '.internet_identity_frontend' "$mappings")
 fi
 
+mkdir -p "$(dirname "$output")"
 sed \
   -e "s|{{INTERNET_IDENTITY_ID}}|$ii_id|g" \
   -e "s|{{INTERNET_IDENTITY_FRONTEND_ID}}|$iif_id|g" \


### PR DESCRIPTION
> Stack: this PR → [#3828 (landing page redesign)](https://github.com/dfinity/internet-identity/pull/3828)

## Summary

Running `icp network start` on a fresh clone fails with:

```
failed to read init_args file for canister 'internet_identity_frontend'
Filesystem operation failed at src/internet_identity_frontend/local_test_arg.did
No such file or directory (os error 2)
```

The file is gitignored and only generated by `scripts/render-local-init-args`, which used to run as part of the `icp.yaml` build step — i.e. *after* icp-cli has already loaded the project and validated `init_args.path`.

This PR moves the rendered output into `.icp/cache/init-args/` (already gitignored as part of the `.icp/` cache) and wires the render script into `package.json`'s `postinstall` hook, so a fresh clone has a valid file before any `icp` command runs. Re-renders during `icp deploy` now write outside the source tree, so the working tree never goes dirty after deploys.

CI keeps invoking the script explicitly (not every CI job runs `npm install` before `icp`), but the surrounding comments are updated to reflect the new flow.

`.dockerignore` also gets a `!scripts/render-local-init-args` exception so the new postinstall script is included in the docker build context — `npm ci` runs after `COPY . .` and would otherwise exit 127 looking for a script that's been ignored.