### PR TITLE
feat(fe): unify II logo and wordmark on landing page

### DIFF
--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -227,8 +227,15 @@
           {#if selectedIdentity !== undefined}
             <!-- Welcome-back state -->
             <div class="md:pt-[max(0px,calc(50dvh-16rem))]">
-              <div class="mb-4 flex items-center gap-3 md:gap-4 lg:gap-5">
-                <Logo class="text-fg-primary h-10 shrink-0 md:h-12 lg:h-14" />
+              <div
+                dir="ltr"
+                class="mb-4 flex items-center gap-3 md:gap-4 lg:gap-5"
+              >
+                <Logo
+                  class="text-fg-primary h-10 shrink-0 md:h-12 lg:h-14"
+                  aria-hidden="true"
+                  focusable="false"
+                />
                 <h1
                   class="text-text-primary text-5xl font-medium tracking-tight text-balance md:text-6xl lg:text-7xl"
                 >
@@ -342,8 +349,15 @@
           {:else}
             <!-- Sign-up state -->
             <div class="md:pt-[max(0px,calc(50dvh-16rem))]">
-              <div class="mb-4 flex items-center gap-3 md:gap-4 lg:gap-5">
-                <Logo class="text-fg-primary h-10 shrink-0 md:h-12 lg:h-14" />
+              <div
+                dir="ltr"
+                class="mb-4 flex items-center gap-3 md:gap-4 lg:gap-5"
+              >
+                <Logo
+                  class="text-fg-primary h-10 shrink-0 md:h-12 lg:h-14"
+                  aria-hidden="true"
+                  focusable="false"
+                />
                 <h1
                   class="text-text-primary text-5xl font-medium tracking-tight text-balance md:text-6xl lg:text-7xl"
                 >

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -188,13 +188,6 @@
 
 <div class="flex min-h-dvh flex-col">
   <div class="h-[env(safe-area-inset-top)]"></div>
-  <header
-    class="relative z-10 flex h-16 flex-row items-center px-4 md:px-6 lg:px-8"
-  >
-    <a href="/" dir="ltr" aria-label={$t`Internet Identity`}>
-      <Logo class="text-fg-primary h-5.5" />
-    </a>
-  </header>
 
   {#if browser}
     <div class="fade-in absolute inset-0 -z-1 hidden opacity-0 md:block">
@@ -234,11 +227,14 @@
           {#if selectedIdentity !== undefined}
             <!-- Welcome-back state -->
             <div class="md:pt-[max(0px,calc(50dvh-16rem))]">
-              <h1
-                class="text-text-primary mb-4 text-5xl font-medium tracking-tight text-balance md:text-6xl lg:text-7xl"
-              >
-                {$t`Internet Identity`}
-              </h1>
+              <div class="mb-4 flex items-center gap-3 md:gap-4 lg:gap-5">
+                <Logo class="text-fg-primary h-10 shrink-0 md:h-12 lg:h-14" />
+                <h1
+                  class="text-text-primary text-5xl font-medium tracking-tight text-balance md:text-6xl lg:text-7xl"
+                >
+                  {$t`Internet Identity`}
+                </h1>
+              </div>
               <p class="text-text-tertiary mb-10 max-w-md text-base md:text-lg">
                 <Trans>Sign in to manage your identity</Trans>
               </p>
@@ -346,11 +342,14 @@
           {:else}
             <!-- Sign-up state -->
             <div class="md:pt-[max(0px,calc(50dvh-16rem))]">
-              <h1
-                class="text-text-primary mb-4 text-5xl font-medium tracking-tight text-balance md:text-6xl lg:text-7xl"
-              >
-                {$t`Internet Identity`}
-              </h1>
+              <div class="mb-4 flex items-center gap-3 md:gap-4 lg:gap-5">
+                <Logo class="text-fg-primary h-10 shrink-0 md:h-12 lg:h-14" />
+                <h1
+                  class="text-text-primary text-5xl font-medium tracking-tight text-balance md:text-6xl lg:text-7xl"
+                >
+                  {$t`Internet Identity`}
+                </h1>
+              </div>
               <p
                 class="text-text-tertiary mb-10 max-w-md text-base text-balance md:text-lg"
               >


### PR DESCRIPTION
The id.ai landing page split the brand into two visually unrelated parts: the infinity icon sat alone in the top-left corner while the giant "Internet Identity" title sat lower in the hero, with empty space between them. They read as two separate elements rather than one mark. This change groups them into a single inline logo + wordmark lockup at the hero so the brand reads as one.

## Changes

- Drop the standalone corner `<header>` from the landing page (`(new-styling)/+page.svelte`). On the root route it was redundant — it linked back to `/`, the page you were already on.
- Wrap each `Internet Identity` h1 (welcome-back and sign-up states) in a horizontal `Logo` + `h1` lockup. Icon height scales `h-10 → md:h-12 → lg:h-14` to track the text steps `text-5xl → md:text-6xl → lg:text-7xl`. `mb-4` moves from the h1 to the flex wrapper so spacing under the lockup is unchanged.
- Pin the lockup wrapper to `dir="ltr"` so the icon stays left of the wordmark under RTL locales, matching the existing `Header.svelte` and manage-sidebar precedents.
- Mark the `Logo` SVG as `aria-hidden="true" focusable="false"` — the adjacent `<h1>` already provides the accessible name.