### PR TITLE
feat(fe): surface doh_reason on the email-recovery recover funnel

### DIFF
--- a/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/recoverWithEmail/RecoverWithEmailWizard.svelte
@@ -149,6 +149,45 @@
     return "unknown";
   };
 
+  /**
+   * Granular machine sub-reason for a DoH transport failure, or
+   * `undefined` for any non-DoH failure. Mirrors the setup wizard:
+   * `DohFetchFailed` collapses several distinct DoH causes (quorum
+   * miss, all providers down, dedup-wait timeout, malformed response)
+   * into one variant name. The canister encodes the cause as the
+   * leading `snake_case` token of the `DohFetchFailed` payload (see
+   * `map_doh_error` in the backend); we lift it out and report it as
+   * the `doh_reason` property on the `email-recovery-recover-failed`
+   * event so the funnel is segmentable by *why* DoH failed — which
+   * bites Gmail and other DoH-path providers on recovery just as it
+   * does on setup.
+   */
+  const dohSubReason = (variant: EmailRecoveryStatus): string | undefined => {
+    if (!("Failed" in variant)) return undefined;
+    const reason = variant.Failed as Record<string, unknown>;
+    const detail = reason["DohFetchFailed"];
+    if (typeof detail !== "string") return undefined;
+    const token = detail.split(":")[0]?.trim();
+    return token !== undefined && /^[a-z0-9_]+$/.test(token)
+      ? token
+      : undefined;
+  };
+
+  /**
+   * Property bag for a `email-recovery-recover-failed` event: the
+   * coarse variant `reason`, plus the granular `doh_reason` when the
+   * failure came from the DoH path.
+   */
+  const failedEventProps = (
+    variant: EmailRecoveryStatus,
+  ): Record<string, string> => {
+    const reason = failureReason(variant);
+    const dohReason = dohSubReason(variant);
+    return dohReason !== undefined
+      ? { reason, doh_reason: dohReason }
+      : { reason };
+  };
+
   const friendlyError = (variant: EmailRecoveryStatus): string => {
     if ("Failed" in variant) {
       const reason = variant.Failed;
@@ -295,9 +334,10 @@
             stage = { kind: "unsupported", domain };
             return;
           }
-          recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.Failed, {
-            reason: failureReason(result),
-          });
+          recoverWithEmailFunnel.trigger(
+            RecoverWithEmailEvents.Failed,
+            failedEventProps(result),
+          );
           recoverWithEmailFunnel.close();
           const diagnosticsBlob = await collectDiagnostics(nonce);
           stage = {
@@ -359,9 +399,10 @@
                 stage = { kind: "unsupported", domain };
                 return;
               }
-              recoverWithEmailFunnel.trigger(RecoverWithEmailEvents.Failed, {
-                reason: failureReason(submission),
-              });
+              recoverWithEmailFunnel.trigger(
+                RecoverWithEmailEvents.Failed,
+                failedEventProps(submission),
+              );
               recoverWithEmailFunnel.close();
               const diagnosticsBlob = await collectDiagnostics(nonce);
               polling = false;

--- a/src/frontend/src/lib/utils/analytics/recoverWithEmailFunnel.ts
+++ b/src/frontend/src/lib/utils/analytics/recoverWithEmailFunnel.ts
@@ -18,7 +18,11 @@ import { Funnel } from "./Funnel";
  *     email-recovery-recover-recovery-ready
  *       email-recovery-recover-delegation-retrieved
  *         email-recovery-recover-signed-in
- *     | email-recovery-recover-failed   (with `reason = <variant>`)
+ *     | email-recovery-recover-failed   (with `reason = <variant>`, plus
+ *       `doh_reason = quorum_failed | all_providers_failed |
+ *       dedup_wait_timeout | response_malformed` when a DoH-path
+ *       `DohFetchFailed` was the cause — mirrors the setup funnel so the
+ *       DoH failure mix is segmentable for non-DNSSEC providers like Gmail)
  * end-email-recovery-recover       (CLOSE — terminal state, carries `duration-…`)
  *
  * Two stages distinguish the recovery flow from setup:


### PR DESCRIPTION
## Why

#3990 added the granular `doh_reason` failure property to the **setup** wizard's funnel, but not the **recover** (sign-in) wizard. Recovery rides the *same* DoH verification path (`smtp_request` → `fetch_txt` → `map_doh_error`) and fails for the same reasons, so Gmail and other non-DNSSEC providers will fail between `email-recovery-recover-prepared` and `email-recovery-recover-recovery-ready` for the same causes — but `email-recovery-recover-failed` only carried the coarse variant name. This closes that parity gap.

## What

Frontend only — mirror the helpers from `SetupEmailRecoveryWizard` into `RecoverWithEmailWizard`:
- `dohSubReason()` — lifts the stable `snake_case` token (`all_providers_failed` / `dedup_wait_timeout` / `quorum_failed` / `response_malformed`) out of the `DohFetchFailed` payload (digit-tolerant regex, same as setup).
- `failedEventProps()` — `{ reason }` plus `doh_reason` when present.
- Applied to the **two genuine `email-recovery-recover-failed` triggers** (main poll loop + DKIM-leaf submission result). The `UnsupportedDomain`, catch-block `SubmitFailed`, and delegation-fetch error triggers are left as-is — a DoH sub-reason never applies there.
- Funnel doc updated to record the new property.

**No backend change:** `map_doh_error` (made `pub(super)` and token-prefixed in #3989/#3990) already emits the tokens for every DoH failure regardless of flow, so the recover path's `DohFetchFailed` payloads already carry them — this just reads them on the FE.

## Result

`email-recovery-recover-failed` becomes segmentable by `doh_reason`, exactly like `email-recovery-setup-failed`. Combined with #3990, both email-recovery funnels now expose *why* DoH failed — so the post-deploy Gmail diagnosis covers sign-in as well as setup.

## Verification

Mirrors the merged #3990 change exactly. No local frontend toolchain here (no `node_modules`); `frontend-checks` will validate tsc/svelte-check/prettier. No behavioural change — analytics property only.

https://claude.ai/code/session_01UFjxDfciqgcygC62zvXDxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFjxDfciqgcygC62zvXDxz)_