### PR TITLE
chore(deps): bump rustls-webpki and quinn-proto for security fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.111",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3017,9 +3017,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -3455,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Targeted Cargo.lock-only bumps via `cargo update -p rustls-webpki -p quinn-proto`. Replaces dependabot PRs #3807 and #3687 (closed earlier as transitive lockfile-only), promoted here because both versions have current security advisories applying to the in-tree code.

**rustls-webpki** 0.103.8 → 0.103.13 — resolves four advisories:
- RUSTSEC-2026-0049 — CRLs not considered authoritative due to faulty distribution-point matching; under `UnknownStatusPolicy::Allow` this could lead to inappropriate acceptance of revoked certificates.
- RUSTSEC-2026-0098 — URI name constraints incorrectly accepted.
- RUSTSEC-2026-0099 — name constraints accepted for certs asserting a wildcard name (similar to CVE-2025-61727).
- RUSTSEC-2026-0104 — reachable panic in CRL parsing prior to signature verification (denial of service).

**quinn-proto** 0.11.13 → 0.11.14 — resolves CVE-2026-31812 / RUSTSEC-2026-0037: receiving QUIC transport parameters with invalid values could panic the endpoint (denial of service).

Both crates are transitive (pulled in via reqwest → quinn / rustls); no Cargo.toml changes required.

Audit of other transitive crypto/network deps (rustls, h2, hyper, tokio, tokio-rustls, ring, hyper-rustls, rustls-pki-types, rustls-native-certs) confirmed all are on patched versions; no additional bumps needed.