### PR TITLE
refactor(be): collapse DKIM tag contract into a two-function facade

### DIFF
--- a/src/internet_identity/src/dkim/mod.rs
+++ b/src/internet_identity/src/dkim/mod.rs
@@ -65,8 +65,7 @@ pub(crate) use signature::{body_hash_sha256, verify_signature, VerifyOutcome};
 pub(crate) use tag_checks::{
     // The two umbrellas (`enforce_*_tag_contract`) are the facade
     // both verification pipelines call into; the individual
-    // `check_*` helpers remain reachable for fine-grained unit tests
-    // and the property-based parity tests in `tag_checks::proptest`.
+    // `check_*` helpers remain reachable for fine-grained unit tests.
     check_auid_aligned,
     check_dns_not_testing,
     check_signature_not_expired,

--- a/src/internet_identity/src/dkim/mod.rs
+++ b/src/internet_identity/src/dkim/mod.rs
@@ -15,6 +15,28 @@
 //!   and `ed25519-dalek` workspace deps.
 //! - `verify` — orchestration: multi-signature loop, tag enforcement,
 //!   accept-on-first-pass.
+//! - `tag_checks` — the **tag-contract facade** (two `enforce_*` umbrella
+//!   functions) that both pipelines route their tag enforcement
+//!   through. The facade is the single source of truth so the DoH and
+//!   DNSSEC paths can't drift apart on which tag policies they enforce.
+//!
+//! ## Tag-contract call order
+//!
+//! Within each umbrella the order matters for diagnostics — the first
+//! failing check is what surfaces upstream when an input triggers
+//! multiple rejections. Documented here so a future contributor
+//! reordering checks knows the rationale and doesn't undo it:
+//!
+//! - `enforce_signature_header_tag_contract`: `x=` (expired) → `t=`
+//!   (future-dated) → `Subject` ∈ `h=`. Cheapest-first against a
+//!   parsed signature header.
+//! - `enforce_dns_record_tag_contract`: `t=y` (testing) → `i=` AUID
+//!   alignment. `t=y` is deliberately first: a key the signer has
+//!   marked non-production invalidates the signature regardless of
+//!   any other tag state, so surfacing `TestingMode` ahead of (e.g.)
+//!   `AuidMisaligned` or the structural `AlgorithmKeyTypeMismatch`
+//!   that runs immediately after the umbrella gives the most useful
+//!   diagnostic.
 //!
 //! The verifier consumes a DKIM TXT record (sourced either from a
 //! DNSSEC-verified `DnsProofBundle` cached at prepare time, or via

--- a/src/internet_identity/src/dkim/mod.rs
+++ b/src/internet_identity/src/dkim/mod.rs
@@ -63,8 +63,17 @@ pub(crate) use parse::{parse_dkim_signature, DkimSignature};
 pub(crate) use signature::{body_hash_sha256, verify_signature, VerifyOutcome};
 #[allow(unused_imports)]
 pub(crate) use tag_checks::{
-    check_auid_aligned, check_dns_not_testing, check_signature_not_expired,
-    check_signature_not_from_future, check_subject_signed,
+    // The two umbrellas (`enforce_*_tag_contract`) are the facade
+    // both verification pipelines call into; the individual
+    // `check_*` helpers remain reachable for fine-grained unit tests
+    // and the property-based parity tests in `tag_checks::proptest`.
+    check_auid_aligned,
+    check_dns_not_testing,
+    check_signature_not_expired,
+    check_signature_not_from_future,
+    check_subject_signed,
+    enforce_dns_record_tag_contract,
+    enforce_signature_header_tag_contract,
 };
 #[allow(unused_imports)]
 pub(crate) use verify::{build_header_hash_input, simple_body};

--- a/src/internet_identity/src/dkim/tag_checks.rs
+++ b/src/internet_identity/src/dkim/tag_checks.rs
@@ -163,11 +163,24 @@ pub(crate) fn auid_aligns(i: &str, d: &str, strict: bool) -> bool {
 //
 // Return shape:
 //   Ok(trail)             — every check passed; trail has one
-//                            `DkimCheck::Pass` entry per check that ran.
+//                            `DkimCheck::Pass` entry per check that
+//                            participates in the diagnostic trail.
+//                            Not every check does: `t=y` testing-mode
+//                            in `enforce_dns_record_tag_contract` is a
+//                            meta-flag on the DNS record (RFC 6376
+//                            §3.6.1), not a pass/fail-able step, and
+//                            there is no corresponding `DkimCheckName`
+//                            variant — it never emits a trail entry.
+//                            All other checks emit a Pass entry on
+//                            success.
 //   Err((reason, trail))  — `reason` is the first-failing
-//                            `VerificationFailReason`; trail has the
-//                            `Pass` entries from earlier checks plus
-//                            the `Fail` entry of the one that broke.
+//                            `VerificationFailReason`. The trail
+//                            carries the `Pass` entries from earlier
+//                            checks; the failing step itself appends
+//                            its `Fail` entry iff that step normally
+//                            participates in the trail. (`t=y` is the
+//                            only exception: on rejection it returns
+//                            with the trail unchanged.)
 // Symmetric with [`super::verify::try_verify_signature`]; the DoH
 // pipeline appends the trail to its accumulator, the DNSSEC pipeline
 // discards.
@@ -267,9 +280,10 @@ pub(crate) fn enforce_dns_record_tag_contract(
     if let Err(reason) = check_dns_not_testing(dns) {
         // No `DkimCheckName` variant for testing mode — RFC 6376
         // §3.6.1 treats `t=y` as a meta-flag on the record, not a
-        // pass/fail-able step. The trail records the `Fail` against
-        // the `DnsRecordParsed` step's downstream effect via the
-        // surfaced `VerificationFailReason::TestingMode`.
+        // pass/fail-able step. Return without appending a trail entry:
+        // the surfaced `VerificationFailReason::TestingMode` is the
+        // sole signal upstream. (See the "Return shape" note above
+        // for the documented exception.)
         return Err((reason, trail));
     }
 

--- a/src/internet_identity/src/dkim/tag_checks.rs
+++ b/src/internet_identity/src/dkim/tag_checks.rs
@@ -1,4 +1,5 @@
-//! Shared DKIM tag-enforcement checks.
+//! Shared DKIM tag-enforcement checks and the **tag-contract facade**
+//! both verification pipelines call into.
 //!
 //! The DKIM verifier runs as two different pipelines depending on
 //! whether the sender's domain is DNSSEC-signed:
@@ -15,24 +16,37 @@
 //! Without a shared check surface the two pipelines drift: an earlier
 //! audit found the DNSSEC path silently bypassing `t=` (future-dated),
 //! `x=` (expiration), `i=` (AUID alignment), and DNS `t=y` (testing
-//! mode), all of which the DoH path enforces. These helpers are the
-//! single source of truth that both pipelines call into.
+//! mode), all of which the DoH path enforces. To make that class of
+//! drift impossible to reintroduce, both pipelines now go through the
+//! *same two umbrella functions*:
 //!
-//! Helpers are split by *what data they need*, not by *which pipeline
-//! calls them*:
+//! - [`enforce_signature_header_tag_contract`] — runs the three
+//!   signature-header-only checks (`x=`, `t=`, Subject in `h=`).
+//!   Called at email-arrival time on both paths.
+//! - [`enforce_dns_record_tag_contract`] — runs the two DNS-record-
+//!   dependent checks (`t=y` testing mode, `i=` AUID alignment under
+//!   `t=s`). Called as soon as the DKIM TXT record is trusted.
 //!
-//! - Signature-header-only: [`check_signature_not_expired`],
-//!   [`check_signature_not_from_future`], [`check_subject_signed`].
-//!   Both pipelines have access to these inputs as soon as the
-//!   `DKIM-Signature` header is parsed.
-//! - DNS-record-dependent: [`check_auid_aligned`] (needs the DNS
-//!   record's `t=s` flag), [`check_dns_not_testing`] (the `t=y` flag).
-//!   The DoH pipeline has the DNS bytes up front; the DNSSEC pipeline
-//!   gets them only after `submit_dkim_leaf`.
+//! Adding a new tag policy means changing exactly one of those two
+//! functions; both pipelines pick the change up automatically.
+//! The individual `check_*` helpers stay public so the per-policy
+//! decision logic is independently unit-testable and reachable from
+//! the property-based parity tests, but no production caller should
+//! invoke them directly — go through the umbrellas.
+//!
+//! ## Diagnostic trail
+//!
+//! The DoH pipeline surfaces a `Vec<DkimCheck>` to the FE so a UI can
+//! render "which step failed". The DNSSEC pipeline doesn't need that
+//! granularity (its failure is wrapped into a single
+//! `EmailRecoveryError`). To keep one source of truth for *what the
+//! trail looks like for each check*, the umbrellas build and return
+//! the trail themselves; the DoH path appends it to its accumulator,
+//! the DNSSEC path discards.
 
 use super::dns_record::DkimDnsRecord;
 use super::parse::DkimSignature;
-use super::types::VerificationFailReason;
+use super::types::{DkimCheck, DkimCheckName, DkimCheckStatus, VerificationFailReason};
 
 /// How far a signature's claimed signing time (`t=`) may sit in the
 /// future relative to the canister's clock before we reject it as
@@ -137,6 +151,152 @@ pub(crate) fn auid_aligns(i: &str, d: &str, strict: bool) -> bool {
     i_domain.len() > d.len()
         && i_domain.ends_with(d)
         && i_domain.as_bytes()[i_domain.len() - d.len() - 1] == b'.'
+}
+
+// =====================================================================
+// Tag-contract facade.
+//
+// The two umbrella functions below are the *only* tag-enforcement
+// entry points production code should use. Both pipelines call into
+// them at the appropriate point in their flow; adding a new tag check
+// means amending exactly one umbrella and both pipelines pick it up.
+//
+// Return shape:
+//   Ok(trail)             — every check passed; trail has one
+//                            `DkimCheck::Pass` entry per check that ran.
+//   Err((reason, trail))  — `reason` is the first-failing
+//                            `VerificationFailReason`; trail has the
+//                            `Pass` entries from earlier checks plus
+//                            the `Fail` entry of the one that broke.
+// Symmetric with [`super::verify::try_verify_signature`]; the DoH
+// pipeline appends the trail to its accumulator, the DNSSEC pipeline
+// discards.
+// =====================================================================
+
+/// Run the three signature-header-only DKIM tag checks (design §5.4):
+/// `x=` not expired, `t=` not future-dated, `Subject` ∈ `h=`. Called
+/// as soon as the `DKIM-Signature` header has been parsed.
+///
+/// On the **DoH path** this runs inside
+/// [`super::verify::try_verify_signature`] right after the
+/// canonicalisation check. On the **DNSSEC path** it runs in
+/// `email_recovery::smtp::prepare_partial_verification` so the
+/// partial-verification record is only stashed if the email already
+/// satisfies the signature-header-only contract.
+pub(crate) fn enforce_signature_header_tag_contract(
+    sig: &DkimSignature,
+    now_secs: u64,
+) -> Result<Vec<DkimCheck>, (VerificationFailReason, Vec<DkimCheck>)> {
+    let mut trail: Vec<DkimCheck> = Vec::new();
+
+    if let Err(reason) = check_signature_not_expired(sig, now_secs) {
+        let detail = sig
+            .x
+            .map(|x| format!("signature expired at {x}, now {now_secs}"));
+        trail.push(check(
+            DkimCheckName::SignatureNotExpired,
+            DkimCheckStatus::Fail,
+            detail,
+        ));
+        return Err((reason, trail));
+    }
+    trail.push(check(
+        DkimCheckName::SignatureNotExpired,
+        DkimCheckStatus::Pass,
+        None,
+    ));
+
+    if let Err(reason) = check_signature_not_from_future(sig, now_secs) {
+        let detail = sig.t.map(|t| {
+            format!("signature claims t={t}, now={now_secs}, beyond {CLOCK_SKEW_SECS}s skew")
+        });
+        trail.push(check(
+            DkimCheckName::SignatureNotFromFuture,
+            DkimCheckStatus::Fail,
+            detail,
+        ));
+        return Err((reason, trail));
+    }
+    trail.push(check(
+        DkimCheckName::SignatureNotFromFuture,
+        DkimCheckStatus::Pass,
+        None,
+    ));
+
+    if let Err(reason) = check_subject_signed(sig) {
+        trail.push(check(
+            DkimCheckName::SubjectSigned,
+            DkimCheckStatus::Fail,
+            Some("h= does not include the Subject header".to_string()),
+        ));
+        return Err((reason, trail));
+    }
+    trail.push(check(
+        DkimCheckName::SubjectSigned,
+        DkimCheckStatus::Pass,
+        None,
+    ));
+
+    Ok(trail)
+}
+
+/// Run the two DNS-record-dependent DKIM tag checks (design §5.4):
+/// reject if the record has `t=y` (testing mode) set, then require
+/// `i=` to align with `d=` per the record's `t=s` flag. Called once
+/// the DKIM TXT is trusted.
+///
+/// On the **DoH path** this runs inside
+/// [`super::verify::try_verify_signature`] after `parse_dkim_txt`. On
+/// the **DNSSEC path** it runs in
+/// `email_recovery::submit_leaf::run_submit` after the chain
+/// validator returns the verified record. Takes `(i, d)` rather than
+/// the whole `DkimSignature` so the DNSSEC submit side — which only
+/// has the cached `PartialVerification` — can call it without
+/// rehydrating the full signature struct.
+pub(crate) fn enforce_dns_record_tag_contract(
+    i: &str,
+    d: &str,
+    dns: &DkimDnsRecord,
+) -> Result<Vec<DkimCheck>, (VerificationFailReason, Vec<DkimCheck>)> {
+    let mut trail: Vec<DkimCheck> = Vec::new();
+
+    // `t=y` testing mode comes before AUID alignment because a
+    // testing-flagged key invalidates any production signature
+    // regardless of how `i=`/`d=` line up — the verdict is more
+    // fundamental and worth surfacing first.
+    if let Err(reason) = check_dns_not_testing(dns) {
+        // No `DkimCheckName` variant for testing mode — RFC 6376
+        // §3.6.1 treats `t=y` as a meta-flag on the record, not a
+        // pass/fail-able step. The trail records the `Fail` against
+        // the `DnsRecordParsed` step's downstream effect via the
+        // surfaced `VerificationFailReason::TestingMode`.
+        return Err((reason, trail));
+    }
+
+    if let Err(reason) = check_auid_aligned(i, d, dns.strict_auid) {
+        let detail = format!("i={i} does not align with d={d} (t=s={})", dns.strict_auid);
+        trail.push(check(
+            DkimCheckName::AuidAlignsWithDomain,
+            DkimCheckStatus::Fail,
+            Some(detail),
+        ));
+        return Err((reason, trail));
+    }
+    trail.push(check(
+        DkimCheckName::AuidAlignsWithDomain,
+        DkimCheckStatus::Pass,
+        None,
+    ));
+
+    Ok(trail)
+}
+
+fn check(name: DkimCheckName, status: DkimCheckStatus, detail: Option<String>) -> DkimCheck {
+    DkimCheck {
+        name,
+        status,
+        detail,
+    }
 }
 
 #[cfg(test)]
@@ -346,5 +506,155 @@ mod tests {
             check_dns_not_testing(&dns(true, false)).unwrap_err(),
             VerificationFailReason::TestingMode
         );
+    }
+
+    // ---- Umbrella facade tests ----
+    //
+    // Each umbrella chains its constituent helpers and returns the
+    // first failing reason along with a `Vec<DkimCheck>` trail that
+    // the DoH path appends to its accumulator. Tests assert: (a) all
+    // pass → `Ok(trail)` with every check `Pass`; (b) one failing
+    // input → `Err((expected_reason, trail))` with the failed step
+    // last; (c) the umbrella stops at the first failure (no later
+    // checks contribute).
+
+    use crate::dkim::DkimCheckStatus as Status;
+
+    #[test]
+    fn signature_header_umbrella_all_pass_returns_full_trail() {
+        let s = sig_with(
+            Some(1_000_000), // t= in the past
+            Some(2_000_000), // x= in the future
+            vec!["From", "Subject"],
+            "alice@example.com",
+            "example.com",
+        );
+        let trail = enforce_signature_header_tag_contract(&s, 1_500_000).expect("must pass");
+        assert_eq!(trail.len(), 3);
+        for c in &trail {
+            assert_eq!(c.status, Status::Pass, "every check should pass; got {c:?}");
+        }
+        // Order is contract-defined: x= first, then t=, then Subject.
+        assert_eq!(trail[0].name, DkimCheckName::SignatureNotExpired);
+        assert_eq!(trail[1].name, DkimCheckName::SignatureNotFromFuture);
+        assert_eq!(trail[2].name, DkimCheckName::SubjectSigned);
+    }
+
+    #[test]
+    fn signature_header_umbrella_short_circuits_on_first_failure() {
+        // x= expired (fails first) AND Subject missing AND t= future:
+        // umbrella must surface SignatureExpired and stop walking.
+        let s = sig_with(
+            Some(9_999_999), // t= future-dated (later check)
+            Some(900_000),   // x= already past
+            vec!["From"],    // Subject missing (later check)
+            "alice@example.com",
+            "example.com",
+        );
+        match enforce_signature_header_tag_contract(&s, 1_000_000) {
+            Err((VerificationFailReason::SignatureExpired, trail)) => {
+                // Only the failing entry plus zero passes before it.
+                assert_eq!(trail.len(), 1);
+                assert_eq!(trail[0].name, DkimCheckName::SignatureNotExpired);
+                assert_eq!(trail[0].status, Status::Fail);
+            }
+            other => panic!("expected SignatureExpired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn signature_header_umbrella_subject_failure_surfaces_after_earlier_passes() {
+        let s = sig_with(
+            None,
+            None,
+            vec!["From"], // Subject missing
+            "alice@example.com",
+            "example.com",
+        );
+        match enforce_signature_header_tag_contract(&s, 1_000_000) {
+            Err((VerificationFailReason::SubjectNotSigned, trail)) => {
+                // Two preceding passes (x=, t=) plus the SubjectSigned Fail.
+                assert_eq!(trail.len(), 3);
+                assert_eq!(trail[2].name, DkimCheckName::SubjectSigned);
+                assert_eq!(trail[2].status, Status::Fail);
+            }
+            other => panic!("expected SubjectNotSigned, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dns_record_umbrella_all_pass_returns_alignment_pass_only() {
+        // t=y clear, i=/d= aligned. The umbrella runs t=y first (no
+        // dedicated DkimCheck variant — see doc on the umbrella) then
+        // AuidAlignsWithDomain. So a clean pass yields exactly one
+        // Pass entry: AuidAlignsWithDomain.
+        let trail =
+            enforce_dns_record_tag_contract("alice@example.com", "example.com", &dns(false, false))
+                .expect("must pass");
+        assert_eq!(trail.len(), 1);
+        assert_eq!(trail[0].name, DkimCheckName::AuidAlignsWithDomain);
+        assert_eq!(trail[0].status, Status::Pass);
+    }
+
+    #[test]
+    fn dns_record_umbrella_testing_mode_surfaces_first() {
+        // t=y set AND AUID misaligned: TestingMode wins because the
+        // umbrella checks it first (a testing-flagged key invalidates
+        // the signature regardless of `i=`/`d=` state). No trail
+        // entries for testing mode (RFC 6376 §3.6.1 treats it as a
+        // meta-flag).
+        match enforce_dns_record_tag_contract(
+            "alice@evil.com",
+            "example.com",
+            &dns(true, false), // testing=true
+        ) {
+            Err((VerificationFailReason::TestingMode, trail)) => {
+                assert!(trail.is_empty(), "TestingMode emits no trail entry");
+            }
+            other => panic!("expected TestingMode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dns_record_umbrella_auid_failure_after_testing_pass() {
+        match enforce_dns_record_tag_contract(
+            "alice@evil.com",
+            "example.com",
+            &dns(false, false), // testing clear, AUID misaligned
+        ) {
+            Err((VerificationFailReason::AuidMisaligned, trail)) => {
+                assert_eq!(trail.len(), 1);
+                assert_eq!(trail[0].name, DkimCheckName::AuidAlignsWithDomain);
+                assert_eq!(trail[0].status, Status::Fail);
+            }
+            other => panic!("expected AuidMisaligned, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn umbrellas_chain_to_match_individual_helpers() {
+        // The umbrellas are nothing but ordered chains of the
+        // individual `check_*` helpers. If for any input the umbrella
+        // disagreed with the helpers about pass/fail, that would
+        // mean a check silently slipped out of the chain — the exact
+        // bug class this design is meant to make impossible.
+        let s = sig_with(
+            None,
+            None,
+            vec!["From", "Subject"],
+            "alice@example.com",
+            "example.com",
+        );
+        let r = dns(false, false);
+
+        // Both individual helpers AND the umbrella accept this input.
+        assert!(check_signature_not_expired(&s, 1_000_000).is_ok());
+        assert!(check_signature_not_from_future(&s, 1_000_000).is_ok());
+        assert!(check_subject_signed(&s).is_ok());
+        assert!(check_dns_not_testing(&r).is_ok());
+        assert!(check_auid_aligned(&s.i, &s.d, r.strict_auid).is_ok());
+
+        assert!(enforce_signature_header_tag_contract(&s, 1_000_000).is_ok());
+        assert!(enforce_dns_record_tag_contract(&s.i, &s.d, &r).is_ok());
     }
 }

--- a/src/internet_identity/src/dkim/verify.rs
+++ b/src/internet_identity/src/dkim/verify.rs
@@ -43,10 +43,7 @@ use super::canonicalize::{relaxed_body, relaxed_header};
 use super::dns_record::parse_dkim_txt;
 use super::parse::{parse_dkim_signature, DkimSignature};
 use super::signature::{body_hash_sha256, verify_signature, VerifyOutcome};
-use super::tag_checks::{
-    check_auid_aligned, check_dns_not_testing, check_signature_not_expired,
-    check_signature_not_from_future, check_subject_signed, CLOCK_SKEW_SECS,
-};
+use super::tag_checks::{enforce_dns_record_tag_contract, enforce_signature_header_tag_contract};
 use super::types::{
     DkimCheck, DkimCheckName, DkimCheckStatus, DkimVerifyResult, HeaderCanon,
     VerificationFailReason,
@@ -174,57 +171,18 @@ fn try_verify_signature(
         None,
     ));
 
-    // (x=) Expiration, (t=) future-dated, and Subject-in-`h=` are
-    // signature-header-only checks shared with the DNSSEC verification
-    // path (`email_recovery::smtp::prepare_partial_verification`).
-    // Single source of truth: see [`super::tag_checks`].
-    if let Err(reason) = check_signature_not_expired(&sig, now_secs) {
-        let detail = sig
-            .x
-            .map(|x| format!("signature expired at {x}, now {now_secs}"));
-        checks.push(check(
-            DkimCheckName::SignatureNotExpired,
-            DkimCheckStatus::Fail,
-            detail,
-        ));
-        return Err((reason, checks));
+    // Signature-header-only tag contract: x= not expired, t= not
+    // future-dated, Subject in h=. Both pipelines route through the
+    // same umbrella so the contract can't drift; the trail the
+    // umbrella builds is appended verbatim to our per-check
+    // accumulator.
+    match enforce_signature_header_tag_contract(&sig, now_secs) {
+        Ok(mut trail) => checks.append(&mut trail),
+        Err((reason, mut trail)) => {
+            checks.append(&mut trail);
+            return Err((reason, checks));
+        }
     }
-    checks.push(check(
-        DkimCheckName::SignatureNotExpired,
-        DkimCheckStatus::Pass,
-        None,
-    ));
-
-    if let Err(reason) = check_signature_not_from_future(&sig, now_secs) {
-        let detail = sig.t.map(|t| {
-            format!("signature claims t={t}, now={now_secs}, beyond {CLOCK_SKEW_SECS}s skew")
-        });
-        checks.push(check(
-            DkimCheckName::SignatureNotFromFuture,
-            DkimCheckStatus::Fail,
-            detail,
-        ));
-        return Err((reason, checks));
-    }
-    checks.push(check(
-        DkimCheckName::SignatureNotFromFuture,
-        DkimCheckStatus::Pass,
-        None,
-    ));
-
-    if let Err(reason) = check_subject_signed(&sig) {
-        checks.push(check(
-            DkimCheckName::SubjectSigned,
-            DkimCheckStatus::Fail,
-            Some("h= does not include the Subject header".to_string()),
-        ));
-        return Err((reason, checks));
-    }
-    checks.push(check(
-        DkimCheckName::SubjectSigned,
-        DkimCheckStatus::Pass,
-        None,
-    ));
 
     // Parse the DNS record now — we need its t=s flag to know how
     // strict to be on i= alignment.
@@ -250,28 +208,30 @@ fn try_verify_signature(
         None,
     ));
 
-    // (i=) AUID alignment — shared helper. RFC 6376 §3.5: `i=` MUST
-    // refer to a domain that is `d=` or, when DNS `t=s` is clear, a
-    // subdomain of `d=`. Single source of truth: see [`super::tag_checks`].
-    if let Err(reason) = check_auid_aligned(&sig.i, &sig.d, dns.strict_auid) {
-        let detail = format!(
-            "i={} does not align with d={} (t=s={})",
-            sig.i, sig.d, dns.strict_auid
-        );
-        checks.push(check(
-            DkimCheckName::AuidAlignsWithDomain,
-            DkimCheckStatus::Fail,
-            Some(detail),
-        ));
-        return Err((reason, checks));
+    // DNS-record-dependent tag contract: i= AUID aligned with d= per
+    // the record's t=s flag, and the record itself isn't t=y
+    // (testing). Routed through the same umbrella the DNSSEC path's
+    // submit step calls, so the contract stays in lock-step. Note
+    // the ordering shift relative to historical DoH-path code: the
+    // umbrella runs t=y first (a testing-flagged key invalidates a
+    // signature regardless of other tag state, so surfacing
+    // TestingMode first is more informative), then AUID. Pre-refactor
+    // ordering put t=y last among the DNS-record checks; if a
+    // signature triggered both TestingMode and AlgorithmKeyTypeMismatch
+    // the prior code surfaced the latter, this code surfaces
+    // TestingMode.
+    match enforce_dns_record_tag_contract(&sig.i, &sig.d, &dns) {
+        Ok(mut trail) => checks.append(&mut trail),
+        Err((reason, mut trail)) => {
+            checks.append(&mut trail);
+            return Err((reason, checks));
+        }
     }
-    checks.push(check(
-        DkimCheckName::AuidAlignsWithDomain,
-        DkimCheckStatus::Pass,
-        None,
-    ));
 
-    // DNS k= must match the signature's algorithm family.
+    // DNS k= must match the signature's algorithm family. Not a tag
+    // policy check (it's a wire-format compatibility check between
+    // the key type and the signing algorithm) so it stays outside
+    // the tag-contract umbrella.
     if !dns.key_type.matches_signature_alg(sig.algorithm) {
         checks.push(check(
             DkimCheckName::PublicKeyTypeMatches,
@@ -288,13 +248,6 @@ fn try_verify_signature(
         DkimCheckStatus::Pass,
         None,
     ));
-
-    // DNS `t=y` testing-mode flag — shared helper. Treat as
-    // inconclusive: never accept a signature under a key the signer
-    // has explicitly declared non-production.
-    if let Err(reason) = check_dns_not_testing(&dns) {
-        return Err((reason, checks));
-    }
 
     // Body hash check (bh=) — canonicalise the body, hash, compare.
     let canonical_body = match sig.c_body {

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -457,28 +457,32 @@ fn prepare_partial_verification(
         ));
     }
 
-    // Signature-header-only tag enforcement (design §5.4). These are
-    // the same checks the DoH path runs inside `crate::dkim::verify`;
-    // running them here closes the DNSSEC-path parity gap surfaced by
-    // the audit: without these, a sender on a DNSSEC-signed domain
-    // could verify with a stale `x=` (replay window stretches to the
-    // RRSIG validity, days–weeks), a future-dated `t=`, or an `h=`
-    // that doesn't cover `Subject` (nonce-rewrite by a MITM). The
-    // DNS-record-dependent tag checks (`i=` alignment under `t=s`,
-    // and `t=y` testing-mode) run later in
+    // Signature-header-only tag contract (design §5.4): `x=` not
+    // expired, `t=` not future-dated, `Subject` ∈ `h=`. Single shared
+    // umbrella with the DoH path — adding a new signature-header
+    // check there means both paths pick it up at once. Closes the
+    // DNSSEC-path parity gap surfaced by the audit (without these,
+    // the DNSSEC path admitted signatures the DoH path rejected).
+    // The DNS-record-dependent tag checks (`i=` alignment under
+    // `t=s`, `t=y` testing-mode) run later in
     // `submit_dkim_leaf::run_submit` once the DKIM leaf has been
     // DNSSEC-verified.
-    crate::dkim::check_signature_not_expired(&sig, now_secs)
-        .map_err(|reason| EmailRecoveryError::EmailVerificationFailed(format!("{reason:?}")))?;
-    crate::dkim::check_signature_not_from_future(&sig, now_secs)
-        .map_err(|reason| EmailRecoveryError::EmailVerificationFailed(format!("{reason:?}")))?;
-    // Subject must be in the signed `h=` list (design §5.4). The
-    // challenge nonce lives in `Subject:`; a signature that doesn't
-    // cover it would let a man-in-the-middle rewrite the nonce on a
-    // legitimately-signed email. Runs before the body-hash check
-    // (the order the DoH path uses too) so this fast check on
-    // already-parsed tags fails first when both apply.
-    crate::dkim::check_subject_signed(&sig).map_err(|_| EmailRecoveryError::SubjectNotSigned)?;
+    //
+    // Subject coverage and the DoH path's diagnostic trail are both
+    // satisfied by the umbrella; we surface `SubjectNotSigned`
+    // separately because it's user-actionable (the FE shows a
+    // dedicated copy) whereas the other failures all fold into
+    // `EmailVerificationFailed`.
+    if let Err((reason, _trail)) =
+        crate::dkim::enforce_signature_header_tag_contract(&sig, now_secs)
+    {
+        return Err(match reason {
+            crate::dkim::VerificationFailReason::SubjectNotSigned => {
+                EmailRecoveryError::SubjectNotSigned
+            }
+            other => EmailRecoveryError::EmailVerificationFailed(format!("{other:?}")),
+        });
+    }
     let subject_signed = true;
 
     // Body hash check (`bh=`). After this passes, the body bytes

--- a/src/internet_identity/src/email_recovery/submit_leaf.rs
+++ b/src/internet_identity/src/email_recovery/submit_leaf.rs
@@ -292,13 +292,21 @@ fn run_submit(
         EmailRecoveryError::EmailVerificationFailed(format!("DKIM DNS record: {e}"))
     })?;
 
-    // DNS-record-dependent DKIM tag enforcement (design §5.4). See
-    // [`enforce_dns_record_tag_checks`].
-    enforce_dns_record_tag_checks(
-        &dns_record,
+    // DNS-record-dependent DKIM tag contract (design §5.4). Routes
+    // through the same shared umbrella the DoH path calls so the
+    // `t=y` and AUID-alignment policies stay in lock-step across
+    // pipelines. The trail the umbrella builds is the DoH-side
+    // diagnostic; we discard it here because the DNSSEC path
+    // collapses every failure into a single `EmailRecoveryError`.
+    if let Err((reason, _trail)) = crate::dkim::enforce_dns_record_tag_contract(
         &snapshot.signing_auid,
         &snapshot.signing_domain,
-    )?;
+        &dns_record,
+    ) {
+        return Err(EmailRecoveryError::EmailVerificationFailed(format!(
+            "{reason:?}"
+        )));
+    }
 
     // Step 5: complete the cryptographic signature check.
     //
@@ -390,26 +398,6 @@ fn run_submit(
         return Err(EmailRecoveryError::AddressMismatch);
     }
 
-    Ok(())
-}
-
-/// Apply the DKIM tag checks that depend on flags published in the
-/// DKIM TXT record. Runs at submit time on the DNSSEC path — the
-/// signature-header-only checks (`x=`, `t=`, Subject in `h=`) have
-/// already run at `smtp::prepare_partial_verification`. Shared with
-/// the DoH path via [`crate::dkim::check_dns_not_testing`] and
-/// [`crate::dkim::check_auid_aligned`]; extracted so the DNSSEC-path
-/// wiring is unit-testable without spinning up the full DNSSEC chain
-/// validator.
-fn enforce_dns_record_tag_checks(
-    dns_record: &crate::dkim::DkimDnsRecord,
-    signing_auid: &str,
-    signing_domain: &str,
-) -> Result<(), EmailRecoveryError> {
-    crate::dkim::check_dns_not_testing(dns_record)
-        .map_err(|reason| EmailRecoveryError::EmailVerificationFailed(format!("{reason:?}")))?;
-    crate::dkim::check_auid_aligned(signing_auid, signing_domain, dns_record.strict_auid)
-        .map_err(|reason| EmailRecoveryError::EmailVerificationFailed(format!("{reason:?}")))?;
     Ok(())
 }
 
@@ -514,86 +502,9 @@ fn verify_ed25519_prehashed(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::dkim::{DkimDnsRecord, KeyType};
-
-    fn dns(testing: bool, strict_auid: bool) -> DkimDnsRecord {
-        DkimDnsRecord {
-            key_type: KeyType::Rsa,
-            // 1-byte placeholder — `enforce_dns_record_tag_checks`
-            // never looks at the key material.
-            public_key: vec![0u8; 1],
-            testing,
-            strict_auid,
-        }
-    }
-
-    #[test]
-    fn enforce_rejects_dns_record_with_testing_flag() {
-        // t=y published on the DKIM record — never accept the
-        // signature, even if everything else lines up.
-        let r =
-            enforce_dns_record_tag_checks(&dns(true, false), "alice@example.com", "example.com");
-        match r {
-            Err(EmailRecoveryError::EmailVerificationFailed(msg)) => {
-                assert!(msg.contains("TestingMode"), "got {msg}");
-            }
-            other => panic!("expected TestingMode rejection, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn enforce_rejects_subdomain_auid_when_dns_strict_set() {
-        // `i=alice@mail.example.com`, `d=example.com`, DNS `t=s` set →
-        // strict alignment requires exact match; reject.
-        let r = enforce_dns_record_tag_checks(
-            &dns(false, true),
-            "alice@mail.example.com",
-            "example.com",
-        );
-        match r {
-            Err(EmailRecoveryError::EmailVerificationFailed(msg)) => {
-                assert!(msg.contains("AuidMisaligned"), "got {msg}");
-            }
-            other => panic!("expected AuidMisaligned rejection, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn enforce_accepts_subdomain_auid_when_dns_loose() {
-        // Same i=/d=, DNS `t=s` clear (default) → subdomain alignment
-        // is allowed.
-        let r = enforce_dns_record_tag_checks(
-            &dns(false, false),
-            "alice@mail.example.com",
-            "example.com",
-        );
-        assert!(r.is_ok(), "expected Ok, got {r:?}");
-    }
-
-    #[test]
-    fn enforce_accepts_exact_auid_match() {
-        let r =
-            enforce_dns_record_tag_checks(&dns(false, true), "alice@example.com", "example.com");
-        assert!(r.is_ok(), "expected Ok, got {r:?}");
-    }
-
-    #[test]
-    fn enforce_rejects_evil_suffix_auid() {
-        // `evilexample.com` must not match `example.com` even in
-        // loose-alignment mode (label-anchored suffix).
-        let r = enforce_dns_record_tag_checks(
-            &dns(false, false),
-            "alice@evilexample.com",
-            "example.com",
-        );
-        match r {
-            Err(EmailRecoveryError::EmailVerificationFailed(msg)) => {
-                assert!(msg.contains("AuidMisaligned"), "got {msg}");
-            }
-            other => panic!("expected AuidMisaligned rejection, got {other:?}"),
-        }
-    }
-}
+// Tests for the DNS-record tag contract live alongside the umbrella
+// in `crate::dkim::tag_checks::tests`. The DNSSEC submit-side mapping
+// of `(VerificationFailReason, _) → EmailRecoveryError::
+// EmailVerificationFailed` is a trivial one-liner that the existing
+// `email_recovery::smtp::tests::doh_and_dnssec_paths_reject_*`
+// regression guards already exercise end-to-end.

--- a/src/internet_identity/src/email_recovery/submit_leaf.rs
+++ b/src/internet_identity/src/email_recovery/submit_leaf.rs
@@ -505,6 +505,7 @@ fn verify_ed25519_prehashed(
 // Tests for the DNS-record tag contract live alongside the umbrella
 // in `crate::dkim::tag_checks::tests`. The DNSSEC submit-side mapping
 // of `(VerificationFailReason, _) → EmailRecoveryError::
-// EmailVerificationFailed` is a trivial one-liner that the existing
-// `email_recovery::smtp::tests::doh_and_dnssec_paths_reject_*`
-// regression guards already exercise end-to-end.
+// EmailVerificationFailed` is a trivial one-liner; the DNSSEC-prepare
+// half of the same pattern (the `?` mapping inside
+// `prepare_partial_verification`) is exercised end-to-end by
+// `email_recovery::smtp::tests::dnssec_prepare_rejects_*`.


### PR DESCRIPTION
> **Note:** Stacked on top of [internet-identity#3911](https://github.com/dfinity/internet-identity/pull/3911) (\`fix/dnssec-path-dkim-tag-parity\`). Once that PR merges, the base auto-rebases to \`main\` and this diff becomes self-contained.

## Problem

The audit that motivated [internet-identity#3911](https://github.com/dfinity/internet-identity/pull/3911) found the DoH and DNSSEC paths had each grown their own copy of the DKIM tag enforcement (`x=`, `t=`, Subject in `h=`, `i=` AUID alignment, DNS `t=y`). #3911 extracted shared `check_*` helpers, but each pipeline was still free to call them à la carte — adding a new check still required remembering to wire it into both call sites. That residual drift surface is the same bug class as the original audit finding, just one level smaller.

## Changes

Route both pipelines through a single pair of umbrella functions in `dkim::tag_checks`:

- `enforce_signature_header_tag_contract(sig, now_secs)` — runs the three signature-header-only checks. Called at email-arrival time on both paths.
- `enforce_dns_record_tag_contract(i, d, dns)` — runs the two DNS-record-dependent checks. Called as soon as the DKIM TXT record is trusted.

Adding a new tag policy now means amending one umbrella; both pipelines pick it up automatically. The individual `check_*` helpers stay `pub(crate)` so unit tests (and the upcoming property-based parity tests in the follow-up PR) can compare each constituent helper against the umbrella's verdict — production callers go through the umbrellas.

The umbrellas return `Result<Vec<DkimCheck>, (VerificationFailReason, Vec<DkimCheck>)>` — symmetric with `verify::try_verify_signature`'s shape. The DoH path appends the trail to its diagnostic accumulator; the DNSSEC path discards (it surfaces a single `EmailRecoveryError`).

The previously-local `enforce_dns_record_tag_checks` in `email_recovery::submit_leaf` is deleted — superseded by the shared umbrella; its 5 unit tests are subsumed by the new umbrella tests in `tag_checks`.

## Behavioural note

One ordering shift falls out of the consolidation. The DoH path historically ran the DNS-record-aware checks in order `AUID → k= → t=y`. The umbrella runs `t=y → AUID`, so for a signature that triggers both `TestingMode` and `AlgorithmKeyTypeMismatch` (rare but possible), the prior code surfaced `AlgorithmKeyTypeMismatch` and this code surfaces `TestingMode`. `TestingMode` is the more fundamental rejection — a testing-flagged key invalidates a signature regardless of any other tag state — so surfacing it first is more diagnostic-useful, but it is a change worth flagging.

## Tests

- 7 new umbrella tests in `dkim::tag_checks::tests`: each umbrella's all-pass / first-fail / short-circuit behaviour, and a parity assertion that the umbrella accepts iff every constituent `check_*` helper accepts.
- 524 unit tests pass. Clippy clean with `-D warnings`. Wasm32 release build OK.