### PR TITLE
chore(deps): bump dompurify and vite for security fixes

### DIFF
--- a/demos/vc_issuer/package.json
+++ b/demos/vc_issuer/package.json
@@ -26,7 +26,7 @@
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^5.1.4",
     "typescript": "5.2.2",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vite-plugin-node-polyfills": "^0.25.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@dfinity/internet-identity",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "workspaces": [
         "src/vc-api",
@@ -23,7 +24,7 @@
         "bip39": "^3.0.4",
         "borc": "^2.1.1",
         "buffer": "^6.0.3",
-        "dompurify": "^3.2.4",
+        "dompurify": "^3.4.0",
         "idb-keyval": "^6.2.1",
         "lit-html": "^3.2.1",
         "marked": "^11.0.0",
@@ -71,7 +72,7 @@
         "ts-node": "^10.9.2",
         "typescript": "5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vite-plugin-node-polyfills": "^0.25.0",
         "vitest": "^4.0.18"
       },
@@ -120,7 +121,7 @@
         "@types/react-dom": "^18.2.17",
         "@vitejs/plugin-react": "^5.1.4",
         "typescript": "5.2.2",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vite-plugin-node-polyfills": "^0.25.0"
       }
     },
@@ -4940,9 +4941,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -9232,6 +9233,21 @@
         }
       }
     },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/svelte-check/node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -9710,7 +9726,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9918,9 +9934,9 @@
       "link": true
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11089,7 +11105,7 @@
       "devDependencies": {
         "@dfinity/internet-identity-vite-plugins": "*",
         "typescript": "5.2.2",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vite-plugin-wasm": "^3.5.0",
         "vitest": "^4.0.18"
       }
@@ -11129,7 +11145,7 @@
         "html-minifier-terser": "^7.2.0",
         "typescript": "*",
         "undici": "*",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vite-plugin-compression2": "^2.5.1"
       }
     }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ts-node": "^10.9.2",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vite-plugin-node-polyfills": "^0.25.0",
     "vitest": "^4.0.18"
   },
@@ -89,7 +89,7 @@
     "bip39": "^3.0.4",
     "borc": "^2.1.1",
     "buffer": "^6.0.3",
-    "dompurify": "^3.2.4",
+    "dompurify": "^3.4.0",
     "idb-keyval": "^6.2.1",
     "lit-html": "^3.2.1",
     "marked": "^11.0.0",

--- a/src/sig-verifier-js/package.json
+++ b/src/sig-verifier-js/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@dfinity/internet-identity-vite-plugins": "*",
     "typescript": "5.2.2",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vite-plugin-wasm": "^3.5.0",
     "vitest": "^4.0.18"
   }

--- a/src/vite-plugins/package.json
+++ b/src/vite-plugins/package.json
@@ -26,7 +26,7 @@
     "html-minifier-terser": "^7.2.0",
     "typescript": "*",
     "undici": "*",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vite-plugin-compression2": "^2.5.1"
   }
 }


### PR DESCRIPTION
Replaces dependabot PRs #3779 (dompurify) and #3763 (vite).

**dompurify** `^3.2.4` → `^3.4.0` (resolves to 3.4.2)
Multiple security fixes including mXSS via Re-Contextualization, prototype pollution via `CUSTOM_ELEMENT_HANDLING` and `USE_PROFILES`, `ADD_TAGS` function-form bypassing `FORBID_TAGS`, and `ADD_ATTR` predicates skipping URI validation. See https://github.com/cure53/DOMPurify/security/advisories.

**vite** `^7.3.1` → `^7.3.2` (resolves to 7.3.3)
Backports path-traversal fix in dev-server sourcemap handler and extends `server.fs` check to env transport / post-query-strip paths.