### PR TITLE
fix(fe): make support-request link one translatable sentence

### DIFF
--- a/src/frontend/src/lib/components/wizards/emailRecovery/shared/views/FailedView.svelte
+++ b/src/frontend/src/lib/components/wizards/emailRecovery/shared/views/FailedView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { t } from "$lib/stores/locale.store";
+  import { Trans } from "$lib/components/locale";
   import { MailXIcon, CopyIcon } from "@lucide/svelte";
   import { waitFor } from "$lib/utils/utils";
   import { SUPPORT_URL } from "$lib/config";
@@ -60,15 +61,15 @@
         {copied ? $t`Copied` : $t`Copy error details`}
       </button>
       <p class="text-text-tertiary text-sm">
-        {$t`If this keeps happening, copy these details and include them in a`}
-        <a
-          class="text-text-primary underline"
-          href={SUPPORT_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {$t`support request`}</a
-        >.
+        <Trans>
+          If this keeps happening, copy these details and include them in a
+          <a
+            class="text-text-primary underline"
+            href={SUPPORT_URL}
+            target="_blank"
+            rel="noopener noreferrer">support request</a
+          >.
+        </Trans>
       </p>
     </div>
   {/if}


### PR DESCRIPTION
The recovery "Verification failed" screen showed a hint whose sentence was split across two translation keys — `If this keeps happening, copy these details and include them in a` and a separate `support request` link label — then concatenated in the template. As flagged in the review on #3993, this is brittle for localization: languages with different word order or inflection can't build a grammatically correct sentence from the two fragments, which already produced broken/awkward Polish and Urdu translations.

# Changes

- `FailedView.svelte`: replaced the split `$t` pair (`...include them in a` + `support request`) with a single `<Trans>` whose message embeds the link as a `<0>…</0>` placeholder. Translators now get one complete sentence. Extraction yields: `If this keeps happening, copy these details and include them in a <0>support request</0>.`

This is the source-side fix the translation bot flagged for code owners (see the acknowledgements on #3993). The `.po` catalogs are bot-managed and intentionally not touched here; the bot will re-extract the new combined msgid and translate it on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)