### PR TITLE
fix(be): raise inbound email header cap from 30 to 100

### DIFF
--- a/src/internet_identity_interface/src/internet_identity/types/smtp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/smtp.rs
@@ -28,7 +28,16 @@ pub const MAX_EMAIL_USER_BYTES: usize = 64;
 pub const MAX_EMAIL_DOMAIN_BYTES: usize = 255;
 pub const MAX_SUBJECT_BYTES: usize = 256;
 pub const MAX_BODY_BYTES: usize = 5_000;
-pub const MAX_HEADERS: usize = 30;
+/// Cap on the number of headers in one inbound message. Real-world mail
+/// that has traversed several hops accumulates a long run of trace and
+/// authentication headers (`Received`, `Authentication-Results`, `ARC-*`,
+/// and provider-specific `X-MS-Exchange-*` / `X-Microsoft-*` fields), so a
+/// legitimate message routed through Outlook/Exchange routinely carries far
+/// more than a hand-authored one. The original bound of 30 was too tight —
+/// it rejected genuine recovery emails (e.g. 39 headers from Outlook) — so
+/// it is raised to 100 to leave comfortable headroom while still keeping
+/// worst-case allocation on the open `smtp_request` endpoint bounded.
+pub const MAX_HEADERS: usize = 100;
 pub const MAX_HEADER_NAME_BYTES: usize = 256;
 pub const MAX_HEADER_VALUE_BYTES: usize = 8_192;
 /// Cap on the optional gateway-supplied `message_id` correlation id.
@@ -476,6 +485,22 @@ mod tests {
         };
         let resp = validate_message(&msg).unwrap_err();
         assert!(err_msg(&resp).contains("Too many headers"));
+    }
+
+    #[test]
+    fn validate_message_accepts_max_headers() {
+        // Exactly at the cap must still pass — defines the inclusive upper
+        // bound, and guards the motivating case: a message that has picked
+        // up a long run of trace/authentication headers en route (e.g.
+        // through Outlook/Exchange) must not be rejected. From and Date
+        // appear exactly once; the remainder are repeatable trace headers so
+        // the occurrence rules in `validate_header_occurrences` are satisfied.
+        let mut headers = minimal_headers();
+        headers.extend(
+            (0..(MAX_HEADERS - headers.len())).map(|i| header("Received", &format!("hop {i}"))),
+        );
+        assert_eq!(headers.len(), MAX_HEADERS);
+        assert!(validate_message(&message_with(headers)).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## What

Raise `MAX_HEADERS` (the cap on the number of headers in one inbound SMTP message) from **30** to **100** in `src/internet_identity_interface/src/internet_identity/types/smtp.rs`.

## Why

Registering a recovery email from Outlook fails at the input-bounds layer:

```
Too many headers: 39 (max 30)
```

Real-world mail that has traversed several hops accumulates a long run of trace and authentication headers — `Received`, `Authentication-Results`, `ARC-*`, and provider-specific `X-MS-Exchange-*` / `X-Microsoft-*` fields — so a legitimate message routed through Outlook/Exchange routinely carries far more headers than a hand-authored one. The original bound of 30 was too tight and rejected genuine recovery emails. 100 leaves comfortable headroom while keeping worst-case allocation on the open `smtp_request` endpoint bounded (it is well below `MAX_RECIPIENTS = 100`-style adversarial concerns, and each header is independently length-capped by `MAX_HEADER_NAME_BYTES` / `MAX_HEADER_VALUE_BYTES`).

The error message text is derived from the constant (`max {MAX_HEADERS}`), so it updates automatically.

## Changes

- `MAX_HEADERS: 30 → 100`, with a rationale comment matching the file's documented-bounds style.
- New boundary test `validate_message_accepts_max_headers` asserting a message at exactly `MAX_HEADERS` is accepted, mirroring the existing `validate_message_rejects_too_many_headers` / `validate_envelope_accepts_max_recipients` coverage. The existing rejection test is unaffected — it is defined relative to the constant.

## Testing

- `cargo test -p internet_identity_interface smtp` — 30 passed.
- `cargo clippy -p internet_identity_interface --all-targets` — clean.
- `cargo fmt --check` — clean.

https://claude.ai/code/session_01QBHsWPt7jbDFyuJqoC7N1H

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBHsWPt7jbDFyuJqoC7N1H)_