### PR TITLE
[do not merge] throwaway: test -j$(nproc) reproducibility

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -140,7 +140,7 @@ function build_canister() {
         --manifest-path "$SRC_DIR/Cargo.toml"
         --target "$TARGET"
         --release
-        -j1
+        -j "$(nproc)"
         )
     # XXX: for bash > 4.4, empty arrays are considered unset, so do some substitution
     cargo_build_args+=(${extra_build_args[@]+"${extra_build_args[@]}"})


### PR DESCRIPTION
**Do not merge** — throwaway branch to gather evidence for whether the historical \`-j1\` in \`scripts/build\` is still load-bearing for reproducibility on the current toolchain.

Single 1-line change: \`-j1\` → \`-j \$(nproc)\` in [\`scripts/build:143\`](https://github.com/dfinity/internet-identity/blob/main/scripts/build#L143). All other build settings preserved.

This PR exists only to trigger CI. The result will be the sha256 of the produced \`internet_identity_backend.wasm.gz\`. Compare it to main's most recent build of the same source commit (\`02bc793\`).

- **Hashes match** → \`-j1\` is no longer load-bearing. I'll open a clean 1-line PR doing this same change for real, with the evidence linked.
- **Hashes differ** → \`-j1\` is doing something. Will document the finding here and close.

Either way, this branch and PR get deleted after the verdict is in.

Context: this is the lean version of (now-closed) #3897.