### PR TITLE
chore(dkim): address Grok review feedback on PR #3877

### DIFF
--- a/src/internet_identity/src/dkim/parse.rs
+++ b/src/internet_identity/src/dkim/parse.rs
@@ -373,4 +373,19 @@ mod tests {
         let err = parse_dkim_signature(v).unwrap_err();
         assert!(err.contains("invalid base64 in bh"));
     }
+
+    #[test]
+    fn unknown_tags_are_ignored() {
+        // RFC 6376 §3.5: implementations MUST ignore tags they don't
+        // recognise (forward-compatibility with future extensions).
+        // `z=` (copied headers) and a synthetic `zz=` are both unknown
+        // to us; parsing must still succeed.
+        let v = "v=1; a=rsa-sha256; d=example.com; s=mail; h=from; \
+                 bh=MTIzNDU2; b=YWJjZGVm; \
+                 z=From:alice@example.com|To:bob@example.org; \
+                 zz=future-extension-value";
+        let s = parse_dkim_signature(v).unwrap();
+        assert_eq!(s.d, "example.com");
+        assert_eq!(s.algorithm, Algorithm::RsaSha256);
+    }
 }

--- a/src/internet_identity/src/dkim/types.rs
+++ b/src/internet_identity/src/dkim/types.rs
@@ -80,7 +80,9 @@ pub enum DkimCheckStatus {
 /// Why a signature didn't verify, mapping straight to a UI message.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum VerificationFailReason {
-    /// No `DKIM-Signature` header in the message.
+    /// No `DKIM-Signature` header in the message. Distinct from the
+    /// other variants so the frontend can render "this provider doesn't
+    /// use DKIM" instead of a generic verification-failed message.
     NoSignature,
     /// At least one DKIM-Signature header was malformed (missing required
     /// tag, bad base64, unparseable folding, etc).

--- a/src/internet_identity/src/dkim/verify.rs
+++ b/src/internet_identity/src/dkim/verify.rs
@@ -179,6 +179,11 @@ fn try_verify_signature(
 
     // Parse the DNS record now — we need its t=s flag to know how
     // strict to be on i= alignment.
+    //
+    // SECURITY: `dkim_txt` is treated as trusted bytes. The caller is
+    // responsible for sourcing it from a DNSSEC-validated chain (PR
+    // #3838) or, for unsigned domains, a DoH outcall whose host is
+    // pinned per the design doc §7.6 (PR #3879).
     let dns = match parse_dkim_txt(dkim_txt) {
         Ok(r) => r,
         Err(e) => {


### PR DESCRIPTION
Addresses the four "easy-to-change improvements" from Grok's review on #3877 (https://github.com/dfinity/internet-identity/pull/3877#pullrequestreview-4272269924). Targets `feat/dkim-verifier` so it can be merged in as a follow-up commit to that PR.

## What changed

1. **`types.rs` — `NoSignature` doc-comment.** The distinct variant Grok asked for (`NoSignaturePresent` or equivalent) already exists as `VerificationFailReason::NoSignature` at types.rs:84 and is returned from `verify()` when no DKIM-Signature headers are present (verify.rs:54, verify.rs:67). The frontend can already distinguish it from a generic failure. Expanded the doc-comment to make the UX intent ("this provider doesn't use DKIM") explicit so future readers (and AI reviewers) don't re-flag this.

2. **`parse.rs` — explicit unknown-tag-ignored test.** RFC 6376 §3.5 requires implementations to ignore unrecognised tags. The parser already does this (it's lookup-by-name in `split_tag_list` → `get(name)`; unknown tags pass straight through — the existing `happy_value()` fixture even contains an unknown `q=dns/txt`). Pinned the behaviour with a dedicated `unknown_tags_are_ignored` test covering `z=` and a synthetic `zz=`.

3. **`verify.rs` — SECURITY comment at the trust boundary.** Added an inline `// SECURITY:` block at the `parse_dkim_txt` call site stating that `dkim_txt` is trusted, sourced from the DNSSEC verifier (#3838) or pinned-host DoH outcall (#3879).

## Not actioned

- **CI job rename (`dkim-test-vectors` → `dkim-verifier-tests`).** No such job exists in `.github/workflows/`; PR #3877 doesn't add one. Nothing to rename.
- **`main.rs::handle_email_recovery` match arm.** That endpoint hasn't been added yet (it's PRs 5–7 of the stack). No-op for this PR.

## Tests

- `cargo test -p internet_identity --bin internet_identity dkim::` — 79 pass (was 78, +1 for the new unknown-tag test).
- `cargo clippy -p internet_identity --bin internet_identity --tests -- -D warnings` — clean.
- `cargo check -p internet_identity --target wasm32-unknown-unknown` — clean.
- `cargo fmt --check` on the three modified files — clean (other pre-existing fmt drifts in `dnssec/`, `openid/`, `tests/integration/` are unrelated and predate this branch).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZmvbHgzN5NQc7Hqx9ZzpP)_