### PR TITLE
fix(fe): add tooltip and keyboard focus to Active access-method badge

### DIFF
--- a/src/frontend/src/lib/locales/en.po
+++ b/src/frontend/src/lib/locales/en.po
@@ -100,6 +100,9 @@ msgstr "Account name"
 msgid "Active"
 msgstr "Active"
 
+msgid "This is the access method you're currently signed in with."
+msgstr "This is the access method you're currently signed in with."
+
 msgid "Activate"
 msgstr "Activate"
 
@@ -312,6 +315,9 @@ msgstr "Creating identity..."
 
 msgid "Creating passkey..."
 msgstr "Creating passkey..."
+
+msgid "Currently active"
+msgstr "Currently active"
 
 msgid "Currently signed in with this account"
 msgstr "Currently signed in with this account"

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/components/OpenIdItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/components/OpenIdItem.svelte
@@ -98,9 +98,19 @@
     {/if}
   </div>
   {#if isCurrentAccessMethod}
-    <Badge color="success" size="sm" dot class="ms-2 flex-none"
-      >{$t`Active`}</Badge
+    <Tooltip
+      label={$t`Currently active`}
+      description={$t`This is the access method you're currently signed in with.`}
+      direction="up"
     >
+      <Badge
+        color="success"
+        size="sm"
+        dot
+        class="ms-2 flex-none cursor-default select-none"
+        tabindex={0}>{$t`Active`}</Badge
+      >
+    </Tooltip>
   {/if}
   {#if options.length > 0}
     <Select {options} align="end">

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/components/PasskeyItem.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/components/PasskeyItem.svelte
@@ -127,9 +127,19 @@
   <div class="mb-3 flex h-9 flex-row items-center">
     <PasskeyIcon class="text-fg-primary size-6" />
     {#if isCurrentAccessMethod}
-      <Badge color="success" size="sm" dot class="ms-2 flex-none"
-        >{$t`Active`}</Badge
+      <Tooltip
+        label={$t`Currently active`}
+        description={$t`This is the access method you're currently signed in with.`}
+        direction="up"
       >
+        <Badge
+          color="success"
+          size="sm"
+          dot
+          class="ms-2 flex-none cursor-default select-none"
+          tabindex={0}>{$t`Active`}</Badge
+        >
+      </Tooltip>
     {/if}
     {#if isLegacy}
       <div

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/ActiveRecoveryPhrase.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/ActiveRecoveryPhrase.svelte
@@ -35,14 +35,22 @@
   ]}
 >
   <div class="mb-3 flex h-9 flex-row items-center">
-    <div class="mb-3 flex h-9 flex-row items-center">
-      <ShieldCheckIcon class="text-fg-success-primary size-6" />
-      {#if isCurrentAccessMethod}
-        <Badge color="success" size="sm" dot class="ms-2 flex-none"
-          >{$t`Active`}</Badge
+    <ShieldCheckIcon class="text-fg-success-primary size-6" />
+    {#if isCurrentAccessMethod}
+      <Tooltip
+        label={$t`Currently active`}
+        description={$t`This is the access method you're currently signed in with.`}
+        direction="up"
+      >
+        <Badge
+          color="success"
+          size="sm"
+          dot
+          class="ms-2 flex-none cursor-default select-none"
+          tabindex={0}>{$t`Active`}</Badge
         >
-      {/if}
-    </div>
+      </Tooltip>
+    {/if}
     <button
       class="btn btn-secondary btn-sm btn-danger ms-auto"
       onclick={onReset}


### PR DESCRIPTION
## Problem
PR #3921 follow up: "Hovering over Active could also show a tooltip (what does it mean to be active?)." The Active badge on access-method cards offered no explanation of what "Active" means.

## Changes
- Wrap the Active <Badge> in a <Tooltip> in PasskeyItem, OpenIdItem, and ActiveRecoveryPhrase. Label "Currently active", description "This is the access method you're currently signed in with.", direction up.
- Badge becomes keyboard-focusable (tabindex={0}) so the tooltip surfaces for keyboard / AT users. The visible text "Active" remains its accessible name; the Tooltip wires aria-describedby for the description.
- cursor-default + select-none so the badge behaves as a label, not selectable text (also addressed in #3930 — same lines).
- Removes a duplicate inner div in ActiveRecoveryPhrase introduced by the original commit.
- 2 new Lingui keys (Currently active + description) across 11 .po files. English populated; non-English msgstr left empty for the translation pipeline.

## Tests
npm run check, lint, test, format-check all green. Pre-existing failures in legacy/storage, ssoDiscovery, and findWebAuthnFlows are unrelated and reproduce on origin/main. No new tests added — pure UI/a11y change.

Conflicts trivially with #3930 on the Badge class attribute (both add cursor-default select-none); whichever lands second needs a one-line rebase. With this PR carrying the non-selectability fix, #3930 becomes effectively redundant.