### PR TITLE
build(ci): add reproducibility check for relaxing -j1 in scripts/build

### DIFF
--- a/.github/workflows/repro-check-cargo-jobs.yml
+++ b/.github/workflows/repro-check-cargo-jobs.yml
@@ -6,8 +6,8 @@
 # Compares the two wasm.gz sha256 hashes and fails if they differ.
 #
 # This workflow exists to gather evidence for or against the `-j1` hedge in
-# scripts/build (added in #490 for reproducibility). Background:
-# https://github.com/dfinity/internet-identity/pull/3895#issuecomment- (closed)
+# scripts/build, added in #490 for reproducibility. See the introducing PR
+# for the theory: https://github.com/dfinity/internet-identity/pull/3897
 #
 # Triggered manually (workflow_dispatch). Not part of the per-PR CI to avoid
 # spending ~15 min of runner time on every push.
@@ -15,6 +15,9 @@ name: Repro check (cargo -j)
 
 on:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build-control:
@@ -27,6 +30,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
 
+      - name: Infer version
+        id: version
+        run: |
+          version="$(./scripts/version)"
+          echo "Inferred version: '$version'"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Record start time
         id: start
         run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
@@ -37,8 +47,13 @@ jobs:
           context: .
           file: Dockerfile
           # No CARGO_BUILD_JOBS build-arg → Dockerfile default of 1 applies.
+          # II_VERSION passed in the same way the production canister-tests
+          # workflow does it; without it, scripts/build falls back to
+          # ./scripts/version which relies on git (not installed in the image).
           # cache-from on cached-stage is fine; we're not asserting on cold
           # build time here, only on byte equivalence.
+          build-args: |
+            II_VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=cached-stage
           outputs: ./out
           target: scratch_internet_identity
@@ -67,6 +82,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
 
+      - name: Infer version
+        id: version
+        run: |
+          version="$(./scripts/version)"
+          echo "Inferred version: '$version'"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Resolve nproc
         id: nproc
         run: |
@@ -84,6 +106,7 @@ jobs:
           context: .
           file: Dockerfile
           build-args: |
+            II_VERSION=${{ steps.version.outputs.version }}
             CARGO_BUILD_JOBS=${{ steps.nproc.outputs.value }}
           # Distinct ENV (CARGO_BUILD_JOBS=N vs 1) gives the deps stage a
           # different layer hash than the control build, so the deps compile

--- a/.github/workflows/repro-check-cargo-jobs.yml
+++ b/.github/workflows/repro-check-cargo-jobs.yml
@@ -1,0 +1,142 @@
+# Reproducibility check: does relaxing `-j1` in scripts/build change the
+# produced wasm? Builds the internet_identity backend twice on the same
+# commit:
+#   - control:    CARGO_BUILD_JOBS unset (defaults to 1, current behavior)
+#   - experiment: CARGO_BUILD_JOBS=$(nproc)
+# Compares the two wasm.gz sha256 hashes and fails if they differ.
+#
+# This workflow exists to gather evidence for or against the `-j1` hedge in
+# scripts/build (added in #490 for reproducibility). Background:
+# https://github.com/dfinity/internet-identity/pull/3895#issuecomment- (closed)
+#
+# Triggered manually (workflow_dispatch). Not part of the per-PR CI to avoid
+# spending ~15 min of runner time on every push.
+name: Repro check (cargo -j)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-control:
+    name: Build with -j1 (control)
+    runs-on: ubuntu-latest
+    outputs:
+      hash: ${{ steps.hash.outputs.value }}
+      seconds: ${{ steps.timing.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Record start time
+        id: start
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Build internet_identity backend (-j1)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          # No CARGO_BUILD_JOBS build-arg → Dockerfile default of 1 applies.
+          # cache-from on cached-stage is fine; we're not asserting on cold
+          # build time here, only on byte equivalence.
+          cache-from: type=gha,scope=cached-stage
+          outputs: ./out
+          target: scratch_internet_identity
+
+      - name: Record timing
+        id: timing
+        run: |
+          end=$(date +%s)
+          echo "seconds=$(( end - ${{ steps.start.outputs.epoch }} ))" >> "$GITHUB_OUTPUT"
+
+      - name: Hash
+        id: hash
+        run: |
+          h=$(sha256sum out/internet_identity.wasm.gz | awk '{print $1}')
+          echo "Control hash: $h"
+          echo "value=$h" >> "$GITHUB_OUTPUT"
+
+  build-experiment:
+    name: Build with -j$(nproc) (experiment)
+    runs-on: ubuntu-latest
+    outputs:
+      hash: ${{ steps.hash.outputs.value }}
+      jobs: ${{ steps.nproc.outputs.value }}
+      seconds: ${{ steps.timing.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Resolve nproc
+        id: nproc
+        run: |
+          n=$(nproc)
+          echo "Runner has $n logical CPUs"
+          echo "value=$n" >> "$GITHUB_OUTPUT"
+
+      - name: Record start time
+        id: start
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Build internet_identity backend (-jN)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          build-args: |
+            CARGO_BUILD_JOBS=${{ steps.nproc.outputs.value }}
+          # Distinct ENV (CARGO_BUILD_JOBS=N vs 1) gives the deps stage a
+          # different layer hash than the control build, so the deps compile
+          # actually re-runs under the experimental setting even if both jobs
+          # were pulling from the same cache scope. We pull from a separate
+          # empty scope anyway to make this explicit.
+          cache-from: type=gha,scope=repro-check-experiment
+          outputs: ./out
+          target: scratch_internet_identity
+
+      - name: Record timing
+        id: timing
+        run: |
+          end=$(date +%s)
+          echo "seconds=$(( end - ${{ steps.start.outputs.epoch }} ))" >> "$GITHUB_OUTPUT"
+
+      - name: Hash
+        id: hash
+        run: |
+          h=$(sha256sum out/internet_identity.wasm.gz | awk '{print $1}')
+          echo "Experiment hash: $h"
+          echo "value=$h" >> "$GITHUB_OUTPUT"
+
+  compare:
+    name: Compare hashes
+    needs: [build-control, build-experiment]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compare
+        run: |
+          control="${{ needs.build-control.outputs.hash }}"
+          experiment="${{ needs.build-experiment.outputs.hash }}"
+          control_s="${{ needs.build-control.outputs.seconds }}"
+          experiment_s="${{ needs.build-experiment.outputs.seconds }}"
+          jobs="${{ needs.build-experiment.outputs.jobs }}"
+
+          echo "============================================"
+          echo "Reproducibility check: cargo -j1 vs -j$jobs"
+          echo "============================================"
+          echo "Control     (-j1)      hash: $control"
+          echo "Experiment  (-j$jobs)  hash: $experiment"
+          echo "Control     job time:  ${control_s}s"
+          echo "Experiment  job time:  ${experiment_s}s"
+          echo ""
+
+          if [ "$control" = "$experiment" ]; then
+            echo "::notice::Hashes MATCH — -j$jobs is byte-equivalent to -j1."
+            echo "::notice::The historical -j1 hedge is no longer load-bearing for reproducibility on this toolchain."
+            echo "::notice::Job-time delta (experiment vs control): $(( experiment_s - control_s ))s."
+            exit 0
+          else
+            echo "::error::Hashes DIFFER — -j$jobs produces a different wasm than -j1."
+            echo "::error::-j1 is still doing something; do NOT relax it without further investigation."
+            echo "::error::Possible next step: also pin codegen-units=1 explicitly and re-test."
+            exit 1
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,6 @@ FROM --platform=linux/amd64 ubuntu@sha256:bbf3d1baa208b7649d1d0264ef7d522e1dc0de
 
 ENV TZ=UTC
 
-# Bring the global ARG into this stage's scope and propagate as ENV so that
-# `scripts/build` (invoked in this stage and inherited by downstream
-# FROM-deps stages) picks it up. ENV declarations propagate to derived
-# stages; ARG declarations do not.
-ARG CARGO_BUILD_JOBS
-ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
-
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     apt -yq update && \
     apt -yqq install --no-install-recommends curl ca-certificates \
@@ -68,6 +61,17 @@ COPY src/internet_identity_frontend/Cargo.toml src/internet_identity_frontend/Ca
 COPY src/asset_util/Cargo.toml src/asset_util/Cargo.toml
 ENV CARGO_TARGET_DIR=/cargo_target
 COPY ./scripts/build ./scripts/build
+
+# Bring the global CARGO_BUILD_JOBS ARG into scope as ENV so that
+# `scripts/build` (invoked here and inherited by downstream FROM-deps
+# stages) picks it up. Placed here, immediately before the deps prebuild,
+# so changing CARGO_BUILD_JOBS does not invalidate the apt/Node/Rust/wasm-pack
+# install layers above — only the cargo build layer (and the downstream
+# build_internet_identity / build_archive / build_internet_identity_frontend
+# stages, which is correct: they also invoke scripts/build).
+ARG CARGO_BUILD_JOBS
+ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
+
 RUN mkdir -p src/internet_identity/src \
     && touch src/internet_identity/src/lib.rs \
     && mkdir -p src/internet_identity_interface/src \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,23 @@
 #
 # The docker image. To update, run `docker pull ubuntu` locally, and update the
 # sha256:... accordingly.
+
+# Global build args. Default values preserve the established build behavior
+# (matching what was running before any of these were declared); the
+# reproducibility-check workflow overrides them to probe whether the legacy
+# settings are still load-bearing for byte-identical output on modern rustc.
+ARG CARGO_BUILD_JOBS=1
+
 FROM --platform=linux/amd64 ubuntu@sha256:bbf3d1baa208b7649d1d0264ef7d522e1dc0deeeaaf6085bf8e4618867f03494 as deps
 
 ENV TZ=UTC
+
+# Bring the global ARG into this stage's scope and propagate as ENV so that
+# `scripts/build` (invoked in this stage and inherited by downstream
+# FROM-deps stages) picks it up. ENV declarations propagate to derived
+# stages; ARG declarations do not.
+ARG CARGO_BUILD_JOBS
+ENV CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
     apt -yq update && \

--- a/scripts/build
+++ b/scripts/build
@@ -136,11 +136,17 @@ function build_canister() {
     CARGO_HOME="${CARGO_HOME:-"$HOME/.cargo"}"
     RUSTFLAGS="--remap-path-prefix $CARGO_HOME=/cargo -C link-args=-zstack-size=3000000"
 
+    # -j defaults to 1 for the historical reproducibility-preserving behavior
+    # (see #490). Override via CARGO_BUILD_JOBS in the environment — used by
+    # the reproducibility-check workflow to test whether modern rustc still
+    # needs this hedge.
+    cargo_build_jobs="${CARGO_BUILD_JOBS:-1}"
+
     cargo_build_args=(
         --manifest-path "$SRC_DIR/Cargo.toml"
         --target "$TARGET"
         --release
-        -j1
+        -j "$cargo_build_jobs"
         )
     # XXX: for bash > 4.4, empty arrays are considered unset, so do some substitution
     cargo_build_args+=(${extra_build_args[@]+"${extra_build_args[@]}"})


### PR DESCRIPTION
## Summary

Adds the machinery to **verify empirically** whether `scripts/build`'s hardcoded `-j1` is still load-bearing for reproducibility on the current Rust toolchain. **No change to default build behavior.**

## Why

`scripts/build` has pinned cargo to `-j1` since [#490 (Dec 2021)](https://github.com/dfinity/internet-identity/pull/490) — *"Make build more reproducible"* — alongside Docker image SHA pinning and lib.rs timestamp normalization. On a 4-core runner this caps the deps prebuild at 1/4 throughput.

The theoretical case for keeping `-j1` is thin on modern rustc:

- `cargo -j N` controls **inter-process** parallelism: how many concurrent rustc invocations cargo spawns across the dep graph.
- A single rustc invocation's output is a deterministic function of source + flags + rustc version + `codegen-units`, **independent** of how many sibling rustc processes happen to be running. Cargo serialises filesystem writes via per-crate paths.
- The actual non-determinism vector documented by the reproducible-builds community is `codegen-units > 1` (default 16 for release), not `-j > 1`. See the [Aug 2024 rb-general thread](https://lists.reproducible-builds.org/pipermail/rb-general/2024-August/003491.html) and [reproducible-builds.org/docs/rust](https://reproducible-builds.org/docs/rust/) — neither lists `-j1` as a required hedge.

But theory should be verified before relaxing a load-bearing-looking flag. This PR is the verification.

## What this PR does

1. **`scripts/build`** — honor `CARGO_BUILD_JOBS` env var. Default 1, so behavior is unchanged when the env is unset (the production CI path).
2. **`Dockerfile`** — declare a global `ARG CARGO_BUILD_JOBS=1` and propagate it via `ENV` from the deps stage so a docker build build-arg flows into `scripts/build`.
3. **New workflow** `.github/workflows/repro-check-cargo-jobs.yml` (workflow_dispatch only) — builds the backend twice on the same commit:
   - control:    `-j1`
   - experiment: `-j$(nproc)`
   
   Compares the two `internet_identity.wasm.gz` sha256 hashes. Fails if they differ; logs the timing delta if they match. Not part of the per-PR CI — runner cost is paid only when manually triggered.

## Test plan

- [ ] Standard CI on this PR is green (existing canister-tests workflow with default `-j1` — proves backward compatibility).
- [ ] Manually trigger the `Repro check (cargo -j)` workflow from the Actions tab. Inspect output.

## Possible outcomes

| Outcome | Interpretation | Follow-up |
| --- | --- | --- |
| Hashes match | `-j1` is no longer load-bearing on this toolchain | Open a 1-line PR removing `-j1` (use `CARGO_BUILD_JOBS=$(nproc)` in CI) |
| Hashes differ | Something *is* sensitive to `-j` | Pin `codegen-units=1` explicitly in `Cargo.toml`, re-run experiment, investigate before relaxing |

## What this PR does NOT do

- Does not change the default build behavior — every existing build path still uses `-j1`.
- Does not touch `Cargo.toml`'s `[profile.release]`.
- Does not delete `-j1` from `scripts/build`. That's the follow-up if the experiment shows it's safe.