### PR TITLE
feat(fe): Plausible funnels for email-recovery setup + sign-in

### DIFF
--- a/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
@@ -101,8 +101,21 @@
   // wizard mounts. Each milestone calls `trigger(...)`; the terminal
   // states (signed-in / failed / unsupported) call `close()` to record
   // duration. See `recoverWithEmailFunnel.ts` for the event shape.
+  //
+  // Belt-and-braces `close()` on unmount: if the user abandons the
+  // wizard mid-flow (Dialog `×`, navigation away, browser back)
+  // without reaching a terminal branch, the funnel's
+  // `trackWindowSession` listener would otherwise stay registered.
+  // A later remount's `init()` would then overwrite the cleanup
+  // pointer, leaking the old listener. `close()` is idempotent (it
+  // only does work if a `start-…` timestamp is set), so calling it
+  // here both fires `end-…` for the abandoned flow and unregisters
+  // the visibility listener cleanly.
   onMount(() => {
     recoverWithEmailFunnel.init();
+  });
+  onDestroy(() => {
+    recoverWithEmailFunnel.close();
   });
 
   /**

--- a/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
@@ -42,8 +42,12 @@
     type Path,
   } from "$lib/utils/dnssec";
   import { isCanisterError } from "$lib/utils/utils";
+  import {
+    recoverWithEmailFunnel,
+    RecoverWithEmailEvents,
+  } from "$lib/utils/analytics/recoverWithEmailFunnel";
   import { ECDSAKeyIdentity } from "@icp-sdk/core/identity";
-  import { onDestroy } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import type { RecoverySuccess } from "./index";
 
   interface Props {
@@ -93,6 +97,30 @@
     polling = false;
   });
 
+  // Plausible funnel: emit `start-email-recovery-recover` when the
+  // wizard mounts. Each milestone calls `trigger(...)`; the terminal
+  // states (signed-in / failed / unsupported) call `close()` to record
+  // duration. See `recoverWithEmailFunnel.ts` for the event shape.
+  onMount(() => {
+    recoverWithEmailFunnel.init();
+  });
+
+  /**
+   * Map a terminal `EmailRecoveryStatus` (`Failed` or `Expired`) to
+   * the variant-name string used as the `reason` property on the
+   * Plausible `*-failed` event.
+   */
+  const failureReason = (variant: EmailRecoveryStatus): string => {
+    if ("Failed" in variant) {
+      const reason = variant.Failed as Record<string, unknown>;
+      return Object.keys(reason)[0] ?? "unknown";
+    }
+    if ("Expired" in variant) {
+      return "Expired";
+    }
+    return "unknown";
+  };
+
   const friendlyError = (variant: EmailRecoveryStatus): string => {
     if ("Failed" in variant) {
       const reason = variant.Failed;
@@ -132,6 +160,7 @@
   };
 
   const handleAddressSubmitted = async (address: string) => {
+    recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.AddressSubmitted);
     const domain = address.split("@")[1] ?? "";
 
     // Generate the session keypair the eventual delegation will be
@@ -159,6 +188,7 @@
 
     try {
       const challenge = await prepareDelegation(input, sessionPublicKey);
+      recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.Prepared, { path });
       stage = { kind: "sending", challenge, address, sessionIdentity, path };
       void runPoll(challenge.nonce, domain, sessionIdentity);
     } catch (e) {
@@ -167,6 +197,11 @@
           e.type === "DomainNotAllowlisted" ||
           e.type === "DomainNotSupported"
         ) {
+          recoverWithEmailFunnel.trigger(
+            RecoverWithEmailEvents.UnsupportedDomain,
+            { reason: e.type },
+          );
+          recoverWithEmailFunnel.close();
           stage = { kind: "unsupported", domain };
           return;
         }
@@ -188,6 +223,7 @@
       while (polling && stage.kind === "sending") {
         const result = await status(nonce);
         if ("RecoveryReady" in result) {
+          recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.RecoveryReady);
           await retrieveDelegation(
             nonce,
             result.RecoveryReady.user_key,
@@ -198,11 +234,16 @@
           return;
         }
         if ("Failed" in result || "Expired" in result) {
+          recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.Failed, {
+            reason: failureReason(result),
+          });
+          recoverWithEmailFunnel.close();
           stage = { kind: "failed", reason: friendlyError(result) };
           return;
         }
         if ("NeedDkimLeaf" in result && !dkimLeafSubmitted) {
           dkimLeafSubmitted = true;
+          recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.NeedDkimLeaf);
           const selector = result.NeedDkimLeaf.selector;
           try {
             const walked = await assembleDkimResolution(domain, selector);
@@ -212,7 +253,13 @@
                 hops: walked.hops,
                 extra_chains: walked.extraChains,
               });
+              recoverWithEmailFunnel.trigger(
+                RecoverWithEmailEvents.DkimLeafSubmitted,
+              );
               if ("RecoveryReady" in submission) {
+                recoverWithEmailFunnel.trigger(
+                  RecoverWithEmailEvents.RecoveryReady,
+                );
                 await retrieveDelegation(
                   nonce,
                   submission.RecoveryReady.user_key,
@@ -223,6 +270,10 @@
                 return;
               }
               if ("Failed" in submission || "Expired" in submission) {
+                recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.Failed, {
+                  reason: failureReason(submission),
+                });
+                recoverWithEmailFunnel.close();
                 stage = { kind: "failed", reason: friendlyError(submission) };
                 return;
               }
@@ -256,13 +307,22 @@
         session_key: sessionPublicKey,
         expiration,
       });
+      recoverWithEmailFunnel.trigger(
+        RecoverWithEmailEvents.DelegationRetrieved,
+      );
       await onSignedIn({
         sessionIdentity,
         userKey,
         delegation,
         identityNumber,
       });
+      recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.SignedIn);
+      recoverWithEmailFunnel.close();
     } catch (e) {
+      recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.Failed, {
+        reason: e instanceof Error ? e.message : String(e),
+      });
+      recoverWithEmailFunnel.close();
       stage = {
         kind: "failed",
         reason: e instanceof Error ? e.message : String(e),

--- a/src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte
@@ -91,8 +91,21 @@
   // wizard mounts. Each milestone calls `trigger(...)`; the terminal
   // states (success / failed / unsupported) call `close()` to record
   // duration. See `setupEmailRecoveryFunnel.ts` for the event shape.
+  //
+  // Belt-and-braces `close()` on unmount: if the user abandons the
+  // wizard mid-flow (Dialog `×`, navigation away, browser back)
+  // without reaching a terminal branch, the funnel's
+  // `trackWindowSession` listener would otherwise stay registered.
+  // A later remount's `init()` would then overwrite the cleanup
+  // pointer, leaking the old listener. `close()` is idempotent (it
+  // only does work if a `start-…` timestamp is set), so calling it
+  // here both fires `end-…` for the abandoned flow and unregisters
+  // the visibility listener cleanly.
   onMount(() => {
     setupEmailRecoveryFunnel.init();
+  });
+  onDestroy(() => {
+    setupEmailRecoveryFunnel.close();
   });
 
   /**

--- a/src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte
@@ -42,7 +42,11 @@
     type Path,
   } from "$lib/utils/dnssec";
   import { isCanisterError } from "$lib/utils/utils";
-  import { onDestroy } from "svelte";
+  import {
+    setupEmailRecoveryFunnel,
+    SetupEmailRecoveryEvents,
+  } from "$lib/utils/analytics/setupEmailRecoveryFunnel";
+  import { onDestroy, onMount } from "svelte";
 
   interface Props {
     /** Authenticated wrapper around `email_recovery_credential_prepare_add`. */
@@ -82,6 +86,31 @@
   onDestroy(() => {
     polling = false;
   });
+
+  // Plausible funnel: emit `start-email-recovery-setup` when the
+  // wizard mounts. Each milestone calls `trigger(...)`; the terminal
+  // states (success / failed / unsupported) call `close()` to record
+  // duration. See `setupEmailRecoveryFunnel.ts` for the event shape.
+  onMount(() => {
+    setupEmailRecoveryFunnel.init();
+  });
+
+  /**
+   * Map a terminal `EmailRecoveryStatus` (`Failed` or `Expired`) to
+   * the variant-name string used as the `reason` property on the
+   * Plausible `*-failed` event. Falls back to `unknown` so a partial
+   * candid-shape change doesn't drop the event entirely.
+   */
+  const failureReason = (variant: EmailRecoveryStatus): string => {
+    if ("Failed" in variant) {
+      const reason = variant.Failed as Record<string, unknown>;
+      return Object.keys(reason)[0] ?? "unknown";
+    }
+    if ("Expired" in variant) {
+      return "Expired";
+    }
+    return "unknown";
+  };
 
   const friendlyError = (variant: EmailRecoveryStatus): string => {
     if ("Failed" in variant) {
@@ -125,6 +154,7 @@
   };
 
   const handleAddressSubmitted = async (address: string) => {
+    setupEmailRecoveryFunnel.trigger(SetupEmailRecoveryEvents.AddressSubmitted);
     const domain = address.split("@")[1] ?? "";
 
     // Best-effort DNSSEC skeleton-bundle assembly. The DKIM leaf is
@@ -150,6 +180,9 @@
 
     try {
       const challenge = await prepare(input);
+      setupEmailRecoveryFunnel.trigger(SetupEmailRecoveryEvents.Prepared, {
+        path,
+      });
       stage = { kind: "sending", challenge, address, path };
       void runPoll(challenge.nonce, domain, address);
     } catch (e) {
@@ -163,6 +196,11 @@
           e.type === "DomainNotAllowlisted" ||
           e.type === "DomainNotSupported"
         ) {
+          setupEmailRecoveryFunnel.trigger(
+            SetupEmailRecoveryEvents.UnsupportedDomain,
+            { reason: e.type },
+          );
+          setupEmailRecoveryFunnel.close();
           stage = { kind: "unsupported", domain };
           return;
         }
@@ -181,16 +219,25 @@
       while (polling && stage.kind === "sending") {
         const result = await status(nonce);
         if ("RegistrationSucceeded" in result) {
+          setupEmailRecoveryFunnel.trigger(SetupEmailRecoveryEvents.Succeeded);
+          setupEmailRecoveryFunnel.close();
           polling = false;
           onSuccess(address);
           return;
         }
         if ("Failed" in result || "Expired" in result) {
+          setupEmailRecoveryFunnel.trigger(SetupEmailRecoveryEvents.Failed, {
+            reason: failureReason(result),
+          });
+          setupEmailRecoveryFunnel.close();
           stage = { kind: "failed", reason: friendlyError(result) };
           return;
         }
         if ("NeedDkimLeaf" in result && !dkimLeafSubmitted) {
           dkimLeafSubmitted = true;
+          setupEmailRecoveryFunnel.trigger(
+            SetupEmailRecoveryEvents.NeedDkimLeaf,
+          );
           // Email arrived; the canister has the selector. Walk the
           // single missing DKIM leaf and submit it. If the leaf
           // walk fails we keep the loop alive — the canister-side
@@ -204,12 +251,24 @@
                 hops: walked.hops,
                 extra_chains: walked.extraChains,
               });
+              setupEmailRecoveryFunnel.trigger(
+                SetupEmailRecoveryEvents.DkimLeafSubmitted,
+              );
               if ("RegistrationSucceeded" in submission) {
+                setupEmailRecoveryFunnel.trigger(
+                  SetupEmailRecoveryEvents.Succeeded,
+                );
+                setupEmailRecoveryFunnel.close();
                 polling = false;
                 onSuccess(address);
                 return;
               }
               if ("Failed" in submission || "Expired" in submission) {
+                setupEmailRecoveryFunnel.trigger(
+                  SetupEmailRecoveryEvents.Failed,
+                  { reason: failureReason(submission) },
+                );
+                setupEmailRecoveryFunnel.close();
                 stage = { kind: "failed", reason: friendlyError(submission) };
                 return;
               }

--- a/src/frontend/src/lib/utils/analytics/recoverWithEmailFunnel.ts
+++ b/src/frontend/src/lib/utils/analytics/recoverWithEmailFunnel.ts
@@ -1,0 +1,53 @@
+import { Funnel } from "./Funnel";
+
+/**
+ * Email-recovery **sign-in** flow events. The user is anonymous and
+ * proving control of a previously-bound email address to obtain a
+ * signed delegation.
+ *
+ * Square brackets [] indicate optional events.
+ *
+ * Funnel shape:
+ *
+ * start-email-recovery-recover    (INIT — recovery picker selects email branch)
+ *   email-recovery-recover-address-submitted
+ *     email-recovery-recover-prepared    (with `path = dnssec | doh`)
+ *     | email-recovery-recover-unsupported-domain
+ *     [email-recovery-recover-need-dkim-leaf]    (DNSSEC path only)
+ *       [email-recovery-recover-dkim-leaf-submitted]
+ *     email-recovery-recover-recovery-ready
+ *       email-recovery-recover-delegation-retrieved
+ *         email-recovery-recover-signed-in
+ *     | email-recovery-recover-failed   (with `reason = <variant>`)
+ * end-email-recovery-recover       (CLOSE — terminal state, carries `duration-…`)
+ *
+ * Two stages distinguish the recovery flow from setup:
+ *  1. `recovery-ready` — the canister has stamped the delegation seed
+ *     and the FE has resolved the anchor from the verified `From:`.
+ *  2. `delegation-retrieved` — the FE has called
+ *     `email_recovery_get_delegation` and now holds the
+ *     `SignedDelegation`. The host page can build the
+ *     `DelegationIdentity` from this point.
+ *
+ * `signed-in` fires once the host's `onSignedIn` callback has resolved
+ * — i.e. the auth store is seeded and the user is actually logged in.
+ *
+ * The DoH path skips `need-dkim-leaf` / `dkim-leaf-submitted` — the
+ * canister finishes verification synchronously inside `smtp_request`,
+ * so the FE polls from `prepared` straight to `recovery-ready`.
+ */
+export const RecoverWithEmailEvents = {
+  AddressSubmitted: "email-recovery-recover-address-submitted",
+  Prepared: "email-recovery-recover-prepared",
+  UnsupportedDomain: "email-recovery-recover-unsupported-domain",
+  NeedDkimLeaf: "email-recovery-recover-need-dkim-leaf",
+  DkimLeafSubmitted: "email-recovery-recover-dkim-leaf-submitted",
+  RecoveryReady: "email-recovery-recover-recovery-ready",
+  DelegationRetrieved: "email-recovery-recover-delegation-retrieved",
+  SignedIn: "email-recovery-recover-signed-in",
+  Failed: "email-recovery-recover-failed",
+} as const;
+
+export const recoverWithEmailFunnel = new Funnel<typeof RecoverWithEmailEvents>(
+  "email-recovery-recover",
+);

--- a/src/frontend/src/lib/utils/analytics/setupEmailRecoveryFunnel.ts
+++ b/src/frontend/src/lib/utils/analytics/setupEmailRecoveryFunnel.ts
@@ -1,0 +1,41 @@
+import { Funnel } from "./Funnel";
+
+/**
+ * Email-recovery **setup** flow events. The user is already signed in
+ * and is binding an email address as a recovery method.
+ *
+ * Square brackets [] indicate optional events.
+ *
+ * Funnel shape:
+ *
+ * start-email-recovery-setup     (INIT — manage page opens the wizard)
+ *   email-recovery-setup-address-submitted
+ *     email-recovery-setup-prepared    (with `path = dnssec | doh`)
+ *     | email-recovery-setup-unsupported-domain
+ *     [email-recovery-setup-need-dkim-leaf]     (DNSSEC path only)
+ *       [email-recovery-setup-dkim-leaf-submitted]
+ *     email-recovery-setup-succeeded
+ *     | email-recovery-setup-failed   (with `reason = <variant>`)
+ * end-email-recovery-setup           (CLOSE — terminal state, carries `duration-…`)
+ *
+ * The DoH path skips `need-dkim-leaf` / `dkim-leaf-submitted` — the
+ * canister finishes verification synchronously inside `smtp_request`,
+ * so the FE polls from `prepared` straight to `succeeded` / `failed`.
+ *
+ * The wizard never explicitly tracks "email sent" — the canister
+ * doesn't know, and the FE's view of it is `NeedDkimLeaf` (DNSSEC)
+ * or the next non-`Pending` poll (DoH). Both are captured above.
+ */
+export const SetupEmailRecoveryEvents = {
+  AddressSubmitted: "email-recovery-setup-address-submitted",
+  Prepared: "email-recovery-setup-prepared",
+  UnsupportedDomain: "email-recovery-setup-unsupported-domain",
+  NeedDkimLeaf: "email-recovery-setup-need-dkim-leaf",
+  DkimLeafSubmitted: "email-recovery-setup-dkim-leaf-submitted",
+  Succeeded: "email-recovery-setup-succeeded",
+  Failed: "email-recovery-setup-failed",
+} as const;
+
+export const setupEmailRecoveryFunnel = new Funnel<
+  typeof SetupEmailRecoveryEvents
+>("email-recovery-setup");


### PR DESCRIPTION
## Summary

Adds two Plausible funnels — `email-recovery-setup` and `email-recovery-recover` — so we can see beta drop-off in the new email-recovery flows without re-introducing the staging debug-log surface that #3883 removed.

Funnel shape mirrors the existing `registrationFunnel` / `authenticationV2Funnel` modules. Each wizard emits:

- `start-<name>` on mount (`funnel.init()`)
- `trigger(event)` at each milestone — address submitted → prepared (with `path = dnssec | doh`) → optional `NeedDkimLeaf` → `DkimLeafSubmitted` → terminal
- `close()` at terminal so `end-<name>` carries `duration-<name>`

The **recovery** funnel adds three flow-specific events between `Prepared` and `SignedIn`:
1. `RecoveryReady` — canister stamped the delegation seed and resolved the anchor from the verified `From:`
2. `DelegationRetrieved` — FE has the `SignedDelegation`
3. `SignedIn` — host's `onSignedIn` callback resolved

### Failure events

`*-failed` events carry a `reason` property holding the `EmailRecoveryError` variant name (e.g. `DkimLeafMismatch`, `AddressMismatch`, `Expired`, `DohFetchFailed`) — Plausible can break down drop-off by cause. `failureReason()` is a small helper that pulls the variant key off the candid record and defaults to `unknown` if a future schema bump adds a variant we don't yet recognise (so a partial-schema change won't drop the event).

### What's NOT emitted

No address, no nonce, no DKIM material, no domain. Only the public funnel event names + the `path` (dnssec / doh) + the error-variant `reason`. The §3.1 enumeration-resistance property of the recovery flow is preserved — Plausible sees aggregate flow shape, not per-anchor data.

## Test plan

- [x] `npm run check` — 0 errors, 21 pre-existing warnings
- [x] `npm run lint:eslint` — clean
- [x] `npm run format-check` — clean
- [ ] Manual: open setup wizard on beta, complete + abandon flows, verify events land in Plausible
- [ ] Manual: same for recovery wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)