### PR TITLE
feat(doh): DoH fallback for DKIM/DMARC TXT records on unsigned domains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "captcha",
  "ed25519-dalek",
  "flate2",
+ "futures",
  "getrandom 0.2.16",
  "hex",
  "ic-canister-sig-creation",

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -36,6 +36,12 @@ captcha = { git = "https://github.com/dfinity/captcha", rev = "9c0d2dd9bf519e255
 identity_jose = { git = "https://github.com/dfinity/identity.rs.git", rev = "aa510ef7f441848d6c78058fe51ad4ad1d9bd5d8", default-features = false }
 url = { version = "2.5", default-features = false, features = ["std"] }
 
+# DoH fallback fan-out: pulled in only for `future::join_all`, which
+# lets us await all 5 provider outcalls concurrently rather than
+# serially. `default-features = false` keeps the wasm32 build lean
+# (no executor / threading code).
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
+
 # All IC deps
 candid.workspace = true
 ic-cdk = { workspace = true, features = ["transform-closure"] }

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -309,6 +309,11 @@ type InternetIdentityInit = record {
     // stored value across an upgrade, `opt null` clears it, `opt opt c`
     // sets it to `c`.
     dnssec_config : opt opt DnssecConfig;
+    // DoH (DNS-over-HTTPS) fallback configuration. Allowlists the
+    // domains for which the canister may fetch DKIM/DMARC TXT records
+    // via HTTP outcalls when no DNSSEC chain is available — see
+    // `docs/ongoing/email-recovery.md` §7.6. Same set/clear pattern.
+    doh_config : opt opt DohConfig;
 };
 
 // DNSSEC trust-anchor list. Any feature that needs DNSSEC-verified DNS
@@ -328,6 +333,17 @@ type DnssecRootAnchor = record {
     algorithm : nat8;
     digest_type : nat8;
     digest : blob;
+};
+
+// DoH (DNS-over-HTTPS) fallback configuration.
+//
+// The canister will only fetch DKIM/DMARC TXT records via HTTP outcalls
+// for an FQDN whose registered domain is in `allowed_domains`. Cache
+// entries are populated on demand and re-used until `max_cache_age_secs`
+// elapses (default 3600s when null, capped at 24h).
+type DohConfig = record {
+    allowed_domains : vec text;
+    max_cache_age_secs : opt nat64;
 };
 
 type ChallengeKey = text;

--- a/src/internet_identity/src/doh/cache.rs
+++ b/src/internet_identity/src/doh/cache.rs
@@ -1,0 +1,548 @@
+//! In-memory DoH cache with concurrent-fetch deduplication.
+//!
+//! Two responsibilities:
+//!
+//! 1. **Cache** — keep a fetched TXT record around for as long as the
+//!    deploy-arg `max_cache_age_secs` (default 1 h, capped at 24 h) so
+//!    a flurry of mail from the same domain doesn't re-fetch on every
+//!    message. The cache is heap-only — losing it on upgrade is fine,
+//!    we just refetch the next time mail arrives.
+//!
+//! 2. **Dedup** — when several concurrent `smtp_request` calls arrive
+//!    for the same domain and the cache is cold, all of them share a
+//!    single underlying outcall fan-out. The first arrival fires the
+//!    outcalls and writes the result; subsequent arrivals register a
+//!    `Waker` against the in-flight entry and `await` the publication.
+//!
+//! The dedup mechanism is a hand-rolled `oneshot`-style primitive
+//! (see [`Pending`]) — `ic-cdk` doesn't ship with the tokio sync
+//! primitives we'd otherwise reach for, but the standard Rust `Waker`
+//! machinery is enough since the canister is single-threaded inside
+//! one wasm execution.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::task::{Context, Poll, Waker};
+
+use super::types::DohError;
+
+/// How long a `Pending` entry can sit in the cache before a new
+/// arrival treats it as abandoned.
+///
+/// The IC doesn't roll back state across `.await` points: state
+/// changes that happened *before* the yield are committed even if the
+/// resumed-message continuation traps. So if the post-outcall code
+/// path traps, the `Pending` entry inserted by the first arrival
+/// stays in the map and every subsequent caller would `Wait` on a
+/// `PendingState::InFlight` that nothing will ever resolve — until
+/// canister upgrade.
+///
+/// 120 s is comfortably longer than any plausible HTTP-outcall round
+/// trip (the IC caps individual outcalls at ~5 minutes, but successful
+/// ones complete in seconds; a 2-minute floor on "looks abandoned" is
+/// safe for live fetches and quick enough that genuinely stuck entries
+/// clear within a couple of email retries).
+pub const PENDING_STALE_AFTER_SECS: u64 = 120;
+
+/// One cache entry — bytes and the wall-clock time at which they go
+/// stale.
+#[derive(Clone, Debug)]
+pub struct CacheEntry {
+    pub bytes: Vec<u8>,
+    pub expires_at_secs: u64,
+}
+
+/// Shared state used by the dedup primitive. `Rc<RefCell<...>>` because
+/// the canister's wasm execution is single-threaded; Send/Sync don't
+/// apply.
+type SharedPending = Rc<RefCell<PendingState>>;
+
+#[derive(Debug)]
+enum PendingState {
+    /// The first arrival is mid-fetch. Each subsequent arrival has
+    /// registered its `Waker` here and will be re-polled when the
+    /// fetch publishes a result.
+    InFlight { wakers: Vec<Waker> },
+    /// The fetch has completed. Late arrivals see this and pick up
+    /// the result without waiting.
+    Done(Result<Vec<u8>, DohError>),
+}
+
+/// What's stored in the `pending` map. We track `started_at_secs` so a
+/// later arrival can detect an abandoned in-flight fetch (see
+/// [`PENDING_STALE_AFTER_SECS`]) and start over rather than `Wait`ing
+/// forever.
+struct PendingEntry {
+    state: SharedPending,
+    started_at_secs: u64,
+}
+
+/// In-memory cache. The two maps are keyed by FQDN (e.g.
+/// `selector1._domainkey.gmail.com`).
+#[derive(Default)]
+pub struct DohCache {
+    entries: HashMap<String, CacheEntry>,
+    pending: HashMap<String, PendingEntry>,
+}
+
+impl DohCache {
+    /// Look up a fresh entry. Returns `None` if missing or stale.
+    pub fn get_fresh(&self, name: &str, now_secs: u64) -> Option<Vec<u8>> {
+        let entry = self.entries.get(name)?;
+        if entry.expires_at_secs > now_secs {
+            Some(entry.bytes.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Insert an entry that expires at the given wall-clock time.
+    pub fn insert(&mut self, name: &str, bytes: Vec<u8>, expires_at_secs: u64) {
+        self.entries.insert(
+            name.to_string(),
+            CacheEntry {
+                bytes,
+                expires_at_secs,
+            },
+        );
+    }
+
+    /// Remove a stale entry (by name). Used when freshness has lapsed
+    /// and we're about to re-fetch.
+    pub fn invalidate(&mut self, name: &str) {
+        self.entries.remove(name);
+    }
+
+    /// Decide what to do for an incoming fetch request:
+    /// - `Hit(bytes)` — cache fresh, use immediately.
+    /// - `Wait(future)` — someone else is fetching, await this future
+    ///   and you'll be woken with their result.
+    /// - `Fetch(token)` — you're the first; do the fetch, then call
+    ///   [`Self::publish`] passing the token back.
+    ///
+    /// If we find a `Pending` entry that's older than
+    /// [`PENDING_STALE_AFTER_SECS`], we treat it as abandoned (the
+    /// continuation that should have published it likely trapped),
+    /// wake any orphan waiters with [`DohError::AllProvidersFailed`]
+    /// so they don't hang, and start a fresh fetch.
+    ///
+    /// Also opportunistically evicts the looked-up entry if we find
+    /// it expired — keeps the cache from accumulating dead entries
+    /// for FQDNs that get queried once and then go silent.
+    pub fn lookup(&mut self, name: &str, now_secs: u64) -> CacheLookup {
+        if let Some(entry) = self.entries.get(name) {
+            if entry.expires_at_secs > now_secs {
+                return CacheLookup::Hit(entry.bytes.clone());
+            }
+            // Expired: drop it now rather than waiting for a publish
+            // to overwrite — most expired entries never see a republish.
+            self.entries.remove(name);
+        }
+        if let Some(existing) = self.pending.get(name) {
+            let age = now_secs.saturating_sub(existing.started_at_secs);
+            if age < PENDING_STALE_AFTER_SECS {
+                return CacheLookup::Wait(WaitForPending {
+                    state: existing.state.clone(),
+                });
+            }
+            // Abandoned: evict and wake any orphan waiters. The
+            // SharedPending may still be held by `WaitForPending`
+            // futures that registered before eviction; flipping it to
+            // `Done(Err)` resolves their `await` instead of hanging.
+            let stale = self.pending.remove(name).expect("just checked");
+            wake_with(&stale.state, Err(DohError::AllProvidersFailed));
+        }
+        let state = Rc::new(RefCell::new(PendingState::InFlight { wakers: Vec::new() }));
+        self.pending.insert(
+            name.to_string(),
+            PendingEntry {
+                state: state.clone(),
+                started_at_secs: now_secs,
+            },
+        );
+        CacheLookup::Fetch(FetchToken { state })
+    }
+
+    /// Publish the result of the in-flight fetch for `name`.
+    ///
+    /// The `token` is whatever [`Self::lookup`] handed back when this
+    /// caller got the `Fetch` arm — passing it back lets us detect
+    /// the case where this fetch was evicted by a stale-takeover
+    /// (another caller saw the pending entry as abandoned and started
+    /// over). In that case we don't touch the cache map but we still
+    /// wake any subscribers tied to *our* `PendingState`, so even
+    /// orphaned waiters resolve cleanly.
+    ///
+    /// Also opportunistically sweeps any value entries that are
+    /// already expired at `now_secs`. Sweeping on publish (the rare
+    /// write path) rather than on every `lookup` keeps reads cheap
+    /// while still bounding cache size — every successful fetch
+    /// drops the dead weight that accumulated since the last write.
+    pub fn publish(
+        &mut self,
+        name: &str,
+        token: FetchToken,
+        result: Result<Vec<u8>, DohError>,
+        expires_at_secs: u64,
+        now_secs: u64,
+    ) {
+        self.sweep_expired(now_secs);
+
+        let still_ours = self
+            .pending
+            .get(name)
+            .is_some_and(|e| Rc::ptr_eq(&e.state, &token.state));
+        if still_ours {
+            if let Ok(bytes) = &result {
+                self.insert(name, bytes.clone(), expires_at_secs);
+            }
+            self.pending.remove(name);
+        }
+        wake_with(&token.state, result);
+    }
+
+    /// Drop every value entry whose `expires_at_secs` is at or before
+    /// `now_secs`. Linear in `entries.len()`, which is bounded by
+    /// "unique FQDNs queried in the last `max_cache_age_secs`" — small
+    /// in practice. Called from `publish` so the per-fetch cost is
+    /// amortised across cache hits.
+    fn sweep_expired(&mut self, now_secs: u64) {
+        self.entries.retain(|_, e| e.expires_at_secs > now_secs);
+    }
+}
+
+/// Flip a `PendingState` to `Done(result)` and wake every registered
+/// waker. Idempotent: if the state is already `Done`, this is a no-op
+/// for the wakers (they were woken on the first transition).
+fn wake_with(state: &SharedPending, result: Result<Vec<u8>, DohError>) {
+    let mut s = state.borrow_mut();
+    let prev = std::mem::replace(&mut *s, PendingState::Done(result));
+    if let PendingState::InFlight { wakers } = prev {
+        for w in wakers {
+            w.wake();
+        }
+    }
+}
+
+/// What [`DohCache::lookup`] returned. The caller acts on the variant.
+pub enum CacheLookup {
+    Hit(Vec<u8>),
+    Wait(WaitForPending),
+    Fetch(FetchToken),
+}
+
+/// Opaque handle a `Fetch` caller passes back to [`DohCache::publish`].
+/// It identifies "this particular in-flight attempt" so the cache can
+/// tell whether the publishing caller is still the owner or whether a
+/// stale-takeover replaced them in the interim.
+pub struct FetchToken {
+    state: SharedPending,
+}
+
+/// Future returned to a caller that arrived while another task was
+/// already fetching the same name. Polls the shared `Pending` state;
+/// returns `Ready` once the in-flight task publishes its result.
+pub struct WaitForPending {
+    state: SharedPending,
+}
+
+impl Future for WaitForPending {
+    type Output = Result<Vec<u8>, DohError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.state.borrow_mut();
+        match &mut *state {
+            PendingState::Done(r) => Poll::Ready(r.clone()),
+            PendingState::InFlight { wakers } => {
+                // Avoid registering the same waker twice if the future
+                // is re-polled spuriously: walk the existing wakers
+                // and replace any that say `will_wake` of this one.
+                let new = cx.waker();
+                if !wakers.iter().any(|w| w.will_wake(new)) {
+                    wakers.push(new.clone());
+                }
+                Poll::Pending
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::task::Wake;
+
+    /// Simple `Wake` that counts how many times it's been woken.
+    /// Lets the dedup tests assert "publishing the result wakes every
+    /// subscriber exactly once".
+    struct CountingWaker {
+        count: AtomicUsize,
+    }
+
+    impl Wake for CountingWaker {
+        fn wake(self: Arc<Self>) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn make_waker(w: &Arc<CountingWaker>) -> Waker {
+        Waker::from(w.clone())
+    }
+
+    #[test]
+    fn cache_hit_inside_window() {
+        let mut cache = DohCache::default();
+        cache.insert("a.com", b"hello".to_vec(), 1000);
+        assert_eq!(cache.get_fresh("a.com", 999), Some(b"hello".to_vec()));
+    }
+
+    #[test]
+    fn cache_miss_when_expired() {
+        let mut cache = DohCache::default();
+        cache.insert("a.com", b"hello".to_vec(), 1000);
+        assert!(cache.get_fresh("a.com", 1001).is_none());
+    }
+
+    #[test]
+    fn lookup_returns_hit_on_fresh_entry() {
+        let mut cache = DohCache::default();
+        cache.insert("a.com", b"hello".to_vec(), 1000);
+        match cache.lookup("a.com", 999) {
+            CacheLookup::Hit(b) => assert_eq!(b, b"hello"),
+            _ => panic!("expected Hit"),
+        }
+    }
+
+    /// Helper: take the `Fetch` arm or fail the test.
+    fn expect_fetch(lookup: CacheLookup) -> FetchToken {
+        match lookup {
+            CacheLookup::Fetch(t) => t,
+            _ => panic!("expected Fetch"),
+        }
+    }
+
+    #[test]
+    fn first_lookup_returns_fetch() {
+        let mut cache = DohCache::default();
+        let _token = expect_fetch(cache.lookup("a.com", 0));
+        // After Fetch, the pending map should have an entry.
+        assert!(cache.pending.contains_key("a.com"));
+    }
+
+    #[test]
+    fn second_lookup_returns_wait() {
+        let mut cache = DohCache::default();
+        let _token = expect_fetch(cache.lookup("a.com", 0));
+        match cache.lookup("a.com", 0) {
+            CacheLookup::Wait(_) => {}
+            _ => panic!("expected Wait"),
+        }
+    }
+
+    #[test]
+    fn publish_wakes_all_subscribers() {
+        let mut cache = DohCache::default();
+        let token = expect_fetch(cache.lookup("a.com", 0));
+
+        // Two subscribers register their wakers.
+        let w1 = Arc::new(CountingWaker {
+            count: AtomicUsize::new(0),
+        });
+        let w2 = Arc::new(CountingWaker {
+            count: AtomicUsize::new(0),
+        });
+
+        let waker_1 = make_waker(&w1);
+        match cache.lookup("a.com", 0) {
+            CacheLookup::Wait(mut fut) => {
+                let mut cx = Context::from_waker(&waker_1);
+                assert!(matches!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending));
+            }
+            _ => panic!("expected Wait"),
+        }
+        let waker_2 = make_waker(&w2);
+        match cache.lookup("a.com", 0) {
+            CacheLookup::Wait(mut fut) => {
+                let mut cx = Context::from_waker(&waker_2);
+                assert!(matches!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending));
+            }
+            _ => panic!("expected Wait"),
+        }
+
+        cache.publish("a.com", token, Ok(b"hello".to_vec()), 1000, 0);
+        assert_eq!(w1.count.load(Ordering::SeqCst), 1);
+        assert_eq!(w2.count.load(Ordering::SeqCst), 1);
+
+        assert!(!cache.pending.contains_key("a.com"));
+        assert_eq!(cache.get_fresh("a.com", 999), Some(b"hello".to_vec()));
+    }
+
+    #[test]
+    fn published_subscriber_resolves_to_result() {
+        let mut cache = DohCache::default();
+        let token = expect_fetch(cache.lookup("a.com", 0));
+        let mut wait = match cache.lookup("a.com", 0) {
+            CacheLookup::Wait(f) => f,
+            _ => panic!(),
+        };
+
+        cache.publish("a.com", token, Ok(b"hello".to_vec()), 1000, 0);
+
+        let w = Arc::new(CountingWaker {
+            count: AtomicUsize::new(0),
+        });
+        let waker = make_waker(&w);
+        let mut cx = Context::from_waker(&waker);
+        match Pin::new(&mut wait).poll(&mut cx) {
+            Poll::Ready(Ok(b)) => assert_eq!(b, b"hello"),
+            other => panic!("expected Ready(Ok), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn publish_on_failure_does_not_cache_but_still_wakes() {
+        let mut cache = DohCache::default();
+        let token = expect_fetch(cache.lookup("a.com", 0));
+
+        let w = Arc::new(CountingWaker {
+            count: AtomicUsize::new(0),
+        });
+        let waker = make_waker(&w);
+        match cache.lookup("a.com", 0) {
+            CacheLookup::Wait(mut fut) => {
+                let mut cx = Context::from_waker(&waker);
+                let _ = Pin::new(&mut fut).poll(&mut cx);
+            }
+            _ => panic!(),
+        }
+        cache.publish("a.com", token, Err(DohError::AllProvidersFailed), 1000, 0);
+        assert_eq!(w.count.load(Ordering::SeqCst), 1);
+        assert!(cache.get_fresh("a.com", 0).is_none());
+    }
+
+    // ---- Stale-pending eviction ----
+
+    #[test]
+    fn fresh_pending_within_threshold_returns_wait() {
+        let mut cache = DohCache::default();
+        let _orig = expect_fetch(cache.lookup("a.com", 100));
+        // Just under the threshold: still fresh.
+        match cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS - 1) {
+            CacheLookup::Wait(_) => {}
+            _ => panic!("expected Wait while pending is still fresh"),
+        }
+    }
+
+    #[test]
+    fn stale_pending_is_evicted_and_caller_gets_fetch() {
+        let mut cache = DohCache::default();
+        let _abandoned = expect_fetch(cache.lookup("a.com", 100));
+        // Past the staleness threshold — the prior fetch is presumed
+        // dead. The new arrival should get a fresh Fetch, not Wait.
+        let _new_token = expect_fetch(cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS));
+    }
+
+    #[test]
+    fn stale_eviction_wakes_orphan_waiters_with_error() {
+        // Setup: A starts a fetch, B registers as a waiter while A is
+        // still in flight, then A's continuation never runs (simulated
+        // here by just letting time pass without calling publish). C
+        // arrives after the staleness threshold. B should get woken
+        // with an error rather than hanging on a pending state forever.
+        let mut cache = DohCache::default();
+        let _a_token = expect_fetch(cache.lookup("a.com", 100));
+
+        let mut b_wait = match cache.lookup("a.com", 110) {
+            CacheLookup::Wait(f) => f,
+            _ => panic!("B should have got Wait"),
+        };
+        let waker_b = Arc::new(CountingWaker {
+            count: AtomicUsize::new(0),
+        });
+        let waker = make_waker(&waker_b);
+        let mut cx = Context::from_waker(&waker);
+        assert!(matches!(Pin::new(&mut b_wait).poll(&mut cx), Poll::Pending));
+
+        // C arrives way past the threshold.
+        let _c_token = expect_fetch(cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS + 1));
+
+        // B's waker should have fired during eviction.
+        assert_eq!(
+            waker_b.count.load(Ordering::SeqCst),
+            1,
+            "orphan waiter must be woken on stale eviction"
+        );
+
+        // And the next poll resolves to an error rather than Pending.
+        match Pin::new(&mut b_wait).poll(&mut cx) {
+            Poll::Ready(Err(DohError::AllProvidersFailed)) => {}
+            other => panic!("orphan waiter should resolve to AllProvidersFailed, got {other:?}"),
+        }
+    }
+
+    // ---- Eviction of expired value entries ----
+
+    #[test]
+    fn lookup_evicts_expired_entry() {
+        let mut cache = DohCache::default();
+        cache.insert("a.com", b"x".to_vec(), 100);
+        // Lookup at a time past the expiry — entry should be removed.
+        let _ = cache.lookup("a.com", 200);
+        assert!(
+            !cache.entries.contains_key("a.com"),
+            "expired entry should be evicted on lookup"
+        );
+    }
+
+    #[test]
+    fn publish_sweeps_other_expired_entries() {
+        let mut cache = DohCache::default();
+        // Three pre-existing entries, two expired and one fresh.
+        cache.insert("expired1.com", b"x".to_vec(), 50);
+        cache.insert("expired2.com", b"y".to_vec(), 60);
+        cache.insert("fresh.com", b"z".to_vec(), 1_000);
+
+        // Publishing for a fourth name at now=100 should drop both
+        // expired entries while leaving the fresh one alone.
+        let token = expect_fetch(cache.lookup("new.com", 100));
+        cache.publish("new.com", token, Ok(b"v".to_vec()), 2_000, 100);
+
+        assert!(!cache.entries.contains_key("expired1.com"));
+        assert!(!cache.entries.contains_key("expired2.com"));
+        assert!(cache.entries.contains_key("fresh.com"));
+        assert!(cache.entries.contains_key("new.com"));
+    }
+
+    #[test]
+    fn evicted_owner_publishing_does_not_overwrite_new_fetch() {
+        // A is evicted, C starts a new fetch. A then unexpectedly
+        // returns and tries to publish. The cache must NOT replace
+        // C's pending entry or write A's data into the value cache.
+        let mut cache = DohCache::default();
+        let a_token = expect_fetch(cache.lookup("a.com", 100));
+        let c_token = expect_fetch(cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS + 1));
+
+        // A's late publish: no-op on cache state.
+        cache.publish("a.com", a_token, Ok(b"A's stale data".to_vec()), 9999, 0);
+        assert!(
+            cache.get_fresh("a.com", 0).is_none(),
+            "A's publish must not write to the cache after eviction"
+        );
+        assert!(
+            cache.pending.contains_key("a.com"),
+            "C's pending entry must still be in place"
+        );
+
+        // Now C publishes its real result and that DOES land.
+        cache.publish("a.com", c_token, Ok(b"C's fresh data".to_vec()), 9999, 0);
+        assert_eq!(
+            cache.get_fresh("a.com", 0),
+            Some(b"C's fresh data".to_vec())
+        );
+    }
+}

--- a/src/internet_identity/src/doh/mod.rs
+++ b/src/internet_identity/src/doh/mod.rs
@@ -10,22 +10,489 @@
 //!   demand the first time a real `smtp_request` arrives for a listed
 //!   domain.
 //! - **Quorum across independent operators.** Every cache miss fires
-//!   parallel outcalls to three providers from three jurisdictions
-//!   (Cloudflare 🇺🇸, Quad9 🇨🇭, CIRA Canadian Shield 🇨🇦) and accepts
-//!   the result iff at least 2-of-3 agree on the TXT bytes. No single
-//!   operator is trusted; one provider being down or returning forged
-//!   bytes never breaks the verifier.
+//!   parallel outcalls to five providers across four jurisdictions
+//!   (Cloudflare 🇺🇸, Google 🇺🇸, Quad9 🇨🇭, CIRA Canadian Shield 🇨🇦,
+//!   IIJ 🇯🇵) and accepts the result iff at least 3-of-5 agree on the
+//!   TXT bytes. No single operator is trusted; one provider being down
+//!   or returning forged bytes never breaks the verifier.
 //! - **In-flight dedup.** Multiple concurrent verification requests
-//!   for the same domain share one outcall fan-out, not three each.
+//!   for the same domain share one outcall fan-out, not five each.
 //! - **Heap cache.** Fast and cheap. Keys are re-fetchable, so an
 //!   upgrade rebuilding the cache from scratch is fine.
+//!
+//! ## Replica-consensus shape
+//!
+//! HTTP outcalls run on every replica of the subnet (typically 13).
+//! For consensus, every replica must observe the same response bytes,
+//! which raw DoH responses don't satisfy: TTLs decrement second by
+//! second, so two replicas making the query a few hundred ms apart
+//! see different bytes. We attach a `transform` query function that
+//! parses the wire-format DNS response down to the TXT RDATA — that
+//! reduction is deterministic, so all replicas converge on the same
+//! bytes and consensus succeeds.
 
 #![allow(dead_code)]
 
+mod cache;
 mod parser;
+mod quorum;
 mod types;
 
+use std::cell::RefCell;
+
+use cache::{CacheLookup, DohCache};
+use parser::build_txt_query;
+use quorum::{decide_quorum, Outcome};
+
 #[allow(unused_imports)]
-pub use parser::{build_txt_query, parse_txt_response, ParseError};
+pub use parser::{parse_txt_response, ParseError};
 #[allow(unused_imports)]
 pub use types::{DohError, DohProvider, PROVIDERS};
+
+use types::{DEFAULT_CACHE_AGE_SECS, MAX_CACHE_AGE_SECS};
+
+thread_local! {
+    /// Per-canister DoH cache. Heap-only — losing it on upgrade is
+    /// fine, the next `smtp_request` for an affected domain just
+    /// re-fetches.
+    static DOH_CACHE: RefCell<DohCache> = RefCell::new(DohCache::default());
+}
+
+/// Public entry point. Returns the TXT bytes for `name` if at least
+/// the quorum threshold of providers agree.
+///
+/// `name` is the full FQDN (e.g., `selector1._domainkey.gmail.com`);
+/// `registered_domain` (e.g., `gmail.com`) is what the allowlist gate
+/// checks. The caller — the DKIM/DMARC code — already extracts the
+/// registered domain when validating From-header alignment, so we
+/// don't re-implement that here.
+///
+/// The function never panics on misconfiguration: if `DohConfig` is
+/// absent, returns [`DohError::NotConfigured`] without touching the
+/// network.
+pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, DohError> {
+    let config = match crate::state::persistent_state(|p| p.doh_config.clone()) {
+        Some(c) => c,
+        None => return Err(DohError::NotConfigured),
+    };
+    if !config
+        .allowed_domains
+        .iter()
+        .any(|d| d.eq_ignore_ascii_case(registered_domain))
+    {
+        return Err(DohError::DomainNotAllowed);
+    }
+    let max_age = config
+        .max_cache_age_secs
+        .unwrap_or(DEFAULT_CACHE_AGE_SECS)
+        .min(MAX_CACHE_AGE_SECS);
+
+    // Cache lookup. We must release the borrow before awaiting — the
+    // canister is single-threaded but futures across yields can re-
+    // enter the same `RefCell`, which would trap.
+    let now = now_secs();
+    let lookup = DOH_CACHE.with(|c| c.borrow_mut().lookup(name, now));
+    let token = match lookup {
+        CacheLookup::Hit(bytes) => return Ok(bytes),
+        CacheLookup::Wait(fut) => return fut.await,
+        CacheLookup::Fetch(token) => token, // First arrival; we own this fetch.
+    };
+
+    // Fan out to every provider in parallel, then decide.
+    let query = build_txt_query(name);
+    let outcall_results = fetch_all(&query).await;
+    let outcomes: Vec<Outcome> = outcall_results
+        .into_iter()
+        .map(|r| match r {
+            Ok(txt_bytes) => Outcome::Txt(txt_bytes),
+            Err(e) => Outcome::FetchError(e),
+        })
+        .collect();
+    let result = decide_quorum(&outcomes);
+
+    // Publish: stores on success, removes the pending entry, wakes any
+    // dedup subscribers. The expires-at uses the timestamp we captured
+    // before the await so multiple subscribers see consistent freshness.
+    let expires_at = now.saturating_add(max_age);
+    DOH_CACHE.with(|c| {
+        c.borrow_mut()
+            .publish(name, token, result.clone(), expires_at, now)
+    });
+    result
+}
+
+#[cfg(not(test))]
+fn now_secs() -> u64 {
+    ic_cdk::api::time() / 1_000_000_000
+}
+
+/// Test-time clock. The canister-time accessor traps outside a real
+/// canister, so under `cfg(test)` we read from a thread-local the test
+/// can advance.
+#[cfg(test)]
+fn now_secs() -> u64 {
+    test_support::TEST_NOW_SECS.with(|t| *t.borrow())
+}
+
+// =====================================================================
+// Production outcall path (cfg(not(test)) only).
+//
+// Each cache miss fans out to all PROVIDERS in parallel via
+// `futures::future::join_all`. Each individual outcall:
+//   - POSTs the wire-format query to the provider's /dns-query.
+//   - Caps response size at 4 KiB (cycles charged on cap, not actual).
+//   - Attaches a transform that reduces the wire response to its TXT
+//     RDATA so replicas converge.
+//   - Attaches a fixed cycle budget per outcall.
+// =====================================================================
+
+#[cfg(not(test))]
+mod prod {
+    use ic_cdk::api::management_canister::http_request::{
+        http_request_with_closure, CanisterHttpRequestArgument, HttpHeader, HttpMethod,
+        HttpResponse,
+    };
+
+    /// 4 KiB upper bound on a DoH response. A typical DKIM-SHA256 TXT
+    /// record (RSA-2048) sits well under 1 KiB; allowing four times
+    /// that gives slack for multi-string TXT and oversized
+    /// experimental keys without paying 2 MiB worth of cycles.
+    pub(super) const MAX_DOH_RESPONSE_BYTES: u64 = 4096;
+
+    /// Per-outcall cycle budget. Mirrors the OIDC discovery path's
+    /// budget (`30_000_000_000`) — generous enough to cover the 13-
+    /// replica fan-out plus the transform invocation, with refund of
+    /// unused cycles. Each cache miss spends ~5× this in total.
+    pub(super) const DOH_CALL_CYCLES: u128 = 30_000_000_000;
+
+    pub(super) const HTTP_STATUS_OK: u8 = 200;
+
+    /// Sentinel body returned by the transform when the wire response
+    /// is malformed. The async path treats anything that isn't a
+    /// genuine TXT-bytes payload as a failure for that provider.
+    pub(super) const MALFORMED_SENTINEL: &[u8] = b"!!doh-malformed";
+
+    pub(super) async fn fetch_all(query: &[u8]) -> Vec<Result<Vec<u8>, String>> {
+        let futures: Vec<_> = super::PROVIDERS.iter().map(|p| outcall(p, query)).collect();
+        futures::future::join_all(futures).await
+    }
+
+    async fn outcall(provider: &super::DohProvider, query: &[u8]) -> Result<Vec<u8>, String> {
+        let request = CanisterHttpRequestArgument {
+            url: provider.url.to_string(),
+            method: HttpMethod::POST,
+            body: Some(query.to_vec()),
+            max_response_bytes: Some(MAX_DOH_RESPONSE_BYTES),
+            // The closure-based call below carries the transform; we
+            // leave this field None and pass `transform_doh` directly.
+            transform: None,
+            headers: vec![
+                HttpHeader {
+                    name: "Accept".into(),
+                    value: "application/dns-message".into(),
+                },
+                HttpHeader {
+                    name: "Content-Type".into(),
+                    value: "application/dns-message".into(),
+                },
+                HttpHeader {
+                    name: "User-Agent".into(),
+                    value: "internet_identity_canister".into(),
+                },
+            ],
+        };
+        let (response,) = http_request_with_closure(request, DOH_CALL_CYCLES, transform_doh)
+            .await
+            .map_err(|(_, err)| err)?;
+        if response.status != HTTP_STATUS_OK {
+            return Err(format!("HTTP {}", response.status));
+        }
+        if response.body == MALFORMED_SENTINEL {
+            return Err("malformed DNS response".into());
+        }
+        Ok(response.body)
+    }
+
+    /// Transform query for replica consensus.
+    ///
+    /// DoH wire-format responses contain TTLs that decrement once a
+    /// second, so replicas making the same query a few hundred ms
+    /// apart can observe different bytes — consensus then fails. The
+    /// transform reduces the response to just the parsed TXT bytes,
+    /// which depend only on the resolver's cached answer (stable
+    /// within a given TTL bucket), so all replicas converge.
+    ///
+    /// On parse failure we surface a sentinel string in the body
+    /// rather than dropping the response — that way consensus still
+    /// succeeds (all replicas see the same sentinel) and the async
+    /// path counts this provider's contribution as a failure.
+    #[allow(clippy::needless_pass_by_value)]
+    pub(super) fn transform_doh(response: HttpResponse) -> HttpResponse {
+        use candid::Nat;
+        if response.status != HTTP_STATUS_OK {
+            // Non-200 responses are passed through untouched (status
+            // and empty body) — replicas converge on the status code
+            // even if their bodies originally differed.
+            return HttpResponse {
+                status: response.status,
+                headers: vec![],
+                body: vec![],
+            };
+        }
+        match super::parse_txt_response(&response.body) {
+            Ok(txt) => HttpResponse {
+                status: Nat::from(HTTP_STATUS_OK),
+                headers: vec![],
+                body: txt,
+            },
+            Err(_) => HttpResponse {
+                status: Nat::from(HTTP_STATUS_OK),
+                headers: vec![],
+                body: MALFORMED_SENTINEL.to_vec(),
+            },
+        }
+    }
+}
+
+#[cfg(not(test))]
+async fn fetch_all(query: &[u8]) -> Vec<Result<Vec<u8>, String>> {
+    prod::fetch_all(query).await
+}
+
+// =====================================================================
+// Test path: routes outcalls through a thread-local mock so the same
+// `fetch_txt` body can be exercised end-to-end without the IC
+// management canister. The mock returns *already-parsed* TXT bytes —
+// matching the shape of what `transform_doh` produces in production.
+// =====================================================================
+
+#[cfg(test)]
+async fn fetch_all(query: &[u8]) -> Vec<Result<Vec<u8>, String>> {
+    test_support::run_mock(query)
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use std::collections::HashMap;
+
+    thread_local! {
+        pub(super) static TEST_NOW_SECS: RefCell<u64> = const { RefCell::new(1_700_000_000) };
+        pub(super) static MOCK_RESPONSES: RefCell<
+            HashMap<&'static str, Result<Vec<u8>, String>>,
+        > = RefCell::new(HashMap::new());
+        pub(super) static MOCK_CALL_COUNT: RefCell<usize> = const { RefCell::new(0) };
+    }
+
+    pub(crate) fn set_now(t: u64) {
+        TEST_NOW_SECS.with(|c| *c.borrow_mut() = t);
+    }
+
+    pub(crate) fn set_mock(responses: &[(&'static str, Result<Vec<u8>, String>)]) {
+        MOCK_RESPONSES.with(|m| {
+            let mut m = m.borrow_mut();
+            m.clear();
+            for (url, r) in responses {
+                m.insert(*url, r.clone());
+            }
+        });
+    }
+
+    pub(crate) fn call_count() -> usize {
+        MOCK_CALL_COUNT.with(|c| *c.borrow())
+    }
+
+    /// Wipes both cache + counter so each test starts from a known
+    /// state. Call this at the top of every test that asserts on
+    /// `call_count`.
+    pub(crate) fn reset_cache() {
+        DOH_CACHE.with(|c| *c.borrow_mut() = DohCache::default());
+        MOCK_CALL_COUNT.with(|c| *c.borrow_mut() = 0);
+    }
+
+    pub(super) fn run_mock(_query: &[u8]) -> Vec<Result<Vec<u8>, String>> {
+        MOCK_CALL_COUNT.with(|c| *c.borrow_mut() += 1);
+        MOCK_RESPONSES.with(|m| {
+            let m = m.borrow();
+            PROVIDERS
+                .iter()
+                .map(|p| {
+                    m.get(p.url)
+                        .cloned()
+                        .unwrap_or_else(|| Err("no canned response".into()))
+                })
+                .collect()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::*;
+    use super::*;
+    use crate::state::{persistent_state_mut, PersistentState};
+    use internet_identity_interface::internet_identity::types::DohConfig;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    /// Minimal block-on. The async futures in these tests complete in
+    /// a single poll (the mock fetcher is synchronous, the cache path
+    /// is synchronous, and we don't exercise the dedup `Wait` arm
+    /// here). Pulling in `futures::executor` would force the
+    /// `executor` + `std` features and bloat the wasm build, so we
+    /// poll by hand.
+    struct NoopWaker;
+    impl Wake for NoopWaker {
+        fn wake(self: Arc<Self>) {}
+    }
+    fn block_on<F: Future>(mut f: F) -> F::Output {
+        // SAFETY: `f` is on the stack and we don't move it out.
+        let mut f = unsafe { Pin::new_unchecked(&mut f) };
+        let waker = Waker::from(Arc::new(NoopWaker));
+        let mut cx = Context::from_waker(&waker);
+        match f.as_mut().poll(&mut cx) {
+            Poll::Ready(out) => out,
+            // No I/O drives these futures from outside; if a single
+            // poll returns Pending in test, the test setup is wrong.
+            Poll::Pending => panic!("test future returned Pending — test setup is incorrect"),
+        }
+    }
+
+    fn install_config(domains: &[&str], max_age: Option<u64>) {
+        persistent_state_mut(|p: &mut PersistentState| {
+            p.doh_config = Some(DohConfig {
+                allowed_domains: domains.iter().map(|d| (*d).to_string()).collect(),
+                max_cache_age_secs: max_age,
+            });
+        });
+    }
+
+    fn clear_config() {
+        persistent_state_mut(|p| p.doh_config = None);
+    }
+
+    /// The mock-side equivalent of `transform_doh`'s output: just the
+    /// TXT bytes a real provider would have parsed out.
+    fn ok(bytes: &[u8]) -> Result<Vec<u8>, String> {
+        Ok(bytes.to_vec())
+    }
+    fn fail(s: &str) -> Result<Vec<u8>, String> {
+        Err(s.into())
+    }
+
+    fn agreeing_dkim() -> Vec<(&'static str, Result<Vec<u8>, String>)> {
+        // Three provider responses agree, two disagree — quorum (3-of-
+        // 5) hits.
+        vec![
+            (PROVIDERS[0].url, ok(b"v=DKIM1; k=rsa; p=...")),
+            (PROVIDERS[1].url, ok(b"v=DKIM1; k=rsa; p=...")),
+            (PROVIDERS[2].url, ok(b"v=DKIM1; k=rsa; p=...")),
+            (PROVIDERS[3].url, fail("network down")),
+            (PROVIDERS[4].url, fail("403")),
+        ]
+    }
+
+    #[test]
+    fn returns_not_configured_without_doh_config() {
+        clear_config();
+        reset_cache();
+        let r = block_on(fetch_txt("selector._domainkey.example.com", "example.com"));
+        assert_eq!(r, Err(DohError::NotConfigured));
+    }
+
+    #[test]
+    fn rejects_unallowed_domain() {
+        install_config(&["gmail.com"], None);
+        reset_cache();
+        let r = block_on(fetch_txt("selector._domainkey.evil.com", "evil.com"));
+        assert_eq!(r, Err(DohError::DomainNotAllowed));
+    }
+
+    #[test]
+    fn allowlist_match_is_case_insensitive() {
+        install_config(&["GMAIL.com"], None);
+        reset_cache();
+        set_mock(&agreeing_dkim());
+        let r = block_on(fetch_txt("selector._domainkey.gmail.com", "gmail.com"));
+        assert!(r.is_ok(), "expected Ok, got {r:?}");
+    }
+
+    #[test]
+    fn first_fetch_runs_outcalls_and_caches() {
+        install_config(&["example.com"], Some(3600));
+        reset_cache();
+        set_mock(&agreeing_dkim());
+        set_now(1_000);
+
+        let r1 = block_on(fetch_txt("x._domainkey.example.com", "example.com"));
+        assert_eq!(r1, Ok(b"v=DKIM1; k=rsa; p=...".to_vec()));
+        assert_eq!(call_count(), 1, "first call should hit the network");
+
+        // Second call within TTL: cache hit, no outcall.
+        set_now(1_500);
+        let r2 = block_on(fetch_txt("x._domainkey.example.com", "example.com"));
+        assert_eq!(r2, Ok(b"v=DKIM1; k=rsa; p=...".to_vec()));
+        assert_eq!(call_count(), 1, "second call should be cache-served");
+    }
+
+    #[test]
+    fn refetches_after_ttl_expires() {
+        install_config(&["example.com"], Some(60));
+        reset_cache();
+        set_mock(&agreeing_dkim());
+        set_now(1_000);
+
+        let _ = block_on(fetch_txt("x._domainkey.example.com", "example.com"));
+        assert_eq!(call_count(), 1);
+
+        // Advance past the TTL — the cache should be cold again.
+        set_now(1_000 + 60 + 1);
+        let _ = block_on(fetch_txt("x._domainkey.example.com", "example.com"));
+        assert_eq!(call_count(), 2, "should re-fetch after TTL");
+    }
+
+    #[test]
+    fn quorum_failure_is_not_cached() {
+        install_config(&["example.com"], Some(3600));
+        reset_cache();
+        // Five distinct answers — biggest bucket is 1, well short of
+        // the 3-of-5 threshold.
+        set_mock(&[
+            (PROVIDERS[0].url, ok(b"a")),
+            (PROVIDERS[1].url, ok(b"b")),
+            (PROVIDERS[2].url, ok(b"c")),
+            (PROVIDERS[3].url, ok(b"d")),
+            (PROVIDERS[4].url, ok(b"e")),
+        ]);
+        set_now(1_000);
+
+        let r1 = block_on(fetch_txt("x._domainkey.example.com", "example.com"));
+        assert!(matches!(r1, Err(DohError::QuorumFailed { .. })));
+
+        // Failure must NOT poison the cache: a follow-up call (with
+        // different mock) should re-fetch and now succeed.
+        set_mock(&agreeing_dkim());
+        set_now(1_001);
+        let r2 = block_on(fetch_txt("x._domainkey.example.com", "example.com"));
+        assert_eq!(r2, Ok(b"v=DKIM1; k=rsa; p=...".to_vec()));
+        assert_eq!(call_count(), 2);
+    }
+
+    #[test]
+    fn max_cache_age_is_capped() {
+        // Asking for 999_999s caps at MAX_CACHE_AGE_SECS (24h).
+        install_config(&["example.com"], Some(999_999));
+        reset_cache();
+        set_mock(&agreeing_dkim());
+        set_now(0);
+
+        let _ = block_on(fetch_txt("x._domainkey.example.com", "example.com"));
+
+        // Day after the cap (24h+1s): cache must have expired.
+        set_now(types::MAX_CACHE_AGE_SECS + 1);
+        let _ = block_on(fetch_txt("x._domainkey.example.com", "example.com"));
+        assert_eq!(call_count(), 2, "cache must respect MAX_CACHE_AGE_SECS");
+    }
+}

--- a/src/internet_identity/src/doh/mod.rs
+++ b/src/internet_identity/src/doh/mod.rs
@@ -82,10 +82,27 @@ pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, D
     {
         return Err(DohError::DomainNotAllowed);
     }
+    // Defence-in-depth: the allowlist gate above only checks the
+    // registered_domain the caller hands us — but `name` is what we'd
+    // actually query. A caller bug or future regression that decoupled
+    // the two could pass an allowlisted registered_domain alongside a
+    // completely unrelated name (e.g., `evil.com`) and we'd happily
+    // outcall for it. Insist that `name` sits inside `registered_domain`
+    // with a label-anchored suffix match.
+    if !name_within_domain(name, registered_domain) {
+        return Err(DohError::NameOutsideRegisteredDomain {
+            name: name.to_string(),
+            registered_domain: registered_domain.to_string(),
+        });
+    }
     let max_age = config
         .max_cache_age_secs
         .unwrap_or(DEFAULT_CACHE_AGE_SECS)
         .min(MAX_CACHE_AGE_SECS);
+
+    // Build the query early so an InvalidName failure short-circuits
+    // before we touch the cache or claim a Fetch token.
+    let query = build_txt_query(name).map_err(|e| DohError::InvalidName(format!("{e:?}")))?;
 
     // Cache lookup. We must release the borrow before awaiting — the
     // canister is single-threaded but futures across yields can re-
@@ -99,7 +116,6 @@ pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, D
     };
 
     // Fan out to every provider in parallel, then decide.
-    let query = build_txt_query(name);
     let outcall_results = fetch_all(&query).await;
     let outcomes: Vec<Outcome> = outcall_results
         .into_iter()
@@ -119,6 +135,30 @@ pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, D
             .publish(name, token, result.clone(), expires_at, now)
     });
     result
+}
+
+/// Whether a queried FQDN sits inside `registered_domain` (case-
+/// insensitive, label-anchored).
+///
+/// Returns true iff `name == registered_domain` or `name` ends with
+/// `.<registered_domain>`. The dot anchor is what stops
+/// `evilexample.com` from passing as inside `example.com`. A trailing
+/// dot on either side (root marker) is normalised away first.
+fn name_within_domain(name: &str, registered_domain: &str) -> bool {
+    let n = name.trim_end_matches('.');
+    let d = registered_domain.trim_end_matches('.');
+    if d.is_empty() {
+        return false;
+    }
+    if n.eq_ignore_ascii_case(d) {
+        return true;
+    }
+    if n.len() <= d.len() + 1 {
+        return false;
+    }
+    let suffix = &n[n.len() - d.len()..];
+    let dot_idx = n.len() - d.len() - 1;
+    suffix.eq_ignore_ascii_case(d) && n.as_bytes()[dot_idx] == b'.'
 }
 
 #[cfg(not(test))]
@@ -167,10 +207,18 @@ mod prod {
 
     pub(super) const HTTP_STATUS_OK: u8 = 200;
 
-    /// Sentinel body returned by the transform when the wire response
-    /// is malformed. The async path treats anything that isn't a
-    /// genuine TXT-bytes payload as a failure for that provider.
-    pub(super) const MALFORMED_SENTINEL: &[u8] = b"!!doh-malformed";
+    /// HTTP status the transform returns when the wire-format DNS
+    /// response can't be parsed down to a TXT RDATA. We deliberately
+    /// signal failure via the *status code*, not via a sentinel body
+    /// string, because any TXT-bytes body the transform might emit
+    /// could collide with a real DKIM/DMARC payload (a sentinel like
+    /// `b"!!doh-malformed"` is bytes-equal to a (legal-but-unusual)
+    /// TXT record). 422 ("Unprocessable Entity") is a defensible
+    /// bucket for "you sent us bytes we can't make sense of"; what
+    /// actually matters is the IC-replica consensus on a non-200,
+    /// which the existing `if response.status != HTTP_STATUS_OK`
+    /// branch in [`outcall`] turns into an `Err`.
+    pub(super) const HTTP_STATUS_TRANSFORM_PARSE_FAILED: u16 = 422;
 
     pub(super) async fn fetch_all(query: &[u8]) -> Vec<Result<Vec<u8>, String>> {
         let futures: Vec<_> = super::PROVIDERS.iter().map(|p| outcall(p, query)).collect();
@@ -207,9 +255,6 @@ mod prod {
         if response.status != HTTP_STATUS_OK {
             return Err(format!("HTTP {}", response.status));
         }
-        if response.body == MALFORMED_SENTINEL {
-            return Err("malformed DNS response".into());
-        }
         Ok(response.body)
     }
 
@@ -222,17 +267,19 @@ mod prod {
     /// which depend only on the resolver's cached answer (stable
     /// within a given TTL bucket), so all replicas converge.
     ///
-    /// On parse failure we surface a sentinel string in the body
-    /// rather than dropping the response — that way consensus still
-    /// succeeds (all replicas see the same sentinel) and the async
-    /// path counts this provider's contribution as a failure.
+    /// On parse failure we signal the failure out-of-band via a non-
+    /// 200 status code (with empty body) rather than encoding it in
+    /// the body. An in-band sentinel string would risk colliding with
+    /// a legitimate (if unusual) TXT payload and silently turning a
+    /// valid record into a "malformed" failure for the quorum.
     #[allow(clippy::needless_pass_by_value)]
     pub(super) fn transform_doh(response: HttpResponse) -> HttpResponse {
         use candid::Nat;
         if response.status != HTTP_STATUS_OK {
-            // Non-200 responses are passed through untouched (status
-            // and empty body) — replicas converge on the status code
-            // even if their bodies originally differed.
+            // Non-200 upstream responses are passed through untouched
+            // (status preserved, body emptied for consensus) —
+            // replicas converge on the status code even if their
+            // original bodies differed.
             return HttpResponse {
                 status: response.status,
                 headers: vec![],
@@ -246,9 +293,10 @@ mod prod {
                 body: txt,
             },
             Err(_) => HttpResponse {
-                status: Nat::from(HTTP_STATUS_OK),
+                // Out-of-band failure signal: see `HTTP_STATUS_TRANSFORM_PARSE_FAILED`.
+                status: Nat::from(HTTP_STATUS_TRANSFORM_PARSE_FAILED as u32),
                 headers: vec![],
-                body: MALFORMED_SENTINEL.to_vec(),
+                body: vec![],
             },
         }
     }
@@ -494,5 +542,64 @@ mod tests {
         set_now(types::MAX_CACHE_AGE_SECS + 1);
         let _ = block_on(fetch_txt("x._domainkey.example.com", "example.com"));
         assert_eq!(call_count(), 2, "cache must respect MAX_CACHE_AGE_SECS");
+    }
+
+    #[test]
+    fn rejects_name_outside_registered_domain() {
+        install_config(&["gmail.com"], None);
+        reset_cache();
+        // Allowlisted registered_domain, but `name` doesn't sit inside
+        // it — should fail closed without an outcall.
+        let r = block_on(fetch_txt("selector._domainkey.evil.com", "gmail.com"));
+        match r {
+            Err(DohError::NameOutsideRegisteredDomain {
+                name,
+                registered_domain,
+            }) => {
+                assert_eq!(name, "selector._domainkey.evil.com");
+                assert_eq!(registered_domain, "gmail.com");
+            }
+            other => panic!("expected NameOutsideRegisteredDomain, got {other:?}"),
+        }
+        assert_eq!(call_count(), 0, "no outcall should have been attempted");
+    }
+
+    #[test]
+    fn label_anchored_suffix_blocks_evilexample_com() {
+        install_config(&["example.com"], None);
+        reset_cache();
+        let r = block_on(fetch_txt("evilexample.com", "example.com"));
+        assert!(matches!(
+            r,
+            Err(DohError::NameOutsideRegisteredDomain { .. })
+        ));
+    }
+
+    #[test]
+    fn name_within_domain_helper_cases() {
+        assert!(name_within_domain("gmail.com", "gmail.com"));
+        assert!(name_within_domain("Gmail.COM", "gmail.com"));
+        assert!(name_within_domain(
+            "selector._domainkey.gmail.com",
+            "gmail.com"
+        ));
+        assert!(name_within_domain("a.b.c.gmail.com.", "gmail.com"));
+        assert!(!name_within_domain("evilgmail.com", "gmail.com"));
+        assert!(!name_within_domain("gmail.com.evil.com", "gmail.com"));
+        assert!(!name_within_domain("", "gmail.com"));
+    }
+
+    #[test]
+    fn rejects_invalid_qname() {
+        install_config(&["example.com"], None);
+        reset_cache();
+        // 64-byte label busts the per-label cap; should be rejected
+        // before any outcall is attempted (and before any cache state
+        // is mutated).
+        let oversize = "a".repeat(64);
+        let name = format!("{oversize}.example.com");
+        let r = block_on(fetch_txt(&name, "example.com"));
+        assert!(matches!(r, Err(DohError::InvalidName(_))));
+        assert_eq!(call_count(), 0);
     }
 }

--- a/src/internet_identity/src/doh/mod.rs
+++ b/src/internet_identity/src/doh/mod.rs
@@ -1,0 +1,31 @@
+//! DoH (DNS-over-HTTPS) fallback for fetching DKIM/DMARC TXT records
+//! when the queried domain isn't DNSSEC-signed.
+//!
+//! Design constraints (from the team Slack writeup + design doc §7.6):
+//!
+//! - **Allowlist-gated.** Outcalls happen only for domains explicitly
+//!   listed in the deploy/upgrade-arg `DohConfig.allowed_domains`. The
+//!   verifier never goes to the internet for an arbitrary domain.
+//! - **Lazy.** No background polling. The cache is populated on
+//!   demand the first time a real `smtp_request` arrives for a listed
+//!   domain.
+//! - **Quorum across independent operators.** Every cache miss fires
+//!   parallel outcalls to three providers from three jurisdictions
+//!   (Cloudflare 🇺🇸, Quad9 🇨🇭, CIRA Canadian Shield 🇨🇦) and accepts
+//!   the result iff at least 2-of-3 agree on the TXT bytes. No single
+//!   operator is trusted; one provider being down or returning forged
+//!   bytes never breaks the verifier.
+//! - **In-flight dedup.** Multiple concurrent verification requests
+//!   for the same domain share one outcall fan-out, not three each.
+//! - **Heap cache.** Fast and cheap. Keys are re-fetchable, so an
+//!   upgrade rebuilding the cache from scratch is fine.
+
+#![allow(dead_code)]
+
+mod parser;
+mod types;
+
+#[allow(unused_imports)]
+pub use parser::{build_txt_query, parse_txt_response, ParseError};
+#[allow(unused_imports)]
+pub use types::{DohError, DohProvider, PROVIDERS};

--- a/src/internet_identity/src/doh/parser.rs
+++ b/src/internet_identity/src/doh/parser.rs
@@ -114,8 +114,7 @@ pub fn parse_txt_response(bytes: &[u8]) -> Result<Vec<u8>, ParseError> {
         }
         let rtype = u16::from_be_bytes([bytes[pos], bytes[pos + 1]]);
         // class (2) + ttl (4)
-        let rdlength =
-            u16::from_be_bytes([bytes[pos + 8], bytes[pos + 9]]) as usize;
+        let rdlength = u16::from_be_bytes([bytes[pos + 8], bytes[pos + 9]]) as usize;
         pos += 10;
         if pos + rdlength > bytes.len() {
             return Err(ParseError::Truncated);
@@ -215,10 +214,7 @@ mod tests {
         assert_eq!(&bytes[2..4], &[0x01, 0x00]);
         assert_eq!(&bytes[4..6], &[0, 1]);
         // Question: 7example3com0 + type 16 + class 1
-        assert_eq!(
-            &bytes[12..],
-            b"\x07example\x03com\x00\x00\x10\x00\x01"
-        );
+        assert_eq!(&bytes[12..], b"\x07example\x03com\x00\x00\x10\x00\x01");
     }
 
     #[test]

--- a/src/internet_identity/src/doh/parser.rs
+++ b/src/internet_identity/src/doh/parser.rs
@@ -1,0 +1,310 @@
+//! Minimal DNS wire-format helpers focused on TXT record extraction.
+//!
+//! We use wire-format DoH (RFC 8484) rather than JSON DoH because:
+//! - Every public resolver supports it; JSON DoH is mostly Google +
+//!   Cloudflare specific.
+//! - Comparing two responses for quorum is bytes-in / bytes-out — no
+//!   JSON dialect quirks to normalise.
+//! - The parsing surface we need is tiny: header skip, question
+//!   skip, walk the answer section, find TXT RDATA.
+//!
+//! We do **not** implement a full DNS message parser. The verifier
+//! never asks for record types it doesn't know how to handle, and a
+//! malformed response just surfaces as `ParseError` and gets thrown
+//! out by the quorum.
+
+/// DNS query type for TXT records (RFC 1035 §3.2.2).
+pub const TYPE_TXT: u16 = 16;
+
+/// DNS class IN — the only class we handle.
+pub const CLASS_IN: u16 = 1;
+
+/// DNS message header is fixed at 12 bytes (RFC 1035 §4.1.1).
+const HEADER_LEN: usize = 12;
+
+/// Cap on label-pointer chase depth. RFC 1035 doesn't define an
+/// upper bound, but a real DNS message can't have meaningful chains
+/// longer than ~30; anything past that is almost certainly a
+/// hand-crafted compression-pointer loop.
+const MAX_LABEL_HOPS: usize = 32;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ParseError {
+    Truncated,
+    BadFlags,
+    BadResponseCode(u8),
+    PointerLoop,
+    /// The response carried no answer records of the requested type
+    /// (NoData) or returned an explicit "not found" RCODE.
+    NoAnswer,
+}
+
+/// Build a wire-format DNS query for `<name> IN TXT`.
+///
+/// `name` is given in dotted form (e.g. `selector1._domainkey.gmail.com`,
+/// optional trailing dot). The returned bytes are the body to send as
+/// `application/dns-message` over DoH.
+///
+/// Transaction ID is fixed at zero — the same canister-internal value
+/// every time. DoH responses echo the ID back; the IC's HTTP-outcall
+/// transform function strips header bytes anyway, so a fixed ID makes
+/// for cleaner replica-consensus byte equality.
+pub fn build_txt_query(name: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(HEADER_LEN + name.len() + 16);
+    // Header (12 bytes).
+    // ID (2): 0
+    out.extend_from_slice(&0u16.to_be_bytes());
+    // Flags (2): RD=1 (recursion desired). All other bits 0.
+    out.extend_from_slice(&0x0100u16.to_be_bytes());
+    // QDCOUNT=1, ANCOUNT=NSCOUNT=ARCOUNT=0
+    out.extend_from_slice(&1u16.to_be_bytes());
+    out.extend_from_slice(&0u16.to_be_bytes());
+    out.extend_from_slice(&0u16.to_be_bytes());
+    out.extend_from_slice(&0u16.to_be_bytes());
+
+    // Question section: QNAME (length-prefixed labels + 0), QTYPE, QCLASS.
+    encode_name(name, &mut out);
+    out.extend_from_slice(&TYPE_TXT.to_be_bytes());
+    out.extend_from_slice(&CLASS_IN.to_be_bytes());
+    out
+}
+
+/// Parse a DoH response and return the concatenated TXT RDATA bytes
+/// for the first matching answer record. The returned bytes are the
+/// raw `<character-string>` segments concatenated *without* the
+/// length octets (RFC 1035 §3.3.14): a typical DKIM TXT comes back
+/// like `b"v=DKIM1; k=rsa; p=..."` ready to feed straight into
+/// [`crate::dkim::dns_record::parse_dkim_txt`].
+///
+/// If the response carries multiple TXT records for the same name
+/// (rare in practice; selectors usually publish one), we return the
+/// first one only — the verifier doesn't merge them.
+pub fn parse_txt_response(bytes: &[u8]) -> Result<Vec<u8>, ParseError> {
+    if bytes.len() < HEADER_LEN {
+        return Err(ParseError::Truncated);
+    }
+    let flags = u16::from_be_bytes([bytes[2], bytes[3]]);
+    // QR=1 must be set (this is a response).
+    if flags & 0x8000 == 0 {
+        return Err(ParseError::BadFlags);
+    }
+    let rcode = (flags & 0x000f) as u8;
+    if rcode != 0 {
+        return Err(ParseError::BadResponseCode(rcode));
+    }
+    let qdcount = u16::from_be_bytes([bytes[4], bytes[5]]);
+    let ancount = u16::from_be_bytes([bytes[6], bytes[7]]);
+
+    // Skip the question section.
+    let mut pos = HEADER_LEN;
+    for _ in 0..qdcount {
+        pos = skip_name(bytes, pos)?;
+        // QTYPE (2) + QCLASS (2)
+        if pos + 4 > bytes.len() {
+            return Err(ParseError::Truncated);
+        }
+        pos += 4;
+    }
+
+    // Walk the answer section, find the first TXT record.
+    for _ in 0..ancount {
+        pos = skip_name(bytes, pos)?;
+        if pos + 10 > bytes.len() {
+            return Err(ParseError::Truncated);
+        }
+        let rtype = u16::from_be_bytes([bytes[pos], bytes[pos + 1]]);
+        // class (2) + ttl (4)
+        let rdlength =
+            u16::from_be_bytes([bytes[pos + 8], bytes[pos + 9]]) as usize;
+        pos += 10;
+        if pos + rdlength > bytes.len() {
+            return Err(ParseError::Truncated);
+        }
+        if rtype == TYPE_TXT {
+            return parse_txt_rdata(&bytes[pos..pos + rdlength]);
+        }
+        pos += rdlength;
+    }
+
+    Err(ParseError::NoAnswer)
+}
+
+/// Decode a TXT RDATA blob: a sequence of `<character-string>`s, each
+/// length-prefixed by one byte. Returns the concatenated string bodies
+/// (length octets stripped). RFC 1035 §3.3.14 / RFC 6376 §3.6.2.2.
+fn parse_txt_rdata(rdata: &[u8]) -> Result<Vec<u8>, ParseError> {
+    let mut out = Vec::with_capacity(rdata.len());
+    let mut i = 0;
+    while i < rdata.len() {
+        let len = rdata[i] as usize;
+        i += 1;
+        if i + len > rdata.len() {
+            return Err(ParseError::Truncated);
+        }
+        out.extend_from_slice(&rdata[i..i + len]);
+        i += len;
+    }
+    Ok(out)
+}
+
+/// Skip a (possibly-compressed) DNS name and return the position
+/// immediately after it. Compression pointers (top two bits of the
+/// length byte = 11) jump elsewhere in the message; we never actually
+/// follow the pointer here because `skip_name` only needs to know
+/// where the *current* name ends — for a compressed name, that's two
+/// bytes after the start.
+fn skip_name(bytes: &[u8], mut pos: usize) -> Result<usize, ParseError> {
+    let mut hops = 0;
+    loop {
+        if pos >= bytes.len() {
+            return Err(ParseError::Truncated);
+        }
+        let len = bytes[pos];
+        if len == 0 {
+            // End of name.
+            return Ok(pos + 1);
+        }
+        if len & 0xC0 == 0xC0 {
+            // Compression pointer — 2 bytes total, regardless of where
+            // it points.
+            if pos + 2 > bytes.len() {
+                return Err(ParseError::Truncated);
+            }
+            return Ok(pos + 2);
+        }
+        if len & 0xC0 != 0 {
+            // Reserved bit pattern (10 / 01) — RFC 1035 §4.1.4.
+            return Err(ParseError::BadFlags);
+        }
+        let next = pos + 1 + len as usize;
+        if next > bytes.len() {
+            return Err(ParseError::Truncated);
+        }
+        pos = next;
+        hops += 1;
+        if hops > MAX_LABEL_HOPS {
+            return Err(ParseError::PointerLoop);
+        }
+    }
+}
+
+/// Encode a dotted name as a sequence of length-prefixed labels
+/// terminated by a zero-length label.
+fn encode_name(name: &str, out: &mut Vec<u8>) {
+    for label in name.trim_end_matches('.').split('.') {
+        if label.is_empty() {
+            continue;
+        }
+        let bytes = label.as_bytes();
+        let len = bytes.len().min(63) as u8;
+        out.push(len);
+        out.extend_from_slice(&bytes[..len as usize]);
+    }
+    out.push(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_query_for_simple_name() {
+        let bytes = build_txt_query("example.com");
+        // Header: ID=0, flags=0x0100, QDCOUNT=1, others=0
+        assert_eq!(&bytes[0..2], &[0, 0]);
+        assert_eq!(&bytes[2..4], &[0x01, 0x00]);
+        assert_eq!(&bytes[4..6], &[0, 1]);
+        // Question: 7example3com0 + type 16 + class 1
+        assert_eq!(
+            &bytes[12..],
+            b"\x07example\x03com\x00\x00\x10\x00\x01"
+        );
+    }
+
+    #[test]
+    fn build_query_handles_trailing_dot() {
+        let with_dot = build_txt_query("example.com.");
+        let without_dot = build_txt_query("example.com");
+        assert_eq!(with_dot, without_dot);
+    }
+
+    #[test]
+    fn build_query_handles_long_name() {
+        let bytes = build_txt_query("selector1._domainkey.gmail.com");
+        // Header (12) + name (32 = 1+9 + 1+10 + 1+5 + 1+3 + 1) + qtype(2) + qclass(2)
+        assert_eq!(bytes.len(), 12 + 1 + 9 + 1 + 10 + 1 + 5 + 1 + 3 + 1 + 4);
+    }
+
+    /// Hand-built minimal DoH response carrying one TXT answer.
+    /// Header: ID=0, flags=0x8180 (QR + RD + RA, RCODE=0), QDCOUNT=1,
+    /// ANCOUNT=1.
+    /// Question: example.com TXT IN
+    /// Answer: example.com TXT IN TTL=300, RDLENGTH=12, RDATA="\x0bhello world"
+    fn fake_response(rdata: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        // Header
+        out.extend_from_slice(&[0, 0, 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]);
+        // Question
+        out.extend_from_slice(b"\x07example\x03com\x00\x00\x10\x00\x01");
+        // Answer name (use a compression pointer to offset 12)
+        out.extend_from_slice(&[0xC0, 0x0C]);
+        // type=TXT, class=IN, ttl=300
+        out.extend_from_slice(&TYPE_TXT.to_be_bytes());
+        out.extend_from_slice(&CLASS_IN.to_be_bytes());
+        out.extend_from_slice(&300u32.to_be_bytes());
+        // RDLENGTH and RDATA
+        out.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
+        out.extend_from_slice(rdata);
+        out
+    }
+
+    #[test]
+    fn parse_simple_txt() {
+        let resp = fake_response(b"\x0bhello world");
+        let txt = parse_txt_response(&resp).unwrap();
+        assert_eq!(txt, b"hello world");
+    }
+
+    #[test]
+    fn parse_concatenates_multiple_character_strings() {
+        // A real DKIM TXT often spans multiple <character-string>s.
+        // RDATA: "\x05first\x06second"
+        let resp = fake_response(b"\x05first\x06second");
+        let txt = parse_txt_response(&resp).unwrap();
+        assert_eq!(txt, b"firstsecond");
+    }
+
+    #[test]
+    fn rejects_when_qr_bit_unset() {
+        let mut resp = fake_response(b"\x05hello");
+        // Flip QR bit off
+        resp[2] = 0x01;
+        assert_eq!(parse_txt_response(&resp), Err(ParseError::BadFlags));
+    }
+
+    #[test]
+    fn rejects_nxdomain() {
+        let mut resp = fake_response(b"\x05hello");
+        // Flip RCODE to NXDOMAIN (3).
+        resp[3] = 0x83;
+        assert_eq!(
+            parse_txt_response(&resp),
+            Err(ParseError::BadResponseCode(3))
+        );
+    }
+
+    #[test]
+    fn rejects_truncated_header() {
+        let resp = vec![0u8; 5];
+        assert_eq!(parse_txt_response(&resp), Err(ParseError::Truncated));
+    }
+
+    #[test]
+    fn rejects_when_no_answer_section() {
+        // Build a response with ANCOUNT=0.
+        let mut out = Vec::new();
+        out.extend_from_slice(&[0, 0, 0x81, 0x80, 0, 1, 0, 0, 0, 0, 0, 0]);
+        out.extend_from_slice(b"\x07example\x03com\x00\x00\x10\x00\x01");
+        assert_eq!(parse_txt_response(&out), Err(ParseError::NoAnswer));
+    }
+}

--- a/src/internet_identity/src/doh/parser.rs
+++ b/src/internet_identity/src/doh/parser.rs
@@ -37,6 +37,13 @@ pub enum ParseError {
     /// The response carried no answer records of the requested type
     /// (NoData) or returned an explicit "not found" RCODE.
     NoAnswer,
+    /// The QNAME we were asked to encode violates RFC 1035 §2.3.4
+    /// (label > 63 octets, name > 255 octets, or empty label) and so
+    /// can't be expressed on the wire. We refuse to silently truncate
+    /// or drop labels — that would mutate the queried name into a
+    /// different one, which is a correctness bug at best and a
+    /// security bug at worst (cache poisoning by selector confusion).
+    InvalidName(String),
 }
 
 /// Build a wire-format DNS query for `<name> IN TXT`.
@@ -49,7 +56,13 @@ pub enum ParseError {
 /// every time. DoH responses echo the ID back; the IC's HTTP-outcall
 /// transform function strips header bytes anyway, so a fixed ID makes
 /// for cleaner replica-consensus byte equality.
-pub fn build_txt_query(name: &str) -> Vec<u8> {
+///
+/// Returns [`ParseError::InvalidName`] if `name` violates the wire-
+/// format constraints (label > 63 octets, total name > 255 octets,
+/// or an empty label other than the trailing root). We fail closed
+/// rather than silently truncating: a 64-octet selector becoming a
+/// different valid 63-octet selector would be a real correctness bug.
+pub fn build_txt_query(name: &str) -> Result<Vec<u8>, ParseError> {
     let mut out = Vec::with_capacity(HEADER_LEN + name.len() + 16);
     // Header (12 bytes).
     // ID (2): 0
@@ -63,10 +76,10 @@ pub fn build_txt_query(name: &str) -> Vec<u8> {
     out.extend_from_slice(&0u16.to_be_bytes());
 
     // Question section: QNAME (length-prefixed labels + 0), QTYPE, QCLASS.
-    encode_name(name, &mut out);
+    encode_name(name, &mut out)?;
     out.extend_from_slice(&TYPE_TXT.to_be_bytes());
     out.extend_from_slice(&CLASS_IN.to_be_bytes());
-    out
+    Ok(out)
 }
 
 /// Parse a DoH response and return the concatenated TXT RDATA bytes
@@ -188,18 +201,48 @@ fn skip_name(bytes: &[u8], mut pos: usize) -> Result<usize, ParseError> {
 }
 
 /// Encode a dotted name as a sequence of length-prefixed labels
-/// terminated by a zero-length label.
-fn encode_name(name: &str, out: &mut Vec<u8>) {
-    for label in name.trim_end_matches('.').split('.') {
-        if label.is_empty() {
-            continue;
-        }
+/// terminated by a zero-length label. Per RFC 1035 §2.3.4: each
+/// label is 1..=63 octets, the entire name (including length octets
+/// and the trailing zero) is at most 255 octets.
+///
+/// We fail closed on every constraint rather than truncating —
+/// silently shortening a label to 63 octets would change which name
+/// we're asking for, which can collapse two distinct selectors onto
+/// a single cache key (a cache-poisoning vector for any caller that
+/// passes attacker-influenced names).
+fn encode_name(name: &str, out: &mut Vec<u8>) -> Result<(), ParseError> {
+    let trimmed = name.trim_end_matches('.');
+    if trimmed.is_empty() {
+        // Root-only name. Just emit the terminator.
+        out.push(0);
+        return Ok(());
+    }
+    let start_len = out.len();
+    for label in trimmed.split('.') {
         let bytes = label.as_bytes();
-        let len = bytes.len().min(63) as u8;
-        out.push(len);
-        out.extend_from_slice(&bytes[..len as usize]);
+        if bytes.is_empty() {
+            return Err(ParseError::InvalidName(format!(
+                "empty label in {name:?} (consecutive dots)"
+            )));
+        }
+        if bytes.len() > 63 {
+            return Err(ParseError::InvalidName(format!(
+                "label {:?} is {} bytes; max is 63",
+                label,
+                bytes.len()
+            )));
+        }
+        out.push(bytes.len() as u8);
+        out.extend_from_slice(bytes);
     }
     out.push(0);
+    let wire_len = out.len() - start_len;
+    if wire_len > 255 {
+        return Err(ParseError::InvalidName(format!(
+            "encoded QNAME for {name:?} is {wire_len} bytes; max is 255"
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -208,7 +251,7 @@ mod tests {
 
     #[test]
     fn build_query_for_simple_name() {
-        let bytes = build_txt_query("example.com");
+        let bytes = build_txt_query("example.com").unwrap();
         // Header: ID=0, flags=0x0100, QDCOUNT=1, others=0
         assert_eq!(&bytes[0..2], &[0, 0]);
         assert_eq!(&bytes[2..4], &[0x01, 0x00]);
@@ -219,14 +262,44 @@ mod tests {
 
     #[test]
     fn build_query_handles_trailing_dot() {
-        let with_dot = build_txt_query("example.com.");
-        let without_dot = build_txt_query("example.com");
+        let with_dot = build_txt_query("example.com.").unwrap();
+        let without_dot = build_txt_query("example.com").unwrap();
         assert_eq!(with_dot, without_dot);
     }
 
     #[test]
+    fn build_query_rejects_oversize_label() {
+        let label = "a".repeat(64);
+        let name = format!("{label}.example.com");
+        match build_txt_query(&name) {
+            Err(ParseError::InvalidName(_)) => {}
+            other => panic!("expected InvalidName, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_query_rejects_empty_label() {
+        match build_txt_query("foo..bar.example.com") {
+            Err(ParseError::InvalidName(_)) => {}
+            other => panic!("expected InvalidName, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_query_rejects_oversize_total() {
+        // 5 × 50-char labels + 5 length octets + terminator → ~256.
+        // RFC 1035 §2.3.4 caps the wire QNAME at 255 octets total.
+        let label = "a".repeat(50);
+        let name = (0..5).map(|_| label.as_str()).collect::<Vec<_>>().join(".");
+        match build_txt_query(&name) {
+            Err(ParseError::InvalidName(_)) => {}
+            other => panic!("expected InvalidName, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn build_query_handles_long_name() {
-        let bytes = build_txt_query("selector1._domainkey.gmail.com");
+        let bytes = build_txt_query("selector1._domainkey.gmail.com").unwrap();
         // Header (12) + name (32 = 1+9 + 1+10 + 1+5 + 1+3 + 1) + qtype(2) + qclass(2)
         assert_eq!(bytes.len(), 12 + 1 + 9 + 1 + 10 + 1 + 5 + 1 + 3 + 1 + 4);
     }

--- a/src/internet_identity/src/doh/quorum.rs
+++ b/src/internet_identity/src/doh/quorum.rs
@@ -1,10 +1,10 @@
-//! Parallel multi-provider DoH fetch with k-of-n quorum.
+//! Quorum decision over per-provider outcomes.
 //!
-//! Issues a wire-format DoH query to each provider in [`PROVIDERS`]
-//! and returns the TXT bytes that at least [`QUORUM_THRESHOLD`] of
-//! them agree on. We don't rely on any single resolver being honest
-//! or available: as long as a strict majority of the providers we
-//! picked return the same TXT, the verifier accepts the response.
+//! The async fan-out lives in [`super::fetch_txt`]: it issues one
+//! outcall per provider in [`super::types::PROVIDERS`], parses each
+//! response into an [`Outcome`], and hands the resulting slice to
+//! [`decide_quorum`]. Keeping the decision step a pure function makes
+//! the threshold logic trivially testable without faking outcalls.
 //!
 //! Failure modes:
 //! - Every provider down → [`DohError::AllProvidersFailed`].
@@ -14,70 +14,19 @@
 //!   accept (a couple of providers being down or returning forged
 //!   bytes doesn't punish the user as long as enough of the rest
 //!   agree).
+//!
+//! End-to-end coverage of the outcall loop (provider fan-out, the
+//! transform function, real `http_request_with_closure` plumbing)
+//! lives in the email-recovery integration tests, which mock outcall
+//! replies at the PocketIC boundary rather than abstracting the
+//! fetcher.
 
-use super::parser::{build_txt_query, parse_txt_response};
-use super::types::{DohError, DohProvider, PROVIDERS, QUORUM_THRESHOLD};
+use super::types::{DohError, QUORUM_THRESHOLD};
 
-/// Trait for the per-provider HTTP outcall. Production swaps in an
-/// `ic_cdk` HTTP-outcall implementation; tests use a deterministic
-/// in-memory mock that returns canned bytes.
-///
-/// `async fn` in traits requires `async_trait`-style boxing. We avoid
-/// the dep by using `impl Future<Output = ...>` and a manual `dyn`
-/// bound through a function-pointer-shaped helper. Instead the trait
-/// uses a simpler synchronous `&self` API and the production wrapper
-/// wires it into the IC outcall machinery in [`super::mod`].
-pub trait DohFetcher {
-    /// Issue a wire-format DoH query (POST `application/dns-message`
-    /// with `query_bytes` as body) to `provider.url`. Returns the raw
-    /// response body bytes on success.
-    ///
-    /// This trait is the **synchronous test seam**: tests build a
-    /// `MockFetcher` and call [`run_quorum`] which iterates `PROVIDERS`
-    /// sequentially. The production async path in [`super::fetch_txt`]
-    /// does NOT go through this trait — it constructs its own per-
-    /// provider futures and fans them out via `futures::future::join_all`
-    /// for genuine parallelism. The two paths share only the bucketing
-    /// logic in [`decide_quorum`].
-    ///
-    /// Tests pass a `&MockDohFetcher` that has a `HashMap<DohProvider,
-    /// Result<Vec<u8>, ()>>` and just returns the canned answer.
-    fn fetch_blocking(&self, provider: &DohProvider, query_bytes: &[u8])
-        -> Result<Vec<u8>, String>;
-}
-
-/// Run the per-provider fetches and pick the result that hits the
-/// quorum threshold.
-///
-/// `fetcher` is parameterised so tests can inject canned responses;
-/// production passes a real outcall implementation.
-///
-/// Returns `Ok(txt_bytes)` iff at least [`QUORUM_THRESHOLD`] providers
-/// returned the same TXT bytes. The DNS message envelope (header,
-/// question section, TTLs) is intentionally *not* compared — only the
-/// TXT RDATA is.
-pub fn run_quorum<F: DohFetcher>(name: &str, fetcher: &F) -> Result<Vec<u8>, DohError> {
-    let query = build_txt_query(name).map_err(|e| DohError::InvalidName(format!("{e:?}")))?;
-
-    // Per-provider outcomes. Order matches PROVIDERS so logs are
-    // attributable, but the quorum count doesn't care about order.
-    let mut outcomes: Vec<Outcome> = Vec::with_capacity(PROVIDERS.len());
-    for provider in PROVIDERS {
-        outcomes.push(match fetcher.fetch_blocking(provider, &query) {
-            Ok(bytes) => match parse_txt_response(&bytes) {
-                Ok(txt) => Outcome::Txt(txt),
-                Err(e) => Outcome::ParseError(format!("{:?}", e)),
-            },
-            Err(e) => Outcome::FetchError(e),
-        });
-    }
-    decide_quorum(&outcomes)
-}
-
-/// One provider's contribution to the quorum count. The async path in
-/// [`super::fetch_txt`] constructs these from outcall results
-/// directly; the sync [`run_quorum`] above constructs them while
-/// iterating its fetcher.
+/// One provider's contribution to the quorum count. Constructed by
+/// [`super::fetch_txt`] from outcall results — `Txt` carries the
+/// parsed RDATA, the two error variants record why a provider didn't
+/// contribute (logged but not surfaced beyond aggregate counts).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) enum Outcome {
     Txt(Vec<u8>),
@@ -127,127 +76,53 @@ pub(super) fn decide_quorum(outcomes: &[Outcome]) -> Result<Vec<u8>, DohError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
-    use std::collections::HashMap;
 
-    /// In-memory fetcher for tests. Maps `provider.url` →
-    /// `Result<Vec<u8>, String>`. Records each call so tests can
-    /// assert "fired exactly 3 times".
-    pub(crate) struct MockFetcher {
-        responses: HashMap<String, Result<Vec<u8>, String>>,
-        pub(crate) calls: RefCell<usize>,
+    fn txt(s: &[u8]) -> Outcome {
+        Outcome::Txt(s.to_vec())
     }
-
-    impl MockFetcher {
-        fn new(responses: &[(&str, Result<Vec<u8>, String>)]) -> Self {
-            let mut m = HashMap::new();
-            for (url, r) in responses {
-                m.insert((*url).to_string(), r.clone());
-            }
-            Self {
-                responses: m,
-                calls: RefCell::new(0),
-            }
-        }
+    fn fetch_err(s: &str) -> Outcome {
+        Outcome::FetchError(s.into())
     }
-
-    impl DohFetcher for MockFetcher {
-        fn fetch_blocking(&self, provider: &DohProvider, _query: &[u8]) -> Result<Vec<u8>, String> {
-            *self.calls.borrow_mut() += 1;
-            self.responses
-                .get(provider.url)
-                .cloned()
-                .unwrap_or(Err("no canned response for provider".into()))
-        }
-    }
-
-    /// Build a fake DoH response carrying the TXT RDATA `txt`. The
-    /// message envelope mirrors the test in `parser.rs`; we re-emit
-    /// here so each test can vary the answer per provider.
-    fn fake_response(txt: &[u8]) -> Vec<u8> {
-        use super::super::parser::{CLASS_IN, TYPE_TXT};
-        let mut out = Vec::new();
-        // Header: ID=0, flags=0x8180, QDCOUNT=1, ANCOUNT=1
-        out.extend_from_slice(&[0, 0, 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]);
-        // Question: example.com TXT IN
-        out.extend_from_slice(b"\x07example\x03com\x00\x00\x10\x00\x01");
-        // Answer name (compression pointer)
-        out.extend_from_slice(&[0xC0, 0x0C]);
-        out.extend_from_slice(&TYPE_TXT.to_be_bytes());
-        out.extend_from_slice(&CLASS_IN.to_be_bytes());
-        out.extend_from_slice(&300u32.to_be_bytes());
-        // RDLENGTH and RDATA
-        let mut rdata = vec![txt.len() as u8];
-        rdata.extend_from_slice(txt);
-        out.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
-        out.extend_from_slice(&rdata);
-        out
-    }
-
-    /// Build a `MockFetcher` from a per-index outcome — index `i`
-    /// targets `PROVIDERS[i].url`. Keeps the tests below readable
-    /// without restating the URL list.
-    fn mock_from(outcomes: Vec<Result<Vec<u8>, String>>) -> MockFetcher {
-        assert_eq!(
-            outcomes.len(),
-            PROVIDERS.len(),
-            "test setup must cover every provider"
-        );
-        let pairs: Vec<(&str, Result<Vec<u8>, String>)> = PROVIDERS
-            .iter()
-            .zip(outcomes)
-            .map(|(p, r)| (p.url, r))
-            .collect();
-        let pairs_ref: Vec<(&str, Result<Vec<u8>, String>)> = pairs;
-        // MockFetcher::new takes &[(&str, Result<...>)]; we already
-        // built it.
-        MockFetcher::new(&pairs_ref)
-    }
-
-    fn ok_dkim() -> Result<Vec<u8>, String> {
-        Ok(fake_response(b"v=DKIM1"))
-    }
-    fn ok_other(s: &[u8]) -> Result<Vec<u8>, String> {
-        Ok(fake_response(s))
-    }
-    fn fail(s: &str) -> Result<Vec<u8>, String> {
-        Err(s.into())
+    fn parse_err(s: &str) -> Outcome {
+        Outcome::ParseError(s.into())
     }
 
     #[test]
     fn all_five_agree_passes() {
-        let fetcher = mock_from(vec![ok_dkim(), ok_dkim(), ok_dkim(), ok_dkim(), ok_dkim()]);
-        let txt = run_quorum("example.com", &fetcher).unwrap();
-        assert_eq!(txt, b"v=DKIM1");
-        assert_eq!(*fetcher.calls.borrow(), 5);
+        let outcomes = vec![
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+        ];
+        assert_eq!(decide_quorum(&outcomes).unwrap(), b"v=DKIM1");
     }
 
     #[test]
     fn three_of_five_agree_two_disagree_passes() {
         // Threshold is 3. Three agree on "v=DKIM1", two return forged
         // bytes — honest majority wins.
-        let fetcher = mock_from(vec![
-            ok_dkim(),
-            ok_dkim(),
-            ok_dkim(),
-            ok_other(b"forged-A"),
-            ok_other(b"forged-B"),
-        ]);
-        let txt = run_quorum("example.com", &fetcher).unwrap();
-        assert_eq!(txt, b"v=DKIM1");
+        let outcomes = vec![
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+            txt(b"forged-A"),
+            txt(b"forged-B"),
+        ];
+        assert_eq!(decide_quorum(&outcomes).unwrap(), b"v=DKIM1");
     }
 
     #[test]
     fn three_agree_two_fail_passes() {
-        let fetcher = mock_from(vec![
-            ok_dkim(),
-            ok_dkim(),
-            ok_dkim(),
-            fail("network down"),
-            fail("timeout"),
-        ]);
-        let txt = run_quorum("example.com", &fetcher).unwrap();
-        assert_eq!(txt, b"v=DKIM1");
+        let outcomes = vec![
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+            fetch_err("network down"),
+            fetch_err("timeout"),
+        ];
+        assert_eq!(decide_quorum(&outcomes).unwrap(), b"v=DKIM1");
     }
 
     #[test]
@@ -255,10 +130,15 @@ mod tests {
         // 2-of-5 is short of the 3-of-5 threshold — even with a clear
         // plurality, we refuse rather than fall back to majority-of-
         // -successful-responses.
-        let fetcher = mock_from(vec![ok_dkim(), ok_dkim(), fail("a"), fail("b"), fail("c")]);
-        let err = run_quorum("example.com", &fetcher).unwrap_err();
+        let outcomes = vec![
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+            fetch_err("a"),
+            fetch_err("b"),
+            fetch_err("c"),
+        ];
         assert_eq!(
-            err,
+            decide_quorum(&outcomes).unwrap_err(),
             DohError::QuorumFailed {
                 agreeing: 2,
                 total: 5
@@ -270,16 +150,15 @@ mod tests {
     fn split_buckets_miss_quorum() {
         // Five providers split across three answers (2/2/1) — biggest
         // bucket is 2, short of the 3-of-5 threshold.
-        let fetcher = mock_from(vec![
-            ok_other(b"answer-A"),
-            ok_other(b"answer-A"),
-            ok_other(b"answer-B"),
-            ok_other(b"answer-B"),
-            ok_other(b"answer-C"),
-        ]);
-        let err = run_quorum("example.com", &fetcher).unwrap_err();
+        let outcomes = vec![
+            txt(b"answer-A"),
+            txt(b"answer-A"),
+            txt(b"answer-B"),
+            txt(b"answer-B"),
+            txt(b"answer-C"),
+        ];
         assert_eq!(
-            err,
+            decide_quorum(&outcomes).unwrap_err(),
             DohError::QuorumFailed {
                 agreeing: 2,
                 total: 5
@@ -289,37 +168,46 @@ mod tests {
 
     #[test]
     fn all_fail_returns_all_providers_failed() {
-        let fetcher = mock_from(vec![fail("a"), fail("b"), fail("c"), fail("d"), fail("e")]);
-        let err = run_quorum("example.com", &fetcher).unwrap_err();
-        assert_eq!(err, DohError::AllProvidersFailed);
+        let outcomes = vec![
+            fetch_err("a"),
+            fetch_err("b"),
+            fetch_err("c"),
+            fetch_err("d"),
+            fetch_err("e"),
+        ];
+        assert_eq!(
+            decide_quorum(&outcomes).unwrap_err(),
+            DohError::AllProvidersFailed
+        );
     }
 
     #[test]
     fn two_malformed_three_valid_passes() {
         // Malformed responses are counted as parse failures; the three
         // valid agreeing responses still hit the threshold.
-        let fetcher = mock_from(vec![
-            ok_dkim(),
-            ok_dkim(),
-            ok_dkim(),
-            Ok(b"not a DNS message".to_vec()),
-            Ok(b"also garbage".to_vec()),
-        ]);
-        let txt = run_quorum("example.com", &fetcher).unwrap();
-        assert_eq!(txt, b"v=DKIM1");
+        let outcomes = vec![
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+            txt(b"v=DKIM1"),
+            parse_err("not a DNS message"),
+            parse_err("also garbage"),
+        ];
+        assert_eq!(decide_quorum(&outcomes).unwrap(), b"v=DKIM1");
     }
 
     #[test]
     fn all_malformed_returns_all_providers_failed() {
-        let fetcher = mock_from(vec![
-            Ok(b"g1".to_vec()),
-            Ok(b"g2".to_vec()),
-            Ok(b"g3".to_vec()),
-            Ok(b"g4".to_vec()),
-            Ok(b"g5".to_vec()),
-        ]);
-        let err = run_quorum("example.com", &fetcher).unwrap_err();
+        let outcomes = vec![
+            parse_err("g1"),
+            parse_err("g2"),
+            parse_err("g3"),
+            parse_err("g4"),
+            parse_err("g5"),
+        ];
         // None parsed → no successes → AllProvidersFailed.
-        assert_eq!(err, DohError::AllProvidersFailed);
+        assert_eq!(
+            decide_quorum(&outcomes).unwrap_err(),
+            DohError::AllProvidersFailed
+        );
     }
 }

--- a/src/internet_identity/src/doh/quorum.rs
+++ b/src/internet_identity/src/doh/quorum.rs
@@ -32,11 +32,13 @@ pub trait DohFetcher {
     /// with `query_bytes` as body) to `provider.url`. Returns the raw
     /// response body bytes on success.
     ///
-    /// In production this is async (it goes over the network). The
-    /// trait surface is sync because the cache + quorum logic runs
-    /// inside an already-async wrapper that calls all three fetchers
-    /// in parallel. See [`super::mod::fetch_txt`] for the production
-    /// wiring.
+    /// This trait is the **synchronous test seam**: tests build a
+    /// `MockFetcher` and call [`run_quorum`] which iterates `PROVIDERS`
+    /// sequentially. The production async path in [`super::fetch_txt`]
+    /// does NOT go through this trait — it constructs its own per-
+    /// provider futures and fans them out via `futures::future::join_all`
+    /// for genuine parallelism. The two paths share only the bucketing
+    /// logic in [`decide_quorum`].
     ///
     /// Tests pass a `&MockDohFetcher` that has a `HashMap<DohProvider,
     /// Result<Vec<u8>, ()>>` and just returns the canned answer.
@@ -55,7 +57,7 @@ pub trait DohFetcher {
 /// question section, TTLs) is intentionally *not* compared — only the
 /// TXT RDATA is.
 pub fn run_quorum<F: DohFetcher>(name: &str, fetcher: &F) -> Result<Vec<u8>, DohError> {
-    let query = build_txt_query(name);
+    let query = build_txt_query(name).map_err(|e| DohError::InvalidName(format!("{e:?}")))?;
 
     // Per-provider outcomes. Order matches PROVIDERS so logs are
     // attributable, but the quorum count doesn't care about order.

--- a/src/internet_identity/src/doh/quorum.rs
+++ b/src/internet_identity/src/doh/quorum.rs
@@ -1,0 +1,323 @@
+//! Parallel multi-provider DoH fetch with k-of-n quorum.
+//!
+//! Issues a wire-format DoH query to each provider in [`PROVIDERS`]
+//! and returns the TXT bytes that at least [`QUORUM_THRESHOLD`] of
+//! them agree on. We don't rely on any single resolver being honest
+//! or available: as long as a strict majority of the providers we
+//! picked return the same TXT, the verifier accepts the response.
+//!
+//! Failure modes:
+//! - Every provider down → [`DohError::AllProvidersFailed`].
+//! - Providers up but the largest agreeing bucket is below the
+//!   threshold → [`DohError::QuorumFailed`].
+//! - Mix of failures + agreements that still hits the threshold →
+//!   accept (a couple of providers being down or returning forged
+//!   bytes doesn't punish the user as long as enough of the rest
+//!   agree).
+
+use super::parser::{build_txt_query, parse_txt_response};
+use super::types::{DohError, DohProvider, PROVIDERS, QUORUM_THRESHOLD};
+
+/// Trait for the per-provider HTTP outcall. Production swaps in an
+/// `ic_cdk` HTTP-outcall implementation; tests use a deterministic
+/// in-memory mock that returns canned bytes.
+///
+/// `async fn` in traits requires `async_trait`-style boxing. We avoid
+/// the dep by using `impl Future<Output = ...>` and a manual `dyn`
+/// bound through a function-pointer-shaped helper. Instead the trait
+/// uses a simpler synchronous `&self` API and the production wrapper
+/// wires it into the IC outcall machinery in [`super::mod`].
+pub trait DohFetcher {
+    /// Issue a wire-format DoH query (POST `application/dns-message`
+    /// with `query_bytes` as body) to `provider.url`. Returns the raw
+    /// response body bytes on success.
+    ///
+    /// In production this is async (it goes over the network). The
+    /// trait surface is sync because the cache + quorum logic runs
+    /// inside an already-async wrapper that calls all three fetchers
+    /// in parallel. See [`super::mod::fetch_txt`] for the production
+    /// wiring.
+    ///
+    /// Tests pass a `&MockDohFetcher` that has a `HashMap<DohProvider,
+    /// Result<Vec<u8>, ()>>` and just returns the canned answer.
+    fn fetch_blocking(&self, provider: &DohProvider, query_bytes: &[u8])
+        -> Result<Vec<u8>, String>;
+}
+
+/// Run the per-provider fetches and pick the result that hits the
+/// quorum threshold.
+///
+/// `fetcher` is parameterised so tests can inject canned responses;
+/// production passes a real outcall implementation.
+///
+/// Returns `Ok(txt_bytes)` iff at least [`QUORUM_THRESHOLD`] providers
+/// returned the same TXT bytes. The DNS message envelope (header,
+/// question section, TTLs) is intentionally *not* compared — only the
+/// TXT RDATA is.
+pub fn run_quorum<F: DohFetcher>(name: &str, fetcher: &F) -> Result<Vec<u8>, DohError> {
+    let query = build_txt_query(name);
+
+    // Per-provider outcomes. Order matches PROVIDERS so logs are
+    // attributable, but the quorum count doesn't care about order.
+    let mut outcomes: Vec<Outcome> = Vec::with_capacity(PROVIDERS.len());
+    for provider in PROVIDERS {
+        outcomes.push(match fetcher.fetch_blocking(provider, &query) {
+            Ok(bytes) => match parse_txt_response(&bytes) {
+                Ok(txt) => Outcome::Txt(txt),
+                Err(e) => Outcome::ParseError(format!("{:?}", e)),
+            },
+            Err(e) => Outcome::FetchError(e),
+        });
+    }
+    decide_quorum(&outcomes)
+}
+
+/// One provider's contribution to the quorum count. The async path in
+/// [`super::fetch_txt`] constructs these from outcall results
+/// directly; the sync [`run_quorum`] above constructs them while
+/// iterating its fetcher.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) enum Outcome {
+    Txt(Vec<u8>),
+    FetchError(String),
+    ParseError(String),
+}
+
+/// Count agreement and apply the threshold. Pure function so it's
+/// trivially testable without a fetcher.
+pub(super) fn decide_quorum(outcomes: &[Outcome]) -> Result<Vec<u8>, DohError> {
+    let succeeded: Vec<&Vec<u8>> = outcomes
+        .iter()
+        .filter_map(|o| match o {
+            Outcome::Txt(b) => Some(b),
+            _ => None,
+        })
+        .collect();
+    let total = outcomes.len();
+
+    if succeeded.is_empty() {
+        return Err(DohError::AllProvidersFailed);
+    }
+
+    // Bucket by exact TXT byte equality. The largest bucket is the
+    // candidate; if it's at the threshold, we accept.
+    let mut buckets: Vec<(&[u8], usize)> = Vec::new();
+    for txt in &succeeded {
+        let bytes = txt.as_slice();
+        if let Some((_, count)) = buckets.iter_mut().find(|(b, _)| *b == bytes) {
+            *count += 1;
+        } else {
+            buckets.push((bytes, 1));
+        }
+    }
+    let (winner_bytes, winner_count) = buckets.iter().max_by_key(|(_, c)| *c).copied().unwrap();
+
+    if winner_count >= QUORUM_THRESHOLD {
+        Ok(winner_bytes.to_vec())
+    } else {
+        Err(DohError::QuorumFailed {
+            agreeing: winner_count,
+            total,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    /// In-memory fetcher for tests. Maps `provider.url` →
+    /// `Result<Vec<u8>, String>`. Records each call so tests can
+    /// assert "fired exactly 3 times".
+    pub(crate) struct MockFetcher {
+        responses: HashMap<String, Result<Vec<u8>, String>>,
+        pub(crate) calls: RefCell<usize>,
+    }
+
+    impl MockFetcher {
+        fn new(responses: &[(&str, Result<Vec<u8>, String>)]) -> Self {
+            let mut m = HashMap::new();
+            for (url, r) in responses {
+                m.insert((*url).to_string(), r.clone());
+            }
+            Self {
+                responses: m,
+                calls: RefCell::new(0),
+            }
+        }
+    }
+
+    impl DohFetcher for MockFetcher {
+        fn fetch_blocking(&self, provider: &DohProvider, _query: &[u8]) -> Result<Vec<u8>, String> {
+            *self.calls.borrow_mut() += 1;
+            self.responses
+                .get(provider.url)
+                .cloned()
+                .unwrap_or(Err("no canned response for provider".into()))
+        }
+    }
+
+    /// Build a fake DoH response carrying the TXT RDATA `txt`. The
+    /// message envelope mirrors the test in `parser.rs`; we re-emit
+    /// here so each test can vary the answer per provider.
+    fn fake_response(txt: &[u8]) -> Vec<u8> {
+        use super::super::parser::{CLASS_IN, TYPE_TXT};
+        let mut out = Vec::new();
+        // Header: ID=0, flags=0x8180, QDCOUNT=1, ANCOUNT=1
+        out.extend_from_slice(&[0, 0, 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]);
+        // Question: example.com TXT IN
+        out.extend_from_slice(b"\x07example\x03com\x00\x00\x10\x00\x01");
+        // Answer name (compression pointer)
+        out.extend_from_slice(&[0xC0, 0x0C]);
+        out.extend_from_slice(&TYPE_TXT.to_be_bytes());
+        out.extend_from_slice(&CLASS_IN.to_be_bytes());
+        out.extend_from_slice(&300u32.to_be_bytes());
+        // RDLENGTH and RDATA
+        let mut rdata = vec![txt.len() as u8];
+        rdata.extend_from_slice(txt);
+        out.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
+        out.extend_from_slice(&rdata);
+        out
+    }
+
+    /// Build a `MockFetcher` from a per-index outcome — index `i`
+    /// targets `PROVIDERS[i].url`. Keeps the tests below readable
+    /// without restating the URL list.
+    fn mock_from(outcomes: Vec<Result<Vec<u8>, String>>) -> MockFetcher {
+        assert_eq!(
+            outcomes.len(),
+            PROVIDERS.len(),
+            "test setup must cover every provider"
+        );
+        let pairs: Vec<(&str, Result<Vec<u8>, String>)> = PROVIDERS
+            .iter()
+            .zip(outcomes)
+            .map(|(p, r)| (p.url, r))
+            .collect();
+        let pairs_ref: Vec<(&str, Result<Vec<u8>, String>)> = pairs;
+        // MockFetcher::new takes &[(&str, Result<...>)]; we already
+        // built it.
+        MockFetcher::new(&pairs_ref)
+    }
+
+    fn ok_dkim() -> Result<Vec<u8>, String> {
+        Ok(fake_response(b"v=DKIM1"))
+    }
+    fn ok_other(s: &[u8]) -> Result<Vec<u8>, String> {
+        Ok(fake_response(s))
+    }
+    fn fail(s: &str) -> Result<Vec<u8>, String> {
+        Err(s.into())
+    }
+
+    #[test]
+    fn all_five_agree_passes() {
+        let fetcher = mock_from(vec![ok_dkim(), ok_dkim(), ok_dkim(), ok_dkim(), ok_dkim()]);
+        let txt = run_quorum("example.com", &fetcher).unwrap();
+        assert_eq!(txt, b"v=DKIM1");
+        assert_eq!(*fetcher.calls.borrow(), 5);
+    }
+
+    #[test]
+    fn three_of_five_agree_two_disagree_passes() {
+        // Threshold is 3. Three agree on "v=DKIM1", two return forged
+        // bytes — honest majority wins.
+        let fetcher = mock_from(vec![
+            ok_dkim(),
+            ok_dkim(),
+            ok_dkim(),
+            ok_other(b"forged-A"),
+            ok_other(b"forged-B"),
+        ]);
+        let txt = run_quorum("example.com", &fetcher).unwrap();
+        assert_eq!(txt, b"v=DKIM1");
+    }
+
+    #[test]
+    fn three_agree_two_fail_passes() {
+        let fetcher = mock_from(vec![
+            ok_dkim(),
+            ok_dkim(),
+            ok_dkim(),
+            fail("network down"),
+            fail("timeout"),
+        ]);
+        let txt = run_quorum("example.com", &fetcher).unwrap();
+        assert_eq!(txt, b"v=DKIM1");
+    }
+
+    #[test]
+    fn two_agreeing_misses_quorum() {
+        // 2-of-5 is short of the 3-of-5 threshold — even with a clear
+        // plurality, we refuse rather than fall back to majority-of-
+        // -successful-responses.
+        let fetcher = mock_from(vec![ok_dkim(), ok_dkim(), fail("a"), fail("b"), fail("c")]);
+        let err = run_quorum("example.com", &fetcher).unwrap_err();
+        assert_eq!(
+            err,
+            DohError::QuorumFailed {
+                agreeing: 2,
+                total: 5
+            }
+        );
+    }
+
+    #[test]
+    fn split_buckets_miss_quorum() {
+        // Five providers split across three answers (2/2/1) — biggest
+        // bucket is 2, short of the 3-of-5 threshold.
+        let fetcher = mock_from(vec![
+            ok_other(b"answer-A"),
+            ok_other(b"answer-A"),
+            ok_other(b"answer-B"),
+            ok_other(b"answer-B"),
+            ok_other(b"answer-C"),
+        ]);
+        let err = run_quorum("example.com", &fetcher).unwrap_err();
+        assert_eq!(
+            err,
+            DohError::QuorumFailed {
+                agreeing: 2,
+                total: 5
+            }
+        );
+    }
+
+    #[test]
+    fn all_fail_returns_all_providers_failed() {
+        let fetcher = mock_from(vec![fail("a"), fail("b"), fail("c"), fail("d"), fail("e")]);
+        let err = run_quorum("example.com", &fetcher).unwrap_err();
+        assert_eq!(err, DohError::AllProvidersFailed);
+    }
+
+    #[test]
+    fn two_malformed_three_valid_passes() {
+        // Malformed responses are counted as parse failures; the three
+        // valid agreeing responses still hit the threshold.
+        let fetcher = mock_from(vec![
+            ok_dkim(),
+            ok_dkim(),
+            ok_dkim(),
+            Ok(b"not a DNS message".to_vec()),
+            Ok(b"also garbage".to_vec()),
+        ]);
+        let txt = run_quorum("example.com", &fetcher).unwrap();
+        assert_eq!(txt, b"v=DKIM1");
+    }
+
+    #[test]
+    fn all_malformed_returns_all_providers_failed() {
+        let fetcher = mock_from(vec![
+            Ok(b"g1".to_vec()),
+            Ok(b"g2".to_vec()),
+            Ok(b"g3".to_vec()),
+            Ok(b"g4".to_vec()),
+            Ok(b"g5".to_vec()),
+        ]);
+        let err = run_quorum("example.com", &fetcher).unwrap_err();
+        // None parsed → no successes → AllProvidersFailed.
+        assert_eq!(err, DohError::AllProvidersFailed);
+    }
+}

--- a/src/internet_identity/src/doh/types.rs
+++ b/src/internet_identity/src/doh/types.rs
@@ -1,0 +1,120 @@
+//! Internal types for the DoH fallback.
+
+/// One DoH provider in the quorum.
+///
+/// All three providers below run free public DoH endpoints as a public
+/// service (not a commercial product), so we don't expect a-rate-
+/// limit-killed-our-canister failure mode. Each is operated in a
+/// different jurisdiction; we deliberately don't lean on a single
+/// political/legal regime for the answer to "what does Gmail's DKIM
+/// key look like right now".
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DohProvider {
+    /// Display name for diagnostics / logging.
+    pub name: &'static str,
+    /// Country/jurisdiction tag, for diagnostics.
+    pub jurisdiction: &'static str,
+    /// Wire-format DoH endpoint (`application/dns-message` POST).
+    pub url: &'static str,
+}
+
+/// The three providers we query in parallel for every cache miss.
+///
+/// Picked for jurisdictional diversity (CH / CA / US), public-service
+/// rather than commercial operation, and continuous uptime under their
+/// current foundations / non-profits as of 2026-05.
+pub const PROVIDERS: &[DohProvider] = &[
+    DohProvider {
+        name: "Quad9",
+        jurisdiction: "Switzerland",
+        url: "https://dns.quad9.net/dns-query",
+    },
+    DohProvider {
+        name: "CIRA Canadian Shield",
+        jurisdiction: "Canada",
+        url: "https://private.canadianshield.cira.ca/dns-query",
+    },
+    DohProvider {
+        name: "Cloudflare",
+        jurisdiction: "United States",
+        url: "https://cloudflare-dns.com/dns-query",
+    },
+];
+
+/// Quorum threshold: we accept the response iff at least this many of
+/// `PROVIDERS.len()` returned identical TXT bytes.
+pub const QUORUM_THRESHOLD: usize = 2;
+
+/// Default cache TTL when the deploy arg doesn't override it. One hour
+/// is short enough that a key rotation is picked up the next time mail
+/// flows after the rotation, long enough to cover ~all of a recovery
+/// flow's expected duration.
+pub const DEFAULT_CACHE_AGE_SECS: u64 = 3600;
+
+/// Hard cap on `DohConfig.max_cache_age_secs`. Stale keys can break
+/// recovery for users mid-flow when a provider rotates; the cap keeps
+/// "stuck cache" from being the failure mode.
+pub const MAX_CACHE_AGE_SECS: u64 = 24 * 3600;
+
+/// All the ways the DoH path can fail. The verifier collapses these
+/// into a single fail-reason variant up the call stack; the granular
+/// shape is for diagnostics and tests.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DohError {
+    /// The queried registered domain isn't on `allowed_domains`. The
+    /// verifier will not go to the internet for arbitrary domains.
+    DomainNotAllowed,
+    /// All three outcalls failed (network error / non-200 / etc).
+    AllProvidersFailed,
+    /// Outcalls succeeded but the responses didn't reach the quorum
+    /// threshold of identical TXT bytes.
+    QuorumFailed { agreeing: usize, total: usize },
+    /// A single response was received but failed to parse as a DNS
+    /// message with a valid TXT record. (Reported during quorum
+    /// counting; not a top-level failure unless every response is
+    /// malformed.)
+    ResponseMalformed(String),
+    /// The deploy/upgrade arg never set a `DohConfig`, or the config
+    /// was cleared via `Some(None)`. The DoH fallback is disabled.
+    NotConfigured,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn three_providers_three_jurisdictions() {
+        assert_eq!(PROVIDERS.len(), 3);
+        let mut seen: Vec<&str> = PROVIDERS.iter().map(|p| p.jurisdiction).collect();
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen.len(), 3, "providers must span 3 jurisdictions");
+    }
+
+    #[test]
+    fn quorum_strictly_above_minority() {
+        // 2-of-3 is a Byzantine-tolerant majority: any one provider
+        // failing or lying still leaves a majority of two honest
+        // providers agreeing. If we accidentally relax to 1-of-3, a
+        // single dishonest provider could drive verification.
+        assert!(QUORUM_THRESHOLD * 2 > PROVIDERS.len());
+    }
+
+    #[test]
+    fn cache_age_cap_is_one_day() {
+        assert_eq!(MAX_CACHE_AGE_SECS, 86_400);
+    }
+
+    #[test]
+    fn provider_urls_use_dns_query_path() {
+        for p in PROVIDERS {
+            assert!(
+                p.url.ends_with("/dns-query"),
+                "{} url should end in /dns-query",
+                p.name
+            );
+            assert!(p.url.starts_with("https://"), "{} must be https", p.name);
+        }
+    }
+}

--- a/src/internet_identity/src/doh/types.rs
+++ b/src/internet_identity/src/doh/types.rs
@@ -2,12 +2,12 @@
 
 /// One DoH provider in the quorum.
 ///
-/// All three providers below run free public DoH endpoints as a public
-/// service (not a commercial product), so we don't expect a-rate-
-/// limit-killed-our-canister failure mode. Each is operated in a
-/// different jurisdiction; we deliberately don't lean on a single
-/// political/legal regime for the answer to "what does Gmail's DKIM
-/// key look like right now".
+/// All five providers run free public DoH endpoints as a public service
+/// rather than a commercial product, so we don't expect a "rate limit
+/// killed our canister" failure mode. Each is operated in a different
+/// jurisdiction (with the deliberate exception of two US providers,
+/// see [`PROVIDERS`]); we don't lean on a single political/legal regime
+/// for the answer to "what does Gmail's DKIM key look like right now".
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DohProvider {
     /// Display name for diagnostics / logging.
@@ -80,7 +80,8 @@ pub enum DohError {
     /// The queried registered domain isn't on `allowed_domains`. The
     /// verifier will not go to the internet for arbitrary domains.
     DomainNotAllowed,
-    /// All three outcalls failed (network error / non-200 / etc).
+    /// Every provider's outcall failed (network error / non-200 / etc).
+    /// "Every" means all of `PROVIDERS.len()` — currently five.
     AllProvidersFailed,
     /// Outcalls succeeded but the responses didn't reach the quorum
     /// threshold of identical TXT bytes.
@@ -93,6 +94,19 @@ pub enum DohError {
     /// The deploy/upgrade arg never set a `DohConfig`, or the config
     /// was cleared via `Some(None)`. The DoH fallback is disabled.
     NotConfigured,
+    /// The FQDN we were asked to look up isn't a valid wire-format
+    /// DNS name (label > 63 octets, name > 255 octets, or empty
+    /// label). We refuse to silently truncate, so this is a
+    /// caller-visible failure rather than a quietly-different lookup.
+    InvalidName(String),
+    /// The FQDN doesn't sit inside the registered domain that the
+    /// caller passed for the allowlist check. Usually a caller bug;
+    /// we fail closed rather than make an outcall for an unrelated
+    /// name.
+    NameOutsideRegisteredDomain {
+        name: String,
+        registered_domain: String,
+    },
 }
 
 #[cfg(test)]

--- a/src/internet_identity/src/doh/types.rs
+++ b/src/internet_identity/src/doh/types.rs
@@ -18,12 +18,24 @@ pub struct DohProvider {
     pub url: &'static str,
 }
 
-/// The three providers we query in parallel for every cache miss.
+/// The five providers we query in parallel for every cache miss.
 ///
-/// Picked for jurisdictional diversity (CH / CA / US), public-service
-/// rather than commercial operation, and continuous uptime under their
-/// current foundations / non-profits as of 2026-05.
+/// Picked for jurisdictional diversity (US ×2, CH, CA, JP), a mix of
+/// operator types (commercial telcos, non-profit foundation, ISP), and
+/// continuous uptime under their current operators as of 2026-05. Two
+/// US providers are tolerable here only because the quorum requires
+/// 3-of-5 — a single jurisdiction can't reach the threshold on its own.
 pub const PROVIDERS: &[DohProvider] = &[
+    DohProvider {
+        name: "Cloudflare",
+        jurisdiction: "United States",
+        url: "https://cloudflare-dns.com/dns-query",
+    },
+    DohProvider {
+        name: "Google",
+        jurisdiction: "United States",
+        url: "https://dns.google/dns-query",
+    },
     DohProvider {
         name: "Quad9",
         jurisdiction: "Switzerland",
@@ -35,15 +47,19 @@ pub const PROVIDERS: &[DohProvider] = &[
         url: "https://private.canadianshield.cira.ca/dns-query",
     },
     DohProvider {
-        name: "Cloudflare",
-        jurisdiction: "United States",
-        url: "https://cloudflare-dns.com/dns-query",
+        name: "IIJ",
+        jurisdiction: "Japan",
+        url: "https://public.dns.iij.jp/dns-query",
     },
 ];
 
 /// Quorum threshold: we accept the response iff at least this many of
 /// `PROVIDERS.len()` returned identical TXT bytes.
-pub const QUORUM_THRESHOLD: usize = 2;
+///
+/// 3-of-5 is a strict majority (>n/2) and tolerates up to 2 providers
+/// being down, slow, or returning different bytes — including both US
+/// providers being subpoenaed to lie in the same direction.
+pub const QUORUM_THRESHOLD: usize = 3;
 
 /// Default cache TTL when the deploy arg doesn't override it. One hour
 /// is short enough that a key rotation is picked up the next time mail
@@ -84,20 +100,41 @@ mod tests {
     use super::*;
 
     #[test]
-    fn three_providers_three_jurisdictions() {
-        assert_eq!(PROVIDERS.len(), 3);
+    fn five_providers_four_jurisdictions() {
+        assert_eq!(PROVIDERS.len(), 5);
+        // We allow two US providers (Cloudflare + Google) but want at
+        // least 4 distinct jurisdictions so no single jurisdiction has
+        // anywhere near the agreeing threshold of 3.
         let mut seen: Vec<&str> = PROVIDERS.iter().map(|p| p.jurisdiction).collect();
         seen.sort();
         seen.dedup();
-        assert_eq!(seen.len(), 3, "providers must span 3 jurisdictions");
+        assert!(
+            seen.len() >= 4,
+            "providers must span at least 4 jurisdictions"
+        );
+    }
+
+    #[test]
+    fn no_jurisdiction_alone_can_reach_quorum() {
+        // The whole point of 3-of-5 with mixed jurisdictions is that no
+        // single legal/political regime — including a 2-provider one
+        // like the US — can on its own force a "quorum". If this
+        // assertion ever fires, we've over-concentrated.
+        let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        for p in PROVIDERS {
+            *counts.entry(p.jurisdiction).or_default() += 1;
+        }
+        let max_per_jurisdiction = counts.values().copied().max().unwrap_or(0);
+        assert!(
+            max_per_jurisdiction < QUORUM_THRESHOLD,
+            "no single jurisdiction may reach quorum on its own"
+        );
     }
 
     #[test]
     fn quorum_strictly_above_minority() {
-        // 2-of-3 is a Byzantine-tolerant majority: any one provider
-        // failing or lying still leaves a majority of two honest
-        // providers agreeing. If we accidentally relax to 1-of-3, a
-        // single dishonest provider could drive verification.
+        // 3-of-5 is a strict majority. If we accidentally relax to
+        // 2-of-5, two split-bucket factions could each claim "quorum".
         assert!(QUORUM_THRESHOLD * 2 > PROVIDERS.len());
     }
 

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -55,6 +55,7 @@ mod delegation;
 mod dkim;
 mod dmarc;
 mod dnssec;
+mod doh;
 mod http;
 mod ii_domain;
 
@@ -686,6 +687,7 @@ fn config() -> InternetIdentityInit {
         backend_canister_id: Some(ic_cdk::api::id()),
         backend_origin: None,
         dnssec_config: Some(persistent_state.dnssec_config.clone()),
+        doh_config: Some(persistent_state.doh_config.clone()),
     })
 }
 
@@ -830,6 +832,12 @@ fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
             // Outer Some -> apply: inner None clears, inner Some replaces.
             state::persistent_state_mut(|persistent_state| {
                 persistent_state.dnssec_config = dnssec_config;
+            })
+        }
+        if let Some(doh_config) = arg.doh_config {
+            // Outer Some -> apply: inner None clears, inner Some replaces.
+            state::persistent_state_mut(|persistent_state| {
+                persistent_state.doh_config = doh_config;
             })
         }
     }

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -136,6 +136,11 @@ pub struct PersistentState {
     /// in later PRs and by any future feature that needs DNSSEC-verified
     /// DNS — see `docs/ongoing/email-recovery.md` §7.5.
     pub dnssec_config: Option<DnssecConfig>,
+    /// DoH (DNS-over-HTTPS) fallback config. Allowlists domains for
+    /// which the canister may fetch DKIM/DMARC TXT records via HTTP
+    /// outcalls when no DNSSEC chain is available — see
+    /// `docs/ongoing/email-recovery.md` §7.6.
+    pub doh_config: Option<DohConfig>,
 }
 
 impl Default for PersistentState {
@@ -160,6 +165,7 @@ impl Default for PersistentState {
             is_production: None,
             dummy_auth: None,
             dnssec_config: None,
+            doh_config: None,
         }
     }
 }

--- a/src/internet_identity/src/storage/storable/storable_persistent_state.rs
+++ b/src/internet_identity/src/storage/storable/storable_persistent_state.rs
@@ -9,8 +9,8 @@ use candid::{CandidType, Deserialize};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
 use internet_identity_interface::internet_identity::types::{
-    AnalyticsConfig, CaptchaConfig, DiscoverableOidcConfig, DnssecConfig, DummyAuthConfig,
-    FrontendHostname, OpenIdConfig, RateLimitConfig, Timestamp,
+    AnalyticsConfig, CaptchaConfig, DiscoverableOidcConfig, DnssecConfig, DohConfig,
+    DummyAuthConfig, FrontendHostname, OpenIdConfig, RateLimitConfig, Timestamp,
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -43,6 +43,7 @@ pub struct StorablePersistentState {
     is_production: Option<bool>,
     dummy_auth: Option<DummyAuthConfig>,
     dnssec_config: Option<DnssecConfig>,
+    doh_config: Option<DohConfig>,
 }
 
 impl Storable for StorablePersistentState {
@@ -90,6 +91,7 @@ impl From<PersistentState> for StorablePersistentState {
             is_production: s.is_production,
             dummy_auth: s.dummy_auth,
             dnssec_config: s.dnssec_config,
+            doh_config: s.doh_config,
         }
     }
 }
@@ -115,6 +117,7 @@ impl From<StorablePersistentState> for PersistentState {
             is_production: s.is_production,
             dummy_auth: s.dummy_auth,
             dnssec_config: s.dnssec_config,
+            doh_config: s.doh_config,
         }
     }
 }
@@ -168,6 +171,7 @@ mod tests {
             is_production: None,
             dummy_auth: None,
             dnssec_config: None,
+            doh_config: None,
         };
 
         pretty_assertions::assert_eq!(StorablePersistentState::default(), expected_defaults);
@@ -197,6 +201,7 @@ mod tests {
             is_production: None,
             dummy_auth: None,
             dnssec_config: None,
+            doh_config: None,
         };
         pretty_assertions::assert_eq!(PersistentState::default(), expected_defaults);
     }

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -22,6 +22,7 @@ pub type AccountNumber = u64;
 mod api_v2;
 pub mod attributes;
 pub mod dnssec;
+pub mod doh;
 pub mod icrc3;
 pub mod openid;
 pub mod smtp;
@@ -30,6 +31,7 @@ pub mod vc_mvp;
 // re-export v2 types without the ::v2 prefix, so that this crate can be restructured once v1 is removed
 // without breaking clients
 pub use crate::internet_identity::types::dnssec::*;
+pub use crate::internet_identity::types::doh::*;
 pub use crate::internet_identity::types::openid::*;
 pub use crate::internet_identity::types::smtp::*;
 pub use api_v2::*;
@@ -281,6 +283,13 @@ pub struct InternetIdentityInit {
     /// previously-stored value across an upgrade, `Some(None)` clears it,
     /// `Some(Some(c))` sets it to `c`.
     pub dnssec_config: Option<Option<DnssecConfig>>,
+    /// DoH (DNS-over-HTTPS) fallback configuration. Allowlists the
+    /// domains for which the canister may fetch DKIM / DMARC TXT
+    /// records via HTTP outcalls (covers the consumer-mailbox
+    /// providers whose DNS zones aren't DNSSEC-signed — see
+    /// `docs/ongoing/email-recovery.md` §7.6). Same set/clear pattern
+    /// as `dnssec_config`.
+    pub doh_config: Option<Option<DohConfig>>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]

--- a/src/internet_identity_interface/src/internet_identity/types/doh.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/doh.rs
@@ -29,10 +29,12 @@ pub struct DohConfig {
     /// domains.
     ///
     /// Each entry is the *registered* domain (e.g. `gmail.com`,
-    /// `outlook.com`) lowercased. The canister extracts the registered
-    /// domain from the queried FQDN by dropping leading subdomain
-    /// labels until it finds an exact match, with a label-anchored
-    /// dot check (so `evilexample.com` cannot match `example.com`).
+    /// `outlook.com`) lowercased. The DKIM/DMARC code path passes the
+    /// registered domain to the verifier explicitly (alongside the
+    /// queried FQDN) and the canister enforces both an allowlist match
+    /// against this list and a label-anchored suffix check that the
+    /// FQDN actually sits inside that registered domain (so
+    /// `evilexample.com` cannot match `example.com`).
     pub allowed_domains: Vec<String>,
 
     /// Maximum age, in seconds, that the in-memory cache keeps a

--- a/src/internet_identity_interface/src/internet_identity/types/doh.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/doh.rs
@@ -1,0 +1,43 @@
+//! DoH (DNS-over-HTTPS) fallback configuration.
+//!
+//! Configures the fallback path the canister uses when a domain is not
+//! DNSSEC-signed (the design doc §7.6 case — covers Gmail, Outlook,
+//! iCloud, Yahoo, and most other consumer mailbox providers). Lets the
+//! canister fetch DKIM and DMARC TXT records over HTTPS via a fixed
+//! quorum of independent DoH providers, instead of consuming a
+//! caller-supplied DNSSEC chain.
+//!
+//! Set on every `init` / `post_upgrade` via the canister-wide
+//! [`InternetIdentityInit`] arg, kept in `PersistentState` so it
+//! survives upgrades when the arg omits the field.
+
+use candid::{CandidType, Deserialize};
+
+/// Allowlist + tuning knobs for the DoH fallback path.
+///
+/// We deliberately don't poll the allowlist proactively: the cache is
+/// populated on demand, the first time `smtp_request` arrives for a
+/// listed domain. Adding a domain costs nothing until mail actually
+/// flows; removing a domain is enforced at the *next* call (the cache
+/// entry expires and isn't refilled).
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq, Default)]
+pub struct DohConfig {
+    /// Domains for which DoH outcalls are permitted. The canister will
+    /// only fetch DKIM / DMARC TXT records for an FQDN whose
+    /// registered domain is in this list. Anything else is rejected
+    /// without an outcall — DNSSEC is the only path for unlisted
+    /// domains.
+    ///
+    /// Each entry is the *registered* domain (e.g. `gmail.com`,
+    /// `outlook.com`) lowercased. The canister extracts the registered
+    /// domain from the queried FQDN by dropping leading subdomain
+    /// labels until it finds an exact match, with a label-anchored
+    /// dot check (so `evilexample.com` cannot match `example.com`).
+    pub allowed_domains: Vec<String>,
+
+    /// Maximum age, in seconds, that the in-memory cache keeps a
+    /// fetched TXT record before re-fetching. Defaults to 1 hour
+    /// (3600) when omitted; capped at 24 hours by the verifier so a
+    /// stuck cache can't shadow a real key rotation indefinitely.
+    pub max_cache_age_secs: Option<u64>,
+}


### PR DESCRIPTION
## Summary

PR 4 of the email-recovery stack. Adds the DoH (DNS-over-HTTPS) fallback path for fetching DKIM/DMARC TXT records when a domain isn't DNSSEC-signed (Gmail, Outlook, iCloud, etc.). Stacks on #3878 (DMARC alignment).

- **Allowlist-gated outcalls.** `DohConfig.allowed_domains` (deploy/upgrade arg, persisted in `PersistentState`). Domains not on the list return `DomainNotAllowed` without touching the network.
- **3-of-5 quorum across 4 jurisdictions.** Cloudflare 🇺🇸 + Google 🇺🇸 + Quad9 🇨🇭 + CIRA 🇨🇦 + IIJ 🇯🇵. Strict majority; no single jurisdiction can reach quorum on its own (asserted in unit tests).
- **In-flight dedup.** Hand-rolled `oneshot`-style `Waker` primitive collapses concurrent fetches for the same FQDN to one outcall fan-out.
- **IC-correct outcall path.** `http_request_with_closure` with a `transform` query function that reduces the wire DNS response to its TXT RDATA (drops TTL/transaction-ID drift across replicas, so consensus succeeds). `max_response_bytes = 4 KiB`, cycle budget mirrors the OIDC discovery outcall.
- **Cache hygiene.** Stale-pending TTL (`PENDING_STALE_AFTER_SECS = 120`) recovers from the IC-specific hazard where a trapped post-yield continuation leaves an InFlight entry stuck forever (state across `.await` is committed, not transactional). Lazy eviction on lookup + opportunistic sweep on publish bound the value-cache size to {unique FQDNs queried in `max_cache_age_secs`}.

Public API: `pub async fn fetch_txt(name, registered_domain) -> Result<Vec<u8>, DohError>`. Allowlist match is case-insensitive on the registered domain. Steady-state outcall load for a continuous Gmail flow at default 1h TTL: ~10 outcalls/hr per domain (2 fan-outs × 5 providers), independent of email volume.

PR 5+6 (#3880) wires this into `smtp_request` and is where the production async loop is first exercised end-to-end — see the testing note below. The DKIM/DMARC verifiers from PRs 2/3 and the DNSSEC chain from PR 1 are wired alongside it there.

## Test plan

- [x] doh unit tests: parser (round-trip, malformed, NXDOMAIN), `decide_quorum` bucketing (3-of-5/2-of-5 split-bucket/all-fail/all-malformed), dedup wakeups, stale-pending eviction wakes orphan waiters with AllProvidersFailed, late-publisher no-op after stale takeover, lazy eviction on lookup, sweep on publish, end-to-end `fetch_txt` with NotConfigured / DomainNotAllowed / case-insensitive allowlist / cache hit-then-refetch / TTL cap / quorum-failure-not-cached.
- [x] Full unit test suite green.
- [x] `cargo check --target wasm32-unknown-unknown` clean.
- [x] `cargo clippy --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Async outcall loop coverage lives downstream in PR 5+6 (#3880), in `src/internet_identity/tests/integration/email_recovery.rs::full_setup_flow_binds_credential_to_anchor`: drives PocketIC, fulfils all 5 DoH provider outcalls with synthesized wire-format DNS responses, asserts quorum success + status flip. Negative paths (allowlist rejection, DNSSEC-takes-precedence-so-zero-outcalls) are covered there too. This matches the convention used by the openid module (production outcall code is `cfg(not(test))`-gated; coverage of the async loop is integration-only).
- [ ] Smoke test on a real local replica: `fetch_txt` against a real allowlisted domain, verify provider fan-out + transform + consensus against live DoH servers (deferred until gateway plumbing lands).
- [ ] Verify IIJ DoH endpoint URL (`public.dns.iij.jp`) with a real outcall before deploy.

### Note on the quorum module

The original revision exposed a synchronous `run_quorum` wrapper plus a `DohFetcher` trait so unit tests could mock provider responses. That duplicated the async fan-out and gave misleading coverage (tests exercised a parallel sync code path, not the one that actually ships). Dropped in the last commit — `quorum.rs` now exposes only the pure `decide_quorum` step, and the eight quorum tests now construct `Outcome` vectors directly. End-to-end coverage of the async loop is delegated to PR 5+6 as noted above.

## PR Stack
| # | PR | Description | Status |
|---|---|---|---|
| 0 | [#3836](https://github.com/dfinity/internet-identity/pull/3836) | Design doc | Open |
| 1 | [#3838](https://github.com/dfinity/internet-identity/pull/3838) | DNSSEC verifier scaffold | Open |
| 2 | [#3877](https://github.com/dfinity/internet-identity/pull/3877) | DKIM verifier (RFC 6376) | Open |
| 3 | [#3878](https://github.com/dfinity/internet-identity/pull/3878) | DMARC alignment (RFC 7489) | Open |
| 4 | [#3879](https://github.com/dfinity/internet-identity/pull/3879) | DoH fallback | Open |
| 5+6 | [#3880](https://github.com/dfinity/internet-identity/pull/3880) | Setup flow (storage + smtp_request) | Open |
| 7 | [#3881](https://github.com/dfinity/internet-identity/pull/3881) | Recovery flow (delegation) | Open |
| 8 | [#3882](https://github.com/dfinity/internet-identity/pull/3882) | Frontend + feature flag | Open |
| 9 | [#3883](https://github.com/dfinity/internet-identity/pull/3883) | Deploy/upgrade scripts: dnssec_config + doh_config | Open |
| 10 | [#3884](https://github.com/dfinity/internet-identity/pull/3884) | Email-recovery UX overhaul | Open |