### PR TITLE
feat(be,fe): smtp_request envelope.to is vec, document SmtpRequestError code 550

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -684,7 +684,10 @@ export const idlFactory = ({ IDL }) => {
     }),
   });
   const SmtpAddress = IDL.Record({ 'domain' : IDL.Text, 'user' : IDL.Text });
-  const SmtpEnvelope = IDL.Record({ 'to' : SmtpAddress, 'from' : SmtpAddress });
+  const SmtpEnvelope = IDL.Record({
+    'to' : IDL.Vec(SmtpAddress),
+    'from' : SmtpAddress,
+  });
   const SmtpHeader = IDL.Record({ 'value' : IDL.Text, 'name' : IDL.Text });
   const SmtpMessage = IDL.Record({
     'body' : IDL.Vec(IDL.Nat8),

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1358,7 +1358,16 @@ export interface SignedRRset {
   'rtype' : number,
 }
 export interface SmtpAddress { 'domain' : string, 'user' : string }
-export interface SmtpEnvelope { 'to' : SmtpAddress, 'from' : SmtpAddress }
+export interface SmtpEnvelope {
+  /**
+   * SMTP allows multiple `RCPT TO` recipients per envelope, so this
+   * is a vec. The canister picks the first recognised recipient
+   * (`register@<domain>` or `recover@<domain>`) to decide which flow
+   * to run; unknown recipients in the same vec are ignored.
+   */
+  'to' : Array<SmtpAddress>,
+  'from' : SmtpAddress,
+}
 /**
  * SMTP gateway types — see `internet_identity_interface::smtp`. Carried
  * forward from PoC #3760 surface (the existing gateway can target this
@@ -1374,6 +1383,18 @@ export interface SmtpRequest {
   'message' : [] | [SmtpMessage],
   'gateway_flags' : [] | [Array<string>],
 }
+/**
+ * Error returned by `smtp_request` / `smtp_request_validate`.
+ * 
+ * `code` mirrors the SMTP reply codes the off-chain gateway should
+ * emit upstream:
+ * - `550` (mailbox unavailable) — "No such user here". Returned when
+ * none of the envelope recipients match a mailbox this canister
+ * handles (i.e. neither `register@<domain>` nor `recover@<domain>`,
+ * for any `<domain>` in the deploy's `related_origins`).
+ * - `555` (syntax error) — the request shape itself is malformed
+ * (e.g. missing envelope, oversize address/header/body).
+ */
 export interface SmtpRequestError { 'code' : bigint, 'message' : string }
 export type SmtpResponse = { 'Ok' : {} } |
   { 'Err' : SmtpRequestError };

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1361,11 +1361,16 @@ export interface SmtpAddress { 'domain' : string, 'user' : string }
 export interface SmtpEnvelope {
   /**
    * SMTP allows multiple `RCPT TO` recipients per envelope, so this
-   * is a vec. The canister picks the first recognised recipient
-   * (`register@<domain>` or `recover@<domain>`) to decide which flow
-   * to run; unknown recipients in the same vec are ignored. Capped
-   * at 100 recipients (RFC 5321 §4.5.3.1.10); envelopes exceeding
-   * the cap are rejected with code 555.
+   * is a vec at the wire level. For the recovery flows this canister
+   * serves, however, we require *exactly one* recipient and it must
+   * be `register@<domain>` or `recover@<domain>` — a legitimate
+   * recovery email never targets a CC/BCC alongside us, so any
+   * additional recipient can only come from a phishy forwarder
+   * trying to exfiltrate the user's canister-signed challenge.
+   * Multi-recipient envelopes (and empty ones) are rejected with
+   * code 550. The vec is also capped at 100 entries (RFC 5321
+   * §4.5.3.1.10); envelopes exceeding the cap are rejected with
+   * code 555.
    */
   'to' : Array<SmtpAddress>,
   'from' : SmtpAddress,

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1368,9 +1368,11 @@ export interface SmtpEnvelope {
    * additional recipient can only come from a phishy forwarder
    * trying to exfiltrate the user's canister-signed challenge.
    * Multi-recipient envelopes (and empty ones) are rejected with
-   * code 550. The vec is also capped at 100 entries (RFC 5321
-   * §4.5.3.1.10); envelopes exceeding the cap are rejected with
-   * code 555.
+   * code 551 ("User not local"); single-recipient envelopes whose
+   * recipient isn't one of our reserved mailboxes get 550 ("No
+   * such user here"). The vec is also capped at 100 entries (RFC
+   * 5321 §4.5.3.1.10); envelopes exceeding the cap are rejected
+   * with code 555.
    */
   'to' : Array<SmtpAddress>,
   'from' : SmtpAddress,
@@ -1396,11 +1398,18 @@ export interface SmtpRequest {
  * `code` mirrors the SMTP reply codes the off-chain gateway should
  * emit upstream:
  * - `550` (mailbox unavailable) — "No such user here". Returned when
- * none of the envelope recipients match a mailbox this canister
- * handles (i.e. neither `register@<domain>` nor `recover@<domain>`,
- * for any `<domain>` in the deploy's `related_origins`).
+ * the envelope carries exactly one recipient but it isn't a mailbox
+ * this canister handles (i.e. neither `register@<domain>` nor
+ * `recover@<domain>` for any `<domain>` in `related_origins`).
+ * - `551` (user not local) — envelope-shape rejection. Returned for
+ * empty `to` and for multi-recipient envelopes, even when one of
+ * the recipients is ours. Distinct from 550 so the gateway can tell
+ * "this envelope shape isn't accepted" from "we don't know this
+ * user". Recovery emails never legitimately address a CC/BCC
+ * alongside `register@…` / `recover@…`.
  * - `555` (syntax error) — the request shape itself is malformed
- * (e.g. missing envelope, oversize address/header/body).
+ * (e.g. missing envelope, oversize address/header/body, recipient
+ * list exceeds the 100-entry cap).
  */
 export interface SmtpRequestError { 'code' : bigint, 'message' : string }
 export type SmtpResponse = { 'Ok' : {} } |

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1363,7 +1363,9 @@ export interface SmtpEnvelope {
    * SMTP allows multiple `RCPT TO` recipients per envelope, so this
    * is a vec. The canister picks the first recognised recipient
    * (`register@<domain>` or `recover@<domain>`) to decide which flow
-   * to run; unknown recipients in the same vec are ignored.
+   * to run; unknown recipients in the same vec are ignored. Capped
+   * at 100 recipients (RFC 5321 §4.5.3.1.10); envelopes exceeding
+   * the cap are rejected with code 555.
    */
   'to' : Array<SmtpAddress>,
   'from' : SmtpAddress,
@@ -1599,10 +1601,18 @@ export interface _SERVICE {
    */
   'discovered_oidc_configs' : ActorMethod<[], Array<OidcConfig>>,
   /**
-   * Email-recovery protocol — setup half
-   * ====================================
-   * See `docs/ongoing/email-recovery.md`. The recovery half (prepare
-   * a delegation from a verified email) lands in a follow-up PR.
+   * Email-recovery protocol
+   * =======================
+   * See `docs/ongoing/email-recovery.md`. Covers both flows:
+   * - Setup: prepare_add (authenticated) → smtp_request for
+   * register@id.ai → credential bound to the anchor. Removed
+   * later via credential_remove.
+   * - Recovery: prepare_delegation (anonymous, bound to a
+   * session_key) → smtp_request for recover@id.ai → canister
+   * stamps a signed delegation seed. The FE then calls
+   * email_recovery_get_delegation to retrieve the
+   * SignedDelegation.
+   * Both flows share the polling status query.
    */
   'email_recovery_credential_prepare_add' : ActorMethod<
     [IdentityNumber, EmailRecoveryDnsInput],
@@ -1869,10 +1879,10 @@ export interface _SERVICE {
    * =====================
    * The off-chain SMTP gateway forwards every inbound message via
    * smtp_request. The canister verifies the email cryptographically
-   * and dispatches by recipient (register@id.ai → setup completion).
-   * Always returns Ok — the gateway shouldn't get a per-message
-   * verification signal back. The FE sees outcomes via the polling
-   * status query.
+   * and dispatches by recipient: register@id.ai → setup completion,
+   * recover@id.ai → recovery delegation stamping. Always returns Ok
+   * — the gateway shouldn't get a per-message verification signal
+   * back. The FE sees outcomes via the polling status query.
    */
   'smtp_request' : ActorMethod<[SmtpRequest], SmtpResponse>,
   /**

--- a/src/frontend/tests/e2e-playwright/utils/dkimTestSigner.ts
+++ b/src/frontend/tests/e2e-playwright/utils/dkimTestSigner.ts
@@ -143,7 +143,7 @@ export class TestSigner {
       envelope: [
         {
           from: { user: fromUser, domain: fromDomain },
-          to: { user: toUser, domain: toDomain },
+          to: [{ user: toUser, domain: toDomain }],
         },
       ],
       message: [

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -644,11 +644,16 @@ type SmtpAddress = record {
 type SmtpEnvelope = record {
     from : SmtpAddress;
     // SMTP allows multiple `RCPT TO` recipients per envelope, so this
-    // is a vec. The canister picks the first recognised recipient
-    // (`register@<domain>` or `recover@<domain>`) to decide which flow
-    // to run; unknown recipients in the same vec are ignored. Capped
-    // at 100 recipients (RFC 5321 §4.5.3.1.10); envelopes exceeding
-    // the cap are rejected with code 555.
+    // is a vec at the wire level. For the recovery flows this canister
+    // serves, however, we require *exactly one* recipient and it must
+    // be `register@<domain>` or `recover@<domain>` — a legitimate
+    // recovery email never targets a CC/BCC alongside us, so any
+    // additional recipient can only come from a phishy forwarder
+    // trying to exfiltrate the user's canister-signed challenge.
+    // Multi-recipient envelopes (and empty ones) are rejected with
+    // code 550. The vec is also capped at 100 entries (RFC 5321
+    // §4.5.3.1.10); envelopes exceeding the cap are rejected with
+    // code 555.
     to : vec SmtpAddress;
 };
 

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -651,9 +651,11 @@ type SmtpEnvelope = record {
     // additional recipient can only come from a phishy forwarder
     // trying to exfiltrate the user's canister-signed challenge.
     // Multi-recipient envelopes (and empty ones) are rejected with
-    // code 550. The vec is also capped at 100 entries (RFC 5321
-    // §4.5.3.1.10); envelopes exceeding the cap are rejected with
-    // code 555.
+    // code 551 ("User not local"); single-recipient envelopes whose
+    // recipient isn't one of our reserved mailboxes get 550 ("No
+    // such user here"). The vec is also capped at 100 entries (RFC
+    // 5321 §4.5.3.1.10); envelopes exceeding the cap are rejected
+    // with code 555.
     to : vec SmtpAddress;
 };
 
@@ -668,11 +670,18 @@ type SmtpRequest = record {
 // `code` mirrors the SMTP reply codes the off-chain gateway should
 // emit upstream:
 // - `550` (mailbox unavailable) — "No such user here". Returned when
-//   none of the envelope recipients match a mailbox this canister
-//   handles (i.e. neither `register@<domain>` nor `recover@<domain>`,
-//   for any `<domain>` in the deploy's `related_origins`).
+//   the envelope carries exactly one recipient but it isn't a mailbox
+//   this canister handles (i.e. neither `register@<domain>` nor
+//   `recover@<domain>` for any `<domain>` in `related_origins`).
+// - `551` (user not local) — envelope-shape rejection. Returned for
+//   empty `to` and for multi-recipient envelopes, even when one of
+//   the recipients is ours. Distinct from 550 so the gateway can tell
+//   "this envelope shape isn't accepted" from "we don't know this
+//   user". Recovery emails never legitimately address a CC/BCC
+//   alongside `register@…` / `recover@…`.
 // - `555` (syntax error) — the request shape itself is malformed
-//   (e.g. missing envelope, oversize address/header/body).
+//   (e.g. missing envelope, oversize address/header/body, recipient
+//   list exceeds the 100-entry cap).
 type SmtpRequestError = record {
     code : nat64;
     message : text;

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -643,7 +643,11 @@ type SmtpAddress = record {
 
 type SmtpEnvelope = record {
     from : SmtpAddress;
-    to : SmtpAddress;
+    // SMTP allows multiple `RCPT TO` recipients per envelope, so this
+    // is a vec. The canister picks the first recognised recipient
+    // (`register@<domain>` or `recover@<domain>`) to decide which flow
+    // to run; unknown recipients in the same vec are ignored.
+    to : vec SmtpAddress;
 };
 
 type SmtpRequest = record {
@@ -652,6 +656,16 @@ type SmtpRequest = record {
     gateway_flags : opt vec text;
 };
 
+// Error returned by `smtp_request` / `smtp_request_validate`.
+//
+// `code` mirrors the SMTP reply codes the off-chain gateway should
+// emit upstream:
+// - `550` (mailbox unavailable) — "No such user here". Returned when
+//   none of the envelope recipients match a mailbox this canister
+//   handles (i.e. neither `register@<domain>` nor `recover@<domain>`,
+//   for any `<domain>` in the deploy's `related_origins`).
+// - `555` (syntax error) — the request shape itself is malformed
+//   (e.g. missing envelope, oversize address/header/body).
 type SmtpRequestError = record {
     code : nat64;
     message : text;

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -646,7 +646,9 @@ type SmtpEnvelope = record {
     // SMTP allows multiple `RCPT TO` recipients per envelope, so this
     // is a vec. The canister picks the first recognised recipient
     // (`register@<domain>` or `recover@<domain>`) to decide which flow
-    // to run; unknown recipients in the same vec are ignored.
+    // to run; unknown recipients in the same vec are ignored. Capped
+    // at 100 recipients (RFC 5321 §4.5.3.1.10); envelopes exceeding
+    // the cap are rejected with code 555.
     to : vec SmtpAddress;
 };
 

--- a/src/internet_identity/src/dkim/test_vectors.rs
+++ b/src/internet_identity/src/dkim/test_vectors.rs
@@ -72,10 +72,10 @@ fn parse_eml(raw: &[u8]) -> SmtpRequest {
     SmtpRequest {
         envelope: Some(SmtpEnvelope {
             from,
-            to: SmtpAddress {
+            to: vec![SmtpAddress {
                 user: "recover".into(),
                 domain: "id.ai".into(),
-            },
+            }],
         }),
         message: Some(SmtpMessage {
             headers,

--- a/src/internet_identity/src/dkim/verify.rs
+++ b/src/internet_identity/src/dkim/verify.rs
@@ -617,10 +617,10 @@ mod tests {
                     user: "alice".into(),
                     domain: "example.com".into(),
                 },
-                to: SmtpAddress {
+                to: vec![SmtpAddress {
                     user: "recover".into(),
                     domain: "id.ai".into(),
-                },
+                }],
             }),
             message: Some(SmtpMessage {
                 headers: vec![SmtpHeader {
@@ -658,10 +658,10 @@ mod tests {
                     user: "alice".into(),
                     domain: "example.com".into(),
                 },
-                to: SmtpAddress {
+                to: vec![SmtpAddress {
                     user: "recover".into(),
                     domain: "id.ai".into(),
-                },
+                }],
             }),
             message: Some(SmtpMessage {
                 headers: vec![
@@ -706,10 +706,10 @@ mod tests {
                     user: "alice".into(),
                     domain: "example.com".into(),
                 },
-                to: SmtpAddress {
+                to: vec![SmtpAddress {
                     user: "recover".into(),
                     domain: "id.ai".into(),
-                },
+                }],
             }),
             message: Some(SmtpMessage {
                 headers: vec![
@@ -752,10 +752,10 @@ mod tests {
                     user: "alice".into(),
                     domain: "example.com".into(),
                 },
-                to: SmtpAddress {
+                to: vec![SmtpAddress {
                     user: "recover".into(),
                     domain: "id.ai".into(),
-                },
+                }],
             }),
             message: Some(SmtpMessage {
                 headers: vec![
@@ -798,10 +798,10 @@ mod tests {
                     user: "alice".into(),
                     domain: "example.com".into(),
                 },
-                to: SmtpAddress {
+                to: vec![SmtpAddress {
                     user: "recover".into(),
                     domain: "id.ai".into(),
-                },
+                }],
             }),
             message: Some(SmtpMessage {
                 headers: vec![
@@ -850,10 +850,10 @@ mod tests {
                     user: "alice".into(),
                     domain: "example.com".into(),
                 },
-                to: SmtpAddress {
+                to: vec![SmtpAddress {
                     user: "recover".into(),
                     domain: "id.ai".into(),
-                },
+                }],
             }),
             message: Some(SmtpMessage {
                 headers: vec![
@@ -911,10 +911,10 @@ mod tests {
                     user: "alice".into(),
                     domain: "example.com".into(),
                 },
-                to: SmtpAddress {
+                to: vec![SmtpAddress {
                     user: "recover".into(),
                     domain: "id.ai".into(),
-                },
+                }],
             }),
             message: Some(SmtpMessage {
                 headers: vec![

--- a/src/internet_identity/src/dmarc/test_vectors.rs
+++ b/src/internet_identity/src/dmarc/test_vectors.rs
@@ -101,10 +101,10 @@ fn parse_eml(raw: &[u8]) -> SmtpRequest {
                 user: "alice".into(),
                 domain: "test.example.com".into(),
             },
-            to: SmtpAddress {
+            to: vec![SmtpAddress {
                 user: "recover".into(),
                 domain: "id.ai".into(),
-            },
+            }],
         }),
         message: Some(SmtpMessage {
             headers,

--- a/src/internet_identity/src/dmarc/verify.rs
+++ b/src/internet_identity/src/dmarc/verify.rs
@@ -148,10 +148,10 @@ mod tests {
                     user: "alice".into(),
                     domain: "example.com".into(),
                 },
-                to: SmtpAddress {
+                to: vec![SmtpAddress {
                     user: "recover".into(),
                     domain: "id.ai".into(),
-                },
+                }],
             }),
             message: Some(SmtpMessage {
                 headers: vec![

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -20,6 +20,14 @@
 //! and surfaces as one. (Per-pending-challenge state, by contrast,
 //! is per-user and stays behind a silent drop further down.)
 //!
+//! Envelopes that don't carry exactly one recipient (empty `to`, or
+//! multi-recipient) are rejected with 551 ("User not local") instead
+//! — distinct from 550 so the gateway can tell envelope-shape
+//! problems from per-recipient ones. Recovery emails never legitimately
+//! address a CC/BCC alongside `register@…` / `recover@…`, so accepting
+//! a multi-recipient envelope would let an attacker BCC themselves a
+//! copy of the user's canister-signed challenge nonce.
+//!
 //! The verification pipeline forks by path:
 //!
 //! - **DoH path** (no DNSSEC chain cached at prepare time): fetch
@@ -56,7 +64,7 @@ use internet_identity_interface::internet_identity::types::email_recovery::{
 };
 use internet_identity_interface::internet_identity::types::smtp::{
     smtp_err, validate_smtp_request, SmtpRequest, SmtpResponse, SMTP_ERR_MAILBOX_UNAVAILABLE,
-    SMTP_ERR_SYNTAX_ERROR,
+    SMTP_ERR_SYNTAX_ERROR, SMTP_ERR_USER_NOT_LOCAL,
 };
 use internet_identity_interface::internet_identity::types::{AnchorNumber, SessionKey};
 
@@ -99,15 +107,19 @@ fn recipient_matches(
 /// for some `d` in [`super::mailbox_domains`] — i.e. for any host
 /// listed in the `related_origins` deploy arg. On prod that's
 /// typically `id.ai` plus the `*.icp0.io` aliases; on beta it's
-/// `beta.id.ai`. Everything else gets a 550 ("No such user here") so
-/// the gateway bounces upstream.
+/// `beta.id.ai`.
 ///
-/// Multi-recipient envelopes addressed (in part) to one of the
-/// recovery mailboxes are rejected too: a legitimate recovery email
-/// only ever targets `register@…` / `recover@…`, so additional
-/// recipients alongside ours can only come from a phishy forwarder
-/// — accepting them would let an attacker BCC themselves a copy of
-/// the user's canister-signed challenge nonce.
+/// Two distinct rejection codes, so the gateway can tell envelope-
+/// shape problems apart from per-recipient ones:
+/// - **551** ("User not local") — envelope doesn't carry exactly one
+///   recipient. Multi-recipient envelopes are refused even when one
+///   of the recipients is ours: a legitimate recovery email only
+///   ever targets `register@…` / `recover@…`, so additional CCs/BCCs
+///   alongside ours can only come from a phishy forwarder trying to
+///   exfiltrate the user's canister-signed challenge nonce. Empty
+///   `to` is in the same bucket.
+/// - **550** ("Mailbox unavailable" / "No such user here") — single
+///   recipient, but not one of our reserved mailboxes.
 ///
 /// The query is open — anyone can call it — but it has no side
 /// effects and leaks nothing beyond the deploy arg, which is already
@@ -124,7 +136,7 @@ pub fn handle_smtp_request_validate(request: SmtpRequest) -> SmtpResponse {
         Some(to) => to,
         None => {
             return smtp_err(
-                SMTP_ERR_MAILBOX_UNAVAILABLE,
+                SMTP_ERR_USER_NOT_LOCAL,
                 "Recovery emails must have exactly one recipient",
             );
         }
@@ -153,7 +165,9 @@ fn single_recipient(
 }
 
 /// Outcome the canister method in `main.rs` returns to the gateway.
-/// Returns `Err(550)` for an unknown recipient, `Err(555)` for a
+/// Returns `Err(551)` for an envelope that doesn't carry exactly one
+/// recipient, `Err(550)` for a single-recipient envelope whose
+/// recipient isn't one of our reserved mailboxes, `Err(555)` for a
 /// malformed request shape, and `Ok` for *verification* outcomes —
 /// see the module-level note on why we don't surface per-message
 /// verification failures.
@@ -180,8 +194,10 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     // can only come from a phishy forwarder — a legitimate recovery
     // email never targets a CC/BCC alongside `register@…` /
     // `recover@…`, so accepting one would let an attacker exfiltrate
-    // the user's canister-signed challenge nonce. Reject with 550 to
-    // mirror what `smtp_request_validate` says at RCPT TO time.
+    // the user's canister-signed challenge nonce. Reject with 551
+    // ("User not local") to mirror what `smtp_request_validate`
+    // says at RCPT TO time; 550 is reserved for the single-recipient
+    // "unknown mailbox" case so the gateway can tell the two apart.
     let envelope = match request.envelope.as_ref() {
         Some(e) => e,
         None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
@@ -190,7 +206,7 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         Some(to) => to,
         None => {
             return smtp_err(
-                SMTP_ERR_MAILBOX_UNAVAILABLE,
+                SMTP_ERR_USER_NOT_LOCAL,
                 "Recovery emails must have exactly one recipient",
             );
         }
@@ -1314,14 +1330,16 @@ mod tests {
         // `recover@…` mailbox. Additional recipients alongside one of
         // ours can only come from a phishy forwarder trying to BCC
         // itself a copy of the user's canister-signed challenge
-        // nonce — refuse the SMTP transaction outright.
+        // nonce — refuse the SMTP transaction outright with 551
+        // ("User not local"), which the gateway can tell apart from
+        // the per-recipient 550.
         set_related_origins(&["https://id.ai"]);
         assert_smtp_err_code(
             handle_smtp_request_validate(smtp_envelope_with_recipients(&[
                 ("register", "id.ai"),
                 ("someone-else", "example.com"),
             ])),
-            SMTP_ERR_MAILBOX_UNAVAILABLE,
+            SMTP_ERR_USER_NOT_LOCAL,
         );
     }
 
@@ -1329,27 +1347,28 @@ mod tests {
     fn validate_rejects_multi_recipient_even_when_all_unknown() {
         // Belt and suspenders: the single-recipient rule fires before
         // the per-recipient match, so multiple unknown recipients
-        // bounce with the same 550 (not a different syntax-level
-        // error). Keeps the response surface predictable for the
-        // gateway.
+        // bounce with the same 551 the mixed case gets — *not* the
+        // 550 we'd return for a single unknown recipient. Keeps the
+        // response surface predictable for the gateway.
         set_related_origins(&["https://id.ai"]);
         assert_smtp_err_code(
             handle_smtp_request_validate(smtp_envelope_with_recipients(&[
                 ("someone-else", "example.com"),
                 ("alice", "id.ai"),
             ])),
-            SMTP_ERR_MAILBOX_UNAVAILABLE,
+            SMTP_ERR_USER_NOT_LOCAL,
         );
     }
 
     #[test]
     fn validate_rejects_empty_recipient_list() {
         // An envelope with no recipients can't address anyone on this
-        // canister — same 550 as the multi-recipient case.
+        // canister — same 551 as the multi-recipient case (the
+        // single-recipient rule also fires on `to.len() == 0`).
         set_related_origins(&["https://id.ai"]);
         assert_smtp_err_code(
             handle_smtp_request_validate(smtp_envelope_with_recipients(&[])),
-            SMTP_ERR_MAILBOX_UNAVAILABLE,
+            SMTP_ERR_USER_NOT_LOCAL,
         );
     }
 }

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -94,20 +94,21 @@ fn recipient_matches(
 /// the message body from the sending MTA — to decide whether to
 /// accept the connection at all.
 ///
-/// An SMTP envelope may carry multiple `RCPT TO` recipients (the
-/// gateway can batch them into one canister call). We accept the
-/// transaction if *at least one* recipient names a mailbox we handle;
-/// the [`handle_smtp_request`] dispatcher ignores the rest. If *no*
-/// recipient is recognised we answer 550 (mailbox unavailable, "No
-/// such user here") so the gateway can bounce upstream rather than
-/// pull the body and have us silently drop it — which would waste the
-/// sender's bandwidth and give the sender's MTA no SMTP-level signal
-/// that the address is invalid.
+/// Accepts an envelope iff it carries *exactly one* recipient and
+/// that recipient is `register@<d>` or `recover@<d>` (case-insensitive)
+/// for some `d` in [`super::mailbox_domains`] — i.e. for any host
+/// listed in the `related_origins` deploy arg. On prod that's
+/// typically `id.ai` plus the `*.icp0.io` aliases; on beta it's
+/// `beta.id.ai`. Everything else gets a 550 ("No such user here") so
+/// the gateway bounces upstream.
 ///
-/// Accepts `register@<d>` and `recover@<d>` (case-insensitive) for
-/// any `d` in [`super::mailbox_domains`] — i.e. for any host listed
-/// in the `related_origins` deploy arg. On prod that's typically
-/// `id.ai` plus the `*.icp0.io` aliases; on beta it's `beta.id.ai`.
+/// Multi-recipient envelopes addressed (in part) to one of the
+/// recovery mailboxes are rejected too: a legitimate recovery email
+/// only ever targets `register@…` / `recover@…`, so additional
+/// recipients alongside ours can only come from a phishy forwarder
+/// — accepting them would let an attacker BCC themselves a copy of
+/// the user's canister-signed challenge nonce.
+///
 /// The query is open — anyone can call it — but it has no side
 /// effects and leaks nothing beyond the deploy arg, which is already
 /// public.
@@ -119,23 +120,36 @@ pub fn handle_smtp_request_validate(request: SmtpRequest) -> SmtpResponse {
         Some(e) => e,
         None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
     };
-    // The gateway may batch multiple `RCPT TO` recipients into a
-    // single envelope. Accept the transaction if at least one
-    // recipient names a mailbox this canister handles — the
-    // dispatcher in `handle_smtp_request` ignores the rest. If none
-    // match, answer 550 ("No such user here") so the gateway bounces
-    // upstream rather than wasting bandwidth pulling the body.
-    let any_known = envelope.to.iter().any(|to| {
-        recipient_matches(to, SETUP_RECIPIENT_USER)
-            || recipient_matches(to, RECOVERY_RECIPIENT_USER)
-    });
-    if any_known {
+    let to = match single_recipient(envelope) {
+        Some(to) => to,
+        None => {
+            return smtp_err(
+                SMTP_ERR_MAILBOX_UNAVAILABLE,
+                "Recovery emails must have exactly one recipient",
+            );
+        }
+    };
+    if recipient_matches(to, SETUP_RECIPIENT_USER) || recipient_matches(to, RECOVERY_RECIPIENT_USER)
+    {
         return SmtpResponse::Ok {};
     }
     smtp_err(
         SMTP_ERR_MAILBOX_UNAVAILABLE,
         "Recipient is not a known mailbox on this canister",
     )
+}
+
+/// Return the sole recipient of `envelope` if there is exactly one,
+/// or `None` if the envelope is empty or carries more than one
+/// recipient. Multi-recipient envelopes don't fit the recovery flows
+/// (see [`handle_smtp_request_validate`] for the threat-model note).
+fn single_recipient(
+    envelope: &internet_identity_interface::internet_identity::types::smtp::SmtpEnvelope,
+) -> Option<&internet_identity_interface::internet_identity::types::smtp::SmtpAddress> {
+    if envelope.to.len() != 1 {
+        return None;
+    }
+    envelope.to.first()
 }
 
 /// Outcome the canister method in `main.rs` returns to the gateway.
@@ -161,39 +175,42 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     // can't bypass dispatch by spoofing just the user-part with a
     // different domain — `smtp_request` is an open update.
     //
-    // An SMTP envelope may carry multiple `RCPT TO` recipients (e.g.
-    // the gateway batched a multi-recipient transaction). We pick the
-    // *first* one that names a mailbox we handle and ignore the rest;
-    // unknown recipients alongside a known one don't taint the dispatch.
+    // We require *exactly one* recipient on the envelope. Multi-
+    // recipient envelopes addressed (in part) to a recovery mailbox
+    // can only come from a phishy forwarder — a legitimate recovery
+    // email never targets a CC/BCC alongside `register@…` /
+    // `recover@…`, so accepting one would let an attacker exfiltrate
+    // the user's canister-signed challenge nonce. Reject with 550 to
+    // mirror what `smtp_request_validate` says at RCPT TO time.
     let envelope = match request.envelope.as_ref() {
         Some(e) => e,
         None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
     };
-    let recipient_flow = envelope.to.iter().find_map(|to| {
-        if recipient_matches(to, SETUP_RECIPIENT_USER) {
-            Some(RecipientFlow::Setup)
-        } else if recipient_matches(to, RECOVERY_RECIPIENT_USER) {
-            Some(RecipientFlow::Recovery)
-        } else {
-            None
-        }
-    });
-    let recipient_flow = match recipient_flow {
-        Some(flow) => flow,
+    let to = match single_recipient(envelope) {
+        Some(to) => to,
         None => {
-            // Unknown recipient → 550 ("No such user here"). The set
-            // of mailboxes we handle is in the public Candid surface,
-            // so there's no secret to hide and a sender targeting any
-            // other mailbox is a caller error that deserves an
-            // SMTP-level signal. `smtp_request_validate` already
-            // returns the same 550 at RCPT TO time; mirroring it on
-            // the update path closes the gap for callers that skipped
-            // validate (or hit this method directly).
             return smtp_err(
                 SMTP_ERR_MAILBOX_UNAVAILABLE,
-                "Recipient is not a known mailbox on this canister",
+                "Recovery emails must have exactly one recipient",
             );
         }
+    };
+    let recipient_flow = if recipient_matches(to, SETUP_RECIPIENT_USER) {
+        RecipientFlow::Setup
+    } else if recipient_matches(to, RECOVERY_RECIPIENT_USER) {
+        RecipientFlow::Recovery
+    } else {
+        // Unknown recipient → 550 ("No such user here"). The set of
+        // mailboxes we handle is in the public Candid surface, so
+        // there's no secret to hide and a sender targeting any other
+        // mailbox is a caller error that deserves an SMTP-level
+        // signal. Mirrors what `smtp_request_validate` returns at
+        // RCPT TO time so callers that skipped validate (or hit this
+        // method directly) get the same answer.
+        return smtp_err(
+            SMTP_ERR_MAILBOX_UNAVAILABLE,
+            "Recipient is not a known mailbox on this canister",
+        );
     };
 
     let message = match request.message.as_ref() {
@@ -1292,18 +1309,29 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_when_one_of_many_recipients_known() {
-        // The gateway may batch multiple RCPT TOs into one envelope.
-        // As long as at least one names a mailbox we handle, accept
-        // the transaction — the dispatcher ignores the rest.
+    fn validate_rejects_multi_recipient_envelope_even_when_one_is_known() {
+        // Recovery emails only ever target a single `register@…` /
+        // `recover@…` mailbox. Additional recipients alongside one of
+        // ours can only come from a phishy forwarder trying to BCC
+        // itself a copy of the user's canister-signed challenge
+        // nonce — refuse the SMTP transaction outright.
         set_related_origins(&["https://id.ai"]);
-        assert_smtp_ok(handle_smtp_request_validate(smtp_envelope_with_recipients(
-            &[("someone-else", "example.com"), ("register", "id.ai")],
-        )));
+        assert_smtp_err_code(
+            handle_smtp_request_validate(smtp_envelope_with_recipients(&[
+                ("register", "id.ai"),
+                ("someone-else", "example.com"),
+            ])),
+            SMTP_ERR_MAILBOX_UNAVAILABLE,
+        );
     }
 
     #[test]
-    fn validate_rejects_when_no_recipients_known() {
+    fn validate_rejects_multi_recipient_even_when_all_unknown() {
+        // Belt and suspenders: the single-recipient rule fires before
+        // the per-recipient match, so multiple unknown recipients
+        // bounce with the same 550 (not a different syntax-level
+        // error). Keeps the response surface predictable for the
+        // gateway.
         set_related_origins(&["https://id.ai"]);
         assert_smtp_err_code(
             handle_smtp_request_validate(smtp_envelope_with_recipients(&[
@@ -1317,7 +1345,7 @@ mod tests {
     #[test]
     fn validate_rejects_empty_recipient_list() {
         // An envelope with no recipients can't address anyone on this
-        // canister — same 550 as an unknown recipient.
+        // canister — same 550 as the multi-recipient case.
         set_related_origins(&["https://id.ai"]);
         assert_smtp_err_code(
             handle_smtp_request_validate(smtp_envelope_with_recipients(&[])),

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -94,20 +94,23 @@ fn recipient_matches(
 /// the message body from the sending MTA — to decide whether to
 /// accept the connection at all.
 ///
-/// We must answer here with a 5xx for any recipient we don't intend
-/// to handle, otherwise the gateway will accept the message, pull
-/// the body, and forward it to `smtp_request` (where we'd silently
-/// drop it). That wastes the sender's bandwidth and, more
-/// importantly, gives no SMTP-level signal that the address is
-/// invalid — the sender's MTA never sees a bounce.
+/// An SMTP envelope may carry multiple `RCPT TO` recipients (the
+/// gateway can batch them into one canister call). We accept the
+/// transaction if *at least one* recipient names a mailbox we handle;
+/// the [`handle_smtp_request`] dispatcher ignores the rest. If *no*
+/// recipient is recognised we answer 550 (mailbox unavailable, "No
+/// such user here") so the gateway can bounce upstream rather than
+/// pull the body and have us silently drop it — which would waste the
+/// sender's bandwidth and give the sender's MTA no SMTP-level signal
+/// that the address is invalid.
 ///
 /// Accepts `register@<d>` and `recover@<d>` (case-insensitive) for
 /// any `d` in [`super::mailbox_domains`] — i.e. for any host listed
 /// in the `related_origins` deploy arg. On prod that's typically
 /// `id.ai` plus the `*.icp0.io` aliases; on beta it's `beta.id.ai`.
-/// Everything else gets a 550 (mailbox unavailable). The query is
-/// open — anyone can call it — but it has no side effects and
-/// leaks nothing beyond the deploy arg, which is already public.
+/// The query is open — anyone can call it — but it has no side
+/// effects and leaks nothing beyond the deploy arg, which is already
+/// public.
 pub fn handle_smtp_request_validate(request: SmtpRequest) -> SmtpResponse {
     if let Err(e) = validate_smtp_request(&request) {
         return e;

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -116,9 +116,17 @@ pub fn handle_smtp_request_validate(request: SmtpRequest) -> SmtpResponse {
         Some(e) => e,
         None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
     };
-    let to = &envelope.to;
-    if recipient_matches(to, SETUP_RECIPIENT_USER) || recipient_matches(to, RECOVERY_RECIPIENT_USER)
-    {
+    // The gateway may batch multiple `RCPT TO` recipients into a
+    // single envelope. Accept the transaction if at least one
+    // recipient names a mailbox this canister handles — the
+    // dispatcher in `handle_smtp_request` ignores the rest. If none
+    // match, answer 550 ("No such user here") so the gateway bounces
+    // upstream rather than wasting bandwidth pulling the body.
+    let any_known = envelope.to.iter().any(|to| {
+        recipient_matches(to, SETUP_RECIPIENT_USER)
+            || recipient_matches(to, RECOVERY_RECIPIENT_USER)
+    });
+    if any_known {
         return SmtpResponse::Ok {};
     }
     smtp_err(
@@ -149,27 +157,40 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     // address (user + domain), case-insensitively, so a direct caller
     // can't bypass dispatch by spoofing just the user-part with a
     // different domain — `smtp_request` is an open update.
+    //
+    // An SMTP envelope may carry multiple `RCPT TO` recipients (e.g.
+    // the gateway batched a multi-recipient transaction). We pick the
+    // *first* one that names a mailbox we handle and ignore the rest;
+    // unknown recipients alongside a known one don't taint the dispatch.
     let envelope = match request.envelope.as_ref() {
         Some(e) => e,
         None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
     };
-    let recipient_flow = if recipient_matches(&envelope.to, SETUP_RECIPIENT_USER) {
-        RecipientFlow::Setup
-    } else if recipient_matches(&envelope.to, RECOVERY_RECIPIENT_USER) {
-        RecipientFlow::Recovery
-    } else {
-        // Unknown recipient → 550 ("No such user here"). The set of
-        // mailboxes we handle is in the public Candid surface, so
-        // there's no secret to hide and a sender targeting any other
-        // mailbox is a caller error that deserves an SMTP-level
-        // signal. `smtp_request_validate` already returns the same
-        // 550 at RCPT TO time; mirroring it on the update path
-        // closes the gap for callers that skipped validate (or hit
-        // this method directly).
-        return smtp_err(
-            SMTP_ERR_MAILBOX_UNAVAILABLE,
-            "Recipient is not a known mailbox on this canister",
-        );
+    let recipient_flow = envelope.to.iter().find_map(|to| {
+        if recipient_matches(to, SETUP_RECIPIENT_USER) {
+            Some(RecipientFlow::Setup)
+        } else if recipient_matches(to, RECOVERY_RECIPIENT_USER) {
+            Some(RecipientFlow::Recovery)
+        } else {
+            None
+        }
+    });
+    let recipient_flow = match recipient_flow {
+        Some(flow) => flow,
+        None => {
+            // Unknown recipient → 550 ("No such user here"). The set
+            // of mailboxes we handle is in the public Candid surface,
+            // so there's no secret to hide and a sender targeting any
+            // other mailbox is a caller error that deserves an
+            // SMTP-level signal. `smtp_request_validate` already
+            // returns the same 550 at RCPT TO time; mirroring it on
+            // the update path closes the gap for callers that skipped
+            // validate (or hit this method directly).
+            return smtp_err(
+                SMTP_ERR_MAILBOX_UNAVAILABLE,
+                "Recipient is not a known mailbox on this canister",
+            );
+        }
     };
 
     let message = match request.message.as_ref() {
@@ -961,6 +982,10 @@ mod tests {
     }
 
     fn smtp_envelope(user: &str, domain: &str) -> SmtpRequest {
+        smtp_envelope_with_recipients(&[(user, domain)])
+    }
+
+    fn smtp_envelope_with_recipients(recipients: &[(&str, &str)]) -> SmtpRequest {
         use internet_identity_interface::internet_identity::types::smtp::{
             SmtpAddress, SmtpEnvelope,
         };
@@ -970,10 +995,13 @@ mod tests {
                     user: "sender".into(),
                     domain: "example.com".into(),
                 },
-                to: SmtpAddress {
-                    user: user.into(),
-                    domain: domain.into(),
-                },
+                to: recipients
+                    .iter()
+                    .map(|(u, d)| SmtpAddress {
+                        user: (*u).into(),
+                        domain: (*d).into(),
+                    })
+                    .collect(),
             }),
             message: None,
             gateway_flags: None,
@@ -1156,10 +1184,10 @@ mod tests {
                     user: "alice".into(),
                     domain: "example.com".into(),
                 },
-                to: SmtpAddress {
+                to: vec![SmtpAddress {
                     user: "register".into(),
                     domain: "id.ai".into(),
-                },
+                }],
             }),
             message: Some(SmtpMessage {
                 headers: vec![
@@ -1258,5 +1286,39 @@ mod tests {
             prepare_partial_verification(&req, &snap, TEST_NOW),
             Err(EmailRecoveryError::SubjectNotSigned)
         ));
+    }
+
+    #[test]
+    fn validate_accepts_when_one_of_many_recipients_known() {
+        // The gateway may batch multiple RCPT TOs into one envelope.
+        // As long as at least one names a mailbox we handle, accept
+        // the transaction — the dispatcher ignores the rest.
+        set_related_origins(&["https://id.ai"]);
+        assert_smtp_ok(handle_smtp_request_validate(smtp_envelope_with_recipients(
+            &[("someone-else", "example.com"), ("register", "id.ai")],
+        )));
+    }
+
+    #[test]
+    fn validate_rejects_when_no_recipients_known() {
+        set_related_origins(&["https://id.ai"]);
+        assert_smtp_err_code(
+            handle_smtp_request_validate(smtp_envelope_with_recipients(&[
+                ("someone-else", "example.com"),
+                ("alice", "id.ai"),
+            ])),
+            SMTP_ERR_MAILBOX_UNAVAILABLE,
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_recipient_list() {
+        // An envelope with no recipients can't address anyone on this
+        // canister — same 550 as an unknown recipient.
+        set_related_origins(&["https://id.ai"]);
+        assert_smtp_err_code(
+            handle_smtp_request_validate(smtp_envelope_with_recipients(&[])),
+            SMTP_ERR_MAILBOX_UNAVAILABLE,
+        );
     }
 }

--- a/src/internet_identity/tests/integration/email_recovery.rs
+++ b/src/internet_identity/tests/integration/email_recovery.rs
@@ -243,10 +243,10 @@ fn smtp_request_silently_drops_email_with_no_nonce_in_subject() {
                 user: "alice".into(),
                 domain: TEST_DOMAIN.into(),
             },
-            to: SmtpAddress {
+            to: vec![SmtpAddress {
                 user: "register".into(),
                 domain: "id.ai".into(),
-            },
+            }],
         }),
         message: Some(SmtpMessage {
             headers: vec![
@@ -282,10 +282,10 @@ fn smtp_request_silently_drops_email_with_unknown_nonce() {
                 user: "alice".into(),
                 domain: TEST_DOMAIN.into(),
             },
-            to: SmtpAddress {
+            to: vec![SmtpAddress {
                 user: "register".into(),
                 domain: "id.ai".into(),
-            },
+            }],
         }),
         message: Some(SmtpMessage {
             headers: vec![
@@ -329,10 +329,10 @@ fn smtp_request_rejects_emails_addressed_to_unknown_recipients_with_550() {
                 user: "alice".into(),
                 domain: TEST_DOMAIN.into(),
             },
-            to: SmtpAddress {
+            to: vec![SmtpAddress {
                 user: "marketing".into(),
                 domain: "id.ai".into(),
-            },
+            }],
         }),
         message: Some(SmtpMessage {
             headers: vec![
@@ -1059,10 +1059,10 @@ mod dkim_signer {
                         user: from_user.into(),
                         domain: from_domain.into(),
                     },
-                    to: SmtpAddress {
+                    to: vec![SmtpAddress {
                         user: to_user.into(),
                         domain: to_domain.into(),
-                    },
+                    }],
                 }),
                 message: Some(SmtpMessage {
                     headers: vec![

--- a/src/internet_identity_interface/src/internet_identity/types/smtp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/smtp.rs
@@ -45,7 +45,22 @@ pub const MAX_RECIPIENTS: usize = 100;
 
 // --- SMTP error codes (RFC 5321) ---
 
+/// 550 — "Requested action not taken: mailbox unavailable" (RFC 5321
+/// §4.2.2). Used here for the "No such user here" case: the envelope
+/// has exactly one recipient but it's not a mailbox this canister
+/// handles (`register@<d>` / `recover@<d>`).
 pub const SMTP_ERR_MAILBOX_UNAVAILABLE: u64 = 550;
+/// 551 — "User not local; please try `<forward-path>`" (RFC 5321
+/// §4.2.2). Used here for envelopes whose **shape** doesn't fit the
+/// recovery flows we serve: an envelope must carry exactly one
+/// recipient, so empty-`to` and multi-recipient envelopes get 551
+/// (a distinct code from 550 so the gateway can tell "we don't know
+/// this user" from "this envelope shape isn't accepted for us").
+pub const SMTP_ERR_USER_NOT_LOCAL: u64 = 551;
+/// 555 — "Syntax error" (RFC 5321 §4.2.2). Used here for malformed
+/// request payloads (missing envelope, bounds violations on
+/// address/header/body lengths, or recipient lists that blow past
+/// `MAX_RECIPIENTS`).
 pub const SMTP_ERR_SYNTAX_ERROR: u64 = 555;
 
 // --- Candid wire types ---

--- a/src/internet_identity_interface/src/internet_identity/types/smtp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/smtp.rs
@@ -31,6 +31,17 @@ pub const MAX_BODY_BYTES: usize = 5_000;
 pub const MAX_HEADERS: usize = 30;
 pub const MAX_HEADER_NAME_BYTES: usize = 256;
 pub const MAX_HEADER_VALUE_BYTES: usize = 8_192;
+/// Cap on `envelope.to` length. `smtp_request` and
+/// `smtp_request_validate` are both open (anyone can call them), so
+/// without an explicit upper bound an attacker could pad the
+/// recipient list out to the ingress size limit and force per-message
+/// allocation + per-recipient case-insensitive dispatch on every
+/// call. RFC 5321 §4.5.3.1 caps a single SMTP session at 100
+/// recipients, which is far more than the gateway will ever batch in
+/// practice (the canister only handles two reserved mailboxes), so
+/// using the RFC ceiling here just kicks the obvious adversarial case
+/// out without constraining any legitimate gateway flow.
+pub const MAX_RECIPIENTS: usize = 100;
 
 // --- SMTP error codes (RFC 5321) ---
 
@@ -148,6 +159,15 @@ pub fn validate_address_bounds(addr: &SmtpAddress, label: &str) -> Result<(), Sm
 
 pub fn validate_envelope(envelope: &SmtpEnvelope) -> Result<(), SmtpResponse> {
     validate_address_bounds(&envelope.from, "Sender")?;
+    if envelope.to.len() > MAX_RECIPIENTS {
+        return Err(smtp_err(
+            SMTP_ERR_SYNTAX_ERROR,
+            format!(
+                "Too many recipients: {} (max {MAX_RECIPIENTS})",
+                envelope.to.len()
+            ),
+        ));
+    }
     for to in &envelope.to {
         validate_address_bounds(to, "Recipient")?;
     }
@@ -301,6 +321,35 @@ mod tests {
         let resp = validate_envelope(&env).unwrap_err();
         assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
         assert!(err_msg(&resp).contains("Recipient user"));
+    }
+
+    #[test]
+    fn validate_envelope_rejects_too_many_recipients() {
+        // `smtp_request` is open; without a cap an attacker could pad
+        // the recipient list out to the ingress size limit. The bound
+        // here keeps worst-case validation/dispatch costs bounded.
+        let env = SmtpEnvelope {
+            from: addr("ok", "ok.com"),
+            to: (0..(MAX_RECIPIENTS + 1))
+                .map(|_| addr("recover", "id.ai"))
+                .collect(),
+        };
+        let resp = validate_envelope(&env).unwrap_err();
+        assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
+        assert!(err_msg(&resp).contains("Too many recipients"));
+    }
+
+    #[test]
+    fn validate_envelope_accepts_max_recipients() {
+        // Exactly at the cap must still pass — defines the inclusive
+        // upper bound.
+        let env = SmtpEnvelope {
+            from: addr("ok", "ok.com"),
+            to: (0..MAX_RECIPIENTS)
+                .map(|_| addr("recover", "id.ai"))
+                .collect(),
+        };
+        assert!(validate_envelope(&env).is_ok());
     }
 
     #[test]

--- a/src/internet_identity_interface/src/internet_identity/types/smtp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/smtp.rs
@@ -60,7 +60,14 @@ pub struct SmtpAddress {
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct SmtpEnvelope {
     pub from: SmtpAddress,
-    pub to: SmtpAddress,
+    /// SMTP allows multiple `RCPT TO` recipients per envelope, so this
+    /// is a `Vec`. The canister-side dispatcher picks the first
+    /// recognised recipient to decide which flow to run; unknown
+    /// recipients in the same vec are ignored. The wire-level
+    /// `smtp_request_validate` query refuses the SMTP transaction
+    /// (550 — "No such user here") only when *no* recipient is
+    /// recognised, mirroring how `RCPT TO` interacts with the gateway.
+    pub to: Vec<SmtpAddress>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -141,7 +148,9 @@ pub fn validate_address_bounds(addr: &SmtpAddress, label: &str) -> Result<(), Sm
 
 pub fn validate_envelope(envelope: &SmtpEnvelope) -> Result<(), SmtpResponse> {
     validate_address_bounds(&envelope.from, "Sender")?;
-    validate_address_bounds(&envelope.to, "Recipient")?;
+    for to in &envelope.to {
+        validate_address_bounds(to, "Recipient")?;
+    }
     Ok(())
 }
 
@@ -260,7 +269,7 @@ mod tests {
     fn validate_envelope_rejects_oversized_user() {
         let env = SmtpEnvelope {
             from: addr(&"x".repeat(MAX_EMAIL_USER_BYTES + 1), "ok.com"),
-            to: addr("a", "ok.com"),
+            to: vec![addr("a", "ok.com")],
         };
         let resp = validate_envelope(&env).unwrap_err();
         assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
@@ -271,10 +280,40 @@ mod tests {
     fn validate_envelope_rejects_oversized_domain() {
         let env = SmtpEnvelope {
             from: addr("ok", "ok.com"),
-            to: addr("a", &"d".repeat(MAX_EMAIL_DOMAIN_BYTES + 1)),
+            to: vec![addr("a", &"d".repeat(MAX_EMAIL_DOMAIN_BYTES + 1))],
         };
         let resp = validate_envelope(&env).unwrap_err();
         assert!(err_msg(&resp).contains("Recipient domain"));
+    }
+
+    #[test]
+    fn validate_envelope_rejects_any_oversized_recipient() {
+        // Bounds checking must run over every recipient in the vec —
+        // not just the first — otherwise a malformed RCPT TO further
+        // down the list could slip past.
+        let env = SmtpEnvelope {
+            from: addr("ok", "ok.com"),
+            to: vec![
+                addr("recover", "id.ai"),
+                addr(&"x".repeat(MAX_EMAIL_USER_BYTES + 1), "ok.com"),
+            ],
+        };
+        let resp = validate_envelope(&env).unwrap_err();
+        assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
+        assert!(err_msg(&resp).contains("Recipient user"));
+    }
+
+    #[test]
+    fn validate_envelope_accepts_empty_to_vec() {
+        // Bounds-only check: an empty `to` vec is shape-valid here.
+        // The recipient-dispatch logic in `email_recovery::smtp`
+        // separately rejects "no known recipient" with 550 — that
+        // semantic isn't this helper's job.
+        let env = SmtpEnvelope {
+            from: addr("ok", "ok.com"),
+            to: vec![],
+        };
+        assert!(validate_envelope(&env).is_ok());
     }
 
     #[test]
@@ -319,7 +358,7 @@ mod tests {
         let req = SmtpRequest {
             envelope: Some(SmtpEnvelope {
                 from: addr("alice", "gmail.com"),
-                to: addr("recover", "id.ai"),
+                to: vec![addr("recover", "id.ai")],
             }),
             message: None,
             gateway_flags: None,


### PR DESCRIPTION
The off-chain SMTP gateway forwards every inbound message to `smtp_request(SmtpRequest)`. The Candid type modelled `Envelope.to` as a single `SmtpAddress`, but SMTP allows a `MAIL FROM` to be followed by multiple `RCPT TO`s and the gateway has no good way to surface that to the canister today. Bring the wire type in line with the protocol, and tighten the canister's recipient policy so the new flexibility doesn't open a phishing door.

# Changes

- `Envelope.to` is now `vec SmtpAddress` (Candid + Rust + regenerated FE bindings).
- `smtp_request` and `smtp_request_validate` accept an envelope iff it carries **exactly one** recipient and that recipient is `register@<d>` or `recover@<d>` for some `d` in `related_origins`. Multi-recipient (and empty) envelopes are rejected with **550** — a legitimate recovery email never targets a CC/BCC alongside our reserved mailbox, so accepting one would let an attacker exfiltrate the user's canister-signed challenge nonce.
- `validate_envelope` caps the recipient list at `MAX_RECIPIENTS = 100` (RFC 5321 §4.5.3.1.10) and rejects over-cap envelopes with **555**, so an open-update caller can't pad the list out to the ingress size limit.
- `SmtpRequestError` now documents what each `code` means: **550** (mailbox unavailable) is "No such user here"; **555** (syntax error) flags a malformed request shape including over-cap recipient lists.

# Tests

- `validate_rejects_multi_recipient_envelope_even_when_one_is_known` / `validate_rejects_multi_recipient_even_when_all_unknown` / `validate_rejects_empty_recipient_list` — both methods reject anything but a single recipient with 550.
- `validate_envelope_rejects_any_oversized_recipient` — bounds-check every recipient, not just the first.
- `validate_envelope_rejects_too_many_recipients` / `validate_envelope_accepts_max_recipients` — `MAX_RECIPIENTS` cap, with the inclusive upper bound covered.
- `validate_envelope_accepts_empty_to_vec` — empty `to` is shape-valid at the bounds layer; recipient-dispatch handles the 550 separately.