### PR TITLE
fix(fe): restore Start over in cross-device passkey pairing

### DIFF
--- a/src/frontend/src/lib/components/wizards/confirmAccessMethod/ConfirmAccessMethodWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/confirmAccessMethod/ConfirmAccessMethodWizard.svelte
@@ -11,16 +11,29 @@
   interface Props {
     registrationId?: string;
     onConfirm: () => void;
+    onRestart?: () => void;
     onError: (error: unknown) => void;
   }
 
-  const { registrationId, onConfirm, onError }: Props = $props();
+  const { registrationId, onConfirm, onRestart, onError }: Props = $props();
 
   const confirmAccessMethodFlow = new ConfirmAccessMethodFlow();
 
   const handleEnterRegistrationMode = async () => {
     try {
       await confirmAccessMethodFlow.enterRegistrationMode(registrationId);
+    } catch (error) {
+      onError(error);
+    }
+  };
+  // Always generate a fresh registrationId on user-initiated restart,
+  // even if the wizard was mounted with one (e.g. via /activate#<id>).
+  // Reusing the same id leaves #newDeviceLink unset and traps the dialog
+  // in the WaitingForNewDevice view.
+  const handleRestart = async () => {
+    onRestart?.();
+    try {
+      await confirmAccessMethodFlow.enterRegistrationMode();
     } catch (error) {
       onError(error);
     }
@@ -56,7 +69,7 @@
 {:else if confirmAccessMethodFlow.view === "enterConfirmationCode"}
   <EnterConfirmationCode
     confirm={handleConfirmDevice}
-    restart={handleEnterRegistrationMode}
+    restart={handleRestart}
   />
 {:else if confirmAccessMethodFlow.view === "finishOnNewDevice"}
   <FinishOnNewDevice />

--- a/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ConfirmThisDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ConfirmThisDevice.svelte
@@ -26,34 +26,36 @@
   };
 </script>
 
-<ConfirmDeviceIllustration class="text-text-primary mt-4 mb-8 h-32" />
-<h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
-  {$t`Confirm this device`}
-</h1>
-<p
-  class="text-text-tertiary mb-8 text-base font-medium sm:text-center sm:text-balance"
->
-  <Trans>
-    To confirm it's you, enter below code on your
-    <b class="text-text-primary">existing device</b>.
-  </Trans>
-</p>
-
-<Tooltip label={$t`Code copied to clipboard`} hidden={!copied} manual>
-  <button
-    class="btn btn-secondary btn-xl"
-    onclick={handleCopyCode}
-    disabled={confirmationCode === undefined}
-    aria-label={$t`Confirmation code`}
+<div class="flex flex-col items-center">
+  <ConfirmDeviceIllustration class="text-text-primary mt-4 mb-8 h-32" />
+  <h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
+    {$t`Confirm this device`}
+  </h1>
+  <p
+    class="text-text-tertiary mb-8 text-base font-medium sm:text-center sm:text-balance"
   >
-    {#if confirmationCode !== undefined}
-      <span>
-        {confirmationCode}
-      </span>
-      <CopyIcon class="size-5" />
-    {:else}
-      <ProgressRing />
-      <span>{$t`Generating code...`}</span>
-    {/if}
-  </button>
-</Tooltip>
+    <Trans>
+      To confirm it's you, enter below code on your
+      <b class="text-text-primary">existing device</b>.
+    </Trans>
+  </p>
+
+  <Tooltip label={$t`Code copied to clipboard`} hidden={!copied} manual>
+    <button
+      class="btn btn-secondary btn-xl"
+      onclick={handleCopyCode}
+      disabled={confirmationCode === undefined}
+      aria-label={$t`Confirmation code`}
+    >
+      {#if confirmationCode !== undefined}
+        <span>
+          {confirmationCode}
+        </span>
+        <CopyIcon class="size-5" />
+      {:else}
+        <ProgressRing />
+        <span>{$t`Generating code...`}</span>
+      {/if}
+    </button>
+  </Tooltip>
+</div>

--- a/src/frontend/src/lib/flows/confirmAccessMethodFlow.svelte.test.ts
+++ b/src/frontend/src/lib/flows/confirmAccessMethodFlow.svelte.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("$app/environment", () => ({ browser: true }));
+
+// Hand-rolled Svelte-store contract so vi.hoisted can construct it
+// synchronously before the mock factory below runs.
+const authStore = vi.hoisted(() => {
+  let value: unknown = undefined;
+  const subs = new Set<(v: unknown) => void>();
+  return {
+    subscribe: (fn: (v: unknown) => void) => {
+      subs.add(fn);
+      fn(value);
+      return () => {
+        subs.delete(fn);
+      };
+    },
+    set: (v: unknown) => {
+      value = v;
+      subs.forEach((fn) => fn(value));
+    },
+  };
+});
+
+vi.mock("$lib/stores/authentication.store", () => ({
+  authenticatedStore: authStore,
+}));
+
+import { ConfirmAccessMethodFlow } from "./confirmAccessMethodFlow.svelte";
+
+const makeActor = () => ({
+  authn_method_registration_mode_exit: vi.fn(() =>
+    Promise.resolve({ Ok: null }),
+  ),
+  // expiration in the past => polling loop never executes
+  authn_method_registration_mode_enter: vi.fn(() =>
+    Promise.resolve({ Ok: { expiration: BigInt(0) } }),
+  ),
+  identity_info: vi.fn(() =>
+    Promise.resolve({ Ok: { authn_method_registration: [] } }),
+  ),
+});
+
+describe("ConfirmAccessMethodFlow.enterRegistrationMode", () => {
+  beforeEach(() => {
+    authStore.set({ actor: makeActor(), identityNumber: BigInt(1) });
+  });
+
+  it("generates a fresh /pair#<id> link when called with no registrationId", async () => {
+    const flow = new ConfirmAccessMethodFlow();
+    await flow.enterRegistrationMode();
+
+    expect(flow.newDeviceLink).toBeDefined();
+    expect(flow.newDeviceLink?.pathname).toBe("/pair");
+    expect(flow.newDeviceLink?.hash).toMatch(/^#[0-9a-zA-Z]{5}$/);
+  });
+
+  it("does not generate a pairing link when called with an existing registrationId", async () => {
+    const flow = new ConfirmAccessMethodFlow();
+    await flow.enterRegistrationMode("abcde");
+
+    expect(flow.newDeviceLink).toBeUndefined();
+  });
+
+  it("regenerates the pairing link on subsequent call with no arg", async () => {
+    const flow = new ConfirmAccessMethodFlow();
+    await flow.enterRegistrationMode("abcde");
+    expect(flow.newDeviceLink).toBeUndefined();
+
+    await flow.enterRegistrationMode();
+    const firstHash = flow.newDeviceLink?.hash;
+    expect(firstHash).toBeDefined();
+
+    await flow.enterRegistrationMode();
+    expect(flow.newDeviceLink).toBeDefined();
+    expect(flow.newDeviceLink?.hash).not.toBe(firstHash);
+  });
+});

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/+page.svelte
@@ -64,6 +64,7 @@
   let switchingAccessMethodKey = $state<string>();
   let accessMethods = $derived(toAccessMethods(data.identityInfo));
   let pendingRegistrationId = $state(data.pendingRegistrationId);
+  let showRegistrationDialog = $state(data.pendingRegistrationId !== null);
 
   // Derived
   const renamingAccessMethod = $derived(
@@ -160,9 +161,23 @@
     toaster.success({
       title: $t`Passkey has been registered from another device.`,
     });
+    showRegistrationDialog = false;
     pendingRegistrationId = null;
     // Remove searchParam and update state
     void goto(page.url.pathname, { replaceState: true, invalidateAll: true });
+  };
+  // Called when the user clicks "Start over" inside the wizard. The wizard
+  // generates a fresh registrationId internally; here we just drop the URL
+  // ?activate=<id> so a refresh doesn't reopen the old pending session.
+  const handleConfirmRestart = () => {
+    pendingRegistrationId = null;
+    if (page.url.searchParams.has("activate")) {
+      void goto(page.url.pathname, { replaceState: true });
+    }
+  };
+  const closeConfirmDialog = () => {
+    showRegistrationDialog = false;
+    pendingRegistrationId = null;
   };
 
   const handleNameChanged = async (name: string) => {
@@ -514,13 +529,14 @@
   </Dialog>
 {/if}
 
-{#if pendingRegistrationId !== null}
-  <Dialog onClose={() => (pendingRegistrationId = null)}>
+{#if showRegistrationDialog}
+  <Dialog onClose={closeConfirmDialog}>
     <ConfirmAccessMethodWizard
-      registrationId={pendingRegistrationId}
+      registrationId={pendingRegistrationId ?? undefined}
       onConfirm={handleOtherDeviceConfirmed}
+      onRestart={handleConfirmRestart}
       onError={(error) => {
-        pendingRegistrationId = null;
+        closeConfirmDialog();
         handleError(error);
         void goto(page.url.pathname, { replaceState: true });
       }}


### PR DESCRIPTION
When a user reaches the "Authorize new device" screen via the sign-in fallback ("Can't find your identity?" → `/activate#<id>` → `/manage/access?activate=<id>`) and clicks **Start over**, nothing useful happens — the wizard reuses the original `registrationId` instead of issuing a fresh one, so no new `/pair#<id>` link is generated and the dialog gets stuck on the "Waiting for new device" spinner with no escape.

## Changes

- The confirm access-method wizard now always generates a fresh `registrationId` (and a new `/pair#<id>` link) when the user clicks **Start over**, regardless of how the wizard was opened. Previously it captured the `registrationId` prop and re-passed it to `enterRegistrationMode`, which short-circuited the new-link generation.
- `/manage/access` drops the `?activate=<id>` URL parameter on Start over so a page refresh doesn't reopen the stale pending session.
- Unrelated: centers the `ConfirmThisDevice` view content (bundled with this branch).

## Tests

- Vitest unit tests on `ConfirmAccessMethodFlow.enterRegistrationMode` covering:
  - calling with no arg generates a `/pair#<id>` link
  - calling with an existing `registrationId` does not regenerate the link
  - a subsequent no-arg call after a previous arg call produces a fresh link with a different id (the Start over path)