### PR TITLE
chore: drop remaining dfx mentions from comments

### DIFF
--- a/demos/test-app/lib.rs
+++ b/demos/test-app/lib.rs
@@ -124,8 +124,8 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
                         .into_iter()
                         .map(|(header_name, header_value)| {
                             // Modify the IC-Certificate header to make certification invalid
-                            // Note: we cannot simply drop the header because then the local replica (dfx 0.15 and later)
-                            // will skip the certification check altogether.
+                            // Note: we cannot simply drop the header because the local replica
+                            // skips the certification check altogether when the header is absent.
                             if header_name == "IC-Certificate" {
                                 (header_name, OUTDATED_INVALID_CERTIFICATE_HEADER.to_string())
                             } else {

--- a/demos/test-app/src/index.tsx
+++ b/demos/test-app/src/index.tsx
@@ -572,7 +572,6 @@ whoamiBtn.addEventListener("click", async () => {
 
   whoAmIResponseEl.innerText = "Loading...";
 
-  // Similar to the sample project on dfx new:
   actor
     .whoami()
     .then((principal: any) => {

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -1022,9 +1022,7 @@ encode_install_arg_bin() {
 # -------------------------
 # Routes the install/upgrade through the proxy canister at PROXY_CANISTER_ID,
 # which is the legacy staging wallet reinstalled with the icp-cli proxy
-# WASM (see
-# https://cli.internetcomputer.org/0.2/migration/from-dfx/#replacing-the-dfx-wallet-canister).
-# The proxy keeps the wallet's canister ID — and therefore its
+# WASM. The proxy keeps the wallet's canister ID — and therefore its
 # controllership of the staging canisters — but now exposes the `proxy`
 # method icp-cli's `--proxy` expects.
 #

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -581,10 +581,8 @@ prepare_staging_frontend_argument() {
 deploy_staging_backend() {
   echo "Deploying II backend release candidate to staging"
   # Routed through the staging proxy canister (legacy wallet reinstalled
-  # with the icp-cli proxy WASM — see
-  # https://cli.internetcomputer.org/0.2/migration/from-dfx/#replacing-the-dfx-wallet-canister).
-  # staging_icp_arg.bin holds the hex output of `didc encode`, so we
-  # tell icp-cli to read the file as hex.
+  # with the icp-cli proxy WASM). staging_icp_arg.bin holds the hex
+  # output of `didc encode`, so we tell icp-cli to read the file as hex.
   icp canister install "$STAGING_BACKEND_CANISTER_ID" \
     -e ic \
     --proxy "$STAGING_PROXY_CANISTER_ID" \


### PR DESCRIPTION
Follow-up to #3924. Cleans up the last leftover `dfx` references the recent icp-cli migration didn't touch.

# Changes

- `scripts/deploy-common.bash` / `scripts/make-upgrade-proposal`: drop the `cli.internetcomputer.org/0.2/migration/from-dfx/…` links from the proxy-routed install runners' comments — the surrounding context already explains what the proxy canister is and why we route through it.
- `demos/test-app/src/index.tsx`: remove the stale `// Similar to the sample project on dfx new:` attribution comment above the `whoami` call.
- `demos/test-app/lib.rs`: reword the certification-header comment to drop the `dfx 0.15 and later` qualifier — the behavior is what the local replica does today, regardless of which CLI launched it.

After this PR, the only remaining `dfx` strings in the repo are the two `secrets.DFX_DEPLOY_KEY` references in `.github/workflows/{deploy-rc,canister-tests}.yml`. Those are GitHub secret names and intentionally left as-is — renaming would require an admin to also rename the secret in repo settings.