### PR TITLE
fix(fe): Update CLI snippet to new 'icp identity link web' syntax

### DIFF
--- a/src/frontend/src/routes/(new-styling)/cli/components/TerminalBlock.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/components/TerminalBlock.svelte
@@ -2,7 +2,7 @@
   import { t } from "$lib/stores/locale.store";
 
   interface Props {
-    /** Command the user ran in their terminal (e.g. `icp identity link ii`). */
+    /** Command the user ran in their terminal (e.g. `icp identity link web`). */
     command: string;
     /** Progress line under the command. */
     progressLine?: string;

--- a/src/frontend/src/routes/(new-styling)/cli/views/CliAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/views/CliAuthorizeView.svelte
@@ -30,7 +30,9 @@
   // the connector visual (CliHeader handles it).
   const isAppMode = $derived(domain !== undefined);
   const command = $derived(
-    isAppMode ? `icp identity link web --app ${domain}` : "icp identity link web",
+    isAppMode
+      ? `icp identity link web --app ${domain}`
+      : "icp identity link web",
   );
 </script>
 

--- a/src/frontend/src/routes/(new-styling)/cli/views/CliAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/views/CliAuthorizeView.svelte
@@ -30,7 +30,7 @@
   // the connector visual (CliHeader handles it).
   const isAppMode = $derived(domain !== undefined);
   const command = $derived(
-    isAppMode ? `icp identity link ii --app ${domain}` : "icp identity link ii",
+    isAppMode ? `icp identity link web --app ${domain}` : "icp identity link web",
   );
 </script>
 

--- a/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
@@ -432,7 +432,7 @@ test("`--app` links the same principal that /authorize gives for that app", asyn
   await page.waitForURL(II_URL + "/manage");
   await enableCliAccessInSettings(page, isMobile);
 
-  // Principal the CLI links via `icp identity link ii --app nice-name.com`: the
+  // Principal the CLI links via `icp identity link web --app nice-name.com`: the
   // self-authenticating principal of the delegation chain's root public key.
   await page.goto(
     await cli.resolveAuthorizeUrl(page, { domain: "nice-name.com" }),


### PR DESCRIPTION
## Summary

Updates the code snippet displayed on https://cli.id.ai/ to match the new CLI syntax documented at https://skills.internetcomputer.org/skills/icp-cli/ ("Using the cli with a web identity").

The command keyword changed from `ii` to `web`:
- Generic: `icp identity link ii` → `icp identity link web`
- App mode: `icp identity link ii --app <domain>` → `icp identity link web --app <domain>`

## Changes
- `CliAuthorizeView.svelte`: updated the displayed command
- `TerminalBlock.svelte`: updated doc comment example
- `cli.spec.ts`: updated comment referencing the command

https://claude.ai/code/session_01BojoZSjznFfXd3xgP65pKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BojoZSjznFfXd3xgP65pKU)_