### PR TITLE
fix(scripts): make-upgrade-proposal trap leak and changelog scoping

### DIFF
--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -957,12 +957,18 @@ proposal_title() {
 select_commits_for_bucket() {
   local bucket="$1"
   local commit_range="$2"
+  case "$bucket" in
+    be|fe) ;;
+    *) echo "select_commits_for_bucket: unknown bucket '$bucket' (expected be|fe)" >&2; return 1 ;;
+  esac
   local pat='^\*[[:space:]]+([a-z]+)(\(([^)]+)\))?!?:'
   git log --format='* %s' --no-merges "$commit_range" | \
   while IFS= read -r line; do
     [[ "$line" =~ $pat ]] || continue
     local type="${BASH_REMATCH[1]}"
-    local scope_padded=",${BASH_REMATCH[3]},"
+    # Strip whitespace so `feat(be, fe)` routes the same as `feat(be,fe)`.
+    local scope="${BASH_REMATCH[3]//[[:space:]]/}"
+    local scope_padded=",${scope},"
     local has_be=false has_fe=false
     [[ "$scope_padded" == *,be,* ]] && has_be=true
     [[ "$scope_padded" == *,fe,* ]] && has_fe=true

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -403,30 +403,32 @@ detect_release_wasm_change() {
     return
   fi
 
-  local prev_wasm
-  prev_wasm=$(mktemp)
-  # RETURN trap fires on every exit path (curl failure, sha256 failure
-  # under set -e, normal return) so the mktemp doesn't leak. Bash's
-  # RETURN trap is function-local — no need to clear it explicitly.
-  trap 'rm -f "$prev_wasm"' RETURN
+  # Subshell scopes the EXIT trap so cleanup doesn't leak into the
+  # caller — a RETURN trap on this function would persist up the call
+  # stack under plain bash and fire again with prev_wasm out of scope.
+  (
+    local prev_wasm
+    prev_wasm=$(mktemp)
+    trap 'rm -f "$prev_wasm"' EXIT
 
-  if ! curl -fsSL "https://github.com/dfinity/internet-identity/releases/download/${prev_release_tag}/${release_filename}" -o "$prev_wasm"; then
-    echo "Could not download ${prev_release_tag}/${release_filename}; treating as changed." >&2
-    echo "true"
-    return
-  fi
+    if ! curl -fsSL "https://github.com/dfinity/internet-identity/releases/download/${prev_release_tag}/${release_filename}" -o "$prev_wasm"; then
+      echo "Could not download ${prev_release_tag}/${release_filename}; treating as changed." >&2
+      echo "true"
+      exit 0
+    fi
 
-  local prev_sha curr_sha
-  prev_sha=$(sha256 "$prev_wasm")
-  curr_sha=$(sha256 "$local_wasm")
-  echo "Previous ${release_filename} (${prev_release_tag}): $prev_sha" >&2
-  echo "Current ${release_filename}:                        $curr_sha" >&2
+    local prev_sha curr_sha
+    prev_sha=$(sha256 "$prev_wasm")
+    curr_sha=$(sha256 "$local_wasm")
+    echo "Previous ${release_filename} (${prev_release_tag}): $prev_sha" >&2
+    echo "Current ${release_filename}:                        $curr_sha" >&2
 
-  if [ "$prev_sha" = "$curr_sha" ]; then
-    echo "false"
-  else
-    echo "true"
-  fi
+    if [ "$prev_sha" = "$curr_sha" ]; then
+      echo "false"
+    else
+      echo "true"
+    fi
+  )
 }
 
 # Compare a local wasm sha256 against the on-chain module_hash of a
@@ -947,23 +949,36 @@ proposal_title() {
   fi
 }
 
+# Select commit subjects in $commit_range for a single proposal bucket.
+# Filters by conventional-commit scope: scope tokens `be` / `fe` route
+# commits to the matching canister. `feat` commits with no scope or an
+# unknown scope land in both buckets so user-facing features aren't
+# silently dropped when the author missed the convention.
+select_commits_for_bucket() {
+  local bucket="$1"
+  local commit_range="$2"
+  local pat='^\*[[:space:]]+([a-z]+)(\(([^)]+)\))?!?:'
+  git log --format='* %s' --no-merges "$commit_range" | \
+  while IFS= read -r line; do
+    [[ "$line" =~ $pat ]] || continue
+    local type="${BASH_REMATCH[1]}"
+    local scope_padded=",${BASH_REMATCH[3]},"
+    local has_be=false has_fe=false
+    [[ "$scope_padded" == *,be,* ]] && has_be=true
+    [[ "$scope_padded" == *,fe,* ]] && has_fe=true
+    local feat_unknown=false
+    if [[ "$type" == "feat" && "$has_be" == false && "$has_fe" == false ]]; then
+      feat_unknown=true
+    fi
+    case "$bucket" in
+      be) if $has_be || $feat_unknown; then echo "$line"; fi ;;
+      fe) if $has_fe || $feat_unknown; then echo "$line"; fi ;;
+    esac
+  done
+}
+
 download_proposal_text() {
   local upgrade_type="$(checklist_must_get 'Upgrade type')"
-
-  # Source paths for filtering commits by canister
-  local -a backend_paths=(
-    src/internet_identity/
-    src/internet_identity_interface/
-    src/archive/
-    src/asset_util/
-    src/canister_tests/
-  )
-  local -a frontend_paths=(
-    src/internet_identity_frontend/
-    src/frontend/
-    src/lingui-svelte/
-    src/vite-plugins/
-  )
 
   local backend_commits=""
   local frontend_commits=""
@@ -987,7 +1002,7 @@ download_proposal_text() {
     local backend_heading="$(proposal_heading 'Backend' "$backend_wasm_changed")"
     if [ "$backend_wasm_changed" = "true" ]; then
       local commit_range="${last_backend_tag}..${TAG_NAME}"
-      backend_commits=$(git log --format='* %s' --no-merges "$commit_range" -- "${backend_paths[@]}")
+      backend_commits=$(select_commits_for_bucket be "$commit_range")
       cat > backend_proposal.md << EOF
 # ${backend_heading}
 
@@ -1035,7 +1050,7 @@ EOF
     local frontend_heading="$(proposal_heading 'Frontend' "$frontend_wasm_changed")"
     if [ "$frontend_wasm_changed" = "true" ]; then
       local commit_range="${last_frontend_tag}..${TAG_NAME}"
-      frontend_commits=$(git log --format='* %s' --no-merges "$commit_range" -- "${frontend_paths[@]}")
+      frontend_commits=$(select_commits_for_bucket fe "$commit_range")
       cat > frontend_proposal.md << EOF
 # ${frontend_heading}
 


### PR DESCRIPTION
The release SOP script broke in two ways during the 2026-05-22 release.

The "Archive changed" step crashed with `prev_wasm: unbound variable`. The `RETURN` trap inside `detect_release_wasm_change` leaked past the function that set it — Bash doesn't scope `RETURN` traps to the declaring function unless `set -T` is enabled, so the trap fired again in the caller with the temp-file variable out of scope and `set -u` tripped. Cleanup is now an `EXIT` trap inside an explicit subshell, which is properly contained.

The backend / frontend proposal markdown filtered commits by changed source paths, so a frontend PR that incidentally edited a backend file (e.g. a Candid types update needed by the frontend) would land in the backend changelog. Replaced with a conventional-commit scope filter — `(be)` → backend, `(fe)` → frontend, `(be,fe)` → both. `feat` commits with no scope or an unknown scope are listed in both proposals so a user-facing feature isn't silently dropped when the author misses the tag.

# Changes

- `detect_release_wasm_change`: temp-file cleanup moved into a subshell with an `EXIT` trap; misleading "RETURN trap is function-local" comment removed
- New `select_commits_for_bucket` helper used by `download_proposal_text`; `backend_paths` / `frontend_paths` arrays no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)