### PR TITLE
fix(be): make DoH in-flight dedup safe under concurrency

### DIFF
--- a/src/internet_identity/src/doh/cache.rs
+++ b/src/internet_identity/src/doh/cache.rs
@@ -448,7 +448,11 @@ mod tests {
             0,
             "publish must not wake subscribers while the cache is borrowed"
         );
-        assert_eq!(wakers.len(), 1, "the registered waker should be handed back");
+        assert_eq!(
+            wakers.len(),
+            1,
+            "the registered waker should be handed back"
+        );
 
         for waker in wakers {
             waker.wake();

--- a/src/internet_identity/src/doh/cache.rs
+++ b/src/internet_identity/src/doh/cache.rs
@@ -125,35 +125,48 @@ impl DohCache {
     ///
     /// If we find a `Pending` entry that's older than
     /// [`PENDING_STALE_AFTER_SECS`], we treat it as abandoned (the
-    /// continuation that should have published it likely trapped),
-    /// wake any orphan waiters with [`DohError::AllProvidersFailed`]
-    /// so they don't hang, and start a fresh fetch.
+    /// continuation that should have published it likely trapped) and
+    /// start a fresh fetch. The abandoned entry's orphan waiters are
+    /// flipped to [`DohError::AllProvidersFailed`] so they don't hang;
+    /// their wakers are returned in the second tuple element for the
+    /// caller to fire *after* releasing the `DOH_CACHE` borrow (waking
+    /// re-enters the cache — see [`take_wakers`]). The list is empty on
+    /// every non-eviction path.
     ///
     /// Also opportunistically evicts the looked-up entry if we find
     /// it expired — keeps the cache from accumulating dead entries
     /// for FQDNs that get queried once and then go silent.
-    pub fn lookup(&mut self, name: &str, now_secs: u64) -> CacheLookup {
+    pub fn lookup(&mut self, name: &str, now_secs: u64) -> (CacheLookup, Vec<Waker>) {
         if let Some(entry) = self.entries.get(name) {
             if entry.expires_at_secs > now_secs {
-                return CacheLookup::Hit(entry.bytes.clone());
+                return (CacheLookup::Hit(entry.bytes.clone()), Vec::new());
             }
             // Expired: drop it now rather than waiting for a publish
             // to overwrite — most expired entries never see a republish.
             self.entries.remove(name);
         }
+        // Wakers of an abandoned in-flight fetch we evict below, if any.
+        // Returned to the caller to fire once the `DOH_CACHE` borrow is
+        // released — never woken inline (see `take_wakers`).
+        let mut orphan_wakers = Vec::new();
         if let Some(existing) = self.pending.get(name) {
             let age = now_secs.saturating_sub(existing.started_at_secs);
             if age < PENDING_STALE_AFTER_SECS {
-                return CacheLookup::Wait(WaitForPending {
-                    state: existing.state.clone(),
-                });
+                return (
+                    CacheLookup::Wait(WaitForPending {
+                        state: existing.state.clone(),
+                    }),
+                    Vec::new(),
+                );
             }
-            // Abandoned: evict and wake any orphan waiters. The
-            // SharedPending may still be held by `WaitForPending`
-            // futures that registered before eviction; flipping it to
-            // `Done(Err)` resolves their `await` instead of hanging.
+            // Abandoned: evict it. The SharedPending may still be held
+            // by `WaitForPending` futures that registered before
+            // eviction; flipping it to `Done(Err)` resolves their
+            // `await` instead of hanging. We hand their wakers back
+            // rather than firing them here — `lookup` runs inside
+            // `DOH_CACHE.borrow_mut()`.
             let stale = self.pending.remove(name).expect("just checked");
-            wake_with(&stale.state, Err(DohError::AllProvidersFailed));
+            orphan_wakers = take_wakers(&stale.state, Err(DohError::AllProvidersFailed));
         }
         let state = Rc::new(RefCell::new(PendingState::InFlight { wakers: Vec::new() }));
         self.pending.insert(
@@ -163,17 +176,26 @@ impl DohCache {
                 started_at_secs: now_secs,
             },
         );
-        CacheLookup::Fetch(FetchToken { state })
+        (CacheLookup::Fetch(FetchToken { state }), orphan_wakers)
     }
 
-    /// Publish the result of the in-flight fetch for `name`.
+    /// Publish the result of the in-flight fetch for `name`, returning
+    /// the wakers of any dedup subscribers.
+    ///
+    /// **The caller must wake the returned wakers, and only after the
+    /// `DOH_CACHE` borrow is released.** `publish` runs inside
+    /// `DOH_CACHE.borrow_mut()`; a woken `WaitForPending` is polled
+    /// synchronously and re-entrantly by the single-threaded canister
+    /// executor, and that poll borrows both this `PendingState` and —
+    /// as the resumed task races on to its next `fetch_txt` — `DOH_CACHE`
+    /// itself. Waking inline would trip `RefCell already borrowed`.
     ///
     /// The `token` is whatever [`Self::lookup`] handed back when this
     /// caller got the `Fetch` arm — passing it back lets us detect
     /// the case where this fetch was evicted by a stale-takeover
     /// (another caller saw the pending entry as abandoned and started
     /// over). In that case we don't touch the cache map but we still
-    /// wake any subscribers tied to *our* `PendingState`, so even
+    /// return the wakers tied to *our* `PendingState`, so even
     /// orphaned waiters resolve cleanly.
     ///
     /// Also opportunistically sweeps any value entries that are
@@ -181,6 +203,7 @@ impl DohCache {
     /// write path) rather than on every `lookup` keeps reads cheap
     /// while still bounding cache size — every successful fetch
     /// drops the dead weight that accumulated since the last write.
+    #[must_use = "the returned wakers must be woken after the DOH_CACHE borrow is released"]
     pub fn publish(
         &mut self,
         name: &str,
@@ -188,7 +211,7 @@ impl DohCache {
         result: Result<Vec<u8>, DohError>,
         expires_at_secs: u64,
         now_secs: u64,
-    ) {
+    ) -> Vec<Waker> {
         self.sweep_expired(now_secs);
 
         let still_ours = self
@@ -201,7 +224,10 @@ impl DohCache {
             }
             self.pending.remove(name);
         }
-        wake_with(&token.state, result);
+        // Flip our `PendingState` to `Done` and hand the registered
+        // wakers back — we must not wake here. See the method doc and
+        // `take_wakers`.
+        take_wakers(&token.state, result)
     }
 
     /// Drop every value entry whose `expires_at_secs` is at or before
@@ -214,16 +240,27 @@ impl DohCache {
     }
 }
 
-/// Flip a `PendingState` to `Done(result)` and wake every registered
-/// waker. Idempotent: if the state is already `Done`, this is a no-op
-/// for the wakers (they were woken on the first transition).
-fn wake_with(state: &SharedPending, result: Result<Vec<u8>, DohError>) {
+/// Flip a `PendingState` to `Done(result)` and return its registered
+/// wakers **without waking them**.
+///
+/// The wake is the caller's responsibility, and it must happen only
+/// after every relevant `RefCell` borrow is released — both this
+/// `PendingState`'s cell and the surrounding `DOH_CACHE`. The canister
+/// runs a single wasm thread and its executor polls a woken task
+/// *synchronously and re-entrantly* from inside `Waker::wake`: that
+/// poll borrows this same cell in [`WaitForPending::poll`], and the
+/// resumed task may run straight into another `fetch_txt` that borrows
+/// `DOH_CACHE`. Waking while either borrow is held panics with
+/// `RefCell already borrowed` — the regression this indirection exists
+/// to prevent.
+///
+/// Idempotent: if the state is already `Done`, its wakers were taken on
+/// the first transition, so this returns an empty list.
+fn take_wakers(state: &SharedPending, result: Result<Vec<u8>, DohError>) -> Vec<Waker> {
     let mut s = state.borrow_mut();
-    let prev = std::mem::replace(&mut *s, PendingState::Done(result));
-    if let PendingState::InFlight { wakers } = prev {
-        for w in wakers {
-            w.wake();
-        }
+    match std::mem::replace(&mut *s, PendingState::Done(result)) {
+        PendingState::InFlight { wakers } => wakers,
+        PendingState::Done(_) => Vec::new(),
     }
 }
 
@@ -312,17 +349,33 @@ mod tests {
     fn lookup_returns_hit_on_fresh_entry() {
         let mut cache = DohCache::default();
         cache.insert("a.com", b"hello".to_vec(), 1000);
-        match cache.lookup("a.com", 999) {
+        match cache.lookup("a.com", 999).0 {
             CacheLookup::Hit(b) => assert_eq!(b, b"hello"),
             _ => panic!("expected Hit"),
         }
     }
 
-    /// Helper: take the `Fetch` arm or fail the test.
-    fn expect_fetch(lookup: CacheLookup) -> FetchToken {
-        match lookup {
+    /// Helper: take the `Fetch` arm or fail the test. Ignores the
+    /// orphan-waker list (empty on the paths these callers exercise).
+    fn expect_fetch(lookup: (CacheLookup, Vec<Waker>)) -> FetchToken {
+        match lookup.0 {
             CacheLookup::Fetch(t) => t,
             _ => panic!("expected Fetch"),
+        }
+    }
+
+    /// Helper: register a waiter on `name` so its waker is stored in the
+    /// shared `PendingState`. The `WaitForPending` future is dropped
+    /// after the single poll, but the waker persists in the map entry —
+    /// exactly what a real `Wait` caller leaves behind before it parks
+    /// on the outcall.
+    fn register_waiter(cache: &mut DohCache, name: &str, now: u64, waker: &Waker) {
+        match cache.lookup(name, now).0 {
+            CacheLookup::Wait(mut fut) => {
+                let mut cx = Context::from_waker(waker);
+                assert!(matches!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending));
+            }
+            _ => panic!("expected Wait"),
         }
     }
 
@@ -338,7 +391,7 @@ mod tests {
     fn second_lookup_returns_wait() {
         let mut cache = DohCache::default();
         let _token = expect_fetch(cache.lookup("a.com", 0));
-        match cache.lookup("a.com", 0) {
+        match cache.lookup("a.com", 0).0 {
             CacheLookup::Wait(_) => {}
             _ => panic!("expected Wait"),
         }
@@ -356,25 +409,12 @@ mod tests {
         let w2 = Arc::new(CountingWaker {
             count: AtomicUsize::new(0),
         });
+        register_waiter(&mut cache, "a.com", 0, &make_waker(&w1));
+        register_waiter(&mut cache, "a.com", 0, &make_waker(&w2));
 
-        let waker_1 = make_waker(&w1);
-        match cache.lookup("a.com", 0) {
-            CacheLookup::Wait(mut fut) => {
-                let mut cx = Context::from_waker(&waker_1);
-                assert!(matches!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending));
-            }
-            _ => panic!("expected Wait"),
+        for w in cache.publish("a.com", token, Ok(b"hello".to_vec()), 1000, 0) {
+            w.wake();
         }
-        let waker_2 = make_waker(&w2);
-        match cache.lookup("a.com", 0) {
-            CacheLookup::Wait(mut fut) => {
-                let mut cx = Context::from_waker(&waker_2);
-                assert!(matches!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending));
-            }
-            _ => panic!("expected Wait"),
-        }
-
-        cache.publish("a.com", token, Ok(b"hello".to_vec()), 1000, 0);
         assert_eq!(w1.count.load(Ordering::SeqCst), 1);
         assert_eq!(w2.count.load(Ordering::SeqCst), 1);
 
@@ -383,15 +423,49 @@ mod tests {
     }
 
     #[test]
+    fn publish_returns_wakers_without_waking_them() {
+        // Regression for the `RefCell already borrowed` panic at
+        // WaitForPending::poll (cache.rs:256): `publish` runs inside
+        // `DOH_CACHE.borrow_mut()` and must hand its subscribers' wakers
+        // back to the caller rather than waking them itself. In the
+        // single-threaded canister executor a woken waiter is polled
+        // synchronously and re-entrantly, re-borrowing the PendingState
+        // (and racing on to another `fetch_txt` that re-borrows the
+        // cache) — so waking while those borrows are held traps. Here we
+        // assert the subscriber is NOT woken by `publish`, only once the
+        // caller drains the returned wakers.
+        let mut cache = DohCache::default();
+        let token = expect_fetch(cache.lookup("a.com", 0));
+
+        let w = Arc::new(CountingWaker {
+            count: AtomicUsize::new(0),
+        });
+        register_waiter(&mut cache, "a.com", 0, &make_waker(&w));
+
+        let wakers = cache.publish("a.com", token, Ok(b"hi".to_vec()), 1000, 0);
+        assert_eq!(
+            w.count.load(Ordering::SeqCst),
+            0,
+            "publish must not wake subscribers while the cache is borrowed"
+        );
+        assert_eq!(wakers.len(), 1, "the registered waker should be handed back");
+
+        for waker in wakers {
+            waker.wake();
+        }
+        assert_eq!(w.count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
     fn published_subscriber_resolves_to_result() {
         let mut cache = DohCache::default();
         let token = expect_fetch(cache.lookup("a.com", 0));
-        let mut wait = match cache.lookup("a.com", 0) {
+        let mut wait = match cache.lookup("a.com", 0).0 {
             CacheLookup::Wait(f) => f,
             _ => panic!(),
         };
 
-        cache.publish("a.com", token, Ok(b"hello".to_vec()), 1000, 0);
+        let _ = cache.publish("a.com", token, Ok(b"hello".to_vec()), 1000, 0);
 
         let w = Arc::new(CountingWaker {
             count: AtomicUsize::new(0),
@@ -412,15 +486,11 @@ mod tests {
         let w = Arc::new(CountingWaker {
             count: AtomicUsize::new(0),
         });
-        let waker = make_waker(&w);
-        match cache.lookup("a.com", 0) {
-            CacheLookup::Wait(mut fut) => {
-                let mut cx = Context::from_waker(&waker);
-                let _ = Pin::new(&mut fut).poll(&mut cx);
-            }
-            _ => panic!(),
+        register_waiter(&mut cache, "a.com", 0, &make_waker(&w));
+
+        for waker in cache.publish("a.com", token, Err(DohError::AllProvidersFailed), 1000, 0) {
+            waker.wake();
         }
-        cache.publish("a.com", token, Err(DohError::AllProvidersFailed), 1000, 0);
         assert_eq!(w.count.load(Ordering::SeqCst), 1);
         assert!(cache.get_fresh("a.com", 0).is_none());
     }
@@ -432,7 +502,7 @@ mod tests {
         let mut cache = DohCache::default();
         let _orig = expect_fetch(cache.lookup("a.com", 100));
         // Just under the threshold: still fresh.
-        match cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS - 1) {
+        match cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS - 1).0 {
             CacheLookup::Wait(_) => {}
             _ => panic!("expected Wait while pending is still fresh"),
         }
@@ -452,12 +522,14 @@ mod tests {
         // Setup: A starts a fetch, B registers as a waiter while A is
         // still in flight, then A's continuation never runs (simulated
         // here by just letting time pass without calling publish). C
-        // arrives after the staleness threshold. B should get woken
-        // with an error rather than hanging on a pending state forever.
+        // arrives after the staleness threshold. B should be woken with
+        // an error rather than hanging on a pending state forever — but
+        // the cache hands B's waker back to the caller rather than
+        // firing it inline (waking re-enters a held borrow in prod).
         let mut cache = DohCache::default();
         let _a_token = expect_fetch(cache.lookup("a.com", 100));
 
-        let mut b_wait = match cache.lookup("a.com", 110) {
+        let mut b_wait = match cache.lookup("a.com", 110).0 {
             CacheLookup::Wait(f) => f,
             _ => panic!("B should have got Wait"),
         };
@@ -468,14 +540,27 @@ mod tests {
         let mut cx = Context::from_waker(&waker);
         assert!(matches!(Pin::new(&mut b_wait).poll(&mut cx), Poll::Pending));
 
-        // C arrives way past the threshold.
-        let _c_token = expect_fetch(cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS + 1));
+        // C arrives way past the threshold and evicts A's pending entry.
+        let (c_lookup, orphans) = cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS + 1);
+        let _c_token = match c_lookup {
+            CacheLookup::Fetch(t) => t,
+            _ => panic!("expected Fetch"),
+        };
 
-        // B's waker should have fired during eviction.
+        // The cache must NOT have woken B itself — that would re-enter a
+        // held borrow in production. It returns B's waker instead.
+        assert_eq!(
+            waker_b.count.load(Ordering::SeqCst),
+            0,
+            "eviction must not wake orphan waiters inline"
+        );
+        for w in orphans {
+            w.wake();
+        }
         assert_eq!(
             waker_b.count.load(Ordering::SeqCst),
             1,
-            "orphan waiter must be woken on stale eviction"
+            "orphan waiter must be woken once the caller drains the wakers"
         );
 
         // And the next poll resolves to an error rather than Pending.
@@ -510,7 +595,7 @@ mod tests {
         // Publishing for a fourth name at now=100 should drop both
         // expired entries while leaving the fresh one alone.
         let token = expect_fetch(cache.lookup("new.com", 100));
-        cache.publish("new.com", token, Ok(b"v".to_vec()), 2_000, 100);
+        let _ = cache.publish("new.com", token, Ok(b"v".to_vec()), 2_000, 100);
 
         assert!(!cache.entries.contains_key("expired1.com"));
         assert!(!cache.entries.contains_key("expired2.com"));
@@ -528,7 +613,7 @@ mod tests {
         let c_token = expect_fetch(cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS + 1));
 
         // A's late publish: no-op on cache state.
-        cache.publish("a.com", a_token, Ok(b"A's stale data".to_vec()), 9999, 0);
+        let _ = cache.publish("a.com", a_token, Ok(b"A's stale data".to_vec()), 9999, 0);
         assert!(
             cache.get_fresh("a.com", 0).is_none(),
             "A's publish must not write to the cache after eviction"
@@ -539,7 +624,7 @@ mod tests {
         );
 
         // Now C publishes its real result and that DOES land.
-        cache.publish("a.com", c_token, Ok(b"C's fresh data".to_vec()), 9999, 0);
+        let _ = cache.publish("a.com", c_token, Ok(b"C's fresh data".to_vec()), 9999, 0);
         assert_eq!(
             cache.get_fresh("a.com", 0),
             Some(b"C's fresh data".to_vec())

--- a/src/internet_identity/src/doh/cache.rs
+++ b/src/internet_identity/src/doh/cache.rs
@@ -9,36 +9,32 @@
 //!    we just refetch the next time mail arrives.
 //!
 //! 2. **Dedup** — when several concurrent `smtp_request` calls arrive
-//!    for the same domain and the cache is cold, all of them share a
-//!    single underlying outcall fan-out. The first arrival fires the
-//!    outcalls and writes the result; subsequent arrivals register a
-//!    `Waker` against the in-flight entry and `await` the publication.
+//!    for the same domain and the cache is cold, only the first fans
+//!    out to the providers. The rest observe an in-flight marker and
+//!    re-check the cache once it publishes, rather than each firing
+//!    their own five-provider fan-out.
 //!
-//! The dedup mechanism is a hand-rolled `oneshot`-style primitive
-//! (see [`Pending`]) — `ic-cdk` doesn't ship with the tokio sync
-//! primitives we'd otherwise reach for, but the standard Rust `Waker`
-//! machinery is enough since the canister is single-threaded inside
-//! one wasm execution.
+//! The waiters do **not** block on a shared future woken by the
+//! fetcher. The canister runs a single wasm thread, and waking another
+//! call's task runs that task to completion *inside the fetcher's call
+//! context* — so the woken waiter's reply is routed to the wrong call
+//! (`ic0.msg_reply ... already replied`) and the real owner is left
+//! unreplied. Instead each waiter polls this cache from its OWN call
+//! context, yielding a round via a cheap downstream call between checks
+//! (see `super::fetch_txt`). This module is therefore just a value map
+//! plus an in-flight marker set — no `Waker`s, no shared `RefCell`
+//! futures, nothing that drives one call's task from another's.
 
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
-use std::rc::Rc;
-use std::task::{Context, Poll, Waker};
 
 use super::types::DohError;
 
-/// How long a `Pending` entry can sit in the cache before a new
-/// arrival treats it as abandoned.
+/// How long an in-flight marker may sit before a new arrival treats the
+/// fetch as abandoned and takes it over.
 ///
-/// The IC doesn't roll back state across `.await` points: state
-/// changes that happened *before* the yield are committed even if the
-/// resumed-message continuation traps. So if the post-outcall code
-/// path traps, the `Pending` entry inserted by the first arrival
-/// stays in the map and every subsequent caller would `Wait` on a
-/// `PendingState::InFlight` that nothing will ever resolve — until
-/// canister upgrade.
+/// The IC commits state changes made *before* an `.await`, so if a
+/// fetcher's post-outcall continuation traps, its in-flight marker
+/// survives and later arrivals would otherwise `Wait` on it forever.
 ///
 /// 120 s is comfortably longer than any plausible HTTP-outcall round
 /// trip (the IC caps individual outcalls at ~5 minutes, but successful
@@ -55,37 +51,20 @@ pub struct CacheEntry {
     pub expires_at_secs: u64,
 }
 
-/// Shared state used by the dedup primitive. `Rc<RefCell<...>>` because
-/// the canister's wasm execution is single-threaded; Send/Sync don't
-/// apply.
-type SharedPending = Rc<RefCell<PendingState>>;
-
-#[derive(Debug)]
-enum PendingState {
-    /// The first arrival is mid-fetch. Each subsequent arrival has
-    /// registered its `Waker` here and will be re-polled when the
-    /// fetch publishes a result.
-    InFlight { wakers: Vec<Waker> },
-    /// The fetch has completed. Late arrivals see this and pick up
-    /// the result without waiting.
-    Done(Result<Vec<u8>, DohError>),
-}
-
-/// What's stored in the `pending` map. We track `started_at_secs` so a
-/// later arrival can detect an abandoned in-flight fetch (see
-/// [`PENDING_STALE_AFTER_SECS`]) and start over rather than `Wait`ing
-/// forever.
-struct PendingEntry {
-    state: SharedPending,
+/// Marker for an in-flight fetch. `fetch_id` identifies *this* attempt
+/// so [`DohCache::publish`] can tell whether a stale-takeover has since
+/// replaced it; `started_at_secs` drives the staleness check.
+struct InFlight {
+    fetch_id: u64,
     started_at_secs: u64,
 }
 
-/// In-memory cache. The two maps are keyed by FQDN (e.g.
-/// `selector1._domainkey.gmail.com`).
+/// In-memory cache, keyed by FQDN (e.g. `selector1._domainkey.gmail.com`).
 #[derive(Default)]
 pub struct DohCache {
     entries: HashMap<String, CacheEntry>,
-    pending: HashMap<String, PendingEntry>,
+    in_flight: HashMap<String, InFlight>,
+    next_fetch_id: u64,
 }
 
 impl DohCache {
@@ -110,101 +89,68 @@ impl DohCache {
         );
     }
 
-    /// Remove a stale entry (by name). Used when freshness has lapsed
-    /// and we're about to re-fetch.
+    /// Remove a value entry (by name).
     pub fn invalidate(&mut self, name: &str) {
         self.entries.remove(name);
     }
 
-    /// Decide what to do for an incoming fetch request:
+    /// Decide what an incoming fetch request should do:
     /// - `Hit(bytes)` — cache fresh, use immediately.
-    /// - `Wait(future)` — someone else is fetching, await this future
-    ///   and you'll be woken with their result.
-    /// - `Fetch(token)` — you're the first; do the fetch, then call
-    ///   [`Self::publish`] passing the token back.
+    /// - `Wait` — another caller is fetching this name; yield a round
+    ///   and re-check (the caller polls from its own context — see
+    ///   `super::fetch_txt`). Returned only for a *fresh* in-flight
+    ///   marker.
+    /// - `Fetch(token)` — you own the fetch; fan out, then call
+    ///   [`Self::publish`] with the token. Returned when there's no
+    ///   in-flight marker, or the existing one is older than
+    ///   [`PENDING_STALE_AFTER_SECS`] (presumed abandoned — you take it
+    ///   over). Marks a fresh in-flight entry for you.
     ///
-    /// If we find a `Pending` entry that's older than
-    /// [`PENDING_STALE_AFTER_SECS`], we treat it as abandoned (the
-    /// continuation that should have published it likely trapped) and
-    /// start a fresh fetch. The abandoned entry's orphan waiters are
-    /// flipped to [`DohError::AllProvidersFailed`] so they don't hang;
-    /// their wakers are returned in the second tuple element for the
-    /// caller to fire *after* releasing the `DOH_CACHE` borrow (waking
-    /// re-enters the cache — see [`take_wakers`]). The list is empty on
-    /// every non-eviction path.
-    ///
-    /// Also opportunistically evicts the looked-up entry if we find
-    /// it expired — keeps the cache from accumulating dead entries
-    /// for FQDNs that get queried once and then go silent.
-    #[must_use = "the returned orphan wakers must be woken after the DOH_CACHE borrow is released"]
-    pub fn lookup(&mut self, name: &str, now_secs: u64) -> (CacheLookup, Vec<Waker>) {
+    /// Also opportunistically evicts the looked-up value entry if it's
+    /// expired — keeps the cache from accumulating dead entries for
+    /// FQDNs queried once and then gone silent.
+    pub fn lookup(&mut self, name: &str, now_secs: u64) -> CacheLookup {
         if let Some(entry) = self.entries.get(name) {
             if entry.expires_at_secs > now_secs {
-                return (CacheLookup::Hit(entry.bytes.clone()), Vec::new());
+                return CacheLookup::Hit(entry.bytes.clone());
             }
-            // Expired: drop it now rather than waiting for a publish
-            // to overwrite — most expired entries never see a republish.
+            // Expired: drop it now rather than waiting for a publish to
+            // overwrite — most expired entries never see a republish.
             self.entries.remove(name);
         }
-        // Wakers of an abandoned in-flight fetch we evict below, if any.
-        // Returned to the caller to fire once the `DOH_CACHE` borrow is
-        // released — never woken inline (see `take_wakers`).
-        let mut orphan_wakers = Vec::new();
-        if let Some(existing) = self.pending.get(name) {
-            let age = now_secs.saturating_sub(existing.started_at_secs);
+        if let Some(inflight) = self.in_flight.get(name) {
+            let age = now_secs.saturating_sub(inflight.started_at_secs);
             if age < PENDING_STALE_AFTER_SECS {
-                return (
-                    CacheLookup::Wait(WaitForPending {
-                        state: existing.state.clone(),
-                    }),
-                    Vec::new(),
-                );
+                return CacheLookup::Wait;
             }
-            // Abandoned: evict it. The SharedPending may still be held
-            // by `WaitForPending` futures that registered before
-            // eviction; flipping it to `Done(Err)` resolves their
-            // `await` instead of hanging. We hand their wakers back
-            // rather than firing them here — `lookup` runs inside
-            // `DOH_CACHE.borrow_mut()`.
-            let stale = self.pending.remove(name).expect("just checked");
-            orphan_wakers = take_wakers(&stale.state, Err(DohError::AllProvidersFailed));
+            // Stale: the owner likely trapped before publishing. Fall
+            // through and take the fetch over — the insert below
+            // overwrites the abandoned marker with a fresh `fetch_id`,
+            // so the old owner's late `publish` becomes a no-op.
         }
-        let state = Rc::new(RefCell::new(PendingState::InFlight { wakers: Vec::new() }));
-        self.pending.insert(
+        let fetch_id = self.next_fetch_id;
+        self.next_fetch_id = self.next_fetch_id.wrapping_add(1);
+        self.in_flight.insert(
             name.to_string(),
-            PendingEntry {
-                state: state.clone(),
+            InFlight {
+                fetch_id,
                 started_at_secs: now_secs,
             },
         );
-        (CacheLookup::Fetch(FetchToken { state }), orphan_wakers)
+        CacheLookup::Fetch(FetchToken { fetch_id })
     }
 
-    /// Publish the result of the in-flight fetch for `name`, returning
-    /// the wakers of any dedup subscribers.
+    /// Publish the result of the fetch you owned. On success the value
+    /// entry is written; either way your in-flight marker is cleared —
+    /// but only if it's still *yours* (`token.fetch_id` matches the
+    /// current marker). If a stale-takeover replaced you, we leave the
+    /// new owner's marker and any value entry untouched, so a late
+    /// publish from a superseded fetch can't clobber fresher state.
     ///
-    /// **The caller must wake the returned wakers, and only after the
-    /// `DOH_CACHE` borrow is released.** `publish` runs inside
-    /// `DOH_CACHE.borrow_mut()`; a woken `WaitForPending` is polled
-    /// synchronously and re-entrantly by the single-threaded canister
-    /// executor, and that poll borrows both this `PendingState` and —
-    /// as the resumed task races on to its next `fetch_txt` — `DOH_CACHE`
-    /// itself. Waking inline would trip `RefCell already borrowed`.
-    ///
-    /// The `token` is whatever [`Self::lookup`] handed back when this
-    /// caller got the `Fetch` arm — passing it back lets us detect
-    /// the case where this fetch was evicted by a stale-takeover
-    /// (another caller saw the pending entry as abandoned and started
-    /// over). In that case we don't touch the cache map but we still
-    /// return the wakers tied to *our* `PendingState`, so even
-    /// orphaned waiters resolve cleanly.
-    ///
-    /// Also opportunistically sweeps any value entries that are
-    /// already expired at `now_secs`. Sweeping on publish (the rare
-    /// write path) rather than on every `lookup` keeps reads cheap
-    /// while still bounding cache size — every successful fetch
-    /// drops the dead weight that accumulated since the last write.
-    #[must_use = "the returned wakers must be woken after the DOH_CACHE borrow is released"]
+    /// Also opportunistically sweeps expired value entries (publish is
+    /// the rare write path, so this keeps reads cheap while bounding
+    /// cache size — every successful fetch drops the dead weight
+    /// accumulated since the last write).
     pub fn publish(
         &mut self,
         name: &str,
@@ -212,131 +158,55 @@ impl DohCache {
         result: Result<Vec<u8>, DohError>,
         expires_at_secs: u64,
         now_secs: u64,
-    ) -> Vec<Waker> {
+    ) {
         self.sweep_expired(now_secs);
 
         let still_ours = self
-            .pending
+            .in_flight
             .get(name)
-            .is_some_and(|e| Rc::ptr_eq(&e.state, &token.state));
+            .is_some_and(|f| f.fetch_id == token.fetch_id);
         if still_ours {
-            if let Ok(bytes) = &result {
-                self.insert(name, bytes.clone(), expires_at_secs);
+            if let Ok(bytes) = result {
+                self.insert(name, bytes, expires_at_secs);
             }
-            self.pending.remove(name);
+            self.in_flight.remove(name);
         }
-        // Flip our `PendingState` to `Done` and hand the registered
-        // wakers back — we must not wake here. See the method doc and
-        // `take_wakers`.
-        take_wakers(&token.state, result)
     }
 
     /// Drop every value entry whose `expires_at_secs` is at or before
     /// `now_secs`. Linear in `entries.len()`, which is bounded by
     /// "unique FQDNs queried in the last `max_cache_age_secs`" — small
-    /// in practice. Called from `publish` so the per-fetch cost is
-    /// amortised across cache hits.
+    /// in practice.
     fn sweep_expired(&mut self, now_secs: u64) {
         self.entries.retain(|_, e| e.expires_at_secs > now_secs);
-    }
-}
-
-/// Flip a `PendingState` to `Done(result)` and return its registered
-/// wakers **without waking them**.
-///
-/// The wake is the caller's responsibility, and it must happen only
-/// after every relevant `RefCell` borrow is released — both this
-/// `PendingState`'s cell and the surrounding `DOH_CACHE`. The canister
-/// runs a single wasm thread and its executor polls a woken task
-/// *synchronously and re-entrantly* from inside `Waker::wake`: that
-/// poll borrows this same cell in [`WaitForPending::poll`], and the
-/// resumed task may run straight into another `fetch_txt` that borrows
-/// `DOH_CACHE`. Waking while either borrow is held panics with
-/// `RefCell already borrowed` — the regression this indirection exists
-/// to prevent.
-///
-/// Idempotent: only the first `InFlight -> Done` transition takes
-/// effect. If the state is already `Done`, the stored result and the
-/// (already taken) wakers are left untouched and this returns an empty
-/// list — so a late publish from an evicted/stale fetch can't overwrite
-/// the outcome a stale-eviction already settled.
-fn take_wakers(state: &SharedPending, result: Result<Vec<u8>, DohError>) -> Vec<Waker> {
-    let mut s = state.borrow_mut();
-    if matches!(*s, PendingState::Done(_)) {
-        return Vec::new();
-    }
-    match std::mem::replace(&mut *s, PendingState::Done(result)) {
-        PendingState::InFlight { wakers } => wakers,
-        // Unreachable: the `Done` case returned above.
-        PendingState::Done(_) => Vec::new(),
     }
 }
 
 /// What [`DohCache::lookup`] returned. The caller acts on the variant.
 pub enum CacheLookup {
     Hit(Vec<u8>),
-    Wait(WaitForPending),
+    Wait,
     Fetch(FetchToken),
 }
 
 /// Opaque handle a `Fetch` caller passes back to [`DohCache::publish`].
-/// It identifies "this particular in-flight attempt" so the cache can
-/// tell whether the publishing caller is still the owner or whether a
-/// stale-takeover replaced them in the interim.
+/// Identifies this particular in-flight attempt, so `publish` can tell
+/// whether the caller is still the owner or was superseded by a
+/// stale-takeover.
 pub struct FetchToken {
-    state: SharedPending,
-}
-
-/// Future returned to a caller that arrived while another task was
-/// already fetching the same name. Polls the shared `Pending` state;
-/// returns `Ready` once the in-flight task publishes its result.
-pub struct WaitForPending {
-    state: SharedPending,
-}
-
-impl Future for WaitForPending {
-    type Output = Result<Vec<u8>, DohError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut state = self.state.borrow_mut();
-        match &mut *state {
-            PendingState::Done(r) => Poll::Ready(r.clone()),
-            PendingState::InFlight { wakers } => {
-                // Avoid registering the same waker twice if the future
-                // is re-polled spuriously: walk the existing wakers
-                // and replace any that say `will_wake` of this one.
-                let new = cx.waker();
-                if !wakers.iter().any(|w| w.will_wake(new)) {
-                    wakers.push(new.clone());
-                }
-                Poll::Pending
-            }
-        }
-    }
+    fetch_id: u64,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
-    use std::task::Wake;
 
-    /// Simple `Wake` that counts how many times it's been woken.
-    /// Lets the dedup tests assert "publishing the result wakes every
-    /// subscriber exactly once".
-    struct CountingWaker {
-        count: AtomicUsize,
-    }
-
-    impl Wake for CountingWaker {
-        fn wake(self: Arc<Self>) {
-            self.count.fetch_add(1, Ordering::SeqCst);
+    /// Helper: take the `Fetch` arm or fail the test.
+    fn expect_fetch(lookup: CacheLookup) -> FetchToken {
+        match lookup {
+            CacheLookup::Fetch(t) => t,
+            _ => panic!("expected Fetch"),
         }
-    }
-
-    fn make_waker(w: &Arc<CountingWaker>) -> Waker {
-        Waker::from(w.clone())
     }
 
     #[test]
@@ -357,255 +227,101 @@ mod tests {
     fn lookup_returns_hit_on_fresh_entry() {
         let mut cache = DohCache::default();
         cache.insert("a.com", b"hello".to_vec(), 1000);
-        match cache.lookup("a.com", 999).0 {
+        match cache.lookup("a.com", 999) {
             CacheLookup::Hit(b) => assert_eq!(b, b"hello"),
             _ => panic!("expected Hit"),
         }
     }
 
-    /// Helper: take the `Fetch` arm or fail the test. Ignores the
-    /// orphan-waker list (empty on the paths these callers exercise).
-    fn expect_fetch(lookup: (CacheLookup, Vec<Waker>)) -> FetchToken {
-        match lookup.0 {
-            CacheLookup::Fetch(t) => t,
-            _ => panic!("expected Fetch"),
-        }
-    }
-
-    /// Helper: register a waiter on `name` so its waker is stored in the
-    /// shared `PendingState`. The `WaitForPending` future is dropped
-    /// after the single poll, but the waker persists in the map entry —
-    /// exactly what a real `Wait` caller leaves behind before it parks
-    /// on the outcall.
-    fn register_waiter(cache: &mut DohCache, name: &str, now: u64, waker: &Waker) {
-        match cache.lookup(name, now).0 {
-            CacheLookup::Wait(mut fut) => {
-                let mut cx = Context::from_waker(waker);
-                assert!(matches!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending));
-            }
-            _ => panic!("expected Wait"),
-        }
-    }
-
     #[test]
-    fn first_lookup_returns_fetch() {
+    fn first_lookup_returns_fetch_and_marks_in_flight() {
         let mut cache = DohCache::default();
         let _token = expect_fetch(cache.lookup("a.com", 0));
-        // After Fetch, the pending map should have an entry.
-        assert!(cache.pending.contains_key("a.com"));
+        assert!(cache.in_flight.contains_key("a.com"));
     }
 
     #[test]
-    fn second_lookup_returns_wait() {
+    fn second_concurrent_lookup_returns_wait() {
         let mut cache = DohCache::default();
         let _token = expect_fetch(cache.lookup("a.com", 0));
-        match cache.lookup("a.com", 0).0 {
-            CacheLookup::Wait(_) => {}
-            _ => panic!("expected Wait"),
-        }
+        assert!(matches!(cache.lookup("a.com", 0), CacheLookup::Wait));
     }
 
     #[test]
-    fn publish_wakes_all_subscribers() {
+    fn publish_success_writes_entry_and_clears_in_flight() {
         let mut cache = DohCache::default();
         let token = expect_fetch(cache.lookup("a.com", 0));
+        cache.publish("a.com", token, Ok(b"hello".to_vec()), 1000, 0);
 
-        // Two subscribers register their wakers.
-        let w1 = Arc::new(CountingWaker {
-            count: AtomicUsize::new(0),
-        });
-        let w2 = Arc::new(CountingWaker {
-            count: AtomicUsize::new(0),
-        });
-        register_waiter(&mut cache, "a.com", 0, &make_waker(&w1));
-        register_waiter(&mut cache, "a.com", 0, &make_waker(&w2));
-
-        for w in cache.publish("a.com", token, Ok(b"hello".to_vec()), 1000, 0) {
-            w.wake();
-        }
-        assert_eq!(w1.count.load(Ordering::SeqCst), 1);
-        assert_eq!(w2.count.load(Ordering::SeqCst), 1);
-
-        assert!(!cache.pending.contains_key("a.com"));
+        assert!(!cache.in_flight.contains_key("a.com"));
         assert_eq!(cache.get_fresh("a.com", 999), Some(b"hello".to_vec()));
+        // A later arrival is a straight hit — no second fetch.
+        assert!(matches!(cache.lookup("a.com", 999), CacheLookup::Hit(_)));
     }
 
     #[test]
-    fn publish_returns_wakers_without_waking_them() {
-        // Regression for the `RefCell already borrowed` panic at
-        // WaitForPending::poll (cache.rs:256): `publish` runs inside
-        // `DOH_CACHE.borrow_mut()` and must hand its subscribers' wakers
-        // back to the caller rather than waking them itself. In the
-        // single-threaded canister executor a woken waiter is polled
-        // synchronously and re-entrantly, re-borrowing the PendingState
-        // (and racing on to another `fetch_txt` that re-borrows the
-        // cache) — so waking while those borrows are held traps. Here we
-        // assert the subscriber is NOT woken by `publish`, only once the
-        // caller drains the returned wakers.
+    fn publish_failure_does_not_cache_but_clears_in_flight() {
         let mut cache = DohCache::default();
         let token = expect_fetch(cache.lookup("a.com", 0));
+        cache.publish("a.com", token, Err(DohError::AllProvidersFailed), 1000, 0);
 
-        let w = Arc::new(CountingWaker {
-            count: AtomicUsize::new(0),
-        });
-        register_waiter(&mut cache, "a.com", 0, &make_waker(&w));
-
-        let wakers = cache.publish("a.com", token, Ok(b"hi".to_vec()), 1000, 0);
-        assert_eq!(
-            w.count.load(Ordering::SeqCst),
-            0,
-            "publish must not wake subscribers while the cache is borrowed"
-        );
-        assert_eq!(
-            wakers.len(),
-            1,
-            "the registered waker should be handed back"
-        );
-
-        for waker in wakers {
-            waker.wake();
-        }
-        assert_eq!(w.count.load(Ordering::SeqCst), 1);
-    }
-
-    #[test]
-    fn published_subscriber_resolves_to_result() {
-        let mut cache = DohCache::default();
-        let token = expect_fetch(cache.lookup("a.com", 0));
-        let mut wait = match cache.lookup("a.com", 0).0 {
-            CacheLookup::Wait(f) => f,
-            _ => panic!(),
-        };
-
-        let _ = cache.publish("a.com", token, Ok(b"hello".to_vec()), 1000, 0);
-
-        let w = Arc::new(CountingWaker {
-            count: AtomicUsize::new(0),
-        });
-        let waker = make_waker(&w);
-        let mut cx = Context::from_waker(&waker);
-        match Pin::new(&mut wait).poll(&mut cx) {
-            Poll::Ready(Ok(b)) => assert_eq!(b, b"hello"),
-            other => panic!("expected Ready(Ok), got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn publish_on_failure_does_not_cache_but_still_wakes() {
-        let mut cache = DohCache::default();
-        let token = expect_fetch(cache.lookup("a.com", 0));
-
-        let w = Arc::new(CountingWaker {
-            count: AtomicUsize::new(0),
-        });
-        register_waiter(&mut cache, "a.com", 0, &make_waker(&w));
-
-        for waker in cache.publish("a.com", token, Err(DohError::AllProvidersFailed), 1000, 0) {
-            waker.wake();
-        }
-        assert_eq!(w.count.load(Ordering::SeqCst), 1);
         assert!(cache.get_fresh("a.com", 0).is_none());
+        assert!(!cache.in_flight.contains_key("a.com"));
+        // The next arrival starts a fresh fetch rather than waiting.
+        assert!(matches!(cache.lookup("a.com", 0), CacheLookup::Fetch(_)));
     }
 
-    #[test]
-    fn take_wakers_is_idempotent_on_already_done() {
-        // A second resolution must be a no-op: once a stale-eviction has
-        // flipped an entry to `Done(Err)`, a late publish from the
-        // evicted fetch must not overwrite the result — a waiter not yet
-        // re-polled would otherwise observe late, stale data.
-        let state: SharedPending =
-            Rc::new(RefCell::new(PendingState::InFlight { wakers: Vec::new() }));
-
-        let first = take_wakers(&state, Err(DohError::AllProvidersFailed));
-        assert!(first.is_empty());
-
-        // Different result against the now-`Done` state — must not take.
-        let second = take_wakers(&state, Ok(b"late stale data".to_vec()));
-        assert!(second.is_empty());
-
-        let settled = state.borrow();
-        match &*settled {
-            PendingState::Done(Err(DohError::AllProvidersFailed)) => {}
-            other => panic!("first result must stick, got {other:?}"),
-        }
-    }
-
-    // ---- Stale-pending eviction ----
+    // ---- Stale in-flight takeover ----
 
     #[test]
-    fn fresh_pending_within_threshold_returns_wait() {
+    fn fresh_in_flight_within_threshold_returns_wait() {
         let mut cache = DohCache::default();
         let _orig = expect_fetch(cache.lookup("a.com", 100));
         // Just under the threshold: still fresh.
-        match cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS - 1).0 {
-            CacheLookup::Wait(_) => {}
-            _ => panic!("expected Wait while pending is still fresh"),
-        }
+        assert!(matches!(
+            cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS - 1),
+            CacheLookup::Wait
+        ));
     }
 
     #[test]
-    fn stale_pending_is_evicted_and_caller_gets_fetch() {
+    fn stale_in_flight_is_taken_over_with_fetch() {
         let mut cache = DohCache::default();
         let _abandoned = expect_fetch(cache.lookup("a.com", 100));
         // Past the staleness threshold — the prior fetch is presumed
-        // dead. The new arrival should get a fresh Fetch, not Wait.
-        let _new_token = expect_fetch(cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS));
+        // dead, so the new arrival takes over with a fresh Fetch.
+        let _new = expect_fetch(cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS));
     }
 
     #[test]
-    fn stale_eviction_wakes_orphan_waiters_with_error() {
-        // Setup: A starts a fetch, B registers as a waiter while A is
-        // still in flight, then A's continuation never runs (simulated
-        // here by just letting time pass without calling publish). C
-        // arrives after the staleness threshold. B should be woken with
-        // an error rather than hanging on a pending state forever — but
-        // the cache hands B's waker back to the caller rather than
-        // firing it inline (waking re-enters a held borrow in prod).
+    fn superseded_owner_publish_does_not_overwrite_new_fetch() {
+        // A starts a fetch; it's presumed abandoned and C takes over. A
+        // then returns late and publishes. The cache must NOT write A's
+        // data or clear C's in-flight marker.
         let mut cache = DohCache::default();
-        let _a_token = expect_fetch(cache.lookup("a.com", 100));
+        let a_token = expect_fetch(cache.lookup("a.com", 100));
+        let c_token = expect_fetch(cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS + 1));
 
-        let mut b_wait = match cache.lookup("a.com", 110).0 {
-            CacheLookup::Wait(f) => f,
-            _ => panic!("B should have got Wait"),
-        };
-        let waker_b = Arc::new(CountingWaker {
-            count: AtomicUsize::new(0),
-        });
-        let waker = make_waker(&waker_b);
-        let mut cx = Context::from_waker(&waker);
-        assert!(matches!(Pin::new(&mut b_wait).poll(&mut cx), Poll::Pending));
-
-        // C arrives way past the threshold and evicts A's pending entry.
-        let (c_lookup, orphans) = cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS + 1);
-        let _c_token = match c_lookup {
-            CacheLookup::Fetch(t) => t,
-            _ => panic!("expected Fetch"),
-        };
-
-        // The cache must NOT have woken B itself — that would re-enter a
-        // held borrow in production. It returns B's waker instead.
-        assert_eq!(
-            waker_b.count.load(Ordering::SeqCst),
-            0,
-            "eviction must not wake orphan waiters inline"
+        cache.publish("a.com", a_token, Ok(b"A's stale data".to_vec()), 9999, 0);
+        assert!(
+            cache.get_fresh("a.com", 0).is_none(),
+            "A's late publish must not write to the cache after takeover"
         );
-        for w in orphans {
-            w.wake();
-        }
-        assert_eq!(
-            waker_b.count.load(Ordering::SeqCst),
-            1,
-            "orphan waiter must be woken once the caller drains the wakers"
+        assert!(
+            cache.in_flight.contains_key("a.com"),
+            "C's in-flight marker must still be in place"
         );
 
-        // And the next poll resolves to an error rather than Pending.
-        match Pin::new(&mut b_wait).poll(&mut cx) {
-            Poll::Ready(Err(DohError::AllProvidersFailed)) => {}
-            other => panic!("orphan waiter should resolve to AllProvidersFailed, got {other:?}"),
-        }
+        // C publishes its real result and that DOES land.
+        cache.publish("a.com", c_token, Ok(b"C's fresh data".to_vec()), 9999, 0);
+        assert_eq!(
+            cache.get_fresh("a.com", 0),
+            Some(b"C's fresh data".to_vec())
+        );
+        assert!(!cache.in_flight.contains_key("a.com"));
     }
 
-    // ---- Eviction of expired value entries ----
+    // ---- Eviction / sweeping of expired value entries ----
 
     #[test]
     fn lookup_evicts_expired_entry() {
@@ -630,39 +346,11 @@ mod tests {
         // Publishing for a fourth name at now=100 should drop both
         // expired entries while leaving the fresh one alone.
         let token = expect_fetch(cache.lookup("new.com", 100));
-        let _ = cache.publish("new.com", token, Ok(b"v".to_vec()), 2_000, 100);
+        cache.publish("new.com", token, Ok(b"v".to_vec()), 2_000, 100);
 
         assert!(!cache.entries.contains_key("expired1.com"));
         assert!(!cache.entries.contains_key("expired2.com"));
         assert!(cache.entries.contains_key("fresh.com"));
         assert!(cache.entries.contains_key("new.com"));
-    }
-
-    #[test]
-    fn evicted_owner_publishing_does_not_overwrite_new_fetch() {
-        // A is evicted, C starts a new fetch. A then unexpectedly
-        // returns and tries to publish. The cache must NOT replace
-        // C's pending entry or write A's data into the value cache.
-        let mut cache = DohCache::default();
-        let a_token = expect_fetch(cache.lookup("a.com", 100));
-        let c_token = expect_fetch(cache.lookup("a.com", 100 + PENDING_STALE_AFTER_SECS + 1));
-
-        // A's late publish: no-op on cache state.
-        let _ = cache.publish("a.com", a_token, Ok(b"A's stale data".to_vec()), 9999, 0);
-        assert!(
-            cache.get_fresh("a.com", 0).is_none(),
-            "A's publish must not write to the cache after eviction"
-        );
-        assert!(
-            cache.pending.contains_key("a.com"),
-            "C's pending entry must still be in place"
-        );
-
-        // Now C publishes its real result and that DOES land.
-        let _ = cache.publish("a.com", c_token, Ok(b"C's fresh data".to_vec()), 9999, 0);
-        assert_eq!(
-            cache.get_fresh("a.com", 0),
-            Some(b"C's fresh data".to_vec())
-        );
     }
 }

--- a/src/internet_identity/src/doh/cache.rs
+++ b/src/internet_identity/src/doh/cache.rs
@@ -136,6 +136,7 @@ impl DohCache {
     /// Also opportunistically evicts the looked-up entry if we find
     /// it expired — keeps the cache from accumulating dead entries
     /// for FQDNs that get queried once and then go silent.
+    #[must_use = "the returned orphan wakers must be woken after the DOH_CACHE borrow is released"]
     pub fn lookup(&mut self, name: &str, now_secs: u64) -> (CacheLookup, Vec<Waker>) {
         if let Some(entry) = self.entries.get(name) {
             if entry.expires_at_secs > now_secs {
@@ -254,12 +255,19 @@ impl DohCache {
 /// `RefCell already borrowed` — the regression this indirection exists
 /// to prevent.
 ///
-/// Idempotent: if the state is already `Done`, its wakers were taken on
-/// the first transition, so this returns an empty list.
+/// Idempotent: only the first `InFlight -> Done` transition takes
+/// effect. If the state is already `Done`, the stored result and the
+/// (already taken) wakers are left untouched and this returns an empty
+/// list — so a late publish from an evicted/stale fetch can't overwrite
+/// the outcome a stale-eviction already settled.
 fn take_wakers(state: &SharedPending, result: Result<Vec<u8>, DohError>) -> Vec<Waker> {
     let mut s = state.borrow_mut();
+    if matches!(*s, PendingState::Done(_)) {
+        return Vec::new();
+    }
     match std::mem::replace(&mut *s, PendingState::Done(result)) {
         PendingState::InFlight { wakers } => wakers,
+        // Unreachable: the `Done` case returned above.
         PendingState::Done(_) => Vec::new(),
     }
 }
@@ -497,6 +505,29 @@ mod tests {
         }
         assert_eq!(w.count.load(Ordering::SeqCst), 1);
         assert!(cache.get_fresh("a.com", 0).is_none());
+    }
+
+    #[test]
+    fn take_wakers_is_idempotent_on_already_done() {
+        // A second resolution must be a no-op: once a stale-eviction has
+        // flipped an entry to `Done(Err)`, a late publish from the
+        // evicted fetch must not overwrite the result — a waiter not yet
+        // re-polled would otherwise observe late, stale data.
+        let state: SharedPending =
+            Rc::new(RefCell::new(PendingState::InFlight { wakers: Vec::new() }));
+
+        let first = take_wakers(&state, Err(DohError::AllProvidersFailed));
+        assert!(first.is_empty());
+
+        // Different result against the now-`Done` state — must not take.
+        let second = take_wakers(&state, Ok(b"late stale data".to_vec()));
+        assert!(second.is_empty());
+
+        let settled = state.borrow();
+        match &*settled {
+            PendingState::Done(Err(DohError::AllProvidersFailed)) => {}
+            other => panic!("first result must stick, got {other:?}"),
+        }
     }
 
     // ---- Stale-pending eviction ----

--- a/src/internet_identity/src/doh/mod.rs
+++ b/src/internet_identity/src/doh/mod.rs
@@ -186,48 +186,48 @@ pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, D
     // before we touch the cache or claim a Fetch token.
     let query = build_txt_query(name).map_err(|e| DohError::InvalidName(format!("{e:?}")))?;
 
-    // Cache lookup. We must release the borrow before awaiting — the
-    // canister is single-threaded but futures across yields can re-
-    // enter the same `RefCell`, which would trap.
-    let now = now_secs();
-    let (lookup, orphan_wakers) = DOH_CACHE.with(|c| c.borrow_mut().lookup(name, now));
-    // Wake any orphaned waiters from a stale fetch we just evicted —
-    // *after* the borrow above is released. A woken waiter is polled
-    // synchronously and may call straight back into the cache, so waking
-    // while `DOH_CACHE` is borrowed would trap (`RefCell already
-    // borrowed`). `orphan_wakers` is empty on the common paths.
-    for w in orphan_wakers {
-        w.wake();
-    }
-    let token = match lookup {
-        CacheLookup::Hit(bytes) => {
-            return Ok(bytes);
+    // Dedup-aware fetch. The first arrival for a cold name owns the
+    // five-provider fan-out; concurrent arrivals observe the in-flight
+    // marker and poll the cache until it publishes. Each waiter yields a
+    // round from its OWN call context (`yield_round`) and re-checks — it
+    // must NOT block on a future the fetcher wakes, because waking
+    // another call's task runs it to completion in the fetcher's call
+    // context and mis-routes its reply (`ic0.msg_reply ... already
+    // replied`). The cache borrow is released before each await: the
+    // canister is single-threaded and a borrow held across a yield would
+    // trap.
+    let mut waits = 0u32;
+    let token = loop {
+        let now = now_secs();
+        match DOH_CACHE.with(|c| c.borrow_mut().lookup(name, now)) {
+            CacheLookup::Hit(bytes) => return Ok(bytes),
+            CacheLookup::Fetch(token) => break token,
+            CacheLookup::Wait => {
+                if waits >= MAX_DEDUP_WAIT_POLLS {
+                    // The in-flight fetch is taking implausibly long (or
+                    // its owner trapped before the staleness window let
+                    // someone take over). Fail transiently rather than
+                    // poll forever; a retry — or the post-staleness
+                    // takeover — resolves it.
+                    return Err(DohError::AllProvidersFailed);
+                }
+                waits += 1;
+                yield_round().await;
+            }
         }
-        CacheLookup::Wait(fut) => {
-            return fut.await;
-        }
-        CacheLookup::Fetch(token) => token,
     };
 
-    // Fan out to every provider in parallel, then decide.
+    // We own the fetch: fan out to every provider in parallel, decide,
+    // then publish (writes the value entry on success, clears our
+    // in-flight marker either way).
     let outcomes = fetch_all(&query).await;
     let result = decide_quorum(&outcomes);
-
-    // Publish: stores on success, removes the pending entry, and hands
-    // back the dedup subscribers' wakers. The expires-at uses the
-    // timestamp we captured before the await so multiple subscribers see
-    // consistent freshness.
+    let now = now_secs();
     let expires_at = now.saturating_add(max_age);
-    let wakers = DOH_CACHE.with(|c| {
+    DOH_CACHE.with(|c| {
         c.borrow_mut()
             .publish(name, token, result.clone(), expires_at, now)
     });
-    // Wake subscribers outside the cache borrow: each woken waiter is
-    // polled synchronously and races on to its own `fetch_txt`
-    // (e.g. DKIM → DMARC), which re-borrows `DOH_CACHE`.
-    for w in wakers {
-        w.wake();
-    }
     result
 }
 
@@ -267,6 +267,38 @@ fn now_secs() -> u64 {
 fn now_secs() -> u64 {
     test_support::TEST_NOW_SECS.with(|t| *t.borrow())
 }
+
+/// Upper bound on how many times a dedup waiter polls the cache before
+/// giving up. Each poll yields one consensus round via [`yield_round`],
+/// so this is ~100 rounds of patience — far more than a healthy fan-out
+/// needs — and bounds the wait so a wedged fetch can't pin a waiter
+/// indefinitely. The post-staleness takeover (see
+/// [`cache::PENDING_STALE_AFTER_SECS`]) is the real recovery path; this
+/// is just a backstop against an unbounded poll loop.
+const MAX_DEDUP_WAIT_POLLS: u32 = 100;
+
+/// Yield one consensus round, resuming in the caller's OWN call context.
+///
+/// A dedup waiter uses this to let the in-flight fetch make progress and
+/// then re-check the cache, *without* being driven by the fetcher's
+/// wake. A timer is no good — its callback can't reply to the waiter's
+/// ingress call — and completing inside another call's context
+/// mis-routes the reply. Awaiting a cheap management-canister round-trip
+/// is the idiomatic way (already used elsewhere in this canister) to
+/// give up a round and come back in our own context; the random bytes
+/// are unused.
+#[cfg(not(test))]
+async fn yield_round() {
+    let _ =
+        ic_cdk::call::<(), (Vec<u8>,)>(candid::Principal::management_canister(), "raw_rand", ())
+            .await;
+}
+
+/// Host-test stand-in: unit tests drive `fetch_txt` sequentially with a
+/// mocked fan-out, so the dedup `Wait` path is never exercised and there
+/// is nothing to yield to.
+#[cfg(test)]
+async fn yield_round() {}
 
 // =====================================================================
 // Production outcall path (cfg(not(test)) only).

--- a/src/internet_identity/src/doh/mod.rs
+++ b/src/internet_identity/src/doh/mod.rs
@@ -190,7 +190,15 @@ pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, D
     // canister is single-threaded but futures across yields can re-
     // enter the same `RefCell`, which would trap.
     let now = now_secs();
-    let lookup = DOH_CACHE.with(|c| c.borrow_mut().lookup(name, now));
+    let (lookup, orphan_wakers) = DOH_CACHE.with(|c| c.borrow_mut().lookup(name, now));
+    // Wake any orphaned waiters from a stale fetch we just evicted —
+    // *after* the borrow above is released. A woken waiter is polled
+    // synchronously and may call straight back into the cache, so waking
+    // while `DOH_CACHE` is borrowed would trap (`RefCell already
+    // borrowed`). `orphan_wakers` is empty on the common paths.
+    for w in orphan_wakers {
+        w.wake();
+    }
     let token = match lookup {
         CacheLookup::Hit(bytes) => {
             return Ok(bytes);
@@ -198,23 +206,28 @@ pub async fn fetch_txt(name: &str, registered_domain: &str) -> Result<Vec<u8>, D
         CacheLookup::Wait(fut) => {
             return fut.await;
         }
-        CacheLookup::Fetch(token) => {
-            token
-        }
+        CacheLookup::Fetch(token) => token,
     };
 
     // Fan out to every provider in parallel, then decide.
     let outcomes = fetch_all(&query).await;
     let result = decide_quorum(&outcomes);
 
-    // Publish: stores on success, removes the pending entry, wakes any
-    // dedup subscribers. The expires-at uses the timestamp we captured
-    // before the await so multiple subscribers see consistent freshness.
+    // Publish: stores on success, removes the pending entry, and hands
+    // back the dedup subscribers' wakers. The expires-at uses the
+    // timestamp we captured before the await so multiple subscribers see
+    // consistent freshness.
     let expires_at = now.saturating_add(max_age);
-    DOH_CACHE.with(|c| {
+    let wakers = DOH_CACHE.with(|c| {
         c.borrow_mut()
             .publish(name, token, result.clone(), expires_at, now)
     });
+    // Wake subscribers outside the cache borrow: each woken waiter is
+    // polled synchronously and races on to its own `fetch_txt`
+    // (e.g. DKIM → DMARC), which re-borrows `DOH_CACHE`.
+    for w in wakers {
+        w.wake();
+    }
     result
 }
 

--- a/src/internet_identity/tests/integration/email_recovery.rs
+++ b/src/internet_identity/tests/integration/email_recovery.rs
@@ -27,7 +27,7 @@
 //! `crate::email_recovery` for the design.
 
 use crate::v2_api::authn_method_test_helpers::{
-    create_identity_with_authn_method, test_authn_method,
+    create_identity_with_authn_method, sample_webauthn_authn_method, test_authn_method,
 };
 use canister_tests::{api::internet_identity as api, framework::*};
 use internet_identity_interface::internet_identity::types::email_recovery::{
@@ -50,6 +50,10 @@ use std::time::Duration;
 
 const TEST_DOMAIN: &str = "test.example.com";
 const TEST_ADDRESS: &str = "alice@test.example.com";
+// A second address in the *same* domain as `TEST_ADDRESS`, so two
+// concurrent verifications resolve the same DKIM FQDN and exercise the
+// in-flight cache dedup path. Used by the concurrency reproduction test.
+const TEST_ADDRESS_2: &str = "bob@test.example.com";
 const TEST_SELECTOR: &str = "test1";
 const TEST_BODY: &[u8] = b"Hello world.\r\nThis is a recovery email.\r\n";
 
@@ -809,6 +813,184 @@ fn full_setup_flow_binds_credential_to_anchor() {
     api::email_recovery_credential_remove(&env, canister_id, p, id, TEST_ADDRESS)
         .expect("remove call failed")
         .expect("remove should succeed");
+}
+
+// ===================================================================
+// DoH path: concurrent in-flight dedup — production-panic reproduction
+// ===================================================================
+//
+// Reproduces the prod trap:
+//
+//     Panicked at 'RefCell already borrowed',
+//     src/internet_identity/src/doh/cache.rs:256
+//
+// When two `smtp_request` calls for addresses in the *same* domain
+// arrive while the DoH cache is cold, they dedup onto a single DKIM
+// outcall fan-out (`doh::cache`): the first becomes the fetcher, the
+// second parks as a waiter on the shared `PendingState`. When the
+// fetcher's outcalls resolve it publishes the result and wakes the
+// waiter — and on the single-threaded canister executor that wake
+// re-polls the waiter *synchronously*, re-entering a `RefCell` the
+// publisher is still holding (the waiter's `WaitForPending::poll`, then
+// `DOH_CACHE` itself as the resumed task races on to its DMARC fetch).
+// The canister traps: the publisher's `smtp_request` is rejected and
+// the waiter never completes.
+//
+// The test drives exactly that interleaving through the public API:
+//   1. Two identities prepare recovery for alice@ and bob@ the same
+//      allow-listed domain.
+//   2. Both DKIM-signed emails are submitted as concurrent in-flight
+//      update calls.
+//   3. We tick *without* answering any outcall, so the second request
+//      is guaranteed to park as a dedup waiter before the fetcher
+//      publishes. (If we answered early, the fetcher would publish and
+//      evict the pending entry, the second request would hit a warm
+//      cache, and the dedup path — hence the bug — would never run.)
+//   4. We fan out the single, deduped DKIM (+ DMARC) outcall set.
+//
+// On the unfixed canister, step 4 traps the publisher with
+// "RefCell already borrowed" and BOTH requests fail to complete. The
+// fix (cache hands wakers back to be fired outside every borrow) lets
+// both requests complete and bind their credentials.
+#[test]
+fn concurrent_doh_dedup_for_same_domain_does_not_trap() {
+    let env = env();
+    let canister_id = setup_canister(&env);
+
+    // Two identities with *distinct* passkeys. We can't call the shared
+    // `fresh_identity` helper twice here: it registers a fixed public
+    // key (`sample_webauthn_authn_method(0)`), and II rejects a second
+    // registration that reuses a public key.
+    let authn_a = sample_webauthn_authn_method(1);
+    let authn_b = sample_webauthn_authn_method(2);
+    let id_a = create_identity_with_authn_method(&env, canister_id, &authn_a);
+    let id_b = create_identity_with_authn_method(&env, canister_id, &authn_b);
+    let p_a = authn_a.principal();
+    let p_b = authn_b.principal();
+
+    // Two pending challenges, one per identity, both in TEST_DOMAIN.
+    let challenge_a = api::email_recovery_credential_prepare_add(
+        &env,
+        canister_id,
+        p_a,
+        id_a,
+        EmailRecoveryDnsInput {
+            address: TEST_ADDRESS.into(),
+            dns_proof: None,
+        },
+    )
+    .expect("prepare_add A call failed")
+    .expect("prepare_add A failed");
+    let challenge_b = api::email_recovery_credential_prepare_add(
+        &env,
+        canister_id,
+        p_b,
+        id_b,
+        EmailRecoveryDnsInput {
+            address: TEST_ADDRESS_2.into(),
+            dns_proof: None,
+        },
+    )
+    .expect("prepare_add B call failed")
+    .expect("prepare_add B failed");
+
+    // One signer (one selector + domain) → both emails resolve the
+    // *same* DKIM FQDN `test1._domainkey.test.example.com`, which is
+    // exactly what makes the two verifications dedup in the cache.
+    let signer = dkim_signer::TestSigner::new(TEST_DOMAIN, TEST_SELECTOR);
+    let now_secs = time(&env) / 1_000_000_000;
+    let signed_a = signer.sign_email(SignedEmailParams {
+        from: TEST_ADDRESS,
+        to: "register@id.ai",
+        subject: &challenge_a.nonce,
+        body: TEST_BODY,
+        timestamp: now_secs,
+    });
+    let signed_b = signer.sign_email(SignedEmailParams {
+        from: TEST_ADDRESS_2,
+        to: "register@id.ai",
+        subject: &challenge_b.nonce,
+        body: TEST_BODY,
+        timestamp: now_secs,
+    });
+
+    // Submit both as concurrent in-flight update calls (no await yet).
+    let msg_a = env
+        .submit_call_with_effective_principal(
+            canister_id,
+            pocket_ic::common::rest::RawEffectivePrincipal::None,
+            candid::Principal::anonymous(),
+            "smtp_request",
+            candid::encode_one(&signed_a.request).expect("encode SmtpRequest A"),
+        )
+        .expect("submit_call A");
+    let msg_b = env
+        .submit_call_with_effective_principal(
+            canister_id,
+            pocket_ic::common::rest::RawEffectivePrincipal::None,
+            candid::Principal::anonymous(),
+            "smtp_request",
+            candid::encode_one(&signed_b.request).expect("encode SmtpRequest B"),
+        )
+        .expect("submit_call B");
+
+    // Let both requests reach their cache-dedup suspend points *before*
+    // any outcall is answered: the fetcher parks on its 5 provider
+    // outcalls and the second request dedups onto it and parks as a
+    // waiter. We must not answer an outcall yet — see the module note
+    // above on why early answers would warm the cache and skip dedup.
+    for _ in 0..5 {
+        env.tick();
+    }
+
+    // Fan out the single (deduped) DKIM + DMARC outcall set. On the
+    // unfixed canister the publish-time wake traps right here.
+    fulfill_doh_outcalls(&env, &signer.public_txt_record());
+    // A few more rounds so both update calls reach a terminal state on
+    // the happy (fixed) path. Harmless on the unfixed path — the dedup
+    // waiter never completes there no matter how long we tick.
+    for _ in 0..10 {
+        env.tick();
+    }
+
+    // Read both terminal statuses *without* blocking. We must never
+    // `await` the dedup waiter: on unfixed code it never completes (the
+    // publisher trapped and rolled back, leaving the pending entry
+    // `InFlight` forever), so a blocking await would hang the test
+    // instead of failing. `ingress_status` is `None` for a call with no
+    // terminal status yet and `Some(Err(reject))` for a trap.
+    let status_a = env.ingress_status(msg_a);
+    let status_b = env.ingress_status(msg_b);
+    let a_ok = matches!(
+        &status_a,
+        Some(Ok(raw)) if matches!(candid::decode_one::<SmtpResponse>(raw), Ok(SmtpResponse::Ok {}))
+    );
+    let b_ok = matches!(
+        &status_b,
+        Some(Ok(raw)) if matches!(candid::decode_one::<SmtpResponse>(raw), Ok(SmtpResponse::Ok {}))
+    );
+
+    // Symptom gate: on the unfixed canister the publisher's status is a
+    // reject carrying "RefCell already borrowed …/doh/cache.rs:256" and
+    // the waiter's is `None` (it never completes). Both must be Ok
+    // replies.
+    assert!(
+        a_ok && b_ok,
+        "concurrent DoH dedup for the same domain did not complete both \
+         requests — reproduction of the prod panic 'RefCell already \
+         borrowed' at src/internet_identity/src/doh/cache.rs.\n  \
+         request A => {status_a:?}\n  request B => {status_b:?}",
+    );
+
+    // End-to-end: both bindings landed on their anchors.
+    for (label, nonce) in [("A", &challenge_a.nonce), ("B", &challenge_b.nonce)] {
+        let status =
+            api::email_recovery_status(&env, canister_id, nonce).expect("status call failed");
+        assert!(
+            matches!(status, EmailRecoveryStatus::RegistrationSucceeded),
+            "expected RegistrationSucceeded for request {label}, got {status:?}",
+        );
+    }
 }
 
 // ===================================================================


### PR DESCRIPTION
## Symptom

`smtp_request` traps in the DoH fallback path:

```
Panicked at 'RefCell already borrowed', src/internet_identity/src/doh/cache.rs:256:36
```

The DoH path is what email-recovery verification falls back to for non-DNSSEC domains, so this aborts verification — the challenge stays `Pending`, the FE polls forever, and setup silently stalls between `email-recovery-setup-prepared` and `…-succeeded`.

## Two bugs, one root cause: cross-call task driving

`DohCache` deduplicates concurrent fetches for the same FQDN. The original design parked waiters on a shared `Rc<RefCell<PendingState>>` future and had the fetcher **wake** them on publish. On the single-threaded IC executor that wake runs the woken task **synchronously, re-entrantly, inside the fetcher's call context** — which causes *two* distinct failures:

1. **`RefCell already borrowed` (the panic).** The wake fired while the fetcher still held `state.borrow_mut()` (and `DOH_CACHE.borrow_mut()`); the re-entrant `WaitForPending::poll` re-borrowed the same cell → trap at `cache.rs:256`.
2. **Reply mis-routing (the deeper bug).** Even with the borrow released, the woken waiter is driven *to completion inside the fetcher's context*, so ic-cdk replies to the **wrong call**: `ic0.msg_reply_data_append: the call is already replied` on one request and `did not reply` on the other, non-deterministically. (The panic was masking this; the concurrent integration test surfaced it.)

On ic-cdk a call can only reply from its own context, which is re-entered **only** via a downstream call *it* made. So any dedup where a waiter is driven by the fetcher's wake is unsound — a timer can't fix it either (a timer callback can't reply to the waiter's ingress call).

## Fix: poll from your own context, never wake cross-call

- **Cache** (`cache.rs`) is now just a value map plus an **in-flight marker set** — no `Waker`s, no shared `RefCell` futures, nothing that drives one call's task from another's. `lookup` → `Hit` / `Wait` / `Fetch(token)`; `publish` writes-on-success and clears the marker only when still owned (`fetch_id` match), preserving stale-takeover safety.
- **`fetch_txt`** (`mod.rs`): the first arrival owns the 5-provider fan-out. Concurrent arrivals get `Wait` and **poll** — they yield one consensus round via a cheap management-canister round-trip (`raw_rand`, already used in this canister), which resumes them **in their own call context**, then re-check the cache. Bounded by `MAX_DEDUP_WAIT_POLLS`; the existing post-staleness takeover (`PENDING_STALE_AFTER_SECS`) recovers a wedged fetch.

Every request now completes and replies to its own caller. The in-flight dedup (design §7.6) is preserved: still one expensive DoH fan-out per cold domain; waiters spend only cheap mgmt round-trips.

## Tests

- DoH unit tests rewritten for the marker-based cache API (no more waker bookkeeping); all pass.
- **Concurrent-dedup integration test** (`email_recovery::concurrent_doh_dedup_for_same_domain_does_not_trap`): two in-flight `smtp_request`s for the same domain. It reproduced both bugs on the unfixed canister (see #3988) and passes with this redesign.

> Note on history: earlier commits implemented a narrower "collect wakers, wake after dropping the borrow" fix that addressed only the panic. The reply-routing bug it left behind drove the redesign here; the net diff is the poll-based dedup.

https://claude.ai/code/session_01UFjxDfciqgcygC62zvXDxz