### PR TITLE
fix(ci): pass mcp_server_origin in e2e frontend install args

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -615,7 +615,7 @@ jobs:
           dnssec_config="$(node src/frontend/tests/e2e-playwright/utils/renderDnssecTestAnchor.mjs)"
           icp canister install internet_identity --wasm internet_identity_backend.wasm.gz --args "(opt record { captcha_config = opt record { max_unsolved_captchas= 50:nat64; captcha_trigger = variant {Static = variant { CaptchaDisabled }}}; related_origins = opt vec { \"https://id.ai\"; \"https://identity.ic0.app\"; \"https://identity.internetcomputer.org\" }; new_flow_origins = opt vec { \"https://id.ai\" }; openid_configs = opt vec { ${{ steps.openid-configs.outputs.OPENID_CONFIGS }} }; sso_discoverable_domains = opt vec { $sso_domains_vec }; enable_dnssec_email_recovery = opt true; dnssec_config = $dnssec_config })"
           II_CANISTER_ID=$(icp canister status internet_identity --id-only)
-          icp canister install internet_identity_frontend --wasm internet_identity_frontend.wasm.gz --args "(record { backend_canister_id = principal \"$II_CANISTER_ID\"; backend_origin = \"https://backend.id.ai\"; related_origins = opt vec { \"https://id.ai\"; \"https://identity.ic0.app\"; \"https://identity.internetcomputer.org\" }; fetch_root_key = opt true; dev_csp = opt true })"
+          icp canister install internet_identity_frontend --wasm internet_identity_frontend.wasm.gz --args "(record { backend_canister_id = principal \"$II_CANISTER_ID\"; backend_origin = \"https://backend.id.ai\"; related_origins = opt vec { \"https://id.ai\"; \"https://identity.ic0.app\"; \"https://identity.internetcomputer.org\" }; fetch_root_key = opt true; dev_csp = opt true; mcp_server_origin = opt \"https://mcp.id.ai\" })"
           icp canister install test_app --wasm demos/test-app/test_app.wasm
 
       - name: Run dev server


### PR DESCRIPTION
## Why CI is failing on #4026

The e2e `e2e-playwright` job (shard `6_6`, both `desktop` and `mobile`) failed: all 6 interactive `routes/mcp.spec.ts` tests timed out (the 2 "Invalid request" cases passed).

Root cause: the `/mcp` flow is gated on the deploy-configured `mcp_server_origin`. When unset, `getMcpServerOrigin()` is `undefined`, so `requestValid` is always `false` and every real request renders the **Invalid request** screen — which is exactly why the gated-screen / Allow-access tests never found their elements.

The e2e job installs the frontend canister with **inline `--args`** (overriding the `local_test_arg.did.template`, as the workflow comments note), and that inline record omitted `mcp_server_origin`. The `mcp` fixture posts to `https://mcp.id.ai`, so the canister must be deployed with that origin.

## Fix

Add `mcp_server_origin = opt "https://mcp.id.ai"` to the frontend install `--args` in `.github/workflows/canister-tests.yml`, matching the origin the fixture uses.

This PR targets `feat/mcp-authorize` so the fix lands on #4026's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174RnuPSyzddg68qZBXYKE1

---
_Generated by [Claude Code](https://claude.ai/code/session_0174RnuPSyzddg68qZBXYKE1)_