### PR TITLE
build: relax cargo -j1 to -j$(nproc) in scripts/build

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -140,7 +140,6 @@ function build_canister() {
         --manifest-path "$SRC_DIR/Cargo.toml"
         --target "$TARGET"
         --release
-        -j "$(nproc)"
         )
     # XXX: for bash > 4.4, empty arrays are considered unset, so do some substitution
     cargo_build_args+=(${extra_build_args[@]+"${extra_build_args[@]}"})

--- a/scripts/build
+++ b/scripts/build
@@ -140,7 +140,7 @@ function build_canister() {
         --manifest-path "$SRC_DIR/Cargo.toml"
         --target "$TARGET"
         --release
-        -j1
+        -j "$(nproc)"
         )
     # XXX: for bash > 4.4, empty arrays are considered unset, so do some substitution
     cargo_build_args+=(${extra_build_args[@]+"${extra_build_args[@]}"})


### PR DESCRIPTION
## Summary

One-line change: \`scripts/build\` now uses \`-j \$(nproc)\` instead of the hardcoded \`-j1\` when invoking cargo. Speeds up the deps prebuild ~2.5–3× on a 4-core CI runner. **Bit-identical wasm output** — verified empirically before posting.

## Why \`-j1\` was here

Added in [#490 (Dec 2021)](https://github.com/dfinity/internet-identity/pull/490), *Make build more reproducible*, alongside Docker image SHA pinning and \`src/lib.rs\` timestamp normalization. The commit doesn't explain the reasoning for \`-j1\` specifically; it's plausibly a 2021-era \"use -j1 for reproducibility\" cargo-cult.

## Why it's no longer needed

\`cargo -j N\` controls **inter-process** parallelism — how many concurrent \`rustc\` invocations cargo spawns across the dep graph. A single \`rustc\` invocation's output is a deterministic function of source + flags + rustc version + codegen-units, **independent** of how many sibling \`rustc\` processes happen to be running. Cargo serialises filesystem writes via per-crate paths.

The actual non-determinism vector in the rust toolchain is \`codegen-units > 1\` — see [reproducible-builds.org/docs/rust](https://reproducible-builds.org/docs/rust/) and the [Aug 2024 rb-general thread](https://lists.reproducible-builds.org/pipermail/rb-general/2024-August/003491.html). \`-j\` is never listed as a required hedge.

## Evidence

Built the backend wasm both ways on commit \`02bc793\`:

| Variant | wasm.gz sha256 |
| --- | --- |
| Main, \`-j1\` (run [26811764794](https://github.com/dfinity/internet-identity/actions/runs/26811764794)) | \`f998a7197ef4af962b7de9f1cc69349a18a2a8a9f18ac6dc214805f1f0f6aeb4\` |
| Throwaway, \`-j\$(nproc)\` (run [26812251856](https://github.com/dfinity/internet-identity/actions/runs/26812251856), [PR #3970](https://github.com/dfinity/internet-identity/pull/3970)) | \`f998a7197ef4af962b7de9f1cc69349a18a2a8a9f18ac6dc214805f1f0f6aeb4\` |

Bit-identical.

## Speedup

The deps prebuild (\`#33\` / \`#34\` RUN in \`docker-build-base\`) is where this helps — ~335 dependency crates that cargo can compile in parallel. In the throwaway run's cold-cache compile, the deps prebuild RUN dropped from ~150s under \`-j1\` (per prior cold-cache CI logs, e.g. [PR #3895 base runs](https://github.com/dfinity/internet-identity/pull/3895)) to **71s under \`-j\$(nproc)\`** — cargo's own \`Finished \`release\` profile\` line clocked the actual compile at **57s**.

That's a ~2.5–3× speedup whenever a Cargo.lock change forces the deps layer to recompile, which is the case on most dependency bumps.

No effect on the per-canister build stages (\`docker-build-internet_identity\`, \`docker-build-archive\`, \`docker-build-internet_identity_frontend\`) — each compiles a single crate, which is one \`rustc\` invocation regardless of \`-j\`. The 2:09 / 2:49 backend timing delta between the two reference runs is within runner variance.

## Test plan

- [ ] Standard \`Canister tests\` workflow passes on this PR (existing reproducibility comes from the unchanged Docker image SHA pin, \`--remap-path-prefix\`, \`gzip --no-name\`, etc.).
- [ ] Backend wasm sha256 on this PR's CI matches main's wasm hash for the same source commit (re-confirmation of what was already verified on the throwaway).

## Out of scope

- Not touching \`[profile.release]\` (\`lto = true\`, \`opt-level = 'z'\`, default \`codegen-units = 16\`). The build is already reproducible with those settings in the wild, and changing them is a separate question. Happy to follow up with \`lto = "thin"\` or \`codegen-units = 1\` experiments if there's appetite.