### PR TITLE
docs(be): post-review documentation polish for Recovery Emails

### DIFF
--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -31,8 +31,9 @@ rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 # `rand_chacha` powers the email-recovery PRNG (`email_recovery::rng`).
 # Seeded once per canister lifetime from `raw_rand`; every subsequent
-# nonce draw is local. `default-features = false` keeps us off the
-# `getrandom`-backed `OsRng` path that doesn't exist on wasm32.
+# nonce draw is local. `default-features = false` drops the `std`
+# feature — matching the `rand` / `rand_core` lines above so the
+# whole `rand_*` family stays on the same no-std-friendly footing.
 rand_chacha = { version = "0.3", default-features = false }
 captcha = { git = "https://github.com/dfinity/captcha", rev = "9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391" }
 

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -29,6 +29,10 @@ lodepng = "*"
 rand = { version = "0.8", default-features = false }
 
 rand_core = { version = "0.6", default-features = false }
+# `rand_chacha` powers the email-recovery PRNG (`email_recovery::rng`).
+# Seeded once per canister lifetime from `raw_rand`; every subsequent
+# nonce draw is local. `default-features = false` keeps us off the
+# `getrandom`-backed `OsRng` path that doesn't exist on wasm32.
 rand_chacha = { version = "0.3", default-features = false }
 captcha = { git = "https://github.com/dfinity/captcha", rev = "9c0d2dd9bf519e255eaa239d9f4e9fdc83f65391" }
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -509,9 +509,10 @@ type OpenIdPrepareDelegationResponse = record {
 
 // Email-recovery types
 // ====================
-// See `docs/ongoing/email-recovery.md` for the full design. This PR
-// only ships the setup half (binding flow); the recovery half lands
-// next.
+// See `docs/ongoing/email-recovery.md` for the full design. Covers
+// both halves of the flow: setup (binding a recovery email to an
+// anchor) and recovery (proving control of a previously-bound
+// address to obtain a signed delegation).
 
 type EmailRecoveryCredential = record {
     address : text;
@@ -1435,10 +1436,18 @@ service : (opt InternetIdentityInit) -> {
     openid_prepare_delegation : (JWT, Salt, SessionKey) -> (variant { Ok : OpenIdPrepareDelegationResponse; Err : OpenIdDelegationError });
     openid_get_delegation : (JWT, Salt, SessionKey, Timestamp) -> (variant { Ok : SignedDelegation; Err : OpenIdDelegationError }) query;
 
-    // Email-recovery protocol — setup half
-    // ====================================
-    // See `docs/ongoing/email-recovery.md`. The recovery half (prepare
-    // a delegation from a verified email) lands in a follow-up PR.
+    // Email-recovery protocol
+    // =======================
+    // See `docs/ongoing/email-recovery.md`. Covers both flows:
+    // - Setup: prepare_add (authenticated) → smtp_request for
+    //   register@id.ai → credential bound to the anchor. Removed
+    //   later via credential_remove.
+    // - Recovery: prepare_delegation (anonymous, bound to a
+    //   session_key) → smtp_request for recover@id.ai → canister
+    //   stamps a signed delegation seed. The FE then calls
+    //   email_recovery_get_delegation to retrieve the
+    //   SignedDelegation.
+    // Both flows share the polling status query.
     email_recovery_credential_prepare_add : (IdentityNumber, EmailRecoveryDnsInput) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
     email_recovery_prepare_delegation : (EmailRecoveryDnsInput, SessionKey) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
     email_recovery_status : (text) -> (EmailRecoveryStatus) query;
@@ -1450,10 +1459,10 @@ service : (opt InternetIdentityInit) -> {
     // =====================
     // The off-chain SMTP gateway forwards every inbound message via
     // smtp_request. The canister verifies the email cryptographically
-    // and dispatches by recipient (register@id.ai → setup completion).
-    // Always returns Ok — the gateway shouldn't get a per-message
-    // verification signal back. The FE sees outcomes via the polling
-    // status query.
+    // and dispatches by recipient: register@id.ai → setup completion,
+    // recover@id.ai → recovery delegation stamping. Always returns Ok
+    // — the gateway shouldn't get a per-message verification signal
+    // back. The FE sees outcomes via the polling status query.
     smtp_request : (SmtpRequest) -> (SmtpResponse);
 
     // Called by the gateway at RCPT TO time to decide whether to

--- a/src/internet_identity/src/email_recovery/mod.rs
+++ b/src/internet_identity/src/email_recovery/mod.rs
@@ -104,6 +104,16 @@ pub const CHALLENGE_TTL_SECS: u64 = 30 * 60;
 /// Cap on the in-flight pending-challenge map. Sized generously
 /// (10 000 entries) so legitimate fill rates never get close, and
 /// the design-doc §8.8 eviction analysis applies cleanly above it.
+///
+/// **Doubles as the per-canister rate-limit on `prepare_add` /
+/// `prepare_delegation`.** There is no per-anchor or per-caller
+/// counter: at sustained call rate `R`, an attacker can hold at
+/// most `min(R × CHALLENGE_TTL_SECS, MAX_PENDING_CHALLENGES)`
+/// entries in flight. The cap + TTL together bound heap residency
+/// to ≈ 10 k × 1 KB ≈ 10 MB — a small fraction of the canister's
+/// heap budget. Legitimate users coexist because oldest-first
+/// eviction targets stale attacker entries first whenever the map
+/// fills (see `evict_oldest` in `pending.rs`).
 pub const MAX_PENDING_CHALLENGES: usize = 10_000;
 
 /// Recipient user-part for the **setup** flow. Together with any of

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -178,6 +178,14 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     // the pipeline. We borrow only briefly so the async outcalls
     // below don't hold a `RefCell` across an await (which would
     // trap inside the canister).
+    //
+    // Note: this lookup *lazily evicts* the entry if it has aged
+    // past `CHALLENGE_TTL_SECS` — `pending::with_mut` checks the
+    // TTL before invoking the closure and drops the entry on
+    // expiry. So a stale nonce surfaces as `SmtpResponse::Ok {}` /
+    // status `Expired` without consuming further canister cycles,
+    // and the global eviction sweep on the next `insert_with_eviction`
+    // call cleans up any other expired entries.
     let snapshot = match pending::with_mut(&nonce, now_secs, |c| {
         let kind = match (&c.kind, recipient_flow) {
             (PendingKind::Register { anchor }, RecipientFlow::Setup) => {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1407,22 +1407,26 @@ mod openid_api {
     }
 }
 
-/// Email-based identity recovery — setup half (binding flow only).
+/// Email-based identity recovery — both halves of the flow.
 ///
 /// See `docs/ongoing/email-recovery.md` (PR #3836) for the full
-/// design, and `crate::email_recovery` for the per-flow logic. The
-/// canister methods below are thin wrappers that handle:
+/// design, and `crate::email_recovery` for the per-flow logic.
 ///
-/// - Authorization (`prepare_add` / `credential_remove` are
-///   authenticated; `status` is anonymous since the nonce is the
-///   only secret needed to poll).
-/// - Wall-clock injection (`now_secs` lifted out of
-///   `ic_cdk::api::time` so the inner functions stay testable).
+/// - **Setup** (binding): `prepare_add` (authenticated) issues a
+///   nonce, `smtp_request` for `register@id.ai` consumes the
+///   verified email and binds the credential to the anchor, and
+///   `credential_remove` (authenticated) detaches it.
+/// - **Recovery** (delegation): `prepare_delegation` (anonymous)
+///   issues a nonce bound to a session_key, `smtp_request` for
+///   `recover@id.ai` consumes the verified email and stamps a
+///   canister-signed delegation seed, and `get_delegation`
+///   (anonymous query) hands the signed delegation to the FE.
 ///
-/// The recovery half (`prepare_delegation` / `get_delegation` /
-/// `recover@id.ai` dispatch in `smtp_request`) is intentionally not
-/// part of this PR — it needs a stable reverse address index that
-/// is best landed on its own.
+/// The canister methods below are thin wrappers handling
+/// authorization, wall-clock injection (`now_secs` lifted out of
+/// `ic_cdk::api::time` so the inner functions stay testable), and
+/// the FE-facing `Result` shape. `status` is anonymous for both
+/// flows since the nonce is the only secret needed to poll.
 mod email_recovery_api {
     use super::*;
     use crate::authz_utils::check_authorization;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1419,8 +1419,9 @@ mod openid_api {
 /// - **Recovery** (delegation): `prepare_delegation` (anonymous)
 ///   issues a nonce bound to a session_key, `smtp_request` for
 ///   `recover@id.ai` consumes the verified email and stamps a
-///   canister-signed delegation seed, and `get_delegation`
-///   (anonymous query) hands the signed delegation to the FE.
+///   canister-signed delegation seed, and
+///   `email_recovery_get_delegation` (anonymous query) hands the
+///   signed delegation to the FE.
 ///
 /// The canister methods below are thin wrappers handling
 /// authorization, wall-clock injection (`now_secs` lifted out of
@@ -1499,12 +1500,18 @@ mod email_recovery_api {
     /// probe the canister for which nonces exist. The FE sees the
     /// outcome via its `email_recovery_status(nonce)` poll.
     ///
-    /// **Security:** no-oracle endpoint — always returns
-    /// `SmtpResponse::Ok {}` so a caller can't probe which nonces
-    /// are in flight via response shape or timing. Recipient
-    /// dispatch matches the full `user@domain` against
-    /// `related_origins`, defence-in-depth against a direct caller
-    /// spoofing just the user-part.
+    /// **Security:** no-oracle on the response *shape* — always
+    /// returns `SmtpResponse::Ok {}` regardless of whether the
+    /// nonce is known, expired, or terminal, so a caller can't
+    /// learn the verification outcome from the response. (Response
+    /// *latency* does differ — an unknown nonce silent-drops in
+    /// microseconds, a valid one on the DoH path runs DKIM/DMARC
+    /// fetches first — but with 64 bits of nonce entropy and a
+    /// 30-minute TTL, timing-based existence probing isn't a
+    /// threat this property is meant to block.) Recipient dispatch
+    /// matches the full `user@domain` against `related_origins`,
+    /// defense-in-depth against a direct caller spoofing just the
+    /// user-part.
     #[update]
     async fn smtp_request(
         request: internet_identity_interface::internet_identity::types::smtp::SmtpRequest,

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1443,6 +1443,12 @@ mod email_recovery_api {
     /// anchor in the heap pending-challenge map; an inbound email
     /// with that nonce in `Subject:` completes the binding via
     /// `smtp_request`.
+    ///
+    /// **Security:** caller must be the anchor controller — enforced
+    /// by `check_authorization(identity_number)`. Resource exposure
+    /// is bounded by the 10 k pending-map cap (see
+    /// `email_recovery::MAX_PENDING_CHALLENGES`) with 30-minute TTL
+    /// and oldest-first eviction.
     #[update]
     async fn email_recovery_credential_prepare_add(
         identity_number: IdentityNumber,
@@ -1488,6 +1494,13 @@ mod email_recovery_api {
     /// "verification failed" answers, and emitting one would let it
     /// probe the canister for which nonces exist. The FE sees the
     /// outcome via its `email_recovery_status(nonce)` poll.
+    ///
+    /// **Security:** no-oracle endpoint — always returns
+    /// `SmtpResponse::Ok {}` so a caller can't probe which nonces
+    /// are in flight via response shape or timing. Recipient
+    /// dispatch matches the full `user@domain` against
+    /// `related_origins`, defence-in-depth against a direct caller
+    /// spoofing just the user-part.
     #[update]
     async fn smtp_request(
         request: internet_identity_interface::internet_identity::types::smtp::SmtpRequest,
@@ -1521,6 +1534,10 @@ mod email_recovery_api {
     /// observably indistinguishable from "the canister forgot it",
     /// which is exactly what we want (the FE shows "timed out, try
     /// again" in either case).
+    ///
+    /// **Security:** unknown-nonce → `Expired` is deliberate: a
+    /// caller without the original `prepare_add` nonce can't
+    /// distinguish "never issued" from "evicted" from "expired".
     #[query]
     fn email_recovery_status(nonce: String) -> EmailRecoveryStatus {
         let now_secs = ic_cdk::api::time() / 1_000_000_000;
@@ -1599,6 +1616,10 @@ mod email_recovery_api {
     /// recovery email the anchor doesn't have is surfaced as
     /// `AddressNotRegistered` so the FE can show a meaningful error
     /// if it got into an inconsistent state.
+    ///
+    /// **Security:** caller must be the anchor controller — enforced
+    /// by `authz_utils::check_authorization` (same path the other
+    /// authenticated anchor mutators use).
     #[update]
     fn email_recovery_credential_remove(
         identity_number: IdentityNumber,


### PR DESCRIPTION
Non-blocking follow-ups from @aterga's review of [#3880](https://github.com/dfinity/internet-identity/pull/3880). Pure documentation; no observable behaviour change.

- [main.rs](src/internet_identity/src/main.rs): add a **Security:** stanza to each new public method — states the authz / rate-limit / no-oracle invariant inline next to the method, so future readers and auditors don't have to grep for it across `email_recovery/`.
- [email_recovery/mod.rs](src/internet_identity/src/email_recovery/mod.rs): spell out that the 10 k pending-map cap + TTL is the per-canister rate-limit on `prepare_add` / `prepare_delegation` (there's no per-anchor / per-caller counter).
- [email_recovery/smtp.rs](src/internet_identity/src/email_recovery/smtp.rs): note that `pending::with_mut` lazily evicts the entry on TTL expiry, so a stale nonce surfaces as `Ok` / `Expired` without further work — and the global sweep on the next `insert_with_eviction` handles the rest.
- [Cargo.toml](src/internet_identity/Cargo.toml): explain why `rand_chacha` was added (email-recovery PRNG) and why `default-features = false` (wasm32 has no `OsRng`).

## PR Stack

Stacked at the top, on top of [#3884](https://github.com/dfinity/internet-identity/pull/3884) (Email-recovery UX overhaul). Lands after the full email-recovery stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)