### PR TITLE
feat(fe): normalise alt-origins matching across gateway variants

### DIFF
--- a/src/frontend/src/lib/utils/canisterIdResolution.test.ts
+++ b/src/frontend/src/lib/utils/canisterIdResolution.test.ts
@@ -63,6 +63,34 @@ test("should resolve canister id from well-known domain", async () => {
   expect(global.fetch).toHaveBeenCalledTimes(0);
 });
 
+test("should not infer canister id from adversarial look-alike domains", async () => {
+  // Hostnames like `evil-ic0.app` end with `ic0.app` but are not the IC.
+  // The well-known shortcut must not fire for them; fall through to BN lookup.
+  const fetchMock = vi.fn();
+  fetchMock.mockReturnValue(
+    new Response(null, {
+      status: 200,
+      headers: [["x-ic-canister-id", "bkyz2-fmaaa-aaaaa-qaaaq-cai"]],
+    }),
+  );
+  global.fetch = fetchMock;
+
+  const canisterId = "bkyz2-fmaaa-aaaaa-qaaaq-cai";
+  const lookalikes = [
+    `https://${canisterId}.evil-ic0.app`,
+    `https://${canisterId}.evil-icp0.io`,
+    `https://${canisterId}.evil-icp.net`,
+    `https://${canisterId}.myinternetcomputer.org`,
+  ];
+
+  for (const origin of lookalikes) {
+    await resolveCanisterId({ origin });
+  }
+
+  // BN lookup performed for each (i.e. shortcut did not fire).
+  expect(fetchMock).toHaveBeenCalledTimes(lookalikes.length);
+});
+
 test("should not resolve canister id from malformed header", async () => {
   const fetchMock = vi.fn();
   fetchMock.mockReturnValueOnce(

--- a/src/frontend/src/lib/utils/canisterIdResolution.test.ts
+++ b/src/frontend/src/lib/utils/canisterIdResolution.test.ts
@@ -42,6 +42,7 @@ test("should resolve canister id from well-known domain", async () => {
   const wellKnownDomains = [
     "ic0.app",
     "icp0.io",
+    "icp.net",
     "internetcomputer.org",
     "localhost",
   ];

--- a/src/frontend/src/lib/utils/canisterIdResolution.ts
+++ b/src/frontend/src/lib/utils/canisterIdResolution.ts
@@ -38,6 +38,7 @@ const parseCanisterIdFromHostname = (
   const wellKnownDomains = [
     "ic0.app",
     "icp0.io",
+    "icp.net",
     "internetcomputer.org",
     "localhost",
   ];

--- a/src/frontend/src/lib/utils/canisterIdResolution.ts
+++ b/src/frontend/src/lib/utils/canisterIdResolution.ts
@@ -43,7 +43,12 @@ const parseCanisterIdFromHostname = (
     "localhost",
   ];
 
-  if (wellKnownDomains.some((domain) => hostname.endsWith(domain))) {
+  // Match by exact equality or by a dot boundary so adversarial subdomains
+  // like `evil-ic0.app` are not treated as well-known IC domains.
+  const matchesWellKnown = wellKnownDomains.some(
+    (domain) => hostname === domain || hostname.endsWith(`.${domain}`),
+  );
+  if (matchesWellKnown) {
     // The canister is running on a well-known domain, infer the canister ID from the hostname directly
     // (e.g. bd3sg-teaaa-aaaaa-qaaba-cai.localhost -> bd3sg-teaaa-aaaaa-qaaba-cai)
     const domainParts = hostname.split(".");

--- a/src/frontend/src/lib/utils/iiConnection.ts
+++ b/src/frontend/src/lib/utils/iiConnection.ts
@@ -1036,8 +1036,7 @@ export const inferHost = (): string => {
   // by a dot boundary, so adversarial subdomains like `evil-ic0.app` are not
   // treated as the IC.
   const isGatewayDomain = (domain: string): boolean =>
-    location.hostname === domain ||
-    location.hostname.endsWith(`.${domain}`);
+    location.hostname === domain || location.hostname.endsWith(`.${domain}`);
 
   if (
     isGatewayDomain("icp0.io") ||

--- a/src/frontend/src/lib/utils/iiConnection.ts
+++ b/src/frontend/src/lib/utils/iiConnection.ts
@@ -1032,11 +1032,18 @@ export const inferHost = (): string => {
     return "https://" + IC_API_DOMAIN;
   }
 
+  // Match a hostname against an official gateway domain by exact equality or
+  // by a dot boundary, so adversarial subdomains like `evil-ic0.app` are not
+  // treated as the IC.
+  const isGatewayDomain = (domain: string): boolean =>
+    location.hostname === domain ||
+    location.hostname.endsWith(`.${domain}`);
+
   if (
-    location.hostname.endsWith("icp0.io") ||
-    location.hostname.endsWith("ic0.app") ||
-    location.hostname.endsWith("icp.net") ||
-    location.hostname.endsWith("internetcomputer.org")
+    isGatewayDomain("icp0.io") ||
+    isGatewayDomain("ic0.app") ||
+    isGatewayDomain("icp.net") ||
+    isGatewayDomain("internetcomputer.org")
   ) {
     // If this is a canister running on one of the official IC domains, then return the
     // official API endpoint

--- a/src/frontend/src/lib/utils/iiConnection.ts
+++ b/src/frontend/src/lib/utils/iiConnection.ts
@@ -993,11 +993,12 @@ export const creationOptions = (
   };
 };
 
-// In order to give dapps a stable principal regardless whether they use the legacy (ic0.app) or the new domain (icp0.io)
-// we map back the derivation origin to the ic0.app domain.
+// In order to give dapps a stable principal regardless whether they use the legacy (ic0.app) or
+// any of the newer canister gateway domains (icp0.io, icp.net) we map back the derivation origin
+// to the ic0.app domain.
 export const remapToLegacyDomain = (origin: string): string => {
   const ORIGIN_MAPPING_REGEX =
-    /^https:\/\/(?<subdomain>[\w-]+(?:\.raw)?)\.icp0\.io$/;
+    /^https:\/\/(?<subdomain>[\w-]+(?:\.raw)?)\.(?:icp0\.io|icp\.net)$/;
   const match = origin.match(ORIGIN_MAPPING_REGEX);
   const subdomain = match?.groups?.subdomain;
   if (subdomain !== undefined) {
@@ -1034,6 +1035,7 @@ export const inferHost = (): string => {
   if (
     location.hostname.endsWith("icp0.io") ||
     location.hostname.endsWith("ic0.app") ||
+    location.hostname.endsWith("icp.net") ||
     location.hostname.endsWith("internetcomputer.org")
   ) {
     // If this is a canister running on one of the official IC domains, then return the

--- a/src/frontend/src/lib/utils/validateDerivationOrigin.test.ts
+++ b/src/frontend/src/lib/utils/validateDerivationOrigin.test.ts
@@ -28,6 +28,40 @@ test("should validate same derivation origin", async () => {
   expect(result).toEqual({ result: "valid" });
 });
 
+test("should validate when request and derivation origin are different gateway variants of the same canister", async () => {
+  // Same canister served from different IC gateway domains: no alternative
+  // origins file lookup is required because the two URLs normalise to the
+  // same canonical (ic0.app) origin.
+  const variants = [
+    [
+      `https://${TEST_CANISTER_ID}.icp0.io`,
+      `https://${TEST_CANISTER_ID}.ic0.app`,
+    ],
+    [
+      `https://${TEST_CANISTER_ID}.ic0.app`,
+      `https://${TEST_CANISTER_ID}.icp.net`,
+    ],
+    [
+      `https://${TEST_CANISTER_ID}.icp.net`,
+      `https://${TEST_CANISTER_ID}.icp0.io`,
+    ],
+    [
+      `https://${TEST_CANISTER_ID}.raw.icp0.io`,
+      `https://${TEST_CANISTER_ID}.raw.icp.net`,
+    ],
+  ];
+
+  for (const [requestOrigin, derivationOrigin] of variants) {
+    const result = await validateDerivationOrigin({
+      requestOrigin,
+      derivationOrigin,
+      resolveCanisterId: () =>
+        Promise.reject("should not be reached for same-canister variants"),
+    });
+    expect(result).toEqual({ result: "valid" });
+  }
+});
+
 test("should fetch alternative origins file from expected URL", async () => {
   const testCases = [
     {
@@ -210,6 +244,37 @@ for (const iiUrl of validIIUrls) {
     });
 
     expect(result.result).toBe("invalid");
+  });
+
+  test("should validate request origin against alternative origins regardless of gateway variant", async () => {
+    // Listing the canister origin under any of its three official gateway
+    // domains should accept requests coming from any of the others, without
+    // needing every variant to be enumerated explicitly.
+    const variants = [
+      `https://${TEST_CANISTER_ID}.ic0.app`,
+      `https://${TEST_CANISTER_ID}.icp0.io`,
+      `https://${TEST_CANISTER_ID}.icp.net`,
+    ];
+
+    for (const listedVariant of variants) {
+      for (const requestVariant of variants) {
+        setupMocks({
+          iiUrl,
+          response: Response.json({
+            alternativeOrigins: [listedVariant],
+          }),
+        });
+
+        const result = await validateDerivationOrigin({
+          requestOrigin: requestVariant,
+          derivationOrigin: "https://some-url.com",
+          resolveCanisterId: () => Promise.resolve({ ok: TEST_CANISTER_ID }),
+        });
+
+        expect(result, `listed=${listedVariant} request=${requestVariant}`)
+          .toEqual({ result: "valid" });
+      }
+    }
   });
 }
 

--- a/src/frontend/src/lib/utils/validateDerivationOrigin.test.ts
+++ b/src/frontend/src/lib/utils/validateDerivationOrigin.test.ts
@@ -30,7 +30,7 @@ test("should validate same derivation origin", async () => {
 
 test("should validate when request and derivation origin are different gateway variants of the same canister", async () => {
   // Same canister served from different IC gateway domains: no alternative
-  // origins file lookup is required because the two URLs normalise to the
+  // origins file lookup is required because the two URLs normalize to the
   // same canonical (ic0.app) origin.
   const variants = [
     [
@@ -271,8 +271,10 @@ for (const iiUrl of validIIUrls) {
           resolveCanisterId: () => Promise.resolve({ ok: TEST_CANISTER_ID }),
         });
 
-        expect(result, `listed=${listedVariant} request=${requestVariant}`)
-          .toEqual({ result: "valid" });
+        expect(
+          result,
+          `listed=${listedVariant} request=${requestVariant}`,
+        ).toEqual({ result: "valid" });
       }
     }
   });

--- a/src/frontend/src/lib/utils/validateDerivationOrigin.ts
+++ b/src/frontend/src/lib/utils/validateDerivationOrigin.ts
@@ -1,4 +1,5 @@
 import { resolveCanisterId as resolveCanisterIdFn } from "$lib/utils/canisterIdResolution";
+import { remapToLegacyDomain } from "$lib/utils/iiConnection";
 import { wrapError } from "$lib/utils/utils";
 import { Principal } from "@icp-sdk/core/principal";
 
@@ -25,7 +26,13 @@ export const validateDerivationOrigin = async ({
   derivationOrigin?: string;
   resolveCanisterId?: typeof resolveCanisterIdFn;
 }): Promise<ValidationResult> => {
-  if (derivationOrigin === undefined || derivationOrigin === requestOrigin) {
+  // Compare in canonical (ic0.app) form so that the three official canister
+  // gateway domains (ic0.app, icp0.io, icp.net) are treated as one site.
+  const normalisedRequestOrigin = remapToLegacyDomain(requestOrigin);
+  if (
+    derivationOrigin === undefined ||
+    remapToLegacyDomain(derivationOrigin) === normalisedRequestOrigin
+  ) {
     // this is the default behaviour -> no further validation necessary
     return { result: "valid" };
   }
@@ -90,8 +97,14 @@ export const validateDerivationOrigin = async ({
       };
     }
 
-    // check allowed alternative origins
-    if (!alternativeOriginsObj.alternativeOrigins.includes(requestOrigin)) {
+    // Check allowed alternative origins. Both the request origin and each
+    // listed entry are normalised to the canonical ic0.app form, so listing
+    // any one of <canister>.ic0.app, <canister>.icp0.io, or <canister>.icp.net
+    // covers requests from all three gateway variants.
+    const normalisedAllowed = alternativeOriginsObj.alternativeOrigins.map(
+      remapToLegacyDomain,
+    );
+    if (!normalisedAllowed.includes(normalisedRequestOrigin)) {
       return {
         result: "invalid",
         message: `"${requestOrigin}" is not listed in the list of allowed alternative origins. Allowed alternative origins: ${alternativeOriginsObj.alternativeOrigins}`,

--- a/src/frontend/src/lib/utils/validateDerivationOrigin.ts
+++ b/src/frontend/src/lib/utils/validateDerivationOrigin.ts
@@ -28,10 +28,10 @@ export const validateDerivationOrigin = async ({
 }): Promise<ValidationResult> => {
   // Compare in canonical (ic0.app) form so that the three official canister
   // gateway domains (ic0.app, icp0.io, icp.net) are treated as one site.
-  const normalisedRequestOrigin = remapToLegacyDomain(requestOrigin);
+  const normalizedRequestOrigin = remapToLegacyDomain(requestOrigin);
   if (
     derivationOrigin === undefined ||
-    remapToLegacyDomain(derivationOrigin) === normalisedRequestOrigin
+    remapToLegacyDomain(derivationOrigin) === normalizedRequestOrigin
   ) {
     // this is the default behaviour -> no further validation necessary
     return { result: "valid" };
@@ -98,13 +98,12 @@ export const validateDerivationOrigin = async ({
     }
 
     // Check allowed alternative origins. Both the request origin and each
-    // listed entry are normalised to the canonical ic0.app form, so listing
+    // listed entry are normalized to the canonical ic0.app form, so listing
     // any one of <canister>.ic0.app, <canister>.icp0.io, or <canister>.icp.net
     // covers requests from all three gateway variants.
-    const normalisedAllowed = alternativeOriginsObj.alternativeOrigins.map(
-      remapToLegacyDomain,
-    );
-    if (!normalisedAllowed.includes(normalisedRequestOrigin)) {
+    const normalizedAllowed =
+      alternativeOriginsObj.alternativeOrigins.map(remapToLegacyDomain);
+    if (!normalizedAllowed.includes(normalizedRequestOrigin)) {
       return {
         result: "invalid",
         message: `"${requestOrigin}" is not listed in the list of allowed alternative origins. Allowed alternative origins: ${alternativeOriginsObj.alternativeOrigins}`,

--- a/src/internet_identity_interface/src/internet_identity/types/attributes.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/attributes.rs
@@ -20,24 +20,27 @@ pub const OPENID_ISSUER_MAX_BYTES: usize = 1024;
 pub const SSO_DOMAIN_MAX_BYTES: usize = 253;
 
 /// Mirror of the frontend's `remapToLegacyDomain`: the frontend rewrites
-/// `https://<sub>.icp0.io` to `https://<sub>.ic0.app` before deriving a
-/// principal so users get the same principal across the two domains. The
-/// canister needs the same transformation to verify that an `unmapped_origin`
-/// supplied alongside the (legacy-mapped) `origin` is just the icp0.io form
-/// of the same site, not a different origin sneaking into the certified
-/// `implicit:origin`.
+/// `https://<sub>.icp0.io` and `https://<sub>.icp.net` to `https://<sub>.ic0.app`
+/// before deriving a principal so users get the same principal across all
+/// canister gateway domains. The canister needs the same transformation to
+/// verify that an `unmapped_origin` supplied alongside the (legacy-mapped)
+/// `origin` is just an alternate gateway form of the same site, not a
+/// different origin sneaking into the certified `implicit:origin`.
 ///
 /// The accepted shape — `<subdomain>(.raw)?` containing only ASCII word
-/// characters or `-` — matches the regex `^https://([\w-]+(?:\.raw)?)\.icp0\.io$`
-/// used in the frontend.
+/// characters or `-` — matches the regex
+/// `^https://([\w-]+(?:\.raw)?)\.(?:icp0\.io|icp\.net)$` used in the frontend.
 pub fn remap_to_legacy_domain(origin: &str) -> String {
     const PREFIX: &str = "https://";
-    const ICP0_SUFFIX: &str = ".icp0.io";
+    const REMAPPED_SUFFIXES: &[&str] = &[".icp0.io", ".icp.net"];
 
     let Some(rest) = origin.strip_prefix(PREFIX) else {
         return origin.to_string();
     };
-    let Some(subdomain) = rest.strip_suffix(ICP0_SUFFIX) else {
+    let Some(subdomain) = REMAPPED_SUFFIXES
+        .iter()
+        .find_map(|suffix| rest.strip_suffix(suffix))
+    else {
         return origin.to_string();
     };
 
@@ -2237,6 +2240,14 @@ mod tests {
         }
 
         #[test]
+        fn maps_icp_net_subdomain_to_ic0_app() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://foo.icp.net"),
+                "https://foo.ic0.app"
+            );
+        }
+
+        #[test]
         fn maps_raw_subdomain() {
             pretty_assert_eq!(
                 remap_to_legacy_domain("https://foo.raw.icp0.io"),
@@ -2245,9 +2256,25 @@ mod tests {
         }
 
         #[test]
+        fn maps_raw_subdomain_on_icp_net() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://foo.raw.icp.net"),
+                "https://foo.raw.ic0.app"
+            );
+        }
+
+        #[test]
         fn allows_underscore_and_hyphen_in_subdomain() {
             pretty_assert_eq!(
                 remap_to_legacy_domain("https://my-app_1.icp0.io"),
+                "https://my-app_1.ic0.app"
+            );
+        }
+
+        #[test]
+        fn allows_underscore_and_hyphen_in_subdomain_on_icp_net() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://my-app_1.icp.net"),
                 "https://my-app_1.ic0.app"
             );
         }
@@ -2270,10 +2297,26 @@ mod tests {
         }
 
         #[test]
+        fn rejects_extra_subdomain_levels_on_icp_net() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("https://foo.bar.icp.net"),
+                "https://foo.bar.icp.net"
+            );
+        }
+
+        #[test]
         fn rejects_http_scheme() {
             pretty_assert_eq!(
                 remap_to_legacy_domain("http://foo.icp0.io"),
                 "http://foo.icp0.io"
+            );
+        }
+
+        #[test]
+        fn rejects_http_scheme_on_icp_net() {
+            pretty_assert_eq!(
+                remap_to_legacy_domain("http://foo.icp.net"),
+                "http://foo.icp.net"
             );
         }
     }


### PR DESCRIPTION
## Summary

> **Depends on #3858** — merge that first, then this PR's diff will only show the normalisation changes.

`validateDerivationOrigin` now runs both the request origin and each allowed alternative origin through `remapToLegacyDomain` before the membership check. Listing the canister origin under any one of its three official gateway domains (`.ic0.app`, `.icp0.io`, `.icp.net`) now covers requests coming from any of the others — relying parties no longer need to enumerate every variant in `/.well-known/ii-alternative-origins`.

The same normalisation is applied to the early-return that skips the alt-origins fetch when request and derivation origins refer to the same site.

## Why

The strict `includes(requestOrigin)` check on the literal postMessage origin meant that a dapp loaded at `<canister>.ic0.app` was rejected unless the alt-origins file listed that exact URL — even if it already listed the equivalent `.icp0.io` form. With this change, all three gateway variants of the same canister are treated as one site for matching purposes, mirroring what the FE/BE remap already does for principal derivation.

## Why no BE change

The BE has no equivalent allowlist comparison — the alt-origins file is hosted by the relying party on its own canister and only the FE fetches and validates it. The closest BE check, `unmapped_origin` vs. `origin` in `attributes.rs`, already runs through `remap_to_legacy_domain` and correctly handles all three variants once #3858 lands.

## Changes (this PR only — ignore #3858 commits in the diff until it merges)

- `src/frontend/src/lib/utils/validateDerivationOrigin.ts`: normalise via `remapToLegacyDomain` on both sides of the alt-origins membership check, and on the same-site early-return.
- `src/frontend/src/lib/utils/validateDerivationOrigin.test.ts`: 4 new same-canister-different-gateway early-return cases plus a 3×3 cross-variant matrix verifying that any listed gateway accepts requests from any other.

## Test plan

- [x] `npx vitest run src/frontend/src/lib/utils/validateDerivationOrigin.test.ts` (23 pass — 19 existing + 4 new)
- [x] `tsc --noEmit` clean
- [x] CI green