### PR TITLE
Add optional `message_id` field to `SmtpRequest`

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -698,6 +698,7 @@ export const idlFactory = ({ IDL }) => {
     'envelope' : IDL.Opt(SmtpEnvelope),
     'message' : IDL.Opt(SmtpMessage),
     'gateway_flags' : IDL.Opt(IDL.Vec(IDL.Text)),
+    'message_id' : IDL.Opt(IDL.Text),
   });
   const SmtpRequestError = IDL.Record({
     'code' : IDL.Nat64,

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1401,6 +1401,15 @@ export interface SmtpRequest {
   'envelope' : [] | [SmtpEnvelope],
   'message' : [] | [SmtpMessage],
   'gateway_flags' : [] | [Array<string>],
+  /**
+   * Optional gateway-supplied correlation id for one inbound message
+   * (e.g. the RFC 5322 Message-ID or a gateway-assigned tracking id).
+   * The canister does not interpret it; it lets a reported case be
+   * lined up across the SMTP gateway logs and the canister's production
+   * logs during support investigations. Capped at 256 bytes; oversize
+   * values are rejected with code 555.
+   */
+  'message_id' : [] | [string],
 }
 /**
  * Error returned by `smtp_request` / `smtp_request_validate`.

--- a/src/frontend/tests/e2e-playwright/utils/dkimTestSigner.ts
+++ b/src/frontend/tests/e2e-playwright/utils/dkimTestSigner.ts
@@ -160,6 +160,7 @@ export class TestSigner {
         },
       ],
       gateway_flags: [],
+      message_id: [],
     };
     return { request };
   }

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -671,6 +671,13 @@ type SmtpRequest = record {
     message : opt SmtpMessage;
     envelope : opt SmtpEnvelope;
     gateway_flags : opt vec text;
+    // Optional gateway-supplied correlation id for one inbound message
+    // (e.g. the RFC 5322 Message-ID or a gateway-assigned tracking id).
+    // The canister does not interpret it; it lets a reported case be
+    // lined up across the SMTP gateway logs and the canister's production
+    // logs during support investigations. Capped at 256 bytes; oversize
+    // values are rejected with code 555.
+    message_id : opt text;
 };
 
 // Error returned by `smtp_request` / `smtp_request_validate`.

--- a/src/internet_identity/src/dkim/test_vectors.rs
+++ b/src/internet_identity/src/dkim/test_vectors.rs
@@ -82,6 +82,7 @@ fn parse_eml(raw: &[u8]) -> SmtpRequest {
             body: ByteBuf::from(body),
         }),
         gateway_flags: None,
+        message_id: None,
     }
 }
 

--- a/src/internet_identity/src/dkim/verify.rs
+++ b/src/internet_identity/src/dkim/verify.rs
@@ -583,6 +583,7 @@ mod tests {
                 body: ByteBuf::from(b"hi".to_vec()),
             }),
             gateway_flags: None,
+            message_id: None,
         };
         let result = verify(&req, "v=DKIM1; p=YWJj", 1_700_000_000);
         match result {
@@ -630,6 +631,7 @@ mod tests {
                 body: ByteBuf::from(b"hi".to_vec()),
             }),
             gateway_flags: None,
+            message_id: None,
         };
         let result = verify(&req, "v=DKIM1; p=YWJj", 1_700_000_000);
         match result {
@@ -678,6 +680,7 @@ mod tests {
                 body: ByteBuf::from(b"hi".to_vec()),
             }),
             gateway_flags: None,
+            message_id: None,
         };
         let result = verify(&req, "v=DKIM1; p=YWJj", 1_700_000_000);
         match result {
@@ -724,6 +727,7 @@ mod tests {
                 body: ByteBuf::from(b"hi".to_vec()),
             }),
             gateway_flags: None,
+            message_id: None,
         };
         let result = verify(&req, "v=DKIM1; p=YWJj", 1_700_000_000);
         match result {
@@ -770,6 +774,7 @@ mod tests {
                 body: ByteBuf::from(b"hi".to_vec()),
             }),
             gateway_flags: None,
+            message_id: None,
         };
         // now = 1_700_000_000, t = 1_700_001_000 → 1000 s in the future,
         // well beyond CLOCK_SKEW_SECS (60).
@@ -822,6 +827,7 @@ mod tests {
                 body: ByteBuf::from(b"hi".to_vec()),
             }),
             gateway_flags: None,
+            message_id: None,
         };
         // now = 1_700_000_000, t = 1_700_000_030 → 30 s in the future,
         // inside the 60 s skew window. The t= check must pass; we
@@ -883,6 +889,7 @@ mod tests {
                 body: ByteBuf::from(b"hi".to_vec()),
             }),
             gateway_flags: None,
+            message_id: None,
         };
         let result = verify(&req, "v=DKIM1; p=YWJj", 1_700_000_000);
         match result {

--- a/src/internet_identity/src/dmarc/test_vectors.rs
+++ b/src/internet_identity/src/dmarc/test_vectors.rs
@@ -111,6 +111,7 @@ fn parse_eml(raw: &[u8]) -> SmtpRequest {
             body: ByteBuf::from(body),
         }),
         gateway_flags: None,
+        message_id: None,
     }
 }
 

--- a/src/internet_identity/src/dmarc/verify.rs
+++ b/src/internet_identity/src/dmarc/verify.rs
@@ -167,6 +167,7 @@ mod tests {
                 body: ByteBuf::from(b"x".to_vec()),
             }),
             gateway_flags: None,
+            message_id: None,
         }
     }
 

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -1045,6 +1045,7 @@ mod tests {
             }),
             message: None,
             gateway_flags: None,
+            message_id: None,
         }
     }
 
@@ -1183,6 +1184,7 @@ mod tests {
             envelope: None,
             message: None,
             gateway_flags: None,
+            message_id: None,
         };
         assert_smtp_err_code(handle_smtp_request_validate(req), SMTP_ERR_SYNTAX_ERROR);
     }
@@ -1243,6 +1245,7 @@ mod tests {
                 body: ByteBuf::from(b"hi".to_vec()),
             }),
             gateway_flags: None,
+            message_id: None,
         }
     }
 

--- a/src/internet_identity/tests/integration/email_recovery.rs
+++ b/src/internet_identity/tests/integration/email_recovery.rs
@@ -270,6 +270,7 @@ fn smtp_request_silently_drops_email_with_no_nonce_in_subject() {
             body: ByteBuf::from(b"hello".to_vec()),
         }),
         gateway_flags: None,
+        message_id: None,
     };
     let resp = api::smtp_request(&env, canister_id, &request).expect("call failed");
     assert!(matches!(resp, SmtpResponse::Ok {}));
@@ -315,6 +316,7 @@ fn smtp_request_silently_drops_email_with_unknown_nonce() {
             body: ByteBuf::from(b"hello".to_vec()),
         }),
         gateway_flags: None,
+        message_id: None,
     };
     let resp = api::smtp_request(&env, canister_id, &request).expect("call failed");
     assert!(matches!(resp, SmtpResponse::Ok {}));
@@ -364,6 +366,7 @@ fn smtp_request_rejects_emails_addressed_to_unknown_recipients_with_550() {
             body: ByteBuf::from(b"hello".to_vec()),
         }),
         gateway_flags: None,
+        message_id: None,
     };
     let resp = api::smtp_request(&env, canister_id, &request).expect("call failed");
     match resp {
@@ -1252,6 +1255,7 @@ mod dkim_signer {
                     body: ByteBuf::from(params.body.to_vec()),
                 }),
                 gateway_flags: None,
+                message_id: None,
             };
 
             super::SignedEmail { request }

--- a/src/internet_identity_interface/src/internet_identity/types/smtp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/smtp.rs
@@ -31,6 +31,13 @@ pub const MAX_BODY_BYTES: usize = 5_000;
 pub const MAX_HEADERS: usize = 30;
 pub const MAX_HEADER_NAME_BYTES: usize = 256;
 pub const MAX_HEADER_VALUE_BYTES: usize = 8_192;
+/// Cap on the optional gateway-supplied `message_id` correlation id.
+/// `smtp_request` and `smtp_request_validate` are both open (anyone can
+/// call them), so — like every other inbound string — it is length-bounded
+/// to keep worst-case allocation on an open endpoint in check. 256 bytes
+/// comfortably fits an RFC 5322 `Message-ID` or a gateway-assigned tracking
+/// id; oversize values are rejected with code 555.
+pub const MAX_MESSAGE_ID_BYTES: usize = 256;
 
 /// Headers that RFC 5322 §3.6 requires to appear exactly once in a
 /// message. Counted case-insensitively.
@@ -124,6 +131,13 @@ pub struct SmtpRequest {
     pub message: Option<SmtpMessage>,
     pub envelope: Option<SmtpEnvelope>,
     pub gateway_flags: Option<Vec<String>>,
+    /// Optional gateway-supplied correlation id for one inbound message
+    /// (e.g. the RFC 5322 `Message-ID` or a gateway-assigned tracking id).
+    /// The canister does not interpret it; it exists purely so a reported
+    /// case can be lined up across the SMTP gateway logs and the canister's
+    /// production logs during support investigations. Length-bounded by
+    /// [`MAX_MESSAGE_ID_BYTES`] since the entrypoints are open.
+    pub message_id: Option<String>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
@@ -288,9 +302,10 @@ pub fn validate_header_occurrences(headers: &[SmtpHeader]) -> Result<(), SmtpRes
     Ok(())
 }
 
-/// Bounds-check both halves of an `SmtpRequest`: the envelope (always)
-/// and the message body if present. Per the PoC review, the validate
-/// path must accept envelope-only requests for `smtp_request_validate`.
+/// Bounds-check an `SmtpRequest`: the envelope (always), the message body
+/// if present, and the optional `message_id`. Per the PoC review, the
+/// validate path must accept envelope-only requests for
+/// `smtp_request_validate`.
 pub fn validate_smtp_request(request: &SmtpRequest) -> Result<(), SmtpResponse> {
     let envelope = request
         .envelope
@@ -299,6 +314,14 @@ pub fn validate_smtp_request(request: &SmtpRequest) -> Result<(), SmtpResponse> 
     validate_envelope(envelope)?;
     if let Some(message) = &request.message {
         validate_message(message)?;
+    }
+    if let Some(message_id) = &request.message_id {
+        if message_id.len() > MAX_MESSAGE_ID_BYTES {
+            return Err(smtp_err(
+                SMTP_ERR_SYNTAX_ERROR,
+                format!("message_id exceeds {MAX_MESSAGE_ID_BYTES} bytes"),
+            ));
+        }
     }
     Ok(())
 }
@@ -471,6 +494,7 @@ mod tests {
             envelope: None,
             message: None,
             gateway_flags: None,
+            message_id: None,
         };
         let resp = validate_smtp_request(&req).unwrap_err();
         assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
@@ -643,7 +667,46 @@ mod tests {
             }),
             message: None,
             gateway_flags: None,
+            message_id: None,
         };
         assert!(validate_smtp_request(&req).is_ok());
+    }
+
+    fn envelope_only_request(message_id: Option<String>) -> SmtpRequest {
+        SmtpRequest {
+            envelope: Some(SmtpEnvelope {
+                from: addr("alice", "gmail.com"),
+                to: vec![addr("recover", "id.ai")],
+            }),
+            message: None,
+            gateway_flags: None,
+            message_id,
+        }
+    }
+
+    #[test]
+    fn validate_smtp_request_accepts_within_bound_message_id() {
+        // A gateway-supplied correlation id within the cap is accepted; the
+        // canister doesn't interpret it, only bounds its length.
+        let req = envelope_only_request(Some("<abc123@gateway.example>".into()));
+        assert!(validate_smtp_request(&req).is_ok());
+    }
+
+    #[test]
+    fn validate_smtp_request_accepts_message_id_at_cap() {
+        // Exactly at the cap must still pass — defines the inclusive bound.
+        let req = envelope_only_request(Some("x".repeat(MAX_MESSAGE_ID_BYTES)));
+        assert!(validate_smtp_request(&req).is_ok());
+    }
+
+    #[test]
+    fn validate_smtp_request_rejects_oversize_message_id() {
+        // `smtp_request` is open, so an over-long correlation id is refused
+        // at the input-bounds layer with a syntax error (555), like every
+        // other oversize field.
+        let req = envelope_only_request(Some("x".repeat(MAX_MESSAGE_ID_BYTES + 1)));
+        let resp = validate_smtp_request(&req).unwrap_err();
+        assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
+        assert!(err_msg(&resp).contains("message_id"));
     }
 }


### PR DESCRIPTION
## What

Extends the II backend SMTP gateway protocol type `SmtpRequest` with an optional `message_id : opt text`.

```candid
type SmtpRequest = record {
    message : opt SmtpMessage;
    envelope : opt SmtpEnvelope;
    gateway_flags : opt vec text;
    message_id : opt text;   // new
};
```

## Why

The gateway can attach a per-message correlation id (e.g. the RFC 5322 `Message-ID` or a gateway-assigned tracking id) so that, when an end user reports that a particular recovery/registration didn't work, the support team can line up that one message across the **SMTP gateway logs** and the **canister's production logs**.

## Scope

This adds the field to the **API surface only** — type, `.did`, generated bindings, and input-bounds validation. It deliberately does **not** add canister-side `ic_cdk::println!` logging of `message_id` yet; that (and any other consumption) is left to the gateway / a follow-up, mirroring how the existing `gateway_flags` field is carried over the wire but not interpreted by the canister.

`SmtpRequest` is a receive-only wire type — the canister only ever *deserializes* it. Because the field is `opt`, the change is backward/forward compatible: requests from an older gateway that omit it decode to `None`.

## Changes

- **`src/internet_identity_interface/.../types/smtp.rs`** — add `pub message_id: Option<String>`, a `MAX_MESSAGE_ID_BYTES = 256` cap, a length check in `validate_smtp_request` (oversize → SMTP code 555, consistent with the other open-endpoint bounds), and 3 unit tests.
- **`src/internet_identity/internet_identity.did`** — add `message_id : opt text` (kept in lockstep with the Rust type; verified by the `check_candid_interface_compatibility` test).
- **Generated bindings** — `internet_identity_types.d.ts` / `internet_identity_idl.js` regenerated with the pinned `didc` (`2025-12-18`).
- **Test constructors** — thread `message_id: None` (Rust) / `message_id: []` (the TS e2e signer) through all `SmtpRequest` literals.

## Verification

- `cargo test -p internet_identity_interface smtp` — 29 passed (incl. 3 new `message_id` tests).
- `cargo test -p internet_identity check_candid_interface_compatibility` — passed (`.did` ↔ Rust match; full canister + integration crates compile).
- `npm run check` (tsc + svelte-check) — 0 errors.
- `cargo fmt --check` — no diffs in the touched files.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018FcS9quvazGADTGr7UbXvw)_