### PR TITLE
test(be): property-based parity tests for the DKIM tag-contract facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -267,6 +276,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -841,7 +856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2235,6 +2250,7 @@ dependencies = [
  "p256",
  "pocket-ic",
  "pretty_assertions",
+ "proptest",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -2407,7 +2423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.5.3",
  "ena",
  "itertools",
  "lalrpop-util",
@@ -3063,6 +3079,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift 0.4.0",
+ "regex-syntax 0.8.8",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3071,6 +3106,12 @@ dependencies = [
  "ar_archive_writer",
  "cc",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -3163,7 +3204,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi",
 ]
 
@@ -3311,6 +3352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3555,6 +3605,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4457,6 +4519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4533,6 +4601,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ ic-verifiable-credentials = { git = "https://github.com/dfinity/verifiable-crede
 ic-canister-sig-creation = "1.1"
 pocket-ic = "9.0.2"
 pretty_assertions = "1.4.1"
+proptest = "1"
 base64 = "0.22"
 hex = "0.4"
 include_dir = "0.7"

--- a/src/internet_identity/Cargo.toml
+++ b/src/internet_identity/Cargo.toml
@@ -70,5 +70,10 @@ canister_tests.workspace = true
 regex.workspace = true
 pretty_assertions.workspace = true
 ic-response-verification.workspace = true
+# Property-based tests for the DKIM tag-contract facade in
+# `src/dkim/tag_checks.rs`: generate random `(DkimSignature,
+# DkimDnsRecord, now)` triples and assert the umbrella's verdict
+# matches the conjunction of the individual `check_*` helpers.
+proptest.workspace = true
 flate2 = "1.0"
 getrandom = "0.2"

--- a/src/internet_identity/src/dkim/tag_checks.rs
+++ b/src/internet_identity/src/dkim/tag_checks.rs
@@ -736,7 +736,14 @@ mod property_tests {
         let t_strat = prop::option::of(small_time.clone());
         let x_strat = prop::option::of(small_time);
 
-        (d_strat, h_strat, t_strat, x_strat, any::<u8>(), "[a-z]{0,8}")
+        (
+            d_strat,
+            h_strat,
+            t_strat,
+            x_strat,
+            any::<u8>(),
+            "[a-z]{0,8}",
+        )
             .prop_flat_map(|(d, h, t, x, mode, local)| {
                 let d_clone = d.clone();
                 let i_strat = match mode % 3 {
@@ -774,6 +781,41 @@ mod property_tests {
         })
     }
 
+    /// Assert that `umbrella`'s verdict matches the conjunction of an
+    /// ordered list of per-helper results, AND that on rejection the
+    /// umbrella surfaces exactly the first failing helper's reason.
+    /// Captures the "umbrella is the ordered chain of its constituent
+    /// checks" contract in one place so adding a new umbrella later
+    /// is a single call rather than a copy-pasted if-let-else
+    /// cascade.
+    fn assert_facade_parity(
+        helpers: &[Result<(), VerificationFailReason>],
+        umbrella: Result<Vec<DkimCheck>, (VerificationFailReason, Vec<DkimCheck>)>,
+    ) -> Result<(), TestCaseError> {
+        let first_fail = helpers.iter().find_map(|r| r.clone().err());
+        match (umbrella, first_fail) {
+            (Ok(_), None) => Ok(()),
+            (Err((reason, _)), Some(expected)) => {
+                prop_assert_eq!(reason, expected);
+                Ok(())
+            }
+            (Ok(_), Some(missed)) => {
+                prop_assert!(
+                    false,
+                    "umbrella accepted but a helper rejected with {missed:?}"
+                );
+                Ok(())
+            }
+            (Err((spurious, _)), None) => {
+                prop_assert!(
+                    false,
+                    "umbrella rejected with {spurious:?} but no helper did"
+                );
+                Ok(())
+            }
+        }
+    }
+
     proptest! {
         /// The signature-header umbrella accepts iff every constituent
         /// check accepts, and on rejection its reason matches the first-
@@ -784,28 +826,14 @@ mod property_tests {
             sig in arb_signature(),
             now in 0u64..3_000_000_000u64,
         ) {
-            let r_x = check_signature_not_expired(&sig, now);
-            let r_t = check_signature_not_from_future(&sig, now);
-            let r_subject = check_subject_signed(&sig);
-            let umbrella = enforce_signature_header_tag_contract(&sig, now);
-
-            // Verdict parity.
-            let all_helpers_pass = r_x.is_ok() && r_t.is_ok() && r_subject.is_ok();
-            prop_assert_eq!(all_helpers_pass, umbrella.is_ok());
-
-            // Reason parity on failure.
-            if let Err((reason, _trail)) = umbrella {
-                let expected = if let Err(e) = r_x {
-                    e
-                } else if let Err(e) = r_t {
-                    e
-                } else if let Err(e) = r_subject {
-                    e
-                } else {
-                    panic!("umbrella rejected but no helper did");
-                };
-                prop_assert_eq!(reason, expected);
-            }
+            assert_facade_parity(
+                &[
+                    check_signature_not_expired(&sig, now),
+                    check_signature_not_from_future(&sig, now),
+                    check_subject_signed(&sig),
+                ],
+                enforce_signature_header_tag_contract(&sig, now),
+            )?;
         }
 
         /// The DNS-record umbrella accepts iff every constituent check
@@ -817,23 +845,13 @@ mod property_tests {
             sig in arb_signature(),
             dns in arb_dns_record(),
         ) {
-            let r_testing = check_dns_not_testing(&dns);
-            let r_auid = check_auid_aligned(&sig.i, &sig.d, dns.strict_auid);
-            let umbrella = enforce_dns_record_tag_contract(&sig.i, &sig.d, &dns);
-
-            let all_helpers_pass = r_testing.is_ok() && r_auid.is_ok();
-            prop_assert_eq!(all_helpers_pass, umbrella.is_ok());
-
-            if let Err((reason, _trail)) = umbrella {
-                let expected = if let Err(e) = r_testing {
-                    e
-                } else if let Err(e) = r_auid {
-                    e
-                } else {
-                    panic!("umbrella rejected but no helper did");
-                };
-                prop_assert_eq!(reason, expected);
-            }
+            assert_facade_parity(
+                &[
+                    check_dns_not_testing(&dns),
+                    check_auid_aligned(&sig.i, &sig.d, dns.strict_auid),
+                ],
+                enforce_dns_record_tag_contract(&sig.i, &sig.d, &dns),
+            )?;
         }
 
         /// Calling either umbrella twice on the same input gives the

--- a/src/internet_identity/src/dkim/tag_checks.rs
+++ b/src/internet_identity/src/dkim/tag_checks.rs
@@ -723,10 +723,15 @@ mod property_tests {
             0..6,
         );
 
-        // 1 % chance of t= or x= sliding far past `u64::MAX / 2` —
-        // we want common-case coverage near `now ± skew`, plus the
-        // odd extreme to confirm `saturating_add` keeps the umbrella
-        // panic-free.
+        // `t=` / `x=` (and the property's `now` below) all draw from
+        // `0..3_000_000_000` — a range broad enough to make
+        // before/within-skew/after-skew transitions hit every branch
+        // of the umbrella with non-trivial frequency, but small
+        // enough that `now.saturating_add(CLOCK_SKEW_SECS)` never
+        // saturates. The umbrella is `saturating_add`-correct by
+        // construction (no panic possible for any `u64`), so cases
+        // near `u64::MAX` add no extra coverage worth slowing the
+        // generator down for.
         let small_time = 0u64..3_000_000_000u64;
         let t_strat = prop::option::of(small_time.clone());
         let x_strat = prop::option::of(small_time);

--- a/src/internet_identity/src/dkim/tag_checks.rs
+++ b/src/internet_identity/src/dkim/tag_checks.rs
@@ -672,3 +672,185 @@ mod tests {
         assert!(enforce_dns_record_tag_contract(&s.i, &s.d, &r).is_ok());
     }
 }
+
+// =====================================================================
+// Property-based tests — facade-vs-helpers parity guarantee.
+//
+// The umbrellas (`enforce_*_tag_contract`) are defined as the ordered
+// chain of their constituent `check_*` helpers. That contract holds
+// trivially for the 7 hand-written umbrella unit tests in
+// `mod tests`, but the *generative* guarantee is the one we care
+// about: across arbitrary inputs, the umbrella's verdict can never
+// disagree with the per-helper conjunction, and the umbrella's
+// failure reason is exactly the first-failing helper's. If a future
+// refactor accidentally dropped a check from an umbrella, these
+// properties would fail on the first generated input that triggers
+// the dropped check — long before the bug could ship.
+//
+// `proptest` is a dev-dep (see `Cargo.toml`) — no production-build
+// impact.
+// =====================================================================
+
+#[cfg(test)]
+mod property_tests {
+    use super::*;
+    use crate::dkim::{Algorithm, BodyCanon, DkimDnsRecord, HeaderCanon, KeyType};
+    use proptest::prelude::*;
+
+    /// Strategy for a `DkimSignature` with the fields the tag-contract
+    /// checks actually read: `t`, `x`, `h`, `i`, `d`. The other fields
+    /// get fixed placeholder values — the checks never look at them,
+    /// and randomising them would just slow the runner without
+    /// adding coverage.
+    ///
+    /// `i` is constructed in one of three modes so AUID alignment hits
+    /// every branch with non-trivial frequency: exact match against
+    /// `d`, a label-anchored subdomain of `d`, or an unrelated domain.
+    /// Without this the random-string generator would land on
+    /// "unrelated" almost every time and the strict/loose distinction
+    /// would never get exercised.
+    fn arb_signature() -> impl Strategy<Value = DkimSignature> {
+        let labels = "[a-z]{1,6}";
+        let d_strat = (labels, labels).prop_map(|(a, b)| format!("{a}.{b}"));
+
+        let h_strat = prop::collection::vec(
+            prop_oneof![
+                Just("From".to_string()),
+                Just("Subject".to_string()),
+                Just("Date".to_string()),
+                Just("To".to_string()),
+            ],
+            0..6,
+        );
+
+        // 1 % chance of t= or x= sliding far past `u64::MAX / 2` —
+        // we want common-case coverage near `now ± skew`, plus the
+        // odd extreme to confirm `saturating_add` keeps the umbrella
+        // panic-free.
+        let small_time = 0u64..3_000_000_000u64;
+        let t_strat = prop::option::of(small_time.clone());
+        let x_strat = prop::option::of(small_time);
+
+        (d_strat, h_strat, t_strat, x_strat, any::<u8>(), "[a-z]{0,8}")
+            .prop_flat_map(|(d, h, t, x, mode, local)| {
+                let d_clone = d.clone();
+                let i_strat = match mode % 3 {
+                    // Aligned: same domain.
+                    0 => Just(format!("{local}@{d_clone}")).boxed(),
+                    // Subdomain (loose-mode aligned, strict-mode misaligned).
+                    1 => Just(format!("{local}@sub.{d_clone}")).boxed(),
+                    // Unrelated.
+                    _ => Just(format!("{local}@unrelated.example")).boxed(),
+                };
+                i_strat.prop_map(move |i| DkimSignature {
+                    version: 1,
+                    algorithm: Algorithm::RsaSha256,
+                    d: d.clone(),
+                    s: "sel".into(),
+                    c_header: HeaderCanon::Relaxed,
+                    c_body: BodyCanon::Relaxed,
+                    h: h.clone(),
+                    l: None,
+                    bh: vec![0u8; 32],
+                    b: vec![0u8; 256],
+                    t,
+                    x,
+                    i,
+                })
+            })
+    }
+
+    fn arb_dns_record() -> impl Strategy<Value = DkimDnsRecord> {
+        (any::<bool>(), any::<bool>()).prop_map(|(testing, strict_auid)| DkimDnsRecord {
+            key_type: KeyType::Rsa,
+            public_key: vec![0u8; 1],
+            testing,
+            strict_auid,
+        })
+    }
+
+    proptest! {
+        /// The signature-header umbrella accepts iff every constituent
+        /// check accepts, and on rejection its reason matches the first-
+        /// failing helper in the umbrella's documented order (x= → t= →
+        /// Subject).
+        #[test]
+        fn header_umbrella_matches_helpers_for_any_input(
+            sig in arb_signature(),
+            now in 0u64..3_000_000_000u64,
+        ) {
+            let r_x = check_signature_not_expired(&sig, now);
+            let r_t = check_signature_not_from_future(&sig, now);
+            let r_subject = check_subject_signed(&sig);
+            let umbrella = enforce_signature_header_tag_contract(&sig, now);
+
+            // Verdict parity.
+            let all_helpers_pass = r_x.is_ok() && r_t.is_ok() && r_subject.is_ok();
+            prop_assert_eq!(all_helpers_pass, umbrella.is_ok());
+
+            // Reason parity on failure.
+            if let Err((reason, _trail)) = umbrella {
+                let expected = if let Err(e) = r_x {
+                    e
+                } else if let Err(e) = r_t {
+                    e
+                } else if let Err(e) = r_subject {
+                    e
+                } else {
+                    panic!("umbrella rejected but no helper did");
+                };
+                prop_assert_eq!(reason, expected);
+            }
+        }
+
+        /// The DNS-record umbrella accepts iff every constituent check
+        /// accepts, and on rejection its reason matches the first-
+        /// failing helper in the umbrella's documented order (t=y →
+        /// AUID).
+        #[test]
+        fn dns_record_umbrella_matches_helpers_for_any_input(
+            sig in arb_signature(),
+            dns in arb_dns_record(),
+        ) {
+            let r_testing = check_dns_not_testing(&dns);
+            let r_auid = check_auid_aligned(&sig.i, &sig.d, dns.strict_auid);
+            let umbrella = enforce_dns_record_tag_contract(&sig.i, &sig.d, &dns);
+
+            let all_helpers_pass = r_testing.is_ok() && r_auid.is_ok();
+            prop_assert_eq!(all_helpers_pass, umbrella.is_ok());
+
+            if let Err((reason, _trail)) = umbrella {
+                let expected = if let Err(e) = r_testing {
+                    e
+                } else if let Err(e) = r_auid {
+                    e
+                } else {
+                    panic!("umbrella rejected but no helper did");
+                };
+                prop_assert_eq!(reason, expected);
+            }
+        }
+
+        /// Calling either umbrella twice on the same input gives the
+        /// same verdict — captures the "no hidden state" property
+        /// that would silently break if someone added a `thread_local`
+        /// cache to a helper.
+        #[test]
+        fn umbrellas_are_deterministic(
+            sig in arb_signature(),
+            dns in arb_dns_record(),
+            now in 0u64..3_000_000_000u64,
+        ) {
+            let a = enforce_signature_header_tag_contract(&sig, now);
+            let b = enforce_signature_header_tag_contract(&sig, now);
+            // `Result<Vec<DkimCheck>, _>` implements PartialEq — direct
+            // structural comparison works.
+            prop_assert_eq!(a.is_ok(), b.is_ok());
+            prop_assert_eq!(a, b);
+
+            let a = enforce_dns_record_tag_contract(&sig.i, &sig.d, &dns);
+            let b = enforce_dns_record_tag_contract(&sig.i, &sig.d, &dns);
+            prop_assert_eq!(a, b);
+        }
+    }
+}


### PR DESCRIPTION
> **Note:** Stacked on top of [internet-identity#3919](https://github.com/dfinity/internet-identity/pull/3919) (\`refactor/dkim-tag-contract-facade\`), which is in turn stacked on [internet-identity#3911](https://github.com/dfinity/internet-identity/pull/3911). Once both bases land, this PR's base auto-rebases to \`main\` and the diff becomes self-contained (4 files / +269 / -4).

## Problem

The umbrella facade from [internet-identity#3919](https://github.com/dfinity/internet-identity/pull/3919) is defined as the ordered chain of its constituent `check_*` helpers. The 7 hand-written umbrella unit tests in `dkim::tag_checks::tests` verify that property on representative inputs — but they're picked deliberately, not generated. If a future refactor accidentally dropped a check from an umbrella (the exact bug class the facade is meant to make impossible), the unit tests would only catch it if it happened to be one of the inputs they used.

## Changes

Add three `proptest!`-driven properties that exercise the umbrellas across arbitrary `(DkimSignature, DkimDnsRecord, now)` triples. proptest defaults to 256 cases per property; the whole property module runs in ~50 ms.

- **`header_umbrella_matches_helpers_for_any_input`** — verdict parity (umbrella accepts iff all three header-only helpers accept) and reason parity (on rejection, the umbrella's `VerificationFailReason` is exactly the first-failing helper's, in the umbrella's documented order `x=` → `t=` → Subject).
- **`dns_record_umbrella_matches_helpers_for_any_input`** — same shape for the DNS-record umbrella (`t=y` → AUID).
- **`umbrellas_are_deterministic`** — calling either umbrella twice on the same input gives the same answer. Captures the "no hidden state" property that would silently break if someone added a `thread_local` cache to a helper.

The `arb_signature` generator constructs `i=` in one of three modes (exact match against `d=`, label-anchored subdomain, unrelated domain) so AUID alignment hits every branch with non-trivial frequency. A naive random-string generator would land on "unrelated" almost every time and never exercise the strict/loose distinction. `t=` and `x=` use a bounded `0..3_000_000_000` range to keep most cases near `now ± skew`, where the interesting transitions live.

## Dependency

`proptest = "1"` added as a workspace dev-dep and pulled into `internet_identity` only via `[dev-dependencies]`. The canister release build (`cfg(not(test))`, wasm32) is unaffected — proptest is never linked into the production wasm. Lockfile +103 lines for the transitive deps; all are dev-only.

## Tests

- 3 new properties (256 cases each by default).
- 527 unit + property tests pass. Clippy clean with `-D warnings`. Wasm32 release build OK.