### PR TITLE
feat(be): seed OpenID JWK cache from install args and persist it across upgrades

### DIFF
--- a/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/addAccessMethodFlow.svelte.ts
@@ -149,6 +149,7 @@ export class AddAccessMethodFlow {
       issuer: discovery.issuer,
       auth_scope: selectAuthScopes(discovery.scopes_supported),
       client_id: clientId,
+      seed_jwks: [],
     };
     return this.linkOpenIdAccount(syntheticConfig);
   };

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -42,6 +42,7 @@ export const idlFactory = ({ IDL }) => {
     'email_verification' : IDL.Opt(OpenIdEmailVerification),
     'issuer' : IDL.Text,
     'auth_scope' : IDL.Vec(IDL.Text),
+    'seed_jwks' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))),
     'client_id' : IDL.Text,
   });
   const CaptchaConfig = IDL.Record({
@@ -1195,6 +1196,7 @@ export const init = ({ IDL }) => {
     'email_verification' : IDL.Opt(OpenIdEmailVerification),
     'issuer' : IDL.Text,
     'auth_scope' : IDL.Vec(IDL.Text),
+    'seed_jwks' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))),
     'client_id' : IDL.Text,
   });
   const CaptchaConfig = IDL.Record({

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -42,7 +42,7 @@ export const idlFactory = ({ IDL }) => {
     'email_verification' : IDL.Opt(OpenIdEmailVerification),
     'issuer' : IDL.Text,
     'auth_scope' : IDL.Vec(IDL.Text),
-    'seed_jwks' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))),
+    'seed_jwks' : IDL.Opt(IDL.Vec(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
     'client_id' : IDL.Text,
   });
   const CaptchaConfig = IDL.Record({
@@ -1196,7 +1196,7 @@ export const init = ({ IDL }) => {
     'email_verification' : IDL.Opt(OpenIdEmailVerification),
     'issuer' : IDL.Text,
     'auth_scope' : IDL.Vec(IDL.Text),
-    'seed_jwks' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))),
+    'seed_jwks' : IDL.Opt(IDL.Vec(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
     'client_id' : IDL.Text,
   });
   const CaptchaConfig = IDL.Record({

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1088,12 +1088,13 @@ export interface OpenIdConfig {
   /**
    * Optional initial set of JWKs used to seed this provider's JWK cache on
    * install, so JWT verification works before the first jwks_uri fetch and
-   * across upgrades (the cache is persisted in stable memory). Each entry is
-   * one JWK represented as the list of its JSON (field, value) pairs, e.g.
-   * vec { record { "kty"; "RSA" }; record { "kid"; "..." };
-   * record { "n"; "..." }; record { "e"; "AQAB" } }.
+   * across upgrades (the cache is persisted in stable memory). The outer vec
+   * is the set of JWKs; each inner vec is one JWK, given as the list of its
+   * JSON (field, value) pairs, e.g. a single RSA key is
+   * vec { vec { record { "kty"; "RSA" }; record { "kid"; "..." };
+   * record { "n"; "..." }; record { "e"; "AQAB" } } }.
    */
-  'seed_jwks' : [] | [Array<[string, string]>],
+  'seed_jwks' : [] | [Array<Array<[string, string]>>],
   'client_id' : string,
 }
 export interface OpenIdCredential {

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1085,6 +1085,15 @@ export interface OpenIdConfig {
   'email_verification' : [] | [OpenIdEmailVerification],
   'issuer' : string,
   'auth_scope' : Array<string>,
+  /**
+   * Optional initial set of JWKs used to seed this provider's JWK cache on
+   * install, so JWT verification works before the first jwks_uri fetch and
+   * across upgrades (the cache is persisted in stable memory). Each entry is
+   * one JWK represented as the list of its JSON (field, value) pairs, e.g.
+   * vec { record { "kty"; "RSA" }; record { "kid"; "..." };
+   * record { "n"; "..." }; record { "e"; "AQAB" } }.
+   */
+  'seed_jwks' : [] | [Array<[string, string]>],
   'client_id' : string,
 }
 export interface OpenIdCredential {

--- a/src/frontend/src/lib/globals.ts
+++ b/src/frontend/src/lib/globals.ts
@@ -38,6 +38,7 @@ const backendCanisterConfigIDL = IDL.Record({
         email_verification: IDL.Opt(OpenIdEmailVerificationIDL),
         issuer: IDL.Text,
         auth_scope: IDL.Vec(IDL.Text),
+        seed_jwks: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))),
         client_id: IDL.Text,
       }),
     ),
@@ -58,6 +59,7 @@ export interface OpenIdConfig {
   email_verification: [] | [OpenIdEmailVerification];
   issuer: string;
   auth_scope: Array<string>;
+  seed_jwks: [] | [Array<[string, string]>];
   client_id: string;
 }
 export type BackendCanisterConfig = {

--- a/src/frontend/src/lib/globals.ts
+++ b/src/frontend/src/lib/globals.ts
@@ -38,7 +38,7 @@ const backendCanisterConfigIDL = IDL.Record({
         email_verification: IDL.Opt(OpenIdEmailVerificationIDL),
         issuer: IDL.Text,
         auth_scope: IDL.Vec(IDL.Text),
-        seed_jwks: IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text))),
+        seed_jwks: IDL.Opt(IDL.Vec(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Text)))),
         client_id: IDL.Text,
       }),
     ),
@@ -59,7 +59,7 @@ export interface OpenIdConfig {
   email_verification: [] | [OpenIdEmailVerification];
   issuer: string;
   auth_scope: Array<string>;
-  seed_jwks: [] | [Array<[string, string]>];
+  seed_jwks: [] | [Array<Array<[string, string]>>];
   client_id: string;
 }
 export type BackendCanisterConfig = {

--- a/src/frontend/src/lib/utils/openID.test.ts
+++ b/src/frontend/src/lib/utils/openID.test.ts
@@ -181,6 +181,7 @@ const createOpenIDConfig = (issuer: string): OpenIdConfig => ({
   auth_scope: ["test"],
   client_id: "test",
   email_verification: [],
+  seed_jwks: [],
 });
 
 describe("findConfig", () => {

--- a/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
@@ -162,6 +162,7 @@
       issuer: result.discovery.issuer,
       auth_scope: selectAuthScopes(result.discovery.scopes_supported),
       client_id: result.clientId,
+      seed_jwks: [],
     };
     initiateOpenId(syntheticConfig);
   };
@@ -214,6 +215,7 @@
         issuer: iss,
         auth_scope: [],
         client_id: aud ?? "",
+        seed_jwks: [],
       };
       authorizationStore.setFlow({ type: "1-click-sso", domain: ssoDomain });
     } else {

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -432,6 +432,13 @@ type OpenIdConfig = record {
     auth_scope : vec text;
     fedcm_uri : opt text;
     email_verification : opt OpenIdEmailVerification;
+    // Optional initial set of JWKs used to seed this provider's JWK cache on
+    // install, so JWT verification works before the first jwks_uri fetch and
+    // across upgrades (the cache is persisted in stable memory). Each entry is
+    // one JWK represented as the list of its JSON (field, value) pairs, e.g.
+    // vec { record { "kty"; "RSA" }; record { "kid"; "..." };
+    //       record { "n"; "..." }; record { "e"; "AQAB" } }.
+    seed_jwks : opt vec record { text; text };
 };
 
 // SSO provider config that uses two-hop discovery.

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -434,11 +434,12 @@ type OpenIdConfig = record {
     email_verification : opt OpenIdEmailVerification;
     // Optional initial set of JWKs used to seed this provider's JWK cache on
     // install, so JWT verification works before the first jwks_uri fetch and
-    // across upgrades (the cache is persisted in stable memory). Each entry is
-    // one JWK represented as the list of its JSON (field, value) pairs, e.g.
-    // vec { record { "kty"; "RSA" }; record { "kid"; "..." };
-    //       record { "n"; "..." }; record { "e"; "AQAB" } }.
-    seed_jwks : opt vec record { text; text };
+    // across upgrades (the cache is persisted in stable memory). The outer vec
+    // is the set of JWKs; each inner vec is one JWK, given as the list of its
+    // JSON (field, value) pairs, e.g. a single RSA key is
+    // vec { vec { record { "kty"; "RSA" }; record { "kid"; "..." };
+    //             record { "n"; "..." }; record { "e"; "AQAB" } } }.
+    seed_jwks : opt vec vec record { text; text };
 };
 
 // SSO provider config that uses two-hop discovery.

--- a/src/internet_identity/src/attributes.rs
+++ b/src/internet_identity/src/attributes.rs
@@ -1028,6 +1028,7 @@ mod tests {
                     auth_scope: vec![],
                     fedcm_uri: None,
                     email_verification: Some(OpenIdEmailVerificationScheme::Google),
+                    seed_jwks: None,
                 },
                 OpenIdConfig {
                     name: "Microsoft".to_string(),
@@ -1039,6 +1040,7 @@ mod tests {
                     auth_scope: vec![],
                     fedcm_uri: None,
                     email_verification: Some(OpenIdEmailVerificationScheme::Microsoft),
+                    seed_jwks: None,
                 },
             ]);
         }
@@ -1648,6 +1650,7 @@ mod tests {
                 auth_scope: vec![],
                 fedcm_uri: None,
                 email_verification: Some(OpenIdEmailVerificationScheme::Microsoft),
+                seed_jwks: None,
             }]);
         }
 
@@ -1739,6 +1742,7 @@ mod tests {
                 auth_scope: vec![],
                 fedcm_uri: None,
                 email_verification: Some(OpenIdEmailVerificationScheme::Google),
+                seed_jwks: None,
             }]);
         }
 
@@ -2013,6 +2017,7 @@ mod tests {
                 auth_scope: vec![],
                 fedcm_uri: None,
                 email_verification: Some(OpenIdEmailVerificationScheme::Google),
+                seed_jwks: None,
             }]);
         }
 

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -216,16 +216,73 @@ impl Provider {
         let certs = Rc::new(RefCell::new(TEST_CERTS.take()));
 
         #[cfg(not(test))]
-        let certs: Rc<RefCell<Vec<Jwk>>> = Rc::new(RefCell::new(vec![]));
+        let certs: Rc<RefCell<Vec<Jwk>>> = Rc::new(RefCell::new(initial_certs(&config)));
 
+        // Persist fetched keys under the provider's `issuer` so the cache
+        // survives upgrades (see `initial_certs`).
         #[cfg(not(test))]
-        schedule_fetch_certs(config.jwks_uri, Rc::clone(&certs), Some(0));
+        schedule_fetch_certs(
+            Some(config.issuer.clone()),
+            config.jwks_uri,
+            Rc::clone(&certs),
+            Some(0),
+        );
 
         Provider {
             client_id: config.client_id,
             issuer: config.issuer,
             certs,
             email_verification: config.email_verification,
+        }
+    }
+}
+
+/// Build a single [`Jwk`] from the `(field, value)` pairs supplied via
+/// [`OpenIdConfig::seed_jwks`]. Each pair is one field of the JWK's JSON object
+/// (e.g. `("kty","RSA")`, `("kid","...")`, `("n","...")`, `("e","AQAB")`). The
+/// pairs are assembled into a JSON object and parsed with the same `serde` path
+/// used for fetched certs, so a seeded key is byte-for-byte identical to a
+/// fetched one.
+fn build_seed_jwk(pairs: &[(String, String)]) -> Result<Jwk, String> {
+    let mut object = serde_json::Map::with_capacity(pairs.len());
+    for (field, value) in pairs {
+        object.insert(field.clone(), serde_json::Value::String(value.clone()));
+    }
+    serde_json::from_value(serde_json::Value::Object(object))
+        .map_err(|err| format!("invalid seed JWK: {err}"))
+}
+
+/// Compute the initial contents of a provider's in-memory JWK cache.
+///
+/// 1. Prefer the cache persisted in stable memory (keyed by `issuer`): this is
+///    populated by previous seeds / fetches and lets JWT verification work
+///    immediately after an upgrade, before the first post-upgrade fetch.
+/// 2. Otherwise, if `seed_jwks` is provided, bootstrap from it and persist the
+///    result so it too survives the next upgrade.
+///
+/// `seed_jwks` only takes effect when nothing is persisted yet; once the cache
+/// holds keys (seeded or fetched) they are never clobbered by a stale seed on
+/// a later upgrade. Use a reinstall to reset.
+#[cfg(not(test))]
+fn initial_certs(config: &OpenIdConfig) -> Vec<Jwk> {
+    if let Some(persisted) = state::storage_borrow(|s| s.read_openid_jwks(&config.issuer)) {
+        return persisted;
+    }
+    let Some(pairs) = config.seed_jwks.as_ref() else {
+        return vec![];
+    };
+    match build_seed_jwk(pairs) {
+        Ok(jwk) => {
+            let keys = vec![jwk];
+            state::storage_borrow_mut(|s| s.write_openid_jwks(&config.issuer, keys.clone()));
+            keys
+        }
+        Err(err) => {
+            ic_cdk::println!(
+                "Ignoring invalid seed_jwks for issuer {}: {err}",
+                config.issuer
+            );
+            vec![]
         }
     }
 }
@@ -561,7 +618,9 @@ async fn run_discovery_tasks() {
         };
         if jwks_changed {
             task.last_jwks_uri.replace(Some(doc.jwks_uri.clone()));
-            schedule_fetch_certs(doc.jwks_uri, Rc::clone(&task.certs_ref), Some(0));
+            // Discoverable providers re-derive their keys from discovery on
+            // every upgrade, so their cache is not persisted (`None`).
+            schedule_fetch_certs(None, doc.jwks_uri, Rc::clone(&task.certs_ref), Some(0));
         }
     }
 }
@@ -871,8 +930,16 @@ fn compute_next_certs_fetch_delay<T, E>(
     }
 }
 
+/// Schedules a (re-)fetch of a provider's JWKs.
+///
+/// When `persist_key` is `Some(issuer)`, successfully fetched keys are also
+/// written through to the persistent JWK cache under that key, so the latest
+/// keys (not just the original seed) survive canister upgrades. `None` skips
+/// persistence (used by the discoverable SSO providers, whose keys are
+/// re-derived from discovery after each upgrade).
 #[cfg(not(test))]
 fn schedule_fetch_certs(
+    persist_key: Option<String>,
     jwks_uri: String,
     certs_reference: Rc<RefCell<Vec<Jwk>>>,
     delay: Option<u64>,
@@ -888,9 +955,12 @@ fn schedule_fetch_certs(
                 let result = fetch_certs(jwks_uri.clone()).await;
                 let next_delay = compute_next_certs_fetch_delay(&result, delay);
                 if let Ok(certs) = result {
-                    certs_reference.replace(certs);
+                    certs_reference.replace(certs.clone());
+                    if let Some(key) = persist_key.as_ref() {
+                        state::storage_borrow_mut(|s| s.write_openid_jwks(key, certs));
+                    }
                 }
-                schedule_fetch_certs(jwks_uri, certs_reference, next_delay);
+                schedule_fetch_certs(persist_key, jwks_uri, certs_reference, next_delay);
             });
         },
     );
@@ -1159,6 +1229,7 @@ fn test_data() -> (String, [u8; 32], OpenIdConfig, Claims) {
         auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://accounts.google.com/gsi/fedcm.json".into()),
         email_verification: None,
+        seed_jwks: None,
     };
 
     (jwt.into(), salt, config, claims)
@@ -1409,4 +1480,53 @@ fn should_compute_next_certs_fetch_delay() {
             expected_next_delay_on_error
         );
     }
+}
+
+#[test]
+fn should_build_seed_jwk_from_field_pairs() {
+    let pairs = vec![
+        ("kty".to_string(), "RSA".to_string()),
+        ("use".to_string(), "sig".to_string()),
+        ("alg".to_string(), "RS256".to_string()),
+        ("kid".to_string(), "test-kid".to_string()),
+        ("n".to_string(), "test-modulus".to_string()),
+        ("e".to_string(), "AQAB".to_string()),
+    ];
+
+    let jwk = build_seed_jwk(&pairs).expect("seed JWK should build");
+    assert_eq!(jwk.kid(), Some("test-kid"));
+    let params = jwk.try_rsa_params().unwrap();
+    assert_eq!(params.n, "test-modulus");
+    assert_eq!(params.e, "AQAB");
+}
+
+#[test]
+fn should_build_seed_jwk_identical_to_fetched_jwk() {
+    // A seed assembled from the JSON field pairs of a fetched JWK must be
+    // indistinguishable from that fetched JWK, so verification behaves the same
+    // whether a key was seeded or fetched.
+    let fetched_json =
+        r#"{"kty":"RSA","use":"sig","alg":"RS256","kid":"abc","n":"modulus","e":"AQAB"}"#;
+    let fetched: Jwk = serde_json::from_str(fetched_json).unwrap();
+    let pairs = vec![
+        ("kty".to_string(), "RSA".to_string()),
+        ("use".to_string(), "sig".to_string()),
+        ("alg".to_string(), "RS256".to_string()),
+        ("kid".to_string(), "abc".to_string()),
+        ("n".to_string(), "modulus".to_string()),
+        ("e".to_string(), "AQAB".to_string()),
+    ];
+
+    let seeded = build_seed_jwk(&pairs).unwrap();
+    assert_eq!(
+        serde_json::to_string(&seeded).unwrap(),
+        serde_json::to_string(&fetched).unwrap()
+    );
+}
+
+#[test]
+fn should_reject_seed_jwk_without_key_type() {
+    // Missing the mandatory `kty` discriminator: not a valid JWK.
+    let pairs = vec![("alg".to_string(), "RS256".to_string())];
+    assert!(build_seed_jwk(&pairs).is_err());
 }

--- a/src/internet_identity/src/openid/generic.rs
+++ b/src/internet_identity/src/openid/generic.rs
@@ -237,12 +237,11 @@ impl Provider {
     }
 }
 
-/// Build a single [`Jwk`] from the `(field, value)` pairs supplied via
-/// [`OpenIdConfig::seed_jwks`]. Each pair is one field of the JWK's JSON object
-/// (e.g. `("kty","RSA")`, `("kid","...")`, `("n","...")`, `("e","AQAB")`). The
-/// pairs are assembled into a JSON object and parsed with the same `serde` path
-/// used for fetched certs, so a seeded key is byte-for-byte identical to a
-/// fetched one.
+/// Build a single [`Jwk`] from one entry of [`OpenIdConfig::seed_jwks`] — the
+/// `(field, value)` pairs of one JWK's JSON object (e.g. `("kty","RSA")`,
+/// `("kid","...")`, `("n","...")`, `("e","AQAB")`). The pairs are assembled into
+/// a JSON object and parsed with the same `serde` path used for fetched certs,
+/// so a seeded key is byte-for-byte identical to a fetched one.
 fn build_seed_jwk(pairs: &[(String, String)]) -> Result<Jwk, String> {
     let mut object = serde_json::Map::with_capacity(pairs.len());
     for (field, value) in pairs {
@@ -252,39 +251,49 @@ fn build_seed_jwk(pairs: &[(String, String)]) -> Result<Jwk, String> {
         .map_err(|err| format!("invalid seed JWK: {err}"))
 }
 
+/// Build every JWK supplied via [`OpenIdConfig::seed_jwks`]: one [`Jwk`] per
+/// entry (each entry is a single JWK's `(field, value)` pairs). Returns the
+/// successfully-parsed keys together with an error message for each entry that
+/// failed to parse, so the caller can log and skip invalid entries rather than
+/// failing the whole install.
+fn build_seed_jwks(entries: &[Vec<(String, String)>]) -> (Vec<Jwk>, Vec<String>) {
+    let mut keys = Vec::with_capacity(entries.len());
+    let mut errors = Vec::new();
+    for pairs in entries {
+        match build_seed_jwk(pairs) {
+            Ok(jwk) => keys.push(jwk),
+            Err(err) => errors.push(err),
+        }
+    }
+    (keys, errors)
+}
+
 /// Compute the initial contents of a provider's in-memory JWK cache.
 ///
-/// 1. Prefer the cache persisted in stable memory (keyed by `issuer`): this is
-///    populated by previous seeds / fetches and lets JWT verification work
-///    immediately after an upgrade, before the first post-upgrade fetch.
-/// 2. Otherwise, if `seed_jwks` is provided, bootstrap from it and persist the
-///    result so it too survives the next upgrade.
-///
-/// `seed_jwks` only takes effect when nothing is persisted yet; once the cache
-/// holds keys (seeded or fetched) they are never clobbered by a stale seed on
-/// a later upgrade. Use a reinstall to reset.
+/// - If `config.seed_jwks` supplies any valid JWKs, they are authoritative:
+///   persist them to stable memory (keyed by `issuer`, so they survive
+///   upgrades) and use them. Invalid entries are logged and skipped.
+/// - Otherwise, fall back to the JWKs already persisted for this `issuer` (from
+///   an earlier seed or a periodic fetch), so verification keeps working across
+///   upgrades before the first post-upgrade fetch completes.
 #[cfg(not(test))]
 fn initial_certs(config: &OpenIdConfig) -> Vec<Jwk> {
-    if let Some(persisted) = state::storage_borrow(|s| s.read_openid_jwks(&config.issuer)) {
-        return persisted;
-    }
-    let Some(pairs) = config.seed_jwks.as_ref() else {
-        return vec![];
-    };
-    match build_seed_jwk(pairs) {
-        Ok(jwk) => {
-            let keys = vec![jwk];
-            state::storage_borrow_mut(|s| s.write_openid_jwks(&config.issuer, keys.clone()));
-            keys
-        }
-        Err(err) => {
+    // Seed JWKs from the config win: persist and use them.
+    if let Some(entries) = config.seed_jwks.as_ref() {
+        let (keys, errors) = build_seed_jwks(entries);
+        for err in errors {
             ic_cdk::println!(
-                "Ignoring invalid seed_jwks for issuer {}: {err}",
+                "Ignoring invalid seed JWK for issuer {}: {err}",
                 config.issuer
             );
-            vec![]
+        }
+        if !keys.is_empty() {
+            state::storage_borrow_mut(|s| s.write_openid_jwks(&config.issuer, keys.clone()));
+            return keys;
         }
     }
+    // No (valid) seed JWKs in the config: fall back to the persisted cache.
+    state::storage_borrow(|s| s.read_openid_jwks(&config.issuer)).unwrap_or_default()
 }
 
 /// Allowlist of domains accepted as `discovery_domain` by
@@ -1529,4 +1538,35 @@ fn should_reject_seed_jwk_without_key_type() {
     // Missing the mandatory `kty` discriminator: not a valid JWK.
     let pairs = vec![("alg".to_string(), "RS256".to_string())];
     assert!(build_seed_jwk(&pairs).is_err());
+}
+
+#[test]
+fn should_build_multiple_seed_jwks_and_skip_invalid() {
+    let key = |kid: &str| {
+        vec![
+            ("kty".to_string(), "RSA".to_string()),
+            ("use".to_string(), "sig".to_string()),
+            ("alg".to_string(), "RS256".to_string()),
+            ("kid".to_string(), kid.to_string()),
+            ("n".to_string(), format!("modulus-{kid}")),
+            ("e".to_string(), "AQAB".to_string()),
+        ]
+    };
+    // Second entry is invalid (no `kty`) and must be skipped, not fatal.
+    let invalid = vec![("alg".to_string(), "RS256".to_string())];
+    let entries = vec![key("kid-a"), invalid, key("kid-b")];
+
+    let (keys, errors) = build_seed_jwks(&entries);
+
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0].kid(), Some("kid-a"));
+    assert_eq!(keys[1].kid(), Some("kid-b"));
+    assert_eq!(errors.len(), 1);
+}
+
+#[test]
+fn should_build_no_seed_jwks_from_empty_set() {
+    let (keys, errors) = build_seed_jwks(&[]);
+    assert!(keys.is_empty());
+    assert!(errors.is_empty());
 }

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -101,6 +101,7 @@ use ic_stable_structures::writer::Writer;
 use ic_stable_structures::{
     Memory, MinHeap, RestrictedMemory, StableBTreeMap, StableCell, Storable,
 };
+use identity_jose::jwk::Jwk;
 use internet_identity_interface::archive::types::BufferedEntry;
 
 use crate::delegation::check_frontend_length;
@@ -131,6 +132,7 @@ use storable::email_recovery_address_hash::StorableEmailRecoveryAddressHash;
 use storable::fixed_anchor::StorableFixedAnchor;
 use storable::openid_credential::StorableOpenIdCredential;
 use storable::openid_credential_key::StorableOpenIdCredentialKey;
+use storable::openid_jwks::StorableJwks;
 use storable::storable_persistent_state::StorablePersistentState;
 
 pub mod anchor;
@@ -180,6 +182,7 @@ const STABLE_ANCHOR_APPLICATION_CONFIG_MEMORY_INDEX: u8 = 20u8;
 const LOOKUP_ANCHOR_WITH_RECOVERY_PHRASE_PRINCIPAL_MEMORY_INDEX: u8 = 21u8;
 const LOOKUP_ANCHOR_WITH_PASSKEY_PUBKEY_HASH_MEMORY_INDEX: u8 = 22u8;
 const LOOKUP_ANCHOR_WITH_EMAIL_RECOVERY_MEMORY_INDEX: u8 = 23u8;
+const OPENID_JWKS_CACHE_MEMORY_INDEX: u8 = 24u8;
 
 const ANCHOR_MEMORY_ID: MemoryId = MemoryId::new(ANCHOR_MEMORY_INDEX);
 const ARCHIVE_BUFFER_MEMORY_ID: MemoryId = MemoryId::new(ARCHIVE_BUFFER_MEMORY_INDEX);
@@ -219,6 +222,12 @@ const LOOKUP_ANCHOR_WITH_PASSKEY_PUBKEY_HASH_MEMORY_ID: MemoryId =
 
 const LOOKUP_ANCHOR_WITH_EMAIL_RECOVERY_MEMORY_ID: MemoryId =
     MemoryId::new(LOOKUP_ANCHOR_WITH_EMAIL_RECOVERY_MEMORY_INDEX);
+
+/// Persistent cache of OpenID provider JWKs, keyed by the provider's `issuer`.
+/// Seeded from `OpenIdConfig.seed_jwks` and written through on every successful
+/// periodic `jwks_uri` fetch, so a provider's keys survive canister upgrades
+/// and are available for JWT verification before the first post-upgrade fetch.
+const OPENID_JWKS_CACHE_MEMORY_ID: MemoryId = MemoryId::new(OPENID_JWKS_CACHE_MEMORY_INDEX);
 
 // The bucket size 128 is relatively low, to avoid wasting memory when using
 // multiple virtual memories for smaller amounts of data.
@@ -354,6 +363,12 @@ pub struct Storage<M: Memory> {
     /// there's no need to store it again here. See design §8.2.
     pub(crate) lookup_anchor_with_email_recovery_memory:
         StableBTreeMap<StorableEmailRecoveryAddressHash, StorableAnchorNumber, ManagedMemory<M>>,
+
+    /// Memory wrapper used to report the size of the OpenID JWKS cache memory.
+    openid_jwks_cache_memory_wrapper: MemoryWrapper<ManagedMemory<M>>,
+    /// Persistent per-provider JWK cache, keyed by the provider's `issuer`.
+    /// See [`OPENID_JWKS_CACHE_MEMORY_ID`].
+    openid_jwks_cache_memory: StableBTreeMap<String, StorableJwks, ManagedMemory<M>>,
 }
 
 #[repr(C, packed)]
@@ -439,6 +454,7 @@ impl<M: Memory + Clone> Storage<M> {
             memory_manager.get(LOOKUP_ANCHOR_WITH_PASSKEY_PUBKEY_HASH_MEMORY_ID);
         let lookup_anchor_with_email_recovery_memory =
             memory_manager.get(LOOKUP_ANCHOR_WITH_EMAIL_RECOVERY_MEMORY_ID);
+        let openid_jwks_cache_memory = memory_manager.get(OPENID_JWKS_CACHE_MEMORY_ID);
 
         let registration_rates = RegistrationRates::new(
             MinHeap::init(registration_ref_rate_memory.clone())
@@ -545,6 +561,8 @@ impl<M: Memory + Clone> Storage<M> {
             lookup_anchor_with_email_recovery_memory: StableBTreeMap::init(
                 lookup_anchor_with_email_recovery_memory,
             ),
+            openid_jwks_cache_memory_wrapper: MemoryWrapper::new(openid_jwks_cache_memory.clone()),
+            openid_jwks_cache_memory: StableBTreeMap::init(openid_jwks_cache_memory),
         }
     }
 
@@ -2073,6 +2091,22 @@ impl<M: Memory + Clone> Storage<M> {
         PersistentState::from(self.persistent_state.get().clone())
     }
 
+    /// Reads the persisted JWK cache for the given provider `issuer`, if any.
+    pub fn read_openid_jwks(&self, issuer: &str) -> Option<Vec<Jwk>> {
+        self.openid_jwks_cache_memory
+            .get(&issuer.to_string())
+            .map(|stored| stored.keys)
+    }
+
+    /// Writes (replacing any previous value) the JWK cache for the given
+    /// provider `issuer`. Used both to seed the cache from
+    /// `OpenIdConfig.seed_jwks` and to write through fetched keys so they
+    /// survive canister upgrades.
+    pub fn write_openid_jwks(&mut self, issuer: &str, keys: Vec<Jwk>) {
+        self.openid_jwks_cache_memory
+            .insert(issuer.to_string(), StorableJwks { keys });
+    }
+
     pub fn version(&self) -> u8 {
         self.header.version
     }
@@ -2156,6 +2190,10 @@ impl<M: Memory + Clone> Storage<M> {
             (
                 "lookup_anchor_with_email_recovery_memory".to_string(),
                 self.lookup_anchor_with_email_recovery_memory_wrapper.size(),
+            ),
+            (
+                "openid_jwks_cache".to_string(),
+                self.openid_jwks_cache_memory_wrapper.size(),
             ),
         ])
     }

--- a/src/internet_identity/src/storage/storable.rs
+++ b/src/internet_identity/src/storage/storable.rs
@@ -17,6 +17,7 @@ pub mod fixed_anchor;
 pub mod metadata_v2;
 pub mod openid_credential;
 pub mod openid_credential_key;
+pub mod openid_jwks;
 pub mod passkey_credential;
 pub mod recovery_key;
 pub mod special_device_migration;

--- a/src/internet_identity/src/storage/storable/openid_jwks.rs
+++ b/src/internet_identity/src/storage/storable/openid_jwks.rs
@@ -1,0 +1,63 @@
+use ic_stable_structures::storable::Bound;
+use ic_stable_structures::Storable;
+use identity_jose::jwk::Jwk;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+/// Stable-memory value holding the set of JWKs cached for a single OpenID
+/// provider (keyed by the provider's `issuer` in the storage layer).
+///
+/// The keys are serialized as a JSON array — the exact `serde` shape used when
+/// the keys are fetched from the provider's `jwks_uri` — so values round-trip
+/// losslessly through `identity_jose::jwk::Jwk` and a seeded entry is
+/// byte-for-byte identical to a fetched one.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct StorableJwks {
+    pub keys: Vec<Jwk>,
+}
+
+impl Storable for StorableJwks {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(serde_json::to_vec(self).expect("failed to serialize JWKs"))
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        serde_json::from_slice(&bytes).expect("failed to deserialize JWKs")
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_jwk() -> Jwk {
+        serde_json::from_str(
+            r#"{"kty":"RSA","use":"sig","alg":"RS256","kid":"test-kid","n":"abc","e":"AQAB"}"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn should_round_trip_through_stable_bytes() {
+        let original = StorableJwks {
+            keys: vec![sample_jwk()],
+        };
+        let restored = StorableJwks::from_bytes(original.to_bytes());
+
+        // `Jwk` does not implement `PartialEq`, so compare via their canonical
+        // JSON serialization instead.
+        assert_eq!(
+            serde_json::to_string(&original).unwrap(),
+            serde_json::to_string(&restored).unwrap()
+        );
+    }
+
+    #[test]
+    fn should_round_trip_empty() {
+        let original = StorableJwks { keys: vec![] };
+        let restored = StorableJwks::from_bytes(original.to_bytes());
+        assert!(restored.keys.is_empty());
+    }
+}

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -137,6 +137,35 @@ fn should_not_overwrite_persistent_state_with_next_anchor_v9() {
 }
 
 #[test]
+fn should_persist_openid_jwks_across_reload() {
+    use identity_jose::jwk::Jwk;
+
+    let memory = VectorMemory::default();
+    let mut storage = Storage::new((10_000, 3_784_873), memory.clone());
+    storage.flush();
+
+    let issuer = "https://accounts.google.com";
+    let jwk: Jwk = serde_json::from_str(
+        r#"{"kty":"RSA","use":"sig","alg":"RS256","kid":"kid-1","n":"modulus","e":"AQAB"}"#,
+    )
+    .unwrap();
+
+    assert!(storage.read_openid_jwks(issuer).is_none());
+    storage.write_openid_jwks(issuer, vec![jwk]);
+
+    // Re-read from the same backing memory to simulate a canister upgrade.
+    let reloaded = Storage::from_memory(memory);
+    let restored = reloaded
+        .read_openid_jwks(issuer)
+        .expect("JWKs should persist across reload");
+    assert_eq!(restored.len(), 1);
+    assert_eq!(restored[0].kid(), Some("kid-1"));
+
+    // Unknown issuers have no cached keys.
+    assert!(reloaded.read_openid_jwks("https://other.example").is_none());
+}
+
+#[test]
 fn should_write_and_update_openid_credential_lookup() {
     let memory = VectorMemory::default();
     let mut storage = Storage::new((10_000, 3_784_873), memory);

--- a/src/internet_identity/tests/integration/attributes.rs
+++ b/src/internet_identity/tests/integration/attributes.rs
@@ -84,6 +84,7 @@ fn should_get_certified_attributes() {
         auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://accounts.google.com/gsi/fedcm.json".into()),
         email_verification: None,
+        seed_jwks: None,
     }]);
 
     let ii_backend_canister_id = install_ii_canister_with_arg_and_cycles(
@@ -277,6 +278,7 @@ fn legacy_prepare_attributes_rejects_sso_scope() {
         auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://accounts.google.com/gsi/fedcm.json".into()),
         email_verification: None,
+        seed_jwks: None,
     }]);
 
     let ii_backend_canister_id = install_ii_canister_with_arg_and_cycles(
@@ -379,6 +381,7 @@ fn should_get_certified_attributes_microsoft() {
         auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("".into()),
         email_verification: None,
+        seed_jwks: None,
     }]);
 
     let ii_backend_canister_id = install_ii_canister_with_arg_and_cycles(
@@ -556,6 +559,7 @@ fn should_get_icrc3_certified_attributes() {
         auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://accounts.google.com/gsi/fedcm.json".into()),
         email_verification: None,
+        seed_jwks: None,
     }]);
 
     let ii_backend_canister_id = install_ii_canister_with_arg_and_cycles(
@@ -701,6 +705,7 @@ fn setup_icrc3_test_env() -> (
         auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://accounts.google.com/gsi/fedcm.json".into()),
         email_verification: None,
+        seed_jwks: None,
     }]);
 
     let ii_backend_canister_id = install_ii_canister_with_arg_and_cycles(
@@ -1364,6 +1369,7 @@ fn setup_icrc3_test_env_with_fake_openid() -> (
         auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://accounts.google.com/gsi/fedcm.json".into()),
         email_verification: None,
+        seed_jwks: None,
     }]);
 
     let ii_backend_canister_id = install_ii_canister_with_arg_and_cycles(

--- a/src/internet_identity/tests/integration/config/oidc_configs.rs
+++ b/src/internet_identity/tests/integration/config/oidc_configs.rs
@@ -75,6 +75,7 @@ fn should_coexist_with_openid_configs() {
                 auth_scope: vec!["openid".into()],
                 fedcm_uri: None,
                 email_verification: None,
+                seed_jwks: None,
             },
         ]),
         ..Default::default()

--- a/src/internet_identity/tests/integration/config/openid_configs.rs
+++ b/src/internet_identity/tests/integration/config/openid_configs.rs
@@ -35,6 +35,7 @@ fn should_init_config() {
                 auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
                 fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
                 email_verification: None,
+                seed_jwks: None,
             }]),
             ..Default::default()
         },
@@ -50,6 +51,7 @@ fn should_init_config() {
                     auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
                     fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
                     email_verification: None,
+                    seed_jwks: None,
                 },
                 OpenIdConfig {
                     name: "Example2".into(),
@@ -61,6 +63,7 @@ fn should_init_config() {
                     auth_uri: "https://example2.com/o/oauth2/v2/auth".into(),
                     fedcm_uri: None,
                     email_verification: None,
+                    seed_jwks: None,
                 },
             ]),
             ..Default::default()
@@ -93,6 +96,7 @@ fn should_enable_config() {
         auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
         fedcm_uri: Some("https://example.com/fedcm.json".into()),
         email_verification: None,
+        seed_jwks: None,
     }]);
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
@@ -118,6 +122,7 @@ fn should_disable_config() {
             auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
             fedcm_uri: Some("https://example.com/fedcm.json".into()),
             email_verification: None,
+            seed_jwks: None,
         }]),
         ..Default::default()
     };
@@ -146,6 +151,7 @@ fn should_update_config() {
             auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
             fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
             email_verification: None,
+            seed_jwks: None,
         }]),
         ..Default::default()
     };
@@ -159,6 +165,7 @@ fn should_update_config() {
         auth_scope: vec!["openid".into()],
         fedcm_uri: None,
         email_verification: None,
+        seed_jwks: None,
     }]);
 
     let canister_id = install_ii_canister_with_arg(&env, II_WASM.clone(), Some(config.clone()));
@@ -193,6 +200,7 @@ fn should_retain_config() {
                 auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
                 fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
                 email_verification: None,
+                seed_jwks: None,
             }]),
             ..Default::default()
         },
@@ -208,6 +216,7 @@ fn should_retain_config() {
                     auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
                     fedcm_uri: Some("https://example.com/gsi/fedcm.json".into()),
                     email_verification: None,
+                    seed_jwks: None,
                 },
                 OpenIdConfig {
                     name: "Example2".into(),
@@ -219,6 +228,7 @@ fn should_retain_config() {
                     auth_scope: vec!["openid".into()],
                     fedcm_uri: None,
                     email_verification: None,
+                    seed_jwks: None,
                 },
             ]),
             ..Default::default()

--- a/src/internet_identity/tests/integration/http.rs
+++ b/src/internet_identity/tests/integration/http.rs
@@ -899,6 +899,7 @@ fn ii_canister_serves_decodable_synchronized_config() -> Result<(), RejectRespon
         auth_scope: vec!["openid".to_string(), "email".to_string()],
         fedcm_uri: None,
         email_verification: None,
+        seed_jwks: None,
     }];
     let config = InternetIdentityInit {
         openid_configs: Some(openid_configs.clone()),

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -648,24 +648,34 @@ pub fn setup_canister(env: &PocketIc) -> Principal {
 }
 
 /// Installs II with a single Google provider whose JWK cache is seeded — via
-/// `OpenIdConfig.seed_jwks` — with the key that signed the JWT returned by
-/// [`openid_google_test_data`] (kid `763f7c4cd26a1eb2b1b39a88f4434d1f4d9a368b`,
-/// the same key served by [`mock_google_certs_response`]).
+/// `OpenIdConfig.seed_jwks` — with *two* keys served by
+/// [`mock_google_certs_response`]: a decoy (kid
+/// `25f8211713788b6145474b5029b0141bd5b3de9c`) and the key that signed the JWT
+/// returned by [`openid_google_test_data`] (kid
+/// `763f7c4cd26a1eb2b1b39a88f4434d1f4d9a368b`). Seeding more than one key
+/// exercises the multi-JWK seed path and the by-`kid` match during
+/// verification.
 ///
-/// The seed is expressed exactly as the API expects it: the list of the JWK's
+/// Each JWK is expressed exactly as the API expects it: the list of that JWK's
 /// JSON `(field, value)` pairs. Unlike [`setup_canister`], this does NOT mock
-/// the certs HTTP response.
+/// the certs HTTP response, so a successful link proves verification used the
+/// seeded cache.
 pub fn setup_canister_with_seeded_google_jwks(env: &PocketIc) -> Principal {
-    // The JWK (as JSON) that signs the test JWT, turned into the `(field, value)`
-    // pair list expected by `seed_jwks`.
-    let google_jwk_json = r#"{"kty":"RSA","use":"sig","alg":"RS256","kid":"763f7c4cd26a1eb2b1b39a88f4434d1f4d9a368b","n":"y8TPCPz2Fp0OhBxsxu6d_7erT9f9XJ7mx7ZJPkkeZRxhdnKtg327D4IGYsC4fLAfpkC8qN58sZGkwRTNs-i7yaoD5_8nupq1tPYvnt38ddVghG9vws-2MvxfPQ9m2uxBEdRHmels8prEYGCH6oFKcuWVsNOt4l_OPoJRl4uiuiwd6trZik2GqDD_M6bn21_w6AD_jmbzN4mh8Od4vkA1Z9lKb3Qesksxdog-LWHsljN8ieiz1NhbG7M-GsIlzu-typJfud3tSJ1QHb-E_dEfoZ1iYK7pMcojb5ylMkaCj5QySRdJESq9ngqVRDjF4nX8DK5RQUS7AkrpHiwqyW0Csw","e":"AQAB"}"#;
-    let jwk_value: serde_json::Value = serde_json::from_str(google_jwk_json).unwrap();
-    let seed_jwks: Vec<(String, String)> = jwk_value
-        .as_object()
-        .unwrap()
-        .iter()
-        .map(|(field, value)| (field.clone(), value.as_str().unwrap().to_string()))
-        .collect();
+    // Turn a JWK JSON object into the `(field, value)` pair list `seed_jwks`
+    // expects for a single key.
+    let jwk_pairs = |jwk_json: &str| -> Vec<(String, String)> {
+        serde_json::from_str::<serde_json::Value>(jwk_json)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .iter()
+            .map(|(field, value)| (field.clone(), value.as_str().unwrap().to_string()))
+            .collect()
+    };
+    // A decoy key (not used to sign the JWT) plus the actual signing key.
+    let decoy_jwk_json = r#"{"kty":"RSA","use":"sig","alg":"RS256","kid":"25f8211713788b6145474b5029b0141bd5b3de9c","n":"0qTcwnqUqJqsyu57JAC4IOAgTuMrccabAKKj5T93F68NoCk4kAax0oJhDArisYpiLrQ__YJJ9HFm3TKkuiPZeb1xqSSXAnIZVo8UigTLQDQLCTq3O-aD5EyQTOhOHWxJBZcpyLO-dZVuOIbv8fNMcXpNCioHVHO04gI_mvaw8ZzbU_j8ZeHSPk4wTBNfmH4l0mYRDhoQHLkZxxvc2V71ppBPYbnX-4t6h7XcuTkLJKBxfrR43G5nNzDuFsIbBnS2fjVLEv_1LYj9G5Q5XwiCFS0BON-oqQNzRWF53nkf91bMm2TaROg21KKJbZqfEjUhCVlMDFmBW-MNv69-C19PZQ","e":"AQAB"}"#;
+    let signing_jwk_json = r#"{"kty":"RSA","use":"sig","alg":"RS256","kid":"763f7c4cd26a1eb2b1b39a88f4434d1f4d9a368b","n":"y8TPCPz2Fp0OhBxsxu6d_7erT9f9XJ7mx7ZJPkkeZRxhdnKtg327D4IGYsC4fLAfpkC8qN58sZGkwRTNs-i7yaoD5_8nupq1tPYvnt38ddVghG9vws-2MvxfPQ9m2uxBEdRHmels8prEYGCH6oFKcuWVsNOt4l_OPoJRl4uiuiwd6trZik2GqDD_M6bn21_w6AD_jmbzN4mh8Od4vkA1Z9lKb3Qesksxdog-LWHsljN8ieiz1NhbG7M-GsIlzu-typJfud3tSJ1QHb-E_dEfoZ1iYK7pMcojb5ylMkaCj5QySRdJESq9ngqVRDjF4nX8DK5RQUS7AkrpHiwqyW0Csw","e":"AQAB"}"#;
+    let seed_jwks = vec![jwk_pairs(decoy_jwk_json), jwk_pairs(signing_jwk_json)];
 
     let args = InternetIdentityInit {
         openid_configs: Some(vec![OpenIdConfig {

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -56,6 +56,40 @@ fn can_link_google_account() -> Result<(), RejectResponse> {
     Ok(())
 }
 
+/// Verifies that a JWT can be verified purely from the JWK cache seeded via
+/// `OpenIdConfig.seed_jwks`, without ever fetching the provider's `jwks_uri`.
+/// No certs HTTP response is mocked here, so a successful add proves the seed
+/// populated the cache.
+#[test]
+fn can_link_google_account_with_seeded_jwks() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = setup_canister_with_seeded_google_jwks(&env);
+    let (jwt, salt, _claims, test_time, test_principal, test_authn_method) =
+        openid_google_test_data();
+
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &test_authn_method);
+
+    sync_time(&env, test_time);
+
+    // NOTE: deliberately NOT calling `mock_google_certs_response` here — the key
+    // used to verify the JWT must come from the install-time `seed_jwks`.
+    let _ = api::openid_credential_add(
+        &env,
+        canister_id,
+        test_principal,
+        identity_number,
+        &jwt,
+        &salt,
+    )?;
+
+    assert_eq!(
+        number_of_openid_credentials(&env, canister_id, test_principal, identity_number)?,
+        1
+    );
+
+    Ok(())
+}
+
 /// Verifies that Microsoft Accounts can be added
 #[test]
 fn can_link_microsoft_account() -> Result<(), RejectResponse> {
@@ -563,6 +597,7 @@ pub fn setup_canister(env: &PocketIc) -> Principal {
             auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
             fedcm_uri: Some("https://accounts.google.com/gsi/fedcm.json".into()),
             email_verification: None,
+            seed_jwks: None,
         }, OpenIdConfig {
             name: "Microsoft".into(),
             logo: "<svg viewBox=\"0 0 24 24\"><path d=\"M2.5 2.5h9v9h-9zm10 0h9v9h-9zm-10 10h9v9h-9zm10 0h9v9h-9z\" style=\"fill: currentColor;\"></path></svg>".into(),
@@ -574,6 +609,7 @@ pub fn setup_canister(env: &PocketIc) -> Principal {
             auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
             fedcm_uri: Some("".into()),
             email_verification: None,
+            seed_jwks: None,
         }]),
         archive_config: Some(ArchiveConfig {
             module_hash: wasm_module_hash(&ARCHIVE_WASM),
@@ -609,6 +645,48 @@ pub fn setup_canister(env: &PocketIc) -> Principal {
     mock_microsoft_certs_response(env);
 
     canister_id
+}
+
+/// Installs II with a single Google provider whose JWK cache is seeded — via
+/// `OpenIdConfig.seed_jwks` — with the key that signed the JWT returned by
+/// [`openid_google_test_data`] (kid `763f7c4cd26a1eb2b1b39a88f4434d1f4d9a368b`,
+/// the same key served by [`mock_google_certs_response`]).
+///
+/// The seed is expressed exactly as the API expects it: the list of the JWK's
+/// JSON `(field, value)` pairs. Unlike [`setup_canister`], this does NOT mock
+/// the certs HTTP response.
+pub fn setup_canister_with_seeded_google_jwks(env: &PocketIc) -> Principal {
+    // The JWK (as JSON) that signs the test JWT, turned into the `(field, value)`
+    // pair list expected by `seed_jwks`.
+    let google_jwk_json = r#"{"kty":"RSA","use":"sig","alg":"RS256","kid":"763f7c4cd26a1eb2b1b39a88f4434d1f4d9a368b","n":"y8TPCPz2Fp0OhBxsxu6d_7erT9f9XJ7mx7ZJPkkeZRxhdnKtg327D4IGYsC4fLAfpkC8qN58sZGkwRTNs-i7yaoD5_8nupq1tPYvnt38ddVghG9vws-2MvxfPQ9m2uxBEdRHmels8prEYGCH6oFKcuWVsNOt4l_OPoJRl4uiuiwd6trZik2GqDD_M6bn21_w6AD_jmbzN4mh8Od4vkA1Z9lKb3Qesksxdog-LWHsljN8ieiz1NhbG7M-GsIlzu-typJfud3tSJ1QHb-E_dEfoZ1iYK7pMcojb5ylMkaCj5QySRdJESq9ngqVRDjF4nX8DK5RQUS7AkrpHiwqyW0Csw","e":"AQAB"}"#;
+    let jwk_value: serde_json::Value = serde_json::from_str(google_jwk_json).unwrap();
+    let seed_jwks: Vec<(String, String)> = jwk_value
+        .as_object()
+        .unwrap()
+        .iter()
+        .map(|(field, value)| (field.clone(), value.as_str().unwrap().to_string()))
+        .collect();
+
+    let args = InternetIdentityInit {
+        openid_configs: Some(vec![OpenIdConfig {
+            name: "Google".into(),
+            logo: String::new(),
+            issuer: "https://accounts.google.com".into(),
+            client_id: "360587991668-63bpc1gngp1s5gbo1aldal4a50c1j0bb.apps.googleusercontent.com"
+                .into(),
+            jwks_uri: "https://www.googleapis.com/oauth2/v3/certs".into(),
+            auth_uri: "https://accounts.google.com/o/oauth2/v2/auth".into(),
+            auth_scope: vec!["openid".into(), "profile".into(), "email".into()],
+            fedcm_uri: Some("https://accounts.google.com/gsi/fedcm.json".into()),
+            email_verification: None,
+            seed_jwks: Some(seed_jwks),
+        }]),
+        canister_creation_cycles_cost: Some(0),
+        ..Default::default()
+    };
+
+    // Cycles are needed before installation because of the async HTTP outcalls.
+    install_ii_canister_with_arg_and_cycles(env, II_WASM.clone(), Some(args), 10_000_000_000_000)
 }
 
 pub fn mock_google_certs_response(env: &PocketIc) {

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -406,17 +406,18 @@ pub struct OpenIdConfig {
     pub email_verification: Option<OpenIdEmailVerificationScheme>,
     /// Optional initial set of JWKs used to seed this provider's JWK cache on
     /// install, so JWT verification works before the first `jwks_uri` fetch
-    /// completes (and across upgrades — see the persistent JWK cache in the
-    /// backend's storage layer).
+    /// completes (and across upgrades — the cache is persisted in stable memory
+    /// in the backend's storage layer).
     ///
-    /// Each entry is one JWK represented as the list of its JSON
-    /// `(field, value)` pairs, e.g.
-    /// `vec { record { "kty"; "RSA" }; record { "kid"; "..." };
-    ///        record { "n"; "..." }; record { "e"; "AQAB" } }`.
-    /// The pairs are assembled into a JSON object and parsed with the same
+    /// The outer vector is the set of JWKs; each inner vector is one JWK,
+    /// represented as the list of its JSON `(field, value)` pairs. For example a
+    /// single RSA key is
+    /// `vec { vec { record { "kty"; "RSA" }; record { "kid"; "..." };
+    ///              record { "n"; "..." }; record { "e"; "AQAB" } } }`.
+    /// Each inner list is assembled into a JSON object and parsed with the same
     /// path used for fetched certs, so all string-valued JWK fields are
-    /// supported.
-    pub seed_jwks: Option<Vec<(String, String)>>,
+    /// supported. Invalid entries are skipped.
+    pub seed_jwks: Option<Vec<Vec<(String, String)>>>,
 }
 
 /// SSO provider configuration that uses two-hop discovery.

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -404,6 +404,19 @@ pub struct OpenIdConfig {
     pub auth_scope: Vec<String>,
     pub fedcm_uri: Option<String>,
     pub email_verification: Option<OpenIdEmailVerificationScheme>,
+    /// Optional initial set of JWKs used to seed this provider's JWK cache on
+    /// install, so JWT verification works before the first `jwks_uri` fetch
+    /// completes (and across upgrades — see the persistent JWK cache in the
+    /// backend's storage layer).
+    ///
+    /// Each entry is one JWK represented as the list of its JSON
+    /// `(field, value)` pairs, e.g.
+    /// `vec { record { "kty"; "RSA" }; record { "kid"; "..." };
+    ///        record { "n"; "..." }; record { "e"; "AQAB" } }`.
+    /// The pairs are assembled into a JSON object and parsed with the same
+    /// path used for fetched certs, so all string-valued JWK fields are
+    /// supported.
+    pub seed_jwks: Option<Vec<(String, String)>>,
 }
 
 /// SSO provider configuration that uses two-hop discovery.


### PR DESCRIPTION
## What

Adds `seed_jwks : opt vec vec record { text; text }` to `OpenIdConfig` in the II backend install args, and makes each provider's JWK cache persistent across canister upgrades using a dedicated stable structure.

## Why

Today each hardcoded OpenID provider (`Provider` in `openid/generic.rs`) keeps its JWK cache as an in-memory `Rc<RefCell<Vec<Jwk>>>` that is **lost on every upgrade** and only repopulated by the periodic `jwks_uri` HTTP fetch. This leaves a window after install/upgrade where JWT verification fails until the first fetch completes. `seed_jwks` lets the cache be pre-populated at install time, and persisting the cache removes the post-upgrade gap (and avoids needing to mock the certs HTTP fetch in tests).

## Seed format

`seed_jwks` is an **optional set of JWKs**: the outer vec is the set, and each inner vec is **one JWK** represented as the list of its JSON `(field, value)` pairs (e.g. `("kty","RSA")`, `("kid","…")`, `("n","…")`, `("e","AQAB")`). Each inner list is assembled into a JSON object and parsed with the same `serde` path used for fetched certs, so a seeded key is byte-for-byte identical to a fetched one. Invalid entries are logged and skipped.

## Persistence & precedence

A new issuer-keyed `StableBTreeMap<String, StorableJwks>` (memory id `24`) holds each provider's JWK cache. `initial_certs` runs on `init`/`post_upgrade`:

- **If the config supplies any valid `seed_jwks`, they are authoritative** — they're persisted to stable memory and used as the cache.
- **Otherwise**, the cache falls back to the JWKs already persisted for that issuer (from an earlier seed or fetch), so verification keeps working across upgrades before the first post-upgrade fetch.

Every successful periodic re-fetch writes its keys through to the same map, so for providers without a seed the latest fetched keys survive upgrades. Discoverable SSO providers are unchanged — they re-derive keys from discovery after each upgrade and pass `None` for the persistence key.

## Frontend

`OpenIdConfig` is part of the config served to the frontend, so the committed Candid bindings are regenerated (`didc bind`) and the hand-written `globals.ts` mirror is kept structurally identical to the generated type (so `findConfig`'s cross-type return still type-checks).

## Testing

- Unit: `build_seed_jwk` (pairs → JWK, identical to fetched, rejects missing `kty`), `build_seed_jwks` (multiple keys + skip invalid), `StorableJwks` round-trip, and `storage::should_persist_openid_jwks_across_reload`.
- Candid: `check_candid_interface_compatibility` passes.
- Integration: `can_link_google_account_with_seeded_jwks` seeds **two** Google keys (a decoy + the signing key) and links a Google account using only the seeded cache — **no** certs HTTP response mocked — exercising the multi-key path and by-`kid` matching.
- Full backend unit suite (544 tests), clippy, and the full `frontend-checks` set (`tsc`, `svelte-check`, `eslint`, `prettier`) all pass.

## Compatibility

Backward compatible: the new memory id is allocated lazily on upgrade, and the new optional `seed_jwks` field decodes to `None` for existing persisted state.

https://claude.ai/code/session_01Rwvp6fpwc4iBvRCa7h8QNo