### PR TITLE
feat(be,fe): surface public email-recovery diagnostics (incl. SmtpRequest message_id)

### DIFF
--- a/src/canister_tests/src/api/internet_identity.rs
+++ b/src/canister_tests/src/api/internet_identity.rs
@@ -607,6 +607,14 @@ pub fn email_recovery_status(
     query_candid(env, canister_id, "email_recovery_status", (nonce,)).map(|(x,)| x)
 }
 
+pub fn email_recovery_diagnostics(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    nonce: &str,
+) -> Result<Option<types::email_recovery::EmailRecoveryDiagnostics>, RejectResponse> {
+    query_candid(env, canister_id, "email_recovery_diagnostics", (nonce,)).map(|(x,)| x)
+}
+
 pub fn email_recovery_prepare_delegation(
     env: &PocketIc,
     canister_id: CanisterId,

--- a/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
@@ -26,8 +26,10 @@
   import SendConfirmationEmail from "$lib/components/wizards/setupEmailRecovery/views/SendConfirmationEmail.svelte";
   import FailedView from "$lib/components/wizards/setupEmailRecovery/views/FailedView.svelte";
   import UnsupportedDomain from "$lib/components/wizards/setupEmailRecovery/views/UnsupportedDomain.svelte";
+  import { buildDiagnosticsBlob } from "$lib/components/wizards/setupEmailRecovery/diagnostics";
   import type {
     EmailRecoveryChallenge,
+    EmailRecoveryDiagnostics,
     EmailRecoveryDnsInput,
     EmailRecoveryError,
     EmailRecoveryGetDelegationArgs,
@@ -58,6 +60,8 @@
     ) => Promise<EmailRecoveryChallenge>;
     /** Anonymous wrapper around `email_recovery_status` (query). */
     status: (nonce: string) => Promise<EmailRecoveryStatus>;
+    /** Anonymous wrapper around `email_recovery_diagnostics` (query). */
+    diagnostics: (nonce: string) => Promise<[] | [EmailRecoveryDiagnostics]>;
     /** Anonymous wrapper around `email_recovery_submit_dkim_leaf`. */
     submitDkimLeaf: (
       arg: EmailRecoverySubmitDkimLeafArg,
@@ -74,6 +78,7 @@
   const {
     prepareDelegation,
     status,
+    diagnostics,
     submitDkimLeaf,
     getDelegation,
     onSignedIn,
@@ -99,7 +104,7 @@
         path: Path;
       }
     | { kind: "unsupported"; domain: string }
-    | { kind: "failed"; reason: string };
+    | { kind: "failed"; reason: string; diagnostics?: string };
 
   let stage = $state<Stage>({ kind: "enter" });
   let polling = $state(false);
@@ -180,6 +185,19 @@
       return "This recovery link timed out. Please try again.";
     }
     return "Unexpected status from the canister.";
+  };
+
+  // Best-effort fetch of the canister's strictly-public diagnostics for
+  // this challenge, formatted into a copyable blob (incl. the gateway
+  // `message_id`). The pending entry is sticky on `Failed`, so this read
+  // lands while it's still present; on any hiccup we fall back to
+  // FE-only fields so the user always gets something to share.
+  const collectDiagnostics = async (nonce: string): Promise<string> => {
+    try {
+      return buildDiagnosticsBlob((await diagnostics(nonce))[0]);
+    } catch {
+      return buildDiagnosticsBlob(undefined);
+    }
   };
 
   const handleAddressSubmitted = async (address: string) => {
@@ -264,7 +282,12 @@
             reason: failureReason(result),
           });
           recoverWithEmailFunnel.close();
-          stage = { kind: "failed", reason: friendlyError(result) };
+          const diagnosticsBlob = await collectDiagnostics(nonce);
+          stage = {
+            kind: "failed",
+            reason: friendlyError(result),
+            diagnostics: diagnosticsBlob,
+          };
           return;
         }
         if ("NeedDkimLeaf" in result && !dkimLeafSubmitted) {
@@ -300,7 +323,12 @@
                   reason: failureReason(submission),
                 });
                 recoverWithEmailFunnel.close();
-                stage = { kind: "failed", reason: friendlyError(submission) };
+                const diagnosticsBlob = await collectDiagnostics(nonce);
+                stage = {
+                  kind: "failed",
+                  reason: friendlyError(submission),
+                  diagnostics: diagnosticsBlob,
+                };
                 return;
               }
             }
@@ -352,6 +380,9 @@
       stage = {
         kind: "failed",
         reason: e instanceof Error ? e.message : String(e),
+        // FE-side failure (the delegation fetch threw) — no canister
+        // challenge state to read, so the blob carries the build id only.
+        diagnostics: buildDiagnosticsBlob(undefined),
       };
     }
   };
@@ -399,5 +430,9 @@
 {:else if stage.kind === "unsupported"}
   <UnsupportedDomain domain={stage.domain} onRetry={handleRetry} />
 {:else}
-  <FailedView reason={stage.reason} onRetry={handleRetry} />
+  <FailedView
+    reason={stage.reason}
+    diagnostics={stage.diagnostics}
+    onRetry={handleRetry}
+  />
 {/if}

--- a/src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte
@@ -28,8 +28,10 @@
   import SendConfirmationEmail from "./views/SendConfirmationEmail.svelte";
   import FailedView from "./views/FailedView.svelte";
   import UnsupportedDomain from "./views/UnsupportedDomain.svelte";
+  import { buildDiagnosticsBlob } from "./diagnostics";
   import type {
     EmailRecoveryChallenge,
+    EmailRecoveryDiagnostics,
     EmailRecoveryDnsInput,
     EmailRecoveryError,
     EmailRecoveryStatus,
@@ -53,6 +55,8 @@
     prepare: (input: EmailRecoveryDnsInput) => Promise<EmailRecoveryChallenge>;
     /** Anonymous wrapper around `email_recovery_status` (query). */
     status: (nonce: string) => Promise<EmailRecoveryStatus>;
+    /** Anonymous wrapper around `email_recovery_diagnostics` (query). */
+    diagnostics: (nonce: string) => Promise<[] | [EmailRecoveryDiagnostics]>;
     /** Anonymous wrapper around `email_recovery_submit_dkim_leaf`. */
     submitDkimLeaf: (
       arg: EmailRecoverySubmitDkimLeafArg,
@@ -62,7 +66,8 @@
     onSuccess: (address: string) => void;
   }
 
-  const { prepare, status, submitDkimLeaf, onSuccess }: Props = $props();
+  const { prepare, status, diagnostics, submitDkimLeaf, onSuccess }: Props =
+    $props();
 
   type Stage =
     | { kind: "enter"; initialError?: string }
@@ -84,7 +89,7 @@
         path: Path;
       }
     | { kind: "unsupported"; domain: string }
-    | { kind: "failed"; reason: string };
+    | { kind: "failed"; reason: string; diagnostics?: string };
 
   let stage = $state<Stage>({ kind: "enter" });
 
@@ -177,6 +182,19 @@
     return "Unexpected status from the canister.";
   };
 
+  // Best-effort fetch of the canister's strictly-public diagnostics for
+  // this challenge, formatted into a copyable blob (incl. the gateway
+  // `message_id`). The pending entry is sticky on `Failed`, so this read
+  // lands while it's still present; on any hiccup we fall back to
+  // FE-only fields so the user always gets something to share.
+  const collectDiagnostics = async (nonce: string): Promise<string> => {
+    try {
+      return buildDiagnosticsBlob((await diagnostics(nonce))[0]);
+    } catch {
+      return buildDiagnosticsBlob(undefined);
+    }
+  };
+
   const handleAddressSubmitted = async (address: string) => {
     setupEmailRecoveryFunnel.trigger(SetupEmailRecoveryEvents.AddressSubmitted);
     const domain = address.split("@")[1] ?? "";
@@ -257,7 +275,12 @@
             reason: failureReason(result),
           });
           setupEmailRecoveryFunnel.close();
-          stage = { kind: "failed", reason: friendlyError(result) };
+          const diagnosticsBlob = await collectDiagnostics(nonce);
+          stage = {
+            kind: "failed",
+            reason: friendlyError(result),
+            diagnostics: diagnosticsBlob,
+          };
           return;
         }
         if ("NeedDkimLeaf" in result && !dkimLeafSubmitted) {
@@ -296,7 +319,12 @@
                   { reason: failureReason(submission) },
                 );
                 setupEmailRecoveryFunnel.close();
-                stage = { kind: "failed", reason: friendlyError(submission) };
+                const diagnosticsBlob = await collectDiagnostics(nonce);
+                stage = {
+                  kind: "failed",
+                  reason: friendlyError(submission),
+                  diagnostics: diagnosticsBlob,
+                };
                 return;
               }
             }
@@ -358,5 +386,9 @@
 {:else if stage.kind === "unsupported"}
   <UnsupportedDomain domain={stage.domain} onRetry={handleRetry} />
 {:else}
-  <FailedView reason={stage.reason} onRetry={handleRetry} />
+  <FailedView
+    reason={stage.reason}
+    diagnostics={stage.diagnostics}
+    onRetry={handleRetry}
+  />
 {/if}

--- a/src/frontend/src/lib/components/wizards/setupEmailRecovery/diagnostics.test.ts
+++ b/src/frontend/src/lib/components/wizards/setupEmailRecovery/diagnostics.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildDiagnosticsBlob } from "./diagnostics";
+import type { EmailRecoveryDiagnostics } from "$lib/generated/internet_identity_types";
+
+// 1_700_000_000 s since epoch → 2023-11-14T22:13:20Z. Stored in ns.
+const CREATED_AT_NS = BigInt("1700000000000000000");
+
+describe("buildDiagnosticsBlob", () => {
+  it("includes the gateway message_id, reason code and DoH path", () => {
+    const diag: EmailRecoveryDiagnostics = {
+      message_id: ["<gw-123@gateway.example>"],
+      reason_code: "Failed:AddressMismatch",
+      verification_path: { Doh: null },
+      created_at: CREATED_AT_NS,
+    };
+    const blob = buildDiagnosticsBlob(diag);
+    expect(blob).toContain("message-id: <gw-123@gateway.example>");
+    expect(blob).toContain("reason:     Failed:AddressMismatch");
+    expect(blob).toContain("path:       doh");
+    expect(blob).toContain("time:       2023-11-14T");
+  });
+
+  it("renders an absent message_id and the DNSSEC path", () => {
+    const diag: EmailRecoveryDiagnostics = {
+      message_id: [],
+      reason_code: "Pending",
+      verification_path: { Dnssec: null },
+      created_at: CREATED_AT_NS,
+    };
+    const blob = buildDiagnosticsBlob(diag);
+    expect(blob).toContain("message-id: —");
+    expect(blob).toContain("path:       dnssec");
+  });
+
+  it("falls back to FE-only fields when there is no canister record", () => {
+    const blob = buildDiagnosticsBlob(undefined);
+    expect(blob).toContain("message-id: —");
+    expect(blob).toContain("reason:     —");
+    expect(blob).toContain("path:       —");
+    expect(blob).toContain("time:       —");
+  });
+});

--- a/src/frontend/src/lib/components/wizards/setupEmailRecovery/diagnostics.ts
+++ b/src/frontend/src/lib/components/wizards/setupEmailRecovery/diagnostics.ts
@@ -1,0 +1,47 @@
+import type { EmailRecoveryDiagnostics } from "$lib/generated/internet_identity_types";
+import { VERSION } from "$lib/legacy/environment";
+
+/**
+ * Build a compact, copyable, strictly-public diagnostics blob for a
+ * failed email-recovery attempt.
+ *
+ * The canister-sourced fields come from `EmailRecoveryDiagnostics`,
+ * which is curated to be non-sensitive (no email address, anchor,
+ * principal, or inner error string — `reason_code` is the failing
+ * variant's name only). The only FE-added field is the build id. The
+ * result is therefore safe to paste into a support ticket, and the
+ * `message-id` lets support line the case up across the SMTP gateway
+ * and canister logs.
+ *
+ * `diag` is `undefined` when the failure is purely FE-side (e.g. the
+ * delegation retrieval threw) — there is no canister challenge to read,
+ * so only the build id is included.
+ */
+export const buildDiagnosticsBlob = (
+  diag: EmailRecoveryDiagnostics | undefined,
+): string => {
+  const path =
+    diag === undefined
+      ? "—"
+      : "Dnssec" in diag.verification_path
+        ? "dnssec"
+        : "doh";
+  // `created_at` is nanoseconds since the epoch (candid nat64 → bigint).
+  // Divide as bigint (exact ms) before narrowing to Number for `Date`.
+  const time =
+    diag !== undefined
+      ? new Date(Number(diag.created_at / BigInt(1_000_000))).toISOString()
+      : "—";
+  // `VERSION` is `import.meta.env.II_VERSION` (untyped) and defaults to
+  // "" when unset; narrow + check explicitly so it's a real string.
+  const build =
+    typeof VERSION === "string" && VERSION.length > 0 ? VERSION : "unknown";
+  return [
+    "Internet Identity — email recovery diagnostics",
+    `build:      ${build}`,
+    `message-id: ${diag?.message_id[0] ?? "—"}`,
+    `reason:     ${diag?.reason_code ?? "—"}`,
+    `path:       ${path}`,
+    `time:       ${time}`,
+  ].join("\n");
+};

--- a/src/frontend/src/lib/components/wizards/setupEmailRecovery/views/FailedView.svelte
+++ b/src/frontend/src/lib/components/wizards/setupEmailRecovery/views/FailedView.svelte
@@ -1,16 +1,42 @@
 <script lang="ts">
   import { t } from "$lib/stores/locale.store";
-  import { MailXIcon } from "@lucide/svelte";
+  import { MailXIcon, CopyIcon } from "@lucide/svelte";
+  import { waitFor } from "$lib/utils/utils";
+  import { SUPPORT_URL } from "$lib/config";
 
   interface Props {
     /** Human-readable summary of what went wrong. The wizard maps
      *  canister error variants to friendly strings before passing
      *  them in. */
     reason: string;
+    /** Strictly-public, copyable diagnostics blob (includes the
+     *  gateway `message_id`) the user can hand to support. Absent when
+     *  there's nothing useful to share (e.g. a purely FE-side failure
+     *  with no canister challenge to read). See
+     *  `setupEmailRecovery/diagnostics.ts`. */
+    diagnostics?: string;
     onRetry: () => void;
   }
 
-  const { reason, onRetry }: Props = $props();
+  const { reason, diagnostics, onRetry }: Props = $props();
+
+  // One-shot "Copied" state. `navigator.clipboard.writeText` rejects in
+  // some embedded/insecure contexts; swallow it rather than throwing an
+  // unhandled rejection (mirrors SendConfirmationEmail's copy helpers).
+  let copied = $state(false);
+  const copyDiagnostics = async () => {
+    if (diagnostics === undefined) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(diagnostics);
+    } catch {
+      return;
+    }
+    copied = true;
+    await waitFor(700);
+    copied = false;
+  };
 </script>
 
 <div class="flex flex-col gap-6">
@@ -24,4 +50,27 @@
   <button class="btn btn-primary btn-lg" type="button" onclick={onRetry}>
     {$t`Try again`}
   </button>
+  {#if diagnostics !== undefined}
+    <div class="flex flex-col items-center gap-3 text-center">
+      <button
+        class="btn btn-tertiary btn-sm"
+        type="button"
+        onclick={copyDiagnostics}
+      >
+        <CopyIcon class="size-4" />
+        {copied ? $t`Copied` : $t`Copy error details`}
+      </button>
+      <p class="text-text-tertiary text-sm">
+        {$t`If this keeps happening, copy these details and include them in a`}
+        <a
+          class="text-text-primary underline"
+          href={SUPPORT_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {$t`support request`}</a
+        >.
+      </p>
+    </div>
+  {/if}
 </div>

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -322,6 +322,16 @@ export const idlFactory = ({ IDL }) => {
     'SubjectNotSigned' : IDL.Null,
     'AddressAlreadyRegistered' : IDL.Null,
   });
+  const VerificationPath = IDL.Variant({
+    'Doh' : IDL.Null,
+    'Dnssec' : IDL.Null,
+  });
+  const EmailRecoveryDiagnostics = IDL.Record({
+    'created_at' : Timestamp,
+    'verification_path' : VerificationPath,
+    'message_id' : IDL.Opt(IDL.Text),
+    'reason_code' : IDL.Text,
+  });
   const SessionKey = PublicKey;
   const EmailRecoveryGetDelegationArgs = IDL.Record({
     'session_key' : SessionKey,
@@ -867,6 +877,11 @@ export const idlFactory = ({ IDL }) => {
         [IdentityNumber, IDL.Text],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : EmailRecoveryError })],
         [],
+      ),
+    'email_recovery_diagnostics' : IDL.Func(
+        [IDL.Text],
+        [IDL.Opt(EmailRecoveryDiagnostics)],
+        ['query'],
       ),
     'email_recovery_get_delegation' : IDL.Func(
         [EmailRecoveryGetDelegationArgs],

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -544,6 +544,20 @@ export interface EmailRecoveryCredential {
   'address' : string,
   'last_used' : [] | [Timestamp],
 }
+/**
+ * Strictly-public, user-copyable diagnostics for one pending challenge
+ * (see email_recovery_diagnostics). Intended for a support ticket so a
+ * case can be lined up across the SMTP gateway logs and the canister's
+ * production logs via message_id. NO email address, anchor, principal,
+ * delegation/seed, or inner error string — reason_code is the failing
+ * variant's name only.
+ */
+export interface EmailRecoveryDiagnostics {
+  'created_at' : Timestamp,
+  'verification_path' : VerificationPath,
+  'message_id' : [] | [string],
+  'reason_code' : string,
+}
 export interface EmailRecoveryDnsInput {
   'dns_proof' : [] | [DnsProofBundle],
   'address' : string,
@@ -1449,6 +1463,13 @@ export type UpdateAccountError = { 'AccountLimitReached' : null } |
   { 'NameTooLong' : null };
 export type UserKey = PublicKey;
 export type UserNumber = bigint;
+/**
+ * Which trust path the canister used (or will use) to verify the
+ * challenge email. Public — already chosen by the FE and derivable
+ * from the public deploy config.
+ */
+export type VerificationPath = { 'Doh' : null } |
+  { 'Dnssec' : null };
 export type VerifyTentativeDeviceResponse = {
     /**
      * Device registration mode is off, either due to timeout or because it was never enabled.
@@ -1656,6 +1677,10 @@ export interface _SERVICE {
     [IdentityNumber, string],
     { 'Ok' : null } |
       { 'Err' : EmailRecoveryError }
+  >,
+  'email_recovery_diagnostics' : ActorMethod<
+    [string],
+    [] | [EmailRecoveryDiagnostics]
   >,
   'email_recovery_get_delegation' : ActorMethod<
     [EmailRecoveryGetDelegationArgs],

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
@@ -271,6 +271,10 @@
   const statusEmailRecovery = (nonce: string) =>
     anonymousActor.email_recovery_status(nonce);
 
+  /** Anonymous wrapper around `email_recovery_diagnostics` (query). */
+  const diagnosticsEmailRecovery = (nonce: string) =>
+    anonymousActor.email_recovery_diagnostics(nonce);
+
   /** Anonymous wrapper around `email_recovery_submit_dkim_leaf`. */
   const submitEmailDkimLeaf = (
     arg: import("$lib/generated/internet_identity_types").EmailRecoverySubmitDkimLeafArg,
@@ -493,6 +497,7 @@
     <SetupEmailRecoveryWizard
       prepare={prepareAddEmail}
       status={statusEmailRecovery}
+      diagnostics={diagnosticsEmailRecovery}
       submitDkimLeaf={submitEmailDkimLeaf}
       onSuccess={handleEmailWizardSuccess}
     />

--- a/src/frontend/src/routes/(new-styling)/recovery/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/recovery/+page.svelte
@@ -87,6 +87,9 @@
   const emailRecoveryStatus = (nonce: string) =>
     anonymousActor.email_recovery_status(nonce);
 
+  const emailRecoveryDiagnostics = (nonce: string) =>
+    anonymousActor.email_recovery_diagnostics(nonce);
+
   const submitEmailDkimLeaf = (
     arg: import("$lib/generated/internet_identity_types").EmailRecoverySubmitDkimLeafArg,
   ) =>
@@ -274,6 +277,7 @@
     <RecoverWithEmailWizard
       prepareDelegation={prepareEmailDelegation}
       status={emailRecoveryStatus}
+      diagnostics={emailRecoveryDiagnostics}
       submitDkimLeaf={submitEmailDkimLeaf}
       getDelegation={getEmailDelegation}
       onSignedIn={handleEmailRecoverySignIn}

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -625,6 +625,24 @@ type EmailRecoveryStatus = variant {
     Expired;
 };
 
+// Which trust path the canister used (or will use) to verify the
+// challenge email. Public — already chosen by the FE and derivable
+// from the public deploy config.
+type VerificationPath = variant { Doh; Dnssec };
+
+// Strictly-public, user-copyable diagnostics for one pending challenge
+// (see email_recovery_diagnostics). Intended for a support ticket so a
+// case can be lined up across the SMTP gateway logs and the canister's
+// production logs via message_id. NO email address, anchor, principal,
+// delegation/seed, or inner error string — reason_code is the failing
+// variant's name only.
+type EmailRecoveryDiagnostics = record {
+    message_id : opt text;
+    reason_code : text;
+    verification_path : VerificationPath;
+    created_at : Timestamp;
+};
+
 type EmailRecoveryGetDelegationArgs = record {
     nonce       : text;
     session_key : SessionKey;
@@ -1496,6 +1514,7 @@ service : (opt InternetIdentityInit) -> {
     email_recovery_credential_prepare_add : (IdentityNumber, EmailRecoveryDnsInput) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
     email_recovery_prepare_delegation : (EmailRecoveryDnsInput, SessionKey) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
     email_recovery_status : (text) -> (EmailRecoveryStatus) query;
+    email_recovery_diagnostics : (text) -> (opt EmailRecoveryDiagnostics) query;
     email_recovery_submit_dkim_leaf : (EmailRecoverySubmitDkimLeafArg) -> (variant { Ok : EmailRecoveryStatus; Err : EmailRecoveryError });
     email_recovery_get_delegation : (EmailRecoveryGetDelegationArgs) -> (variant { Ok : SignedDelegation; Err : EmailRecoveryError }) query;
     email_recovery_credential_remove : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });

--- a/src/internet_identity/src/email_recovery/mod.rs
+++ b/src/internet_identity/src/email_recovery/mod.rs
@@ -63,6 +63,20 @@ pub fn pending_status(
     pending::status_of(nonce, now_secs)
 }
 
+/// Wrapper around `pending::diagnostics_of` (see
+/// `EmailRecoveryDiagnostics`) so the canister method in `main.rs`
+/// doesn't reach into the submodule. Returns `None` for an
+/// unknown/expired nonce; the record carries strictly-public fields
+/// only.
+pub fn pending_diagnostics(
+    nonce: &str,
+    now_secs: u64,
+) -> Option<
+    internet_identity_interface::internet_identity::types::email_recovery::EmailRecoveryDiagnostics,
+> {
+    pending::diagnostics_of(nonce, now_secs)
+}
+
 /// Look up the cached `RecoveryOutcome.seed` for a recovery-flow
 /// pending challenge. Used by `email_recovery_get_delegation` to
 /// find the canister-signature without having to recompute the

--- a/src/internet_identity/src/email_recovery/pending.rs
+++ b/src/internet_identity/src/email_recovery/pending.rs
@@ -12,7 +12,8 @@
 
 use ic_certification::Hash;
 use internet_identity_interface::internet_identity::types::email_recovery::{
-    EmailRecoveryError, EmailRecoveryStatus,
+    error_code_name, EmailRecoveryDiagnostics, EmailRecoveryError, EmailRecoveryStatus,
+    VerificationPath,
 };
 use internet_identity_interface::internet_identity::types::{AnchorNumber, SessionKey, Timestamp};
 use std::cell::RefCell;
@@ -82,6 +83,14 @@ pub struct PendingChallenge {
     /// `email_recovery_get_delegation` can recover the seed without
     /// recomputing it. `None` on the setup path.
     pub recovery_outcome: Option<RecoveryOutcome>,
+    /// Gateway-supplied correlation id from the inbound `SmtpRequest`
+    /// (`SmtpRequest.message_id`), captured in `handle_smtp_request`
+    /// the first time an email bearing this nonce arrives. Surfaced
+    /// verbatim by `email_recovery_diagnostics` so a support ticket can
+    /// be lined up across the gateway and canister logs. Public,
+    /// non-sensitive; `None` until an email arrives (or if the gateway
+    /// omitted it).
+    pub message_id: Option<String>,
 }
 
 /// Cached output of a successful recovery flow. Used to answer
@@ -274,6 +283,55 @@ pub fn status_of(nonce: &str, now_secs: u64) -> EmailRecoveryStatus {
     })
 }
 
+/// Read public diagnostics for a pending challenge. Mirrors
+/// [`status_of`]'s lazy-expire-on-read semantics: an entry past its TTL
+/// is evicted and reported as `None`, and an unknown nonce is likewise
+/// `None` — the same observable collapse `status_of` makes to
+/// `Expired`, so this query is no more of an existence oracle than that
+/// one.
+///
+/// The returned record is **strictly public** (see
+/// [`EmailRecoveryDiagnostics`]): the gateway `message_id`, a coarse
+/// reason code (variant name only), the verification path, and the
+/// challenge creation time. No address, anchor, principal, or inner
+/// error string is ever included.
+pub fn diagnostics_of(nonce: &str, now_secs: u64) -> Option<EmailRecoveryDiagnostics> {
+    PENDING.with(|cell| {
+        let mut map = cell.borrow_mut();
+
+        // Lazy-expire on read, exactly like `status_of`, so a polled
+        // diagnostics read sees a timely eviction rather than stale state.
+        if let Some(challenge) = map.get(nonce) {
+            if is_expired_at(challenge, now_secs) {
+                map.remove(nonce);
+                return None;
+            }
+        }
+
+        let c = map.get(nonce)?;
+        let reason_code = match &c.status {
+            PendingStatus::Pending => "Pending".to_string(),
+            PendingStatus::NeedDkimLeaf { .. } => "NeedDkimLeaf".to_string(),
+            PendingStatus::Succeeded => "Succeeded".to_string(),
+            PendingStatus::Expired => "Expired".to_string(),
+            // Variant NAME only — never the inner payload. See
+            // `error_code_name` for why this stays strictly public.
+            PendingStatus::Failed(e) => format!("Failed:{}", error_code_name(e)),
+        };
+        Some(EmailRecoveryDiagnostics {
+            message_id: c.message_id.clone(),
+            reason_code,
+            verification_path: if c.cached_root_dnskey.is_some() {
+                VerificationPath::Dnssec
+            } else {
+                VerificationPath::Doh
+            },
+            // `created_at_secs` is Unix-seconds; `Timestamp` is ns.
+            created_at: c.created_at_secs.saturating_mul(1_000_000_000),
+        })
+    })
+}
+
 /// Look up a pending challenge by nonce, applying the TTL check, and
 /// run a closure against its mutable state. Returns `None` if the
 /// nonce is unknown or has just expired.
@@ -353,6 +411,7 @@ mod tests {
             partial_verification: None,
             status: PendingStatus::Pending,
             recovery_outcome: None,
+            message_id: None,
         }
     }
 
@@ -471,6 +530,63 @@ mod tests {
         let outcome = with_mut("n1", t + super::super::CHALLENGE_TTL_SECS, |_| ());
         assert!(outcome.is_none());
         // And the entry was evicted in the process.
+        assert_eq!(len_for_tests(), 0);
+    }
+
+    #[test]
+    fn diagnostics_of_unknown_nonce_returns_none() {
+        // Unknown and expired collapse to `None`, mirroring how
+        // `status_of` collapses both to `Expired` — no existence oracle.
+        reset_for_tests();
+        assert!(diagnostics_of("never-issued", 0).is_none());
+    }
+
+    #[test]
+    fn diagnostics_of_surfaces_message_id_reason_and_path() {
+        reset_for_tests();
+        insert_with_eviction("n1".into(), challenge("a@x.com", 100), 100);
+        // Simulate `handle_smtp_request`: capture the gateway id, then a
+        // verification failure flips the status to `Failed`.
+        with_mut("n1", 200, |c| {
+            c.message_id = Some("<gw-123@gateway.example>".into());
+            c.status = PendingStatus::Failed(EmailRecoveryError::AddressMismatch);
+        });
+        let d = diagnostics_of("n1", 200).expect("diagnostics present");
+        assert_eq!(d.message_id.as_deref(), Some("<gw-123@gateway.example>"));
+        assert_eq!(d.reason_code, "Failed:AddressMismatch");
+        // The test `challenge()` helper has no cached root DNSKEY → DoH.
+        assert_eq!(d.verification_path, VerificationPath::Doh);
+        // `created_at` is the challenge creation time, in ns.
+        assert_eq!(d.created_at, 100u64.saturating_mul(1_000_000_000));
+    }
+
+    #[test]
+    fn diagnostics_of_reason_code_is_variant_name_only() {
+        // A still-`Pending` challenge reports "Pending"; the failure code
+        // is the variant NAME only — never the inner payload (here a
+        // domain) — keeping the copyable blob strictly public.
+        reset_for_tests();
+        insert_with_eviction("n1".into(), challenge("a@x.com", 100), 100);
+        assert_eq!(diagnostics_of("n1", 200).unwrap().reason_code, "Pending");
+        with_mut("n1", 200, |c| {
+            c.status = PendingStatus::Failed(EmailRecoveryError::DomainNotAllowlisted(
+                "secret-domain.example".into(),
+            ));
+        });
+        let code = diagnostics_of("n1", 200).unwrap().reason_code;
+        assert_eq!(code, "Failed:DomainNotAllowlisted");
+        assert!(!code.contains("secret-domain"));
+    }
+
+    #[test]
+    fn diagnostics_of_expires_on_ttl() {
+        reset_for_tests();
+        let created_at = 1_000;
+        insert_with_eviction("n1".into(), challenge("a@x.com", created_at), created_at);
+        // Just under the TTL → present.
+        assert!(diagnostics_of("n1", created_at + super::super::CHALLENGE_TTL_SECS - 1).is_some());
+        // Right at the TTL → None, and the entry is evicted on read.
+        assert!(diagnostics_of("n1", created_at + super::super::CHALLENGE_TTL_SECS).is_none());
         assert_eq!(len_for_tests(), 0);
     }
 }

--- a/src/internet_identity/src/email_recovery/prepare.rs
+++ b/src/internet_identity/src/email_recovery/prepare.rs
@@ -176,6 +176,9 @@ async fn prepare_common(
         partial_verification: None,
         status: PendingStatus::Pending,
         recovery_outcome: None,
+        // Populated later, in `handle_smtp_request`, once an email
+        // bearing this nonce arrives carrying a gateway correlation id.
+        message_id: None,
     };
     insert_with_eviction(nonce.clone(), challenge, now_secs);
 

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -259,6 +259,21 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
     // and the global eviction sweep on the next `insert_with_eviction`
     // call cleans up any other expired entries.
     let snapshot = match pending::with_mut(&nonce, now_secs, |c| {
+        // Retain the gateway-supplied correlation id on the user's own
+        // (nonce-keyed) entry as early as possible — before the
+        // recipient/kind dispatch below — so `email_recovery_diagnostics`
+        // can surface it even in silent-drop cases where the entry exists
+        // but we don't process the email (e.g. a recipient/kind mismatch
+        // leaves `status` at `Pending`, still retryable). Guarded to
+        // non-terminal status so a stray gateway redelivery can't clobber
+        // the id of the decisive message. Length already bounded by
+        // `validate_smtp_request` at the top of this fn.
+        if matches!(
+            c.status,
+            PendingStatus::Pending | PendingStatus::NeedDkimLeaf { .. }
+        ) {
+            c.message_id = request.message_id.clone();
+        }
         let kind = match (&c.kind, recipient_flow) {
             (PendingKind::Register { anchor }, RecipientFlow::Setup) => {
                 SnapshotKind::Setup { anchor: *anchor }

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -263,15 +263,15 @@ pub async fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
         // (nonce-keyed) entry as early as possible — before the
         // recipient/kind dispatch below — so `email_recovery_diagnostics`
         // can surface it even in silent-drop cases where the entry exists
-        // but we don't process the email (e.g. a recipient/kind mismatch
-        // leaves `status` at `Pending`, still retryable). Guarded to
-        // non-terminal status so a stray gateway redelivery can't clobber
-        // the id of the decisive message. Length already bounded by
-        // `validate_smtp_request` at the top of this fn.
-        if matches!(
-            c.status,
-            PendingStatus::Pending | PendingStatus::NeedDkimLeaf { .. }
-        ) {
+        // but we don't process the email (e.g. a recipient/kind mismatch).
+        //
+        // First-writer-wins: only record an id if we haven't captured one
+        // yet, so a gateway redelivery — which can arrive after the DNSSEC
+        // path has flipped to `NeedDkimLeaf` — can't clobber the decisive
+        // email's id and surface a misleading one in diagnostics. A later
+        // delivery still fills it in when the first carried none. Length
+        // already bounded by `validate_smtp_request` at the top of this fn.
+        if c.message_id.is_none() {
             c.message_id = request.message_id.clone();
         }
         let kind = match (&c.kind, recipient_flow) {

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1442,8 +1442,9 @@ mod email_recovery_api {
     use ic_canister_sig_creation::signature_map::CanisterSigInputs;
     use ic_canister_sig_creation::DELEGATION_SIG_DOMAIN;
     use internet_identity_interface::internet_identity::types::email_recovery::{
-        EmailRecoveryChallenge, EmailRecoveryDnsInput, EmailRecoveryError,
-        EmailRecoveryGetDelegationArgs, EmailRecoveryStatus, EmailRecoverySubmitDkimLeafArg,
+        EmailRecoveryChallenge, EmailRecoveryDiagnostics, EmailRecoveryDnsInput,
+        EmailRecoveryError, EmailRecoveryGetDelegationArgs, EmailRecoveryStatus,
+        EmailRecoverySubmitDkimLeafArg,
     };
     use internet_identity_interface::internet_identity::types::SessionKey;
 
@@ -1559,6 +1560,28 @@ mod email_recovery_api {
     fn email_recovery_status(nonce: String) -> EmailRecoveryStatus {
         let now_secs = ic_cdk::api::time() / 1_000_000_000;
         email_recovery::pending_status(&nonce, now_secs)
+    }
+
+    /// Anonymous. Returns strictly-public, user-copyable diagnostics for
+    /// a pending challenge — the gateway `message_id`, a coarse reason
+    /// code, the verification path, and the challenge creation time — so
+    /// a user who hits a recovery-email failure can paste them into a
+    /// support ticket and let support line the case up across the SMTP
+    /// gateway and canister logs.
+    ///
+    /// Returns `None` for an unknown/expired nonce, the same observable
+    /// collapse `email_recovery_status` makes to `Expired`.
+    ///
+    /// **Security:** strictly non-sensitive — NO email address, anchor,
+    /// principal, delegation/seed, or inner error string (the
+    /// `reason_code` is the failing variant's name only). Readable only
+    /// by the holder of the 64-bit nonce, exactly like
+    /// `email_recovery_status`; it adds no pre-verification distinction a
+    /// prober could use as an existence/linkage oracle.
+    #[query]
+    fn email_recovery_diagnostics(nonce: String) -> Option<EmailRecoveryDiagnostics> {
+        let now_secs = ic_cdk::api::time() / 1_000_000_000;
+        email_recovery::pending_diagnostics(&nonce, now_secs)
     }
 
     /// Anonymous. Phase 2 of the DNSSEC path: once

--- a/src/internet_identity/tests/integration/email_recovery.rs
+++ b/src/internet_identity/tests/integration/email_recovery.rs
@@ -31,7 +31,7 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use canister_tests::{api::internet_identity as api, framework::*};
 use internet_identity_interface::internet_identity::types::email_recovery::{
-    EmailRecoveryDnsInput, EmailRecoveryError, EmailRecoveryStatus,
+    EmailRecoveryDnsInput, EmailRecoveryError, EmailRecoveryStatus, VerificationPath,
 };
 use internet_identity_interface::internet_identity::types::smtp::{
     SmtpAddress, SmtpEnvelope, SmtpHeader, SmtpMessage, SmtpRequest, SmtpResponse,
@@ -955,6 +955,131 @@ fn doh_path_dns_record_umbrella_rejects_testing_mode_key() {
         }
         other => panic!("expected Failed(EmailVerificationFailed(TestingMode…)), got {other:?}"),
     }
+}
+
+// ===================================================================
+// email_recovery_diagnostics — the gateway message_id reaches the FE.
+// ===================================================================
+
+/// Happy path: the gateway sets `message_id` on the inbound
+/// `SmtpRequest`; the canister retains it on the pending challenge and
+/// surfaces it (verbatim) via `email_recovery_diagnostics`, alongside a
+/// public reason code + verification path. Confirms the new query + the
+/// `canister_tests` API wrapper end-to-end.
+#[test]
+fn diagnostics_surface_message_id_from_smtp_request() {
+    let env = env();
+    let canister_id = setup_canister(&env);
+    let (id, p) = fresh_identity(&env, canister_id);
+
+    let challenge =
+        api::email_recovery_credential_prepare_add(&env, canister_id, p, id, dns_input())
+            .expect("prepare_add call failed")
+            .expect("prepare_add failed");
+
+    let signer = dkim_signer::TestSigner::new(TEST_DOMAIN, TEST_SELECTOR);
+    let now_secs = time(&env) / 1_000_000_000;
+    let mut signed = signer.sign_email(SignedEmailParams {
+        from: TEST_ADDRESS,
+        to: "register@id.ai",
+        subject: &challenge.nonce,
+        body: TEST_BODY,
+        timestamp: now_secs,
+    });
+    // The gateway attaches a per-message correlation id.
+    const GW_ID: &str = "<gw-test-id@gateway.example>";
+    signed.request.message_id = Some(GW_ID.into());
+
+    let dkim_txt = signer.public_txt_record();
+    let raw_msg_id = env
+        .submit_call_with_effective_principal(
+            canister_id,
+            pocket_ic::common::rest::RawEffectivePrincipal::None,
+            candid::Principal::anonymous(),
+            "smtp_request",
+            candid::encode_one(&signed.request).expect("encode SmtpRequest"),
+        )
+        .expect("submit_call");
+    fulfill_doh_outcalls(&env, &dkim_txt);
+    let raw = env
+        .await_call_no_ticks(raw_msg_id)
+        .expect("await_call_no_ticks");
+    let resp: SmtpResponse = candid::decode_one(&raw).expect("decode SmtpResponse");
+    assert!(matches!(resp, SmtpResponse::Ok {}));
+
+    let diag = api::email_recovery_diagnostics(&env, canister_id, &challenge.nonce)
+        .expect("diagnostics call failed")
+        .expect("diagnostics present for a live challenge");
+    assert_eq!(diag.message_id.as_deref(), Some(GW_ID));
+    assert_eq!(diag.reason_code, "Succeeded");
+    assert!(matches!(diag.verification_path, VerificationPath::Doh));
+}
+
+/// The core promise: a *verification failure* still retains the gateway
+/// `message_id` (the email reached the canister), so a user who reports
+/// "it didn't work" has a correlation id to hand to support. Uses the
+/// future-dated `t=` failure shape from the umbrella tests above.
+#[test]
+fn diagnostics_cover_the_failed_path_with_message_id() {
+    let env = env();
+    let canister_id = setup_canister(&env);
+    let (id, p) = fresh_identity(&env, canister_id);
+
+    let challenge =
+        api::email_recovery_credential_prepare_add(&env, canister_id, p, id, dns_input())
+            .expect("prepare_add call failed")
+            .expect("prepare_add failed");
+
+    let signer = dkim_signer::TestSigner::new(TEST_DOMAIN, TEST_SELECTOR);
+    let now_secs = time(&env) / 1_000_000_000;
+    let mut signed = signer.sign_email(SignedEmailParams {
+        from: TEST_ADDRESS,
+        to: "register@id.ai",
+        subject: &challenge.nonce,
+        body: TEST_BODY,
+        timestamp: now_secs + 10_000, // future-dated → verification fails
+    });
+    const GW_ID: &str = "<gw-failed-id@gateway.example>";
+    signed.request.message_id = Some(GW_ID.into());
+
+    let dkim_txt = signer.public_txt_record();
+    let raw_msg_id = env
+        .submit_call_with_effective_principal(
+            canister_id,
+            pocket_ic::common::rest::RawEffectivePrincipal::None,
+            candid::Principal::anonymous(),
+            "smtp_request",
+            candid::encode_one(&signed.request).expect("encode SmtpRequest"),
+        )
+        .expect("submit_call");
+    fulfill_doh_outcalls(&env, &dkim_txt);
+    let _ = env
+        .await_call_no_ticks(raw_msg_id)
+        .expect("await_call_no_ticks");
+
+    let status = api::email_recovery_status(&env, canister_id, &challenge.nonce)
+        .expect("status call failed");
+    assert!(
+        matches!(status, EmailRecoveryStatus::Failed(_)),
+        "expected Failed, got {status:?}",
+    );
+
+    let diag = api::email_recovery_diagnostics(&env, canister_id, &challenge.nonce)
+        .expect("diagnostics call failed")
+        .expect("diagnostics present for a failed challenge");
+    assert_eq!(diag.message_id.as_deref(), Some(GW_ID));
+    assert_eq!(diag.reason_code, "Failed:EmailVerificationFailed");
+}
+
+/// An unknown/expired nonce yields `None`, mirroring how
+/// `email_recovery_status` collapses both to `Expired` — no oracle.
+#[test]
+fn diagnostics_returns_none_for_unknown_nonce() {
+    let env = env();
+    let canister_id = setup_canister(&env);
+    let diag = api::email_recovery_diagnostics(&env, canister_id, "II-Recovery-deadbeefcafe1234")
+        .expect("diagnostics call failed");
+    assert!(diag.is_none());
 }
 
 /// Drive PocketIC forward until each of the 5 DoH provider outcalls

--- a/src/internet_identity_interface/src/internet_identity/types/email_recovery.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/email_recovery.rs
@@ -260,6 +260,36 @@ pub enum EmailRecoveryError {
     InternalCanisterError(String),
 }
 
+/// Stable, public reason code for an `EmailRecoveryError`: the variant
+/// **name** only, dropping every inner payload (`String` / `Principal`).
+///
+/// Used to build [`EmailRecoveryDiagnostics::reason_code`] for the
+/// user-copyable support blob. Returning the bare discriminant is what
+/// keeps that blob strictly public — variants like
+/// `EmailVerificationFailed(String)`, `InternalCanisterError(String)`,
+/// `DomainNotAllowlisted(String)` and `Unauthorized(Principal)` carry
+/// payloads (domains, principals, free-form internal detail) that must
+/// never leak into it. Mirrors the FE's existing `failureReason()`,
+/// which already treats the variant name as the stable reason.
+pub fn error_code_name(error: &EmailRecoveryError) -> &'static str {
+    match error {
+        EmailRecoveryError::Unauthorized(_) => "Unauthorized",
+        EmailRecoveryError::NonceUnknown => "NonceUnknown",
+        EmailRecoveryError::NonceExpired => "NonceExpired",
+        EmailRecoveryError::DomainNotAllowlisted(_) => "DomainNotAllowlisted",
+        EmailRecoveryError::DohFetchFailed(_) => "DohFetchFailed",
+        EmailRecoveryError::DomainNotSupported(_) => "DomainNotSupported",
+        EmailRecoveryError::EmailVerificationFailed(_) => "EmailVerificationFailed",
+        EmailRecoveryError::DkimLeafMismatch => "DkimLeafMismatch",
+        EmailRecoveryError::NoDkimLeafExpected => "NoDkimLeafExpected",
+        EmailRecoveryError::AddressMismatch => "AddressMismatch",
+        EmailRecoveryError::SubjectNotSigned => "SubjectNotSigned",
+        EmailRecoveryError::AddressAlreadyRegistered => "AddressAlreadyRegistered",
+        EmailRecoveryError::AddressNotRegistered => "AddressNotRegistered",
+        EmailRecoveryError::InternalCanisterError(_) => "InternalCanisterError",
+    }
+}
+
 /// Polling result for a pending challenge. The FE polls
 /// `email_recovery_status(nonce)` at 1–5 s cadence until it sees a
 /// terminal variant — or sees `NeedDkimLeaf`, which is the trigger
@@ -299,6 +329,47 @@ pub enum EmailRecoveryStatus {
     Failed(EmailRecoveryError),
     /// 30-minute TTL elapsed without an email matching the nonce.
     Expired,
+}
+
+/// Which trust path the canister used (or will use) to verify the
+/// challenge email. Decided at prepare time: a supplied DNSSEC skeleton
+/// bundle → `Dnssec`; otherwise the DoH allowlist → `Doh`. Public — the
+/// FE already chose the branch and the deploy config is public, so
+/// surfacing it leaks nothing.
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq, Serialize)]
+pub enum VerificationPath {
+    Doh,
+    Dnssec,
+}
+
+/// Strictly-public, user-copyable diagnostics for one pending
+/// challenge, returned by `email_recovery_diagnostics(nonce)`.
+///
+/// Intended to be pasted into a support ticket so the case can be lined
+/// up against the SMTP gateway logs and the canister's production logs
+/// via `message_id`. Every field here is deliberately
+/// **non-sensitive**: there is NO email address, NO anchor number, NO
+/// principal, NO delegation/seed material, and NO inner error string —
+/// `reason_code` is the failing variant's *name* only (see
+/// [`error_code_name`]). Readable only by whoever holds the 64-bit
+/// nonce, exactly like `EmailRecoveryStatus`.
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq, Serialize)]
+pub struct EmailRecoveryDiagnostics {
+    /// The gateway-supplied `SmtpRequest.message_id`, verbatim. `None`
+    /// until an email bearing this nonce reaches the canister (or if
+    /// the gateway omitted it). This is the cross-log correlation id.
+    pub message_id: Option<String>,
+    /// Coarse, stable status/failure code: the current lifecycle state
+    /// (`"Pending"`, `"NeedDkimLeaf"`, `"Succeeded"`, `"Expired"`), or
+    /// for a failed challenge `"Failed:<Variant>"` (variant name only,
+    /// never a payload).
+    pub reason_code: String,
+    /// The trust path this challenge is on.
+    pub verification_path: VerificationPath,
+    /// Challenge creation time, nanoseconds since the Unix epoch
+    /// (matches this crate's `Timestamp` encoding). Bounds the incident
+    /// to the ~30-minute challenge window for log lookup.
+    pub created_at: Timestamp,
 }
 
 /// Argument shape for `email_recovery_get_delegation` — mirrors the


### PR DESCRIPTION
## What

Adds a way for users who hit an issue with the **Recovery Emails** feature to export a small, **strictly-public** diagnostics bundle — and crucially that bundle includes the newly-added gateway `SmtpRequest.message_id` (#3963).

- New **`email_recovery_diagnostics(nonce)` query** returning a curated public record:
  - `message_id : opt text` — the gateway-supplied correlation id, verbatim
  - `reason_code : text` — the lifecycle state, or `Failed:<Variant>` (variant **name** only)
  - `verification_path : variant { Doh; Dnssec }`
  - `created_at : Timestamp`
- The canister now **retains `message_id`** on the pending challenge (captured in `handle_smtp_request`).
- A **"Copy error details"** button on the shared `FailedView`, so both the setup (`SetupEmailRecoveryWizard`) and recovery (`RecoverWithEmailWizard`) flows can offer a copyable blob (canister record + FE build id) to paste into a support ticket.

## Why

`message_id` landed in #3963 as a wire-level-only field, explicitly so a reported case can be lined up across the SMTP gateway logs and the canister's production logs. But the canister dropped it after `smtp_request` and it never reached the FE, so a user hitting a failure had no correlation id to give support. This closes that loop.

## Design notes

**Strictly public / no PII.** The record carries **no** email address, anchor, principal, delegation/seed, or inner error string — `reason_code` comes from a new `error_code_name` helper that returns only the variant discriminant. It therefore cannot reveal "email X ↔ anchor Y". The query is anonymous + nonce-keyed like `email_recovery_status`, returns only the caller's own challenge, and collapses unknown/expired to `None` (same oracle protection as status→`Expired`). `smtp_request` still returns `SmtpResponse::Ok {}` unchanged — the gateway gets no new existence signal.

**Error-path coverage.** `message_id` is captured as early as the nonce-keyed entry exists (in the snapshot closure, before the recipient/kind dispatch), so it's retained even for the recipient/kind-mismatch silent-drop (entry stays `Pending`, still retryable), not just verification failures. The `Failed` cases (the bulk of reports) are fully covered since the entry is sticky; `Expired` is best-effort (the status poll lazy-evicts). Cases where the email never reaches the canister (or carries an unknown/typo'd nonce) inherently have no canister-side id — that half lives in the gateway logs.

## Files
- **Types/interface:** `internet_identity_interface/.../email_recovery.rs` (`VerificationPath`, `EmailRecoveryDiagnostics`, `error_code_name`)
- **Canister:** `email_recovery/{pending,smtp,prepare,mod}.rs`, `main.rs`, `internet_identity.did`
- **Bindings:** regenerated `internet_identity_types.d.ts` / `internet_identity_idl.js` (pinned `didc`)
- **Test API:** `canister_tests/.../internet_identity.rs`
- **Frontend:** both wizards, the shared `FailedView`, both route hosts, and a new `setupEmailRecovery/diagnostics.ts` blob builder

## Verification
- ✅ `cargo check` (canister + canister_tests + interface); `check_candid_interface_compatibility` (the `.did` ↔ Rust gate)
- ✅ `cargo test` email-recovery unit tests: 50 pass (46 existing + 4 new `diagnostics_of` tests)
- ✅ `npm run check` (0 errors), `eslint` + `prettier` clean on touched files, 3 new `vitest` cases for the blob builder
- ✅ Integration tests **written and compiling** (`tests/integration/email_recovery.rs`): happy-path capture, `Failed`-path coverage, unknown-nonce→`None`. They were **not executed locally** (no prebuilt wasm / PocketIC server / `ic-wasm` in this sandbox) — CI runs them.

🤖 Draft opened by Claude Code.

https://claude.ai/code/session_01TdEjz36PXqLSD7XeqrEE11

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdEjz36PXqLSD7XeqrEE11)_