### PR TITLE
feat(dmarc): RFC 7489 alignment + combined DKIM+DMARC verifier (PR 3 of email-recovery stack)

### DIFF
--- a/src/internet_identity/src/dkim/mod.rs
+++ b/src/internet_identity/src/dkim/mod.rs
@@ -37,8 +37,11 @@ mod verify;
 
 #[allow(unused_imports)]
 pub use types::{
-    Algorithm, BodyCanon, DkimCheck, DkimCheckName, DkimCheckStatus, EmailVerificationStatus,
+    Algorithm, BodyCanon, DkimCheck, DkimCheckName, DkimCheckStatus, DkimVerifyResult,
     HeaderCanon, VerificationFailReason,
 };
+// Re-exported as `verify_dkim` so downstream callers (the dmarc layer)
+// don't have to deal with both a `dkim::verify` and `dmarc::verify`
+// in scope at the same time.
 #[allow(unused_imports)]
-pub use verify::verify;
+pub use verify::verify as verify_dkim;

--- a/src/internet_identity/src/dkim/mod.rs
+++ b/src/internet_identity/src/dkim/mod.rs
@@ -37,8 +37,8 @@ mod verify;
 
 #[allow(unused_imports)]
 pub use types::{
-    Algorithm, BodyCanon, DkimCheck, DkimCheckName, DkimCheckStatus, DkimVerifyResult,
-    HeaderCanon, VerificationFailReason,
+    Algorithm, BodyCanon, DkimCheck, DkimCheckName, DkimCheckStatus, DkimVerifyResult, HeaderCanon,
+    VerificationFailReason,
 };
 // Re-exported as `verify_dkim` so downstream callers (the dmarc layer)
 // don't have to deal with both a `dkim::verify` and `dmarc::verify`

--- a/src/internet_identity/src/dkim/test_vectors.rs
+++ b/src/internet_identity/src/dkim/test_vectors.rs
@@ -14,7 +14,7 @@
 //! public key) live in `test_vectors/dkim/`. See that directory's
 //! README for the regeneration procedure.
 
-use super::types::{EmailVerificationStatus, VerificationFailReason};
+use super::types::{DkimVerifyResult, VerificationFailReason};
 use super::verify::verify;
 use internet_identity_interface::internet_identity::types::smtp::{
     SmtpAddress, SmtpEnvelope, SmtpHeader, SmtpMessage, SmtpRequest,
@@ -177,7 +177,7 @@ fn verifies_synthetic_rsa_relaxed_relaxed() {
     let req = parse_eml(SYNTH_RSA_RELAXED_RELAXED);
     let result = verify(&req, SYNTH_RSA_TXT, frozen_now());
     match result {
-        EmailVerificationStatus::Verified { dkim_domain, .. } => {
+        DkimVerifyResult::Verified { dkim_domain, .. } => {
             assert_eq!(dkim_domain, "test.example.com");
         }
         other => panic!("expected Verified, got {:?}", other),
@@ -189,7 +189,7 @@ fn verifies_synthetic_rsa_relaxed_simple_body() {
     let req = parse_eml(SYNTH_RSA_RELAXED_SIMPLE);
     let result = verify(&req, SYNTH_RSA_TXT, frozen_now());
     match result {
-        EmailVerificationStatus::Verified { dkim_domain, .. } => {
+        DkimVerifyResult::Verified { dkim_domain, .. } => {
             assert_eq!(dkim_domain, "test.example.com");
         }
         other => panic!("expected Verified, got {:?}", other),
@@ -201,7 +201,7 @@ fn rejects_simple_simple_canonicalization() {
     let req = parse_eml(SYNTH_RSA_SIMPLE_SIMPLE);
     let result = verify(&req, SYNTH_RSA_TXT, frozen_now());
     match result {
-        EmailVerificationStatus::Unverified { reason, .. } => {
+        DkimVerifyResult::Unverified { reason, .. } => {
             assert_eq!(reason, VerificationFailReason::UnsupportedCanonicalization);
         }
         other => panic!(
@@ -223,7 +223,7 @@ fn rejects_flipped_body_byte() {
     message.body = ByteBuf::from(body);
     let result = verify(&req, SYNTH_RSA_TXT, frozen_now());
     match result {
-        EmailVerificationStatus::Unverified { reason, .. } => {
+        DkimVerifyResult::Unverified { reason, .. } => {
             assert_eq!(reason, VerificationFailReason::BodyHashMismatch);
         }
         other => panic!("expected BodyHashMismatch, got {:?}", other),
@@ -257,7 +257,7 @@ fn rejects_flipped_signature_byte() {
     assert!(
         matches!(
             result,
-            EmailVerificationStatus::Unverified {
+            DkimVerifyResult::Unverified {
                 reason: VerificationFailReason::SignatureInvalid
                     | VerificationFailReason::SignatureMalformed(_)
                     | VerificationFailReason::BodyHashMismatch,
@@ -279,7 +279,7 @@ fn rejects_wrong_public_key() {
     assert!(
         matches!(
             result,
-            EmailVerificationStatus::Unverified {
+            DkimVerifyResult::Unverified {
                 reason: VerificationFailReason::SignatureInvalid
                     | VerificationFailReason::DnsRecordMalformed(_),
                 ..
@@ -302,7 +302,7 @@ fn no_dkim_signature_header() {
     let result = verify(&req, SYNTH_RSA_TXT, frozen_now());
     assert!(matches!(
         result,
-        EmailVerificationStatus::Unverified {
+        DkimVerifyResult::Unverified {
             reason: VerificationFailReason::NoSignature,
             ..
         }

--- a/src/internet_identity/src/dkim/types.rs
+++ b/src/internet_identity/src/dkim/types.rs
@@ -1,7 +1,7 @@
 //! Type definitions for the DKIM verifier.
 //!
 //! Mirrors the result-shape design from `docs/ongoing/email-recovery.md`
-//! §6.6: a [`EmailVerificationStatus`] is the verifier's externally
+//! §6.6: a [`DkimVerifyResult`] is the verifier's externally
 //! visible verdict, carrying a per-step breakdown so the UI can show
 //! *why* a signature failed when one did.
 
@@ -110,19 +110,30 @@ pub enum VerificationFailReason {
     /// DNS record's `t=y` testing flag is set; the verifier treats every
     /// signature from such a record as inconclusive.
     TestingMode,
+    /// `From:` header missing, malformed, or carrying more than one
+    /// mailbox (RFC 7489 §3.1.1 requires exactly one). The string
+    /// carries a parser diagnostic.
+    MalformedFromHeader(String),
+    /// DMARC TXT record was supplied but couldn't be parsed.
+    DmarcMalformed(String),
+    /// DKIM signed `d=` doesn't align with the From-header domain
+    /// under the published `adkim=` mode (or, when no DMARC record
+    /// exists, doesn't equal it exactly).
+    DmarcMisaligned,
 }
 
-/// Overall verifier verdict.
+/// DKIM-only verdict, the result of [`super::verify::verify`].
 ///
 /// Per RFC 6376 §5.5 / design §5.5, an email may carry multiple
 /// `DKIM-Signature` headers (e.g. original sender + mailing list
-/// forwarder). The verifier accepts the email as soon as *any one*
-/// signature passes; it returns `Verified` together with the `d=` of the
-/// signature that won. If all signatures fail, it returns `Unverified`
-/// with a single best-fit reason and the per-check breakdown for every
-/// signature it tried.
+/// forwarder). The DKIM verifier accepts the email as soon as *any
+/// one* signature passes the cryptographic check.
+///
+/// The combined DKIM + DMARC verdict (what callers actually want) is
+/// [`crate::dmarc::EmailVerificationStatus`], returned by
+/// `dmarc::verify_email`.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum EmailVerificationStatus {
+pub enum DkimVerifyResult {
     /// At least one signature passed.
     Verified {
         /// The `d=` of the signature that verified.
@@ -141,8 +152,8 @@ pub enum EmailVerificationStatus {
     },
 }
 
-impl EmailVerificationStatus {
+impl DkimVerifyResult {
     pub fn is_verified(&self) -> bool {
-        matches!(self, EmailVerificationStatus::Verified { .. })
+        matches!(self, DkimVerifyResult::Verified { .. })
     }
 }

--- a/src/internet_identity/src/dkim/verify.rs
+++ b/src/internet_identity/src/dkim/verify.rs
@@ -8,7 +8,7 @@
 //!     email: &SmtpRequest,
 //!     dkim_txt: &str,
 //!     now_secs: u64,
-//! ) -> EmailVerificationStatus
+//! ) -> DkimVerifyResult
 //! ```
 //!
 //! `dkim_txt` is the (already-trusted) content of the DKIM TXT record
@@ -37,7 +37,7 @@ use super::dns_record::parse_dkim_txt;
 use super::parse::{parse_dkim_signature, DkimSignature};
 use super::signature::{body_hash_sha256, verify_signature, VerifyOutcome};
 use super::types::{
-    DkimCheck, DkimCheckName, DkimCheckStatus, EmailVerificationStatus, HeaderCanon,
+    DkimCheck, DkimCheckName, DkimCheckStatus, DkimVerifyResult, HeaderCanon,
     VerificationFailReason,
 };
 use internet_identity_interface::internet_identity::types::smtp::{SmtpHeader, SmtpRequest};
@@ -47,7 +47,7 @@ const DKIM_SIGNATURE_HEADER: &str = "DKIM-Signature";
 /// Verify an `SmtpRequest` against an already-trusted DKIM TXT record.
 ///
 /// `now_secs` is Unix seconds — passed in so unit tests can pin time.
-pub fn verify(email: &SmtpRequest, dkim_txt: &str, now_secs: u64) -> EmailVerificationStatus {
+pub fn verify(email: &SmtpRequest, dkim_txt: &str, now_secs: u64) -> DkimVerifyResult {
     let message = match email.message.as_ref() {
         Some(m) => m,
         None => {
@@ -81,7 +81,7 @@ pub fn verify(email: &SmtpRequest, dkim_txt: &str, now_secs: u64) -> EmailVerifi
         match try_verify_signature(email, message, dkim_header, dkim_txt, now_secs) {
             Ok((dkim_domain, mut checks)) => {
                 all_checks.append(&mut checks);
-                return EmailVerificationStatus::Verified {
+                return DkimVerifyResult::Verified {
                     dkim_domain,
                     checks: all_checks,
                 };
@@ -97,8 +97,8 @@ pub fn verify(email: &SmtpRequest, dkim_txt: &str, now_secs: u64) -> EmailVerifi
 }
 
 #[allow(non_snake_case)]
-fn Unverified(reason: VerificationFailReason, checks: Vec<DkimCheck>) -> EmailVerificationStatus {
-    EmailVerificationStatus::Unverified { reason, checks }
+fn Unverified(reason: VerificationFailReason, checks: Vec<DkimCheck>) -> DkimVerifyResult {
+    DkimVerifyResult::Unverified { reason, checks }
 }
 
 /// Try to verify one specific DKIM-Signature header. Returns the `d=`
@@ -622,7 +622,7 @@ mod tests {
         };
         let result = verify(&req, "v=DKIM1; p=YWJj", 1_700_000_000);
         match result {
-            EmailVerificationStatus::Unverified { reason, .. } => {
+            DkimVerifyResult::Unverified { reason, .. } => {
                 assert_eq!(reason, VerificationFailReason::NoSignature);
             }
             other => panic!("expected Unverified(NoSignature), got {:?}", other),
@@ -669,7 +669,7 @@ mod tests {
         };
         let result = verify(&req, "v=DKIM1; p=YWJj", 1_700_000_000);
         match result {
-            EmailVerificationStatus::Unverified { reason, .. } => {
+            DkimVerifyResult::Unverified { reason, .. } => {
                 assert_eq!(reason, VerificationFailReason::UnsupportedCanonicalization);
             }
             other => panic!(
@@ -717,7 +717,7 @@ mod tests {
         };
         let result = verify(&req, "v=DKIM1; p=YWJj", 1_700_000_000);
         match result {
-            EmailVerificationStatus::Unverified { reason, .. } => {
+            DkimVerifyResult::Unverified { reason, .. } => {
                 assert_eq!(reason, VerificationFailReason::SignatureExpired);
             }
             other => panic!("expected Unverified(SignatureExpired), got {:?}", other),
@@ -763,7 +763,7 @@ mod tests {
         };
         let result = verify(&req, "v=DKIM1; p=YWJj", 1_700_000_000);
         match result {
-            EmailVerificationStatus::Unverified { reason, .. } => {
+            DkimVerifyResult::Unverified { reason, .. } => {
                 assert_eq!(reason, VerificationFailReason::AuidMisaligned);
             }
             other => panic!("expected Unverified(AuidMisaligned), got {:?}", other),

--- a/src/internet_identity/src/dkim/verify.rs
+++ b/src/internet_identity/src/dkim/verify.rs
@@ -1,10 +1,10 @@
 //! DKIM verification entry point — orchestrates parsing, canonicalisation,
 //! body hash, and signature verification per RFC 6376 §6.1.
 //!
-//! Caller-facing API:
+//! Caller-facing API (re-exported as `crate::dkim::verify_dkim`):
 //!
 //! ```ignore
-//! pub fn verify(
+//! pub fn verify_dkim(
 //!     email: &SmtpRequest,
 //!     dkim_txt: &str,
 //!     now_secs: u64,
@@ -79,11 +79,15 @@ pub fn verify(email: &SmtpRequest, dkim_txt: &str, now_secs: u64) -> DkimVerifyR
 
     for dkim_header in &dkim_headers {
         match try_verify_signature(email, message, dkim_header, dkim_txt, now_secs) {
-            Ok((dkim_domain, mut checks)) => {
-                all_checks.append(&mut checks);
+            Ok((dkim_domain, checks)) => {
+                // Per `DkimVerifyResult::Verified.checks` ("checks for
+                // the winning signature"), surface only the successful
+                // attempt's per-step trail — not the accumulated trail
+                // of every failed signature before it. Callers (and the
+                // DMARC layer) reason about the winning signature only.
                 return DkimVerifyResult::Verified {
                     dkim_domain,
-                    checks: all_checks,
+                    checks,
                 };
             }
             Err((reason, mut checks)) => {

--- a/src/internet_identity/src/dmarc/alignment.rs
+++ b/src/internet_identity/src/dmarc/alignment.rs
@@ -118,11 +118,7 @@ mod tests {
             "googlemail.com",
             AlignmentMode::Relaxed
         ));
-        assert!(!aligns(
-            "example.com",
-            "evil.com",
-            AlignmentMode::Relaxed
-        ));
+        assert!(!aligns("example.com", "evil.com", AlignmentMode::Relaxed));
     }
 
     #[test]

--- a/src/internet_identity/src/dmarc/alignment.rs
+++ b/src/internet_identity/src/dmarc/alignment.rs
@@ -1,0 +1,136 @@
+//! Domain alignment check for DMARC.
+//!
+//! Per design doc §6.3 we accept two cases:
+//!
+//! - **Strict** (`adkim=s`): the DKIM `d=` must equal the From-header
+//!   domain byte-for-byte after ASCII-lowercasing.
+//! - **Relaxed** (`adkim=r`): the two domains must equal *or* one must
+//!   be a strict subdomain of the other (label-aligned suffix).
+//!
+//! This is *stricter* than RFC-7489-compliant relaxed alignment, which
+//! uses the Public Suffix List to compute the "organizational domain"
+//! and accepts e.g. `gmail.com` ↔ `googlemail.com` if both are listed
+//! as the same org. We deliberately don't consult the PSL — design
+//! doc §6.4 documents the trust + asymmetric-failure-mode reasoning.
+//! In exchange we fail closed on multi-domain orgs (we reject
+//! `googlemail.com` + `From: gmail.com` mail), which is the safe
+//! direction for an account-recovery surface.
+//!
+//! Both inputs are expected to already be ASCII-lowercased.
+
+use super::types::AlignmentMode;
+
+/// Returns true iff the DKIM `d=` aligns with the From-header domain
+/// under `mode`.
+pub fn aligns(dkim_domain: &str, from_domain: &str, mode: AlignmentMode) -> bool {
+    if dkim_domain == from_domain {
+        return true;
+    }
+    if matches!(mode, AlignmentMode::Strict) {
+        return false;
+    }
+    is_subdomain_of(dkim_domain, from_domain) || is_subdomain_of(from_domain, dkim_domain)
+}
+
+/// Returns true iff `child` is a strict subdomain of `parent` — i.e.
+/// `child == "<labels>." + parent`. We anchor on the dot so a suffix
+/// match like `evilexample.com` ↔ `example.com` does **not** align.
+fn is_subdomain_of(child: &str, parent: &str) -> bool {
+    if child.len() <= parent.len() {
+        return false;
+    }
+    if !child.ends_with(parent) {
+        return false;
+    }
+    let dot_pos = child.len() - parent.len() - 1;
+    child.as_bytes()[dot_pos] == b'.'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strict_exact_match() {
+        assert!(aligns("example.com", "example.com", AlignmentMode::Strict));
+    }
+
+    #[test]
+    fn strict_subdomain_does_not_align() {
+        assert!(!aligns(
+            "mail.example.com",
+            "example.com",
+            AlignmentMode::Strict
+        ));
+        assert!(!aligns(
+            "example.com",
+            "mail.example.com",
+            AlignmentMode::Strict
+        ));
+    }
+
+    #[test]
+    fn relaxed_exact_match() {
+        assert!(aligns("example.com", "example.com", AlignmentMode::Relaxed));
+    }
+
+    #[test]
+    fn relaxed_dkim_subdomain_of_from() {
+        assert!(aligns(
+            "mail.example.com",
+            "example.com",
+            AlignmentMode::Relaxed
+        ));
+    }
+
+    #[test]
+    fn relaxed_from_subdomain_of_dkim() {
+        // The opposite direction (sending service signs as the
+        // registered domain on behalf of a sub-domain of itself) is
+        // valid per spec. We accept both directions in relaxed mode.
+        assert!(aligns(
+            "example.com",
+            "mail.example.com",
+            AlignmentMode::Relaxed
+        ));
+    }
+
+    #[test]
+    fn relaxed_evil_suffix_does_not_align() {
+        // The whole point of the dot anchor: a suffix match without a
+        // label boundary must NOT align.
+        assert!(!aligns(
+            "evilexample.com",
+            "example.com",
+            AlignmentMode::Relaxed
+        ));
+        assert!(!aligns(
+            "example.com",
+            "evilexample.com",
+            AlignmentMode::Relaxed
+        ));
+    }
+
+    #[test]
+    fn relaxed_unrelated_does_not_align() {
+        assert!(!aligns(
+            "gmail.com",
+            "googlemail.com",
+            AlignmentMode::Relaxed
+        ));
+        assert!(!aligns(
+            "example.com",
+            "evil.com",
+            AlignmentMode::Relaxed
+        ));
+    }
+
+    #[test]
+    fn relaxed_deep_subdomain_aligns() {
+        assert!(aligns(
+            "deep.nested.example.com",
+            "example.com",
+            AlignmentMode::Relaxed
+        ));
+    }
+}

--- a/src/internet_identity/src/dmarc/from_header.rs
+++ b/src/internet_identity/src/dmarc/from_header.rs
@@ -49,10 +49,19 @@ fn parse_single_mailbox_domain(value: &str) -> Result<String, String> {
     // somewhere later is the giveaway. We also reject any unquoted top-
     // level `,` because that would be an address-list with multiple
     // entries — DMARC requires exactly one.
-    let address_part = match find_address_spec(value)? {
-        Some(s) => s,
+    let (address_part, in_angle_brackets) = match find_address_spec(value)? {
+        Some(spec) => spec,
         None => return Err("could not locate address-spec".to_string()),
     };
+
+    // Bare addr-spec (no angle brackets) must be a single token: no
+    // whitespace at all. With angle brackets, the inside has already
+    // been carved out so anything outside is display-name territory.
+    // Without them, `"Alice alice@example.com"` or `"alice @example.com"`
+    // would otherwise slip through with domain == example.com.
+    if !in_angle_brackets && address_part.chars().any(char::is_whitespace) {
+        return Err("From: addr-spec contains whitespace".to_string());
+    }
 
     let (_, domain) = address_part
         .split_once('@')
@@ -74,11 +83,15 @@ fn parse_single_mailbox_domain(value: &str) -> Result<String, String> {
 /// - `Display Name <local@domain>`   — name-addr
 /// - `"Quoted, Name" <local@domain>` — name-addr with quoted display
 ///
-/// Returns the inside of the angle brackets if any; otherwise the whole
-/// trimmed value. Rejects on an unquoted top-level `,` (address-list)
-/// or any `:` that appears outside angle brackets / quotes (group
-/// syntax).
-fn find_address_spec(value: &str) -> Result<Option<&str>, String> {
+/// Returns `(addr-spec, in_angle_brackets)`. `in_angle_brackets` is
+/// `true` when the addr-spec came from inside `<...>` — the caller uses
+/// that to relax whitespace rules outside the brackets (display name)
+/// while still rejecting whitespace inside the bare addr-spec form.
+///
+/// Rejects on an unquoted top-level `,` (address-list), any `:` outside
+/// angle brackets / quotes (group syntax), or a `>` without a preceding
+/// `<`.
+fn find_address_spec(value: &str) -> Result<Option<(&str, bool)>, String> {
     let bytes = value.as_bytes();
     let mut in_quotes = false;
     let mut angle_start: Option<usize> = None;
@@ -108,11 +121,20 @@ fn find_address_spec(value: &str) -> Result<Option<&str>, String> {
             if angle_start.is_some() {
                 return Err("nested '<' in From: value".to_string());
             }
+            if angle_end.is_some() {
+                return Err("'<' after '>' in From: value".to_string());
+            }
             angle_start = Some(i + 1);
             i += 1;
             continue;
         }
         if b == b'>' {
+            if angle_start.is_none() {
+                return Err("'>' without matching '<' in From: value".to_string());
+            }
+            if angle_end.is_some() {
+                return Err("multiple '>' in From: value".to_string());
+            }
             angle_end = Some(i);
             i += 1;
             continue;
@@ -121,6 +143,12 @@ fn find_address_spec(value: &str) -> Result<Option<&str>, String> {
             // Inside angle brackets — anything goes (no further checks).
             i += 1;
             continue;
+        }
+        // Outside angle brackets (or after the closing `>`): only
+        // whitespace is permitted as trailing content. Anything else
+        // after `>` would be a malformed mailbox like `<a@b> garbage`.
+        if angle_end.is_some() && !b.is_ascii_whitespace() {
+            return Err("trailing content after '>' in From: value".to_string());
         }
         if b == b',' {
             return Err("From: contains an address list, not a single mailbox".to_string());
@@ -135,12 +163,12 @@ fn find_address_spec(value: &str) -> Result<Option<&str>, String> {
         if start > end {
             return Err("malformed angle-bracket pair in From:".to_string());
         }
-        return Ok(Some(value[start..end].trim()));
+        return Ok(Some((value[start..end].trim(), true)));
     }
     if angle_start.is_some() {
         return Err("unclosed '<' in From: value".to_string());
     }
-    Ok(Some(value.trim()))
+    Ok(Some((value.trim(), false)))
 }
 
 #[cfg(test)]
@@ -271,5 +299,43 @@ mod tests {
         let m = message_with(&["<<alice@example.com>>"]);
         let err = extract_from_domain(&m).unwrap_err();
         assert!(err.contains("nested"));
+    }
+
+    #[test]
+    fn rejects_whitespace_in_bare_addr_spec() {
+        // No angle brackets → the whole value is the addr-spec, so a
+        // leading display name with a space would otherwise sneak the
+        // last token through as a fake mailbox.
+        let m = message_with(&["Alice alice@example.com"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("whitespace"));
+    }
+
+    #[test]
+    fn rejects_space_around_at_in_bare_addr_spec() {
+        let m = message_with(&["alice @example.com"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("whitespace"));
+    }
+
+    #[test]
+    fn rejects_stray_closing_angle_without_opening() {
+        let m = message_with(&["alice@example.com>"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("'>' without matching '<'"));
+    }
+
+    #[test]
+    fn rejects_content_after_closing_angle() {
+        let m = message_with(&["<alice@example.com> garbage"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("trailing content"));
+    }
+
+    #[test]
+    fn rejects_multiple_closing_angles() {
+        let m = message_with(&["<alice@example.com>>"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("multiple '>'"));
     }
 }

--- a/src/internet_identity/src/dmarc/from_header.rs
+++ b/src/internet_identity/src/dmarc/from_header.rs
@@ -83,12 +83,25 @@ fn find_address_spec(value: &str) -> Result<Option<&str>, String> {
     let mut in_quotes = false;
     let mut angle_start: Option<usize> = None;
     let mut angle_end: Option<usize> = None;
-    for (i, &b) in bytes.iter().enumerate() {
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // RFC 5322 §3.2.4: inside a quoted-string a backslash escapes
+        // the next character (notably an embedded `"`). Without this
+        // we'd close the quoted region prematurely on something like
+        // `"Alice \"Ops, Inc\"" <alice@example.com>` and then
+        // misinterpret the comma as an address-list separator.
+        if in_quotes && b == b'\\' && i + 1 < bytes.len() {
+            i += 2;
+            continue;
+        }
         if b == b'"' {
             in_quotes = !in_quotes;
+            i += 1;
             continue;
         }
         if in_quotes {
+            i += 1;
             continue;
         }
         if b == b'<' {
@@ -96,14 +109,17 @@ fn find_address_spec(value: &str) -> Result<Option<&str>, String> {
                 return Err("nested '<' in From: value".to_string());
             }
             angle_start = Some(i + 1);
+            i += 1;
             continue;
         }
         if b == b'>' {
             angle_end = Some(i);
+            i += 1;
             continue;
         }
         if angle_start.is_some() && angle_end.is_none() {
             // Inside angle brackets — anything goes (no further checks).
+            i += 1;
             continue;
         }
         if b == b',' {
@@ -112,6 +128,7 @@ fn find_address_spec(value: &str) -> Result<Option<&str>, String> {
         if b == b':' {
             return Err("From: contains group syntax, not a single mailbox".to_string());
         }
+        i += 1;
     }
 
     if let (Some(start), Some(end)) = (angle_start, angle_end) {

--- a/src/internet_identity/src/dmarc/from_header.rs
+++ b/src/internet_identity/src/dmarc/from_header.rs
@@ -1,0 +1,260 @@
+//! Extract the From-header domain for DMARC alignment.
+//!
+//! RFC 5322 §3.6.2 defines `From:` as an `address-list`. RFC 7489 §3.1.1
+//! adds an extra constraint for DMARC: the message MUST have *exactly
+//! one* `From:` header containing *exactly one* mailbox. Multiple
+//! addresses, group syntax, or a missing/duplicated header all map to
+//! a verifier failure.
+//!
+//! This module is a deliberately minimal parser: enough to spot the
+//! valid single-mailbox case and reject everything else. We do *not*
+//! try to decode RFC 2047 encoded-words, comments, or quoted-pair
+//! sequences inside display names — those are display concerns and
+//! don't affect the domain we extract for alignment.
+
+use internet_identity_interface::internet_identity::types::smtp::SmtpMessage;
+
+const FROM_HEADER: &str = "From";
+
+/// Locate exactly one `From:` header in `message`, parse the single
+/// mailbox out of its value, and return the lowercased domain.
+///
+/// Returns `Err` with a human-readable reason on:
+/// - zero or more than one `From:` header,
+/// - a header value that's empty / has no `@` / has trailing list
+///   syntax / uses RFC 5322 group syntax (`name:addrs;`),
+/// - a domain that's empty after `@`.
+pub fn extract_from_domain(message: &SmtpMessage) -> Result<String, String> {
+    let mut iter = message
+        .headers
+        .iter()
+        .filter(|h| h.name.eq_ignore_ascii_case(FROM_HEADER));
+    let from = iter
+        .next()
+        .ok_or_else(|| "no From: header".to_string())?;
+    if iter.next().is_some() {
+        return Err("multiple From: headers".to_string());
+    }
+    parse_single_mailbox_domain(&from.value)
+}
+
+/// Parse a single-mailbox `From:` value and return the domain
+/// lowercased. Tolerates an optional display name and angle-bracket
+/// `<addr-spec>`; rejects address-lists and group syntax.
+fn parse_single_mailbox_domain(value: &str) -> Result<String, String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err("empty From: value".to_string());
+    }
+
+    // Reject group syntax: `name: a@x, b@y;`. The `:` followed by `;`
+    // somewhere later is the giveaway. We also reject any unquoted top-
+    // level `,` because that would be an address-list with multiple
+    // entries — DMARC requires exactly one.
+    let address_part = match find_address_spec(value)? {
+        Some(s) => s,
+        None => return Err("could not locate address-spec".to_string()),
+    };
+
+    let (_, domain) = address_part
+        .split_once('@')
+        .ok_or_else(|| format!("From: value missing '@': {value}"))?;
+    let domain = domain.trim().trim_end_matches('.').to_ascii_lowercase();
+    if domain.is_empty() {
+        return Err("From: value has empty domain".to_string());
+    }
+    if domain.contains(char::is_whitespace) {
+        return Err("From: domain contains whitespace".to_string());
+    }
+    Ok(domain)
+}
+
+/// Walk the value looking for the address-spec. The grammar we accept:
+///
+/// - `local@domain`                  — bare addr-spec
+/// - `<local@domain>`                — angle-addr (display name absent)
+/// - `Display Name <local@domain>`   — name-addr
+/// - `"Quoted, Name" <local@domain>` — name-addr with quoted display
+///
+/// Returns the inside of the angle brackets if any; otherwise the whole
+/// trimmed value. Rejects on an unquoted top-level `,` (address-list)
+/// or any `:` that appears outside angle brackets / quotes (group
+/// syntax).
+fn find_address_spec(value: &str) -> Result<Option<&str>, String> {
+    let bytes = value.as_bytes();
+    let mut in_quotes = false;
+    let mut angle_start: Option<usize> = None;
+    let mut angle_end: Option<usize> = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'"' {
+            in_quotes = !in_quotes;
+            continue;
+        }
+        if in_quotes {
+            continue;
+        }
+        if b == b'<' {
+            if angle_start.is_some() {
+                return Err("nested '<' in From: value".to_string());
+            }
+            angle_start = Some(i + 1);
+            continue;
+        }
+        if b == b'>' {
+            angle_end = Some(i);
+            continue;
+        }
+        if angle_start.is_some() && angle_end.is_none() {
+            // Inside angle brackets — anything goes (no further checks).
+            continue;
+        }
+        if b == b',' {
+            return Err("From: contains an address list, not a single mailbox".to_string());
+        }
+        if b == b':' {
+            return Err("From: contains group syntax, not a single mailbox".to_string());
+        }
+    }
+
+    if let (Some(start), Some(end)) = (angle_start, angle_end) {
+        if start > end {
+            return Err("malformed angle-bracket pair in From:".to_string());
+        }
+        return Ok(Some(value[start..end].trim()));
+    }
+    if angle_start.is_some() {
+        return Err("unclosed '<' in From: value".to_string());
+    }
+    Ok(Some(value.trim()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use internet_identity_interface::internet_identity::types::smtp::SmtpHeader;
+    use serde_bytes::ByteBuf;
+
+    fn message_with(from_values: &[&str]) -> SmtpMessage {
+        let mut headers: Vec<SmtpHeader> = vec![SmtpHeader {
+            name: "Subject".into(),
+            value: "x".into(),
+        }];
+        for v in from_values {
+            headers.push(SmtpHeader {
+                name: "From".into(),
+                value: (*v).into(),
+            });
+        }
+        SmtpMessage {
+            headers,
+            body: ByteBuf::from(b"x".to_vec()),
+        }
+    }
+
+    #[test]
+    fn bare_addr_spec() {
+        let m = message_with(&["alice@example.com"]);
+        assert_eq!(extract_from_domain(&m).unwrap(), "example.com");
+    }
+
+    #[test]
+    fn angle_bracketed() {
+        let m = message_with(&["<alice@example.com>"]);
+        assert_eq!(extract_from_domain(&m).unwrap(), "example.com");
+    }
+
+    #[test]
+    fn name_addr() {
+        let m = message_with(&["Alice Smith <alice@example.com>"]);
+        assert_eq!(extract_from_domain(&m).unwrap(), "example.com");
+    }
+
+    #[test]
+    fn quoted_display_with_comma_in_name() {
+        // A `,` inside quotes is part of the display name and must not
+        // be mistaken for an address-list separator.
+        let m = message_with(&["\"Smith, Alice\" <alice@example.com>"]);
+        assert_eq!(extract_from_domain(&m).unwrap(), "example.com");
+    }
+
+    #[test]
+    fn quoted_display_with_colon_in_name() {
+        let m = message_with(&["\"Note: subject\" <alice@example.com>"]);
+        assert_eq!(extract_from_domain(&m).unwrap(), "example.com");
+    }
+
+    #[test]
+    fn lowercases_domain() {
+        let m = message_with(&["alice@EXAMPLE.COM"]);
+        assert_eq!(extract_from_domain(&m).unwrap(), "example.com");
+    }
+
+    #[test]
+    fn strips_trailing_dot() {
+        let m = message_with(&["alice@example.com."]);
+        assert_eq!(extract_from_domain(&m).unwrap(), "example.com");
+    }
+
+    #[test]
+    fn rejects_no_from_header() {
+        let m = message_with(&[]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("no From"));
+    }
+
+    #[test]
+    fn rejects_multiple_from_headers() {
+        let m = message_with(&["alice@example.com", "bob@example.com"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("multiple"));
+    }
+
+    #[test]
+    fn rejects_address_list() {
+        let m = message_with(&["alice@example.com, bob@example.com"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("address list"));
+    }
+
+    #[test]
+    fn rejects_group_syntax() {
+        let m = message_with(&["recipients: alice@example.com;"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("group"));
+    }
+
+    #[test]
+    fn rejects_missing_at() {
+        let m = message_with(&["alice"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("'@'"));
+    }
+
+    #[test]
+    fn rejects_empty_value() {
+        let m = message_with(&[""]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("empty"));
+    }
+
+    #[test]
+    fn rejects_empty_domain_after_at() {
+        let m = message_with(&["alice@"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("empty domain"));
+    }
+
+    #[test]
+    fn rejects_unclosed_angle_bracket() {
+        let m = message_with(&["<alice@example.com"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("unclosed"));
+    }
+
+    #[test]
+    fn rejects_nested_angle_brackets() {
+        let m = message_with(&["<<alice@example.com>>"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("nested"));
+    }
+}

--- a/src/internet_identity/src/dmarc/from_header.rs
+++ b/src/internet_identity/src/dmarc/from_header.rs
@@ -29,9 +29,7 @@ pub fn extract_from_domain(message: &SmtpMessage) -> Result<String, String> {
         .headers
         .iter()
         .filter(|h| h.name.eq_ignore_ascii_case(FROM_HEADER));
-    let from = iter
-        .next()
-        .ok_or_else(|| "no From: header".to_string())?;
+    let from = iter.next().ok_or_else(|| "no From: header".to_string())?;
     if iter.next().is_some() {
         return Err("multiple From: headers".to_string());
     }

--- a/src/internet_identity/src/dmarc/mod.rs
+++ b/src/internet_identity/src/dmarc/mod.rs
@@ -1,0 +1,36 @@
+//! DMARC alignment check (RFC 7489) + the combined DKIM + DMARC
+//! email verifier entry point.
+//!
+//! This module sits one layer above `dkim`: it consumes a parsed
+//! `SmtpRequest` plus the (already-trusted) DKIM TXT record bytes and
+//! the DMARC TXT record bytes, runs DKIM verification, then checks
+//! that the DKIM-signed `d=` aligns with the From-header domain under
+//! the published `adkim=` mode. The public entry point is
+//! [`verify::verify_email`].
+//!
+//! The submodules are:
+//! - `types` — `DmarcOutcome`, `DmarcPolicy`, `AlignmentMode`,
+//!   `DmarcRecord`, plus the combined `EmailVerificationStatus`.
+//! - `parse` — DMARC TXT record parser (RFC 7489 §6.3).
+//! - `from_header` — RFC 5322 single-mailbox From-header parser.
+//! - `alignment` — strict / relaxed alignment check (no PSL — see
+//!   design doc §6.4).
+//! - `verify` — orchestration; the public entry point lives here.
+
+// PR 3 lands the verifier without an in-canister consumer (PR 8's
+// `smtp_request` dispatch is the first caller). Suppress dead-code
+// warnings for the public surface until consumers land.
+#![allow(dead_code)]
+
+mod alignment;
+mod from_header;
+mod parse;
+mod types;
+mod verify;
+
+#[allow(unused_imports)]
+pub use types::{
+    AlignmentMode, DmarcOutcome, DmarcPolicy, DmarcRecord, EmailVerificationStatus,
+};
+#[allow(unused_imports)]
+pub use verify::verify_email;

--- a/src/internet_identity/src/dmarc/mod.rs
+++ b/src/internet_identity/src/dmarc/mod.rs
@@ -25,12 +25,12 @@
 mod alignment;
 mod from_header;
 mod parse;
+#[cfg(test)]
+mod test_vectors;
 mod types;
 mod verify;
 
 #[allow(unused_imports)]
-pub use types::{
-    AlignmentMode, DmarcOutcome, DmarcPolicy, DmarcRecord, EmailVerificationStatus,
-};
+pub use types::{AlignmentMode, DmarcOutcome, DmarcPolicy, DmarcRecord, EmailVerificationStatus};
 #[allow(unused_imports)]
 pub use verify::verify_email;

--- a/src/internet_identity/src/dmarc/mod.rs
+++ b/src/internet_identity/src/dmarc/mod.rs
@@ -16,6 +16,33 @@
 //! - `alignment` — strict / relaxed alignment check (no PSL — see
 //!   design doc §6.4).
 //! - `verify` — orchestration; the public entry point lives here.
+//!
+//! # Security model
+//!
+//! Three intentional deviations from "stock" DMARC, each documented in
+//! the design doc and worth surfacing here for auditors:
+//!
+//! - **No Public Suffix List.** Relaxed alignment uses a label-anchored
+//!   suffix check (see `alignment::is_subdomain_of`) instead of computing
+//!   the PSL-defined organizational domain. This prevents suffix
+//!   attacks (`evilexample.com` masquerading as `example.com`) and
+//!   removes a large, slowly-changing trust dependency from the
+//!   canister. The cost is that legitimate multi-domain orgs
+//!   (`gmail.com` ↔ `googlemail.com`) fail closed; that's the safe
+//!   direction for an account-recovery surface. Design doc §6.4.
+//!
+//! - **No SPF.** The recovery flow proves *mailbox control*, not
+//!   *path-of-delivery*. DKIM gives us a cryptographic binding from the
+//!   message content to the signing domain; SPF would only tell us the
+//!   message came from an IP the domain authorised, which we can't
+//!   meaningfully check in-canister anyway (no source IP in the gateway
+//!   payload). Design doc §6.5.
+//!
+//! - **Fail-closed everywhere.** Every malformed input, every
+//!   unrecognised value, every step that can't produce a positive
+//!   answer collapses to `Unverified`. We never quarantine, never
+//!   downgrade — a recovery attempt either proves mailbox control or
+//!   it doesn't run.
 
 // PR 3 lands the verifier without an in-canister consumer (PR 8's
 // `smtp_request` dispatch is the first caller). Suppress dead-code

--- a/src/internet_identity/src/dmarc/parse.rs
+++ b/src/internet_identity/src/dmarc/parse.rs
@@ -1,0 +1,233 @@
+//! DMARC DNS record parser per RFC 7489 §6.3.
+//!
+//! A DMARC record is a TXT RR at `_dmarc.<domain>` with the same
+//! tag-value list shape as DKIM (a `;`-separated `k=v` sequence). The
+//! verifier only honours the tags listed here; reporting/forensic tags
+//! (`fo=` / `rua=` / `ruf=` / `rf=`) are accepted at parse time and
+//! dropped — we don't act on policy *for* the sending domain, only
+//! against it.
+
+use super::types::{AlignmentMode, DmarcPolicy, DmarcRecord};
+
+/// Parse a DMARC TXT record. Returns `Err` with a human-readable
+/// reason on malformed input; the caller maps that to
+/// [`DmarcOutcome::Malformed`].
+pub fn parse_dmarc_txt(record: &str) -> Result<DmarcRecord, String> {
+    let tags = split_tag_list(record)?;
+
+    // §6.3: v=DMARC1 MUST be the first tag. Any other order is invalid.
+    let v = tags
+        .first()
+        .ok_or_else(|| "empty DMARC record".to_string())?;
+    if !v.0.eq_ignore_ascii_case("v") {
+        return Err("v= must be the first tag".to_string());
+    }
+    if !v.1.eq_ignore_ascii_case("DMARC1") {
+        return Err(format!("unsupported DMARC version v={}", v.1));
+    }
+
+    let get = |name: &str| -> Option<&str> {
+        tags.iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    };
+
+    // §6.3: p= is required, must be one of {none, quarantine, reject}.
+    let policy = match get("p")
+        .ok_or_else(|| "missing required p= tag".to_string())?
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "none" => DmarcPolicy::None,
+        "quarantine" => DmarcPolicy::Quarantine,
+        "reject" => DmarcPolicy::Reject,
+        other => return Err(format!("unsupported p={other}")),
+    };
+
+    // sp= inherits from p= when absent or unrecognised. Per §6.3 the
+    // tag MUST be one of the three policy values when present.
+    let subdomain_policy = match get("sp") {
+        None => policy,
+        Some(v) => match v.trim().to_ascii_lowercase().as_str() {
+            "none" => DmarcPolicy::None,
+            "quarantine" => DmarcPolicy::Quarantine,
+            "reject" => DmarcPolicy::Reject,
+            other => return Err(format!("unsupported sp={other}")),
+        },
+    };
+
+    // adkim/aspf default to relaxed.
+    let adkim = match get("adkim") {
+        None => AlignmentMode::Relaxed,
+        Some(v) => parse_alignment_mode(v, "adkim")?,
+    };
+    let aspf = match get("aspf") {
+        None => AlignmentMode::Relaxed,
+        Some(v) => parse_alignment_mode(v, "aspf")?,
+    };
+
+    // pct= defaults to 100. Only u8 0..=100 is valid per §6.3.
+    let pct = match get("pct") {
+        None => 100u8,
+        Some(v) => {
+            let n: u32 = v
+                .trim()
+                .parse()
+                .map_err(|_| format!("pct= is not a number: {v}"))?;
+            if n > 100 {
+                return Err(format!("pct={n} out of range 0..=100"));
+            }
+            n as u8
+        }
+    };
+
+    Ok(DmarcRecord {
+        policy,
+        subdomain_policy,
+        adkim,
+        aspf,
+        pct,
+    })
+}
+
+fn parse_alignment_mode(v: &str, label: &str) -> Result<AlignmentMode, String> {
+    match v.trim().to_ascii_lowercase().as_str() {
+        "s" => Ok(AlignmentMode::Strict),
+        "r" => Ok(AlignmentMode::Relaxed),
+        other => Err(format!("unsupported {label}={other}")),
+    }
+}
+
+/// Split a tag-value list into `(name, value)` pairs in receipt order.
+///
+/// Like the DKIM tag-list splitter ([`crate::dkim::parse`]) but
+/// preserving order so we can enforce "v= must be first" per §6.3.
+/// Per RFC 7489 §6.3 each tag may appear at most once; we reject
+/// duplicates so a malformed-but-still-parseable record can't smuggle
+/// surprising semantics past us.
+fn split_tag_list(record: &str) -> Result<Vec<(String, String)>, String> {
+    let mut tags: Vec<(String, String)> = Vec::new();
+    for part in record.split(';') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let (name, value) = match part.split_once('=') {
+            Some(p) => p,
+            None => return Err(format!("tag without '=' separator: {part}")),
+        };
+        let name = name.trim().to_string();
+        if name.is_empty() {
+            return Err("empty tag name".into());
+        }
+        if tags
+            .iter()
+            .any(|(existing, _)| existing.eq_ignore_ascii_case(&name))
+        {
+            return Err(format!("duplicate tag {name}"));
+        }
+        tags.push((name, value.trim().to_string()));
+    }
+    Ok(tags)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_record() {
+        let r = "v=DMARC1; p=none";
+        let parsed = parse_dmarc_txt(r).unwrap();
+        assert_eq!(parsed.policy, DmarcPolicy::None);
+        assert_eq!(parsed.subdomain_policy, DmarcPolicy::None);
+        assert_eq!(parsed.adkim, AlignmentMode::Relaxed);
+        assert_eq!(parsed.aspf, AlignmentMode::Relaxed);
+        assert_eq!(parsed.pct, 100);
+    }
+
+    #[test]
+    fn parses_full_record() {
+        let r = "v=DMARC1; p=reject; sp=quarantine; adkim=s; aspf=s; pct=50; \
+                 fo=1; rua=mailto:reports@example.com";
+        let parsed = parse_dmarc_txt(r).unwrap();
+        assert_eq!(parsed.policy, DmarcPolicy::Reject);
+        assert_eq!(parsed.subdomain_policy, DmarcPolicy::Quarantine);
+        assert_eq!(parsed.adkim, AlignmentMode::Strict);
+        assert_eq!(parsed.aspf, AlignmentMode::Strict);
+        assert_eq!(parsed.pct, 50);
+    }
+
+    #[test]
+    fn case_insensitive_tag_names_and_values() {
+        let r = "V=DMARC1; P=Reject; ADKIM=S";
+        let parsed = parse_dmarc_txt(r).unwrap();
+        assert_eq!(parsed.policy, DmarcPolicy::Reject);
+        assert_eq!(parsed.adkim, AlignmentMode::Strict);
+    }
+
+    #[test]
+    fn sp_inherits_from_p_when_absent() {
+        let r = "v=DMARC1; p=quarantine";
+        let parsed = parse_dmarc_txt(r).unwrap();
+        assert_eq!(parsed.subdomain_policy, DmarcPolicy::Quarantine);
+    }
+
+    #[test]
+    fn rejects_v_not_first() {
+        let r = "p=none; v=DMARC1";
+        let err = parse_dmarc_txt(r).unwrap_err();
+        assert!(err.contains("v="));
+    }
+
+    #[test]
+    fn rejects_unsupported_v() {
+        let r = "v=DMARC2; p=none";
+        let err = parse_dmarc_txt(r).unwrap_err();
+        assert!(err.contains("DMARC2"));
+    }
+
+    #[test]
+    fn rejects_missing_p() {
+        let r = "v=DMARC1; sp=none";
+        let err = parse_dmarc_txt(r).unwrap_err();
+        assert!(err.contains("p="));
+    }
+
+    #[test]
+    fn rejects_unsupported_p() {
+        let r = "v=DMARC1; p=warn";
+        let err = parse_dmarc_txt(r).unwrap_err();
+        assert!(err.contains("p=warn"));
+    }
+
+    #[test]
+    fn rejects_pct_out_of_range() {
+        let r = "v=DMARC1; p=none; pct=150";
+        let err = parse_dmarc_txt(r).unwrap_err();
+        assert!(err.contains("pct"));
+    }
+
+    #[test]
+    fn rejects_duplicate_tag() {
+        let r = "v=DMARC1; p=none; p=reject";
+        let err = parse_dmarc_txt(r).unwrap_err();
+        assert!(err.contains("duplicate"));
+    }
+
+    #[test]
+    fn unknown_tags_are_ignored() {
+        let r = "v=DMARC1; p=none; unknownnewtag=42; rua=mailto:foo@bar";
+        let parsed = parse_dmarc_txt(r).unwrap();
+        assert_eq!(parsed.policy, DmarcPolicy::None);
+    }
+
+    #[test]
+    fn whitespace_around_separators_tolerated() {
+        let r = "v=DMARC1 ; p = quarantine ;  adkim = r ";
+        let parsed = parse_dmarc_txt(r).unwrap();
+        assert_eq!(parsed.policy, DmarcPolicy::Quarantine);
+        assert_eq!(parsed.adkim, AlignmentMode::Relaxed);
+    }
+}

--- a/src/internet_identity/src/dmarc/parse.rs
+++ b/src/internet_identity/src/dmarc/parse.rs
@@ -26,23 +26,34 @@ pub fn parse_dmarc_txt(record: &str) -> Result<DmarcRecord, String> {
         return Err(format!("unsupported DMARC version v={}", v.1));
     }
 
-    let get = |name: &str| -> Option<&str> {
-        tags.iter()
-            .find(|(k, _)| k.eq_ignore_ascii_case(name))
-            .map(|(_, v)| v.as_str())
-    };
-
-    // §6.3: p= is required, must be one of {none, quarantine, reject}.
-    let policy = match get("p")
-        .ok_or_else(|| "missing required p= tag".to_string())?
-        .trim()
-        .to_ascii_lowercase()
-        .as_str()
-    {
+    // §6.3: p= is required for policy records and must immediately
+    // follow v=. Every real-world DMARC record we've surveyed (Gmail,
+    // Outlook, Yahoo, ProtonMail, Cloudflare, …) places p= as the
+    // second tag, and several reference DMARC parsers (OpenDMARC and
+    // others) reject the alternative. Accepting `v=DMARC1; rua=...;
+    // p=reject` would let a malformed record influence acceptance
+    // decisions on receivers that *do* enforce the position rule —
+    // we'd be silently more permissive than the spec's intent.
+    let p_tag = tags
+        .get(1)
+        .ok_or_else(|| "missing required p= tag (must follow v=)".to_string())?;
+    if !p_tag.0.eq_ignore_ascii_case("p") {
+        return Err(format!(
+            "p= must be the second tag (got {}=) per RFC 7489 §6.3",
+            p_tag.0
+        ));
+    }
+    let policy = match p_tag.1.trim().to_ascii_lowercase().as_str() {
         "none" => DmarcPolicy::None,
         "quarantine" => DmarcPolicy::Quarantine,
         "reject" => DmarcPolicy::Reject,
         other => return Err(format!("unsupported p={other}")),
+    };
+
+    let get = |name: &str| -> Option<&str> {
+        tags.iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
     };
 
     // sp= inherits from p= when absent or unrecognised. Per §6.3 the

--- a/src/internet_identity/src/dmarc/test_vectors.rs
+++ b/src/internet_identity/src/dmarc/test_vectors.rs
@@ -185,6 +185,32 @@ fn rejects_end_to_end_when_dmarc_record_is_malformed() {
 }
 
 #[test]
+fn verifies_end_to_end_when_dmarc_record_has_unknown_tags() {
+    // RFC 7489 §6.3 requires verifiers to ignore tags they don't
+    // understand. We exercise the full verify_email path with a DMARC
+    // record carrying reporting tags (`rua=`, `ruf=`, `fo=`), a vendor
+    // extension we've never heard of, and a duplicate-looking-but-
+    // different reporting tag — verification must still succeed.
+    let req = parse_eml(SYNTH_RSA_RELAXED_RELAXED);
+    let dmarc_txt = "v=DMARC1; p=reject; rua=mailto:reports@example.com; \
+                     ruf=mailto:forensics@example.com; fo=1; \
+                     vendorext=experimental-value; adkim=s";
+    let result = verify_email(&req, SYNTH_RSA_TXT, Some(dmarc_txt), frozen_now());
+    match result {
+        EmailVerificationStatus::Verified { dmarc, .. } => {
+            assert_eq!(
+                dmarc,
+                DmarcOutcome::Aligned {
+                    policy: DmarcPolicy::Reject,
+                    alignment_mode: AlignmentMode::Strict,
+                }
+            );
+        }
+        other => panic!("expected Verified, got {:?}", other),
+    }
+}
+
+#[test]
 fn rejects_end_to_end_when_from_header_is_address_list() {
     let mut req = parse_eml(SYNTH_RSA_RELAXED_RELAXED);
     // Replace From: with an address list. DKIM signs From, so this

--- a/src/internet_identity/src/dmarc/test_vectors.rs
+++ b/src/internet_identity/src/dmarc/test_vectors.rs
@@ -1,0 +1,204 @@
+//! End-to-end tests for the combined DKIM + DMARC verifier.
+//!
+//! Reuses the synthetic `.eml` fixtures committed for PR 2 (DKIM
+//! verifier) — they all sign `d=test.example.com` with `From:
+//! alice@test.example.com`, so we get exact-match alignment regardless
+//! of the published DMARC mode. The corresponding DKIM TXT record is
+//! also reused; we synthesise the DMARC TXT inline.
+
+use super::types::{AlignmentMode, DmarcOutcome, DmarcPolicy, EmailVerificationStatus};
+use super::verify::verify_email;
+use crate::dkim::VerificationFailReason;
+use internet_identity_interface::internet_identity::types::smtp::{
+    SmtpAddress, SmtpEnvelope, SmtpHeader, SmtpMessage, SmtpRequest,
+};
+use serde_bytes::ByteBuf;
+
+const SYNTH_RSA_RELAXED_RELAXED: &[u8] =
+    include_bytes!("../../../../test_vectors/dkim/synth-rsa-relaxed-relaxed.eml");
+const SYNTH_RSA_TXT: &str =
+    include_str!("../../../../test_vectors/dkim/synth-rsa-test1._domainkey.test.example.com.txt");
+
+/// `now_secs` pinned to the synth fixtures' signing time so the
+/// `t=`/`x=` checks in the DKIM layer pass even after the captured
+/// timestamps drift past real wall-clock time.
+fn frozen_now() -> u64 {
+    1_777_972_289
+}
+
+/// Parse the synth RSA `.eml` into the gateway-shaped `SmtpRequest`,
+/// reusing the loader we wrote for PR 2's tests. We can't `pub use`
+/// it from `crate::dkim::test_vectors` (it's in `#[cfg(test)]`), so
+/// the implementation is duplicated here. Both copies parse the same
+/// way; the duplication is contained to test code.
+fn parse_eml(raw: &[u8]) -> SmtpRequest {
+    let mut header_end = 0;
+    while header_end + 4 <= raw.len() {
+        if &raw[header_end..header_end + 4] == b"\r\n\r\n" {
+            break;
+        }
+        header_end += 1;
+    }
+    if header_end + 4 > raw.len() {
+        header_end = raw.len();
+    }
+    let header_bytes = &raw[..header_end];
+    let body = if header_end + 4 <= raw.len() {
+        raw[header_end + 4..].to_vec()
+    } else {
+        Vec::new()
+    };
+
+    let mut headers: Vec<SmtpHeader> = Vec::new();
+    let mut i = 0;
+    while i < header_bytes.len() {
+        let mut end = i;
+        while end < header_bytes.len() {
+            let mut nl = end;
+            while nl + 1 < header_bytes.len() {
+                if header_bytes[nl] == b'\r' && header_bytes[nl + 1] == b'\n' {
+                    break;
+                }
+                nl += 1;
+            }
+            if nl + 1 >= header_bytes.len() {
+                end = header_bytes.len();
+                break;
+            }
+            if nl + 2 < header_bytes.len()
+                && (header_bytes[nl + 2] == b' ' || header_bytes[nl + 2] == b'\t')
+            {
+                end = nl + 2;
+                continue;
+            }
+            end = nl;
+            break;
+        }
+        let raw_header = &header_bytes[i..end];
+        i = if end + 2 <= header_bytes.len() && &header_bytes[end..end + 2] == b"\r\n" {
+            end + 2
+        } else {
+            end
+        };
+        if raw_header.is_empty() {
+            continue;
+        }
+        if let Some(colon_idx) = raw_header.iter().position(|&b| b == b':') {
+            let name = String::from_utf8_lossy(&raw_header[..colon_idx])
+                .trim()
+                .to_string();
+            let mut value = String::from_utf8_lossy(&raw_header[colon_idx + 1..]).to_string();
+            if value.starts_with(' ') {
+                value.remove(0);
+            }
+            headers.push(SmtpHeader { name, value });
+        }
+    }
+
+    SmtpRequest {
+        envelope: Some(SmtpEnvelope {
+            from: SmtpAddress {
+                user: "alice".into(),
+                domain: "test.example.com".into(),
+            },
+            to: SmtpAddress {
+                user: "recover".into(),
+                domain: "id.ai".into(),
+            },
+        }),
+        message: Some(SmtpMessage {
+            headers,
+            body: ByteBuf::from(body),
+        }),
+        gateway_flags: None,
+    }
+}
+
+#[test]
+fn verifies_end_to_end_with_no_dmarc_record_when_dkim_equals_from() {
+    let req = parse_eml(SYNTH_RSA_RELAXED_RELAXED);
+    let result = verify_email(&req, SYNTH_RSA_TXT, None, frozen_now());
+    match result {
+        EmailVerificationStatus::Verified {
+            dkim_domain,
+            from_domain,
+            dmarc,
+            ..
+        } => {
+            assert_eq!(dkim_domain, "test.example.com");
+            assert_eq!(from_domain, "test.example.com");
+            assert_eq!(dmarc, DmarcOutcome::NoRecord);
+        }
+        other => panic!("expected Verified, got {:?}", other),
+    }
+}
+
+#[test]
+fn verifies_end_to_end_with_aligned_dmarc_strict() {
+    let req = parse_eml(SYNTH_RSA_RELAXED_RELAXED);
+    let dmarc_txt = "v=DMARC1; p=reject; adkim=s";
+    let result = verify_email(&req, SYNTH_RSA_TXT, Some(dmarc_txt), frozen_now());
+    match result {
+        EmailVerificationStatus::Verified { dmarc, .. } => {
+            assert_eq!(
+                dmarc,
+                DmarcOutcome::Aligned {
+                    policy: DmarcPolicy::Reject,
+                    alignment_mode: AlignmentMode::Strict,
+                }
+            );
+        }
+        other => panic!("expected Verified, got {:?}", other),
+    }
+}
+
+#[test]
+fn verifies_end_to_end_with_aligned_dmarc_relaxed_default() {
+    let req = parse_eml(SYNTH_RSA_RELAXED_RELAXED);
+    let dmarc_txt = "v=DMARC1; p=quarantine"; // adkim defaults to relaxed
+    let result = verify_email(&req, SYNTH_RSA_TXT, Some(dmarc_txt), frozen_now());
+    match result {
+        EmailVerificationStatus::Verified { dmarc, .. } => {
+            assert_eq!(
+                dmarc,
+                DmarcOutcome::Aligned {
+                    policy: DmarcPolicy::Quarantine,
+                    alignment_mode: AlignmentMode::Relaxed,
+                }
+            );
+        }
+        other => panic!("expected Verified, got {:?}", other),
+    }
+}
+
+#[test]
+fn rejects_end_to_end_when_dmarc_record_is_malformed() {
+    let req = parse_eml(SYNTH_RSA_RELAXED_RELAXED);
+    let bad_dmarc = "this is not a DMARC record";
+    let result = verify_email(&req, SYNTH_RSA_TXT, Some(bad_dmarc), frozen_now());
+    match result {
+        EmailVerificationStatus::Unverified { reason, .. } => {
+            assert!(matches!(reason, VerificationFailReason::DmarcMalformed(_)));
+        }
+        other => panic!("expected Unverified(DmarcMalformed), got {:?}", other),
+    }
+}
+
+#[test]
+fn rejects_end_to_end_when_from_header_is_address_list() {
+    let mut req = parse_eml(SYNTH_RSA_RELAXED_RELAXED);
+    // Replace From: with an address list. DKIM signs From, so this
+    // also breaks the DKIM signature — but the verifier checks From
+    // *after* DKIM, so the From-header parse failure will only show
+    // up if DKIM happens to verify. Here we expect either NoSignature-
+    // adjacent failures or, if DKIM passes, MalformedFromHeader.
+    let message = req.message.as_mut().unwrap();
+    for h in message.headers.iter_mut() {
+        if h.name.eq_ignore_ascii_case("From") {
+            h.value = "alice@test.example.com, eve@test.example.com".into();
+        }
+    }
+    let result = verify_email(&req, SYNTH_RSA_TXT, None, frozen_now());
+    // Whatever the precise failure mode, the result must be Unverified.
+    assert!(matches!(result, EmailVerificationStatus::Unverified { .. }));
+}

--- a/src/internet_identity/src/dmarc/types.rs
+++ b/src/internet_identity/src/dmarc/types.rs
@@ -1,0 +1,128 @@
+//! Type definitions for the DMARC alignment check.
+//!
+//! Mirrors `docs/ongoing/email-recovery.md` §6.6. The canister-side
+//! verifier accepts a message only when [`DmarcOutcome`] is `Aligned`
+//! *or* `NoRecord` with the DKIM `d=` matching the From-header domain
+//! exactly (i.e. when the lack of a published DMARC record can still
+//! be inferred from a coincidentally-aligned signature). Misaligned
+//! mail is rejected outright; there is no "spoofing suspected" middle
+//! state because the call has no value if the proof isn't a usable one.
+
+/// DMARC published policy (`p=` tag, RFC 7489 §6.3).
+///
+/// We track the signer's stated intent so the failure path can
+/// surface an informational reason ("the sending domain says this
+/// kind of misaligned mail should be rejected"), but the canister's
+/// recovery flow rejects misaligned mail regardless of policy. The
+/// PoC postbox UI may still want the distinction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DmarcPolicy {
+    /// `p=none` — the domain owner asks receivers not to act on
+    /// failed alignment, only to report.
+    None,
+    /// `p=quarantine` — failed mail should land in spam.
+    Quarantine,
+    /// `p=reject` — failed mail should be discarded outright.
+    Reject,
+}
+
+/// DMARC alignment mode (`adkim=` tag, RFC 7489 §3.1.2).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AlignmentMode {
+    /// `s` — DKIM `d=` must equal the From-header domain byte-for-byte
+    /// (after ASCII-lowercasing).
+    Strict,
+    /// `r` — DKIM `d=` must equal the From-header domain or be a
+    /// subdomain of it (or the From-header domain be a subdomain of
+    /// the DKIM `d=`). Note: this is *stricter* than RFC-7489-compliant
+    /// `adkim=r` which uses the Public Suffix List to compute the
+    /// "organizational domain" — see design doc §6.4 for why we
+    /// deliberately don't consult the PSL.
+    Relaxed,
+}
+
+impl Default for AlignmentMode {
+    /// `adkim=r` is the RFC default when the tag is absent.
+    fn default() -> Self {
+        AlignmentMode::Relaxed
+    }
+}
+
+/// A parsed DMARC record. We track only the tags we honour at the
+/// verifier; reporting tags (`fo=` / `rua=` / `ruf=` / `rf=`) are
+/// accepted at parse time and dropped here.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DmarcRecord {
+    /// `p=` — required, applies to the queried domain.
+    pub policy: DmarcPolicy,
+    /// `sp=` — applies to subdomains of the queried domain. Inherits
+    /// from `p=` when absent.
+    pub subdomain_policy: DmarcPolicy,
+    /// `adkim=` — DKIM alignment mode.
+    pub adkim: AlignmentMode,
+    /// `aspf=` — SPF alignment mode. Tracked for completeness but
+    /// not enforced; we don't check SPF (design doc §6.5).
+    pub aspf: AlignmentMode,
+    /// `pct=` — fraction of failing mail to which `p=` applies, 0–100.
+    /// Defaults to 100 when absent.
+    pub pct: u8,
+}
+
+/// Verifier output for the DMARC alignment check.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DmarcOutcome {
+    /// The DKIM-signed `d=` aligns with the From-header domain under
+    /// the published `adkim=` mode.
+    Aligned {
+        policy: DmarcPolicy,
+        alignment_mode: AlignmentMode,
+    },
+    /// A DMARC record exists, but the DKIM-signed `d=` does NOT align
+    /// with the From-header domain. The message is rejected; the
+    /// embedded policy is informational (so a UI can say "the sending
+    /// domain says misaligned mail should be rejected").
+    Misaligned { policy: DmarcPolicy },
+    /// No DMARC record was supplied (caller passed `None`).
+    NoRecord,
+    /// A DMARC record was supplied but couldn't be parsed.
+    Malformed(String),
+}
+
+/// Combined DKIM + DMARC verifier verdict — the public top-level
+/// result of [`super::verify::verify_email`].
+///
+/// `Verified` carries the per-step DKIM checks plus the DMARC
+/// outcome so a caller (or a reviewer-facing UI) can render the full
+/// audit trail. `Unverified` collapses to a single best-fit reason
+/// from whichever stage actually failed (DKIM signature, From-header
+/// parsing, DMARC alignment, ...).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EmailVerificationStatus {
+    /// DKIM passed and the DKIM `d=` aligns with the From-header
+    /// domain (per DMARC, or de-facto when no DMARC record).
+    Verified {
+        /// The `d=` of the DKIM signature that verified.
+        dkim_domain: String,
+        /// The lowercased domain extracted from the `From:` header.
+        from_domain: String,
+        /// DMARC outcome — `Aligned` carries the published policy +
+        /// mode, `NoRecord` indicates the caller didn't supply one.
+        dmarc: DmarcOutcome,
+        /// Per-step DKIM checks for the winning signature.
+        checks: Vec<crate::dkim::DkimCheck>,
+    },
+    /// Either DKIM failed, the From-header was malformed, the DMARC
+    /// record was malformed, or alignment failed.
+    Unverified {
+        /// Best-fit reason from the most-recent stage that failed.
+        reason: crate::dkim::VerificationFailReason,
+        /// Per-step DKIM checks across every signature attempted.
+        checks: Vec<crate::dkim::DkimCheck>,
+    },
+}
+
+impl EmailVerificationStatus {
+    pub fn is_verified(&self) -> bool {
+        matches!(self, EmailVerificationStatus::Verified { .. })
+    }
+}

--- a/src/internet_identity/src/dmarc/verify.rs
+++ b/src/internet_identity/src/dmarc/verify.rs
@@ -16,8 +16,8 @@ use super::alignment::aligns;
 use super::from_header::extract_from_domain;
 use super::parse::parse_dmarc_txt;
 use super::types::{DmarcOutcome, DmarcRecord, EmailVerificationStatus};
-use crate::dkim::{DkimVerifyResult, VerificationFailReason};
 use crate::dkim::verify_dkim;
+use crate::dkim::{DkimVerifyResult, VerificationFailReason};
 use internet_identity_interface::internet_identity::types::smtp::SmtpRequest;
 
 /// Verify an `SmtpRequest` end-to-end: DKIM signature + DMARC alignment.
@@ -58,9 +58,7 @@ pub fn verify_email(
         Some(m) => m,
         None => {
             return EmailVerificationStatus::Unverified {
-                reason: VerificationFailReason::MalformedFromHeader(
-                    "message body missing".into(),
-                ),
+                reason: VerificationFailReason::MalformedFromHeader("message body missing".into()),
                 checks: dkim_checks,
             };
         }
@@ -109,11 +107,7 @@ pub fn verify_email(
     }
 }
 
-fn compute_outcome(
-    dkim_domain: &str,
-    from_domain: &str,
-    dmarc_txt: Option<&str>,
-) -> DmarcOutcome {
+fn compute_outcome(dkim_domain: &str, from_domain: &str, dmarc_txt: Option<&str>) -> DmarcOutcome {
     let txt = match dmarc_txt {
         None => return DmarcOutcome::NoRecord,
         Some(t) => t,

--- a/src/internet_identity/src/dmarc/verify.rs
+++ b/src/internet_identity/src/dmarc/verify.rs
@@ -51,14 +51,18 @@ pub fn verify_email(
         }
     };
 
-    // Step 2: From-header domain. We need a message body to read the
-    // headers from; if `email.message` was missing the DKIM step would
-    // have already failed (NoSignature). Unwrap is safe.
+    // Step 2: From-header domain. DKIM having returned `Verified`
+    // already implies `email.message.is_some()` — `verify_dkim` would
+    // have returned `Unverified(NoSignature)` otherwise. We still
+    // re-check defensively rather than `.expect(...)` because canister
+    // code on the IC must never trap: an invariant violation should
+    // surface as a structured fail-closed verdict, not as a rolled-back
+    // message with an opaque trap message.
     let message = match email.message.as_ref() {
         Some(m) => m,
         None => {
             return EmailVerificationStatus::Unverified {
-                reason: VerificationFailReason::MalformedFromHeader("message body missing".into()),
+                reason: VerificationFailReason::NoSignature,
                 checks: dkim_checks,
             };
         }

--- a/src/internet_identity/src/dmarc/verify.rs
+++ b/src/internet_identity/src/dmarc/verify.rs
@@ -131,7 +131,6 @@ fn compute_outcome(dkim_domain: &str, from_domain: &str, dmarc_txt: Option<&str>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dkim::{DkimCheck, DkimCheckName, DkimCheckStatus};
     use internet_identity_interface::internet_identity::types::smtp::{
         SmtpAddress, SmtpEnvelope, SmtpHeader, SmtpMessage,
     };
@@ -242,22 +241,9 @@ mod tests {
         }
     }
 
-    /// Sanity check: a "DKIM verified, no DMARC, exact d=From" case
-    /// should accept end-to-end.
-    #[test]
-    fn end_to_end_accepts_when_dkim_equals_from_no_dmarc() {
-        // Synthesize a fake DKIM-passed result by going through the
-        // wrapper with a DKIM TXT that resolves correctly only if a
-        // synth fixture is provided. Here we just check the alignment
-        // logic via the lower-level helper, which is what the unit
-        // tests above exercise. End-to-end with a real captured email
-        // is in the `test_vectors` test module.
-        let _checks: Vec<DkimCheck> = vec![DkimCheck {
-            name: DkimCheckName::SignatureValid,
-            status: DkimCheckStatus::Pass,
-            detail: None,
-        }];
-        // This documents the intended shape; real cryptographic round-
-        // trip lives in test_vectors::*.
-    }
+    // Note: the "DKIM verified, no DMARC, exact d=From" end-to-end path
+    // is covered by the cryptographic round-trip tests in
+    // `crate::dmarc::test_vectors` (which load real `.eml` fixtures and
+    // run the full `verify_email`). The unit tests in this module
+    // exercise the orchestration in isolation via lower-level helpers.
 }

--- a/src/internet_identity/src/dmarc/verify.rs
+++ b/src/internet_identity/src/dmarc/verify.rs
@@ -1,0 +1,269 @@
+//! Combined DKIM + DMARC verifier — the public top-level entry point
+//! the canister-side recovery flow consumes.
+//!
+//! Per design doc §6.6, the verifier accepts a message iff:
+//! - DKIM passes (cryptographic signature valid, all the §5.4 tags
+//!   pass), **and**
+//! - the DKIM-signed `d=` aligns with the From-header domain under
+//!   the published `adkim=` mode (or, when no DMARC record exists,
+//!   matches it byte-for-byte).
+//!
+//! We never accept a Misaligned outcome regardless of policy — this
+//! is a recovery surface, not a delivery system, and a non-aligned
+//! signature has no value to us as a proof of mailbox control.
+
+use super::alignment::aligns;
+use super::from_header::extract_from_domain;
+use super::parse::parse_dmarc_txt;
+use super::types::{DmarcOutcome, DmarcRecord, EmailVerificationStatus};
+use crate::dkim::{DkimVerifyResult, VerificationFailReason};
+use crate::dkim::verify_dkim;
+use internet_identity_interface::internet_identity::types::smtp::SmtpRequest;
+
+/// Verify an `SmtpRequest` end-to-end: DKIM signature + DMARC alignment.
+///
+/// Inputs:
+/// - `email` — the parsed `SmtpRequest` the gateway delivered.
+/// - `dkim_txt` — the (already-trusted) DKIM TXT record content. In
+///   production this comes from PR 1's DNSSEC verifier or PR 4's DoH
+///   fallback. PR 3 takes it as input and does no DNS work itself.
+/// - `dmarc_txt` — the (already-trusted) DMARC TXT record content,
+///   or `None` if the From-header domain has no published DMARC
+///   record. When `None`, the verifier still requires DKIM `d=` to
+///   match the From-header domain exactly.
+/// - `now_secs` — current Unix time (passed in so tests can pin it).
+pub fn verify_email(
+    email: &SmtpRequest,
+    dkim_txt: &str,
+    dmarc_txt: Option<&str>,
+    now_secs: u64,
+) -> EmailVerificationStatus {
+    // Step 1: DKIM. If it fails, surface the DKIM verdict directly —
+    // there's no point checking alignment against a forged signature.
+    let dkim = verify_dkim(email, dkim_txt, now_secs);
+    let (dkim_domain, dkim_checks) = match dkim {
+        DkimVerifyResult::Verified {
+            dkim_domain,
+            checks,
+        } => (dkim_domain, checks),
+        DkimVerifyResult::Unverified { reason, checks } => {
+            return EmailVerificationStatus::Unverified { reason, checks };
+        }
+    };
+
+    // Step 2: From-header domain. We need a message body to read the
+    // headers from; if `email.message` was missing the DKIM step would
+    // have already failed (NoSignature). Unwrap is safe.
+    let message = match email.message.as_ref() {
+        Some(m) => m,
+        None => {
+            return EmailVerificationStatus::Unverified {
+                reason: VerificationFailReason::MalformedFromHeader(
+                    "message body missing".into(),
+                ),
+                checks: dkim_checks,
+            };
+        }
+    };
+    let from_domain = match extract_from_domain(message) {
+        Ok(d) => d,
+        Err(e) => {
+            return EmailVerificationStatus::Unverified {
+                reason: VerificationFailReason::MalformedFromHeader(e),
+                checks: dkim_checks,
+            };
+        }
+    };
+
+    // Step 3: DMARC alignment. If a DMARC record is supplied, parse
+    // it and check alignment under its `adkim=` mode. Otherwise, the
+    // implicit policy is "DKIM `d=` must equal the From domain".
+    let outcome = compute_outcome(&dkim_domain, &from_domain, dmarc_txt);
+
+    let accepted = match &outcome {
+        DmarcOutcome::Aligned { .. } => true,
+        DmarcOutcome::NoRecord => dkim_domain == from_domain,
+        DmarcOutcome::Misaligned { .. } | DmarcOutcome::Malformed(_) => false,
+    };
+
+    if accepted {
+        EmailVerificationStatus::Verified {
+            dkim_domain,
+            from_domain,
+            dmarc: outcome,
+            checks: dkim_checks,
+        }
+    } else {
+        let reason = match &outcome {
+            DmarcOutcome::Malformed(e) => VerificationFailReason::DmarcMalformed(e.clone()),
+            // Both Misaligned (DMARC says no) and NoRecord-with-mismatch
+            // (no DMARC says-so but the bare-DKIM-equals-From check
+            // failed) collapse to DmarcMisaligned for the UI; the
+            // Verified variant carries the full DmarcOutcome detail.
+            _ => VerificationFailReason::DmarcMisaligned,
+        };
+        EmailVerificationStatus::Unverified {
+            reason,
+            checks: dkim_checks,
+        }
+    }
+}
+
+fn compute_outcome(
+    dkim_domain: &str,
+    from_domain: &str,
+    dmarc_txt: Option<&str>,
+) -> DmarcOutcome {
+    let txt = match dmarc_txt {
+        None => return DmarcOutcome::NoRecord,
+        Some(t) => t,
+    };
+    let record: DmarcRecord = match parse_dmarc_txt(txt) {
+        Ok(r) => r,
+        Err(e) => return DmarcOutcome::Malformed(e),
+    };
+    if aligns(dkim_domain, from_domain, record.adkim) {
+        DmarcOutcome::Aligned {
+            policy: record.policy,
+            alignment_mode: record.adkim,
+        }
+    } else {
+        DmarcOutcome::Misaligned {
+            policy: record.policy,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dkim::{DkimCheck, DkimCheckName, DkimCheckStatus};
+    use internet_identity_interface::internet_identity::types::smtp::{
+        SmtpAddress, SmtpEnvelope, SmtpHeader, SmtpMessage,
+    };
+    use serde_bytes::ByteBuf;
+
+    fn empty_message_with_from(from_value: &str) -> SmtpRequest {
+        SmtpRequest {
+            envelope: Some(SmtpEnvelope {
+                from: SmtpAddress {
+                    user: "alice".into(),
+                    domain: "example.com".into(),
+                },
+                to: SmtpAddress {
+                    user: "recover".into(),
+                    domain: "id.ai".into(),
+                },
+            }),
+            message: Some(SmtpMessage {
+                headers: vec![
+                    SmtpHeader {
+                        name: "From".into(),
+                        value: from_value.into(),
+                    },
+                    SmtpHeader {
+                        name: "Subject".into(),
+                        value: "x".into(),
+                    },
+                ],
+                body: ByteBuf::from(b"x".to_vec()),
+            }),
+            gateway_flags: None,
+        }
+    }
+
+    /// `verify_email` propagates a DKIM failure verbatim without
+    /// running DMARC. We exercise this by passing a request that has
+    /// no DKIM-Signature header at all.
+    #[test]
+    fn dkim_failure_short_circuits_dmarc() {
+        let req = empty_message_with_from("alice@example.com");
+        let result = verify_email(&req, "v=DKIM1; p=YWJj", None, 1_700_000_000);
+        match result {
+            EmailVerificationStatus::Unverified { reason, .. } => {
+                assert_eq!(reason, VerificationFailReason::NoSignature);
+            }
+            other => panic!("expected Unverified(NoSignature), got {:?}", other),
+        }
+    }
+
+    /// `compute_outcome` returns `NoRecord` when no DMARC TXT is
+    /// supplied. The wrapper then gates acceptance on dkim==from.
+    #[test]
+    fn no_record_aligned_when_dkim_equals_from() {
+        let outcome = compute_outcome("example.com", "example.com", None);
+        assert_eq!(outcome, DmarcOutcome::NoRecord);
+    }
+
+    #[test]
+    fn no_record_aligned_when_dkim_subdomain_of_from() {
+        // No DMARC record + dkim is a subdomain → still rejected. The
+        // bare-DKIM check requires exact equality without a policy.
+        let outcome = compute_outcome("mail.example.com", "example.com", None);
+        assert_eq!(outcome, DmarcOutcome::NoRecord);
+        // Wrapper-level acceptance check happens in verify_email; the
+        // outcome here is still NoRecord regardless.
+    }
+
+    #[test]
+    fn record_aligned_under_relaxed_subdomain() {
+        let txt = "v=DMARC1; p=reject"; // adkim defaults to relaxed
+        let outcome = compute_outcome("mail.example.com", "example.com", Some(txt));
+        assert!(matches!(
+            outcome,
+            DmarcOutcome::Aligned {
+                policy: super::super::types::DmarcPolicy::Reject,
+                alignment_mode: super::super::types::AlignmentMode::Relaxed,
+            }
+        ));
+    }
+
+    #[test]
+    fn record_misaligned_under_strict_subdomain() {
+        let txt = "v=DMARC1; p=reject; adkim=s";
+        let outcome = compute_outcome("mail.example.com", "example.com", Some(txt));
+        assert!(matches!(outcome, DmarcOutcome::Misaligned { .. }));
+    }
+
+    #[test]
+    fn record_aligned_strict_exact_match() {
+        let txt = "v=DMARC1; p=reject; adkim=s";
+        let outcome = compute_outcome("example.com", "example.com", Some(txt));
+        assert!(matches!(
+            outcome,
+            DmarcOutcome::Aligned {
+                alignment_mode: super::super::types::AlignmentMode::Strict,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn malformed_dmarc_surfaces_as_outcome() {
+        let txt = "v=BOGUS";
+        let outcome = compute_outcome("example.com", "example.com", Some(txt));
+        match outcome {
+            DmarcOutcome::Malformed(e) => assert!(e.contains("BOGUS")),
+            other => panic!("expected Malformed, got {:?}", other),
+        }
+    }
+
+    /// Sanity check: a "DKIM verified, no DMARC, exact d=From" case
+    /// should accept end-to-end.
+    #[test]
+    fn end_to_end_accepts_when_dkim_equals_from_no_dmarc() {
+        // Synthesize a fake DKIM-passed result by going through the
+        // wrapper with a DKIM TXT that resolves correctly only if a
+        // synth fixture is provided. Here we just check the alignment
+        // logic via the lower-level helper, which is what the unit
+        // tests above exercise. End-to-end with a real captured email
+        // is in the `test_vectors` test module.
+        let _checks: Vec<DkimCheck> = vec![DkimCheck {
+            name: DkimCheckName::SignatureValid,
+            status: DkimCheckStatus::Pass,
+            detail: None,
+        }];
+        // This documents the intended shape; real cryptographic round-
+        // trip lives in test_vectors::*.
+    }
+}

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -53,6 +53,7 @@ mod attributes;
 mod conversions;
 mod delegation;
 mod dkim;
+mod dmarc;
 mod dnssec;
 mod http;
 mod ii_domain;


### PR DESCRIPTION
## Summary

PR 3 of the email-recovery stack (`docs/ongoing/email-recovery.md` §6). Stacks on top of #3877 (DKIM verifier). Lands a hand-rolled DMARC alignment check and reshapes the verifier API: `dkim::verify_dkim` becomes a DKIM-only primitive, and the new `dmarc::verify_email` is the public top-level entry point that produces the combined `EmailVerificationStatus`.

**Note:** This PR targets `main` but includes PRs 1+2's commits as its base. Review the DMARC-specific changes by looking at commits on top of `ec371aae3` (PR 2's tip). Once PRs 1+2 merge, this PR's diff shrinks to just the DMARC additions.

## What's in this PR

### `src/internet_identity/src/dmarc/`

- **`types.rs`** — `DmarcOutcome` (Aligned / Misaligned / NoRecord / Malformed), `DmarcPolicy` (None / Quarantine / Reject), `AlignmentMode` (Strict / Relaxed), `DmarcRecord`, plus the combined `EmailVerificationStatus` that carries both DKIM diagnostics and the DMARC outcome on success.
- **`parse.rs`** (RFC 7489 §6.3) — DMARC TXT record parser. Enforces `v=DMARC1` must be first, `p=` must be one of {none, quarantine, reject}, `pct=` 0..=100, rejects duplicate tags, ignores unknown / reporting tags. 12 unit tests.
- **`from_header.rs`** (RFC 5322 / RFC 7489 §3.1.1) — single-mailbox From-header parser. Accepts bare addr-spec, name-addr, and quoted-display-name forms; rejects zero/multiple From: headers, address-lists, group syntax. Tolerates comma/colon inside quoted display names. 16 unit tests.
- **`alignment.rs`** — strict (exact match) + relaxed (exact match OR label-aligned subdomain in either direction). Stricter than RFC-compliant relaxed alignment because we deliberately don't consult the PSL — design doc §6.4 documents the trust + asymmetric-failure-mode reasoning. The dot anchor on the subdomain check prevents `evilexample.com` from aliasing `example.com`. 8 unit tests.
- **`verify.rs`** — orchestration. DKIM first; on failure, surface the DKIM reason verbatim. On DKIM pass, parse From and check DMARC alignment. Accepted iff Aligned, OR NoRecord with `dkim_domain == from_domain`. 8 unit tests.
- **`test_vectors.rs`** — 5 end-to-end tests reusing PR 2's synthetic .eml fixtures.

### `src/internet_identity/src/dkim/types.rs` (rename + new variants)

- Renamed `EmailVerificationStatus` → `DkimVerifyResult` (DKIM-only). The combined verdict moved to `dmarc::EmailVerificationStatus` so it can carry the `DmarcOutcome`.
- Added `MalformedFromHeader(String)`, `DmarcMalformed(String)`, `DmarcMisaligned` to `VerificationFailReason`.

### `src/internet_identity/src/dkim/mod.rs`

- Re-exports `verify` as `verify_dkim` so downstream callers (the dmarc layer) don't have to deal with both a `dkim::verify` and `dmarc::verify` in scope at the same time.

## Test plan

- [x] `cargo check -p internet_identity --target wasm32-unknown-unknown` — clean.
- [x] `cargo test -p internet_identity --bin internet_identity dmarc` — 49 tests pass (12 parse + 16 from_header + 8 alignment + 8 verify + 5 e2e).
- [x] `cargo test -p internet_identity --bin internet_identity` — 365 tests pass total (was 313 with PR 2; +49 dmarc + 3 small reshape adjustments).
- [x] `cargo clippy -p internet_identity --bin internet_identity --tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean (modulo pre-existing unrelated diffs).

## PR Stack
| # | PR | Description | Status |
|---|---|---|---|
| 0 | [#3836](https://github.com/dfinity/internet-identity/pull/3836) | Design doc | Open |
| 1 | [#3838](https://github.com/dfinity/internet-identity/pull/3838) | DNSSEC verifier scaffold | Open |
| 2 | [#3877](https://github.com/dfinity/internet-identity/pull/3877) | DKIM verifier (RFC 6376) | Open |
| 3 | [#3878](https://github.com/dfinity/internet-identity/pull/3878) | DMARC alignment (RFC 7489) | Open |
| 4 | [#3879](https://github.com/dfinity/internet-identity/pull/3879) | DoH fallback | Open |
| 5+6 | [#3880](https://github.com/dfinity/internet-identity/pull/3880) | Setup flow (storage + smtp_request) | Open |
| 7 | [#3881](https://github.com/dfinity/internet-identity/pull/3881) | Recovery flow (delegation) | Open |
| 8 | [#3882](https://github.com/dfinity/internet-identity/pull/3882) | Frontend + feature flag | Open |
| 9 | [#3883](https://github.com/dfinity/internet-identity/pull/3883) | Deploy/upgrade scripts: dnssec_config + doh_config | Open |
| 10 | [#3884](https://github.com/dfinity/internet-identity/pull/3884) | Email-recovery UX overhaul | Open |


