### PR TITLE
feat(email-recovery): recovery flow — prepare_delegation + delegation stamping + get_delegation (PR 7 of email-recovery stack)

### DIFF
--- a/src/canister_tests/src/api/archive.rs
+++ b/src/canister_tests/src/api/archive.rs
@@ -130,7 +130,9 @@ pub mod compat {
                 Operation::AddName => CompatOperation::AddName,
                 Operation::UpdateName => CompatOperation::UpdateName,
                 Operation::RemoveName => CompatOperation::RemoveName,
-                Operation::IdentityMetadataReplace { .. } => {
+                Operation::IdentityMetadataReplace { .. }
+                | Operation::AddEmailRecovery
+                | Operation::RemoveEmailRecovery => {
                     panic!("not available in compat type")
                 }
                 Operation::CreateAccount { name } => CompatOperation::CreateAccount { name },

--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -607,6 +607,28 @@ pub fn email_recovery_status(
     query_candid(env, canister_id, "email_recovery_status", (nonce,)).map(|(x,)| x)
 }
 
+pub fn email_recovery_prepare_delegation(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    dns_input: types::email_recovery::EmailRecoveryDnsInput,
+    session_key: types::SessionKey,
+) -> Result<
+    Result<
+        types::email_recovery::EmailRecoveryChallenge,
+        types::email_recovery::EmailRecoveryError,
+    >,
+    RejectResponse,
+> {
+    call_candid(
+        env,
+        canister_id,
+        RawEffectivePrincipal::None,
+        "email_recovery_prepare_delegation",
+        (dns_input, session_key),
+    )
+    .map(|(x,)| x)
+}
+
 pub fn email_recovery_submit_dkim_leaf(
     env: &PocketIc,
     canister_id: CanisterId,
@@ -623,6 +645,17 @@ pub fn email_recovery_submit_dkim_leaf(
         (arg,),
     )
     .map(|(x,)| x)
+}
+
+pub fn email_recovery_get_delegation(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    args: types::email_recovery::EmailRecoveryGetDelegationArgs,
+) -> Result<
+    Result<types::SignedDelegation, types::email_recovery::EmailRecoveryError>,
+    RejectResponse,
+> {
+    query_candid(env, canister_id, "email_recovery_get_delegation", (args,)).map(|(x,)| x)
 }
 
 pub fn email_recovery_credential_remove(

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -321,6 +321,21 @@ export const idlFactory = ({ IDL }) => {
     'SubjectNotSigned' : IDL.Null,
     'AddressAlreadyRegistered' : IDL.Null,
   });
+  const SessionKey = PublicKey;
+  const EmailRecoveryGetDelegationArgs = IDL.Record({
+    'session_key' : SessionKey,
+    'expiration' : Timestamp,
+    'nonce' : IDL.Text,
+  });
+  const Delegation = IDL.Record({
+    'pubkey' : PublicKey,
+    'targets' : IDL.Opt(IDL.Vec(IDL.Principal)),
+    'expiration' : Timestamp,
+  });
+  const SignedDelegation = IDL.Record({
+    'signature' : IDL.Vec(IDL.Nat8),
+    'delegation' : Delegation,
+  });
   const UserKey = PublicKey;
   const EmailRecoveryStatus = IDL.Variant({
     'Failed' : EmailRecoveryError,
@@ -328,6 +343,7 @@ export const idlFactory = ({ IDL }) => {
     'RecoveryReady' : IDL.Record({
       'user_key' : UserKey,
       'expiration' : Timestamp,
+      'anchor_number' : IdentityNumber,
     }),
     'RegistrationSucceeded' : IDL.Null,
     'Expired' : IDL.Null,
@@ -342,16 +358,6 @@ export const idlFactory = ({ IDL }) => {
     'entry' : IDL.Vec(IDL.Nat8),
     'anchor_number' : UserNumber,
     'timestamp' : Timestamp,
-  });
-  const SessionKey = PublicKey;
-  const Delegation = IDL.Record({
-    'pubkey' : PublicKey,
-    'targets' : IDL.Opt(IDL.Vec(IDL.Principal)),
-    'expiration' : Timestamp,
-  });
-  const SignedDelegation = IDL.Record({
-    'signature' : IDL.Vec(IDL.Nat8),
-    'delegation' : Delegation,
   });
   const AccountDelegationError = IDL.Variant({
     'NoSuchDelegation' : IDL.Null,
@@ -499,6 +505,11 @@ export const idlFactory = ({ IDL }) => {
     'authn_methods' : IDL.Vec(AuthnMethod),
     'recovery_authn_methods' : IDL.Vec(AuthnMethod),
   });
+  const EmailRecoveryCredential = IDL.Record({
+    'created_at' : Timestamp,
+    'address' : IDL.Text,
+    'last_used' : IDL.Opt(Timestamp),
+  });
   const AuthnMethodRegistrationInfo = IDL.Record({
     'expiration' : Timestamp,
     'session' : IDL.Opt(IDL.Principal),
@@ -508,6 +519,7 @@ export const idlFactory = ({ IDL }) => {
     'authn_methods' : IDL.Vec(AuthnMethodData),
     'metadata' : MetadataMapV2,
     'name' : IDL.Opt(IDL.Text),
+    'email_recovery' : IDL.Opt(EmailRecoveryCredential),
     'created_at' : IDL.Opt(Timestamp),
     'authn_method_registration' : IDL.Opt(AuthnMethodRegistrationInfo),
     'openid_credentials' : IDL.Opt(IDL.Vec(OpenIdCredential)),
@@ -848,6 +860,21 @@ export const idlFactory = ({ IDL }) => {
     'email_recovery_credential_remove' : IDL.Func(
         [IdentityNumber, IDL.Text],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : EmailRecoveryError })],
+        [],
+      ),
+    'email_recovery_get_delegation' : IDL.Func(
+        [EmailRecoveryGetDelegationArgs],
+        [IDL.Variant({ 'Ok' : SignedDelegation, 'Err' : EmailRecoveryError })],
+        ['query'],
+      ),
+    'email_recovery_prepare_delegation' : IDL.Func(
+        [EmailRecoveryDnsInput, SessionKey],
+        [
+          IDL.Variant({
+            'Ok' : EmailRecoveryChallenge,
+            'Err' : EmailRecoveryError,
+          }),
+        ],
         [],
       ),
     'email_recovery_status' : IDL.Func(

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -551,9 +551,20 @@ export type EmailRecoveryError = { 'EmailVerificationFailed' : string } |
   { 'DomainNotAllowlisted' : string } |
   { 'SubjectNotSigned' : null } |
   { 'AddressAlreadyRegistered' : null };
+export interface EmailRecoveryGetDelegationArgs {
+  'session_key' : SessionKey,
+  'expiration' : Timestamp,
+  'nonce' : string,
+}
 export type EmailRecoveryStatus = { 'Failed' : EmailRecoveryError } |
   { 'NeedDkimLeaf' : { 'selector' : string } } |
-  { 'RecoveryReady' : { 'user_key' : UserKey, 'expiration' : Timestamp } } |
+  {
+    'RecoveryReady' : {
+      'user_key' : UserKey,
+      'expiration' : Timestamp,
+      'anchor_number' : IdentityNumber,
+    }
+  } |
   { 'RegistrationSucceeded' : null } |
   { 'Expired' : null } |
   { 'Pending' : null };
@@ -788,6 +799,12 @@ export interface IdentityInfo {
    */
   'metadata' : MetadataMapV2,
   'name' : [] | [string],
+  /**
+   * The email-recovery credential bound to this anchor, if any.
+   * Lets the FE render the recovery-email card's active vs.
+   * inactive state without a separate query.
+   */
+  'email_recovery' : [] | [EmailRecoveryCredential],
   /**
    * The timestamp at which the anchor was created
    */
@@ -1549,6 +1566,16 @@ export interface _SERVICE {
   'email_recovery_credential_remove' : ActorMethod<
     [IdentityNumber, string],
     { 'Ok' : null } |
+      { 'Err' : EmailRecoveryError }
+  >,
+  'email_recovery_get_delegation' : ActorMethod<
+    [EmailRecoveryGetDelegationArgs],
+    { 'Ok' : SignedDelegation } |
+      { 'Err' : EmailRecoveryError }
+  >,
+  'email_recovery_prepare_delegation' : ActorMethod<
+    [EmailRecoveryDnsInput, SessionKey],
+    { 'Ok' : EmailRecoveryChallenge } |
       { 'Err' : EmailRecoveryError }
   >,
   'email_recovery_status' : ActorMethod<[string], EmailRecoveryStatus>,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -602,9 +602,16 @@ type EmailRecoveryStatus = variant {
     RecoveryReady : record {
         user_key : UserKey;
         expiration : Timestamp;
+        anchor_number : IdentityNumber;
     };
     Failed : EmailRecoveryError;
     Expired;
+};
+
+type EmailRecoveryGetDelegationArgs = record {
+    nonce       : text;
+    session_key : SessionKey;
+    expiration  : Timestamp;
 };
 
 // SMTP gateway types — see `internet_identity_interface::smtp`. Carried
@@ -805,6 +812,10 @@ type IdentityInfo = record {
     name : opt text;
     // The timestamp at which the anchor was created
     created_at : opt Timestamp;
+    // The email-recovery credential bound to this anchor, if any.
+    // Lets the FE render the recovery-email card's active vs.
+    // inactive state without a separate query.
+    email_recovery : opt EmailRecoveryCredential;
 };
 
 type IdentityInfoError = variant {
@@ -1419,8 +1430,10 @@ service : (opt InternetIdentityInit) -> {
     // See `docs/ongoing/email-recovery.md`. The recovery half (prepare
     // a delegation from a verified email) lands in a follow-up PR.
     email_recovery_credential_prepare_add : (IdentityNumber, EmailRecoveryDnsInput) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
+    email_recovery_prepare_delegation : (EmailRecoveryDnsInput, SessionKey) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
     email_recovery_status : (text) -> (EmailRecoveryStatus) query;
     email_recovery_submit_dkim_leaf : (EmailRecoverySubmitDkimLeafArg) -> (variant { Ok : EmailRecoveryStatus; Err : EmailRecoveryError });
+    email_recovery_get_delegation : (EmailRecoveryGetDelegationArgs) -> (variant { Ok : SignedDelegation; Err : EmailRecoveryError }) query;
     email_recovery_credential_remove : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });
 
     // SMTP gateway protocol

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -531,7 +531,15 @@ type EmailRecoveryDnsInput = record {
 
 type EmailRecoverySubmitDkimLeafArg = record {
     nonce : text;
-    dkim_leaf : SignedRRset;
+    // The DKIM resolution chain in CNAME order, ending in a TXT. At
+    // least one hop required; bounded by `MAX_CNAME_HOPS = 4` at the
+    // canister side. For the Gmail-style direct-TXT case this is a
+    // single-element vec.
+    hops : vec SignedRRset;
+    // Delegation chains for signed zones touched by `hops` that
+    // weren't already covered by the skeleton chain anchored at
+    // prepare time. Empty for same-zone resolution.
+    extra_chains : vec DelegationChain;
 };
 
 // DNSSEC proof bundle and supporting types — see

--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -63,13 +63,29 @@ pub fn activity_bookkeeping(anchor: &mut Anchor, current_authorization_key: &Aut
     activity_stats::update_activity_stats(anchor, current_authorization_key);
     match current_authorization_key {
         AuthorizationKey::DeviceKey(device_key) => {
-            anchor.set_device_usage_timestamp(device_key, time())
+            anchor
+                .set_device_usage_timestamp(device_key, time())
+                .expect("unable to update last usage timestamp");
         }
         AuthorizationKey::OpenIdCredentialKey((openid_credential_key, _)) => {
-            anchor.set_openid_credential_usage_timestamp(openid_credential_key, time())
+            anchor
+                .set_openid_credential_usage_timestamp(openid_credential_key, time())
+                .expect("unable to update last usage timestamp");
+        }
+        AuthorizationKey::EmailRecoveryAddress(address) => {
+            // Bump `last_used` on the matching credential. No-op if
+            // the credential was removed between authz and now (we
+            // checked authorization moments ago, so this is unlikely
+            // but possible across concurrent canister calls).
+            if let Some(credential) = anchor
+                .email_recovery
+                .iter_mut()
+                .find(|c| c.address.eq_ignore_ascii_case(address))
+            {
+                credential.last_used = Some(time());
+            }
         }
     }
-    .expect("unable to update last usage timestamp");
 }
 
 /// Handles all the bookkeeping required after a successful anchor operation:

--- a/src/internet_identity/src/authz_utils.rs
+++ b/src/internet_identity/src/authz_utils.rs
@@ -125,6 +125,24 @@ pub fn check_authorization(
             ));
         }
     }
+    // Else check email-recovery authorization. The recovery flow
+    // stamps a delegation whose user_key is `der(canister_sig_key(seed))`
+    // with `seed = H(salt || "email-recovery" || lowercase(address) ||
+    // anchor)`. Re-derive the same principal for each bound credential
+    // and compare. See `crate::email_recovery::smtp::calculate_email_recovery_seed`.
+    for credential in &anchor.email_recovery {
+        let seed = crate::email_recovery::smtp::calculate_email_recovery_seed(
+            &credential.address,
+            anchor_number,
+        );
+        let public_key = crate::delegation::der_encode_canister_sig_key(seed.to_vec());
+        if caller == Principal::self_authenticating(public_key) {
+            return Ok((
+                anchor.clone(),
+                AuthorizationKey::EmailRecoveryAddress(credential.address.clone()),
+            ));
+        }
+    }
 
     Err(AuthorizationError::from(caller))
 }

--- a/src/internet_identity/src/email_recovery/mod.rs
+++ b/src/internet_identity/src/email_recovery/mod.rs
@@ -35,10 +35,10 @@ mod pending;
 mod prepare;
 mod remove;
 mod rng;
-mod smtp;
+pub(crate) mod smtp;
 mod submit_leaf;
 
-pub use prepare::prepare_add;
+pub use prepare::{prepare_add, prepare_delegation};
 pub use remove::{remove_credential, RemoveError};
 pub use smtp::{handle_smtp_request, handle_smtp_request_validate};
 pub use submit_leaf::submit_dkim_leaf;
@@ -51,6 +51,22 @@ pub fn pending_status(
     now_secs: u64,
 ) -> internet_identity_interface::internet_identity::types::email_recovery::EmailRecoveryStatus {
     pending::status_of(nonce, now_secs)
+}
+
+/// Look up the cached `RecoveryOutcome.seed` for a recovery-flow
+/// pending challenge. Used by `email_recovery_get_delegation` to
+/// find the canister-signature without having to recompute the
+/// seed (which requires the address + anchor — both already
+/// resolved at submit-leaf time).
+///
+/// Returns `None` if the nonce is unknown, expired, isn't a
+/// recovery-kind entry, or hasn't yet completed (`recovery_outcome`
+/// is `None`).
+pub fn recovery_seed_for_nonce(nonce: &str, now_secs: u64) -> Option<ic_certification::Hash> {
+    pending::with_mut(nonce, now_secs, |c| {
+        c.recovery_outcome.as_ref().map(|o| o.seed)
+    })
+    .flatten()
 }
 
 #[allow(unused_imports)]
@@ -167,3 +183,10 @@ pub const MAX_ADDRESS: usize = 254;
 /// flow, not a protocol-level claim.
 pub const MAX_DKIM_TXT_BYTES: usize = 4096;
 pub const MAX_DMARC_TXT_BYTES: usize = 1024;
+
+/// Cap on the FE-supplied `session_pk` length carried on a recovery
+/// pending entry. Real session keys are well under 1 KB regardless
+/// of algorithm (Ed25519 ~44 bytes, ECDSA P-256 ~91, RSA-2048 ~294);
+/// this leaves headroom without giving an anonymous caller room to
+/// inflate the challenge map.
+pub const MAX_SESSION_KEY_BYTES: usize = 1024;

--- a/src/internet_identity/src/email_recovery/mod.rs
+++ b/src/internet_identity/src/email_recovery/mod.rs
@@ -1,14 +1,20 @@
-//! Email-based identity recovery: setup (binding) flow.
+//! Email-based identity recovery: setup + recovery flows.
 //!
 //! See `docs/ongoing/email-recovery.md` (PR #3836) for the full design.
-//! This module implements the canister-side **setup** half — the
-//! recovery half (`email_recovery_prepare_delegation` +
-//! `recover@id.ai` dispatch + delegation issuance) is layered on top
-//! in `feat/email-recovery-flow` (PR #3843), which adds the reverse
-//! `address → AnchorNumber` stable index that recovery needs to
-//! resolve the verified `From:` to an anchor.
+//! Both halves of the canister-side flow live in this module:
 //!
-//! Setup half:
+//! - **Setup** (binding): an authenticated caller binds a recovery
+//!   email address to an anchor.
+//! - **Recovery** (delegation): an anonymous caller proves control
+//!   of a previously-bound address and ends with a `SignedDelegation`
+//!   rooted in the anchor that address resolves to.
+//!
+//! Both share the SMTP gateway protocol (`smtp_request`), the DKIM
+//! verifier, the DMARC alignment check, and the `(address →
+//! AnchorNumber)` reverse index in stable memory used at recovery
+//! time to resolve the verified `From:` to an anchor.
+//!
+//! Setup flow at a glance:
 //!
 //! 1. The user, while authenticated, calls
 //!    `email_recovery_credential_prepare_add(anchor, dns_input)`.
@@ -19,6 +25,10 @@
 //! 4. The SMTP gateway forwards the email via `smtp_request`. The
 //!    canister verifies DKIM + DMARC, matches the From: against the
 //!    claimed address, and binds the credential to the anchor.
+//!
+//! Recovery follows the same two-phase DNSSEC shape but starts
+//! anonymous, sends to `recover@id.ai`, and finishes by stamping a
+//! delegation seed bound to the FE's session_pk (see §8.5).
 //!
 //! ## Why heap state, not stable
 //!

--- a/src/internet_identity/src/email_recovery/pending.rs
+++ b/src/internet_identity/src/email_recovery/pending.rs
@@ -38,18 +38,26 @@ pub struct PendingChallenge {
     /// Unix-seconds at which `prepare_add` ran. Used for TTL expiry
     /// and as the basis for `expires_at` shipped to the FE.
     pub created_at_secs: u64,
-    /// Cached deepest-zone DNSKEY RRset from the skeleton chain. Set
-    /// when the FE took the DNSSEC path at prepare time
-    /// (`dns_proof.is_some()`). The canister validates the chain
-    /// against its trust anchors at prepare time and stashes the
-    /// validated DNSKEY RRset here so a follow-up
-    /// `email_recovery_submit_dkim_leaf` can admit a single TXT leaf
-    /// without re-walking the chain. `None` means the DoH path —
+    /// Cached root DNSKEY RRset, set when the FE took the DNSSEC
+    /// path at prepare time (`dns_proof.is_some()`). The canister
+    /// validates it against the configured trust anchors at prepare
+    /// time and stashes it here so that
+    /// `email_recovery_submit_dkim_leaf` can admit *additional*
+    /// delegation chains under the same root if the DKIM CNAME chain
+    /// crosses into a new signed zone (Proton/Tutanota-style; see
+    /// design doc §7.2). `None` means the DoH path —
     /// `smtp_request` resolves the DKIM TXT via
     /// `crate::doh::fetch_txt` instead.
-    pub cached_zone_dnskey: Option<crate::dnssec::SignedRRset>,
+    pub cached_root_dnskey: Option<crate::dnssec::SignedRRset>,
+    /// Cached `(zone_name → DNSKEY RRset)` map populated from the
+    /// skeleton chain at prepare time. Empty on the DoH path. The
+    /// map starts with one zone (the registered apex) for Gmail-
+    /// style direct-TXT domains and grows at `submit_dkim_leaf`
+    /// time when the DKIM resolution crosses into a different
+    /// signed zone.
+    pub cached_zones: crate::dnssec::ZoneKeysMap,
     /// Cached DMARC TXT record bytes from the DNSSEC path. Only
-    /// meaningful when `cached_zone_dnskey.is_some()` (DNSSEC path).
+    /// meaningful when `cached_root_dnskey.is_some()` (DNSSEC path).
     /// `Some(bytes)` means the FE included a DMARC leaf in the
     /// skeleton chain and the canister validated it. `None` (on the
     /// DNSSEC path) means the FE didn't include DMARC — treated as
@@ -332,7 +340,8 @@ mod tests {
             claimed_address: addr.into(),
             registered_domain,
             created_at_secs: now,
-            cached_zone_dnskey: None,
+            cached_root_dnskey: None,
+            cached_zones: crate::dnssec::ZoneKeysMap::new(),
             cached_dmarc_txt: None,
             partial_verification: None,
             status: PendingStatus::Pending,

--- a/src/internet_identity/src/email_recovery/pending.rs
+++ b/src/internet_identity/src/email_recovery/pending.rs
@@ -10,10 +10,11 @@
 //! random-nonce-only key (untargetability) and bound the map size
 //! (eviction is benign for both legitimate users and attackers).
 
+use ic_certification::Hash;
 use internet_identity_interface::internet_identity::types::email_recovery::{
     EmailRecoveryError, EmailRecoveryStatus,
 };
-use internet_identity_interface::internet_identity::types::AnchorNumber;
+use internet_identity_interface::internet_identity::types::{AnchorNumber, SessionKey, Timestamp};
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -67,6 +68,33 @@ pub struct PendingChallenge {
     /// variant (DoH path, or `submit_dkim_leaf` outcome). Terminal
     /// variants are sticky.
     pub status: PendingStatus,
+    /// Set on the recovery path when the verification pipeline
+    /// completes successfully. Stored here (rather than as a payload
+    /// on `PendingStatus`) so `PendingStatus` stays a flat enum and so
+    /// `email_recovery_get_delegation` can recover the seed without
+    /// recomputing it. `None` on the setup path.
+    pub recovery_outcome: Option<RecoveryOutcome>,
+}
+
+/// Cached output of a successful recovery flow. Used to answer
+/// `email_recovery_status` (which returns `RecoveryReady { user_key,
+/// expiration, anchor_number }`) and to look up the
+/// canister-signature in `email_recovery_get_delegation` (the `seed`
+/// is what the canister-sig store is keyed by).
+#[derive(Clone, Debug)]
+pub struct RecoveryOutcome {
+    pub user_key: Vec<u8>,
+    pub expiration: Timestamp,
+    /// The anchor the verified `From:` was bound to. Surfaced back
+    /// to the FE in `RecoveryReady` so the auth store can be seeded
+    /// without an extra lookup hop.
+    pub anchor_number: AnchorNumber,
+    /// `H(salt || "email-recovery" || lowercase(address) || anchor)`,
+    /// computed at submit-leaf time. Cached so `get_delegation` can
+    /// ask the signature store for the signed delegation without
+    /// re-deriving from the anchor (which it'd have to look up by
+    /// hash).
+    pub seed: Hash,
 }
 
 /// What the canister stashes between email arrival and DKIM-leaf
@@ -122,7 +150,12 @@ pub enum PendingKind {
     /// Setup flow — caller is authenticated; the email-recovery
     /// credential will be written to this anchor on success.
     Register { anchor: AnchorNumber },
-    // `Recover { session_pk }` is added by the recovery follow-up PR.
+    /// Recovery flow — caller is anonymous. The anchor is resolved
+    /// at submit-leaf time from the verified `From:` of the inbound
+    /// email (via the `address → AnchorNumber` reverse index). The
+    /// cached `session_pk` is what the eventual delegation will be
+    /// bound to.
+    Recover { session_pk: SessionKey },
 }
 
 /// Status the FE polls. The terminal variants (`Succeeded`,
@@ -202,8 +235,22 @@ pub fn status_of(nonce: &str, now_secs: u64) -> EmailRecoveryStatus {
                 PendingStatus::NeedDkimLeaf { selector } => EmailRecoveryStatus::NeedDkimLeaf {
                     selector: selector.clone(),
                 },
-                PendingStatus::Succeeded => match &c.kind {
-                    PendingKind::Register { .. } => EmailRecoveryStatus::RegistrationSucceeded,
+                PendingStatus::Succeeded => match (&c.kind, &c.recovery_outcome) {
+                    (PendingKind::Register { .. }, _) => EmailRecoveryStatus::RegistrationSucceeded,
+                    (PendingKind::Recover { .. }, Some(outcome)) => {
+                        EmailRecoveryStatus::RecoveryReady {
+                            user_key: serde_bytes::ByteBuf::from(outcome.user_key.clone()),
+                            expiration: outcome.expiration,
+                            anchor_number: outcome.anchor_number,
+                        }
+                    }
+                    // Recover succeeded without a cached outcome →
+                    // canister bug. Fail closed so the FE retries.
+                    (PendingKind::Recover { .. }, None) => {
+                        EmailRecoveryStatus::Failed(EmailRecoveryError::InternalCanisterError(
+                            "Recover challenge marked Succeeded without outcome".into(),
+                        ))
+                    }
                 },
                 PendingStatus::Failed(e) => EmailRecoveryStatus::Failed(e.clone()),
                 PendingStatus::Expired => EmailRecoveryStatus::Expired,
@@ -289,6 +336,7 @@ mod tests {
             cached_dmarc_txt: None,
             partial_verification: None,
             status: PendingStatus::Pending,
+            recovery_outcome: None,
         }
     }
 

--- a/src/internet_identity/src/email_recovery/prepare.rs
+++ b/src/internet_identity/src/email_recovery/prepare.rs
@@ -4,8 +4,8 @@
 //! the verification path (DNSSEC if a skeleton bundle is supplied,
 //! DoH allowlist otherwise), draws a fresh nonce from the heap PRNG,
 //! and parks a `PendingChallenge` keyed by that nonce. Returns the
-//! user-visible challenge (nonce + mailbox + expiry) so the FE can
-//! render the "send a magic email" screen.
+//! user-visible challenge (nonce + expiry) so the FE can render
+//! the "send a magic email" screen.
 //!
 //! See `docs/ongoing/email-recovery.md` §8.4. Two-phase path picker:
 //!
@@ -47,13 +47,7 @@ pub async fn prepare_add(
     dns_input: EmailRecoveryDnsInput,
     now_secs: u64,
 ) -> Result<EmailRecoveryChallenge, EmailRecoveryError> {
-    prepare_common(
-        dns_input,
-        now_secs,
-        PendingKind::Register { anchor },
-        super::SETUP_MAILBOX,
-    )
-    .await
+    prepare_common(dns_input, now_secs, PendingKind::Register { anchor }).await
 }
 
 /// Body of `email_recovery_prepare_delegation(dns_input, session_pk)`.
@@ -80,13 +74,7 @@ pub async fn prepare_delegation(
             super::MAX_SESSION_KEY_BYTES,
         )));
     }
-    prepare_common(
-        dns_input,
-        now_secs,
-        PendingKind::Recover { session_pk },
-        super::RECOVERY_MAILBOX,
-    )
-    .await
+    prepare_common(dns_input, now_secs, PendingKind::Recover { session_pk }).await
 }
 
 /// Shared input-validation + nonce-issuing core. `kind` parametrises
@@ -97,7 +85,6 @@ async fn prepare_common(
     dns_input: EmailRecoveryDnsInput,
     now_secs: u64,
     kind: PendingKind,
-    mailbox: &str,
 ) -> Result<EmailRecoveryChallenge, EmailRecoveryError> {
     let EmailRecoveryDnsInput { address, dns_proof } = dns_input;
 
@@ -191,7 +178,6 @@ async fn prepare_common(
 
     Ok(EmailRecoveryChallenge {
         nonce,
-        mailbox: mailbox.to_string(),
         // `Timestamp` is nanoseconds since epoch in this crate (see
         // `internet_identity_interface::types`). We work in seconds
         // internally for the TTL math and convert at the wire boundary.
@@ -559,7 +545,6 @@ mod tests {
         let challenge = result.expect("expected Ok");
 
         assert!(challenge.nonce.starts_with(super::super::NONCE_PREFIX));
-        assert_eq!(challenge.mailbox, super::super::SETUP_MAILBOX);
         // expires_at is in nanoseconds since epoch; we passed
         // now_secs = 1_000.
         assert_eq!(

--- a/src/internet_identity/src/email_recovery/prepare.rs
+++ b/src/internet_identity/src/email_recovery/prepare.rs
@@ -4,8 +4,8 @@
 //! the verification path (DNSSEC if a skeleton bundle is supplied,
 //! DoH allowlist otherwise), draws a fresh nonce from the heap PRNG,
 //! and parks a `PendingChallenge` keyed by that nonce. Returns the
-//! user-visible challenge (nonce + expiry) so the FE can render
-//! the "send a magic email" screen.
+//! user-visible challenge (nonce + mailbox + expiry) so the FE can
+//! render the "send a magic email" screen.
 //!
 //! See `docs/ongoing/email-recovery.md` §8.4. Two-phase path picker:
 //!
@@ -29,7 +29,7 @@ use crate::state;
 use internet_identity_interface::internet_identity::types::email_recovery::{
     EmailRecoveryChallenge, EmailRecoveryDnsInput, EmailRecoveryError,
 };
-use internet_identity_interface::internet_identity::types::AnchorNumber;
+use internet_identity_interface::internet_identity::types::{AnchorNumber, SessionKey};
 
 /// Body of the canister method
 /// `email_recovery_credential_prepare_add(anchor, dns_input)`.
@@ -46,6 +46,58 @@ pub async fn prepare_add(
     anchor: AnchorNumber,
     dns_input: EmailRecoveryDnsInput,
     now_secs: u64,
+) -> Result<EmailRecoveryChallenge, EmailRecoveryError> {
+    prepare_common(
+        dns_input,
+        now_secs,
+        PendingKind::Register { anchor },
+        super::SETUP_MAILBOX,
+    )
+    .await
+}
+
+/// Body of `email_recovery_prepare_delegation(dns_input, session_pk)`.
+///
+/// Anonymous: anyone can call this. The `session_pk` is a fresh
+/// public key the FE just generated; the eventual delegation will be
+/// bound to it. The pending challenge holds it until
+/// `submit_dkim_leaf` succeeds, at which point the canister stamps a
+/// delegation seed and adds the matching canister-signature.
+pub async fn prepare_delegation(
+    dns_input: EmailRecoveryDnsInput,
+    session_pk: SessionKey,
+    now_secs: u64,
+) -> Result<EmailRecoveryChallenge, EmailRecoveryError> {
+    // Cap the FE-supplied `session_pk` length. The pending entry
+    // holds this for up to 30 minutes; without a bound an open
+    // caller could inflate every challenge they prepare. Real
+    // session keys are well under 1 KB regardless of algorithm
+    // (Ed25519 ~44 bytes, ECDSA P-256 ~91, RSA-2048 ~294).
+    if session_pk.len() > super::MAX_SESSION_KEY_BYTES {
+        return Err(EmailRecoveryError::InternalCanisterError(format!(
+            "session_pk is {} bytes, exceeds the {}-byte limit",
+            session_pk.len(),
+            super::MAX_SESSION_KEY_BYTES,
+        )));
+    }
+    prepare_common(
+        dns_input,
+        now_secs,
+        PendingKind::Recover { session_pk },
+        super::RECOVERY_MAILBOX,
+    )
+    .await
+}
+
+/// Shared input-validation + nonce-issuing core. `kind` parametrises
+/// over which flow we're starting; `mailbox` is the recipient string
+/// returned to the FE so the wizard can render "send your email
+/// to ...".
+async fn prepare_common(
+    dns_input: EmailRecoveryDnsInput,
+    now_secs: u64,
+    kind: PendingKind,
+    mailbox: &str,
 ) -> Result<EmailRecoveryChallenge, EmailRecoveryError> {
     let EmailRecoveryDnsInput { address, dns_proof } = dns_input;
 
@@ -120,7 +172,7 @@ pub async fn prepare_add(
     };
 
     let challenge = PendingChallenge {
-        kind: PendingKind::Register { anchor },
+        kind,
         claimed_address: address,
         registered_domain,
         created_at_secs: now_secs,
@@ -128,11 +180,13 @@ pub async fn prepare_add(
         cached_dmarc_txt,
         partial_verification: None,
         status: PendingStatus::Pending,
+        recovery_outcome: None,
     };
     insert_with_eviction(nonce.clone(), challenge, now_secs);
 
     Ok(EmailRecoveryChallenge {
         nonce,
+        mailbox: mailbox.to_string(),
         // `Timestamp` is nanoseconds since epoch in this crate (see
         // `internet_identity_interface::types`). We work in seconds
         // internally for the TTL math and convert at the wire boundary.
@@ -185,79 +239,46 @@ fn verify_dnssec_skeleton(
     // for the From<> impls.)
     let bundle: crate::dnssec::DnsProofBundle = proof.into();
 
-    // The skeleton bundle covers a single signing zone (the
-    // registered domain) and at most one hop (the optional DMARC
-    // TXT at `_dmarc.<registered_domain>`). A DKIM leaf in the
-    // skeleton would let an attacker who got a different TXT
-    // validated under the same chain smuggle it through here, so we
-    // reject anything other than zero or one hops.
-    if bundle.hops.len() > 1 {
-        return Err(EmailRecoveryError::EmailVerificationFailed(format!(
-            "skeleton bundle has {} hops; expected 0 (no DMARC) or 1 (DMARC TXT)",
-            bundle.hops.len()
-        )));
-    }
-
-    // Step 1: validate the root DNSKEY against trust anchors +
-    // RRSIG freshness.
-    crate::dnssec::verify_root_dnskey_with_clock(&bundle.root_dnskey, &trust_anchors, now_secs)
+    // Validate the chain (root + delegations); produces the
+    // deepest-zone DNSKEY RRset that we cache for later leaf
+    // admission. `bundle.leaf` is *not* consulted here.
+    let zone_dnskey = crate::dnssec::verify_chain_with_clock(&bundle, &trust_anchors, now_secs)
         .map_err(|e| EmailRecoveryError::EmailVerificationFailed(format!("DNSSEC: {e:?}")))?;
 
-    // Step 2: walk the delegation chain(s); the deepest zone's
-    // DNSKEY RRset is what we cache for later leaf admission.
-    let mut zones = crate::dnssec::ZoneKeysMap::new();
-    crate::dnssec::verify_extra_chains_with_clock(
-        &bundle.chains,
-        &bundle.root_dnskey,
-        &mut zones,
-        now_secs,
-    )
-    .map_err(|e| EmailRecoveryError::EmailVerificationFailed(format!("DNSSEC: {e:?}")))?;
-
-    // Extract the single zone's DNSKEY for the cache. The skeleton
-    // case is one chain → one zone; multi-zone bundles (CNAME) are
-    // a follow-up PR.
-    let zone_dnskey = zones
-        .iter()
-        .next()
-        .map(|(_, k)| k.clone())
-        .ok_or_else(|| {
-            EmailRecoveryError::EmailVerificationFailed(
-                "skeleton bundle produced no validated zones".into(),
-            )
-        })?;
-
-    // Step 3 (optional): validate the DMARC hop and cache the TXT.
+    // Optional DMARC leaf: if present, validate against the same
+    // chain and cache the TXT bytes.
     let dmarc_fqdn = format!("_dmarc.{registered_domain}.");
-    let dmarc = if bundle.hops.is_empty() {
-        None
-    } else {
-        let requested_name = bundle.hops[0].name.clone();
-        let verified = crate::dnssec::verify_hops_with_clock(
-            &bundle.hops,
-            &zones,
-            &requested_name,
-            crate::dnssec::TYPE_TXT,
-            now_secs,
-        )
-        .map_err(|e| EmailRecoveryError::EmailVerificationFailed(format!("DNSSEC leaf: {e:?}")))?;
-        let leaf_name = decode_dns_name_lowercase(&verified.name.0);
-        if !leaf_name.eq_ignore_ascii_case(&dmarc_fqdn) {
-            return Err(EmailRecoveryError::EmailVerificationFailed(format!(
-                "skeleton bundle leaf name {leaf_name:?} is not the expected \
-                 DMARC name {dmarc_fqdn:?} — DKIM leaves belong in submit_dkim_leaf"
-            )));
+    let dmarc = match bundle.leaf.as_ref() {
+        None => None,
+        Some(leaf) => {
+            let verified = crate::dnssec::verify_leaf_against_dnskey(leaf, &zone_dnskey, now_secs)
+                .map_err(|e| {
+                    EmailRecoveryError::EmailVerificationFailed(format!("DNSSEC leaf: {e:?}"))
+                })?;
+            if verified.rtype != crate::dnssec::types::TYPE_TXT {
+                return Err(EmailRecoveryError::EmailVerificationFailed(format!(
+                    "skeleton bundle leaf is not TXT (got rtype {})",
+                    verified.rtype
+                )));
+            }
+            let leaf_name = decode_dns_name_lowercase(&verified.name.0);
+            if !leaf_name.eq_ignore_ascii_case(&dmarc_fqdn) {
+                return Err(EmailRecoveryError::EmailVerificationFailed(format!(
+                    "skeleton bundle leaf name {leaf_name:?} is not the expected \
+                     DMARC name {dmarc_fqdn:?} — DKIM leaves belong in submit_dkim_leaf"
+                )));
+            }
+            let txt = parse_txt_rdata(&verified.rdata)?;
+            if txt.len() > super::MAX_DMARC_TXT_BYTES {
+                return Err(EmailRecoveryError::EmailVerificationFailed(format!(
+                    "DMARC TXT record at {leaf_name:?} is {} bytes; \
+                     refusing to cache more than {} bytes per pending entry",
+                    txt.len(),
+                    super::MAX_DMARC_TXT_BYTES,
+                )));
+            }
+            Some(txt)
         }
-        let txt = parse_txt_rdata(&verified.rdata)?;
-        if txt.len() > super::MAX_DMARC_TXT_BYTES {
-            return Err(EmailRecoveryError::EmailVerificationFailed(format!(
-                "DMARC TXT record at {leaf_name:?} is {} bytes; \
-                 refusing to cache more than {} bytes per pending entry",
-                txt.len(),
-                super::MAX_DMARC_TXT_BYTES,
-            )));
-        }
-        Some(txt)
     };
 
     Ok(DnssecExtracted { zone_dnskey, dmarc })
@@ -487,6 +508,7 @@ mod tests {
         let challenge = result.expect("expected Ok");
 
         assert!(challenge.nonce.starts_with(super::super::NONCE_PREFIX));
+        assert_eq!(challenge.mailbox, super::super::SETUP_MAILBOX);
         // expires_at is in nanoseconds since epoch; we passed
         // now_secs = 1_000.
         assert_eq!(

--- a/src/internet_identity/src/email_recovery/prepare.rs
+++ b/src/internet_identity/src/email_recovery/prepare.rs
@@ -123,9 +123,13 @@ async fn prepare_common(
     //   arrival.
     // - Neither: reject — the FE will surface a "we can't accept
     //   email from this domain" error.
-    let (cached_zone_dnskey, cached_dmarc_txt) = if let Some(proof) = dns_proof {
+    let (cached_root_dnskey, cached_zones, cached_dmarc_txt) = if let Some(proof) = dns_proof {
         let extracted = verify_dnssec_skeleton(proof, &registered_domain, now_secs)?;
-        (Some(extracted.zone_dnskey), extracted.dmarc)
+        (
+            Some(extracted.root_dnskey),
+            extracted.zones,
+            extracted.dmarc,
+        )
     } else {
         // No DNSSEC bundle → DoH allowlist gate.
         let allowlisted = state::persistent_state(|p| {
@@ -141,7 +145,7 @@ async fn prepare_common(
         if !allowlisted {
             return Err(EmailRecoveryError::DomainNotAllowlisted(registered_domain));
         }
-        (None, None)
+        (None, crate::dnssec::ZoneKeysMap::new(), None)
     };
 
     // Now we can mutate state. The async raw_rand fetch happens at
@@ -176,7 +180,8 @@ async fn prepare_common(
         claimed_address: address,
         registered_domain,
         created_at_secs: now_secs,
-        cached_zone_dnskey,
+        cached_root_dnskey,
+        cached_zones,
         cached_dmarc_txt,
         partial_verification: None,
         status: PendingStatus::Pending,
@@ -197,26 +202,29 @@ async fn prepare_common(
 }
 
 /// Output of a successful DNSSEC skeleton-bundle verification — the
-/// validated deepest-zone DNSKEY RRset (always cached) plus the
-/// optional DMARC TXT bytes (set when the FE included a DMARC leaf
-/// in the skeleton bundle). The DKIM leaf isn't part of the prepare
-/// bundle — it lands later via `email_recovery_submit_dkim_leaf`.
+/// validated root DNSKEY RRset (cached so the canister can admit
+/// further chains under it at submit time when the DKIM CNAME chain
+/// crosses into a new zone), the validated `(zone → DNSKEY)` map for
+/// every zone the prepare bundle covered, and the optional DMARC
+/// TXT bytes (set when the FE included a DMARC leaf in the skeleton
+/// bundle).
 struct DnssecExtracted {
-    zone_dnskey: crate::dnssec::SignedRRset,
+    root_dnskey: crate::dnssec::SignedRRset,
+    zones: crate::dnssec::ZoneKeysMap,
     dmarc: Option<Vec<u8>>,
 }
 
 /// Validate a caller-supplied DNSSEC *skeleton* bundle against the
-/// canister's configured trust anchors and extract the deepest-zone
-/// DNSKEY (always required for the cache) plus the optional DMARC
-/// TXT bytes.
+/// canister's configured trust anchors and extract the validated
+/// zone-keys map and optional DMARC TXT bytes.
 ///
-/// The bundle is allowed to carry at most one leaf, and that leaf
-/// must be the DMARC TXT at `_dmarc.<registered_domain>`. Any other
-/// leaf — including a DKIM TXT — is rejected: the DKIM leaf belongs
-/// in the post-email submit-leaf call, not the prepare bundle, and
-/// an attacker who got a different TXT validated under the same
-/// chain shouldn't be able to smuggle it through here.
+/// The bundle's `hops` is allowed to carry at most one entry, and
+/// that entry must be the DMARC TXT at `_dmarc.<registered_domain>`.
+/// Any other hop — including a DKIM TXT — is rejected: the DKIM
+/// resolution belongs in the post-email submit-leaf call, not the
+/// prepare bundle, and an attacker who got a different TXT
+/// validated under the same chain shouldn't be able to smuggle it
+/// through here.
 fn verify_dnssec_skeleton(
     proof: internet_identity_interface::internet_identity::types::DnsProofBundle,
     registered_domain: &str,
@@ -239,49 +247,68 @@ fn verify_dnssec_skeleton(
     // for the From<> impls.)
     let bundle: crate::dnssec::DnsProofBundle = proof.into();
 
-    // Validate the chain (root + delegations); produces the
-    // deepest-zone DNSKEY RRset that we cache for later leaf
-    // admission. `bundle.leaf` is *not* consulted here.
-    let zone_dnskey = crate::dnssec::verify_chain_with_clock(&bundle, &trust_anchors, now_secs)
-        .map_err(|e| EmailRecoveryError::EmailVerificationFailed(format!("DNSSEC: {e:?}")))?;
+    // The skeleton bundle must carry at most one hop (the optional
+    // DMARC TXT). Reject up front if the FE tried to smuggle a DKIM
+    // resolution — that belongs in submit_dkim_leaf, not here.
+    if bundle.hops.len() > 1 {
+        return Err(EmailRecoveryError::EmailVerificationFailed(
+            "skeleton bundle carries more than one hop; DKIM resolution \
+             belongs in submit_dkim_leaf"
+                .into(),
+        ));
+    }
 
-    // Optional DMARC leaf: if present, validate against the same
-    // chain and cache the TXT bytes.
-    let dmarc_fqdn = format!("_dmarc.{registered_domain}.");
-    let dmarc = match bundle.leaf.as_ref() {
-        None => None,
-        Some(leaf) => {
-            let verified = crate::dnssec::verify_leaf_against_dnskey(leaf, &zone_dnskey, now_secs)
-                .map_err(|e| {
-                    EmailRecoveryError::EmailVerificationFailed(format!("DNSSEC leaf: {e:?}"))
-                })?;
-            if verified.rtype != crate::dnssec::types::TYPE_TXT {
-                return Err(EmailRecoveryError::EmailVerificationFailed(format!(
-                    "skeleton bundle leaf is not TXT (got rtype {})",
-                    verified.rtype
-                )));
-            }
-            let leaf_name = decode_dns_name_lowercase(&verified.name.0);
-            if !leaf_name.eq_ignore_ascii_case(&dmarc_fqdn) {
-                return Err(EmailRecoveryError::EmailVerificationFailed(format!(
-                    "skeleton bundle leaf name {leaf_name:?} is not the expected \
-                     DMARC name {dmarc_fqdn:?} — DKIM leaves belong in submit_dkim_leaf"
-                )));
-            }
-            let txt = parse_txt_rdata(&verified.rdata)?;
-            if txt.len() > super::MAX_DMARC_TXT_BYTES {
-                return Err(EmailRecoveryError::EmailVerificationFailed(format!(
-                    "DMARC TXT record at {leaf_name:?} is {} bytes; \
-                     refusing to cache more than {} bytes per pending entry",
-                    txt.len(),
-                    super::MAX_DMARC_TXT_BYTES,
-                )));
-            }
-            Some(txt)
+    // Validate the root DNSKEY against trust anchors and walk every
+    // chain into the zone-keys map.
+    crate::dnssec::verify_root_dnskey_with_clock(&bundle.root_dnskey, &trust_anchors, now_secs)
+        .map_err(|e| EmailRecoveryError::EmailVerificationFailed(format!("DNSSEC root: {e:?}")))?;
+    let mut zones = crate::dnssec::ZoneKeysMap::new();
+    crate::dnssec::verify_extra_chains_with_clock(
+        &bundle.chains,
+        &bundle.root_dnskey,
+        &mut zones,
+        now_secs,
+    )
+    .map_err(|e| EmailRecoveryError::EmailVerificationFailed(format!("DNSSEC chain: {e:?}")))?;
+    if zones.is_empty() {
+        return Err(EmailRecoveryError::EmailVerificationFailed(
+            "skeleton bundle supplied no delegation chains".into(),
+        ));
+    }
+
+    // Optional DMARC hop: if present, validate it as a single TXT
+    // hop at `_dmarc.<registered_domain>`.
+    let dmarc = if bundle.hops.is_empty() {
+        None
+    } else {
+        let dmarc_fqdn = format!("_dmarc.{registered_domain}.");
+        let dmarc_name = encode_dns_name_lowercase(&dmarc_fqdn);
+        let verified = crate::dnssec::verify_hops_with_clock(
+            &bundle.hops,
+            &zones,
+            &crate::dnssec::DnsName(dmarc_name),
+            crate::dnssec::types::TYPE_TXT,
+            now_secs,
+        )
+        .map_err(|e| EmailRecoveryError::EmailVerificationFailed(format!("DMARC: {e:?}")))?;
+        let leaf_name = decode_dns_name_lowercase(&verified.name.0);
+        let txt = parse_txt_rdata(&verified.rdata)?;
+        if txt.len() > super::MAX_DMARC_TXT_BYTES {
+            return Err(EmailRecoveryError::EmailVerificationFailed(format!(
+                "DMARC TXT record at {leaf_name:?} is {} bytes; \
+                 refusing to cache more than {} bytes per pending entry",
+                txt.len(),
+                super::MAX_DMARC_TXT_BYTES,
+            )));
         }
+        Some(txt)
     };
 
-    Ok(DnssecExtracted { zone_dnskey, dmarc })
+    Ok(DnssecExtracted {
+        root_dnskey: bundle.root_dnskey,
+        zones,
+        dmarc,
+    })
 }
 
 /// Concatenate one or more TXT character-strings (each prefixed by a
@@ -306,6 +333,30 @@ fn parse_txt_rdata(rdata: &[Vec<u8>]) -> Result<Vec<u8>, EmailRecoveryError> {
         }
     }
     Ok(txt_bytes)
+}
+
+/// Encode a dotted ASCII DNS name (with or without a trailing dot)
+/// into wire format: a sequence of length-prefixed labels terminated
+/// by a zero-length root label. Labels are lowercased on the way in.
+/// Caller is responsible for passing a syntactically valid ASCII
+/// name; labels longer than 63 bytes are truncated to 63 (RFC 1035
+/// caps).
+fn encode_dns_name_lowercase(dotted: &str) -> Vec<u8> {
+    let trimmed = dotted.strip_suffix('.').unwrap_or(dotted);
+    let mut out = Vec::with_capacity(trimmed.len() + 2);
+    for label in trimmed.split('.') {
+        if label.is_empty() {
+            continue;
+        }
+        let bytes = label.as_bytes();
+        let len = bytes.len().min(63) as u8;
+        out.push(len);
+        for &b in &bytes[..len as usize] {
+            out.push(b.to_ascii_lowercase());
+        }
+    }
+    out.push(0);
+    out
 }
 
 /// Decode a wire-format DNS name (length-prefixed labels) into a

--- a/src/internet_identity/src/email_recovery/remove.rs
+++ b/src/internet_identity/src/email_recovery/remove.rs
@@ -18,12 +18,12 @@
 //!   "Remove `alice@gmail.com`?" and on confirm passes the same
 //!   string back. Mismatch → `NotRegistered`. This keeps the FE
 //!   honest if it ever caches a stale list.
-//! - We emit a typed `Operation::EmailRecoveryRemove` for the archive
-//!   stream so removals show up in the audit log alongside passkey /
-//!   recovery-phrase removals. *(TODO: until that operation variant
-//!   lands in the archive types, we map onto the existing
-//!   `Operation::IdentityMetadataReplace` placeholder so the archive
-//!   call still succeeds.)*
+//! - We emit `Operation::RemoveEmailRecovery` for the archive
+//!   stream so removals show up in the audit log alongside passkey
+//!   and recovery-phrase removals. The variant carries no payload —
+//!   the anchor + timestamp on the surrounding archive entry are
+//!   enough for "who changed their recovery email when?" analytics
+//!   without leaking the address itself.
 
 use crate::storage::anchor::Anchor;
 use internet_identity_interface::archive::types::Operation;
@@ -59,13 +59,7 @@ pub fn remove_credential(anchor: &mut Anchor, address: &str) -> Result<Operation
 
     anchor.email_recovery.remove(position);
 
-    // TODO(email-recovery): once the archive `Operation` enum gains
-    // an `EmailRecoveryRemove` variant, switch to it. Using the
-    // metadata-replace placeholder here keeps the type-checker happy
-    // without inventing new variants on a separate PR's surface.
-    Ok(Operation::IdentityMetadataReplace {
-        metadata_keys: vec![],
-    })
+    Ok(Operation::RemoveEmailRecovery)
 }
 
 #[cfg(test)]

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -697,8 +697,16 @@ pub(super) fn bind_credential(
         created_at: now_secs.saturating_mul(1_000_000_000),
         last_used: None,
     }];
-    state::storage_borrow_mut(|storage| storage.write(a))
-        .map_err(|e| EmailRecoveryError::InternalCanisterError(format!("write anchor: {e:?}")))?;
+    state::storage_borrow_mut(|storage| storage.write(a)).map_err(|e| match e {
+        // The reverse-address index hit a "this address is already
+        // bound to a different anchor" — surface that as the
+        // user-facing error rather than the InternalCanisterError
+        // catch-all. See `Storage::update_email_recovery_lookup`.
+        crate::storage::StorageError::EmailRecoveryAddressAlreadyBound { .. } => {
+            EmailRecoveryError::AddressAlreadyRegistered
+        }
+        other => EmailRecoveryError::InternalCanisterError(format!("write anchor: {other:?}")),
+    })?;
     Ok(())
 }
 

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -56,25 +56,32 @@ use internet_identity_interface::internet_identity::types::smtp::{
 };
 use internet_identity_interface::internet_identity::types::{AnchorNumber, SessionKey};
 
-/// Recipient mailbox name for the setup flow.
-pub const SETUP_RECIPIENT_USER: &str = "register";
-/// Recipient mailbox name for the recovery flow.
-pub const RECOVERY_RECIPIENT_USER: &str = "recover";
-/// The domain on which both flows expect to receive mail. The
-/// gateway operator chooses this — `id.ai` is the design-doc
-/// example. Future enhancement: lift this into a deploy-arg.
-pub const SETUP_RECIPIENT_DOMAIN: &str = "id.ai";
+// Recipient user-parts (`register`, `recover`) live on the parent
+// `email_recovery` module so the shared mailbox-domain helpers can
+// read them too. Imported here for the dispatch logic.
+use super::{RECOVERY_RECIPIENT_USER, SETUP_RECIPIENT_USER};
 
-/// Whether `to` matches `<user>@<domain>` exactly, case-insensitive
-/// on both halves. Defence-in-depth against a direct caller
-/// constructing an SmtpRequest with `to.user="register"` but a
-/// different domain to bypass recipient dispatch.
+/// Whether `to` matches `<expected_user>@<one of the configured
+/// mailbox domains>`, case-insensitive on both halves. The set of
+/// accepted domains comes from the `related_origins` deploy arg via
+/// [`super::mailbox_domains`] — on prod that's typically `id.ai` +
+/// the `*.icp0.io` aliases, on beta it's `beta.id.ai`. The same
+/// WASM works for both deployments because the domain isn't pinned
+/// in source.
+///
+/// Defence-in-depth against a direct caller constructing an
+/// `SmtpRequest` with `to.user="register"` but a different domain
+/// to bypass recipient dispatch — only domains the deploy arg
+/// authorised count.
 fn recipient_matches(
     to: &internet_identity_interface::internet_identity::types::smtp::SmtpAddress,
     expected_user: &str,
-    expected_domain: &str,
 ) -> bool {
-    to.user.eq_ignore_ascii_case(expected_user) && to.domain.eq_ignore_ascii_case(expected_domain)
+    if !to.user.eq_ignore_ascii_case(expected_user) {
+        return false;
+    }
+    let to_domain = to.domain.to_ascii_lowercase();
+    super::mailbox_domains().iter().any(|d| d == &to_domain)
 }
 
 /// Query-mode counterpart to [`handle_smtp_request`]. The off-chain
@@ -89,20 +96,13 @@ fn recipient_matches(
 /// importantly, gives no SMTP-level signal that the address is
 /// invalid — the sender's MTA never sees a bounce.
 ///
-/// Accepts:
-///
-/// - `register@id.ai` (case-insensitive) — setup flow.
-/// - `recover@id.ai` (case-insensitive) — recovery flow. The
-///   recipient is recognised here even on the storage-and-smtp PR
-///   where the actual handler lives in a follow-up: a query that
-///   says "yes, accept this address" is harmless without the
-///   handler, and gating the gateway accept on the recovery PR
-///   would force a deploy-step ordering we don't otherwise need.
-///
+/// Accepts `register@<d>` and `recover@<d>` (case-insensitive) for
+/// any `d` in [`super::mailbox_domains`] — i.e. for any host listed
+/// in the `related_origins` deploy arg. On prod that's typically
+/// `id.ai` plus the `*.icp0.io` aliases; on beta it's `beta.id.ai`.
 /// Everything else gets a 550 (mailbox unavailable). The query is
 /// open — anyone can call it — but it has no side effects and
-/// leaks nothing beyond the two recipient labels themselves, both
-/// of which are documented in the design doc.
+/// leaks nothing beyond the deploy arg, which is already public.
 pub fn handle_smtp_request_validate(request: SmtpRequest) -> SmtpResponse {
     if let Err(e) = validate_smtp_request(&request) {
         return e;
@@ -112,8 +112,7 @@ pub fn handle_smtp_request_validate(request: SmtpRequest) -> SmtpResponse {
         None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
     };
     let to = &envelope.to;
-    if recipient_matches(to, SETUP_RECIPIENT_USER, SETUP_RECIPIENT_DOMAIN)
-        || recipient_matches(to, RECOVERY_RECIPIENT_USER, SETUP_RECIPIENT_DOMAIN)
+    if recipient_matches(to, SETUP_RECIPIENT_USER) || recipient_matches(to, RECOVERY_RECIPIENT_USER)
     {
         return SmtpResponse::Ok {};
     }
@@ -147,20 +146,15 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         Some(e) => e,
         None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
     };
-    let recipient_flow =
-        if recipient_matches(&envelope.to, SETUP_RECIPIENT_USER, SETUP_RECIPIENT_DOMAIN) {
-            RecipientFlow::Setup
-        } else if recipient_matches(
-            &envelope.to,
-            RECOVERY_RECIPIENT_USER,
-            SETUP_RECIPIENT_DOMAIN,
-        ) {
-            RecipientFlow::Recovery
-        } else {
-            // Drop with Ok — we don't emit a per-recipient signal back
-            // to the gateway.
-            return SmtpResponse::Ok {};
-        };
+    let recipient_flow = if recipient_matches(&envelope.to, SETUP_RECIPIENT_USER) {
+        RecipientFlow::Setup
+    } else if recipient_matches(&envelope.to, RECOVERY_RECIPIENT_USER) {
+        RecipientFlow::Recovery
+    } else {
+        // Drop with Ok — we don't emit a per-recipient signal back
+        // to the gateway.
+        return SmtpResponse::Ok {};
+    };
 
     let message = match request.message.as_ref() {
         Some(m) => m,
@@ -935,8 +929,19 @@ mod tests {
         }
     }
 
+    /// Configure the per-deploy `related_origins` so
+    /// `super::mailbox_domains()` returns the listed hosts.
+    /// Recipient dispatch and the `smtp_request_validate` query
+    /// both pull the accepted domain set from this list.
+    fn set_related_origins(origins: &[&str]) {
+        crate::state::persistent_state_mut(|p| {
+            p.related_origins = Some(origins.iter().map(|s| (*s).to_string()).collect());
+        });
+    }
+
     #[test]
     fn validate_accepts_register_recipient() {
+        set_related_origins(&["https://id.ai"]);
         assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
             "register", "id.ai",
         )));
@@ -944,6 +949,7 @@ mod tests {
 
     #[test]
     fn validate_accepts_recover_recipient() {
+        set_related_origins(&["https://id.ai"]);
         assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
             "recover", "id.ai",
         )));
@@ -951,6 +957,11 @@ mod tests {
 
     #[test]
     fn validate_accepts_case_insensitive() {
+        // Source `related_origins` are already lowercased by the
+        // host-extraction helper, so accepting an upper-case input
+        // exercises the case-insensitive comparison on the SMTP
+        // side.
+        set_related_origins(&["https://id.ai"]);
         assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
             "REGISTER", "ID.AI",
         )));
@@ -960,9 +971,47 @@ mod tests {
     }
 
     #[test]
+    fn validate_accepts_any_related_origin_alias() {
+        // All `related_origins` entries are equal aliases. A prod
+        // deploy with id.ai + the *.icp0.io aliases must accept
+        // mail at register@<any of them>.
+        set_related_origins(&[
+            "https://id.ai",
+            "https://identity.ic0.app",
+            "https://identity.internetcomputer.org",
+        ]);
+        assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
+            "register",
+            "identity.ic0.app",
+        )));
+        assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
+            "recover",
+            "identity.internetcomputer.org",
+        )));
+    }
+
+    #[test]
+    fn validate_accepts_beta_alias_only_when_configured() {
+        // beta deploy: only beta.id.ai is on the allowlist.
+        set_related_origins(&["https://beta.id.ai"]);
+        assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
+            "register",
+            "beta.id.ai",
+        )));
+        // The bare `id.ai` is *not* on this deploy's list, so it's
+        // bounced — the canister doesn't accept it just because the
+        // string contains "id.ai".
+        assert_smtp_err_code(
+            handle_smtp_request_validate(smtp_envelope("register", "id.ai")),
+            SMTP_ERR_MAILBOX_UNAVAILABLE,
+        );
+    }
+
+    #[test]
     fn validate_rejects_unknown_user() {
         // Numeric anchor numbers (PoC postbox style) are not handled
         // by this canister anymore — the gateway should bounce them.
+        set_related_origins(&["https://id.ai"]);
         assert_smtp_err_code(
             handle_smtp_request_validate(smtp_envelope("12345", "id.ai")),
             SMTP_ERR_MAILBOX_UNAVAILABLE,
@@ -975,10 +1024,22 @@ mod tests {
 
     #[test]
     fn validate_rejects_known_user_wrong_domain() {
-        // `register` at the wrong domain must not slip through — the
-        // domain check is part of the recipient match.
+        // `register` at a domain not on the deploy's
+        // `related_origins` must not slip through.
+        set_related_origins(&["https://id.ai"]);
         assert_smtp_err_code(
             handle_smtp_request_validate(smtp_envelope("register", "evil.example")),
+            SMTP_ERR_MAILBOX_UNAVAILABLE,
+        );
+    }
+
+    #[test]
+    fn validate_rejects_when_no_origins_configured() {
+        // No `related_origins` set → no domains accepted. Defensive
+        // path — real deploys always configure this.
+        crate::state::persistent_state_mut(|p| p.related_origins = None);
+        assert_smtp_err_code(
+            handle_smtp_request_validate(smtp_envelope("register", "id.ai")),
             SMTP_ERR_MAILBOX_UNAVAILABLE,
         );
     }

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -54,35 +54,27 @@ use internet_identity_interface::internet_identity::types::smtp::{
     smtp_err, validate_smtp_request, SmtpRequest, SmtpResponse, SMTP_ERR_MAILBOX_UNAVAILABLE,
     SMTP_ERR_SYNTAX_ERROR,
 };
-use internet_identity_interface::internet_identity::types::AnchorNumber;
+use internet_identity_interface::internet_identity::types::{AnchorNumber, SessionKey};
 
-// Recipient user-parts (`register`, `recover`) live on the parent
-// `email_recovery` module so the shared mailbox-domain helpers and
-// the user-facing mailbox labels can read them too. Imported here
-// for the dispatch logic.
-use super::{RECOVERY_RECIPIENT_USER, SETUP_RECIPIENT_USER};
+/// Recipient mailbox name for the setup flow.
+pub const SETUP_RECIPIENT_USER: &str = "register";
+/// Recipient mailbox name for the recovery flow.
+pub const RECOVERY_RECIPIENT_USER: &str = "recover";
+/// The domain on which both flows expect to receive mail. The
+/// gateway operator chooses this — `id.ai` is the design-doc
+/// example. Future enhancement: lift this into a deploy-arg.
+pub const SETUP_RECIPIENT_DOMAIN: &str = "id.ai";
 
-/// Whether `to` matches `<expected_user>@<one of the configured
-/// mailbox domains>`, case-insensitive on both halves. The set of
-/// accepted domains comes from the `related_origins` deploy arg via
-/// [`super::mailbox_domains`] — on prod that's typically `id.ai` +
-/// the `*.icp0.io` aliases, on beta it's `beta.id.ai`. The same
-/// WASM works for both deployments because the domain isn't pinned
-/// in source.
-///
-/// Defence-in-depth against a direct caller constructing an
-/// `SmtpRequest` with `to.user="register"` but a different domain
-/// to bypass recipient dispatch — only domains the deploy arg
-/// authorised count.
+/// Whether `to` matches `<user>@<domain>` exactly, case-insensitive
+/// on both halves. Defence-in-depth against a direct caller
+/// constructing an SmtpRequest with `to.user="register"` but a
+/// different domain to bypass recipient dispatch.
 fn recipient_matches(
     to: &internet_identity_interface::internet_identity::types::smtp::SmtpAddress,
     expected_user: &str,
+    expected_domain: &str,
 ) -> bool {
-    if !to.user.eq_ignore_ascii_case(expected_user) {
-        return false;
-    }
-    let to_domain = to.domain.to_ascii_lowercase();
-    super::mailbox_domains().iter().any(|d| d == &to_domain)
+    to.user.eq_ignore_ascii_case(expected_user) && to.domain.eq_ignore_ascii_case(expected_domain)
 }
 
 /// Query-mode counterpart to [`handle_smtp_request`]. The off-chain
@@ -97,13 +89,20 @@ fn recipient_matches(
 /// importantly, gives no SMTP-level signal that the address is
 /// invalid — the sender's MTA never sees a bounce.
 ///
-/// Accepts `register@<d>` and `recover@<d>` (case-insensitive) for
-/// any `d` in [`super::mailbox_domains`] — i.e. for any host listed
-/// in the `related_origins` deploy arg. On prod that's typically
-/// `id.ai` plus the `*.icp0.io` aliases; on beta it's `beta.id.ai`.
+/// Accepts:
+///
+/// - `register@id.ai` (case-insensitive) — setup flow.
+/// - `recover@id.ai` (case-insensitive) — recovery flow. The
+///   recipient is recognised here even on the storage-and-smtp PR
+///   where the actual handler lives in a follow-up: a query that
+///   says "yes, accept this address" is harmless without the
+///   handler, and gating the gateway accept on the recovery PR
+///   would force a deploy-step ordering we don't otherwise need.
+///
 /// Everything else gets a 550 (mailbox unavailable). The query is
 /// open — anyone can call it — but it has no side effects and
-/// leaks nothing beyond the deploy arg, which is already public.
+/// leaks nothing beyond the two recipient labels themselves, both
+/// of which are documented in the design doc.
 pub fn handle_smtp_request_validate(request: SmtpRequest) -> SmtpResponse {
     if let Err(e) = validate_smtp_request(&request) {
         return e;
@@ -113,7 +112,8 @@ pub fn handle_smtp_request_validate(request: SmtpRequest) -> SmtpResponse {
         None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
     };
     let to = &envelope.to;
-    if recipient_matches(to, SETUP_RECIPIENT_USER) || recipient_matches(to, RECOVERY_RECIPIENT_USER)
+    if recipient_matches(to, SETUP_RECIPIENT_USER, SETUP_RECIPIENT_DOMAIN)
+        || recipient_matches(to, RECOVERY_RECIPIENT_USER, SETUP_RECIPIENT_DOMAIN)
     {
         return SmtpResponse::Ok {};
     }
@@ -134,21 +134,33 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         return e;
     }
 
-    // Recipient dispatch. Setup is the only flow wired up in this
-    // PR; recovery is reserved (and silently no-ops, see module
-    // note). We match on the *full* recipient address (user +
-    // domain), case-insensitively, so a direct caller can't bypass
-    // dispatch by spoofing just the user-part with a different
-    // domain — `smtp_request` is an open update.
+    // Recipient dispatch. We accept either of the two reserved
+    // recipients (`register@id.ai` for setup, `recover@id.ai` for
+    // recovery); after the pending lookup we cross-check that the
+    // recipient matches the `PendingKind` of the entry, so a direct
+    // caller can't trick us into running a recovery flow against a
+    // setup challenge or vice versa. We match on the *full* recipient
+    // address (user + domain), case-insensitively, so a direct caller
+    // can't bypass dispatch by spoofing just the user-part with a
+    // different domain — `smtp_request` is an open update.
     let envelope = match request.envelope.as_ref() {
         Some(e) => e,
         None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
     };
-    if !recipient_matches(&envelope.to, SETUP_RECIPIENT_USER) {
-        // Drop with Ok — we don't emit a per-recipient signal back
-        // to the gateway.
-        return SmtpResponse::Ok {};
-    }
+    let recipient_flow =
+        if recipient_matches(&envelope.to, SETUP_RECIPIENT_USER, SETUP_RECIPIENT_DOMAIN) {
+            RecipientFlow::Setup
+        } else if recipient_matches(
+            &envelope.to,
+            RECOVERY_RECIPIENT_USER,
+            SETUP_RECIPIENT_DOMAIN,
+        ) {
+            RecipientFlow::Recovery
+        } else {
+            // Drop with Ok — we don't emit a per-recipient signal back
+            // to the gateway.
+            return SmtpResponse::Ok {};
+        };
 
     let message = match request.message.as_ref() {
         Some(m) => m,
@@ -169,9 +181,25 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     // the pipeline. We borrow only briefly so the async outcalls
     // below don't hold a `RefCell` across an await (which would
     // trap inside the canister).
-    let snapshot = match pending::with_mut(&nonce, now_secs, |c| match &c.kind {
-        PendingKind::Register { anchor } => Some(PendingSnapshot {
-            anchor: *anchor,
+    let snapshot = match pending::with_mut(&nonce, now_secs, |c| {
+        let kind = match (&c.kind, recipient_flow) {
+            (PendingKind::Register { anchor }, RecipientFlow::Setup) => {
+                SnapshotKind::Setup { anchor: *anchor }
+            }
+            (PendingKind::Recover { session_pk }, RecipientFlow::Recovery) => {
+                SnapshotKind::Recovery {
+                    session_pk: session_pk.clone(),
+                }
+            }
+            // Recipient ↔ kind mismatch. Could be a forged `to:`
+            // value from a direct caller, or a benign cross-up
+            // (the user copy-pasted the recovery-flow nonce into
+            // an email addressed to `register@id.ai`). Either way:
+            // drop silently.
+            _ => return None,
+        };
+        Some(PendingSnapshot {
+            kind,
             claimed_address: c.claimed_address.clone(),
             registered_domain: c.registered_domain.clone(),
             cached_zone_dnskey: c.cached_zone_dnskey.is_some(),
@@ -184,13 +212,12 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
                     | PendingStatus::Expired
                     | PendingStatus::NeedDkimLeaf { .. }
             ),
-        }),
+        })
     }) {
         Some(Some(s)) => s,
         // Either nonce is unknown / expired (None), or the pending
-        // entry is for a flow not yet wired up here (Some(None) —
-        // currently the `Recover` variant; lands with the recovery
-        // flow). Drop silently — see module note.
+        // entry's kind didn't match the recipient (Some(None)).
+        // Drop silently — see module note.
         _ => return SmtpResponse::Ok {},
     };
 
@@ -226,19 +253,34 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         // verification finishes synchronously inside this one call.
         let outcome = verify_setup_email_doh(&request, &snapshot, now_secs).await;
         match outcome {
-            Ok(()) => {
-                if let Err(e) =
-                    bind_credential(snapshot.anchor, &snapshot.claimed_address, now_secs)
-                {
-                    pending::with_mut(&nonce, now_secs, |c| {
-                        c.status = PendingStatus::Failed(e);
-                    });
-                } else {
-                    pending::with_mut(&nonce, now_secs, |c| {
-                        c.status = PendingStatus::Succeeded;
-                    });
+            Ok(()) => match &snapshot.kind {
+                SnapshotKind::Setup { anchor } => {
+                    if let Err(e) = bind_credential(*anchor, &snapshot.claimed_address, now_secs) {
+                        pending::with_mut(&nonce, now_secs, |c| {
+                            c.status = PendingStatus::Failed(e);
+                        });
+                    } else {
+                        pending::with_mut(&nonce, now_secs, |c| {
+                            c.status = PendingStatus::Succeeded;
+                        });
+                    }
                 }
-            }
+                SnapshotKind::Recovery { session_pk } => {
+                    match stamp_recovery_delegation(&snapshot, session_pk).await {
+                        Ok(outcome) => {
+                            pending::with_mut(&nonce, now_secs, |c| {
+                                c.recovery_outcome = Some(outcome);
+                                c.status = PendingStatus::Succeeded;
+                            });
+                        }
+                        Err(e) => {
+                            pending::with_mut(&nonce, now_secs, |c| {
+                                c.status = PendingStatus::Failed(e);
+                            });
+                        }
+                    }
+                }
+            },
             Err(reason) => {
                 pending::with_mut(&nonce, now_secs, |c| {
                     c.status = PendingStatus::Failed(reason);
@@ -254,8 +296,8 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
 /// borrow so the async verification pipeline doesn't have to hold
 /// the cell across awaits.
 #[derive(Clone, Debug)]
-struct PendingSnapshot {
-    anchor: AnchorNumber,
+pub(super) struct PendingSnapshot {
+    kind: SnapshotKind,
     /// Lowercased canonical form (matches what `prepare_add` stored).
     claimed_address: String,
     /// Pinned at prepare time; `submit_dkim_leaf` rejects DKIM leaves
@@ -276,6 +318,31 @@ struct PendingSnapshot {
     /// `true` if `status` is already terminal or `NeedDkimLeaf` —
     /// the gateway redelivered an email we already processed.
     already_terminal: bool,
+}
+
+#[derive(Clone, Debug)]
+enum SnapshotKind {
+    /// Setup-flow snapshot. The anchor was supplied by the
+    /// (authenticated) caller at prepare time and is pinned.
+    Setup { anchor: AnchorNumber },
+    /// Recovery-flow snapshot. The anchor isn't yet known — it's
+    /// resolved at submit-leaf time from the verified `From:` via
+    /// the reverse address index. The cached `session_pk` is what
+    /// the eventual delegation will be stamped for.
+    Recovery { session_pk: SessionKey },
+}
+
+/// Recipient-half of the dispatch — paired with the entry's
+/// `PendingKind` to ensure they match.
+#[derive(Clone, Copy, Debug)]
+enum RecipientFlow {
+    /// Inbound to `register@id.ai` — bind the verified `From:`
+    /// address to the anchor named in the pending challenge.
+    Setup,
+    /// Inbound to `recover@id.ai` — stamp a delegation seed for the
+    /// session_pk cached in the pending challenge and mark the
+    /// challenge `RecoveryReady`.
+    Recovery,
 }
 
 /// Look up the `Subject:` header and find a `II-Recovery-…` nonce
@@ -635,6 +702,124 @@ pub(super) fn bind_credential(
     Ok(())
 }
 
+/// Build a `PendingSnapshot` shape suitable for
+/// `stamp_recovery_delegation` from the data submit_leaf.rs already
+/// has at hand. Used so the same delegation-stamping helper serves
+/// both the DoH path (called inline in `handle_smtp_request`) and
+/// the DNSSEC path (called from `submit_leaf::submit_dkim_leaf`
+/// after the leaf admits and the cryptographic check passes).
+pub(super) fn recovery_snapshot(
+    claimed_address: String,
+    registered_domain: String,
+    session_pk: SessionKey,
+) -> PendingSnapshot {
+    PendingSnapshot {
+        kind: SnapshotKind::Recovery { session_pk },
+        claimed_address,
+        registered_domain,
+        cached_zone_dnskey: true,
+        cached_dmarc_txt: None,
+        partial_set: false,
+        already_terminal: false,
+    }
+}
+
+/// Recovery-flow counterpart to `bind_credential`: resolve the
+/// verified `From:` address (already checked to match the claimed
+/// address by the verification pipeline) to its bound anchor via the
+/// reverse index, derive the delegation seed, and add the canister
+/// signature so a subsequent `email_recovery_get_delegation` query
+/// can retrieve it.
+///
+/// Returns the `RecoveryOutcome` to cache on the pending challenge —
+/// `email_recovery_status` reads it to answer with
+/// `RecoveryReady { user_key, expiration, anchor_number }`, and
+/// `email_recovery_get_delegation` reads the cached `seed` to look
+/// up the signature without re-deriving from the anchor.
+pub(super) async fn stamp_recovery_delegation(
+    snapshot: &PendingSnapshot,
+    session_pk: &SessionKey,
+) -> Result<super::pending::RecoveryOutcome, EmailRecoveryError> {
+    use ic_certification::Hash;
+
+    // The verifier already checked that From == claimed_address, so
+    // this lookup is for the address the user typed at prepare time
+    // *and* signed mail from. If the address isn't bound to any
+    // anchor (registration step never happened, or the user removed
+    // the credential after starting the wizard), fail closed.
+    let anchor_number = state::storage_borrow(|storage| {
+        storage.lookup_anchor_with_email_recovery_address(&snapshot.claimed_address)
+    })
+    .ok_or(EmailRecoveryError::AddressNotRegistered)?;
+
+    // The signature-map operations need the canister salt. In
+    // production it's already initialised (every prior delegation
+    // call paid that cost); we await defensively in case this is
+    // the very first delegation since deploy.
+    state::ensure_salt_set().await;
+
+    let expiration =
+        ic_cdk::api::time().saturating_add(crate::delegation::DEFAULT_EXPIRATION_PERIOD_NS);
+    let seed: Hash = calculate_email_recovery_seed(&snapshot.claimed_address, anchor_number);
+
+    state::signature_map_mut(|sigs| {
+        crate::delegation::add_delegation_signature(sigs, session_pk.clone(), &seed, expiration);
+    });
+    crate::update_root_hash();
+
+    let user_key = crate::delegation::der_encode_canister_sig_key(seed.to_vec());
+
+    Ok(super::pending::RecoveryOutcome {
+        user_key,
+        expiration,
+        anchor_number,
+        seed,
+    })
+}
+
+/// Compute the canister-signature seed binding a recovery email to
+/// an anchor. Mirrors `openid::calculate_delegation_seed` in shape:
+/// length-prefixed components hashed with SHA-256, prefixed by the
+/// canister-wide salt so principals are unique to *this* II
+/// instance.
+///
+/// The components are:
+/// - `salt` (32 bytes) — the canister-wide salt set on first call.
+/// - the literal byte string `"email-recovery"` — domain separator,
+///   so this seed never collides with the OpenID, anchor, or
+///   account seeds.
+/// - the lowercased canonical address (variable, ≤ 254 bytes per
+///   RFC 5321 §4.5.3.1, enforced upstream).
+/// - the anchor number as little-endian bytes.
+pub(crate) fn calculate_email_recovery_seed(
+    address: &str,
+    anchor_number: AnchorNumber,
+) -> ic_certification::Hash {
+    use sha2::{Digest, Sha256};
+
+    const DOMAIN_SEPARATOR: &[u8] = b"email-recovery";
+
+    let salt = state::salt();
+    let address_lower = address.to_ascii_lowercase();
+
+    let mut blob: Vec<u8> = Vec::new();
+    blob.push(salt.len() as u8);
+    blob.extend_from_slice(&salt);
+
+    blob.push(DOMAIN_SEPARATOR.len() as u8);
+    blob.extend_from_slice(DOMAIN_SEPARATOR);
+
+    blob.push(address_lower.len() as u8);
+    blob.extend_from_slice(address_lower.as_bytes());
+
+    blob.push(anchor_number.to_le_bytes().len() as u8);
+    blob.extend_from_slice(&anchor_number.to_le_bytes());
+
+    let mut hasher = Sha256::new();
+    hasher.update(&blob);
+    hasher.finalize().into()
+}
+
 #[cfg(not(test))]
 fn now_secs() -> u64 {
     ic_cdk::api::time() / 1_000_000_000
@@ -741,19 +926,8 @@ mod tests {
         }
     }
 
-    /// Configure the per-deploy `related_origins` so
-    /// `super::mailbox_domains()` returns the listed hosts.
-    /// Recipient dispatch and the `smtp_request_validate` query
-    /// both pull the accepted domain set from this list.
-    fn set_related_origins(origins: &[&str]) {
-        crate::state::persistent_state_mut(|p| {
-            p.related_origins = Some(origins.iter().map(|s| (*s).to_string()).collect());
-        });
-    }
-
     #[test]
     fn validate_accepts_register_recipient() {
-        set_related_origins(&["https://id.ai"]);
         assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
             "register", "id.ai",
         )));
@@ -761,7 +935,6 @@ mod tests {
 
     #[test]
     fn validate_accepts_recover_recipient() {
-        set_related_origins(&["https://id.ai"]);
         assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
             "recover", "id.ai",
         )));
@@ -769,11 +942,6 @@ mod tests {
 
     #[test]
     fn validate_accepts_case_insensitive() {
-        // Source `related_origins` are already lowercased by the
-        // host-extraction helper, so accepting an upper-case input
-        // exercises the case-insensitive comparison on the SMTP
-        // side.
-        set_related_origins(&["https://id.ai"]);
         assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
             "REGISTER", "ID.AI",
         )));
@@ -783,47 +951,9 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_any_related_origin_alias() {
-        // All `related_origins` entries are equal aliases. A prod
-        // deploy with id.ai + the *.icp0.io aliases must accept
-        // mail at register@<any of them>.
-        set_related_origins(&[
-            "https://id.ai",
-            "https://identity.ic0.app",
-            "https://identity.internetcomputer.org",
-        ]);
-        assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
-            "register",
-            "identity.ic0.app",
-        )));
-        assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
-            "recover",
-            "identity.internetcomputer.org",
-        )));
-    }
-
-    #[test]
-    fn validate_accepts_beta_alias_only_when_configured() {
-        // beta deploy: only beta.id.ai is on the allowlist.
-        set_related_origins(&["https://beta.id.ai"]);
-        assert_smtp_ok(handle_smtp_request_validate(smtp_envelope(
-            "register",
-            "beta.id.ai",
-        )));
-        // The bare `id.ai` is *not* on this deploy's list, so it's
-        // bounced — the canister doesn't accept it just because the
-        // string contains "id.ai".
-        assert_smtp_err_code(
-            handle_smtp_request_validate(smtp_envelope("register", "id.ai")),
-            SMTP_ERR_MAILBOX_UNAVAILABLE,
-        );
-    }
-
-    #[test]
     fn validate_rejects_unknown_user() {
         // Numeric anchor numbers (PoC postbox style) are not handled
         // by this canister anymore — the gateway should bounce them.
-        set_related_origins(&["https://id.ai"]);
         assert_smtp_err_code(
             handle_smtp_request_validate(smtp_envelope("12345", "id.ai")),
             SMTP_ERR_MAILBOX_UNAVAILABLE,
@@ -836,22 +966,10 @@ mod tests {
 
     #[test]
     fn validate_rejects_known_user_wrong_domain() {
-        // `register` at a domain not on the deploy's
-        // `related_origins` must not slip through.
-        set_related_origins(&["https://id.ai"]);
+        // `register` at the wrong domain must not slip through — the
+        // domain check is part of the recipient match.
         assert_smtp_err_code(
             handle_smtp_request_validate(smtp_envelope("register", "evil.example")),
-            SMTP_ERR_MAILBOX_UNAVAILABLE,
-        );
-    }
-
-    #[test]
-    fn validate_rejects_when_no_origins_configured() {
-        // No `related_origins` set → no domains accepted. Defensive
-        // path — real deploys always configure this.
-        crate::state::persistent_state_mut(|p| p.related_origins = None);
-        assert_smtp_err_code(
-            handle_smtp_request_validate(smtp_envelope("register", "id.ai")),
             SMTP_ERR_MAILBOX_UNAVAILABLE,
         );
     }

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -202,7 +202,7 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
             kind,
             claimed_address: c.claimed_address.clone(),
             registered_domain: c.registered_domain.clone(),
-            cached_zone_dnskey: c.cached_zone_dnskey.is_some(),
+            is_dnssec_path: c.cached_root_dnskey.is_some(),
             cached_dmarc_txt: c.cached_dmarc_txt.clone(),
             partial_set: c.partial_verification.is_some(),
             already_terminal: matches!(
@@ -230,7 +230,7 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         return SmtpResponse::Ok {};
     }
 
-    if snapshot.cached_zone_dnskey {
+    if snapshot.is_dnssec_path {
         // DNSSEC path — pre-DKIM-key verification only. Body is
         // dropped after `bh=` validates; status flips to
         // `NeedDkimLeaf { selector }` so the FE submits the leaf.
@@ -303,9 +303,10 @@ pub(super) struct PendingSnapshot {
     /// Pinned at prepare time; `submit_dkim_leaf` rejects DKIM leaves
     /// at any other zone.
     registered_domain: String,
-    /// `true` when prepare took the DNSSEC path (zone DNSKEY cached).
-    /// Decides whether `smtp_request` finishes here or hands off.
-    cached_zone_dnskey: bool,
+    /// `true` when prepare took the DNSSEC path (root DNSKEY + zone
+    /// keys cached). Decides whether `smtp_request` finishes here or
+    /// hands off to the FE for the DKIM leaf walk.
+    is_dnssec_path: bool,
     /// Pre-validated DMARC TXT bytes from the DNSSEC path. `Some` means
     /// the FE included a DMARC leaf in the skeleton bundle; `None`
     /// means it didn't (we'll fall back to strict `d=` alignment at
@@ -725,7 +726,7 @@ pub(super) fn recovery_snapshot(
         kind: SnapshotKind::Recovery { session_pk },
         claimed_address,
         registered_domain,
-        cached_zone_dnskey: true,
+        is_dnssec_path: true,
         cached_dmarc_txt: None,
         partial_set: false,
         already_terminal: false,

--- a/src/internet_identity/src/email_recovery/submit_leaf.rs
+++ b/src/internet_identity/src/email_recovery/submit_leaf.rs
@@ -5,19 +5,26 @@
 //! header, validated the body hash, and stashed a small
 //! `PartialVerification` record on the pending challenge. It then
 //! flipped the polled status to `NeedDkimLeaf { selector }` so the
-//! FE could walk DNSSEC for that one TXT and submit it back here.
+//! FE could walk DNSSEC for that selector and submit the resulting
+//! `(hops, extra_chains)` bundle back here.
 //!
 //! This call:
 //!
 //! 1. Looks up the pending challenge by nonce; rejects with
 //!    `NoDkimLeafExpected` if the entry isn't in `NeedDkimLeaf`.
-//! 2. Validates the FE-supplied `SignedRRset` against the cached
-//!    deepest-zone DNSKEY (the chain itself was already validated
-//!    at prepare time — see `verify_chain_with_clock`).
-//! 3. Confirms the leaf's owner name is exactly
+//! 2. Re-validates the cached root DNSKEY against the configured
+//!    trust anchors (it may have aged out of its inception/expiration
+//!    window since prepare), then walks each `extra_chain` under it,
+//!    extending the cached `(zone → DNSKEY)` map for any new signed
+//!    zone the DKIM CNAME chain crosses into (Proton/Tutanota-style;
+//!    see design doc §7.2).
+//! 3. Verifies each FE-supplied hop under the zone its
+//!    `RRSIG.signer_name` names, then walks the hop sequence as a
+//!    coherent CNAME → … → TXT resolution starting at
 //!    `<expected_selector>._domainkey.<registered_domain>.`. Both
-//!    sides come from canister-pinned state, never the FE.
-//! 4. Parses the DKIM TXT, runs the cryptographic signature check
+//!    the selector and the registered domain come from canister-
+//!    pinned state, never the FE.
+//! 4. Parses the final TXT, runs the cryptographic signature check
 //!    using the cached headers digest + signature blob, and
 //!    optionally verifies DMARC alignment against the cached DMARC
 //!    bytes (or strict `d=` alignment when no DMARC was cached).
@@ -42,7 +49,11 @@ pub async fn submit_dkim_leaf(
     arg: EmailRecoverySubmitDkimLeafArg,
     now_secs: u64,
 ) -> Result<EmailRecoveryStatus, EmailRecoveryError> {
-    let EmailRecoverySubmitDkimLeafArg { nonce, dkim_leaf } = arg;
+    let EmailRecoverySubmitDkimLeafArg {
+        nonce,
+        hops,
+        extra_chains,
+    } = arg;
 
     // Snapshot everything we need under one borrow so the rest of
     // the function works against owned data. Includes early
@@ -51,7 +62,7 @@ pub async fn submit_dkim_leaf(
     let snapshot = pending::with_mut(&nonce, now_secs, |c| Snapshot::take(c))
         .ok_or(EmailRecoveryError::NonceUnknown)??;
 
-    if let Err(e) = run_submit(&dkim_leaf, &snapshot, now_secs) {
+    if let Err(e) = run_submit(&hops, &extra_chains, &snapshot, now_secs) {
         let cloned = e.clone();
         pending::with_mut(&nonce, now_secs, |c| {
             c.status = PendingStatus::Failed(cloned);
@@ -125,7 +136,8 @@ struct Snapshot {
     claimed_address: String,
     registered_domain: String,
     expected_selector: String,
-    cached_zone_dnskey: crate::dnssec::SignedRRset,
+    cached_root_dnskey: crate::dnssec::SignedRRset,
+    cached_zones: crate::dnssec::ZoneKeysMap,
     cached_dmarc_txt: Option<Vec<u8>>,
     headers_digest: [u8; 32],
     signature: Vec<u8>,
@@ -158,8 +170,8 @@ impl Snapshot {
             PendingStatus::NeedDkimLeaf { selector } => selector.clone(),
             _ => return Err(EmailRecoveryError::NoDkimLeafExpected),
         };
-        let cached_zone_dnskey = c
-            .cached_zone_dnskey
+        let cached_root_dnskey = c
+            .cached_root_dnskey
             .as_ref()
             .ok_or(EmailRecoveryError::NoDkimLeafExpected)?
             .clone();
@@ -178,7 +190,8 @@ impl Snapshot {
             claimed_address: c.claimed_address.clone(),
             registered_domain: c.registered_domain.clone(),
             expected_selector,
-            cached_zone_dnskey,
+            cached_root_dnskey,
+            cached_zones: c.cached_zones.clone(),
             cached_dmarc_txt: c.cached_dmarc_txt.clone(),
             headers_digest: partial.headers_digest,
             signature: partial.signature.clone(),
@@ -192,51 +205,68 @@ impl Snapshot {
 /// The leaf-validation + signature-verification + alignment-check
 /// pipeline. Returns `Ok(())` on full success.
 fn run_submit(
-    dkim_leaf: &internet_identity_interface::internet_identity::types::SignedRRset,
+    hops: &[internet_identity_interface::internet_identity::types::SignedRRset],
+    extra_chains: &[internet_identity_interface::internet_identity::types::DelegationChain],
     snapshot: &Snapshot,
     now_secs: u64,
 ) -> Result<(), EmailRecoveryError> {
-    // Step 1: validate the FE-supplied leaf against the cached zone
-    // DNSKEY. The cached DNSKEY was itself validated at prepare time
-    // against the canister's trust anchors; the chain is implicit
-    // here.
-    //
-    // The verifier's top-level entry points are bundle / hops shaped;
-    // for the single-leaf single-zone case we wrap the cached zone
-    // DNSKEY in a one-entry `ZoneKeysMap` and the leaf in a one-hop
-    // slice, and use the leaf's own owner name as `requested_name`
-    // (the policy check on the verified owner happens in step 2).
-    let leaf_internal: crate::dnssec::SignedRRset = dkim_leaf.clone().into();
-    let mut zones = crate::dnssec::ZoneKeysMap::new();
-    zones
-        .insert(
-            snapshot.cached_zone_dnskey.name.clone(),
-            snapshot.cached_zone_dnskey.clone(),
-        )
-        .map_err(|_| EmailRecoveryError::DkimLeafMismatch)?;
-    let verified = crate::dnssec::verify_hops_with_clock(
-        std::slice::from_ref(&leaf_internal),
-        &zones,
-        &leaf_internal.name,
-        leaf_internal.rtype,
+    // Step 1: re-validate the cached root DNSKEY against the trust
+    // anchors. The pending challenge has a 30-min TTL but the RRSIG
+    // window is what really decides freshness — re-checking is
+    // cheap (one signature verify) and removes any chance of
+    // admitting a chain under a now-stale root DNSKEY.
+    let trust_anchors = crate::state::persistent_state(|p| {
+        p.dnssec_config
+            .as_ref()
+            .map(|c| c.root_anchors.clone())
+            .unwrap_or_default()
+    });
+    crate::dnssec::verify_root_dnskey_with_clock(
+        &snapshot.cached_root_dnskey,
+        &trust_anchors,
         now_secs,
     )
     .map_err(|_| EmailRecoveryError::DkimLeafMismatch)?;
 
-    // Step 2: confirm the leaf's owner name and rtype.
-    if verified.rtype != crate::dnssec::types::TYPE_TXT {
-        return Err(EmailRecoveryError::DkimLeafMismatch);
-    }
-    let leaf_name = decode_dns_name_lowercase(&verified.name.0);
+    // Step 2: extend the cached zone-keys map with any *new*
+    // delegation chains the FE supplied. Empty for the Gmail-style
+    // same-zone case; one new chain for the Proton/Tutanota-style
+    // cross-zone CNAME case.
+    let mut zones = snapshot.cached_zones.clone();
+    let extra_chains_internal: Vec<crate::dnssec::DelegationChain> =
+        extra_chains.iter().cloned().map(Into::into).collect();
+    crate::dnssec::verify_extra_chains_with_clock(
+        &extra_chains_internal,
+        &snapshot.cached_root_dnskey,
+        &mut zones,
+        now_secs,
+    )
+    .map_err(|_| EmailRecoveryError::DkimLeafMismatch)?;
+
+    // Step 3: walk the hops as a CNAME → … → TXT resolution
+    // anchored at the canister-pinned `<selector>._domainkey.<d>.`
+    // FQDN. Any incoherence (wrong first hop, intermediate that
+    // isn't a CNAME, bad target chaining, oversized chain, loop) is
+    // surfaced as DkimLeafMismatch.
+    let hops_internal: Vec<crate::dnssec::SignedRRset> =
+        hops.iter().cloned().map(Into::into).collect();
     let expected_fqdn = format!(
         "{}._domainkey.{}.",
         snapshot.expected_selector, snapshot.registered_domain
     );
-    if !leaf_name.eq_ignore_ascii_case(&expected_fqdn) {
-        return Err(EmailRecoveryError::DkimLeafMismatch);
-    }
+    let expected_wire = encode_dns_name_lowercase(&expected_fqdn);
+    let verified = crate::dnssec::verify_hops_with_clock(
+        &hops_internal,
+        &zones,
+        &crate::dnssec::DnsName(expected_wire),
+        crate::dnssec::types::TYPE_TXT,
+        now_secs,
+    )
+    .map_err(|_| EmailRecoveryError::DkimLeafMismatch)?;
 
-    // Step 3: parse the DKIM TXT, get the public key + key type.
+    let leaf_name = decode_dns_name_lowercase(&verified.name.0);
+
+    // Step 4: parse the DKIM TXT, get the public key + key type.
     let txt = parse_txt_rdata(&verified.rdata)?;
     if txt.len() > super::MAX_DKIM_TXT_BYTES {
         return Err(EmailRecoveryError::EmailVerificationFailed(format!(
@@ -251,7 +281,7 @@ fn run_submit(
         EmailRecoveryError::EmailVerificationFailed(format!("DKIM DNS record: {e}"))
     })?;
 
-    // Step 4: complete the cryptographic signature check.
+    // Step 5: complete the cryptographic signature check.
     //
     // `verify_signature` takes the raw signed_data and hashes it
     // internally. Since we cached only the SHA-256 digest, feed
@@ -298,7 +328,7 @@ fn run_submit(
         }
     }
 
-    // Step 5: DMARC alignment. The smtp.rs path enforced that the
+    // Step 6: DMARC alignment. The smtp.rs path enforced that the
     // signing domain (`d=`) is within the registered zone, so any
     // strict-or-relaxed alignment under DMARC is trivially
     // satisfied. We re-check explicitly here against the cached
@@ -464,6 +494,27 @@ fn parse_txt_rdata(rdata: &[Vec<u8>]) -> Result<Vec<u8>, EmailRecoveryError> {
         }
     }
     Ok(txt_bytes)
+}
+
+/// Encode a dotted ASCII DNS name (with or without a trailing dot)
+/// into wire format: a sequence of length-prefixed labels terminated
+/// by a zero-length root label. Labels are lowercased on the way in.
+fn encode_dns_name_lowercase(dotted: &str) -> Vec<u8> {
+    let trimmed = dotted.strip_suffix('.').unwrap_or(dotted);
+    let mut out = Vec::with_capacity(trimmed.len() + 2);
+    for label in trimmed.split('.') {
+        if label.is_empty() {
+            continue;
+        }
+        let bytes = label.as_bytes();
+        let len = bytes.len().min(63) as u8;
+        out.push(len);
+        for &b in &bytes[..len as usize] {
+            out.push(b.to_ascii_lowercase());
+        }
+    }
+    out.push(0);
+    out
 }
 
 /// Decode a wire-format DNS name (length-prefixed labels) into a

--- a/src/internet_identity/src/email_recovery/submit_leaf.rs
+++ b/src/internet_identity/src/email_recovery/submit_leaf.rs
@@ -30,13 +30,15 @@ use crate::email_recovery::pending;
 use internet_identity_interface::internet_identity::types::email_recovery::{
     EmailRecoveryError, EmailRecoveryStatus, EmailRecoverySubmitDkimLeafArg,
 };
+use internet_identity_interface::internet_identity::types::SessionKey;
 
 /// Body of `email_recovery_submit_dkim_leaf(arg)`. Returns the
-/// post-call polling status — typically `RegistrationSucceeded` or
+/// post-call polling status — `RegistrationSucceeded` for the setup
+/// flow, `RecoveryReady{...}` for the recovery flow, or
 /// `Failed(reason)`. The FE can also poll
 /// `email_recovery_status(nonce)` for the same answer; returning it
 /// here saves the FE one round-trip on the happy path.
-pub fn submit_dkim_leaf(
+pub async fn submit_dkim_leaf(
     arg: EmailRecoverySubmitDkimLeafArg,
     now_secs: u64,
 ) -> Result<EmailRecoveryStatus, EmailRecoveryError> {
@@ -49,18 +51,19 @@ pub fn submit_dkim_leaf(
     let snapshot = pending::with_mut(&nonce, now_secs, |c| Snapshot::take(c))
         .ok_or(EmailRecoveryError::NonceUnknown)??;
 
-    let outcome = run_submit(&dkim_leaf, &snapshot, now_secs);
-    match outcome {
-        Ok(()) => {
-            // Bind the credential and flip status. Re-borrow the
-            // map; the entry still exists (we didn't await between
-            // borrows, so no one else can mutate it).
-            let bind_result = match &snapshot.kind {
-                SnapshotKind::Register { anchor } => {
-                    super::smtp::bind_credential(*anchor, &snapshot.claimed_address, now_secs)
-                }
-            };
-            match bind_result {
+    if let Err(e) = run_submit(&dkim_leaf, &snapshot, now_secs) {
+        let cloned = e.clone();
+        pending::with_mut(&nonce, now_secs, |c| {
+            c.status = PendingStatus::Failed(cloned);
+        });
+        return Err(e);
+    }
+
+    // Verification passed — finalize per kind. Setup binds the
+    // credential, recovery stamps a delegation seed.
+    match &snapshot.kind {
+        SnapshotKind::Register { anchor } => {
+            match super::smtp::bind_credential(*anchor, &snapshot.claimed_address, now_secs) {
                 Ok(()) => {
                     pending::with_mut(&nonce, now_secs, |c| {
                         c.status = PendingStatus::Succeeded;
@@ -77,12 +80,41 @@ pub fn submit_dkim_leaf(
                 }
             }
         }
-        Err(e) => {
-            let cloned = e.clone();
-            pending::with_mut(&nonce, now_secs, |c| {
-                c.status = PendingStatus::Failed(cloned);
-            });
-            Err(e)
+        SnapshotKind::Recovery { session_pk } => {
+            // Build a transient `PendingSnapshot` shape that
+            // `stamp_recovery_delegation` already accepts (the DoH
+            // path uses the same helper). The stamper looks up the
+            // anchor via the reverse-address index and adds the
+            // canister signature.
+            let smtp_snapshot = super::smtp::recovery_snapshot(
+                snapshot.claimed_address.clone(),
+                snapshot.registered_domain.clone(),
+                session_pk.clone(),
+            );
+            match super::smtp::stamp_recovery_delegation(&smtp_snapshot, session_pk).await {
+                Ok(outcome) => {
+                    let user_key = serde_bytes::ByteBuf::from(outcome.user_key.clone());
+                    let expiration = outcome.expiration;
+                    let anchor_number = outcome.anchor_number;
+                    pending::with_mut(&nonce, now_secs, |c| {
+                        c.recovery_outcome = Some(outcome);
+                        c.status = PendingStatus::Succeeded;
+                        c.partial_verification = None;
+                    });
+                    Ok(EmailRecoveryStatus::RecoveryReady {
+                        user_key,
+                        expiration,
+                        anchor_number,
+                    })
+                }
+                Err(e) => {
+                    let cloned = e.clone();
+                    pending::with_mut(&nonce, now_secs, |c| {
+                        c.status = PendingStatus::Failed(cloned);
+                    });
+                    Err(e)
+                }
+            }
         }
     }
 }
@@ -106,6 +138,9 @@ struct Snapshot {
 enum SnapshotKind {
     Register {
         anchor: internet_identity_interface::internet_identity::types::AnchorNumber,
+    },
+    Recovery {
+        session_pk: SessionKey,
     },
 }
 
@@ -134,6 +169,9 @@ impl Snapshot {
             .ok_or(EmailRecoveryError::NoDkimLeafExpected)?;
         let kind = match &c.kind {
             PendingKind::Register { anchor } => SnapshotKind::Register { anchor: *anchor },
+            PendingKind::Recover { session_pk } => SnapshotKind::Recovery {
+                session_pk: session_pk.clone(),
+            },
         };
         Ok(Snapshot {
             kind,

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -973,6 +973,14 @@ mod v2_api {
             .map(|(k, v)| (k, MetadataEntryV2::from(v)))
             .collect();
 
+        // Anchor stores email recoveries as a Vec to leave room for
+        // future multi-credential support; the candid surface only
+        // exposes the first one (the canister API enforces ≤1 entry).
+        let email_recovery = state::anchor(identity_number)
+            .email_recovery
+            .first()
+            .cloned();
+
         let identity_info = IdentityInfo {
             authn_methods: anchor_info
                 .devices
@@ -986,6 +994,7 @@ mod v2_api {
             metadata,
             name: anchor_info.name,
             created_at: anchor_info.created_at,
+            email_recovery,
         };
         Ok(identity_info)
     }
@@ -1414,10 +1423,14 @@ mod email_recovery_api {
     use super::*;
     use crate::authz_utils::check_authorization;
     use crate::email_recovery;
+    use ic_canister_sig_creation::delegation_signature_msg;
+    use ic_canister_sig_creation::signature_map::CanisterSigInputs;
+    use ic_canister_sig_creation::DELEGATION_SIG_DOMAIN;
     use internet_identity_interface::internet_identity::types::email_recovery::{
-        EmailRecoveryChallenge, EmailRecoveryDnsInput, EmailRecoveryError, EmailRecoveryStatus,
-        EmailRecoverySubmitDkimLeafArg,
+        EmailRecoveryChallenge, EmailRecoveryDnsInput, EmailRecoveryError,
+        EmailRecoveryGetDelegationArgs, EmailRecoveryStatus, EmailRecoverySubmitDkimLeafArg,
     };
+    use internet_identity_interface::internet_identity::types::SessionKey;
 
     /// Authenticated. Validates the caller owns `identity_number`,
     /// validates the DNS input shape (DNSSEC bundle if supplied,
@@ -1436,6 +1449,28 @@ mod email_recovery_api {
 
         let now_secs = ic_cdk::api::time() / 1_000_000_000;
         email_recovery::prepare_add(identity_number, dns_input, now_secs).await
+    }
+
+    /// Anonymous. The FE-side counterpart of `prepare_add` for the
+    /// recovery flow: validates the same DNSSEC skeleton chain or
+    /// DoH allowlist, parks a pending challenge bound to the
+    /// FE-supplied `session_key`, and returns the nonce +
+    /// `recover@id.ai` recipient. The anchor isn't resolved here —
+    /// that happens at submit-leaf (or DoH-path smtp_request) time
+    /// from the verified `From:` of the inbound email.
+    ///
+    /// Anonymous because by the time the user reaches for recovery
+    /// they may have lost every authn method on their anchor; the
+    /// DKIM-verified email itself is the credential. The
+    /// nonce-rotation + Subject-visibility defenses (design §3.2)
+    /// stand in for caller authentication.
+    #[update]
+    async fn email_recovery_prepare_delegation(
+        dns_input: EmailRecoveryDnsInput,
+        session_key: SessionKey,
+    ) -> Result<EmailRecoveryChallenge, EmailRecoveryError> {
+        let now_secs = ic_cdk::api::time() / 1_000_000_000;
+        email_recovery::prepare_delegation(dns_input, session_key, now_secs).await
     }
 
     /// Open update. Called by the off-chain SMTP gateway for every
@@ -1506,11 +1541,52 @@ mod email_recovery_api {
     /// entry, and the leaf submission is a no-op against any other
     /// entry.
     #[update]
-    fn email_recovery_submit_dkim_leaf(
+    async fn email_recovery_submit_dkim_leaf(
         arg: EmailRecoverySubmitDkimLeafArg,
     ) -> Result<EmailRecoveryStatus, EmailRecoveryError> {
         let now_secs = ic_cdk::api::time() / 1_000_000_000;
-        email_recovery::submit_dkim_leaf(arg, now_secs)
+        email_recovery::submit_dkim_leaf(arg, now_secs).await
+    }
+
+    /// **Anonymous query.** Final step of the recovery flow: after
+    /// `email_recovery_status` reports `RecoveryReady { user_key,
+    /// expiration, anchor_number }`, the FE calls this to retrieve
+    /// the actual `SignedDelegation`. Mirrors `openid_get_delegation`
+    /// in shape — the args (`session_key`, `expiration`) must match
+    /// exactly what was stamped at submit-leaf time, otherwise the
+    /// canister-signature store has no entry to return.
+    #[query]
+    fn email_recovery_get_delegation(
+        args: EmailRecoveryGetDelegationArgs,
+    ) -> Result<SignedDelegation, EmailRecoveryError> {
+        let now_secs = ic_cdk::api::time() / 1_000_000_000;
+        let seed = email_recovery::recovery_seed_for_nonce(&args.nonce, now_secs)
+            .ok_or(EmailRecoveryError::NonceUnknown)?;
+
+        crate::state::assets_and_signatures(|certified_assets, sigs| {
+            let inputs = CanisterSigInputs {
+                domain: DELEGATION_SIG_DOMAIN,
+                seed: &seed,
+                message: &delegation_signature_msg(&args.session_key, args.expiration, None),
+            };
+            sigs.get_signature_as_cbor(&inputs, Some(certified_assets.root_hash()))
+                .map(|signature| SignedDelegation {
+                    delegation: Delegation {
+                        pubkey: args.session_key,
+                        expiration: args.expiration,
+                        targets: None,
+                    },
+                    signature: serde_bytes::ByteBuf::from(signature),
+                })
+                .map_err(|_| {
+                    EmailRecoveryError::InternalCanisterError(
+                        "no canister signature for the supplied (nonce, session_key, expiration); \
+                         either the recovery flow hasn't completed yet, the args don't match \
+                         what was stamped, or the signature has been evicted"
+                            .into(),
+                    )
+                })
+        })
     }
 
     /// Authenticated. Detaches the recovery email from the anchor.

--- a/src/internet_identity/src/stats/activity_stats/activity_counter/authn_method_counter.rs
+++ b/src/internet_identity/src/stats/activity_stats/activity_counter/authn_method_counter.rs
@@ -22,6 +22,8 @@ pub struct AuthnMethodCounter {
     pub browser_storage_key_counter: u64,
     /// Number of authentications with an OpenID credential per issuer
     pub openid_credential_auth_counter: Option<HashMap<String, u64>>,
+    /// Number of authentications via an email-recovery delegation.
+    pub email_recovery_counter: Option<u64>,
     /// Number of authentications with a key not fitting any of the above criteria.
     pub other_counter: u64,
 }
@@ -37,6 +39,7 @@ impl ActivityCounter for AuthnMethodCounter {
             recovery_phrase_counter: 0,
             browser_storage_key_counter: 0,
             openid_credential_auth_counter: Some(HashMap::new()),
+            email_recovery_counter: Some(0),
             other_counter: 0,
         }
     }
@@ -57,6 +60,11 @@ impl ActivityCounter for AuthnMethodCounter {
             AuthorizationKey::OpenIdCredentialKey((openid_credential_key, _)) => anchor
                 .openid_credential(openid_credential_key)
                 .and_then(|c| c.last_usage_timestamp),
+            AuthorizationKey::EmailRecoveryAddress(address) => anchor
+                .email_recovery
+                .iter()
+                .find(|c| c.address.eq_ignore_ascii_case(address))
+                .and_then(|c| c.last_used),
         };
 
         // only count authentications on devices that have not already been counted
@@ -105,6 +113,11 @@ impl ActivityCounter for AuthnMethodCounter {
                             .and_modify(|count| *count += 1)
                             .or_insert(1);
                     }
+                }
+            }
+            AuthorizationKey::EmailRecoveryAddress(_) => {
+                if let Some(counter) = &mut self.email_recovery_counter {
+                    *counter += 1;
                 }
             }
         }

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -127,6 +127,7 @@ use storable::anchor_number::StorableAnchorNumber;
 use storable::application::StorableApplication;
 use storable::credential_id::StorableCredentialId;
 use storable::discrepancy_counter::{DiscrepancyType, StorableDiscrepancyCounter};
+use storable::email_recovery_address_hash::StorableEmailRecoveryAddressHash;
 use storable::fixed_anchor::StorableFixedAnchor;
 use storable::openid_credential::StorableOpenIdCredential;
 use storable::openid_credential_key::StorableOpenIdCredentialKey;
@@ -178,6 +179,7 @@ const LOOKUP_APPLICATION_WITH_ORIGIN_MEMORY_INDEX: u8 = 19u8;
 const STABLE_ANCHOR_APPLICATION_CONFIG_MEMORY_INDEX: u8 = 20u8;
 const LOOKUP_ANCHOR_WITH_RECOVERY_PHRASE_PRINCIPAL_MEMORY_INDEX: u8 = 21u8;
 const LOOKUP_ANCHOR_WITH_PASSKEY_PUBKEY_HASH_MEMORY_INDEX: u8 = 22u8;
+const LOOKUP_ANCHOR_WITH_EMAIL_RECOVERY_MEMORY_INDEX: u8 = 23u8;
 
 const ANCHOR_MEMORY_ID: MemoryId = MemoryId::new(ANCHOR_MEMORY_INDEX);
 const ARCHIVE_BUFFER_MEMORY_ID: MemoryId = MemoryId::new(ARCHIVE_BUFFER_MEMORY_INDEX);
@@ -214,6 +216,9 @@ const LOOKUP_ANCHOR_WITH_RECOVERY_PHRASE_PRINCIPAL_MEMORY_ID: MemoryId =
 
 const LOOKUP_ANCHOR_WITH_PASSKEY_PUBKEY_HASH_MEMORY_ID: MemoryId =
     MemoryId::new(LOOKUP_ANCHOR_WITH_PASSKEY_PUBKEY_HASH_MEMORY_INDEX);
+
+const LOOKUP_ANCHOR_WITH_EMAIL_RECOVERY_MEMORY_ID: MemoryId =
+    MemoryId::new(LOOKUP_ANCHOR_WITH_EMAIL_RECOVERY_MEMORY_INDEX);
 
 // The bucket size 128 is relatively low, to avoid wasting memory when using
 // multiple virtual memories for smaller amounts of data.
@@ -339,6 +344,16 @@ pub struct Storage<M: Memory> {
     lookup_anchor_with_passkey_pubkey_hash_memory_wrapper: MemoryWrapper<ManagedMemory<M>>,
     pub(crate) lookup_anchor_with_passkey_pubkey_hash_memory:
         StableBTreeMap<Principal, StorableAnchorNumber, ManagedMemory<M>>,
+
+    lookup_anchor_with_email_recovery_memory_wrapper: MemoryWrapper<ManagedMemory<M>>,
+    /// Reverse index for the email-recovery flow: maps
+    /// `SHA-256(lowercase(address))` to the anchor that bound it. The
+    /// hash key is fixed-size (32 bytes) so the per-entry footprint
+    /// is bounded regardless of address length; the address itself
+    /// already lives on the anchor's `email_recovery` credential, so
+    /// there's no need to store it again here. See design §8.2.
+    pub(crate) lookup_anchor_with_email_recovery_memory:
+        StableBTreeMap<StorableEmailRecoveryAddressHash, StorableAnchorNumber, ManagedMemory<M>>,
 }
 
 #[repr(C, packed)]
@@ -422,6 +437,8 @@ impl<M: Memory + Clone> Storage<M> {
             memory_manager.get(LOOKUP_ANCHOR_WITH_RECOVERY_PHRASE_PRINCIPAL_MEMORY_ID);
         let lookup_anchor_with_passkey_pubkey_hash_memory =
             memory_manager.get(LOOKUP_ANCHOR_WITH_PASSKEY_PUBKEY_HASH_MEMORY_ID);
+        let lookup_anchor_with_email_recovery_memory =
+            memory_manager.get(LOOKUP_ANCHOR_WITH_EMAIL_RECOVERY_MEMORY_ID);
 
         let registration_rates = RegistrationRates::new(
             MinHeap::init(registration_ref_rate_memory.clone())
@@ -521,6 +538,12 @@ impl<M: Memory + Clone> Storage<M> {
             ),
             lookup_anchor_with_passkey_pubkey_hash_memory: StableBTreeMap::init(
                 lookup_anchor_with_passkey_pubkey_hash_memory,
+            ),
+            lookup_anchor_with_email_recovery_memory_wrapper: MemoryWrapper::new(
+                lookup_anchor_with_email_recovery_memory.clone(),
+            ),
+            lookup_anchor_with_email_recovery_memory: StableBTreeMap::init(
+                lookup_anchor_with_email_recovery_memory,
             ),
         }
     }
@@ -670,31 +693,33 @@ impl<M: Memory + Clone> Storage<M> {
             .insert(anchor_number, storable_anchor.clone());
 
         // Second, deconstruct the previous anchor, obtaining the previous credentials and recovery keys.
-        let (previous_openid_credentials, previous_passkey_credentials, previous_recovery_keys) =
-            if let Some(StorableAnchor {
-                // The following fields need to be compared with the previous anchor
-                openid_credentials,
-                passkey_credentials,
-                recovery_keys,
+        let (
+            previous_openid_credentials,
+            previous_passkey_credentials,
+            previous_recovery_keys,
+            previous_email_recovery,
+        ) = if let Some(StorableAnchor {
+            // The following fields need to be compared with the previous anchor
+            openid_credentials,
+            passkey_credentials,
+            recovery_keys,
+            email_recovery,
 
-                // The following fields do not require merging.
-                created_at_ns: _,
-                name: _,
-                // email_recovery is overwritten on every write — there's
-                // a single optional credential, no per-anchor index to
-                // sync, so no merge is needed.
-                email_recovery: _,
-            }) = previous_anchor_maybe
-            {
-                (
-                    openid_credentials,
-                    passkey_credentials.unwrap_or_default(),
-                    recovery_keys.unwrap_or_default(),
-                )
-            } else {
-                // Should never happen in practice, since each anchor number should correspond to a `StorableAnchor`.
-                (vec![], vec![], vec![])
-            };
+            // The following fields do not require merging.
+            created_at_ns: _,
+            name: _,
+        }) = previous_anchor_maybe
+        {
+            (
+                openid_credentials,
+                passkey_credentials.unwrap_or_default(),
+                recovery_keys.unwrap_or_default(),
+                email_recovery.unwrap_or_default(),
+            )
+        } else {
+            // Should never happen in practice, since each anchor number should correspond to a `StorableAnchor`.
+            (vec![], vec![], vec![], vec![])
+        };
 
         // Right now, this is the only index that needs to be updated based on `StorableAnchor`.
         self.sync_anchor_with_openid_credential_index(
@@ -720,6 +745,25 @@ impl<M: Memory + Clone> Storage<M> {
             &previous_passkey_credentials,
             &current_passkey_credentials,
         );
+
+        // The reverse address index for email recovery: map
+        // SHA-256(lowercase(address)) → AnchorNumber. Each anchor
+        // holds at most one recovery email (the API caps it; the
+        // storage Vec is ≤ 1 in practice). Sync prev → curr so
+        // address swaps and removals stay consistent.
+        let previous_email_address = previous_email_recovery.first().map(|c| c.address.clone());
+        let current_email_address = storable_anchor
+            .email_recovery
+            .as_ref()
+            .and_then(|v| v.first())
+            .map(|c| c.address.clone());
+        if previous_email_address != current_email_address {
+            self.update_email_recovery_lookup(
+                anchor_number,
+                previous_email_address.as_deref(),
+                current_email_address.as_deref(),
+            );
+        }
 
         Ok(())
     }
@@ -905,6 +949,48 @@ impl<M: Memory + Clone> Storage<M> {
         let principal = Principal::self_authenticating(pubkey);
         self.lookup_anchor_with_passkey_pubkey_hash_memory
             .get(&principal)
+    }
+
+    /// Resolve the verified `From:` of an inbound recovery email to
+    /// the anchor it was bound to at setup time. Returns `None` if
+    /// the address has never been registered (or has been removed).
+    /// The lookup is by `SHA-256(lowercase(address))` — see design
+    /// §8.2 for why.
+    pub fn lookup_anchor_with_email_recovery_address(&self, address: &str) -> Option<AnchorNumber> {
+        let hash = StorableEmailRecoveryAddressHash::of(address);
+        self.lookup_anchor_with_email_recovery_memory.get(&hash)
+    }
+
+    /// Apply a setup/replace: update the reverse index to reflect
+    /// `anchor`'s current bound address. `previous` is the address
+    /// that was bound before the operation (or `None` for an initial
+    /// add); `current` is the new bound address (or `None` for a
+    /// remove). Both transitions are exercised by the email-recovery
+    /// flow:
+    ///
+    /// - `(None, Some(addr))` — first registration: insert the new hash.
+    /// - `(Some(prev), Some(new))` — replacement (anchor swaps which
+    ///   address recovers it): drop the old hash, insert the new.
+    /// - `(Some(prev), None)` — remove: drop the old hash.
+    ///
+    /// `(None, None)` is a no-op. The two operations are sequenced
+    /// so that during a swap the old entry is removed before the new
+    /// one is written; an interleaving observer never sees both.
+    pub fn update_email_recovery_lookup(
+        &mut self,
+        anchor_number: AnchorNumber,
+        previous: Option<&str>,
+        current: Option<&str>,
+    ) {
+        if let Some(prev) = previous {
+            let hash = StorableEmailRecoveryAddressHash::of(prev);
+            self.lookup_anchor_with_email_recovery_memory.remove(&hash);
+        }
+        if let Some(curr) = current {
+            let hash = StorableEmailRecoveryAddressHash::of(curr);
+            self.lookup_anchor_with_email_recovery_memory
+                .insert(hash, anchor_number);
+        }
     }
 
     fn sync_anchor_with_passkey_pubkey_index(
@@ -2023,6 +2109,10 @@ impl<M: Memory + Clone> Storage<M> {
                 "lookup_anchor_with_passkey_pubkey_hash_memory".to_string(),
                 self.lookup_anchor_with_passkey_pubkey_hash_memory_wrapper
                     .size(),
+            ),
+            (
+                "lookup_anchor_with_email_recovery_memory".to_string(),
+                self.lookup_anchor_with_email_recovery_memory_wrapper.size(),
             ),
         ])
     }

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -762,7 +762,10 @@ impl<M: Memory + Clone> Storage<M> {
                 anchor_number,
                 previous_email_address.as_deref(),
                 current_email_address.as_deref(),
-            );
+            )
+            .map_err(|existing_anchor| {
+                StorageError::EmailRecoveryAddressAlreadyBound { existing_anchor }
+            })?;
         }
 
         Ok(())
@@ -976,12 +979,30 @@ impl<M: Memory + Clone> Storage<M> {
     /// `(None, None)` is a no-op. The two operations are sequenced
     /// so that during a swap the old entry is removed before the new
     /// one is written; an interleaving observer never sees both.
+    ///
+    /// Returns `Err(other_anchor)` if `current` is already bound to a
+    /// different anchor — this enforces the "one anchor per address"
+    /// invariant from design §8.2 at the storage layer regardless of
+    /// what the caller checked. The caller is expected to surface
+    /// `AddressAlreadyRegistered` (setup) or `AddressNotRegistered`
+    /// (recovery) to the FE.
     pub fn update_email_recovery_lookup(
         &mut self,
         anchor_number: AnchorNumber,
         previous: Option<&str>,
         current: Option<&str>,
-    ) {
+    ) -> Result<(), AnchorNumber> {
+        // Enforce "one anchor per address" before mutating anything.
+        // Same-anchor rebinds are idempotent (the API uses this to
+        // re-confirm a binding); cross-anchor rebinds are rejected.
+        if let Some(curr) = current {
+            let hash = StorableEmailRecoveryAddressHash::of(curr);
+            if let Some(existing) = self.lookup_anchor_with_email_recovery_memory.get(&hash) {
+                if existing != anchor_number {
+                    return Err(existing);
+                }
+            }
+        }
         if let Some(prev) = previous {
             let hash = StorableEmailRecoveryAddressHash::of(prev);
             self.lookup_anchor_with_email_recovery_memory.remove(&hash);
@@ -991,6 +1012,7 @@ impl<M: Memory + Clone> Storage<M> {
             self.lookup_anchor_with_email_recovery_memory
                 .insert(hash, anchor_number);
         }
+        Ok(())
     }
 
     fn sync_anchor_with_passkey_pubkey_index(
@@ -2149,6 +2171,13 @@ pub enum StorageError {
         application_number: ApplicationNumber,
     },
     ErrorUpdatingAccountCounter,
+    /// Tried to bind a recovery email that's already on a different
+    /// anchor. The "one anchor per address" invariant from design
+    /// §8.2 is enforced at the storage layer; the caller surfaces
+    /// `EmailRecoveryError::AddressAlreadyRegistered`.
+    EmailRecoveryAddressAlreadyBound {
+        existing_anchor: AnchorNumber,
+    },
 }
 
 impl fmt::Display for StorageError {
@@ -2204,6 +2233,10 @@ impl fmt::Display for StorageError {
                 "Origin not found for application number {application_number}",
             ),
             Self::ErrorUpdatingAccountCounter => write!(f, "Error updating account counter"),
+            Self::EmailRecoveryAddressAlreadyBound { existing_anchor } => write!(
+                f,
+                "recovery email is already bound to a different anchor ({existing_anchor})",
+            ),
         }
     }
 }

--- a/src/internet_identity/src/storage/storable.rs
+++ b/src/internet_identity/src/storage/storable.rs
@@ -11,6 +11,7 @@ pub mod application;
 pub mod application_number;
 pub mod credential_id;
 pub mod discrepancy_counter;
+pub mod email_recovery_address_hash;
 pub mod email_recovery_credential;
 pub mod fixed_anchor;
 pub mod metadata_v2;

--- a/src/internet_identity/src/storage/storable/email_recovery_address_hash.rs
+++ b/src/internet_identity/src/storage/storable/email_recovery_address_hash.rs
@@ -1,0 +1,79 @@
+//! Stable-map key for the `address → AnchorNumber` reverse index used
+//! by the email-recovery flow.
+//!
+//! See `docs/ongoing/email-recovery.md` §8.2: we hash the address
+//! before storing it as a key, both to keep entry size fixed (32
+//! bytes) regardless of the underlying address length, and because
+//! the address itself already lives on the anchor — there is no
+//! reason to store it again in the index. Lookup recomputes the hash
+//! from the verified `From:` of the inbound email.
+
+use ic_stable_structures::{storable::Bound, Storable};
+use std::borrow::Cow;
+
+/// SHA-256 of the lowercased canonical address.
+///
+/// Always produced via [`StorableEmailRecoveryAddressHash::of`] —
+/// don't construct directly with raw bytes from outside the module so
+/// the "address must be lowercased before hashing" invariant stays
+/// inside one place.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct StorableEmailRecoveryAddressHash([u8; 32]);
+
+impl StorableEmailRecoveryAddressHash {
+    /// Hash the lowercased canonical form of `address`. Callers that
+    /// have already normalised the address can rely on the
+    /// `to_ascii_lowercase` here as a no-op for ASCII (which is the
+    /// only form we accept — IDN inputs are rejected at the Candid
+    /// boundary; see `email_recovery::prepare`).
+    pub fn of(address: &str) -> Self {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(address.to_ascii_lowercase().as_bytes());
+        Self(hasher.finalize().into())
+    }
+}
+
+impl Storable for StorableEmailRecoveryAddressHash {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(&self.0)
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&bytes);
+        Self(out)
+    }
+
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 32,
+        is_fixed_size: true,
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lowercases_before_hashing() {
+        let lower = StorableEmailRecoveryAddressHash::of("alice@example.com");
+        let mixed = StorableEmailRecoveryAddressHash::of("Alice@Example.COM");
+        assert_eq!(lower, mixed);
+    }
+
+    #[test]
+    fn distinct_addresses_distinct_hashes() {
+        let a = StorableEmailRecoveryAddressHash::of("alice@example.com");
+        let b = StorableEmailRecoveryAddressHash::of("bob@example.com");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn round_trip_storable() {
+        let original = StorableEmailRecoveryAddressHash::of("alice@example.com");
+        let bytes = original.to_bytes();
+        let parsed = StorableEmailRecoveryAddressHash::from_bytes(bytes);
+        assert_eq!(original, parsed);
+    }
+}

--- a/src/internet_identity/src/storage/storable/email_recovery_address_hash.rs
+++ b/src/internet_identity/src/storage/storable/email_recovery_address_hash.rs
@@ -8,6 +8,7 @@
 //! reason to store it again in the index. Lookup recomputes the hash
 //! from the verified `From:` of the inbound email.
 
+use crate::utils::slice_to_bounded_32;
 use ic_stable_structures::{storable::Bound, Storable};
 use std::borrow::Cow;
 
@@ -40,9 +41,12 @@ impl Storable for StorableEmailRecoveryAddressHash {
     }
 
     fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
-        let mut out = [0u8; 32];
-        out.copy_from_slice(&bytes);
-        Self(out)
+        // `BOUND` says 32 bytes fixed-size, so this should always be
+        // exactly 32 bytes. Use the same defensive helper as
+        // `StorableApplication`'s hash key — copy up to 32, zero-pad
+        // any short input — so corrupted stable memory never makes
+        // the canister trap mid-call.
+        Self(slice_to_bounded_32(bytes.as_ref()))
     }
 
     const BOUND: Bound = Bound::Bounded {

--- a/src/internet_identity/tests/integration/email_recovery.rs
+++ b/src/internet_identity/tests/integration/email_recovery.rs
@@ -659,7 +659,8 @@ fn full_setup_flow_via_dnssec_path() {
         canister_id,
         internet_identity_interface::internet_identity::types::email_recovery::EmailRecoverySubmitDkimLeafArg {
             nonce: challenge.nonce.clone(),
-            dkim_leaf: chain.dkim_leaf.clone(),
+            hops: vec![chain.dkim_leaf.clone()],
+            extra_chains: vec![],
         },
     )
     .expect("submit_dkim_leaf call failed")

--- a/src/internet_identity_interface/src/archive/types.rs
+++ b/src/internet_identity_interface/src/archive/types.rs
@@ -39,6 +39,17 @@ pub enum Operation {
     #[serde(rename = "register_anchor_with_openid_credential")]
     RegisterAnchorWithOpenIdCredential { iss: String },
 
+    // Email-recovery credentials. We deliberately carry no payload —
+    // emitting the address (or even just its domain) would let an
+    // archive consumer correlate anchors back to mailbox providers.
+    // The audit log already includes the anchor + timestamp, which
+    // is enough to answer "who changed their recovery email when?"
+    // without leaking the address itself.
+    #[serde(rename = "add_email_recovery")]
+    AddEmailRecovery,
+    #[serde(rename = "remove_email_recovery")]
+    RemoveEmailRecovery,
+
     // Identity name, set for new users in new discoverable passkeys flow
     #[serde(rename = "add_name")]
     AddName,

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -426,6 +426,11 @@ pub struct OidcConfig {
 pub enum AuthorizationKey {
     DeviceKey(DeviceKey),
     OpenIdCredentialKey((OpenIdCredentialKey, Option<ConfigIss>)),
+    /// The caller authenticated via an email-recovery delegation.
+    /// Carries the lowercased canonical address whose binding on the
+    /// anchor produced the matching principal — `activity_bookkeeping`
+    /// uses it to bump `last_used` on the credential.
+    EmailRecoveryAddress(String),
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -85,6 +85,10 @@ pub struct IdentityInfo {
     pub metadata: HashMap<String, MetadataEntryV2>,
     pub name: Option<String>,
     pub created_at: Option<Timestamp>,
+    /// The email-recovery credential bound to this anchor, if any.
+    /// Lets the FE render the recovery-email card's active vs. inactive
+    /// state without a separate query.
+    pub email_recovery: Option<crate::internet_identity::types::EmailRecoveryCredential>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/internet_identity_interface/src/internet_identity/types/email_recovery.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/email_recovery.rs
@@ -37,7 +37,9 @@
 //!    verification finishes inside that one call — no `submit_leaf`
 //!    follow-up needed.
 
-use crate::internet_identity::types::{DnsProofBundle, SignedRRset, Timestamp, UserKey};
+use crate::internet_identity::types::{
+    AnchorNumber, DnsProofBundle, SignedRRset, Timestamp, UserKey,
+};
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
 use serde_bytes::ByteBuf;
@@ -256,10 +258,14 @@ pub enum EmailRecoveryStatus {
     RegistrationSucceeded,
     /// Recovery succeeded. The FE follows up with
     /// `email_recovery_get_delegation(nonce, session_key, expiration)`
-    /// to retrieve the actual `SignedDelegation`.
+    /// to retrieve the actual `SignedDelegation`. The `anchor_number`
+    /// is included so the FE can seed its auth store without making a
+    /// separate lookup call — the canister already resolved it from
+    /// the verified `From:` at submit-leaf time.
     RecoveryReady {
         user_key: UserKey,
         expiration: Timestamp,
+        anchor_number: AnchorNumber,
     },
     /// Verification failed. The FE shows the granular reason and
     /// offers a retry.

--- a/src/internet_identity_interface/src/internet_identity/types/email_recovery.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/email_recovery.rs
@@ -38,7 +38,7 @@
 //!    follow-up needed.
 
 use crate::internet_identity::types::{
-    AnchorNumber, DnsProofBundle, SignedRRset, Timestamp, UserKey,
+    AnchorNumber, DelegationChain, DnsProofBundle, SignedRRset, Timestamp, UserKey,
 };
 use candid::{CandidType, Deserialize};
 use serde::Serialize;
@@ -155,16 +155,39 @@ pub struct EmailRecoveryDnsInput {
 }
 
 /// What the FE submits at `email_recovery_submit_dkim_leaf` —
-/// the DKIM leaf RRset for the selector embedded in the
-/// just-arrived email's DKIM-Signature header.
+/// the signed DKIM resolution chain `<selector>._domainkey.<d>`
+/// → … → final TXT, plus any *additional* delegation chains for
+/// signed zones the resolution crosses into.
 ///
-/// The canister already cached the validated zone DNSKEY at prepare
-/// time and the partial-verification record (the signed-headers
-/// digest and the signature blob) at email-arrival time. This call
-/// admits the leaf against the cached DNSKEY, parses the DKIM TXT
-/// to recover the public key, and finishes the signature check
-/// using the cached digest and signature. See design doc §8.4 /
-/// §8.5.
+/// Operational shape per provider category (see design doc §7.6):
+///
+/// - **Same-zone direct TXT** (Gmail, iCloud, most ESPs configured
+///   directly): `hops = [TXT]`, `extra_chains = []`. The apex zone
+///   was already chained at prepare time.
+/// - **Cross-zone CNAME** (Proton: `proton.me` → `proton.ch`,
+///   Tutanota: `tutanota.com` → `tutanota.de`, M365 custom
+///   domains, …): `hops = [CNAME, …, TXT]`, `extra_chains` carries
+///   one chain per zone touched that wasn't already covered by the
+///   skeleton chain.
+///
+/// The canister already cached the root DNSKEY + apex zone DNSKEY at
+/// prepare time, and the partial-verification record (the signed-
+/// headers digest and the signature blob) at email-arrival time.
+/// This call:
+///
+/// 1. Validates each `extra_chains` entry under the cached root
+///    DNSKEY and merges the resulting `(zone → DNSKEY)` entries
+///    into the cached map.
+/// 2. Verifies each hop under the zone its RRSIG names
+///    (`rrsig.signer_name`).
+/// 3. Walks the hop sequence: `hops[0].name` must equal
+///    `<selector>._domainkey.<registered_domain>`, each
+///    intermediate hop must be a CNAME whose target equals the next
+///    hop's owner, the final hop must be the TXT we want.
+/// 4. Parses the final TXT for the DKIM public key and finishes the
+///    signature check against the cached digest + signature blob.
+///
+/// See design doc §8.4 / §8.5.
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct EmailRecoverySubmitDkimLeafArg {
     /// The challenge nonce from `email_recovery_credential_prepare_add`
@@ -172,14 +195,18 @@ pub struct EmailRecoverySubmitDkimLeafArg {
     /// flows share the same submit-leaf surface — the canister
     /// dispatches by the pending entry's `kind`.
     pub nonce: String,
-    /// The DKIM TXT leaf at `<selector>._domainkey.<registered_domain>`,
-    /// signed under the same zone the skeleton chain anchored at
-    /// prepare time. The canister rejects with `DkimLeafMismatch`
-    /// if the leaf's owner name doesn't end at the registered
-    /// domain or if the selector doesn't match the
-    /// `NeedDkimLeaf { selector }` status set when the email
-    /// arrived.
-    pub dkim_leaf: SignedRRset,
+    /// The DKIM resolution chain in CNAME order, ending in a TXT.
+    /// At least one hop required; bounded by
+    /// `MAX_CNAME_HOPS = 4` at the canister side. For the Gmail-
+    /// style direct-TXT case this is a single-element vec.
+    pub hops: Vec<SignedRRset>,
+    /// Delegation chains for signed zones touched by `hops` that
+    /// weren't already covered by the skeleton chain anchored at
+    /// prepare time. Empty for same-zone resolution. Each chain
+    /// must anchor at the same root DNSKEY the prepare bundle did
+    /// (verified internally by re-validating against the cached
+    /// root DNSKEY RRset).
+    pub extra_chains: Vec<DelegationChain>,
 }
 
 /// Errors surfaced by every email-recovery flow method.


### PR DESCRIPTION
## Summary
Recovery flow on top of the two-phase DNSSEC architecture. Stacked on #3842 (setup flow).

- `email_recovery_prepare_delegation(dns_input, session_pk)` — anonymous. Same as setup-prepare plus a FE-generated session public key that the eventual delegation will be bound to.
- `email_recovery_get_delegation(nonce, session_key, expiration)` — query. After `RecoveryReady`, the FE fetches the `SignedDelegation`.
- Reverse `address → AnchorNumber` stable index (memory ID 24) for resolving the verified `From:` to an anchor at recovery time.
- `RecoveryReady` status variant carries `anchor_number` so the FE seeds its auth store directly.
- Recovery delegation principals recognised by `check_authorization` via a new `AuthorizationKey::EmailRecoveryAddress` variant.

## PR Stack
| # | PR | Description | Status |
|---|---|---|---|
| 0 | [#3836](https://github.com/dfinity/internet-identity/pull/3836) | Design doc | Open |
| 1 | [#3838](https://github.com/dfinity/internet-identity/pull/3838) | DNSSEC verifier scaffold | Open |
| 2 | [#3839](https://github.com/dfinity/internet-identity/pull/3839) | DKIM verifier (RFC 6376) | Open |
| 3 | [#3840](https://github.com/dfinity/internet-identity/pull/3840) | DMARC alignment (RFC 7489) | Open |
| 4 | [#3841](https://github.com/dfinity/internet-identity/pull/3841) | DoH fallback | Open |
| 5+6 | [#3842](https://github.com/dfinity/internet-identity/pull/3842) | Setup flow (storage + smtp_request) | Open |
| **7** | **this PR** | **Recovery flow (delegation)** | Open |
| 8 | [#3844](https://github.com/dfinity/internet-identity/pull/3844) | Frontend + feature flag | Open |
| 9 | [#3855](https://github.com/dfinity/internet-identity/pull/3855) | Deploy/upgrade scripts: dnssec_config + doh_config | Open |
| 10 | [#3857](https://github.com/dfinity/internet-identity/pull/3857) | Email-recovery UX overhaul | Open |

## Changes during review

- `RecoveryReady` gained an `anchor_number` field. The recovery flow already knows the anchor at smtp time (address → anchor reverse index) — surfacing it on the status payload lets the FE seed its auth store directly instead of running a recovery-phrase-keyed lookup against an email-recovery delegation. (See PR #3844's discussion.)
- `bind_credential_to_anchor` now refuses cross-anchor rebinds (`EmailRecoveryError::AddressAlreadyRegistered`); same-anchor rebinds remain idempotent.
- Recovery delegation principals are now recognised by `check_authorization`: `AuthorizationKey` gains an `EmailRecoveryAddress(String)` variant and the authz check derives the canister-sig principal from `H(salt || "email-recovery" || lowercase(address) || anchor)` for each bound credential. `activity_bookkeeping` updates `last_used` on the matched credential, and the daily/monthly stats counter gets an `email_recovery_counter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)