### PR TITLE
feat(deploy): wire dnssec_config + doh_config into beta + prod install args

### DIFF
--- a/scripts/default-doh-domains.bash
+++ b/scripts/default-doh-domains.bash
@@ -9,25 +9,40 @@
 # which take a comma-separated list and accept the empty string
 # as "disable DoH entirely (DNSSEC-only)".
 #
-# What's on the list: major consumer mailbox providers that *don't*
-# publish DNSSEC. Domains that DO publish DS records (Proton, GMX,
-# Tutanota, mail.com, live.com, …) are deliberately excluded —
-# the FE walks DNSSEC for them natively, and putting them on this
-# list would let an unsigned-zone misconfiguration silently
-# downgrade them to the canister's DoH path.
+# What's on the list: major consumer mailbox providers whose DKIM
+# resolution can't be authenticated end-to-end via DNSSEC. The
+# audit criterion is *not* "does the apex publish DS" — what
+# matters is whether the DKIM CNAME chain stays in signed
+# territory. A domain whose apex is signed but whose DKIM TXT
+# lives behind a CNAME in an unsigned zone (live.com → unsigned
+# protection.outlook.com) belongs on this list anyway, because
+# the canister's DNSSEC verifier can't validate the resolution.
 #
-# Audited 2026-05 with `dig +short DS <domain>` cross-checked
-# against both Google (8.8.8.8) and Cloudflare (1.1.1.1)
-# resolvers. Re-run the audit when adding entries.
+# Domains explicitly *excluded* (DNSSEC works end-to-end):
+# - protonmail.com, pm.me — DKIM TXT lives in the same signed zone.
+# - proton.me — DKIM CNAMEs into proton.ch (different signed zone).
+# - tutanota.com / tuta.com / tuta.io — DKIM CNAMEs into tutanota.de
+#   (different signed zone).
+# The DNSSEC verifier handles the cross-zone CNAME case via
+# multi-zone bundles (see docs/ongoing/email-recovery.md §7.2).
+# Putting these on the DoH list would silently downgrade them.
+#
+# Audit procedure: resolve `<active-selector>._domainkey.<domain>`
+# end-to-end via a DNSSEC-validating resolver and check the AD bit
+# on the response. AD=1 → DNSSEC works; AD=0 → add to this list.
+# Re-run the audit when adding entries.
 
 readonly DEFAULT_DOH_ALLOWED_DOMAINS=(
     # Google
     gmail.com
     googlemail.com
-    # Microsoft (note: live.com IS DNSSEC-signed and is omitted here)
+    # Microsoft (live.com: apex is signed but DKIM CNAMEs into
+    #  unsigned protection.outlook.com, so the DNSSEC chain breaks
+    #  end-to-end — DoH path is the only workable verification).
     outlook.com
     hotmail.com
     msn.com
+    live.com
     # Apple
     icloud.com
     me.com

--- a/scripts/default-doh-domains.bash
+++ b/scripts/default-doh-domains.bash
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Default DoH allowlist for the email-recovery flow.
+#
+# Single source of truth — sourced by both `deploy-common.bash`
+# (used by `deploy-pr-to-beta` + `deploy-local-to-beta`) and by
+# `make-upgrade-proposal` (production). Don't redefine this list
+# anywhere else; if you need to override, use the deploy script's
+# `--doh-domains` flag or the `II_DOH_DOMAINS` env var, both of
+# which take a comma-separated list and accept the empty string
+# as "disable DoH entirely (DNSSEC-only)".
+#
+# What's on the list: major consumer mailbox providers that *don't*
+# publish DNSSEC. Domains that DO publish DS records (Proton, GMX,
+# Tutanota, mail.com, live.com, …) are deliberately excluded —
+# the FE walks DNSSEC for them natively, and putting them on this
+# list would let an unsigned-zone misconfiguration silently
+# downgrade them to the canister's DoH path.
+#
+# Audited 2026-05 with `dig +short DS <domain>` cross-checked
+# against both Google (8.8.8.8) and Cloudflare (1.1.1.1)
+# resolvers. Re-run the audit when adding entries.
+
+readonly DEFAULT_DOH_ALLOWED_DOMAINS=(
+    # Google
+    gmail.com
+    googlemail.com
+    # Microsoft (note: live.com IS DNSSEC-signed and is omitted here)
+    outlook.com
+    hotmail.com
+    msn.com
+    # Apple
+    icloud.com
+    me.com
+    mac.com
+    # Yahoo / Verizon Media
+    yahoo.com
+    ymail.com
+    aol.com
+    # Other Western providers
+    zoho.com
+    fastmail.com
+    fastmail.fm
+    hey.com
+    # Yandex / Mail.ru (Russia)
+    yandex.com
+    yandex.ru
+    mail.ru
+    # Asia
+    qq.com
+    163.com
+    126.com
+    naver.com
+    daum.net
+)

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -30,23 +30,48 @@ readonly IC_NETWORK="ic"
 
 # Default DoH allowlist for the email-recovery flow. Domains here can
 # bind/recover via the DoH-fallback path even when they don't publish
-# DNSSEC. The list covers the major consumer mailbox providers we
-# expect to support on beta — adding a domain is operator config, not
-# code. Override by passing --doh-domains <comma-list> to the deploy
-# script. Empty allowlist disables the DoH path entirely (DNSSEC-only).
+# DNSSEC. The list is curated from the major consumer mailbox
+# providers that *don't* publish DS records — those that do (Proton,
+# GMX, Tutanota, mail.com, live.com, …) are deliberately excluded
+# because the FE walks DNSSEC for them natively, and putting them on
+# this list would let an unsigned-zone misconfiguration silently
+# downgrade them to the DoH path. Audited 2026-05; every entry below
+# returns an empty `dig +short DS <domain>`.
+#
+# Adding a domain is operator config, not code. Override by passing
+# --doh-domains <comma-list> to the deploy script; empty list
+# disables the DoH path entirely (DNSSEC-only).
 readonly DEFAULT_DOH_ALLOWED_DOMAINS=(
+    # Google
     gmail.com
     googlemail.com
+    # Microsoft (note: live.com IS DNSSEC-signed and is omitted here)
     outlook.com
     hotmail.com
-    live.com
+    msn.com
+    # Apple
     icloud.com
     me.com
     mac.com
+    # Yahoo / Verizon Media
     yahoo.com
-    protonmail.com
-    proton.me
-    pm.me
+    ymail.com
+    aol.com
+    # Other Western providers
+    zoho.com
+    fastmail.com
+    fastmail.fm
+    hey.com
+    # Yandex / Mail.ru (Russia)
+    yandex.com
+    yandex.ru
+    mail.ru
+    # Asia
+    qq.com
+    163.com
+    126.com
+    naver.com
+    daum.net
 )
 
 # Source the IANA fetcher so build_be_install_arg can reach it.

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -28,6 +28,31 @@
 readonly WALLET_CANISTER_ID="cvthj-wyaaa-aaaad-aaaaq-cai"
 readonly IC_NETWORK="ic"
 
+# Default DoH allowlist for the email-recovery flow. Domains here can
+# bind/recover via the DoH-fallback path even when they don't publish
+# DNSSEC. The list covers the major consumer mailbox providers we
+# expect to support on beta — adding a domain is operator config, not
+# code. Override by passing --doh-domains <comma-list> to the deploy
+# script. Empty allowlist disables the DoH path entirely (DNSSEC-only).
+readonly DEFAULT_DOH_ALLOWED_DOMAINS=(
+    gmail.com
+    googlemail.com
+    outlook.com
+    hotmail.com
+    live.com
+    icloud.com
+    me.com
+    mac.com
+    yahoo.com
+    protonmail.com
+    proton.me
+    pm.me
+)
+
+# Source the IANA fetcher so build_be_install_arg can reach it.
+# shellcheck source=fetch-iana-root-anchors.bash
+source "$(dirname "${BASH_SOURCE[0]}")/fetch-iana-root-anchors.bash"
+
 # -------------------------
 # Staging environments
 # -------------------------
@@ -125,6 +150,13 @@ Common options:
   -be                       Shortcut for --end back
   --dry-run                 Print icp canister install commands instead of running them
   --no-checks               Skip reachability and consistency checks
+  --skip-email-recovery-init
+                            Leave dnssec_config and doh_config as opt null on
+                            this upgrade (preserve previous on-chain values).
+                            Default: fetch fresh IANA root anchors + use the
+                            built-in DoH allowlist.
+  --doh-domains <a,b,...>   Override the default DoH allowlist. Empty disables
+                            the DoH path (DNSSEC-only).
   -h, --help                Show this help
 EOF
 }
@@ -143,6 +175,8 @@ parse_common_args() {
     REBUILD_BE=false
     DRY_RUN=false
     NO_CHECKS=false
+    UPDATE_EMAIL_RECOVERY_INIT=true
+    DOH_DOMAINS_ARG=""
     REMAINING_ARGS=()
 
     while [[ $# -gt 0 ]]; do
@@ -233,6 +267,24 @@ parse_common_args() {
                 ;;
             --no-checks)
                 NO_CHECKS=true
+                shift
+                ;;
+            --skip-email-recovery-init)
+                # Don't fetch IANA anchors / set DoH allowlist on this
+                # upgrade. The fields stay `opt null` in the install
+                # arg, which the canister interprets as "preserve the
+                # previous value". Use this on subsequent upgrades
+                # once the values are already on chain.
+                UPDATE_EMAIL_RECOVERY_INIT=false
+                shift
+                ;;
+            --doh-domains)
+                shift
+                if [ $# -eq 0 ]; then
+                    echo "Error: --doh-domains requires a comma-separated list" >&2
+                    return 1
+                fi
+                DOH_DOMAINS_ARG="$1"
                 shift
                 ;;
             --)
@@ -525,18 +577,75 @@ EOF
 # Build the BE install arg. The BE init type is `opt InternetIdentityInit`
 # where every field is itself `opt` and "absent" = preserve previous value,
 # so we only set the fields that follow from the shared quad (BE_ID, BE_URL,
-# FE_URL). Everything else stays untouched on upgrade.
+# FE_URL) plus — when `UPDATE_EMAIL_RECOVERY_INIT` is true — the
+# `dnssec_config` and `doh_config` knobs the email-recovery flow needs.
+# Everything else stays untouched on upgrade.
 #
 # Output: Candid text on stdout.
 build_be_install_arg() {
+    local extra=""
+    if [ "$UPDATE_EMAIL_RECOVERY_INIT" = true ]; then
+        # IANA root anchors — fetched + reviewed live. Each call hits
+        # data.iana.org, so we cache the result for the lifetime of the
+        # script run by stashing it on the first call.
+        if [ -z "${_BE_DNSSEC_CONFIG_CANDID:-}" ]; then
+            local anchors_vec
+            anchors_vec="$(fetch_and_review_iana_root_anchors)" || return 1
+            _BE_DNSSEC_CONFIG_CANDID="opt opt record { root_anchors = $anchors_vec }"
+        fi
+        # DoH allowlist — operator config (the user can override via
+        # --doh-domains; empty disables the DoH path entirely).
+        local doh_record
+        doh_record="$(_be_doh_config_candid)"
+        extra=$(cat <<EXTRA
+    dnssec_config = $_BE_DNSSEC_CONFIG_CANDID;
+    doh_config = $doh_record;
+EXTRA
+)
+    fi
+
     cat <<EOF
 (
   opt record {
     backend_canister_id = opt principal "$BE_ID";
     backend_origin = opt "$BE_URL";
     related_origins = opt vec { "$FE_URL" };
+$extra
   }
 )
+EOF
+}
+
+# Internal: render the DoH allowlist as Candid `opt opt DohConfig`.
+# Reads either DOH_DOMAINS_ARG (when --doh-domains was passed) or
+# the static DEFAULT_DOH_ALLOWED_DOMAINS list. An empty list still
+# emits the record (with `allowed_domains = vec {}`), which the
+# canister treats as "no domain may use the DoH path".
+_be_doh_config_candid() {
+    local -a domains
+    if [ -n "$DOH_DOMAINS_ARG" ]; then
+        # Comma-separated list → array. Trim whitespace per element.
+        IFS=',' read -ra domains <<< "$DOH_DOMAINS_ARG"
+        local i
+        for i in "${!domains[@]}"; do
+            domains[i]="${domains[i]## }"
+            domains[i]="${domains[i]%% }"
+        done
+    else
+        domains=("${DEFAULT_DOH_ALLOWED_DOMAINS[@]}")
+    fi
+
+    local list=""
+    local d
+    for d in "${domains[@]}"; do
+        if [ -z "$d" ]; then continue; fi
+        list+="\"$d\"; "
+    done
+    cat <<EOF
+opt opt record {
+      allowed_domains = vec { $list};
+      max_cache_age_secs = opt (3600 : nat64);
+    }
 EOF
 }
 

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -150,13 +150,15 @@ Common options:
   -be                       Shortcut for --end back
   --dry-run                 Print icp canister install commands instead of running them
   --no-checks               Skip reachability and consistency checks
-  --skip-email-recovery-init
-                            Leave dnssec_config and doh_config as opt null on
-                            this upgrade (preserve previous on-chain values).
-                            Default: fetch fresh IANA root anchors + use the
-                            built-in DoH allowlist.
-  --doh-domains <a,b,...>   Override the default DoH allowlist. Empty disables
-                            the DoH path (DNSSEC-only).
+  --update-email-recovery-init
+                            Fetch fresh IANA root anchors + set the curated
+                            DoH allowlist on this upgrade. Without this flag
+                            both fields stay opt null (i.e. preserve previous
+                            on-chain values), which is what most upgrades
+                            want once the canister has been initialized once.
+  --doh-domains <a,b,...>   Override the default DoH allowlist (only used
+                            with --update-email-recovery-init). Empty
+                            disables the DoH path (DNSSEC-only).
   -h, --help                Show this help
 EOF
 }
@@ -175,7 +177,7 @@ parse_common_args() {
     REBUILD_BE=false
     DRY_RUN=false
     NO_CHECKS=false
-    UPDATE_EMAIL_RECOVERY_INIT=true
+    UPDATE_EMAIL_RECOVERY_INIT=false
     DOH_DOMAINS_ARG=""
     REMAINING_ARGS=()
 
@@ -269,13 +271,13 @@ parse_common_args() {
                 NO_CHECKS=true
                 shift
                 ;;
-            --skip-email-recovery-init)
-                # Don't fetch IANA anchors / set DoH allowlist on this
-                # upgrade. The fields stay `opt null` in the install
-                # arg, which the canister interprets as "preserve the
-                # previous value". Use this on subsequent upgrades
-                # once the values are already on chain.
-                UPDATE_EMAIL_RECOVERY_INIT=false
+            --update-email-recovery-init)
+                # Opt in to fetching IANA anchors + setting the DoH
+                # allowlist on this upgrade. Without this flag both
+                # fields stay `opt null` (preserve previous on-chain
+                # value), which is what most upgrades want once the
+                # canister has been initialized once.
+                UPDATE_EMAIL_RECOVERY_INIT=true
                 shift
                 ;;
             --doh-domains)

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -179,6 +179,10 @@ parse_common_args() {
     NO_CHECKS=false
     UPDATE_EMAIL_RECOVERY_INIT=false
     DOH_DOMAINS_ARG=""
+    # Distinguishes "--doh-domains was not passed" (use the curated
+    # default) from "--doh-domains '' was passed" (operator wants the
+    # empty list to disable the DoH path entirely).
+    DOH_DOMAINS_ARG_SET=false
     REMAINING_ARGS=()
 
     while [[ $# -gt 0 ]]; do
@@ -283,10 +287,11 @@ parse_common_args() {
             --doh-domains)
                 shift
                 if [ $# -eq 0 ]; then
-                    echo "Error: --doh-domains requires a comma-separated list" >&2
+                    echo "Error: --doh-domains requires a comma-separated list (use '' to disable DoH)" >&2
                     return 1
                 fi
                 DOH_DOMAINS_ARG="$1"
+                DOH_DOMAINS_ARG_SET=true
                 shift
                 ;;
             --)
@@ -619,14 +624,17 @@ EOF
 }
 
 # Internal: render the DoH allowlist as Candid `opt opt DohConfig`.
-# Reads either DOH_DOMAINS_ARG (when --doh-domains was passed) or
-# the static DEFAULT_DOH_ALLOWED_DOMAINS list. An empty list still
-# emits the record (with `allowed_domains = vec {}`), which the
-# canister treats as "no domain may use the DoH path".
+# - `--doh-domains` not passed → use DEFAULT_DOH_ALLOWED_DOMAINS.
+# - `--doh-domains foo,bar` → that list.
+# - `--doh-domains ''` → empty list, which the canister treats as
+#   "no domain may use the DoH path" (DNSSEC-only).
 _be_doh_config_candid() {
     local -a domains
-    if [ -n "$DOH_DOMAINS_ARG" ]; then
+    if [ "$DOH_DOMAINS_ARG_SET" = true ]; then
         # Comma-separated list → array. Trim whitespace per element.
+        # An empty string yields a single empty element, which we drop
+        # in the rendering loop below — so `--doh-domains ''` emits
+        # `allowed_domains = vec { };`.
         IFS=',' read -ra domains <<< "$DOH_DOMAINS_ARG"
         local i
         for i in "${!domains[@]}"; do

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -28,51 +28,13 @@
 readonly WALLET_CANISTER_ID="cvthj-wyaaa-aaaad-aaaaq-cai"
 readonly IC_NETWORK="ic"
 
-# Default DoH allowlist for the email-recovery flow. Domains here can
-# bind/recover via the DoH-fallback path even when they don't publish
-# DNSSEC. The list is curated from the major consumer mailbox
-# providers that *don't* publish DS records — those that do (Proton,
-# GMX, Tutanota, mail.com, live.com, …) are deliberately excluded
-# because the FE walks DNSSEC for them natively, and putting them on
-# this list would let an unsigned-zone misconfiguration silently
-# downgrade them to the DoH path. Audited 2026-05; every entry below
-# returns an empty `dig +short DS <domain>`.
-#
-# Adding a domain is operator config, not code. Override by passing
-# --doh-domains <comma-list> to the deploy script; empty list
+# Default DoH allowlist for the email-recovery flow — single source
+# of truth in `default-doh-domains.bash`, shared with
+# `make-upgrade-proposal`. See that file for the audit notes.
+# Override per-deploy via `--doh-domains <comma-list>`; empty list
 # disables the DoH path entirely (DNSSEC-only).
-readonly DEFAULT_DOH_ALLOWED_DOMAINS=(
-    # Google
-    gmail.com
-    googlemail.com
-    # Microsoft (note: live.com IS DNSSEC-signed and is omitted here)
-    outlook.com
-    hotmail.com
-    msn.com
-    # Apple
-    icloud.com
-    me.com
-    mac.com
-    # Yahoo / Verizon Media
-    yahoo.com
-    ymail.com
-    aol.com
-    # Other Western providers
-    zoho.com
-    fastmail.com
-    fastmail.fm
-    hey.com
-    # Yandex / Mail.ru (Russia)
-    yandex.com
-    yandex.ru
-    mail.ru
-    # Asia
-    qq.com
-    163.com
-    126.com
-    naver.com
-    daum.net
-)
+# shellcheck source=default-doh-domains.bash
+source "$(dirname "${BASH_SOURCE[0]}")/default-doh-domains.bash"
 
 # Source the IANA fetcher so build_be_install_arg can reach it.
 # shellcheck source=fetch-iana-root-anchors.bash

--- a/scripts/fetch-iana-root-anchors.bash
+++ b/scripts/fetch-iana-root-anchors.bash
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Fetch the IANA DNSSEC root trust anchors and emit them as Candid
+# `vec DnssecRootAnchor` text suitable for the II install-arg
+# `dnssec_config.root_anchors` field.
+#
+# Why we need a "trusted" anchor inside an init arg:
+#
+#   The canister-side DNSSEC verifier (PR #3838) takes a `DnsProofBundle`
+#   from the FE and validates its `root_dnskey` against a configured
+#   set of `DnssecRootAnchor` records — algo, digest_type, key_tag,
+#   digest. Those four values *are* the IANA root KSK trust anchors
+#   published at https://data.iana.org/root-anchors/root-anchors.xml.
+#   We don't bundle them into the wasm because they roll over every
+#   ~7 years; instead the deploy/upgrade arg carries them, so a
+#   key rollover is a one-line change in the next upgrade.
+#
+# This script:
+#
+#   1. `curl`s the IANA XML.
+#   2. Parses the `<KeyDigest>` entries with Node (we already depend
+#      on Node for the FE build), filtering to those whose validity
+#      window contains "now" — i.e. dropping retired KSKs (Kjqmt7v,
+#      retired 2019) and warning if a not-yet-valid one is present.
+#   3. Renders each entry as a one-line summary on stderr for human
+#      review (`--review` mode), then prints the Candid record-list
+#      to stdout.
+#
+# The Candid output shape matches `DnssecRootAnchor` in
+# `src/internet_identity_interface/src/internet_identity/types/dnssec.rs`:
+#
+#   record {
+#     key_tag : nat16;
+#     algorithm : nat8;
+#     digest_type : nat8;
+#     digest : blob;
+#   }
+#
+# Usage:
+#   source scripts/fetch-iana-root-anchors.bash
+#   anchors_candid=$(fetch_and_review_iana_root_anchors)
+#   echo "$anchors_candid"   # → "vec { record { ... }; record { ... }; }"
+#
+# The function exits non-zero (and the caller should bail) if the
+# user declines the on-screen review, the network fetch fails, or
+# parsing turns up something unexpected.
+
+readonly IANA_ROOT_ANCHORS_URL="https://data.iana.org/root-anchors/root-anchors.xml"
+
+# Internal: fetch the XML to stdout, exit non-zero on transport failure.
+_iana_fetch_xml() {
+    curl --fail --silent --show-error --location \
+         --retry 3 --connect-timeout 10 --max-time 30 \
+         "$IANA_ROOT_ANCHORS_URL"
+}
+
+# Internal: parse the XML on stdin, emit JSON `[{...}, ...]` on stdout
+# with one entry per *currently-valid* KeyDigest. Invalid (retired or
+# not-yet-valid) entries are dropped silently — the script's job is
+# to surface what the canister should trust right now.
+_iana_parse_xml_to_json() {
+    node --input-type=module -e '
+        let xml = "";
+        process.stdin.setEncoding("utf8");
+        process.stdin.on("data", (chunk) => { xml += chunk; });
+        process.stdin.on("end", () => {
+            try {
+                const now = new Date();
+                const blocks = [...xml.matchAll(/<KeyDigest\b([^>]*)>([\s\S]*?)<\/KeyDigest>/g)];
+                const out = [];
+                for (const [, attrStr, body] of blocks) {
+                    const attrs = {};
+                    for (const m of attrStr.matchAll(/(\w+)="([^"]*)"/g)) {
+                        attrs[m[1]] = m[2];
+                    }
+                    const validFrom = attrs.validFrom ? new Date(attrs.validFrom) : null;
+                    const validUntil = attrs.validUntil ? new Date(attrs.validUntil) : null;
+                    if (validFrom && validFrom > now) continue;
+                    if (validUntil && validUntil < now) continue;
+
+                    const child = (tag) => {
+                        const m = body.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+                        return m ? m[1].trim() : null;
+                    };
+                    const keyTag = child("KeyTag");
+                    const algorithm = child("Algorithm");
+                    const digestType = child("DigestType");
+                    const digest = child("Digest");
+                    if (!keyTag || !algorithm || !digestType || !digest) {
+                        process.stderr.write(`KeyDigest ${attrs.id || "(no id)"} missing required fields, skipping\n`);
+                        continue;
+                    }
+                    out.push({
+                        id: attrs.id || "",
+                        validFrom: attrs.validFrom || null,
+                        validUntil: attrs.validUntil || null,
+                        keyTag: Number(keyTag),
+                        algorithm: Number(algorithm),
+                        digestType: Number(digestType),
+                        digest: digest.replace(/\s+/g, "").toUpperCase(),
+                    });
+                }
+                if (out.length === 0) {
+                    process.stderr.write("No currently-valid KeyDigest entries found in IANA XML.\n");
+                    process.exit(1);
+                }
+                process.stdout.write(JSON.stringify(out));
+            } catch (e) {
+                process.stderr.write(`IANA XML parse failed: ${e.message}\n`);
+                process.exit(1);
+            }
+        });
+    '
+}
+
+# Internal: convert the JSON list to Candid `vec record { ... }` text.
+# Reads JSON on stdin, writes Candid on stdout.
+_iana_json_to_candid() {
+    node --input-type=module -e '
+        let json = "";
+        process.stdin.setEncoding("utf8");
+        process.stdin.on("data", (chunk) => { json += chunk; });
+        process.stdin.on("end", () => {
+            const list = JSON.parse(json);
+            const escapeBlobBytes = (hex) => {
+                // Candid blob literal: `blob "\HH\HH..."`, hex bytes
+                // escaped one byte at a time.
+                let out = "";
+                for (let i = 0; i < hex.length; i += 2) {
+                    out += "\\" + hex.slice(i, i + 2).toLowerCase();
+                }
+                return out;
+            };
+            const lines = ["vec {"];
+            for (const a of list) {
+                lines.push("  record {");
+                lines.push(`    key_tag = ${a.keyTag} : nat16;`);
+                lines.push(`    algorithm = ${a.algorithm} : nat8;`);
+                lines.push(`    digest_type = ${a.digestType} : nat8;`);
+                lines.push(`    digest = blob "${escapeBlobBytes(a.digest)}";`);
+                lines.push("  };");
+            }
+            lines.push("}");
+            process.stdout.write(lines.join("\n"));
+        });
+    '
+}
+
+# Internal: print one human-readable summary line per parsed entry to
+# stderr. Used by the --review prompt.
+_iana_pretty_print_to_stderr() {
+    node --input-type=module -e '
+        let json = "";
+        process.stdin.setEncoding("utf8");
+        process.stdin.on("data", (chunk) => { json += chunk; });
+        process.stdin.on("end", () => {
+            const list = JSON.parse(json);
+            for (const a of list) {
+                const valid =
+                    "[" + (a.validFrom || "?") +
+                    " — " + (a.validUntil || "no-expiry") + "]";
+                const digestPreview =
+                    a.digest.slice(0, 8) + "…" + a.digest.slice(-8);
+                process.stderr.write(
+                    `  ${a.id.padEnd(10)}  key_tag=${String(a.keyTag).padEnd(6)}` +
+                    `  alg=${a.algorithm}  digest_type=${a.digestType}` +
+                    `  digest=${digestPreview}  ${valid}\n`,
+                );
+            }
+        });
+    '
+}
+
+# Public: fetch + review + emit the Candid value on stdout.
+#
+# - On success: writes `vec { record { ... }; ... }` to stdout, returns 0.
+# - On user decline / fetch failure / parse failure: writes an error
+#   to stderr and returns non-zero. Caller should `exit 1`.
+#
+# Honours the existing `is_interactive` helper from deploy-common.bash
+# when sourced from there; falls back to a static check on /dev/tty
+# otherwise so this script stays usable on its own.
+fetch_and_review_iana_root_anchors() {
+    local interactive
+    if declare -f is_interactive > /dev/null; then
+        if is_interactive; then interactive=true; else interactive=false; fi
+    elif [ -r /dev/tty ] && [ -w /dev/tty ]; then
+        interactive=true
+    else
+        interactive=false
+    fi
+
+    echo "Fetching IANA DNSSEC root anchors from $IANA_ROOT_ANCHORS_URL …" >&2
+    local xml json
+    if ! xml="$(_iana_fetch_xml)"; then
+        echo "Error: could not fetch IANA root anchors XML." >&2
+        return 1
+    fi
+    if ! json="$(printf '%s' "$xml" | _iana_parse_xml_to_json)"; then
+        return 1
+    fi
+
+    echo "" >&2
+    echo "Currently-valid IANA root KSK trust anchors:" >&2
+    printf '%s' "$json" | _iana_pretty_print_to_stderr
+    echo "" >&2
+
+    # Best-effort verify that /dev/tty actually opens — `[ -r/-w
+    # /dev/tty ]` reports yes whenever the device file exists, even
+    # when the process has no controlling terminal (sandboxes,
+    # unit-tested CI runners). Try to acquire the tty as the prompt
+    # would; if that fails, treat as non-interactive regardless of
+    # what the upstream check decided.
+    if [ "$interactive" = true ] && ! { exec 3>/dev/tty; } 2>/dev/null; then
+        interactive=false
+    fi
+    if [ "$interactive" = true ]; then
+        local reply=""
+        printf '%s' "Use these anchors as dnssec_config.root_anchors? [Y/n] " >&3
+        exec 3>&-
+        IFS= read -r reply < /dev/tty || reply=""
+        case "$reply" in
+            ""|y|Y|yes|YES) ;;
+            *)
+                echo "Aborted by user." >&2
+                return 1
+                ;;
+        esac
+    else
+        echo "Non-interactive run: using fetched anchors without prompt." >&2
+    fi
+
+    printf '%s' "$json" | _iana_json_to_candid
+}

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -12,6 +12,10 @@ source "$SOURCE_DIR/frontend-arg-helpers.bash"
 # IANA root-anchor fetcher (used to fill dnssec_config in BE init args).
 # shellcheck source=fetch-iana-root-anchors.bash
 source "$SOURCE_DIR/fetch-iana-root-anchors.bash"
+# Default DoH allowlist — shared with deploy-common.bash so beta and
+# prod deploys agree on which domains use the DoH-fallback path.
+# shellcheck source=default-doh-domains.bash
+source "$SOURCE_DIR/default-doh-domains.bash"
 
 # Resolve the HTTPS remote URL for git operations that don't need SSH.
 # gh is authenticated via HTTPS, so this avoids SSH key prompts for
@@ -534,11 +538,8 @@ didc_assist_ii_init() {
 }
 
 # Default DoH allowlist for the email-recovery flow on production.
-# Mirrors `DEFAULT_DOH_ALLOWED_DOMAINS` in deploy-common.bash — keep
-# them in sync. Curated from major consumer mailbox providers that
-# *don't* publish DNSSEC; signed zones (Proton, GMX, Tutanota,
-# mail.com, live.com, …) are excluded because the FE walks DNSSEC
-# for them natively. Audited 2026-05.
+# Reads `DEFAULT_DOH_ALLOWED_DOMAINS` from `default-doh-domains.bash`
+# (sourced at the top of this script) so beta and prod always agree.
 #
 # The `II_DOH_DOMAINS` env var overrides — including with the empty
 # string, which yields `allowed_domains = vec {}` (DoH disabled,
@@ -549,7 +550,13 @@ default_doh_domains_for_prod() {
     echo "$II_DOH_DOMAINS"
     return
   fi
-  echo "gmail.com,googlemail.com,outlook.com,hotmail.com,msn.com,icloud.com,me.com,mac.com,yahoo.com,ymail.com,aol.com,zoho.com,fastmail.com,fastmail.fm,hey.com,yandex.com,yandex.ru,mail.ru,qq.com,163.com,126.com,naver.com,daum.net"
+  # Bash array → comma-separated for the patcher. printf with `,` as
+  # the separator is the simplest portable join; the trailing comma
+  # is dropped by `_be_doh_config_candid`'s per-element loop in
+  # deploy-common.bash and by `build_doh_config_candid_for_prod`'s
+  # equivalent below, which both skip empty elements.
+  local IFS=,
+  echo "${DEFAULT_DOH_ALLOWED_DOMAINS[*]}"
 }
 
 # Render the DoH allowlist as a Candid `opt opt DohConfig` value.

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -9,6 +9,9 @@ set -euo pipefail
 
 SOURCE_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "$SOURCE_DIR/frontend-arg-helpers.bash"
+# IANA root-anchor fetcher (used to fill dnssec_config in BE init args).
+# shellcheck source=fetch-iana-root-anchors.bash
+source "$SOURCE_DIR/fetch-iana-root-anchors.bash"
 
 # Resolve the HTTPS remote URL for git operations that don't need SSH.
 # gh is authenticated via HTTPS, so this avoids SSH key prompts for
@@ -423,6 +426,7 @@ prepare_staging_backend_argument() {
   if [ ! -s staging_args.txt ]; then
     echo "(null)" > staging_args.txt
   fi
+  patch_email_recovery_init_fields staging_args.txt
   didc_encode_ii_init staging_args.txt > staging_icp_arg.bin
 }
 
@@ -529,6 +533,105 @@ didc_assist_ii_init() {
   run_didc_command_for_ii_init assist | awk '/\(/ {flag=1} flag {print} /\)/ {flag=0}'
 }
 
+# Default DoH allowlist for the email-recovery flow on production.
+# Mirrors `DEFAULT_DOH_ALLOWED_DOMAINS` in deploy-common.bash. Override
+# at runtime with the `II_DOH_DOMAINS` env var (comma-separated). Empty
+# disables the DoH path entirely (DNSSEC-only).
+default_doh_domains_for_prod() {
+  if [ -n "${II_DOH_DOMAINS:-}" ]; then
+    echo "$II_DOH_DOMAINS"
+    return
+  fi
+  echo "gmail.com,googlemail.com,outlook.com,hotmail.com,live.com,icloud.com,me.com,mac.com,yahoo.com,protonmail.com,proton.me,pm.me"
+}
+
+# Render the DoH allowlist as a Candid `opt opt DohConfig` value.
+build_doh_config_candid_for_prod() {
+  local list_csv="$(default_doh_domains_for_prod)"
+  local list=""
+  local IFS=','
+  for d in $list_csv; do
+    d="${d## }"; d="${d%% }"
+    if [ -z "$d" ]; then continue; fi
+    list+="\"$d\"; "
+  done
+  cat <<EOF
+opt opt record {
+      allowed_domains = vec { $list};
+      max_cache_age_secs = opt (3600 : nat64);
+    }
+EOF
+}
+
+# After didc-assist has produced a Candid arg file, replace whatever
+# the user typed (or didn't) for `dnssec_config` and `doh_config` with
+# values fetched live from IANA + the curated DoH allowlist. This keeps
+# the rest of the didc-assist flow (each opt field can stay as null
+# = preserve, or be set explicitly) untouched while making sure these
+# two fields land with operator-controlled values rather than human-
+# typed blobs.
+#
+# Args: <args-file>  (in-place edit)
+#
+# If `II_SKIP_EMAIL_RECOVERY_INIT=1`, skip the patch entirely — useful
+# for upgrades where the on-chain values are already set and we want
+# them preserved by leaving the fields as `opt null`.
+patch_email_recovery_init_fields() {
+  local args_file="$1"
+  if [ "${II_SKIP_EMAIL_RECOVERY_INIT:-0}" = "1" ]; then
+    echo "II_SKIP_EMAIL_RECOVERY_INIT=1 — leaving dnssec_config/doh_config as didc-assist wrote them." >&2
+    return 0
+  fi
+  echo ""
+  echo "=== Filling email-recovery init args (dnssec_config + doh_config) ==="
+  echo ""
+  local anchors_vec
+  anchors_vec="$(fetch_and_review_iana_root_anchors)" || {
+    echo "Failed to fetch IANA root anchors. Set II_SKIP_EMAIL_RECOVERY_INIT=1 to skip." >&2
+    return 1
+  }
+  local doh_record="$(build_doh_config_candid_for_prod)"
+  local dnssec_record="opt opt record { root_anchors = $anchors_vec }"
+  # Patch the args file with Node — find/replace the two field
+  # values, or append them inside the record if they aren't there.
+  # didc-assist always emits the field name even when the value is
+  # null, so the find branch is the common path.
+  ARGS_FILE="$args_file" \
+  DNSSEC_RECORD="$dnssec_record" \
+  DOH_RECORD="$doh_record" \
+  node --input-type=module -e '
+    import { readFileSync, writeFileSync } from "fs";
+    const path = process.env.ARGS_FILE;
+    const dnssec = process.env.DNSSEC_RECORD;
+    const doh = process.env.DOH_RECORD;
+    let body = readFileSync(path, "utf8");
+    // Match `<field> = <value>;` where <value> can span multiple
+    // lines (didc-assist sometimes pretty-prints opt records). The
+    // match terminator is the next `;` followed by either a newline
+    // or another field name. We use a non-greedy match anchored at
+    // the next `<ident> =` boundary.
+    const replaceField = (name, replacement) => {
+        const re = new RegExp(`(\\b${name}\\s*=\\s*)(?:[\\s\\S]*?)(;\\s*(?:\\}|[a-zA-Z_]+\\s*=))`, "");
+        if (re.test(body)) {
+            body = body.replace(re, (_, head, tail) => `${head}${replacement}${tail}`);
+        } else {
+            // Append the field inside the outermost `record { ... }`
+            // before the closing brace.
+            const insert = `    ${name} = ${replacement};\n  `;
+            body = body.replace(/(record\s*\{[\s\S]*?)(\}\s*\)\s*$)/, (_, head, tail) => `${head}${insert}${tail}`);
+        }
+    };
+    if (body.trim() === "(null)") {
+        body = `(\n  opt record {\n    dnssec_config = ${dnssec};\n    doh_config = ${doh};\n  }\n)\n`;
+    } else {
+        replaceField("dnssec_config", dnssec);
+        replaceField("doh_config", doh);
+    }
+    writeFileSync(path, body);
+  '
+  echo "Patched $args_file with IANA-fetched dnssec_config + curated doh_config." >&2
+}
+
 compute_sha256sum_for_args() {
   local ARG_FILE="$1"
   didc_encode_ii_init "$ARG_FILE" | xxd -r -p | sha256sum | cut -f1 -d' '
@@ -566,6 +669,7 @@ prepare_production_backend_argument() {
   if [ ! -s args.txt ]; then
     echo "(null)" > args.txt
   fi
+  patch_email_recovery_init_fields args.txt
   didc_encode_ii_init args.txt > icp_arg.bin
   # icp-cli raw arguments are encoded differently than ic-admin's --arg values (mainnet_arg.bin).
   xxd -r -p icp_arg.bin > mainnet_arg.bin

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -534,8 +534,13 @@ didc_assist_ii_init() {
 }
 
 # Default DoH allowlist for the email-recovery flow on production.
-# Mirrors `DEFAULT_DOH_ALLOWED_DOMAINS` in deploy-common.bash. The
-# `II_DOH_DOMAINS` env var overrides — including with the empty
+# Mirrors `DEFAULT_DOH_ALLOWED_DOMAINS` in deploy-common.bash — keep
+# them in sync. Curated from major consumer mailbox providers that
+# *don't* publish DNSSEC; signed zones (Proton, GMX, Tutanota,
+# mail.com, live.com, …) are excluded because the FE walks DNSSEC
+# for them natively. Audited 2026-05.
+#
+# The `II_DOH_DOMAINS` env var overrides — including with the empty
 # string, which yields `allowed_domains = vec {}` (DoH disabled,
 # DNSSEC-only). The check looks for "is the var *set*", not "is it
 # non-empty", so the documented "empty disables" semantics work.
@@ -544,7 +549,7 @@ default_doh_domains_for_prod() {
     echo "$II_DOH_DOMAINS"
     return
   fi
-  echo "gmail.com,googlemail.com,outlook.com,hotmail.com,live.com,icloud.com,me.com,mac.com,yahoo.com,protonmail.com,proton.me,pm.me"
+  echo "gmail.com,googlemail.com,outlook.com,hotmail.com,msn.com,icloud.com,me.com,mac.com,yahoo.com,ymail.com,aol.com,zoho.com,fastmail.com,fastmail.fm,hey.com,yandex.com,yandex.ru,mail.ru,qq.com,163.com,126.com,naver.com,daum.net"
 }
 
 # Render the DoH allowlist as a Candid `opt opt DohConfig` value.

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -534,11 +534,13 @@ didc_assist_ii_init() {
 }
 
 # Default DoH allowlist for the email-recovery flow on production.
-# Mirrors `DEFAULT_DOH_ALLOWED_DOMAINS` in deploy-common.bash. Override
-# at runtime with the `II_DOH_DOMAINS` env var (comma-separated). Empty
-# disables the DoH path entirely (DNSSEC-only).
+# Mirrors `DEFAULT_DOH_ALLOWED_DOMAINS` in deploy-common.bash. The
+# `II_DOH_DOMAINS` env var overrides — including with the empty
+# string, which yields `allowed_domains = vec {}` (DoH disabled,
+# DNSSEC-only). The check looks for "is the var *set*", not "is it
+# non-empty", so the documented "empty disables" semantics work.
 default_doh_domains_for_prod() {
-  if [ -n "${II_DOH_DOMAINS:-}" ]; then
+  if [ -n "${II_DOH_DOMAINS+set}" ]; then
     echo "$II_DOH_DOMAINS"
     return
   fi

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -573,13 +573,14 @@ EOF
 #
 # Args: <args-file>  (in-place edit)
 #
-# If `II_SKIP_EMAIL_RECOVERY_INIT=1`, skip the patch entirely — useful
-# for upgrades where the on-chain values are already set and we want
-# them preserved by leaving the fields as `opt null`.
+# Opt-in: only runs when `II_UPDATE_EMAIL_RECOVERY_INIT=1`. Without
+# the env var the patch is skipped and didc-assist's output is used
+# verbatim — most upgrades want this, since the on-chain values are
+# already set after the first init and `opt null` preserves them.
 patch_email_recovery_init_fields() {
   local args_file="$1"
-  if [ "${II_SKIP_EMAIL_RECOVERY_INIT:-0}" = "1" ]; then
-    echo "II_SKIP_EMAIL_RECOVERY_INIT=1 — leaving dnssec_config/doh_config as didc-assist wrote them." >&2
+  if [ "${II_UPDATE_EMAIL_RECOVERY_INIT:-0}" != "1" ]; then
+    echo "II_UPDATE_EMAIL_RECOVERY_INIT not set — leaving dnssec_config/doh_config as didc-assist wrote them." >&2
     return 0
   fi
   echo ""
@@ -587,7 +588,7 @@ patch_email_recovery_init_fields() {
   echo ""
   local anchors_vec
   anchors_vec="$(fetch_and_review_iana_root_anchors)" || {
-    echo "Failed to fetch IANA root anchors. Set II_SKIP_EMAIL_RECOVERY_INIT=1 to skip." >&2
+    echo "Failed to fetch IANA root anchors. Unset II_UPDATE_EMAIL_RECOVERY_INIT to skip." >&2
     return 1
   }
   local doh_record="$(build_doh_config_candid_for_prod)"

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1460,6 +1460,13 @@ service : (opt InternetIdentityInit) -> {
     // 550 (mailbox unavailable) for everything else.
     smtp_request_validate : (SmtpRequest) -> (SmtpResponse) query;
 
+    // TEMPORARY (PR #3855): anonymous debug surface for tracing the
+    // email-recovery + DoH flow on staging. Remove together with the
+    // `email_recovery_debug_log` Rust module once outlook.com is
+    // confirmed working end-to-end.
+    email_recovery_debug_logs : () -> (vec text) query;
+    email_recovery_debug_clear : () -> ();
+
     // HTTP Gateway protocol
     // =====================
     http_request : (request : HttpRequest) -> (HttpResponse) query;

--- a/src/internet_identity/src/doh/mod.rs
+++ b/src/internet_identity/src/doh/mod.rs
@@ -71,15 +71,24 @@ thread_local! {
 /// absent, returns [`DohError::NotConfigured`] without touching the
 /// network.
 pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, DohError> {
+    crate::er_dbg!("doh.fetch_txt.start name={} reg={}", name, registered_domain);
     let config = match crate::state::persistent_state(|p| p.doh_config.clone()) {
         Some(c) => c,
-        None => return Err(DohError::NotConfigured),
+        None => {
+            crate::er_dbg!("doh.fetch_txt NotConfigured");
+            return Err(DohError::NotConfigured);
+        }
     };
     if !config
         .allowed_domains
         .iter()
         .any(|d| d.eq_ignore_ascii_case(registered_domain))
     {
+        crate::er_dbg!(
+            "doh.fetch_txt DomainNotAllowed reg={} list_len={}",
+            registered_domain,
+            config.allowed_domains.len()
+        );
         return Err(DohError::DomainNotAllowed);
     }
     // Defence-in-depth: the allowlist gate above only checks the
@@ -90,6 +99,11 @@ pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, D
     // outcall for it. Insist that `name` sits inside `registered_domain`
     // with a label-anchored suffix match.
     if !name_within_domain(name, registered_domain) {
+        crate::er_dbg!(
+            "doh.fetch_txt NameOutsideRegisteredDomain name={} reg={}",
+            name,
+            registered_domain
+        );
         return Err(DohError::NameOutsideRegisteredDomain {
             name: name.to_string(),
             registered_domain: registered_domain.to_string(),
@@ -103,6 +117,7 @@ pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, D
     // Build the query early so an InvalidName failure short-circuits
     // before we touch the cache or claim a Fetch token.
     let query = build_txt_query(name).map_err(|e| DohError::InvalidName(format!("{e:?}")))?;
+    crate::er_dbg!("doh.fetch_txt query_built len={}", query.len());
 
     // Cache lookup. We must release the borrow before awaiting — the
     // canister is single-threaded but futures across yields can re-
@@ -110,21 +125,57 @@ pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, D
     let now = now_secs();
     let lookup = DOH_CACHE.with(|c| c.borrow_mut().lookup(name, now));
     let token = match lookup {
-        CacheLookup::Hit(bytes) => return Ok(bytes),
-        CacheLookup::Wait(fut) => return fut.await,
-        CacheLookup::Fetch(token) => token, // First arrival; we own this fetch.
+        CacheLookup::Hit(bytes) => {
+            crate::er_dbg!("doh.fetch_txt cache_hit len={}", bytes.len());
+            return Ok(bytes);
+        }
+        CacheLookup::Wait(fut) => {
+            crate::er_dbg!("doh.fetch_txt cache_wait_for_inflight");
+            return fut.await;
+        }
+        CacheLookup::Fetch(token) => {
+            crate::er_dbg!("doh.fetch_txt cache_miss_fanning_out");
+            token
+        }
     };
 
     // Fan out to every provider in parallel, then decide.
     let outcall_results = fetch_all(&query).await;
     let outcomes: Vec<Outcome> = outcall_results
         .into_iter()
-        .map(|r| match r {
-            Ok(txt_bytes) => Outcome::Txt(txt_bytes),
-            Err(e) => Outcome::FetchError(e),
+        .enumerate()
+        .map(|(i, r)| match r {
+            Ok(txt_bytes) => {
+                let preview: String = txt_bytes
+                    .iter()
+                    .take(60)
+                    .map(|b| {
+                        if b.is_ascii_graphic() || *b == b' ' {
+                            *b as char
+                        } else {
+                            '.'
+                        }
+                    })
+                    .collect();
+                crate::er_dbg!(
+                    "doh.fetch_txt provider[{}] ok txt_len={} preview=\"{}\"",
+                    i,
+                    txt_bytes.len(),
+                    preview
+                );
+                Outcome::Txt(txt_bytes)
+            }
+            Err(e) => {
+                crate::er_dbg!("doh.fetch_txt provider[{}] err {}", i, e);
+                Outcome::FetchError(e)
+            }
         })
         .collect();
     let result = decide_quorum(&outcomes);
+    match &result {
+        Ok(b) => crate::er_dbg!("doh.fetch_txt quorum_ok len={}", b.len()),
+        Err(e) => crate::er_dbg!("doh.fetch_txt quorum_err {:?}", e),
+    }
 
     // Publish: stores on success, removes the pending entry, wakes any
     // dedup subscribers. The expires-at uses the timestamp we captured
@@ -249,13 +300,43 @@ mod prod {
                 },
             ],
         };
-        let (response,) = http_request_with_closure(request, DOH_CALL_CYCLES, transform_doh)
-            .await
-            .map_err(|(_, err)| err)?;
-        if response.status != HTTP_STATUS_OK {
-            return Err(format!("HTTP {}", response.status));
+        crate::er_dbg!("doh.outcall.start url={}", provider.url);
+        match http_request_with_closure(request, DOH_CALL_CYCLES, transform_doh).await {
+            Ok((response,)) => {
+                let preview: String = response
+                    .body
+                    .iter()
+                    .take(60)
+                    .map(|b| {
+                        if b.is_ascii_graphic() || *b == b' ' {
+                            *b as char
+                        } else {
+                            '.'
+                        }
+                    })
+                    .collect();
+                crate::er_dbg!(
+                    "doh.outcall.resp url={} status={} body_len={} preview=\"{}\"",
+                    provider.url,
+                    response.status,
+                    response.body.len(),
+                    preview
+                );
+                if response.status != HTTP_STATUS_OK {
+                    return Err(format!("HTTP {}", response.status));
+                }
+                Ok(response.body)
+            }
+            Err((rc, err)) => {
+                crate::er_dbg!(
+                    "doh.outcall.err url={} rejection={:?} err={}",
+                    provider.url,
+                    rc,
+                    err
+                );
+                Err(err)
+            }
         }
-        Ok(response.body)
     }
 
     /// Transform query for replica consensus.

--- a/src/internet_identity/src/email_recovery/prepare.rs
+++ b/src/internet_identity/src/email_recovery/prepare.rs
@@ -78,11 +78,11 @@ pub async fn prepare_delegation(
 }
 
 /// Shared input-validation + nonce-issuing core. `kind`
-/// parametrises over which flow we're starting. The challenge
-/// no longer carries a `mailbox` field — the FE pairs the user-
-/// part (`register` / `recover`) with `window.location.hostname`
-/// to render the user-facing label, and the canister accepts mail
-/// at any of the configured `related_origins` aliases (see
+/// parametrises over which flow we're starting. The challenge no
+/// longer carries a `mailbox` field — the FE pairs the user-part
+/// (`register` / `recover`) with `window.location.hostname` to
+/// render the user-facing label, and the canister accepts mail at
+/// any of the configured `related_origins` aliases (see
 /// [`super::mailbox_domains`]).
 async fn prepare_common(
     dns_input: EmailRecoveryDnsInput,

--- a/src/internet_identity/src/email_recovery/prepare.rs
+++ b/src/internet_identity/src/email_recovery/prepare.rs
@@ -90,6 +90,15 @@ async fn prepare_common(
     kind: PendingKind,
 ) -> Result<EmailRecoveryChallenge, EmailRecoveryError> {
     let EmailRecoveryDnsInput { address, dns_proof } = dns_input;
+    crate::er_dbg!(
+        "prepare.start address={} kind={} dns_proof={}",
+        address,
+        match &kind {
+            PendingKind::Register { anchor } => format!("Register({anchor})"),
+            PendingKind::Recover { .. } => "Recover".into(),
+        },
+        if dns_proof.is_some() { "DNSSEC" } else { "DoH" }
+    );
 
     // Sanity check the address shape. Detailed RFC 5321/5322 validation
     // is the verifier's job; here we just want to fail fast on the
@@ -133,8 +142,13 @@ async fn prepare_common(
                 .unwrap_or(false)
         });
         if !allowlisted {
+            crate::er_dbg!(
+                "prepare DomainNotAllowlisted reg={}",
+                registered_domain
+            );
             return Err(EmailRecoveryError::DomainNotAllowlisted(registered_domain));
         }
+        crate::er_dbg!("prepare doh_path_ok reg={}", registered_domain);
         (None, crate::dnssec::ZoneKeysMap::new(), None)
     };
 
@@ -178,6 +192,7 @@ async fn prepare_common(
         recovery_outcome: None,
     };
     insert_with_eviction(nonce.clone(), challenge, now_secs);
+    crate::er_dbg!("prepare.ok nonce={}", nonce);
 
     Ok(EmailRecoveryChallenge {
         nonce,

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -126,10 +126,27 @@ pub fn handle_smtp_request_validate(request: SmtpRequest) -> SmtpResponse {
 /// We only ever return `Ok` for verification results — see the
 /// module-level note on why we don't surface verification failures.
 pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
+    crate::er_dbg!(
+        "smtp.handle_smtp_request from={:?} to={:?} headers={}",
+        request
+            .envelope
+            .as_ref()
+            .map(|e| format!("{}@{}", e.from.user, e.from.domain)),
+        request
+            .envelope
+            .as_ref()
+            .map(|e| format!("{}@{}", e.to.user, e.to.domain)),
+        request
+            .message
+            .as_ref()
+            .map(|m| m.headers.len())
+            .unwrap_or(0)
+    );
     // Bound-check up front so a malformed gateway-side payload
     // returns a clean syntax error instead of trapping somewhere
     // inside the verifier.
     if let Err(e) = validate_smtp_request(&request) {
+        crate::er_dbg!("smtp.handle_smtp_request validate_failed {:?}", e);
         return e;
     }
 
@@ -147,10 +164,18 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
     };
     let recipient_flow = if recipient_matches(&envelope.to, SETUP_RECIPIENT_USER) {
+        crate::er_dbg!("smtp.recipient_flow=Setup");
         RecipientFlow::Setup
     } else if recipient_matches(&envelope.to, RECOVERY_RECIPIENT_USER) {
+        crate::er_dbg!("smtp.recipient_flow=Recovery");
         RecipientFlow::Recovery
     } else {
+        crate::er_dbg!(
+            "smtp.recipient_flow=DROP to={}@{} mailbox_domains={:?}",
+            envelope.to.user,
+            envelope.to.domain,
+            super::mailbox_domains()
+        );
         // Drop with Ok — we don't emit a per-recipient signal back
         // to the gateway.
         return SmtpResponse::Ok {};
@@ -158,7 +183,10 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
 
     let message = match request.message.as_ref() {
         Some(m) => m,
-        None => return SmtpResponse::Ok {},
+        None => {
+            crate::er_dbg!("smtp.no_message_body DROP");
+            return SmtpResponse::Ok {};
+        }
     };
 
     // Extract the canister-issued nonce from the Subject header. If
@@ -166,8 +194,10 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     // challenge for the discovered nonce, treat the message as not
     // for us and silently drop.
     let Some(nonce) = extract_nonce_from_subject(message) else {
+        crate::er_dbg!("smtp.no_nonce_in_subject DROP");
         return SmtpResponse::Ok {};
     };
+    crate::er_dbg!("smtp.nonce={}", nonce);
 
     let now_secs = now_secs();
 
@@ -224,6 +254,12 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         return SmtpResponse::Ok {};
     }
 
+    crate::er_dbg!(
+        "smtp.snapshot path={} claimed={} reg={}",
+        if snapshot.is_dnssec_path { "DNSSEC" } else { "DoH" },
+        snapshot.claimed_address,
+        snapshot.registered_domain
+    );
     if snapshot.is_dnssec_path {
         // DNSSEC path — pre-DKIM-key verification only. Body is
         // dropped after `bh=` validates; status flips to
@@ -513,6 +549,7 @@ async fn verify_setup_email_doh(
     snapshot: &PendingSnapshot,
     now_secs: u64,
 ) -> Result<(), EmailRecoveryError> {
+    crate::er_dbg!("smtp.verify_doh.start claimed={}", snapshot.claimed_address);
     // We need a selector to fetch the DKIM TXT, and on the DoH path
     // we don't have one cached at prepare time. Read it directly
     // from the email's DKIM-Signature header.
@@ -538,10 +575,27 @@ async fn verify_setup_email_doh(
         })?;
     let dkim_fqdn = format!("{}._domainkey.{}", sig.s, domain);
     let dmarc_fqdn = format!("_dmarc.{}", domain);
-    let dkim_bytes = crate::doh::fetch_txt(&dkim_fqdn, &domain)
-        .await
-        .map_err(|e| map_doh_error(e, &domain))?;
+    crate::er_dbg!(
+        "smtp.verify_doh dkim_fqdn={} dmarc_fqdn={} domain={}",
+        dkim_fqdn,
+        dmarc_fqdn,
+        domain
+    );
+    let dkim_bytes = crate::doh::fetch_txt(&dkim_fqdn, &domain).await.map_err(
+        |e| {
+            crate::er_dbg!("smtp.verify_doh dkim_fetch_failed {:?}", e);
+            map_doh_error(e, &domain)
+        },
+    )?;
+    crate::er_dbg!("smtp.verify_doh dkim_fetch_ok len={}", dkim_bytes.len());
     let dmarc_bytes_opt = (crate::doh::fetch_txt(&dmarc_fqdn, &domain).await).ok();
+    crate::er_dbg!(
+        "smtp.verify_doh dmarc_fetch={}",
+        dmarc_bytes_opt
+            .as_ref()
+            .map(|b| format!("ok len={}", b.len()))
+            .unwrap_or_else(|| "missing".into())
+    );
 
     let dkim_txt = std::str::from_utf8(&dkim_bytes)
         .map_err(|_| EmailRecoveryError::DohFetchFailed("DKIM TXT is not valid UTF-8".into()))?;
@@ -553,8 +607,11 @@ async fn verify_setup_email_doh(
     // Run the combined DKIM + DMARC verifier.
     let status = crate::dmarc::verify_email(request, dkim_txt, dmarc_txt_opt, now_secs);
     match status {
-        crate::dmarc::EmailVerificationStatus::Verified { .. } => {}
+        crate::dmarc::EmailVerificationStatus::Verified { .. } => {
+            crate::er_dbg!("smtp.verify_doh dmarc_verified");
+        }
         crate::dmarc::EmailVerificationStatus::Unverified { reason, .. } => {
+            crate::er_dbg!("smtp.verify_doh dmarc_unverified reason={:?}", reason);
             return Err(EmailRecoveryError::EmailVerificationFailed(format!(
                 "{reason:?}"
             )));
@@ -569,9 +626,15 @@ async fn verify_setup_email_doh(
     // Pin the address explicitly here.
     let from = extract_from_address(message)?;
     if !from.eq_ignore_ascii_case(&snapshot.claimed_address) {
+        crate::er_dbg!(
+            "smtp.verify_doh from_mismatch from={} claimed={}",
+            from,
+            snapshot.claimed_address
+        );
         return Err(EmailRecoveryError::AddressMismatch);
     }
 
+    crate::er_dbg!("smtp.verify_doh.ok");
     Ok(())
 }
 

--- a/src/internet_identity/src/email_recovery/submit_leaf.rs
+++ b/src/internet_identity/src/email_recovery/submit_leaf.rs
@@ -54,21 +54,32 @@ pub async fn submit_dkim_leaf(
         hops,
         extra_chains,
     } = arg;
+    crate::er_dbg!(
+        "submit_dkim_leaf.start nonce={} hops={} extra_chains={}",
+        nonce,
+        hops.len(),
+        extra_chains.len()
+    );
 
     // Snapshot everything we need under one borrow so the rest of
     // the function works against owned data. Includes early
     // rejection of "not a DNSSEC pending entry" / "not in
     // NeedDkimLeaf state" / etc.
     let snapshot = pending::with_mut(&nonce, now_secs, |c| Snapshot::take(c))
-        .ok_or(EmailRecoveryError::NonceUnknown)??;
+        .ok_or_else(|| {
+            crate::er_dbg!("submit_dkim_leaf NonceUnknown nonce={}", nonce);
+            EmailRecoveryError::NonceUnknown
+        })??;
 
     if let Err(e) = run_submit(&hops, &extra_chains, &snapshot, now_secs) {
+        crate::er_dbg!("submit_dkim_leaf run_submit_failed {:?}", e);
         let cloned = e.clone();
         pending::with_mut(&nonce, now_secs, |c| {
             c.status = PendingStatus::Failed(cloned);
         });
         return Err(e);
     }
+    crate::er_dbg!("submit_dkim_leaf run_submit_ok");
 
     // Verification passed — finalize per kind. Setup binds the
     // credential, recovery stamps a delegation seed.

--- a/src/internet_identity/src/email_recovery_debug_log.rs
+++ b/src/internet_identity/src/email_recovery_debug_log.rs
@@ -49,9 +49,13 @@ pub fn clear() {
 }
 
 /// Convenience macro: `er_dbg!("doh.fetch.start name={}", name);`
+///
+/// Body has no trailing semicolon so the expansion stays an
+/// expression — usable inside `match` arms and `|e| { … }`-style
+/// closures without tripping `semicolon_in_expressions_from_macros`.
 #[macro_export]
 macro_rules! er_dbg {
     ($($arg:tt)*) => {
-        $crate::email_recovery_debug_log::push(format!($($arg)*));
+        $crate::email_recovery_debug_log::push(format!($($arg)*))
     };
 }

--- a/src/internet_identity/src/email_recovery_debug_log.rs
+++ b/src/internet_identity/src/email_recovery_debug_log.rs
@@ -1,0 +1,57 @@
+//! TEMPORARY (PR #3855): heap-only ring buffer for tracing the
+//! email-recovery + DoH flow on staging. Exposed via the
+//! `email_recovery_debug_logs` query — *anonymous, no authentication*
+//! — so the debug surface is reachable without staging credentials.
+//! Contents are lost on every upgrade and capped at [`MAX_LINES`] so
+//! the heap can't grow without bound.
+//!
+//! Remove this module along with its query and all `er_dbg!`
+//! call-sites once the staging outlook.com flow is confirmed working
+//! end-to-end.
+use std::cell::RefCell;
+use std::collections::VecDeque;
+
+const MAX_LINES: usize = 2000;
+
+thread_local! {
+    static LOG: RefCell<VecDeque<String>> = const { RefCell::new(VecDeque::new()) };
+}
+
+#[cfg(not(test))]
+fn now_ms() -> u64 {
+    ic_cdk::api::time() / 1_000_000
+}
+
+#[cfg(test)]
+fn now_ms() -> u64 {
+    0
+}
+
+/// Append one line. The canister wall-clock (ms since epoch) is
+/// prepended so ordering is recoverable even when multiple flows
+/// interleave their entries.
+pub fn push(line: String) {
+    LOG.with(|l| {
+        let mut buf = l.borrow_mut();
+        if buf.len() == MAX_LINES {
+            buf.pop_front();
+        }
+        buf.push_back(format!("[{}ms] {}", now_ms(), line));
+    });
+}
+
+pub fn snapshot() -> Vec<String> {
+    LOG.with(|l| l.borrow().iter().cloned().collect())
+}
+
+pub fn clear() {
+    LOG.with(|l| l.borrow_mut().clear());
+}
+
+/// Convenience macro: `er_dbg!("doh.fetch.start name={}", name);`
+#[macro_export]
+macro_rules! er_dbg {
+    ($($arg:tt)*) => {
+        $crate::email_recovery_debug_log::push(format!($($arg)*));
+    };
+}

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -57,6 +57,7 @@ mod dmarc;
 mod dnssec;
 mod doh;
 mod email_recovery;
+mod email_recovery_debug_log;
 mod http;
 mod ii_domain;
 
@@ -1620,6 +1621,25 @@ mod email_recovery_api {
 
         crate::anchor_management::post_operation_bookkeeping(identity_number, operation);
         Ok(())
+    }
+
+    /// TEMPORARY (PR #3855): anonymous query exposing the in-memory
+    /// debug log appended by `er_dbg!` calls scattered through the
+    /// email-recovery + DoH path. Heap-only, lost on every upgrade,
+    /// capped at a few thousand lines. Remove together with the
+    /// `email_recovery_debug_log` module once the staging
+    /// outlook.com flow is confirmed working.
+    #[query]
+    fn email_recovery_debug_logs() -> Vec<String> {
+        crate::email_recovery_debug_log::snapshot()
+    }
+
+    /// TEMPORARY (PR #3855): companion to `email_recovery_debug_logs`.
+    /// Anonymous update so a tester can reset the buffer between
+    /// flows. Remove with the rest of the debug surface.
+    #[update]
+    fn email_recovery_debug_clear() {
+        crate::email_recovery_debug_log::clear();
     }
 }
 

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -601,32 +601,6 @@ impl<M: Memory + Clone> Storage<M> {
             trap(&format!("unsupported header version: {}", header.version));
         }
 
-        // TEMPORARY (PR #3855): one-shot wipe of the BTreeMap magic at
-        // memory IDs 23 and 24. The Postbox PoC (dfinity/internet-identity
-        // PR #3760, never merged but deployed to staging A) used these
-        // for `SMTP_POSTBOX` and `PUSH_SUBSCRIPTION` BTreeMaps with a
-        // different storable layout — left in place, our re-use of ID 23
-        // for `lookup_anchor_with_email_recovery` traps inside
-        // stable-structures on first read because the loaded node header
-        // disagrees with our K/V config. Zeroing the first bytes makes
-        // `StableBTreeMap::init` fall through the magic check and create
-        // a fresh map with our layout. Idempotent (writing zeros to
-        // already-zero bytes is fine), so it's safe to leave for one
-        // upgrade cycle. Remove this block once staging A has been
-        // upgraded with this code at least once.
-        {
-            let mm = MemoryManager::init_with_bucket_size(
-                RestrictedMemory::new(memory.clone(), 1..MAX_MANAGED_WASM_PAGES),
-                BUCKET_SIZE_IN_PAGES,
-            );
-            for id in [23u8, 24u8] {
-                let m = mm.get(MemoryId::new(id));
-                if m.size() > 0 {
-                    m.write(0, &[0u8; 16]);
-                }
-            }
-        }
-
         Self::init_with_header(memory, header)
     }
 

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -601,6 +601,32 @@ impl<M: Memory + Clone> Storage<M> {
             trap(&format!("unsupported header version: {}", header.version));
         }
 
+        // TEMPORARY (PR #3855): one-shot wipe of the BTreeMap magic at
+        // memory IDs 23 and 24. The Postbox PoC (dfinity/internet-identity
+        // PR #3760, never merged but deployed to staging A) used these
+        // for `SMTP_POSTBOX` and `PUSH_SUBSCRIPTION` BTreeMaps with a
+        // different storable layout — left in place, our re-use of ID 23
+        // for `lookup_anchor_with_email_recovery` traps inside
+        // stable-structures on first read because the loaded node header
+        // disagrees with our K/V config. Zeroing the first bytes makes
+        // `StableBTreeMap::init` fall through the magic check and create
+        // a fresh map with our layout. Idempotent (writing zeros to
+        // already-zero bytes is fine), so it's safe to leave for one
+        // upgrade cycle. Remove this block once staging A has been
+        // upgraded with this code at least once.
+        {
+            let mm = MemoryManager::init_with_bucket_size(
+                RestrictedMemory::new(memory.clone(), 1..MAX_MANAGED_WASM_PAGES),
+                BUCKET_SIZE_IN_PAGES,
+            );
+            for id in [23u8, 24u8] {
+                let m = mm.get(MemoryId::new(id));
+                if m.size() > 0 {
+                    m.write(0, &[0u8; 16]);
+                }
+            }
+        }
+
         Self::init_with_header(memory, header)
     }
 

--- a/src/internet_identity/tests/integration/email_recovery.rs
+++ b/src/internet_identity/tests/integration/email_recovery.rs
@@ -65,14 +65,17 @@ fn dns_input() -> EmailRecoveryDnsInput {
 // ===================================================================
 
 /// Stand up a canister with an `allowed_domains` list that lets
-/// `test.example.com` through to the DoH path. We don't need any
-/// other init knobs for these tests.
+/// `test.example.com` through to the DoH path, and a `related_origins`
+/// entry so `mailbox_domains()` accepts `register@id.ai` /
+/// `recover@id.ai` envelopes (recipient acceptance reads from
+/// `related_origins`; see `email_recovery::mailbox_domains`).
 fn setup_canister(env: &PocketIc) -> candid::Principal {
     let args = InternetIdentityInit {
         doh_config: Some(Some(DohConfig {
             allowed_domains: vec![TEST_DOMAIN.into()],
             max_cache_age_secs: Some(3600),
         })),
+        related_origins: Some(vec!["https://id.ai".into()]),
         canister_creation_cycles_cost: Some(0),
         ..Default::default()
     };
@@ -580,6 +583,7 @@ fn full_setup_flow_via_dnssec_path() {
         dnssec_config: Some(Some(DnssecConfig {
             root_anchors: vec![chain.anchor],
         })),
+        related_origins: Some(vec!["https://id.ai".into()]),
         canister_creation_cycles_cost: Some(0),
         ..Default::default()
     };


### PR DESCRIPTION
## Summary
- New `scripts/fetch-iana-root-anchors.bash` — fetches IANA KSK trust anchors from data.iana.org/root-anchors/root-anchors.xml, filters to currently-valid entries, prints a one-line review per anchor, prompts for confirmation, and emits Candid `vec record { key_tag, algorithm, digest_type, digest }` ready to drop into `dnssec_config.root_anchors`.
- `scripts/deploy-common.bash` (used by `deploy-pr-to-beta` + `deploy-local-to-beta`): `build_be_install_arg` can now also emit `dnssec_config` and `doh_config` alongside the existing trio. **Opt-in** behind `--update-email-recovery-init` — without the flag both fields stay `opt null` (preserve previous on-chain values), which is what most upgrades want once the canister has been initialized once. Companion `--doh-domains <csv>` overrides the curated allowlist (empty string = disable DoH entirely).
- `scripts/make-upgrade-proposal` (production): didc-assist can't type 32-byte SHA-256 digests as Candid blobs, so we post-process the args.txt it produces to inject the IANA-fetched + DoH-allowlist values. **Opt-in via `II_UPDATE_EMAIL_RECOVERY_INIT=1`**. Companion `II_DOH_DOMAINS=...` overrides the allowlist (empty string = disable DoH entirely; the env-var presence check honours `set-but-empty` distinct from `unset`).
- Single source of truth for the curated DoH allowlist lives in `scripts/default-doh-domains.bash`, sourced by both deploy-common.bash and make-upgrade-proposal so the two stay in sync. Allowlist criterion is 'DKIM resolution can't be authenticated end-to-end via DNSSEC' — which catches both apex-unsigned domains (Gmail, Outlook, iCloud, Yahoo) AND domains whose apex is signed but whose DKIM CNAMEs into unsigned territory (live.com → `protection.outlook.com`).

The reason we don't bundle the IANA anchors into the wasm is that they roll over every ~7 years; the next rollover becomes a one-line change in the next upgrade arg instead of a code change + recompile.

## PR Stack
| # | PR | Description | Status |
|---|---|---|---|
| 0 | [#3836](https://github.com/dfinity/internet-identity/pull/3836) | Design doc | Open |
| 1 | [#3838](https://github.com/dfinity/internet-identity/pull/3838) | DNSSEC verifier scaffold | Open |
| 2 | [#3839](https://github.com/dfinity/internet-identity/pull/3839) | DKIM verifier (RFC 6376) | Open |
| 3 | [#3840](https://github.com/dfinity/internet-identity/pull/3840) | DMARC alignment (RFC 7489) | Open |
| 4 | [#3841](https://github.com/dfinity/internet-identity/pull/3841) | DoH fallback | Open |
| 5+6 | [#3842](https://github.com/dfinity/internet-identity/pull/3842) | Setup flow (storage + smtp_request) | Open |
| 7 | [#3843](https://github.com/dfinity/internet-identity/pull/3843) | Recovery flow (delegation) | Open |
| 8 | [#3844](https://github.com/dfinity/internet-identity/pull/3844) | Frontend + feature flag | Open |
| **9** | **this PR** | **Deploy/upgrade scripts: dnssec_config + doh_config install args** | Open |
| 10 | [#3857](https://github.com/dfinity/internet-identity/pull/3857) | Email-recovery UX overhaul | Open |

See the design doc (#3836) for the architecture; the deploy-arg approach is described in §7.5 (root anchors) and §7.6 (DoH allowlist + audit criterion that catches the live.com class).

## Test plan
- [x] `./scripts/deploy-pr-to-beta --help` shows the new `--update-email-recovery-init` and `--doh-domains` flags
- [x] `./scripts/deploy-pr-to-beta -sa -be --dry-run <PR>` (default) prints an `icp install` command with `dnssec_config` and `doh_config` **absent** — both fields stay `opt null` to preserve previous on-chain values
- [x] `./scripts/deploy-pr-to-beta -sa -be --dry-run --update-email-recovery-init <PR>` populates both fields with IANA-fetched anchors + the curated DoH list, and the install arg encodes via `didc encode -t '(opt InternetIdentityInit)'`
- [x] `./scripts/deploy-pr-to-beta -sa -be --dry-run --update-email-recovery-init --doh-domains gmail.com,outlook.com <PR>` produces an install arg with only those two domains in the allowlist
- [x] `./scripts/deploy-pr-to-beta -sa -be --dry-run --update-email-recovery-init --doh-domains '' <PR>` produces an install arg with an empty allowlist (DoH disabled, DNSSEC-only)
- [x] `./scripts/deploy-local-to-beta -sa -be --dry-run` works analogously
- [x] `make-upgrade-proposal` (without `II_UPDATE_EMAIL_RECOVERY_INIT`) leaves the args.txt unchanged after didc-assist
- [x] `II_UPDATE_EMAIL_RECOVERY_INIT=1 make-upgrade-proposal` populates `dnssec_config` + `doh_config` from IANA + the curated allowlist, and the encoded `*.bin` files validate
- [x] `II_UPDATE_EMAIL_RECOVERY_INIT=1 II_DOH_DOMAINS='' make-upgrade-proposal` produces an install arg with an empty `allowed_domains` vec

🤖 Generated with [Claude Code](https://claude.com/claude-code)