### PR TITLE
chore(scripts): args-only proposal support in make-upgrade-proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,11 +36,13 @@ pocket-ic
 
 *.tsbuildinfo
 
-# Proposals
+# Proposals — scratch files written by scripts/make-upgrade-proposal
+# (both the --new release flow and the --reconfigure args-only flow).
 release*.json
-arg.bin
-args.txt
-proposal.md
+reconfigure-*.json
+*args.txt
+*arg.bin
+*proposal.md
 
 # Playwright
 /test-results/

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -28,13 +28,17 @@ print_help() {
 	Performs or guides the steps in the Internet Identity release SOP checklist.
 
 	To start a new release process, run:
-	  ./make-upgrade-proposal.sh --new --name release-\$(date +%Y-%m-%d)
+	  ./make-upgrade-proposal --new --name release-\$(date +%Y-%m-%d)
 
 	To start a new release process on the same day as a previous release, run:
-	  ./make-upgrade-proposal.sh --new --name release-\$(date +%Y-%m-%d)-v2
+	  ./make-upgrade-proposal --new --name release-\$(date +%Y-%m-%d)-v2
 
 	To continue an existing release process, run:
-	  ./make-upgrade-proposal.sh --continue --name <release-used-on-new>
+	  ./make-upgrade-proposal --continue --name <release-used-on-new>
+
+	To create an args-only proposal that re-uses the wasm currently on
+	chain (auto-resolved from the latest proposal-\\<role\\>-* tag), run:
+	  ./make-upgrade-proposal --reconfigure
 
 	EOF
 }
@@ -44,17 +48,30 @@ source "$SOURCE_DIR/clap.bash"
 # Define options
 clap.define long=new desc="Start a new release branch" variable=IS_NEW_RELEASE nargs=0 default="false"
 clap.define long=continue desc="Continue with an existing release branch" variable=CONTINUE nargs=0 default="false"
+clap.define long=reconfigure desc="Args-only proposal: re-use the wasm currently on chain (auto-resolved from latest proposal-<role>-* tag)" variable=IS_RECONFIGURE nargs=0 default="false"
 clap.define long=name desc="The name of the new release branch" variable=TAG_NAME
 # Source the output file ------------------------------------------------------
 source "$(clap.build)"
 
-if [ "$IS_NEW_RELEASE" = "true" ] && [ "$CONTINUE" = "true" ]; then
-  echo "Cannot specify both --new and --continue" >&2
+# Exactly one mode flag must be set. --reconfigure is incompatible with
+# --new/--continue because it owns both TAG_NAME and CHECKLIST_FILE
+# selection internally — there's nothing left to specify or resume.
+mode_count=0
+[ "$IS_NEW_RELEASE" = "true" ] && mode_count=$((mode_count + 1))
+[ "$CONTINUE" = "true" ] && mode_count=$((mode_count + 1))
+[ "$IS_RECONFIGURE" = "true" ] && mode_count=$((mode_count + 1))
+
+if [ "$mode_count" -eq 0 ]; then
+  echo "Must specify one of --new, --continue, --reconfigure" >&2
+  exit 1
+fi
+if [ "$mode_count" -gt 1 ]; then
+  echo "--new, --continue, --reconfigure are mutually exclusive" >&2
   exit 1
 fi
 
-if [ "$IS_NEW_RELEASE" = "false" ] && [ "$CONTINUE" = "false" ]; then
-  echo "Must specify either --new or --continue" >&2
+if [ "$IS_RECONFIGURE" = "true" ] && [ -n "${TAG_NAME+x}" ]; then
+  echo "--name is not allowed with --reconfigure (the release tag is auto-resolved from the latest proposal-<role>-* tag)" >&2
   exit 1
 fi
 
@@ -102,28 +119,33 @@ execute() {
 
 RELEASE_NAME_PATTERN="^release-[0-9]{4}-[0-9]{2}-[0-9]{2}"
 
-if [ -z "${TAG_NAME+x}" ]; then
-  echo "Must specify TAG_NAME"
-  echo ""
-  echo "Make sure to checkout the latest main branch,"
-  echo "and then create a git release tag: release-yyyy-mm-dd"
-  echo ""
-  echo "Then use the following command to start: TAG_NAME=release-yyyy-mm-dd ./scripts/make_upgrade_proposal --new"
-  exit 1;
-fi
+# --new / --continue require an explicit --name. --reconfigure resolves
+# it later (from the latest proposal-<role>-* tag), so defer the
+# TAG_NAME and CHECKLIST_FILE setup until after the helpers are defined.
+if [ "$IS_RECONFIGURE" != "true" ]; then
+  if [ -z "${TAG_NAME+x}" ]; then
+    echo "Must specify TAG_NAME"
+    echo ""
+    echo "Make sure to checkout the latest main branch,"
+    echo "and then create a git release tag: release-yyyy-mm-dd"
+    echo ""
+    echo "Then use the following command to start: TAG_NAME=release-yyyy-mm-dd ./scripts/make_upgrade_proposal --new"
+    exit 1;
+  fi
 
-if [ "$IS_NEW_RELEASE" = "true" ]; then
-  CHECKLIST_FILE="${SOURCE_DIR}/${TAG_NAME}.json"
+  if [ "$IS_NEW_RELEASE" = "true" ]; then
+    CHECKLIST_FILE="${SOURCE_DIR}/${TAG_NAME}.json"
 
-  echo "[]" >"$CHECKLIST_FILE"
-else
+    echo "[]" >"$CHECKLIST_FILE"
+  else
 
-  CHECKLIST_FILE="${SOURCE_DIR}/${TAG_NAME}.json"
+    CHECKLIST_FILE="${SOURCE_DIR}/${TAG_NAME}.json"
 
-  if [ ! -f "$CHECKLIST_FILE" ]; then
-    echo "Error: Checklist '$CHECKLIST_FILE' not found!" >&2
-    exit 1
-fi
+    if [ ! -f "$CHECKLIST_FILE" ]; then
+      echo "Error: Checklist '$CHECKLIST_FILE' not found!" >&2
+      exit 1
+    fi
+  fi
 fi
 
 TOP_DIR=$(execute git rev-parse --show-toplevel)
@@ -1207,6 +1229,97 @@ create_forum_post() {
     echo "$url"
   fi
 }
+
+# --reconfigure: derive TAG_NAME from the latest proposal-<role>-* tag
+# and pre-populate the checklist so the wasm/tag/release-page steps
+# don't fire. Runs here (rather than at clap-parse time) because it
+# needs select_canisters_to_upgrade and resolve_release_tag.
+if [ "$IS_RECONFIGURE" = "true" ]; then
+  echo "=== --reconfigure mode (args-only proposal) ==="
+  echo "Re-uses the wasm currently on chain — only the install args"
+  echo "change. The release tag is auto-resolved from the most recent"
+  echo "proposal-<role>-* tag."
+  echo ""
+
+  RECONFIGURE_TYPE=$(select_canisters_to_upgrade)
+
+  # Make sure proposal-*-* tags are fresh enough to resolve.
+  git fetch "$REPO_HTTPS_URL" --tags --force >&2
+
+  resolve_latest_release_for() {
+    local role="$1"
+    local prop_tag
+    prop_tag=$(git tag -l "proposal-${role}-*" | sort -V | tail -1)
+    if [ -z "$prop_tag" ]; then
+      echo "No proposal-${role}-* tag found; nothing to reconfigure." >&2
+      return 1
+    fi
+    local release_tag
+    release_tag=$(resolve_release_tag "$prop_tag")
+    if [ -z "$release_tag" ]; then
+      echo "Could not resolve ${prop_tag} to a release-* tag." >&2
+      return 1
+    fi
+    echo "$release_tag"
+  }
+
+  if should_upgrade_backend "$RECONFIGURE_TYPE"; then
+    BE_RELEASE_TAG=$(resolve_latest_release_for backend) || exit 1
+  fi
+  if should_upgrade_frontend "$RECONFIGURE_TYPE"; then
+    FE_RELEASE_TAG=$(resolve_latest_release_for frontend) || exit 1
+  fi
+
+  if [ "$RECONFIGURE_TYPE" = "both" ]; then
+    # The script has one TAG_NAME, so reconfiguring both at once only
+    # works if the latest BE and FE proposals point at the same release.
+    # Otherwise we'd have to download two different wasms with two
+    # different release tags, which the rest of the script isn't wired
+    # for. Tell the user to do them separately.
+    if [ "$BE_RELEASE_TAG" != "$FE_RELEASE_TAG" ]; then
+      echo "Latest backend proposal points at $BE_RELEASE_TAG;" >&2
+      echo "latest frontend proposal points at $FE_RELEASE_TAG." >&2
+      echo "Run --reconfigure separately for each canister." >&2
+      exit 1
+    fi
+    TAG_NAME="$BE_RELEASE_TAG"
+  elif [ "$RECONFIGURE_TYPE" = "backend" ]; then
+    TAG_NAME="$BE_RELEASE_TAG"
+  else
+    TAG_NAME="$FE_RELEASE_TAG"
+  fi
+
+  # Pick a unique checklist filename — never overwrite a prior run.
+  # Format: reconfigure-<role>-<date>[-vN].json
+  RECONFIGURE_DATE=$(date +%Y-%m-%d)
+  RECONFIGURE_BASE="reconfigure-${RECONFIGURE_TYPE}-${RECONFIGURE_DATE}"
+  CHECKLIST_FILE="${SOURCE_DIR}/${RECONFIGURE_BASE}.json"
+  RECONFIGURE_VARIANT=2
+  while [ -f "$CHECKLIST_FILE" ]; do
+    CHECKLIST_FILE="${SOURCE_DIR}/${RECONFIGURE_BASE}-v${RECONFIGURE_VARIANT}.json"
+    RECONFIGURE_VARIANT=$((RECONFIGURE_VARIANT + 1))
+  done
+
+  # Pre-populate the steps that don't apply when re-using the on-chain
+  # wasm. The keys must match what confirm_cmd / confirm_manual /
+  # record compute internally; see those helpers above.
+  jq -n \
+    --arg upgrade_type "$RECONFIGURE_TYPE" \
+    --arg git_fetch_cmd "git fetch $REPO_HTTPS_URL --tags --force" \
+    --arg git_tag_cmd "git tag -f $TAG_NAME" \
+    '[
+      {name: "Upgrade type",                value: $upgrade_type},
+      {name: $git_fetch_cmd,                value: "Done"},
+      {name: $git_tag_cmd,                  value: "Done"},
+      {name: "New tag pushed",              value: "Done"},
+      {name: "wait_for_release",            value: "Done"},
+      {name: "Review release page update",  value: "Done"}
+    ]' > "$CHECKLIST_FILE"
+
+  echo "Resolved release tag: ${TAG_NAME}"
+  echo "Created checklist:    ${CHECKLIST_FILE}"
+  echo ""
+fi
 
 echo Checklist file: "$CHECKLIST_FILE"
 

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -63,6 +63,8 @@ NOT_MOCKED_COMMANDS=(
   printf
   update_release_text
   detect_archive_hash_change
+  detect_ii_hash_change
+  detect_frontend_hash_change
   download_wasms
   request_verification_command
   deploy_release_candidate
@@ -337,16 +339,25 @@ resolve_release_tag() {
   git tag --points-at "$commit" | grep "^release-" | sort | head -1 || true
 }
 
-detect_archive_hash_change() {
-  # Compare local archive.wasm.gz sha256 against the archive attached to the
-  # release that corresponds to the previous proposal-backend-*. Emits "true"
-  # or "false" on stdout. Falls back to "true" if the previous archive can't
-  # be fetched, so the BE proposal includes the archive hash in the
-  # conservative case.
+# Compare a local wasm against the wasm attached to the release that
+# corresponds to the previous proposal-<role>-*. Emits "true" / "false"
+# on stdout. Falls back to "true" on any lookup/download failure so the
+# proposal stays conservative (verify-hash includes the hash, headline
+# reads as a Wasm upgrade) when we can't tell.
+#
+# Args:
+#   $1 proposal-prefix    proposal-backend | proposal-frontend
+#   $2 release-filename   filename under the GH release assets
+#   $3 local-wasm-path    path on disk to compare against
+detect_release_wasm_change() {
+  local proposal_prefix="$1"
+  local release_filename="$2"
+  local local_wasm="$3"
+
   local prev_proposal_tag
-  prev_proposal_tag=$(git tag -l "proposal-backend-*" | sort -V | tail -1)
+  prev_proposal_tag=$(git tag -l "${proposal_prefix}-*" | sort -V | tail -1)
   if [ -z "$prev_proposal_tag" ]; then
-    echo "No previous proposal-backend-* tag found; treating archive as changed." >&2
+    echo "No previous ${proposal_prefix}-* tag found; treating ${release_filename} as changed." >&2
     echo "true"
     return
   fi
@@ -354,33 +365,49 @@ detect_archive_hash_change() {
   local prev_release_tag
   prev_release_tag=$(resolve_release_tag "$prev_proposal_tag")
   if [ -z "$prev_release_tag" ]; then
-    echo "Could not resolve ${prev_proposal_tag} to a release-* tag; treating archive as changed." >&2
+    echo "Could not resolve ${prev_proposal_tag} to a release-* tag; treating ${release_filename} as changed." >&2
     echo "true"
     return
   fi
 
-  local prev_archive
-  prev_archive=$(mktemp)
+  local prev_wasm
+  prev_wasm=$(mktemp)
 
-  if ! curl -fsSL "https://github.com/dfinity/internet-identity/releases/download/${prev_release_tag}/archive.wasm.gz" -o "$prev_archive"; then
-    rm -f "$prev_archive"
-    echo "Could not download ${prev_release_tag}/archive.wasm.gz; treating archive as changed." >&2
+  if ! curl -fsSL "https://github.com/dfinity/internet-identity/releases/download/${prev_release_tag}/${release_filename}" -o "$prev_wasm"; then
+    rm -f "$prev_wasm"
+    echo "Could not download ${prev_release_tag}/${release_filename}; treating as changed." >&2
     echo "true"
     return
   fi
 
   local prev_sha curr_sha
-  prev_sha=$(sha256 "$prev_archive")
-  curr_sha=$(sha256 ./archive.wasm.gz)
-  rm -f "$prev_archive"
-  echo "Previous archive (${prev_release_tag}): $prev_sha" >&2
-  echo "Current archive:                        $curr_sha" >&2
+  prev_sha=$(sha256 "$prev_wasm")
+  curr_sha=$(sha256 "$local_wasm")
+  rm -f "$prev_wasm"
+  echo "Previous ${release_filename} (${prev_release_tag}): $prev_sha" >&2
+  echo "Current ${release_filename}:                        $curr_sha" >&2
 
   if [ "$prev_sha" = "$curr_sha" ]; then
     echo "false"
   else
     echo "true"
   fi
+}
+
+# Per-wasm wrappers — the script uses these as `record` commands so the
+# output is captured in the checklist as a "true"/"false" flag.
+detect_archive_hash_change() {
+  detect_release_wasm_change "proposal-backend" "archive.wasm.gz" ./archive.wasm.gz
+}
+
+detect_ii_hash_change() {
+  # The GH release asset is internet_identity_production.wasm.gz, but
+  # download_wasms saves it locally as internet_identity.wasm.gz.
+  detect_release_wasm_change "proposal-backend" "internet_identity_production.wasm.gz" ./internet_identity.wasm.gz
+}
+
+detect_frontend_hash_change() {
+  detect_release_wasm_change "proposal-frontend" "internet_identity_frontend.wasm.gz" ./internet_identity_frontend.wasm.gz
 }
 
 download_wasms() {
@@ -801,6 +828,35 @@ EOF
   fi
 }
 
+# Heading and proposal title vary based on whether the wasm differs from
+# what's currently on chain. Args-only proposals (the wasm in the
+# proposal matches the on-chain wasm) read as "Configuration Change"
+# instead of "Upgrade", since the only effective change is the install
+# args.
+#
+# Args: <canister: Backend | Frontend> <wasm-changed: true | false>
+proposal_heading() {
+  local canister="$1"
+  local wasm_changed="$2"
+  if [ "$wasm_changed" = "true" ]; then
+    echo "${canister} Canister Upgrade"
+  else
+    echo "${canister} Canister Configuration Change"
+  fi
+}
+
+proposal_title() {
+  local canister="$1"
+  local wasm_changed="$2"
+  local short_sha
+  short_sha=$(git rev-parse --short "$TAG_NAME")
+  if [ "$wasm_changed" = "true" ]; then
+    echo "Upgrade Internet Identity ${canister} Canister to ${short_sha}"
+  else
+    echo "Update Internet Identity ${canister} Canister install args (commit ${short_sha})"
+  fi
+}
+
 download_proposal_text() {
   local upgrade_type="$(checklist_must_get 'Upgrade type')"
 
@@ -825,7 +881,7 @@ download_proposal_text() {
   if should_upgrade_backend "$upgrade_type"; then
     # Find last backend proposal tag
     local last_backend_tag=$(git tag -l "proposal-backend-*" | sort -V | tail -1)
-    
+
     if [ -z "$last_backend_tag" ]; then
       echo "No previous proposal-backend-* tag found."
       echo "Available release tags:"
@@ -837,11 +893,13 @@ download_proposal_text() {
       fi
     fi
 
-    local commit_range="${last_backend_tag}..${TAG_NAME}"
-    backend_commits=$(git log --format='* %s' --no-merges "$commit_range" -- "${backend_paths[@]}")
-    
-    cat > backend_proposal.md << EOF
-# Backend Canister Upgrade
+    local backend_wasm_changed="$(checklist_must_get 'II WASM changed')"
+    local backend_heading="$(proposal_heading 'Backend' "$backend_wasm_changed")"
+    if [ "$backend_wasm_changed" = "true" ]; then
+      local commit_range="${last_backend_tag}..${TAG_NAME}"
+      backend_commits=$(git log --format='* %s' --no-merges "$commit_range" -- "${backend_paths[@]}")
+      cat > backend_proposal.md << EOF
+# ${backend_heading}
 
 ## What's Changed
 _Since \`${last_backend_tag}\`_
@@ -850,12 +908,28 @@ ${backend_commits}
 
 [Full release notes](https://github.com/dfinity/internet-identity/releases/tag/$TAG_NAME)
 EOF
+    else
+      # Args-only: wasm bytes match what's on chain. There are no commits
+      # to enumerate (same release tag), so leave a TODO comment for the
+      # human to describe the install-args change before submitting.
+      cat > backend_proposal.md << EOF
+# ${backend_heading}
+
+This proposal updates the backend canister install arguments without changing the Wasm. The Wasm bytes in this proposal match the one currently installed on chain (from \`${last_backend_tag}\`).
+
+## What's Changed
+
+<!-- TODO: Describe the install-args change here, then delete this comment. -->
+
+[Full release notes](https://github.com/dfinity/internet-identity/releases/tag/$TAG_NAME)
+EOF
+    fi
   fi
-  
+
   if should_upgrade_frontend "$upgrade_type"; then
     # Find last frontend proposal tag
     local last_frontend_tag=$(git tag -l "proposal-frontend-*" | sort -V | tail -1)
-    
+
     if [ -z "$last_frontend_tag" ]; then
       echo "No previous proposal-frontend-* tag found."
       echo "Available release tags:"
@@ -867,11 +941,13 @@ EOF
       fi
     fi
 
-    local commit_range="${last_frontend_tag}..${TAG_NAME}"
-    frontend_commits=$(git log --format='* %s' --no-merges "$commit_range" -- "${frontend_paths[@]}")
-    
-    cat > frontend_proposal.md << EOF
-# Frontend Canister Upgrade
+    local frontend_wasm_changed="$(checklist_must_get 'Frontend WASM changed')"
+    local frontend_heading="$(proposal_heading 'Frontend' "$frontend_wasm_changed")"
+    if [ "$frontend_wasm_changed" = "true" ]; then
+      local commit_range="${last_frontend_tag}..${TAG_NAME}"
+      frontend_commits=$(git log --format='* %s' --no-merges "$commit_range" -- "${frontend_paths[@]}")
+      cat > frontend_proposal.md << EOF
+# ${frontend_heading}
 
 ## What's Changed
 _Since \`${last_frontend_tag}\`_
@@ -880,6 +956,19 @@ ${frontend_commits}
 
 [Full release notes](https://github.com/dfinity/internet-identity/releases/tag/$TAG_NAME)
 EOF
+    else
+      cat > frontend_proposal.md << EOF
+# ${frontend_heading}
+
+This proposal updates the frontend canister install arguments without changing the Wasm. The Wasm bytes in this proposal match the one currently installed on chain (from \`${last_frontend_tag}\`).
+
+## What's Changed
+
+<!-- TODO: Describe the install-args change here, then delete this comment. -->
+
+[Full release notes](https://github.com/dfinity/internet-identity/releases/tag/$TAG_NAME)
+EOF
+    fi
   fi
 }
 
@@ -907,7 +996,7 @@ dry_run_proposal() {
       --arg-sha256 "$(compute_sha256sum_for_args args.txt)" \
       --dry-run \
       --summary-file ./backend_proposal.md \
-      --proposal-title "Upgrade Internet Identity Backend Canister to $(git rev-parse --short "$TAG_NAME")"
+      --proposal-title "$(proposal_title 'Backend' "$(checklist_must_get 'II WASM changed')")"
   fi
 
   if should_upgrade_frontend "$upgrade_type"; then
@@ -929,7 +1018,7 @@ dry_run_proposal() {
       --arg-sha256 "$(compute_sha256sum_for_frontend_args frontend_args.txt)" \
       --dry-run \
       --summary-file ./frontend_proposal.md \
-      --proposal-title "Upgrade Internet Identity Frontend Canister to $(git rev-parse --short "$TAG_NAME")"
+      --proposal-title "$(proposal_title 'Frontend' "$(checklist_must_get 'Frontend WASM changed')")"
   fi
 }
 
@@ -986,7 +1075,7 @@ make_backend_proposal() {
     --arg mainnet_arg.bin \
     --arg-sha256 "$(compute_sha256sum_for_args args.txt)" \
     --summary-file ./backend_proposal.md \
-    --proposal-title "Upgrade Internet Identity Backend Canister to $(git rev-parse --short "$TAG_NAME")" \
+    --proposal-title "$(proposal_title 'Backend' "$(checklist_must_get 'II WASM changed')")" \
     2>&1 | tee /dev/stderr)
   parse_proposal_id "$output" "backend proposal number"
 }
@@ -1011,7 +1100,7 @@ make_frontend_proposal() {
     --arg mainnet_frontend_arg.bin \
     --arg-sha256 "$(compute_sha256sum_for_frontend_args frontend_args.txt)" \
     --summary-file ./frontend_proposal.md \
-    --proposal-title "Upgrade Internet Identity Frontend Canister to $(git rev-parse --short "$TAG_NAME")" \
+    --proposal-title "$(proposal_title 'Frontend' "$(checklist_must_get 'Frontend WASM changed')")" \
     2>&1 | tee /dev/stderr)
   parse_proposal_id "$output" "frontend proposal number"
 }
@@ -1144,14 +1233,21 @@ confirm_cmd download_wasms
 if should_upgrade_backend "$UPGRADE_TYPE"; then
   record "II WASM hash" sha256 internet_identity.wasm.gz
   record "Archive WASM hash" sha256 archive.wasm.gz
-  # Auto-detect whether the archive wasm differs from the previous
+  # Auto-detect whether each backend wasm differs from the previous
   # proposal-backend-* release. The BE proposal's verify-hash command
-  # includes --archive-hash only when this says "true".
+  # includes --archive-hash only when "Archive changed" is "true", and
+  # the proposal title/heading switch to "configuration change" wording
+  # when "II WASM changed" is "false".
+  record "II WASM changed" detect_ii_hash_change
   record "Archive changed" detect_archive_hash_change
 fi
 
 if should_upgrade_frontend "$UPGRADE_TYPE"; then
   record "Frontend WASM hash" sha256 internet_identity_frontend.wasm.gz
+  # Used the same way as "II WASM changed" above — flips the FE
+  # proposal title/heading to "configuration change" wording when the
+  # wasm matches what's already on chain.
+  record "Frontend WASM changed" detect_frontend_hash_change
 fi
 
 confirm_manual "Request Run Verification Command" request_verification_command

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -376,6 +376,17 @@ detect_release_wasm_change() {
   local release_filename="$2"
   local local_wasm="$3"
 
+  # The whole point of the "fall back to 'true' on failure" contract is
+  # to avoid aborting the SOP run if the comparison can't be made. Bail
+  # out cleanly before any command that would crash under `set -e` —
+  # most likely cause is a re-run where `download_wasms` was already
+  # marked Done in the checklist but the local artifacts were wiped.
+  if [ ! -r "$local_wasm" ]; then
+    echo "Local wasm '${local_wasm}' is missing or unreadable; treating ${release_filename} as changed." >&2
+    echo "true"
+    return
+  fi
+
   local prev_proposal_tag
   prev_proposal_tag=$(git tag -l "${proposal_prefix}-*" | sort -V | tail -1)
   if [ -z "$prev_proposal_tag" ]; then
@@ -394,9 +405,12 @@ detect_release_wasm_change() {
 
   local prev_wasm
   prev_wasm=$(mktemp)
+  # RETURN trap fires on every exit path (curl failure, sha256 failure
+  # under set -e, normal return) so the mktemp doesn't leak. Bash's
+  # RETURN trap is function-local — no need to clear it explicitly.
+  trap 'rm -f "$prev_wasm"' RETURN
 
   if ! curl -fsSL "https://github.com/dfinity/internet-identity/releases/download/${prev_release_tag}/${release_filename}" -o "$prev_wasm"; then
-    rm -f "$prev_wasm"
     echo "Could not download ${prev_release_tag}/${release_filename}; treating as changed." >&2
     echo "true"
     return
@@ -405,7 +419,6 @@ detect_release_wasm_change() {
   local prev_sha curr_sha
   prev_sha=$(sha256 "$prev_wasm")
   curr_sha=$(sha256 "$local_wasm")
-  rm -f "$prev_wasm"
   echo "Previous ${release_filename} (${prev_release_tag}): $prev_sha" >&2
   echo "Current ${release_filename}:                        $curr_sha" >&2
 

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -429,20 +429,74 @@ detect_release_wasm_change() {
   fi
 }
 
+# Compare a local wasm sha256 against the on-chain module_hash of a
+# canister on mainnet. This is the authoritative source for "is this
+# an args-only proposal?" — looking at GitHub release artifacts (or
+# proposal-<role>-* tags, which we used to do) is misleading because a
+# release can exist without ever having been adopted by a proposal
+# (rejected proposal, manually-pushed tag, leftover from a draft).
+# Falls back to "true" on any failure so the proposal stays
+# conservative when we can't tell.
+#
+# Args:
+#   $1 canister-id        principal of the canister to query
+#   $2 local-wasm-path    path on disk to compare against
+detect_canister_wasm_change() {
+  local canister_id="$1"
+  local local_wasm="$2"
+
+  if [ ! -r "$local_wasm" ]; then
+    echo "Local wasm '${local_wasm}' is missing or unreadable; treating ${canister_id}'s wasm as changed." >&2
+    echo "true"
+    return
+  fi
+
+  # --public reads module_hash from the state tree (no controllership
+  # needed); --identity anonymous avoids the "failed to read password"
+  # prompt that fires when the default identity is encrypted.
+  local onchain_hash
+  if ! onchain_hash=$(icp canister status "$canister_id" -e ic --public --identity anonymous --json 2>/dev/null | jq -er '.module_hash'); then
+    echo "Could not read on-chain module_hash for ${canister_id}; treating as changed." >&2
+    echo "true"
+    return
+  fi
+  # The state tree returns module_hash as "0x<hex>"; sha256sum on the
+  # local wasm produces just "<hex>". Strip the prefix before comparing.
+  onchain_hash="${onchain_hash#0x}"
+
+  local local_hash
+  local_hash=$(sha256 "$local_wasm")
+
+  echo "On-chain module_hash (${canister_id}): $onchain_hash" >&2
+  echo "Local wasm hash:                              $local_hash" >&2
+
+  if [ "$onchain_hash" = "$local_hash" ]; then
+    echo "false"
+  else
+    echo "true"
+  fi
+}
+
 # Per-wasm wrappers — the script uses these as `record` commands so the
 # output is captured in the checklist as a "true"/"false" flag.
+#
+# `detect_archive_hash_change` deliberately still compares against the
+# previous release's archive.wasm.gz (not on-chain), because the
+# archive bytes aren't a directly-queryable canister's module_hash —
+# they're stored inside the II BE's state and the BE installs them
+# into child canisters on demand. The flag is used solely to decide
+# whether to include `--archive-hash` in the verify-hash command voters
+# run; it's not the args-only-vs-upgrade detection.
 detect_archive_hash_change() {
   detect_release_wasm_change "proposal-backend" "archive.wasm.gz" ./archive.wasm.gz
 }
 
 detect_ii_hash_change() {
-  # The GH release asset is internet_identity_production.wasm.gz, but
-  # download_wasms saves it locally as internet_identity.wasm.gz.
-  detect_release_wasm_change "proposal-backend" "internet_identity_production.wasm.gz" ./internet_identity.wasm.gz
+  detect_canister_wasm_change "$PROD_BACKEND_CANISTER_ID" ./internet_identity.wasm.gz
 }
 
 detect_frontend_hash_change() {
-  detect_release_wasm_change "proposal-frontend" "internet_identity_frontend.wasm.gz" ./internet_identity_frontend.wasm.gz
+  detect_canister_wasm_change "$PROD_FRONTEND_CANISTER_ID" ./internet_identity_frontend.wasm.gz
 }
 
 download_wasms() {
@@ -480,6 +534,7 @@ request_verification_command() {
   echo "./scripts/verify-hash ${cmd_parts[@]}"
 }
 
+PROD_BACKEND_CANISTER_ID="rdmx6-jaaaa-aaaaa-aaadq-cai"
 STAGING_BACKEND_CANISTER_ID="fgte5-ciaaa-aaaad-aaatq-cai"
 STAGING_FRONTEND_CANISTER_ID="gjxif-ryaaa-aaaad-ae4ka-cai"
 # Proxy canister routing the wallet_call-equivalent install path for
@@ -1023,7 +1078,7 @@ dry_run_proposal() {
       --nns-url "https://ic0.app" \
       propose-to-change-nns-canister \
       --proposer "$(read -p 'NEURON ID? '; echo "$REPLY")" \
-      --canister-id rdmx6-jaaaa-aaaaa-aaadq-cai \
+      --canister-id "$PROD_BACKEND_CANISTER_ID" \
       --mode upgrade \
       --wasm-module-path ./internet_identity.wasm.gz \
       --wasm-module-sha256 "$(sha256 internet_identity-$TAG_NAME.wasm.gz)" \
@@ -1103,7 +1158,7 @@ make_backend_proposal() {
     --nns-url "https://ic0.app" \
     propose-to-change-nns-canister \
     --proposer "$(read -p 'NEURON ID? '; echo "$REPLY")" \
-    --canister-id rdmx6-jaaaa-aaaaa-aaadq-cai \
+    --canister-id "$PROD_BACKEND_CANISTER_ID" \
     --mode upgrade \
     --wasm-module-path ./internet_identity.wasm.gz \
     --wasm-module-sha256 "$(sha256 internet_identity-$TAG_NAME.wasm.gz)" \

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -1302,12 +1302,17 @@ if [ "$IS_RECONFIGURE" = "true" ]; then
 
   # Pre-populate the steps that don't apply when re-using the on-chain
   # wasm. The keys must match what confirm_cmd / confirm_manual /
-  # record compute internally; see those helpers above.
+  # record compute internally; see those helpers above. "Release tag"
+  # is read back in the main flow (below) so subsequent
+  # `--continue --name <checklist-basename>` runs use the resolved
+  # release tag rather than the basename.
   jq -n \
+    --arg release_tag "$TAG_NAME" \
     --arg upgrade_type "$RECONFIGURE_TYPE" \
     --arg git_fetch_cmd "git fetch $REPO_HTTPS_URL --tags --force" \
     --arg git_tag_cmd "git tag -f $TAG_NAME" \
     '[
+      {name: "Release tag",                 value: $release_tag},
       {name: "Upgrade type",                value: $upgrade_type},
       {name: $git_fetch_cmd,                value: "Done"},
       {name: $git_tag_cmd,                  value: "Done"},
@@ -1322,6 +1327,23 @@ if [ "$IS_RECONFIGURE" = "true" ]; then
 fi
 
 echo Checklist file: "$CHECKLIST_FILE"
+
+# Authoritative TAG_NAME comes from the checklist. --reconfigure writes
+# a "Release tag" entry whose value differs from the checklist filename
+# (the file is named reconfigure-<role>-<date>.json, but TAG_NAME has to
+# be the original release-* tag so downstream commands fetch the right
+# wasm/commit). Sync here so `--continue --name <basename>` is robust
+# against the basename — and for --new / older checklists, stash
+# TAG_NAME on first run so the invariant holds going forward.
+RECORDED_TAG="$(checklist_get 'Release tag')"
+if [ -n "$RECORDED_TAG" ]; then
+  if [ "$RECORDED_TAG" != "$TAG_NAME" ]; then
+    echo "Note: using release tag '$RECORDED_TAG' from checklist (not '$TAG_NAME' from --name)." >&2
+  fi
+  TAG_NAME="$RECORDED_TAG"
+else
+  checklist_add "Release tag" "$TAG_NAME"
+fi
 
 record "Start time" date +"%Y-%m-%d %H:%M:%S"
 


### PR DESCRIPTION
## Summary

Improvements to `make-upgrade-proposal` for proposals that change install args
only — i.e. the wasm in the proposal already matches what's on chain:

1. **Detect args-only changes automatically.** When the new release's wasm
   bytes match the wasm attached to the previous `proposal-<role>-*` release,
   record a `{II,Frontend} WASM changed = false` flag in the checklist and use
   it to switch the proposal title and markdown headline:
   - title: `Update Internet Identity <Backend|Frontend> Canister install args (commit <sha>)`
   - heading: `# <Backend|Frontend> Canister Configuration Change`
   - the `What's Changed` commit list (empty when the release tag hasn't moved)
     is replaced with a `TODO` placeholder for the human to fill in
   The detection extends the existing `detect_archive_hash_change` pattern
   into a generic `detect_release_wasm_change` helper.

2. **New `--reconfigure` mode.** Previously, doing an args-only proposal meant
   re-using `--new --name <last-release>` and hand-faking a checklist JSON to
   skip the tag/release-page steps. `--reconfigure` owns that bookkeeping
   internally — it asks which canister(s) to reconfigure, resolves the release
   tag from the latest `proposal-<role>-*`, and generates a unique
   `reconfigure-<role>-<date>[-vN].json` checklist pre-populated to skip
   what doesn't apply. The user goes straight to the wasm download and args
   prompts.

3. **Persist `Release tag` inside the checklist.** `--continue --name <basename>`
   previously used the `--name` as `TAG_NAME`, which silently corrupted
   downstream behaviour when the checklist was created by `--reconfigure`
   (basename != release tag). The authoritative `TAG_NAME` now lives in the
   checklist as a `Release tag` entry — written by `--reconfigure` at setup
   time and stashed on first read for `--new`-style checklists. A warning
   fires when `--name` disagrees with the recorded value.

4. **Broaden `.gitignore` for script artifacts.** The script writes
   `frontend_proposal.md`, `frontend_args.txt`, `staging_args.txt`, several
   `*arg.bin` binaries (BE + FE × staging + prod), and `reconfigure-*.json`
   checklists. The existing Proposals patterns only covered a subset, leaving
   the worktree dirty after any real run. Switch to broader patterns
   (`*args.txt`, `*arg.bin`, `*proposal.md`, `reconfigure-*.json`).

`--reconfigure` is mutually exclusive with `--new` / `--continue` and does not
accept `--name`. For `--reconfigure` on both canisters, the latest BE and FE
proposals must point at the same release commit; otherwise the script asks
the user to run twice.

## Tests

No new tests — the script has no harness today. Manually exercised:
- `detect_release_wasm_change` against the real
  `release-2026-05-08/internet_identity_frontend.wasm.gz` — returns `false`
  (unchanged) against the wasm already on chain via proposal 141736
- CLI validation: rejects missing mode, conflicting modes, `--name` with
  `--reconfigure`
- `--reconfigure` end-to-end setup: resolves `release-2026-05-08` from the
  latest `proposal-frontend-*` tag and writes the checklist with the right
  pre-populated entries including `Release tag`
- Full args-only proposal preparation through `prepare_production_frontend_argument`,
  `append_proposal_argument`, and verifying the encoded arg sha256 matches the
  `didc encode` command in the proposal markdown (used to fix a typo in
  `related_origins`)
- Confirmed `.gitignore` patterns don't match any currently-tracked file