### PR TITLE
fix(fe): make Active badge non-selectable with default cursor

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/components/OpenIdItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/components/OpenIdItem.svelte
@@ -98,8 +98,11 @@
     {/if}
   </div>
   {#if isCurrentAccessMethod}
-    <Badge color="success" size="sm" dot class="ms-2 flex-none"
-      >{$t`Active`}</Badge
+    <Badge
+      color="success"
+      size="sm"
+      dot
+      class="ms-2 flex-none cursor-default select-none">{$t`Active`}</Badge
     >
   {/if}
   {#if options.length > 0}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/components/PasskeyItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/components/PasskeyItem.svelte
@@ -127,8 +127,11 @@
   <div class="mb-3 flex h-9 flex-row items-center">
     <PasskeyIcon class="text-fg-primary size-6" />
     {#if isCurrentAccessMethod}
-      <Badge color="success" size="sm" dot class="ms-2 flex-none"
-        >{$t`Active`}</Badge
+      <Badge
+        color="success"
+        size="sm"
+        dot
+        class="ms-2 flex-none cursor-default select-none">{$t`Active`}</Badge
       >
     {/if}
     {#if isLegacy}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/ActiveRecoveryPhrase.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/ActiveRecoveryPhrase.svelte
@@ -38,8 +38,11 @@
     <div class="mb-3 flex h-9 flex-row items-center">
       <ShieldCheckIcon class="text-fg-success-primary size-6" />
       {#if isCurrentAccessMethod}
-        <Badge color="success" size="sm" dot class="ms-2 flex-none"
-          >{$t`Active`}</Badge
+        <Badge
+          color="success"
+          size="sm"
+          dot
+          class="ms-2 flex-none cursor-default select-none">{$t`Active`}</Badge
         >
       {/if}
     </div>


### PR DESCRIPTION
## Problem
The "Active" badge on access-method cards (passkey, OpenID, recovery) renders selectable text and shows the text-cursor I-beam on hover, suggesting it's selectable content. The badge is a label, not data — the cursor should stay default and the text shouldn't highlight.

## Changes
Add `cursor-default select-none` to the Active <Badge> class in three components:
- (new-styling)/manage/(authenticated)/access/components/PasskeyItem.svelte
- (new-styling)/manage/(authenticated)/access/components/OpenIdItem.svelte
- (new-styling)/manage/(authenticated)/recovery/components/ActiveRecoveryPhrase.svelte

## Tests
npm run check, lint, test, format all green. Pre-existing failures in legacy/storage and ssoDiscovery are unrelated and reproduce on the base commit. No new tests added — pure CSS change.