### PR TITLE
fix: filter COSE key to only signature-relevant parameters

### DIFF
--- a/src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts
+++ b/src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts
@@ -20,13 +20,23 @@ import { getPrimaryOrigin } from "$lib/globals";
  * @returns The COSE key of the authData.
  */
 export function authDataToCose(authData: Uint8Array): Uint8Array {
+  // COSE key parameter labels used for signature verification.
+  // See https://www.iana.org/assignments/cose/cose.xhtml#key-common-parameters
+  // and https://www.iana.org/assignments/cose/cose.xhtml#key-type-parameters
+  const COSE_KEY_PARAMS = new Set([
+    1, // kty
+    3, // alg
+    -1, // crv (EC2) / n (RSA)
+    -2, // x (EC2) / e (RSA)
+    -3, // y (EC2)
+  ]);
+
   const view = new DataView(bufFromBufLike(authData));
   const coseKey = authData.slice(55 + view.getUint16(53, false));
   const decoded = borc.decodeFirst(coseKey);
   const cleaned = new Map();
   for (const [key, value] of decoded.entries()) {
-    if (typeof key === "number") {
-      // Only keep numeric keys, removing WebAuthn extension keys as a result
+    if (COSE_KEY_PARAMS.has(key)) {
       cleaned.set(key, value);
     }
   }


### PR DESCRIPTION
## Summary

- Some authenticators (e.g. NitroKey 3A) include optional COSE key parameters like `key_ops` (label 4) in the credential public key when creating discoverable credentials with `residentKey: "required"` and `userVerification: "required"`
- The IC's COSE parser (`rs/crypto/internal/crypto_lib/basic_sig/cose/src/lib.rs`) rejects keys containing `key_ops` in any RFC 8152-compliant format (array values), causing `"Algorithm not supported in COSE parser"` errors on `/api/v4/canister/.../call`
- The previous `typeof key === "number"` filter correctly stripped WebAuthn extensions (text-keyed like `"credProtect"`, `"hmac-secret"`) but preserved numeric COSE metadata labels like `key_ops` (4) that aren't needed for verification
- Replace with an allowlist of the 5 COSE key parameters the IC actually uses: `kty` (1), `alg` (3), `crv` (-1), `x` (-2), `y` (-3)

Note: this issue may not reproduce on webauthn.me/debugger because it uses different credential creation options than II. The NitroKey 3A appears to include `key_ops` only for discoverable credentials.

There is also a bug on the IC side (`verify_key_ops` in `dfinity/ic`) that rejects spec-compliant `key_ops` values, but that is a separate fix.

## Test plan
- [ ] Register a NitroKey 3A passkey and verify canister calls succeed
- [ ] Verify existing passkeys (YubiKey, platform authenticators) still work
- [ ] Unit test `authDataToCose` with a COSE key containing `key_ops`

🤖 Generated with [Claude Code](https://claude.com/claude-code)