### PR TITLE
feat(fe): extend active-method protection to recovery email

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
@@ -82,6 +82,9 @@
   const isCurrentAccessMethod = $derived(
     "recoveryPhrase" in $authenticatedStore.authMethod,
   );
+  const isCurrentEmailRecovery = $derived(
+    "emailRecovery" in $authenticatedStore.authMethod,
+  );
   const isUnverified = $derived(
     recoveryPhraseData !== undefined &&
       recoveryPhraseData.last_authentication[0] === undefined &&
@@ -410,6 +413,7 @@
     {#if emailRecovery !== undefined}
       <ActiveEmailRecovery
         credential={emailRecovery}
+        isCurrentRecoveryMethod={isCurrentEmailRecovery}
         onReplace={() => (showEmailRecoverySetup = true)}
         onRemove={() => (removingEmailRecovery = true)}
       />

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/+page.svelte
@@ -413,7 +413,7 @@
     {#if emailRecovery !== undefined}
       <ActiveEmailRecovery
         credential={emailRecovery}
-        isCurrentRecoveryMethod={isCurrentEmailRecovery}
+        isCurrentAccessMethod={isCurrentEmailRecovery}
         onReplace={() => (showEmailRecoverySetup = true)}
         onRemove={() => (removingEmailRecovery = true)}
       />

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/ActiveEmailRecovery.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/ActiveEmailRecovery.svelte
@@ -11,18 +11,21 @@
   import { nanosToMillis } from "$lib/utils/time";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import Select from "$lib/components/ui/Select.svelte";
+  import Badge from "$lib/components/ui/Badge.svelte";
   import type { EmailRecoveryCredential } from "$lib/generated/internet_identity_types";
 
   type Props = {
     credential: EmailRecoveryCredential;
     onReplace: () => void;
     onRemove: () => void;
+    isCurrentRecoveryMethod?: boolean;
   } & SvelteHTMLElements["section"];
 
   const {
     credential,
     onReplace,
     onRemove,
+    isCurrentRecoveryMethod = false,
     class: className,
     ...props
   }: Props = $props();
@@ -37,16 +40,39 @@
 >
   <div class="mb-3 flex h-9 flex-row items-center">
     <MailCheckIcon class="text-fg-success-primary size-6" />
+    {#if isCurrentRecoveryMethod}
+      <Tooltip
+        label={$t`Currently active`}
+        description={$t`This is the recovery method you're currently signed in with.`}
+        direction="up"
+      >
+        <Badge
+          color="success"
+          size="sm"
+          dot
+          class="ms-2 flex-none cursor-default select-none"
+          tabindex={0}>{$t`Active`}</Badge
+        >
+      </Tooltip>
+    {/if}
     <Select
       options={[
         {
           label: $t`Replace`,
           icon: PencilIcon,
+          disabled: isCurrentRecoveryMethod,
+          tooltip: isCurrentRecoveryMethod
+            ? $t`Sign in with another method before changing this email`
+            : undefined,
           onClick: onReplace,
         },
         {
           label: $t`Remove`,
           icon: Trash2Icon,
+          disabled: isCurrentRecoveryMethod,
+          tooltip: isCurrentRecoveryMethod
+            ? $t`Sign in with another method before removing this email`
+            : undefined,
           onClick: onRemove,
         },
       ]}
@@ -71,7 +97,15 @@
         {$t`Last used`}
       </div>
       <div class="text-text-primary cursor-default text-xs">
-        {#if credential.last_used[0] !== undefined}
+        {#if isCurrentRecoveryMethod}
+          <Tooltip
+            label={$t`Currently signed in with this recovery email`}
+            direction="up"
+            align="start"
+          >
+            <span>{$t`Right now`}</span>
+          </Tooltip>
+        {:else if credential.last_used[0] !== undefined}
           {@const date = new Date(nanosToMillis(credential.last_used[0]))}
           <Tooltip
             label={$formatDate(date, {

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/ActiveEmailRecovery.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/ActiveEmailRecovery.svelte
@@ -18,14 +18,14 @@
     credential: EmailRecoveryCredential;
     onReplace: () => void;
     onRemove: () => void;
-    isCurrentRecoveryMethod?: boolean;
+    isCurrentAccessMethod?: boolean;
   } & SvelteHTMLElements["section"];
 
   const {
     credential,
     onReplace,
     onRemove,
-    isCurrentRecoveryMethod = false,
+    isCurrentAccessMethod = false,
     class: className,
     ...props
   }: Props = $props();
@@ -40,7 +40,7 @@
 >
   <div class="mb-3 flex h-9 flex-row items-center">
     <MailCheckIcon class="text-fg-success-primary size-6" />
-    {#if isCurrentRecoveryMethod}
+    {#if isCurrentAccessMethod}
       <Tooltip
         label={$t`Currently active`}
         description={$t`This is the recovery method you're currently signed in with.`}
@@ -60,8 +60,8 @@
         {
           label: $t`Replace`,
           icon: PencilIcon,
-          disabled: isCurrentRecoveryMethod,
-          tooltip: isCurrentRecoveryMethod
+          disabled: isCurrentAccessMethod,
+          tooltip: isCurrentAccessMethod
             ? $t`Sign in with another method before changing this email`
             : undefined,
           onClick: onReplace,
@@ -69,8 +69,8 @@
         {
           label: $t`Remove`,
           icon: Trash2Icon,
-          disabled: isCurrentRecoveryMethod,
-          tooltip: isCurrentRecoveryMethod
+          disabled: isCurrentAccessMethod,
+          tooltip: isCurrentAccessMethod
             ? $t`Sign in with another method before removing this email`
             : undefined,
           onClick: onRemove,
@@ -97,7 +97,7 @@
         {$t`Last used`}
       </div>
       <div class="text-text-primary cursor-default text-xs">
-        {#if isCurrentRecoveryMethod}
+        {#if isCurrentAccessMethod}
           <Tooltip
             label={$t`Currently signed in with this recovery email`}
             direction="up"

--- a/src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts
@@ -195,5 +195,32 @@ test.describe("Email recovery — real DNSSEC + DKIM flow", () => {
     await expect(
       page.getByRole("heading", { name: /access methods/i }).first(),
     ).toBeVisible();
+
+    // ---------------------------------------------------------------
+    // ADP — signed in via email recovery, the recovery-email card
+    // disables both Replace and Remove and shows an Active badge.
+    // ---------------------------------------------------------------
+    await page.goto(II_URL + "/manage/recovery");
+    const emailCard = page.locator("section").filter({
+      has: page.getByRole("heading", { name: "Recovery email" }),
+    });
+    await expect(emailCard.getByText("Active", { exact: true })).toBeVisible();
+
+    await emailCard.getByRole("button", { name: "More options" }).click();
+    const replaceItem = page
+      .getByRole("menu")
+      .getByRole("menuitem", { name: "Replace" });
+    const removeItem = page
+      .getByRole("menu")
+      .getByRole("menuitem", { name: "Remove" });
+    await expect(replaceItem).toBeDisabled();
+    await expect(removeItem).toBeDisabled();
+
+    await replaceItem.hover({ force: true });
+    await expect(
+      page
+        .getByRole("tooltip")
+        .filter({ hasText: "Sign in with another method before changing" }),
+    ).toBeVisible();
   });
 });

--- a/src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts
@@ -200,7 +200,15 @@ test.describe("Email recovery — real DNSSEC + DKIM flow", () => {
     // ADP — signed in via email recovery, the recovery-email card
     // disables both Replace and Remove and shows an Active badge.
     // ---------------------------------------------------------------
-    await page.goto(II_URL + "/manage/recovery");
+    // Use the sidebar link, not page.goto: a full reload wipes the
+    // in-memory authentication store and the card would render in
+    // its non-active state.
+    const openMenu = page.getByRole("button", { name: "Open menu" });
+    if (await openMenu.isVisible()) {
+      await openMenu.click();
+    }
+    await page.getByRole("link", { name: "Recovery" }).click();
+    await page.waitForURL(/\/manage\/recovery/);
     const emailCard = page.locator("section").filter({
       has: page.getByRole("heading", { name: "Recovery email" }),
     });

--- a/src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts
@@ -207,12 +207,9 @@ test.describe("Email recovery — real DNSSEC + DKIM flow", () => {
     await expect(emailCard.getByText("Active", { exact: true })).toBeVisible();
 
     await emailCard.getByRole("button", { name: "More options" }).click();
-    const replaceItem = page
-      .getByRole("menu")
-      .getByRole("menuitem", { name: "Replace" });
-    const removeItem = page
-      .getByRole("menu")
-      .getByRole("menuitem", { name: "Remove" });
+    const menu = emailCard.getByRole("menu");
+    const replaceItem = menu.getByRole("menuitem", { name: "Replace" });
+    const removeItem = menu.getByRole("menuitem", { name: "Remove" });
     await expect(replaceItem).toBeDisabled();
     await expect(removeItem).toBeDisabled();
 
@@ -221,6 +218,13 @@ test.describe("Email recovery — real DNSSEC + DKIM flow", () => {
       page
         .getByRole("tooltip")
         .filter({ hasText: "Sign in with another method before changing" }),
+    ).toBeVisible();
+
+    await removeItem.hover({ force: true });
+    await expect(
+      page
+        .getByRole("tooltip")
+        .filter({ hasText: "Sign in with another method before removing" }),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Problem

PR #3921 introduced Active-method protection that prevents users from removing or replacing the access method they are currently signed in with — but only for passkeys and OpenID. Recovery email was left out, so a user signed in via email recovery could remove or replace the recovery email and lock themselves out.

## Changes

- Detect when the current session was authenticated via email recovery and mark the recovery-email card as the active method.
- Show the existing Active badge on the recovery-email card in that case.
- Disable both Replace and Remove, with a tooltip prompting the user to sign in with another method first.

Mirrors the existing guard pattern on `ActivePasskey` and `ActiveOpenIdCredential`.

## Tests

- New Playwright case in `emailRecovery.spec.ts` covering the active-badge + disabled-actions state after an email-recovery sign-in.
- Manual: signed in via email recovery and verified the badge appears + Replace/Remove are disabled with the tooltip.