### PR TITLE
fix(fe): export COSE debug data from passkey test on self-service page

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -970,6 +970,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'stats' : IDL.Func([], [InternetIdentityStats], ['query']),
+    'whoami' : IDL.Func([], [IDL.Principal], ['query']),
     'update' : IDL.Func([UserNumber, DeviceKey, DeviceData], [], []),
     'update_account' : IDL.Func(
         [UserNumber, FrontendHostname, IDL.Opt(AccountNumber), AccountUpdate],

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1631,6 +1631,7 @@ export interface _SERVICE {
       { 'Err' : SetDefaultAccountError }
   >,
   'stats' : ActorMethod<[], InternetIdentityStats>,
+  'whoami' : ActorMethod<[], Principal>,
   'update' : ActorMethod<[UserNumber, DeviceKey, DeviceData], undefined>,
   'update_account' : ActorMethod<
     [UserNumber, FrontendHostname, [] | [AccountNumber], AccountUpdate],

--- a/src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts
+++ b/src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts
@@ -7,7 +7,7 @@ import {
 import { DER_COSE_OID, unwrapDER, wrapDER } from "@icp-sdk/core/identity";
 import borc from "borc";
 import { extractAAGUID } from "$lib/utils/webAuthn";
-import { bufFromBufLike } from "$lib/utils/utils";
+import { bufFromBufLike, toHex } from "$lib/utils/utils";
 import { getPrimaryOrigin } from "$lib/globals";
 
 /**
@@ -19,18 +19,52 @@ import { getPrimaryOrigin } from "$lib/globals";
  * @param authData The authData field of the attestation response.
  * @returns The COSE key of the authData.
  */
+// COSE key parameters defined in RFC 8152 that IC accepts
+const COSE_KEY_PARAMS = new Set([1, 3, -1, -2, -3]);
+
 export function authDataToCose(authData: Uint8Array): Uint8Array {
   const view = new DataView(bufFromBufLike(authData));
   const coseKey = authData.slice(55 + view.getUint16(53, false));
   const decoded = borc.decodeFirst(coseKey);
   const cleaned = new Map();
   for (const [key, value] of decoded.entries()) {
-    if (typeof key === "number") {
-      // Only keep numeric keys, removing WebAuthn extension keys as a result
+    if (COSE_KEY_PARAMS.has(key)) {
       cleaned.set(key, value);
     }
   }
   return borc.encode(cleaned);
+}
+
+export function authDataToCoseDebug(authData: Uint8Array): {
+  rawCoseHex: string;
+  cleanedCoseHex: string;
+  allEntries: Array<{ key: number | string; valueHex: string }>;
+  filteredEntries: Array<{ key: number | string; valueHex: string }>;
+} {
+  const view = new DataView(bufFromBufLike(authData));
+  const coseKey = authData.slice(55 + view.getUint16(53, false));
+  const decoded = borc.decodeFirst(coseKey);
+
+  const allEntries: Array<{ key: number | string; valueHex: string }> = [];
+  const filteredEntries: Array<{ key: number | string; valueHex: string }> = [];
+  const cleaned = new Map();
+
+  for (const [key, value] of decoded.entries()) {
+    const encoded = borc.encode(value);
+    const entry = { key, valueHex: toHex(new Uint8Array(encoded)) };
+    allEntries.push(entry);
+    if (COSE_KEY_PARAMS.has(key)) {
+      filteredEntries.push(entry);
+      cleaned.set(key, value);
+    }
+  }
+
+  return {
+    rawCoseHex: toHex(new Uint8Array(coseKey)),
+    cleanedCoseHex: toHex(new Uint8Array(borc.encode(cleaned))),
+    allEntries,
+    filteredEntries,
+  };
 }
 
 function coseToDerEncodedBlob(cose: Uint8Array): DerEncodedPublicKey {

--- a/src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts
+++ b/src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts
@@ -36,22 +36,26 @@ export function authDataToCose(authData: Uint8Array): Uint8Array {
 }
 
 export function authDataToCoseDebug(authData: Uint8Array): {
+  cleanedCose: Uint8Array;
   rawCoseHex: string;
   cleanedCoseHex: string;
-  allEntries: Array<{ key: number | string; valueHex: string }>;
-  filteredEntries: Array<{ key: number | string; valueHex: string }>;
+  allEntries: Array<{ key: number | string; valueCborHex: string }>;
+  filteredEntries: Array<{ key: number | string; valueCborHex: string }>;
 } {
   const view = new DataView(bufFromBufLike(authData));
   const coseKey = authData.slice(55 + view.getUint16(53, false));
   const decoded = borc.decodeFirst(coseKey);
 
-  const allEntries: Array<{ key: number | string; valueHex: string }> = [];
-  const filteredEntries: Array<{ key: number | string; valueHex: string }> = [];
+  const allEntries: Array<{ key: number | string; valueCborHex: string }> = [];
+  const filteredEntries: Array<{ key: number | string; valueCborHex: string }> =
+    [];
   const cleaned = new Map();
 
   for (const [key, value] of decoded.entries()) {
-    const encoded = borc.encode(value);
-    const entry = { key, valueHex: toHex(new Uint8Array(encoded)) };
+    const entry = {
+      key,
+      valueCborHex: toHex(new Uint8Array(borc.encode(value))),
+    };
     allEntries.push(entry);
     if (COSE_KEY_PARAMS.has(key)) {
       filteredEntries.push(entry);
@@ -59,9 +63,11 @@ export function authDataToCoseDebug(authData: Uint8Array): {
     }
   }
 
+  const cleanedCose = new Uint8Array(borc.encode(cleaned));
   return {
+    cleanedCose,
     rawCoseHex: toHex(new Uint8Array(coseKey)),
-    cleanedCoseHex: toHex(new Uint8Array(borc.encode(cleaned))),
+    cleanedCoseHex: toHex(cleanedCose),
     allEntries,
     filteredEntries,
   };

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -44,6 +44,7 @@
   import { toaster } from "$lib/components/utils/toaster";
   import { toHex, waitFor } from "$lib/utils/utils";
   import { handleError } from "$lib/components/utils/error";
+  import { SvelteMap } from "svelte/reactivity";
 
   interface IdentityResult {
     identityNumber: bigint;
@@ -76,7 +77,7 @@
   let knownProviders = $state<Record<string, Provider>>({});
   let testResults = $state<TestResult[]>([]);
   let highlightIdentity = $state<bigint>();
-  const knownCredentials = new Map<
+  const knownCredentials = new SvelteMap<
     string,
     { publicKey: CosePublicKey; aaguid?: string }
   >();

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -269,6 +269,13 @@
           callerPrincipal: principal.toText(),
         };
       } catch (icError) {
+        // Re-throw user cancellations — the test was not completed
+        if (
+          icError instanceof DOMException &&
+          icError.name === "NotAllowedError"
+        ) {
+          throw icError;
+        }
         icCall = {
           senderPubkeyHex: derHex,
           delegationPubkeyHex: toHex(
@@ -539,7 +546,12 @@
                   {provider?.name ?? $t`Unknown`}
                 </div>
                 <Badge class="ms-auto !flex flex-row items-center gap-1">
-                  {#if testResult.aaguid === undefined}
+                  {#if testResult.debug?.icCall?.error !== undefined}
+                    <XIcon class="text-text-error-primary size-5" />
+                    <span class="text-text-error-primary">
+                      {$t`Unsupported`}
+                    </span>
+                  {:else if testResult.aaguid === undefined}
                     <span>{$t`Unknown`}</span>
                   {:else if verifiedSupportedProviders.includes(testResult.aaguid)}
                     <CheckIcon class="text-text-success-primary size-5" />

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -23,7 +23,7 @@
     getRpId,
   } from "$lib/utils/discoverablePasskeyIdentity";
   import borc from "borc";
-  import { aaguidToString, extractAAGUID } from "$lib/utils/webAuthn";
+  import { aaguidToString } from "$lib/utils/webAuthn";
   import Badge from "$lib/components/ui/Badge.svelte";
   import type { Provider } from "$lib/assets/aaguid";
   import { onMount } from "svelte";
@@ -201,35 +201,39 @@
   };
   const testPasskeyCreation = async () => {
     try {
+      let debug: ReturnType<typeof authDataToCoseDebug> | undefined;
       const rpId = getRpId();
-      const options = creationOptions(
-        `self-service (Test passkey – safe to delete)`,
-        rpId,
-      );
-      const challenge = window.crypto.getRandomValues(new Uint8Array(32));
-      const credential = await navigator.credentials.create({
-        ...options,
-        publicKey: { ...options.publicKey, challenge },
+      const identity = new DiscoverablePasskeyIdentity({
+        credentialCreationOptions: creationOptions(
+          `self-service (Test passkey – safe to delete)`,
+          rpId,
+        ),
+        getPublicKey: async (result) => {
+          if (result.response.attestationObject === undefined) {
+            throw new Error("Was expecting an attestation response.");
+          }
+          const attObject = borc.decodeFirst(
+            new Uint8Array(result.response.attestationObject),
+          );
+          const authData = new Uint8Array(attObject.authData);
+          debug = authDataToCoseDebug(authData);
+          return new CosePublicKey(debug.cleanedCose);
+        },
       });
-      if (credential === null)
-        throw new Error("WebAuthn credential is missing");
-      const cred = credential as PublicKeyCredential & {
-        response: AuthenticatorAttestationResponse;
-      };
-      const attObject = borc.decodeFirst(
-        new Uint8Array(cred.response.attestationObject),
+      await identity.sign(
+        Uint8Array.from("<ic0.app>", (c) => c.charCodeAt(0)),
       );
-      const authData = new Uint8Array(attObject.authData);
-      const aaguid = extractAAGUID(authData);
-      const debug = authDataToCoseDebug(authData);
-      const cosePublicKey = new CosePublicKey(debug.cleanedCose);
+      if (debug === undefined) throw new Error("Debug info missing");
+      const credentialId = identity.getCredentialId()!;
+      const aaguid = identity.getAaguid();
+      const cosePublicKey = identity.getPublicKey() as CosePublicKey;
       const derHex = toHex(new Uint8Array(cosePublicKey.toDer()));
 
       // Attempt an actual IC canister call using a delegation from this passkey.
       // This triggers full IC ingress validation of the COSE key — if the key is
       // malformed (e.g. contains key_ops) the IC rejects the call here.
       const passkeyIdentity = DiscoverablePasskeyIdentity.useExisting({
-        credentialIds: [new Uint8Array(cred.rawId)],
+        credentialIds: [credentialId],
         getPublicKey: () => Promise.resolve(cosePublicKey),
       });
       const sessionIdentity = await ECDSAKeyIdentity.generate();
@@ -280,7 +284,7 @@
         aaguid: aaguid !== undefined ? aaguidToString(aaguid) : undefined,
         date: Date.now(),
         debug: {
-          credentialIdHex: toHex(new Uint8Array(cred.rawId)),
+          credentialIdHex: toHex(credentialId),
           rawCoseHex: debug.rawCoseHex,
           cleanedCoseHex: debug.cleanedCoseHex,
           allEntries: debug.allEntries,

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -261,6 +261,7 @@
   const testDiscoverableAuth = async () => {
     try {
       let resolvedCredHex: string | undefined;
+      const sessionIdentity = await ECDSAKeyIdentity.generate();
       const discoverableIdentity = DiscoverablePasskeyIdentity.useExisting({
         getPublicKey: (result) => {
           const credHex = toHex(new Uint8Array(result.rawId));
@@ -274,13 +275,22 @@
           return Promise.resolve(known.publicKey);
         },
       });
-      await discoverableIdentity.sign(
-        Uint8Array.from("<ic0.app>", (c) => c.charCodeAt(0)),
+      // Single WebAuthn prompt: DelegationChain.create calls discoverableIdentity.sign() once
+      const delegationChain = await DelegationChain.create(
+        discoverableIdentity,
+        sessionIdentity.getPublicKey(),
       );
+      const delegationIdentity = DelegationIdentity.fromDelegation(
+        sessionIdentity,
+        delegationChain,
+      );
+      const agent = await HttpAgent.from(anonymousAgent);
+      agent.replaceIdentity(delegationIdentity);
+      await anonymousActor.whoami.withOptions({ agent })();
+
       if (resolvedCredHex === undefined)
         throw new Error("Credential not resolved");
 
-      // Mark the existing creation result for this credential as sign-in verified
       const existing = testResults.find(
         (r) => r.debug?.credentialIdHex === resolvedCredHex,
       );

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -57,6 +57,7 @@
   interface TestResult {
     aaguid?: string;
     date: number;
+    signInVerified?: boolean;
     debug?: {
       credentialIdHex: string;
       rawCoseHex: string;
@@ -259,97 +260,33 @@
   };
   const testDiscoverableAuth = async () => {
     try {
-      let resolvedCredential:
-        | { publicKey: CosePublicKey; aaguid?: string }
-        | undefined;
+      let resolvedCredHex: string | undefined;
       const discoverableIdentity = DiscoverablePasskeyIdentity.useExisting({
         getPublicKey: (result) => {
           const credHex = toHex(new Uint8Array(result.rawId));
-          resolvedCredential = knownCredentials.get(credHex);
-          if (resolvedCredential === undefined) {
+          const known = knownCredentials.get(credHex);
+          if (known === undefined) {
             throw new Error(
-              "Run 'Test passkey support' first to register this passkey.",
+              "Run 'Test passkey support' first for this passkey.",
             );
           }
-          return Promise.resolve(resolvedCredential.publicKey);
+          resolvedCredHex = credHex;
+          return Promise.resolve(known.publicKey);
         },
       });
       await discoverableIdentity.sign(
         Uint8Array.from("<ic0.app>", (c) => c.charCodeAt(0)),
       );
-      if (resolvedCredential === undefined)
+      if (resolvedCredHex === undefined)
         throw new Error("Credential not resolved");
-      const credentialId = discoverableIdentity.getCredentialId()!;
-      const cosePublicKey = resolvedCredential.publicKey;
-      const derHex = toHex(new Uint8Array(cosePublicKey.toDer()));
 
-      const passkeyIdentity = DiscoverablePasskeyIdentity.useExisting({
-        credentialIds: [credentialId],
-        getPublicKey: () => Promise.resolve(cosePublicKey),
-      });
-      const sessionIdentity = await ECDSAKeyIdentity.generate();
-      let icCall:
-        | {
-            senderPubkeyHex: string;
-            delegationPubkeyHex: string;
-            callerPrincipal?: string;
-            error?: string;
-          }
-        | undefined;
-      try {
-        const delegationChain = await DelegationChain.create(
-          passkeyIdentity,
-          sessionIdentity.getPublicKey(),
-        );
-        const senderPubkeyHex = toHex(
-          new Uint8Array(delegationChain.publicKey),
-        );
-        const delegationPubkeyHex = toHex(
-          new Uint8Array(
-            delegationChain.delegations[0]?.delegation.pubkey ?? [],
-          ),
-        );
-        const delegationIdentity = DelegationIdentity.fromDelegation(
-          sessionIdentity,
-          delegationChain,
-        );
-        const agent = await HttpAgent.from(anonymousAgent);
-        agent.replaceIdentity(delegationIdentity);
-        const principal = await anonymousActor.whoami.withOptions({ agent })();
-        icCall = {
-          senderPubkeyHex,
-          delegationPubkeyHex,
-          callerPrincipal: principal.toText(),
-        };
-      } catch (icError) {
-        if (
-          icError instanceof DOMException &&
-          icError.name === "NotAllowedError"
-        ) {
-          throw icError;
-        }
-        icCall = {
-          senderPubkeyHex: derHex,
-          delegationPubkeyHex: toHex(
-            new Uint8Array(sessionIdentity.getPublicKey().toDer()),
-          ),
-          error: icError instanceof Error ? icError.message : String(icError),
-        };
-      }
-
-      testResults.push({
-        aaguid: resolvedCredential.aaguid,
-        date: Date.now(),
-        debug: {
-          credentialIdHex: toHex(credentialId),
-          rawCoseHex: "",
-          cleanedCoseHex: toHex(cosePublicKey.getCose()),
-          allEntries: [],
-          filteredEntries: [],
-          derHex,
-          icCall,
-        },
-      });
+      // Mark the existing creation result for this credential as sign-in verified
+      const existing = testResults.find(
+        (r) => r.debug?.credentialIdHex === resolvedCredHex,
+      );
+      if (existing === undefined)
+        throw new Error("No creation test found for this credential.");
+      existing.signInVerified = true;
     } catch (error) {
       handleError(error);
     }
@@ -608,13 +545,17 @@
                 </div>
                 <Badge class="ms-auto !flex flex-row items-center gap-1">
                   {#if testResult.debug?.icCall?.error !== undefined}
-                    <XIcon class="text-text-error-primary size-5" />
+                    <XIcon class="text-text-error-primary size-4" />
                     <span class="text-text-error-primary">{$t`Error`}</span>
+                  {:else if testResult.signInVerified}
+                    <CheckIcon class="text-text-success-primary size-4" />
+                    <span class="text-text-success-primary">{$t`Sign-up`}</span>
+                    <span class="text-text-tertiary">·</span>
+                    <CheckIcon class="text-text-success-primary size-4" />
+                    <span class="text-text-success-primary">{$t`Sign-in`}</span>
                   {:else}
-                    <CheckIcon class="text-text-success-primary size-5" />
-                    <span class="text-text-success-primary"
-                      >{$t`Supported`}</span
-                    >
+                    <CheckIcon class="text-text-success-primary size-4" />
+                    <span class="text-text-success-primary">{$t`Sign-up`}</span>
                   {/if}
                 </Badge>
               </div>

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -9,7 +9,6 @@
     PlayIcon,
     CheckIcon,
     XIcon,
-    TriangleAlertIcon,
     CircleXIcon,
     CircleCheckIcon,
   } from "@lucide/svelte";
@@ -73,65 +72,14 @@
     };
   }
 
-  const verifiedSupportedProviders = [
-    "6028b017-b1d4-4c02-b4b3-afcdafc96bb2", // Windows Hello
-    "9ddd1817-af5a-4672-a2b9-3e3dd95000a9", // Windows Hello
-    "08987058-cadc-4b81-b6e1-30de50dcbe96", // Windows Hello
-    "fbfc3007-154e-4ecc-8c0b-6e020557d7bd", // Apple Passwords
-    "d548826e-79b4-db40-a3d8-11116f7e8349", // Bitwarden
-    "bada5566-a7aa-401f-bd96-45619a55120d", // 1Password
-    "ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4", // Google Password Manager
-    "53414d53-554e-4700-0000-000000000000", // Samsung Pass
-    "a25342c0-3cdc-4414-8e46-f4807fca511c", // YubiKey latest firmware (5.7)
-    "d7781e5d-e353-46aa-afe2-3ca49f13332a", // YubiKey latest firmware (5.7)
-    "662ef48a-95e2-4aaa-a6c1-5b9c40375824", // YubiKey latest firmware (5.7)
-    "19083c3d-8383-4b18-bc03-8f1c9ab2fd1b", // YubiKey latest firmware (5.7)
-    "ff4dac45-ede8-4ec2-aced-cf66103f4335", // YubiKey latest firmware (5.7)
-    "a02167b9-ae71-4ac7-9a07-06432ebb6f1c", // YubiKey latest firmware (5.7)
-    "24673149-6c86-42e7-98d9-433fb5b73296", // YubiKey latest firmware (5.7)
-    "fcc0118f-cd45-435b-8da1-9782b2da0715", // YubiKey latest firmware (5.7)
-    "57f7de54-c807-4eab-b1c6-1c9be7984e92", // YubiKey latest firmware (5.7)
-    "7b96457d-e3cd-432b-9ceb-c9fdd7ef7432", // YubiKey latest firmware (5.7)
-    "dd86a2da-86a0-4cbe-b462-4bd31f57bc6f", // YubiKey latest firmware (5.7)
-    "7409272d-1ff9-4e10-9fc9-ac0019c124fd", // YubiKey latest firmware (5.7)
-    "90636e1f-ef82-43bf-bdcf-5255f139d12f", // YubiKey latest firmware (5.7)
-    "34744913-4f57-4e6e-a527-e9ec3c4b94e6", // YubiKey latest firmware (5.7)
-    "e77e3c64-05e3-428b-8824-0cbeb04b829d", // YubiKey latest firmware (5.7)
-    "b7d3f68e-88a6-471e-9ecf-2df26d041ede", // YubiKey latest firmware (5.7)
-    "47ab2fb4-66ac-4184-9ae1-86be814012d5", // YubiKey latest firmware (5.7)
-    "ed042a3a-4b22-4455-bb69-a267b652ae7e", // YubiKey latest firmware (5.7)
-  ];
-  const verifiedUnsupportedProviders: Record<string, string> = {
-    "cb69481e-8ff7-4039-93ec-0a2729a154a8": $t`This YubiKey has older firmware (5.1) that's incompatible.`,
-    "fa2b99dc-9e39-4257-8f92-4a30d23c4118": $t`This YubiKey has older firmware (5.1) that's incompatible.`,
-    "f8a011f3-8c0a-4d15-8006-17111f9edc7d": $t`This YubiKey has older firmware (5.1) that's incompatible.`,
-    "531126d6-e717-415c-9320-3d9aa6981239": $t`Dashlane has been confirmed to be incompatible.`,
-    "b84e4048-15dc-4dd0-8640-f4f60813c8af": $t`NordPass has been confirmed to be incompatible.`,
-    "6e24d385-004a-16a0-7bfe-efd963845b34": $t`Ledger has been confirmed to be incompatible.`,
-    "341e4da9-3c2e-8103-5a9f-aad887135200": $t`Ledger has been confirmed to be incompatible.`,
-    "58b44d0b-0a7c-f33a-fd48-f7153c871352": $t`Ledger has been confirmed to be incompatible.`,
-    "1d8cac46-47a1-3386-af50-e88ae46fe802": $t`Ledger has been confirmed to be incompatible.`,
-    "fcb1bcb4-f370-078c-6993-bc24d0ae3fbe": $t`Ledger has been confirmed to be incompatible.`,
-  };
-  const possiblyUnsupportedProviders: Record<string, string> = {
-    "b92c3f9a-c014-4056-887f-140a2501163b": $t`This YubiKey has older firmware (5.2) that might be incompatible.`,
-    "ee882879-721c-4913-9775-3dfcce97072a": $t`This YubiKey has older firmware (5.2 - 5.4) that might be incompatible.`,
-    "2fc0579f-8113-47ea-b116-bb5a8db9202a": $t`This YubiKey has older firmware (5.2 - 5.4) that might be incompatible.`,
-    "c5ef55ff-ad9a-4b9f-b580-adebafe026d0": $t`This YubiKey has older firmware (5.2 - 5.4) that might be incompatible.`,
-    "149a2021-8ef6-4133-96b8-81f8d5b7f1f5": $t`This YubiKey has older firmware (5.2 - 5.4) that might be incompatible.`,
-    "c1f9a0bc-1dd2-404a-b27f-8e29047a43fd": $t`This YubiKey has older firmware (5.4) that might be incompatible.`,
-    "73bb0cd4-e502-49b8-9c6f-b59445bf720b": $t`This YubiKey has older firmware (5.4) that might be incompatible.`,
-    "85203421-48f9-4355-9bc8-8a53846e5083": $t`This YubiKey has older firmware (5.4) that might be incompatible.`,
-    "a4e9fc6d-4cbe-4758-b8ba-37598bb5bbaa": $t`This YubiKey has older firmware (5.4) that might be incompatible.`,
-    "0bb43545-fd2c-4185-87dd-feb0b2916ace": $t`This YubiKey has older firmware (5.4) that might be incompatible.`,
-    "d8522d9f-575b-4866-88a9-ba99fa02f35b": $t`This YubiKey has older firmware (5.5 - 5.6) that might be incompatible.`,
-    "7d1351a6-e097-4852-b8bf-c9ac5c9ce4a3": $t`This YubiKey has older firmware (5.6) that might be incompatible.`,
-  };
-
   let identityResults = $state<IdentityResult[]>([]);
   let knownProviders = $state<Record<string, Provider>>({});
   let testResults = $state<TestResult[]>([]);
   let highlightIdentity = $state<bigint>();
+  const knownCredentials = new Map<
+    string,
+    { publicKey: CosePublicKey; aaguid?: string }
+  >();
 
   const missingUpgradedPasskey = (devices: DeviceData[]) =>
     // Has at least one passkey (else likely OpenID sign-in identity)
@@ -285,8 +233,14 @@
         };
       }
 
+      const resolvedAaguid =
+        aaguid !== undefined ? aaguidToString(aaguid) : undefined;
+      knownCredentials.set(toHex(new Uint8Array(credentialId)), {
+        publicKey: cosePublicKey,
+        aaguid: resolvedAaguid,
+      });
       testResults.push({
-        aaguid: aaguid !== undefined ? aaguidToString(aaguid) : undefined,
+        aaguid: resolvedAaguid,
         date: Date.now(),
         debug: {
           credentialIdHex: toHex(credentialId),
@@ -294,6 +248,103 @@
           cleanedCoseHex: debug.cleanedCoseHex,
           allEntries: debug.allEntries,
           filteredEntries: debug.filteredEntries,
+          derHex,
+          icCall,
+        },
+      });
+    } catch (error) {
+      handleError(error);
+    }
+  };
+  const testDiscoverableAuth = async () => {
+    try {
+      let resolvedCredential:
+        | { publicKey: CosePublicKey; aaguid?: string }
+        | undefined;
+      const discoverableIdentity = DiscoverablePasskeyIdentity.useExisting({
+        getPublicKey: (result) => {
+          const credHex = toHex(new Uint8Array(result.rawId));
+          resolvedCredential = knownCredentials.get(credHex);
+          if (resolvedCredential === undefined) {
+            throw new Error(
+              "Run 'Test passkey support' first to register this passkey.",
+            );
+          }
+          return Promise.resolve(resolvedCredential.publicKey);
+        },
+      });
+      await discoverableIdentity.sign(
+        Uint8Array.from("<ic0.app>", (c) => c.charCodeAt(0)),
+      );
+      if (resolvedCredential === undefined)
+        throw new Error("Credential not resolved");
+      const credentialId = discoverableIdentity.getCredentialId()!;
+      const cosePublicKey = resolvedCredential.publicKey;
+      const derHex = toHex(new Uint8Array(cosePublicKey.toDer()));
+
+      const passkeyIdentity = DiscoverablePasskeyIdentity.useExisting({
+        credentialIds: [credentialId],
+        getPublicKey: () => Promise.resolve(cosePublicKey),
+      });
+      const sessionIdentity = await ECDSAKeyIdentity.generate();
+      let icCall:
+        | {
+            senderPubkeyHex: string;
+            delegationPubkeyHex: string;
+            callerPrincipal?: string;
+            error?: string;
+          }
+        | undefined;
+      try {
+        const delegationChain = await DelegationChain.create(
+          passkeyIdentity,
+          sessionIdentity.getPublicKey(),
+        );
+        const senderPubkeyHex = toHex(
+          new Uint8Array(delegationChain.publicKey),
+        );
+        const delegationPubkeyHex = toHex(
+          new Uint8Array(
+            delegationChain.delegations[0]?.delegation.pubkey ?? [],
+          ),
+        );
+        const delegationIdentity = DelegationIdentity.fromDelegation(
+          sessionIdentity,
+          delegationChain,
+        );
+        const agent = await HttpAgent.from(anonymousAgent);
+        agent.replaceIdentity(delegationIdentity);
+        const principal = await anonymousActor.whoami.withOptions({ agent })();
+        icCall = {
+          senderPubkeyHex,
+          delegationPubkeyHex,
+          callerPrincipal: principal.toText(),
+        };
+      } catch (icError) {
+        if (
+          icError instanceof DOMException &&
+          icError.name === "NotAllowedError"
+        ) {
+          throw icError;
+        }
+        icCall = {
+          senderPubkeyHex: derHex,
+          delegationPubkeyHex: toHex(
+            new Uint8Array(sessionIdentity.getPublicKey().toDer()),
+          ),
+          error: icError instanceof Error ? icError.message : String(icError),
+        };
+      }
+
+      testResults.push({
+        aaguid: resolvedCredential.aaguid,
+        date: Date.now(),
+        debug: {
+          credentialIdHex: toHex(credentialId),
+          rawCoseHex: "",
+          cleanedCoseHex: toHex(cosePublicKey.getCose()),
+          allEntries: [],
+          filteredEntries: [],
           derHex,
           icCall,
         },
@@ -526,10 +577,19 @@
       <p class="text-text-tertiary mb-6 text-base text-pretty">
         <Trans>Test passkey support and view authenticator details</Trans>
       </p>
-      <button onclick={testPasskeyCreation} class="btn gap-2 max-sm:w-full">
-        <PlayIcon class="size-5" />
-        <span>{$t`Test passkey support`}</span>
-      </button>
+      <div class="flex flex-wrap gap-3">
+        <button onclick={testPasskeyCreation} class="btn gap-2 max-sm:w-full">
+          <PlayIcon class="size-5" />
+          <span>{$t`Test passkey support`}</span>
+        </button>
+        <button
+          onclick={testDiscoverableAuth}
+          class="btn btn-secondary gap-2 max-sm:w-full"
+        >
+          <PlayIcon class="size-5" />
+          <span>{$t`Test sign-in`}</span>
+        </button>
+      </div>
       <hr class="bt-1 border-border-secondary my-4" />
       {#if testResults.length > 0}
         <div class="flex flex-col gap-4">
@@ -548,28 +608,12 @@
                 <Badge class="ms-auto !flex flex-row items-center gap-1">
                   {#if testResult.debug?.icCall?.error !== undefined}
                     <XIcon class="text-text-error-primary size-5" />
-                    <span class="text-text-error-primary">
-                      {$t`Error`}
-                    </span>
-                  {:else if testResult.aaguid === undefined}
-                    <span>{$t`Unknown`}</span>
-                  {:else if verifiedSupportedProviders.includes(testResult.aaguid)}
-                    <CheckIcon class="text-text-success-primary size-5" />
-                    <span class="text-text-success-primary">
-                      {$t`Supported`}
-                    </span>
-                  {:else if testResult.aaguid in verifiedUnsupportedProviders}
-                    <XIcon class="text-text-error-primary size-5" />
-                    <span class="text-text-error-primary">
-                      {$t`Unsupported`}
-                    </span>
-                  {:else if testResult.aaguid in possiblyUnsupportedProviders}
-                    <TriangleAlertIcon
-                      class="text-text-warning-primary size-5"
-                    />
-                    <span class="text-text-warning-primary">{$t`Warning`}</span>
+                    <span class="text-text-error-primary">{$t`Error`}</span>
                   {:else}
-                    <span>{$t`Unknown`}</span>
+                    <CheckIcon class="text-text-success-primary size-5" />
+                    <span class="text-text-success-primary"
+                      >{$t`Supported`}</span
+                    >
                   {/if}
                 </Badge>
               </div>
@@ -580,12 +624,6 @@
                 <div class="text-text-primary text-xs">
                   {#if testResult.debug?.icCall?.error !== undefined}
                     {$t`This passkey seems to have issues, please share the export with support.`}
-                  {:else if testResult.aaguid === undefined}
-                    {$t`The passkey could not be identified, support unknown.`}
-                  {:else if testResult.aaguid in verifiedUnsupportedProviders}
-                    {verifiedUnsupportedProviders[testResult.aaguid]}
-                  {:else if testResult.aaguid in possiblyUnsupportedProviders}
-                    {possiblyUnsupportedProviders[testResult.aaguid]}
                   {:else if provider?.type === "cloud"}
                     {provider.platform === undefined
                       ? $t`Stored in your ${provider.account} account and synced across your devices.`

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -549,7 +549,7 @@
                   {#if testResult.debug?.icCall?.error !== undefined}
                     <XIcon class="text-text-error-primary size-5" />
                     <span class="text-text-error-primary">
-                      {$t`Unsupported`}
+                      {$t`Error`}
                     </span>
                   {:else if testResult.aaguid === undefined}
                     <span>{$t`Unknown`}</span>
@@ -578,7 +578,9 @@
               </div>
               <div class="flex flex-col items-end gap-4 sm:flex-row">
                 <div class="text-text-primary text-xs">
-                  {#if testResult.aaguid === undefined}
+                  {#if testResult.debug?.icCall?.error !== undefined}
+                    {$t`This passkey seems to have issues, please share the export with support.`}
+                  {:else if testResult.aaguid === undefined}
                     {$t`The passkey could not be identified, support unknown.`}
                   {:else if testResult.aaguid in verifiedUnsupportedProviders}
                     {verifiedUnsupportedProviders[testResult.aaguid]}

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -208,7 +208,7 @@
           `self-service (Test passkey – safe to delete)`,
           rpId,
         ),
-        getPublicKey: async (result) => {
+        getPublicKey: (result) => {
           if (result.response.attestationObject === undefined) {
             throw new Error("Was expecting an attestation response.");
           }
@@ -217,7 +217,7 @@
           );
           const authData = new Uint8Array(attObject.authData);
           debug = authDataToCoseDebug(authData);
-          return new CosePublicKey(debug.cleanedCose);
+          return Promise.resolve(new CosePublicKey(debug.cleanedCose));
         },
       });
       await identity.sign(

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -230,7 +230,7 @@
       // malformed (e.g. contains key_ops) the IC rejects the call here.
       const passkeyIdentity = DiscoverablePasskeyIdentity.useExisting({
         credentialIds: [new Uint8Array(cred.rawId)],
-        getPublicKey: async () => cosePublicKey,
+        getPublicKey: () => Promise.resolve(cosePublicKey),
       });
       const sessionIdentity = await ECDSAKeyIdentity.generate();
       let icCall:

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -18,11 +18,15 @@
   import {
     CosePublicKey,
     DiscoverablePasskeyIdentity,
+    authDataToCoseDebug,
+    creationOptions,
+    getRpId,
   } from "$lib/utils/discoverablePasskeyIdentity";
+  import borc from "borc";
+  import { aaguidToString, extractAAGUID } from "$lib/utils/webAuthn";
   import Badge from "$lib/components/ui/Badge.svelte";
   import type { Provider } from "$lib/assets/aaguid";
   import { onMount } from "svelte";
-  import { aaguidToString } from "$lib/utils/webAuthn";
   import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
   import {
     anonymousActor,
@@ -53,6 +57,14 @@
   interface TestResult {
     aaguid?: string;
     date: number;
+    debug?: {
+      credentialIdHex: string;
+      rawCoseHex: string;
+      cleanedCoseHex: string;
+      derHex: string;
+      allEntries: Array<{ key: number | string; valueHex: string }>;
+      filteredEntries: Array<{ key: number | string; valueHex: string }>;
+    };
   }
 
   const verifiedSupportedProviders = [
@@ -183,13 +195,40 @@
   };
   const testPasskeyCreation = async () => {
     try {
-      const identity = await DiscoverablePasskeyIdentity.createNew(
+      const rpId = getRpId();
+      const options = creationOptions(
         `self-service (Test passkey – safe to delete)`,
+        rpId,
       );
-      const aaguid = await identity.getAaguid();
+      const challenge = window.crypto.getRandomValues(new Uint8Array(32));
+      const credential = await navigator.credentials.create({
+        ...options,
+        publicKey: { ...options.publicKey, challenge },
+      });
+      if (credential === null)
+        throw new Error("WebAuthn credential is missing");
+      const cred = credential as PublicKeyCredential & {
+        response: AuthenticatorAttestationResponse;
+      };
+      const attObject = borc.decodeFirst(
+        new Uint8Array(cred.response.attestationObject),
+      );
+      const authData = new Uint8Array(attObject.authData);
+      const aaguid = extractAAGUID(authData);
+      const debug = authDataToCoseDebug(authData);
+      const cosePublicKey = new CosePublicKey(
+        Uint8Array.from(
+          (debug.cleanedCoseHex.match(/../g) ?? []).map((h) => parseInt(h, 16)),
+        ),
+      );
       testResults.push({
         aaguid: aaguid !== undefined ? aaguidToString(aaguid) : undefined,
         date: Date.now(),
+        debug: {
+          credentialIdHex: toHex(new Uint8Array(cred.rawId)),
+          ...debug,
+          derHex: toHex(new Uint8Array(cosePublicKey.toDer())),
+        },
       });
     } catch (error) {
       handleError(error);

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -62,8 +62,8 @@
       rawCoseHex: string;
       cleanedCoseHex: string;
       derHex: string;
-      allEntries: Array<{ key: number | string; valueHex: string }>;
-      filteredEntries: Array<{ key: number | string; valueHex: string }>;
+      allEntries: Array<{ key: number | string; valueCborHex: string }>;
+      filteredEntries: Array<{ key: number | string; valueCborHex: string }>;
       icCall?: {
         senderPubkeyHex: string;
         delegationPubkeyHex: string;
@@ -222,11 +222,7 @@
       const authData = new Uint8Array(attObject.authData);
       const aaguid = extractAAGUID(authData);
       const debug = authDataToCoseDebug(authData);
-      const cosePublicKey = new CosePublicKey(
-        Uint8Array.from(
-          (debug.cleanedCoseHex.match(/../g) ?? []).map((h) => parseInt(h, 16)),
-        ),
-      );
+      const cosePublicKey = new CosePublicKey(debug.cleanedCose);
       const derHex = toHex(new Uint8Array(cosePublicKey.toDer()));
 
       // Attempt an actual IC canister call using a delegation from this passkey.
@@ -285,7 +281,10 @@
         date: Date.now(),
         debug: {
           credentialIdHex: toHex(new Uint8Array(cred.rawId)),
-          ...debug,
+          rawCoseHex: debug.rawCoseHex,
+          cleanedCoseHex: debug.cleanedCoseHex,
+          allEntries: debug.allEntries,
+          filteredEntries: debug.filteredEntries,
           derHex,
           icCall,
         },

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -64,6 +64,12 @@
       derHex: string;
       allEntries: Array<{ key: number | string; valueHex: string }>;
       filteredEntries: Array<{ key: number | string; valueHex: string }>;
+      icCall?: {
+        senderPubkeyHex: string;
+        delegationPubkeyHex: string;
+        callerPrincipal?: string;
+        error?: string;
+      };
     };
   }
 
@@ -221,13 +227,67 @@
           (debug.cleanedCoseHex.match(/../g) ?? []).map((h) => parseInt(h, 16)),
         ),
       );
+      const derHex = toHex(new Uint8Array(cosePublicKey.toDer()));
+
+      // Attempt an actual IC canister call using a delegation from this passkey.
+      // This triggers full IC ingress validation of the COSE key — if the key is
+      // malformed (e.g. contains key_ops) the IC rejects the call here.
+      const passkeyIdentity = DiscoverablePasskeyIdentity.useExisting({
+        credentialIds: [new Uint8Array(cred.rawId)],
+        getPublicKey: async () => cosePublicKey,
+      });
+      const sessionIdentity = await ECDSAKeyIdentity.generate();
+      let icCall:
+        | {
+            senderPubkeyHex: string;
+            delegationPubkeyHex: string;
+            callerPrincipal?: string;
+            error?: string;
+          }
+        | undefined;
+      try {
+        const delegationChain = await DelegationChain.create(
+          passkeyIdentity,
+          sessionIdentity.getPublicKey(),
+        );
+        const senderPubkeyHex = toHex(
+          new Uint8Array(delegationChain.publicKey),
+        );
+        const delegationPubkeyHex = toHex(
+          new Uint8Array(
+            delegationChain.delegations[0]?.delegation.pubkey ?? [],
+          ),
+        );
+        const delegationIdentity = DelegationIdentity.fromDelegation(
+          sessionIdentity,
+          delegationChain,
+        );
+        const agent = await HttpAgent.from(anonymousAgent);
+        agent.replaceIdentity(delegationIdentity);
+        const principal = await anonymousActor.whoami.withOptions({ agent })();
+        icCall = {
+          senderPubkeyHex,
+          delegationPubkeyHex,
+          callerPrincipal: principal.toText(),
+        };
+      } catch (icError) {
+        icCall = {
+          senderPubkeyHex: derHex,
+          delegationPubkeyHex: toHex(
+            new Uint8Array(sessionIdentity.getPublicKey().toDer()),
+          ),
+          error: icError instanceof Error ? icError.message : String(icError),
+        };
+      }
+
       testResults.push({
         aaguid: aaguid !== undefined ? aaguidToString(aaguid) : undefined,
         date: Date.now(),
         debug: {
           credentialIdHex: toHex(new Uint8Array(cred.rawId)),
           ...debug,
-          derHex: toHex(new Uint8Array(cosePublicKey.toDer())),
+          derHex,
+          icCall,
         },
       });
     } catch (error) {

--- a/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/self-service/+page.svelte
@@ -220,9 +220,7 @@
           return Promise.resolve(new CosePublicKey(debug.cleanedCose));
         },
       });
-      await identity.sign(
-        Uint8Array.from("<ic0.app>", (c) => c.charCodeAt(0)),
-      );
+      await identity.sign(Uint8Array.from("<ic0.app>", (c) => c.charCodeAt(0)));
       if (debug === undefined) throw new Error("Debug info missing");
       const credentialId = identity.getCredentialId()!;
       const aaguid = identity.getAaguid();

--- a/src/frontend/tests/e2e-playwright/routes/self-service.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/self-service.spec.ts
@@ -1,0 +1,188 @@
+import { expect } from "@playwright/test";
+import { test } from "../fixtures";
+import { addVirtualAuthenticator, II_URL } from "../utils";
+import fs from "fs";
+
+const SELF_SERVICE_URL = II_URL + "/self-service";
+
+test.describe("Self-service passkey debugging", () => {
+  test("Shows passkey test result after clicking 'Test passkey support'", async ({
+    page,
+  }) => {
+    await addVirtualAuthenticator(page);
+    await page.goto(SELF_SERVICE_URL);
+
+    await expect(page.getByText("No passkey tests yet")).toBeVisible();
+    await page.getByRole("button", { name: "Test passkey support" }).click();
+
+    // Placeholder disappears and a result card appears
+    await expect(page.getByText("No passkey tests yet")).toBeHidden();
+    // Virtual authenticator has no AAGUID → provider shown as "Unknown"
+    await expect(page.getByText("Unknown").first()).toBeVisible();
+  });
+
+  test("Multiple test runs each produce a result card", async ({ page }) => {
+    await addVirtualAuthenticator(page);
+    await page.goto(SELF_SERVICE_URL);
+
+    await page.getByRole("button", { name: "Test passkey support" }).click();
+    await expect(page.getByText("No passkey tests yet")).toBeHidden();
+
+    await page.getByRole("button", { name: "Test passkey support" }).click();
+
+    // Two result cards should be visible (the component renders them in a list)
+    const resultCards = page.locator(
+      ".border-border-secondary.bg-bg-tertiary.rounded-xl",
+    );
+    await expect(resultCards).toHaveCount(2);
+  });
+
+  test("Exported JSON contains all required debug fields", async ({ page }) => {
+    await addVirtualAuthenticator(page);
+    await page.goto(SELF_SERVICE_URL);
+
+    await page.getByRole("button", { name: "Test passkey support" }).click();
+    await expect(page.getByText("No passkey tests yet")).toBeHidden();
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Export JSON" }).click();
+    const download = await downloadPromise;
+
+    // Filename should match `<hostname>-<timestamp>-self-service.json`
+    expect(download.suggestedFilename()).toMatch(/^.+-\d+-self-service\.json$/);
+
+    const filePath = await download.path();
+    const json = JSON.parse(fs.readFileSync(filePath!, "utf-8")) as {
+      origin: string;
+      date: number;
+      identities: unknown[];
+      tests: Array<{
+        aaguid?: string;
+        date: number;
+        debug?: {
+          credentialIdHex: string;
+          rawCoseHex: string;
+          cleanedCoseHex: string;
+          derHex: string;
+          allEntries: Array<{ key: number | string; valueCborHex: string }>;
+          filteredEntries: Array<{ key: number | string; valueCborHex: string }>;
+          icCall?: {
+            senderPubkeyHex: string;
+            delegationPubkeyHex: string;
+            callerPrincipal?: string;
+            error?: string;
+          };
+        };
+      }>;
+    };
+
+    // Top-level shape
+    expect(json.origin).toMatch(/^https?:\/\//);
+    expect(typeof json.date).toBe("number");
+    expect(Array.isArray(json.identities)).toBe(true);
+    expect(json.tests).toHaveLength(1);
+
+    const { debug } = json.tests[0];
+    expect(debug).toBeDefined();
+
+    // All COSE debug fields must be present and non-empty hex strings
+    expect(debug!.credentialIdHex).toMatch(/^[0-9a-f]+$/);
+    expect(debug!.rawCoseHex).toMatch(/^[0-9a-f]+$/);
+    expect(debug!.cleanedCoseHex).toMatch(/^[0-9a-f]+$/);
+    expect(debug!.derHex).toMatch(/^[0-9a-f]+$/);
+
+    // Entry arrays must be present
+    expect(Array.isArray(debug!.allEntries)).toBe(true);
+    expect(Array.isArray(debug!.filteredEntries)).toBe(true);
+
+    // filteredEntries must be a subset of allEntries
+    expect(debug!.filteredEntries.length).toBeLessThanOrEqual(
+      debug!.allEntries.length,
+    );
+  });
+
+  test("IC call succeeds — passkey COSE key is accepted by the IC", async ({
+    page,
+  }) => {
+    await addVirtualAuthenticator(page);
+    await page.goto(SELF_SERVICE_URL);
+
+    await page.getByRole("button", { name: "Test passkey support" }).click();
+    await expect(page.getByText("No passkey tests yet")).toBeHidden();
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Export JSON" }).click();
+    const download = await downloadPromise;
+
+    const filePath = await download.path();
+    const json = JSON.parse(fs.readFileSync(filePath!, "utf-8")) as {
+      tests: Array<{
+        debug?: {
+          icCall?: {
+            senderPubkeyHex: string;
+            delegationPubkeyHex: string;
+            callerPrincipal?: string;
+            error?: string;
+          };
+        };
+      }>;
+    };
+
+    const icCall = json.tests[0]?.debug?.icCall;
+    expect(icCall).toBeDefined();
+
+    // The IC must return a valid principal — not an error.
+    // This proves the COSE key produced by the virtual authenticator passes
+    // the IC's COSE parser (no unexpected entries such as key_ops).
+    expect(icCall!.callerPrincipal).toBeTruthy();
+    expect(icCall!.error).toBeUndefined();
+
+    // Hex keys must be present (used for offline debugging if the IC rejects the key)
+    expect(icCall!.senderPubkeyHex).toMatch(/^[0-9a-f]+$/);
+    expect(icCall!.delegationPubkeyHex).toMatch(/^[0-9a-f]+$/);
+  });
+
+  test("COSE filteredEntries only contain the standard IC-accepted key parameters", async ({
+    page,
+  }) => {
+    // Standard COSE key parameters the IC accepts: kty=1, alg=3, crv=-1, x=-2, y=-3
+    const STANDARD_COSE_PARAMS = new Set([1, 3, -1, -2, -3]);
+
+    await addVirtualAuthenticator(page);
+    await page.goto(SELF_SERVICE_URL);
+
+    await page.getByRole("button", { name: "Test passkey support" }).click();
+    await expect(page.getByText("No passkey tests yet")).toBeHidden();
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Export JSON" }).click();
+    const download = await downloadPromise;
+
+    const filePath = await download.path();
+    const json = JSON.parse(fs.readFileSync(filePath!, "utf-8")) as {
+      tests: Array<{
+        debug?: {
+          filteredEntries: Array<{ key: number | string; valueCborHex: string }>;
+          allEntries: Array<{ key: number | string; valueCborHex: string }>;
+        };
+      }>;
+    };
+
+    const { filteredEntries, allEntries } = json.tests[0].debug!;
+
+    // Every filtered entry must be one of the 5 standard COSE key parameters
+    for (const entry of filteredEntries) {
+      expect(STANDARD_COSE_PARAMS.has(entry.key as number)).toBe(true);
+    }
+
+    // A P-256 key must have all 5 standard entries
+    const filteredKeys = filteredEntries.map((e) => e.key);
+    expect(filteredKeys).toEqual(expect.arrayContaining([1, 3, -1, -2, -3]));
+
+    // allEntries must include everything in filteredEntries
+    const allKeys = new Set(allEntries.map((e) => e.key));
+    for (const key of filteredKeys) {
+      expect(allKeys.has(key)).toBe(true);
+    }
+  });
+});

--- a/src/frontend/tests/e2e-playwright/routes/self-service.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/self-service.spec.ts
@@ -145,6 +145,29 @@ test.describe("Self-service passkey debugging", () => {
     expect(icCall!.delegationPubkeyHex).toMatch(/^[0-9a-f]+$/);
   });
 
+  test("Test sign-in updates existing card badge to Sign-up · Sign-in", async ({
+    page,
+  }) => {
+    await addVirtualAuthenticator(page);
+    await page.goto(SELF_SERVICE_URL);
+
+    // Run creation test first
+    await page.getByRole("button", { name: "Test passkey support" }).click();
+    await expect(page.getByText("No passkey tests yet")).toBeHidden();
+
+    // Run sign-in test — should reuse the passkey created above (single prompt)
+    await page.getByRole("button", { name: "Test sign-in" }).click();
+
+    // Badge should update to show both Sign-up and Sign-in check marks
+    await expect(page.getByText("Sign-in").first()).toBeVisible();
+
+    // Still only one result card — sign-in updates existing, not adds new
+    const resultCards = page.locator(
+      ".border-border-secondary.bg-bg-tertiary.rounded-xl",
+    );
+    await expect(resultCards).toHaveCount(1);
+  });
+
   test("COSE filteredEntries only contain the standard IC-accepted key parameters", async ({
     page,
   }) => {

--- a/src/frontend/tests/e2e-playwright/routes/self-service.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/self-service.spec.ts
@@ -65,7 +65,10 @@ test.describe("Self-service passkey debugging", () => {
           cleanedCoseHex: string;
           derHex: string;
           allEntries: Array<{ key: number | string; valueCborHex: string }>;
-          filteredEntries: Array<{ key: number | string; valueCborHex: string }>;
+          filteredEntries: Array<{
+            key: number | string;
+            valueCborHex: string;
+          }>;
           icCall?: {
             senderPubkeyHex: string;
             delegationPubkeyHex: string;
@@ -162,7 +165,10 @@ test.describe("Self-service passkey debugging", () => {
     const json = JSON.parse(fs.readFileSync(filePath!, "utf-8")) as {
       tests: Array<{
         debug?: {
-          filteredEntries: Array<{ key: number | string; valueCborHex: string }>;
+          filteredEntries: Array<{
+            key: number | string;
+            valueCborHex: string;
+          }>;
           allEntries: Array<{ key: number | string; valueCborHex: string }>;
         };
       }>;

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1244,6 +1244,7 @@ service : (opt InternetIdentityInit) -> {
     init_salt : () -> ();
     stats : () -> (InternetIdentityStats) query;
     config : () -> (InternetIdentityInit) query;
+    whoami : () -> (principal) query;
 
     deploy_archive : (wasm : blob) -> (DeployArchiveResult);
     // Returns a batch of entries _sorted by sequence number_ to be archived.

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -642,6 +642,11 @@ fn stats() -> InternetIdentityStats {
 }
 
 #[query]
+fn whoami() -> Principal {
+    caller()
+}
+
+#[query]
 fn discovered_oidc_configs() -> Vec<OidcConfig> {
     openid::get_discovered_oidc_configs()
 }


### PR DESCRIPTION
## Problem

NitroKey 3A passkeys fail to authenticate with Internet Identity with:
> Invalid delegation: Invalid public key: Algorithm Unspecified not supported: Algorithm not supported in COSE parser

The root cause is suspected to be extra COSE map entries (specifically `key_ops`, label 4) included in the public key when II creates discoverable credentials. These fields cause the IC's COSE parser to reject the key.

To confirm the root cause, we need to capture the exact COSE bytes produced by the NitroKey 3A when using II's exact credential creation options, and attempt an actual IC canister call to reproduce the error.

## Changes

### `discoverablePasskeyIdentity.ts`
- Fixes `authDataToCose` to use an **explicit allowlist** of the 5 standard COSE key parameters (`kty=1`, `alg=3`, `crv=-1`, `x=-2`, `y=-3`) instead of keeping all numeric keys. Previously label `4` (`key_ops`) would have been kept, which the IC rejects.
- Exports new `authDataToCoseDebug` function that returns all COSE map entries (with hex-encoded values), filtered entries, raw COSE hex, and cleaned COSE hex for diagnostic purposes.

### Backend: new `whoami` canister method
- Adds a trivial query method that returns the caller's principal
- Registered in the DID file and generated frontend bindings
- Exists purely to give the debug test a real canister endpoint to call

### Self-service: IC call test
- After creating the passkey credential, the test prompts a second WebAuthn interaction to create a delegation chain and calls `whoami` on the canister
- On success: captures `callerPrincipal` (confirms the passkey COSE key is IC-valid)
- On failure: captures the exact IC error string (e.g. "Algorithm Unspecified not supported") plus `senderPubkeyHex` and `delegationPubkeyHex`
- All captured in the JSON export for offline analysis

### `self-service/+page.svelte`
- Updates `testPasskeyCreation` to go through `DiscoverablePasskeyIdentity` directly (using the same `creationOptions` and `sign()` path as normal II registration) via a custom `getPublicKey` callback that captures `authDataToCoseDebug` output. This ensures the test and real passkey creation code share the exact same credential creation path and can never diverge.
- Captures `authDataToCoseDebug` output and DER-encoded key into the `debug` field of each test result.
- This debug data (`credentialIdHex`, `rawCoseHex`, `cleanedCoseHex`, `derHex`, `allEntries`, `filteredEntries`, `icCall`) is included in the JSON export at `/self-service`.

## How to use

The NitroKey 3A owner can go to `/self-service`, click "Test passkey support" (two WebAuthn prompts: create then sign), then "Export JSON" and share the file. The exported JSON will contain:
- Raw COSE key bytes and all map entries (reveals any `key_ops` or extension fields)
- DER-encoded key (exactly what gets sent to the IC)
- IC call result: either the caller's principal (key is valid) or the exact error message

## Test plan

- [ ] Visit `/self-service` and click "Test passkey support" with any passkey
- [ ] Confirm two WebAuthn prompts appear (create + sign for delegation)
- [ ] Click "Export JSON" and verify the exported file contains the `debug` field with `rawCoseHex`, `cleanedCoseHex`, `allEntries`, `filteredEntries`, `derHex`, `credentialIdHex`, and `icCall`
- [ ] Verify `icCall` contains either `callerPrincipal` (success) or `error` (failure)
- [ ] Verify normal passkey creation flow is unaffected