### PR TITLE
feat(fe): add labels under OpenID and SSO buttons on auth picker

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -59,35 +59,30 @@
     <div class="flex flex-row flex-nowrap justify-stretch gap-3">
       {#each openIdProviders as provider (provider.issuer)}
         {@const name = provider.name}
-        <div class="flex min-w-0 flex-1 flex-col items-stretch gap-1.5">
-          <Tooltip
-            label={$t`Interaction canceled. Please try again.`}
-            hidden={cancelledProviderId !== provider.client_id}
-            manual
+        <Tooltip
+          label={$t`Interaction canceled. Please try again.`}
+          hidden={cancelledProviderId !== provider.client_id}
+          manual
+        >
+          <button
+            class="btn btn-secondary h-auto min-w-0 flex-1 flex-col gap-2 px-3 py-4 text-xs font-medium"
+            onclick={() => handleContinueWithOpenId(provider)}
+            disabled={authenticatingProviderId !== undefined}
+            aria-label={$t`Continue with ${name}`}
           >
-            <button
-              class="btn btn-secondary btn-xl"
-              onclick={() => handleContinueWithOpenId(provider)}
-              disabled={authenticatingProviderId !== undefined}
-              aria-label={$t`Continue with ${name}`}
-            >
-              {#if authenticatingProviderId === provider.client_id}
-                <ProgressRing />
-              {:else}
-                <div class="size-6">
-                  <!-- eslint-disable-next-line svelte/no-at-html-tags -- provider.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
-                  {@html provider.logo}
-                </div>
-              {/if}
-            </button>
-          </Tooltip>
-          <span
-            aria-hidden="true"
-            class="text-text-tertiary truncate text-center text-xs"
-          >
-            {name}
-          </span>
-        </div>
+            {#if authenticatingProviderId === provider.client_id}
+              <ProgressRing />
+            {:else}
+              <div class="size-6">
+                <!-- eslint-disable-next-line svelte/no-at-html-tags -- provider.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
+                {@html provider.logo}
+              </div>
+            {/if}
+            <span aria-hidden="true" class="text-text-tertiary w-full truncate">
+              {name}
+            </span>
+          </button>
+        </Tooltip>
       {/each}
       <!--
         SSO entry is always rendered. Registration is enforced on the
@@ -99,22 +94,17 @@
         here — we keep this option visible so users know the mechanism
         exists.
       -->
-      <div class="flex min-w-0 flex-1 flex-col items-stretch gap-1.5">
-        <button
-          class="btn btn-secondary btn-xl"
-          onclick={signInWithSso}
-          disabled={authenticatingProviderId !== undefined}
-          aria-label={$t`Continue with SSO`}
-        >
-          <SsoIcon class="size-6" />
-        </button>
-        <span
-          aria-hidden="true"
-          class="text-text-tertiary truncate text-center text-xs"
-        >
+      <button
+        class="btn btn-secondary h-auto min-w-0 flex-1 flex-col gap-2 px-3 py-4 text-xs font-medium"
+        onclick={signInWithSso}
+        disabled={authenticatingProviderId !== undefined}
+        aria-label={$t`Continue with SSO`}
+      >
+        <SsoIcon class="size-6" />
+        <span aria-hidden="true" class="text-text-tertiary w-full truncate">
           {$t`SSO`}
         </span>
-      </div>
+      </button>
     </div>
   </div>
   <div class="border-border-tertiary border-t"></div>

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -59,27 +59,35 @@
     <div class="flex flex-row flex-nowrap justify-stretch gap-3">
       {#each openIdProviders as provider (provider.issuer)}
         {@const name = provider.name}
-        <Tooltip
-          label={$t`Interaction canceled. Please try again.`}
-          hidden={cancelledProviderId !== provider.client_id}
-          manual
-        >
-          <button
-            class="btn btn-secondary btn-xl flex-1"
-            onclick={() => handleContinueWithOpenId(provider)}
-            disabled={authenticatingProviderId !== undefined}
-            aria-label={$t`Continue with ${name}`}
+        <div class="flex flex-1 flex-col items-stretch gap-1.5">
+          <Tooltip
+            label={$t`Interaction canceled. Please try again.`}
+            hidden={cancelledProviderId !== provider.client_id}
+            manual
           >
-            {#if authenticatingProviderId === provider.client_id}
-              <ProgressRing />
-            {:else}
-              <div class="size-6">
-                <!-- eslint-disable-next-line svelte/no-at-html-tags -- provider.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
-                {@html provider.logo}
-              </div>
-            {/if}
-          </button>
-        </Tooltip>
+            <button
+              class="btn btn-secondary btn-xl"
+              onclick={() => handleContinueWithOpenId(provider)}
+              disabled={authenticatingProviderId !== undefined}
+              aria-label={$t`Continue with ${name}`}
+            >
+              {#if authenticatingProviderId === provider.client_id}
+                <ProgressRing />
+              {:else}
+                <div class="size-6">
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -- provider.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
+                  {@html provider.logo}
+                </div>
+              {/if}
+            </button>
+          </Tooltip>
+          <span
+            aria-hidden="true"
+            class="text-text-tertiary truncate text-center text-xs"
+          >
+            {name}
+          </span>
+        </div>
       {/each}
       <!--
         SSO entry is always rendered. Registration is enforced on the
@@ -91,14 +99,22 @@
         here — we keep this option visible so users know the mechanism
         exists.
       -->
-      <button
-        class="btn btn-secondary btn-xl flex-1"
-        onclick={signInWithSso}
-        disabled={authenticatingProviderId !== undefined}
-        aria-label={$t`Continue with SSO`}
-      >
-        <SsoIcon class="size-6" />
-      </button>
+      <div class="flex flex-1 flex-col items-stretch gap-1.5">
+        <button
+          class="btn btn-secondary btn-xl"
+          onclick={signInWithSso}
+          disabled={authenticatingProviderId !== undefined}
+          aria-label={$t`Continue with SSO`}
+        >
+          <SsoIcon class="size-6" />
+        </button>
+        <span
+          aria-hidden="true"
+          class="text-text-tertiary truncate text-center text-xs"
+        >
+          {$t`SSO`}
+        </span>
+      </div>
     </div>
   </div>
   <div class="border-border-tertiary border-t"></div>

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -59,7 +59,7 @@
     <div class="flex flex-row flex-nowrap justify-stretch gap-3">
       {#each openIdProviders as provider (provider.issuer)}
         {@const name = provider.name}
-        <div class="flex flex-1 flex-col items-stretch gap-1.5">
+        <div class="flex min-w-0 flex-1 flex-col items-stretch gap-1.5">
           <Tooltip
             label={$t`Interaction canceled. Please try again.`}
             hidden={cancelledProviderId !== provider.client_id}
@@ -99,7 +99,7 @@
         here — we keep this option visible so users know the mechanism
         exists.
       -->
-      <div class="flex flex-1 flex-col items-stretch gap-1.5">
+      <div class="flex min-w-0 flex-1 flex-col items-stretch gap-1.5">
         <button
           class="btn btn-secondary btn-xl"
           onclick={signInWithSso}

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -65,7 +65,7 @@
           manual
         >
           <button
-            class="btn btn-secondary h-auto min-w-0 flex-1 flex-col gap-2 px-3 py-4 text-xs font-medium"
+            class="btn btn-secondary h-auto min-w-0 flex-1 flex-col gap-1.5 px-2 py-3 text-xs font-medium"
             onclick={() => handleContinueWithOpenId(provider)}
             disabled={authenticatingProviderId !== undefined}
             aria-label={$t`Continue with ${name}`}
@@ -95,7 +95,7 @@
         exists.
       -->
       <button
-        class="btn btn-secondary h-auto min-w-0 flex-1 flex-col gap-2 px-3 py-4 text-xs font-medium"
+        class="btn btn-secondary h-auto min-w-0 flex-1 flex-col gap-1.5 px-2 py-3 text-xs font-medium"
         onclick={signInWithSso}
         disabled={authenticatingProviderId !== undefined}
         aria-label={$t`Continue with SSO`}


### PR DESCRIPTION
## Summary
- The Google / Apple / Microsoft / SSO buttons on the auth picker (PickAuthenticationMethod) were icon-only. Users who don't recognize the logos had no way to tell which provider was which.
- Adds a muted caption (`text-text-tertiary text-xs`) inside each button, below the icon. The icon and label are stacked vertically (`flex-col`) with compact padding so the buttons work well in both the full-width auth page and the narrower add-access-method dialog.
- The captions are `aria-hidden` — screen reader users continue to get the existing `aria-label="Continue with {name}"` from the button itself, which is more descriptive than the visual caption alone.

## Test plan
- [x] Render the auth picker with multiple OpenID providers configured and confirm names appear inside each button
- [x] Confirm SSO button shows 'SSO' caption
- [x] Verify buttons remain equal-width (`flex-1`)
- [x] Verify "Microsoft" label fits without truncation in the narrower add-access-method dialog
- [x] Verify captions truncate gracefully with very long provider names
- [x] Confirm screen reader still announces 'Continue with Google' etc. (no double-read)