### PR TITLE
fix(fe): de-flake mobile manage-menu navigation in e2e

### DIFF
--- a/src/frontend/tests/e2e-playwright/routes/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/index.spec.ts
@@ -6,6 +6,7 @@ import {
   TEST_APP_CANONICAL_URL,
   II_URL,
   addVirtualAuthenticator,
+  openManageMenuIfMobile,
 } from "../../utils";
 import { test } from "../../fixtures";
 import { SSO_OPENID_PORT } from "../../fixtures/sso";
@@ -49,6 +50,7 @@ test("Authorize by signing in with an existing passkey", async ({
 test("Authorize by signing in from another device", async ({
   browser,
   page,
+  isMobile,
   identities,
   addAuthenticatorForIdentity,
   signInWithIdentity,
@@ -141,12 +143,7 @@ test("Authorize by signing in from another device", async ({
         .waitFor({ state: "hidden" });
 
       // Navigate to access methods
-      const menuButton = otherDevicePage.getByRole("button", {
-        name: "Open menu",
-      });
-      if (await menuButton.isVisible()) {
-        await menuButton.click();
-      }
+      await openManageMenuIfMobile(otherDevicePage, isMobile);
       await otherDevicePage.getByRole("link", { name: "Access" }).click();
 
       // Verify we have two passkeys

--- a/src/frontend/tests/e2e-playwright/routes/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/index.spec.ts
@@ -1,5 +1,9 @@
 import { expect } from "@playwright/test";
-import { addVirtualAuthenticator, II_URL } from "../utils";
+import {
+  addVirtualAuthenticator,
+  II_URL,
+  openManageMenuIfMobile,
+} from "../utils";
 import { test } from "../fixtures";
 import { SSO_OPENID_PORT } from "../fixtures/sso";
 
@@ -38,6 +42,7 @@ test.describe("First visit", () => {
   test("Sign in from another device", async ({
     browser,
     page,
+    isMobile,
     identities,
     addAuthenticatorForIdentity,
   }) => {
@@ -120,12 +125,7 @@ test.describe("First visit", () => {
       await existingDevicePage
         .getByRole("heading", { level: 1, name: "Continue on your new device" })
         .waitFor({ state: "hidden" });
-      const existingMenuButton = existingDevicePage.getByRole("button", {
-        name: "Open menu",
-      });
-      if (await existingMenuButton.isVisible()) {
-        await existingMenuButton.click();
-      }
+      await openManageMenuIfMobile(existingDevicePage, isMobile);
       await existingDevicePage.getByRole("link", { name: "Access" }).click();
       await expect(existingDevicePage.getByText("Unknown")).toHaveCount(2);
 

--- a/src/frontend/tests/e2e-playwright/routes/manage/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/manage/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import { test } from "../../fixtures";
-import { II_URL } from "../../utils";
+import { II_URL, openManageMenuIfMobile } from "../../utils";
 
 test.describe("Session re-authentication", () => {
   test("Shows re-auth dialog after session timeout and re-authenticates", async ({
@@ -66,6 +66,7 @@ test.describe("Session re-authentication", () => {
 test.describe("Dashboard Navigation", () => {
   test("User can register, sign in, access the dashboard and navigate to security page", async ({
     page,
+    isMobile,
     identities,
     signInWithIdentity,
     managePage,
@@ -75,10 +76,7 @@ test.describe("Dashboard Navigation", () => {
     await managePage.assertVisible();
 
     // Navigate to access methods
-    const menuButton = page.getByRole("button", { name: "Open menu" });
-    if (await menuButton.isVisible()) {
-      await menuButton.click();
-    }
+    await openManageMenuIfMobile(page, isMobile);
     await page.getByRole("link", { name: "Access" }).click();
 
     // Check that we have one passkey listed
@@ -115,6 +113,7 @@ test.describe("Dashboard Navigation", () => {
 
     test("User can switch between identities", async ({
       page,
+      isMobile,
       managePage,
       identities,
       addAuthenticatorForIdentity,
@@ -134,10 +133,7 @@ test.describe("Dashboard Navigation", () => {
       ).toBeVisible();
 
       // Navigate to access methods
-      const menuButton = page.getByRole("button", { name: "Open menu" });
-      if (await menuButton.isVisible()) {
-        await menuButton.click();
-      }
+      await openManageMenuIfMobile(page, isMobile);
       await page.getByRole("link", { name: "Access" }).click();
 
       // Switch to second identity

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -267,6 +267,26 @@ export const signOut = async (page: Page): Promise<void> => {
 };
 
 /**
+ * Opens the manage hamburger menu on the mobile project so a following
+ * section-link click (Access, Settings, …) can't race a not-yet-hydrated
+ * menu. On desktop the links are always visible, so this is a no-op.
+ *
+ * Branch on the `isMobile` fixture rather than a non-waiting
+ * `menuButton.isVisible()` probe: that probe returns `false` while the page
+ * is still hydrating, silently skips opening the menu, and leaves the next
+ * link click waiting on a hidden element until the test times out. Same
+ * fix as cli.spec.ts's Settings navigation.
+ */
+export const openManageMenuIfMobile = async (
+  page: Page,
+  isMobile: boolean,
+): Promise<void> => {
+  if (isMobile) {
+    await page.getByRole("button", { name: "Open menu" }).click();
+  }
+};
+
+/**
  * Opens test app and configures II URL
  */
 export const openTestAppWithII = async (page: Page): Promise<void> => {


### PR DESCRIPTION
Running the full Playwright e2e suite repeatedly on the mobile project surfaced a flake that passes in isolation but hangs intermittently under full-suite load: "Authorize by signing in from another device" timed out at 60s. Four specs reached the Access page via a non-waiting guard (`if (await menuButton.isVisible()) { await menuButton.click(); }`); on mobile that point-in-time probe returns `false` while the page is still hydrating, the menu is never opened, and the "Access" link click then waits on a hidden element until the test times out.

## Changes

Replaced all four occurrences with a shared `openManageMenuIfMobile(page, isMobile)` helper (in `tests/e2e-playwright/utils.ts`) that branches on the `isMobile` fixture and opens the menu with a waiting click — the same approach #3975 introduced in `cli.spec.ts`. Sites: `routes/index.spec.ts`, `routes/authorize/index.spec.ts`, `routes/manage/index.spec.ts` (x2).

## Tests

Reproduced under full-suite mobile load before the fix; after the fix the another-device and dashboard-navigation tests passed across multiple full mobile runs (including a fresh-stack run) and a full desktop run (`--workers=1 --retries=0`).

<div align="left">Previous: #3975</div>
