### PR TITLE
feat(fe): configure frontend feature flags from canister deploy args; split EMAIL_RECOVERY into recovery + set-up flags

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_frontend_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_frontend_idl.js
@@ -17,6 +17,7 @@ export const idlFactory = ({ IDL }) => {
     'dev_csp' : IDL.Opt(IDL.Bool),
     'dummy_auth' : IDL.Opt(IDL.Opt(DummyAuthConfig)),
     'featured_dashboard_apps' : IDL.Opt(IDL.Vec(IDL.Text)),
+    'feature_flags' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Bool))),
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
@@ -55,6 +56,7 @@ export const init = ({ IDL }) => {
     'dev_csp' : IDL.Opt(IDL.Bool),
     'dummy_auth' : IDL.Opt(IDL.Opt(DummyAuthConfig)),
     'featured_dashboard_apps' : IDL.Opt(IDL.Vec(IDL.Text)),
+    'feature_flags' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Bool))),
   });
   return [InternetIdentityFrontendInit];
 };

--- a/src/frontend/src/lib/generated/internet_identity_frontend_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_frontend_idl.js
@@ -10,13 +10,13 @@ export const idlFactory = ({ IDL }) => {
   const DummyAuthConfig = IDL.Record({ 'prompt_for_index' : IDL.Bool });
   const InternetIdentityFrontendInit = IDL.Record({
     'fetch_root_key' : IDL.Opt(IDL.Bool),
+    'featured_dashboard_apps' : IDL.Opt(IDL.Vec(IDL.Text)),
     'backend_canister_id' : IDL.Principal,
     'analytics_config' : IDL.Opt(IDL.Opt(AnalyticsConfig)),
     'related_origins' : IDL.Opt(IDL.Vec(IDL.Text)),
     'backend_origin' : IDL.Text,
     'dev_csp' : IDL.Opt(IDL.Bool),
     'dummy_auth' : IDL.Opt(IDL.Opt(DummyAuthConfig)),
-    'featured_dashboard_apps' : IDL.Opt(IDL.Vec(IDL.Text)),
     'feature_flags' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Bool))),
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
@@ -49,13 +49,13 @@ export const init = ({ IDL }) => {
   const DummyAuthConfig = IDL.Record({ 'prompt_for_index' : IDL.Bool });
   const InternetIdentityFrontendInit = IDL.Record({
     'fetch_root_key' : IDL.Opt(IDL.Bool),
+    'featured_dashboard_apps' : IDL.Opt(IDL.Vec(IDL.Text)),
     'backend_canister_id' : IDL.Principal,
     'analytics_config' : IDL.Opt(IDL.Opt(AnalyticsConfig)),
     'related_origins' : IDL.Opt(IDL.Vec(IDL.Text)),
     'backend_origin' : IDL.Text,
     'dev_csp' : IDL.Opt(IDL.Bool),
     'dummy_auth' : IDL.Opt(IDL.Opt(DummyAuthConfig)),
-    'featured_dashboard_apps' : IDL.Opt(IDL.Vec(IDL.Text)),
     'feature_flags' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, IDL.Bool))),
   });
   return [InternetIdentityFrontendInit];

--- a/src/frontend/src/lib/generated/internet_identity_frontend_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_frontend_types.d.ts
@@ -40,6 +40,7 @@ export interface InternetIdentityFrontendInit {
   'dev_csp' : [] | [boolean],
   'dummy_auth' : [] | [[] | [DummyAuthConfig]],
   'featured_dashboard_apps' : [] | [Array<string>],
+  'feature_flags' : [] | [Array<[string, boolean]>],
 }
 export interface StreamingCallbackHttpResponse {
   'token' : [] | [Token],

--- a/src/frontend/src/lib/generated/internet_identity_frontend_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_frontend_types.d.ts
@@ -33,13 +33,23 @@ export interface HttpResponse {
 }
 export interface InternetIdentityFrontendInit {
   'fetch_root_key' : [] | [boolean],
+  /**
+   * Origins of apps to feature on the dashboard home. Each origin is resolved
+   * against the bundled dapps catalogue to render name, description and logo.
+   */
+  'featured_dashboard_apps' : [] | [Array<string>],
   'backend_canister_id' : Principal,
   'analytics_config' : [] | [[] | [AnalyticsConfig]],
   'related_origins' : [] | [Array<string>],
   'backend_origin' : string,
   'dev_csp' : [] | [boolean],
   'dummy_auth' : [] | [[] | [DummyAuthConfig]],
-  'featured_dashboard_apps' : [] | [Array<string>],
+  /**
+   * Frontend feature flag overrides keyed by flag name, e.g.
+   * record { "EMAIL_RECOVERY"; true }. Sets the deployment-level baseline for
+   * each flag; localStorage, the flag's init callback and ?feature_flag_* URL
+   * params still take precedence. Unknown flag names are ignored.
+   */
   'feature_flags' : [] | [Array<[string, boolean]>],
 }
 export interface StreamingCallbackHttpResponse {

--- a/src/frontend/src/lib/globals.ts
+++ b/src/frontend/src/lib/globals.ts
@@ -114,3 +114,8 @@ export const getPrimaryOrigin = () =>
   frontendCanisterConfig.related_origins[0]?.find((origin) =>
     origin.endsWith("id.ai"),
   );
+
+// Get the feature flag value configured via the canister deploy args, or
+// `undefined` when the operator didn't configure this flag.
+export const getConfiguredFeatureFlag = (name: string): boolean | undefined =>
+  frontendCanisterConfig.feature_flags[0]?.find(([key]) => key === name)?.[1];

--- a/src/frontend/src/lib/state/featureFlags.test.ts
+++ b/src/frontend/src/lib/state/featureFlags.test.ts
@@ -1,0 +1,62 @@
+import { get } from "svelte/store";
+import { beforeEach, expect, test, vi } from "vitest";
+
+const { mockGetConfiguredFeatureFlag, mockGetPrimaryOrigin } = vi.hoisted(
+  () => ({
+    mockGetConfiguredFeatureFlag:
+      vi.fn<(name: string) => boolean | undefined>(),
+    mockGetPrimaryOrigin: vi.fn<() => string | undefined>(() => undefined),
+  }),
+);
+
+vi.mock("$lib/globals", () => ({
+  getConfiguredFeatureFlag: mockGetConfiguredFeatureFlag,
+  getPrimaryOrigin: mockGetPrimaryOrigin,
+}));
+
+// Imported after the mock so the store factory picks up the mocked globals.
+const { DISCOVERABLE_PASSKEY_FLOW, MIN_GUIDED_UPGRADE } =
+  await import("$lib/state/featureFlags");
+
+beforeEach(() => {
+  window.localStorage.clear();
+  mockGetConfiguredFeatureFlag.mockReset();
+  mockGetConfiguredFeatureFlag.mockReturnValue(undefined);
+  // Clear any value left on the stores by a previous test.
+  MIN_GUIDED_UPGRADE.getFeatureFlag()?.reset();
+  DISCOVERABLE_PASSKEY_FLOW.getFeatureFlag()?.reset();
+});
+
+test("keeps the compile-time default when nothing is configured", () => {
+  MIN_GUIDED_UPGRADE.initialize();
+  expect(get(MIN_GUIDED_UPGRADE)).toEqual(false);
+
+  DISCOVERABLE_PASSKEY_FLOW.initialize();
+  expect(get(DISCOVERABLE_PASSKEY_FLOW)).toEqual(true);
+});
+
+test("canister deploy arg overrides the compile-time default", () => {
+  mockGetConfiguredFeatureFlag.mockImplementation((name) =>
+    name === "MIN_GUIDED_UPGRADE" ? true : undefined,
+  );
+  MIN_GUIDED_UPGRADE.initialize();
+  expect(get(MIN_GUIDED_UPGRADE)).toEqual(true);
+
+  mockGetConfiguredFeatureFlag.mockImplementation((name) =>
+    name === "DISCOVERABLE_PASSKEY_FLOW" ? false : undefined,
+  );
+  DISCOVERABLE_PASSKEY_FLOW.initialize();
+  expect(get(DISCOVERABLE_PASSKEY_FLOW)).toEqual(false);
+});
+
+test("localStorage takes precedence over the canister deploy arg", () => {
+  // Persist a user choice that disagrees with the configured value.
+  MIN_GUIDED_UPGRADE.getFeatureFlag()?.set(false);
+  mockGetConfiguredFeatureFlag.mockReturnValue(true);
+
+  MIN_GUIDED_UPGRADE.initialize();
+
+  expect(get(MIN_GUIDED_UPGRADE)).toEqual(false);
+  // The configured value isn't even consulted once a stored value exists.
+  expect(mockGetConfiguredFeatureFlag).not.toHaveBeenCalled();
+});

--- a/src/frontend/src/lib/state/featureFlags.test.ts
+++ b/src/frontend/src/lib/state/featureFlags.test.ts
@@ -1,5 +1,5 @@
 import { get } from "svelte/store";
-import { beforeEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 const { mockGetConfiguredFeatureFlag, mockGetPrimaryOrigin } = vi.hoisted(
   () => ({
@@ -15,8 +15,28 @@ vi.mock("$lib/globals", () => ({
 }));
 
 // Imported after the mock so the store factory picks up the mocked globals.
-const { DISCOVERABLE_PASSKEY_FLOW, MIN_GUIDED_UPGRADE } =
-  await import("$lib/state/featureFlags");
+const {
+  DISCOVERABLE_PASSKEY_FLOW,
+  MIN_GUIDED_UPGRADE,
+  EMAIL_RECOVERY,
+  EMAIL_RECOVERY_SETUP,
+} = await import("$lib/state/featureFlags");
+
+// `window.location` is read-only, so swap it for a writable stand-in we can
+// point at the host under test. Capture the original property descriptor (not
+// just the value) so `afterEach` can restore `location` exactly as it was,
+// rather than leaving a plain data property behind for the rest of the worker.
+const originalLocation = window.location;
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "location",
+);
+const setHostname = (hostname: string) => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...originalLocation, hostname },
+  });
+};
 
 beforeEach(() => {
   window.localStorage.clear();
@@ -25,6 +45,18 @@ beforeEach(() => {
   // Clear any value left on the stores by a previous test.
   MIN_GUIDED_UPGRADE.getFeatureFlag()?.reset();
   DISCOVERABLE_PASSKEY_FLOW.getFeatureFlag()?.reset();
+  EMAIL_RECOVERY.getFeatureFlag()?.reset();
+  EMAIL_RECOVERY_SETUP.getFeatureFlag()?.reset();
+});
+
+afterEach(() => {
+  if (originalLocationDescriptor !== undefined) {
+    Object.defineProperty(window, "location", originalLocationDescriptor);
+  } else {
+    // `location` was inherited rather than an own property — drop our override
+    // so lookups fall back to the prototype again.
+    delete (window as { location?: unknown }).location;
+  }
 });
 
 test("keeps the compile-time default when nothing is configured", () => {
@@ -59,4 +91,65 @@ test("localStorage takes precedence over the canister deploy arg", () => {
   expect(get(MIN_GUIDED_UPGRADE)).toEqual(false);
   // The configured value isn't even consulted once a stored value exists.
   expect(mockGetConfiguredFeatureFlag).not.toHaveBeenCalled();
+});
+
+test("email-recovery flags default on for id.ai and beta.id.ai", () => {
+  for (const hostname of ["id.ai", "beta.id.ai"]) {
+    setHostname(hostname);
+    EMAIL_RECOVERY.getFeatureFlag()?.reset();
+    EMAIL_RECOVERY_SETUP.getFeatureFlag()?.reset();
+
+    EMAIL_RECOVERY.initialize();
+    EMAIL_RECOVERY_SETUP.initialize();
+
+    expect(get(EMAIL_RECOVERY), hostname).toEqual(true);
+    expect(get(EMAIL_RECOVERY_SETUP), hostname).toEqual(true);
+  }
+});
+
+test("email-recovery flags stay off on other domains when unconfigured", () => {
+  setHostname("example.com");
+
+  EMAIL_RECOVERY.initialize();
+  EMAIL_RECOVERY_SETUP.initialize();
+
+  expect(get(EMAIL_RECOVERY)).toEqual(false);
+  expect(get(EMAIL_RECOVERY_SETUP)).toEqual(false);
+});
+
+test("configured false keeps email-recovery flags off even on id.ai", () => {
+  setHostname("id.ai");
+  mockGetConfiguredFeatureFlag.mockReturnValue(false);
+
+  EMAIL_RECOVERY.initialize();
+  EMAIL_RECOVERY_SETUP.initialize();
+
+  expect(get(EMAIL_RECOVERY)).toEqual(false);
+  expect(get(EMAIL_RECOVERY_SETUP)).toEqual(false);
+});
+
+test("configured true turns email-recovery flags on off-domain", () => {
+  setHostname("example.com");
+  mockGetConfiguredFeatureFlag.mockReturnValue(true);
+
+  EMAIL_RECOVERY.initialize();
+  EMAIL_RECOVERY_SETUP.initialize();
+
+  expect(get(EMAIL_RECOVERY)).toEqual(true);
+  expect(get(EMAIL_RECOVERY_SETUP)).toEqual(true);
+});
+
+test("the two email-recovery flags resolve independently from config", () => {
+  setHostname("example.com");
+  mockGetConfiguredFeatureFlag.mockImplementation((name) =>
+    name === "EMAIL_RECOVERY_SETUP" ? true : undefined,
+  );
+
+  EMAIL_RECOVERY.initialize();
+  EMAIL_RECOVERY_SETUP.initialize();
+
+  // Only the set-up flag is configured on; the recovery flow flag stays at its
+  // off-domain default.
+  expect(get(EMAIL_RECOVERY)).toEqual(false);
+  expect(get(EMAIL_RECOVERY_SETUP)).toEqual(true);
 });

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -1,6 +1,6 @@
 import { writable, type Writable } from "svelte/store";
 import { FeatureFlag } from "$lib/utils/featureFlags";
-import { getPrimaryOrigin } from "$lib/globals";
+import { getConfiguredFeatureFlag, getPrimaryOrigin } from "$lib/globals";
 
 declare global {
   interface Window {
@@ -52,10 +52,21 @@ const createFeatureFlagStore = (
     return initializedFeatureFlag;
   };
   const initialize = (): void => {
-    // Call init callback if not already set
-    if (initCallback !== undefined && !initializedFeatureFlag.isSet()) {
-      initCallback?.(initializedFeatureFlag);
+    // A value persisted in localStorage (from the browser console or a
+    // `?feature_flag_*` URL param) always wins — leave it untouched.
+    if (initializedFeatureFlag.isSet()) {
+      return;
     }
+    // Apply the deployment-level baseline from the canister deploy args, when
+    // the operator configured this flag. Uses `temporaryOverride` so the value
+    // is re-derived on every load and never persisted to localStorage.
+    const configuredValue = getConfiguredFeatureFlag(name);
+    if (configuredValue !== undefined) {
+      initializedFeatureFlag.temporaryOverride(configuredValue);
+    }
+    // Let the flag's init callback layer host-based logic on top of the
+    // resolved baseline (callbacks read the current value via `isEnabled()`).
+    initCallback?.(initializedFeatureFlag);
   };
 
   return {

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -118,20 +118,38 @@ export const MIN_GUIDED_UPGRADE = createFeatureFlagStore(
   false,
 );
 
-/// Email-based recovery method (design doc §8). Default `false`
-/// everywhere except `beta.id.ai`, where the init callback flips it
-/// on so internal beta testers can exercise the wizard without
-/// reaching for the browser console. Same override path as
-/// `GUIDED_UPGRADE` above — we use `temporaryOverride` so a manual
-/// `set()` from the console takes precedence on any host.
+// Init callback shared by the email-recovery flags. Defaults the flag on for
+// the production and beta domains (`id.ai`, `beta.id.ai`) and leaves it off
+// everywhere else, but an explicit canister-config value always wins: when the
+// operator configured the flag, a `false` stays off on every domain and a
+// `true` stays on. We use `temporaryOverride` so the value is re-derived on
+// every load and a manual `set()` from the console still takes precedence.
+const enableOnIdAiDomains =
+  (name: string) =>
+  (featureFlag: FeatureFlag): void => {
+    if (getConfiguredFeatureFlag(name) !== undefined) {
+      return;
+    }
+    const { hostname } = window.location;
+    if (hostname === "id.ai" || hostname === "beta.id.ai") {
+      featureFlag.temporaryOverride(true);
+    }
+  };
+
+/// Recover an identity with a previously bound recovery email (the
+/// recover-with-email flow on the `/recovery` sign-in page).
 export const EMAIL_RECOVERY = createFeatureFlagStore(
   "EMAIL_RECOVERY",
   false,
-  (featureFlag) => {
-    if (window.location.hostname === "beta.id.ai") {
-      featureFlag.temporaryOverride(true);
-    }
-  },
+  enableOnIdAiDomains("EMAIL_RECOVERY"),
+);
+
+/// Set up, replace or remove a recovery email on an identity (the recovery
+/// email card in the manage area and the dashboard's set-up smart-action).
+export const EMAIL_RECOVERY_SETUP = createFeatureFlagStore(
+  "EMAIL_RECOVERY_SETUP",
+  false,
+  enableOnIdAiDomains("EMAIL_RECOVERY_SETUP"),
 );
 
 export default {
@@ -142,4 +160,5 @@ export default {
   GUIDED_UPGRADE,
   MIN_GUIDED_UPGRADE,
   EMAIL_RECOVERY,
+  EMAIL_RECOVERY_SETUP,
 } as Record<string, FeatureFlagStore>;

--- a/src/frontend/src/lib/utils/featureFlags/index.test.ts
+++ b/src/frontend/src/lib/utils/featureFlags/index.test.ts
@@ -78,3 +78,31 @@ test("feature flag to be reset", () => {
   expect(storage.getItem("a")).toEqual(null);
   expect(storage.getItem("b")).toEqual(null);
 });
+
+test("temporary override changes value without persisting", () => {
+  const storage = new MockStorage();
+  const aStore = writable(false);
+
+  const flag = new FeatureFlag(storage, "a", false, aStore);
+
+  flag.temporaryOverride(true);
+
+  expect(flag.isEnabled()).toEqual(true);
+  // Not persisted, so storage stays empty and `isSet` keeps reporting false.
+  expect(flag.isSet()).toEqual(false);
+  expect(storage.getItem("a")).toEqual(null);
+});
+
+test("set persists over a previous temporary override", () => {
+  const storage = new MockStorage();
+  const aStore = writable(false);
+
+  const flag = new FeatureFlag(storage, "a", false, aStore);
+
+  flag.temporaryOverride(true);
+  flag.set(false);
+
+  expect(flag.isEnabled()).toEqual(false);
+  expect(flag.isSet()).toEqual(true);
+  expect(storage.getItem("a")).toEqual("false");
+});

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/+page.svelte
@@ -17,7 +17,7 @@
     type KnownDapp,
   } from "$lib/legacy/flows/dappsExplorer/dapps";
   import { deriveSmartActions, type SmartActionId } from "./smartActions";
-  import { EMAIL_RECOVERY } from "$lib/state/featureFlags";
+  import { EMAIL_RECOVERY_SETUP } from "$lib/state/featureFlags";
 
   const { data }: PageProps = $props();
 
@@ -27,7 +27,7 @@
 
   const smartActions = $derived(
     deriveSmartActions(data.identityInfo, {
-      emailRecoveryEnabled: $EMAIL_RECOVERY,
+      emailRecoveryEnabled: $EMAIL_RECOVERY_SETUP,
     }),
   );
 

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
@@ -28,7 +28,7 @@
   import RemoveEmailRecovery from "./components/RemoveEmailRecovery.svelte";
   import { SetupEmailRecoveryWizard } from "$lib/components/wizards/setupEmailRecovery";
   import type { EmailRecoveryDnsInput } from "$lib/generated/internet_identity_types";
-  import { EMAIL_RECOVERY } from "$lib/state/featureFlags";
+  import { EMAIL_RECOVERY_SETUP } from "$lib/state/featureFlags";
   import { recoveryAuthnMethodData } from "$lib/utils/authnMethodData";
   import {
     fromMnemonicWithoutValidation,
@@ -355,13 +355,13 @@
 
   // Trigger email recovery wizard (set up or replace, depending on
   // whether an email is already bound). Used by the home dashboard's
-  // smart-action strip when EMAIL_RECOVERY is enabled.
+  // smart-action strip when EMAIL_RECOVERY_SETUP is enabled.
   afterNavigate(() => {
     if (!("email" in page.state)) {
       return;
     }
     replaceState("", {});
-    if ($EMAIL_RECOVERY) {
+    if ($EMAIL_RECOVERY_SETUP) {
       showEmailRecoverySetup = true;
     }
   });
@@ -403,10 +403,10 @@
     />
   {/if}
 
-  <!-- Recovery email card. Gated by the EMAIL_RECOVERY feature
-       flag (default false; auto-enabled on beta.id.ai by the
+  <!-- Recovery email card. Gated by the EMAIL_RECOVERY_SETUP feature
+       flag (default false; auto-enabled on id.ai and beta.id.ai by the
        flag's init callback). -->
-  {#if $EMAIL_RECOVERY}
+  {#if $EMAIL_RECOVERY_SETUP}
     {#if emailRecovery !== undefined}
       <ActiveEmailRecovery
         credential={emailRecovery}
@@ -421,7 +421,7 @@
   {/if}
 </div>
 
-{#if !$EMAIL_RECOVERY}
+{#if !$EMAIL_RECOVERY_SETUP}
   <section>
     <h2 class="text-text-primary mt-10 text-lg font-semibold">
       {$t`How to stay secure`}

--- a/src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts
@@ -57,30 +57,36 @@ function makeFromAddress(): string {
 }
 
 /**
- * Inject `localStorage` overrides for the email-recovery feature
- * flag before the page's JS runs. The runtime flag store at
- * `lib/state/featureFlags.ts` reads from this key on init, so this
- * is enough to flip the flag without faking the page hostname.
+ * Force the email-recovery feature off via `localStorage` before the
+ * page's JS runs.
+ *
+ * The feature is gated by two flags: `EMAIL_RECOVERY` (the
+ * recover-with-email flow) and `EMAIL_RECOVERY_SETUP` (the set-up /
+ * management surface). Both default *on* for `id.ai`, which the e2e
+ * suite runs against (`II_URL`), so there's nothing to do to enable
+ * them. To exercise the off-path we persist `false` for both keys,
+ * which beats the domain default in `featureFlags.ts`.
  *
  * The corresponding key shape is the runtime constant
  * `LOCALSTORAGE_FEATURE_FLAGS_PREFIX + name` from `featureFlags.ts`.
- * We hardcode the literal here on purpose — if the runtime prefix
+ * We hardcode the literals here on purpose — if the runtime prefix
  * changes we want the test to fail loudly.
  */
-async function setEmailRecoveryFlag(page: Page, on: boolean) {
-  await page.addInitScript(
-    ({ value }) => {
-      try {
-        window.localStorage.setItem(
-          "ii-localstorage-feature-flags__EMAIL_RECOVERY",
-          JSON.stringify(value),
-        );
-      } catch {
-        // localStorage may be locked in some test contexts.
-      }
-    },
-    { value: on },
-  );
+async function disableEmailRecoveryFlags(page: Page) {
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem(
+        "ii-localstorage-feature-flags__EMAIL_RECOVERY",
+        JSON.stringify(false),
+      );
+      window.localStorage.setItem(
+        "ii-localstorage-feature-flags__EMAIL_RECOVERY_SETUP",
+        JSON.stringify(false),
+      );
+    } catch {
+      // localStorage may be locked in some test contexts.
+    }
+  });
 }
 
 class EmailRecoveryWizard {
@@ -191,12 +197,10 @@ class EmailRecoveryFixtures {
   // Flag + card surface — used by every email-recovery test
   // ---------------------------------------------------------------
 
-  async enableFlag(): Promise<void> {
-    await setEmailRecoveryFlag(this.#page, true);
-  }
-
+  // The flags default on for `id.ai` (the suite's `II_URL`), so the
+  // "on" tests need no setup. Only the off-path is forced explicitly.
   async disableFlag(): Promise<void> {
-    await setEmailRecoveryFlag(this.#page, false);
+    await disableEmailRecoveryFlags(this.#page);
   }
 
   async assertSetupCardVisible(): Promise<void> {

--- a/src/frontend/tests/e2e-playwright/fixtures/manageRecoveryPage.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/manageRecoveryPage.ts
@@ -161,9 +161,12 @@ class ManageRecoveryPage {
   async activate<T>(
     fn: (wizard: CreateRecoveryPhraseWizard) => Promise<T>,
   ): Promise<T> {
+    // Target the phrase card's button by its full aria-label: the recovery
+    // email card (shown when EMAIL_RECOVERY_SETUP is on, e.g. on id.ai) renders
+    // its own "Activate" button, so a bare "Activate" match is ambiguous.
     await this.#page
       .getByRole("main")
-      .getByRole("button", { name: "Activate" })
+      .getByRole("button", { name: "Activate recovery phrase" })
       .click();
     return this.#withWizard(fn);
   }

--- a/src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts
@@ -60,7 +60,6 @@ test.describe("Email recovery — wizard surface", () => {
     signInWithIdentity,
     identities,
   }) => {
-    await emailRecovery.enableFlag();
     await manageRecoveryPage.goto();
     await signInWithIdentity(page, identities[0].identityNumber);
     await emailRecovery.assertSetupCardVisible();
@@ -83,9 +82,7 @@ test.describe("Email recovery — wizard surface", () => {
 
   test("recover sign-in shows the email button and opens the wizard", async ({
     page,
-    emailRecovery,
   }) => {
-    await emailRecovery.enableFlag();
     await page.goto(II_URL + "/recovery");
     await expect(
       page.getByRole("button", { name: "Recover with email" }),
@@ -112,7 +109,6 @@ test.describe("Email recovery — real DNSSEC + DKIM flow", () => {
   }) => {
     test.slow(); // RSA keygen + DNSSEC walk + status polling
 
-    await emailRecovery.enableFlag();
     await emailRecovery.installDohInterceptor();
 
     // ---------------------------------------------------------------

--- a/src/internet_identity_frontend/internet_identity_frontend.did
+++ b/src/internet_identity_frontend/internet_identity_frontend.did
@@ -58,6 +58,11 @@ type InternetIdentityFrontendInit = record {
     // Origins of apps to feature on the dashboard home. Each origin is resolved
     // against the bundled dapps catalogue to render name, description and logo.
     featured_dashboard_apps : opt vec text;
+    // Frontend feature flag overrides keyed by flag name, e.g.
+    // record { "EMAIL_RECOVERY"; true }. Sets the deployment-level baseline for
+    // each flag; localStorage, the flag's init callback and ?feature_flag_* URL
+    // params still take precedence. Unknown flag names are ignored.
+    feature_flags : opt vec record { text; bool };
 };
 
 service : (InternetIdentityFrontendInit) -> {

--- a/src/internet_identity_frontend/tests/integration/http.rs
+++ b/src/internet_identity_frontend/tests/integration/http.rs
@@ -62,6 +62,7 @@ fn default_frontend_args() -> InternetIdentityFrontendArgs {
         dummy_auth: None,
         dev_csp: None,
         featured_dashboard_apps: None,
+        feature_flags: None,
     }
 }
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -237,6 +237,12 @@ pub struct InternetIdentityFrontendArgs {
     /// against the bundled dapps catalogue (`dapps.json`) at runtime to obtain
     /// the name, description and logo. Unknown origins are skipped.
     pub featured_dashboard_apps: Option<Vec<String>>,
+    /// Frontend feature flag overrides keyed by flag name (e.g.
+    /// `("EMAIL_RECOVERY", true)`). Each entry sets the deployment-level
+    /// baseline for that flag; the frontend still lets `localStorage`, a flag's
+    /// own init callback, and `?feature_flag_*` URL params take precedence.
+    /// Names that don't match a known frontend flag are ignored by the frontend.
+    pub feature_flags: Option<Vec<(String, bool)>>,
 }
 
 /// Config fields that are synchronized between the frontend and backend.


### PR DESCRIPTION
This PR now contains the work from two stacked PRs: the original canister-deploy-arg feature-flag plumbing, and the `EMAIL_RECOVERY` flag split from #3974 (merged into this branch).

---

## Part 1 — Configure frontend feature flags from canister deploy args

Frontend feature flags can currently only be flipped per-browser (localStorage via the console, or a `?feature_flag_*` URL param) or by changing a compile-time default. There is no way for an operator to set a flag's baseline for a deployment (e.g. enable `EMAIL_RECOVERY` on a specific environment) without a code change and release. This adds that, reusing the existing init-arg channel that already carries config from the frontend canister to the browser (the same path `getPrimaryOrigin` uses).

### Changes
- Add `feature_flags : opt vec record { text; bool }` to `InternetIdentityFrontendArgs` and `internet_identity_frontend.did`, with a full `npm run generate` regen of the frontend bindings (the pinned didc also pulls in pre-existing field reordering and the `featured_dashboard_apps` doc comment that the committed bindings were missing).
- `globals.ts`: add `getConfiguredFeatureFlag(name)` reading the decoded init arg.
- `featureFlags.ts`: in each flag's `initialize()`, apply the configured value as the baseline via `temporaryOverride` (non-persistent) before running the flag's init callback. A persisted localStorage value short-circuits this, so user/console/URL choices still win. Unknown flag names in the deploy arg are ignored.

Resolution order (low → high): compile-time default → canister deploy arg → localStorage → init callback → URL param.

Example deploy arg:
```
feature_flags = opt vec {
  record { "EMAIL_RECOVERY"; true };
  record { "DISCOVERABLE_PASSKEY_FLOW"; false };
};
```

### Tests
- `featureFlags/index.test.ts`: `temporaryOverride` changes the value without persisting, and a later `set` persists over it.
- `state/featureFlags.test.ts` (new): resolution order — default held when unconfigured, canister arg overrides the default, localStorage takes precedence over the canister arg.
- Existing `check_candid_interface_compatibility` passes (`.did` matches the Rust type).

---

## Part 2 — Split `EMAIL_RECOVERY` into recovery and set-up flags (was #3974)

Splits the single `EMAIL_RECOVERY` feature flag into two independent flags so the recover-with-email flow and the recovery-email set-up surface can be gated separately:

- `EMAIL_RECOVERY` — recover an identity with a bound recovery email (the recover-with-email button on the `/recovery` sign-in page).
- `EMAIL_RECOVERY_SETUP` — set up, replace or remove a recovery email (the recovery email card in the manage area and the dashboard set-up smart-action).

### Resolution
Both flags resolve identically, via the shared `enableOnIdAiDomains` init callback:
- **on** for `id.ai` and `beta.id.ai`,
- **off** on every other domain,
- but an explicit canister-config value (Part 1) always wins — a configured `false` keeps the flag off on every domain, and a configured `true` turns it on regardless of domain.

The callback returns early when the operator configured the flag, so the domain default never overrides an explicit `false`. localStorage / `?feature_flag_*` overrides still take precedence as before. Note this widens the previous beta-only auto-enable (`beta.id.ai`) to also include `id.ai`.

### Changes
- `featureFlags.ts`: add the `EMAIL_RECOVERY_SETUP` store and the shared `enableOnIdAiDomains(name)` init callback; register both flags in the exported map.
- `manage/(authenticated)/recovery/+page.svelte` and `manage/(authenticated)/(home)/+page.svelte`: gate the set-up card, set-up wizard trigger, and dashboard smart-action with `EMAIL_RECOVERY_SETUP`; the `/recovery` flow stays on `EMAIL_RECOVERY`.

### Tests
- `state/featureFlags.test.ts`: domain defaults (`id.ai`/`beta.id.ai` on, other domains off), configured-`false`-wins-on-`id.ai`, configured-`true`-on-off-domain, and independent resolution of the two flags. The test captures and restores the original `window.location` property descriptor so the override doesn't leak across the Vitest worker.
- e2e: the suite runs against `https://id.ai`, where both flags default on, so the wizard/flow tests rely on the domain default (the fixture's `enableFlag` helper was removed); the off-path fixture writes `false` to both localStorage keys. The shared `ManageRecoveryPage.activate()` helper now targets the phrase button by its full aria-label (`Activate recovery phrase`) so it isn't ambiguous now that the recovery-email card renders on `id.ai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
