### PR TITLE
fix(fe): always show OpenID provider name when logo is missing

### DIFF
--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -117,11 +117,13 @@
             >
               {#if authenticatingProviderId === provider.client_id}
                 <ProgressRing />
-              {:else if provider.logo}
-                <div class="size-5">
-                  <!-- eslint-disable-next-line svelte/no-at-html-tags -- provider.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
-                  {@html provider.logo}
-                </div>
+              {:else}
+                {#if provider.logo}
+                  <div class="size-5">
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -- provider.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
+                    {@html provider.logo}
+                  </div>
+                {/if}
                 <span>{name}</span>
               {/if}
             </button>

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -120,10 +120,12 @@
             {#if authenticatingProviderId === key}
               <ProgressRing />
             {:else}
-              <div class="size-5">
-                <!-- eslint-disable-next-line svelte/no-at-html-tags -- provider.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
-                {@html provider.logo}
-              </div>
+              {#if provider.logo}
+                <div class="size-5">
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -- provider.logo is a trusted SVG string sourced from the backend canister's openid_configs -->
+                  {@html provider.logo}
+                </div>
+              {/if}
               <span>{name}</span>
             {/if}
           </button>


### PR DESCRIPTION
A configured OpenID provider with an empty or missing logo rendered as a button with no visible text — only an invisible aria-label — on the "Add access method" screen, so it looked blank.

## Changes
- The provider name now always renders on access-method buttons; only the logo is gated on whether the provider has one.
- Applied the same gating to the sign-in provider picker so a logo-less provider no longer leaves an empty icon box above the name.

<div align="left">Previous: #3991</div>
