### PR TITLE
fix(fe): drop invalid IPv6 loopback source from form-action CSP

### DIFF
--- a/src/frontend/src/routes/(new-styling)/cli/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/+page.ts
@@ -83,7 +83,11 @@ const parseLoopbackCallback = (raw: string | null): string | undefined => {
   if (url.protocol !== "http:") {
     return undefined;
   }
-  if (url.hostname !== "127.0.0.1" && url.hostname !== "::1") {
+  // Only the IPv4 loopback literal. CSP's host-source grammar can't express
+  // IPv6 literals, so `http://[::1]:*` is an invalid `form-action` source the
+  // browser ignores — a `::1` callback would pass here but die on the CSP at
+  // submit time, the same trap as https above. The CLI must bind 127.0.0.1.
+  if (url.hostname !== "127.0.0.1") {
     return undefined;
   }
   return raw;

--- a/src/internet_identity_frontend/src/main.rs
+++ b/src/internet_identity_frontend/src/main.rs
@@ -260,14 +260,17 @@ fn get_asset_headers(
 /// base-uri 'none':
 ///   Prevents injection of <base> tags that could redirect relative URLs
 ///
-/// form-action 'self' http://127.0.0.1:* http://[::1]:*:
+/// form-action 'self' http://127.0.0.1:*:
 ///   The CLI authorize flow (`/cli`) delivers the delegation to the CLI's
 ///   loopback callback via a top-level form POST (a top-level navigation
 ///   avoids Chrome's Local Network Access permission prompt that a `fetch`
 ///   would trigger). Submissions are restricted to same origin and the http
-///   loopback literals the `/cli` callback parser accepts (127.0.0.1, ::1) —
-///   `localhost` is intentionally excluded there (it can resolve off-loopback)
-///   so it's omitted here too — so a form can never post to a remote origin.
+///   127.0.0.1 loopback the `/cli` callback parser accepts. CSP's host-source
+///   grammar can't express IPv6 literals — `http://[::1]:*` is rejected as an
+///   invalid source and silently ignored by the browser — so IPv6 loopback
+///   isn't allowlistable here; the `/cli` parser only accepts 127.0.0.1 to
+///   match. `localhost` is also excluded (it can resolve off-loopback) — so a
+///   form can never post to a remote origin.
 ///
 /// style-src 'self' 'unsafe-inline':
 ///   Allow stylesheets from same origin and inline styles
@@ -333,7 +336,7 @@ fn get_content_security_policy(
          img-src 'self' data: https://*.googleusercontent.com;\
          script-src {script_src};\
          base-uri 'none';\
-         form-action 'self' http://127.0.0.1:* http://[::1]:*;\
+         form-action 'self' http://127.0.0.1:*;\
          style-src 'self' 'unsafe-inline';\
          style-src-elem 'self' 'unsafe-inline';\
          font-src 'self';\


### PR DESCRIPTION
The browser console logs "The source list for the Content Security Policy directive 'form-action' contains an invalid source: 'http://[::1]:*'. It will be ignored." on every II page load. CSP's host-source grammar can't express IPv6 literals, so `http://[::1]:*` is invalid and the browser drops it.

It was also a latent bug: the `/cli` callback parser accepted `::1` loopback callbacks, but because the CSP source is ignored, such a callback passed validation and then silently failed when the delegation form tried to POST to it — the same trap the parser already guards against for `https` callbacks.

## Changes
- Remove `http://[::1]:*` from the `form-action` directive in the frontend canister CSP (`src/internet_identity_frontend/src/main.rs`).
- Stop the `/cli` callback parser from accepting `::1`, so it only allows the IPv4 loopback `127.0.0.1` that CSP can actually allowlist (`src/frontend/src/routes/(new-styling)/cli/+page.ts`).
- Update surrounding comments to explain CSP can't express IPv6 literals.

No behavior that worked before changes: the e2e loopback fixture and real CLIs bind `127.0.0.1`; IPv6 loopback callbacks were already non-functional because the CSP source was silently ignored.