### PR TITLE
fix(ci): use --slurpfile in notify-ci-approval to avoid ARG_MAX

### DIFF
--- a/.github/scripts/notify-ci-approval.sh
+++ b/.github/scripts/notify-ci-approval.sh
@@ -32,11 +32,11 @@ open_prs=$(gh api --paginate "repos/${REPO}/pulls?state=open&per_page=100" \
 # Group runs by (pr_number, head_sha). For runs with empty pull_requests[],
 # fall back to matching head_sha against the open-PR list.
 grouped=$(jq -n \
-  --slurpfile runs <(echo "$runs") \
-  --slurpfile prs <(echo "$open_prs") \
+  --slurpfile runs_json <(printf '%s' "$runs") \
+  --slurpfile prs_json <(printf '%s' "$open_prs") \
   '
-  ($runs[0]) as $runs |
-  ($prs[0]) as $prs |
+  ($runs_json[0]) as $runs |
+  ($prs_json[0]) as $prs |
   ($prs | map({key: .head_sha, value: .}) | from_entries) as $sha_map |
   [
     $runs[] |

--- a/.github/scripts/notify-ci-approval.sh
+++ b/.github/scripts/notify-ci-approval.sh
@@ -32,9 +32,11 @@ open_prs=$(gh api --paginate "repos/${REPO}/pulls?state=open&per_page=100" \
 # Group runs by (pr_number, head_sha). For runs with empty pull_requests[],
 # fall back to matching head_sha against the open-PR list.
 grouped=$(jq -n \
-  --argjson runs "$runs" \
-  --argjson prs "$open_prs" \
+  --slurpfile runs <(echo "$runs") \
+  --slurpfile prs <(echo "$open_prs") \
   '
+  ($runs[0]) as $runs |
+  ($prs[0]) as $prs |
   ($prs | map({key: .head_sha, value: .}) | from_entries) as $sha_map |
   [
     $runs[] |


### PR DESCRIPTION
## Problem

The CI Approval Slack Notifier started failing on every scheduled run:

\`\`\`
.github/scripts/notify-ci-approval.sh: line 65: /usr/bin/jq: Argument list too long
##[error]Process completed with exit code 126.
\`\`\`

Failing run: https://github.com/dfinity/internet-identity/actions/runs/27330546010/job/80741649691

The script paginates all open PRs and all \`action_required\` workflow runs into shell variables, then passes both payloads to \`jq\` via \`--argjson\`. With the current PR/run volume, the combined JSON has grown past Linux's \`ARG_MAX\` (~128KB), so the \`jq\` invocation itself refuses to execute (exit 126 = command found but not executable). No notifications get sent.

## Changes

- Replace \`--argjson runs "$runs"\` / \`--argjson prs "$open_prs"\` with \`--slurpfile runs <(echo "$runs")\` / \`--slurpfile prs <(echo "$open_prs")\`. \`jq\` reads JSON from a file descriptor instead of argv, so payload size no longer constrains us.
- Add \`($runs[0]) as $runs | ($prs[0]) as $prs |\` at the top of the jq script to unwrap the array that \`--slurpfile\` always wraps around the loaded JSON. Rest of the script unchanged.

## Tests

- Smoke test with mock \`runs\` / \`open_prs\` payloads produces identical output to the \`--argjson\` version.
- Bash syntax check passes.
- Real verification: next scheduled fire (every 30 min) post-merge.