### PR TITLE
build(ci): cache rustc invocations across builds via sccache

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -25,7 +25,38 @@ jobs:
       # more information, see
       # https://github.com/docker/build-push-action/issues/539
       - name: Set up docker buildx
+        id: setup-buildx
         uses: docker/setup-buildx-action@v3
+
+      # The GHA cache backend (type=gha on docker/build-push-action) does NOT
+      # persist BuildKit cache-mount contents across runs — only image layers.
+      # To persist the sccache directory (where compiled rustc outputs live),
+      # we use actions/cache for a host directory and buildkit-cache-dance to
+      # inject it into BuildKit's cache mount before the build / extract it
+      # back after. Done here on the base job because that's where the deps
+      # compile happens (~335 rustc invocations); downstream jobs only compile
+      # their canister crate on top of the pre-built deps layer and don't need
+      # their own persisted sccache.
+      - name: Restore sccache directory
+        id: sccache-cache
+        uses: actions/cache@v4
+        with:
+          path: sccache-cache
+          key: ii-sccache-base-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ii-sccache-base-${{ runner.os }}-
+
+      - name: Inject sccache into BuildKit cache mount
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.setup-buildx.outputs.name }}
+          cache-map: |
+            {
+              "sccache-cache": {
+                "target": "/sccache-cache",
+                "id": "ii-sccache"
+              }
+            }
 
       - name: Build base Docker image
         uses: docker/build-push-action@v5
@@ -64,13 +95,12 @@ jobs:
           file: Dockerfile
           build-args: |
             II_VERSION=${{ steps.version.outputs.version }}
-          # Pull deps-stage layers from the shared base cache, and this job's
-          # own sccache cache mount from prior runs. Push only the sccache
-          # additions back so we don't pollute the base scope.
-          cache-from: |
-            type=gha,scope=cached-stage
-            type=gha,scope=ii-build-backend
-          cache-to: type=gha,scope=ii-build-backend,mode=max
+          # Reuses the deps layer from the base build (compiled deps live in
+          # /cargo_target). The canister-specific compilation here is small;
+          # adding a persisted sccache scope for it didn't pay for itself
+          # (mount contents aren't preserved by type=gha — see comment on
+          # docker-build-base for the persistence mechanism).
+          cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: ./out
           target: scratch_internet_identity

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -64,7 +64,13 @@ jobs:
           file: Dockerfile
           build-args: |
             II_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=cached-stage
+          # Pull deps-stage layers from the shared base cache, and this job's
+          # own sccache cache mount from prior runs. Push only the sccache
+          # additions back so we don't pollute the base scope.
+          cache-from: |
+            type=gha,scope=cached-stage
+            type=gha,scope=ii-build-backend
+          cache-to: type=gha,scope=ii-build-backend,mode=max
           # Exports the artefacts from the final stage
           outputs: ./out
           target: scratch_internet_identity
@@ -94,7 +100,10 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          cache-from: type=gha,scope=cached-stage
+          cache-from: |
+            type=gha,scope=cached-stage
+            type=gha,scope=ii-build-archive
+          cache-to: type=gha,scope=ii-build-archive,mode=max
           # Exports the artefacts from the final stage
           outputs: ./out
           target: scratch_archive
@@ -133,7 +142,10 @@ jobs:
           file: Dockerfile
           build-args: |
             II_VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha,scope=cached-stage
+          cache-from: |
+            type=gha,scope=cached-stage
+            type=gha,scope=ii-build-frontend
+          cache-to: type=gha,scope=ii-build-frontend,mode=max
           # Exports the artefacts from the final stage
           outputs: ./out
           target: scratch_internet_identity_frontend

--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -100,10 +100,10 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          cache-from: |
-            type=gha,scope=cached-stage
-            type=gha,scope=ii-build-archive
-          cache-to: type=gha,scope=ii-build-archive,mode=max
+          # Archive build is short and not on the critical path; reuse the
+          # base cache only. (Adding cache-to here caused BuildKit to
+          # re-execute the deps stage instead of reusing it from cached-stage.)
+          cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: ./out
           target: scratch_archive
@@ -142,10 +142,10 @@ jobs:
           file: Dockerfile
           build-args: |
             II_VERSION=${{ steps.version.outputs.version }}
-          cache-from: |
-            type=gha,scope=cached-stage
-            type=gha,scope=ii-build-frontend
-          cache-to: type=gha,scope=ii-build-frontend,mode=max
+          # Frontend build is short and not on the critical path; reuse the
+          # base cache only. (Adding cache-to here caused BuildKit to
+          # re-execute the deps stage instead of reusing it from cached-stage.)
+          cache-from: type=gha,scope=cached-stage
           # Exports the artefacts from the final stage
           outputs: ./out
           target: scratch_internet_identity_frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,23 @@ RUN ./scripts/bootstrap
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 RUN wasm-pack --version
 
+# Install sccache for caching rustc invocations across builds. Pinned for
+# reproducibility — bump deliberately when upgrading.
+ARG SCCACHE_VERSION=v0.15.0
+RUN curl -sSfL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+        -o /tmp/sccache.tar.gz \
+    && tar -xzf /tmp/sccache.tar.gz -C /tmp \
+    && mv /tmp/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache \
+    && chmod +x /usr/local/bin/sccache \
+    && rm -rf /tmp/sccache* \
+    && sccache --version
+
+# Wrap rustc with sccache so unchanged compilation units are served from cache.
+# Output bytes are content-addressed by source+flags+rustc, so the resulting
+# wasm is bit-identical to a non-cached build.
+ENV RUSTC_WRAPPER=sccache \
+    SCCACHE_DIR=/sccache-cache
+
 # Pre-build all cargo dependencies. Because cargo doesn't have a build option
 # to build only the dependencies, we pretend that our project is a simple, empty
 # `lib.rs`. When we COPY the actual files we make sure to `touch` lib.rs so
@@ -54,7 +71,8 @@ COPY src/internet_identity_frontend/Cargo.toml src/internet_identity_frontend/Ca
 COPY src/asset_util/Cargo.toml src/asset_util/Cargo.toml
 ENV CARGO_TARGET_DIR=/cargo_target
 COPY ./scripts/build ./scripts/build
-RUN mkdir -p src/internet_identity/src \
+RUN --mount=type=cache,target=/sccache-cache,id=ii-sccache,sharing=locked \
+    mkdir -p src/internet_identity/src \
     && touch src/internet_identity/src/lib.rs \
     && mkdir -p src/internet_identity_interface/src \
     && touch src/internet_identity_interface/src/lib.rs \
@@ -69,6 +87,7 @@ RUN mkdir -p src/internet_identity/src \
     && mkdir -p src/internet_identity_frontend/src \
     && touch src/internet_identity_frontend/src/main.rs \
     && ./scripts/build --only-dependencies --internet-identity --archive \
+    && sccache --show-stats \
     && rm -rf src
 
 FROM deps as build_internet_identity
@@ -81,7 +100,8 @@ ARG II_VERSION=
 RUN touch src/*/src/lib.rs
 RUN npm ci
 
-RUN ./scripts/build
+RUN --mount=type=cache,target=/sccache-cache,id=ii-sccache,sharing=locked \
+    ./scripts/build && sccache --show-stats
 RUN sha256sum /internet_identity.wasm.gz
 
 FROM deps as build_archive
@@ -90,7 +110,8 @@ COPY . .
 
 RUN touch src/*/src/lib.rs
 
-RUN ./scripts/build --archive
+RUN --mount=type=cache,target=/sccache-cache,id=ii-sccache,sharing=locked \
+    ./scripts/build --archive && sccache --show-stats
 RUN sha256sum /archive.wasm.gz
 
 FROM deps as build_internet_identity_frontend
@@ -103,7 +124,8 @@ ARG II_VERSION=
 RUN touch src/*/src/lib.rs
 RUN npm ci
 
-RUN ./scripts/build --frontend
+RUN --mount=type=cache,target=/sccache-cache,id=ii-sccache,sharing=locked \
+    ./scripts/build --frontend && sccache --show-stats
 RUN sha256sum /internet_identity_frontend.wasm.gz
 
 FROM scratch AS scratch_internet_identity


### PR DESCRIPTION
## Summary

Wraps `rustc` with [sccache](https://github.com/mozilla/sccache) inside the Docker build, persisted across CI runs via BuildKit cache mounts and GHA cache. Unchanged compilation units are served from cache instead of being recompiled.

## Why

Today, every push to a PR recompiles the entire `internet_identity` crate from scratch in `docker-build-internet_identity`. With recent feature work that adds material new code to the backend (e.g. the DKIM verifier in #3877, ~2,800 LOC), the backend Docker build is the longest pole — frequently 25–35+ min — and downstream `canister-tests` jobs wait on its artifact before they can start.

sccache is a transparent `rustc` wrapper: it stores rustc outputs in a content-addressed cache keyed by source + flags + rustc version. When inputs match, it returns the cached object bytes; otherwise it falls through to real rustc.

## Reproducibility

This is intentionally a no-op for the build output:

- `-j1` is preserved.
- `--remap-path-prefix`, pinned rustc, pinned Docker image, `lto = true`, `opt-level = 'z'`, `gzip --no-name` — all preserved.
- sccache returns byte-identical rustc outputs for matching inputs (Mozilla, ChromeOS, and many others rely on this property in production).
- Crates with non-deterministic build scripts are silently skipped by sccache (it falls through to real rustc), so output is always correct even on misses.

**Verification before un-drafting / merging**: compare the `sha256sum internet_identity.wasm.gz` printed in this PR's CI to the most recent `main` build of the same source commit. If hashes match, sccache preserves reproducibility on the II codepath as designed. If they don't, this PR should not merge.

## What changed

- **`Dockerfile`**:
  - Install pinned sccache v0.15.0 (musl prebuilt, no compile required).
  - Set `RUSTC_WRAPPER=sccache`, `SCCACHE_DIR=/sccache-cache`.
  - Add a shared cache mount (`id=ii-sccache`) to every RUN that compiles Rust: deps pre-build, `build_internet_identity`, `build_archive`, `build_internet_identity_frontend`. Print `sccache --show-stats` after each for visibility.
- **`.github/workflows/canister-tests.yml`**:
  - Each of the three downstream `docker-build-*` jobs gets its own GHA cache scope (`ii-build-backend`, `ii-build-archive`, `ii-build-frontend`) with `mode=max` (required to export BuildKit cache mounts). Each pulls from both its own scope and the shared `cached-stage` base.

## Expected impact

| Scenario | Today | With sccache |
| --- | --- | --- |
| 1st build after Cargo.lock change | ~21 min deps + ~30 min backend | Similar deps build (caches cold), similar 1st backend |
| 2nd+ push on same PR, few files changed | Full backend recompile (~30 min) | Backend drops to a few minutes (only changed CGUs recompile) |
| Steady-state across PRs | Cold each time | Warm — most CGUs hit |

## Costs / caveats

- GHA Actions cache is 10 GB/repo with LRU eviction. We add three new scopes; under cache pressure, eviction churn may reduce hit rate. Cache hit rate is visible in `sccache --show-stats` output in each build's logs — worth watching for the first few PRs after merge.
- BuildKit cache mounts and `cache-to: mode=max` only work with BuildKit ≥ 0.10 (provided by `docker/setup-buildx-action@v3`, already in use).
- `-j1` is still the bottleneck on cold compilation. This PR doesn't touch that — happy to follow up with a separate experiment validating whether modern rustc produces bit-identical output under `-j$(nproc)` before relaxing it.

## Test plan

- [ ] CI green on this PR.
- [ ] Compare `internet_identity_backend.wasm.gz` sha256 against latest `main` build of the same commit → confirm bit-identical.
- [ ] Push a trivial 1-line change to this branch → confirm backend build time drops materially on the 2nd run vs the 1st.
- [ ] Inspect `sccache --show-stats` output in the backend job's log to confirm meaningful hit rate.