### PR TITLE
DO NOT MERGE: add email_recovery_logs debug query

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1485,6 +1485,14 @@ service : (opt InternetIdentityInit) -> {
     email_recovery_get_delegation : (EmailRecoveryGetDelegationArgs) -> (variant { Ok : SignedDelegation; Err : EmailRecoveryError }) query;
     email_recovery_credential_remove : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });
 
+    // Debug-only. Returns the heap-resident log of recovery-flow
+    // steps (prepare_add, prepare_delegation, smtp_request,
+    // submit_dkim_leaf, credential_remove). Each entry is
+    // "[<unix_secs>] <message>" with truncated nonces / no
+    // session-key bytes. Not persisted across upgrades, bounded
+    // size with oldest-first eviction.
+    email_recovery_logs : () -> (vec text) query;
+
     // SMTP gateway protocol
     // =====================
     // The off-chain SMTP gateway forwards every inbound message via

--- a/src/internet_identity/src/dkim/canonicalize.rs
+++ b/src/internet_identity/src/dkim/canonicalize.rs
@@ -54,7 +54,20 @@ fn relaxed_header_value(value: &str) -> String {
     // before the first non-WSP byte (handles step 5's "WSP after colon"
     // case since the colon is consumed by the caller); strip trailing
     // WSP at the end.
-    let bytes = value.as_bytes();
+    // FIXME(gateway): defensively strip any trailing CR/LF the SMTP
+    // gateway leaks into header values. Per RFC 5322 §2.2 the CRLF that
+    // terminates a header line is structural framing, not field-body —
+    // the gateway should be stripping it during parsing and the value
+    // we receive should never end with `\r` or `\n`. Today's beta
+    // gateway leaves it attached (e.g. `Subject` arrives as
+    // " II-Recovery-…\r\n"), which makes our DKIM hash input end with
+    // `…\r\n\r\n` instead of `…\r\n` and breaks every signature with
+    // SignatureInvalid. Once the gateway parser is corrected this
+    // workaround can be removed and `is_wsp` left at its RFC-strict
+    // SP/HTAB definition. See https://github.com/dfinity/internet-identity/pull/3934
+    // for the debug-log query that surfaced the problem.
+    let trimmed = value.trim_end_matches(['\r', '\n']);
+    let bytes = trimmed.as_bytes();
     let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
     let mut i = 0;
     let mut last_was_sp = true; // true so leading WSP is dropped (step 5)
@@ -79,7 +92,8 @@ fn relaxed_header_value(value: &str) -> String {
         i += 1;
     }
     // Step 4: strip trailing WSP. Above loop already collapses runs to
-    // a single SP, so at most one trailing SP can exist now.
+    // a single SP, so at most one trailing SP can exist now. (Trailing
+    // CR/LF was already removed at the top of the function.)
     if out.last() == Some(&b' ') {
         out.pop();
     }
@@ -221,6 +235,49 @@ mod tests {
     fn relaxed_header_unfolds_continuation_with_space() {
         let h = relaxed_header("X-Note", "first\r\n  second");
         assert_eq!(s(&h), "x-note:first second\r\n");
+    }
+
+    // The beta SMTP gateway currently leaves the structural line
+    // terminator attached to each header value (e.g. delivers the
+    // Subject as " II-Recovery-…\r\n" instead of " II-Recovery-…").
+    // Per RFC 5322 §2.2 the CRLF is framing, not field-body, and a
+    // strictly RFC-correct canonicalizer wouldn't see it. Until the
+    // gateway parser is fixed we tolerate the trailing terminator so
+    // DKIM verification doesn't fail with a misleading SignatureInvalid
+    // on every well-formed inbound message.
+    #[test]
+    fn relaxed_header_strips_trailing_line_terminator() {
+        let h = relaxed_header("Subject", " II-Recovery-deadbeef\r\n");
+        assert_eq!(s(&h), "subject:II-Recovery-deadbeef\r\n");
+    }
+
+    #[test]
+    fn relaxed_header_strips_trailing_terminator_with_wsp() {
+        let h = relaxed_header("Subject", " hello \t\r\n");
+        assert_eq!(s(&h), "subject:hello\r\n");
+    }
+
+    #[test]
+    fn relaxed_header_strips_bare_trailing_lf() {
+        let h = relaxed_header("Subject", " hello\n");
+        assert_eq!(s(&h), "subject:hello\r\n");
+    }
+
+    #[test]
+    fn relaxed_header_folded_value_with_trailing_terminator() {
+        // The DKIM-Signature value from a Gmail-signed message: folded
+        // multi-line, with the structural CRLF still attached at the
+        // end. The unfold step must still handle the internal CRLF+WSP
+        // boundaries, and the trailing CRLF must not leak into the
+        // canonical form.
+        let h = relaxed_header(
+            "DKIM-Signature",
+            " v=1; a=rsa-sha256;\r\n        d=gmail.com; s=20251104;\r\n        b=AAAA\r\n",
+        );
+        assert_eq!(
+            s(&h),
+            "dkim-signature:v=1; a=rsa-sha256; d=gmail.com; s=20251104; b=AAAA\r\n",
+        );
     }
 
     #[test]

--- a/src/internet_identity/src/email_recovery/mod.rs
+++ b/src/internet_identity/src/email_recovery/mod.rs
@@ -53,6 +53,41 @@ pub use remove::{remove_credential, RemoveError};
 pub use smtp::{handle_smtp_request, handle_smtp_request_validate};
 pub use submit_leaf::submit_dkim_leaf;
 
+/// Append a line to the heap-resident email-recovery debug log.
+/// Each entry is prefixed with the wall-clock second the caller
+/// supplied so an operator reading the log via
+/// `email_recovery_logs` can correlate entries across the flow.
+///
+/// The log is **not** persisted across canister upgrades and is
+/// bounded by [`crate::state::RECOVERY_LOG_MAX_ENTRIES`]; oldest
+/// entries are evicted first when the buffer fills. Intended purely
+/// for debugging the recovery pipeline — production callers should
+/// not depend on its contents.
+pub(crate) fn log(now_secs: u64, msg: impl Into<String>) {
+    crate::state::push_recovery_log(format!("[{}] {}", now_secs, msg.into()));
+}
+
+/// Truncate a nonce for log display. The nonce is a per-challenge
+/// secret (anyone who knows it can poll
+/// `email_recovery_status`/`_get_delegation` for that flow); we
+/// keep only enough of the random suffix to correlate log lines
+/// belonging to the same challenge without leaking the full token.
+pub(crate) fn nonce_for_log(nonce: &str) -> String {
+    // Show the verbose prefix plus the first 4 chars of the random
+    // suffix. With 16 hex chars in the suffix, leaking 4 of them
+    // keeps ~48 bits of entropy in the unrevealed tail.
+    const SHOWN_SUFFIX_CHARS: usize = 4;
+    if let Some(rest) = nonce.strip_prefix(NONCE_PREFIX) {
+        let visible: String = rest.chars().take(SHOWN_SUFFIX_CHARS).collect();
+        format!("{NONCE_PREFIX}{visible}…")
+    } else {
+        // Caller-supplied or malformed nonce — show the same short
+        // amount and mark it as unrecognised.
+        let visible: String = nonce.chars().take(SHOWN_SUFFIX_CHARS).collect();
+        format!("?{visible}…")
+    }
+}
+
 /// Wrapper around `pending::status_of` so the canister method in
 /// `main.rs` doesn't need to know which submodule the heap state
 /// lives in.

--- a/src/internet_identity/src/email_recovery/prepare.rs
+++ b/src/internet_identity/src/email_recovery/prepare.rs
@@ -47,7 +47,26 @@ pub async fn prepare_add(
     dns_input: EmailRecoveryDnsInput,
     now_secs: u64,
 ) -> Result<EmailRecoveryChallenge, EmailRecoveryError> {
-    prepare_common(dns_input, now_secs, PendingKind::Register { anchor }).await
+    super::log(
+        now_secs,
+        format!(
+            "prepare_add: anchor={anchor} address={:?} has_dns_proof={}",
+            dns_input.address,
+            dns_input.dns_proof.is_some(),
+        ),
+    );
+    let result = prepare_common(dns_input, now_secs, PendingKind::Register { anchor }).await;
+    super::log(
+        now_secs,
+        match &result {
+            Ok(c) => format!(
+                "prepare_add: ok anchor={anchor} nonce={}",
+                super::nonce_for_log(&c.nonce),
+            ),
+            Err(e) => format!("prepare_add: err anchor={anchor} err={e:?}"),
+        },
+    );
+    result
 }
 
 /// Body of `email_recovery_prepare_delegation(dns_input, session_pk)`.
@@ -62,19 +81,47 @@ pub async fn prepare_delegation(
     session_pk: SessionKey,
     now_secs: u64,
 ) -> Result<EmailRecoveryChallenge, EmailRecoveryError> {
+    super::log(
+        now_secs,
+        format!(
+            "prepare_delegation: address={:?} has_dns_proof={} session_pk_len={}",
+            dns_input.address,
+            dns_input.dns_proof.is_some(),
+            session_pk.len(),
+        ),
+    );
     // Cap the FE-supplied `session_pk` length. The pending entry
     // holds this for up to 30 minutes; without a bound an open
     // caller could inflate every challenge they prepare. Real
     // session keys are well under 1 KB regardless of algorithm
     // (Ed25519 ~44 bytes, ECDSA P-256 ~91, RSA-2048 ~294).
     if session_pk.len() > super::MAX_SESSION_KEY_BYTES {
+        super::log(
+            now_secs,
+            format!(
+                "prepare_delegation: err session_pk_too_large len={} max={}",
+                session_pk.len(),
+                super::MAX_SESSION_KEY_BYTES,
+            ),
+        );
         return Err(EmailRecoveryError::InternalCanisterError(format!(
             "session_pk is {} bytes, exceeds the {}-byte limit",
             session_pk.len(),
             super::MAX_SESSION_KEY_BYTES,
         )));
     }
-    prepare_common(dns_input, now_secs, PendingKind::Recover { session_pk }).await
+    let result = prepare_common(dns_input, now_secs, PendingKind::Recover { session_pk }).await;
+    super::log(
+        now_secs,
+        match &result {
+            Ok(c) => format!(
+                "prepare_delegation: ok nonce={}",
+                super::nonce_for_log(&c.nonce),
+            ),
+            Err(e) => format!("prepare_delegation: err err={e:?}"),
+        },
+    );
+    result
 }
 
 /// Shared input-validation + nonce-issuing core. `kind`
@@ -114,7 +161,19 @@ async fn prepare_common(
     // - Neither: reject — the FE will surface a "we can't accept
     //   email from this domain" error.
     let (cached_root_dnskey, cached_zones, cached_dmarc_txt) = if let Some(proof) = dns_proof {
+        super::log(
+            now_secs,
+            format!("prepare_common: path=dnssec domain={registered_domain} address={address}"),
+        );
         let extracted = verify_dnssec_skeleton(proof, &registered_domain, now_secs)?;
+        super::log(
+            now_secs,
+            format!(
+                "prepare_common: dnssec_skeleton verified zones={} dmarc_cached={}",
+                extracted.zones.len(),
+                extracted.dmarc.is_some(),
+            ),
+        );
         (
             Some(extracted.root_dnskey),
             extracted.zones,
@@ -132,6 +191,12 @@ async fn prepare_common(
                 })
                 .unwrap_or(false)
         });
+        super::log(
+            now_secs,
+            format!(
+                "prepare_common: path=doh domain={registered_domain} address={address} allowlisted={allowlisted}"
+            ),
+        );
         if !allowlisted {
             return Err(EmailRecoveryError::DomainNotAllowlisted(registered_domain));
         }

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -172,10 +172,16 @@ fn single_recipient(
 /// see the module-level note on why we don't surface per-message
 /// verification failures.
 pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
+    let now_log_secs = now_secs();
+    super::log(now_log_secs, "smtp_request: enter");
     // Bound-check up front so a malformed gateway-side payload
     // returns a clean syntax error instead of trapping somewhere
     // inside the verifier.
     if let Err(e) = validate_smtp_request(&request) {
+        super::log(
+            now_log_secs,
+            format!("smtp_request: rejected malformed_request err={e:?}"),
+        );
         return e;
     }
 
@@ -200,11 +206,21 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     // "unknown mailbox" case so the gateway can tell the two apart.
     let envelope = match request.envelope.as_ref() {
         Some(e) => e,
-        None => return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope"),
+        None => {
+            super::log(now_log_secs, "smtp_request: rejected missing_envelope");
+            return smtp_err(SMTP_ERR_SYNTAX_ERROR, "Missing envelope");
+        }
     };
     let to = match single_recipient(envelope) {
         Some(to) => to,
         None => {
+            super::log(
+                now_log_secs,
+                format!(
+                    "smtp_request: rejected wrong_recipient_count to_len={}",
+                    envelope.to.len(),
+                ),
+            );
             return smtp_err(
                 SMTP_ERR_USER_NOT_LOCAL,
                 "Recovery emails must have exactly one recipient",
@@ -216,6 +232,10 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     } else if recipient_matches(to, RECOVERY_RECIPIENT_USER) {
         RecipientFlow::Recovery
     } else {
+        super::log(
+            now_log_secs,
+            format!("smtp_request: rejected unknown_mailbox to={to:?}"),
+        );
         // Unknown recipient → 550 ("No such user here"). The set of
         // mailboxes we handle is in the public Candid surface, so
         // there's no secret to hide and a sender targeting any other
@@ -228,10 +248,15 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
             "Recipient is not a known mailbox on this canister",
         );
     };
+    super::log(
+        now_log_secs,
+        format!("smtp_request: dispatch to={to:?} flow={recipient_flow:?}"),
+    );
 
     let message = match request.message.as_ref() {
         Some(m) => m,
         None => {
+            super::log(now_log_secs, "smtp_request: drop missing_message");
             return SmtpResponse::Ok {};
         }
     };
@@ -241,10 +266,18 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     // challenge for the discovered nonce, treat the message as not
     // for us and silently drop.
     let Some(nonce) = extract_nonce_from_subject(message) else {
+        super::log(now_log_secs, "smtp_request: drop no_nonce_in_subject");
         return SmtpResponse::Ok {};
     };
 
     let now_secs = now_secs();
+    super::log(
+        now_secs,
+        format!(
+            "smtp_request: nonce_extracted nonce={}",
+            super::nonce_for_log(&nonce),
+        ),
+    );
 
     // Snapshot the pending challenge enough to drive the rest of
     // the pipeline. We borrow only briefly so the async outcalls
@@ -295,8 +328,42 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         // Either nonce is unknown / expired (None), or the pending
         // entry's kind didn't match the recipient (Some(None)).
         // Drop silently — see module note.
-        _ => return SmtpResponse::Ok {},
+        Some(None) => {
+            super::log(
+                now_secs,
+                format!(
+                    "smtp_request: drop kind_recipient_mismatch nonce={}",
+                    super::nonce_for_log(&nonce),
+                ),
+            );
+            return SmtpResponse::Ok {};
+        }
+        None => {
+            super::log(
+                now_secs,
+                format!(
+                    "smtp_request: drop unknown_or_expired_nonce nonce={}",
+                    super::nonce_for_log(&nonce),
+                ),
+            );
+            return SmtpResponse::Ok {};
+        }
     };
+    super::log(
+        now_secs,
+        format!(
+            "smtp_request: pending_found nonce={} address={} domain={} path={} cached_dmarc={}",
+            super::nonce_for_log(&nonce),
+            snapshot.claimed_address,
+            snapshot.registered_domain,
+            if snapshot.is_dnssec_path {
+                "dnssec"
+            } else {
+                "doh"
+            },
+            snapshot.cached_dmarc_txt.is_some(),
+        ),
+    );
 
     // Idempotency: if the pending entry already moved past
     // `Pending` (a terminal status, or `NeedDkimLeaf` set by an
@@ -304,6 +371,15 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     // gateway sometimes redelivers; we silently treat the second
     // call as a no-op rather than risk overwriting state.
     if snapshot.already_terminal || snapshot.partial_set {
+        super::log(
+            now_secs,
+            format!(
+                "smtp_request: drop redelivery nonce={} terminal={} partial_set={}",
+                super::nonce_for_log(&nonce),
+                snapshot.already_terminal,
+                snapshot.partial_set,
+            ),
+        );
         return SmtpResponse::Ok {};
     }
     if snapshot.is_dnssec_path {
@@ -313,12 +389,26 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         match prepare_partial_verification(&request, &snapshot, now_secs) {
             Ok(partial) => {
                 let selector = partial.selector.clone();
+                super::log(
+                    now_secs,
+                    format!(
+                        "smtp_request: dnssec partial_verified nonce={} selector={selector}",
+                        super::nonce_for_log(&nonce),
+                    ),
+                );
                 pending::with_mut(&nonce, now_secs, |c| {
                     c.partial_verification = Some(partial);
                     c.status = PendingStatus::NeedDkimLeaf { selector };
                 });
             }
             Err(e) => {
+                super::log(
+                    now_secs,
+                    format!(
+                        "smtp_request: dnssec partial_failed nonce={} err={e:?}",
+                        super::nonce_for_log(&nonce),
+                    ),
+                );
                 pending::with_mut(&nonce, now_secs, |c| {
                     c.status = PendingStatus::Failed(e);
                 });
@@ -329,35 +419,83 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         // verification finishes synchronously inside this one call.
         let outcome = verify_setup_email_doh(&request, &snapshot, now_secs).await;
         match outcome {
-            Ok(()) => match &snapshot.kind {
-                SnapshotKind::Setup { anchor } => {
-                    if let Err(e) = bind_credential(*anchor, &snapshot.claimed_address, now_secs) {
-                        pending::with_mut(&nonce, now_secs, |c| {
-                            c.status = PendingStatus::Failed(e);
-                        });
-                    } else {
-                        pending::with_mut(&nonce, now_secs, |c| {
-                            c.status = PendingStatus::Succeeded;
-                        });
-                    }
-                }
-                SnapshotKind::Recovery { session_pk } => {
-                    match stamp_recovery_delegation(&snapshot, session_pk).await {
-                        Ok(outcome) => {
-                            pending::with_mut(&nonce, now_secs, |c| {
-                                c.recovery_outcome = Some(outcome);
-                                c.status = PendingStatus::Succeeded;
-                            });
-                        }
-                        Err(e) => {
+            Ok(()) => {
+                super::log(
+                    now_secs,
+                    format!(
+                        "smtp_request: doh email_verified nonce={}",
+                        super::nonce_for_log(&nonce),
+                    ),
+                );
+                match &snapshot.kind {
+                    SnapshotKind::Setup { anchor } => {
+                        if let Err(e) =
+                            bind_credential(*anchor, &snapshot.claimed_address, now_secs)
+                        {
+                            super::log(
+                                now_secs,
+                                format!(
+                                    "smtp_request: doh setup_bind_failed nonce={} anchor={anchor} err={e:?}",
+                                    super::nonce_for_log(&nonce),
+                                ),
+                            );
                             pending::with_mut(&nonce, now_secs, |c| {
                                 c.status = PendingStatus::Failed(e);
                             });
+                        } else {
+                            super::log(
+                                now_secs,
+                                format!(
+                                    "smtp_request: doh setup_bound nonce={} anchor={anchor} address={}",
+                                    super::nonce_for_log(&nonce),
+                                    snapshot.claimed_address,
+                                ),
+                            );
+                            pending::with_mut(&nonce, now_secs, |c| {
+                                c.status = PendingStatus::Succeeded;
+                            });
+                        }
+                    }
+                    SnapshotKind::Recovery { session_pk } => {
+                        match stamp_recovery_delegation(&snapshot, session_pk).await {
+                            Ok(outcome) => {
+                                super::log(
+                                    now_secs,
+                                    format!(
+                                        "smtp_request: doh recovery_stamped nonce={} address={}",
+                                        super::nonce_for_log(&nonce),
+                                        snapshot.claimed_address,
+                                    ),
+                                );
+                                pending::with_mut(&nonce, now_secs, |c| {
+                                    c.recovery_outcome = Some(outcome);
+                                    c.status = PendingStatus::Succeeded;
+                                });
+                            }
+                            Err(e) => {
+                                super::log(
+                                    now_secs,
+                                    format!(
+                                        "smtp_request: doh recovery_stamp_failed nonce={} err={e:?}",
+                                        super::nonce_for_log(&nonce),
+                                    ),
+                                );
+                                pending::with_mut(&nonce, now_secs, |c| {
+                                    c.status = PendingStatus::Failed(e);
+                                });
+                            }
                         }
                     }
                 }
-            },
+            }
             Err(reason) => {
+                super::log(
+                    now_secs,
+                    format!(
+                        "smtp_request: doh verify_failed nonce={} err={reason:?}",
+                        super::nonce_for_log(&nonce),
+                    ),
+                );
                 pending::with_mut(&nonce, now_secs, |c| {
                     c.status = PendingStatus::Failed(reason);
                 });

--- a/src/internet_identity/src/email_recovery/submit_leaf.rs
+++ b/src/internet_identity/src/email_recovery/submit_leaf.rs
@@ -55,14 +55,52 @@ pub async fn submit_dkim_leaf(
         extra_chains,
     } = arg;
 
+    super::log(
+        now_secs,
+        format!(
+            "submit_dkim_leaf: enter nonce={} hops={} extra_chains={}",
+            super::nonce_for_log(&nonce),
+            hops.len(),
+            extra_chains.len(),
+        ),
+    );
+
     // Snapshot everything we need under one borrow so the rest of
     // the function works against owned data. Includes early
     // rejection of "not a DNSSEC pending entry" / "not in
     // NeedDkimLeaf state" / etc.
-    let snapshot = pending::with_mut(&nonce, now_secs, |c| Snapshot::take(c))
-        .ok_or(EmailRecoveryError::NonceUnknown)??;
+    let snapshot = match pending::with_mut(&nonce, now_secs, |c| Snapshot::take(c)) {
+        Some(Ok(s)) => s,
+        Some(Err(e)) => {
+            super::log(
+                now_secs,
+                format!(
+                    "submit_dkim_leaf: snapshot_rejected nonce={} err={e:?}",
+                    super::nonce_for_log(&nonce),
+                ),
+            );
+            return Err(e);
+        }
+        None => {
+            super::log(
+                now_secs,
+                format!(
+                    "submit_dkim_leaf: nonce_unknown nonce={}",
+                    super::nonce_for_log(&nonce),
+                ),
+            );
+            return Err(EmailRecoveryError::NonceUnknown);
+        }
+    };
 
     if let Err(e) = run_submit(&hops, &extra_chains, &snapshot, now_secs) {
+        super::log(
+            now_secs,
+            format!(
+                "submit_dkim_leaf: run_submit_failed nonce={} err={e:?}",
+                super::nonce_for_log(&nonce),
+            ),
+        );
         let cloned = e.clone();
         pending::with_mut(&nonce, now_secs, |c| {
             c.status = PendingStatus::Failed(cloned);
@@ -77,6 +115,14 @@ pub async fn submit_dkim_leaf(
         SnapshotKind::Register { anchor } => {
             match super::smtp::bind_credential(*anchor, &snapshot.claimed_address, now_secs) {
                 Ok(()) => {
+                    super::log(
+                        now_secs,
+                        format!(
+                            "submit_dkim_leaf: setup_bound nonce={} anchor={anchor} address={}",
+                            super::nonce_for_log(&nonce),
+                            snapshot.claimed_address,
+                        ),
+                    );
                     pending::with_mut(&nonce, now_secs, |c| {
                         c.status = PendingStatus::Succeeded;
                         c.partial_verification = None;
@@ -84,6 +130,13 @@ pub async fn submit_dkim_leaf(
                     Ok(EmailRecoveryStatus::RegistrationSucceeded)
                 }
                 Err(e) => {
+                    super::log(
+                        now_secs,
+                        format!(
+                            "submit_dkim_leaf: setup_bind_failed nonce={} anchor={anchor} err={e:?}",
+                            super::nonce_for_log(&nonce),
+                        ),
+                    );
                     let cloned = e.clone();
                     pending::with_mut(&nonce, now_secs, |c| {
                         c.status = PendingStatus::Failed(cloned);
@@ -109,6 +162,14 @@ pub async fn submit_dkim_leaf(
                     let user_key = serde_bytes::ByteBuf::from(outcome.user_key.clone());
                     let expiration = outcome.expiration;
                     let anchor_number = outcome.anchor_number;
+                    super::log(
+                        now_secs,
+                        format!(
+                            "submit_dkim_leaf: recovery_stamped nonce={} anchor={anchor_number} address={}",
+                            super::nonce_for_log(&nonce),
+                            snapshot.claimed_address,
+                        ),
+                    );
                     pending::with_mut(&nonce, now_secs, |c| {
                         c.recovery_outcome = Some(outcome);
                         c.status = PendingStatus::Succeeded;
@@ -121,6 +182,13 @@ pub async fn submit_dkim_leaf(
                     })
                 }
                 Err(e) => {
+                    super::log(
+                        now_secs,
+                        format!(
+                            "submit_dkim_leaf: recovery_stamp_failed nonce={} err={e:?}",
+                            super::nonce_for_log(&nonce),
+                        ),
+                    );
                     let cloned = e.clone();
                     pending::with_mut(&nonce, now_secs, |c| {
                         c.status = PendingStatus::Failed(cloned);

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1636,28 +1636,76 @@ mod email_recovery_api {
         identity_number: IdentityNumber,
         address: String,
     ) -> Result<(), EmailRecoveryError> {
+        let now_secs = ic_cdk::api::time() / 1_000_000_000;
+        email_recovery::log(
+            now_secs,
+            format!("credential_remove: enter anchor={identity_number} address={address:?}"),
+        );
         // Inlined auth + write rather than going through
         // `anchor_operation_with_authz_check` because that helper's
         // `E: From<IdentityUpdateError>` bound is awkward to satisfy
         // for an interface-crate error type (orphan rule).
         let (mut anchor, authz_key) = crate::authz_utils::check_authorization(identity_number)
-            .map_err(|err| EmailRecoveryError::Unauthorized(err.principal))?;
+            .map_err(|err| {
+                email_recovery::log(
+                    now_secs,
+                    format!("credential_remove: unauthorized anchor={identity_number}"),
+                );
+                EmailRecoveryError::Unauthorized(err.principal)
+            })?;
         crate::anchor_management::activity_bookkeeping(&mut anchor, &authz_key);
 
         let operation =
             email_recovery::remove_credential(&mut anchor, &address).map_err(|err| match err {
                 crate::email_recovery::RemoveError::NotRegistered => {
+                    email_recovery::log(
+                        now_secs,
+                        format!(
+                            "credential_remove: address_not_registered anchor={identity_number}"
+                        ),
+                    );
                     EmailRecoveryError::AddressNotRegistered
                 }
             })?;
 
-        crate::state::storage_borrow_mut(|storage| storage.write(anchor))
-            .map_err(|err| EmailRecoveryError::InternalCanisterError(format!("{err:?}")))?;
+        crate::state::storage_borrow_mut(|storage| storage.write(anchor)).map_err(|err| {
+            email_recovery::log(
+                now_secs,
+                format!(
+                    "credential_remove: storage_write_failed anchor={identity_number} err={err:?}"
+                ),
+            );
+            EmailRecoveryError::InternalCanisterError(format!("{err:?}"))
+        })?;
 
         crate::anchor_management::post_operation_bookkeeping(identity_number, operation);
+        email_recovery::log(
+            now_secs,
+            format!("credential_remove: ok anchor={identity_number}"),
+        );
         Ok(())
     }
 
+    /// Anonymous query. Returns the in-memory debug log accumulated
+    /// by the recovery flow's update methods (`prepare_add`,
+    /// `prepare_delegation`, `smtp_request`, `submit_dkim_leaf`,
+    /// `credential_remove`). Each entry is `[<unix_secs>] <message>`.
+    ///
+    /// The buffer is heap-resident, NOT persisted across upgrades,
+    /// and bounded by `state::RECOVERY_LOG_MAX_ENTRIES` with
+    /// oldest-first eviction once full. Intended purely for
+    /// debugging the recovery pipeline — production callers should
+    /// not depend on its shape or contents.
+    ///
+    /// The log entries do **not** include full nonces or session
+    /// public keys: nonces are truncated by `nonce_for_log`
+    /// (verbose prefix + 4 chars of suffix) so the persistent
+    /// secret isn't recoverable from the buffer, and session keys
+    /// are logged only as a byte count.
+    #[query]
+    fn email_recovery_logs() -> Vec<String> {
+        crate::state::recovery_logs(|logs| logs.clone())
+    }
 }
 
 mod attribute_sharing {

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -229,7 +229,18 @@ struct State {
     registration_rate_limit: RefCell<Option<RateLimitState>>,
     // Counter to ensure uniqueness of event data in case multiple events have the same timestamp
     event_data_uniqueness_counter: Cell<u16>,
+    // Debug log for email-recovery flow steps. Heap-resident, not persisted across upgrades,
+    // bounded by `RECOVERY_LOG_MAX_ENTRIES` with oldest-first eviction. Exposed via the
+    // `email_recovery_logs` query so operators can inspect the canister-side view of an
+    // in-flight recovery without re-deploying with extra `ic_cdk::println!` instrumentation.
+    recovery_logs: RefCell<Vec<String>>,
 }
+
+/// Cap on the in-memory email-recovery debug log. Sized to retain
+/// enough recent entries to follow one or two interleaved flows
+/// (each emits ~10 lines) while bounding heap residency: at 256
+/// bytes per line, 1024 lines ≈ 256 KB worst case.
+pub const RECOVERY_LOG_MAX_ENTRIES: usize = 1024;
 
 // Checks if salt is empty and calls `init_salt` to set it.
 pub async fn ensure_salt_set() {
@@ -484,6 +495,25 @@ pub fn invalidate_archive_status_cache() {
     STATE.with(|state| {
         *state.archive_status_cache.borrow_mut() = None;
     })
+}
+
+pub fn recovery_logs<R>(f: impl FnOnce(&Vec<String>) -> R) -> R {
+    STATE.with(|s| f(&s.recovery_logs.borrow()))
+}
+
+/// Append a line to the email-recovery debug log. Evicts oldest
+/// entries when the log would exceed [`RECOVERY_LOG_MAX_ENTRIES`].
+/// Called from inside the recovery flow steps; the
+/// `email_recovery_logs` query exposes the accumulated buffer.
+pub fn push_recovery_log(line: String) {
+    STATE.with(|s| {
+        let mut logs = s.recovery_logs.borrow_mut();
+        if logs.len() >= RECOVERY_LOG_MAX_ENTRIES {
+            let overflow = logs.len() + 1 - RECOVERY_LOG_MAX_ENTRIES;
+            logs.drain(0..overflow);
+        }
+        logs.push(line);
+    });
 }
 
 pub fn get_and_inc_event_data_counter() -> u16 {


### PR DESCRIPTION
Adds a debug-only `email_recovery_logs` query that returns the canister-side view of recent recovery-flow steps. Helpful when investigating why an in-flight recovery is stuck (DNSSEC verification, DKIM/DMARC failure, gateway misdelivery, etc.) without redeploying the canister with ad-hoc `ic_cdk::println!` instrumentation.

Each log entry is `[<unix_secs>] <message>` and covers `prepare_add`, `prepare_delegation`, `smtp_request`, `submit_dkim_leaf`, and `credential_remove`. Nonces are truncated (verbose prefix + 4 suffix chars) and `session_pk` is logged only as a byte count so the per-challenge secret isn't recoverable from the buffer.

The log lives in a heap `Vec<String>` keyed off thread-local state, bounded by `RECOVERY_LOG_MAX_ENTRIES` (1024 entries) with oldest-first eviction, and is not persisted across canister upgrades.

## Changes

- New `state::recovery_logs` field + `push_recovery_log` helper with bounded growth.
- New `email_recovery::log` / `nonce_for_log` helpers used from `prepare`, `smtp`, `submit_leaf`, and the `credential_remove` canister method.
- New `email_recovery_logs : () -> (vec text) query` in the candid surface.

<div align="left">Previous: #3939</div>