### PR TITLE
test(fe): wait for /manage sidebar before probing mobile menu button

### DIFF
--- a/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
@@ -408,11 +408,16 @@ test("`--app` links the same principal that /authorize gives for that app", asyn
   await page.goto(II_URL);
   await signInWithIdentity(page, identityNumber);
   await page.waitForURL(II_URL + "/manage");
+  // The manage layout's sidebar can finish first paint a tick after the
+  // URL flips, so probing `isVisible()` immediately can return a stale
+  // false on mobile — wait for a stable sidebar element first.
+  const settingsLink = page.getByRole("link", { name: "Settings" });
+  await settingsLink.waitFor();
   const menuButton = page.getByRole("button", { name: "Open menu" });
   if (await menuButton.isVisible()) {
     await menuButton.click();
   }
-  await page.getByRole("link", { name: "Settings" }).click();
+  await settingsLink.click();
   await page.waitForURL(II_URL + "/manage/settings");
   await page.getByRole("switch").click();
   await page


### PR DESCRIPTION
The mobile shard of the `\`--app\` links the same principal` test in `cli.spec.ts` was timing out on the Settings link click, even after the sidebar fix in #3966.

## Problem

```ts
await page.waitForURL(II_URL + "/manage");
const menuButton = page.getByRole("button", { name: "Open menu" });
if (await menuButton.isVisible()) {
  await menuButton.click();
}
await page.getByRole("link", { name: "Settings" }).click();
```

`waitForURL` resolves when the URL flips, but on mobile the manage layout's first paint can land a tick later. `isVisible()` does not auto-wait — when it ran on the unrendered header, it returned a stale `false`, the conditional skipped the menu open, and the Settings click then timed out trying to reach a link inside the still-closed `translate-x-[-100%]` sidebar.

## Changes

Wait for a stable sidebar element (the Settings link itself, which is always attached on `/manage`) before probing visibility. On desktop the conditional still correctly skips (menu button is hidden by the `sm:hidden` wrapper); on mobile we now reliably see and click the menu button.