### PR TITLE
feat(fe,be): include icp.net in canister origin remapping

### DIFF
--- a/src/frontend/src/lib/utils/canisterIdResolution.test.ts
+++ b/src/frontend/src/lib/utils/canisterIdResolution.test.ts
@@ -63,6 +63,34 @@ test("should resolve canister id from well-known domain", async () => {
   expect(global.fetch).toHaveBeenCalledTimes(0);
 });
 
+test("should not infer canister id from adversarial look-alike domains", async () => {
+  // Hostnames like `evil-ic0.app` end with `ic0.app` but are not the IC.
+  // The well-known shortcut must not fire for them; fall through to BN lookup.
+  const fetchMock = vi.fn();
+  fetchMock.mockReturnValue(
+    new Response(null, {
+      status: 200,
+      headers: [["x-ic-canister-id", "bkyz2-fmaaa-aaaaa-qaaaq-cai"]],
+    }),
+  );
+  global.fetch = fetchMock;
+
+  const canisterId = "bkyz2-fmaaa-aaaaa-qaaaq-cai";
+  const lookalikes = [
+    `https://${canisterId}.evil-ic0.app`,
+    `https://${canisterId}.evil-icp0.io`,
+    `https://${canisterId}.evil-icp.net`,
+    `https://${canisterId}.myinternetcomputer.org`,
+  ];
+
+  for (const origin of lookalikes) {
+    await resolveCanisterId({ origin });
+  }
+
+  // BN lookup performed for each (i.e. shortcut did not fire).
+  expect(fetchMock).toHaveBeenCalledTimes(lookalikes.length);
+});
+
 test("should not resolve canister id from malformed header", async () => {
   const fetchMock = vi.fn();
   fetchMock.mockReturnValueOnce(

--- a/src/frontend/src/lib/utils/canisterIdResolution.test.ts
+++ b/src/frontend/src/lib/utils/canisterIdResolution.test.ts
@@ -42,6 +42,7 @@ test("should resolve canister id from well-known domain", async () => {
   const wellKnownDomains = [
     "ic0.app",
     "icp0.io",
+    "icp.net",
     "internetcomputer.org",
     "localhost",
   ];

--- a/src/frontend/src/lib/utils/canisterIdResolution.ts
+++ b/src/frontend/src/lib/utils/canisterIdResolution.ts
@@ -38,6 +38,7 @@ const parseCanisterIdFromHostname = (
   const wellKnownDomains = [
     "ic0.app",
     "icp0.io",
+    "icp.net",
     "internetcomputer.org",
     "localhost",
   ];

--- a/src/frontend/src/lib/utils/canisterIdResolution.ts
+++ b/src/frontend/src/lib/utils/canisterIdResolution.ts
@@ -43,7 +43,12 @@ const parseCanisterIdFromHostname = (
     "localhost",
   ];
 
-  if (wellKnownDomains.some((domain) => hostname.endsWith(domain))) {
+  // Match by exact equality or by a dot boundary so adversarial subdomains
+  // like `evil-ic0.app` are not treated as well-known IC domains.
+  const matchesWellKnown = wellKnownDomains.some(
+    (domain) => hostname === domain || hostname.endsWith(`.${domain}`),
+  );
+  if (matchesWellKnown) {
     // The canister is running on a well-known domain, infer the canister ID from the hostname directly
     // (e.g. bd3sg-teaaa-aaaaa-qaaba-cai.localhost -> bd3sg-teaaa-aaaaa-qaaba-cai)
     const domainParts = hostname.split(".");

--- a/src/frontend/src/lib/utils/iiConnection.ts
+++ b/src/frontend/src/lib/utils/iiConnection.ts
@@ -1036,8 +1036,7 @@ export const inferHost = (): string => {
   // by a dot boundary, so adversarial subdomains like `evil-ic0.app` are not
   // treated as the IC.
   const isGatewayDomain = (domain: string): boolean =>
-    location.hostname === domain ||
-    location.hostname.endsWith(`.${domain}`);
+    location.hostname === domain || location.hostname.endsWith(`.${domain}`);
 
   if (
     isGatewayDomain("icp0.io") ||

--- a/src/frontend/src/lib/utils/iiConnection.ts
+++ b/src/frontend/src/lib/utils/iiConnection.ts
@@ -1032,11 +1032,18 @@ export const inferHost = (): string => {
     return "https://" + IC_API_DOMAIN;
   }
 
+  // Match a hostname against an official gateway domain by exact equality or
+  // by a dot boundary, so adversarial subdomains like `evil-ic0.app` are not
+  // treated as the IC.
+  const isGatewayDomain = (domain: string): boolean =>
+    location.hostname === domain ||
+    location.hostname.endsWith(`.${domain}`);
+
   if (
-    location.hostname.endsWith("icp0.io") ||
-    location.hostname.endsWith("ic0.app") ||
-    location.hostname.endsWith("icp.net") ||
-    location.hostname.endsWith("internetcomputer.org")
+    isGatewayDomain("icp0.io") ||
+    isGatewayDomain("ic0.app") ||
+    isGatewayDomain("icp.net") ||
+    isGatewayDomain("internetcomputer.org")
   ) {
     // If this is a canister running on one of the official IC domains, then return the
     // official API endpoint

--- a/src/frontend/src/lib/utils/iiConnection.ts
+++ b/src/frontend/src/lib/utils/iiConnection.ts
@@ -993,11 +993,12 @@ export const creationOptions = (
   };
 };
 
-// In order to give dapps a stable principal regardless whether they use the legacy (ic0.app) or the new domain (icp0.io)
-// we map back the derivation origin to the ic0.app domain.
+// In order to give dapps a stable principal regardless whether they use the legacy (ic0.app) or
+// any of the newer canister gateway domains (icp0.io, icp.net) we map back the derivation origin
+// to the ic0.app domain.
 export const remapToLegacyDomain = (origin: string): string => {
   const ORIGIN_MAPPING_REGEX =
-    /^https:\/\/(?<subdomain>[\w-]+(?:\.raw)?)\.icp0\.io$/;
+    /^https:\/\/(?<subdomain>[\w-]+(?:\.raw)?)\.(?:icp0\.io|icp\.net)$/;
   const match = origin.match(ORIGIN_MAPPING_REGEX);
   const subdomain = match?.groups?.subdomain;
   if (subdomain !== undefined) {
@@ -1034,6 +1035,7 @@ export const inferHost = (): string => {
   if (
     location.hostname.endsWith("icp0.io") ||
     location.hostname.endsWith("ic0.app") ||
+    location.hostname.endsWith("icp.net") ||
     location.hostname.endsWith("internetcomputer.org")
   ) {
     // If this is a canister running on one of the official IC domains, then return the

--- a/src/internet_identity_interface/src/internet_identity/types/attributes.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/attributes.rs
@@ -20,24 +20,27 @@ pub const OPENID_ISSUER_MAX_BYTES: usize = 1024;
 pub const SSO_DOMAIN_MAX_BYTES: usize = 253;
 
 /// Mirror of the frontend's `remapToLegacyDomain`: the frontend rewrites
-/// `https://<sub>.icp0.io` to `https://<sub>.ic0.app` before deriving a
-/// principal so users get the same principal across the two domains. The
-/// canister needs the same transformation to verify that an `unmapped_origin`
-/// supplied alongside the (legacy-mapped) `origin` is just the icp0.io form
-/// of the same site, not a different origin sneaking into the certified
-/// `implicit:origin`.
+/// `https://<sub>.icp0.io` and `https://<sub>.icp.net` to `https://<sub>.ic0.app`
+/// before deriving a principal so users get the same principal across all
+/// canister gateway domains. The canister needs the same transformation to
+/// verify that an `unmapped_origin` supplied alongside the (legacy-mapped)
+/// `origin` is just an alternate gateway form of the same site, not a
+/// different origin sneaking into the certified `implicit:origin`.
 ///
 /// The accepted shape — `<subdomain>(.raw)?` containing only ASCII word
-/// characters or `-` — matches the regex `^https://([\w-]+(?:\.raw)?)\.icp0\.io$`
-/// used in the frontend.
+/// characters or `-` — matches the regex
+/// `^https://([\w-]+(?:\.raw)?)\.(?:icp0\.io|icp\.net)$` used in the frontend.
 pub fn remap_to_legacy_domain(origin: &str) -> String {
     const PREFIX: &str = "https://";
-    const ICP0_SUFFIX: &str = ".icp0.io";
+    const REMAPPED_SUFFIXES: &[&str] = &[".icp0.io", ".icp.net"];
 
     let Some(rest) = origin.strip_prefix(PREFIX) else {
         return origin.to_string();
     };
-    let Some(subdomain) = rest.strip_suffix(ICP0_SUFFIX) else {
+    let Some(subdomain) = REMAPPED_SUFFIXES
+        .iter()
+        .find_map(|suffix| rest.strip_suffix(suffix))
+    else {
         return origin.to_string();
     };
 
@@ -2237,6 +2240,14 @@ mod tests {
         }
 
         #[test]
+        fn maps_icp_net_subdomain_to_ic0_app() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://foo.icp.net"),
+                "https://foo.ic0.app"
+            );
+        }
+
+        #[test]
         fn maps_raw_subdomain() {
             pretty_assert_eq!(
                 remap_to_legacy_domain("https://foo.raw.icp0.io"),
@@ -2245,9 +2256,25 @@ mod tests {
         }
 
         #[test]
+        fn maps_raw_subdomain_on_icp_net() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://foo.raw.icp.net"),
+                "https://foo.raw.ic0.app"
+            );
+        }
+
+        #[test]
         fn allows_underscore_and_hyphen_in_subdomain() {
             pretty_assert_eq!(
                 remap_to_legacy_domain("https://my-app_1.icp0.io"),
+                "https://my-app_1.ic0.app"
+            );
+        }
+
+        #[test]
+        fn allows_underscore_and_hyphen_in_subdomain_on_icp_net() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://my-app_1.icp.net"),
                 "https://my-app_1.ic0.app"
             );
         }
@@ -2270,10 +2297,26 @@ mod tests {
         }
 
         #[test]
+        fn rejects_extra_subdomain_levels_on_icp_net() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://foo.bar.icp.net"),
+                "https://foo.bar.icp.net"
+            );
+        }
+
+        #[test]
         fn rejects_http_scheme() {
             pretty_assert_eq!(
                 remap_to_legacy_domain("http://foo.icp0.io"),
                 "http://foo.icp0.io"
+            );
+        }
+
+        #[test]
+        fn rejects_http_scheme_on_icp_net() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("http://foo.icp.net"),
+                "http://foo.icp.net"
             );
         }
     }


### PR DESCRIPTION
## Summary

Treats `<canister>.icp.net` as a peer of `<canister>.icp0.io` so users get the same principal across all three official canister gateway domains (`.ic0.app`, `.icp0.io`, `.icp.net`).

Changes:

- **FE** `remapToLegacyDomain` (`src/frontend/src/lib/utils/iiConnection.ts`): regex now accepts both `icp0.io` and `icp.net`, mapping either to `ic0.app`.
- **FE** `inferHost` (same file): adds `icp.net` to the list of recognised IC gateway domains so the official `icp-api.io` endpoint is used.
- **FE** `parseCanisterIdFromHostname` (`src/frontend/src/lib/utils/canisterIdResolution.ts`): adds `icp.net` to the well-known domain list so the canister id is inferred directly from the hostname (no BN HEAD lookup).
- **BE** `remap_to_legacy_domain` (`src/internet_identity_interface/src/internet_identity/types/attributes.rs`): strips either `.icp0.io` or `.icp.net` and rewrites to `.ic0.app`. Doc comment + regex hint updated.
- **Tests**: mirrored every existing BE `remap_to_legacy_domain` test for the new `.icp.net` suffix; FE `canisterIdResolution.test.ts` well-known list now includes `icp.net`.

## Test plan

- [x] `cargo test -p internet_identity_interface remap_to_legacy_domain` (11 tests pass, including 6 new mirror cases)
- [x] `npx vitest run src/frontend/src/lib/utils/canisterIdResolution.test.ts` (6 pass)
- [x] `npx vitest run src/frontend/src/lib/utils/validateDerivationOrigin.test.ts` (19 pass — verifies existing alt-origins behaviour unchanged)
- [x] `tsc --noEmit` clean
- [x] CI green