### PR TITLE
fix(fe): use active identity for sign-out confirmation

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -112,10 +112,7 @@
   };
 
   const handleConfirmSignOutAndRemove = () => {
-    const identity = $lastUsedIdentitiesStore.selected;
-    if (identity !== undefined) {
-      lastUsedIdentitiesStore.removeIdentity(identity.identityNumber);
-    }
+    lastUsedIdentitiesStore.removeIdentity($authenticatedStore.identityNumber);
     window.location.replace("/");
   };
 
@@ -478,14 +475,20 @@
   </Dialog>
 {/if}
 
-{#if isSignOutDialogOpen && $lastUsedIdentitiesStore.selected !== undefined}
-  <Dialog onClose={() => (isSignOutDialogOpen = false)}>
-    <SignOutConfirmation
-      identity={$lastUsedIdentitiesStore.selected}
-      onSignOut={handleConfirmSignOut}
-      onSignOutAndRemove={handleConfirmSignOutAndRemove}
-    />
-  </Dialog>
+{#if isSignOutDialogOpen}
+  {@const currentIdentity =
+    $lastUsedIdentitiesStore.identities[
+      $authenticatedStore.identityNumber.toString()
+    ]}
+  {#if currentIdentity !== undefined}
+    <Dialog onClose={() => (isSignOutDialogOpen = false)}>
+      <SignOutConfirmation
+        identity={currentIdentity}
+        onSignOut={handleConfirmSignOut}
+        onSignOutAndRemove={handleConfirmSignOutAndRemove}
+      />
+    </Dialog>
+  {/if}
 {/if}
 
 {#if isReauthDialogOpen}

--- a/src/frontend/tests/e2e-playwright/routes/manage/sign-out-active-identity.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/manage/sign-out-active-identity.spec.ts
@@ -1,0 +1,88 @@
+import { expect } from "@playwright/test";
+import { test } from "../../fixtures";
+import {
+  fromMnemonicWithoutValidation,
+  generateMnemonic,
+  IC_DERIVATION_PATH,
+} from "$lib/utils/recoveryPhrase";
+import { createActorForCredential, II_URL } from "../../utils";
+import { DEFAULT_PASSKEY_NAME } from "../../fixtures/manageAccessPage";
+
+test.describe("Sign-out confirmation targets the active identity", () => {
+  test.use({
+    identityConfig: {
+      createIdentities: [{ name: "Identity X" }, { name: "Identity Y" }],
+    },
+  });
+
+  test("removes the active identity after recovery + access-method switch", async ({
+    page,
+    identities,
+    signInWithIdentity,
+    addAuthenticatorForIdentity,
+    managePage,
+    manageAccessPage,
+    recoveryPage,
+  }) => {
+    const [identityX, identityY] = identities;
+
+    const actor = await createActorForCredential(
+      identityY.host,
+      identityY.canisterId,
+      identityY.credentials[0],
+    );
+    const words = generateMnemonic();
+    const recoveryIdentity = await fromMnemonicWithoutValidation(
+      words.join(" "),
+      IC_DERIVATION_PATH,
+    );
+    await actor.authn_method_add(identityY.identityNumber, {
+      metadata: [
+        ["alias", { String: "Recovery phrase" }],
+        ["usage", { String: "recovery_phrase" }],
+      ],
+      authn_method: {
+        PubKey: {
+          pubkey: new Uint8Array(recoveryIdentity.getPublicKey().derKey),
+        },
+      },
+      security_settings: {
+        protection: { Unprotected: null },
+        purpose: { Recovery: null },
+      },
+      last_authentication: [],
+    });
+
+    await page.goto(II_URL);
+    await signInWithIdentity(page, identityX.identityNumber);
+    await managePage.assertVisible();
+    await managePage.signOut();
+
+    await recoveryPage.goto();
+    await recoveryPage.start(async (wizard) => {
+      await wizard.enterRecoveryPhrase(words);
+      await wizard.confirmFoundIdentity(identityY.name);
+    });
+    await manageAccessPage.assertVisible();
+
+    await addAuthenticatorForIdentity(page, identityY.identityNumber);
+    await manageAccessPage
+      .findPasskey(DEFAULT_PASSKEY_NAME)
+      .switch((dialog) => dialog.confirm());
+
+    await managePage.signOut(async (confirmation) => {
+      const dialog = page.getByRole("dialog");
+      await expect(dialog.getByText(identityY.name)).toBeVisible();
+      await expect(dialog.getByText(identityX.name)).toBeHidden();
+      await confirmation.removeFromDevice();
+    });
+
+    const raw = await page.evaluate(() =>
+      localStorage.getItem("ii-last-used-identities"),
+    );
+    expect(raw).not.toBeNull();
+    const stored = JSON.parse(raw!);
+    expect(stored.data).toHaveProperty(identityX.identityNumber.toString());
+    expect(stored.data).not.toHaveProperty(identityY.identityNumber.toString());
+  });
+});


### PR DESCRIPTION
After recovering an identity and then switching to one of its existing access methods, opening the sidebar Sign out dialog could show a different identity than the one currently signed in. If the user picked "Sign out and remove from device" they removed the wrong saved identity from the device.

## Changes

Drive the sign-out confirmation dialog and the "remove from device" action from `$authenticatedStore.identityNumber` — the authoritative active identity in the authenticated manage layout — instead of `lastUsedIdentitiesStore.selected`. The `selected` writable is only mutated by `selectIdentity()`, which the recovery handlers and the access-method switch flow never call, so it can stay pointing at whatever identity was most-recently-used on this device before recovery.

## Tests

- Playwright spec `src/frontend/tests/e2e-playwright/routes/manage/sign-out-active-identity.spec.ts` reproduces the original report end-to-end: seed identity X via normal sign-in, recover identity Y via its recovery phrase, switch to one of Y's existing access methods, then open the sidebar Sign out dialog. Asserts the dialog shows Y (the active identity), and that "Sign out and remove from device" deletes Y from localStorage while leaving X intact. Confirmed to fail against the pre-fix layout.