### PR TITLE
feat(scripts): prompt for missing FE/BE args, pin didc, add --reconfigure

### DIFF
--- a/.didc-checksums
+++ b/.didc-checksums
@@ -1,0 +1,23 @@
+# Pinned sha256 hashes for the didc binaries listed in `.didc-release`.
+#
+# Kept in lockstep with `.didc-release` so the helper in
+# `scripts/didc-helpers.bash` can verify each downloaded binary before
+# executing it — without this, the download path is plain HTTPS-with-no-
+# integrity-check (caught by the ZeroPath static-analysis ruleset that
+# guards against unverified-binary-execution patterns).
+#
+# When bumping `.didc-release`, refresh these too. The format is one
+# `<platform> <sha256>` pair per line (whitespace-separated, comments
+# allowed); platforms must match the asset suffix on the
+# dfinity/candid release page (linux64 / macos / arm32).
+#
+# To recompute by hand:
+#   release=$(sed <.didc-release 's/#.*$//' | sed '/^$/d')
+#   for plat in linux64 macos arm32; do
+#     curl -sfL "https://github.com/dfinity/candid/releases/download/$release/didc-$plat" \
+#       | shasum -a 256 | awk -v p="$plat" '{print p, $1}'
+#   done
+
+linux64 32693c76d9c6fe0f273f2c1ebf7e48ba3c383e925e5afd17dd264a06aed9fbcc
+macos   e7c4f2450ea7eb7535a9fe8853102f6068b2787d6197f6a6587dd96c7f5110bb
+arm32   91303ee9e2ee59824deab45ab86949afcf3f283e8f0780e4665c10db973bbdf3

--- a/.didc-release
+++ b/.didc-release
@@ -1,3 +1,3 @@
 # the release used to pull the didc executable
 # see frontend-checks for more info
-2025-10-16
+2025-12-18

--- a/.github/workflows/update-didc.yml
+++ b/.github/workflows/update-didc.yml
@@ -29,12 +29,37 @@ jobs:
             sed -i -e \
               "s/$current_didc_release/$latest_didc_release/g" \
               ".didc-release"
+
+            # Refresh `.didc-checksums` in lockstep with `.didc-release`
+            # so `scripts/didc-helpers.bash` can keep verifying downloads.
+            # Skipping this would land a bot-bump PR that breaks every
+            # caller of the pinned didc on the next CI run.
+            #
+            # Strategy: strip existing `<platform> <sha>` lines (anything
+            # matching one of the three known platform names at column 1)
+            # to keep the header comments, then re-append fresh hashes
+            # at the bottom. Robust to the header growing/shrinking.
+            checksums_tmp=$(mktemp)
+            grep -vE '^(linux64|macos|arm32)[[:space:]]' ./.didc-checksums \
+              > "$checksums_tmp"
+            # Collapse trailing blank lines + add a single separator
+            # before the new hash block.
+            sed -e :a -e '/^[[:space:]]*$/{$d;N;ba' -e '}' -i "$checksums_tmp"
+            printf '\n' >> "$checksums_tmp"
+            for plat in linux64 macos arm32; do
+              sha=$(curl --location --fail --silent --show-error \
+                "https://github.com/dfinity/candid/releases/download/$latest_didc_release/didc-$plat" \
+                | shasum -a 256 | awk '{print $1}')
+              printf '%-7s %s\n' "$plat" "$sha" >> "$checksums_tmp"
+            done
+            mv "$checksums_tmp" ./.didc-checksums
+
             echo "updated=1" >> "$GITHUB_OUTPUT"
           else
             echo "updated=0" >> "$GITHUB_OUTPUT"
           fi
 
-          cat ./.didc-release
+          cat ./.didc-release ./.didc-checksums
 
         # If the .didc-release was updated, create a PR.
       - name: Create Pull Request
@@ -43,7 +68,9 @@ jobs:
         with:
           token: ${{ secrets.GIX_BOT_PAT }}
           base: main
-          add-paths: ./.didc-release
+          add-paths: |
+            ./.didc-release
+            ./.didc-checksums
           commit-message: Update didc release
           committer: GitHub <noreply@github.com>
           author: gix-bot <gix-bot@users.noreply.github.com>

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -10,13 +10,15 @@
 #   each upgrade:
 #     * `backend_origin` and `related_origins` (FE + BE) — staging environments
 #       often front custom domains in addition to the canister-default URLs,
-#       and silently overwriting the on-chain lists has bitten us in the past;
+#       and silently overwriting the on-chain lists has bitten us in the past.
 #     * the behavior knobs `dev_csp` / `dummy_auth` / `analytics_config` (FE).
-#   Defaults are read from the canister's current `/.config` (FE, Candid text)
-#   or `/.config.did.bin` (BE, decoded via `didc` against the BE `.did`), so
-#   hitting Enter through preserves the existing on-chain values. Everything
-#   else is derived from the shared (BE_ID, FE_ID, BE_URL, FE_URL) quad or left
-#   absent so the BE preserves prior state.
+#   FE defaults are parsed from the canister's `/.config` Candid-text endpoint,
+#   which faithfully exposes its required (non-opt) record. The BE's
+#   `/.config.did.bin` only mirrors a `synchronized` subset of init args
+#   (`openid_configs`, …) — `backend_origin` / `related_origins` aren't in
+#   that subset — so the BE prompts default to `null` (= preserve under the
+#   `opt`-field semantics of `InternetIdentityInit`'s `post_upgrade`) and the
+#   operator types `opt "..."` to set explicit new values.
 # - Install-arg builders that emit Candid text for each canister.
 # - An icp install runner that honours --dry-run.
 #
@@ -584,69 +586,33 @@ prompt_fe_extra_args() {
 }
 
 # -------------------------
-# Per-BE interactive prompts for the install-arg fields where the on-chain
-# value matters and the staging-quad-derived default would silently
-# overwrite a custom-domain setup: `backend_origin` and `related_origins`.
+# Per-BE interactive prompts for `backend_origin` and `related_origins`.
 #
-# The BE init type is `opt InternetIdentityInit` where every field is itself
-# `opt` and "absent = preserve previous value", so unlike the FE we *could*
-# stay silent by emitting `null` for both fields — but that resets them
-# rather than preserving, which is just as destructive. Prompting with the
-# decoded on-chain values as defaults makes "hit Enter through" actually
-# preserve current state.
+# The BE init type wraps every field in `opt`, and the canister's
+# `post_upgrade` treats `null` as "leave the previously stored value
+# untouched" — so emitting `null` for either field on upgrade is the
+# safe preserve default, not destructive. Hitting Enter through these
+# prompts therefore guarantees that any custom-domain config currently
+# on chain is left in place; the operator only departs from `null` if
+# they explicitly want to set new values.
 #
-# The BE config endpoint serves binary Candid (`/.config.did.bin`), so we
-# need `didc` plus the BE `.did` schema to decode it for human-readable
-# field names. If either is missing we fall back to the canister-URL
-# defaults with a loud warning.
+# We deliberately don't try to read the live on-chain values back to
+# fill the defaults: the BE's `/.config.did.bin` endpoint only mirrors
+# the `synchronized` subset of init args (currently `openid_configs`
+# and a couple of others), so `backend_origin` / `related_origins`
+# decode as `null` there regardless of what was actually set at last
+# upgrade. Using `null` defaults is honest about that — anything else
+# would imply we know the on-chain values when we don't.
 # -------------------------
 prompt_be_extra_args() {
-    local scripts_dir
-    scripts_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    local did_file="$scripts_dir/../src/internet_identity/internet_identity.did"
-    local config_url="${BE_URL}/.config.did.bin"
-
-    # Fallback defaults — see warning text below for what these do on chain.
-    local backend_origin_default="opt \"$BE_URL\""
-    local related_origins_default="opt vec { \"$FE_URL\" }"
-
     echo "" >&2
-    if ! ensure_pinned_didc 2>/dev/null; then
-        echo "Note: pinned didc download failed — skipping BE config decode." >&2
-        echo "      Defaults below are derived from the staging quad, NOT live values." >&2
-        echo "      Hitting Enter through will OVERWRITE any custom-domain config on chain." >&2
-    elif [ ! -f "$did_file" ]; then
-        echo "Note: BE .did schema not found at $did_file — skipping BE config decode." >&2
-        echo "      Defaults below are derived from the staging quad, NOT live values." >&2
-    else
-        echo "Fetching current BE config from $config_url ..." >&2
-        local tmp
-        tmp=$(mktemp)
-        if ! curl --connect-timeout 10 --max-time 30 -sfL "$config_url" -o "$tmp" 2>/dev/null \
-                || [ ! -s "$tmp" ]; then
-            echo "  Warning: could not fetch BE config; defaults are derived from the staging quad, NOT live values." >&2
-        else
-            local decoded
-            decoded=$("$PINNED_DIDC" decode -d "$did_file" -t '(InternetIdentityInit)' \
-                "$(xxd -p "$tmp" | tr -d '\n')" 2>/dev/null || true)
-            if [ -z "$decoded" ]; then
-                echo "  Warning: \`$PINNED_DIDC decode\` failed; defaults are derived from the staging quad." >&2
-            else
-                local parsed
-                parsed=$(_parse_candid_field "backend_origin" "$decoded")
-                [ -n "$parsed" ] && backend_origin_default="$parsed"
-                parsed=$(_parse_candid_field "related_origins" "$decoded")
-                [ -n "$parsed" ] && related_origins_default="$parsed"
-            fi
-        fi
-        rm -f "$tmp"
-    fi
+    echo "Backend install-arg prompts (Enter = null = preserve previous on-chain value):" >&2
 
-    echo "" >&2
-    echo "Backend install-arg prompts (hit Enter to keep current value):" >&2
-
-    BE_BACKEND_ORIGIN_ARG=$(prompt_default  "backend_origin (opt text)"       "$backend_origin_default")
-    BE_RELATED_ORIGINS_ARG=$(prompt_default "related_origins (opt vec text)"  "$related_origins_default")
+    # Defaults are `null` (preserve). To set a value, type the full
+    # Candid expression at the prompt — e.g. `opt "https://backend.beta.id.ai"`
+    # or `opt vec { "https://beta.id.ai"; "https://beta.identity.icp0.io" }`.
+    BE_BACKEND_ORIGIN_ARG=$(prompt_default  "backend_origin (opt text)"       "null")
+    BE_RELATED_ORIGINS_ARG=$(prompt_default "related_origins (opt vec text)"  "null")
 }
 
 # -------------------------

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -151,6 +151,10 @@ Common options:
   -be                       Shortcut for --end back
   --dry-run                 Print icp canister install commands instead of running them
   --no-checks               Skip reachability and consistency checks
+  --reconfigure             (deploy-pr-to-beta only) Args-only upgrade: no PR #,
+                            script finds the CI artifact whose Wasm hash matches
+                            what's currently on chain and re-uses it, so only the
+                            install args change.
   --update-email-recovery-init
                             Fetch fresh IANA root anchors + set the curated
                             DoH allowlist on this upgrade. Without this flag
@@ -178,6 +182,7 @@ parse_common_args() {
     REBUILD_BE=false
     DRY_RUN=false
     NO_CHECKS=false
+    IS_RECONFIGURE=false
     UPDATE_EMAIL_RECOVERY_INIT=false
     DOH_DOMAINS_ARG=""
     # Distinguishes "--doh-domains was not passed" (use the curated
@@ -274,6 +279,14 @@ parse_common_args() {
                 ;;
             --no-checks)
                 NO_CHECKS=true
+                shift
+                ;;
+            --reconfigure)
+                # Args-only mode (see deploy-pr-to-beta): no PR # required;
+                # the script finds a CI artifact whose Wasm hash matches
+                # whatever's currently on chain so the wasm bytes don't
+                # change across the upgrade.
+                IS_RECONFIGURE=true
                 shift
                 ;;
             --update-email-recovery-init)
@@ -737,6 +750,121 @@ opt opt record {
       max_cache_age_secs = opt (3600 : nat64);
     }
 EOF
+}
+
+# -------------------------
+# `--reconfigure` helpers
+# -------------------------
+# Args-only deploy support: find the CI artifact whose gzipped wasm
+# sha256 matches whatever's currently on chain, so we can upgrade the
+# install args without changing the on-chain wasm bytes. Verified
+# empirically against Staging A: `module_hash` (from canister_status)
+# equals `sha256(internet_identity_backend.wasm.gz)` — i.e. the IC
+# stores the *gzipped* bytes and hashes them, rather than the
+# decompressed module. So no `gunzip` step here.
+
+# Read the on-chain module_hash via the public ic-api endpoint. No
+# authentication, no canister call — just the dashboard's read-only
+# REST surface. Stdout: lowercase hex sha256, or empty on failure.
+fetch_onchain_module_hash() {
+    local canister_id="$1"
+    curl --connect-timeout 10 --max-time 30 -fsSL \
+        "https://ic-api.internetcomputer.org/api/v3/canisters/$canister_id" 2>/dev/null \
+        | jq -r '.module_hash // empty'
+}
+
+# Search recent CI artifacts for one whose .wasm.gz sha256 matches
+# `$2`. Writes the matching wasm.gz to `$3` and prints the run id (for
+# the per-end "=== Deploying ... ===" log line) to stdout. Returns
+# non-zero with a diagnostic if no match is found in the search window.
+#
+# Args:
+#   $1  artifact name (e.g. "internet_identity_backend.wasm.gz")
+#   $2  expected sha256 (lowercase hex)
+#   $3  destination path for the matching wasm.gz
+#
+# Requires: $REPO, $AUTH_HEADER set by the caller (deploy-pr-to-beta
+# initialises both right after PR/auth resolution).
+#
+# Uses the per-repo artifacts endpoint with the `?name=...` filter,
+# which returns up to 100 matching artifacts per page directly — much
+# denser than walking workflow runs (most runs don't host the artifact
+# we want, so per-run scans waste API budget). Searches at most
+# `max_artifacts` artifacts before giving up; bump as needed if the
+# on-chain wasm reliably exceeds the window.
+find_artifact_by_hash() {
+    local artifact_name="$1"
+    local expected_hash="$2"
+    local dest_path="$3"
+    local max_artifacts=300
+
+    echo "  Searching $REPO for $artifact_name with hash $expected_hash (up to $max_artifacts artifacts)..." >&2
+
+    local tmp_zip tmp_dir
+    tmp_zip=$(mktemp -t ii-reconfigure.XXXX.zip)
+    tmp_dir=$(mktemp -d -t ii-reconfigure.XXXX)
+    # shellcheck disable=SC2064 # we want $tmp_* expanded at trap setup
+    trap "rm -rf '$tmp_zip' '$tmp_dir'" RETURN
+
+    local page=1 checked=0 expired_skipped=0
+    while [ "$checked" -lt "$max_artifacts" ]; do
+        local artifacts_json
+        artifacts_json=$(curl -sf -H "$AUTH_HEADER" \
+            "https://api.github.com/repos/$REPO/actions/artifacts?name=$artifact_name&per_page=100&page=$page" \
+            2>/dev/null || echo '{"artifacts":[]}')
+
+        local count
+        count=$(echo "$artifacts_json" | jq '.artifacts | length')
+        if [ "$count" -eq 0 ]; then
+            break
+        fi
+
+        local i
+        for ((i=0; i<count && checked<max_artifacts; i++)); do
+            local expired url run_id branch
+            expired=$(echo "$artifacts_json" | jq -r ".artifacts[$i].expired")
+            if [ "$expired" = "true" ]; then
+                expired_skipped=$((expired_skipped + 1))
+                continue
+            fi
+            url=$(echo "$artifacts_json" | jq -r ".artifacts[$i].archive_download_url")
+            run_id=$(echo "$artifacts_json" | jq -r ".artifacts[$i].workflow_run.id")
+            branch=$(echo "$artifacts_json" | jq -r ".artifacts[$i].workflow_run.head_branch")
+
+            checked=$((checked + 1))
+            if ! curl -sfL -H "$AUTH_HEADER" -o "$tmp_zip" "$url" 2>/dev/null; then
+                continue
+            fi
+            rm -rf "$tmp_dir" && mkdir -p "$tmp_dir"
+            if ! unzip -o -q "$tmp_zip" -d "$tmp_dir" 2>/dev/null; then
+                continue
+            fi
+            if [ ! -f "$tmp_dir/$artifact_name" ]; then
+                continue
+            fi
+
+            local hash
+            hash=$(shasum -a 256 "$tmp_dir/$artifact_name" | awk '{print $1}')
+            if [ "$hash" = "$expected_hash" ]; then
+                mv "$tmp_dir/$artifact_name" "$dest_path"
+                echo "  Match: run $run_id ($branch)" >&2
+                echo "$run_id"
+                return 0
+            fi
+        done
+
+        page=$((page + 1))
+        if [ "$count" -lt 100 ]; then
+            break  # last page
+        fi
+    done
+
+    echo "  Error: no artifact matching sha256 $expected_hash found in the most recent $checked artifacts" \
+         "(of $artifact_name; $expired_skipped expired skipped)." >&2
+    echo "         The on-chain wasm probably pre-dates GitHub's 90-day artifact retention window, or the" >&2
+    echo "         deploy was performed by a path that didn't go through canister-tests.yml. Fall back to" >&2
+    echo "         the regular PR-anchored flow: \`./scripts/deploy-pr-to-beta -s<env> -fe -be <PR>\`." >&2
+    return 1
 }
 
 # -------------------------

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -900,41 +900,92 @@ bootstrap_init_args() {
 
 # -------------------------
 # Encode a Candid text install arg into a raw-binary file using the
-# pinned didc. Validates the args against the canister's `.did` schema
-# (`-d` + `-t`), so a typo lands here rather than as a CanisterError
-# during `install_code`.
+# pinned didc, validated against the schema embedded *in the wasm being
+# deployed* — not the working tree's `.did`. The local `.did` and the
+# CI artifact's wasm can be from different commits (especially after a
+# rebase or when running `--reconfigure` against an old on-chain wasm),
+# so encoding against the local schema lets the type checker silently
+# pass on a payload the deployed code can't parse. ic-wasm gives us the
+# exact `candid:service` + `candid:args` sections the deployed module
+# advertises, eliminating that drift.
 #
 # Args:
-#   $1  Path to the canister's `.did` schema (e.g. internet_identity.did)
-#   $2  Candid type to encode against (e.g. `(opt InternetIdentityInit)`)
-#   $3  Candid text payload (output of build_{fe,be}_install_arg)
-#   $4  Output path for the raw-binary args file
+#   $1  Path to the wasm being installed (.wasm or .wasm.gz)
+#   $2  Candid text payload (output of build_{fe,be}_install_arg)
+#   $3  Output path for the raw-binary args file
 #
-# Output: writes raw Candid bytes to $4. Returns non-zero (and prints a
-# targeted error) on download / encode failure so the caller can bail
-# before invoking `icp canister install` with a half-baked file.
+# Output: writes raw Candid bytes to $3. Returns non-zero (and prints a
+# targeted error) on download / extract / encode failure so the caller
+# can bail before invoking `icp canister install` with a half-baked
+# file.
 encode_install_arg_bin() {
-    local did_file="$1"
-    local candid_type="$2"
-    local candid_text="$3"
-    local out_file="$4"
+    local wasm_path="$1"
+    local candid_text="$2"
+    local out_file="$3"
 
-    if [ ! -f "$did_file" ]; then
-        echo "Error: .did schema not found at $did_file" >&2
+    if [ ! -f "$wasm_path" ]; then
+        echo "Error: wasm not found at $wasm_path" >&2
+        return 1
+    fi
+    if ! command -v ic-wasm >/dev/null 2>&1; then
+        echo "Error: \`ic-wasm\` not on PATH. Run \`./scripts/bootstrap\` (or" >&2
+        echo "       \`cargo install ic-wasm --version 0.8.5\`) to install it." >&2
         return 1
     fi
     ensure_pinned_didc || return 1
 
+    # ic-wasm needs a raw .wasm input. Decompress to a temp if we were
+    # handed a .wasm.gz (CI artifact). Use a single temp dir for both
+    # the decompressed wasm and the extracted .did so cleanup is easy.
+    local tmp_dir
+    tmp_dir=$(mktemp -d -t ii-encode-args.XXXX)
+    local wasm_for_metadata
+    if [[ "$wasm_path" == *.gz ]]; then
+        wasm_for_metadata="$tmp_dir/wasm-input.wasm"
+        if ! gunzip -c "$wasm_path" > "$wasm_for_metadata"; then
+            echo "Error: failed to gunzip $wasm_path" >&2
+            rm -rf "$tmp_dir"
+            return 1
+        fi
+    else
+        wasm_for_metadata="$wasm_path"
+    fi
+
+    # Extract the full Candid service definition (types + methods) and
+    # the init args type from the wasm's metadata sections — both are
+    # required to type-check the encode. `candid:args` is just the
+    # parenthesised init type (e.g. `(opt InternetIdentityInit)`), so
+    # the caller doesn't have to hard-code the name and can't drift.
+    local did_file="$tmp_dir/wasm-input.did"
+    if ! ic-wasm "$wasm_for_metadata" metadata candid:service > "$did_file" 2>/dev/null \
+            || [ ! -s "$did_file" ]; then
+        echo "Error: failed to extract candid:service metadata from $wasm_path" >&2
+        echo "       (Is this an internet-identity backend / frontend wasm?)" >&2
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+    local candid_type
+    candid_type=$(ic-wasm "$wasm_for_metadata" metadata candid:args 2>/dev/null)
+    if [ -z "$candid_type" ]; then
+        echo "Error: failed to extract candid:args metadata from $wasm_path" >&2
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
     local hex
     if ! hex=$("$PINNED_DIDC" encode -d "$did_file" -t "$candid_type" "$candid_text"); then
-        echo "Error: didc encode failed for $did_file / $candid_type" >&2
+        echo "Error: didc encode failed for $wasm_path / $candid_type" >&2
         echo "       Candid input was:" >&2
         echo "$candid_text" | sed 's/^/         /' >&2
+        rm -rf "$tmp_dir"
         return 1
     fi
     # `didc encode` emits hex; the icp-cli `--args-format bin` path
     # expects raw bytes, so we collapse hex → bytes with `xxd -r -p`.
     printf '%s' "$hex" | xxd -r -p > "$out_file"
+
+    rm -rf "$tmp_dir"
+
     if [ ! -s "$out_file" ]; then
         echo "Error: encoded args file is empty after xxd conversion: $out_file" >&2
         return 1

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -47,6 +47,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/default-doh-domains.bash"
 # shellcheck source=fetch-iana-root-anchors.bash
 source "$(dirname "${BASH_SOURCE[0]}")/fetch-iana-root-anchors.bash"
 
+# Pinned-didc helper (shared with make-upgrade-proposal). Exposes
+# `ensure_pinned_didc` + `$PINNED_DIDC` so every script encodes /
+# decodes Candid against the same dfinity/candid release listed in
+# `.didc-release`, instead of whatever's on `PATH`.
+# shellcheck source=didc-helpers.bash
+source "$(dirname "${BASH_SOURCE[0]}")/didc-helpers.bash"
+
 # -------------------------
 # Staging environments
 # -------------------------
@@ -372,7 +379,9 @@ check_fe_reachable() {
 }
 
 # Verify the backend URL serves `/.config.did.bin` with a non-empty body.
-# If `didc` is available, additionally check the blob decodes as Candid.
+# Best-effort Candid-decode check uses the pinned didc when it can be
+# fetched; falls back to a body-non-empty assertion if the download
+# fails (e.g. offline).
 #
 # Uses explicit cleanup rather than `trap ... RETURN` — the RETURN trap isn't
 # auto-restored, so a trap set inside a function keeps firing on every
@@ -392,8 +401,8 @@ check_be_reachable() {
     elif [ ! -s "$tmp" ]; then
         echo "  Error: $config_url returned an empty body" >&2
         rc=1
-    elif command -v didc >/dev/null 2>&1; then
-        if ! didc decode "$(xxd -p "$tmp" | tr -d '\n')" >/dev/null 2>&1; then
+    elif ensure_pinned_didc 2>/dev/null; then
+        if ! "$PINNED_DIDC" decode "$(xxd -p "$tmp" | tr -d '\n')" >/dev/null 2>&1; then
             echo "  Error: $config_url did not decode as Candid" >&2
             rc=1
         else
@@ -401,7 +410,7 @@ check_be_reachable() {
         fi
     else
         echo "  OK — $config_url returns HTTP 200 ($(wc -c <"$tmp" | tr -d ' ') bytes)." >&2
-        echo "       (install didc to additionally verify the body decodes as Candid)" >&2
+        echo "       (pinned didc download failed; skipping Candid validation)" >&2
     fi
     rm -f "$tmp"
     return $rc
@@ -589,8 +598,8 @@ prompt_be_extra_args() {
     local related_origins_default="opt vec { \"$FE_URL\" }"
 
     echo "" >&2
-    if ! command -v didc >/dev/null 2>&1; then
-        echo "Note: \`didc\` not installed — skipping BE config decode." >&2
+    if ! ensure_pinned_didc 2>/dev/null; then
+        echo "Note: pinned didc download failed — skipping BE config decode." >&2
         echo "      Defaults below are derived from the staging quad, NOT live values." >&2
         echo "      Hitting Enter through will OVERWRITE any custom-domain config on chain." >&2
     elif [ ! -f "$did_file" ]; then
@@ -605,10 +614,10 @@ prompt_be_extra_args() {
             echo "  Warning: could not fetch BE config; defaults are derived from the staging quad, NOT live values." >&2
         else
             local decoded
-            decoded=$(didc decode -d "$did_file" -t '(InternetIdentityInit)' \
+            decoded=$("$PINNED_DIDC" decode -d "$did_file" -t '(InternetIdentityInit)' \
                 "$(xxd -p "$tmp" | tr -d '\n')" 2>/dev/null || true)
             if [ -z "$decoded" ]; then
-                echo "  Warning: \`didc decode\` failed; defaults are derived from the staging quad." >&2
+                echo "  Warning: \`$PINNED_DIDC decode\` failed; defaults are derived from the staging quad." >&2
             else
                 local parsed
                 parsed=$(_parse_candid_field "backend_origin" "$decoded")
@@ -762,6 +771,49 @@ bootstrap_init_args() {
 }
 
 # -------------------------
+# Encode a Candid text install arg into a raw-binary file using the
+# pinned didc. Validates the args against the canister's `.did` schema
+# (`-d` + `-t`), so a typo lands here rather than as a CanisterError
+# during `install_code`.
+#
+# Args:
+#   $1  Path to the canister's `.did` schema (e.g. internet_identity.did)
+#   $2  Candid type to encode against (e.g. `(opt InternetIdentityInit)`)
+#   $3  Candid text payload (output of build_{fe,be}_install_arg)
+#   $4  Output path for the raw-binary args file
+#
+# Output: writes raw Candid bytes to $4. Returns non-zero (and prints a
+# targeted error) on download / encode failure so the caller can bail
+# before invoking `icp canister install` with a half-baked file.
+encode_install_arg_bin() {
+    local did_file="$1"
+    local candid_type="$2"
+    local candid_text="$3"
+    local out_file="$4"
+
+    if [ ! -f "$did_file" ]; then
+        echo "Error: .did schema not found at $did_file" >&2
+        return 1
+    fi
+    ensure_pinned_didc || return 1
+
+    local hex
+    if ! hex=$("$PINNED_DIDC" encode -d "$did_file" -t "$candid_type" "$candid_text"); then
+        echo "Error: didc encode failed for $did_file / $candid_type" >&2
+        echo "       Candid input was:" >&2
+        echo "$candid_text" | sed 's/^/         /' >&2
+        return 1
+    fi
+    # `didc encode` emits hex; the icp-cli `--args-format bin` path
+    # expects raw bytes, so we collapse hex → bytes with `xxd -r -p`.
+    printf '%s' "$hex" | xxd -r -p > "$out_file"
+    if [ ! -s "$out_file" ]; then
+        echo "Error: encoded args file is empty after xxd conversion: $out_file" >&2
+        return 1
+    fi
+}
+
+# -------------------------
 # Proxy-routed install runner (honours DRY_RUN)
 # -------------------------
 # Routes the upgrade through the proxy canister at PROXY_CANISTER_ID,
@@ -772,14 +824,23 @@ bootstrap_init_args() {
 # controllership of the staging canisters — but now exposes the `proxy`
 # method icp-cli's `--proxy` expects.
 #
-# Args: <canister_id> <wasm_path> <install_arg_candid_text>
+# Args: <canister_id> <wasm_path> <install_arg_bin_file>
+#
+# `install_arg_bin_file` is the raw-binary Candid arg produced by
+# `encode_install_arg_bin` — same format `make-upgrade-proposal` ships
+# in its NNS proposals, so the bytes on chain are bit-identical between
+# both paths.
 run_icp_install() {
     local canister_id="$1"
     local wasm_path="$2"
-    local install_arg="$3"
+    local install_arg_bin="$3"
 
     if [ ! -f "$wasm_path" ]; then
         echo "Error: wasm not found at $wasm_path" >&2
+        return 1
+    fi
+    if [ ! -f "$install_arg_bin" ]; then
+        echo "Error: install-arg binary not found at $install_arg_bin" >&2
         return 1
     fi
 
@@ -789,7 +850,8 @@ run_icp_install() {
             --proxy "$PROXY_CANISTER_ID"
             --mode upgrade
             --wasm "$wasm_path"
-            --args "$install_arg"
+            --args-file "$install_arg_bin"
+            --args-format bin
     )
 
     if [ "$DRY_RUN" = true ]; then

--- a/scripts/deploy-common.bash
+++ b/scripts/deploy-common.bash
@@ -6,10 +6,17 @@
 #   end selection (-fe/-be/--end), dry-run, no-checks, and (for the local
 #   script) the rebuild flags.
 # - Reachability + consistency checks against the selected staging canisters.
-# - Interactive prompting for the small set of install-arg fields we actually
-#   want humans to make decisions about (dev_csp / dummy_auth / analytics_config)
-#   — everything else is derived from the four shared values (BE_ID, FE_ID,
-#   BE_URL, FE_URL) or left opaque via opt null to preserve prior state.
+# - Interactive prompting for the install-arg fields humans should review on
+#   each upgrade:
+#     * `backend_origin` and `related_origins` (FE + BE) — staging environments
+#       often front custom domains in addition to the canister-default URLs,
+#       and silently overwriting the on-chain lists has bitten us in the past;
+#     * the behavior knobs `dev_csp` / `dummy_auth` / `analytics_config` (FE).
+#   Defaults are read from the canister's current `/.config` (FE, Candid text)
+#   or `/.config.did.bin` (BE, decoded via `didc` against the BE `.did`), so
+#   hitting Enter through preserves the existing on-chain values. Everything
+#   else is derived from the shared (BE_ID, FE_ID, BE_URL, FE_URL) quad or left
+#   absent so the BE preserves prior state.
 # - Install-arg builders that emit Candid text for each canister.
 # - An icp install runner that honours --dry-run.
 #
@@ -496,15 +503,16 @@ _parse_candid_field() {
 }
 
 # -------------------------
-# Per-FE interactive prompts for the small set of fields that aren't derived
-# from the shared quad (dev_csp, dummy_auth, analytics_config). fetch_root_key
-# is auto-selected by network.
+# Per-FE interactive prompts for the install-arg fields that aren't tied to
+# the staging quad: `backend_origin`, `related_origins`, `dev_csp`,
+# `dummy_auth`, `analytics_config`. `backend_canister_id` is derived from
+# BE_ID and `fetch_root_key` from the network, so neither is prompted.
 #
 # Fetches the FE canister's current `/.config` so each prompt offers the
-# currently-stored value as its default. Sending `null` on upgrade actively
-# resets these fields on the canister — it is NOT a no-op — so using the
-# current values as defaults preserves behavior when the user just hits
-# Enter.
+# currently-stored value as its default. The FE init type is a required
+# record (not opt), so every prompted field is set on each upgrade — there
+# is no "absent = preserve" path — and using the current values as defaults
+# is the only way hitting Enter through preserves behavior.
 # -------------------------
 prompt_fe_extra_args() {
     # Mainnet is the only target we currently support → fetch_root_key false.
@@ -521,26 +529,102 @@ prompt_fe_extra_args() {
     echo "Fetching current FE config from $config_url ..." >&2
     raw_config=$(curl --connect-timeout 10 --max-time 30 -sfL "$config_url" 2>/dev/null || true)
 
+    # Fallback defaults derived from the staging quad. These match the
+    # canister-default URLs and so will overwrite any custom-domain config
+    # currently on chain — hence the prominent warning when the live
+    # `/.config` couldn't be fetched.
+    local backend_origin_default="\"$BE_URL\""
+    local related_origins_default="opt vec { \"$FE_URL\" }"
     local dev_csp_default="null"
     local dummy_auth_default="null"
     local analytics_default="null"
 
     if [ -n "$raw_config" ]; then
         local parsed
+        parsed=$(_parse_candid_field "backend_origin" "$raw_config");   [ -n "$parsed" ] && backend_origin_default="$parsed"
+        parsed=$(_parse_candid_field "related_origins" "$raw_config");  [ -n "$parsed" ] && related_origins_default="$parsed"
         parsed=$(_parse_candid_field "dev_csp" "$raw_config");          [ -n "$parsed" ] && dev_csp_default="$parsed"
         parsed=$(_parse_candid_field "dummy_auth" "$raw_config");       [ -n "$parsed" ] && dummy_auth_default="$parsed"
         parsed=$(_parse_candid_field "analytics_config" "$raw_config"); [ -n "$parsed" ] && analytics_default="$parsed"
     else
-        echo "  Warning: could not fetch current config; defaulting all three fields to null." >&2
-        echo "           (This will reset them on the canister if you hit Enter through.)" >&2
+        echo "  Warning: could not fetch current config; defaults are derived from the staging quad, NOT live values." >&2
+        echo "           Hitting Enter through will OVERWRITE any custom-domain backend_origin / related_origins on chain." >&2
     fi
 
     echo "" >&2
-    echo "Frontend-only install-arg prompts (hit Enter to keep current value):" >&2
+    echo "Frontend install-arg prompts (hit Enter to keep current value):" >&2
 
-    DEV_CSP_ARG=$(prompt_default "dev_csp (opt bool)" "$dev_csp_default")
-    DUMMY_AUTH_ARG=$(prompt_default "dummy_auth (opt opt DummyAuthConfig)" "$dummy_auth_default")
-    ANALYTICS_ARG=$(prompt_default "analytics_config (opt opt AnalyticsConfig)" "$analytics_default")
+    BACKEND_ORIGIN_ARG=$(prompt_default  "backend_origin (text)"                       "$backend_origin_default")
+    RELATED_ORIGINS_ARG=$(prompt_default "related_origins (opt vec text)"              "$related_origins_default")
+    DEV_CSP_ARG=$(prompt_default         "dev_csp (opt bool)"                          "$dev_csp_default")
+    DUMMY_AUTH_ARG=$(prompt_default      "dummy_auth (opt opt DummyAuthConfig)"        "$dummy_auth_default")
+    ANALYTICS_ARG=$(prompt_default       "analytics_config (opt opt AnalyticsConfig)"  "$analytics_default")
+}
+
+# -------------------------
+# Per-BE interactive prompts for the install-arg fields where the on-chain
+# value matters and the staging-quad-derived default would silently
+# overwrite a custom-domain setup: `backend_origin` and `related_origins`.
+#
+# The BE init type is `opt InternetIdentityInit` where every field is itself
+# `opt` and "absent = preserve previous value", so unlike the FE we *could*
+# stay silent by emitting `null` for both fields — but that resets them
+# rather than preserving, which is just as destructive. Prompting with the
+# decoded on-chain values as defaults makes "hit Enter through" actually
+# preserve current state.
+#
+# The BE config endpoint serves binary Candid (`/.config.did.bin`), so we
+# need `didc` plus the BE `.did` schema to decode it for human-readable
+# field names. If either is missing we fall back to the canister-URL
+# defaults with a loud warning.
+# -------------------------
+prompt_be_extra_args() {
+    local scripts_dir
+    scripts_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    local did_file="$scripts_dir/../src/internet_identity/internet_identity.did"
+    local config_url="${BE_URL}/.config.did.bin"
+
+    # Fallback defaults — see warning text below for what these do on chain.
+    local backend_origin_default="opt \"$BE_URL\""
+    local related_origins_default="opt vec { \"$FE_URL\" }"
+
+    echo "" >&2
+    if ! command -v didc >/dev/null 2>&1; then
+        echo "Note: \`didc\` not installed — skipping BE config decode." >&2
+        echo "      Defaults below are derived from the staging quad, NOT live values." >&2
+        echo "      Hitting Enter through will OVERWRITE any custom-domain config on chain." >&2
+    elif [ ! -f "$did_file" ]; then
+        echo "Note: BE .did schema not found at $did_file — skipping BE config decode." >&2
+        echo "      Defaults below are derived from the staging quad, NOT live values." >&2
+    else
+        echo "Fetching current BE config from $config_url ..." >&2
+        local tmp
+        tmp=$(mktemp)
+        if ! curl --connect-timeout 10 --max-time 30 -sfL "$config_url" -o "$tmp" 2>/dev/null \
+                || [ ! -s "$tmp" ]; then
+            echo "  Warning: could not fetch BE config; defaults are derived from the staging quad, NOT live values." >&2
+        else
+            local decoded
+            decoded=$(didc decode -d "$did_file" -t '(InternetIdentityInit)' \
+                "$(xxd -p "$tmp" | tr -d '\n')" 2>/dev/null || true)
+            if [ -z "$decoded" ]; then
+                echo "  Warning: \`didc decode\` failed; defaults are derived from the staging quad." >&2
+            else
+                local parsed
+                parsed=$(_parse_candid_field "backend_origin" "$decoded")
+                [ -n "$parsed" ] && backend_origin_default="$parsed"
+                parsed=$(_parse_candid_field "related_origins" "$decoded")
+                [ -n "$parsed" ] && related_origins_default="$parsed"
+            fi
+        fi
+        rm -f "$tmp"
+    fi
+
+    echo "" >&2
+    echo "Backend install-arg prompts (hit Enter to keep current value):" >&2
+
+    BE_BACKEND_ORIGIN_ARG=$(prompt_default  "backend_origin (opt text)"       "$backend_origin_default")
+    BE_RELATED_ORIGINS_ARG=$(prompt_default "related_origins (opt vec text)"  "$related_origins_default")
 }
 
 # -------------------------
@@ -557,8 +641,8 @@ build_fe_install_arg() {
 (
   record {
     backend_canister_id = principal "$BE_ID";
-    backend_origin = "$BE_URL";
-    related_origins = opt vec { "$FE_URL" };
+    backend_origin = $BACKEND_ORIGIN_ARG;
+    related_origins = $RELATED_ORIGINS_ARG;
     fetch_root_key = $FETCH_ROOT_KEY_ARG;
     dev_csp = $DEV_CSP_ARG;
     dummy_auth = $DUMMY_AUTH_ARG;
@@ -602,8 +686,8 @@ EXTRA
 (
   opt record {
     backend_canister_id = opt principal "$BE_ID";
-    backend_origin = opt "$BE_URL";
-    related_origins = opt vec { "$FE_URL" };
+    backend_origin = $BE_BACKEND_ORIGIN_ARG;
+    related_origins = $BE_RELATED_ORIGINS_ARG;
 $extra
   }
 )

--- a/scripts/deploy-local-to-beta
+++ b/scripts/deploy-local-to-beta
@@ -101,19 +101,38 @@ fi
 
 # -------------------------
 # Deploy (honours --dry-run)
+#
+# Args are encoded via the pinned didc against each canister's `.did`
+# schema *before* the install runs — see the equivalent comment in
+# deploy-pr-to-beta for the rationale.
 # -------------------------
+ARGS_TMP=$(mktemp -d -t ii-deploy-local-args.XXXXXX)
+trap 'rm -rf "$ARGS_TMP"' EXIT
+
 if [ "$DEPLOY_BE" = true ]; then
     BE_WASM="$ROOT_DIR/internet_identity.wasm.gz"
     echo ""
     echo "=== Deploying backend to $BE_ID ==="
-    run_icp_install "$BE_ID" "$BE_WASM" "$(build_be_install_arg)"
+    encode_install_arg_bin \
+        "$ROOT_DIR/src/internet_identity/internet_identity.did" \
+        "(opt InternetIdentityInit)" \
+        "$(build_be_install_arg)" \
+        "$ARGS_TMP/be.args.bin" \
+        || exit 1
+    run_icp_install "$BE_ID" "$BE_WASM" "$ARGS_TMP/be.args.bin"
 fi
 
 if [ "$DEPLOY_FE" = true ]; then
     FE_WASM="$ROOT_DIR/internet_identity_frontend.wasm.gz"
     echo ""
     echo "=== Deploying frontend to $FE_ID ==="
-    run_icp_install "$FE_ID" "$FE_WASM" "$(build_fe_install_arg)"
+    encode_install_arg_bin \
+        "$ROOT_DIR/src/internet_identity_frontend/internet_identity_frontend.did" \
+        "(InternetIdentityFrontendInit)" \
+        "$(build_fe_install_arg)" \
+        "$ARGS_TMP/fe.args.bin" \
+        || exit 1
+    run_icp_install "$FE_ID" "$FE_WASM" "$ARGS_TMP/fe.args.bin"
 fi
 
 echo ""

--- a/scripts/deploy-local-to-beta
+++ b/scripts/deploy-local-to-beta
@@ -88,8 +88,13 @@ run_reachability_checks || exit 1
 run_consistency_checks
 
 # -------------------------
-# Prompt for FE extras (only if deploying FE)
+# Prompt for install-arg fields that the operator should review on each
+# upgrade (custom-domain origins, behaviour knobs). See deploy-common.bash
+# for the per-end fields.
 # -------------------------
+if [ "$DEPLOY_BE" = true ]; then
+    prompt_be_extra_args
+fi
 if [ "$DEPLOY_FE" = true ]; then
     prompt_fe_extra_args
 fi

--- a/scripts/deploy-local-to-beta
+++ b/scripts/deploy-local-to-beta
@@ -113,12 +113,7 @@ if [ "$DEPLOY_BE" = true ]; then
     BE_WASM="$ROOT_DIR/internet_identity.wasm.gz"
     echo ""
     echo "=== Deploying backend to $BE_ID ==="
-    encode_install_arg_bin \
-        "$ROOT_DIR/src/internet_identity/internet_identity.did" \
-        "(opt InternetIdentityInit)" \
-        "$(build_be_install_arg)" \
-        "$ARGS_TMP/be.args.bin" \
-        || exit 1
+    encode_install_arg_bin "$BE_WASM" "$(build_be_install_arg)" "$ARGS_TMP/be.args.bin" || exit 1
     run_icp_install "$BE_ID" "$BE_WASM" "$ARGS_TMP/be.args.bin"
 fi
 
@@ -126,12 +121,7 @@ if [ "$DEPLOY_FE" = true ]; then
     FE_WASM="$ROOT_DIR/internet_identity_frontend.wasm.gz"
     echo ""
     echo "=== Deploying frontend to $FE_ID ==="
-    encode_install_arg_bin \
-        "$ROOT_DIR/src/internet_identity_frontend/internet_identity_frontend.did" \
-        "(InternetIdentityFrontendInit)" \
-        "$(build_fe_install_arg)" \
-        "$ARGS_TMP/fe.args.bin" \
-        || exit 1
+    encode_install_arg_bin "$FE_WASM" "$(build_fe_install_arg)" "$ARGS_TMP/fe.args.bin" || exit 1
     run_icp_install "$FE_ID" "$FE_WASM" "$ARGS_TMP/fe.args.bin"
 fi
 

--- a/scripts/deploy-pr-to-beta
+++ b/scripts/deploy-pr-to-beta
@@ -254,23 +254,42 @@ fi
 
 # -------------------------
 # Deploy (honours --dry-run)
+#
+# Args are encoded via the pinned didc against each canister's `.did`
+# schema *before* the install runs, so a typo lands here (with the bad
+# Candid echoed back) rather than as an opaque CanisterError from
+# install_code. The resulting raw-binary file is what icp-cli ships
+# through `--args-file ... --args-format bin` — identical to the bytes
+# `make-upgrade-proposal` puts in its NNS proposals.
 # -------------------------
 if [ "$DEPLOY_BE" = true ]; then
     echo ""
     echo "=== Deploying backend (PR #$PR_NUMBER, run $RUN_ID) to $BE_ID ==="
+    encode_install_arg_bin \
+        "$ROOT_DIR/src/internet_identity/internet_identity.did" \
+        "(opt InternetIdentityInit)" \
+        "$(build_be_install_arg)" \
+        "$ARTIFACT_DIR/internet_identity_backend.args.bin" \
+        || exit 1
     run_icp_install \
         "$BE_ID" \
         "$ARTIFACT_DIR/internet_identity_backend.wasm.gz" \
-        "$(build_be_install_arg)"
+        "$ARTIFACT_DIR/internet_identity_backend.args.bin"
 fi
 
 if [ "$DEPLOY_FE" = true ]; then
     echo ""
     echo "=== Deploying frontend (PR #$PR_NUMBER, run $RUN_ID) to $FE_ID ==="
+    encode_install_arg_bin \
+        "$ROOT_DIR/src/internet_identity_frontend/internet_identity_frontend.did" \
+        "(InternetIdentityFrontendInit)" \
+        "$(build_fe_install_arg)" \
+        "$ARTIFACT_DIR/internet_identity_frontend.args.bin" \
+        || exit 1
     run_icp_install \
         "$FE_ID" \
         "$ARTIFACT_DIR/internet_identity_frontend.wasm.gz" \
-        "$(build_fe_install_arg)"
+        "$ARTIFACT_DIR/internet_identity_frontend.args.bin"
 fi
 
 echo ""

--- a/scripts/deploy-pr-to-beta
+++ b/scripts/deploy-pr-to-beta
@@ -1,19 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: ./deploy-pr-to-beta [-sa|-sb|-sc|--staging custom] (-fe|-be) [options] <PR_NUMBER>
+# Usage:
+#   ./deploy-pr-to-beta [-sa|-sb|-sc|--staging custom] (-fe|-be) [options] <PR_NUMBER>
+#   ./deploy-pr-to-beta [-sa|-sb|-sc|--staging custom] (-fe|-be) --reconfigure [options]
 #
-# Deploy CI-built artifacts from a pull request's canister-tests.yml run to
-# a staging canister. The PR's workflow run artifacts are fetched first —
-# before we ask the user any install-arg questions — so we can fail fast if
-# CI hasn't produced usable WASMs.
+# Default flow deploys CI-built artifacts from a pull request's
+# canister-tests.yml run. `--reconfigure` drops the PR # and instead
+# finds the CI artifact whose wasm hash matches what's currently on
+# chain, so only the install args change (wasm bytes stay identical).
 
 print_usage() {
     cat <<EOF
-Usage: $0 [-sa|-sb|-sc|--staging custom] (-fe|-be) [--dry-run] [--no-checks] <PR_NUMBER>
+Usage:
+  $0 [-sa|-sb|-sc|--staging custom] (-fe|-be) [--dry-run] [--no-checks] <PR_NUMBER>
+  $0 [-sa|-sb|-sc|--staging custom] (-fe|-be) --reconfigure [--dry-run] [--no-checks]
 
-Download CI-built wasm.gz files from the most recent canister-tests.yml run
-for <PR_NUMBER> and upgrade the selected staging canister(s) to them.
+Default mode downloads CI-built wasm.gz files from the most recent
+canister-tests.yml run for <PR_NUMBER> and upgrades the selected staging
+canister(s) to them.
+
+\`--reconfigure\` is an args-only mode: no PR # is required. For each end
+being deployed the script fetches the on-chain module_hash, locates the
+CI artifact with the matching sha256, and re-installs that same wasm
+with the new install args.
 
 EOF
     print_common_usage
@@ -38,16 +48,25 @@ source "$SCRIPTS_DIR/deploy-common.bash"
 # -------------------------
 parse_common_args "$@" || { rc=$?; if [ "$rc" -eq 2 ]; then print_usage; exit 0; fi; print_usage; exit 1; }
 
-# This script does require a PR number as a positional argument.
+# PR number is required for the normal PR-anchored flow; `--reconfigure`
+# replaces it with an on-chain-hash lookup so no PR # is expected (or
+# allowed — accepting one would be confusing).
 PR_NUMBER=""
-if [ "${#REMAINING_ARGS[@]}" -eq 1 ]; then
+if [ "$IS_RECONFIGURE" = true ]; then
+    if [ "${#REMAINING_ARGS[@]}" -gt 0 ]; then
+        echo "Error: --reconfigure does not accept a PR number (got: ${REMAINING_ARGS[*]})." >&2
+        echo "       --reconfigure fetches the on-chain wasm hash and finds a matching CI artifact." >&2
+        print_usage
+        exit 1
+    fi
+elif [ "${#REMAINING_ARGS[@]}" -eq 1 ]; then
     PR_NUMBER="${REMAINING_ARGS[0]}"
 elif [ "${#REMAINING_ARGS[@]}" -gt 1 ]; then
     echo "Error: expected a single PR number, got: ${REMAINING_ARGS[*]}" >&2
     print_usage
     exit 1
 else
-    echo "Error: PR number is required" >&2
+    echo "Error: PR number is required (or pass --reconfigure for an args-only upgrade)" >&2
     print_usage
     exit 1
 fi
@@ -73,6 +92,84 @@ if [ -z "$GITHUB_TOKEN" ]; then
     exit 1
 fi
 AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
+
+# -------------------------
+# Set up the artifact temp dir early — both code paths below write into
+# it (the regular flow's `unzip` extract; --reconfigure's
+# `find_artifact_by_hash` direct write).
+# -------------------------
+ARTIFACT_DIR=$(mktemp -d -t ii-deploy-pr.XXXXXX)
+cleanup() {
+    if [ -n "$ARTIFACT_DIR" ] && [ -d "$ARTIFACT_DIR" ]; then
+        echo "Cleaning up downloaded artifacts (in $ARTIFACT_DIR)..." >&2
+        rm -rf "$ARTIFACT_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# Tracks which CI run each artifact came from, for the per-end deploy
+# log lines below. In the regular flow this is the same id for both
+# ends; under --reconfigure the FE and BE wasms can come from
+# different runs (whatever runs happen to host artifacts with matching
+# hashes).
+declare -A RUN_ID_BY_ARTIFACT=()
+
+# Header line for the per-end "=== Deploying ... ===" log. Set
+# differently by the two flows so the operator can tell at a glance
+# whether they're shipping fresh code or just rotating args.
+deploy_label() {
+    local artifact_name="$1"
+    if [ "$IS_RECONFIGURE" = true ]; then
+        echo "reconfigure, run ${RUN_ID_BY_ARTIFACT[$artifact_name]}"
+    else
+        echo "PR #$PR_NUMBER, run $RUN_ID"
+    fi
+}
+
+if [ "$IS_RECONFIGURE" = true ]; then
+    # -------------------------
+    # --reconfigure flow
+    #
+    # Skip the PR-anchored resolution / job validation entirely. For
+    # each end being deployed, fetch the on-chain module_hash via the
+    # public ic-api endpoint and search recent canister-tests.yml runs
+    # for an artifact whose `sha256(<wasm>.wasm.gz)` matches. That
+    # artifact's wasm becomes the one we re-install, byte-identical to
+    # what's already on chain — only the install args change.
+    # -------------------------
+    echo ""
+    echo "=== --reconfigure: matching CI artifacts to on-chain wasm hashes ==="
+
+    if [ "$DEPLOY_BE" = true ]; then
+        echo "Backend ($BE_ID):"
+        BE_HASH=$(fetch_onchain_module_hash "$BE_ID")
+        if [ -z "$BE_HASH" ]; then
+            echo "  Error: could not fetch on-chain module_hash from ic-api." >&2
+            exit 1
+        fi
+        echo "  on-chain hash: $BE_HASH"
+        BE_RUN_ID=$(find_artifact_by_hash \
+            "internet_identity_backend.wasm.gz" \
+            "$BE_HASH" \
+            "$ARTIFACT_DIR/internet_identity_backend.wasm.gz") || exit 1
+        RUN_ID_BY_ARTIFACT["internet_identity_backend.wasm.gz"]="$BE_RUN_ID"
+    fi
+
+    if [ "$DEPLOY_FE" = true ]; then
+        echo "Frontend ($FE_ID):"
+        FE_HASH=$(fetch_onchain_module_hash "$FE_ID")
+        if [ -z "$FE_HASH" ]; then
+            echo "  Error: could not fetch on-chain module_hash from ic-api." >&2
+            exit 1
+        fi
+        echo "  on-chain hash: $FE_HASH"
+        FE_RUN_ID=$(find_artifact_by_hash \
+            "internet_identity_frontend.wasm.gz" \
+            "$FE_HASH" \
+            "$ARTIFACT_DIR/internet_identity_frontend.wasm.gz") || exit 1
+        RUN_ID_BY_ARTIFACT["internet_identity_frontend.wasm.gz"]="$FE_RUN_ID"
+    fi
+else
 
 echo ""
 echo "Resolving PR #$PR_NUMBER head branch..."
@@ -198,24 +295,11 @@ for tuple in "${ARTIFACTS[@]}"; do
 done
 
 # -------------------------
-# Download CI artifacts into a dedicated temp directory rather than the
-# repo root — the CI artifact names collide with names produced by
-# `scripts/build` locally (e.g. `internet_identity_frontend.wasm.gz`), so
-# extracting into the repo root would overwrite and then (via cleanup)
-# delete the developer's local build outputs. The temp dir is wiped on
-# EXIT regardless of outcome.
-# -------------------------
-ARTIFACT_DIR=$(mktemp -d -t ii-deploy-pr.XXXXXX)
-cleanup() {
-    if [ -n "$ARTIFACT_DIR" ] && [ -d "$ARTIFACT_DIR" ]; then
-        echo "Cleaning up downloaded artifacts (in $ARTIFACT_DIR)..." >&2
-        rm -rf "$ARTIFACT_DIR"
-    fi
-}
-trap cleanup EXIT
-
-# -------------------------
-# Download + extract each artifact
+# Download + extract each artifact into $ARTIFACT_DIR (set up earlier
+# alongside its EXIT-trap cleanup). The CI artifact names collide with
+# the names `scripts/build` produces locally, so extracting in the repo
+# root would clobber the developer's working-tree wasms — keep them
+# isolated in the temp dir.
 # -------------------------
 echo ""
 echo "Downloading CI artifacts to $ARTIFACT_DIR..."
@@ -232,7 +316,10 @@ for tuple in "${ARTIFACTS[@]}"; do
         exit 1
     fi
     echo "  Extracted: $ARTIFACT_DIR/$ARTIFACT_NAME"
+    RUN_ID_BY_ARTIFACT["$ARTIFACT_NAME"]="$RUN_ID"
 done
+
+fi  # end of `if [ "$IS_RECONFIGURE" = true ]; ... else ... fi`
 
 # -------------------------
 # Reachability + consistency
@@ -264,7 +351,7 @@ fi
 # -------------------------
 if [ "$DEPLOY_BE" = true ]; then
     echo ""
-    echo "=== Deploying backend (PR #$PR_NUMBER, run $RUN_ID) to $BE_ID ==="
+    echo "=== Deploying backend ($(deploy_label internet_identity_backend.wasm.gz)) to $BE_ID ==="
     encode_install_arg_bin \
         "$ROOT_DIR/src/internet_identity/internet_identity.did" \
         "(opt InternetIdentityInit)" \
@@ -279,7 +366,7 @@ fi
 
 if [ "$DEPLOY_FE" = true ]; then
     echo ""
-    echo "=== Deploying frontend (PR #$PR_NUMBER, run $RUN_ID) to $FE_ID ==="
+    echo "=== Deploying frontend ($(deploy_label internet_identity_frontend.wasm.gz)) to $FE_ID ==="
     encode_install_arg_bin \
         "$ROOT_DIR/src/internet_identity_frontend/internet_identity_frontend.did" \
         "(InternetIdentityFrontendInit)" \

--- a/scripts/deploy-pr-to-beta
+++ b/scripts/deploy-pr-to-beta
@@ -353,8 +353,7 @@ if [ "$DEPLOY_BE" = true ]; then
     echo ""
     echo "=== Deploying backend ($(deploy_label internet_identity_backend.wasm.gz)) to $BE_ID ==="
     encode_install_arg_bin \
-        "$ROOT_DIR/src/internet_identity/internet_identity.did" \
-        "(opt InternetIdentityInit)" \
+        "$ARTIFACT_DIR/internet_identity_backend.wasm.gz" \
         "$(build_be_install_arg)" \
         "$ARTIFACT_DIR/internet_identity_backend.args.bin" \
         || exit 1
@@ -368,8 +367,7 @@ if [ "$DEPLOY_FE" = true ]; then
     echo ""
     echo "=== Deploying frontend ($(deploy_label internet_identity_frontend.wasm.gz)) to $FE_ID ==="
     encode_install_arg_bin \
-        "$ROOT_DIR/src/internet_identity_frontend/internet_identity_frontend.did" \
-        "(InternetIdentityFrontendInit)" \
+        "$ARTIFACT_DIR/internet_identity_frontend.wasm.gz" \
         "$(build_fe_install_arg)" \
         "$ARTIFACT_DIR/internet_identity_frontend.args.bin" \
         || exit 1

--- a/scripts/deploy-pr-to-beta
+++ b/scripts/deploy-pr-to-beta
@@ -241,8 +241,13 @@ run_reachability_checks || exit 1
 run_consistency_checks
 
 # -------------------------
-# Now — after CI artifacts are verified AND on disk — prompt for FE extras.
+# Now — after CI artifacts are verified AND on disk — prompt for install-arg
+# fields that the operator should review on each upgrade (custom-domain
+# origins, behaviour knobs). See deploy-common.bash for the per-end fields.
 # -------------------------
+if [ "$DEPLOY_BE" = true ]; then
+    prompt_be_extra_args
+fi
 if [ "$DEPLOY_FE" = true ]; then
     prompt_fe_extra_args
 fi

--- a/scripts/didc-helpers.bash
+++ b/scripts/didc-helpers.bash
@@ -11,6 +11,30 @@
 # The binary is cached under `.icp/cache/didc/` (already gitignored as
 # part of the `.icp/` tool cache) keyed by release + platform, so
 # multiple checkouts on the same machine share downloads.
+#
+# Downloads are sha256-verified against `.didc-checksums` before the
+# binary becomes executable — a mismatch (or missing checksum entry)
+# aborts and removes the partial download, so a tampered upstream or
+# stale-pin failure mode never leaves an unverified binary on disk
+# that a later run might trust by file-exists check.
+
+# Look up the sha256 pinned for the given platform in `.didc-checksums`.
+# Stdout: the lowercase hex sha256 on success; nothing on failure.
+_pinned_didc_expected_sha256() {
+    local checksums_file="$1"
+    local platform="$2"
+    if [ ! -f "$checksums_file" ]; then
+        return 1
+    fi
+    # File format: `<platform> <sha256>` pairs, with `#`-prefixed comment
+    # lines + blank lines tolerated. The awk handles inline comments by
+    # only printing the second field when the first matches.
+    awk -v p="$platform" '
+        /^[[:space:]]*#/ { next }
+        /^[[:space:]]*$/ { next }
+        $1 == p { print $2; exit }
+    ' "$checksums_file"
+}
 
 # Ensure $PINNED_DIDC is set to the pinned didc binary. Downloads on
 # first use; subsequent calls are a no-op (file-exists check).
@@ -19,8 +43,10 @@
 #   - missing or empty `.didc-release`
 #   - unsupported host OS (we only ship for macOS + linux64)
 #   - download failure
+#   - missing sha256 pin in `.didc-checksums`
+#   - sha256 mismatch between the downloaded binary and the pin
 ensure_pinned_didc() {
-    local scripts_dir root_dir release platform url cache
+    local scripts_dir root_dir release platform url cache expected_sha actual_sha
     scripts_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     root_dir="$scripts_dir/.."
 
@@ -46,21 +72,45 @@ ensure_pinned_didc() {
             ;;
     esac
 
+    expected_sha=$(_pinned_didc_expected_sha256 "$root_dir/.didc-checksums" "$platform")
+    if [ -z "$expected_sha" ]; then
+        echo "Error: no sha256 pin for platform '$platform' in $root_dir/.didc-checksums." >&2
+        echo "       Add an entry (see the header comment in that file for instructions) before" >&2
+        echo "       any caller can use the pinned didc — we refuse to execute an unverified binary." >&2
+        return 1
+    fi
+
     cache="$root_dir/.icp/cache/didc/didc-$release-$platform"
-    if [ ! -x "$cache" ]; then
+    if [ ! -f "$cache" ]; then
         echo "Downloading pinned didc $release ($platform) → $cache ..." >&2
         mkdir -p "$(dirname "$cache")"
         url="https://github.com/dfinity/candid/releases/download/$release/didc-$platform"
-        # Download to `.tmp` and atomically rename so a concurrent
-        # script run never sees a half-written binary on its $cache check.
+        # Download to `.tmp` so an interrupted download never leaves
+        # `$cache` looking complete to the file-exists check above.
         if ! curl --location --fail --silent --show-error "$url" -o "$cache.tmp"; then
             rm -f "$cache.tmp"
             echo "Error: failed to download $url" >&2
             return 1
         fi
-        chmod +x "$cache.tmp"
         mv "$cache.tmp" "$cache"
     fi
+
+    # Verify the on-disk binary's sha256 against the pin on every call —
+    # both cold-cache (just-downloaded) and warm-cache (long-lived) — so
+    # a tampered or corrupted cached binary can't slip past the file-
+    # exists short-circuit above. Cheap (~10ms for a 5MB file) and worth
+    # it since the alternative is silently executing the bad binary.
+    actual_sha=$(shasum -a 256 "$cache" | awk '{print $1}')
+    if [ "$actual_sha" != "$expected_sha" ]; then
+        echo "Error: sha256 mismatch for cached didc at $cache." >&2
+        echo "       expected: $expected_sha" >&2
+        echo "       got:      $actual_sha" >&2
+        echo "       Removing the bad file so the next run re-downloads. If you just bumped" >&2
+        echo "       .didc-release, refresh .didc-checksums to match (see the header in that file)." >&2
+        rm -f "$cache"
+        return 1
+    fi
+    chmod +x "$cache"
 
     PINNED_DIDC="$cache"
     export PINNED_DIDC

--- a/scripts/didc-helpers.bash
+++ b/scripts/didc-helpers.bash
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Shared helper: download + cache the pinned `didc` release listed in
+# `.didc-release` (the same source CI's `setup-didc` composite action
+# reads), and expose it as `$PINNED_DIDC`.
+#
+# Every deploy / proposal script that hand-encodes Candid install args
+# should source this and call `ensure_pinned_didc` before invoking the
+# binary, so the encoded bytes don't drift between operators with
+# different `didc` versions on `PATH`.
+#
+# The binary is cached under `.icp/cache/didc/` (already gitignored as
+# part of the `.icp/` tool cache) keyed by release + platform, so
+# multiple checkouts on the same machine share downloads.
+
+# Ensure $PINNED_DIDC is set to the pinned didc binary. Downloads on
+# first use; subsequent calls are a no-op (file-exists check).
+#
+# Exits non-zero on:
+#   - missing or empty `.didc-release`
+#   - unsupported host OS (we only ship for macOS + linux64)
+#   - download failure
+ensure_pinned_didc() {
+    local scripts_dir root_dir release platform url cache
+    scripts_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    root_dir="$scripts_dir/.."
+
+    if [ ! -f "$root_dir/.didc-release" ]; then
+        echo "Error: $root_dir/.didc-release missing — can't pin didc version." >&2
+        return 1
+    fi
+    # Strip comments and blank lines — matches .github/actions/setup-didc.
+    release=$(sed <"$root_dir/.didc-release" 's/#.*$//' | sed '/^$/d')
+    if [ -z "$release" ]; then
+        echo "Error: $root_dir/.didc-release is empty after stripping comments." >&2
+        return 1
+    fi
+
+    case "$(uname -s)" in
+        Darwin) platform="macos" ;;
+        Linux)  platform="linux64" ;;
+        *)
+            echo "Error: pinned didc isn't published for OS '$(uname -s)'." >&2
+            echo "       The dfinity/candid release only ships macos / linux64 / arm32 — add support" >&2
+            echo "       here if you need another platform." >&2
+            return 1
+            ;;
+    esac
+
+    cache="$root_dir/.icp/cache/didc/didc-$release-$platform"
+    if [ ! -x "$cache" ]; then
+        echo "Downloading pinned didc $release ($platform) → $cache ..." >&2
+        mkdir -p "$(dirname "$cache")"
+        url="https://github.com/dfinity/candid/releases/download/$release/didc-$platform"
+        # Download to `.tmp` and atomically rename so a concurrent
+        # script run never sees a half-written binary on its $cache check.
+        if ! curl --location --fail --silent --show-error "$url" -o "$cache.tmp"; then
+            rm -f "$cache.tmp"
+            echo "Error: failed to download $url" >&2
+            return 1
+        fi
+        chmod +x "$cache.tmp"
+        mv "$cache.tmp" "$cache"
+    fi
+
+    PINNED_DIDC="$cache"
+    export PINNED_DIDC
+}

--- a/scripts/frontend-arg-helpers.bash
+++ b/scripts/frontend-arg-helpers.bash
@@ -142,9 +142,10 @@ ${record_fields};
     echo "  $FRONTEND_CANDID_ARG"
     echo ""
 
-    echo "Encoding argument with didc..."
+    echo "Encoding argument with pinned didc..."
+    ensure_pinned_didc || exit 1
     local encoded
-    encoded=$(didc encode \
+    encoded=$("$PINNED_DIDC" encode \
         -d ./src/internet_identity_frontend/internet_identity_frontend.did \
         -t '(InternetIdentityFrontendInit)' \
         "$FRONTEND_CANDID_ARG")

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -16,6 +16,11 @@ source "$SOURCE_DIR/fetch-iana-root-anchors.bash"
 # prod deploys agree on which domains use the DoH-fallback path.
 # shellcheck source=default-doh-domains.bash
 source "$SOURCE_DIR/default-doh-domains.bash"
+# Pinned-didc helper: every `didc encode/decode/assist` call below
+# routes through `$PINNED_DIDC` so the encoded Candid bytes (and their
+# sha256 hashes in the proposal) match across operators and CI.
+# shellcheck source=didc-helpers.bash
+source "$SOURCE_DIR/didc-helpers.bash"
 
 # Resolve the HTTPS remote URL for git operations that don't need SSH.
 # gh is authenticated via HTTPS, so this avoids SSH key prompts for
@@ -553,14 +558,18 @@ prepare_staging_backend_argument() {
     echo "(null)" > staging_args.txt
   fi
   patch_email_recovery_init_fields staging_args.txt
-  didc_encode_ii_init staging_args.txt > staging_icp_arg.bin
+  # didc encode emits hex; collapse to raw bytes so icp-cli's
+  # `--args-format bin` reads it directly (same on-chain bytes as the
+  # production NNS proposal's args).
+  didc_encode_ii_init staging_args.txt | xxd -r -p > staging_icp_arg.bin
 }
 
 prepare_staging_frontend_argument() {
   echo ""
   echo "=== Filling init arguments for STAGING FRONTEND canister ==="
   build_frontend_install_arg "$STAGING_FRONTEND_CANISTER_ID"
-  echo "$FRONTEND_INSTALL_ARG" > staging_icp_frontend_arg.bin
+  # See prepare_staging_backend_argument for why hex → raw.
+  printf '%s' "$FRONTEND_INSTALL_ARG" | xxd -r -p > staging_icp_frontend_arg.bin
 }
 
 deploy_staging_backend() {
@@ -576,7 +585,7 @@ deploy_staging_backend() {
     --mode upgrade \
     --wasm ./internet_identity.wasm.gz \
     --args-file ./staging_icp_arg.bin \
-    --args-format hex
+    --args-format bin
 }
 
 deploy_staging_frontend() {
@@ -589,7 +598,7 @@ deploy_staging_frontend() {
     --mode upgrade \
     --wasm ./internet_identity_frontend.wasm.gz \
     --args-file ./staging_icp_frontend_arg.bin \
-    --args-format hex
+    --args-format bin
 }
 
 test_release_candidate() {
@@ -647,7 +656,8 @@ run_didc_command_for_ii_init() {
   local SUBCOMMAND="$1"
   shift
   local ARGS=("$@")
-  didc "$SUBCOMMAND" -d ./src/internet_identity/internet_identity.did -t '(opt InternetIdentityInit)' "${ARGS[@]}"
+  ensure_pinned_didc || exit 1
+  "$PINNED_DIDC" "$SUBCOMMAND" -d ./src/internet_identity/internet_identity.did -t '(opt InternetIdentityInit)' "${ARGS[@]}"
 }
 
 didc_encode_ii_init() {
@@ -792,7 +802,8 @@ run_didc_command_for_frontend_init() {
   local SUBCOMMAND="$1"
   shift
   local ARGS=("$@")
-  didc "$SUBCOMMAND" -d ./src/internet_identity_frontend/internet_identity_frontend.did -t '(InternetIdentityFrontendInit)' "${ARGS[@]}"
+  ensure_pinned_didc || exit 1
+  "$PINNED_DIDC" "$SUBCOMMAND" -d ./src/internet_identity_frontend/internet_identity_frontend.did -t '(InternetIdentityFrontendInit)' "${ARGS[@]}"
 }
 
 didc_encode_frontend_init() {
@@ -811,7 +822,7 @@ compute_sha256sum_for_frontend_args() {
 }
 
 prepare_production_backend_argument() {
-  echo "You need at least the didc from 2024-07-29 https://github.com/dfinity/candid/releases/tag/2024-07-29"
+  echo "(Using pinned didc $(sed <"$SOURCE_DIR/../.didc-release" 's/#.*$//' | sed '/^$/d').)"
   echo ""
   echo "=== Filling init arguments for PRODUCTION BACKEND canister (InternetIdentityInit) ==="
   echo ""


### PR DESCRIPTION
> **Stack**: this PR builds on top of #3928 (init_args bootstrap). Review or land that one first; this one will rebase cleanly onto main afterwards.

Three related fixes that together let an operator confidently tweak install args on a staging canister without surprises.

---

## 1. Prompt for `backend_origin` + `related_origins` (FE + BE)

`deploy-{pr,local}-to-beta` previously hardcoded both fields to the canister-default URLs derived from the staging quad. The moment a staging environment fronts a custom domain (e.g. `https://backend.beta.id.ai`, or a multi-origin `related_origins` list), the deploy silently overwrote the on-chain config — no prompt, no escape hatch.

- **FE:** `prompt_fe_extra_args` now prompts for both fields, with defaults parsed from the FE's live `/.config`.
- **BE:** new `prompt_be_extra_args` does the same. Defaults come from `/.config.did.bin` decoded via `didc` against `src/internet_identity/internet_identity.did`. If `didc` is unavailable the script falls back to canister-URL defaults with a loud warning.

## 2. Pin didc + encode install args as raw binary

The two release-SOP scripts disagreed on how they encoded Candid install args:

| path                        | encoding                                                       |
|-----------------------------|----------------------------------------------------------------|
| `make-upgrade-proposal`     | `didc encode` (PATH version) → hex file → `--args-format hex`  |
| `deploy-{pr,local}-to-beta` | inline Candid text → `--args` (default `candid`, no type-check)|

That meant beta and prod could legitimately ship different bytes for the same intended config — text parsing is looser than didc's type-checked encode, and "whatever's on `$PATH`" drifts between operators.

New `scripts/didc-helpers.bash` downloads + caches the dfinity/candid release listed in `.didc-release` (same source CI's `setup-didc` composite action reads) under `.icp/cache/didc/` and exposes the resulting binary as `$PINNED_DIDC`.

`deploy-common.bash` adds `encode_install_arg_bin <did> <type> <candid-text> <out-file>` which validates against the `.did` schema, encodes via the pinned didc, and writes raw bytes. `run_icp_install` now takes a binary args file and forwards it via `--args-file <file> --args-format bin`. `make-upgrade-proposal` + `frontend-arg-helpers.bash` route all `didc encode/decode/assist` through `$PINNED_DIDC`; staging-deploy args files switch from hex to raw binary (`--args-format bin`).

## 3. `--reconfigure` flag for args-only upgrades

```
./scripts/deploy-pr-to-beta -sa -fe -be --reconfigure
```

No PR # required. For each end, the script:

1. Fetches the on-chain `module_hash` via the public ic-api endpoint.
2. Walks `actions/artifacts?name=<wasm>` (up to 300 non-expired artifacts) downloading + sha256-ing until a match is found.
3. Re-installs that same wasm with freshly-prompted args.

Empirically verified on Staging A: `module_hash` = `sha256(<wasm>.wasm.gz)` (IC stores the gzipped bytes and hashes them — no `gunzip` step). If the on-chain wasm pre-dates GitHub's 90-day artifact retention, search exits with a hint to fall back to `deploy-pr-to-beta <PR>`.

---

## Tests

- [ ] `./scripts/deploy-pr-to-beta -sa -fe -be <PR> --dry-run` — both prompt blocks appear with on-chain values as defaults; printed `icp canister install` command shows `--args-file ... --args-format bin`.
- [ ] Hit Enter through every prompt on a known-good staging; verify the encoded args round-trip via `didc decode` matches what's on chain (no surprise resets).
- [ ] Type custom values; verify they land in the printed `--args-file` payload.
- [ ] Move `didc` off `PATH`; first run downloads pinned didc to `.icp/cache/didc/`.
- [ ] `--reconfigure -sa -be` against a recent deploy; verify the search finds the matching artifact and the run id in the log line matches the PR you last deployed.
- [ ] `--reconfigure` with a stale (>90 day) on-chain wasm; verify the error message points the operator at the PR-anchored fallback.