### PR TITLE
feat(fe): switch access method modal with re-authentication

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/OpenIdItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/OpenIdItem.svelte
@@ -19,8 +19,12 @@
     isCurrentAccessMethod?: boolean;
   }
 
-  const { openid, onUnlink, onSwitch, isCurrentAccessMethod }: Props =
-    $props();
+  const {
+    openid,
+    onUnlink,
+    onSwitch,
+    isCurrentAccessMethod = false,
+  }: Props = $props();
 
   // `sso_domain` / `sso_name` are populated by the canister at response
   // time via `openid::generic::sso_fields_for(iss, aud)`. Candid `opt

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/PasskeyItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/PasskeyItem.svelte
@@ -32,7 +32,7 @@
     onRename,
     onRemove,
     onSwitch,
-    isCurrentAccessMethod,
+    isCurrentAccessMethod = false,
   }: Props = $props();
 
   let knownProviders = $state<Record<string, Provider>>({});


### PR DESCRIPTION
## Access Method Controls — Stack

| # | Branch | PR |
|---|--------|----|
| 1 | `feat/access-method-controls-disable-remove` | [#3913 — https://github.com/dfinity/internet-identity/pull/3913](https://github.com/dfinity/internet-identity/pull/3913) |
| 2 | `feat/access-method-controls-switch-dropdown` | [#3914 — https://github.com/dfinity/internet-identity/pull/3914](https://github.com/dfinity/internet-identity/pull/3914) |
| 3 | `feat/access-method-controls-switch-modal` | **this PR** |
| 4 | `feat/access-method-controls-remove-modals` | [#3916 — https://github.com/dfinity/internet-identity/pull/3916](https://github.com/dfinity/internet-identity/pull/3916) |
| 5 | `feat/access-method-controls-tests` | [#3917 — https://github.com/dfinity/internet-identity/pull/3917](https://github.com/dfinity/internet-identity/pull/3917) |

## Summary

Adds `SwitchAccessMethod.svelte` — the confirmation dialog opened when the user clicks Switch in the dropdown ([#3914](https://github.com/dfinity/internet-identity/pull/3914)).

- Confirms intent, then re-authenticates with the selected method
  - Passkeys — WebAuthn credential assertion via `authenticateWithPasskey`
  - OpenID / SSO — FedCM / OAuth popup via `requestJWT` + `authenticateWithJWT`
- On success: updates the active session store and the last-used identity record

## Test plan

- [ ] Click Switch on a non-active passkey — confirmation modal appears, confirm triggers WebAuthn prompt, session updates to new method
- [ ] Click Switch on an OpenID credential — confirmation modal, OAuth flow, session updates
- [ ] Click Cancel in the modal — no session change, no error