### PR TITLE
fix(ci): grant update-deps write permissions for deps workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   update-deps:


### PR DESCRIPTION
## Problem

After #3998 merged, the first manual run of the new dependency-updates workflow failed at the \`Create Pull Request\` step with \`Error: Requires authentication\` — all four updaters succeeded but the PR-creation step couldn't write.

Failing run: https://github.com/dfinity/internet-identity/actions/runs/27285768379/job/80593220134

The \`permissions: contents: read\` block we added (to satisfy CodeQL's "workflow does not contain permissions" finding) was too restrictive. \`peter-evans/create-pull-request\` still makes internal calls that need \`contents:write\` + \`pull-requests:write\` even when an App token is supplied via \`token:\`.

\`update-passkey-aaguid.yml\` doesn't hit this because it has no \`permissions:\` block at all — the implicit GITHUB_TOKEN keeps its default broad scopes.

## Changes

- \`permissions: contents: read\` → \`permissions: { contents: write, pull-requests: write }\` in \`.github/workflows/update-deps.yml\`.

## Tests

https://github.com/dfinity/internet-identity/pull/4006