### PR TITLE
fix(scripts,ci): skip rejected proposals when picking changelog baseline

### DIFF
--- a/.github/actions/release/run.sh
+++ b/.github/actions/release/run.sh
@@ -5,6 +5,14 @@
 
 set -euo pipefail
 
+# NNS-aware proposal-tag resolution: skips rejected/open tags so the
+# changelog baseline is the last *adopted* proposal, not just the
+# highest-numbered tag. Path is resolved relative to this script so it
+# works both in CI ($GITHUB_WORKSPACE-rooted) and during local debug.
+RUN_SH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../scripts/proposal-status.bash
+source "$RUN_SH_DIR/../../../scripts/proposal-status.bash"
+
 RELEASE_TAG=${RELEASE_TAG:-${GITHUB_REF_NAME:?No value for tag}}
 
 # Starting the "intro" section where we display a short intro
@@ -140,8 +148,8 @@ resolve_release_tag() {
 # Generate per-canister "What's Changed" section using proposal tags as baselines.
 # Falls back to the GitHub-generated changelog if no proposal tags exist.
 section_changelog=$(mktemp)
-LAST_BACKEND_TAG=$(git tag -l "proposal-backend-*" | sort -V | tail -1 || true)
-LAST_FRONTEND_TAG=$(git tag -l "proposal-frontend-*" | sort -V | tail -1 || true)
+LAST_BACKEND_TAG=$(latest_executed_proposal_tag backend || true)
+LAST_FRONTEND_TAG=$(latest_executed_proposal_tag frontend || true)
 
 if [ -n "$LAST_BACKEND_TAG" ] || [ -n "$LAST_FRONTEND_TAG" ]; then
   >&2 echo "Generating per-canister changelog (backend baseline: ${LAST_BACKEND_TAG:-none}, frontend baseline: ${LAST_FRONTEND_TAG:-none})"

--- a/.github/actions/release/run.sh
+++ b/.github/actions/release/run.sh
@@ -146,12 +146,17 @@ resolve_release_tag() {
 }
 
 # Generate per-canister "What's Changed" section using proposal tags as baselines.
-# Falls back to the GitHub-generated changelog if no proposal tags exist.
+# Falls back to the GitHub-generated changelog if either lookup couldn't confirm
+# a baseline — `|| true` would conflate "no executed tag" with "transient API
+# failure", letting a partial per-canister changelog silently hide one side's
+# changes when only the other side resolved.
 section_changelog=$(mktemp)
-LAST_BACKEND_TAG=$(latest_executed_proposal_tag backend || true)
-LAST_FRONTEND_TAG=$(latest_executed_proposal_tag frontend || true)
+BACKEND_OK=1
+LAST_BACKEND_TAG=$(latest_executed_proposal_tag backend) || BACKEND_OK=0
+FRONTEND_OK=1
+LAST_FRONTEND_TAG=$(latest_executed_proposal_tag frontend) || FRONTEND_OK=0
 
-if [ -n "$LAST_BACKEND_TAG" ] || [ -n "$LAST_FRONTEND_TAG" ]; then
+if [ "$BACKEND_OK" = "1" ] && [ "$FRONTEND_OK" = "1" ]; then
   >&2 echo "Generating per-canister changelog (backend baseline: ${LAST_BACKEND_TAG:-none}, frontend baseline: ${LAST_FRONTEND_TAG:-none})"
   echo "## What's Changed" >> "$section_changelog"
   echo "" >> "$section_changelog"
@@ -188,7 +193,7 @@ if [ -n "$LAST_BACKEND_TAG" ] || [ -n "$LAST_FRONTEND_TAG" ]; then
     fi
   fi
 else
-  >&2 echo "No proposal tags found, using GitHub-generated changelog"
+  >&2 echo "Could not resolve both baselines (backend ok=${BACKEND_OK}, frontend ok=${FRONTEND_OK}); using GitHub-generated changelog"
   echo "$INPUT_CHANGELOG" > "$section_changelog"
 fi
 

--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -16,6 +16,10 @@ source "$SOURCE_DIR/fetch-iana-root-anchors.bash"
 # prod deploys agree on which domains use the DoH-fallback path.
 # shellcheck source=default-doh-domains.bash
 source "$SOURCE_DIR/default-doh-domains.bash"
+# NNS-aware proposal-tag resolution: skips rejected/open tags so
+# "the last release" really means "the last release that shipped".
+# shellcheck source=proposal-status.bash
+source "$SOURCE_DIR/proposal-status.bash"
 
 # Resolve the HTTPS remote URL for git operations that don't need SSH.
 # gh is authenticated via HTTPS, so this avoids SSH key prompts for
@@ -388,9 +392,9 @@ detect_release_wasm_change() {
   fi
 
   local prev_proposal_tag
-  prev_proposal_tag=$(git tag -l "${proposal_prefix}-*" | sort -V | tail -1)
+  prev_proposal_tag=$(latest_executed_proposal_tag "${proposal_prefix#proposal-}" || true)
   if [ -z "$prev_proposal_tag" ]; then
-    echo "No previous ${proposal_prefix}-* tag found; treating ${release_filename} as changed." >&2
+    echo "No previous executed ${proposal_prefix}-* tag found; treating ${release_filename} as changed." >&2
     echo "true"
     return
   fi
@@ -969,14 +973,13 @@ download_proposal_text() {
   local frontend_commits=""
 
   if should_upgrade_backend "$upgrade_type"; then
-    # Find last backend proposal tag
-    local last_backend_tag=$(git tag -l "proposal-backend-*" | sort -V | tail -1)
+    local last_backend_tag
+    last_backend_tag=$(latest_executed_proposal_tag backend || true)
 
     if [ -z "$last_backend_tag" ]; then
-      echo "No previous proposal-backend-* tag found."
       echo "Available release tags:"
       git tag -l "release-*" | sort -V | tail -5
-      read -p "Enter the tag or commit of the last backend deployment: " last_backend_tag
+      read -p "Enter the tag or commit of the last ADOPTED backend proposal (e.g. release-2026-05-08 or proposal-backend-141735): " last_backend_tag
       if ! git rev-parse "$last_backend_tag" >/dev/null 2>&1; then
         echo "Error: '$last_backend_tag' is not a valid tag or commit" >&2
         exit 1
@@ -1017,14 +1020,13 @@ EOF
   fi
 
   if should_upgrade_frontend "$upgrade_type"; then
-    # Find last frontend proposal tag
-    local last_frontend_tag=$(git tag -l "proposal-frontend-*" | sort -V | tail -1)
+    local last_frontend_tag
+    last_frontend_tag=$(latest_executed_proposal_tag frontend || true)
 
     if [ -z "$last_frontend_tag" ]; then
-      echo "No previous proposal-frontend-* tag found."
       echo "Available release tags:"
       git tag -l "release-*" | sort -V | tail -5
-      read -p "Enter the tag or commit of the last frontend deployment: " last_frontend_tag
+      read -p "Enter the tag or commit of the last ADOPTED frontend proposal (e.g. release-2026-05-26 or proposal-frontend-141884): " last_frontend_tag
       if ! git rev-parse "$last_frontend_tag" >/dev/null 2>&1; then
         echo "Error: '$last_frontend_tag' is not a valid tag or commit" >&2
         exit 1
@@ -1317,10 +1319,15 @@ if [ "$IS_RECONFIGURE" = "true" ]; then
   resolve_latest_release_for() {
     local role="$1"
     local prop_tag
-    prop_tag=$(git tag -l "proposal-${role}-*" | sort -V | tail -1)
+    prop_tag=$(latest_executed_proposal_tag "$role" || true)
     if [ -z "$prop_tag" ]; then
-      echo "No proposal-${role}-* tag found; nothing to reconfigure." >&2
-      return 1
+      echo "Available release tags:" >&2
+      git tag -l "release-*" | sort -V | tail -5 >&2
+      read -p "Enter the tag or commit of the last ADOPTED ${role} proposal (e.g. release-2026-05-08 or proposal-${role}-141735): " prop_tag
+      if ! git rev-parse "$prop_tag" >/dev/null 2>&1; then
+        echo "Error: '${prop_tag}' is not a valid tag or commit." >&2
+        return 1
+      fi
     fi
     local release_tag
     release_tag=$(resolve_release_tag "$prop_tag")

--- a/scripts/proposal-status.bash
+++ b/scripts/proposal-status.bash
@@ -25,10 +25,12 @@ nns_proposal_status() {
 
 # Walk `proposal-<role>-*` tags newest→oldest and print the first whose
 # NNS status is EXECUTED.
-# Exit 0 + tag on stdout → found
-# Exit 1                 → no EXECUTED tag (genuine empty / all
-#                          rejected, OR API failures). Stderr says
-#                          which, so callers can phrase prompts.
+# Exit 0 + tag on stdout → confirmed EXECUTED with no unreachable tags above
+# Exit 1                 → no usable baseline: genuine empty / all rejected /
+#                          API failures, including the stale-baseline guard
+#                          where an EXECUTED tag was found below a tag whose
+#                          status couldn't be confirmed. Stderr says which,
+#                          so callers can phrase prompts.
 # Bounded at 20 tags scanned: the executed baseline is always within
 # the most recent handful and this keeps API load trivially small.
 # Args: $1 = "backend" | "frontend"
@@ -41,7 +43,17 @@ latest_executed_proposal_tag() {
     [[ "$id" =~ ^[0-9]+$ ]] && [ "$id" -ge 100000 ] || continue
     if status=$(nns_proposal_status "$id"); then
       seen_success=1
-      [ "$status" = "EXECUTED" ] && { echo "$tag"; return 0; }
+      if [ "$status" = "EXECUTED" ]; then
+        if [ "$seen_transient" = "1" ]; then
+          # A newer tag's status couldn't be confirmed, so we can't tell
+          # if it was actually EXECUTED. Returning this older tag would
+          # silently use a stale baseline — let the caller fall back.
+          echo "Refusing ${tag} as baseline: a newer tag's NNS status was unreachable, ${tag} may be stale." >&2
+          return 1
+        fi
+        echo "$tag"
+        return 0
+      fi
       echo "Skipping ${tag} (status: ${status})" >&2
     else
       seen_transient=1

--- a/scripts/proposal-status.bash
+++ b/scripts/proposal-status.bash
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Helpers for resolving the latest *adopted* (EXECUTED) NNS proposal
+# for an II canister role from local `proposal-<role>-N` git tags.
+#
+# Why: `make-upgrade-proposal` tags `proposal-<role>-N` at proposal
+# *creation*, not adoption. The tag namespace therefore contains
+# rejected/open/failed proposals too. Anything that needs "the last
+# release that actually shipped" must check NNS status before
+# trusting the highest-numbered tag.
+
+# Print the NNS proposal status string ("EXECUTED" / "REJECTED" / ...).
+# Exit 0 on success, 2 on transient API/network failure (so callers
+# can distinguish "we know the answer" from "we couldn't tell").
+# Honors $IC_API_BASE for tests.
+nns_proposal_status() {
+  local id="$1"
+  local base="${IC_API_BASE:-https://ic-api.internetcomputer.org}"
+  local body
+  body=$(curl -fsS --max-time 10 "${base}/api/v3/proposals/${id}") || return 2
+  local status
+  status=$(echo "$body" | jq -r '.status // empty') || return 2
+  [ -n "$status" ] || return 2
+  echo "$status"
+}
+
+# Walk `proposal-<role>-*` tags newest→oldest and print the first whose
+# NNS status is EXECUTED.
+# Exit 0 + tag on stdout → found
+# Exit 1                 → no EXECUTED tag (genuine empty / all
+#                          rejected, OR API failures). Stderr says
+#                          which, so callers can phrase prompts.
+# Bounded at 20 tags scanned: the executed baseline is always within
+# the most recent handful and this keeps API load trivially small.
+# Args: $1 = "backend" | "frontend"
+latest_executed_proposal_tag() {
+  local role="$1"
+  local tag id status
+  local seen_transient=0 seen_success=0
+  while IFS= read -r tag; do
+    id="${tag#proposal-${role}-}"
+    [[ "$id" =~ ^[0-9]+$ ]] && [ "$id" -ge 100000 ] || continue
+    if status=$(nns_proposal_status "$id"); then
+      seen_success=1
+      [ "$status" = "EXECUTED" ] && { echo "$tag"; return 0; }
+      echo "Skipping ${tag} (status: ${status})" >&2
+    else
+      seen_transient=1
+      echo "Warning: could not query NNS status for ${tag}" >&2
+    fi
+  done < <(git tag -l "proposal-${role}-*" \
+            | sed -E "s/^proposal-${role}-//" \
+            | sort -n -r \
+            | head -20 \
+            | sed -E "s/^/proposal-${role}-/")
+  if [ "$seen_transient" = "1" ]; then
+    echo "No EXECUTED proposal-${role}-* tag confirmed; dashboard API was unreachable for at least one tag." >&2
+  elif [ "$seen_success" = "1" ]; then
+    echo "No EXECUTED proposal-${role}-* tag exists (all recent ${role} proposals were rejected/open/failed)." >&2
+  fi
+  return 1
+}


### PR DESCRIPTION
This PR makes `make-upgrade-proposal` and the release-notes CI action skip rejected/open NNS proposals when picking the baseline for "the last release that shipped" — so a rejected proposal can no longer poison the changelog or `--reconfigure`.

Concrete prior failure: release-2026-05-26-be initially cited the rejected `proposal-backend-141860` as its changelog baseline instead of the actually-executed `proposal-backend-141735` → release-2026-05-08.

# Changes

- New shared helper `scripts/proposal-status.bash` queries the IC dashboard API (`ic-api.internetcomputer.org/api/v3/proposals/{id}`) and walks `proposal-<role>-*` tags newest-first, returning the first whose status is `EXECUTED`. Stderr explains which earlier tags were skipped and why.
- Four callsites switched to the helper:
  - `.github/actions/release/run.sh` — GH release-notes baseline (CI)
  - `detect_release_wasm_change` — archive-hash flag for `verify-hash`
  - `download_proposal_text` (backend + frontend) — per-canister proposal text changelog
  - `--reconfigure resolve_latest_release_for` — on-chain wasm baseline
- Recovery when the helper can't confirm an `EXECUTED` tag:
  - Interactive callers prompt for the last adopted proposal tag (reusing the existing prompt pattern, with text asking for the last *ADOPTED* proposal).
  - The CI release-notes generator falls through to GitHub's auto-generated changelog with the warning visible in the workflow log.
- The existing `tag_proposal` step is unchanged. The `proposal-<role>-N` namespace continues to mean "proposal N was submitted"; adoption is derived from the live source of truth, not a second tag.
- The stale `proposal-backend-141860` tag is left in place — the new code skips it automatically and the tag is correctly named (it does point at proposal 141860's commit).