### PR TITLE
fix(be,fe): make IdentityInfo.email_recovery an opt vec

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -520,7 +520,7 @@ export const idlFactory = ({ IDL }) => {
     'authn_methods' : IDL.Vec(AuthnMethodData),
     'metadata' : MetadataMapV2,
     'name' : IDL.Opt(IDL.Text),
-    'email_recovery' : IDL.Vec(EmailRecoveryCredential),
+    'email_recovery' : IDL.Opt(IDL.Vec(EmailRecoveryCredential)),
     'created_at' : IDL.Opt(Timestamp),
     'authn_method_registration' : IDL.Opt(AuthnMethodRegistrationInfo),
     'openid_credentials' : IDL.Opt(IDL.Vec(OpenIdCredential)),

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -823,13 +823,13 @@ export interface IdentityInfo {
   'metadata' : MetadataMapV2,
   'name' : [] | [string],
   /**
-   * Email-recovery credentials bound to this anchor (empty when
+   * Email-recovery credentials bound to this anchor (absent when
    * none is configured). The canister API currently caps the list
    * at one entry — the FE renders the recovery-email card from
    * the first one — but exposing it as a `vec` lets future
    * multi-credential support land without a candid schema bump.
    */
-  'email_recovery' : Array<EmailRecoveryCredential>,
+  'email_recovery' : [] | [Array<EmailRecoveryCredential>],
   /**
    * The timestamp at which the anchor was created
    */

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/smartActions.test.ts
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/smartActions.test.ts
@@ -54,11 +54,13 @@ const withUnverifiedRecoveryPhrase = (info: IdentityInfo): IdentityInfo => ({
 const withEmailRecovery = (info: IdentityInfo): IdentityInfo => ({
   ...info,
   email_recovery: [
-    {
-      address: "user@example.com",
-      created_at: BigInt(0),
-      last_used: [],
-    },
+    [
+      {
+        address: "user@example.com",
+        created_at: BigInt(0),
+        last_used: [],
+      },
+    ],
   ],
 });
 

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/smartActions.ts
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/smartActions.ts
@@ -61,7 +61,7 @@ const getRecoveryPhraseState = (
 };
 
 const hasEmailRecovery = (identityInfo: IdentityInfo): boolean =>
-  identityInfo.email_recovery[0] !== undefined;
+  identityInfo.email_recovery[0]?.[0] !== undefined;
 
 /**
  * Derives a contextual list of dashboard actions for the user's

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
@@ -63,7 +63,7 @@
    * "active" right after a successful binding without waiting for
    * the next route load to re-fetch.
    */
-  let emailRecovery = $derived(data.identityInfo.email_recovery[0]);
+  let emailRecovery = $derived(data.identityInfo.email_recovery[0]?.[0]);
 
   let recoveryPhraseData = $derived(
     data.identityInfo.authn_methods.find(

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -851,12 +851,12 @@ type IdentityInfo = record {
     name : opt text;
     // The timestamp at which the anchor was created
     created_at : opt Timestamp;
-    // Email-recovery credentials bound to this anchor (empty when
+    // Email-recovery credentials bound to this anchor (absent when
     // none is configured). The canister API currently caps the list
     // at one entry — the FE renders the recovery-email card from
     // the first one — but exposing it as a `vec` lets future
     // multi-credential support land without a candid schema bump.
-    email_recovery : vec EmailRecoveryCredential;
+    email_recovery : opt vec EmailRecoveryCredential;
 };
 
 type IdentityInfoError = variant {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -979,11 +979,17 @@ mod v2_api {
             .collect();
 
         // Anchor stores email recoveries as a Vec; the candid surface
-        // exposes the full list. The canister API currently enforces
-        // ≤1 entry, so the FE picks the first to render the recovery-
-        // email card — but a future bump to N>1 won't need a candid
-        // schema change.
-        let email_recovery = state::anchor(identity_number).email_recovery.clone();
+        // exposes the full list as an `opt vec`, with `None` when no
+        // recovery email is configured. The canister API currently
+        // enforces ≤1 entry, so the FE picks the first to render the
+        // recovery-email card — but a future bump to N>1 won't need a
+        // candid schema change.
+        let stored_email_recovery = state::anchor(identity_number).email_recovery.clone();
+        let email_recovery = if stored_email_recovery.is_empty() {
+            None
+        } else {
+            Some(stored_email_recovery)
+        };
 
         let identity_info = IdentityInfo {
             authn_methods: anchor_info

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -85,14 +85,14 @@ pub struct IdentityInfo {
     pub metadata: HashMap<String, MetadataEntryV2>,
     pub name: Option<String>,
     pub created_at: Option<Timestamp>,
-    /// Email-recovery credentials bound to this anchor. Empty for
+    /// Email-recovery credentials bound to this anchor. `None` for
     /// anchors with no recovery email configured. The canister API
     /// currently caps the list at one entry — the FE picks the
     /// first to render the recovery-email card's active vs inactive
     /// state without round-tripping a separate query. Exposing it as
     /// a `vec` lets future multi-credential support land without a
     /// candid schema bump.
-    pub email_recovery: Vec<crate::internet_identity::types::EmailRecoveryCredential>,
+    pub email_recovery: Option<Vec<crate::internet_identity::types::EmailRecoveryCredential>>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
Switches the candid surface of `IdentityInfo.email_recovery` from `vec EmailRecoveryCredential` to `opt vec EmailRecoveryCredential` so anchors with no recovery email configured are represented as absent rather than as an empty list. Stored anchor data is unchanged — only the canister-returned `IdentityInfo` and its frontend consumers are updated.

## Changes
- Candid: `internet_identity.did` — `email_recovery` is now `opt vec EmailRecoveryCredential`.
- Generated bindings: regenerated `internet_identity_idl.js` and `internet_identity_types.d.ts` from the .did file via `npm run generate`.
- Backend (Rust): `IdentityInfo.email_recovery` is now `Option<Vec<EmailRecoveryCredential>>`. `identity_info` wraps the stored `Vec` in `Some(…)` when non-empty and returns `None` when empty. The anchor's storage Vec is unchanged.
- Frontend (TS/Svelte): consumers now access the first credential via `identityInfo.email_recovery[0]?.[0]` (unwrap the opt, then index the inner vec). Updated `smartActions.ts`, the recovery page derived state, and the `smartActions` test fixture accordingly.