### PR TITLE
feat(fe): split EMAIL_RECOVERY flag into recovery and set-up flags

### DIFF
--- a/src/frontend/src/lib/state/featureFlags.test.ts
+++ b/src/frontend/src/lib/state/featureFlags.test.ts
@@ -1,5 +1,5 @@
 import { get } from "svelte/store";
-import { beforeEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 const { mockGetConfiguredFeatureFlag, mockGetPrimaryOrigin } = vi.hoisted(
   () => ({
@@ -15,8 +15,22 @@ vi.mock("$lib/globals", () => ({
 }));
 
 // Imported after the mock so the store factory picks up the mocked globals.
-const { DISCOVERABLE_PASSKEY_FLOW, MIN_GUIDED_UPGRADE } =
-  await import("$lib/state/featureFlags");
+const {
+  DISCOVERABLE_PASSKEY_FLOW,
+  MIN_GUIDED_UPGRADE,
+  EMAIL_RECOVERY,
+  EMAIL_RECOVERY_SETUP,
+} = await import("$lib/state/featureFlags");
+
+// `window.location` is read-only, so swap it for a writable stand-in we can
+// point at the host under test. Restored in `afterEach`.
+const originalLocation = window.location;
+const setHostname = (hostname: string) => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...originalLocation, hostname },
+  });
+};
 
 beforeEach(() => {
   window.localStorage.clear();
@@ -25,6 +39,15 @@ beforeEach(() => {
   // Clear any value left on the stores by a previous test.
   MIN_GUIDED_UPGRADE.getFeatureFlag()?.reset();
   DISCOVERABLE_PASSKEY_FLOW.getFeatureFlag()?.reset();
+  EMAIL_RECOVERY.getFeatureFlag()?.reset();
+  EMAIL_RECOVERY_SETUP.getFeatureFlag()?.reset();
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
 });
 
 test("keeps the compile-time default when nothing is configured", () => {
@@ -59,4 +82,65 @@ test("localStorage takes precedence over the canister deploy arg", () => {
   expect(get(MIN_GUIDED_UPGRADE)).toEqual(false);
   // The configured value isn't even consulted once a stored value exists.
   expect(mockGetConfiguredFeatureFlag).not.toHaveBeenCalled();
+});
+
+test("email-recovery flags default on for id.ai and beta.id.ai", () => {
+  for (const hostname of ["id.ai", "beta.id.ai"]) {
+    setHostname(hostname);
+    EMAIL_RECOVERY.getFeatureFlag()?.reset();
+    EMAIL_RECOVERY_SETUP.getFeatureFlag()?.reset();
+
+    EMAIL_RECOVERY.initialize();
+    EMAIL_RECOVERY_SETUP.initialize();
+
+    expect(get(EMAIL_RECOVERY), hostname).toEqual(true);
+    expect(get(EMAIL_RECOVERY_SETUP), hostname).toEqual(true);
+  }
+});
+
+test("email-recovery flags stay off on other domains when unconfigured", () => {
+  setHostname("example.com");
+
+  EMAIL_RECOVERY.initialize();
+  EMAIL_RECOVERY_SETUP.initialize();
+
+  expect(get(EMAIL_RECOVERY)).toEqual(false);
+  expect(get(EMAIL_RECOVERY_SETUP)).toEqual(false);
+});
+
+test("configured false keeps email-recovery flags off even on id.ai", () => {
+  setHostname("id.ai");
+  mockGetConfiguredFeatureFlag.mockReturnValue(false);
+
+  EMAIL_RECOVERY.initialize();
+  EMAIL_RECOVERY_SETUP.initialize();
+
+  expect(get(EMAIL_RECOVERY)).toEqual(false);
+  expect(get(EMAIL_RECOVERY_SETUP)).toEqual(false);
+});
+
+test("configured true turns email-recovery flags on off-domain", () => {
+  setHostname("example.com");
+  mockGetConfiguredFeatureFlag.mockReturnValue(true);
+
+  EMAIL_RECOVERY.initialize();
+  EMAIL_RECOVERY_SETUP.initialize();
+
+  expect(get(EMAIL_RECOVERY)).toEqual(true);
+  expect(get(EMAIL_RECOVERY_SETUP)).toEqual(true);
+});
+
+test("the two email-recovery flags resolve independently from config", () => {
+  setHostname("example.com");
+  mockGetConfiguredFeatureFlag.mockImplementation((name) =>
+    name === "EMAIL_RECOVERY_SETUP" ? true : undefined,
+  );
+
+  EMAIL_RECOVERY.initialize();
+  EMAIL_RECOVERY_SETUP.initialize();
+
+  // Only the set-up flag is configured on; the recovery flow flag stays at its
+  // off-domain default.
+  expect(get(EMAIL_RECOVERY)).toEqual(false);
+  expect(get(EMAIL_RECOVERY_SETUP)).toEqual(true);
 });

--- a/src/frontend/src/lib/state/featureFlags.test.ts
+++ b/src/frontend/src/lib/state/featureFlags.test.ts
@@ -23,8 +23,14 @@ const {
 } = await import("$lib/state/featureFlags");
 
 // `window.location` is read-only, so swap it for a writable stand-in we can
-// point at the host under test. Restored in `afterEach`.
+// point at the host under test. Capture the original property descriptor (not
+// just the value) so `afterEach` can restore `location` exactly as it was,
+// rather than leaving a plain data property behind for the rest of the worker.
 const originalLocation = window.location;
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "location",
+);
 const setHostname = (hostname: string) => {
   Object.defineProperty(window, "location", {
     configurable: true,
@@ -44,10 +50,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  Object.defineProperty(window, "location", {
-    configurable: true,
-    value: originalLocation,
-  });
+  if (originalLocationDescriptor !== undefined) {
+    Object.defineProperty(window, "location", originalLocationDescriptor);
+  } else {
+    // `location` was inherited rather than an own property — drop our override
+    // so lookups fall back to the prototype again.
+    delete (window as { location?: unknown }).location;
+  }
 });
 
 test("keeps the compile-time default when nothing is configured", () => {

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -118,20 +118,38 @@ export const MIN_GUIDED_UPGRADE = createFeatureFlagStore(
   false,
 );
 
-/// Email-based recovery method (design doc §8). Default `false`
-/// everywhere except `beta.id.ai`, where the init callback flips it
-/// on so internal beta testers can exercise the wizard without
-/// reaching for the browser console. Same override path as
-/// `GUIDED_UPGRADE` above — we use `temporaryOverride` so a manual
-/// `set()` from the console takes precedence on any host.
+// Init callback shared by the email-recovery flags. Defaults the flag on for
+// the production and beta domains (`id.ai`, `beta.id.ai`) and leaves it off
+// everywhere else, but an explicit canister-config value always wins: when the
+// operator configured the flag, a `false` stays off on every domain and a
+// `true` stays on. We use `temporaryOverride` so the value is re-derived on
+// every load and a manual `set()` from the console still takes precedence.
+const enableOnIdAiDomains =
+  (name: string) =>
+  (featureFlag: FeatureFlag): void => {
+    if (getConfiguredFeatureFlag(name) !== undefined) {
+      return;
+    }
+    const { hostname } = window.location;
+    if (hostname === "id.ai" || hostname === "beta.id.ai") {
+      featureFlag.temporaryOverride(true);
+    }
+  };
+
+/// Recover an identity with a previously bound recovery email (the
+/// recover-with-email flow on the `/recovery` sign-in page).
 export const EMAIL_RECOVERY = createFeatureFlagStore(
   "EMAIL_RECOVERY",
   false,
-  (featureFlag) => {
-    if (window.location.hostname === "beta.id.ai") {
-      featureFlag.temporaryOverride(true);
-    }
-  },
+  enableOnIdAiDomains("EMAIL_RECOVERY"),
+);
+
+/// Set up, replace or remove a recovery email on an identity (the recovery
+/// email card in the manage area and the dashboard's set-up smart-action).
+export const EMAIL_RECOVERY_SETUP = createFeatureFlagStore(
+  "EMAIL_RECOVERY_SETUP",
+  false,
+  enableOnIdAiDomains("EMAIL_RECOVERY_SETUP"),
 );
 
 export default {
@@ -142,4 +160,5 @@ export default {
   GUIDED_UPGRADE,
   MIN_GUIDED_UPGRADE,
   EMAIL_RECOVERY,
+  EMAIL_RECOVERY_SETUP,
 } as Record<string, FeatureFlagStore>;

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/+page.svelte
@@ -17,7 +17,7 @@
     type KnownDapp,
   } from "$lib/legacy/flows/dappsExplorer/dapps";
   import { deriveSmartActions, type SmartActionId } from "./smartActions";
-  import { EMAIL_RECOVERY } from "$lib/state/featureFlags";
+  import { EMAIL_RECOVERY_SETUP } from "$lib/state/featureFlags";
 
   const { data }: PageProps = $props();
 
@@ -27,7 +27,7 @@
 
   const smartActions = $derived(
     deriveSmartActions(data.identityInfo, {
-      emailRecoveryEnabled: $EMAIL_RECOVERY,
+      emailRecoveryEnabled: $EMAIL_RECOVERY_SETUP,
     }),
   );
 

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
@@ -28,7 +28,7 @@
   import RemoveEmailRecovery from "./components/RemoveEmailRecovery.svelte";
   import { SetupEmailRecoveryWizard } from "$lib/components/wizards/setupEmailRecovery";
   import type { EmailRecoveryDnsInput } from "$lib/generated/internet_identity_types";
-  import { EMAIL_RECOVERY } from "$lib/state/featureFlags";
+  import { EMAIL_RECOVERY_SETUP } from "$lib/state/featureFlags";
   import { recoveryAuthnMethodData } from "$lib/utils/authnMethodData";
   import {
     fromMnemonicWithoutValidation,
@@ -351,13 +351,13 @@
 
   // Trigger email recovery wizard (set up or replace, depending on
   // whether an email is already bound). Used by the home dashboard's
-  // smart-action strip when EMAIL_RECOVERY is enabled.
+  // smart-action strip when EMAIL_RECOVERY_SETUP is enabled.
   afterNavigate(() => {
     if (!("email" in page.state)) {
       return;
     }
     replaceState("", {});
-    if ($EMAIL_RECOVERY) {
+    if ($EMAIL_RECOVERY_SETUP) {
       showEmailRecoverySetup = true;
     }
   });
@@ -399,10 +399,10 @@
     />
   {/if}
 
-  <!-- Recovery email card. Gated by the EMAIL_RECOVERY feature
-       flag (default false; auto-enabled on beta.id.ai by the
+  <!-- Recovery email card. Gated by the EMAIL_RECOVERY_SETUP feature
+       flag (default false; auto-enabled on id.ai and beta.id.ai by the
        flag's init callback). -->
-  {#if $EMAIL_RECOVERY}
+  {#if $EMAIL_RECOVERY_SETUP}
     {#if emailRecovery !== undefined}
       <ActiveEmailRecovery
         credential={emailRecovery}
@@ -417,7 +417,7 @@
   {/if}
 </div>
 
-{#if !$EMAIL_RECOVERY}
+{#if !$EMAIL_RECOVERY_SETUP}
   <section>
     <h2 class="text-text-primary mt-10 text-lg font-semibold">
       {$t`How to stay secure`}

--- a/src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts
@@ -57,39 +57,36 @@ function makeFromAddress(): string {
 }
 
 /**
- * Inject `localStorage` overrides for the email-recovery feature
- * flags before the page's JS runs. The runtime flag stores at
- * `lib/state/featureFlags.ts` read from these keys on init, so this
- * is enough to flip the flags without faking the page hostname.
+ * Force the email-recovery feature off via `localStorage` before the
+ * page's JS runs.
  *
  * The feature is gated by two flags: `EMAIL_RECOVERY` (the
  * recover-with-email flow) and `EMAIL_RECOVERY_SETUP` (the set-up /
- * management surface). The tests exercise both surfaces, so we drive
- * both flags together here.
+ * management surface). Both default *on* for `id.ai`, which the e2e
+ * suite runs against (`II_URL`), so there's nothing to do to enable
+ * them. To exercise the off-path we persist `false` for both keys,
+ * which beats the domain default in `featureFlags.ts`.
  *
  * The corresponding key shape is the runtime constant
  * `LOCALSTORAGE_FEATURE_FLAGS_PREFIX + name` from `featureFlags.ts`.
  * We hardcode the literals here on purpose — if the runtime prefix
  * changes we want the test to fail loudly.
  */
-async function setEmailRecoveryFlag(page: Page, on: boolean) {
-  await page.addInitScript(
-    ({ value }) => {
-      try {
-        window.localStorage.setItem(
-          "ii-localstorage-feature-flags__EMAIL_RECOVERY",
-          JSON.stringify(value),
-        );
-        window.localStorage.setItem(
-          "ii-localstorage-feature-flags__EMAIL_RECOVERY_SETUP",
-          JSON.stringify(value),
-        );
-      } catch {
-        // localStorage may be locked in some test contexts.
-      }
-    },
-    { value: on },
-  );
+async function disableEmailRecoveryFlags(page: Page) {
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem(
+        "ii-localstorage-feature-flags__EMAIL_RECOVERY",
+        JSON.stringify(false),
+      );
+      window.localStorage.setItem(
+        "ii-localstorage-feature-flags__EMAIL_RECOVERY_SETUP",
+        JSON.stringify(false),
+      );
+    } catch {
+      // localStorage may be locked in some test contexts.
+    }
+  });
 }
 
 class EmailRecoveryWizard {
@@ -200,12 +197,10 @@ class EmailRecoveryFixtures {
   // Flag + card surface — used by every email-recovery test
   // ---------------------------------------------------------------
 
-  async enableFlag(): Promise<void> {
-    await setEmailRecoveryFlag(this.#page, true);
-  }
-
+  // The flags default on for `id.ai` (the suite's `II_URL`), so the
+  // "on" tests need no setup. Only the off-path is forced explicitly.
   async disableFlag(): Promise<void> {
-    await setEmailRecoveryFlag(this.#page, false);
+    await disableEmailRecoveryFlags(this.#page);
   }
 
   async assertSetupCardVisible(): Promise<void> {

--- a/src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts
@@ -58,13 +58,18 @@ function makeFromAddress(): string {
 
 /**
  * Inject `localStorage` overrides for the email-recovery feature
- * flag before the page's JS runs. The runtime flag store at
- * `lib/state/featureFlags.ts` reads from this key on init, so this
- * is enough to flip the flag without faking the page hostname.
+ * flags before the page's JS runs. The runtime flag stores at
+ * `lib/state/featureFlags.ts` read from these keys on init, so this
+ * is enough to flip the flags without faking the page hostname.
+ *
+ * The feature is gated by two flags: `EMAIL_RECOVERY` (the
+ * recover-with-email flow) and `EMAIL_RECOVERY_SETUP` (the set-up /
+ * management surface). The tests exercise both surfaces, so we drive
+ * both flags together here.
  *
  * The corresponding key shape is the runtime constant
  * `LOCALSTORAGE_FEATURE_FLAGS_PREFIX + name` from `featureFlags.ts`.
- * We hardcode the literal here on purpose — if the runtime prefix
+ * We hardcode the literals here on purpose — if the runtime prefix
  * changes we want the test to fail loudly.
  */
 async function setEmailRecoveryFlag(page: Page, on: boolean) {
@@ -73,6 +78,10 @@ async function setEmailRecoveryFlag(page: Page, on: boolean) {
       try {
         window.localStorage.setItem(
           "ii-localstorage-feature-flags__EMAIL_RECOVERY",
+          JSON.stringify(value),
+        );
+        window.localStorage.setItem(
+          "ii-localstorage-feature-flags__EMAIL_RECOVERY_SETUP",
           JSON.stringify(value),
         );
       } catch {

--- a/src/frontend/tests/e2e-playwright/fixtures/manageRecoveryPage.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/manageRecoveryPage.ts
@@ -161,9 +161,12 @@ class ManageRecoveryPage {
   async activate<T>(
     fn: (wizard: CreateRecoveryPhraseWizard) => Promise<T>,
   ): Promise<T> {
+    // Target the phrase card's button by its full aria-label: the recovery
+    // email card (shown when EMAIL_RECOVERY_SETUP is on, e.g. on id.ai) renders
+    // its own "Activate" button, so a bare "Activate" match is ambiguous.
     await this.#page
       .getByRole("main")
-      .getByRole("button", { name: "Activate" })
+      .getByRole("button", { name: "Activate recovery phrase" })
       .click();
     return this.#withWizard(fn);
   }

--- a/src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts
@@ -60,7 +60,6 @@ test.describe("Email recovery — wizard surface", () => {
     signInWithIdentity,
     identities,
   }) => {
-    await emailRecovery.enableFlag();
     await manageRecoveryPage.goto();
     await signInWithIdentity(page, identities[0].identityNumber);
     await emailRecovery.assertSetupCardVisible();
@@ -83,9 +82,7 @@ test.describe("Email recovery — wizard surface", () => {
 
   test("recover sign-in shows the email button and opens the wizard", async ({
     page,
-    emailRecovery,
   }) => {
-    await emailRecovery.enableFlag();
     await page.goto(II_URL + "/recovery");
     await expect(
       page.getByRole("button", { name: "Recover with email" }),
@@ -112,7 +109,6 @@ test.describe("Email recovery — real DNSSEC + DKIM flow", () => {
   }) => {
     test.slow(); // RSA keygen + DNSSEC walk + status polling
 
-    await emailRecovery.enableFlag();
     await emailRecovery.installDohInterceptor();
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
Stacked on top of #3973 — review/merge that one first; this PR's base is its branch.

Splits the single `EMAIL_RECOVERY` feature flag into two independent flags so the recover-with-email flow and the recovery-email set-up surface can be gated separately:

- `EMAIL_RECOVERY` — recover an identity with a bound recovery email (the recover-with-email button on the `/recovery` sign-in page).
- `EMAIL_RECOVERY_SETUP` — set up, replace or remove a recovery email (the recovery email card in the manage area and the dashboard set-up smart-action).

### Resolution
Both flags resolve identically:
- **on** for `id.ai` and `beta.id.ai`,
- **off** on every other domain,
- but an explicit canister-config value always wins — a configured `false` keeps the flag off on every domain, and a configured `true` turns it on regardless of domain.

The shared `enableOnIdAiDomains` init callback returns early when the operator configured the flag, so the domain default never overrides an explicit `false`. localStorage / `?feature_flag_*` overrides still take precedence as before.

### Notes
- This also widens the previous beta-only auto-enable (`beta.id.ai`) to include `id.ai`, per the requested behavior.
- e2e fixture `emailRecovery.ts` now drives both localStorage keys so existing setup + recovery tests keep working.
- Added unit tests in `featureFlags.test.ts` covering domain defaults, configured-false-wins, configured-true-off-domain, and independent resolution of the two flags.

### Checks run
- `vitest` featureFlags + utils/featureFlags: 13 passed
- `prettier --check`, `eslint --max-warnings 0`: clean
- `tsc --noEmit` + `svelte-check`: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)