### PR TITLE
feat(fe): disable remove/unlink on active access method

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/OpenIdItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/OpenIdItem.svelte
@@ -14,7 +14,7 @@
     isCurrentAccessMethod?: boolean;
   }
 
-  const { openid, onUnlink, isCurrentAccessMethod }: Props = $props();
+  const { openid, onUnlink, isCurrentAccessMethod = false }: Props = $props();
 
   // `sso_domain` / `sso_name` are populated by the canister at response
   // time via `openid::generic::sso_fields_for(iss, aud)`. Candid `opt

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/PasskeyItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/PasskeyItem.svelte
@@ -25,7 +25,7 @@
     recoveryPhraseStatus,
     onRename,
     onRemove,
-    isCurrentAccessMethod,
+    isCurrentAccessMethod = false,
   }: Props = $props();
 
   let knownProviders = $state<Record<string, Provider>>({});


### PR DESCRIPTION
## Access Method Controls — Stack

| # | Branch | PR |
|---|--------|----|
| 1 | `feat/access-method-controls-disable-remove` | **this PR** |
| 2 | `feat/access-method-controls-switch-dropdown` | [#3914 — https://github.com/dfinity/internet-identity/pull/3914](https://github.com/dfinity/internet-identity/pull/3914) |
| 3 | `feat/access-method-controls-switch-modal` | [#3915 — https://github.com/dfinity/internet-identity/pull/3915](https://github.com/dfinity/internet-identity/pull/3915) |
| 4 | `feat/access-method-controls-remove-modals` | [#3916 — https://github.com/dfinity/internet-identity/pull/3916](https://github.com/dfinity/internet-identity/pull/3916) |
| 5 | `feat/access-method-controls-tests` | [#3917 — https://github.com/dfinity/internet-identity/pull/3917](https://github.com/dfinity/internet-identity/pull/3917) |

## Summary

Remove/Unlink options in the access method card dropdown are shown but disabled (not hidden) when the user is signed in with that method, rather than being omitted or triggering an error flow.

- Passkey remove tooltip: "Switch to another method before removing"
- OpenID unlink tooltip: "Switch to another method before unlinking"
- `isCurrentAccessMethod` prop added to both `PasskeyItem` and `OpenIdItem`, defaulting to `false`

## Test plan

- [ ] Sign in with a passkey, open its card dropdown — Remove is visible, disabled, and shows the tooltip on hover
- [ ] Sign in with an OpenID account, open its card dropdown — Unlink is visible, disabled, and shows the tooltip
- [ ] Open any non-active method's dropdown — Remove/Unlink is enabled and clickable