### PR TITLE
feat(fe): remove/unlink confirmation modals with edge case handling

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/OpenIdItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/OpenIdItem.svelte
@@ -25,7 +25,7 @@
     openid,
     onUnlink,
     onSwitch,
-    isCurrentAccessMethod,
+    isCurrentAccessMethod = false,
     isLastAccessMethod = false,
     isSignedInWithRecovery = true,
   }: Props = $props();
@@ -71,8 +71,8 @@
               isCurrentAccessMethod && !isLastAccessMethod
                 ? $t`Switch to another method before unlinking`
                 : isLastAccessMethod && !isSignedInWithRecovery
-                ? $t`Sign in with a recovery method to unlink`
-                : undefined,
+                  ? $t`Sign in with a recovery method to unlink`
+                  : undefined,
             onClick: onUnlink,
           },
         ]

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/PasskeyItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/PasskeyItem.svelte
@@ -34,7 +34,7 @@
     onRename,
     onRemove,
     onSwitch,
-    isCurrentAccessMethod,
+    isCurrentAccessMethod = false,
     isLastAccessMethod = false,
     isSignedInWithRecovery = true,
   }: Props = $props();
@@ -103,12 +103,12 @@
               isCurrentAccessMethod && !isLastAccessMethod
                 ? $t`Switch to another method before removing`
                 : isLastAccessMethod && !isSignedInWithRecovery
-                ? $t`Sign in with a recovery method to remove`
-                : isLegacy && recoveryPhraseStatus !== "verified"
-                ? recoveryPhraseStatus === "unverified"
-                  ? $t`Verify recovery to remove`
-                  : $t`Activate recovery to remove`
-                : undefined,
+                  ? $t`Sign in with a recovery method to remove`
+                  : isLegacy && recoveryPhraseStatus !== "verified"
+                    ? recoveryPhraseStatus === "unverified"
+                      ? $t`Verify recovery to remove`
+                      : $t`Activate recovery to remove`
+                    : undefined,
             onClick: onRemove,
           },
         ]

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/RemoveAccessMethod.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/RemoveAccessMethod.svelte
@@ -54,14 +54,14 @@
           {#if type === "openid"}
             <Trans>
               You are about to unlink your last remaining access method. Your
-              recovery phrase will become your sole method of regaining access to
-              this identity.
+              recovery phrase will become your sole method of regaining access
+              to this identity.
             </Trans>
           {:else}
             <Trans>
               You are about to remove your last remaining access method. Your
-              recovery phrase will become your sole method of regaining access to
-              this identity.
+              recovery phrase will become your sole method of regaining access
+              to this identity.
             </Trans>
           {/if}
         </p>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/SwitchAccessMethod.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(access-and-recovery)/access/components/SwitchAccessMethod.svelte
@@ -40,13 +40,14 @@
     >
       <p>
         <Trans>
-          You are about to re-authenticate yourself with another access method on this device.
+          You are about to re-authenticate yourself with another access method
+          on this device.
         </Trans>
       </p>
       <p>
         <Trans>
-          This will become the default method used to authenticate on this device moving
-          forward.
+          This will become the default method used to authenticate on this
+          device moving forward.
         </Trans>
       </p>
     </div>


### PR DESCRIPTION
## Access Method Controls — Stack

| # | Branch | PR |
|---|--------|----|
| 1 | `feat/access-method-controls-disable-remove` | [#3913 — https://github.com/dfinity/internet-identity/pull/3913](https://github.com/dfinity/internet-identity/pull/3913) |
| 2 | `feat/access-method-controls-switch-dropdown` | [#3914 — https://github.com/dfinity/internet-identity/pull/3914](https://github.com/dfinity/internet-identity/pull/3914) |
| 3 | `feat/access-method-controls-switch-modal` | [#3915 — https://github.com/dfinity/internet-identity/pull/3915](https://github.com/dfinity/internet-identity/pull/3915) |
| 4 | `feat/access-method-controls-remove-modals` | **this PR** |
| 5 | `feat/access-method-controls-tests` | [#3917 — https://github.com/dfinity/internet-identity/pull/3917](https://github.com/dfinity/internet-identity/pull/3917) |

## Summary

Consolidates `RemovePasskey.svelte` and `RemoveOpenIdCredential.svelte` into a single `RemoveAccessMethod.svelte` component and extends the removal/unlink logic to cover all edge cases.

**New `RemoveAccessMethod.svelte`**
- Accepts `type: "passkey" | "openid"` — correct verb ("remove" vs "unlink") and copy are selected statically to remain Lingui-extractable
- 6 confirmation variants driven by `type x isLastAccessMethod x isCurrentAccessMethod`

**Last-method gate**
- Removing the last access method requires an active recovery session (recovery phrase or email recovery)
- Remove/Unlink is disabled with tooltip "Sign in with a recovery method to remove/unlink" until the session is established via recovery

## Test plan

- [ ] Remove a non-current passkey — standard confirmation, removes cleanly
- [ ] Attempt to remove the currently active passkey when other methods exist — disabled (covered by [#3913](https://github.com/dfinity/internet-identity/pull/3913))
- [ ] Remove the last passkey while signed in via recovery phrase — last-method warning shown, proceeds on confirm
- [ ] Attempt last-method removal while signed in with a passkey (no recovery session) — disabled with tooltip
- [ ] Unlink a non-current OpenID credential — confirmation uses "unlink" language with provider name
- [ ] Unlink the last OpenID credential while signed in via recovery — last-method warning, proceeds on confirm