### PR TITLE
feat(fe): update icons across recovery surfaces

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/+page.svelte
@@ -4,10 +4,10 @@
   import { goto } from "$app/navigation";
   import {
     ArrowUpRightIcon,
+    BookAlertIcon,
+    BookOpenIcon,
     MailIcon,
     PlusIcon,
-    ShieldAlertIcon,
-    ShieldIcon,
   } from "@lucide/svelte";
   import { t } from "$lib/stores/locale.store";
   import { Trans } from "$lib/components/locale";
@@ -61,17 +61,17 @@
       },
       "setup-phrase": {
         label: $t`Set up recovery phrase`,
-        icon: ShieldIcon,
+        icon: BookOpenIcon,
         onclick: () => goto("/manage/recovery", { state: { activate: true } }),
       },
       "verify-phrase": {
         label: $t`Verify recovery phrase`,
-        icon: ShieldAlertIcon,
+        icon: BookAlertIcon,
         onclick: () => goto("/manage/recovery", { state: { verify: true } }),
       },
       "reset-phrase": {
         label: $t`Reset recovery phrase`,
-        icon: ShieldIcon,
+        icon: BookOpenIcon,
         onclick: () => goto("/manage/recovery", { state: { reset: true } }),
       },
     });

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    BriefcaseMedicalIcon,
     ChevronDownIcon,
     HouseIcon,
     KeyRoundIcon,
@@ -9,7 +10,6 @@
     CodeIcon,
     LanguagesIcon,
     SettingsIcon,
-    ShieldIcon,
     UserIcon,
   } from "@lucide/svelte";
   import { page } from "$app/state";
@@ -358,7 +358,7 @@
             href="/manage/recovery"
             current={page.url.pathname === "/manage/recovery"}
           >
-            <ShieldIcon class="size-5 sm:max-md:mx-auto" />
+            <BriefcaseMedicalIcon class="size-5 sm:max-md:mx-auto" />
             <span class="sm:max-md:hidden">{$t`Recovery`}</span>
           </NavItem>
         </li>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/ActiveRecoveryPhrase.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/ActiveRecoveryPhrase.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ShieldCheckIcon, LockKeyholeIcon } from "@lucide/svelte";
+  import { BookOpenCheckIcon, LockKeyholeIcon } from "@lucide/svelte";
   import { formatDate, formatRelative, t } from "$lib/stores/locale.store";
   import { Trans } from "$lib/components/locale";
   import type { SvelteHTMLElements } from "svelte/elements";
@@ -35,7 +35,7 @@
   ]}
 >
   <div class="mb-3 flex h-9 flex-row items-center">
-    <ShieldCheckIcon class="text-fg-success-primary size-6" />
+    <BookOpenCheckIcon class="text-fg-success-primary size-6" />
     {#if isCurrentAccessMethod}
       <Tooltip
         label={$t`Currently active`}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/InactiveRecoveryPhrase.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/InactiveRecoveryPhrase.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ShieldOffIcon } from "@lucide/svelte";
+  import { BookXIcon } from "@lucide/svelte";
   import { t } from "$lib/stores/locale.store";
   import { Trans } from "$lib/components/locale";
   import type { SvelteHTMLElements } from "svelte/elements";
@@ -19,7 +19,7 @@
   ]}
 >
   <div class="mb-3 flex h-9 flex-row items-center">
-    <ShieldOffIcon class="text-fg-tertiary size-6" />
+    <BookXIcon class="text-fg-tertiary size-6" />
     <button
       class="btn btn-primary btn-sm ms-auto"
       onclick={onActivate}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/UnverifiedRecoveryPhrase.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/recovery/components/UnverifiedRecoveryPhrase.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import {
+    BookAlertIcon,
+    BookOpenCheckIcon,
     EllipsisVerticalIcon,
-    ShieldIcon,
-    ShieldCheckIcon,
     Trash2Icon,
   } from "@lucide/svelte";
   import { t } from "$lib/stores/locale.store";
@@ -26,12 +26,12 @@
   ]}
 >
   <div class="mb-3 flex h-9 flex-row items-center">
-    <ShieldIcon class="text-fg-warning-primary size-6" />
+    <BookAlertIcon class="text-fg-warning-primary size-6" />
     <Select
       options={[
         {
           label: $t`Verify`,
-          icon: ShieldCheckIcon,
+          icon: BookOpenCheckIcon,
           onClick: onVerify,
         },
         {

--- a/src/frontend/src/routes/(new-styling)/recovery/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/recovery/+page.svelte
@@ -4,8 +4,8 @@
   import {
     ArrowRightIcon,
     BookOpenIcon,
+    BriefcaseMedicalIcon,
     HashIcon,
-    HeartPulseIcon,
     MailIcon,
   } from "@lucide/svelte";
   import ButtonCard from "$lib/components/ui/ButtonCard.svelte";
@@ -208,7 +208,7 @@
     <AuthPanel class="sm:max-w-100">
       <div class="mt-auto flex flex-col sm:my-auto">
         <FeaturedIcon size="lg" class="mb-4">
-          <HeartPulseIcon class="size-5" />
+          <BriefcaseMedicalIcon class="size-5" />
         </FeaturedIcon>
         <h1 class="text-text-primary mb-3 text-2xl font-medium">
           {$t`Recover your identity`}


### PR DESCRIPTION
## Problem

Recovery surfaces used generic `Shield*` / `HeartPulse` icons that didn't read as recovery-specific.

## Changes

- `/manage` sidebar Recovery item and `/recovery` landing hero: `ShieldIcon` / `HeartPulseIcon` → `BriefcaseMedicalIcon`.
- Recovery-phrase tiles (Active, Inactive, Unverified) and manage-home setup/verify/reset rows: `Shield*` family → `Book*` family (`BookOpenIcon`, `BookOpenCheckIcon`, `BookAlertIcon`, `BookXIcon`).

## Tests

Visual-only change, no logic touched.