### PR TITLE
fix(ci): notify-ci-approval dedup never matched; gate marker on confirmed send

### DIFF
--- a/.github/scripts/notify-ci-approval.sh
+++ b/.github/scripts/notify-ci-approval.sh
@@ -89,13 +89,13 @@ while IFS= read -r entry; do
   pr_title=$(echo "$pr_info" | jq -r '.title')
   pr_html=$(echo "$pr_info"  | jq -r '.html_url')
 
-  # Dedup: look for our marker comment with this head SHA.
+  # Dedup: look for our marker comment with this head SHA. Marker
+  # bodies are multi-line, so grep the full stream of comment bodies;
+  # collapsing to one line (tail -1) only ever saw the footer line,
+  # never the marker, and re-notified on every cron tick.
   marker="${MARKER_PREFIX} head=${head_sha} -->"
-  existing=$(gh api --paginate "repos/${REPO}/issues/${pr_number}/comments" \
-    --jq '.[] | select(.body | contains("'"${MARKER_PREFIX}"'")) | .body' \
-    | tail -1)
-
-  if echo "${existing:-}" | grep -qF "head=${head_sha}"; then
+  if gh api --paginate "repos/${REPO}/issues/${pr_number}/comments" \
+       --jq '.[].body' | grep -qF "${MARKER_PREFIX} head=${head_sha}"; then
     echo "PR #${pr_number} head=${head_short}: already notified, skipping."
     continue
   fi
@@ -104,18 +104,22 @@ while IFS= read -r entry; do
 
   slack_text=":warning: *CI approval needed* for <${pr_html}|${pr_title}> by \`${actor}\`\n:point_right: Head: \`${head_short}\` · ${run_count} pending run(s)\n<${approve_url}|Approve workflow runs>"
 
-  response=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  # A transport-level curl failure must not abort the run (set -e);
+  # treat it as HTTP 000 and fall through to the non-200 branch.
+  response=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 -X POST \
     -H 'Content-Type: application/json' \
     --data "$(jq -n --arg text "$slack_text" '{text: $text}')" \
-    "$SLACK_PRIVATE_IDENTITY_WEBHOOK_URL")
+    "$SLACK_PRIVATE_IDENTITY_WEBHOOK_URL" || true)
+  response="${response:-000}"
 
-  if [[ "$response" == "200" ]]; then
-    echo "PR #${pr_number} head=${head_short}: Slack notification sent."
-  else
-    echo "PR #${pr_number} head=${head_short}: Slack returned HTTP ${response}."
+  if [[ "$response" != "200" ]]; then
+    # No marker on failure: the next cron tick retries the delivery.
+    echo "PR #${pr_number} head=${head_short}: Slack returned HTTP ${response}; will retry next run."
+    continue
   fi
+  echo "PR #${pr_number} head=${head_short}: Slack notification sent."
 
-  # Post dedup marker on the PR.
+  # Post dedup marker on the PR (only after a confirmed 200 send).
   marker_body="${marker}
 :robot_face: Slack notification sent for CI approval on head \`${head_short}\` (${run_count} pending run(s)).
 


### PR DESCRIPTION
## Problem

The CI-approval Slack notifier (added in #3969, ARG_MAX fix in #4005) sends **duplicate notifications on every cron tick** for the same (PR, head). Confirmed live: #3960 (head `aefb79b`) and #3993 each received two identical Slack messages + two identical dedup markers (09:01Z and 10:53Z today), and would keep re-notifying until their runs are approved.

**Root cause:** the marker comment body is multi-line (marker line, robot line, blank, footer). The dedup read did:

```bash
existing=$(gh api ... --jq '... | .body' | tail -1)
grep -qF "head=${head_sha}" <<< "$existing"
```

`--jq '.body'` prints each body with embedded newlines, so `tail -1` always captures the **last physical line** — the `_Automated by …_` footer — never the `head=<sha>` line. The grep never matches, so no (PR, head) is ever considered "already notified".

Reproduced against the real comments on #3960: `tail -1` yields the footer (no match → re-notify); grepping the full body stream matches correctly, and a never-notified SHA correctly does not match.

## Fix

1. **Dedup:** grep the full stream of comment bodies for the marker token (`<!-- ci-approval-slack: head=<sha>`), no line-collapsing.
2. **Marker only after confirmed send:** previously a non-200 Slack response was logged but the dedup marker was still posted — once dedup works, that would *permanently* swallow the lost notification. Now a non-200 skips the marker and the next cron retries (at-least-once delivery).
3. **Transport hardening:** `--max-time 15` and `|| true` on the curl so a connect failure degrades to HTTP `000` → retried next run, instead of aborting the whole script under `set -e`.

The pre-existing duplicate markers on #3960/#3993 are harmless: the fixed dedup matches any marker containing the SHA, so those PRs won't be re-notified.

## Verification

- `bash -n` clean.
- Dedup logic exercised against live production comment data on #3960 (positive match) and a synthetic never-notified SHA (negative).
- Behavior otherwise unchanged: same grouping filter, same message format, same marker format.