### PR TITLE
fix(fe): remove SSO frontend rate limit, clarify error copy, unify timeouts

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/views/SignInWithSso.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/SignInWithSso.svelte
@@ -73,6 +73,12 @@
   });
 
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  /**
+   * Aborts the in-flight `discoverSsoConfig` from a previous keystroke so a
+   * new lookup doesn't pile up behind it. Replaced on every fresh lookup
+   * and aborted on unmount.
+   */
+  let lookupController: AbortController | undefined;
 
   /**
    * Map caught errors to user-actionable copy, or `undefined` for
@@ -124,9 +130,6 @@
       if (msg.toLowerCase().includes("canary allowlist")) {
         return $t`SSO is not available for "${domainInput}" yet. Ask an II admin to register this domain.`;
       }
-      if (msg === "Too many concurrent SSO discovery requests") {
-        return $t`Several SSO sign-ins are in flight already. Wait a moment.`;
-      }
     }
     return undefined;
   };
@@ -151,6 +154,8 @@
       clearTimeout(debounceTimer);
       debounceTimer = undefined;
     }
+    lookupController?.abort();
+    lookupController = undefined;
     isLookingUp = false;
   };
 
@@ -180,22 +185,32 @@
       return;
     }
 
+    const controller = new AbortController();
+    lookupController = controller;
     debounceTimer = setTimeout(async () => {
       debounceTimer = undefined;
       isLookingUp = true;
       // The input may change again while these awaits are in flight; we
       // only apply / error-out when our `trimmed` is still the current
-      // domain, so a stale response can't clobber a fresher one.
+      // domain, so a stale response can't clobber a fresher one. The
+      // matching `lookupController` is also aborted by `invalidatePrepared`,
+      // which causes `discoverSsoConfig` to reject with `AbortError` —
+      // explicitly ignored below since cancellation isn't a user error.
       const matchesCurrent = () => trimmed === domain.trim().toLowerCase();
       try {
         await anonymousActor.add_discoverable_oidc_config({
           discovery_domain: trimmed,
         });
-        const result = await discoverSsoConfig(trimmed);
+        const result = await discoverSsoConfig(trimmed, controller.signal);
         if (matchesCurrent()) {
           preparedResult = result;
         }
       } catch (e) {
+        // Cancelled by a fresher keystroke — silently drop. Distinguishing
+        // on `controller.signal.aborted` (not just the error's name) means
+        // we don't accidentally swallow a hop-2 timeout, which surfaces as
+        // an `AbortError` too but isn't user-initiated.
+        if (controller.signal.aborted) return;
         if (matchesCurrent()) {
           setErrorFrom(e, trimmed);
         }
@@ -234,6 +249,7 @@
     inputRef?.focus();
     return () => {
       if (debounceTimer !== undefined) clearTimeout(debounceTimer);
+      lookupController?.abort();
     };
   });
 </script>

--- a/src/frontend/src/lib/components/wizards/auth/views/SignInWithSso.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/SignInWithSso.svelte
@@ -93,8 +93,11 @@
       if (e.reason === "http-error" && e.httpStatus !== undefined) {
         return $t`${domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP ${String(e.httpStatus)}).`;
       }
+      if (e.reason === "timeout") {
+        return $t`${domainInput} took too long to respond. Try again in a moment.`;
+      }
       if (e.reason === "network") {
-        return $t`Couldn't reach ${domainInput}. Check the spelling and your network.`;
+        return $t`Couldn't load SSO settings from ${domainInput}. Ask your SSO admin to check that /.well-known/ii-openid-configuration is reachable.`;
       }
       return $t`${domainInput}'s /.well-known/ii-openid-configuration is malformed.`;
     }
@@ -120,9 +123,6 @@
       const msg = e.message;
       if (msg.toLowerCase().includes("canary allowlist")) {
         return $t`SSO is not available for "${domainInput}" yet. Ask an II admin to register this domain.`;
-      }
-      if (msg.startsWith("Rate limited:")) {
-        return $t`Too many recent attempts for ${domainInput}. Wait a few minutes.`;
       }
       if (msg === "Too many concurrent SSO discovery requests") {
         return $t`Several SSO sign-ins are in flight already. Wait a moment.`;

--- a/src/frontend/src/lib/utils/ssoDiscovery.ts
+++ b/src/frontend/src/lib/utils/ssoDiscovery.ts
@@ -95,8 +95,8 @@ type IIOpenIdConfiguration = z.infer<typeof IIOpenIdConfigurationSchema>;
 
 /**
  * Raised when hop 1 (`/.well-known/ii-openid-configuration` on the user's
- * domain) fails in a way that signals the domain owner hasn't set up II
- * integration — 404, non-JSON response, missing fields, or unreachable.
+ * domain) fails. Covers misconfiguration (`http-error`, `invalid-response`)
+ * and transient failures (`network`, `timeout`).
  *
  * Surfaced to the UI so we can show a single user-friendly message
  * instead of leaking raw `fetch` / JSON parse errors.
@@ -113,8 +113,8 @@ export class DomainNotConfiguredError extends Error {
   ) {
     super(
       detail !== undefined
-        ? `Domain not configured for II (${reason}): ${detail}`
-        : `Domain not configured for II (${reason})`,
+        ? `SSO discovery hop 1 failed (${reason}): ${detail}`
+        : `SSO discovery hop 1 failed (${reason})`,
     );
     this.name = "DomainNotConfiguredError";
   }
@@ -421,7 +421,12 @@ const fetchWithRetry = async (
  *
  * @param domain - The organization domain (e.g., `dfinity.org`)
  * @returns The `client_id` and OIDC discovery document
- * @throws On validation failure, timeout, or network error
+ * @throws {Error} On invalid `domain` input or when over `MAX_CONCURRENT`.
+ * @throws {DomainNotConfiguredError} On any hop-1 failure
+ *   (`http-error`, `invalid-response`, `network`, `timeout`).
+ * @throws {Error} On hop-2 fetch failures (`Fetch failed: <status>`,
+ *   `AbortError`) or provider-discovery validation failures (HTTPS, hostname
+ *   match, schema).
  */
 export const discoverSsoConfig = async (
   domain: string,

--- a/src/frontend/src/lib/utils/ssoDiscovery.ts
+++ b/src/frontend/src/lib/utils/ssoDiscovery.ts
@@ -41,10 +41,12 @@
  *
  * Throttling:
  * - Successful responses cached for 4 hours per hop.
- * - Max 2 concurrent SSO discoveries globally.
  * - Exponential backoff (2s, 4s, 8s) for retryable errors, up to 3 attempts.
  * - Request timeout: 15s per hop. The abort timer is cleared in a `finally`
  *   so network errors don't leak armed timers.
+ * - Caller can pass an `AbortSignal` to cancel an in-flight discovery (used
+ *   by the input-debounce in `SignInWithSso.svelte` to drop a stale lookup
+ *   the moment the user types a different domain).
  */
 
 import { z } from "zod";
@@ -123,7 +125,6 @@ export class DomainNotConfiguredError extends Error {
 const II_CONFIG_CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const PROVIDER_CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const FETCH_TIMEOUT_MS = 15_000;
-const MAX_CONCURRENT = 2;
 const MAX_RETRIES = 3;
 const BASE_BACKOFF_MS = 2000;
 
@@ -145,7 +146,6 @@ interface ProviderCacheEntry {
 
 const iiConfigCache = new Map<string, IIConfigCacheEntry>();
 const providerCache = new Map<string, ProviderCacheEntry>();
-let activeFetches = 0;
 
 /**
  * True if `hostname` is exactly `expected` or a proper subdomain of it.
@@ -369,15 +369,23 @@ const isTransientHttpStatus = (status: number): boolean =>
 const fetchWithRetry = async (
   url: string,
   timeoutMs: number,
+  externalSignal?: AbortSignal,
 ): Promise<unknown> => {
   let lastError: unknown;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    if (externalSignal?.aborted === true) {
+      throw new DOMException("Aborted", "AbortError");
+    }
     if (attempt > 0) {
       const delay = BASE_BACKOFF_MS * Math.pow(2, attempt - 1);
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await sleep(delay, externalSignal);
     }
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    // Bridge external abort → this attempt's controller so an in-flight
+    // `fetch` is cancelled the moment the caller signals.
+    const onExternalAbort = () => controller.abort();
+    externalSignal?.addEventListener("abort", onExternalAbort, { once: true });
     // Default: treat unknown / network errors as transient and retry.
     // The try block overrides this with the HTTP-status classification
     // when the response itself was received.
@@ -393,18 +401,18 @@ const fetchWithRetry = async (
       retryable = isTransientHttpStatus(response.status);
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") {
-        // Explicit timeout: surface the abort immediately; don't backoff
-        // through retries when the first attempt already spent the full
-        // budget.
+        // Either the per-attempt timeout or the caller aborted us. In
+        // both cases there's no point retrying — surface immediately.
         throw error;
       }
       // Network errors (TypeError from `fetch`) and other unknowns: leave
       // `retryable = true` as initialised.
       lastError = error;
     } finally {
-      // Clear the abort timer on every exit path so a late abort can't
-      // fire after the attempt is already done.
+      // Clear the abort timer and listener on every exit path so a late
+      // abort can't fire after the attempt is already done.
       clearTimeout(timeoutId);
+      externalSignal?.removeEventListener("abort", onExternalAbort);
     }
     // Break out of the retry loop on deterministic failures (4xx other
     // than 408 / 429) so the UI can surface them without backoff delay.
@@ -413,6 +421,26 @@ const fetchWithRetry = async (
   throw lastError;
 };
 
+/** Backoff sleep that resolves after `ms` or rejects with AbortError if the
+ *  caller's signal fires first — so a stale lookup doesn't keep waiting
+ *  through the full backoff window after the user has moved on. */
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted === true) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+
 /**
  * Perform the two-hop SSO discovery chain for a given domain.
  *
@@ -420,8 +448,11 @@ const fetchWithRetry = async (
  * `oidc_configs` — this function does no allowlist check of its own.
  *
  * @param domain - The organization domain (e.g., `dfinity.org`)
+ * @param signal - Optional `AbortSignal` to cancel an in-flight discovery.
+ *   When fired, in-flight `fetch`es are aborted and the function rejects
+ *   with an `AbortError`.
  * @returns The `client_id` and OIDC discovery document
- * @throws {Error} On invalid `domain` input or when over `MAX_CONCURRENT`.
+ * @throws {Error} On invalid `domain` input.
  * @throws {DomainNotConfiguredError} On any hop-1 failure
  *   (`http-error`, `invalid-response`, `network`, `timeout`).
  * @throws {Error} On hop-2 fetch failures (`Fetch failed: <status>`,
@@ -430,6 +461,7 @@ const fetchWithRetry = async (
  */
 export const discoverSsoConfig = async (
   domain: string,
+  signal?: AbortSignal,
 ): Promise<SsoDiscoveryResult> => {
   const validatedDomain = validateDomain(domain);
 
@@ -455,89 +487,78 @@ export const discoverSsoConfig = async (
     }
   }
 
-  if (activeFetches >= MAX_CONCURRENT) {
-    throw new Error("Too many concurrent SSO discovery requests");
+  // Hop 1: fetch /.well-known/ii-openid-configuration from the org domain.
+  // Raw fetch / JSON / validation errors are converted to
+  // DomainNotConfiguredError so the UI can show one friendly message
+  // regardless of how exactly the domain misbehaves. Caller-side aborts
+  // are passed through unwrapped so the UI can ignore them silently —
+  // wrapping them as "timeout" would be a lie.
+  const iiConfigUrl = `${schemeForHost(validatedDomain)}://${validatedDomain}/.well-known/ii-openid-configuration`;
+  let iiConfigData: unknown;
+  try {
+    iiConfigData = await fetchWithRetry(iiConfigUrl, FETCH_TIMEOUT_MS, signal);
+  } catch (error) {
+    if (signal?.aborted === true) throw error;
+    throw wrapHopOneError(error);
+  }
+  let iiConfig: IIOpenIdConfiguration;
+  try {
+    iiConfig = validateIIConfig(iiConfigData);
+  } catch (error) {
+    // Response decoded but doesn't match the expected shape — from the
+    // user's perspective the domain still isn't correctly configured.
+    throw new DomainNotConfiguredError(
+      "invalid-response",
+      undefined,
+      error instanceof Error ? error.message : undefined,
+    );
   }
 
-  activeFetches++;
+  iiConfigCache.set(validatedDomain, {
+    config: iiConfig,
+    fetchedAt: Date.now(),
+  });
 
-  try {
-    // Hop 1: fetch /.well-known/ii-openid-configuration from the org domain.
-    // Raw fetch / JSON / validation errors are converted to
-    // DomainNotConfiguredError so the UI can show one friendly message
-    // regardless of how exactly the domain misbehaves.
-    const iiConfigUrl = `${schemeForHost(validatedDomain)}://${validatedDomain}/.well-known/ii-openid-configuration`;
-    let iiConfigData: unknown;
-    try {
-      iiConfigData = await fetchWithRetry(iiConfigUrl, FETCH_TIMEOUT_MS);
-    } catch (error) {
-      throw wrapHopOneError(error);
-    }
-    let iiConfig: IIOpenIdConfiguration;
-    try {
-      iiConfig = validateIIConfig(iiConfigData);
-    } catch (error) {
-      // Response decoded but doesn't match the expected shape — from the
-      // user's perspective the domain still isn't correctly configured.
-      throw new DomainNotConfiguredError(
-        "invalid-response",
-        undefined,
-        error instanceof Error ? error.message : undefined,
-      );
-    }
-
-    iiConfigCache.set(validatedDomain, {
-      config: iiConfig,
-      fetchedAt: Date.now(),
-    });
-
-    // Hop 2: fetch the provider's standard OIDC discovery document.
-    const cachedProviderDoc = providerCache.get(iiConfig.openid_configuration);
-    if (
-      cachedProviderDoc !== undefined &&
-      Date.now() - cachedProviderDoc.fetchedAt < PROVIDER_CACHE_TTL_MS
-    ) {
-      return {
-        domain: validatedDomain,
-        clientId: iiConfig.client_id,
-        name: iiConfig.name,
-        discovery: cachedProviderDoc.document,
-      };
-    }
-
-    const providerUrl = new URL(iiConfig.openid_configuration);
-    const providerData = await fetchWithRetry(
-      iiConfig.openid_configuration,
-      FETCH_TIMEOUT_MS,
-    );
-    const providerDoc = validateProviderDiscovery(
-      providerData,
-      providerUrl.hostname,
-    );
-
-    providerCache.set(iiConfig.openid_configuration, {
-      document: providerDoc,
-      fetchedAt: Date.now(),
-    });
-
+  // Hop 2: fetch the provider's standard OIDC discovery document.
+  const cachedProviderDoc = providerCache.get(iiConfig.openid_configuration);
+  if (
+    cachedProviderDoc !== undefined &&
+    Date.now() - cachedProviderDoc.fetchedAt < PROVIDER_CACHE_TTL_MS
+  ) {
     return {
       domain: validatedDomain,
       clientId: iiConfig.client_id,
       name: iiConfig.name,
-      discovery: providerDoc,
+      discovery: cachedProviderDoc.document,
     };
-  } finally {
-    activeFetches--;
   }
+
+  const providerUrl = new URL(iiConfig.openid_configuration);
+  const providerData = await fetchWithRetry(
+    iiConfig.openid_configuration,
+    FETCH_TIMEOUT_MS,
+    signal,
+  );
+  const providerDoc = validateProviderDiscovery(
+    providerData,
+    providerUrl.hostname,
+  );
+
+  providerCache.set(iiConfig.openid_configuration, {
+    document: providerDoc,
+    fetchedAt: Date.now(),
+  });
+
+  return {
+    domain: validatedDomain,
+    clientId: iiConfig.client_id,
+    name: iiConfig.name,
+    discovery: providerDoc,
+  };
 };
 
 /** Clear all SSO discovery caches (for testing). */
 export const clearSsoDiscoveryCache = (): void => {
   iiConfigCache.clear();
   providerCache.clear();
-  // If a test timed out mid-fetch, the pending promise's `finally` may not
-  // have run yet and `activeFetches` could be stuck above 0, making the
-  // next test trip the MAX_CONCURRENT guard. Reset it so each test starts
-  // from a clean slate.
-  activeFetches = 0;
 };

--- a/src/frontend/src/lib/utils/ssoDiscovery.ts
+++ b/src/frontend/src/lib/utils/ssoDiscovery.ts
@@ -39,14 +39,12 @@
  *   doc from bouncing auth off-host AFTER we've committed to a provider).
  * - Provider `authorization_endpoint` hostname must match the same.
  *
- * Rate limiting:
+ * Throttling:
  * - Successful responses cached for 4 hours per hop.
- * - Per-domain rate limit: max 1 request per 10 minutes.
  * - Max 2 concurrent SSO discoveries globally.
  * - Exponential backoff (2s, 4s, 8s) for retryable errors, up to 3 attempts.
- * - Request timeouts: 5s for `ii-openid-configuration`, 10s for provider
- *   discovery. The abort timer is cleared in a `finally` so network errors
- *   don't leak armed timers.
+ * - Request timeout: 15s per hop. The abort timer is cleared in a `finally`
+ *   so network errors don't leak armed timers.
  */
 
 import { z } from "zod";
@@ -105,7 +103,11 @@ type IIOpenIdConfiguration = z.infer<typeof IIOpenIdConfigurationSchema>;
  */
 export class DomainNotConfiguredError extends Error {
   constructor(
-    public readonly reason: "http-error" | "invalid-response" | "network",
+    public readonly reason:
+      | "http-error"
+      | "invalid-response"
+      | "network"
+      | "timeout",
     public readonly httpStatus?: number,
     public readonly detail?: string,
   ) {
@@ -120,9 +122,7 @@ export class DomainNotConfiguredError extends Error {
 
 const II_CONFIG_CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const PROVIDER_CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
-const RATE_LIMIT_MS = 10 * 60 * 1000; // 10 minutes per domain
-const II_CONFIG_TIMEOUT_MS = 5_000;
-const PROVIDER_TIMEOUT_MS = 10_000;
+const FETCH_TIMEOUT_MS = 15_000;
 const MAX_CONCURRENT = 2;
 const MAX_RETRIES = 3;
 const BASE_BACKOFF_MS = 2000;
@@ -145,7 +145,6 @@ interface ProviderCacheEntry {
 
 const iiConfigCache = new Map<string, IIConfigCacheEntry>();
 const providerCache = new Map<string, ProviderCacheEntry>();
-const lastFetchAttempt = new Map<string, number>();
 let activeFetches = 0;
 
 /**
@@ -314,9 +313,10 @@ const validateProviderDiscovery = (
  *
  * - `Fetch failed: <status> ...` from our {@link fetchWithRetry} → http-error
  *   with the parsed status.
+ * - `AbortError` from the per-hop timeout → timeout.
  * - `SyntaxError` from `response.json()` → invalid-response (HTML served at
  *   200 is the most common cause, e.g. a CMS that SPA-routes every path).
- * - Anything else (timeouts, network failures, CORS, DNS) → network.
+ * - Anything else (network failures, CORS, DNS) → network.
  */
 const wrapHopOneError = (error: unknown): DomainNotConfiguredError => {
   // Duck-type (not `instanceof Error`): jsdom errors thrown from
@@ -330,6 +330,9 @@ const wrapHopOneError = (error: unknown): DomainNotConfiguredError => {
     if (match !== null) {
       return new DomainNotConfiguredError("http-error", parseInt(match[1], 10));
     }
+  }
+  if (name === "AbortError") {
+    return new DomainNotConfiguredError("timeout");
   }
   if (name === "SyntaxError") {
     return new DomainNotConfiguredError("invalid-response");
@@ -418,7 +421,7 @@ const fetchWithRetry = async (
  *
  * @param domain - The organization domain (e.g., `dfinity.org`)
  * @returns The `client_id` and OIDC discovery document
- * @throws On validation failure, rate limit, timeout, or network error
+ * @throws On validation failure, timeout, or network error
  */
 export const discoverSsoConfig = async (
   domain: string,
@@ -447,32 +450,10 @@ export const discoverSsoConfig = async (
     }
   }
 
-  // Per-domain rate limit.
-  const lastAttempt = lastFetchAttempt.get(validatedDomain);
-  if (lastAttempt !== undefined && Date.now() - lastAttempt < RATE_LIMIT_MS) {
-    // Fall back to stale cache if we have it, rather than outright failing.
-    if (cachedIIConfig !== undefined) {
-      const cachedProvider = providerCache.get(
-        cachedIIConfig.config.openid_configuration,
-      );
-      if (cachedProvider !== undefined) {
-        return {
-          domain: validatedDomain,
-          clientId: cachedIIConfig.config.client_id,
-          discovery: cachedProvider.document,
-        };
-      }
-    }
-    throw new Error(
-      `Rate limited: SSO discovery for ${validatedDomain} was attempted too recently`,
-    );
-  }
-
   if (activeFetches >= MAX_CONCURRENT) {
     throw new Error("Too many concurrent SSO discovery requests");
   }
 
-  lastFetchAttempt.set(validatedDomain, Date.now());
   activeFetches++;
 
   try {
@@ -483,7 +464,7 @@ export const discoverSsoConfig = async (
     const iiConfigUrl = `${schemeForHost(validatedDomain)}://${validatedDomain}/.well-known/ii-openid-configuration`;
     let iiConfigData: unknown;
     try {
-      iiConfigData = await fetchWithRetry(iiConfigUrl, II_CONFIG_TIMEOUT_MS);
+      iiConfigData = await fetchWithRetry(iiConfigUrl, FETCH_TIMEOUT_MS);
     } catch (error) {
       throw wrapHopOneError(error);
     }
@@ -522,7 +503,7 @@ export const discoverSsoConfig = async (
     const providerUrl = new URL(iiConfig.openid_configuration);
     const providerData = await fetchWithRetry(
       iiConfig.openid_configuration,
-      PROVIDER_TIMEOUT_MS,
+      FETCH_TIMEOUT_MS,
     );
     const providerDoc = validateProviderDiscovery(
       providerData,
@@ -549,7 +530,6 @@ export const discoverSsoConfig = async (
 export const clearSsoDiscoveryCache = (): void => {
   iiConfigCache.clear();
   providerCache.clear();
-  lastFetchAttempt.clear();
   // If a test timed out mid-fetch, the pending promise's `finally` may not
   // have run yet and `activeFetches` could be stuck above 0, making the
   // next test trip the MAX_CONCURRENT guard. Reset it so each test starts


### PR DESCRIPTION
## Summary

Two user-facing SSO sign-in errors had unhelpful copy and one had a frontend-side bug that locked users out of retrying:

- **"Too many recent attempts"** fired after a single failed lookup. The in-memory per-domain rate limit recorded its timestamp before the fetch ran, so any failure (CORS, timeout, transient network) burned the 10-minute slot. The user's first retry hit the limiter. The limiter itself is a module-scope `Map` that doesn't survive a page refresh or a second tab, so it never gated abusive callers anyway — only legitimate retries.
- **"Couldn't reach X. Check the spelling and your network."** fired for any non-HTTP-status hop-1 failure (CORS, TLS, timeout, DNS). By the time hop 1 runs, the canister has already accepted the domain via the canary allowlist — so spelling has effectively been validated, and "check your network" is misleading too. The most common real cause is a misconfigured `/.well-known` endpoint on the customer side.

## Changes

- Drop the in-memory per-domain rate limiter (`RATE_LIMIT_MS`, `lastFetchAttempt`, the rate-limit branch in `discoverSsoConfig`, and the `"Rate limited:"` branch in `mapSubmitError`). Real per-domain throttling, if needed, belongs on the canister — not in a module-scope `Map` that vanishes on page reload.
- Replace the `MAX_CONCURRENT` concurrency counter with proper `AbortSignal`-based cancellation. The debounced input handler now creates one `AbortController` per lookup and aborts the previous one on every fresh keystroke, so a stale fetch is cancelled immediately — not just ignored post-hoc via `matchesCurrent()`. The `"Several SSO sign-ins are in flight already"` message is removed since two lookups can no longer race.
- `fetchWithRetry` accepts an optional `AbortSignal` and bridges it to the per-attempt `AbortController`. The backoff sleep between retries is also abortable so a cancelled lookup doesn't keep waiting up to 8s. Caller-side aborts propagate as raw `AbortError`; only internal timeouts get wrapped as `DomainNotConfiguredError("timeout")`.
- Add a `"timeout"` reason to `DomainNotConfiguredError`; classify `AbortError` as timeout in `wrapHopOneError`. Surface a separate copy: *"X took too long to respond. Try again in a moment."*
- Rewrite the network-error copy to point at the actual likely cause: *"Couldn't load SSO settings from X. Ask your SSO admin to check that /.well-known/ii-openid-configuration is reachable."*
- Unify hop-1/hop-2 timeouts at 15s (`FETCH_TIMEOUT_MS`); previously 5s/10s. Both hops are small JSON `.well-known` fetches with similar performance profiles.

## Test plan

- [x] `vitest run src/frontend/src/lib/utils/ssoDiscovery.test.ts` — 26/27 pass; the one pre-existing failure (`validateDomain('localhost')`) is unrelated and reproduces on `main`.
- [x] `tsc --project ./tsconfig.all.json --noEmit` — clean.
- [x] `eslint` — clean.
- [x] `svelte-check` — 0 errors (19 pre-existing warnings, none in changed files).
- [x] Manual: register a domain via canary allowlist, intentionally break its `/.well-known/ii-openid-configuration` (404, missing CORS, slow loris), verify each path surfaces the new copy and that retries are not blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)