### PR TITLE
chore(fe): add missing translations across all languages

### DIFF
--- a/src/frontend/src/lib/locales/de.po
+++ b/src/frontend/src/lib/locales/de.po
@@ -86,7 +86,7 @@ msgid "A way to regain access to your identity if you ever lose it."
 msgstr "Eine Möglichkeit, den Zugang zu Ihrer Identität wiederzuerlangen, falls Sie sie verlieren sollten."
 
 msgid "About"
-msgstr ""
+msgstr "Info"
 
 msgid "Access and recovery"
 msgstr "Zugriff und Wiederherstellung"
@@ -126,9 +126,6 @@ msgstr "Weiteren Passkey hinzufügen"
 
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "Fügen Sie eine weitere Möglichkeit hinzu, sich mit einem Passkey oder einem Drittanbieter-Konto für sicheren Zugriff anzumelden."
-
-msgid "Add identity"
-msgstr ""
 
 msgid "Add new"
 msgstr "Neu hinzufügen"
@@ -507,7 +504,7 @@ msgid "Interaction canceled. Please try again."
 msgstr "Interaktion abgebrochen. Bitte versuchen Sie es erneut."
 
 msgid "Internet Identity"
-msgstr ""
+msgstr "Internet Identity"
 
 msgid "Internet Identity <0>does not</0> store your biometric data. It stays on your device. Your identity acts as a secure passkey manager."
 msgstr "Internet Identity speichert Ihre biometrischen Daten <0>nicht</0>. Sie bleiben auf Ihrem Gerät. Ihre Identität fungiert als sicherer Passkey-Manager."
@@ -720,7 +717,7 @@ msgid "Open menu"
 msgstr "Menü öffnen"
 
 msgid "Or sign in with another identity"
-msgstr ""
+msgstr "Oder mit einer anderen Identität anmelden"
 
 msgid "Pairing link"
 msgstr "Kopplungslink"
@@ -906,13 +903,13 @@ msgid "Sign in again to continue where you left off."
 msgstr "Melden Sie sich erneut an, um dort fortzufahren, wo Sie aufgehört haben."
 
 msgid "Sign in or create an identity to access apps without passwords or sharing personal data."
-msgstr ""
+msgstr "Melden Sie sich an oder erstellen Sie eine Identität, um auf Apps zuzugreifen, ohne Passwörter zu benötigen oder persönliche Daten zu teilen."
 
 msgid "Sign in there."
 msgstr "Melden Sie sich dort an."
 
 msgid "Sign in to manage your identity"
-msgstr ""
+msgstr "Melden Sie sich an, um Ihre Identität zu verwalten"
 
 msgid "Sign in using familiar methods"
 msgstr "Anmelden mit bekannten Methoden"

--- a/src/frontend/src/lib/locales/en.po
+++ b/src/frontend/src/lib/locales/en.po
@@ -127,9 +127,6 @@ msgstr "Add another passkey"
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "Add another way to sign in with a passkey or third-party account for secure access."
 
-msgid "Add identity"
-msgstr "Add identity"
-
 msgid "Add new"
 msgstr "Add new"
 

--- a/src/frontend/src/lib/locales/es.po
+++ b/src/frontend/src/lib/locales/es.po
@@ -86,7 +86,7 @@ msgid "A way to regain access to your identity if you ever lose it."
 msgstr "Una forma de recuperar el acceso a tu identidad si alguna vez la pierdes."
 
 msgid "About"
-msgstr ""
+msgstr "Acerca de"
 
 msgid "Access and recovery"
 msgstr "Acceso y recuperación"
@@ -126,9 +126,6 @@ msgstr "Añade otra passkey"
 
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "Añade otra forma de iniciar sesión con una passkey o una cuenta de terceros para un acceso seguro."
-
-msgid "Add identity"
-msgstr ""
 
 msgid "Add new"
 msgstr "Añadir nuevo"
@@ -507,7 +504,7 @@ msgid "Interaction canceled. Please try again."
 msgstr "Interacción cancelada. Por favor, inténtalo de nuevo."
 
 msgid "Internet Identity"
-msgstr ""
+msgstr "Internet Identity"
 
 msgid "Internet Identity <0>does not</0> store your biometric data. It stays on your device. Your identity acts as a secure passkey manager."
 msgstr "Internet Identity <0>no</0> almacena tus datos biométricos. Permanecen en tu dispositivo. Tu identidad actúa como un gestor seguro de passkeys."
@@ -720,7 +717,7 @@ msgid "Open menu"
 msgstr "Abrir menú"
 
 msgid "Or sign in with another identity"
-msgstr ""
+msgstr "O inicia sesión con otra identidad"
 
 msgid "Pairing link"
 msgstr "Enlace de emparejamiento"
@@ -906,13 +903,13 @@ msgid "Sign in again to continue where you left off."
 msgstr "Inicia sesión de nuevo para continuar donde lo dejaste."
 
 msgid "Sign in or create an identity to access apps without passwords or sharing personal data."
-msgstr ""
+msgstr "Inicia sesión o crea una identidad para acceder a las aplicaciones sin contraseñas ni compartir datos personales."
 
 msgid "Sign in there."
 msgstr "Inicia sesión ahí."
 
 msgid "Sign in to manage your identity"
-msgstr ""
+msgstr "Inicia sesión para gestionar tu identidad"
 
 msgid "Sign in using familiar methods"
 msgstr "Inicia la sesión usando métodos conocidos"

--- a/src/frontend/src/lib/locales/fr.po
+++ b/src/frontend/src/lib/locales/fr.po
@@ -86,7 +86,7 @@ msgid "A way to regain access to your identity if you ever lose it."
 msgstr "Un moyen de retrouver l’accès à votre identité si jamais vous la perdez."
 
 msgid "About"
-msgstr ""
+msgstr "À propos"
 
 msgid "Access and recovery"
 msgstr "Accès et récupération"
@@ -126,9 +126,6 @@ msgstr "Ajouter une autre passkey"
 
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "Ajoutez un autre moyen de connexion avec une passkey ou un compte tiers pour un accès sécurisé."
-
-msgid "Add identity"
-msgstr ""
 
 msgid "Add new"
 msgstr "Ajouter"
@@ -507,7 +504,7 @@ msgid "Interaction canceled. Please try again."
 msgstr "Interaction annulée. Veuillez réessayer."
 
 msgid "Internet Identity"
-msgstr ""
+msgstr "Internet Identity"
 
 msgid "Internet Identity <0>does not</0> store your biometric data. It stays on your device. Your identity acts as a secure passkey manager."
 msgstr "Internet Identity <0>ne stocke pas</0> vos données biométriques. Elles restent sur votre appareil. Votre identité agit comme un gestionnaire sécurisé de passkeys."
@@ -720,7 +717,7 @@ msgid "Open menu"
 msgstr "Ouvrir le menu"
 
 msgid "Or sign in with another identity"
-msgstr ""
+msgstr "Ou se connecter avec une autre identité"
 
 msgid "Pairing link"
 msgstr "Lien d’appairage"
@@ -906,13 +903,13 @@ msgid "Sign in again to continue where you left off."
 msgstr "Reconnectez-vous pour reprendre là où vous vous étiez arrêté."
 
 msgid "Sign in or create an identity to access apps without passwords or sharing personal data."
-msgstr ""
+msgstr "Connectez-vous ou créez une identité pour accéder aux applications sans mots de passe ni partage de données personnelles."
 
 msgid "Sign in there."
 msgstr "Se connecter ici."
 
 msgid "Sign in to manage your identity"
-msgstr ""
+msgstr "Connectez-vous pour gérer votre identité"
 
 msgid "Sign in using familiar methods"
 msgstr "Se connecter avec des méthodes familières"

--- a/src/frontend/src/lib/locales/id.po
+++ b/src/frontend/src/lib/locales/id.po
@@ -86,7 +86,7 @@ msgid "A way to regain access to your identity if you ever lose it."
 msgstr "Cara untuk mendapatkan kembali akses ke identitas Anda jika Anda kehilangannya."
 
 msgid "About"
-msgstr ""
+msgstr "Tentang"
 
 msgid "Access and recovery"
 msgstr "Akses dan pemulihan"
@@ -126,9 +126,6 @@ msgstr "Tambahkan passkey lain"
 
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "Tambahkan cara lain untuk masuk dengan passkey atau akun pihak ketiga untuk akses aman."
-
-msgid "Add identity"
-msgstr ""
 
 msgid "Add new"
 msgstr "Tambah baru"
@@ -507,7 +504,7 @@ msgid "Interaction canceled. Please try again."
 msgstr "Interaksi dibatalkan. Silakan coba lagi."
 
 msgid "Internet Identity"
-msgstr ""
+msgstr "Internet Identity"
 
 msgid "Internet Identity <0>does not</0> store your biometric data. It stays on your device. Your identity acts as a secure passkey manager."
 msgstr "Internet Identity <0>tidak</0> menyimpan data biometrik Anda. Data tersebut tetap ada di perangkat Anda. Identitas Anda berfungsi sebagai pengelola passkey yang aman."
@@ -720,7 +717,7 @@ msgid "Open menu"
 msgstr "Buka menu"
 
 msgid "Or sign in with another identity"
-msgstr ""
+msgstr "Atau masuk dengan identitas lain"
 
 msgid "Pairing link"
 msgstr "Tautan penyambungan"
@@ -906,13 +903,13 @@ msgid "Sign in again to continue where you left off."
 msgstr "Masuk kembali untuk melanjutkan dari tempat terakhir Anda tinggalkan."
 
 msgid "Sign in or create an identity to access apps without passwords or sharing personal data."
-msgstr ""
+msgstr "Masuk atau buat identitas untuk mengakses aplikasi tanpa kata sandi atau berbagi data pribadi."
 
 msgid "Sign in there."
 msgstr "Masuk di sana."
 
 msgid "Sign in to manage your identity"
-msgstr ""
+msgstr "Masuk untuk mengelola identitas Anda"
 
 msgid "Sign in using familiar methods"
 msgstr "Masuk menggunakan metode yang dikenal"

--- a/src/frontend/src/lib/locales/it.po
+++ b/src/frontend/src/lib/locales/it.po
@@ -86,7 +86,7 @@ msgid "A way to regain access to your identity if you ever lose it."
 msgstr "Un modo per riottenere l'accesso alla tua identità se dovessi perderla."
 
 msgid "About"
-msgstr ""
+msgstr "Informazioni"
 
 msgid "Access and recovery"
 msgstr "Accesso e recupero"
@@ -126,9 +126,6 @@ msgstr "Aggiungi un'altra passkey"
 
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "Aggiungi un altro modo per accedere con una passkey o un account di terze parti per un accesso sicuro."
-
-msgid "Add identity"
-msgstr ""
 
 msgid "Add new"
 msgstr "Aggiungi nuovo"
@@ -507,7 +504,7 @@ msgid "Interaction canceled. Please try again."
 msgstr "Interazione annullata. Riprova."
 
 msgid "Internet Identity"
-msgstr ""
+msgstr "Internet Identity"
 
 msgid "Internet Identity <0>does not</0> store your biometric data. It stays on your device. Your identity acts as a secure passkey manager."
 msgstr "Internet Identity <0>non</0> memorizza i tuoi dati biometrici. Restano sul tuo dispositivo. La tua identità funge da gestore sicuro di passkey."
@@ -720,7 +717,7 @@ msgid "Open menu"
 msgstr "Apri menu"
 
 msgid "Or sign in with another identity"
-msgstr ""
+msgstr "Oppure accedi con un'altra identità"
 
 msgid "Pairing link"
 msgstr "Link di abbinamento"
@@ -906,13 +903,13 @@ msgid "Sign in again to continue where you left off."
 msgstr "Accedi di nuovo per riprendere da dove avevi interrotto."
 
 msgid "Sign in or create an identity to access apps without passwords or sharing personal data."
-msgstr ""
+msgstr "Accedi o crea un'identità per accedere alle app senza password né condivisione di dati personali."
 
 msgid "Sign in there."
 msgstr "Accedi lì."
 
 msgid "Sign in to manage your identity"
-msgstr ""
+msgstr "Accedi per gestire la tua identità"
 
 msgid "Sign in using familiar methods"
 msgstr "Accedi utilizzando metodi familiari"

--- a/src/frontend/src/lib/locales/nl.po
+++ b/src/frontend/src/lib/locales/nl.po
@@ -86,7 +86,7 @@ msgid "A way to regain access to your identity if you ever lose it."
 msgstr "Een manier om weer toegang te krijgen tot uw identiteit als u deze ooit verliest."
 
 msgid "About"
-msgstr ""
+msgstr "Over"
 
 msgid "Access and recovery"
 msgstr "Toegang en herstel"
@@ -126,9 +126,6 @@ msgstr "Voeg een andere passkey toe"
 
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "Voeg een andere manier toe om in te loggen met een passkey of account van derden voor veilige toegang."
-
-msgid "Add identity"
-msgstr ""
 
 msgid "Add new"
 msgstr "Voeg nieuw toe"
@@ -507,7 +504,7 @@ msgid "Interaction canceled. Please try again."
 msgstr "Interactie geannuleerd. Probeer het opnieuw."
 
 msgid "Internet Identity"
-msgstr ""
+msgstr "Internet Identity"
 
 msgid "Internet Identity <0>does not</0> store your biometric data. It stays on your device. Your identity acts as a secure passkey manager."
 msgstr "Internet Identity slaat uw biometrische gegevens <0>niet</0> op. Deze blijven op uw apparaat. Uw identiteit fungeert als een veilige passkey-manager."
@@ -720,7 +717,7 @@ msgid "Open menu"
 msgstr "Menu openen"
 
 msgid "Or sign in with another identity"
-msgstr ""
+msgstr "Of log in met een andere identiteit"
 
 msgid "Pairing link"
 msgstr "Koppelingslink"
@@ -906,13 +903,13 @@ msgid "Sign in again to continue where you left off."
 msgstr "Log opnieuw in om verder te gaan waar u gebleven was."
 
 msgid "Sign in or create an identity to access apps without passwords or sharing personal data."
-msgstr ""
+msgstr "Log in of maak een identiteit aan om toegang te krijgen tot apps zonder wachtwoorden of het delen van persoonlijke gegevens."
 
 msgid "Sign in there."
 msgstr "Log daar in."
 
 msgid "Sign in to manage your identity"
-msgstr ""
+msgstr "Log in om uw identiteit te beheren"
 
 msgid "Sign in using familiar methods"
 msgstr "Inloggen met vertrouwde methoden"

--- a/src/frontend/src/lib/locales/pl.po
+++ b/src/frontend/src/lib/locales/pl.po
@@ -86,7 +86,7 @@ msgid "A way to regain access to your identity if you ever lose it."
 msgstr "Sposób na odzyskanie dostępu do swojej tożsamości, jeśli ją kiedykolwiek utracisz."
 
 msgid "About"
-msgstr ""
+msgstr "O nas"
 
 msgid "Access and recovery"
 msgstr "Dostęp i odzyskiwanie"
@@ -126,9 +126,6 @@ msgstr "Dodaj kolejny klucz dostępu"
 
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "Dodaj inny sposób logowania za pomocą klucza dostępu lub konta strony trzeciej dla bezpiecznego dostępu."
-
-msgid "Add identity"
-msgstr ""
 
 msgid "Add new"
 msgstr "Dodaj nowe"
@@ -507,7 +504,7 @@ msgid "Interaction canceled. Please try again."
 msgstr "Interakcja anulowana. Spróbuj ponownie."
 
 msgid "Internet Identity"
-msgstr ""
+msgstr "Internet Identity"
 
 msgid "Internet Identity <0>does not</0> store your biometric data. It stays on your device. Your identity acts as a secure passkey manager."
 msgstr "Internet Identity <0>nie</0> przechowuje Twoich danych biometrycznych. Pozostają one na Twoim urządzeniu. Twoja tożsamość działa jako bezpieczny menedżer kluczy dostępu."
@@ -720,7 +717,7 @@ msgid "Open menu"
 msgstr "Otwórz menu"
 
 msgid "Or sign in with another identity"
-msgstr ""
+msgstr "Lub zaloguj się inną tożsamością"
 
 msgid "Pairing link"
 msgstr "Link do parowania"
@@ -906,13 +903,13 @@ msgid "Sign in again to continue where you left off."
 msgstr "Zaloguj się ponownie, aby kontynuować od miejsca, w którym przerwano."
 
 msgid "Sign in or create an identity to access apps without passwords or sharing personal data."
-msgstr ""
+msgstr "Zaloguj się lub utwórz tożsamość, aby uzyskać dostęp do aplikacji bez haseł i udostępniania danych osobowych."
 
 msgid "Sign in there."
 msgstr "Zaloguj się tam."
 
 msgid "Sign in to manage your identity"
-msgstr ""
+msgstr "Zaloguj się, aby zarządzać swoją tożsamością"
 
 msgid "Sign in using familiar methods"
 msgstr "Loguj się za pomocą znanych metod"

--- a/src/frontend/src/lib/locales/ru.po
+++ b/src/frontend/src/lib/locales/ru.po
@@ -86,7 +86,7 @@ msgid "A way to regain access to your identity if you ever lose it."
 msgstr "Способ восстановить доступ, если вы его потеряете."
 
 msgid "About"
-msgstr ""
+msgstr "О сервисе"
 
 msgid "Access and recovery"
 msgstr "Доступ и восстановление"
@@ -126,9 +126,6 @@ msgstr "Добавить другой ключ доступа"
 
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "Добавьте еще один способ входа с помощью ключа доступа или стороннего аккаунта для безопасного доступа."
-
-msgid "Add identity"
-msgstr ""
 
 msgid "Add new"
 msgstr "Добавить новый способ"
@@ -507,7 +504,7 @@ msgid "Interaction canceled. Please try again."
 msgstr "Взаимодействие отменено. Пожалуйста, попробуйте снова."
 
 msgid "Internet Identity"
-msgstr ""
+msgstr "Internet Identity"
 
 msgid "Internet Identity <0>does not</0> store your biometric data. It stays on your device. Your identity acts as a secure passkey manager."
 msgstr "Internet Identity <0>не запоминает</0> ваши биометрические данные — они остаются на устройстве. Ваша учётная запись управляет ключами доступа."
@@ -720,7 +717,7 @@ msgid "Open menu"
 msgstr "Открыть меню"
 
 msgid "Or sign in with another identity"
-msgstr ""
+msgstr "Или войдите с другой учётной записью"
 
 msgid "Pairing link"
 msgstr "Ссылка для сопряжения"
@@ -906,13 +903,13 @@ msgid "Sign in again to continue where you left off."
 msgstr "Войдите снова, чтобы продолжить с того места, где вы остановились."
 
 msgid "Sign in or create an identity to access apps without passwords or sharing personal data."
-msgstr ""
+msgstr "Войдите или создайте учётную запись, чтобы пользоваться приложениями без паролей и без передачи персональных данных."
 
 msgid "Sign in there."
 msgstr "Войти там."
 
 msgid "Sign in to manage your identity"
-msgstr ""
+msgstr "Войдите, чтобы управлять своей учётной записью"
 
 msgid "Sign in using familiar methods"
 msgstr "Вход через знакомые сервисы"

--- a/src/frontend/src/lib/locales/uk.po
+++ b/src/frontend/src/lib/locales/uk.po
@@ -86,7 +86,7 @@ msgid "A way to regain access to your identity if you ever lose it."
 msgstr "Спосіб відновити доступ до вашого ідентифікатора, якщо ви його коли-небудь втратите."
 
 msgid "About"
-msgstr ""
+msgstr "Про сервіс"
 
 msgid "Access and recovery"
 msgstr "Доступ та відновлення"
@@ -126,9 +126,6 @@ msgstr "Додати інший ключ доступу"
 
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "Додайте ще один спосіб входу за допомогою ключа доступу або стороннього облікового запису для безпечного доступу."
-
-msgid "Add identity"
-msgstr ""
 
 msgid "Add new"
 msgstr "Додати новий"
@@ -507,7 +504,7 @@ msgid "Interaction canceled. Please try again."
 msgstr "Взаємодія скасована. Будь ласка, спробуйте ще раз."
 
 msgid "Internet Identity"
-msgstr ""
+msgstr "Internet Identity"
 
 msgid "Internet Identity <0>does not</0> store your biometric data. It stays on your device. Your identity acts as a secure passkey manager."
 msgstr "Internet Identity <0>не</0> зберігає ваші біометричні дані. Вони залишаються на вашому пристрої. Ваш ідентифікатор працює як менеджер безпечних ключів доступу."
@@ -720,7 +717,7 @@ msgid "Open menu"
 msgstr "Відкрити меню"
 
 msgid "Or sign in with another identity"
-msgstr ""
+msgstr "Або увійдіть з іншим ідентифікатором"
 
 msgid "Pairing link"
 msgstr "Посилання для сполучення"
@@ -906,13 +903,13 @@ msgid "Sign in again to continue where you left off."
 msgstr "Увійдіть знову, щоб продовжити з того місця, де ви зупинилися."
 
 msgid "Sign in or create an identity to access apps without passwords or sharing personal data."
-msgstr ""
+msgstr "Увійдіть або створіть ідентифікатор, щоб користуватися додатками без паролів і без передачі особистих даних."
 
 msgid "Sign in there."
 msgstr "Увійдіть там."
 
 msgid "Sign in to manage your identity"
-msgstr ""
+msgstr "Увійдіть, щоб керувати своїм ідентифікатором"
 
 msgid "Sign in using familiar methods"
 msgstr "Увійдіть за допомогою звичних методів"

--- a/src/frontend/src/lib/locales/ur.po
+++ b/src/frontend/src/lib/locales/ur.po
@@ -86,7 +86,7 @@ msgid "A way to regain access to your identity if you ever lose it."
 msgstr "اگر آپ اپنی شناخت تک رسائی کھو دیں تو اسے دوبارہ حاصل کرنے کا ایک طریقہ۔"
 
 msgid "About"
-msgstr ""
+msgstr "تعارف"
 
 msgid "Access and recovery"
 msgstr "رسائی اور ریکوری"
@@ -126,9 +126,6 @@ msgstr "ایک اور پاس کی شامل کریں"
 
 msgid "Add another way to sign in with a passkey or third-party account for secure access."
 msgstr "محفوظ رسائی کے لیے پاس کی یا تھرڈ پارٹی اکاؤنٹ کے ذریعے سائن اِن کرنے کا ایک اور طریقہ شامل کریں۔"
-
-msgid "Add identity"
-msgstr ""
 
 msgid "Add new"
 msgstr "نیا شامل کریں"
@@ -507,7 +504,7 @@ msgid "Interaction canceled. Please try again."
 msgstr "عمل منسوخ کر دیا گیا۔ براہ کرم دوبارہ کوشش کریں۔"
 
 msgid "Internet Identity"
-msgstr ""
+msgstr "Internet Identity"
 
 msgid "Internet Identity <0>does not</0> store your biometric data. It stays on your device. Your identity acts as a secure passkey manager."
 msgstr "Internet Identity آپ کا بائیومیٹرک ڈیٹا <0>ذخیرہ نہیں کرتی</0>۔ یہ آپ کی ڈیوائس پر ہی رہتا ہے۔ آپ کی شناخت ایک محفوظ پاس کی مینیجر کے طور پر کام کرتی ہے۔"
@@ -720,7 +717,7 @@ msgid "Open menu"
 msgstr "مینو کھولیں"
 
 msgid "Or sign in with another identity"
-msgstr ""
+msgstr "یا کسی دوسری شناخت سے سائن اِن کریں"
 
 msgid "Pairing link"
 msgstr "پیئرنگ لنک"
@@ -906,13 +903,13 @@ msgid "Sign in again to continue where you left off."
 msgstr "جہاں آپ نے چھوڑا تھا وہاں سے جاری رکھنے کے لیے دوبارہ سائن ان کریں۔"
 
 msgid "Sign in or create an identity to access apps without passwords or sharing personal data."
-msgstr ""
+msgstr "بغیر پاس ورڈز یا ذاتی ڈیٹا شیئر کیے ایپس تک رسائی کے لیے سائن اِن کریں یا شناخت بنائیں۔"
 
 msgid "Sign in there."
 msgstr "وہاں سائن اِن کریں۔"
 
 msgid "Sign in to manage your identity"
-msgstr ""
+msgstr "اپنی شناخت کا انتظام کرنے کے لیے سائن اِن کریں"
 
 msgid "Sign in using familiar methods"
 msgstr "مانوس طریقوں سے سائن اِن کریں"


### PR DESCRIPTION
The new landing page introduced five user-visible strings that landed on `main` without translations in any of the ten non-English catalogs, so users browsing in `de`/`es`/`fr`/`id`/`it`/`nl`/`pl`/`ru`/`uk`/`ur` see the English copy on the welcome / welcome-back screens and in the footer:

- `About`
- `Internet Identity`
- `Or sign in with another identity`
- `Sign in or create an identity to access apps without passwords or sharing personal data.`
- `Sign in to manage your identity`

PR #3796 (still open) automates this gap-filling end-to-end via GitHub Actions and per-language PRs, but until it merges the gap remains. This PR closes it manually in a single bundled change.

# Changes

- Translated the five missing entries in each of `de.po`, `es.po`, `fr.po`, `id.po`, `it.po`, `nl.po`, `pl.po`, `ru.po`, `uk.po`, `ur.po`, matching the tone and terminology already established in each file.
- `Internet Identity` is kept verbatim as a brand name, per `rules/general.md` from #3796.
- Russian uses `учётная запись` for "identity" (not `идентификатор`), per the language rule from #3796.
- `en.po` drops an obsolete `Add identity` entry that `npm run extract --clean` prunes from the source catalog.