### PR TITLE
docs(be,fe): design doc and implementation checklist for verified emails as a first-class II primitive

### DIFF
--- a/docs/design/verified-email-attributes.md
+++ b/docs/design/verified-email-attributes.md
@@ -2,35 +2,34 @@
 
 **Status:** Draft
 **Owner:** Mario Ruci
-**Last edited:** 2026-06-16
+**Last edited:** 2026-06-17
 **Companion:** [verified-email-implementation.md](verified-email-implementation.md) — the operational checklist (file paths, concrete changes, PR breakdown). This doc explains the _why_; the checklist is _what to do_.
 
 ## TL;DR
 
-Today, Internet Identity has a single "recovery email" slot per anchor, verified through an inbound DKIM/DMARC/DNSSEC ownership-proof flow. Dapps can request user attributes (`email`, `name`, `verified_email`) but only from linked OpenID or SSO sources; the recovery email is invisible to that surface.
+Internet Identity has a single "recovery email" slot per anchor, verified through an inbound DKIM/DMARC/DNSSEC ownership-proof flow. Dapps can request `email` / `name` / `verified_email` attributes but only from linked OpenID/SSO sources — the recovery email is invisible to that surface.
 
-This doc proposes promoting "verified emails" to a **first-class anchor primitive** that supersedes the current single-slot recovery model and unlocks two downstream uses:
+This doc proposes adding **verified emails as a new, independent first-class anchor primitive** that lives alongside the existing recovery-email slot. The recovery flow stays untouched; verified emails are a separate bucket the user can populate independently.
 
-1. **Phase 1 — Verified emails as a first-class anchor primitive.** The user can register multiple proven-ownership email addresses on their anchor. One entry at a time can be designated as the recovery email (today's single use case). The verification mechanism is the existing inbound DKIM flow, generalized. Phase 1 ships in three releases: 1a introduces the new schema and lazy-migrates on every anchor touch, 1b runs a controller-driven sweep for dormant anchors, 1c drops the legacy storage field. See "Storage model and batched migration" for the rationale.
-2. **Phase 2 — Verified emails as attribute sources.** All verified email entries become candidate sources in the existing ICRC-3 attribute system under a new `verified:<H(address)>:email` scope. Dapps requesting `email` against a passkey-only anchor with at least one verified email now receive a value via the per-request consent dialog.
-3. **Phase 3 — Smart-routing + last-used default.** The consent dialog pre-selects the user's last-shared choice (or a smart-routed default for first-time users), and the canister tracks it automatically. There is no explicit "primary email" or "don't share" setting — every share is an explicit click in the consent dialog, and the user's revealed preference (including denials) is what shapes future defaults.
+Three phases, each shipping as a single release:
 
-Phases ship in this order. Phase 1a stands on its own (users get value from multiple proven emails regardless of attribute exposure). Phase 2 builds on Phase 1a's storage abstraction and can ship before 1b/1c complete. Phase 3 builds on Phase 2.
+1. **Phase 1 — Verified emails as a first-class anchor primitive.** The user can register multiple verified email addresses on their anchor through a new flow that reuses the existing inbound-DKIM verification primitive. New storage field, new candid surface, new wizard, new settings panel. Existing recovery flow is unchanged.
+2. **Phase 2 — Verified emails as attribute sources.** Verified email entries surface in the existing ICRC-3 attribute system under a new `verified:<H(address)>:email` scope. Dapps requesting `email` against a passkey-only anchor with at least one verified email now receive a value via the consent dialog.
+3. **Phase 3 — Smart-routing + last-used default.** The consent dialog pre-selects the user's last-shared choice (or a smart-routed default for first-time users), and the canister tracks it automatically.
 
----
+Phases ship in order. Phase 1 stands on its own (the user gets value from being able to verify multiple emails regardless of attribute exposure).
 
 ## Background
 
 ### The existing ICRC-3 attribute system
 
-Source files:
 Internet Identity ships an ICRC-3 attribute system that lets dapps request `email`, `name`, and `verified_email` from a signed-in user, scoped per source (`openid:<issuer>:<name>`, `sso:<domain>:<name>`) or unscoped (the canister picks any matching source). All values today come from `Anchor.openid_credentials` — OIDC- and SSO-linked credentials. The consent UI is per-request and lives in [`AttributeConsentView.svelte`](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte>) (multi-source attributes get a chevron-expandable picker).
 
 ### The existing email-recovery flow
 
-Internet Identity also ships an inbound-DKIM ownership-proof flow used to verify a user's recovery email: the user sends a message from the address they claim to `register@<domain>`, an off-canister SMTP relay forwards it to the canister, and the canister verifies DKIM / DMARC / DNSSEC + DoH before binding the address to the anchor. The verified address is stored in `Anchor.email_recovery` (today a `Vec` used cap-1 by convention). The verification dialog and the wizard live under [src/frontend/src/lib/components/wizards/](../../src/frontend/src/lib/components/wizards/); the verification primitives live under [src/internet_identity/src/email_recovery/](../../src/internet_identity/src/email_recovery/) and [src/internet_identity/src/dkim/](../../src/internet_identity/src/dkim/) / [dmarc/](../../src/internet_identity/src/dmarc/) / [dnssec/](../../src/internet_identity/src/dnssec/) / [doh/](../../src/internet_identity/src/doh/). The recovery email is not exposed to the attribute system.
+Internet Identity also ships an inbound-DKIM ownership-proof flow used to verify a user's recovery email: the user sends a message from the address they claim to `register@<domain>`, an off-canister SMTP relay forwards it to the canister, and the canister verifies DKIM / DMARC / DNSSEC + DoH before binding the address to the anchor. The verified address is stored in `Anchor.email_recovery`. The flow's wizards live under [src/frontend/src/lib/components/wizards/](../../src/frontend/src/lib/components/wizards/); the verification primitives live under [src/internet_identity/src/email_recovery/](../../src/internet_identity/src/email_recovery/) and [src/internet_identity/src/dkim/](../../src/internet_identity/src/dkim/) / [dmarc/](../../src/internet_identity/src/dmarc/) / [dnssec/](../../src/internet_identity/src/dnssec/) / [doh/](../../src/internet_identity/src/doh/).
 
-Phase 1's implementation analysis section cites the specific constants, candid methods, and file:line references where each piece of work lands.
+**This doc does not change the recovery flow.** Verified emails are a parallel new feature that shares the verification primitive (inbound DKIM challenge) but uses separate storage, separate candid methods, a separate wizard component, a separate subject prefix, and a separate `PendingKind` variant. The two concepts coexist; a user can have any combination of recovery email and verified emails.
 
 ---
 
@@ -38,242 +37,122 @@ Phase 1's implementation analysis section cites the specific constants, candid m
 
 ### Concept
 
-Each anchor can carry up to 5 verified email addresses. One entry at a time can be designated as the recovery email — that's the only per-entry flag. Verification is the existing inbound DKIM challenge flow. Today's single recovery-email slot becomes "the entry whose `is_recovery` flag is true".
+Each anchor can carry up to 5 verified email addresses. Each entry is just `{ address, verified_at }` — no role flags, no shareability toggle, no recovery designation. Verification reuses the existing inbound DKIM challenge flow, but with a new subject prefix and a new `PendingKind` variant so the canister can route the inbound message to the right destination after verification.
 
-A verified email's mere existence makes it eligible to be shared with dapps — there is **no per-entry "shareable" toggle and no global "don't share" toggle**. Sharing is always an explicit click in the per-request consent dialog. A user who never wants to share simply denies every time; "Deny all" is already a one-click action in the consent UI.
+A verified email's mere existence makes it eligible to be shared with dapps. The user decides on every request, in the consent dialog, which (if any) email to share. There's no per-entry "shareable" toggle and no global "don't share" toggle.
 
-### Storage model and batched migration
+**Verified emails are independent from the recovery email.** They can overlap (a user can verify the same address both as a recovery email and as a verified email — they go through both flows) or differ entirely. Cross-promotion ("also set as recovery" / "also add as verified") is out of scope for v1 but a plausible future enhancement.
 
-The existing storage layout could technically be extended in-place by adding an optional `is_recovery: Option<bool>` field to `StorableEmailRecoveryCredential`. That would avoid a migration entirely. Rejected: the resulting code reads `cred.is_recovery.unwrap_or(true)` against a type literally named `EmailRecoveryCredential` even when the entry has nothing to do with recovery. Readers a year from now will be confused, and the misnaming compounds every place the type appears.
+### Storage — additive, no migration
 
-Better to do the rename properly and pay the migration cost once. The migration ships in three releases.
-
-#### Target schema
-
-New storable type, named to match the generalized meaning, with field renames where the legacy names had become misleading:
-
-```rust
-#[derive(Encode, Decode, Clone, Debug, Eq, PartialEq)]
-#[cbor(map)]
-pub struct StorableVerifiedEmail {
-    #[n(0)] pub address: String,
-    #[n(1)] pub verified_at: Timestamp,                   // ← was `created_at` on the legacy type
-    #[n(2)] pub last_used_for_recovery_at: Option<Timestamp>,  // ← was `last_used`
-    #[n(3)] pub is_recovery: bool,                        // ← non-optional; always set on write
-}
-```
-
-Anchor schema carries both fields during the migration window:
+New anchor field, sitting alongside the existing recovery-email field:
 
 ```rust
 pub struct StorableAnchor {
     // ...
-    #[n(N1)] pub email_recovery: Option<Vec<StorableEmailRecoveryCredential>>,  // legacy; never written by new code
-    #[n(N2)] pub verified_emails: Option<Vec<StorableVerifiedEmail>>,            // new; authoritative once set
+    pub email_recovery: Option<Vec<StorableEmailRecoveryCredential>>,  // existing — untouched
+    pub verified_emails: Option<Vec<StorableVerifiedEmail>>,           // new
     // ...
 }
-```
 
-Pick a new `#[n(...)]` field number for `verified_emails`. Don't reuse the legacy field's number (`minicbor-derive`'s `#[cbor(map)]` would break stable-memory compatibility otherwise).
-
-#### Read/write abstraction
-
-All access goes through two helpers. New code never touches `anchor.email_recovery` or `anchor.verified_emails` directly.
-
-```rust
-pub fn read_verified_emails(anchor: &StorableAnchor) -> Vec<StorableVerifiedEmail> {
-    if let Some(v) = &anchor.verified_emails {
-        return v.clone();
-    }
-    // Lazy migration: synthesize from legacy when the new field is absent.
-    if let Some(legacy) = &anchor.email_recovery {
-        return legacy.iter().cloned().map(StorableVerifiedEmail::from).collect();
-    }
-    Vec::new()
-}
-
-pub fn write_verified_emails(anchor: &mut StorableAnchor, new: Vec<StorableVerifiedEmail>) {
-    anchor.verified_emails = Some(new);
-    anchor.email_recovery = None;  // clear legacy: new field is now authoritative for this anchor
+#[derive(Encode, Decode, Clone, Debug, Eq, PartialEq)]
+#[cbor(map)]
+pub struct StorableVerifiedEmail {
+    #[n(0)] pub address: String,
+    #[n(1)] pub verified_at: Timestamp,
 }
 ```
 
-The `From<StorableEmailRecoveryCredential> for StorableVerifiedEmail` impl maps `created_at → verified_at`, `last_used → last_used_for_recovery_at`, and sets `is_recovery: true` (legacy entries are recovery by definition — that's the only kind that ever got written under the old schema).
+Pick a new `#[n(...)]` field number for `verified_emails`; do not touch the legacy `email_recovery` field. The anchor schema uses `minicbor-derive` with `#[cbor(map)]`, which is forward-compatible across optional-field additions: existing anchors decode with `verified_emails: None` and behave exactly as they do today until they add their first verified email.
 
-#### Why batched, not big-bang
+No migration logic, no post-upgrade hook, no read/write abstraction. The two storage locations are entirely independent.
 
-II has many anchors. A full migration in `post_upgrade` is unsafe: the hook has a finite cycle budget, a write storm at upgrade time blocks rollback, and the operational risk is concentrated in one moment with no observability between "start" and "finish".
-
-Batched migration is the standard pattern. The work ships across three releases:
-
-**Phase 1a — schema lands, lazy migration on touch.** Both fields coexist on the anchor. `read_verified_emails` prefers the new field, synthesizes from legacy when absent. Every write goes through `write_verified_emails`, which sets the new field and clears the legacy one. Active anchors migrate organically as users authenticate, add devices, log in. No post-upgrade hook.
-
-**Phase 1b — controller-driven sweep of the long tail.** A stable cursor walks anchors and migrates the ones that haven't been touched. Ships ~one release after 1a so we can verify the lazy path is working in production before sweeping. Runs in batches under operator control; not a timer (no benefit from automated cycle pressure, and the operator wants to pick the low-traffic window).
-
-**Phase 1c — drop the legacy field.** After the sweep reports complete on prod, remove `email_recovery: Option<Vec<StorableEmailRecoveryCredential>>` and `StorableEmailRecoveryCredential` from the schema entirely. Cleanup release. Safe because every anchor has been touched.
-
-The reverse `address-hash → AnchorNumber` index ([src/internet_identity/src/storage/storable/email_recovery_address_hash.rs](../../src/internet_identity/src/storage/storable/email_recovery_address_hash.rs)) doesn't migrate — it was always per-address, not per-purpose. Multiple addresses pointing at the same anchor is already N entries pointing at the same value.
-
-#### Per-entry cap
-
-`MAX_VERIFIED_EMAILS_PER_ANCHOR = 5`. Decided. Enforced at write time in both `verified_email_prepare_add` and the legacy `email_recovery_credential_prepare_add` facade. Uses `read_verified_emails(anchor).len()` so the cap is consistent across migrated and not-yet-migrated anchors.
-
-#### `is_recovery` mutex
-
-Exactly zero or one entry on a given anchor has `is_recovery: true`. The new `verified_email_set_recovery` call atomically sets the flag on the target entry and clears it on every other entry of the same anchor in a single mutation, then calls `write_verified_emails`.
-
-### Candid types
-
-New candid type `VerifiedEmail` matching the storable shape, added to [src/internet_identity_interface/src/internet_identity/types/email_recovery.rs](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs). The legacy `EmailRecoveryCredential` candid type stays defined as long as the legacy facade methods exist (Phase 1a through 1c — at which point both go away together).
-
-Legacy candid methods return `EmailRecoveryCredential` (unchanged wire shape, preserving back-compat). New candid methods return `VerifiedEmail`.
+Cap at 5 entries per anchor (bounds stable-memory growth, suffices for any real user). Enforced at `verified_email_prepare_add` time.
 
 ### Verification flow
 
-Reuses the existing primitive verbatim: user composes an email from the address they're claiming, addressed to `register@<mailbox-domain>`, with a `Subject:` containing the canister-issued nonce. The off-canister relay forwards via `smtp_request`. The canister verifies DKIM, DMARC, and DNSSEC/DoH. On success, the entry is committed to `verified_emails` with `is_recovery: false`.
+User initiates "Add a verified email" from the dashboard's new "Verified emails" panel or from the authorize-flow empty-state prompt. The wizard:
 
-**Decoupling intent from verification.** The pending challenge proves _ownership_ of the address. Whether the new entry should be marked for recovery is set in a separate authenticated call after the entry exists. This keeps the SMTP/DKIM path as a pure ownership-proof primitive — no purpose data leaks through the verification pipeline. See "Open decisions: pending intent" below.
+1. Asks for the email address.
+2. Issues a challenge via `verified_email_prepare_add` — the canister registers a pending challenge with `PendingKind::VerifyEmail { anchor }` and returns a nonce with the new `II-Verify-` prefix.
+3. Shows the existing send-this-email confirmation dialog. The dialog renders whatever nonce the canister returns; with the new prefix, the user sees `Subject: II-Verify-<nonce>`.
+4. Polls for status.
+5. On success, the entry lands in `Anchor.verified_emails`.
 
-### Implementation analysis: reuse, generalize, fork
+The inbound verification mechanism is identical to the recovery flow: same `register@<domain>` mailbox, same DKIM/DMARC/DNSSEC/DoH stack, same SMTP gateway methods (`smtp_request`, `smtp_request_validate`), same pending-challenge map mechanics. The canister disambiguates between flows via the `PendingKind` on the pending challenge after the inbound message is matched:
 
-#### What we reuse verbatim
+- `PendingKind::Register { anchor }` — existing, drives the recovery-email setup flow. Writes to `email_recovery`.
+- `PendingKind::Recover { session_pk }` — existing, drives the recovery-as-login flow.
+- `PendingKind::VerifyEmail { anchor }` — **new**, drives the verified-email add flow. Writes to `verified_emails`.
 
-| Layer                                                                                | Reuse                                                                                |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
-| Canister-side SMTP candid methods (`smtp_request`, `smtp_request_validate`)          | unchanged — no new methods, no signature changes                                     |
-| DKIM signature verification                                                          | unchanged                                                                            |
-| DMARC alignment (deferred today)                                                     | unchanged                                                                            |
-| DNSSEC + DoH key resolution paths                                                    | unchanged                                                                            |
-| Pending-challenge map mechanics + TTL + eviction                                     | unchanged                                                                            |
-| `register@<domain>` mailbox                                                          | unchanged — same user-part for adding any verified email, regardless of intended use |
-| Shared `SendConfirmationEmail.svelte` dialog                                         | unchanged                                                                            |
-| FE poll cadence (`runEmailRecoveryPoll`)                                             | unchanged                                                                            |
-| `recover@<domain>` mailbox + login flow                                              | unchanged (login-via-email is a different feature)                                   |
-| Canister-side mailbox-domain derivation (`mailbox_domains()` from `related_origins`) | unchanged — no DNS/MX/cert changes                                                   |
+The subject-prefix parser (`find_nonce_in`) accepts both `II-Recovery-` and `II-Verify-` prefixes — it's just an anchor for the 16-hex nonce suffix, not a security primitive. Once the nonce matches a pending entry, dispatch is by `PendingKind`.
 
-#### Off-canister SMTP relay (boundary node) — coordinate, may need updates
+### Candid surface
 
-The off-canister SMTP relay that fronts the canister is a separate service (not in this repo). It receives inbound mail to `register@<domain>` / `recover@<domain>`, calls `smtp_request_validate` at `RCPT TO` time, and calls `smtp_request` after DATA. Based on the canister-side design at [smtp.rs:1-58](../../src/internet_identity/src/email_recovery/smtp.rs:1) the canister is the sole authority on whether a message belongs to a pending challenge (it parses the Subject and silently drops unknown nonces). The relay's role is envelope forwarding, not Subject filtering.
-
-That said, we should **explicitly confirm** with the relay owners that the deployed relay does not have any of the following recovery-specific assumptions baked in:
-
-- **Subject regex pre-filter** — e.g. only forwarding messages whose Subject matches `II-Recovery-[0-9a-f]{16}`. If such a filter exists, it must be widened to `II-(Recovery|Verify)-[0-9a-f]{16}` during the grace period, then narrowed to `II-Verify-` once the canister stops accepting the legacy prefix.
-- **Operator-facing documentation / runbooks** referring to "recovery emails" as the only accepted message kind — needs neutral wording so on-call doesn't reject legitimate verified-email traffic as out-of-scope.
-- **Per-message tagging** (correlation IDs, metrics labels) that classifies traffic as "recovery". Metrics should switch to neutral labels ("verified-email setup", say) or grow a second label to distinguish recovery-flagged from generic adds.
-- **Rate-limit buckets keyed by intended purpose.** If the relay rate-limits "recovery-email" traffic differently from other traffic, the new generic verified-email flow should be on a separate bucket so legitimate add-an-email traffic doesn't burn the recovery rate limit (and vice versa).
-
-If the relay is purely an envelope forwarder with no Subject-level inspection — which is what the canister-side comments imply — then **no relay-side changes are needed**. We need an explicit confirmation, not an assumption.
-
-**Action item:** before Phase 1 lands, get a written confirmation from whoever owns the deployed SMTP relay that one of the following holds:
-
-1. The relay does no Subject-level filtering and no purpose-based bucketing → no changes needed.
-2. There are Subject-level / purpose-level hooks → list them and coordinate the corresponding update window with the canister grace period.
-
-#### What we generalize
-
-**1. Subject-line nonce prefix: `II-Recovery-` → `II-Verify-`**
-
-- One-line constant change at [mod.rs:111](../../src/internet_identity/src/email_recovery/mod.rs:111).
-- `format_nonce` ([rng.rs:73](../../src/internet_identity/src/email_recovery/rng.rs:73)) reads the constant, so newly-issued nonces auto-update to the new prefix.
-- **`find_nonce_in` ([smtp.rs:436](../../src/internet_identity/src/email_recovery/smtp.rs:436)) accepts both prefixes indefinitely.** The prefix isn't a security primitive — it's a regex anchor for finding the 16-hex suffix, and a matching pending entry only exists if the canister itself issued it. Accepting `II-(Recovery|Verify)-<16-hex>` is exactly as secure as accepting only one. This avoids both (a) a second NNS proposal to remove the legacy prefix later and (b) the up-to-30-minute UX drop for in-flight users at upgrade time. Cost: ~5 lines of permanent code that say "we also accept the old prefix".
-- Doc comments referencing the old prefix: [types/email_recovery.rs:78](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs:78). Update.
-- Test fixtures and assertions to update (cosmetic; can land alongside or later): [dkim/canonicalize.rs:254-255](../../src/internet_identity/src/dkim/canonicalize.rs:254), [types/smtp.rs:662](../../src/internet_identity_interface/src/internet_identity/types/smtp.rs:662), several assertions in [tests/integration/email_recovery.rs](../../src/internet_identity/tests/integration/email_recovery.rs). Add a unit test that asserts both prefixes still parse.
-- Playwright fixtures and specs: regex `/II-Recovery-[0-9a-f]{16}/` in [tests/e2e-playwright/fixtures/emailRecovery.ts:122](../../src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts:122), [tests/e2e-playwright/routes/emailRecovery.spec.ts](../../src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts). Update to `/II-Verify-[0-9a-f]{16}/` to match what the canister will emit going forward.
-
-**2. `PendingKind::Register` semantics narrowed to "address-ownership proof"**
-
-Variant signature stays the same — `Register { anchor }`. The semantic meaning changes: it no longer carries the intent to write a recovery credential. On verification success, the canister commits a `VerifiedEmail` entry with `is_recovery: false`. The FE then makes a separate authenticated call to set `is_recovery: true` if (and only if) the user launched from the recovery-flow entry point.
-
-**3. Storage**
-
-New `StorableVerifiedEmail` type with renamed fields (`verified_at`, `last_used_for_recovery_at`, `is_recovery: bool`). New `verified_emails` field on the anchor lives alongside the legacy `email_recovery` field during the migration window. All access through `read_verified_emails` / `write_verified_emails` helpers, which lazy-migrate on every anchor touch. See "Storage model and batched migration" above for the three-release rollout (1a lazy + 1b sweep + 1c drop legacy).
-
-**4. Candid surface: additive**
-
-Add new methods alongside the existing ones, preserving the legacy facade:
+New methods, additive:
 
 ```
-# new — verified-emails feature
 type VerifiedEmail = record {
     address: text;
     verified_at: nat64;
-    last_used_for_recovery_at: opt nat64;
-    is_recovery: bool;
 };
 
-verified_email_prepare_add  : (IdentityNumber, EmailRecoveryDnsInput) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
-verified_email_set_recovery : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });  # promotes one entry; clears others
-verified_email_remove       : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });
-list_verified_emails        : (IdentityNumber) -> (vec VerifiedEmail) query;
-
-# legacy — preserved for compatibility through Phase 1a–1c; thin facades that read/write
-# through the same storage abstraction. Removed in Phase 1c alongside the legacy storage field.
-email_recovery_credential_prepare_add  → calls prepare_add internally, then verified_email_set_recovery on commit
-email_recovery_credential_remove       → calls verified_email_remove for the entry currently is_recovery
+verified_email_prepare_add : (IdentityNumber, EmailRecoveryDnsInput) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
+verified_email_remove      : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });
+list_verified_emails       : (IdentityNumber) -> (vec VerifiedEmail) query;
 ```
 
-Login-flow methods (`email_recovery_prepare_delegation`, `_status`, `_submit_dkim_leaf`, `_resolve_via_doh`, `_get_delegation`) and gateway methods (`smtp_request*`) **are not changed**.
+Existing `email_recovery_*` candid methods stay live and unchanged. There are no facade methods, no deprecation layer, no migration window for integrators. The two surfaces are independent.
 
-**5. Frontend wizards**
+Shared inbound primitives (`smtp_request`, `smtp_request_validate`, `EmailRecoveryDnsInput`, `EmailRecoveryChallenge`, `EmailRecoveryError`) are reused as-is — they're already generic ownership-proof types; we're just adding a new consumer.
 
-The `setupEmailRecovery` wizard ([SetupEmailRecoveryWizard.svelte](../../src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte)) is purpose-tied to recovery via its copy and its post-success flagging. Parameterize it:
+### Frontend
 
-```
-<EmailVerificationWizard
-  markAsRecovery={true}
-  copy="recovery"
-/>
-```
+**New "Verified emails" panel** on the `/manage` dashboard. Lists the user's verified emails; lets them add and remove. No "set as recovery" radio (that's a recovery-flow concern, separate). No global "don't share" toggle.
 
-The wizard's internal flow (open dialog → user sends email → poll → success/failure views) is purpose-agnostic. After success it conditionally calls `verified_email_set_recovery` only when `markAsRecovery` is true; otherwise the entry stays as a generic verified email.
+**New email-verification wizard** at a new component path (e.g. `src/frontend/src/lib/components/wizards/emailVerification/`). Parallel to the existing `setupEmailRecovery/` wizard, not a rename of it. The new wizard:
 
-Rename the directory from `setupEmailRecovery/` to `emailVerification/`. The recovery-flow entry point becomes a thin caller that mounts the generic wizard with `markAsRecovery={true}`. The shared views directory ([emailRecovery/shared/](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/)) renames similarly to drop "recovery" from its path — both the add flow and the login flow share purpose-neutral verification views now.
+- Reuses the shared `SendConfirmationEmail` dialog (renders whatever nonce the canister returns, including the new `II-Verify-` prefix).
+- Reuses the polling helper (`runEmailRecoveryPoll` — the polling pipeline is purpose-neutral once the pending entry exists).
+- Calls `verified_email_prepare_add` instead of `email_recovery_credential_prepare_add`.
 
-The dialog itself ([SendConfirmationEmail.svelte](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/views/SendConfirmationEmail.svelte)) renders the canister-issued nonce verbatim — once the prefix is `II-Verify-`, the dialog shows `II-Verify-…` with no FE changes.
+**/authorize empty-state inline flow.** When a dapp requests `email` and the anchor has no source at all (no OIDC, no SSO, no verified email), the consent handler today short-circuits to an empty response ([attributes.ts:674-678](../../src/frontend/src/lib/stores/channelHandlers/attributes.ts:674)). Replace with an inline "this dapp wants your email; verify one now?" affordance that opens the new wizard inside the authorize popup. On success, control returns to the consent dialog with the new entry available.
 
-#### What stays recovery-only
+The existing recovery-flow entry point on `/manage` ("Add a recovery email" CTA, wherever it lives) is **unchanged**. Users who think of the flow as "set up account recovery" still find it in the same place and get the same UX they have today. Users who think of it as "I want to share my email with a dapp" find the new Verified emails panel.
 
-| Element                                                        | Reason                                      |
-| -------------------------------------------------------------- | ------------------------------------------- |
-| `RECOVERY_RECIPIENT_USER = "recover"` mailbox                  | Only used by the anonymous login flow       |
-| `PendingKind::Recover { session_pk }`                          | Carries session-key state specific to login |
-| `recoverWithEmail/RecoverWithEmailWizard.svelte`               | The login UX                                |
-| `email_recovery_prepare_delegation` / `_get_delegation` candid | Login API                                   |
+### Copy and tone
 
-These don't change. Recovery-as-a-login-method is a separate feature from verified-emails-as-a-shareable-attribute; they share the verification primitive but diverge after it. Keeping them separate keeps the doc honest about what is and isn't being touched.
+Sharing a verified email is always **optional** — every consent surface gives the user a clear way out, and the consent dialog still fires on every authorize. But the copy on the new surfaces (the empty-state inline prompt in `/authorize`, the settings panel CTAs, and the success states of the wizard) should frame the share as a net benefit rather than as a friction the user is forced through.
 
-### Migration
+**Principles:**
 
-Detailed in "Storage model and batched migration" above. Summary:
+- Lead with what the user gets ("stay in touch with the dapp", "easier account recovery"), not what the dapp is asking for.
+- Make the skip path visible without making it feel like the wrong choice.
+- Never imply the user "must" verify or share — the dapp can ask again on the next authorize flow if the user skips.
+- Match the existing consent dialog's neutral tone for the per-request picker (the user has already chosen to engage at that point — the dialog should be matter-of-fact, not promotional).
 
-- **Phase 1a (this release).** Both `email_recovery` and `verified_emails` fields live on the anchor. All access through `read_verified_emails` / `write_verified_emails` helpers. Active anchors migrate organically on next write. No post-upgrade hook.
-- **Phase 1b (release N+1).** Controller-driven sweep walks anchors that haven't been touched and migrates them in batches.
-- **Phase 1c (release N+2, after sweep confirms complete).** Drop the legacy field and `StorableEmailRecoveryCredential` from the schema. Legacy candid methods (`email_recovery_credential_*`) and the legacy candid type are removed at this point too.
+**Proposed copy for the new surfaces** (final wording is an open decision; submit for UX review before shipping):
 
-The surrounding pieces are also versioned:
+- **/authorize empty-state inline prompt** (no verified email on file, dapp requests `email`):
+  - Title: "Stay in touch with `<dapp>`"
+  - Body: "Adding a verified email lets `<dapp>` reach you about account events — login alerts, receipts, recovery. You stay in control of what gets shared."
+  - Primary: "Verify an email"
+  - Secondary: "Skip for now"
 
-- **Subject prefix.** Phase 1a flips `NONCE_PREFIX` to `"II-Verify-"`; `find_nonce_in` accepts both prefixes indefinitely. No grace-period removal needed (see "Subject-line nonce prefix" under "What we generalize" above).
-- **Candid surface.** Legacy `email_recovery_credential_*` methods stay live through Phase 1c; they're removed alongside the legacy storage field, since they were facades around it. External integrators get one deprecation window covering both phases.
+- **Verified emails settings panel** (dashboard, no verified emails yet):
+  - Title: "Verified emails"
+  - Body: "Verify the emails you'd like to share with apps that ask. Apps never see an email until you confirm in the consent dialog."
+  - Primary: "Add an email"
 
-Reverse index: no migration. The `address-hash → AnchorNumber` map already supports N-addresses-per-anchor and is unchanged across all three phases.
+- **Wizard success state** (after a new verified email lands):
+  - Title: "Email verified"
+  - Body: "You can now share `<address>` with apps that ask. You'll be prompted to confirm every time — nothing is shared until you click."
 
-### Verification UX (settings entry point)
+- **Existing consent dialog** (per-request picker): unchanged. The user is already in the share-or-deny moment; promotional copy would feel manipulative. The "Deny all" link stays one click away.
 
-Reuses the shipped dialog ([SendConfirmationEmail.svelte](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/views/SendConfirmationEmail.svelte)), with one prefix update visible to the user.
+### Verification UX
 
-Today the dialog renders:
-
-```
-TO       register@id.ai
-FROM     marioruci15@gmail.com  ✓
-SUBJECT  II-Recovery-173036316cf99279
-BODY     (anything, leave it blank)
-
-[Open in mail app]
-[I've sent the email]
-```
-
-After Phase 1, the same dialog renders:
+The new wizard mounts the shipped send-this-email dialog ([SendConfirmationEmail.svelte](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/views/SendConfirmationEmail.svelte)). The dialog renders the canister-issued nonce verbatim, so once the prefix is `II-Verify-`, it shows up automatically:
 
 ```
 TO       register@id.ai
@@ -285,48 +164,13 @@ BODY     (anything, leave it blank)
 [I've sent the email]
 ```
 
-The dialog's title ("Verify your email") and body ("Send the email below to confirm") are already generic and need no change.
-
-### Settings UX — "Verified emails" panel
-
-New section on the identity management page (`/manage`).
-
-**Content:**
-
-- One row per verified email entry. Each row shows:
-  - The email address.
-  - Verification timestamp (tertiary styling).
-  - A "Used for recovery" radio button (radio across all rows — only one can be selected; selecting another atomically demotes the previous one).
-  - A "Remove" button.
-- An "Add an email" button — opens the verification wizard. New entries land in the list with no recovery flag; the user can promote any entry to recovery later via the row's radio.
-  No global "don't share" toggle. Sharing happens (or doesn't) per-request in the consent dialog, which already provides a one-click "Deny all". A user who never wants to share simply denies every time — that's the system learning their revealed preference.
-
-**States:**
-
-- **Empty state** (no verified emails): the panel shows the "Add an email" CTA prominently with explanatory copy ("Verified emails can be used to recover your account, and apps that ask for your email can request to receive one").
-- **Single entry, marked recovery**: the row shows the recovery radio selected. No "promote to recovery" UI is needed since it's already the recovery email.
-- **Multiple entries**: standard list; recovery radio is mutex across rows.
-
-The shipped recovery-flow entry point (today's "Add a recovery email" button somewhere in `/manage`) stays as a shortcut: clicking it launches the same wizard with `is_recovery: true` queued to apply on success. Users who think of the flow as "set up account recovery" get exactly the same UX they have today; users who think of it as "add a verified email I can also share" find the new panel.
-
-### Entry points
-
-Two surfaces launch the verification wizard, both pointing at the same component:
-
-**1. Dashboard.** "Add an email" in the Verified emails panel, or the legacy "Add a recovery email" shortcut.
-
-**2. `/authorize`, conditionally.** When a dapp requests `email` and the anchor has zero verified emails (and no OIDC/SSO source either), the consent handler today short-circuits to an empty response ([attributes.ts:674-678](../../src/frontend/src/lib/stores/channelHandlers/attributes.ts:674)). Replace that short-circuit with an inline affordance: "_this dapp wants your email; verify one now?_" with an "Add a verified email" button that opens the wizard inside the authorize popup. On success, control returns to the consent dialog which now has a source to offer.
-
-Both entry points hand the wizard the same component, the same candid call, the same SMTP flow. The only difference is the surrounding navigation.
+The only user-visible difference from the recovery flow's dialog is the subject prefix.
 
 ### Phase 1 open decisions
 
-- [ ] **Pending intent.** When a user launches the wizard from the recovery-flow entry point, the new entry needs to end up with `is_recovery: true`. Two ways to get there: (a) the FE always commits with `is_recovery: false` and then makes a follow-up `verified_email_set_recovery` call once polling sees success, or (b) the pending challenge carries the intent so the entry comes out of verification already flagged. (a) is one extra round-trip but keeps the ownership-proof pipeline purpose-agnostic; (b) is atomic but couples verification to intent.
-- [ ] **Boundary-node SMTP relay coordination.** II uses an off-canister SMTP relay (run by the boundary-node team) to forward inbound verification emails to the canister. The canister-side parser looks for `II-Recovery-` in the Subject today and will look for `II-Verify-` after Phase 1a. If the relay also filters on the Subject before forwarding — a regex pre-filter, purpose-based metric labels, rate-limit buckets — it needs to be updated to accept both prefixes. We need a written confirmation from the relay owners on whether any such filtering exists, and a coordinated change if it does.
-- [ ] **Phase 1b sweep mechanism.** Phase 1b is the migration step that walks dormant anchors and rewrites their storage from the legacy field to the new one. The question is how it's invoked: a controller-callable canister method (operator picks the window and batch size by hand) or an automated timer (runs on every replica without operator intervention). Controller-callable is the safer default — explicit go/no-go, lower-traffic windows, easier to pause if something goes wrong. Timer-driven would add replica-side cycle pressure for marginal benefit.
-- [ ] **Phase 1b batch size.** How many anchors per sweep invocation. Drives the per-call cycle cost and the total number of operator invocations needed to clear the long tail. Tune in staging before running on prod.
-- [ ] **Phase 1c timing.** Phase 1c is the cleanup release that removes the legacy `email_recovery` field, `StorableEmailRecoveryCredential`, and the legacy candid facade methods. It can only ship after Phase 1b reports the sweep complete. How long to wait between "1b complete on prod" and "1c shipped" — a buffer that gives any leftover lazy-migration corner case a chance to surface in production traffic. At least one full release cycle is the conservative answer.
-- [ ] **Translation strings.** Final user-facing wording for the new strings introduced by Phase 1 and Phase 2: the Verified emails panel header, the "Used for recovery" row label, the "Add an email" CTA, the row "Remove" / confirmation copy, and the "Verified email" source label that also appears in the Phase 2 consent dialog.
+- [ ] **Cross-promotion (v2 framing).** A user who wants the same address as both their recovery email and a shareable verified email currently has to verify it twice. Worth designing in v2: a "also set as my recovery email" affordance on the new verified-email row, and a "also add as a verified email" affordance on the recovery email management view. Both would skip re-verification since the address is already DKIM-proven in one bucket. Out of scope for v1.
+- [ ] **Wizard directory name.** `emailVerification/` is the working name; could also be `verifiedEmail/` or `addVerifiedEmail/`. Pick before scaffolding the component.
+- [ ] **Final wording for new translation strings.** Panel header, "Add an email" CTA, row remove confirmation, the "Verified email" source label, and the full copy proposed in the "Copy and tone" subsection above (empty-state inline prompt, settings empty state, wizard success state). All of this should land with UX review before shipping. The principles section is the harder commitment; the specific strings are bikeshed-easy to change.
 
 ---
 
@@ -334,43 +178,43 @@ Both entry points hand the wizard the same component, the same candid call, the 
 
 ### Scope syntax
 
-New scope variant: `verified:<H(address)>:email` and `verified:<H(address)>:verified_email`.
+New scope: `verified:<H(address)>:email` and `verified:<H(address)>:verified_email`.
 
-- The scope id is the hash of the address (e.g. SHA-256 truncated to 16 hex). Rationale:
-  - **Privacy** — the plaintext address doesn't appear in the candid key, so dapps querying `list_available_attributes` see hashes only.
-  - **Stability** — remove + re-add of the same address yields the same scope id, so any user-side bookmarks / dapp-side caches keyed on scope survive.
-  - **Reorderability** — the storage list can be rearranged without changing scope keys.
-- `name` is **not** supported for verified emails (no name claim collected during the inbound DKIM flow). `list_available_attributes` excludes `verified:<H>:name` like it does today for `sso:<domain>:verified_email`.
+- Scope id is SHA-256 of the lowercased address, truncated to the first 16 hex chars — short, plenty of collision resistance, doesn't leak the plaintext into the candid key.
+- `name` is not supported (no name claim from the verification flow). `list_available_attributes` excludes `verified:<H>:name` — mirrors the existing exclusion of `sso:<domain>:verified_email`.
 
 ### Plumbing
 
 **Canister:**
 
 - Add `AttributeScope::Verified { address_hash: String }` to the scope enum in [types/attributes.rs](../../src/internet_identity_interface/src/internet_identity/types/attributes.rs).
-- Extend `Anchor.list_available_attributes` ([attributes.rs:513](../../src/internet_identity/src/attributes.rs:513)) to also walk the result of `read_verified_emails(anchor)` (the storage abstraction introduced in Phase 1a). Every entry surfaces `verified:<H(address)>:email` and `verified:<H(address)>:verified_email` — verified existence is the sole eligibility test, no per-entry flag. Reading through the abstraction means Phase 2 works correctly on both migrated and not-yet-migrated anchors.
-- Extend `Anchor.prepare_attributes` / `prepare_icrc3_attributes` to resolve `verified:<H>:email` keys by looking up the entry whose `H(address)` matches (also via `read_verified_emails`).
-
-**OIDC/SSO unchanged.** They continue to surface under their existing `openid:` / `sso:` scopes alongside `verified:` entries. The user's verified-email entries are an _additional_ attribute bucket, not a replacement for IdP-sourced credentials.
+- Extend `Anchor.list_available_attributes` ([attributes.rs:513](../../src/internet_identity/src/attributes.rs:513)) to also walk `Anchor.verified_emails`. Each entry surfaces `verified:<H(addr)>:email` and `verified:<H(addr)>:verified_email`.
+- Extend `Anchor.prepare_attributes` / `prepare_icrc3_attributes` to resolve `verified:<H>:email` keys by hash lookup against `verified_emails`.
+- **Do not** expose `Anchor.email_recovery` as an attribute. The recovery email stays private to the recovery flow; users who want to share their recovery address with dapps verify it separately as a verified email.
+- OIDC/SSO sources unchanged.
 
 ### Frontend
 
-**No consent-dialog changes.** The shipped [`AttributeConsentView.svelte`](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte>) + [`AttributePicker.svelte`](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributePicker.svelte>) already merge multi-source unscoped requests into a chevron-expandable group. New `verified:` options appear as additional entries in that group automatically.
+No consent-dialog changes beyond a new "Verified email" source label. The shipped [`AttributeConsentView.svelte`](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte>) + [`AttributePicker.svelte`](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributePicker.svelte>) already group multi-source unscoped requests into a chevron-expandable picker; new `verified:` options appear as additional entries automatically.
 
-**One label addition.** A new translation string for the "Verified email" source label so the consent picker can render "Verified email (alice@gmail.com)" rather than a raw scope key. The source-label resolution lives in `scopedProviderLabel` ([AttributeConsentView.svelte:165-173](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte:165>)) — extend to recognise `verified:` and return a localised "Verified email" string; the address is already surfaced as the value column.
+The source-label resolution lives in `scopedProviderLabel` ([AttributeConsentView.svelte:165-173](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte:165>)) — extend to recognise `verified:` and return a localised "Verified email" string; the address is already surfaced as the value column.
 
-### Attribute-name coverage
+### Email-attribute coverage
 
-| Source               | `email` | `name`             | `verified_email`           |
-| -------------------- | ------- | ------------------ | -------------------------- |
-| OIDC (e.g. Google)   | ✅      | ✅                 | ✅                         |
-| SSO (e.g. Okta)      | ✅      | ✅                 | ❌ (kept out, intentional) |
-| Verified email entry | ✅      | ❌ (no name claim) | ✅                         |
+| Source             | `email`     | `verified_email`           |
+| ------------------ | ----------- | -------------------------- |
+| OIDC (e.g. Google) | ✅          | ✅                         |
+| SSO (e.g. Okta)    | ✅          | ❌ (kept out, intentional) |
+| Verified email     | ✅          | ✅                         |
+| Recovery email     | not exposed | not exposed                |
 
-A verified email is considered to satisfy `verified_email` because the inbound DKIM proof is the same kind of evidence OIDC's `email_verified: true` represents — both demonstrate the user controls the mailbox.
+A verified email satisfies `verified_email` because the inbound DKIM proof is the same kind of evidence OIDC's `email_verified: true` represents — both demonstrate the user controls the mailbox.
+
+(`name` is unaffected by this design; it continues to come from OIDC/SSO sources only, exactly as today.)
 
 ### Phase 2 open decisions
 
-- [ ] **Address-hash function and truncation length.** The new `verified:<H(address)>:email` scope identifies an entry by hash so the plaintext address doesn't appear in the candid key. Which hash, and how many bytes do we keep? Full SHA-256 is 64 hex chars and overkill; the first 16 hex (~64 bits) is enough collision resistance for per-anchor uniqueness without bloating every `list_available_attributes` response. The hash input is the address as already stored — canonical-lowercased — so no further normalization needed.
+- [ ] **Address-hash function and truncation length.** The new `verified:<H(address)>:email` scope identifies an entry by hash so the plaintext address doesn't appear in the candid key. Recommend SHA-256 truncated to the first 16 hex chars — short, plenty of collision resistance, doesn't bloat `list_available_attributes` responses. The hash input is the address as already stored (canonical-lowercased), so no further normalization needed.
 
 ---
 
@@ -396,7 +240,7 @@ For unscoped `email` / `verified_email` requests:
 
 "Deny all" doesn't update `last_shared_email_scope` — we track the last _shared_ choice, not the last action. So denying once doesn't change the default the next time.
 
-Scoped requests (`openid:...:email`, `verified:<H>:email`, etc.) bypass step 1 — the dapp asked for a specific source. They go straight to the consent dialog with that source pre-selected; user-side accept/deny semantics are unchanged.
+Scoped requests (`openid:...:email`, `verified:<H>:email`, etc.) bypass step 1 — the dapp asked for a specific source. They go straight to the consent dialog with that source pre-selected.
 
 ### Frontend changes
 
@@ -406,29 +250,24 @@ Two surgical edits to the existing consent UI:
 
 **2.** On Continue (the `handleContinue` callback), send the chosen attribute keys back as today, and the canister stores the resolved scope into `last_shared_email_scope` as a side effect of `prepare_icrc3_attributes`.
 
-Nothing else changes. No new dialog modes, no "Primary" badge, no "remember this choice" affordance, no first-time priming flow. The user never has to declare a default — the system learns from their first authorize flow.
+Nothing else changes. No new dialog modes, no "Primary" badge, no "remember this choice" affordance, no first-time priming flow.
 
 ### Phase 3 open decisions
 
-- [ ] **Stale-source fallback.** The canister remembers the user's last-shared scope (e.g. `openid:https://accounts.google.com`) so the consent dialog can pre-select it the next time the user authorizes. If that source has since been removed from the anchor — the user unlinked Google, deleted the verified email, etc. — what does the dialog default to? Options: silently fall back to smart-routing (current session's IdP first, then any available source), or surface a one-time "your previous default isn't available anymore" notice. Silent fallback is lower-friction but less transparent.
-- [ ] **Cross-device persistence of `last_shared_email_scope`.** The field is stored on the anchor (canister state), so the same value reaches every device the user signs in from. Alternative would be per-device `localStorage`, which would mean a new device sees a different default than the user's primary device. Anchor-side is more consistent with how II treats other anchor-level state.
-- [ ] **Deterministic ordering for "first available" fallback.** When smart-routing has nothing better to recommend (no last-shared source, no current-session IdP signal), it picks "the first available email source". What does "first" mean — most-recently-verified, insertion order in the storage list, alphabetical by address? Most-recently-verified is likeliest to be the email the user actually wants to share but introduces an ordering dependency on the upgrade-timing of recent writes.
+- [ ] **Stale-source fallback.** When `last_shared_email_scope` points to a source that's no longer on the anchor (unlinked Google, removed verified email, etc.), what does the consent dialog default to? Silently fall back to smart-routing, or surface a one-time "your previous default isn't available" notice. Silent fallback is lower-friction but less transparent.
+- [ ] **Cross-device persistence of `last_shared_email_scope`.** The field lives on the anchor (canister state) so it reaches every device. Alternative: per-device `localStorage` — but then a new device sees a different default than the primary device. Anchor-side is more consistent with how II treats other per-anchor state.
+- [ ] **Deterministic ordering for "first available" fallback.** When smart-routing has nothing better — no last-shared source, no current-session IdP signal — it falls back to "first available source". Which one is "first": most-recently-verified, insertion order in the storage list, or alphabetical by address? Most-recently-verified is likeliest to be the email the user wants but introduces an ordering dependency on the relative timestamps of recent writes.
 
 ---
 
 ## Sequencing
 
-| Step                                | Touches                                                                                                                                                                                                                                                                                                                                                                                                           | Ships independently?                                                                     |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Phase 1a backend                    | new `StorableVerifiedEmail` type, new `verified_emails` field on `StorableAnchor` alongside legacy `email_recovery`, `read_verified_emails` / `write_verified_emails` helpers, cap-5 enforcement, `verified_email_*` candid + `VerifiedEmail` type, legacy facades for `email_recovery_credential_*`, subject-prefix flip (with dual-accept parser). Lazy migration on every anchor touch — no post-upgrade hook. | Yes                                                                                      |
-| Phase 1a FE                         | generic email-verification wizard, new "Verified emails" settings panel, dashboard wiring, /authorize empty-state inline flow                                                                                                                                                                                                                                                                                     | After Phase 1a BE                                                                        |
-| Phase 1a boundary-node coordination | external — written confirmation or coordinated change to the SMTP relay                                                                                                                                                                                                                                                                                                                                           | Must complete before Phase 1a BE ships                                                   |
-| Phase 1b backend                    | controller-callable batched sweep of anchors still on legacy storage, stable cursor, `verified_email_migration_status()` query                                                                                                                                                                                                                                                                                    | Ships ~one release after 1a; runs in production until status reports complete            |
-| Phase 1c backend                    | drop legacy `email_recovery` field, `StorableEmailRecoveryCredential`, and the `email_recovery_credential_*` candid facades; remove legacy candid type. Cleanup release.                                                                                                                                                                                                                                          | After 1b sweep reports complete on prod                                                  |
-| Phase 2                             | `AttributeScope::Verified` variant, `list_available_attributes` + `prepare_*` extensions reading through `read_verified_emails`, FE source label                                                                                                                                                                                                                                                                  | After Phase 1a (works on both migrated and not-yet-migrated anchors via the abstraction) |
-| Phase 3                             | one anchor field, resolution logic, `AttributeConsentView` default-selection edit                                                                                                                                                                                                                                                                                                                                 | After Phase 2                                                                            |
-
-The boundary-node coordination is the only step on the critical path that depends on a team outside this codebase. Phase 2 doesn't have to wait for 1b/1c — it reads through the storage abstraction, so unmigrated anchors are still serveable.
+| Step            | Touches                                                                                                                                                                                                                                                                           |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Phase 1 backend | new `StorableVerifiedEmail` type, new `verified_emails` field on `StorableAnchor`, new `PendingKind::VerifyEmail` variant, SMTP-dispatch arm for the new variant, `find_nonce_in` accepts `II-Verify-` alongside `II-Recovery-`, `verified_email_*` candid + `VerifiedEmail` type |
+| Phase 1 FE      | new email-verification wizard (parallel to `setupEmailRecovery/`), new "Verified emails" settings panel, /authorize empty-state inline flow                                                                                                                                       |
+| Phase 2         | `AttributeScope::Verified` variant, `list_available_attributes` + `prepare_*` extensions reading from `verified_emails`, FE source label                                                                                                                                          |
+| Phase 3         | one anchor field, resolution logic, `AttributeConsentView` default-selection edit                                                                                                                                                                                                 |
 
 ---
 
@@ -437,7 +276,8 @@ The boundary-node coordination is the only step on the critical path that depend
 - **Push notifications.** Separate workstream — WebPush + Service Worker on the II origin. The two channels are orthogonal: email-attribute settings and push allowlists may share a settings UI but share no implementation.
 - **Per-dapp pseudonymous email aliases (`<hash>@id.ai`).** Discussed as a possible future phase once verified emails exist as a primitive. Requires an MX server commitment that's a separate organisational decision. See prior art in [#3760](https://github.com/dfinity/internet-identity/pull/3760) for the inbox/postbox path the team has explored and parked.
 - **Cross-attribute pinning (primary name, primary DoB, etc.).** Email-specific concerns drove this design; other attributes don't have the "multiple sources, hard to pick" problem.
-- **Per-dapp persistent overrides.** Considered and rejected — the Apple "Hide my email" analogy doesn't transfer because we share the user's real address, not per-app aliases. Without per-app aliases, persistent per-dapp overrides add complexity without solving a real problem.
+- **Cross-promotion between recovery and verified emails.** A user who wants the same address in both buckets verifies twice today. Cross-promotion ("also set as recovery" on a verified-email row, "also add as verified" on the recovery email view) is a plausible v2 enhancement; both would skip re-verification since the address is already DKIM-proven.
+- **Modifying the existing recovery flow.** Recovery storage, candid, wizard, and `II-Recovery-` subject prefix are all unchanged.
 
 ---
 
@@ -445,21 +285,16 @@ The boundary-node coordination is the only step on the critical path that depend
 
 **Phase 1:**
 
-- [ ] **Pending intent.** When the wizard runs from the recovery entry point, the new entry needs `is_recovery: true` on commit. Two ways to land it: (a) the FE always commits with `is_recovery: false` and then makes a follow-up `verified_email_set_recovery` call once polling succeeds, or (b) the pending challenge carries the intent through the verification pipeline. (a) keeps the ownership-proof pipeline purpose-agnostic at the cost of one extra round-trip.
-- [ ] **Boundary-node SMTP relay coordination.** II uses an off-canister SMTP relay (boundary-node team) to forward inbound verification emails to the canister. The canister-side Subject parser looks for `II-Recovery-` today and will look for `II-Verify-` after Phase 1a. If the relay does any Subject-level filtering, purpose-based metric labels, or rate-limit buckets keyed on the prefix, those need updating to accept both. Need a written confirmation on what (if anything) is in place.
-- [ ] **Phase 1b sweep mechanism.** Phase 1b walks anchors that haven't been touched since 1a shipped and migrates them to the new storage layout in batches. Choose: a controller-callable canister method (operator picks the window and batch size by hand) or an automated timer (runs on every replica without operator intervention). Controller-callable is the safer default.
-- [ ] **Phase 1b batch size.** How many anchors per sweep call. Per-call cycle cost vs. total operator invocations to clear the long tail. Tune in staging before prod.
-- [ ] **Phase 1c timing.** Phase 1c is the cleanup release that removes the legacy `email_recovery` field, `StorableEmailRecoveryCredential`, and the legacy candid facade methods. It ships after Phase 1b reports the sweep complete. How long to wait between "1b complete on prod" and "1c shipped" — a buffer for any leftover lazy-migration corner case to surface. At least one full release cycle is the conservative answer.
-- [ ] **Translation strings.** Final user-facing wording for the new strings introduced by Phase 1 and 2: the Verified emails panel header, the "Used for recovery" row label, the "Add an email" CTA, the row remove confirmation, and the "Verified email" source label that also appears in the Phase 2 consent dialog picker.
+- [ ] Cross-promotion v2 design (deferred).
+- [ ] Wizard directory name (`emailVerification/` vs alternatives).
+- [ ] Translation strings: Verified emails panel header, "Add an email" CTA, "Remove" confirmation copy, "Verified email" source label (also used by Phase 2's consent dialog).
 
-**Decided (Phase 1):**
+**Phase 2:**
 
-- Per-anchor cap: 5 verified emails.
-- Wizard directory: `setupEmailRecovery/` renames to `emailVerification/`; the shared views directory renames to drop "recovery". The recovery-flow entry point becomes a thin call site mounting the generic wizard with `markAsRecovery={true}`.
-- Candid evolution: additive — new `verified_email_*` methods alongside the legacy `email_recovery_credential_*` facades, with both available through Phases 1a-1b and the legacy ones removed in 1c alongside the legacy storage field.
+- [ ] Address-hash function and truncation length (recommend SHA-256 first 16 hex).
 
 **Phase 3:**
 
-- [ ] **Stale-source fallback.** When `last_shared_email_scope` points to a source that's no longer on the anchor (unlinked Google, removed verified email, etc.), what does the consent dialog default to? Silently fall back to smart-routing, or surface a one-time "your previous default isn't available" notice. Silent fallback is lower-friction but less transparent.
-- [ ] **Cross-device persistence of `last_shared_email_scope`.** The field lives on the anchor (canister state) so it reaches every device. Alternative: per-device `localStorage` — but then a new device sees a different default than the primary device. Anchor-side is more consistent with how II treats other per-anchor state.
-- [ ] **Deterministic ordering for "first available" fallback.** When smart-routing has nothing better — no last-shared source, no current-session IdP signal — it falls back to "first available source". Which one is "first": most-recently-verified, insertion order in the storage list, or alphabetical by address? Most-recently-verified is likeliest to be the email the user wants but introduces an ordering dependency on the relative timestamps of recent writes.
+- [ ] Stale-source fallback behaviour (silent vs notice).
+- [ ] Cross-device persistence of `last_shared_email_scope` (recommend anchor-side).
+- [ ] Deterministic ordering for "first available" fallback.

--- a/docs/design/verified-email-attributes.md
+++ b/docs/design/verified-email-attributes.md
@@ -11,13 +11,14 @@ Internet Identity has a single "recovery email" slot per anchor, verified throug
 
 This doc proposes adding **verified emails as a new, independent first-class anchor primitive** that lives alongside the existing recovery-email slot. The recovery flow stays untouched; verified emails are a separate bucket the user can populate independently.
 
-Three phases, each shipping as a single release:
+Four phases, each shipping as a single release:
 
-1. **Phase 1 — Verified emails as a first-class anchor primitive.** The user can register multiple verified email addresses on their anchor through a new flow that reuses the existing inbound-DKIM verification primitive. New storage field, new candid surface, new wizard, new settings panel. Existing recovery flow is unchanged.
-2. **Phase 2 — Verified emails as attribute sources.** Verified email entries surface in the existing ICRC-3 attribute system under a new `verified:<H(address)>:email` scope. Dapps requesting `email` against a passkey-only anchor with at least one verified email now receive a value via the consent dialog.
-3. **Phase 3 — Smart-routing + last-used default.** The consent dialog pre-selects the user's last-shared choice (or a smart-routed default for first-time users), and the canister tracks it automatically.
+1. **Phase 1 — Verified emails as a first-class anchor primitive.** The user can register multiple verified email addresses on their anchor through a new flow that reuses the existing inbound-DKIM verification primitive. New storage field, new candid surface, new wizard, and a narrow dashboard panel listing only `verified_emails` entries. Existing recovery flow is unchanged.
+2. **Phase 1.5 — Reach page (unified emails dashboard).** Pure frontend work. The narrow panel from Phase 1 widens into a "Reach" page that surfaces emails from all sources — OIDC, SSO, and `verified_emails` — in one verified list, plus a separate "Unverified emails" section listing OIDC/SSO emails where the IdP didn't vouch for verification. Each unverified row has a "Verify" CTA that opens the Phase 1 wizard pre-filled with that address; on success the entry joins the verified list. No backend changes.
+3. **Phase 2 — Verified emails as attribute sources.** Verified email entries surface in the existing ICRC-3 attribute system under a new `verified:<H(address)>:email` scope. Dapps requesting `email` against a passkey-only anchor with at least one verified email now receive a value via the consent dialog.
+4. **Phase 3 — Smart-routing + last-used default.** The consent dialog pre-selects the user's last-shared choice (or a smart-routed default for first-time users), and the canister tracks it automatically.
 
-Phases ship in order. Phase 1 stands on its own (the user gets value from being able to verify multiple emails regardless of attribute exposure).
+Phases ship in order. Phase 1 stands on its own (users get value from verifying emails). Phase 1.5 is pure FE on top of Phase 1's backend and can ship independently of Phase 2/3.
 
 ## Background
 
@@ -108,9 +109,9 @@ Shared inbound primitives (`smtp_request`, `smtp_request_validate`, `EmailRecove
 
 ### Frontend
 
-**New "Verified emails" panel** on the `/manage` dashboard. Lists the user's verified emails; lets them add and remove. No "set as recovery" radio (that's a recovery-flow concern, separate). No global "don't share" toggle.
+**New "Verified emails" panel** on the `/manage` dashboard — narrow version, ships with Phase 1. Lists only `verified_emails` entries (OIDC/SSO sources are out of scope here; Phase 1.5 widens this panel into the unified "Reach" page). Lets the user add and remove. No "set as recovery" radio (that's a recovery-flow concern, separate). No global "don't share" toggle.
 
-**New email-verification wizard** at a new component path (e.g. `src/frontend/src/lib/components/wizards/emailVerification/`). Parallel to the existing `setupEmailRecovery/` wizard, not a rename of it. The new wizard:
+**New email-verification wizard** at `src/frontend/src/lib/components/wizards/verifiedEmail/`. Parallel to the existing `setupEmailRecovery/` wizard, not a rename of it. The new wizard:
 
 - Reuses the shared `SendConfirmationEmail` dialog (renders whatever nonce the canister returns, including the new `II-Verify-` prefix).
 - Reuses the polling helper (`runEmailRecoveryPoll` — the polling pipeline is purpose-neutral once the pending entry exists).
@@ -129,26 +130,9 @@ Sharing a verified email is always **optional** — every consent surface gives 
 - Lead with what the user gets ("stay in touch with the dapp", "easier account recovery"), not what the dapp is asking for.
 - Make the skip path visible without making it feel like the wrong choice.
 - Never imply the user "must" verify or share — the dapp can ask again on the next authorize flow if the user skips.
-- Match the existing consent dialog's neutral tone for the per-request picker (the user has already chosen to engage at that point — the dialog should be matter-of-fact, not promotional).
+- Match the existing consent dialog's neutral tone for the per-request picker (the user has already chosen to engage at that point — the dialog should be matter-of-fact, not promotional). The existing consent dialog itself stays unchanged; the principles above apply only to the new surfaces (empty-state prompt, settings panel CTAs, wizard success state).
 
-**Proposed copy for the new surfaces** (final wording is an open decision; submit for UX review before shipping):
-
-- **/authorize empty-state inline prompt** (no verified email on file, dapp requests `email`):
-  - Title: "Stay in touch with `<dapp>`"
-  - Body: "Adding a verified email lets `<dapp>` reach you about account events — login alerts, receipts, recovery. You stay in control of what gets shared."
-  - Primary: "Verify an email"
-  - Secondary: "Skip for now"
-
-- **Verified emails settings panel** (dashboard, no verified emails yet):
-  - Title: "Verified emails"
-  - Body: "Verify the emails you'd like to share with apps that ask. Apps never see an email until you confirm in the consent dialog."
-  - Primary: "Add an email"
-
-- **Wizard success state** (after a new verified email lands):
-  - Title: "Email verified"
-  - Body: "You can now share `<address>` with apps that ask. You'll be prompted to confirm every time — nothing is shared until you click."
-
-- **Existing consent dialog** (per-request picker): unchanged. The user is already in the share-or-deny moment; promotional copy would feel manipulative. The "Deny all" link stays one click away.
+Final wording lands with UX review.
 
 ### Verification UX
 
@@ -169,8 +153,64 @@ The only user-visible difference from the recovery flow's dialog is the subject 
 ### Phase 1 open decisions
 
 - [ ] **Cross-promotion (v2 framing).** A user who wants the same address as both their recovery email and a shareable verified email currently has to verify it twice. Worth designing in v2: a "also set as my recovery email" affordance on the new verified-email row, and a "also add as a verified email" affordance on the recovery email management view. Both would skip re-verification since the address is already DKIM-proven in one bucket. Out of scope for v1.
-- [ ] **Wizard directory name.** `emailVerification/` is the working name; could also be `verifiedEmail/` or `addVerifiedEmail/`. Pick before scaffolding the component.
-- [ ] **Final wording for new translation strings.** Panel header, "Add an email" CTA, row remove confirmation, the "Verified email" source label, and the full copy proposed in the "Copy and tone" subsection above (empty-state inline prompt, settings empty state, wizard success state). All of this should land with UX review before shipping. The principles section is the harder commitment; the specific strings are bikeshed-easy to change.
+
+---
+
+## Phase 1.5 — Reach page (unified emails dashboard)
+
+### Concept
+
+The narrow Verified emails panel from Phase 1 widens into a page titled **"Reach"** with the subtitle "How apps can reach you when you sign in." The page presents the user's emails across all sources in two sections:
+
+- **Verified emails** — emails from OIDC credentials where `email_verified: true`, SSO credentials where the IdP vouches for the address, and `verified_emails` entries from Phase 1. Rendered as one unified list, deduped by address.
+- **Unverified emails** — emails from OIDC/SSO credentials where the IdP did not vouch for verification (`email_verified: false`). Each row has a "Verify" CTA that opens the Phase 1 wizard pre-filled with the address; on success, the address joins the Verified list.
+
+This phase is purely frontend work. No new candid, no new storage, no new backend logic. It depends on Phase 1's backend but doesn't gate Phase 2 or Phase 3.
+
+### Verified emails section
+
+- Lists the union of `openid_credentials` (where verified), SSO credentials (where verified), and `verified_emails` entries from Phase 1.
+- **Dedup by address.** Same address in multiple sources (e.g. an OIDC cred + a `verified_emails` entry the user added through DKIM) renders as one row. Source label prefers the IdP name when present; verification date uses whichever source produced it.
+- **Source icon** per row: per-IdP icon (Google, Microsoft, Apple, etc.) for entries backed by an OIDC/SSO credential; a generic envelope icon for entries backed only by `verified_emails`.
+- **Remove button** is only shown on rows backed exclusively by `verified_emails`. Rows backed by an IdP-issued credential don't show Remove — removing such an email means unlinking the IdP, which is a different concern handled elsewhere on `/manage`. Silently hidden, no tooltip.
+- **Cap counter** "N of 5 verified emails" rendered below the list, always visible.
+- **"Add an email"** CTA → mounts the wizard from Phase 1.
+
+### Unverified emails section
+
+- Lists `openid_credentials` and SSO credentials whose `email_verified` claim is false.
+- Per row: address, source label ("Microsoft · Not verified"), source icon, "Verify" CTA.
+- **Section hidden entirely** when there are no unverified entries.
+
+### Verify-from-unverified flow
+
+When the user clicks Verify on an unverified row:
+
+1. The Phase 1 wizard mounts with the address pre-filled and read-only (the user can't accidentally verify a different address than the one they clicked).
+2. Standard `verified_email_prepare_add` → DKIM challenge → poll.
+3. On success, a new `StorableVerifiedEmail` entry lands in `Anchor.verified_emails`.
+4. The dashboard re-fetches. The address now appears in both `openid_credentials` (the unverified IdP cred, untouched) and `verified_emails` (the new II-DKIM entry). Dedup shows one row in the Verified section, sourced from the IdP, with II's verification date.
+
+The original OIDC/SSO credential is not modified — the IdP still thinks the email is unverified. But II has its own proof, so the attribute-resolution downstream of Phase 2 correctly surfaces it:
+
+- `verified:<H(addr)>:verified_email` resolves to the address (Phase 2 reads `verified_emails`).
+- `openid:<issuer>:verified_email` still doesn't resolve (the IdP claim is false).
+- A dapp asking unscoped `verified_email` gets the value via the `verified:` path.
+
+### Phase 1.5 locked decisions
+
+- **Page name:** "Reach" (with subtitle "How apps can reach you when you sign in.").
+- **Dedup rule:** one row per address. When an address is in both `openid_credentials` (or SSO) and `verified_emails`, prefer the IdP source label; the verification date is whichever source produced it most recently.
+- **Source icons:** per-IdP (Google, Microsoft, Apple) for IdP-backed entries; generic envelope for `verified_emails`-only entries.
+- **Remove on IdP-backed rows:** hidden, no tooltip.
+- **Verify CTA on SSO rows:** behaves identically to OIDC — same DKIM wizard, same `verified_email_prepare_add` flow.
+- **Cap counter:** always visible.
+- **Unverified section visibility:** hidden when empty.
+
+### Phase 1.5 open decisions
+
+- [ ] **Counter format.** "2 of 5 verified emails" (mockup wording), "2/5", or something else. Bikeshed-easy.
+- [ ] **Section subtitles.** Mockup uses "Apps can request one of these to reach you. Never shared without your consent." and "Verify one of these so apps can use it to reach you." Final wording with UX review.
 
 ---
 
@@ -265,7 +305,8 @@ Nothing else changes. No new dialog modes, no "Primary" badge, no "remember this
 | Step            | Touches                                                                                                                                                                                                                                                                           |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Phase 1 backend | new `StorableVerifiedEmail` type, new `verified_emails` field on `StorableAnchor`, new `PendingKind::VerifyEmail` variant, SMTP-dispatch arm for the new variant, `find_nonce_in` accepts `II-Verify-` alongside `II-Recovery-`, `verified_email_*` candid + `VerifiedEmail` type |
-| Phase 1 FE      | new email-verification wizard (parallel to `setupEmailRecovery/`), new "Verified emails" settings panel, /authorize empty-state inline flow                                                                                                                                       |
+| Phase 1 FE      | new email-verification wizard (parallel to `setupEmailRecovery/`), narrow "Verified emails" settings panel, /authorize empty-state inline flow                                                                                                                                    |
+| Phase 1.5 FE    | widen the panel into the "Reach" page — unified Verified/Unverified sections sourced from `openid_credentials` + `verified_emails`, dedup, source icons, cap counter, Verify-from-unverified flow                                                                                 |
 | Phase 2         | `AttributeScope::Verified` variant, `list_available_attributes` + `prepare_*` extensions reading from `verified_emails`, FE source label                                                                                                                                          |
 | Phase 3         | one anchor field, resolution logic, `AttributeConsentView` default-selection edit                                                                                                                                                                                                 |
 
@@ -286,8 +327,11 @@ Nothing else changes. No new dialog modes, no "Primary" badge, no "remember this
 **Phase 1:**
 
 - [ ] Cross-promotion v2 design (deferred).
-- [ ] Wizard directory name (`emailVerification/` vs alternatives).
-- [ ] Translation strings: Verified emails panel header, "Add an email" CTA, "Remove" confirmation copy, "Verified email" source label (also used by Phase 2's consent dialog).
+
+**Phase 1.5:**
+
+- [ ] Counter format ("2 of 5 verified emails" vs alternatives).
+- [ ] Section subtitle wording (lands with UX review).
 
 **Phase 2:**
 

--- a/docs/design/verified-email-attributes.md
+++ b/docs/design/verified-email-attributes.md
@@ -68,7 +68,11 @@ Pick a new `#[n(...)]` field number for `verified_emails`; do not touch the lega
 
 No migration logic, no post-upgrade hook, no read/write abstraction. The two storage locations are entirely independent.
 
-Cap at 5 entries per anchor (bounds stable-memory growth, suffices for any real user). Enforced at `verified_email_prepare_add` time.
+Cap at 5 entries per anchor (bounds stable-memory growth, suffices for any real user). Enforced both at `verified_email_prepare_add` time **and** at commit time (in the SnapshotKind::VerifyEmail arm that writes to `Anchor.verified_emails`). The double-check exists because prepare and commit are separated by an async DKIM round-trip — two concurrent prepares at cap-1 would both pass a prepare-only check and both commit, blowing past the cap. The commit-time recheck makes the cap an invariant of the stored anchor, not just an entry condition on the wizard.
+
+**Address normalization.** Stored addresses are ASCII-lowercased on commit. The wizard SHOULD also normalize on submit (trim leading/trailing whitespace + lowercase) so what the user sees in the wizard matches what gets stored — and so the cross-bucket overlap warnings (above) compare apples to apples. Plus-addressing (`user+tag@example.com`) is treated as a literal address distinct from `user@example.com`; no plus-stripping. IDN domains follow whatever normalization the DKIM-recovery flow already does; no new logic here.
+
+**Pending-entry collision.** If `verified_email_prepare_add` is called while a pending entry for the same address (under the same anchor + `PendingKind::VerifyEmail`) already exists, the call inherits the recovery flow's behavior: the existing pending entry is replaced with a fresh nonce. The user clicking "Resend" in the wizard issues a new nonce; an old nonce already in the user's inbox stops working. There is no separate "cancel pending" action — the entry expires on its own TTL (same as the recovery pending map's TTL) or is overwritten by the next prepare call.
 
 ### Verification flow
 
@@ -87,6 +91,19 @@ The inbound verification mechanism is identical to the recovery flow: same `regi
 - `PendingKind::VerifyEmail { anchor }` — **new**, drives the verified-email add flow. Writes to `verified_emails`.
 
 The subject-prefix parser (`find_nonce_in`) accepts both `II-Recovery-` and `II-Verify-` prefixes — it's just an anchor for the 16-hex nonce suffix, not a security primitive. Once the nonce matches a pending entry, dispatch is by `PendingKind`.
+
+### Silent mirror on OIDC / SSO link
+
+Whenever an OIDC or SSO credential is added to an anchor and the provider vouches for the email (`OpenIdCredential::get_verified_email()` returns `Some` — Google with `email_verified: true`, Microsoft personal-tenant, etc.), the canister silently appends a `StorableVerifiedEmail` entry to `Anchor.verified_emails` in the same atomic write. The address is lowercased; `verified_at` is `ic_cdk::api::time()`. Both add paths share the mirror — `openid_credential_add` (post-registration) and `openid_identity_registration_finish` (registration) both flow through `add_openid_credential_skip_checks`.
+
+The mirror exists so a verified address survives an OIDC unlink. The user picks a "reach" email once; unlinking the IdP later doesn't quietly take that email away from the dapps that already learnt to ask for it via `verified:<H>:email`.
+
+Properties:
+
+- **Idempotent.** If the address is already in `verified_emails` (case-insensitive ASCII match), the call is a no-op. Re-linking an OIDC credential never refreshes a pre-existing entry's `verified_at`.
+- **Cap-respecting.** If `verified_emails.len() >= MAX_VERIFIED_EMAILS_PER_ANCHOR`, the mirror is skipped silently. The OIDC link still succeeds — the surrounding operation must not fail because the verified-emails bucket is full.
+- **One-way.** Removing the OIDC credential does **not** remove the mirrored entry. The user removes verified-email entries from the panel, like any other entry.
+- **No DKIM-bypass round-trip.** If the user manually removes the verified-email entry, re-adding the same address requires going through the DKIM flow — the mirror only fires on a fresh OIDC link, and the entry it left behind is gone.
 
 ### Candid surface
 
@@ -150,6 +167,17 @@ BODY     (anything, leave it blank)
 
 The only user-visible difference from the recovery flow's dialog is the subject prefix.
 
+### Cross-bucket overlap warnings
+
+Recovery and verified are independent buckets. The same address can live in both, but each side requires its own DKIM proof — there is no cross-promotion in v1. To keep the "verify twice" semantic from feeling like a mistake on the user's part, each wizard surfaces a non-blocking heads-up when the address the user just typed already lives in the other bucket:
+
+- **Verified-email wizard (Phase 1).** If the entered address case-insensitively matches the anchor's current `email_recovery` entry, the address-entry view shows a banner above the Continue button: "This is also your recovery email. Verifying it here adds it as a separate verified entry — the two are independent, so removing one won't affect the other." The user can still proceed; the banner just makes the duplicate-verification cost legible up front.
+- **Recovery-email wizard (Phase 1).** Symmetric. If the entered address matches any entry in `verified_emails`, the wizard shows: "This is already a verified email on your account. Setting it as your recovery email adds it to a separate bucket — the two are independent, so removing one won't affect the other." Same shape, same non-blocking posture.
+
+Both checks are FE-only, run against the data already loaded for the wizard's surrounding panel — no extra canister calls. The check fires on Continue (not on every keystroke) so the user isn't nagged while typing. If the user updates the address after seeing the banner so it no longer overlaps, the banner clears.
+
+The warnings deliberately do not offer a "skip re-verification" shortcut: cross-promotion is out of scope for v1 (see Phase 1 open decisions and §11 future enhancements). The banner is purely informational so the user understands why they are about to be asked to send a second email.
+
 ### Phase 1 open decisions
 
 - [ ] **Cross-promotion (v2 framing).** A user who wants the same address as both their recovery email and a shareable verified email currently has to verify it twice. Worth designing in v2: a "also set as my recovery email" affordance on the new verified-email row, and a "also add as a verified email" affordance on the recovery email management view. Both would skip re-verification since the address is already DKIM-proven in one bucket. Out of scope for v1.
@@ -160,25 +188,24 @@ The only user-visible difference from the recovery flow's dialog is the subject 
 
 ### Concept
 
-The narrow Verified emails panel from Phase 1 widens into a page titled **"Reach"** with the subtitle "How apps can reach you when you sign in." The page presents the user's emails across all sources in two sections:
+The narrow Verified emails panel from Phase 1 widens into a page titled **"Reach"** with the subtitle "How apps can reach you when you sign in." The page presents the user's emails in two sections:
 
-- **Verified emails** — emails from OIDC credentials where `email_verified: true`, SSO credentials where the IdP vouches for the address, and `verified_emails` entries from Phase 1. Rendered as one unified list, deduped by address.
-- **Unverified emails** — emails from OIDC/SSO credentials where the IdP did not vouch for verification (`email_verified: false`). Each row has a "Verify" CTA that opens the Phase 1 wizard pre-filled with the address; on success, the address joins the Verified list.
+- **Verified emails** — `Anchor.verified_emails` entries. The canister already mirrored IdP-vouched OIDC/SSO emails into this list at link time (Phase 1, "Silent mirror on OIDC / SSO link"), so this section is a single-source read: no front-end dedup needed.
+- **Unverified emails** — emails from OIDC/SSO credentials where the IdP did not vouch for verification (`email_verified: false` and no other signal). Each row has a "Verify" CTA that opens the Phase 1 wizard pre-filled with the address; on success the entry lands in `verified_emails` and the row moves up to the Verified section on the next refetch.
 
 This phase is purely frontend work. No new candid, no new storage, no new backend logic. It depends on Phase 1's backend but doesn't gate Phase 2 or Phase 3.
 
 ### Verified emails section
 
-- Lists the union of `openid_credentials` (where verified), SSO credentials (where verified), and `verified_emails` entries from Phase 1.
-- **Dedup by address.** Same address in multiple sources (e.g. an OIDC cred + a `verified_emails` entry the user added through DKIM) renders as one row. Source label prefers the IdP name when present; verification date uses whichever source produced it.
-- **Source icon** per row: per-IdP icon (Google, Microsoft, Apple, etc.) for entries backed by an OIDC/SSO credential; a generic envelope icon for entries backed only by `verified_emails`.
-- **Remove button** is only shown on rows backed exclusively by `verified_emails`. Rows backed by an IdP-issued credential don't show Remove — removing such an email means unlinking the IdP, which is a different concern handled elsewhere on `/manage`. Silently hidden, no tooltip.
+- Lists `Anchor.verified_emails` directly — no union, no dedup. Whether the entry got there by the DKIM wizard or by the OIDC-link mirror is the same as far as the user is concerned: it's a verified address dapps can reach them at.
+- **Source affinity badge** (optional, FE-only join). For each verified entry whose address also appears on a current `openid_credentials` row, render a small IdP icon next to the row as a hint that this address is also tied to a linked account. The join is a pure FE convenience — case-insensitive address match against the live `openid_credentials` list. Removing the OIDC credential drops the badge; the verified-email entry persists. **Tie-break when multiple IdPs vouch for the same address** (Google + Microsoft both with `email_verified: true` for `user@example.com`): render the icon of whichever credential was linked most recently (largest `last_usage_timestamp`, ties broken by insertion order). The badge is a hint, not a source-of-truth; we don't render multi-IdP stacks.
+- **Remove button** is always shown — every row is a `verified_emails` entry the user controls. Removing the entry is a manual deletion, even if the underlying OIDC credential is still linked. Re-adding the same address has two paths: either run the DKIM wizard again, or unlink and re-link the OIDC credential (a fresh credential add re-fires the silent mirror). Both are explicit user actions — there is no passive re-population of a row the user just removed.
 - **Cap counter** "N of 5 verified emails" rendered below the list, always visible.
 - **"Add an email"** CTA → mounts the wizard from Phase 1.
 
 ### Unverified emails section
 
-- Lists `openid_credentials` and SSO credentials whose `email_verified` claim is false.
+- Lists `openid_credentials` (or SSO) entries whose `email_verified` claim is false **and** whose address is not already in `verified_emails` (i.e. the user hasn't separately DKIM-proven it). Same case-insensitive address compare used for the source-affinity badge.
 - Per row: address, source label ("Microsoft · Not verified"), source icon, "Verify" CTA.
 - **Section hidden entirely** when there are no unverified entries.
 
@@ -189,9 +216,9 @@ When the user clicks Verify on an unverified row:
 1. The Phase 1 wizard mounts with the address pre-filled and read-only (the user can't accidentally verify a different address than the one they clicked).
 2. Standard `verified_email_prepare_add` → DKIM challenge → poll.
 3. On success, a new `StorableVerifiedEmail` entry lands in `Anchor.verified_emails`.
-4. The dashboard re-fetches. The address now appears in both `openid_credentials` (the unverified IdP cred, untouched) and `verified_emails` (the new II-DKIM entry). Dedup shows one row in the Verified section, sourced from the IdP, with II's verification date.
+4. The dashboard re-fetches. The address now lives in `verified_emails`; the OIDC credential is untouched (still `email_verified: false`). The Unverified section filter drops the row (address now in `verified_emails`); the Verified section renders it with the source-affinity badge for the originating IdP.
 
-The original OIDC/SSO credential is not modified — the IdP still thinks the email is unverified. But II has its own proof, so the attribute-resolution downstream of Phase 2 correctly surfaces it:
+The original OIDC/SSO credential is not modified — the IdP still thinks the email is unverified. But II has its own proof, so Phase 2 attribute resolution correctly surfaces it:
 
 - `verified:<H(addr)>:verified_email` resolves to the address (Phase 2 reads `verified_emails`).
 - `openid:<issuer>:verified_email` still doesn't resolve (the IdP claim is false).
@@ -200,9 +227,11 @@ The original OIDC/SSO credential is not modified — the IdP still thinks the em
 ### Phase 1.5 locked decisions
 
 - **Page name:** "Reach" (with subtitle "How apps can reach you when you sign in.").
-- **Dedup rule:** one row per address. When an address is in both `openid_credentials` (or SSO) and `verified_emails`, prefer the IdP source label; the verification date is whichever source produced it most recently.
-- **Source icons:** per-IdP (Google, Microsoft, Apple) for IdP-backed entries; generic envelope for `verified_emails`-only entries.
-- **Remove on IdP-backed rows:** hidden, no tooltip.
+- **Verified emails source:** `Anchor.verified_emails` only — no front-end union with `openid_credentials`. The mirror in Phase 1 makes the union redundant.
+- **Source-affinity badge:** purely an FE-side hint; address-equality join against `openid_credentials`. No effect on Remove visibility or row identity.
+- **Source icons:** per-IdP icon on the badge for verified rows when the address also lives on an OIDC credential; generic envelope when there's no matching credential.
+- **Remove visibility:** always shown on verified rows. The user owns the `verified_emails` entry independently of any OIDC link.
+- **Unverified section filter:** an OIDC/SSO email with `email_verified: false` only appears in the Unverified section if it's not already in `verified_emails`. Otherwise the verified row covers it.
 - **Verify CTA on SSO rows:** behaves identically to OIDC — same DKIM wizard, same `verified_email_prepare_add` flow.
 - **Cap counter:** always visible.
 - **Unverified section visibility:** hidden when empty.
@@ -279,6 +308,8 @@ For unscoped `email` / `verified_email` requests:
 3. On Continue with a non-empty selection, the canister updates `last_shared_email_scope` to whatever was shared.
 
 "Deny all" doesn't update `last_shared_email_scope` — we track the last _shared_ choice, not the last action. So denying once doesn't change the default the next time.
+
+**Write timing.** The scope is written as a side effect of `prepare_icrc3_attributes` succeeding — i.e. the moment the canister has packaged the attributes for delivery. This is technically before the dapp consumes the result (the FE still has to surface them through the delegation channel), so an unlucky network drop after prepare and before delivery would record a "share" that never reached the dapp. That's accepted: from the user's perspective, they clicked Continue with that selection, and the next time they see the dialog we honor that intent. The alternative — deferring the write until `get_icrc3_attributes` is consumed — costs an extra update call on a hot path and saves us from a vanishingly rare edge case where the FE crashes between prepare and consume. Not worth it.
 
 Scoped requests (`openid:...:email`, `verified:<H>:email`, etc.) bypass step 1 — the dapp asked for a specific source. They go straight to the consent dialog with that source pre-selected.
 

--- a/docs/design/verified-email-attributes.md
+++ b/docs/design/verified-email-attributes.md
@@ -1,0 +1,465 @@
+# Verified emails on Internet Identity
+
+**Status:** Draft
+**Owner:** Mario Ruci
+**Last edited:** 2026-06-16
+**Companion:** [verified-email-implementation.md](verified-email-implementation.md) — the operational checklist (file paths, concrete changes, PR breakdown). This doc explains the _why_; the checklist is _what to do_.
+
+## TL;DR
+
+Today, Internet Identity has a single "recovery email" slot per anchor, verified through an inbound DKIM/DMARC/DNSSEC ownership-proof flow. Dapps can request user attributes (`email`, `name`, `verified_email`) but only from linked OpenID or SSO sources; the recovery email is invisible to that surface.
+
+This doc proposes promoting "verified emails" to a **first-class anchor primitive** that supersedes the current single-slot recovery model and unlocks two downstream uses:
+
+1. **Phase 1 — Verified emails as a first-class anchor primitive.** The user can register multiple proven-ownership email addresses on their anchor. One entry at a time can be designated as the recovery email (today's single use case). The verification mechanism is the existing inbound DKIM flow, generalized. Phase 1 ships in three releases: 1a introduces the new schema and lazy-migrates on every anchor touch, 1b runs a controller-driven sweep for dormant anchors, 1c drops the legacy storage field. See "Storage model and batched migration" for the rationale.
+2. **Phase 2 — Verified emails as attribute sources.** All verified email entries become candidate sources in the existing ICRC-3 attribute system under a new `verified:<H(address)>:email` scope. Dapps requesting `email` against a passkey-only anchor with at least one verified email now receive a value via the per-request consent dialog.
+3. **Phase 3 — Smart-routing + last-used default.** The consent dialog pre-selects the user's last-shared choice (or a smart-routed default for first-time users), and the canister tracks it automatically. There is no explicit "primary email" or "don't share" setting — every share is an explicit click in the consent dialog, and the user's revealed preference (including denials) is what shapes future defaults.
+
+Phases ship in this order. Phase 1a stands on its own (users get value from multiple proven emails regardless of attribute exposure). Phase 2 builds on Phase 1a's storage abstraction and can ship before 1b/1c complete. Phase 3 builds on Phase 2.
+
+---
+
+## Background
+
+### The existing ICRC-3 attribute system
+
+Source files:
+Internet Identity ships an ICRC-3 attribute system that lets dapps request `email`, `name`, and `verified_email` from a signed-in user, scoped per source (`openid:<issuer>:<name>`, `sso:<domain>:<name>`) or unscoped (the canister picks any matching source). All values today come from `Anchor.openid_credentials` — OIDC- and SSO-linked credentials. The consent UI is per-request and lives in [`AttributeConsentView.svelte`](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte>) (multi-source attributes get a chevron-expandable picker).
+
+### The existing email-recovery flow
+
+Internet Identity also ships an inbound-DKIM ownership-proof flow used to verify a user's recovery email: the user sends a message from the address they claim to `register@<domain>`, an off-canister SMTP relay forwards it to the canister, and the canister verifies DKIM / DMARC / DNSSEC + DoH before binding the address to the anchor. The verified address is stored in `Anchor.email_recovery` (today a `Vec` used cap-1 by convention). The verification dialog and the wizard live under [src/frontend/src/lib/components/wizards/](../../src/frontend/src/lib/components/wizards/); the verification primitives live under [src/internet_identity/src/email_recovery/](../../src/internet_identity/src/email_recovery/) and [src/internet_identity/src/dkim/](../../src/internet_identity/src/dkim/) / [dmarc/](../../src/internet_identity/src/dmarc/) / [dnssec/](../../src/internet_identity/src/dnssec/) / [doh/](../../src/internet_identity/src/doh/). The recovery email is not exposed to the attribute system.
+
+Phase 1's implementation analysis section cites the specific constants, candid methods, and file:line references where each piece of work lands.
+
+---
+
+## Phase 1 — Verified emails as a first-class anchor primitive
+
+### Concept
+
+Each anchor can carry up to 5 verified email addresses. One entry at a time can be designated as the recovery email — that's the only per-entry flag. Verification is the existing inbound DKIM challenge flow. Today's single recovery-email slot becomes "the entry whose `is_recovery` flag is true".
+
+A verified email's mere existence makes it eligible to be shared with dapps — there is **no per-entry "shareable" toggle and no global "don't share" toggle**. Sharing is always an explicit click in the per-request consent dialog. A user who never wants to share simply denies every time; "Deny all" is already a one-click action in the consent UI.
+
+### Storage model and batched migration
+
+The existing storage layout could technically be extended in-place by adding an optional `is_recovery: Option<bool>` field to `StorableEmailRecoveryCredential`. That would avoid a migration entirely. Rejected: the resulting code reads `cred.is_recovery.unwrap_or(true)` against a type literally named `EmailRecoveryCredential` even when the entry has nothing to do with recovery. Readers a year from now will be confused, and the misnaming compounds every place the type appears.
+
+Better to do the rename properly and pay the migration cost once. The migration ships in three releases.
+
+#### Target schema
+
+New storable type, named to match the generalized meaning, with field renames where the legacy names had become misleading:
+
+```rust
+#[derive(Encode, Decode, Clone, Debug, Eq, PartialEq)]
+#[cbor(map)]
+pub struct StorableVerifiedEmail {
+    #[n(0)] pub address: String,
+    #[n(1)] pub verified_at: Timestamp,                   // ← was `created_at` on the legacy type
+    #[n(2)] pub last_used_for_recovery_at: Option<Timestamp>,  // ← was `last_used`
+    #[n(3)] pub is_recovery: bool,                        // ← non-optional; always set on write
+}
+```
+
+Anchor schema carries both fields during the migration window:
+
+```rust
+pub struct StorableAnchor {
+    // ...
+    #[n(N1)] pub email_recovery: Option<Vec<StorableEmailRecoveryCredential>>,  // legacy; never written by new code
+    #[n(N2)] pub verified_emails: Option<Vec<StorableVerifiedEmail>>,            // new; authoritative once set
+    // ...
+}
+```
+
+Pick a new `#[n(...)]` field number for `verified_emails`. Don't reuse the legacy field's number (`minicbor-derive`'s `#[cbor(map)]` would break stable-memory compatibility otherwise).
+
+#### Read/write abstraction
+
+All access goes through two helpers. New code never touches `anchor.email_recovery` or `anchor.verified_emails` directly.
+
+```rust
+pub fn read_verified_emails(anchor: &StorableAnchor) -> Vec<StorableVerifiedEmail> {
+    if let Some(v) = &anchor.verified_emails {
+        return v.clone();
+    }
+    // Lazy migration: synthesize from legacy when the new field is absent.
+    if let Some(legacy) = &anchor.email_recovery {
+        return legacy.iter().cloned().map(StorableVerifiedEmail::from).collect();
+    }
+    Vec::new()
+}
+
+pub fn write_verified_emails(anchor: &mut StorableAnchor, new: Vec<StorableVerifiedEmail>) {
+    anchor.verified_emails = Some(new);
+    anchor.email_recovery = None;  // clear legacy: new field is now authoritative for this anchor
+}
+```
+
+The `From<StorableEmailRecoveryCredential> for StorableVerifiedEmail` impl maps `created_at → verified_at`, `last_used → last_used_for_recovery_at`, and sets `is_recovery: true` (legacy entries are recovery by definition — that's the only kind that ever got written under the old schema).
+
+#### Why batched, not big-bang
+
+II has many anchors. A full migration in `post_upgrade` is unsafe: the hook has a finite cycle budget, a write storm at upgrade time blocks rollback, and the operational risk is concentrated in one moment with no observability between "start" and "finish".
+
+Batched migration is the standard pattern. The work ships across three releases:
+
+**Phase 1a — schema lands, lazy migration on touch.** Both fields coexist on the anchor. `read_verified_emails` prefers the new field, synthesizes from legacy when absent. Every write goes through `write_verified_emails`, which sets the new field and clears the legacy one. Active anchors migrate organically as users authenticate, add devices, log in. No post-upgrade hook.
+
+**Phase 1b — controller-driven sweep of the long tail.** A stable cursor walks anchors and migrates the ones that haven't been touched. Ships ~one release after 1a so we can verify the lazy path is working in production before sweeping. Runs in batches under operator control; not a timer (no benefit from automated cycle pressure, and the operator wants to pick the low-traffic window).
+
+**Phase 1c — drop the legacy field.** After the sweep reports complete on prod, remove `email_recovery: Option<Vec<StorableEmailRecoveryCredential>>` and `StorableEmailRecoveryCredential` from the schema entirely. Cleanup release. Safe because every anchor has been touched.
+
+The reverse `address-hash → AnchorNumber` index ([src/internet_identity/src/storage/storable/email_recovery_address_hash.rs](../../src/internet_identity/src/storage/storable/email_recovery_address_hash.rs)) doesn't migrate — it was always per-address, not per-purpose. Multiple addresses pointing at the same anchor is already N entries pointing at the same value.
+
+#### Per-entry cap
+
+`MAX_VERIFIED_EMAILS_PER_ANCHOR = 5`. Decided. Enforced at write time in both `verified_email_prepare_add` and the legacy `email_recovery_credential_prepare_add` facade. Uses `read_verified_emails(anchor).len()` so the cap is consistent across migrated and not-yet-migrated anchors.
+
+#### `is_recovery` mutex
+
+Exactly zero or one entry on a given anchor has `is_recovery: true`. The new `verified_email_set_recovery` call atomically sets the flag on the target entry and clears it on every other entry of the same anchor in a single mutation, then calls `write_verified_emails`.
+
+### Candid types
+
+New candid type `VerifiedEmail` matching the storable shape, added to [src/internet_identity_interface/src/internet_identity/types/email_recovery.rs](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs). The legacy `EmailRecoveryCredential` candid type stays defined as long as the legacy facade methods exist (Phase 1a through 1c — at which point both go away together).
+
+Legacy candid methods return `EmailRecoveryCredential` (unchanged wire shape, preserving back-compat). New candid methods return `VerifiedEmail`.
+
+### Verification flow
+
+Reuses the existing primitive verbatim: user composes an email from the address they're claiming, addressed to `register@<mailbox-domain>`, with a `Subject:` containing the canister-issued nonce. The off-canister relay forwards via `smtp_request`. The canister verifies DKIM, DMARC, and DNSSEC/DoH. On success, the entry is committed to `verified_emails` with `is_recovery: false`.
+
+**Decoupling intent from verification.** The pending challenge proves _ownership_ of the address. Whether the new entry should be marked for recovery is set in a separate authenticated call after the entry exists. This keeps the SMTP/DKIM path as a pure ownership-proof primitive — no purpose data leaks through the verification pipeline. See "Open decisions: pending intent" below.
+
+### Implementation analysis: reuse, generalize, fork
+
+#### What we reuse verbatim
+
+| Layer                                                                                | Reuse                                                                                |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| Canister-side SMTP candid methods (`smtp_request`, `smtp_request_validate`)          | unchanged — no new methods, no signature changes                                     |
+| DKIM signature verification                                                          | unchanged                                                                            |
+| DMARC alignment (deferred today)                                                     | unchanged                                                                            |
+| DNSSEC + DoH key resolution paths                                                    | unchanged                                                                            |
+| Pending-challenge map mechanics + TTL + eviction                                     | unchanged                                                                            |
+| `register@<domain>` mailbox                                                          | unchanged — same user-part for adding any verified email, regardless of intended use |
+| Shared `SendConfirmationEmail.svelte` dialog                                         | unchanged                                                                            |
+| FE poll cadence (`runEmailRecoveryPoll`)                                             | unchanged                                                                            |
+| `recover@<domain>` mailbox + login flow                                              | unchanged (login-via-email is a different feature)                                   |
+| Canister-side mailbox-domain derivation (`mailbox_domains()` from `related_origins`) | unchanged — no DNS/MX/cert changes                                                   |
+
+#### Off-canister SMTP relay (boundary node) — coordinate, may need updates
+
+The off-canister SMTP relay that fronts the canister is a separate service (not in this repo). It receives inbound mail to `register@<domain>` / `recover@<domain>`, calls `smtp_request_validate` at `RCPT TO` time, and calls `smtp_request` after DATA. Based on the canister-side design at [smtp.rs:1-58](../../src/internet_identity/src/email_recovery/smtp.rs:1) the canister is the sole authority on whether a message belongs to a pending challenge (it parses the Subject and silently drops unknown nonces). The relay's role is envelope forwarding, not Subject filtering.
+
+That said, we should **explicitly confirm** with the relay owners that the deployed relay does not have any of the following recovery-specific assumptions baked in:
+
+- **Subject regex pre-filter** — e.g. only forwarding messages whose Subject matches `II-Recovery-[0-9a-f]{16}`. If such a filter exists, it must be widened to `II-(Recovery|Verify)-[0-9a-f]{16}` during the grace period, then narrowed to `II-Verify-` once the canister stops accepting the legacy prefix.
+- **Operator-facing documentation / runbooks** referring to "recovery emails" as the only accepted message kind — needs neutral wording so on-call doesn't reject legitimate verified-email traffic as out-of-scope.
+- **Per-message tagging** (correlation IDs, metrics labels) that classifies traffic as "recovery". Metrics should switch to neutral labels ("verified-email setup", say) or grow a second label to distinguish recovery-flagged from generic adds.
+- **Rate-limit buckets keyed by intended purpose.** If the relay rate-limits "recovery-email" traffic differently from other traffic, the new generic verified-email flow should be on a separate bucket so legitimate add-an-email traffic doesn't burn the recovery rate limit (and vice versa).
+
+If the relay is purely an envelope forwarder with no Subject-level inspection — which is what the canister-side comments imply — then **no relay-side changes are needed**. We need an explicit confirmation, not an assumption.
+
+**Action item:** before Phase 1 lands, get a written confirmation from whoever owns the deployed SMTP relay that one of the following holds:
+
+1. The relay does no Subject-level filtering and no purpose-based bucketing → no changes needed.
+2. There are Subject-level / purpose-level hooks → list them and coordinate the corresponding update window with the canister grace period.
+
+#### What we generalize
+
+**1. Subject-line nonce prefix: `II-Recovery-` → `II-Verify-`**
+
+- One-line constant change at [mod.rs:111](../../src/internet_identity/src/email_recovery/mod.rs:111).
+- `format_nonce` ([rng.rs:73](../../src/internet_identity/src/email_recovery/rng.rs:73)) reads the constant, so newly-issued nonces auto-update to the new prefix.
+- **`find_nonce_in` ([smtp.rs:436](../../src/internet_identity/src/email_recovery/smtp.rs:436)) accepts both prefixes indefinitely.** The prefix isn't a security primitive — it's a regex anchor for finding the 16-hex suffix, and a matching pending entry only exists if the canister itself issued it. Accepting `II-(Recovery|Verify)-<16-hex>` is exactly as secure as accepting only one. This avoids both (a) a second NNS proposal to remove the legacy prefix later and (b) the up-to-30-minute UX drop for in-flight users at upgrade time. Cost: ~5 lines of permanent code that say "we also accept the old prefix".
+- Doc comments referencing the old prefix: [types/email_recovery.rs:78](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs:78). Update.
+- Test fixtures and assertions to update (cosmetic; can land alongside or later): [dkim/canonicalize.rs:254-255](../../src/internet_identity/src/dkim/canonicalize.rs:254), [types/smtp.rs:662](../../src/internet_identity_interface/src/internet_identity/types/smtp.rs:662), several assertions in [tests/integration/email_recovery.rs](../../src/internet_identity/tests/integration/email_recovery.rs). Add a unit test that asserts both prefixes still parse.
+- Playwright fixtures and specs: regex `/II-Recovery-[0-9a-f]{16}/` in [tests/e2e-playwright/fixtures/emailRecovery.ts:122](../../src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts:122), [tests/e2e-playwright/routes/emailRecovery.spec.ts](../../src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts). Update to `/II-Verify-[0-9a-f]{16}/` to match what the canister will emit going forward.
+
+**2. `PendingKind::Register` semantics narrowed to "address-ownership proof"**
+
+Variant signature stays the same — `Register { anchor }`. The semantic meaning changes: it no longer carries the intent to write a recovery credential. On verification success, the canister commits a `VerifiedEmail` entry with `is_recovery: false`. The FE then makes a separate authenticated call to set `is_recovery: true` if (and only if) the user launched from the recovery-flow entry point.
+
+**3. Storage**
+
+New `StorableVerifiedEmail` type with renamed fields (`verified_at`, `last_used_for_recovery_at`, `is_recovery: bool`). New `verified_emails` field on the anchor lives alongside the legacy `email_recovery` field during the migration window. All access through `read_verified_emails` / `write_verified_emails` helpers, which lazy-migrate on every anchor touch. See "Storage model and batched migration" above for the three-release rollout (1a lazy + 1b sweep + 1c drop legacy).
+
+**4. Candid surface: additive**
+
+Add new methods alongside the existing ones, preserving the legacy facade:
+
+```
+# new — verified-emails feature
+type VerifiedEmail = record {
+    address: text;
+    verified_at: nat64;
+    last_used_for_recovery_at: opt nat64;
+    is_recovery: bool;
+};
+
+verified_email_prepare_add  : (IdentityNumber, EmailRecoveryDnsInput) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
+verified_email_set_recovery : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });  # promotes one entry; clears others
+verified_email_remove       : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });
+list_verified_emails        : (IdentityNumber) -> (vec VerifiedEmail) query;
+
+# legacy — preserved for compatibility through Phase 1a–1c; thin facades that read/write
+# through the same storage abstraction. Removed in Phase 1c alongside the legacy storage field.
+email_recovery_credential_prepare_add  → calls prepare_add internally, then verified_email_set_recovery on commit
+email_recovery_credential_remove       → calls verified_email_remove for the entry currently is_recovery
+```
+
+Login-flow methods (`email_recovery_prepare_delegation`, `_status`, `_submit_dkim_leaf`, `_resolve_via_doh`, `_get_delegation`) and gateway methods (`smtp_request*`) **are not changed**.
+
+**5. Frontend wizards**
+
+The `setupEmailRecovery` wizard ([SetupEmailRecoveryWizard.svelte](../../src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte)) is purpose-tied to recovery via its copy and its post-success flagging. Parameterize it:
+
+```
+<EmailVerificationWizard
+  markAsRecovery={true}
+  copy="recovery"
+/>
+```
+
+The wizard's internal flow (open dialog → user sends email → poll → success/failure views) is purpose-agnostic. After success it conditionally calls `verified_email_set_recovery` only when `markAsRecovery` is true; otherwise the entry stays as a generic verified email.
+
+Rename the directory from `setupEmailRecovery/` to `emailVerification/`. The recovery-flow entry point becomes a thin caller that mounts the generic wizard with `markAsRecovery={true}`. The shared views directory ([emailRecovery/shared/](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/)) renames similarly to drop "recovery" from its path — both the add flow and the login flow share purpose-neutral verification views now.
+
+The dialog itself ([SendConfirmationEmail.svelte](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/views/SendConfirmationEmail.svelte)) renders the canister-issued nonce verbatim — once the prefix is `II-Verify-`, the dialog shows `II-Verify-…` with no FE changes.
+
+#### What stays recovery-only
+
+| Element                                                        | Reason                                      |
+| -------------------------------------------------------------- | ------------------------------------------- |
+| `RECOVERY_RECIPIENT_USER = "recover"` mailbox                  | Only used by the anonymous login flow       |
+| `PendingKind::Recover { session_pk }`                          | Carries session-key state specific to login |
+| `recoverWithEmail/RecoverWithEmailWizard.svelte`               | The login UX                                |
+| `email_recovery_prepare_delegation` / `_get_delegation` candid | Login API                                   |
+
+These don't change. Recovery-as-a-login-method is a separate feature from verified-emails-as-a-shareable-attribute; they share the verification primitive but diverge after it. Keeping them separate keeps the doc honest about what is and isn't being touched.
+
+### Migration
+
+Detailed in "Storage model and batched migration" above. Summary:
+
+- **Phase 1a (this release).** Both `email_recovery` and `verified_emails` fields live on the anchor. All access through `read_verified_emails` / `write_verified_emails` helpers. Active anchors migrate organically on next write. No post-upgrade hook.
+- **Phase 1b (release N+1).** Controller-driven sweep walks anchors that haven't been touched and migrates them in batches.
+- **Phase 1c (release N+2, after sweep confirms complete).** Drop the legacy field and `StorableEmailRecoveryCredential` from the schema. Legacy candid methods (`email_recovery_credential_*`) and the legacy candid type are removed at this point too.
+
+The surrounding pieces are also versioned:
+
+- **Subject prefix.** Phase 1a flips `NONCE_PREFIX` to `"II-Verify-"`; `find_nonce_in` accepts both prefixes indefinitely. No grace-period removal needed (see "Subject-line nonce prefix" under "What we generalize" above).
+- **Candid surface.** Legacy `email_recovery_credential_*` methods stay live through Phase 1c; they're removed alongside the legacy storage field, since they were facades around it. External integrators get one deprecation window covering both phases.
+
+Reverse index: no migration. The `address-hash → AnchorNumber` map already supports N-addresses-per-anchor and is unchanged across all three phases.
+
+### Verification UX (settings entry point)
+
+Reuses the shipped dialog ([SendConfirmationEmail.svelte](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/views/SendConfirmationEmail.svelte)), with one prefix update visible to the user.
+
+Today the dialog renders:
+
+```
+TO       register@id.ai
+FROM     marioruci15@gmail.com  ✓
+SUBJECT  II-Recovery-173036316cf99279
+BODY     (anything, leave it blank)
+
+[Open in mail app]
+[I've sent the email]
+```
+
+After Phase 1, the same dialog renders:
+
+```
+TO       register@id.ai
+FROM     marioruci15@gmail.com  ✓
+SUBJECT  II-Verify-173036316cf99279
+BODY     (anything, leave it blank)
+
+[Open in mail app]
+[I've sent the email]
+```
+
+The dialog's title ("Verify your email") and body ("Send the email below to confirm") are already generic and need no change.
+
+### Settings UX — "Verified emails" panel
+
+New section on the identity management page (`/manage`).
+
+**Content:**
+
+- One row per verified email entry. Each row shows:
+  - The email address.
+  - Verification timestamp (tertiary styling).
+  - A "Used for recovery" radio button (radio across all rows — only one can be selected; selecting another atomically demotes the previous one).
+  - A "Remove" button.
+- An "Add an email" button — opens the verification wizard. New entries land in the list with no recovery flag; the user can promote any entry to recovery later via the row's radio.
+  No global "don't share" toggle. Sharing happens (or doesn't) per-request in the consent dialog, which already provides a one-click "Deny all". A user who never wants to share simply denies every time — that's the system learning their revealed preference.
+
+**States:**
+
+- **Empty state** (no verified emails): the panel shows the "Add an email" CTA prominently with explanatory copy ("Verified emails can be used to recover your account, and apps that ask for your email can request to receive one").
+- **Single entry, marked recovery**: the row shows the recovery radio selected. No "promote to recovery" UI is needed since it's already the recovery email.
+- **Multiple entries**: standard list; recovery radio is mutex across rows.
+
+The shipped recovery-flow entry point (today's "Add a recovery email" button somewhere in `/manage`) stays as a shortcut: clicking it launches the same wizard with `is_recovery: true` queued to apply on success. Users who think of the flow as "set up account recovery" get exactly the same UX they have today; users who think of it as "add a verified email I can also share" find the new panel.
+
+### Entry points
+
+Two surfaces launch the verification wizard, both pointing at the same component:
+
+**1. Dashboard.** "Add an email" in the Verified emails panel, or the legacy "Add a recovery email" shortcut.
+
+**2. `/authorize`, conditionally.** When a dapp requests `email` and the anchor has zero verified emails (and no OIDC/SSO source either), the consent handler today short-circuits to an empty response ([attributes.ts:674-678](../../src/frontend/src/lib/stores/channelHandlers/attributes.ts:674)). Replace that short-circuit with an inline affordance: "_this dapp wants your email; verify one now?_" with an "Add a verified email" button that opens the wizard inside the authorize popup. On success, control returns to the consent dialog which now has a source to offer.
+
+Both entry points hand the wizard the same component, the same candid call, the same SMTP flow. The only difference is the surrounding navigation.
+
+### Phase 1 open decisions
+
+- [ ] **Pending intent.** When a user launches the wizard from the recovery-flow entry point, the new entry needs to end up with `is_recovery: true`. Two ways to get there: (a) the FE always commits with `is_recovery: false` and then makes a follow-up `verified_email_set_recovery` call once polling sees success, or (b) the pending challenge carries the intent so the entry comes out of verification already flagged. (a) is one extra round-trip but keeps the ownership-proof pipeline purpose-agnostic; (b) is atomic but couples verification to intent.
+- [ ] **Boundary-node SMTP relay coordination.** II uses an off-canister SMTP relay (run by the boundary-node team) to forward inbound verification emails to the canister. The canister-side parser looks for `II-Recovery-` in the Subject today and will look for `II-Verify-` after Phase 1a. If the relay also filters on the Subject before forwarding — a regex pre-filter, purpose-based metric labels, rate-limit buckets — it needs to be updated to accept both prefixes. We need a written confirmation from the relay owners on whether any such filtering exists, and a coordinated change if it does.
+- [ ] **Phase 1b sweep mechanism.** Phase 1b is the migration step that walks dormant anchors and rewrites their storage from the legacy field to the new one. The question is how it's invoked: a controller-callable canister method (operator picks the window and batch size by hand) or an automated timer (runs on every replica without operator intervention). Controller-callable is the safer default — explicit go/no-go, lower-traffic windows, easier to pause if something goes wrong. Timer-driven would add replica-side cycle pressure for marginal benefit.
+- [ ] **Phase 1b batch size.** How many anchors per sweep invocation. Drives the per-call cycle cost and the total number of operator invocations needed to clear the long tail. Tune in staging before running on prod.
+- [ ] **Phase 1c timing.** Phase 1c is the cleanup release that removes the legacy `email_recovery` field, `StorableEmailRecoveryCredential`, and the legacy candid facade methods. It can only ship after Phase 1b reports the sweep complete. How long to wait between "1b complete on prod" and "1c shipped" — a buffer that gives any leftover lazy-migration corner case a chance to surface in production traffic. At least one full release cycle is the conservative answer.
+- [ ] **Translation strings.** Final user-facing wording for the new strings introduced by Phase 1 and Phase 2: the Verified emails panel header, the "Used for recovery" row label, the "Add an email" CTA, the row "Remove" / confirmation copy, and the "Verified email" source label that also appears in the Phase 2 consent dialog.
+
+---
+
+## Phase 2 — Verified emails as attribute sources
+
+### Scope syntax
+
+New scope variant: `verified:<H(address)>:email` and `verified:<H(address)>:verified_email`.
+
+- The scope id is the hash of the address (e.g. SHA-256 truncated to 16 hex). Rationale:
+  - **Privacy** — the plaintext address doesn't appear in the candid key, so dapps querying `list_available_attributes` see hashes only.
+  - **Stability** — remove + re-add of the same address yields the same scope id, so any user-side bookmarks / dapp-side caches keyed on scope survive.
+  - **Reorderability** — the storage list can be rearranged without changing scope keys.
+- `name` is **not** supported for verified emails (no name claim collected during the inbound DKIM flow). `list_available_attributes` excludes `verified:<H>:name` like it does today for `sso:<domain>:verified_email`.
+
+### Plumbing
+
+**Canister:**
+
+- Add `AttributeScope::Verified { address_hash: String }` to the scope enum in [types/attributes.rs](../../src/internet_identity_interface/src/internet_identity/types/attributes.rs).
+- Extend `Anchor.list_available_attributes` ([attributes.rs:513](../../src/internet_identity/src/attributes.rs:513)) to also walk the result of `read_verified_emails(anchor)` (the storage abstraction introduced in Phase 1a). Every entry surfaces `verified:<H(address)>:email` and `verified:<H(address)>:verified_email` — verified existence is the sole eligibility test, no per-entry flag. Reading through the abstraction means Phase 2 works correctly on both migrated and not-yet-migrated anchors.
+- Extend `Anchor.prepare_attributes` / `prepare_icrc3_attributes` to resolve `verified:<H>:email` keys by looking up the entry whose `H(address)` matches (also via `read_verified_emails`).
+
+**OIDC/SSO unchanged.** They continue to surface under their existing `openid:` / `sso:` scopes alongside `verified:` entries. The user's verified-email entries are an _additional_ attribute bucket, not a replacement for IdP-sourced credentials.
+
+### Frontend
+
+**No consent-dialog changes.** The shipped [`AttributeConsentView.svelte`](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte>) + [`AttributePicker.svelte`](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributePicker.svelte>) already merge multi-source unscoped requests into a chevron-expandable group. New `verified:` options appear as additional entries in that group automatically.
+
+**One label addition.** A new translation string for the "Verified email" source label so the consent picker can render "Verified email (alice@gmail.com)" rather than a raw scope key. The source-label resolution lives in `scopedProviderLabel` ([AttributeConsentView.svelte:165-173](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte:165>)) — extend to recognise `verified:` and return a localised "Verified email" string; the address is already surfaced as the value column.
+
+### Attribute-name coverage
+
+| Source               | `email` | `name`             | `verified_email`           |
+| -------------------- | ------- | ------------------ | -------------------------- |
+| OIDC (e.g. Google)   | ✅      | ✅                 | ✅                         |
+| SSO (e.g. Okta)      | ✅      | ✅                 | ❌ (kept out, intentional) |
+| Verified email entry | ✅      | ❌ (no name claim) | ✅                         |
+
+A verified email is considered to satisfy `verified_email` because the inbound DKIM proof is the same kind of evidence OIDC's `email_verified: true` represents — both demonstrate the user controls the mailbox.
+
+### Phase 2 open decisions
+
+- [ ] **Address-hash function and truncation length.** The new `verified:<H(address)>:email` scope identifies an entry by hash so the plaintext address doesn't appear in the candid key. Which hash, and how many bytes do we keep? Full SHA-256 is 64 hex chars and overkill; the first 16 hex (~64 bits) is enough collision resistance for per-anchor uniqueness without bloating every `list_available_attributes` response. The hash input is the address as already stored — canonical-lowercased — so no further normalization needed.
+
+---
+
+## Phase 3 — Smart-routing + last-used default
+
+The consent dialog pre-selects what the user picked last time (or smart-routes if it's their first time). The user never has to declare a default — the system learns from their first authorize flow. Sharing is always an explicit click in the dialog; denying is always one click in "Deny all".
+
+### State model
+
+One new field on the anchor:
+
+- `last_shared_email_scope: Option<String>` — updated by the canister whenever the user shares an email through the consent dialog. Holds the scope key (e.g. `openid:https://accounts.google.com`, `verified:<H>`). Internal — not surfaced as a settings control.
+
+### Resolution
+
+For unscoped `email` / `verified_email` requests:
+
+1. The FE selects a default for the consent dialog:
+   - If `last_shared_email_scope` is set and the matching source still exists → that scope's index in the picker.
+   - Else apply smart-routing (current session signed in via OIDC/SSO → that source; passkey + any verified email → first such entry; else first available).
+2. User reviews / changes / accepts in the picker (or denies).
+3. On Continue with a non-empty selection, the canister updates `last_shared_email_scope` to whatever was shared.
+
+"Deny all" doesn't update `last_shared_email_scope` — we track the last _shared_ choice, not the last action. So denying once doesn't change the default the next time.
+
+Scoped requests (`openid:...:email`, `verified:<H>:email`, etc.) bypass step 1 — the dapp asked for a specific source. They go straight to the consent dialog with that source pre-selected; user-side accept/deny semantics are unchanged.
+
+### Frontend changes
+
+Two surgical edits to the existing consent UI:
+
+**1.** [`AttributeConsentView.svelte`](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte>) — `selections` map init (around line 130). Default `selectedIndex` resolves via last-used → smart-routing → 0.
+
+**2.** On Continue (the `handleContinue` callback), send the chosen attribute keys back as today, and the canister stores the resolved scope into `last_shared_email_scope` as a side effect of `prepare_icrc3_attributes`.
+
+Nothing else changes. No new dialog modes, no "Primary" badge, no "remember this choice" affordance, no first-time priming flow. The user never has to declare a default — the system learns from their first authorize flow.
+
+### Phase 3 open decisions
+
+- [ ] **Stale-source fallback.** The canister remembers the user's last-shared scope (e.g. `openid:https://accounts.google.com`) so the consent dialog can pre-select it the next time the user authorizes. If that source has since been removed from the anchor — the user unlinked Google, deleted the verified email, etc. — what does the dialog default to? Options: silently fall back to smart-routing (current session's IdP first, then any available source), or surface a one-time "your previous default isn't available anymore" notice. Silent fallback is lower-friction but less transparent.
+- [ ] **Cross-device persistence of `last_shared_email_scope`.** The field is stored on the anchor (canister state), so the same value reaches every device the user signs in from. Alternative would be per-device `localStorage`, which would mean a new device sees a different default than the user's primary device. Anchor-side is more consistent with how II treats other anchor-level state.
+- [ ] **Deterministic ordering for "first available" fallback.** When smart-routing has nothing better to recommend (no last-shared source, no current-session IdP signal), it picks "the first available email source". What does "first" mean — most-recently-verified, insertion order in the storage list, alphabetical by address? Most-recently-verified is likeliest to be the email the user actually wants to share but introduces an ordering dependency on the upgrade-timing of recent writes.
+
+---
+
+## Sequencing
+
+| Step                                | Touches                                                                                                                                                                                                                                                                                                                                                                                                           | Ships independently?                                                                     |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Phase 1a backend                    | new `StorableVerifiedEmail` type, new `verified_emails` field on `StorableAnchor` alongside legacy `email_recovery`, `read_verified_emails` / `write_verified_emails` helpers, cap-5 enforcement, `verified_email_*` candid + `VerifiedEmail` type, legacy facades for `email_recovery_credential_*`, subject-prefix flip (with dual-accept parser). Lazy migration on every anchor touch — no post-upgrade hook. | Yes                                                                                      |
+| Phase 1a FE                         | generic email-verification wizard, new "Verified emails" settings panel, dashboard wiring, /authorize empty-state inline flow                                                                                                                                                                                                                                                                                     | After Phase 1a BE                                                                        |
+| Phase 1a boundary-node coordination | external — written confirmation or coordinated change to the SMTP relay                                                                                                                                                                                                                                                                                                                                           | Must complete before Phase 1a BE ships                                                   |
+| Phase 1b backend                    | controller-callable batched sweep of anchors still on legacy storage, stable cursor, `verified_email_migration_status()` query                                                                                                                                                                                                                                                                                    | Ships ~one release after 1a; runs in production until status reports complete            |
+| Phase 1c backend                    | drop legacy `email_recovery` field, `StorableEmailRecoveryCredential`, and the `email_recovery_credential_*` candid facades; remove legacy candid type. Cleanup release.                                                                                                                                                                                                                                          | After 1b sweep reports complete on prod                                                  |
+| Phase 2                             | `AttributeScope::Verified` variant, `list_available_attributes` + `prepare_*` extensions reading through `read_verified_emails`, FE source label                                                                                                                                                                                                                                                                  | After Phase 1a (works on both migrated and not-yet-migrated anchors via the abstraction) |
+| Phase 3                             | one anchor field, resolution logic, `AttributeConsentView` default-selection edit                                                                                                                                                                                                                                                                                                                                 | After Phase 2                                                                            |
+
+The boundary-node coordination is the only step on the critical path that depends on a team outside this codebase. Phase 2 doesn't have to wait for 1b/1c — it reads through the storage abstraction, so unmigrated anchors are still serveable.
+
+---
+
+## Out of scope
+
+- **Push notifications.** Separate workstream — WebPush + Service Worker on the II origin. The two channels are orthogonal: email-attribute settings and push allowlists may share a settings UI but share no implementation.
+- **Per-dapp pseudonymous email aliases (`<hash>@id.ai`).** Discussed as a possible future phase once verified emails exist as a primitive. Requires an MX server commitment that's a separate organisational decision. See prior art in [#3760](https://github.com/dfinity/internet-identity/pull/3760) for the inbox/postbox path the team has explored and parked.
+- **Cross-attribute pinning (primary name, primary DoB, etc.).** Email-specific concerns drove this design; other attributes don't have the "multiple sources, hard to pick" problem.
+- **Per-dapp persistent overrides.** Considered and rejected — the Apple "Hide my email" analogy doesn't transfer because we share the user's real address, not per-app aliases. Without per-app aliases, persistent per-dapp overrides add complexity without solving a real problem.
+
+---
+
+## Open decisions checklist
+
+**Phase 1:**
+
+- [ ] **Pending intent.** When the wizard runs from the recovery entry point, the new entry needs `is_recovery: true` on commit. Two ways to land it: (a) the FE always commits with `is_recovery: false` and then makes a follow-up `verified_email_set_recovery` call once polling succeeds, or (b) the pending challenge carries the intent through the verification pipeline. (a) keeps the ownership-proof pipeline purpose-agnostic at the cost of one extra round-trip.
+- [ ] **Boundary-node SMTP relay coordination.** II uses an off-canister SMTP relay (boundary-node team) to forward inbound verification emails to the canister. The canister-side Subject parser looks for `II-Recovery-` today and will look for `II-Verify-` after Phase 1a. If the relay does any Subject-level filtering, purpose-based metric labels, or rate-limit buckets keyed on the prefix, those need updating to accept both. Need a written confirmation on what (if anything) is in place.
+- [ ] **Phase 1b sweep mechanism.** Phase 1b walks anchors that haven't been touched since 1a shipped and migrates them to the new storage layout in batches. Choose: a controller-callable canister method (operator picks the window and batch size by hand) or an automated timer (runs on every replica without operator intervention). Controller-callable is the safer default.
+- [ ] **Phase 1b batch size.** How many anchors per sweep call. Per-call cycle cost vs. total operator invocations to clear the long tail. Tune in staging before prod.
+- [ ] **Phase 1c timing.** Phase 1c is the cleanup release that removes the legacy `email_recovery` field, `StorableEmailRecoveryCredential`, and the legacy candid facade methods. It ships after Phase 1b reports the sweep complete. How long to wait between "1b complete on prod" and "1c shipped" — a buffer for any leftover lazy-migration corner case to surface. At least one full release cycle is the conservative answer.
+- [ ] **Translation strings.** Final user-facing wording for the new strings introduced by Phase 1 and 2: the Verified emails panel header, the "Used for recovery" row label, the "Add an email" CTA, the row remove confirmation, and the "Verified email" source label that also appears in the Phase 2 consent dialog picker.
+
+**Decided (Phase 1):**
+
+- Per-anchor cap: 5 verified emails.
+- Wizard directory: `setupEmailRecovery/` renames to `emailVerification/`; the shared views directory renames to drop "recovery". The recovery-flow entry point becomes a thin call site mounting the generic wizard with `markAsRecovery={true}`.
+- Candid evolution: additive — new `verified_email_*` methods alongside the legacy `email_recovery_credential_*` facades, with both available through Phases 1a-1b and the legacy ones removed in 1c alongside the legacy storage field.
+
+**Phase 3:**
+
+- [ ] **Stale-source fallback.** When `last_shared_email_scope` points to a source that's no longer on the anchor (unlinked Google, removed verified email, etc.), what does the consent dialog default to? Silently fall back to smart-routing, or surface a one-time "your previous default isn't available" notice. Silent fallback is lower-friction but less transparent.
+- [ ] **Cross-device persistence of `last_shared_email_scope`.** The field lives on the anchor (canister state) so it reaches every device. Alternative: per-device `localStorage` — but then a new device sees a different default than the primary device. Anchor-side is more consistent with how II treats other per-anchor state.
+- [ ] **Deterministic ordering for "first available" fallback.** When smart-routing has nothing better — no last-shared source, no current-session IdP signal — it falls back to "first available source". Which one is "first": most-recently-verified, insertion order in the storage list, or alphabetical by address? Most-recently-verified is likeliest to be the email the user wants but introduces an ordering dependency on the relative timestamps of recent writes.

--- a/docs/design/verified-email-implementation.md
+++ b/docs/design/verified-email-implementation.md
@@ -5,28 +5,29 @@
 **How to use this:**
 
 - Items are discrete units of work with file:line citations and named function targets.
-- Phases ship in order (1a → 1b → 1c → 2 → 3); within a phase, sub-sections can land in parallel.
-- Open decisions (cap, pending intent, etc.) and locked decisions (cap=5, wizard rename, etc.) are documented in the design doc's "Open decisions checklist" — refer there before starting any sub-section that touches them.
-- LLM agents implementing this should treat the checklist as canonical for "what to do" and consult the design doc for "why" when a decision is ambiguous.
+- Phases ship in order (1 → 2 → 3); each phase is a single release.
+- Locked decisions are stated below — refer there before starting any sub-section that touches them.
+- LLM agents implementing this should treat this checklist as canonical for "what to do" and consult the design doc for "why" when a decision is ambiguous.
 
 ---
 
-## Locked decisions baked into this checklist
+## Locked decisions
 
+- **Verified emails are independent from the recovery email.** Existing recovery storage, candid, wizard, and `II-Recovery-` subject prefix are untouched. Verified emails get their own storage, candid, wizard, and `II-Verify-` subject prefix.
 - Cap = 5 verified emails per anchor.
-- Wizard directory: `setupEmailRecovery/` → `emailVerification/`. Shared views directory renames similarly to drop "recovery".
-- Candid evolution: additive new methods + legacy facades. Both live through Phases 1a-1b; legacy removed in 1c.
-- Storage: batched migration (1a lazy + 1b sweep + 1c cleanup). No big-bang `post_upgrade` rewrite.
-- Pending intent: FE-call path (commit with `is_recovery: false`; recovery-flow caller invokes `verified_email_set_recovery` after polling sees success). Flagged "still open" in the doc — implementation can proceed on this path and revisit only if it turns out to be wrong.
-- Subject prefix: `NONCE_PREFIX` flips to `II-Verify-`; `find_nonce_in` accepts both prefixes permanently.
-- No per-dapp pin; no global "don't share" toggle; no persistent retraction mechanism.
+- `StorableVerifiedEmail` carries only `{ address, verified_at }`. No `is_recovery` flag — recovery is a separate concept that lives in `email_recovery`.
+- No migration. The new `verified_emails` field is additive; `minicbor-derive` forward-compatibility handles legacy anchors.
+- Subject prefix: `find_nonce_in` accepts both `II-Recovery-` (existing) and `II-Verify-` (new) so the verified-email flow can issue nonces with the new prefix.
+- `PendingKind::VerifyEmail { anchor }` is the new variant that disambiguates verified-email verification from the existing recovery flows after the SMTP gateway hands the inbound message off.
+- No per-dapp pin, no global "don't share" toggle, no persistent retraction mechanism (consent dialog fires per request).
 - `last_shared_email_scope` lives on the anchor (canister-side), travels across devices.
+- Cross-promotion (same address as both recovery and verified) is out of scope for v1; user verifies twice.
 
 ---
 
-## Phase 1a — New schema + lazy migration on touch
+## Phase 1 — Verified emails primitive
 
-### 1a.A. Backend: new types
+### 1.A. Backend: new types
 
 - [ ] Create [src/internet_identity/src/storage/storable/verified_email.rs](../../src/internet_identity/src/storage/storable/verified_email.rs):
   ```rust
@@ -35,56 +36,72 @@
   pub struct StorableVerifiedEmail {
       #[n(0)] pub address: String,
       #[n(1)] pub verified_at: Timestamp,
-      #[n(2)] pub last_used_for_recovery_at: Option<Timestamp>,
-      #[n(3)] pub is_recovery: bool,
   }
   ```
-- [ ] Add `impl From<StorableEmailRecoveryCredential> for StorableVerifiedEmail` — maps `created_at → verified_at`, `last_used → last_used_for_recovery_at`, sets `is_recovery: true`. One-way only (this is the lazy-migration synthesizer).
-- [ ] Add candid mirror `VerifiedEmail` in [src/internet_identity_interface/src/internet_identity/types/email_recovery.rs](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs) with the same shape.
+- [ ] Add candid mirror `VerifiedEmail` in [src/internet_identity_interface/src/internet_identity/types/email_recovery.rs](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs) (or a new sibling module if you prefer; the types module is fine):
+  ```rust
+  pub struct VerifiedEmail {
+      pub address: String,
+      pub verified_at: Timestamp,
+  }
+  ```
 - [ ] Add `impl From<StorableVerifiedEmail> for VerifiedEmail` and the reverse.
 
-### 1a.B. Backend: dual storage on anchor
+### 1.B. Backend: anchor field (additive, no migration)
 
-- [ ] [src/internet_identity/src/storage/storable/anchor.rs:30](../../src/internet_identity/src/storage/storable/anchor.rs:30) — add the new field alongside the legacy:
+- [ ] [src/internet_identity/src/storage/storable/anchor.rs:30](../../src/internet_identity/src/storage/storable/anchor.rs:30) — add the new field alongside the existing one. The legacy `email_recovery` field stays exactly as it is.
   ```rust
-  #[n(N1)] pub email_recovery: Option<Vec<StorableEmailRecoveryCredential>>,  // legacy; never written by new code
-  #[n(N2)] pub verified_emails: Option<Vec<StorableVerifiedEmail>>,            // new
-  ```
-  Pick a new `#[n(...)]` field number; do not reuse the legacy one.
-
-### 1a.C. Backend: read/write abstraction
-
-- [ ] Add to [src/internet_identity/src/storage/anchor.rs](../../src/internet_identity/src/storage/anchor.rs):
-
-  ```rust
-  pub fn read_verified_emails(anchor: &StorableAnchor) -> Vec<StorableVerifiedEmail> {
-      if let Some(v) = &anchor.verified_emails { return v.clone(); }
-      if let Some(legacy) = &anchor.email_recovery {
-          return legacy.iter().cloned().map(StorableVerifiedEmail::from).collect();
-      }
-      Vec::new()
-  }
-
-  pub fn write_verified_emails(anchor: &mut StorableAnchor, new: Vec<StorableVerifiedEmail>) {
-      anchor.verified_emails = Some(new);
-      anchor.email_recovery = None;  // clear legacy
+  pub struct StorableAnchor {
+      // ...
+      #[n(N1)] pub email_recovery: Option<Vec<StorableEmailRecoveryCredential>>,   // existing — DO NOT TOUCH
+      #[n(N2)] pub verified_emails: Option<Vec<StorableVerifiedEmail>>,            // new
+      // ...
   }
   ```
+  Pick a new `#[n(...)]` field number for `verified_emails`; do not reuse the legacy one. Existing anchors decode with `verified_emails: None` automatically — no migration logic needed.
 
-- [ ] Audit every direct access to `anchor.email_recovery`. Route through `read_verified_emails` / `write_verified_emails`. Expected call sites: [smtp.rs:727](../../src/internet_identity/src/email_recovery/smtp.rs:727), [remove.rs:51](../../src/internet_identity/src/email_recovery/remove.rs:51), [prepare.rs:582](../../src/internet_identity/src/email_recovery/prepare.rs:582), candid response builders in main.rs.
-- [ ] Unit test: legacy-only anchor (`verified_emails: None`, `email_recovery: Some(...)`) reads back correctly via `read_verified_emails`. First write through `write_verified_emails` clears the legacy field.
+### 1.C. Backend: PendingKind variant + SMTP dispatch
 
-### 1a.D. Backend: subject-prefix flip + cap + new helpers
+- [ ] [src/internet_identity/src/email_recovery/pending.rs:172](../../src/internet_identity/src/email_recovery/pending.rs:172) — add a new variant to `PendingKind`:
+  ```rust
+  pub enum PendingKind {
+      Register { anchor: AnchorNumber },           // existing — recovery setup
+      Recover { session_pk: SessionKey },          // existing — recovery login
+      VerifyEmail { anchor: AnchorNumber },        // new — verified-email add
+  }
+  ```
+- [ ] [src/internet_identity/src/email_recovery/smtp.rs:278](../../src/internet_identity/src/email_recovery/smtp.rs:278) — extend the dispatch match in `handle_smtp_request` to include a new arm:
+  ```rust
+  let kind = match (&c.kind, recipient_flow) {
+      (PendingKind::Register { anchor }, RecipientFlow::Setup) => SnapshotKind::Setup { anchor: *anchor },
+      (PendingKind::Recover { session_pk }, RecipientFlow::Recovery) => SnapshotKind::Recovery { session_pk: session_pk.clone() },
+      (PendingKind::VerifyEmail { anchor }, RecipientFlow::Setup) => SnapshotKind::VerifyEmail { anchor: *anchor },
+      _ => return None,  // recipient ↔ kind mismatch
+  };
+  ```
+- [ ] Add `SnapshotKind::VerifyEmail { anchor }` to the snapshot enum in [smtp.rs](../../src/internet_identity/src/email_recovery/smtp.rs) and wire the rest of the verification pipeline (DKIM check, DMARC, DNSSEC/DoH) to it. The pipeline itself is identical to the Setup arm; the only difference is **where the committed entry lands**: instead of writing to `Anchor.email_recovery`, write a new `StorableVerifiedEmail` to `Anchor.verified_emails`.
+- [ ] The shared inbound code (DKIM body-hash, partial-verification record, pending-status transitions, polling cadence) is reused unchanged.
 
-- [ ] [mod.rs:111](../../src/internet_identity/src/email_recovery/mod.rs:111) — `NONCE_PREFIX = "II-Verify-"`.
-- [ ] [smtp.rs:436](../../src/internet_identity/src/email_recovery/smtp.rs:436) (`find_nonce_in`) — accept both `II-Verify-` and `II-Recovery-` permanently. Unit test asserting both parse.
-- [ ] [mod.rs](../../src/internet_identity/src/email_recovery/mod.rs) — `pub const MAX_VERIFIED_EMAILS_PER_ANCHOR: usize = 5;`.
-- [ ] [prepare.rs:45](../../src/internet_identity/src/email_recovery/prepare.rs:45) (`prepare_add`) — enforce cap-5 using `read_verified_emails(anchor).len()`.
-- [ ] [smtp.rs:727](../../src/internet_identity/src/email_recovery/smtp.rs:727) — replace "overwrite the Vec with a single entry" with append-via-abstraction. New entries commit with `is_recovery: false`.
-- [ ] New function `set_recovery(anchor, address)` (in a new `src/internet_identity/src/email_recovery/set_recovery.rs`): atomically set `is_recovery: true` on the matching entry, clear it on every other entry of the same anchor, persist via `write_verified_emails`. Reject if the address isn't found.
-- [ ] [remove.rs:51](../../src/internet_identity/src/email_recovery/remove.rs:51) — route through `read_verified_emails` / `write_verified_emails`; behaviour for multi-entry follows naturally.
+### 1.D. Backend: subject prefix
 
-### 1a.E. Backend: candid surface
+- [ ] [src/internet_identity/src/email_recovery/mod.rs:111](../../src/internet_identity/src/email_recovery/mod.rs:111) — leave `NONCE_PREFIX = "II-Recovery-"` as-is (it's used by the recovery flow). Add a new constant:
+  ```rust
+  pub const VERIFIED_EMAIL_NONCE_PREFIX: &str = "II-Verify-";
+  ```
+- [ ] Update `format_nonce` ([rng.rs:73](../../src/internet_identity/src/email_recovery/rng.rs:73)) — it currently reads `NONCE_PREFIX`. Either parameterize it on which prefix to use (preferred), or fork into `format_recovery_nonce` and `format_verified_email_nonce`. The verified-email-prepare-add path uses the new prefix; the recovery-prepare-add path keeps using the old one.
+- [ ] [src/internet_identity/src/email_recovery/smtp.rs:436](../../src/internet_identity/src/email_recovery/smtp.rs:436) (`find_nonce_in`) — extend to try both prefixes. Once it finds a match, the pending-entry lookup is the same for either; `PendingKind` disambiguates after that. Unit test asserting both prefixes parse.
+- [ ] Add a unit test that the recovery flow still issues `II-Recovery-` nonces and the verified-email flow issues `II-Verify-`.
+
+### 1.E. Backend: cap + helpers
+
+- [ ] [src/internet_identity/src/email_recovery/mod.rs](../../src/internet_identity/src/email_recovery/mod.rs) — `pub const MAX_VERIFIED_EMAILS_PER_ANCHOR: usize = 5;`.
+- [ ] New module `src/internet_identity/src/verified_emails/` (or extend `email_recovery/` if you prefer — the verification primitive is genuinely shared). New file `verified_emails/prepare.rs` mirroring [prepare.rs](../../src/internet_identity/src/email_recovery/prepare.rs):
+  - `pub async fn prepare_add(anchor: AnchorNumber, dns_input: EmailRecoveryDnsInput, now_secs: u64) -> Result<EmailRecoveryChallenge, EmailRecoveryError>` — same structure as the recovery `prepare_add`, but stores `PendingKind::VerifyEmail { anchor }` and issues the nonce with the `II-Verify-` prefix.
+  - Enforce the cap: reject if `anchor.verified_emails.as_ref().map_or(0, |v| v.len()) >= MAX_VERIFIED_EMAILS_PER_ANCHOR`.
+- [ ] New `verified_emails/remove.rs`: `pub fn remove(anchor: &mut Anchor, address: &str) -> Result<Operation, RemoveError>`. Find the matching entry in `verified_emails`, remove it. Does not touch `email_recovery`.
+- [ ] Commit logic on verification success (in `submit_leaf.rs` or wherever the `SnapshotKind::VerifyEmail` arm lands): append a new `StorableVerifiedEmail { address, verified_at: now }` to `Anchor.verified_emails`. Initialize the Vec if `None`.
+
+### 1.F. Backend: candid surface
 
 - [ ] [internet_identity.did:1570](../../src/internet_identity/internet_identity.did:1570) — add:
 
@@ -92,137 +109,66 @@
   type VerifiedEmail = record {
       address: text;
       verified_at: nat64;
-      last_used_for_recovery_at: opt nat64;
-      is_recovery: bool;
   };
 
-  verified_email_prepare_add  : (IdentityNumber, EmailRecoveryDnsInput) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
-  verified_email_set_recovery : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });
-  verified_email_remove       : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });
-  list_verified_emails        : (IdentityNumber) -> (vec VerifiedEmail) query;
+  verified_email_prepare_add : (IdentityNumber, EmailRecoveryDnsInput) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
+  verified_email_remove      : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });
+  list_verified_emails       : (IdentityNumber) -> (vec VerifiedEmail) query;
   ```
 
-- [ ] [src/internet_identity/src/main.rs](../../src/internet_identity/src/main.rs) — add handlers that delegate to the email_recovery module. Keep the existing `email_recovery_credential_prepare_add` and `email_recovery_credential_remove` handlers as facades:
-  - `email_recovery_credential_prepare_add` → calls `prepare_add`, then `set_recovery` on commit so the new entry comes out with `is_recovery: true` (preserves legacy semantics).
-  - `email_recovery_credential_remove` → calls the underlying remove against the entry currently flagged as recovery.
+- [ ] [src/internet_identity/src/main.rs](../../src/internet_identity/src/main.rs) — add handlers that delegate to the new module. **Do not touch the existing `email_recovery_*` handlers.**
 - [ ] `npm run generate` after the `.did` change to refresh frontend types.
 
-### 1a.F. Backend: integration tests
+### 1.G. Backend: tests
 
-Two test files, split by concern:
-
-- [ ] **Keep** [src/internet_identity/tests/integration/email_recovery.rs](../../src/internet_identity/tests/integration/email_recovery.rs) — this is the regression net for the legacy candid surface (`email_recovery_credential_prepare_add`, `email_recovery_credential_remove`, the recovery-as-login flow). All of it still exists through Phases 1a-1b as facades over the new storage. Update only what changes:
-  - Existing assertions referencing `II-Recovery-` prefix → flip to assert `II-Verify-` for newly-issued nonces.
-  - Keep at least one test exercising the dual-accept parser by feeding an inbound message with `II-Recovery-<hex>` Subject and asserting it still resolves.
-  - Add a back-compat test: `email_recovery_credential_prepare_add` results in the new entry having `is_recovery: true` (via the facade calling `set_recovery` on commit).
-- [ ] **New file** `src/internet_identity/tests/integration/verified_emails.rs` — covers the new feature surface, no legacy concerns:
-  - Add via `verified_email_prepare_add` + SMTP flow → entry committed with `is_recovery: false`.
+- [ ] Existing [src/internet_identity/tests/integration/email_recovery.rs](../../src/internet_identity/tests/integration/email_recovery.rs) — should pass unchanged. The recovery flow is unmodified.
+- [ ] **New file** `src/internet_identity/tests/integration/verified_emails.rs`:
+  - Add via `verified_email_prepare_add` + completing the SMTP flow (subject `II-Verify-<hex>`, recipient `register@<domain>`) → entry committed in `Anchor.verified_emails`, `Anchor.email_recovery` unchanged.
   - Cap-5: a 6th `verified_email_prepare_add` is rejected.
-  - `verified_email_set_recovery` sets `is_recovery: true` and atomically clears it on every other entry of the same anchor.
-  - `verified_email_remove` deletes a non-recovery entry without affecting any other.
+  - `verified_email_remove` deletes a matching entry without touching `email_recovery`.
   - `list_verified_emails` returns entries in their stored order.
-  - **Lazy migration**: a legacy-only anchor (`verified_emails: None`, `email_recovery: Some(...)`) returns the expected synthesized entry via `list_verified_emails`. The next `verified_email_*` write clears the legacy field.
-- [ ] Update DKIM test fixtures: [dkim/canonicalize.rs:254-255](../../src/internet_identity/src/dkim/canonicalize.rs:254), [types/smtp.rs:662](../../src/internet_identity_interface/src/internet_identity/types/smtp.rs:662) — flip to `II-Verify-deadbeef`. Keep one `II-Recovery-` fixture in the dual-accept tests.
+  - Same-anchor parallelism: a user can have a recovery email AND verified emails simultaneously, including the same address in both buckets (verified twice).
+  - Subject-prefix dispatch: an inbound message with `II-Recovery-<hex>` Subject still hits the recovery flow (PendingKind::Register); an inbound with `II-Verify-<hex>` hits the verified-email flow (PendingKind::VerifyEmail).
+- [ ] DKIM test fixtures: update one fixture in [dkim/canonicalize.rs:254-255](../../src/internet_identity/src/dkim/canonicalize.rs:254) to exercise `II-Verify-deadbeef` alongside the existing `II-Recovery-deadbeef`. Same for [types/smtp.rs:662](../../src/internet_identity_interface/src/internet_identity/types/smtp.rs:662).
 
-### 1a.G. Frontend: rename + parameterize the wizard
+### 1.H. Frontend: new email-verification wizard
 
-- [ ] Rename [src/frontend/src/lib/components/wizards/setupEmailRecovery/](../../src/frontend/src/lib/components/wizards/setupEmailRecovery/) to `src/frontend/src/lib/components/wizards/emailVerification/`. Update import paths everywhere.
-- [ ] Rename the shared views directory [src/frontend/src/lib/components/wizards/emailRecovery/shared/](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/) similarly to drop "recovery" from the path (e.g. `src/frontend/src/lib/components/wizards/shared/email/`).
-- [ ] Add a `markAsRecovery: boolean` prop to the wizard's top-level component.
-- [ ] On polling success: if `markAsRecovery === true`, call `verified_email_set_recovery`; else the entry stays with `is_recovery: false`.
-- [ ] Existing recovery-flow caller passes `markAsRecovery={true}`; new settings-panel caller passes `markAsRecovery={false}`.
+- [ ] Create `src/frontend/src/lib/components/wizards/emailVerification/EmailVerificationWizard.svelte` — **parallel to**, not a rename of, [setupEmailRecovery/SetupEmailRecoveryWizard.svelte](../../src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte). Reuses:
+  - The shared `SendConfirmationEmail` dialog from [emailRecovery/shared/views/](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/views/) (renders whatever nonce the canister returns; no changes needed).
+  - The polling helper `runEmailRecoveryPoll` from [emailRecovery/shared/](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/) (purpose-neutral once the pending entry exists).
+- [ ] Wizard flow: address input → call `verified_email_prepare_add` → show the dialog with the canister-issued nonce (`II-Verify-…`) → poll for status → success/failure view.
+- [ ] **No `markAsRecovery` prop, no recovery branching.** The wizard is exclusively for adding entries to `verified_emails`. If a user wants their address as a recovery email too, they use the existing recovery flow separately.
 
-### 1a.H. Frontend: new "Verified emails" settings panel
+### 1.I. Frontend: "Verified emails" settings panel
 
-- [ ] Create `src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte`:
+- [ ] New `src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte`:
   - Lists `VerifiedEmail` rows from `list_verified_emails`.
-  - Per row: address, `verified_at`, "Used for recovery" radio (mutex across rows), Remove button.
-  - "Add an email" button → mounts the wizard with `markAsRecovery: false`.
-  - Recovery radio click → `verified_email_set_recovery`.
-  - Remove button → `verified_email_remove`.
-- [ ] Mount under the `/manage` route.
-- [ ] **No "Don't share my email" toggle.** Sharing happens (or doesn't) per-request in the consent dialog. Settings has no global sharing control.
-- [ ] Translation strings via `$t` calls; don't edit `.po` files directly.
+  - Per row: address, `verified_at`, Remove button.
+  - "Add an email" button → mounts the new wizard.
+  - **No "Used for recovery" radio** (recovery is a separate concept managed in the existing recovery section of the dashboard).
+  - **No global "Don't share my email" toggle.**
+- [ ] Mount under the `/manage` route, alongside (not replacing) the existing recovery email section.
+- [ ] Copy follows the "Copy and tone" guidance in the design doc — empty state leads with user benefit, not "add an email" as a bare CTA. Strings via `$t` calls; don't edit `.po` files directly.
 
-### 1a.I. Frontend: /authorize empty-state inline flow
+### 1.J. Frontend: /authorize empty-state inline flow
 
-- [ ] [attributes.ts:674-678](../../src/frontend/src/lib/stores/channelHandlers/attributes.ts:674) — replace the silent empty-set short-circuit with an inline "Add a verified email" affordance that opens the wizard inside the authorize popup. On wizard success, the consent dialog re-evaluates sources and proceeds.
+- [ ] [attributes.ts:674-678](../../src/frontend/src/lib/stores/channelHandlers/attributes.ts:674) — replace the silent empty-set short-circuit with an inline "Verify an email" affordance that opens the new wizard inside the authorize popup. On wizard success, the consent dialog re-evaluates sources and proceeds.
+- [ ] Copy on this prompt and on the wizard's other surfaces (settings empty state, wizard success state) follows the "Copy and tone" guidance in the design doc. Lead with user benefit; make "Skip for now" visibly available; do not imply the user must verify. The strings ship via `$t` calls and should land alongside a UX review of the proposed wording.
 
-### 1a.J. Frontend: e2e tests (file split + new specs)
+### 1.K. Frontend: e2e tests
 
-**Fixture rename:**
-
-- [ ] Rename [src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts](../../src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts) → `emailVerification.ts`. The contents (waiters, nonce regex, mailbox helpers) are about the verification flow, not specifically about recovery.
-- [ ] Update the nonce regex inside the renamed file from `/II-Recovery-[0-9a-f]{16}/` to `/II-(Verify|Recovery)-[0-9a-f]{16}/`. Both prefixes must still match because tests will be exercising both new flows (which emit `II-Verify-`) and dual-accept paths (which feed `II-Recovery-` inputs to assert backward compatibility).
-- [ ] Sweep all imports that referenced `emailRecovery.ts` → point at `emailVerification.ts`.
-
-**Spec split:**
-
-- [ ] **Rename** [src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts](../../src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts) → `recoveryEmailLogin.spec.ts`. Scope it to **only** the recovery-as-login flow (anonymous user proves email ownership and gets a delegation — uses `recover@<domain>` mailbox). This concern is orthogonal to verified-emails-as-attribute-sources and stays roughly as-is.
-- [ ] Audit the renamed spec and remove any test cases that exercise the "setup a recovery email" flow — those move to the new file below.
-- [ ] **New spec** `src/frontend/tests/e2e-playwright/routes/verifiedEmails.spec.ts` — exercises the new feature surface:
-  - Add a verified email via the new settings panel → entry lands with no recovery flag.
-  - Promote a non-recovery entry to recovery via the row's radio → previously-recovery entry is demoted atomically.
-  - Remove a verified email → it disappears from `list_verified_emails`.
+- [ ] [src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts](../../src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts) — keep this file scoped to the recovery flow. Existing tests should pass unchanged.
+- [ ] **New fixture** `src/frontend/tests/e2e-playwright/fixtures/emailVerification.ts`: helpers for the verified-email flow (waiters, nonce regex `/II-Verify-[0-9a-f]{16}/`, mailbox helpers — likely shares ~80% with the recovery fixture; extract genuinely shared bits into a smaller shared module if it's clean).
+- [ ] **New spec** `src/frontend/tests/e2e-playwright/routes/verifiedEmails.spec.ts`:
+  - Add a verified email via the new settings panel → entry appears in `list_verified_emails`.
+  - Remove a verified email → it disappears.
   - Cap-5: attempting to add a 6th surfaces the right error.
-  - Legacy-flow back-compat: launching the wizard from the existing "Add a recovery email" entry point still produces an entry with `is_recovery: true`.
+  - The recovery email flow remains untouched: adding a recovery email through the existing CTA still produces an `email_recovery` entry and does NOT populate `verified_emails`.
 
-### 1a.K. Boundary-node coordination
+### 1.L. Documentation cleanup
 
-- [ ] **Out of repo** — confirm with the relay owners whether the deployed SMTP relay does any Subject-level filtering, purpose-based bucketing, or operator-doc references to "recovery email".
-- [ ] If yes → coordinate the relay-side regex to accept both `II-Recovery-` and `II-Verify-` (matches the canister's parser). No grace period; both accepted permanently.
-- [ ] If no → record the confirmation. Nothing to do.
-
-### 1a.L. Documentation cleanup
-
-- [ ] [types/email_recovery.rs:78](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs:78) — update doc comment about nonce format.
-- [ ] Sweep comments referring to "recovery email" where the broader meaning is now correct — switch to neutral wording. Leave comments that genuinely refer to the `is_recovery` role untouched.
-
----
-
-## Phase 1b — Controller-driven sweep of the long tail
-
-Ships in release N+1, after Phase 1a is stable in production.
-
-### 1b.A. Backend: sweep mechanism
-
-- [ ] Add `verified_email_migration_cursor: Option<AnchorNumber>` to persistent state (`None` = sweep complete).
-- [ ] New internal function `migrate_anchors_batch(batch_size: usize)`:
-  - From the current cursor, iterate up to `batch_size` anchors.
-  - For each, call `read_verified_emails(anchor)` then `write_verified_emails(anchor, ...)` — no-op for already-migrated anchors, copies legacy → new for the rest.
-  - Advance the cursor.
-- [ ] **Controller-callable** (not timer-driven). Expose as a controller-only update method.
-- [ ] Add query `verified_email_migration_status() -> { cursor, complete: bool, total_remaining: u64 }` so the operator knows when it's done.
-
-### 1b.B. Backend: tests
-
-- [ ] Integration test: anchors with legacy data, run `migrate_anchors_batch` until cursor reaches the end, confirm all anchors have `verified_emails: Some(...)` and `email_recovery: None`.
-- [ ] Idempotency test: running the sweep over already-migrated anchors is a no-op.
-
-### 1b.C. Operator runbook
-
-- [ ] Write a short runbook (either in repo at [docs/](../) or external if that's where ops lives): pre-migration status check, invocation pattern (batch size, cadence), post-migration confirmation. Include rollback notes — the legacy field is still present until 1c, so any individual anchor can be inspected for both fields.
-
----
-
-## Phase 1c — Drop legacy field
-
-Ships in release N+2, after the sweep reports complete on prod and at least one full release cycle has passed.
-
-### 1c.A. Backend
-
-- [ ] Confirm `verified_email_migration_status()` reports `complete: true` on prod and has been stable for the buffer window.
-- [ ] Remove `email_recovery: Option<Vec<StorableEmailRecoveryCredential>>` from `StorableAnchor`.
-- [ ] Delete `StorableEmailRecoveryCredential`, its `From`/`Into` impls, and its source file [src/internet_identity/src/storage/storable/email_recovery_credential.rs](../../src/internet_identity/src/storage/storable/email_recovery_credential.rs).
-- [ ] Delete the synthesis path from `read_verified_emails`; it now reads `verified_emails` directly. `write_verified_emails` no longer needs to clear the legacy field.
-- [ ] Remove the legacy candid type `EmailRecoveryCredential` from [src/internet_identity_interface/src/internet_identity/types/email_recovery.rs](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs).
-- [ ] Remove the legacy candid methods `email_recovery_credential_prepare_add` and `email_recovery_credential_remove` from [internet_identity.did](../../src/internet_identity/internet_identity.did) and their handlers in main.rs.
-- [ ] Remove `verified_email_migration_cursor` and `verified_email_migration_status` from state — they served their purpose.
-- [ ] (Optional, cosmetic) Rename `src/internet_identity/src/email_recovery/` modules to `verified_emails/` to match the model. Defer if it adds noise to the cleanup PR.
-
-### 1c.B. Tests
-
-- [ ] Verify the dual-accept `II-Recovery-` parser still works (intentionally kept indefinitely). Don't drop unless you've actively decided to.
+- [ ] No changes to existing recovery-related doc comments. They still describe the recovery flow accurately.
+- [ ] Add module-level doc comments to the new `verified_emails/` module explaining the relationship to `email_recovery/` (sibling, shares verification primitive, disambiguated by `PendingKind`).
 
 ---
 
@@ -231,8 +177,8 @@ Ships in release N+2, after the sweep reports complete on prod and at least one 
 ### 2.A. Backend
 
 - [ ] [types/attributes.rs](../../src/internet_identity_interface/src/internet_identity/types/attributes.rs) — add `AttributeScope::Verified { address_hash: String }` variant. Implement `Display` / parse to handle `verified:<16-hex>:<name>` consistently with the existing `openid:` / `sso:` shapes.
-- [ ] [attributes.rs:513](../../src/internet_identity/src/attributes.rs:513) (`list_available_attributes`) — extend the loop. After the existing `openid_credentials` walk, walk `read_verified_emails(anchor)`. For each entry, surface `verified:<H(addr)>:email` and `verified:<H(addr)>:verified_email`. Hash: SHA-256 of the lowercased address, truncated to the first 16 hex chars. **Read through the abstraction** so this works on both migrated and not-yet-migrated anchors.
-- [ ] Same module, `prepare_attributes` / `prepare_icrc3_attributes` — resolve `verified:<H>:email` by finding the entry whose hash matches (also via `read_verified_emails`).
+- [ ] [attributes.rs:513](../../src/internet_identity/src/attributes.rs:513) (`list_available_attributes`) — extend the loop. After the existing `openid_credentials` walk, walk `anchor.verified_emails` (not `email_recovery` — recovery emails are intentionally not exposed). For each entry, surface `verified:<H(addr)>:email` and `verified:<H(addr)>:verified_email`. Hash: SHA-256 of the lowercased address, truncated to the first 16 hex chars.
+- [ ] Same module, `prepare_attributes` / `prepare_icrc3_attributes` — resolve `verified:<H>:email` by finding the entry in `verified_emails` whose hash matches.
 - [ ] Skip `verified:<H>:name` (no name claim from the verification flow). Mirror the existing exclusion pattern that skips `sso:<domain>:verified_email`.
 
 ### 2.B. Frontend
@@ -244,10 +190,11 @@ Ships in release N+2, after the sweep reports complete on prod and at least one 
 
 - [ ] Backend unit test: anchor with one verified email surfaces it via `list_available_attributes`; `prepare_icrc3_attributes` returns its value.
 - [ ] Backend unit test: hash stability — same address always hashes to the same scope key.
+- [ ] Backend unit test: the recovery email is **not** exposed via the attribute system (asserting an anchor with only a recovery email and no verified emails returns no email attributes).
 - [ ] **New e2e spec** `src/frontend/tests/e2e-playwright/routes/emailAsAttribute.spec.ts`:
   - Dapp requests `email` against an anchor with one verified email → consent dialog shows the "Verified email (<address>)" row → user accepts → dapp receives the value.
   - Same with multiple verified emails → consent picker chevron expands to show each → user picks one → only that value is shared.
-  - Anchor with zero sources → empty-state inline "Add a verified email" affordance appears (Phase 1a's empty-state flow), wizard completes, control returns to the consent dialog with a now-available source.
+  - Anchor with zero sources (no OIDC, no SSO, no verified email) → empty-state inline "Verify an email" affordance appears (Phase 1's empty-state flow), wizard completes, control returns to the consent dialog with a now-available source.
 
 ---
 
@@ -255,7 +202,7 @@ Ships in release N+2, after the sweep reports complete on prod and at least one 
 
 ### 3.A. Backend
 
-- [ ] Add `last_shared_email_scope: Option<String>` to `StorableAnchor` (new `#[n(N)]` tag).
+- [ ] Add `last_shared_email_scope: Option<String>` to `StorableAnchor` (new `#[n(N)]` tag, additive).
 - [ ] [attributes.rs](../../src/internet_identity/src/attributes.rs) — `prepare_icrc3_attributes` (or the equivalent commit path): when the user shares an unscoped `email` / `verified_email`, write the resolved scope into `last_shared_email_scope` on the anchor. **Deny does not update this field** — we track last _shared_, not last action.
 - [ ] Expose `last_shared_email_scope` to the FE — add it to `IdentityInfo` (or whatever the FE reads at authorize time) as `opt text`.
 
@@ -281,12 +228,10 @@ Ships in release N+2, after the sweep reports complete on prod and at least one 
 - [ ] `npm run check`, `npm run lint`, `npm run test`, `npm run format`.
 - [ ] `npm run generate` after every `.did` change.
 - [ ] Don't commit `.po` files — the translation bot owns those.
-- [ ] User-visible strings say "verify"/"verified", not "recovery" (except where they specifically refer to the recovery role).
+- [ ] User-visible strings for the verified-emails feature say "verify"/"verified". Recovery-flow strings stay as they are.
 
 ## Suggested PR breakdown
 
-- `feat(be,fe): verified emails as a first-class anchor primitive (lazy migration from recovery-email storage)` — Phase 1a end to end.
-- `feat(be): controller-driven sweep of legacy email_recovery entries` — Phase 1b.
-- `chore(be): drop legacy email_recovery field after migration sweep completes` — Phase 1c.
+- `feat(be,fe): verified emails as a new first-class anchor primitive` — Phase 1 end to end.
 - `feat(be,fe): verified emails as ICRC-3 attribute sources` — Phase 2.
 - `feat(be,fe): last-used default in attribute consent dialog` — Phase 3.

--- a/docs/design/verified-email-implementation.md
+++ b/docs/design/verified-email-implementation.md
@@ -15,6 +15,9 @@
 
 - **Verified emails are independent from the recovery email.** Existing recovery storage, candid, wizard, and `II-Recovery-` subject prefix are untouched. Verified emails get their own storage, candid, wizard, and `II-Verify-` subject prefix.
 - Cap = 5 verified emails per anchor.
+- Wizard directory: `verifiedEmail/`; top-level component `VerifiedEmailWizard.svelte`. E2E fixture file: `verifiedEmail.ts`.
+- Phase 1 ships a **narrow** dashboard panel listing only `verified_emails` entries. Phase 1.5 widens it into the unified "Reach" page (FE-only follow-up).
+- Phase 1.5 page name: "Reach", subtitle "How apps can reach you when you sign in." Source icons per IdP (Google, Microsoft, Apple, etc.) + generic envelope for `verified_emails`-only entries. Dedup one row per address. Remove button hidden on IdP-backed rows. Cap counter always visible.
 - `StorableVerifiedEmail` carries only `{ address, verified_at }`. No `is_recovery` flag — recovery is a separate concept that lives in `email_recovery`.
 - No migration. The new `verified_emails` field is additive; `minicbor-derive` forward-compatibility handles legacy anchors.
 - Subject prefix: `find_nonce_in` accepts both `II-Recovery-` (existing) and `II-Verify-` (new) so the verified-email flow can issue nonces with the new prefix.
@@ -133,16 +136,18 @@
 
 ### 1.H. Frontend: new email-verification wizard
 
-- [ ] Create `src/frontend/src/lib/components/wizards/emailVerification/EmailVerificationWizard.svelte` — **parallel to**, not a rename of, [setupEmailRecovery/SetupEmailRecoveryWizard.svelte](../../src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte). Reuses:
+- [ ] Create `src/frontend/src/lib/components/wizards/verifiedEmail/VerifiedEmailWizard.svelte` — **parallel to**, not a rename of, [setupEmailRecovery/SetupEmailRecoveryWizard.svelte](../../src/frontend/src/lib/components/wizards/setupEmailRecovery/SetupEmailRecoveryWizard.svelte). Reuses:
   - The shared `SendConfirmationEmail` dialog from [emailRecovery/shared/views/](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/views/) (renders whatever nonce the canister returns; no changes needed).
   - The polling helper `runEmailRecoveryPoll` from [emailRecovery/shared/](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/) (purpose-neutral once the pending entry exists).
 - [ ] Wizard flow: address input → call `verified_email_prepare_add` → show the dialog with the canister-issued nonce (`II-Verify-…`) → poll for status → success/failure view.
 - [ ] **No `markAsRecovery` prop, no recovery branching.** The wizard is exclusively for adding entries to `verified_emails`. If a user wants their address as a recovery email too, they use the existing recovery flow separately.
 
-### 1.I. Frontend: "Verified emails" settings panel
+### 1.I. Frontend: narrow "Verified emails" settings panel
+
+This is the **narrow** version that ships with Phase 1. Phase 1.5 widens it into the unified "Reach" page (sections 1.5.\* below) and renames the component accordingly. Don't duplicate the layout work — build the narrow version as the small list, and Phase 1.5 grows it.
 
 - [ ] New `src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte`:
-  - Lists `VerifiedEmail` rows from `list_verified_emails`.
+  - Lists `VerifiedEmail` rows from `list_verified_emails` only (no OIDC/SSO sources — Phase 1.5).
   - Per row: address, `verified_at`, Remove button.
   - "Add an email" button → mounts the new wizard.
   - **No "Used for recovery" radio** (recovery is a separate concept managed in the existing recovery section of the dashboard).
@@ -158,7 +163,7 @@
 ### 1.K. Frontend: e2e tests
 
 - [ ] [src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts](../../src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts) — keep this file scoped to the recovery flow. Existing tests should pass unchanged.
-- [ ] **New fixture** `src/frontend/tests/e2e-playwright/fixtures/emailVerification.ts`: helpers for the verified-email flow (waiters, nonce regex `/II-Verify-[0-9a-f]{16}/`, mailbox helpers — likely shares ~80% with the recovery fixture; extract genuinely shared bits into a smaller shared module if it's clean).
+- [ ] **New fixture** `src/frontend/tests/e2e-playwright/fixtures/verifiedEmail.ts`: helpers for the verified-email flow (waiters, nonce regex `/II-Verify-[0-9a-f]{16}/`, mailbox helpers — likely shares ~80% with the recovery fixture; extract genuinely shared bits into a smaller shared module if it's clean).
 - [ ] **New spec** `src/frontend/tests/e2e-playwright/routes/verifiedEmails.spec.ts`:
   - Add a verified email via the new settings panel → entry appears in `list_verified_emails`.
   - Remove a verified email → it disappears.
@@ -169,6 +174,54 @@
 
 - [ ] No changes to existing recovery-related doc comments. They still describe the recovery flow accurately.
 - [ ] Add module-level doc comments to the new `verified_emails/` module explaining the relationship to `email_recovery/` (sibling, shares verification primitive, disambiguated by `PendingKind`).
+
+---
+
+## Phase 1.5 — Reach page (unified emails dashboard)
+
+Pure FE work. No new candid, no new storage, no backend changes. Depends on Phase 1 BE having shipped (the FE needs `list_verified_emails`).
+
+### 1.5.A. Rename / restructure the panel
+
+- [ ] Rename or refactor `src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte` into a "Reach" page component (or restructure as a child of the existing settings page — pick whatever matches the existing `/manage` layout best). Page title: "Reach". Subtitle: "How apps can reach you when you sign in." (Final strings land with UX review.)
+- [ ] Inside the page, add a "Verified emails" section header with a short subtitle (mockup uses "Apps can request one of these to reach you. Never shared without your consent.").
+
+### 1.5.B. Verified emails section (unified)
+
+- [ ] Render the list from the union of two sources:
+  - `openid_credentials` entries whose `email_verified` claim is true.
+  - SSO credentials whose IdP vouches for the address (same condition; the credential type already encodes verified status).
+  - `verified_emails` entries from Phase 1.
+- [ ] Dedup by address: if the same address appears in multiple sources, render one row. Source label prefers the IdP name; verification date uses whichever source produced it (most-recent wins on ties).
+- [ ] Source icon per row: per-IdP icon (Google, Microsoft, Apple, and any other configured IdPs); generic envelope for entries backed only by `verified_emails`. Reuse existing icon assets when available — most are already in `src/frontend/src/lib/components/icons/` or similar.
+- [ ] Remove button: only on rows backed exclusively by `verified_emails`. IdP-backed rows silently hide the Remove button (no tooltip).
+- [ ] Cap counter below the list, always visible: "N of 5 verified emails" (final wording TBD).
+- [ ] "Add an email" CTA → mounts the wizard from Phase 1.
+
+### 1.5.C. Unverified emails section
+
+- [ ] New section "Unverified emails" beneath the Verified section. Subtitle (mockup wording): "Verify one of these so apps can use it to reach you."
+- [ ] Lists `openid_credentials` / SSO credentials whose `email_verified` claim is false.
+- [ ] Per row: address, source label ("Microsoft · Not verified"), source icon, "Verify" CTA.
+- [ ] **Hide the section entirely** when no unverified entries exist.
+
+### 1.5.D. Verify-from-unverified flow
+
+- [ ] "Verify" button on an unverified row opens the Phase 1 wizard with the address pre-filled. The address field is **read-only** in this entry mode so the user can't accidentally verify a different address than the one they clicked.
+- [ ] On wizard success: a new `StorableVerifiedEmail` entry lands in `Anchor.verified_emails` via `verified_email_prepare_add` → DKIM challenge → poll. **The original OIDC/SSO credential is not modified.**
+- [ ] After success, refetch the dashboard data. The address now appears in both `openid_credentials` (the unchanged IdP cred, still `email_verified: false`) and `verified_emails` (the new entry). Dedup renders one row in the Verified section, sourced from the IdP, dated as the II verification.
+
+### 1.5.E. Tests
+
+- [ ] FE unit test: dedup produces one row when the same address is in both `openid_credentials` and `verified_emails`.
+- [ ] FE unit test: Remove button visibility — visible on `verified_emails`-only rows, hidden on IdP-backed rows.
+- [ ] FE unit test: Unverified section hides entirely when there are no unverified entries.
+- [ ] E2E test: anchor with an unverified OIDC email → user clicks Verify → wizard opens with the address pre-filled and read-only → completes DKIM → row moves to Verified section after re-fetch.
+- [ ] E2E test: cap counter reflects the actual count.
+
+### 1.5.F. Translation strings
+
+- [ ] All new strings via `$t` calls. Don't edit `.po` files directly. Final wording lands with UX review.
 
 ---
 
@@ -232,6 +285,7 @@
 
 ## Suggested PR breakdown
 
-- `feat(be,fe): verified emails as a new first-class anchor primitive` — Phase 1 end to end.
+- `feat(be,fe): verified emails as a new first-class anchor primitive` — Phase 1 end to end (narrow panel).
+- `feat(fe): Reach dashboard page with unified verified and unverified emails` — Phase 1.5.
 - `feat(be,fe): verified emails as ICRC-3 attribute sources` — Phase 2.
 - `feat(be,fe): last-used default in attribute consent dialog` — Phase 3.

--- a/docs/design/verified-email-implementation.md
+++ b/docs/design/verified-email-implementation.md
@@ -1,0 +1,292 @@
+# Verified emails — implementation checklist
+
+**Companion to:** [verified-email-attributes.md](verified-email-attributes.md) — the design doc, which explains the _why_. This file is the _what to do_, one phase at a time, with concrete file paths and changes.
+
+**How to use this:**
+
+- Items are discrete units of work with file:line citations and named function targets.
+- Phases ship in order (1a → 1b → 1c → 2 → 3); within a phase, sub-sections can land in parallel.
+- Open decisions (cap, pending intent, etc.) and locked decisions (cap=5, wizard rename, etc.) are documented in the design doc's "Open decisions checklist" — refer there before starting any sub-section that touches them.
+- LLM agents implementing this should treat the checklist as canonical for "what to do" and consult the design doc for "why" when a decision is ambiguous.
+
+---
+
+## Locked decisions baked into this checklist
+
+- Cap = 5 verified emails per anchor.
+- Wizard directory: `setupEmailRecovery/` → `emailVerification/`. Shared views directory renames similarly to drop "recovery".
+- Candid evolution: additive new methods + legacy facades. Both live through Phases 1a-1b; legacy removed in 1c.
+- Storage: batched migration (1a lazy + 1b sweep + 1c cleanup). No big-bang `post_upgrade` rewrite.
+- Pending intent: FE-call path (commit with `is_recovery: false`; recovery-flow caller invokes `verified_email_set_recovery` after polling sees success). Flagged "still open" in the doc — implementation can proceed on this path and revisit only if it turns out to be wrong.
+- Subject prefix: `NONCE_PREFIX` flips to `II-Verify-`; `find_nonce_in` accepts both prefixes permanently.
+- No per-dapp pin; no global "don't share" toggle; no persistent retraction mechanism.
+- `last_shared_email_scope` lives on the anchor (canister-side), travels across devices.
+
+---
+
+## Phase 1a — New schema + lazy migration on touch
+
+### 1a.A. Backend: new types
+
+- [ ] Create [src/internet_identity/src/storage/storable/verified_email.rs](../../src/internet_identity/src/storage/storable/verified_email.rs):
+  ```rust
+  #[derive(Encode, Decode, Clone, Debug, Eq, PartialEq)]
+  #[cbor(map)]
+  pub struct StorableVerifiedEmail {
+      #[n(0)] pub address: String,
+      #[n(1)] pub verified_at: Timestamp,
+      #[n(2)] pub last_used_for_recovery_at: Option<Timestamp>,
+      #[n(3)] pub is_recovery: bool,
+  }
+  ```
+- [ ] Add `impl From<StorableEmailRecoveryCredential> for StorableVerifiedEmail` — maps `created_at → verified_at`, `last_used → last_used_for_recovery_at`, sets `is_recovery: true`. One-way only (this is the lazy-migration synthesizer).
+- [ ] Add candid mirror `VerifiedEmail` in [src/internet_identity_interface/src/internet_identity/types/email_recovery.rs](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs) with the same shape.
+- [ ] Add `impl From<StorableVerifiedEmail> for VerifiedEmail` and the reverse.
+
+### 1a.B. Backend: dual storage on anchor
+
+- [ ] [src/internet_identity/src/storage/storable/anchor.rs:30](../../src/internet_identity/src/storage/storable/anchor.rs:30) — add the new field alongside the legacy:
+  ```rust
+  #[n(N1)] pub email_recovery: Option<Vec<StorableEmailRecoveryCredential>>,  // legacy; never written by new code
+  #[n(N2)] pub verified_emails: Option<Vec<StorableVerifiedEmail>>,            // new
+  ```
+  Pick a new `#[n(...)]` field number; do not reuse the legacy one.
+
+### 1a.C. Backend: read/write abstraction
+
+- [ ] Add to [src/internet_identity/src/storage/anchor.rs](../../src/internet_identity/src/storage/anchor.rs):
+
+  ```rust
+  pub fn read_verified_emails(anchor: &StorableAnchor) -> Vec<StorableVerifiedEmail> {
+      if let Some(v) = &anchor.verified_emails { return v.clone(); }
+      if let Some(legacy) = &anchor.email_recovery {
+          return legacy.iter().cloned().map(StorableVerifiedEmail::from).collect();
+      }
+      Vec::new()
+  }
+
+  pub fn write_verified_emails(anchor: &mut StorableAnchor, new: Vec<StorableVerifiedEmail>) {
+      anchor.verified_emails = Some(new);
+      anchor.email_recovery = None;  // clear legacy
+  }
+  ```
+
+- [ ] Audit every direct access to `anchor.email_recovery`. Route through `read_verified_emails` / `write_verified_emails`. Expected call sites: [smtp.rs:727](../../src/internet_identity/src/email_recovery/smtp.rs:727), [remove.rs:51](../../src/internet_identity/src/email_recovery/remove.rs:51), [prepare.rs:582](../../src/internet_identity/src/email_recovery/prepare.rs:582), candid response builders in main.rs.
+- [ ] Unit test: legacy-only anchor (`verified_emails: None`, `email_recovery: Some(...)`) reads back correctly via `read_verified_emails`. First write through `write_verified_emails` clears the legacy field.
+
+### 1a.D. Backend: subject-prefix flip + cap + new helpers
+
+- [ ] [mod.rs:111](../../src/internet_identity/src/email_recovery/mod.rs:111) — `NONCE_PREFIX = "II-Verify-"`.
+- [ ] [smtp.rs:436](../../src/internet_identity/src/email_recovery/smtp.rs:436) (`find_nonce_in`) — accept both `II-Verify-` and `II-Recovery-` permanently. Unit test asserting both parse.
+- [ ] [mod.rs](../../src/internet_identity/src/email_recovery/mod.rs) — `pub const MAX_VERIFIED_EMAILS_PER_ANCHOR: usize = 5;`.
+- [ ] [prepare.rs:45](../../src/internet_identity/src/email_recovery/prepare.rs:45) (`prepare_add`) — enforce cap-5 using `read_verified_emails(anchor).len()`.
+- [ ] [smtp.rs:727](../../src/internet_identity/src/email_recovery/smtp.rs:727) — replace "overwrite the Vec with a single entry" with append-via-abstraction. New entries commit with `is_recovery: false`.
+- [ ] New function `set_recovery(anchor, address)` (in a new `src/internet_identity/src/email_recovery/set_recovery.rs`): atomically set `is_recovery: true` on the matching entry, clear it on every other entry of the same anchor, persist via `write_verified_emails`. Reject if the address isn't found.
+- [ ] [remove.rs:51](../../src/internet_identity/src/email_recovery/remove.rs:51) — route through `read_verified_emails` / `write_verified_emails`; behaviour for multi-entry follows naturally.
+
+### 1a.E. Backend: candid surface
+
+- [ ] [internet_identity.did:1570](../../src/internet_identity/internet_identity.did:1570) — add:
+
+  ```
+  type VerifiedEmail = record {
+      address: text;
+      verified_at: nat64;
+      last_used_for_recovery_at: opt nat64;
+      is_recovery: bool;
+  };
+
+  verified_email_prepare_add  : (IdentityNumber, EmailRecoveryDnsInput) -> (variant { Ok : EmailRecoveryChallenge; Err : EmailRecoveryError });
+  verified_email_set_recovery : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });
+  verified_email_remove       : (IdentityNumber, text) -> (variant { Ok; Err : EmailRecoveryError });
+  list_verified_emails        : (IdentityNumber) -> (vec VerifiedEmail) query;
+  ```
+
+- [ ] [src/internet_identity/src/main.rs](../../src/internet_identity/src/main.rs) — add handlers that delegate to the email_recovery module. Keep the existing `email_recovery_credential_prepare_add` and `email_recovery_credential_remove` handlers as facades:
+  - `email_recovery_credential_prepare_add` → calls `prepare_add`, then `set_recovery` on commit so the new entry comes out with `is_recovery: true` (preserves legacy semantics).
+  - `email_recovery_credential_remove` → calls the underlying remove against the entry currently flagged as recovery.
+- [ ] `npm run generate` after the `.did` change to refresh frontend types.
+
+### 1a.F. Backend: integration tests
+
+Two test files, split by concern:
+
+- [ ] **Keep** [src/internet_identity/tests/integration/email_recovery.rs](../../src/internet_identity/tests/integration/email_recovery.rs) — this is the regression net for the legacy candid surface (`email_recovery_credential_prepare_add`, `email_recovery_credential_remove`, the recovery-as-login flow). All of it still exists through Phases 1a-1b as facades over the new storage. Update only what changes:
+  - Existing assertions referencing `II-Recovery-` prefix → flip to assert `II-Verify-` for newly-issued nonces.
+  - Keep at least one test exercising the dual-accept parser by feeding an inbound message with `II-Recovery-<hex>` Subject and asserting it still resolves.
+  - Add a back-compat test: `email_recovery_credential_prepare_add` results in the new entry having `is_recovery: true` (via the facade calling `set_recovery` on commit).
+- [ ] **New file** `src/internet_identity/tests/integration/verified_emails.rs` — covers the new feature surface, no legacy concerns:
+  - Add via `verified_email_prepare_add` + SMTP flow → entry committed with `is_recovery: false`.
+  - Cap-5: a 6th `verified_email_prepare_add` is rejected.
+  - `verified_email_set_recovery` sets `is_recovery: true` and atomically clears it on every other entry of the same anchor.
+  - `verified_email_remove` deletes a non-recovery entry without affecting any other.
+  - `list_verified_emails` returns entries in their stored order.
+  - **Lazy migration**: a legacy-only anchor (`verified_emails: None`, `email_recovery: Some(...)`) returns the expected synthesized entry via `list_verified_emails`. The next `verified_email_*` write clears the legacy field.
+- [ ] Update DKIM test fixtures: [dkim/canonicalize.rs:254-255](../../src/internet_identity/src/dkim/canonicalize.rs:254), [types/smtp.rs:662](../../src/internet_identity_interface/src/internet_identity/types/smtp.rs:662) — flip to `II-Verify-deadbeef`. Keep one `II-Recovery-` fixture in the dual-accept tests.
+
+### 1a.G. Frontend: rename + parameterize the wizard
+
+- [ ] Rename [src/frontend/src/lib/components/wizards/setupEmailRecovery/](../../src/frontend/src/lib/components/wizards/setupEmailRecovery/) to `src/frontend/src/lib/components/wizards/emailVerification/`. Update import paths everywhere.
+- [ ] Rename the shared views directory [src/frontend/src/lib/components/wizards/emailRecovery/shared/](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/) similarly to drop "recovery" from the path (e.g. `src/frontend/src/lib/components/wizards/shared/email/`).
+- [ ] Add a `markAsRecovery: boolean` prop to the wizard's top-level component.
+- [ ] On polling success: if `markAsRecovery === true`, call `verified_email_set_recovery`; else the entry stays with `is_recovery: false`.
+- [ ] Existing recovery-flow caller passes `markAsRecovery={true}`; new settings-panel caller passes `markAsRecovery={false}`.
+
+### 1a.H. Frontend: new "Verified emails" settings panel
+
+- [ ] Create `src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte`:
+  - Lists `VerifiedEmail` rows from `list_verified_emails`.
+  - Per row: address, `verified_at`, "Used for recovery" radio (mutex across rows), Remove button.
+  - "Add an email" button → mounts the wizard with `markAsRecovery: false`.
+  - Recovery radio click → `verified_email_set_recovery`.
+  - Remove button → `verified_email_remove`.
+- [ ] Mount under the `/manage` route.
+- [ ] **No "Don't share my email" toggle.** Sharing happens (or doesn't) per-request in the consent dialog. Settings has no global sharing control.
+- [ ] Translation strings via `$t` calls; don't edit `.po` files directly.
+
+### 1a.I. Frontend: /authorize empty-state inline flow
+
+- [ ] [attributes.ts:674-678](../../src/frontend/src/lib/stores/channelHandlers/attributes.ts:674) — replace the silent empty-set short-circuit with an inline "Add a verified email" affordance that opens the wizard inside the authorize popup. On wizard success, the consent dialog re-evaluates sources and proceeds.
+
+### 1a.J. Frontend: e2e tests (file split + new specs)
+
+**Fixture rename:**
+
+- [ ] Rename [src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts](../../src/frontend/tests/e2e-playwright/fixtures/emailRecovery.ts) → `emailVerification.ts`. The contents (waiters, nonce regex, mailbox helpers) are about the verification flow, not specifically about recovery.
+- [ ] Update the nonce regex inside the renamed file from `/II-Recovery-[0-9a-f]{16}/` to `/II-(Verify|Recovery)-[0-9a-f]{16}/`. Both prefixes must still match because tests will be exercising both new flows (which emit `II-Verify-`) and dual-accept paths (which feed `II-Recovery-` inputs to assert backward compatibility).
+- [ ] Sweep all imports that referenced `emailRecovery.ts` → point at `emailVerification.ts`.
+
+**Spec split:**
+
+- [ ] **Rename** [src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts](../../src/frontend/tests/e2e-playwright/routes/emailRecovery.spec.ts) → `recoveryEmailLogin.spec.ts`. Scope it to **only** the recovery-as-login flow (anonymous user proves email ownership and gets a delegation — uses `recover@<domain>` mailbox). This concern is orthogonal to verified-emails-as-attribute-sources and stays roughly as-is.
+- [ ] Audit the renamed spec and remove any test cases that exercise the "setup a recovery email" flow — those move to the new file below.
+- [ ] **New spec** `src/frontend/tests/e2e-playwright/routes/verifiedEmails.spec.ts` — exercises the new feature surface:
+  - Add a verified email via the new settings panel → entry lands with no recovery flag.
+  - Promote a non-recovery entry to recovery via the row's radio → previously-recovery entry is demoted atomically.
+  - Remove a verified email → it disappears from `list_verified_emails`.
+  - Cap-5: attempting to add a 6th surfaces the right error.
+  - Legacy-flow back-compat: launching the wizard from the existing "Add a recovery email" entry point still produces an entry with `is_recovery: true`.
+
+### 1a.K. Boundary-node coordination
+
+- [ ] **Out of repo** — confirm with the relay owners whether the deployed SMTP relay does any Subject-level filtering, purpose-based bucketing, or operator-doc references to "recovery email".
+- [ ] If yes → coordinate the relay-side regex to accept both `II-Recovery-` and `II-Verify-` (matches the canister's parser). No grace period; both accepted permanently.
+- [ ] If no → record the confirmation. Nothing to do.
+
+### 1a.L. Documentation cleanup
+
+- [ ] [types/email_recovery.rs:78](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs:78) — update doc comment about nonce format.
+- [ ] Sweep comments referring to "recovery email" where the broader meaning is now correct — switch to neutral wording. Leave comments that genuinely refer to the `is_recovery` role untouched.
+
+---
+
+## Phase 1b — Controller-driven sweep of the long tail
+
+Ships in release N+1, after Phase 1a is stable in production.
+
+### 1b.A. Backend: sweep mechanism
+
+- [ ] Add `verified_email_migration_cursor: Option<AnchorNumber>` to persistent state (`None` = sweep complete).
+- [ ] New internal function `migrate_anchors_batch(batch_size: usize)`:
+  - From the current cursor, iterate up to `batch_size` anchors.
+  - For each, call `read_verified_emails(anchor)` then `write_verified_emails(anchor, ...)` — no-op for already-migrated anchors, copies legacy → new for the rest.
+  - Advance the cursor.
+- [ ] **Controller-callable** (not timer-driven). Expose as a controller-only update method.
+- [ ] Add query `verified_email_migration_status() -> { cursor, complete: bool, total_remaining: u64 }` so the operator knows when it's done.
+
+### 1b.B. Backend: tests
+
+- [ ] Integration test: anchors with legacy data, run `migrate_anchors_batch` until cursor reaches the end, confirm all anchors have `verified_emails: Some(...)` and `email_recovery: None`.
+- [ ] Idempotency test: running the sweep over already-migrated anchors is a no-op.
+
+### 1b.C. Operator runbook
+
+- [ ] Write a short runbook (either in repo at [docs/](../) or external if that's where ops lives): pre-migration status check, invocation pattern (batch size, cadence), post-migration confirmation. Include rollback notes — the legacy field is still present until 1c, so any individual anchor can be inspected for both fields.
+
+---
+
+## Phase 1c — Drop legacy field
+
+Ships in release N+2, after the sweep reports complete on prod and at least one full release cycle has passed.
+
+### 1c.A. Backend
+
+- [ ] Confirm `verified_email_migration_status()` reports `complete: true` on prod and has been stable for the buffer window.
+- [ ] Remove `email_recovery: Option<Vec<StorableEmailRecoveryCredential>>` from `StorableAnchor`.
+- [ ] Delete `StorableEmailRecoveryCredential`, its `From`/`Into` impls, and its source file [src/internet_identity/src/storage/storable/email_recovery_credential.rs](../../src/internet_identity/src/storage/storable/email_recovery_credential.rs).
+- [ ] Delete the synthesis path from `read_verified_emails`; it now reads `verified_emails` directly. `write_verified_emails` no longer needs to clear the legacy field.
+- [ ] Remove the legacy candid type `EmailRecoveryCredential` from [src/internet_identity_interface/src/internet_identity/types/email_recovery.rs](../../src/internet_identity_interface/src/internet_identity/types/email_recovery.rs).
+- [ ] Remove the legacy candid methods `email_recovery_credential_prepare_add` and `email_recovery_credential_remove` from [internet_identity.did](../../src/internet_identity/internet_identity.did) and their handlers in main.rs.
+- [ ] Remove `verified_email_migration_cursor` and `verified_email_migration_status` from state — they served their purpose.
+- [ ] (Optional, cosmetic) Rename `src/internet_identity/src/email_recovery/` modules to `verified_emails/` to match the model. Defer if it adds noise to the cleanup PR.
+
+### 1c.B. Tests
+
+- [ ] Verify the dual-accept `II-Recovery-` parser still works (intentionally kept indefinitely). Don't drop unless you've actively decided to.
+
+---
+
+## Phase 2 — Verified emails as attribute sources
+
+### 2.A. Backend
+
+- [ ] [types/attributes.rs](../../src/internet_identity_interface/src/internet_identity/types/attributes.rs) — add `AttributeScope::Verified { address_hash: String }` variant. Implement `Display` / parse to handle `verified:<16-hex>:<name>` consistently with the existing `openid:` / `sso:` shapes.
+- [ ] [attributes.rs:513](../../src/internet_identity/src/attributes.rs:513) (`list_available_attributes`) — extend the loop. After the existing `openid_credentials` walk, walk `read_verified_emails(anchor)`. For each entry, surface `verified:<H(addr)>:email` and `verified:<H(addr)>:verified_email`. Hash: SHA-256 of the lowercased address, truncated to the first 16 hex chars. **Read through the abstraction** so this works on both migrated and not-yet-migrated anchors.
+- [ ] Same module, `prepare_attributes` / `prepare_icrc3_attributes` — resolve `verified:<H>:email` by finding the entry whose hash matches (also via `read_verified_emails`).
+- [ ] Skip `verified:<H>:name` (no name claim from the verification flow). Mirror the existing exclusion pattern that skips `sso:<domain>:verified_email`.
+
+### 2.B. Frontend
+
+- [ ] [AttributeConsentView.svelte:165-173](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte:165>) (`scopedProviderLabel`) — extend to recognise `verified:` and return a localised "Verified email" string.
+- [ ] Add the "Verified email" translation string.
+
+### 2.C. Tests
+
+- [ ] Backend unit test: anchor with one verified email surfaces it via `list_available_attributes`; `prepare_icrc3_attributes` returns its value.
+- [ ] Backend unit test: hash stability — same address always hashes to the same scope key.
+- [ ] **New e2e spec** `src/frontend/tests/e2e-playwright/routes/emailAsAttribute.spec.ts`:
+  - Dapp requests `email` against an anchor with one verified email → consent dialog shows the "Verified email (<address>)" row → user accepts → dapp receives the value.
+  - Same with multiple verified emails → consent picker chevron expands to show each → user picks one → only that value is shared.
+  - Anchor with zero sources → empty-state inline "Add a verified email" affordance appears (Phase 1a's empty-state flow), wizard completes, control returns to the consent dialog with a now-available source.
+
+---
+
+## Phase 3 — Smart-routing + last-used default
+
+### 3.A. Backend
+
+- [ ] Add `last_shared_email_scope: Option<String>` to `StorableAnchor` (new `#[n(N)]` tag).
+- [ ] [attributes.rs](../../src/internet_identity/src/attributes.rs) — `prepare_icrc3_attributes` (or the equivalent commit path): when the user shares an unscoped `email` / `verified_email`, write the resolved scope into `last_shared_email_scope` on the anchor. **Deny does not update this field** — we track last _shared_, not last action.
+- [ ] Expose `last_shared_email_scope` to the FE — add it to `IdentityInfo` (or whatever the FE reads at authorize time) as `opt text`.
+
+### 3.B. Frontend
+
+- [ ] [AttributeConsentView.svelte](<../../src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte>) — `selections` map init (around line 130). Change `selectedIndex: 0` to resolve via:
+  1. If `anchor.last_shared_email_scope` matches one of this group's option scopes → that index.
+  2. Else smart-routing: current session signed in via OIDC/SSO → that source; passkey + any verified email → first such entry; else first available.
+  3. Else `0`.
+- [ ] No other UI changes. No "Primary" badge, no "remember this choice" affordance, no first-time priming flow, no per-dapp pin, no global "don't share" toggle.
+
+### 3.C. Tests
+
+- [ ] Backend unit test: sharing an unscoped `email` updates `last_shared_email_scope`. Deny-all doesn't.
+- [ ] Backend unit test: stale-source — `last_shared_email_scope` points at a now-removed entry; resolution falls back to smart-routing silently.
+- [ ] Frontend test: pre-selection matches `last_shared_email_scope` after a previous share.
+
+---
+
+## Cross-cutting before merge (every PR)
+
+- [ ] `cargo fmt`, `cargo clippy`, `cargo test` per [backend-format](../../.identity-team-skills/skills/backend-format/SKILL.md).
+- [ ] `npm run check`, `npm run lint`, `npm run test`, `npm run format`.
+- [ ] `npm run generate` after every `.did` change.
+- [ ] Don't commit `.po` files — the translation bot owns those.
+- [ ] User-visible strings say "verify"/"verified", not "recovery" (except where they specifically refer to the recovery role).
+
+## Suggested PR breakdown
+
+- `feat(be,fe): verified emails as a first-class anchor primitive (lazy migration from recovery-email storage)` — Phase 1a end to end.
+- `feat(be): controller-driven sweep of legacy email_recovery entries` — Phase 1b.
+- `chore(be): drop legacy email_recovery field after migration sweep completes` — Phase 1c.
+- `feat(be,fe): verified emails as ICRC-3 attribute sources` — Phase 2.
+- `feat(be,fe): last-used default in attribute consent dialog` — Phase 3.

--- a/docs/design/verified-email-implementation.md
+++ b/docs/design/verified-email-implementation.md
@@ -98,11 +98,21 @@
 ### 1.E. Backend: cap + helpers
 
 - [ ] [src/internet_identity/src/email_recovery/mod.rs](../../src/internet_identity/src/email_recovery/mod.rs) — `pub const MAX_VERIFIED_EMAILS_PER_ANCHOR: usize = 5;`.
-- [ ] New module `src/internet_identity/src/verified_emails/` (or extend `email_recovery/` if you prefer — the verification primitive is genuinely shared). New file `verified_emails/prepare.rs` mirroring [prepare.rs](../../src/internet_identity/src/email_recovery/prepare.rs):
+- [ ] Three sibling modules at the crate root reflect the actual layering: `email_inbound/` owns the shared inbound-DKIM-challenge primitive (pending map, SMTP dispatcher, DKIM leaf submission, nonce RNG, shared `prepare_common` core, shared constants), and `email_recovery/` and `verified_emails/` are two consumer flows built on top of it. Neither flow module reaches into the other. New file `verified_emails/prepare.rs` calls `email_inbound::prepare::prepare_common` to mirror the recovery prepare path:
   - `pub async fn prepare_add(anchor: AnchorNumber, dns_input: EmailRecoveryDnsInput, now_secs: u64) -> Result<EmailRecoveryChallenge, EmailRecoveryError>` — same structure as the recovery `prepare_add`, but stores `PendingKind::VerifyEmail { anchor }` and issues the nonce with the `II-Verify-` prefix.
   - Enforce the cap: reject if `anchor.verified_emails.as_ref().map_or(0, |v| v.len()) >= MAX_VERIFIED_EMAILS_PER_ANCHOR`.
 - [ ] New `verified_emails/remove.rs`: `pub fn remove(anchor: &mut Anchor, address: &str) -> Result<Operation, RemoveError>`. Find the matching entry in `verified_emails`, remove it. Does not touch `email_recovery`.
 - [ ] Commit logic on verification success (in `submit_leaf.rs` or wherever the `SnapshotKind::VerifyEmail` arm lands): append a new `StorableVerifiedEmail { address, verified_at: now }` to `Anchor.verified_emails`. Initialize the Vec if `None`.
+- [ ] **Commit-time cap recheck.** Inside the same `SnapshotKind::VerifyEmail` commit arm, before appending, re-evaluate `anchor.verified_emails.len() >= MAX_VERIFIED_EMAILS_PER_ANCHOR` and drop the write (return an error suitable for the polling loop to surface) if the cap is now full. Necessary because two concurrent `prepare_add` calls at cap-1 both pass the prepare-time check, both verify, and a single check at prepare time would let both commits land. Unit test: simulate two committed verifications racing into a cap-1 anchor; only one should land.
+- [ ] **Pending-entry collision behavior.** When `verified_email_prepare_add` is called for an anchor + address that already has a pending `PendingKind::VerifyEmail` entry, replace the existing entry with the fresh nonce (mirrors the recovery flow's behavior). Do not create two pending entries for the same (anchor, address). Old nonces still in the user's inbox stop matching. Unit test asserting the second prepare overwrites, doesn't duplicate.
+
+### 1.E.bis. Backend: silent mirror on OIDC / SSO link
+
+- [ ] [src/internet_identity/src/storage/anchor.rs](../../src/internet_identity/src/storage/anchor.rs) — add `Anchor::mirror_verified_email_from_oidc(&mut self, address: &str, verified_at_ns: Timestamp) -> bool`. Case-insensitive ASCII dedup against `verified_emails`; respect `MAX_VERIFIED_EMAILS_PER_ANCHOR`; lowercase the stored address; never return an error. Returns `true` when an entry was appended.
+- [ ] [src/internet_identity/src/anchor_management.rs](../../src/internet_identity/src/anchor_management.rs) — inside `add_openid_credential_skip_checks` (the choke point for both `openid_credential_add` and `openid_identity_registration_finish`), read `openid_credential.get_verified_email()` _before_ moving the credential into the anchor, then call `anchor.mirror_verified_email_from_oidc(&addr, ic_cdk::api::time())` after the credential add succeeds. The mirror writes happen in the same atomic anchor write as the OIDC credential add.
+- [ ] Do **not** mirror on `openid_credential_remove` or anywhere else. The mirror is one-way.
+- [ ] Unit tests in [storage/anchor/tests.rs](../../src/internet_identity/src/storage/anchor/tests.rs) covering: append on new address, lowercase normalisation, dedup preserves existing `verified_at` (no refresh on re-link), cap-respect skips silently.
+- [ ] Integration test: link an OIDC credential whose JWT carries `email_verified: true` → `Anchor.verified_emails` contains the address; remove the OIDC credential → entry persists; remove the verified-email entry through the panel; re-adding the same address only works through the DKIM flow.
 
 ### 1.F. Backend: candid surface
 
@@ -141,6 +151,9 @@
   - The polling helper `runEmailRecoveryPoll` from [emailRecovery/shared/](../../src/frontend/src/lib/components/wizards/emailRecovery/shared/) (purpose-neutral once the pending entry exists).
 - [ ] Wizard flow: address input → call `verified_email_prepare_add` → show the dialog with the canister-issued nonce (`II-Verify-…`) → poll for status → success/failure view.
 - [ ] **No `markAsRecovery` prop, no recovery branching.** The wizard is exclusively for adding entries to `verified_emails`. If a user wants their address as a recovery email too, they use the existing recovery flow separately.
+- [ ] **Recovery-overlap heads-up.** On the address-entry view, when the user presses Continue, case-insensitively compare the typed address against the anchor's current `email_recovery` entry (already loaded for the surrounding Communication panel — no extra canister call). On match, render a non-blocking banner above Continue: "This is also your recovery email. Verifying it here adds it as a separate verified entry — the two are independent, so removing one won't affect the other." Continue still works. Banner clears if the user edits the address so it no longer overlaps. String via `$t`.
+- [ ] **Normalize the typed address before the overlap check** (and before sending to the canister): `.trim().toLowerCase()`. Without normalization, `Foo@Example.com` typed in the wizard wouldn't match a stored `foo@example.com` and the overlap banner would silently fail to fire.
+- [ ] **Cap-full error UX.** When `verified_email_prepare_add` returns the cap-reached error variant, the wizard's address-entry view renders a blocking inline error in place of the normal validation row: "You already have 5 verified emails — the limit per identity. Remove one from the Communication settings page to add another." Continue is disabled until the user edits the field (the disabling exists only to make it obvious that retrying won't help; the next attempt is still allowed). The wizard does not surface this as a toast — the user is already in the wizard, the message belongs there. String via `$t`.
 
 ### 1.I. Frontend: narrow "Verified emails" settings panel
 
@@ -154,6 +167,7 @@ This is the **narrow** version that ships with Phase 1. Phase 1.5 widens it into
   - **No global "Don't share my email" toggle.**
 - [ ] Mount under the `/manage` route, alongside (not replacing) the existing recovery email section.
 - [ ] Copy follows the "Copy and tone" guidance in the design doc — empty state leads with user benefit, not "add an email" as a bare CTA. Strings via `$t` calls; don't edit `.po` files directly.
+- [ ] **Verified-overlap heads-up on the recovery wizard.** Symmetric to the verified wizard's recovery-overlap banner: in [src/frontend/src/lib/components/wizards/setupEmailRecovery/views/EnterAddress.svelte](../../src/frontend/src/lib/components/wizards/setupEmailRecovery/views/EnterAddress.svelte), on Continue, case-insensitively compare the typed address against `Anchor.verified_emails` (loaded via `identity_info` for the surrounding manage view — no extra canister call). On match, render a non-blocking banner above Continue: "This is already a verified email on your account. Setting it as your recovery email adds it to a separate bucket — the two are independent, so removing one won't affect the other." Continue still works. Banner clears if the user edits the address so it no longer overlaps. String via `$t`.
 
 ### 1.J. Frontend: /authorize empty-state inline flow
 
@@ -169,6 +183,8 @@ This is the **narrow** version that ships with Phase 1. Phase 1.5 widens it into
   - Remove a verified email → it disappears.
   - Cap-5: attempting to add a 6th surfaces the right error.
   - The recovery email flow remains untouched: adding a recovery email through the existing CTA still produces an `email_recovery` entry and does NOT populate `verified_emails`.
+- [ ] FE unit test (verified wizard): Continue with an address matching the anchor's `email_recovery` entry → recovery-overlap banner appears; Continue still proceeds; editing the address to a non-overlapping value clears the banner. Case-insensitive match.
+- [ ] FE unit test (recovery wizard): Continue with an address matching any `verified_emails` entry → verified-overlap banner appears; Continue still proceeds; editing the address to a non-overlapping value clears the banner. Case-insensitive match.
 
 ### 1.L. Documentation cleanup
 
@@ -186,35 +202,33 @@ Pure FE work. No new candid, no new storage, no backend changes. Depends on Phas
 - [ ] Rename or refactor `src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte` into a "Reach" page component (or restructure as a child of the existing settings page — pick whatever matches the existing `/manage` layout best). Page title: "Reach". Subtitle: "How apps can reach you when you sign in." (Final strings land with UX review.)
 - [ ] Inside the page, add a "Verified emails" section header with a short subtitle (mockup uses "Apps can request one of these to reach you. Never shared without your consent.").
 
-### 1.5.B. Verified emails section (unified)
+### 1.5.B. Verified emails section
 
-- [ ] Render the list from the union of two sources:
-  - `openid_credentials` entries whose `email_verified` claim is true.
-  - SSO credentials whose IdP vouches for the address (same condition; the credential type already encodes verified status).
-  - `verified_emails` entries from Phase 1.
-- [ ] Dedup by address: if the same address appears in multiple sources, render one row. Source label prefers the IdP name; verification date uses whichever source produced it (most-recent wins on ties).
-- [ ] Source icon per row: per-IdP icon (Google, Microsoft, Apple, and any other configured IdPs); generic envelope for entries backed only by `verified_emails`. Reuse existing icon assets when available — most are already in `src/frontend/src/lib/components/icons/` or similar.
-- [ ] Remove button: only on rows backed exclusively by `verified_emails`. IdP-backed rows silently hide the Remove button (no tooltip).
+- [ ] Render the list from `Anchor.verified_emails` only. No union, no dedup — the Phase 1 backend mirror already writes IdP-vouched emails into this field at link time.
+- [ ] Source-affinity badge (FE-only join, case-insensitive address compare): for each verified row whose address also appears on a current `openid_credentials` row, render the per-IdP icon (Google, Microsoft, Apple, or any other configured provider) as a small badge. Verified rows without a matching credential render a generic envelope icon. Reuse existing icon assets from `src/frontend/src/lib/components/icons/`.
+- [ ] Multi-IdP tie-break for the badge: when two or more `openid_credentials` entries match the same verified address (e.g. user linked both Google and Microsoft for the same mailbox), pick the credential with the largest `last_usage_timestamp`; on tie, fall back to insertion order in the credentials list. Render that IdP's icon only — no stacking. FE unit test asserting the deterministic pick.
+- [ ] Remove button: always shown. Every row is a `verified_emails` entry the user owns; removing it is a direct deletion and does not affect any linked OIDC credential.
 - [ ] Cap counter below the list, always visible: "N of 5 verified emails" (final wording TBD).
 - [ ] "Add an email" CTA → mounts the wizard from Phase 1.
 
 ### 1.5.C. Unverified emails section
 
 - [ ] New section "Unverified emails" beneath the Verified section. Subtitle (mockup wording): "Verify one of these so apps can use it to reach you."
-- [ ] Lists `openid_credentials` / SSO credentials whose `email_verified` claim is false.
+- [ ] Lists `openid_credentials` / SSO credentials whose `email_verified` claim is false **and** whose address is not already in `verified_emails` (same case-insensitive compare used for the source-affinity badge). The filter prevents an OIDC unverified row from shadowing a verified row covering the same address.
 - [ ] Per row: address, source label ("Microsoft · Not verified"), source icon, "Verify" CTA.
-- [ ] **Hide the section entirely** when no unverified entries exist.
+- [ ] **Hide the section entirely** when no unverified entries exist after the filter.
 
 ### 1.5.D. Verify-from-unverified flow
 
 - [ ] "Verify" button on an unverified row opens the Phase 1 wizard with the address pre-filled. The address field is **read-only** in this entry mode so the user can't accidentally verify a different address than the one they clicked.
 - [ ] On wizard success: a new `StorableVerifiedEmail` entry lands in `Anchor.verified_emails` via `verified_email_prepare_add` → DKIM challenge → poll. **The original OIDC/SSO credential is not modified.**
-- [ ] After success, refetch the dashboard data. The address now appears in both `openid_credentials` (the unchanged IdP cred, still `email_verified: false`) and `verified_emails` (the new entry). Dedup renders one row in the Verified section, sourced from the IdP, dated as the II verification.
+- [ ] After success, refetch the dashboard data. The Unverified-section filter drops the row (address now in `verified_emails`); the Verified section renders it with the originating IdP's icon as the source-affinity badge.
 
 ### 1.5.E. Tests
 
-- [ ] FE unit test: dedup produces one row when the same address is in both `openid_credentials` and `verified_emails`.
-- [ ] FE unit test: Remove button visibility — visible on `verified_emails`-only rows, hidden on IdP-backed rows.
+- [ ] FE unit test: source-affinity badge renders the IdP icon when the address matches an `openid_credentials` entry; generic envelope otherwise.
+- [ ] FE unit test: Remove button is always present on verified rows (independent of whether the address also lives on an `openid_credentials` entry).
+- [ ] FE unit test: Unverified section filter drops OIDC `email_verified: false` rows whose address is already in `verified_emails`.
 - [ ] FE unit test: Unverified section hides entirely when there are no unverified entries.
 - [ ] E2E test: anchor with an unverified OIDC email → user clicks Verify → wizard opens with the address pre-filled and read-only → completes DKIM → row moves to Verified section after re-fetch.
 - [ ] E2E test: cap counter reflects the actual count.
@@ -257,6 +271,7 @@ Pure FE work. No new candid, no new storage, no backend changes. Depends on Phas
 
 - [ ] Add `last_shared_email_scope: Option<String>` to `StorableAnchor` (new `#[n(N)]` tag, additive).
 - [ ] [attributes.rs](../../src/internet_identity/src/attributes.rs) — `prepare_icrc3_attributes` (or the equivalent commit path): when the user shares an unscoped `email` / `verified_email`, write the resolved scope into `last_shared_email_scope` on the anchor. **Deny does not update this field** — we track last _shared_, not last action.
+- [ ] Write timing is at `prepare_icrc3_attributes` success, **not** deferred to `get_icrc3_attributes` consumption. A network drop between prepare and consume could record a share the dapp never collected — accepted, since from the user's perspective they clicked Continue with that intent. Documented in the spec under Phase 3 "Write timing".
 - [ ] Expose `last_shared_email_scope` to the FE — add it to `IdentityInfo` (or whatever the FE reads at authorize time) as `opt text`.
 
 ### 3.B. Frontend


### PR DESCRIPTION
Internet Identity has a single recovery-email slot per anchor, verified through an inbound DKIM/DMARC/DNSSEC ownership-proof flow. Dapps can request `email` / `name` / `verified_email` attributes but only from linked OpenID/SSO sources — the recovery email is invisible to that surface. Users can't add multiple verified emails for any other purpose, and there's no way to share an email with a dapp that doesn't go through a third-party identity provider.

This PR adds two design artifacts to start the conversation; no code changes.

## Changes

Two new files under `docs/design/`:

- **`verified-email-attributes.md`** — design doc. Proposes adding verified emails as a **new, independent first-class anchor primitive** that lives alongside the existing recovery-email slot. The recovery flow stays untouched; verified emails are a parallel new feature that shares the verification primitive (inbound DKIM challenge) but uses separate storage, separate candid methods, a separate wizard component, a separate `II-Verify-` subject prefix, and a separate `PendingKind::VerifyEmail` variant. Four phases, each shipping as a single release:
  - Phase 1: verified-emails primitive — new `StorableVerifiedEmail` type, new `verified_emails` field added additively (no migration), new `verified_email_*` candid surface, new wizard + narrow settings panel + `/authorize` empty-state inline flow.
  - Phase 1.5: pure-FE "Reach" page that widens the narrow panel into a unified dashboard surfacing OIDC/SSO emails alongside `verified_emails` entries, with a separate "Unverified emails" section and a Verify-from-unverified flow that promotes IdP-issued emails through the DKIM challenge.
  - Phase 2: verified emails as ICRC-3 attribute sources under a new `verified:<H(address)>:email` scope. Recovery email is intentionally not exposed.
  - Phase 3: smart-routing + last-used default in the consent dialog; no per-dapp pin, no global "don't share" toggle (sharing is per-request, always).
- **`verified-email-implementation.md`** — operational checklist. File-path-level steps for implementers, with locked decisions stated up front (cap=5, additive storage, parallel concepts, no migration, dual-prefix parser, `verifiedEmail/` wizard directory, "Reach" page name with per-IdP source icons) and a suggested PR breakdown for the eventual feature work.

Includes a "Copy and tone" subsection that commits to framing the share as a net benefit rather than as friction, with principles for the new surfaces (empty-state prompt, settings panel, wizard success) and explicit non-changes for the existing consent dialog.

Both files cross-link to each other. The design doc explains *why*; the checklist is *what to do*.