### PR TITLE
chore(dmarc): address Grok review feedback on PR #3878

### DIFF
--- a/src/internet_identity/src/dmarc/mod.rs
+++ b/src/internet_identity/src/dmarc/mod.rs
@@ -16,6 +16,33 @@
 //! - `alignment` — strict / relaxed alignment check (no PSL — see
 //!   design doc §6.4).
 //! - `verify` — orchestration; the public entry point lives here.
+//!
+//! # Security model
+//!
+//! Three intentional deviations from "stock" DMARC, each documented in
+//! the design doc and worth surfacing here for auditors:
+//!
+//! - **No Public Suffix List.** Relaxed alignment uses a label-anchored
+//!   suffix check (see `alignment::is_subdomain_of`) instead of computing
+//!   the PSL-defined organizational domain. This prevents suffix
+//!   attacks (`evilexample.com` masquerading as `example.com`) and
+//!   removes a large, slowly-changing trust dependency from the
+//!   canister. The cost is that legitimate multi-domain orgs
+//!   (`gmail.com` ↔ `googlemail.com`) fail closed; that's the safe
+//!   direction for an account-recovery surface. Design doc §6.4.
+//!
+//! - **No SPF.** The recovery flow proves *mailbox control*, not
+//!   *path-of-delivery*. DKIM gives us a cryptographic binding from the
+//!   message content to the signing domain; SPF would only tell us the
+//!   message came from an IP the domain authorised, which we can't
+//!   meaningfully check in-canister anyway (no source IP in the gateway
+//!   payload). Design doc §6.5.
+//!
+//! - **Fail-closed everywhere.** Every malformed input, every
+//!   unrecognised value, every step that can't produce a positive
+//!   answer collapses to `Unverified`. We never quarantine, never
+//!   downgrade — a recovery attempt either proves mailbox control or
+//!   it doesn't run.
 
 // PR 3 lands the verifier without an in-canister consumer (PR 8's
 // `smtp_request` dispatch is the first caller). Suppress dead-code

--- a/src/internet_identity/src/dmarc/test_vectors.rs
+++ b/src/internet_identity/src/dmarc/test_vectors.rs
@@ -185,6 +185,32 @@ fn rejects_end_to_end_when_dmarc_record_is_malformed() {
 }
 
 #[test]
+fn verifies_end_to_end_when_dmarc_record_has_unknown_tags() {
+    // RFC 7489 §6.3 requires verifiers to ignore tags they don't
+    // understand. We exercise the full verify_email path with a DMARC
+    // record carrying reporting tags (`rua=`, `ruf=`, `fo=`), a vendor
+    // extension we've never heard of, and a duplicate-looking-but-
+    // different reporting tag — verification must still succeed.
+    let req = parse_eml(SYNTH_RSA_RELAXED_RELAXED);
+    let dmarc_txt = "v=DMARC1; p=reject; rua=mailto:reports@example.com; \
+                     ruf=mailto:forensics@example.com; fo=1; \
+                     vendorext=experimental-value; adkim=s";
+    let result = verify_email(&req, SYNTH_RSA_TXT, Some(dmarc_txt), frozen_now());
+    match result {
+        EmailVerificationStatus::Verified { dmarc, .. } => {
+            assert_eq!(
+                dmarc,
+                DmarcOutcome::Aligned {
+                    policy: DmarcPolicy::Reject,
+                    alignment_mode: AlignmentMode::Strict,
+                }
+            );
+        }
+        other => panic!("expected Verified, got {:?}", other),
+    }
+}
+
+#[test]
 fn rejects_end_to_end_when_from_header_is_address_list() {
     let mut req = parse_eml(SYNTH_RSA_RELAXED_RELAXED);
     // Replace From: with an address list. DKIM signs From, so this


### PR DESCRIPTION
Addresses the two actionable "easy-to-change improvements" from Grok's review on #3878 (https://github.com/dfinity/internet-identity/pull/3878#issuecomment-4431820615). Targets `feat/dmarc-alignment` so it can land as a follow-up commit on that PR.

(Tried to push directly to `feat/dmarc-alignment` per the maintainer's note from #3877 / #3885, but my account got a 403 against that branch — falling back to a stacked draft PR.)

## What changed

1. **`dmarc/mod.rs` — consolidated `# Security model` docblock.** Calls out the three deliberate deviations from "stock" DMARC, each with a one-paragraph rationale:
   - **No Public Suffix List** — label-anchored suffix check prevents `evilexample.com`-style spoofs at the cost of closing multi-domain orgs (`gmail.com` ↔ `googlemail.com`). Safe direction for a recovery surface. Design doc §6.4.
   - **No SPF** — recovery proves mailbox control, not path-of-delivery. DKIM gives the cryptographic binding; SPF would need a source IP the gateway payload doesn't carry. Design doc §6.5.
   - **Fail-closed everywhere** — every malformed/unknown step collapses to `Unverified`. No quarantine, no downgrade.

2. **`dmarc/test_vectors.rs` — `verifies_end_to_end_when_dmarc_record_has_unknown_tags`.** Runs the full `verify_email` against a DMARC record carrying `rua=`, `ruf=`, `fo=`, and a synthetic `vendorext=` tag. Pins the ignore-unknown-tags behaviour through the public entry point, not just the parser unit (which already has a `unknown_tags_are_ignored` test in `dmarc/parse.rs`).

## Not actioned

- **Grok item #1 ("parser must ignore unknown tags").** Already implemented and unit-tested before this PR. `dmarc/parse.rs` is lookup-by-name, so unknown tags pass through silently. The PR description even calls this out: "ignores unknown / reporting tags". The new end-to-end test is the explicit confirmation Grok asked for under item #3.

The four strategic recommendations (observability metrics, frontend error surface, SPF wiring, README) are explicitly "nice-to-have" / "future" and belong in later PRs of the stack.

## Tests

- `cargo test -p internet_identity --bin internet_identity dmarc::` — 49 pass (was 48, +1 e2e unknown-tag test).
- `cargo clippy -p internet_identity --bin internet_identity --tests -- -D warnings` — clean.
- `cargo check -p internet_identity --target wasm32-unknown-unknown` — clean.
- `cargo fmt --check` on the two touched files — clean (other pre-existing fmt drifts in `dnssec/`, `openid/`, `tests/integration/`, `types/attributes.rs` are unrelated and predate this branch).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZmvbHgzN5NQc7Hqx9ZzpP)_