### PR TITLE
feat(fe): add Switch option to access method card dropdown

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/+page.svelte
@@ -43,7 +43,7 @@
   let isAddingAccessMethod = $state(false);
   let renamingAccessMethodKey = $state<string>();
   let removingAccessMethodKey = $state<string>();
-  let switchingAccessMethodKey = $state<string>();
+  let _switchingAccessMethodKey = $state<string>();
   let accessMethods = $derived(toAccessMethods(data.identityInfo));
   let pendingRegistrationId = $state(data.pendingRegistrationId);
 
@@ -254,7 +254,7 @@
               onRemove={accessMethods.length > 1
                 ? () => (removingAccessMethodKey = toKey(accessMethod))
                 : undefined}
-              onSwitch={() => (switchingAccessMethodKey = toKey(accessMethod))}
+              onSwitch={() => (_switchingAccessMethodKey = toKey(accessMethod))}
               isCurrentAccessMethod={isCurrentAccessMethod(
                 $authenticatedStore,
                 accessMethod,
@@ -267,7 +267,7 @@
               onUnlink={accessMethods.length > 1
                 ? () => (removingAccessMethodKey = toKey(accessMethod))
                 : undefined}
-              onSwitch={() => (switchingAccessMethodKey = toKey(accessMethod))}
+              onSwitch={() => (_switchingAccessMethodKey = toKey(accessMethod))}
               isCurrentAccessMethod={isCurrentAccessMethod(
                 $authenticatedStore,
                 accessMethod,

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/OpenIdItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/OpenIdItem.svelte
@@ -19,8 +19,12 @@
     isCurrentAccessMethod?: boolean;
   }
 
-  const { openid, onUnlink, onSwitch, isCurrentAccessMethod }: Props =
-    $props();
+  const {
+    openid,
+    onUnlink,
+    onSwitch,
+    isCurrentAccessMethod = false,
+  }: Props = $props();
 
   // `sso_domain` / `sso_name` are populated by the canister at response
   // time via `openid::generic::sso_fields_for(iss, aud)`. Candid `opt

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/PasskeyItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/PasskeyItem.svelte
@@ -32,7 +32,7 @@
     onRename,
     onRemove,
     onSwitch,
-    isCurrentAccessMethod,
+    isCurrentAccessMethod = false,
   }: Props = $props();
 
   let knownProviders = $state<Record<string, Provider>>({});


### PR DESCRIPTION
## Access Method Controls — Stack

| # | Branch | PR |
|---|--------|----|
| 1 | `feat/access-method-controls-disable-remove` | [#3913 — https://github.com/dfinity/internet-identity/pull/3913](https://github.com/dfinity/internet-identity/pull/3913) |
| 2 | `feat/access-method-controls-switch-dropdown` | **this PR** |
| 3 | `feat/access-method-controls-switch-modal` | [#3915 — https://github.com/dfinity/internet-identity/pull/3915](https://github.com/dfinity/internet-identity/pull/3915) |
| 4 | `feat/access-method-controls-remove-modals` | [#3916 — https://github.com/dfinity/internet-identity/pull/3916](https://github.com/dfinity/internet-identity/pull/3916) |
| 5 | `feat/access-method-controls-tests` | [#3917 — https://github.com/dfinity/internet-identity/pull/3917](https://github.com/dfinity/internet-identity/pull/3917) |

## Summary

Adds a Switch menu item to every access method card dropdown (passkeys and OpenID credentials). The option lets users re-authenticate with a different method and make it the active session.

- Disabled with tooltip "Already signed-in" when that method is already the active session
- The confirmation and re-auth flow is wired up in [#3915](https://github.com/dfinity/internet-identity/pull/3915)

## Test plan

- [ ] Open the dropdown of a non-active passkey or OpenID credential — Switch is enabled
- [ ] Open the dropdown of the currently active method — Switch is greyed out with "Already signed-in" tooltip