### PR TITLE
feat(fe): add identity-number recovery option on /recovery

### DIFF
--- a/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
+++ b/src/frontend/src/lib/components/ui/IdentitySwitcher.svelte
@@ -235,7 +235,7 @@
     {/if}
     <button onclick={onUseAnotherIdentity} class="btn btn-tertiary m-4">
       <PlusIcon class="size-4" />
-      {$t`Add another identity`}
+      {$t`Add identity`}
     </button>
   </div>
 </fieldset>

--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -67,6 +67,11 @@
     onSwitchMode?: () => void;
     withinDialog?: boolean;
     mode?: "signin" | "signup" | "both";
+    // Optional override for the picker's switch-mode CTA title — useful
+    // when the wizard is hosted inside a surface (e.g. /manage's Add
+    // identity dialog) where the default "New to Internet Identity?"
+    // copy is misleading.
+    switchModeTitle?: string;
     children?: Snippet;
   }
 
@@ -81,6 +86,7 @@
     onSwitchMode,
     withinDialog = false,
     mode = "both",
+    switchModeTitle,
     children,
   }: Props = $props();
 
@@ -392,6 +398,7 @@
       {mode}
       {onSwitchMode}
       {withinDialog}
+      {switchModeTitle}
     />
   {/if}
   {#if authFlow.view !== "chooseMethod"}

--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -7,7 +7,6 @@
   import SetupOrUseExistingPasskey from "$lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte";
   import CreatePasskey from "$lib/components/wizards/auth/views/CreatePasskey.svelte";
   import SystemOverlayBackdrop from "$lib/components/utils/SystemOverlayBackdrop.svelte";
-  import { MigrationWizard } from "$lib/components/wizards/migration";
   import { isWebAuthnCancelError } from "$lib/utils/webAuthnErrorUtils";
   import { isOpenIdCancelError } from "$lib/utils/openID";
   import ContinueOnAnotherDeviceView from "$lib/components/wizards/auth/views/ContinueOnAnotherDeviceView.svelte";
@@ -59,7 +58,6 @@
   interface Props {
     onSignIn: (identityNumber: bigint) => Promise<void>;
     onSignUp: (identityNumber: bigint) => Promise<void>;
-    onUpgrade: (identityNumber: bigint) => Promise<void>;
     onError: (error: unknown) => void;
     onOpenIdNotConnected?: (args: OpenIdNotConnectedArgs) => void;
     onOpenIdAlreadyLinked?: (args: OpenIdAlreadyLinkedArgs) => void;
@@ -78,7 +76,6 @@
   let {
     onSignIn,
     onSignUp,
-    onUpgrade,
     onError,
     onOpenIdNotConnected,
     onOpenIdAlreadyLinked,
@@ -118,7 +115,6 @@
 
   let isContinueFromAnotherDeviceVisible = $state(false);
   let isAuthenticating = $state(false);
-  let isUpgrading = $state(false);
   // True while a deferred SSO registration is awaiting the name-entry view
   // (`setupNewIdentity`). Used by `handleCompleteOpenIdRegistration` to
   // dispatch to `completeSsoRegistration` instead of the direct-provider
@@ -364,7 +360,6 @@
     <SetupOrUseExistingPasskey
       setupNew={authFlow.setupNewPasskey}
       useExisting={handleContinueWithExistingPasskey}
-      upgrade={() => (isUpgrading = true)}
     />
   {:else if authFlow.view === "setupNewPasskey"}
     <CreatePasskey create={handleCreatePasskey} />
@@ -382,8 +377,6 @@
   <SolveCaptcha {...authFlow.captcha} />
 {:else if withinDialog && isContinueFromAnotherDeviceVisible}
   <ContinueOnAnotherDeviceView onRegistered={handleRegistered} {onError} />
-{:else if withinDialog && isUpgrading}
-  <MigrationWizard onSuccess={onUpgrade} {onError} />
 {:else}
   {#if authFlow.view === "chooseMethod" || !withinDialog}
     {@render children?.()}
@@ -403,7 +396,7 @@
   {/if}
   {#if authFlow.view !== "chooseMethod"}
     {#if !withinDialog}
-      {#if !isContinueFromAnotherDeviceVisible && !isUpgrading}
+      {#if !isContinueFromAnotherDeviceVisible}
         <Dialog
           onClose={() => {
             if (isAuthenticating) {
@@ -425,11 +418,6 @@
 {#if !withinDialog && isContinueFromAnotherDeviceVisible}
   <Dialog onClose={() => (isContinueFromAnotherDeviceVisible = false)}>
     <ContinueOnAnotherDeviceView onRegistered={handleRegistered} {onError} />
-  </Dialog>
-{/if}
-{#if !withinDialog && isUpgrading}
-  <Dialog onClose={() => (isUpgrading = false)}>
-    <MigrationWizard onSuccess={onUpgrade} {onError} />
   </Dialog>
 {/if}
 

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -17,6 +17,11 @@
     mode?: "signin" | "signup" | "both";
     onSwitchMode?: () => void;
     withinDialog?: boolean;
+    // Override the switch-mode CTA title (used when the picker lives
+    // inside a logged-in surface where the default "New to Internet
+    // Identity?" copy is misleading). When set, the description line is
+    // suppressed and the title carries the full prompt on its own.
+    switchModeTitle?: string;
   }
 
   const {
@@ -26,6 +31,7 @@
     mode = "both",
     onSwitchMode,
     withinDialog = false,
+    switchModeTitle,
   }: Props = $props();
 
   const showLostAccess = $derived(mode !== "signup");
@@ -174,15 +180,18 @@
     >
       <div class="min-w-0 flex-1">
         <div class="text-text-primary text-sm font-semibold">
-          {mode === "signin"
-            ? $t`New to Internet Identity?`
-            : $t`Already have an identity?`}
+          {switchModeTitle ??
+            (mode === "signin"
+              ? $t`New to Internet Identity?`
+              : $t`Already have an identity?`)}
         </div>
-        <div class="text-text-tertiary mt-0.5 text-xs">
-          {mode === "signin"
-            ? $t`Create your private, passwordless identity.`
-            : $t`Sign in with a passkey or familiar provider.`}
-        </div>
+        {#if switchModeTitle === undefined}
+          <div class="text-text-tertiary mt-0.5 text-xs">
+            {mode === "signin"
+              ? $t`Create your private, passwordless identity.`
+              : $t`Sign in with a passkey or familiar provider.`}
+          </div>
+        {/if}
       </div>
       <button
         onclick={onSwitchMode}

--- a/src/frontend/src/lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/SetupOrUseExistingPasskey.svelte
@@ -10,10 +10,9 @@
   interface Props {
     setupNew: () => void;
     useExisting: () => Promise<void | "cancelled">;
-    upgrade: () => void;
   }
 
-  const { setupNew, useExisting, upgrade }: Props = $props();
+  const { setupNew, useExisting }: Props = $props();
 
   let isAuthenticating = $state(false);
   let isCancelled = $state(false);
@@ -72,16 +71,4 @@
       {/if}
     </button>
   </Tooltip>
-  <div class="border-border-tertiary my-5 border-t"></div>
-  <div class="flex flex-row items-center justify-between gap-4">
-    <p class="text-text-secondary text-sm">
-      {$t`Still have an identity number?`}
-    </p>
-    <button
-      onclick={upgrade}
-      class="text-text-primary text-sm font-semibold outline-0 hover:underline focus-visible:underline"
-    >
-      {$t`Upgrade`}
-    </button>
-  </div>
 </div>

--- a/src/frontend/src/lib/locales/en.po
+++ b/src/frontend/src/lib/locales/en.po
@@ -830,8 +830,14 @@ msgstr "Real privacy"
 msgid "Recover"
 msgstr "Recover"
 
+msgid "Recover a legacy identity with its number."
+msgstr "Recover a legacy identity with its number."
+
 msgid "Recover with email"
 msgstr "Recover with email"
+
+msgid "Recover with identity number"
+msgstr "Recover with identity number"
 
 msgid "Recover with phrase"
 msgstr "Recover with phrase"
@@ -1076,9 +1082,6 @@ msgstr "SSO sign-in for {domainInput} failed. Please try again."
 
 msgid "Start over"
 msgstr "Start over"
-
-msgid "Still have an identity number?"
-msgstr "Still have an identity number?"
 
 msgid "Still using an identity number?"
 msgstr "Still using an identity number?"

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -62,6 +62,7 @@
     resume: () => Promise<void>;
     cancel: () => void;
   }>();
+  let isResumingRegistration = $state(false);
 
   let alreadyLinkedPayload = $state<{
     providerName: string;
@@ -71,6 +72,7 @@
     signIn: () => Promise<void>;
     cancel: () => void;
   }>();
+  let isSigningInAlreadyLinked = $state(false);
 
   let methodSwitchPayload = $state<{
     previous: LastUsedIdentity;
@@ -534,7 +536,7 @@
   {@const payload = notConnectedPayload}
   <Dialog
     onClose={() => {
-      if (isAuthenticating) {
+      if (isAuthenticating || isResumingRegistration) {
         return;
       }
       const cancel = payload.cancel;
@@ -547,10 +549,15 @@
       providerLogo={payload.providerLogo}
       userName={payload.userName ?? payload.userEmail ?? payload.providerName}
       userEmail={payload.userName !== undefined ? payload.userEmail : undefined}
-      onSignUp={() => {
-        const resume = payload.resume;
-        notConnectedPayload = undefined;
-        void resume();
+      loading={isResumingRegistration}
+      onSignUp={async () => {
+        isResumingRegistration = true;
+        try {
+          await payload.resume();
+        } finally {
+          isResumingRegistration = false;
+          notConnectedPayload = undefined;
+        }
       }}
       onRecover={() => {
         const cancel = payload.cancel;
@@ -566,7 +573,7 @@
   {@const payload = alreadyLinkedPayload}
   <Dialog
     onClose={() => {
-      if (isAuthenticating) {
+      if (isAuthenticating || isSigningInAlreadyLinked) {
         return;
       }
       const cancel = payload.cancel;
@@ -579,10 +586,15 @@
       providerLogo={payload.providerLogo}
       userName={payload.userName ?? payload.userEmail ?? payload.providerName}
       userEmail={payload.userName !== undefined ? payload.userEmail : undefined}
-      onSignIn={() => {
-        const signIn = payload.signIn;
-        alreadyLinkedPayload = undefined;
-        void signIn();
+      loading={isSigningInAlreadyLinked}
+      onSignIn={async () => {
+        isSigningInAlreadyLinked = true;
+        try {
+          await payload.signIn();
+        } finally {
+          isSigningInAlreadyLinked = false;
+          alreadyLinkedPayload = undefined;
+        }
       }}
     />
   </Dialog>

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -146,13 +146,6 @@
       handleError(error);
     }
   };
-  const handleUpgrade = async (identityNumber: bigint) => {
-    await handleSignIn(identityNumber);
-    toaster.success({
-      title: $t`Upgrade completed successfully`,
-      duration: 4000,
-    });
-  };
   const handleSignUp = async (identityNumber: bigint) => {
     await handleSignIn(identityNumber);
     toaster.success({
@@ -423,7 +416,6 @@
               <AuthWizard
                 onSignIn={handleSignIn}
                 onSignUp={handleSignUp}
-                onUpgrade={handleUpgrade}
                 onError={(error) => {
                   isAuthenticating = false;
                   handleError(error);
@@ -459,7 +451,6 @@
     <AuthWizard
       onSignIn={handleSignIn}
       onSignUp={handleSignUp}
-      onUpgrade={handleUpgrade}
       onError={(error) => {
         isAuthDialogOpen = false;
         isAuthenticating = false;
@@ -498,7 +489,6 @@
     <AuthWizard
       onSignIn={handleSignIn}
       onSignUp={handleSignUp}
-      onUpgrade={handleUpgrade}
       onError={(error) => {
         isCreateIdentityDialogOpen = false;
         isAuthenticating = false;

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -17,7 +17,17 @@
   import { analytics } from "$lib/utils/analytics/analytics";
   import { throwCanisterError } from "$lib/utils/utils";
   import { AuthLastUsedFlow } from "$lib/flows/authLastUsedFlow.svelte";
-  import { AuthWizard } from "$lib/components/wizards/auth";
+  import {
+    AuthWizard,
+    SignUpHero,
+    IdentityNotConnected,
+    IdentityAlreadyLinked,
+    SwitchAccessMethod,
+  } from "$lib/components/wizards/auth";
+  import type { AccessMethod } from "$lib/components/wizards/auth/views/SwitchAccessMethod.svelte";
+  import type { LastUsedIdentity } from "$lib/stores/last-used-identities.store";
+  import { backendCanisterConfig } from "$lib/globals";
+  import { getMetadataString } from "$lib/utils/openID";
   import ChannelError from "$lib/components/ui/ChannelError.svelte";
   import Header from "$lib/components/layout/Header.svelte";
   import Footer from "$lib/components/layout/Footer.svelte";
@@ -121,8 +131,51 @@
   let identityButtonRef = $state<HTMLElement>();
   let isIdentityPopoverOpen = $state(false);
   let isAuthDialogOpen = $state(false);
+  let isCreateIdentityDialogOpen = $state(false);
   let isAuthenticating = $state(false);
   let isManageIdentitiesDialogOpen = $state(false);
+  let signUpOpenedFromSignInModal = $state(false);
+
+  let notConnectedPayload = $state<{
+    providerName: string;
+    providerLogo?: string;
+    userName?: string;
+    userEmail?: string;
+    resume: () => Promise<void>;
+    cancel: () => void;
+  }>();
+  let isResumingRegistration = $state(false);
+  let alreadyLinkedPayload = $state<{
+    providerName: string;
+    providerLogo?: string;
+    userName?: string;
+    userEmail?: string;
+    signIn: () => Promise<void>;
+    cancel: () => void;
+  }>();
+  let isSigningInAlreadyLinked = $state(false);
+  let methodSwitchPayload = $state<{
+    previous: LastUsedIdentity;
+    newProvider: AccessMethod;
+    proceed: () => Promise<void>;
+  }>();
+
+  const authMethodToAccessMethod = (
+    m: LastUsedIdentity["authMethod"],
+  ): AccessMethod => {
+    if ("passkey" in m) return { type: "passkey" };
+    if ("openid" in m) {
+      const config = backendCanisterConfig.openid_configs[0]?.find(
+        (c) => c.issuer === m.openid.iss,
+      );
+      return {
+        type: "openid",
+        logo: config?.logo ?? "",
+        name: config?.name ?? m.openid.iss,
+      };
+    }
+    return { type: "sso", name: m.sso.name ?? m.sso.domain };
+  };
 
   const handleSignIn = async (identityNumber: bigint) => {
     try {
@@ -137,6 +190,8 @@
     } finally {
       isIdentityPopoverOpen = false;
       isAuthDialogOpen = false;
+      isCreateIdentityDialogOpen = false;
+      signUpOpenedFromSignInModal = false;
       isAuthenticating = false;
     }
   };
@@ -294,9 +349,18 @@
                 onUpgrade={handleUpgrade}
                 onError={(error) => {
                   isAuthDialogOpen = false;
+                  isAuthenticating = false;
                   handleError(error);
                 }}
+                onOpenIdNotConnected={(args) => (notConnectedPayload = args)}
+                onMethodSwitch={(args) => (methodSwitchPayload = args)}
+                onSwitchMode={() => {
+                  signUpOpenedFromSignInModal = true;
+                  isAuthDialogOpen = false;
+                  isCreateIdentityDialogOpen = true;
+                }}
                 withinDialog
+                mode="signin"
               >
                 <h1
                   class="text-text-primary my-2 self-start text-2xl font-medium"
@@ -306,6 +370,41 @@
                 <p class="text-text-secondary mb-6 self-start text-sm">
                   {$t`Choose method to continue`}
                 </p>
+              </AuthWizard>
+            </Dialog>
+          {/if}
+          {#if isCreateIdentityDialogOpen}
+            <Dialog
+              onClose={() => {
+                if (isAuthenticating) {
+                  return;
+                }
+                isCreateIdentityDialogOpen = false;
+                signUpOpenedFromSignInModal = false;
+              }}
+            >
+              <AuthWizard
+                onSignIn={handleSignIn}
+                onSignUp={handleSignUp}
+                onUpgrade={handleUpgrade}
+                onError={(error) => {
+                  isCreateIdentityDialogOpen = false;
+                  isAuthenticating = false;
+                  handleError(error);
+                }}
+                onMethodSwitch={(args) => (methodSwitchPayload = args)}
+                onOpenIdAlreadyLinked={(args) => (alreadyLinkedPayload = args)}
+                onSwitchMode={() => {
+                  isCreateIdentityDialogOpen = false;
+                  if (signUpOpenedFromSignInModal) {
+                    signUpOpenedFromSignInModal = false;
+                    isAuthDialogOpen = true;
+                  }
+                }}
+                withinDialog
+                mode="signup"
+              >
+                <SignUpHero />
               </AuthWizard>
             </Dialog>
           {/if}
@@ -326,6 +425,108 @@
       <ManageIdentities
         identities={lastUsedIdentities}
         onRemoveIdentity={handleRemoveIdentity}
+      />
+    </Dialog>
+  {/if}
+
+  {#if notConnectedPayload !== undefined}
+    {@const payload = notConnectedPayload}
+    <Dialog
+      onClose={() => {
+        if (isAuthenticating || isResumingRegistration) {
+          return;
+        }
+        payload.cancel();
+        notConnectedPayload = undefined;
+      }}
+    >
+      <IdentityNotConnected
+        providerName={payload.providerName}
+        providerLogo={payload.providerLogo}
+        userName={payload.userName ?? payload.userEmail ?? payload.providerName}
+        userEmail={payload.userName !== undefined
+          ? payload.userEmail
+          : undefined}
+        loading={isResumingRegistration}
+        onSignUp={async () => {
+          isResumingRegistration = true;
+          try {
+            await payload.resume();
+          } finally {
+            isResumingRegistration = false;
+            notConnectedPayload = undefined;
+          }
+        }}
+        onRecover={() => {
+          payload.cancel();
+          notConnectedPayload = undefined;
+          void goto("/recovery");
+        }}
+      />
+    </Dialog>
+  {/if}
+
+  {#if alreadyLinkedPayload !== undefined}
+    {@const payload = alreadyLinkedPayload}
+    <Dialog
+      onClose={() => {
+        if (isAuthenticating || isSigningInAlreadyLinked) {
+          return;
+        }
+        payload.cancel();
+        alreadyLinkedPayload = undefined;
+      }}
+    >
+      <IdentityAlreadyLinked
+        providerName={payload.providerName}
+        providerLogo={payload.providerLogo}
+        userName={payload.userName ?? payload.userEmail ?? payload.providerName}
+        userEmail={payload.userName !== undefined
+          ? payload.userEmail
+          : undefined}
+        loading={isSigningInAlreadyLinked}
+        onSignIn={async () => {
+          isSigningInAlreadyLinked = true;
+          try {
+            await payload.signIn();
+          } finally {
+            isSigningInAlreadyLinked = false;
+            alreadyLinkedPayload = undefined;
+          }
+        }}
+      />
+    </Dialog>
+  {/if}
+
+  {#if methodSwitchPayload !== undefined}
+    {@const payload = methodSwitchPayload}
+    {@const previous = payload.previous}
+    {@const previousEmail =
+      "openid" in previous.authMethod &&
+      previous.authMethod.openid.metadata !== undefined
+        ? getMetadataString(previous.authMethod.openid.metadata, "email")
+        : "sso" in previous.authMethod
+          ? previous.authMethod.sso.email
+          : undefined}
+    <Dialog
+      onClose={() => {
+        const proceed = payload.proceed;
+        methodSwitchPayload = undefined;
+        void proceed();
+      }}
+    >
+      <SwitchAccessMethod
+        userName={previous.name ??
+          previousEmail ??
+          `${previous.identityNumber}`}
+        userEmail={previous.name !== undefined ? previousEmail : undefined}
+        fromMethod={authMethodToAccessMethod(previous.authMethod)}
+        toMethod={payload.newProvider}
+        onSwitch={() => {
+          const proceed = payload.proceed;
+          methodSwitchPayload = undefined;
+          void proceed();
+        }}
       />
     </Dialog>
   {/if}

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -202,9 +202,6 @@
       duration: 4000,
     });
   };
-  const handleUpgrade = async (identityNumber: bigint) => {
-    await handleSignIn(identityNumber);
-  };
   const handleRemoveIdentity = (identityNumber: bigint) => {
     const isCurrent = selectedIdentity?.identityNumber === identityNumber;
     if (isCurrent) {
@@ -346,7 +343,6 @@
               <AuthWizard
                 onSignIn={handleSignIn}
                 onSignUp={handleSignUp}
-                onUpgrade={handleUpgrade}
                 onError={(error) => {
                   isAuthDialogOpen = false;
                   isAuthenticating = false;
@@ -386,7 +382,6 @@
               <AuthWizard
                 onSignIn={handleSignIn}
                 onSignUp={handleSignUp}
-                onUpgrade={handleUpgrade}
                 onError={(error) => {
                   isCreateIdentityDialogOpen = false;
                   isAuthenticating = false;

--- a/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
@@ -24,6 +24,18 @@
   import AuthWizardView from "./views/AuthWizardView.svelte";
   import AttributeConsentView from "./views/AttributeConsentView.svelte";
   import {
+    AuthWizard,
+    SignUpHero,
+    IdentityNotConnected,
+    IdentityAlreadyLinked,
+    SwitchAccessMethod,
+  } from "$lib/components/wizards/auth";
+  import type { AccessMethod } from "$lib/components/wizards/auth/views/SwitchAccessMethod.svelte";
+  import { backendCanisterConfig } from "$lib/globals";
+  import { getMetadataString } from "$lib/utils/openID";
+  import type { LastUsedIdentity } from "$lib/stores/last-used-identities.store";
+  import { goto } from "$app/navigation";
+  import {
     type AttributeConsent,
     attributeConsentStore,
     attributeConsentResultStore,
@@ -50,6 +62,49 @@
   // --- Local state ---
   let upgradeSuccess = $state(false);
   let openIdResumeProcessing = $state(false);
+  let isCreateIdentityDialogOpen = $state(false);
+
+  // --- Disambiguation dialog payloads (mirrors homepage flow) ---
+  let notConnectedPayload = $state<{
+    providerName: string;
+    providerLogo?: string;
+    userName?: string;
+    userEmail?: string;
+    resume: () => Promise<void>;
+    cancel: () => void;
+  }>();
+  let isResumingRegistration = $state(false);
+  let alreadyLinkedPayload = $state<{
+    providerName: string;
+    providerLogo?: string;
+    userName?: string;
+    userEmail?: string;
+    signIn: () => Promise<void>;
+    cancel: () => void;
+  }>();
+  let isSigningInAlreadyLinked = $state(false);
+  let methodSwitchPayload = $state<{
+    previous: LastUsedIdentity;
+    newProvider: AccessMethod;
+    proceed: () => Promise<void>;
+  }>();
+
+  const authMethodToAccessMethod = (
+    m: LastUsedIdentity["authMethod"],
+  ): AccessMethod => {
+    if ("passkey" in m) return { type: "passkey" };
+    if ("openid" in m) {
+      const config = backendCanisterConfig.openid_configs[0]?.find(
+        (c) => c.issuer === m.openid.iss,
+      );
+      return {
+        type: "openid",
+        logo: config?.logo ?? "",
+        name: config?.name ?? m.openid.iss,
+      };
+    }
+    return { type: "sso", name: m.sso.name ?? m.sso.domain };
+  };
 
   // --- Upgrade panel state ---
   let isUpgradeCollapsed = $state(
@@ -77,6 +132,7 @@
   // --- Handlers ---
   const handleAuthWizardSignIn = (identityNumber: bigint): Promise<void> => {
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
+    isCreateIdentityDialogOpen = false;
     return Promise.resolve();
   };
   const handleAuthWizardSignUp = (identityNumber: bigint): Promise<void> => {
@@ -85,6 +141,7 @@
       duration: 4000,
     });
     lastUsedIdentitiesStore.selectIdentity(identityNumber);
+    isCreateIdentityDialogOpen = false;
     return Promise.resolve();
   };
   const handleAuthWizardUpgrade = (): Promise<void> => {
@@ -424,5 +481,132 @@
     onSignUp={handleAuthWizardSignUp}
     onUpgrade={handleAuthWizardUpgrade}
     onError={handleError}
+    onOpenIdNotConnected={(args) => (notConnectedPayload = args)}
+    onMethodSwitch={(args) => (methodSwitchPayload = args)}
+    onSwitchMode={() => {
+      isCreateIdentityDialogOpen = true;
+    }}
+    mode="signin"
   />
 {/snippet}
+
+{#if isCreateIdentityDialogOpen}
+  <Dialog
+    onClose={() => {
+      isCreateIdentityDialogOpen = false;
+    }}
+  >
+    <AuthWizard
+      onSignIn={handleAuthWizardSignIn}
+      onSignUp={handleAuthWizardSignUp}
+      onUpgrade={handleAuthWizardUpgrade}
+      onError={(error) => {
+        isCreateIdentityDialogOpen = false;
+        handleError(error);
+      }}
+      onMethodSwitch={(args) => (methodSwitchPayload = args)}
+      onOpenIdAlreadyLinked={(args) => (alreadyLinkedPayload = args)}
+      onSwitchMode={undefined}
+      withinDialog={true}
+      mode="signup"
+    >
+      <SignUpHero />
+    </AuthWizard>
+  </Dialog>
+{/if}
+
+{#if notConnectedPayload !== undefined}
+  {@const payload = notConnectedPayload}
+  <Dialog
+    onClose={() => {
+      if (isResumingRegistration) {
+        return;
+      }
+      payload.cancel();
+      notConnectedPayload = undefined;
+    }}
+  >
+    <IdentityNotConnected
+      providerName={payload.providerName}
+      providerLogo={payload.providerLogo}
+      userName={payload.userName ?? payload.userEmail ?? payload.providerName}
+      userEmail={payload.userName !== undefined ? payload.userEmail : undefined}
+      loading={isResumingRegistration}
+      onSignUp={async () => {
+        isResumingRegistration = true;
+        try {
+          await payload.resume();
+        } finally {
+          isResumingRegistration = false;
+          notConnectedPayload = undefined;
+        }
+      }}
+      onRecover={() => {
+        payload.cancel();
+        notConnectedPayload = undefined;
+        void goto("/recovery");
+      }}
+    />
+  </Dialog>
+{/if}
+
+{#if alreadyLinkedPayload !== undefined}
+  {@const payload = alreadyLinkedPayload}
+  <Dialog
+    onClose={() => {
+      if (isSigningInAlreadyLinked) {
+        return;
+      }
+      payload.cancel();
+      alreadyLinkedPayload = undefined;
+    }}
+  >
+    <IdentityAlreadyLinked
+      providerName={payload.providerName}
+      providerLogo={payload.providerLogo}
+      userName={payload.userName ?? payload.userEmail ?? payload.providerName}
+      userEmail={payload.userName !== undefined ? payload.userEmail : undefined}
+      loading={isSigningInAlreadyLinked}
+      onSignIn={async () => {
+        isSigningInAlreadyLinked = true;
+        try {
+          await payload.signIn();
+        } finally {
+          isSigningInAlreadyLinked = false;
+          alreadyLinkedPayload = undefined;
+        }
+      }}
+    />
+  </Dialog>
+{/if}
+
+{#if methodSwitchPayload !== undefined}
+  {@const payload = methodSwitchPayload}
+  {@const previous = payload.previous}
+  {@const previousEmail =
+    "openid" in previous.authMethod &&
+    previous.authMethod.openid.metadata !== undefined
+      ? getMetadataString(previous.authMethod.openid.metadata, "email")
+      : "sso" in previous.authMethod
+        ? previous.authMethod.sso.email
+        : undefined}
+  <Dialog
+    onClose={() => {
+      const proceed = payload.proceed;
+      methodSwitchPayload = undefined;
+      void proceed();
+    }}
+  >
+    <SwitchAccessMethod
+      userName={previous.name ?? previousEmail ?? `${previous.identityNumber}`}
+      userEmail={previous.name !== undefined ? previousEmail : undefined}
+      fromMethod={authMethodToAccessMethod(previous.authMethod)}
+      toMethod={payload.newProvider}
+      onSwitch={() => {
+        const proceed = payload.proceed;
+        methodSwitchPayload = undefined;
+        void proceed();
+      }}
+    />
+  </Dialog>
+{/if}

--- a/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
@@ -144,11 +144,6 @@
     isCreateIdentityDialogOpen = false;
     return Promise.resolve();
   };
-  const handleAuthWizardUpgrade = (): Promise<void> => {
-    upgradeSuccess = true;
-    return Promise.resolve();
-  };
-
   const handleAuthorize = (accountNumber: Promise<bigint | undefined>) => {
     authorizationStore.authorize(accountNumber);
   };
@@ -479,7 +474,6 @@
   <AuthWizardView
     onSignIn={handleAuthWizardSignIn}
     onSignUp={handleAuthWizardSignUp}
-    onUpgrade={handleAuthWizardUpgrade}
     onError={handleError}
     onOpenIdNotConnected={(args) => (notConnectedPayload = args)}
     onMethodSwitch={(args) => (methodSwitchPayload = args)}
@@ -499,7 +493,6 @@
     <AuthWizard
       onSignIn={handleAuthWizardSignIn}
       onSignUp={handleAuthWizardSignUp}
-      onUpgrade={handleAuthWizardUpgrade}
       onError={(error) => {
         isCreateIdentityDialogOpen = false;
         handleError(error);

--- a/src/frontend/src/routes/(new-styling)/authorize/views/AuthWizardView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/AuthWizardView.svelte
@@ -4,36 +4,87 @@
   import { getDapps } from "$lib/legacy/flows/dappsExplorer/dapps";
   import { AuthWizard } from "$lib/components/wizards/auth";
   import { t } from "$lib/stores/locale.store";
-  import { Trans } from "$lib/components/locale";
+  import type { LastUsedIdentity } from "$lib/stores/last-used-identities.store";
+
+  type NewProvider =
+    | { type: "passkey" }
+    | { type: "openid"; logo: string; name: string }
+    | { type: "sso"; name: string };
+
+  interface OpenIdNotConnectedArgs {
+    providerName: string;
+    providerLogo?: string;
+    userName?: string;
+    userEmail?: string;
+    resume: () => Promise<void>;
+    cancel: () => void;
+  }
+
+  interface OpenIdAlreadyLinkedArgs {
+    providerName: string;
+    providerLogo?: string;
+    userName?: string;
+    userEmail?: string;
+    signIn: () => Promise<void>;
+    cancel: () => void;
+  }
+
+  interface MethodSwitchArgs {
+    previous: LastUsedIdentity;
+    newProvider: NewProvider;
+    proceed: () => Promise<void>;
+  }
 
   interface Props {
     onSignIn: (identityNumber: bigint) => Promise<void>;
     onSignUp: (identityNumber: bigint) => Promise<void>;
     onUpgrade: (identityNumber: bigint) => Promise<void>;
     onError: (error: unknown) => void;
+    onOpenIdNotConnected?: (args: OpenIdNotConnectedArgs) => void;
+    onOpenIdAlreadyLinked?: (args: OpenIdAlreadyLinkedArgs) => void;
+    onMethodSwitch?: (args: MethodSwitchArgs) => void;
+    onSwitchMode?: () => void;
+    mode?: "signin" | "signup" | "both";
   }
 
-  const { onSignIn, onSignUp, onUpgrade, onError }: Props = $props();
+  const {
+    onSignIn,
+    onSignUp,
+    onUpgrade,
+    onError,
+    onOpenIdNotConnected,
+    onOpenIdAlreadyLinked,
+    onMethodSwitch,
+    onSwitchMode,
+    mode = "both",
+  }: Props = $props();
 
   const dapps = getDapps();
   const dapp = $derived(
     dapps.find((dapp) => dapp.hasOrigin($establishedChannelStore.origin)),
   );
+  const dappName = $derived(
+    dapp?.name ?? new URL($establishedChannelStore.origin).hostname,
+  );
 </script>
 
-<AuthWizard {onSignIn} {onSignUp} {onUpgrade} {onError}>
+<AuthWizard
+  {onSignIn}
+  {onSignUp}
+  {onUpgrade}
+  {onError}
+  {onOpenIdNotConnected}
+  {onOpenIdAlreadyLinked}
+  {onMethodSwitch}
+  {onSwitchMode}
+  {mode}
+  withinDialog
+>
   <AuthorizeHeader origin={$establishedChannelStore.origin} />
   <h1 class="text-text-primary mb-2 self-start text-2xl font-medium">
-    {$t`Choose method`}
+    {$t`Sign in to Internet Identity`}
   </h1>
   <p class="text-text-secondary mb-6 self-start text-sm">
-    {#if dapp?.name !== undefined}
-      {@const application = dapp.name}
-      <Trans>
-        to continue with <b>{application}</b>
-      </Trans>
-    {:else}
-      <Trans>to continue with this app</Trans>
-    {/if}
+    {$t`to continue to ${dappName}`}
   </p>
 </AuthWizard>

--- a/src/frontend/src/routes/(new-styling)/authorize/views/AuthWizardView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/AuthWizardView.svelte
@@ -38,7 +38,6 @@
   interface Props {
     onSignIn: (identityNumber: bigint) => Promise<void>;
     onSignUp: (identityNumber: bigint) => Promise<void>;
-    onUpgrade: (identityNumber: bigint) => Promise<void>;
     onError: (error: unknown) => void;
     onOpenIdNotConnected?: (args: OpenIdNotConnectedArgs) => void;
     onOpenIdAlreadyLinked?: (args: OpenIdAlreadyLinkedArgs) => void;
@@ -50,7 +49,6 @@
   const {
     onSignIn,
     onSignUp,
-    onUpgrade,
     onError,
     onOpenIdNotConnected,
     onOpenIdAlreadyLinked,
@@ -71,7 +69,6 @@
 <AuthWizard
   {onSignIn}
   {onSignUp}
-  {onUpgrade}
   {onError}
   {onOpenIdNotConnected}
   {onOpenIdAlreadyLinked}

--- a/src/frontend/src/routes/(new-styling)/authorize/views/ContinueView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/ContinueView.svelte
@@ -71,6 +71,9 @@
   const application = $derived(
     dapps.find((dapp) => dapp.hasOrigin($establishedChannelStore.origin))?.name,
   );
+  const dappName = $derived(
+    application ?? new URL($establishedChannelStore.origin).hostname,
+  );
   const primaryAccountName = $derived(
     application !== undefined ? $t`My ${application} account` : $t`My account`,
   );
@@ -347,7 +350,7 @@
 <div class="flex flex-1 flex-col">
   <AuthorizeHeader origin={$establishedChannelStore.origin} />
   <h1 class="text-text-primary mb-2 self-start text-2xl font-medium">
-    {$t`Sign in`}
+    {$t`Continue to ${dappName}`}
   </h1>
   <p class="text-text-secondary mb-6 self-start text-sm">
     {$t`with your Internet Identity`}

--- a/src/frontend/src/routes/(new-styling)/cli/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/+layout.svelte
@@ -48,8 +48,6 @@
       duration: 4000,
     });
   };
-  const handleUpgrade = (identityNumber: bigint): Promise<void> =>
-    handleSelectIdentity(identityNumber);
   const handleRemoveIdentity = (identityNumber: bigint) => {
     const isCurrent = selectedIdentity?.identityNumber === identityNumber;
     if (isCurrent) {
@@ -146,7 +144,6 @@
           <AuthWizard
             onSignIn={handleSelectIdentity}
             onSignUp={handleSignUp}
-            onUpgrade={handleUpgrade}
             onError={(error) => {
               isAuthDialogOpen = false;
               handleError(error);

--- a/src/frontend/src/routes/(new-styling)/cli/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/+page.svelte
@@ -229,10 +229,6 @@
       });
       return Promise.resolve();
     },
-    onUpgrade: (identityNumber: bigint): Promise<void> => {
-      lastUsedIdentitiesStore.selectIdentity(identityNumber);
-      return Promise.resolve();
-    },
     onError: handleError,
   };
 </script>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -37,7 +37,16 @@
   import ManageIdentities from "$lib/components/ui/ManageIdentities.svelte";
   import SignOutConfirmation from "$lib/components/ui/SignOutConfirmation.svelte";
   import ReauthPrompt from "$lib/components/ui/ReauthPrompt.svelte";
-  import AuthWizard from "$lib/components/wizards/auth/AuthWizard.svelte";
+  import {
+    AuthWizard,
+    IdentityNotConnected,
+    IdentityAlreadyLinked,
+    SwitchAccessMethod,
+  } from "$lib/components/wizards/auth";
+  import type { AccessMethod } from "$lib/components/wizards/auth/views/SwitchAccessMethod.svelte";
+  import type { LastUsedIdentity } from "$lib/stores/last-used-identities.store";
+  import { backendCanisterConfig } from "$lib/globals";
+  import { getMetadataString } from "$lib/utils/openID";
   import ChooseLanguage from "$lib/components/views/ChooseLanguage.svelte";
 
   // --- Props & state ---
@@ -49,11 +58,54 @@
   let isMobileSidebarOpen = $state(false);
   let isIdentityPopoverOpen = $state(false);
   let isAuthDialogOpen = $state(false);
+  let isCreateIdentityDialogOpen = $state(false);
   let isAuthenticating = $state(false);
   let isManageIdentitiesDialogOpen = $state(false);
   let isSignOutDialogOpen = $state(false);
   let isLanguageDialogOpen = $state(false);
   let isReauthDialogOpen = $state(false);
+  let signUpOpenedFromSignInModal = $state(false);
+
+  let notConnectedPayload = $state<{
+    providerName: string;
+    providerLogo?: string;
+    userName?: string;
+    userEmail?: string;
+    resume: () => Promise<void>;
+    cancel: () => void;
+  }>();
+  let isResumingRegistration = $state(false);
+  let alreadyLinkedPayload = $state<{
+    providerName: string;
+    providerLogo?: string;
+    userName?: string;
+    userEmail?: string;
+    signIn: () => Promise<void>;
+    cancel: () => void;
+  }>();
+  let isSigningInAlreadyLinked = $state(false);
+  let methodSwitchPayload = $state<{
+    previous: LastUsedIdentity;
+    newProvider: AccessMethod;
+    proceed: () => Promise<void>;
+  }>();
+
+  const authMethodToAccessMethod = (
+    m: LastUsedIdentity["authMethod"],
+  ): AccessMethod => {
+    if ("passkey" in m) return { type: "passkey" };
+    if ("openid" in m) {
+      const config = backendCanisterConfig.openid_configs[0]?.find(
+        (c) => c.issuer === m.openid.iss,
+      );
+      return {
+        type: "openid",
+        logo: config?.logo ?? "",
+        name: config?.name ?? m.openid.iss,
+      };
+    }
+    return { type: "sso", name: m.sso.name ?? m.sso.domain };
+  };
 
   // --- Derived ---
 
@@ -80,6 +132,8 @@
     } finally {
       isIdentityPopoverOpen = false;
       isAuthDialogOpen = false;
+      isCreateIdentityDialogOpen = false;
+      signUpOpenedFromSignInModal = false;
       isAuthenticating = false;
     }
   };
@@ -450,7 +504,16 @@
         isAuthenticating = false;
         handleError(error);
       }}
+      onOpenIdNotConnected={(args) => (notConnectedPayload = args)}
+      onMethodSwitch={(args) => (methodSwitchPayload = args)}
+      onSwitchMode={() => {
+        signUpOpenedFromSignInModal = true;
+        isAuthDialogOpen = false;
+        isCreateIdentityDialogOpen = true;
+      }}
       withinDialog
+      mode="signin"
+      switchModeTitle={$t`Want to create a new identity?`}
     >
       <h1 class="text-text-primary my-2 self-start text-2xl font-medium">
         {$t`Sign in`}
@@ -459,6 +522,143 @@
         {$t`Choose method to continue`}
       </p>
     </AuthWizard>
+  </Dialog>
+{/if}
+
+{#if isCreateIdentityDialogOpen}
+  <Dialog
+    onClose={() => {
+      if (isAuthenticating) {
+        return;
+      }
+      isCreateIdentityDialogOpen = false;
+      signUpOpenedFromSignInModal = false;
+    }}
+  >
+    <AuthWizard
+      onSignIn={handleSignIn}
+      onSignUp={handleSignUp}
+      onUpgrade={handleUpgrade}
+      onError={(error) => {
+        isCreateIdentityDialogOpen = false;
+        isAuthenticating = false;
+        handleError(error);
+      }}
+      onMethodSwitch={(args) => (methodSwitchPayload = args)}
+      onOpenIdAlreadyLinked={(args) => (alreadyLinkedPayload = args)}
+      onSwitchMode={() => {
+        isCreateIdentityDialogOpen = false;
+        if (signUpOpenedFromSignInModal) {
+          signUpOpenedFromSignInModal = false;
+          isAuthDialogOpen = true;
+        }
+      }}
+      withinDialog
+      mode="signup"
+    >
+      <h1 class="text-text-primary my-2 self-start text-2xl font-medium">
+        {$t`Create another identity`}
+      </h1>
+      <p class="text-text-secondary mb-6 self-start text-sm">
+        {$t`Set up a new identity.`}
+      </p>
+    </AuthWizard>
+  </Dialog>
+{/if}
+
+{#if notConnectedPayload !== undefined}
+  {@const payload = notConnectedPayload}
+  <Dialog
+    onClose={() => {
+      if (isAuthenticating || isResumingRegistration) {
+        return;
+      }
+      payload.cancel();
+      notConnectedPayload = undefined;
+    }}
+  >
+    <IdentityNotConnected
+      providerName={payload.providerName}
+      providerLogo={payload.providerLogo}
+      userName={payload.userName ?? payload.userEmail ?? payload.providerName}
+      userEmail={payload.userName !== undefined ? payload.userEmail : undefined}
+      loading={isResumingRegistration}
+      onSignUp={async () => {
+        isResumingRegistration = true;
+        try {
+          await payload.resume();
+        } finally {
+          isResumingRegistration = false;
+          notConnectedPayload = undefined;
+        }
+      }}
+      onRecover={() => {
+        payload.cancel();
+        notConnectedPayload = undefined;
+        void goto("/recovery");
+      }}
+    />
+  </Dialog>
+{/if}
+
+{#if alreadyLinkedPayload !== undefined}
+  {@const payload = alreadyLinkedPayload}
+  <Dialog
+    onClose={() => {
+      if (isAuthenticating || isSigningInAlreadyLinked) {
+        return;
+      }
+      payload.cancel();
+      alreadyLinkedPayload = undefined;
+    }}
+  >
+    <IdentityAlreadyLinked
+      providerName={payload.providerName}
+      providerLogo={payload.providerLogo}
+      userName={payload.userName ?? payload.userEmail ?? payload.providerName}
+      userEmail={payload.userName !== undefined ? payload.userEmail : undefined}
+      loading={isSigningInAlreadyLinked}
+      onSignIn={async () => {
+        isSigningInAlreadyLinked = true;
+        try {
+          await payload.signIn();
+        } finally {
+          isSigningInAlreadyLinked = false;
+          alreadyLinkedPayload = undefined;
+        }
+      }}
+    />
+  </Dialog>
+{/if}
+
+{#if methodSwitchPayload !== undefined}
+  {@const payload = methodSwitchPayload}
+  {@const previous = payload.previous}
+  {@const previousEmail =
+    "openid" in previous.authMethod &&
+    previous.authMethod.openid.metadata !== undefined
+      ? getMetadataString(previous.authMethod.openid.metadata, "email")
+      : "sso" in previous.authMethod
+        ? previous.authMethod.sso.email
+        : undefined}
+  <Dialog
+    onClose={() => {
+      const proceed = payload.proceed;
+      methodSwitchPayload = undefined;
+      void proceed();
+    }}
+  >
+    <SwitchAccessMethod
+      userName={previous.name ?? previousEmail ?? `${previous.identityNumber}`}
+      userEmail={previous.name !== undefined ? previousEmail : undefined}
+      fromMethod={authMethodToAccessMethod(previous.authMethod)}
+      toMethod={payload.newProvider}
+      onSwitch={() => {
+        const proceed = payload.proceed;
+        methodSwitchPayload = undefined;
+        void proceed();
+      }}
+    />
   </Dialog>
 {/if}
 

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -146,14 +146,6 @@
     });
   };
 
-  const handleUpgrade = async (identityNumber: bigint) => {
-    await handleSignIn(identityNumber);
-    toaster.success({
-      title: $t`Upgrade completed successfully`,
-      duration: 4000,
-    });
-  };
-
   // --- Sign out ---
 
   const handleSignOut = (): Promise<void> => {
@@ -498,7 +490,6 @@
     <AuthWizard
       onSignIn={handleSignIn}
       onSignUp={handleSignUp}
-      onUpgrade={handleUpgrade}
       onError={(error) => {
         isAuthDialogOpen = false;
         isAuthenticating = false;
@@ -538,7 +529,6 @@
     <AuthWizard
       onSignIn={handleSignIn}
       onSignUp={handleSignUp}
-      onUpgrade={handleUpgrade}
       onError={(error) => {
         isCreateIdentityDialogOpen = false;
         isAuthenticating = false;

--- a/src/frontend/src/routes/(new-styling)/recovery/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/recovery/+page.svelte
@@ -3,6 +3,7 @@
   import { t } from "$lib/stores/locale.store";
   import {
     ArrowRightIcon,
+    KeyIcon,
     MailIcon,
     RefreshCcw,
     ShieldIcon,
@@ -16,6 +17,7 @@
     type FoundIdentity,
     RecoverIdentityWizard,
   } from "$lib/components/wizards/recoverIdentity";
+  import { MigrationWizard } from "$lib/components/wizards/migration";
   import {
     RecoverWithEmailWizard,
     type RecoverySuccess,
@@ -43,6 +45,7 @@
 
   let showRecoveryDialog = $state(false);
   let showEmailRecoveryDialog = $state(false);
+  let showIdentityNumberDialog = $state(false);
 
   const handleSubmit = async (
     recoveryPhrase: string[],
@@ -180,6 +183,22 @@
       handleError(error);
     }
   };
+
+  const handleIdentityNumberSuccess = async (_identityNumber: bigint) => {
+    try {
+      showIdentityNumberDialog = false;
+      await preloadData("/manage/access");
+      await goto("/manage/access");
+      toaster.success({
+        title: $t`Successfully restored access to your identity`,
+        description: $t`You can manage your access methods on this page.`,
+        duration: 5000,
+      });
+    } catch (error) {
+      showIdentityNumberDialog = false;
+      handleError(error);
+    }
+  };
 </script>
 
 <div class="flex min-h-[100dvh] flex-col">
@@ -248,6 +267,30 @@
               </span>
             </ButtonCard>
           {/if}
+          <ButtonCard
+            onclick={() => (showIdentityNumberDialog = true)}
+            class="group !flex-col !items-stretch !gap-1 py-4 text-start"
+            aria-label={$t`Recover with identity number`}
+          >
+            <span class="flex w-full items-center gap-3">
+              <KeyIcon class="text-fg-tertiary size-5 shrink-0" />
+              <span
+                class="text-text-primary grow text-start text-base font-semibold"
+              >
+                {$t`Identity number`}
+              </span>
+              <ArrowRightIcon
+                class={[
+                  "text-fg-tertiary me-3 size-5 shrink-0 transform opacity-0 transition-all duration-200 rtl:-scale-x-100",
+                  "group-enabled:group-hover:me-2 group-enabled:group-hover:opacity-100",
+                  "group-enabled:group-focus-visible:me-0 group-enabled:group-focus-visible:opacity-100",
+                ]}
+              />
+            </span>
+            <span class="text-text-tertiary ps-8 text-sm font-normal">
+              {$t`Recover a legacy identity with its number.`}
+            </span>
+          </ButtonCard>
         </div>
         <a href="/" class="btn btn-secondary btn-xl">
           {$t`Cancel`}
@@ -281,6 +324,18 @@
       submitDkimLeaf={submitEmailDkimLeaf}
       getDelegation={getEmailDelegation}
       onSignedIn={handleEmailRecoverySignIn}
+    />
+  </Dialog>
+{/if}
+
+{#if showIdentityNumberDialog}
+  <Dialog onClose={() => (showIdentityNumberDialog = false)}>
+    <MigrationWizard
+      onSuccess={handleIdentityNumberSuccess}
+      onError={(error) => {
+        showIdentityNumberDialog = false;
+        handleError(error);
+      }}
     />
   </Dialog>
 {/if}

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -9,7 +9,10 @@
   onMount(() => {
     // Always redirect to primary origin
     const primaryOrigin = getPrimaryOrigin();
+    const hostname = window.location.hostname;
+    const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1";
     if (
+      !isLocalhost &&
       primaryOrigin !== undefined &&
       window.location.origin !== primaryOrigin &&
       // Don't redirect if we're coming from legacy AuthClient

--- a/src/frontend/tests/e2e-playwright-chrome-extension/chromeExtension.spec.ts
+++ b/src/frontend/tests/e2e-playwright-chrome-extension/chromeExtension.spec.ts
@@ -17,11 +17,12 @@ authorizeTest.describe("Authorize from chrome extension", () => {
 
   authorizeTest("should authenticate", async ({ authorizePage }) => {
     await addVirtualAuthenticator(authorizePage.page);
+    // /authorize renders the picker in mode="signin"; switch to sign-up.
     await authorizePage.page
-      .getByRole("button", { name: "Continue with Passkey" })
+      .getByRole("button", { name: "Sign up", exact: true })
       .click();
     await authorizePage.page
-      .getByRole("button", { name: "Create new identity" })
+      .getByRole("button", { name: "Sign up with passkey" })
       .click();
     await authorizePage.page.getByLabel("Identity name").fill("Extension User");
     await authorizePage.page

--- a/src/frontend/tests/e2e-playwright/fixtures/identity.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/identity.ts
@@ -275,13 +275,12 @@ export class IdentityWizard {
    * Bring the page to a state where the auth picker is on screen.
    *
    * The picker is rendered inline on the homepage's empty state but
-   * sits behind an "Add identity" / "Add another identity" / "Switch
-   * identity" CTA on the welcome-back state and on `/authorize` /
-   * `/manage`. The picker may be in mode="both" ("Continue with
-   * passkey") or in a mode-specific variant ("Sign in with passkey" /
-   * "Sign up with passkey") depending on which surface rendered it.
-   * Callers handle the variants themselves; this method just makes sure
-   * a picker is on screen.
+   * sits behind an "Add identity" / "Switch identity" CTA on the
+   * welcome-back state and on `/authorize` / `/manage`. The picker may
+   * be in mode="both" ("Continue with passkey") or in a mode-specific
+   * variant ("Sign in with passkey" / "Sign up with passkey") depending
+   * on which surface rendered it. Callers handle the variants
+   * themselves; this method just makes sure a picker is on screen.
    */
   async #openPicker(): Promise<void> {
     const switchIdentity = this.#page.getByRole("button", {
@@ -289,9 +288,6 @@ export class IdentityWizard {
     });
     const addIdentity = this.#page.getByRole("button", {
       name: "Add identity",
-    });
-    const addAnotherIdentity = this.#page.getByRole("button", {
-      name: "Add another identity",
     });
     const continueWithPasskey = this.#page.getByRole("button", {
       name: "Continue with passkey",
@@ -304,7 +300,6 @@ export class IdentityWizard {
     });
     await switchIdentity
       .or(addIdentity)
-      .or(addAnotherIdentity)
       .or(continueWithPasskey)
       .or(signInWithPasskey)
       .or(signUpWithPasskey)
@@ -322,11 +317,7 @@ export class IdentityWizard {
     if (await switchIdentity.isVisible()) {
       await switchIdentity.click();
     }
-    if (await addIdentity.isVisible()) {
-      await addIdentity.click();
-    } else {
-      await addAnotherIdentity.click();
-    }
+    await addIdentity.click();
     await continueWithPasskey
       .or(signInWithPasskey)
       .or(signUpWithPasskey)

--- a/src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts
@@ -105,10 +105,13 @@ test("Should issue delegation when derivationOrigin is properly configured in /.
 
   // Create a new identity in II
   await addVirtualAuthenticator(authPage);
-  await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
-  await authPage.getByRole("button", { name: "Create new identity" }).click();
+  await authPage.getByRole("button", { name: "Sign up", exact: true }).click();
+  await authPage.getByRole("button", { name: "Sign up with passkey" }).click();
   await authPage.getByLabel("Identity name").fill("John Doe");
   await authPage.getByRole("button", { name: "Create identity" }).click();
+  await expect(
+    authPage.getByRole("heading", { name: /^Continue to / }),
+  ).toBeVisible();
   await authPage.getByRole("button", { name: "Continue", exact: true }).click();
 
   // Wait for II window to close

--- a/src/frontend/tests/e2e-playwright/routes/authorize/auth-disambiguation.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/auth-disambiguation.spec.ts
@@ -1,0 +1,339 @@
+import { expect } from "@playwright/test";
+import { test } from "../../fixtures";
+import { authorize, addVirtualAuthenticator, II_URL } from "../../utils";
+import { DEFAULT_OPENID_PORT } from "../../fixtures/openid";
+
+const DEFAULT_USER_NAME = "John Doe";
+
+// AuthWizardView heading and subtitle (new-user path at /authorize)
+test.describe("AuthWizardView heading and subtitle", () => {
+  test("new user sees 'Sign in to Internet Identity' heading and dapp subtitle", async ({
+    page,
+  }) => {
+    await authorize(page, async (authPage) => {
+      await expect(
+        authPage.getByRole("heading", {
+          name: "Sign in to Internet Identity",
+        }),
+      ).toBeVisible();
+      await expect(authPage.getByText("to continue to")).toBeVisible();
+
+      await addVirtualAuthenticator(authPage);
+      await authPage
+        .getByRole("button", { name: "Sign up", exact: true })
+        .click();
+      await authPage
+        .getByRole("button", { name: "Sign up with passkey" })
+        .click();
+      await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
+      await authPage.getByRole("button", { name: "Create identity" }).click();
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    });
+  });
+
+  test("new user can toggle to sign-up modal from the picker footer 'Sign up' CTA", async ({
+    page,
+  }) => {
+    await authorize(page, async (authPage) => {
+      await expect(
+        authPage.getByRole("button", { name: "Sign up", exact: true }),
+      ).toBeVisible();
+
+      await authPage
+        .getByRole("button", { name: "Sign up", exact: true })
+        .click();
+      await expect(authPage.getByRole("dialog")).toBeVisible();
+
+      // Sign-up dialog must NOT show the "Already have an identity?" footer
+      await expect(
+        authPage.getByText("Already have an identity?"),
+      ).toBeHidden();
+
+      await authPage.getByRole("button", { name: "Close" }).click();
+      await expect(authPage.getByRole("dialog")).toBeHidden();
+      await expect(
+        authPage.getByRole("heading", {
+          name: "Sign in to Internet Identity",
+        }),
+      ).toBeVisible();
+
+      await addVirtualAuthenticator(authPage);
+      await authPage
+        .getByRole("button", { name: "Sign up", exact: true })
+        .click();
+      await authPage
+        .getByRole("button", { name: "Sign up with passkey" })
+        .click();
+      await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
+      await authPage.getByRole("button", { name: "Create identity" }).click();
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    });
+  });
+});
+
+test.describe("ContinueView heading and subtitle — returning user", () => {
+  test("returning user sees 'Continue to <dapp>' heading and 'with your Internet Identity' subtitle", async ({
+    page,
+    identities,
+    addAuthenticatorForIdentity,
+    signInWithIdentity,
+  }) => {
+    await page.goto(II_URL);
+    await signInWithIdentity(page, identities[0].identityNumber);
+    await page.waitForURL(II_URL + "/manage");
+
+    await authorize(page, async (authPage) => {
+      await expect(
+        authPage.getByRole("heading", { name: /^Continue to / }),
+      ).toBeVisible();
+      await expect(
+        authPage.getByText("with your Internet Identity"),
+      ).toBeVisible();
+      await addAuthenticatorForIdentity(authPage, identities[0].identityNumber);
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    });
+  });
+});
+
+// IdentityNotConnectedDialog — OIDC sign-in for a user without an II
+test.describe("IdentityNotConnectedDialog at /authorize", () => {
+  test.use({
+    openIdConfig: {
+      defaultPort: DEFAULT_OPENID_PORT,
+      createUsers: [
+        {
+          claims: {
+            name: DEFAULT_USER_NAME,
+            email: "john.doe@example.com",
+          },
+        },
+      ],
+    },
+  });
+
+  test("OIDC sign-in for unknown user shows IdentityNotConnected dialog; dismiss returns to picker", async ({
+    page,
+    signInWithOpenId,
+    openIdUsers,
+  }) => {
+    await authorize(page, async (authPage) => {
+      const popupPromise = authPage.context().waitForEvent("page");
+      await authPage
+        .getByRole("button", { name: openIdUsers[0].issuer.name })
+        .click();
+      const popup = await popupPromise;
+      const closePromise = popup.waitForEvent("close", { timeout: 15_000 });
+      await signInWithOpenId(popup, openIdUsers[0].id);
+      await closePromise;
+
+      await expect(
+        authPage.getByRole("heading", { name: "Create your Identity" }),
+      ).toBeVisible();
+      await expect(authPage.getByText("Not connected yet")).toBeVisible();
+
+      await authPage.getByRole("button", { name: "Close" }).click();
+      await expect(
+        authPage.getByRole("heading", { name: "Create your Identity" }),
+      ).toBeHidden();
+      await expect(
+        authPage.getByRole("heading", {
+          name: "Sign in to Internet Identity",
+        }),
+      ).toBeVisible();
+
+      await addVirtualAuthenticator(authPage);
+      await authPage
+        .getByRole("button", { name: "Sign up", exact: true })
+        .click();
+      await authPage
+        .getByRole("button", { name: "Sign up with passkey" })
+        .click();
+      await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
+      await authPage.getByRole("button", { name: "Create identity" }).click();
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    });
+  });
+
+  test("clicking Sign up inside IdentityNotConnectedDialog completes registration", async ({
+    page,
+    signInWithOpenId,
+    openIdUsers,
+  }) => {
+    await authorize(page, async (authPage) => {
+      const popupPromise = authPage.context().waitForEvent("page");
+      await authPage
+        .getByRole("button", { name: openIdUsers[0].issuer.name })
+        .click();
+      const popup = await popupPromise;
+      const closePromise = popup.waitForEvent("close", { timeout: 15_000 });
+      await signInWithOpenId(popup, openIdUsers[0].id);
+      await closePromise;
+
+      await expect(
+        authPage.getByRole("heading", { name: "Create your Identity" }),
+      ).toBeVisible();
+      await authPage
+        .getByRole("dialog")
+        .getByRole("button", { name: "Sign up", exact: true })
+        .click();
+
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    });
+  });
+});
+
+// IdentityAlreadyLinkedDialog — OIDC sign-up where provider is already linked
+test.describe("IdentityAlreadyLinkedDialog at /authorize (sign-up path)", () => {
+  const name = DEFAULT_USER_NAME;
+
+  test.use({
+    openIdConfig: {
+      defaultPort: DEFAULT_OPENID_PORT,
+      createUsers: [
+        {
+          claims: { name, email: "john.doe@example.com" },
+        },
+      ],
+    },
+  });
+
+  test("OIDC sign-up with already-linked provider shows IdentityAlreadyLinked dialog; Sign in proceeds", async ({
+    page,
+    signInWithOpenId,
+    openIdUsers,
+    managePage,
+  }) => {
+    await page.goto(II_URL);
+    const signUpPopupPromise = page.context().waitForEvent("page");
+    await page
+      .getByRole("button", { name: openIdUsers[0].issuer.name })
+      .click();
+    const signUpPopup = await signUpPopupPromise;
+    const signUpClosePromise = signUpPopup.waitForEvent("close", {
+      timeout: 15_000,
+    });
+    await signInWithOpenId(signUpPopup, openIdUsers[0].id);
+    await signUpClosePromise;
+    // Fresh OIDC user on the homepage surfaces IdentityNotConnectedDialog
+    // — confirm sign-up to land on /manage.
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Sign up" })
+      .click();
+    await page.waitForURL(II_URL + "/manage");
+    await managePage.signOut((c) => c.removeFromDevice());
+
+    await authorize(page, async (authPage) => {
+      await authPage
+        .getByRole("button", { name: "Sign up", exact: true })
+        .click();
+      await expect(authPage.getByRole("dialog")).toBeVisible();
+
+      await authPage.context().clearCookies();
+      const popupPromise = authPage.context().waitForEvent("page");
+      await authPage
+        .getByRole("dialog")
+        .getByRole("button", { name: openIdUsers[0].issuer.name })
+        .click();
+      const popup = await popupPromise;
+      const closePromise = popup.waitForEvent("close", { timeout: 15_000 });
+      await signInWithOpenId(popup, openIdUsers[0].id);
+      await closePromise;
+
+      await expect(
+        authPage.getByRole("heading", { name: "Already connected" }),
+      ).toBeVisible();
+      await expect(
+        authPage.getByText("Connected", { exact: true }),
+      ).toBeVisible();
+
+      await authPage
+        .getByRole("button", { name: "Sign in", exact: true })
+        .click();
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    });
+  });
+
+  test("dismissing IdentityAlreadyLinkedDialog stays in sign-up modal; no auto-sign-in", async ({
+    page,
+    signInWithOpenId,
+    openIdUsers,
+    managePage,
+  }) => {
+    await page.goto(II_URL);
+    const signUpPopupPromise = page.context().waitForEvent("page");
+    await page
+      .getByRole("button", { name: openIdUsers[0].issuer.name })
+      .click();
+    const signUpPopup = await signUpPopupPromise;
+    const signUpClosePromise = signUpPopup.waitForEvent("close", {
+      timeout: 15_000,
+    });
+    await signInWithOpenId(signUpPopup, openIdUsers[0].id);
+    await signUpClosePromise;
+    // Fresh OIDC user on the homepage surfaces IdentityNotConnectedDialog
+    // — confirm sign-up to land on /manage.
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Sign up" })
+      .click();
+    await page.waitForURL(II_URL + "/manage");
+    await managePage.signOut((c) => c.removeFromDevice());
+
+    await authorize(page, async (authPage) => {
+      await authPage
+        .getByRole("button", { name: "Sign up", exact: true })
+        .click();
+
+      await authPage.context().clearCookies();
+      const popupPromise = authPage.context().waitForEvent("page");
+      await authPage
+        .getByRole("dialog")
+        .getByRole("button", { name: openIdUsers[0].issuer.name })
+        .click();
+      const popup = await popupPromise;
+      const closePromise = popup.waitForEvent("close", { timeout: 15_000 });
+      await signInWithOpenId(popup, openIdUsers[0].id);
+      await closePromise;
+
+      await expect(
+        authPage.getByRole("heading", { name: "Already connected" }),
+      ).toBeVisible();
+
+      await authPage
+        .getByRole("dialog")
+        .filter({
+          has: authPage.getByRole("heading", { name: "Already connected" }),
+        })
+        .getByRole("button", { name: "Close" })
+        .click();
+      await expect(
+        authPage.getByRole("heading", { name: "Already connected" }),
+      ).toBeHidden();
+      await expect(authPage.getByRole("dialog")).toBeVisible();
+
+      await addVirtualAuthenticator(authPage);
+      await authPage
+        .getByRole("button", { name: "Sign up with passkey" })
+        .click();
+      await authPage.getByLabel("Identity name").fill("New User");
+      await authPage.getByRole("button", { name: "Create identity" }).click();
+      await authPage.getByRole("button", { name: "Close" }).click();
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    });
+  });
+});

--- a/src/frontend/tests/e2e-playwright/routes/authorize/consent.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/consent.spec.ts
@@ -557,10 +557,20 @@ test.describe("Authorize — explicit consent UI", () => {
       openIdUsers,
     }) => {
       const consent = attributeConsentView(authorizePage.page);
-      const ssoPage = await openSsoPopup(authorizePage.page);
+      const ssoPage = await openSsoPopup(
+        authorizePage.page,
+        undefined,
+        "signin",
+      );
       const closePromise = ssoPage.waitForEvent("close", { timeout: 15_000 });
       await signInWithOpenId(ssoPage, openIdUsers[0].id);
       await closePromise;
+      // Fresh SSO user surfaces IdentityNotConnectedDialog — confirm
+      // sign-up before the authorize "Continue" is available.
+      await authorizePage.page
+        .getByRole("dialog")
+        .getByRole("button", { name: "Sign up" })
+        .click();
       await authorizePage.page
         .getByRole("button", { name: "Continue", exact: true })
         .click();

--- a/src/frontend/tests/e2e-playwright/routes/authorize/continue.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/continue.spec.ts
@@ -112,14 +112,11 @@ test.describe("multiple identities", () => {
     const principal = await authorize(page, async (authPage) => {
       await addAuthenticatorForIdentity(authPage, identities[0].identityNumber);
       await authPage.getByRole("button", { name: "Switch identity" }).click();
+      await authPage.getByRole("button", { name: "Add identity" }).click();
+      // Sign-in dialog renders the mode="signin" picker; clicking it
+      // goes straight to existing-passkey WebAuthn.
       await authPage
-        .getByRole("button", { name: "Add another identity" })
-        .click();
-      await authPage
-        .getByRole("button", { name: "Continue with passkey" })
-        .click();
-      await authPage
-        .getByRole("button", { name: "Use existing identity" })
+        .getByRole("button", { name: "Sign in with passkey" })
         .click();
       await authPage
         .getByRole("button", { name: "Continue", exact: true })

--- a/src/frontend/tests/e2e-playwright/routes/authorize/delegationTtl.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/delegationTtl.spec.ts
@@ -16,8 +16,8 @@ test("Delegation maxTimeToLive: 1 min", async ({ page }) => {
 
   // Create new identity and authenticate
   await addVirtualAuthenticator(authPage);
-  await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
-  await authPage.getByRole("button", { name: "Create new identity" }).click();
+  await authPage.getByRole("button", { name: "Sign up", exact: true }).click();
+  await authPage.getByRole("button", { name: "Sign up with passkey" }).click();
   await authPage.getByLabel("Identity name").fill("Test User");
   await authPage.getByRole("button", { name: "Create identity" }).click();
   await authPage.getByRole("button", { name: "Continue", exact: true }).click();
@@ -50,8 +50,8 @@ test("Delegation maxTimeToLive: 1 day", async ({ page }) => {
 
   // Create new identity and authenticate
   await addVirtualAuthenticator(authPage);
-  await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
-  await authPage.getByRole("button", { name: "Create new identity" }).click();
+  await authPage.getByRole("button", { name: "Sign up", exact: true }).click();
+  await authPage.getByRole("button", { name: "Sign up with passkey" }).click();
   await authPage.getByLabel("Identity name").fill("Test User");
   await authPage.getByRole("button", { name: "Create identity" }).click();
   await authPage.getByRole("button", { name: "Continue", exact: true }).click();
@@ -83,8 +83,8 @@ test("Delegation maxTimeToLive: 2 months", async ({ page }) => {
 
   // Create new identity and authenticate
   await addVirtualAuthenticator(authPage);
-  await authPage.getByRole("button", { name: "Continue with Passkey" }).click();
-  await authPage.getByRole("button", { name: "Create new identity" }).click();
+  await authPage.getByRole("button", { name: "Sign up", exact: true }).click();
+  await authPage.getByRole("button", { name: "Sign up with passkey" }).click();
   await authPage.getByLabel("Identity name").fill("Test User");
   await authPage.getByRole("button", { name: "Create identity" }).click();
   await authPage.getByRole("button", { name: "Continue", exact: true }).click();

--- a/src/frontend/tests/e2e-playwright/routes/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/index.spec.ts
@@ -16,9 +16,11 @@ test("Authorize by registering a new passkey", async ({ page }) => {
   await authorize(page, async (authPage) => {
     await addVirtualAuthenticator(authPage);
     await authPage
-      .getByRole("button", { name: "Continue with Passkey" })
+      .getByRole("button", { name: "Sign up", exact: true })
       .click();
-    await authPage.getByRole("button", { name: "Create new identity" }).click();
+    await authPage
+      .getByRole("button", { name: "Sign up with passkey" })
+      .click();
     await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
     await authPage.getByRole("button", { name: "Create identity" }).click();
     await authPage
@@ -35,10 +37,7 @@ test("Authorize by signing in with an existing passkey", async ({
   await authorize(page, async (authPage) => {
     await addAuthenticatorForIdentity(authPage, identities[0].identityNumber);
     await authPage
-      .getByRole("button", { name: "Continue with Passkey" })
-      .click();
-    await authPage
-      .getByRole("button", { name: "Use existing identity" })
+      .getByRole("button", { name: "Sign in with passkey" })
       .click();
     await authPage
       .getByRole("button", { name: "Continue", exact: true })
@@ -77,12 +76,7 @@ test("Authorize by signing in from another device", async ({
       // Switch to current device and start "Continue from another device" flow to get link
       await addVirtualAuthenticator(authPage);
       await authPage
-        .getByRole("button", { name: "Continue with Passkey" })
-        .click();
-      await authPage
-        .getByRole("button", {
-          name: "Use existing identity",
-        })
+        .getByRole("button", { name: "Sign in with passkey" })
         .click();
       await authPage
         .getByRole("heading", {
@@ -196,7 +190,18 @@ test.describe("Sign up with OpenID", () => {
       await signInWithOpenId(openIdPage, openIdUsers[0].id);
       await closePromise;
 
-      // Continue to dapp
+      // Fresh OIDC user surfaces IdentityNotConnectedDialog — confirm
+      // sign-up to land on ContinueView.
+      await authPage
+        .getByRole("dialog")
+        .getByRole("button", { name: "Sign up" })
+        .click();
+
+      // Continue to dapp — wait for the confirmation heading first so any
+      // dialog transition has fully resolved before clicking.
+      await expect(
+        authPage.getByRole("heading", { name: /^Continue to / }),
+      ).toBeVisible();
       await authPage
         .getByRole("button", { name: "Continue", exact: true })
         .click();
@@ -225,10 +230,19 @@ test.describe("Sign up with SSO", () => {
     await authorize(page, async (authPage) => {
       // Pick SSO entry, type the discovery domain, wait for two-hop
       // discovery, then drive the IdP popup the same way as direct OpenID.
-      const ssoPage = await openSsoPopup(authPage);
+      // The /authorize picker renders with mode="signin", so the SSO
+      // button label is "Sign in with SSO" not the mode="both" default.
+      const ssoPage = await openSsoPopup(authPage, undefined, "signin");
       const closePromise = ssoPage.waitForEvent("close", { timeout: 15_000 });
       await signInWithOpenId(ssoPage, openIdUsers[0].id);
       await closePromise;
+
+      // Fresh SSO user surfaces IdentityNotConnectedDialog — confirm
+      // sign-up to land on ContinueView.
+      await authPage
+        .getByRole("dialog")
+        .getByRole("button", { name: "Sign up" })
+        .click();
 
       await authPage
         .getByRole("button", { name: "Continue", exact: true })
@@ -245,10 +259,10 @@ test("Authorize with ICRC-29", async ({ page }) => {
     async (authPage) => {
       await addVirtualAuthenticator(authPage);
       await authPage
-        .getByRole("button", { name: "Continue with Passkey" })
+        .getByRole("button", { name: "Sign up", exact: true })
         .click();
       await authPage
-        .getByRole("button", { name: "Create new identity" })
+        .getByRole("button", { name: "Sign up with passkey" })
         .click();
       await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
       await authPage.getByRole("button", { name: "Create identity" }).click();
@@ -270,10 +284,10 @@ test("App logo doesn't appear when app is not known", async ({ page }) => {
       await expect(authPage.locator('img[alt*="logo"]')).not.toBeVisible();
 
       await authPage
-        .getByRole("button", { name: "Continue with Passkey" })
+        .getByRole("button", { name: "Sign up", exact: true })
         .click();
       await authPage
-        .getByRole("button", { name: "Create new identity" })
+        .getByRole("button", { name: "Sign up with passkey" })
         .click();
       await authPage.getByLabel("Identity name").fill("John Doe");
       await authPage.getByRole("button", { name: "Create identity" }).click();

--- a/src/frontend/tests/e2e-playwright/routes/authorize/legacy.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/legacy.spec.ts
@@ -27,10 +27,10 @@ import {
           ).toBeVisible();
           // Create new identity and continue to app
           await authPage
-            .getByRole("button", { name: "Continue with Passkey" })
+            .getByRole("button", { name: "Sign up", exact: true })
             .click();
           await authPage
-            .getByRole("button", { name: "Create new identity" })
+            .getByRole("button", { name: "Sign up with passkey" })
             .click();
           await authPage.getByLabel("Identity name").fill("Test");
           await authPage

--- a/src/frontend/tests/e2e-playwright/routes/authorize/openid-disambiguation.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/openid-disambiguation.spec.ts
@@ -1,0 +1,128 @@
+import { expect } from "@playwright/test";
+import { test } from "../../fixtures";
+import { authorize, addVirtualAuthenticator, II_URL } from "../../utils";
+import { DEFAULT_OPENID_PORT } from "../../fixtures/openid";
+
+const DEFAULT_USER_NAME = "John Doe";
+
+// OIDC cancellation → "Sign-in was canceled" toast
+test.describe("OIDC cancel toast", () => {
+  test.use({
+    openIdConfig: {
+      defaultPort: DEFAULT_OPENID_PORT,
+      createUsers: [
+        {
+          claims: { name: DEFAULT_USER_NAME },
+        },
+      ],
+    },
+  });
+
+  test("closing the OIDC popup without signing in shows 'Sign-in was canceled' toast", async ({
+    page,
+    openIdUsers,
+  }) => {
+    await authorize(page, async (authPage) => {
+      // Click the OpenID provider button — popup opens
+      const popupPromise = authPage.context().waitForEvent("page");
+      await authPage
+        .getByRole("button", { name: openIdUsers[0].issuer.name })
+        .click();
+      const popup = await popupPromise;
+
+      // Close the popup without signing in (user cancels)
+      await popup.close();
+
+      // The cancel toast should appear
+      await expect(
+        authPage
+          .getByRole("status")
+          .filter({ hasText: "Sign-in was canceled" }),
+      ).toBeVisible({ timeout: 5_000 });
+
+      // Complete the flow so authorize utility can finish
+      await addVirtualAuthenticator(authPage);
+      await authPage
+        .getByRole("button", { name: "Sign up", exact: true })
+        .click();
+      await authPage
+        .getByRole("button", { name: "Sign up with passkey" })
+        .click();
+      await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
+      await authPage.getByRole("button", { name: "Create identity" }).click();
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    });
+  });
+});
+
+// OIDC sign-in succeeds for existing II — no disambiguation dialog
+test.describe("OIDC sign-in for existing II at /authorize", () => {
+  const name = DEFAULT_USER_NAME;
+
+  test.use({
+    openIdConfig: {
+      defaultPort: DEFAULT_OPENID_PORT,
+      createUsers: [
+        {
+          claims: { name },
+        },
+      ],
+    },
+  });
+
+  test("OIDC sign-in with known identity proceeds without disambiguation dialog", async ({
+    page,
+    managePage,
+    signInWithOpenId,
+    openIdUsers,
+  }) => {
+    // Register the user first
+    await page.goto(II_URL);
+    const signUpPopupPromise = page.context().waitForEvent("page");
+    await page
+      .getByRole("button", { name: openIdUsers[0].issuer.name })
+      .click();
+    const signUpPopup = await signUpPopupPromise;
+    const signUpClosePromise = signUpPopup.waitForEvent("close", {
+      timeout: 15_000,
+    });
+    await signInWithOpenId(signUpPopup, openIdUsers[0].id);
+    await signUpClosePromise;
+    // Fresh OIDC user on the homepage surfaces IdentityNotConnectedDialog
+    // — confirm sign-up to land on /manage.
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Sign up" })
+      .click();
+    await page.waitForURL(II_URL + "/manage");
+    await managePage.signOut((c) => c.keepIdentity());
+    await page.context().clearCookies();
+
+    // Now sign in via /authorize — known (iss, sub) should go straight to ContinueView
+    await authorize(page, async (authPage) => {
+      const signInPopupPromise = authPage.context().waitForEvent("page");
+      await authPage
+        .getByRole("button", { name: openIdUsers[0].issuer.name })
+        .click();
+      const signInPopup = await signInPopupPromise;
+      const signInClosePromise = signInPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(signInPopup, openIdUsers[0].id);
+      await signInClosePromise;
+
+      // No disambiguation dialog — ContinueView should be visible immediately
+      await expect(
+        authPage.getByRole("heading", { name: "Create your Identity" }),
+      ).toBeHidden();
+      await expect(
+        authPage.getByRole("heading", { name: "Already connected" }),
+      ).toBeHidden();
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    });
+  });
+});

--- a/src/frontend/tests/e2e-playwright/routes/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/index.spec.ts
@@ -272,12 +272,45 @@ test.describe("First visit", () => {
       await signInWithOpenId(popup, openIdUsers[0].id);
       await closePromise;
 
-      await page
-        .getByRole("dialog")
-        .getByRole("button", { name: "Sign up" })
-        .click();
-
       // Assert that dashboard is shown
+      await page.waitForURL(II_URL + "/manage");
+      await expect(
+        page.getByRole("heading", {
+          name: new RegExp(`Welcome, ${name}\\.`),
+        }),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("SSO user without name claim", () => {
+    test.use({
+      openIdConfig: {
+        defaultPort: SSO_OPENID_PORT,
+        createUsers: [
+          {
+            claims: {},
+          },
+        ],
+      },
+    });
+
+    test("Sign up with SSO", async ({
+      page,
+      openSsoPopup,
+      signInWithOpenId,
+      openIdUsers,
+    }) => {
+      await page.goto(II_URL);
+      const popup = await openSsoPopup(page, undefined, "signin");
+
+      const closePromise = popup.waitForEvent("close", { timeout: 15_000 });
+      await signInWithOpenId(popup, openIdUsers[0].id);
+      await closePromise;
+
+      const name = "John Doe";
+      await page.getByLabel("Identity name").fill(name);
+      await page.getByRole("button", { name: "Create identity" }).click();
+
       await page.waitForURL(II_URL + "/manage");
       await expect(
         page.getByRole("heading", {

--- a/src/frontend/tests/e2e-playwright/routes/manage/add-identity.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/manage/add-identity.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from "@playwright/test";
+import { test } from "../../fixtures";
+import { II_URL } from "../../utils";
+
+// Covers the "Add identity" CTA in the IdentitySwitcher popover (manage layout).
+// The popover opens isAuthDialogOpen → AuthWizard(mode="signin"); the sign-up
+// toggle opens isCreateIdentityDialogOpen → AuthWizard(mode="signup"), and the
+// sign-in toggle inside the sign-up dialog re-opens the sign-in dialog (because
+// signUpOpenedFromSignInModal is true).
+
+test.describe("Add identity from manage layout header popover", () => {
+  test.use({
+    identityConfig: {
+      createIdentities: [{ name: "Alice" }],
+    },
+  });
+
+  test.beforeEach(async ({ page, identities, signInWithIdentity }) => {
+    await page.goto(II_URL);
+    await signInWithIdentity(page, identities[0].identityNumber);
+    await page.waitForURL(II_URL + "/manage");
+  });
+
+  test("clicking Add identity opens sign-in modal with correct heading and subtitle", async ({
+    page,
+  }) => {
+    // Open the identity popover
+    await page.getByRole("button", { name: "Switch identity" }).click();
+
+    // Click "Add identity" in the popover
+    await page.getByRole("button", { name: "Add identity" }).click();
+
+    // Sign-in modal should appear with the disambiguation heading
+    await expect(
+      page.getByRole("heading", { name: "Sign in", exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText("Choose method to continue")).toBeVisible();
+  });
+
+  test("clicking Sign up inside sign-in modal opens sign-up modal", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Switch identity" }).click();
+    await page.getByRole("button", { name: "Add identity" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Sign in", exact: true }),
+    ).toBeVisible();
+
+    // Toggle to sign-up
+    await page.getByRole("button", { name: "Sign up", exact: true }).click();
+    // Sign-up dialog heading should appear
+    await expect(
+      page.getByRole("heading", {
+        name: "Create another identity",
+        exact: true,
+      }),
+    ).toBeVisible();
+  });
+
+  test("clicking Sign in inside sign-up modal returns to sign-in modal when opened from sign-in modal", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Switch identity" }).click();
+    await page.getByRole("button", { name: "Add identity" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Sign in", exact: true }),
+    ).toBeVisible();
+
+    // Toggle to sign-up
+    await page.getByRole("button", { name: "Sign up", exact: true }).click();
+    await expect(
+      page.getByRole("heading", {
+        name: "Create another identity",
+        exact: true,
+      }),
+    ).toBeVisible();
+
+    // Toggle back to sign-in
+    await page.getByRole("button", { name: "Sign in", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "Sign in", exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/src/frontend/tests/e2e-playwright/routes/recovery-identity-number.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/recovery-identity-number.spec.ts
@@ -1,0 +1,290 @@
+import { test } from "../fixtures";
+import { expect } from "@playwright/test";
+import {
+  addVirtualAuthenticator,
+  authorizeWithUrl,
+  fromBase64URL,
+  getCredentialsFromVirtualAuthenticator,
+  II_URL,
+  LEGACY_II_URL,
+  TEST_APP_URL,
+  removeVirtualAuthenticator,
+  addCredentialToVirtualAuthenticator,
+  CredentialIdentity,
+  createActorForCredential,
+} from "../utils";
+
+const LEGACY_PASSKEY_ALIAS = "pre-upgrade-passkey";
+
+/**
+ * Creates a virtual authenticator scoped to LEGACY_II_URL, registers a
+ * passkey credential against that RP ID, removes the authenticator, and
+ * returns the raw CDP credential so callers can re-add it on demand.
+ */
+const createLegacyCredential = async (
+  page: import("@playwright/test").Page,
+) => {
+  await page.goto(LEGACY_II_URL + "/self-service");
+  const legacyAuthenticatorId = await addVirtualAuthenticator(page);
+  await page.evaluate(
+    async (rpId) => {
+      await navigator.credentials.create({
+        publicKey: {
+          challenge: Uint8Array.from("<ic0.app>", (c) => c.charCodeAt(0)),
+          attestation: "direct",
+          pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+          rp: { name: "Internet Identity Service", id: rpId },
+          user: {
+            id: window.crypto.getRandomValues(new Uint8Array(16)),
+            displayName: "Internet Identity User",
+            name: "Internet Identity User",
+          },
+        },
+      });
+    },
+    LEGACY_II_URL.replace(/^https?:\/\//, ""),
+  );
+  const [credential] = await getCredentialsFromVirtualAuthenticator(
+    page,
+    legacyAuthenticatorId,
+  );
+  await removeVirtualAuthenticator(page, legacyAuthenticatorId);
+  return credential;
+};
+
+test.describe("/recovery — identity number entry point", () => {
+  test("Identity number card is visible on the /recovery page", async ({
+    page,
+  }) => {
+    await page.goto(II_URL + "/recovery");
+    await expect(
+      page.getByRole("button", { name: "Recover with identity number" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Recover a legacy identity with its number."),
+    ).toBeVisible();
+  });
+
+  test("Clicking Identity number opens the MigrationWizard dialog", async ({
+    page,
+  }) => {
+    await page.goto(II_URL + "/recovery");
+    await page
+      .getByRole("button", { name: "Recover with identity number" })
+      .click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByPlaceholder("Internet Identity number"),
+    ).toBeVisible();
+  });
+
+  test("MigrationWizard dialog can be dismissed", async ({ page }) => {
+    await page.goto(II_URL + "/recovery");
+    await page
+      .getByRole("button", { name: "Recover with identity number" })
+      .click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Close" }).click();
+    await expect(dialog).toBeHidden();
+    await expect(
+      page.getByRole("button", { name: "Recover with identity number" }),
+    ).toBeVisible();
+  });
+
+  test("Completes the identity-number upgrade path and lands on /manage/access", async ({
+    page,
+    identities,
+  }) => {
+    // Prepare a legacy credential at LEGACY_II_URL's RP ID.
+    const legacyCredential = await createLegacyCredential(page);
+
+    // Use a test actor (authenticated as identities[0]) to register the
+    // legacy passkey on the identity and remove the modern one, leaving only
+    // the legacy passkey — the state of a not-yet-upgraded identity.
+    const actor = await createActorForCredential(
+      identities[0].host,
+      identities[0].canisterId,
+      identities[0].credentials[0],
+    );
+
+    const legacyIdentity =
+      await CredentialIdentity.fromCredential(legacyCredential);
+    await actor.authn_method_add(identities[0].identityNumber, {
+      metadata: [
+        ["alias", { String: LEGACY_PASSKEY_ALIAS }],
+        ["origin", { String: LEGACY_II_URL }],
+      ],
+      authn_method: {
+        WebAuthn: {
+          pubkey: legacyIdentity.getPublicKey().toDer(),
+          credential_id: fromBase64URL(legacyCredential.credentialId),
+          aaguid: [],
+        },
+      },
+      security_settings: {
+        protection: { Unprotected: null },
+        purpose: { Authentication: null },
+      },
+      last_authentication: [],
+    });
+
+    const modernIdentity = await CredentialIdentity.fromCredential(
+      identities[0].credentials[0],
+    );
+    await actor.authn_method_remove(
+      identities[0].identityNumber,
+      modernIdentity.getPublicKey().toDer(),
+    );
+
+    // Navigate to /recovery and open the identity-number wizard.
+    await page.goto(II_URL + "/recovery");
+    await page
+      .getByRole("button", { name: "Recover with identity number" })
+      .click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Step 1 — enter identity number.
+    await dialog
+      .getByPlaceholder("Internet Identity number")
+      .fill(identities[0].identityNumber.toString());
+
+    // Add virtual authenticator with the legacy credential so WebAuthn
+    // authentication against LEGACY_II_URL's RP ID succeeds.
+    const authenticatorId = await addVirtualAuthenticator(page);
+    await addCredentialToVirtualAuthenticator(
+      page,
+      authenticatorId,
+      legacyCredential,
+    );
+
+    await dialog.getByRole("button", { name: "Continue" }).click();
+
+    // Step 2 — name the new identity and create the upgrade passkey.
+    await expect(
+      dialog.getByRole("heading", { name: "Name your identity" }),
+    ).toBeVisible();
+    const upgradedName = identities[0].name + " (upgraded)";
+    await dialog.getByLabel("Identity name").fill(upgradedName);
+    await dialog.getByRole("button", { name: "Upgrade identity" }).click();
+
+    // After success the dialog closes and we're redirected to /manage/access.
+    await expect(dialog).toBeHidden();
+    await page.waitForURL(II_URL + "/manage/access");
+    await expect(
+      page.getByRole("heading", { name: "Access methods" }),
+    ).toBeVisible();
+
+    await removeVirtualAuthenticator(page, authenticatorId);
+  });
+});
+
+test.describe("AuthWizard passkey picker — no in-dialog upgrade link", () => {
+  test("SetupOrUseExistingPasskey does not render an identity number upgrade link", async ({
+    page,
+  }) => {
+    // Navigate to II landing page — first-time state shows the passkey picker inline.
+    await page.goto(II_URL);
+    await page.getByRole("button", { name: "Continue with passkey" }).click();
+
+    // The picker dialog / inline view must NOT contain the removed upgrade link.
+    await expect(page.getByText("Still have an identity number?")).toBeHidden();
+    await expect(page.getByRole("button", { name: "Upgrade" })).toBeHidden();
+
+    // Verify the two core actions are still present.
+    await expect(
+      page.getByRole("button", { name: "Create new identity" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Use existing identity" }),
+    ).toBeVisible();
+  });
+
+  test("SetupOrUseExistingPasskey inside 'Add another identity' dialog has no upgrade link", async ({
+    page,
+    identities,
+    signInWithIdentity,
+  }) => {
+    // Sign in to reach the welcome-back state where the picker is behind a dialog.
+    await page.goto(II_URL);
+    await signInWithIdentity(page, identities[0].identityNumber);
+
+    // Now on welcome-back state: open "Add another identity" to reach picker.
+    await page.goto(II_URL);
+    await page.getByRole("button", { name: "Add another identity" }).click();
+    await page.getByRole("button", { name: "Continue with passkey" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    await expect(
+      dialog.getByText("Still have an identity number?"),
+    ).toBeHidden();
+    await expect(dialog.getByRole("button", { name: "Upgrade" })).toBeHidden();
+
+    await expect(
+      dialog.getByRole("button", { name: "Create new identity" }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole("button", { name: "Use existing identity" }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("/authorize — standalone upgrade panel sanity check", () => {
+  test("Upgrade panel is present and opens the MigrationWizard when arriving from a legacy domain", async ({
+    page,
+  }) => {
+    // Use the legacy II URL as the identity provider — visiting /authorize
+    // from a non-primary origin triggers the GUIDED_UPGRADE feature flag,
+    // causing the "Still using an identity number?" upgrade panel to render.
+    await authorizeWithUrl(
+      page,
+      TEST_APP_URL,
+      LEGACY_II_URL,
+      async (authPage) => {
+        await addVirtualAuthenticator(authPage);
+
+        await expect(
+          authPage.getByRole("paragraph").filter({
+            hasText: "Still using an identity number?",
+          }),
+        ).toBeVisible({ timeout: 10000 });
+
+        // Expand the panel if collapsed (MIN_GUIDED_UPGRADE flag may start it collapsed).
+        const upgradeBtn = authPage.getByRole("button", {
+          name: "Upgrade your identity",
+        });
+        const isExpanded = await upgradeBtn.isVisible();
+        if (!isExpanded) {
+          await authPage
+            .getByRole("button", { name: "Upgrade" })
+            .first()
+            .click();
+        }
+        await upgradeBtn.click();
+
+        // MigrationWizard should now be active — the identity number input is the gate.
+        await expect(
+          authPage.getByPlaceholder("Internet Identity number"),
+        ).toBeVisible();
+
+        // Cancel: close the wizard and complete the authorize flow by creating a new identity.
+        await authPage.keyboard.press("Escape");
+        await authPage
+          .getByRole("button", { name: "Continue with passkey" })
+          .click();
+        await authPage
+          .getByRole("button", { name: "Create new identity" })
+          .click();
+        await authPage.getByLabel("Identity name").fill("Test");
+        await authPage.getByRole("button", { name: "Create identity" }).click();
+        await authPage
+          .getByRole("button", { name: "Continue", exact: true })
+          .click();
+      },
+    );
+  });
+});

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -140,7 +140,7 @@ export const createNewIdentityInII = async (
   if (onContinueScreen) {
     // If we're on the continue screen, go through the identity switcher
     await page.getByRole("button", { name: "Switch identity" }).click();
-    await page.getByRole("button", { name: "Add another identity" }).click();
+    await page.getByRole("button", { name: "Add identity" }).click();
   }
 
   // Create passkey identity


### PR DESCRIPTION
Users who created an identity before the upgrade flow want a clear path to recover it by its identity number. Previously the upgrade was buried inside the auth wizard via an `onUpgrade` prop; now it surfaces as a dedicated "Identity number" option on `/recovery` alongside the existing recovery-phrase and email-recovery entries.

The dapp-driven upgrade panel on `/authorize` (gated by `GUIDED_UPGRADE`, introduced in the parent PR) is unaffected.

## Changes

- `/recovery/+page.svelte`: new "Identity number" `ButtonCard` that opens `MigrationWizard` and routes to `/manage/access` on success
- `AuthWizard.svelte`, `AuthWizardView.svelte`, `SetupOrUseExistingPasskey.svelte`: drop `onUpgrade` prop, `isUpgrading` state, and the in-wizard `MigrationWizard` rendering
- Homepage, `/authorize/+layout.svelte`, `/authorize/+page.svelte`, `/cli/+layout.svelte`, `/cli/+page.svelte`, `/manage/(authenticated)/+layout.svelte`: drop the now-dead `handleUpgrade` definitions and `onUpgrade={…}` callsites

## Tests

- New `recovery-identity-number.spec.ts` covering the identity-number recovery flow on `/recovery`

<div align="left">Previous: #3968</div>