### PR TITLE
fix(be,fe): email recovery hangs for Outlook addresses

### DIFF
--- a/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
@@ -375,26 +375,35 @@
             // Pending / NeedDkimLeaf from a submit: non-terminal, fall
             // through and let the polling loop carry the flow forward.
           } catch (e) {
-            // The submit wrapper throws on a canister `Err`. A
-            // DomainNotAllowlisted / DomainNotSupported verdict means
-            // even the DoH fallback can't verify this domain — show
-            // the unsupported-domain view instead of hanging. Any
-            // other error falls through to keep polling so a transient
-            // failure still resolves cleanly.
-            if (
-              isCanisterError<EmailRecoveryError>(e) &&
-              (e.type === "DomainNotAllowlisted" ||
-                e.type === "DomainNotSupported")
-            ) {
-              recoverWithEmailFunnel.trigger(
-                RecoverWithEmailEvents.UnsupportedDomain,
-                { reason: e.type },
-              );
+            // A non-canister error (transport failure, dropped
+            // response, an unexpected throw in the leaf walk) leaves
+            // the canister state unknown, and our single submit attempt
+            // is already spent (`dkimLeafSubmitted`), so the poll loop
+            // would never re-submit and the entry would hang at
+            // NeedDkimLeaf until the 30-minute Expired. Surface a
+            // retryable failure instead of staying silent.
+            if (!isCanisterError<EmailRecoveryError>(e)) {
+              recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.Failed, {
+                reason: "SubmitFailed",
+              });
               recoverWithEmailFunnel.close();
+              const diagnosticsBlob = await collectDiagnostics(nonce);
               polling = false;
-              stage = { kind: "unsupported", domain };
+              stage = {
+                kind: "failed",
+                reason:
+                  "We couldn't reach Internet Identity to verify your email. Please try again.",
+                diagnostics: diagnosticsBlob,
+              };
               return;
             }
+            // A canister `Err` means the canister has already moved the
+            // pending entry to a terminal state, so we let the polling
+            // loop's Failed/Expired branch surface the authoritative
+            // reason on its next tick — it routes
+            // DomainNotAllowlisted/DomainNotSupported to the
+            // unsupported-domain view and every other reason to the
+            // failed view (with diagnostics). Nothing is swallowed.
           }
         }
         await new Promise((r) => setTimeout(r, intervalMs));

--- a/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
@@ -278,6 +278,23 @@
           return;
         }
         if ("Failed" in result || "Expired" in result) {
+          // A DomainNotAllowlisted / DomainNotSupported verdict (e.g.
+          // a DoH-fallback leaf submission for a domain the operator
+          // hasn't enabled) gets the dedicated unsupported-domain
+          // view, matching the prepare-time routing.
+          if (
+            "Failed" in result &&
+            ("DomainNotAllowlisted" in result.Failed ||
+              "DomainNotSupported" in result.Failed)
+          ) {
+            recoverWithEmailFunnel.trigger(
+              RecoverWithEmailEvents.UnsupportedDomain,
+              { reason: failureReason(result) },
+            );
+            recoverWithEmailFunnel.close();
+            stage = { kind: "unsupported", domain };
+            return;
+          }
           recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.Failed, {
             reason: failureReason(result),
           });
@@ -293,48 +310,91 @@
         if ("NeedDkimLeaf" in result && !dkimLeafSubmitted) {
           dkimLeafSubmitted = true;
           recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.NeedDkimLeaf);
+          // Try a DNSSEC leaf walk; when the DKIM record CNAMEs into
+          // an unsigned zone (outlook.com ->
+          // outbound.protection.outlook.com) the walk yields
+          // `undefined` and we submit an empty hop set, asking the
+          // canister to resolve the key over DoH instead. That
+          // completes the flow for an allowlisted domain or throws
+          // DomainNotAllowlisted, routed to the unsupported view.
           const selector = result.NeedDkimLeaf.selector;
           try {
             const walked = await assembleDkimResolution(domain, selector);
-            if (walked !== undefined) {
-              const submission = await submitDkimLeaf({
-                nonce,
-                hops: walked.hops,
-                extra_chains: walked.extraChains,
-              });
+            const submission = await submitDkimLeaf(
+              walked !== undefined
+                ? { nonce, hops: walked.hops, extra_chains: walked.extraChains }
+                : { nonce, hops: [], extra_chains: [] },
+            );
+            recoverWithEmailFunnel.trigger(
+              RecoverWithEmailEvents.DkimLeafSubmitted,
+            );
+            // Handle every terminal variant the status type can carry,
+            // not just the one the canister returns today — the FE must
+            // stay correct if the backend's `Ok` arm changes.
+            if ("RecoveryReady" in submission) {
               recoverWithEmailFunnel.trigger(
-                RecoverWithEmailEvents.DkimLeafSubmitted,
+                RecoverWithEmailEvents.RecoveryReady,
               );
-              if ("RecoveryReady" in submission) {
-                recoverWithEmailFunnel.trigger(
-                  RecoverWithEmailEvents.RecoveryReady,
-                );
-                await retrieveDelegation(
-                  nonce,
-                  submission.RecoveryReady.user_key,
-                  submission.RecoveryReady.expiration,
-                  submission.RecoveryReady.anchor_number,
-                  sessionIdentity,
-                );
-                return;
-              }
-              if ("Failed" in submission || "Expired" in submission) {
-                recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.Failed, {
-                  reason: failureReason(submission),
-                });
-                recoverWithEmailFunnel.close();
-                const diagnosticsBlob = await collectDiagnostics(nonce);
-                stage = {
-                  kind: "failed",
-                  reason: friendlyError(submission),
-                  diagnostics: diagnosticsBlob,
-                };
-                return;
-              }
+              await retrieveDelegation(
+                nonce,
+                submission.RecoveryReady.user_key,
+                submission.RecoveryReady.expiration,
+                submission.RecoveryReady.anchor_number,
+                sessionIdentity,
+              );
+              return;
             }
-          } catch {
-            // Leave the loop running so the user sees a clean
-            // Expired if the canister times out.
+            if ("Failed" in submission || "Expired" in submission) {
+              if (
+                "Failed" in submission &&
+                ("DomainNotAllowlisted" in submission.Failed ||
+                  "DomainNotSupported" in submission.Failed)
+              ) {
+                recoverWithEmailFunnel.trigger(
+                  RecoverWithEmailEvents.UnsupportedDomain,
+                  { reason: failureReason(submission) },
+                );
+                recoverWithEmailFunnel.close();
+                polling = false;
+                stage = { kind: "unsupported", domain };
+                return;
+              }
+              recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.Failed, {
+                reason: failureReason(submission),
+              });
+              recoverWithEmailFunnel.close();
+              const diagnosticsBlob = await collectDiagnostics(nonce);
+              polling = false;
+              stage = {
+                kind: "failed",
+                reason: friendlyError(submission),
+                diagnostics: diagnosticsBlob,
+              };
+              return;
+            }
+            // Pending / NeedDkimLeaf from a submit: non-terminal, fall
+            // through and let the polling loop carry the flow forward.
+          } catch (e) {
+            // The submit wrapper throws on a canister `Err`. A
+            // DomainNotAllowlisted / DomainNotSupported verdict means
+            // even the DoH fallback can't verify this domain — show
+            // the unsupported-domain view instead of hanging. Any
+            // other error falls through to keep polling so a transient
+            // failure still resolves cleanly.
+            if (
+              isCanisterError<EmailRecoveryError>(e) &&
+              (e.type === "DomainNotAllowlisted" ||
+                e.type === "DomainNotSupported")
+            ) {
+              recoverWithEmailFunnel.trigger(
+                RecoverWithEmailEvents.UnsupportedDomain,
+                { reason: e.type },
+              );
+              recoverWithEmailFunnel.close();
+              polling = false;
+              stage = { kind: "unsupported", domain };
+              return;
+            }
           }
         }
         await new Promise((r) => setTimeout(r, intervalMs));

--- a/src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte
@@ -271,6 +271,24 @@
           return;
         }
         if ("Failed" in result || "Expired" in result) {
+          // A DomainNotAllowlisted / DomainNotSupported verdict (e.g.
+          // a DoH-fallback leaf submission for a domain the operator
+          // hasn't enabled) gets the dedicated unsupported-domain
+          // view, matching the prepare-time routing — not the generic
+          // failure screen.
+          if (
+            "Failed" in result &&
+            ("DomainNotAllowlisted" in result.Failed ||
+              "DomainNotSupported" in result.Failed)
+          ) {
+            setupEmailRecoveryFunnel.trigger(
+              SetupEmailRecoveryEvents.UnsupportedDomain,
+              { reason: failureReason(result) },
+            );
+            setupEmailRecoveryFunnel.close();
+            stage = { kind: "unsupported", domain };
+            return;
+          }
           setupEmailRecoveryFunnel.trigger(SetupEmailRecoveryEvents.Failed, {
             reason: failureReason(result),
           });
@@ -288,49 +306,92 @@
           setupEmailRecoveryFunnel.trigger(
             SetupEmailRecoveryEvents.NeedDkimLeaf,
           );
-          // Email arrived; the canister has the selector. Walk the
-          // single missing DKIM leaf and submit it. If the leaf
-          // walk fails we keep the loop alive — the canister-side
-          // entry will time out and the user will see Expired.
+          // Email arrived; the canister has the selector. Try to walk
+          // the missing DKIM leaf via DNSSEC. When the record CNAMEs
+          // into an unsigned zone (outlook.com ->
+          // outbound.protection.outlook.com) the walk yields
+          // `undefined`; we then submit an empty hop set, which asks
+          // the canister to resolve the key over its own DoH path
+          // instead. That either completes the flow (allowlisted
+          // domain) or throws DomainNotAllowlisted, which we route to
+          // the unsupported-domain view rather than poll to Expired.
           const selector = result.NeedDkimLeaf.selector;
           try {
             const walked = await assembleDkimResolution(domain, selector);
-            if (walked !== undefined) {
-              const submission = await submitDkimLeaf({
-                nonce,
-                hops: walked.hops,
-                extra_chains: walked.extraChains,
-              });
+            const submission = await submitDkimLeaf(
+              walked !== undefined
+                ? { nonce, hops: walked.hops, extra_chains: walked.extraChains }
+                : { nonce, hops: [], extra_chains: [] },
+            );
+            setupEmailRecoveryFunnel.trigger(
+              SetupEmailRecoveryEvents.DkimLeafSubmitted,
+            );
+            // Handle every terminal variant the status type can carry,
+            // not just the one the canister returns today — the FE must
+            // stay correct if the backend's `Ok` arm changes.
+            if ("RegistrationSucceeded" in submission) {
               setupEmailRecoveryFunnel.trigger(
-                SetupEmailRecoveryEvents.DkimLeafSubmitted,
+                SetupEmailRecoveryEvents.Succeeded,
               );
-              if ("RegistrationSucceeded" in submission) {
+              setupEmailRecoveryFunnel.close();
+              polling = false;
+              onSuccess(address);
+              return;
+            }
+            if ("Failed" in submission || "Expired" in submission) {
+              if (
+                "Failed" in submission &&
+                ("DomainNotAllowlisted" in submission.Failed ||
+                  "DomainNotSupported" in submission.Failed)
+              ) {
                 setupEmailRecoveryFunnel.trigger(
-                  SetupEmailRecoveryEvents.Succeeded,
-                );
-                setupEmailRecoveryFunnel.close();
-                polling = false;
-                onSuccess(address);
-                return;
-              }
-              if ("Failed" in submission || "Expired" in submission) {
-                setupEmailRecoveryFunnel.trigger(
-                  SetupEmailRecoveryEvents.Failed,
+                  SetupEmailRecoveryEvents.UnsupportedDomain,
                   { reason: failureReason(submission) },
                 );
                 setupEmailRecoveryFunnel.close();
-                const diagnosticsBlob = await collectDiagnostics(nonce);
-                stage = {
-                  kind: "failed",
-                  reason: friendlyError(submission),
-                  diagnostics: diagnosticsBlob,
-                };
+                polling = false;
+                stage = { kind: "unsupported", domain };
                 return;
               }
+              setupEmailRecoveryFunnel.trigger(
+                SetupEmailRecoveryEvents.Failed,
+                {
+                  reason: failureReason(submission),
+                },
+              );
+              setupEmailRecoveryFunnel.close();
+              const diagnosticsBlob = await collectDiagnostics(nonce);
+              polling = false;
+              stage = {
+                kind: "failed",
+                reason: friendlyError(submission),
+                diagnostics: diagnosticsBlob,
+              };
+              return;
             }
-          } catch {
-            // Submit failed; fall through to keep polling so the
-            // user sees a clean Expired if the canister times out.
+            // Pending / NeedDkimLeaf from a submit: non-terminal, fall
+            // through and let the polling loop carry the flow forward.
+          } catch (e) {
+            // The submit wrapper throws on a canister `Err`. A
+            // DomainNotAllowlisted / DomainNotSupported verdict means
+            // even the DoH fallback can't verify this domain — show
+            // the unsupported-domain view instead of hanging. Any
+            // other error falls through to keep polling so a
+            // transient failure still resolves cleanly.
+            if (
+              isCanisterError<EmailRecoveryError>(e) &&
+              (e.type === "DomainNotAllowlisted" ||
+                e.type === "DomainNotSupported")
+            ) {
+              setupEmailRecoveryFunnel.trigger(
+                SetupEmailRecoveryEvents.UnsupportedDomain,
+                { reason: e.type },
+              );
+              setupEmailRecoveryFunnel.close();
+              polling = false;
+              stage = { kind: "unsupported", domain };
+              return;
+            }
           }
         }
         // Pending or NeedDkimLeaf-but-already-submitted: back off

--- a/src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte
@@ -372,26 +372,38 @@
             // Pending / NeedDkimLeaf from a submit: non-terminal, fall
             // through and let the polling loop carry the flow forward.
           } catch (e) {
-            // The submit wrapper throws on a canister `Err`. A
-            // DomainNotAllowlisted / DomainNotSupported verdict means
-            // even the DoH fallback can't verify this domain — show
-            // the unsupported-domain view instead of hanging. Any
-            // other error falls through to keep polling so a
-            // transient failure still resolves cleanly.
-            if (
-              isCanisterError<EmailRecoveryError>(e) &&
-              (e.type === "DomainNotAllowlisted" ||
-                e.type === "DomainNotSupported")
-            ) {
+            // A non-canister error (transport failure, dropped
+            // response, an unexpected throw in the leaf walk) leaves
+            // the canister state unknown, and our single submit attempt
+            // is already spent (`dkimLeafSubmitted`), so the poll loop
+            // would never re-submit and the entry would hang at
+            // NeedDkimLeaf until the 30-minute Expired. Surface a
+            // retryable failure instead of staying silent.
+            if (!isCanisterError<EmailRecoveryError>(e)) {
               setupEmailRecoveryFunnel.trigger(
-                SetupEmailRecoveryEvents.UnsupportedDomain,
-                { reason: e.type },
+                SetupEmailRecoveryEvents.Failed,
+                {
+                  reason: "SubmitFailed",
+                },
               );
               setupEmailRecoveryFunnel.close();
+              const diagnosticsBlob = await collectDiagnostics(nonce);
               polling = false;
-              stage = { kind: "unsupported", domain };
+              stage = {
+                kind: "failed",
+                reason:
+                  "We couldn't reach Internet Identity to verify your email. Please try again.",
+                diagnostics: diagnosticsBlob,
+              };
               return;
             }
+            // A canister `Err` means the canister has already moved the
+            // pending entry to a terminal state, so we let the polling
+            // loop's Failed/Expired branch surface the authoritative
+            // reason on its next tick — it routes
+            // DomainNotAllowlisted/DomainNotSupported to the
+            // unsupported-domain view and every other reason to the
+            // failed view (with diagnostics). Nothing is swallowed.
           }
         }
         // Pending or NeedDkimLeaf-but-already-submitted: back off

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -540,10 +540,24 @@ type EmailRecoveryDnsInput = record {
 
 type EmailRecoverySubmitDkimLeafArg = record {
     nonce : text;
-    // The DKIM resolution chain in CNAME order, ending in a TXT. At
-    // least one hop required; bounded by `MAX_CNAME_HOPS = 4` at the
-    // canister side. For the Gmail-style direct-TXT case this is a
-    // single-element vec.
+    // The DKIM resolution chain in CNAME order, ending in a TXT,
+    // bounded by `MAX_CNAME_HOPS = 4` at the canister side. For the
+    // Gmail-style direct-TXT case this is a single-element vec.
+    //
+    // An EMPTY vec is a distinct signal: the FE could not walk a
+    // fully-signed DNSSEC resolution for this leaf, because the DKIM
+    // record CNAMEs into an unsigned zone (e.g.
+    // `selector1._domainkey.outlook.com` is a signed CNAME into the
+    // unsigned `outbound.protection.outlook.com`). The DNSSEC walk has
+    // to verify every hop and so fails on the unsigned one. The
+    // canister then resolves the key over its own DoH path: it issues
+    // ONE outcall for the in-zone name
+    // `<selector>._domainkey.<signing_domain>` and lets the recursive
+    // resolver chase the CNAME, so the unsigned target zone is never
+    // queried (or allowlist-checked) directly. The fetch is
+    // allowlist-gated on the registered domain; a non-allowlisted
+    // domain comes back as `DomainNotAllowlisted` rather than leaving
+    // the entry pending until it expires.
     hops : vec SignedRRset;
     // Delegation chains for signed zones touched by `hops` that
     // weren't already covered by the skeleton chain anchored at

--- a/src/internet_identity/src/email_recovery/smtp.rs
+++ b/src/internet_identity/src/email_recovery/smtp.rs
@@ -771,7 +771,10 @@ pub(super) fn extract_from_address(
 /// caller-bug variants (`InvalidName`, `NameOutsideRegisteredDomain`)
 /// surface as `InternalCanisterError` because they shouldn't reach
 /// here in practice (`prepare_add` already validates the inputs).
-fn map_doh_error(err: crate::doh::DohError, domain: &str) -> EmailRecoveryError {
+///
+/// `pub(super)` so the DNSSEC-path DoH fallback in `submit_leaf.rs`
+/// (empty `hops`) maps its own `fetch_txt` errors identically.
+pub(super) fn map_doh_error(err: crate::doh::DohError, domain: &str) -> EmailRecoveryError {
     use crate::doh::DohError;
     match err {
         DohError::DomainNotAllowed | DohError::NotConfigured => {

--- a/src/internet_identity/src/email_recovery/submit_leaf.rs
+++ b/src/internet_identity/src/email_recovery/submit_leaf.rs
@@ -62,7 +62,22 @@ pub async fn submit_dkim_leaf(
     let snapshot = pending::with_mut(&nonce, now_secs, |c| Snapshot::take(c))
         .ok_or(EmailRecoveryError::NonceUnknown)??;
 
-    if let Err(e) = run_submit(&hops, &extra_chains, &snapshot, now_secs) {
+    // An empty `hops` set is the FE's signal that it could not walk a
+    // DNSSEC resolution for this leaf — the DKIM record CNAMEs into an
+    // unsigned zone (the `outlook.com` -> `outbound.protection.outlook.com`
+    // case, or `live.com`). A genuine DNSSEC submission always carries at
+    // least the final TXT hop. In that case we resolve the DKIM key over
+    // DoH instead, reusing the cached `partial_verification` crypto
+    // material; this is allowlist-gated, so a domain the operator hasn't
+    // enabled comes back as `DomainNotAllowlisted` rather than hanging the
+    // pending entry until it expires.
+    let verification = if hops.is_empty() {
+        run_doh_fallback(&snapshot).await
+    } else {
+        run_submit(&hops, &extra_chains, &snapshot, now_secs)
+    };
+
+    if let Err(e) = verification {
         let cloned = e.clone();
         pending::with_mut(&nonce, now_secs, |c| {
             c.status = PendingStatus::Failed(cloned);
@@ -275,17 +290,95 @@ fn run_submit(
 
     let leaf_name = crate::dnssec::wire::decode_dns_name_lowercase(&verified.name.0);
 
-    // Step 4: parse the DKIM TXT, get the public key + key type.
+    // Steps 4–6 (parse TXT → tag contract → signature → DMARC
+    // alignment → From-match) are shared with the DoH fallback. The
+    // DNSSEC path feeds the TXT it just authenticated through the hop
+    // walk and the DMARC record cached at prepare time.
     let txt = crate::dnssec::wire::parse_txt_rdata(&verified.rdata).map_err(|_| {
         EmailRecoveryError::EmailVerificationFailed("DNSSEC TXT RDATA truncated".into())
     })?;
-    if txt.len() > super::MAX_DKIM_TXT_BYTES {
+    verify_dkim_key_against_partial(
+        &txt,
+        snapshot.cached_dmarc_txt.as_deref(),
+        snapshot,
+        &leaf_name,
+    )
+}
+
+/// DoH fallback for the DNSSEC path: invoked from `submit_dkim_leaf`
+/// when the FE submits an empty `hops` set, signalling it could not
+/// walk a fully-signed DNSSEC resolution for the leaf (the DKIM record
+/// CNAMEs into an unsigned zone — `outlook.com` ->
+/// `outbound.protection.outlook.com`, `live.com`, …).
+///
+/// Rather than leave the pending entry stuck in `NeedDkimLeaf` until it
+/// expires, we resolve the DKIM public key over the canister's own DoH
+/// path and verify the signature the same way the synchronous DoH path
+/// (`smtp::verify_setup_email_doh`) does — except the email body is long
+/// gone (dropped after `bh=` validated at `smtp_request` time), so we
+/// reuse the cached `partial_verification` crypto material instead of
+/// re-parsing the message.
+///
+/// All DNS names handed to `fetch_txt` come from canister-pinned state
+/// (`expected_selector` from the email's `s=` tag, `signing_domain` from
+/// its `d=`, `registered_domain` from the claimed address), never the FE.
+/// The fetch is allowlist-gated on `registered_domain`: a domain the
+/// operator hasn't enabled returns `DomainNotAllowed`/`NotConfigured`,
+/// which [`super::smtp::map_doh_error`] folds into
+/// `DomainNotAllowlisted` — the FE turns that into the unsupported-domain
+/// view.
+async fn run_doh_fallback(snapshot: &Snapshot) -> Result<(), EmailRecoveryError> {
+    // DKIM key lives at `<selector>._domainkey.<d>`; the allowlist gate
+    // and the in-domain check both key off the registered domain.
+    let dkim_fqdn = format!(
+        "{}._domainkey.{}",
+        snapshot.expected_selector, snapshot.signing_domain
+    );
+    let dmarc_fqdn = format!("_dmarc.{}", snapshot.registered_domain);
+
+    let dkim_bytes = crate::doh::fetch_txt(&dkim_fqdn, &snapshot.registered_domain)
+        .await
+        .map_err(|e| super::smtp::map_doh_error(e, &snapshot.registered_domain))?;
+
+    // DMARC: a quorum reporting "no record" is a valid DNS state and
+    // drops us to strict `d=` alignment; any other failure must
+    // propagate rather than quietly tighten the check. Mirrors the
+    // handling in `smtp::verify_setup_email_doh`.
+    let dmarc_bytes = match crate::doh::fetch_txt(&dmarc_fqdn, &snapshot.registered_domain).await {
+        Ok(bytes) => Some(bytes),
+        Err(crate::doh::DohError::NoAnswer) => None,
+        Err(e) => return Err(super::smtp::map_doh_error(e, &snapshot.registered_domain)),
+    };
+
+    verify_dkim_key_against_partial(
+        &dkim_bytes,
+        dmarc_bytes.as_deref(),
+        snapshot,
+        &dkim_fqdn,
+    )
+}
+
+/// Steps 4–6 of leaf verification, shared by the DNSSEC hop-walk path
+/// and the DoH fallback: parse the DKIM TXT, enforce the DNS-record tag
+/// contract, run the cached-digest signature check, then DMARC
+/// alignment and the final From-match. `dkim_txt` is the decoded TXT
+/// (record value) bytes; `dmarc_txt` is the decoded DMARC TXT or `None`
+/// when no record is published (strict `d=`/From equality applies).
+/// `context` names the leaf for diagnostics only.
+fn verify_dkim_key_against_partial(
+    dkim_txt: &[u8],
+    dmarc_txt: Option<&[u8]>,
+    snapshot: &Snapshot,
+    context: &str,
+) -> Result<(), EmailRecoveryError> {
+    // Step 4: parse the DKIM TXT, get the public key + key type.
+    if dkim_txt.len() > super::MAX_DKIM_TXT_BYTES {
         return Err(EmailRecoveryError::EmailVerificationFailed(format!(
-            "DKIM TXT record at {leaf_name:?} is {} bytes; refusing to admit",
-            txt.len()
+            "DKIM TXT record at {context:?} is {} bytes; refusing to admit",
+            dkim_txt.len()
         )));
     }
-    let txt_str = std::str::from_utf8(&txt).map_err(|_| {
+    let txt_str = std::str::from_utf8(dkim_txt).map_err(|_| {
         EmailRecoveryError::EmailVerificationFailed("DKIM TXT is not valid UTF-8".into())
     })?;
     let dns_record = crate::dkim::parse_dkim_txt(txt_str).map_err(|e| {
@@ -296,8 +389,8 @@ fn run_submit(
     // through the same shared umbrella the DoH path calls so the
     // `t=y` and AUID-alignment policies stay in lock-step across
     // pipelines. The trail the umbrella builds is the DoH-side
-    // diagnostic; we discard it here because the DNSSEC path
-    // collapses every failure into a single `EmailRecoveryError`.
+    // diagnostic; we discard it here because this path collapses
+    // every failure into a single `EmailRecoveryError`.
     if let Err((reason, _trail)) = crate::dkim::enforce_dns_record_tag_contract(
         &snapshot.signing_auid,
         &snapshot.signing_domain,
@@ -358,16 +451,17 @@ fn run_submit(
     // Step 6: DMARC alignment. The smtp.rs path enforced that the
     // signing domain (`d=`) is within the registered zone, so any
     // strict-or-relaxed alignment under DMARC is trivially
-    // satisfied. We re-check explicitly here against the cached
-    // DMARC record (when one was supplied at prepare time).
+    // satisfied. We re-check explicitly here against the DMARC
+    // record (cached at prepare time on the DNSSEC path, or
+    // freshly DoH-fetched on the fallback path).
     let from_domain = snapshot
         .from_address_lc
         .rsplit_once('@')
         .map(|(_, d)| d.to_string())
         .ok_or(EmailRecoveryError::AddressMismatch)?;
-    if let Some(dmarc_bytes) = &snapshot.cached_dmarc_txt {
+    if let Some(dmarc_bytes) = dmarc_txt {
         let dmarc_str = std::str::from_utf8(dmarc_bytes).map_err(|_| {
-            EmailRecoveryError::EmailVerificationFailed("cached DMARC is not valid UTF-8".into())
+            EmailRecoveryError::EmailVerificationFailed("DMARC TXT is not valid UTF-8".into())
         })?;
         let dmarc = crate::dmarc::parse_dmarc_txt(dmarc_str).map_err(|e| {
             EmailRecoveryError::EmailVerificationFailed(format!("DMARC parse: {e}"))
@@ -388,9 +482,9 @@ fn run_submit(
         }
     }
 
-    // Step 6: From: matches the claimed address. smtp.rs already
-    // confirmed this when caching `from_address_lc` on the partial
-    // verification record, but pin again as defense-in-depth.
+    // From: matches the claimed address. smtp.rs already confirmed
+    // this when caching `from_address_lc` on the partial verification
+    // record, but pin again as defense-in-depth.
     if !snapshot
         .from_address_lc
         .eq_ignore_ascii_case(&snapshot.claimed_address)

--- a/src/internet_identity/tests/integration/email_recovery.rs
+++ b/src/internet_identity/tests/integration/email_recovery.rs
@@ -31,7 +31,8 @@ use crate::v2_api::authn_method_test_helpers::{
 };
 use canister_tests::{api::internet_identity as api, framework::*};
 use internet_identity_interface::internet_identity::types::email_recovery::{
-    EmailRecoveryDnsInput, EmailRecoveryError, EmailRecoveryStatus, VerificationPath,
+    EmailRecoveryDnsInput, EmailRecoveryError, EmailRecoveryStatus, EmailRecoverySubmitDkimLeafArg,
+    VerificationPath,
 };
 use internet_identity_interface::internet_identity::types::smtp::{
     SmtpAddress, SmtpEnvelope, SmtpHeader, SmtpMessage, SmtpRequest, SmtpResponse,
@@ -715,6 +716,211 @@ fn full_setup_flow_via_dnssec_path() {
     api::email_recovery_credential_remove(&env, canister_id, p, id, TEST_ADDRESS)
         .expect("remove call failed")
         .expect("remove should succeed");
+}
+
+// ===================================================================
+// DNSSEC path: DoH fallback for an unsigned DKIM leaf
+// ===================================================================
+//
+// The DNSSEC path commits at prepare time based on the *apex* being
+// signed. But some providers publish the DKIM record as a CNAME into
+// an unsigned zone — `selector1._domainkey.outlook.com` is a signed
+// CNAME into the unsigned `outbound.protection.outlook.com`,
+// `live.com` likewise. The FE's DNSSEC hop-walk can't authenticate
+// that hop, so it submits an EMPTY `hops` set, asking the canister to
+// resolve the DKIM key over its own (allowlist-gated) DoH path using
+// the cached `partial_verification` crypto material instead of leaving
+// the entry stuck in `NeedDkimLeaf` until it expires.
+//
+// These tests reuse the same DNSSEC-signed `TEST_DOMAIN` fixture to
+// reach `NeedDkimLeaf`, then exercise the empty-hops fallback with the
+// domain on / off the DoH allowlist.
+
+/// Drive a DNSSEC-path setup flow up to the `NeedDkimLeaf` state.
+/// `allowed_domains` sets the DoH allowlist the subsequent empty-hops
+/// fallback will be gated on. Returns the canister + identity handles,
+/// the issued nonce, and the DKIM TXT the fallback's outcall expects
+/// to fetch (so the caller can fulfil the DoH fan-out).
+fn dnssec_flow_until_need_dkim_leaf(
+    env: &PocketIc,
+    allowed_domains: Vec<String>,
+) -> (candid::Principal, u64, candid::Principal, String, Vec<u8>) {
+    use internet_identity_interface::internet_identity::types::DnssecConfig;
+
+    let dkim = dkim_signer::TestSigner::new(TEST_DOMAIN, TEST_SELECTOR);
+    let dkim_txt = dkim.public_txt_record();
+    let now_secs: u32 = (time(env) / 1_000_000_000)
+        .try_into()
+        .expect("PocketIC initial time fits in u32");
+    // Skeleton bundle = chain + DMARC leaf (no DKIM leaf; its selector
+    // is unknown at prepare). `p=none` keeps DMARC alignment permissive.
+    let dmarc_txt = b"v=DMARC1; p=none;";
+    let chain = dnssec_signer::build_chain(
+        TEST_DOMAIN,
+        TEST_SELECTOR,
+        &dkim_txt,
+        Some(dmarc_txt),
+        now_secs,
+    );
+
+    let args = InternetIdentityInit {
+        doh_config: Some(Some(DohConfig {
+            allowed_domains,
+            max_cache_age_secs: Some(3600),
+        })),
+        dnssec_config: Some(Some(DnssecConfig {
+            root_anchors: vec![chain.anchor],
+        })),
+        related_origins: Some(vec!["https://id.ai".into()]),
+        canister_creation_cycles_cost: Some(0),
+        ..Default::default()
+    };
+    let canister_id = install_ii_canister_with_arg_and_cycles(
+        env,
+        II_WASM.clone(),
+        Some(args),
+        10_000_000_000_000,
+    );
+    let (id, p) = fresh_identity(env, canister_id);
+
+    let input = EmailRecoveryDnsInput {
+        address: TEST_ADDRESS.into(),
+        dns_proof: Some(DnsProofBundle {
+            hops: chain.dmarc_leaf.clone().map_or(vec![], |l| vec![l]),
+            ..chain.skeleton.clone()
+        }),
+    };
+    let challenge = api::email_recovery_credential_prepare_add(env, canister_id, p, id, input)
+        .expect("prepare_add call failed")
+        .expect("DNSSEC prepare_add should succeed");
+
+    let signed = dkim.sign_email(SignedEmailParams {
+        from: TEST_ADDRESS,
+        to: "register@id.ai",
+        subject: &challenge.nonce,
+        body: TEST_BODY,
+        timestamp: time(env) / 1_000_000_000,
+    });
+    let raw_msg_id = env
+        .submit_call_with_effective_principal(
+            canister_id,
+            pocket_ic::common::rest::RawEffectivePrincipal::None,
+            candid::Principal::anonymous(),
+            "smtp_request",
+            candid::encode_one(&signed.request).expect("encode SmtpRequest"),
+        )
+        .expect("submit_call");
+    // The DNSSEC path issues no outcalls at email-arrival time (chain +
+    // DMARC were anchored at prepare); a handful of ticks executes the
+    // message before we collect the response.
+    for _ in 0..30 {
+        env.tick();
+    }
+    let raw = env
+        .await_call_no_ticks(raw_msg_id)
+        .expect("await_call_no_ticks");
+    let resp: SmtpResponse = candid::decode_one(&raw).expect("decode SmtpResponse");
+    assert!(matches!(resp, SmtpResponse::Ok {}));
+
+    let status =
+        api::email_recovery_status(env, canister_id, &challenge.nonce).expect("status call failed");
+    match status {
+        EmailRecoveryStatus::NeedDkimLeaf { ref selector } => {
+            assert_eq!(selector, TEST_SELECTOR)
+        }
+        other => panic!("expected NeedDkimLeaf, got {other:?}"),
+    };
+
+    (canister_id, id, p, challenge.nonce, dkim_txt)
+}
+
+#[test]
+fn dnssec_path_falls_back_to_doh_when_leaf_is_unsigned() {
+    let env = env();
+    // Domain IS on the DoH allowlist, so the fallback can complete.
+    let (canister_id, id, p, nonce, dkim_txt) =
+        dnssec_flow_until_need_dkim_leaf(&env, vec![TEST_DOMAIN.into()]);
+
+    // The FE could not DNSSEC-resolve the leaf, so it submits an EMPTY
+    // hop set. The canister resolves the DKIM key over DoH instead;
+    // submit now issues outcalls, so drive it asynchronously and fulfil
+    // the provider fan-out with the test signer's DKIM TXT.
+    let raw_msg_id = env
+        .submit_call_with_effective_principal(
+            canister_id,
+            pocket_ic::common::rest::RawEffectivePrincipal::None,
+            candid::Principal::anonymous(),
+            "email_recovery_submit_dkim_leaf",
+            candid::encode_one(&EmailRecoverySubmitDkimLeafArg {
+                nonce: nonce.clone(),
+                hops: vec![],
+                extra_chains: vec![],
+            })
+            .expect("encode submit arg"),
+        )
+        .expect("submit_call");
+
+    fulfill_doh_outcalls(&env, &dkim_txt);
+
+    let raw = env
+        .await_call_no_ticks(raw_msg_id)
+        .expect("await_call_no_ticks");
+    let result: Result<EmailRecoveryStatus, EmailRecoveryError> =
+        candid::decode_one(&raw).expect("decode submit_dkim_leaf result");
+    let submit_status = result.expect("DoH fallback should succeed for an allowlisted domain");
+    assert!(
+        matches!(submit_status, EmailRecoveryStatus::RegistrationSucceeded),
+        "expected RegistrationSucceeded from the DoH fallback, got {submit_status:?}",
+    );
+
+    // Polled status agrees, and the credential actually persisted to
+    // the anchor (otherwise remove would return AddressNotRegistered).
+    let status = api::email_recovery_status(&env, canister_id, &nonce).expect("status call failed");
+    assert!(
+        matches!(status, EmailRecoveryStatus::RegistrationSucceeded),
+        "expected RegistrationSucceeded, got {status:?}",
+    );
+    api::email_recovery_credential_remove(&env, canister_id, p, id, TEST_ADDRESS)
+        .expect("remove call failed")
+        .expect("remove should succeed");
+}
+
+#[test]
+fn dnssec_path_doh_fallback_rejects_non_allowlisted_domain() {
+    let env = env();
+    // TEST_DOMAIN is DNSSEC-signed (so the DNSSEC path + NeedDkimLeaf
+    // are reached) but is NOT on the DoH allowlist.
+    let (canister_id, _id, _p, nonce, _dkim_txt) =
+        dnssec_flow_until_need_dkim_leaf(&env, vec![]);
+
+    // Empty hops -> DoH fallback. The allowlist gate rejects before any
+    // outcall, so this resolves synchronously with DomainNotAllowlisted
+    // — no DoH fan-out to fulfil.
+    let result = api::email_recovery_submit_dkim_leaf(
+        &env,
+        canister_id,
+        EmailRecoverySubmitDkimLeafArg {
+            nonce: nonce.clone(),
+            hops: vec![],
+            extra_chains: vec![],
+        },
+    )
+    .expect("submit_dkim_leaf call failed");
+    assert!(
+        matches!(result, Err(EmailRecoveryError::DomainNotAllowlisted(ref d)) if d == TEST_DOMAIN),
+        "expected Err(DomainNotAllowlisted({TEST_DOMAIN})), got {result:?}",
+    );
+
+    // The pending entry is now terminally Failed — the user sees the
+    // unsupported-domain view instead of polling until Expired.
+    let status = api::email_recovery_status(&env, canister_id, &nonce).expect("status call failed");
+    assert!(
+        matches!(
+            status,
+            EmailRecoveryStatus::Failed(EmailRecoveryError::DomainNotAllowlisted(_))
+        ),
+        "expected Failed(DomainNotAllowlisted), got {status:?}",
+    );
 }
 
 /// Drive PocketIC forward and panic if any DoH outcall is observed.


### PR DESCRIPTION
Setting up or recovering an identity with an @outlook.com address (and some other providers such as live.com) would get stuck on the "waiting for your email" screen. The confirmation email was sent and accepted, but the wizard never advanced and only failed after the 30-minute timeout.

These domains are DNSSEC-signed at the apex, so the flow commits to the DNSSEC verification path at prepare time and the canister asks the frontend to supply the DKIM leaf (`NeedDkimLeaf`). But Outlook publishes its DKIM record as a signed CNAME into an *unsigned* zone (`selector1._domainkey.outlook.com` → `outbound.protection.outlook.com`), which the per-hop DNSSEC walk can't authenticate. The frontend gave up with no fallback, so the canister waited for a leaf that never came until the challenge expired.

## Changes

- Backend: `email_recovery_submit_dkim_leaf` now accepts an empty `hops` set as "the frontend could not DNSSEC-resolve this leaf". It resolves the DKIM key over the canister's own allowlist-gated DoH path (one outcall for the in-zone name `<selector>._domainkey.<signing_domain>`, letting the resolver chase the CNAME) and verifies the cached signature through the same helper the DNSSEC path uses. A domain not on the DoH allowlist returns `DomainNotAllowlisted` instead of leaving the challenge pending.
- Frontend (both setup and recovery wizards): on `NeedDkimLeaf`, submit the walked hops when DNSSEC resolution succeeds, otherwise submit an empty hops set to request the DoH fallback. A `DomainNotAllowlisted` / `DomainNotSupported` result routes to the existing unsupported-domain screen instead of hanging. The submit-result handling now covers every `EmailRecoveryStatus` variant the type allows, so the frontend stays correct if the backend changes which variant it returns.
- Candid comment updated to document the empty-hops signal.

Note: for Outlook to *succeed* (rather than show the unsupported-domain screen) `outlook.com` must be present in the deploy `DohConfig.allowed_domains` — a deploy-arg decision, not part of this PR.

## Tests

- New integration tests in `tests/integration/email_recovery.rs`: DoH fallback succeeds for an allowlisted domain; returns `DomainNotAllowlisted` (terminal `Failed`) when not allowlisted. Full `email_recovery` integration suite passes (22 tests), plus canister unit tests, clippy, and frontend check/lint/format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
