### PR TITLE
feat(fe): gate MCP card and /mcp route behind a feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ dist-showcase/
 lib
 !src/frontend/src/lib
 !src/try-ii/src/try-ii-frontend/src/lib
-/.svelte-kit
+.svelte-kit
 
 # Cargo build output
 target/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9308,6 +9308,21 @@
         }
       }
     },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/svelte-check/node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -9786,7 +9801,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/frontend/src/lib/state/featureFlags.test.ts
+++ b/src/frontend/src/lib/state/featureFlags.test.ts
@@ -20,6 +20,7 @@ const {
   MIN_GUIDED_UPGRADE,
   EMAIL_RECOVERY,
   EMAIL_RECOVERY_SETUP,
+  MCP,
 } = await import("$lib/state/featureFlags");
 
 // `window.location` is read-only, so swap it for a writable stand-in we can
@@ -47,6 +48,7 @@ beforeEach(() => {
   DISCOVERABLE_PASSKEY_FLOW.getFeatureFlag()?.reset();
   EMAIL_RECOVERY.getFeatureFlag()?.reset();
   EMAIL_RECOVERY_SETUP.getFeatureFlag()?.reset();
+  MCP.getFeatureFlag()?.reset();
 });
 
 afterEach(() => {
@@ -137,6 +139,45 @@ test("configured true turns email-recovery flags on off-domain", () => {
 
   expect(get(EMAIL_RECOVERY)).toEqual(true);
   expect(get(EMAIL_RECOVERY_SETUP)).toEqual(true);
+});
+
+test("MCP flag defaults on for id.ai and beta.id.ai", () => {
+  for (const hostname of ["id.ai", "beta.id.ai"]) {
+    setHostname(hostname);
+    MCP.getFeatureFlag()?.reset();
+
+    MCP.initialize();
+
+    expect(get(MCP), hostname).toEqual(true);
+  }
+});
+
+test("MCP flag stays off on other domains when unconfigured", () => {
+  setHostname("example.com");
+
+  MCP.initialize();
+
+  expect(get(MCP)).toEqual(false);
+});
+
+test("configured false keeps MCP flag off even on id.ai", () => {
+  setHostname("id.ai");
+  mockGetConfiguredFeatureFlag.mockReturnValue(false);
+
+  MCP.initialize();
+
+  expect(get(MCP)).toEqual(false);
+});
+
+test("configured true turns MCP flag on off-domain", () => {
+  setHostname("example.com");
+  mockGetConfiguredFeatureFlag.mockImplementation((name) =>
+    name === "MCP" ? true : undefined,
+  );
+
+  MCP.initialize();
+
+  expect(get(MCP)).toEqual(true);
 });
 
 test("the two email-recovery flags resolve independently from config", () => {

--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -152,6 +152,14 @@ export const EMAIL_RECOVERY_SETUP = createFeatureFlagStore(
   enableOnIdAiDomains("EMAIL_RECOVERY_SETUP"),
 );
 
+/// Show the MCP access card in settings and allow the /mcp delegation flow.
+/// Defaults on for id.ai and beta.id.ai; off everywhere else.
+export const MCP = createFeatureFlagStore(
+  "MCP",
+  false,
+  enableOnIdAiDomains("MCP"),
+);
+
 export default {
   DOMAIN_COMPATIBILITY,
   HARDWARE_KEY_TEST,
@@ -161,4 +169,5 @@ export default {
   MIN_GUIDED_UPGRADE,
   EMAIL_RECOVERY,
   EMAIL_RECOVERY_SETUP,
+  MCP,
 } as Record<string, FeatureFlagStore>;

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/+page.svelte
@@ -2,6 +2,7 @@
   import { authenticatedStore } from "$lib/stores/authentication.store";
   import { Trans } from "$lib/components/locale";
   import { t } from "$lib/stores/locale.store";
+  import { MCP } from "$lib/state/featureFlags";
   import CliAccessSection from "./components/CliAccessSection.svelte";
   import McpAccessSection from "./components/McpAccessSection.svelte";
 </script>
@@ -17,5 +18,7 @@
 
 <div class="mt-10 flex max-w-3xl flex-col gap-5">
   <CliAccessSection identityNumber={$authenticatedStore.identityNumber} />
-  <McpAccessSection identityNumber={$authenticatedStore.identityNumber} />
+  {#if $MCP}
+    <McpAccessSection identityNumber={$authenticatedStore.identityNumber} />
+  {/if}
 </div>

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -66,7 +66,9 @@
     }
   };
   const requestValid = $derived(
-    $MCP && params.kind === "valid" && callbackMatchesMcpServer(params.callback),
+    $MCP &&
+      params.kind === "valid" &&
+      callbackMatchesMcpServer(params.callback),
   );
 
   const authFlow = new AuthLastUsedFlow();

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -14,6 +14,7 @@
   import { handleError } from "$lib/components/utils/error";
   import { toaster } from "$lib/components/utils/toaster";
   import { getMcpServerOrigin } from "$lib/globals";
+  import { MCP } from "$lib/state/featureFlags";
   import { get } from "svelte/store";
   import { onMount } from "svelte";
   import McpHero from "./components/McpHero.svelte";
@@ -65,7 +66,7 @@
     }
   };
   const requestValid = $derived(
-    params.kind === "valid" && callbackMatchesMcpServer(params.callback),
+    $MCP && params.kind === "valid" && callbackMatchesMcpServer(params.callback),
   );
 
   const authFlow = new AuthLastUsedFlow();


### PR DESCRIPTION
## Summary

- Adds a new `MCP` feature flag in `featureFlags.ts` that defaults **off** everywhere except `id.ai` and `beta.id.ai` (matching the `EMAIL_RECOVERY_SETUP` pattern)
- Gates `McpAccessSection` in the Settings page behind `{#if $MCP}` so the card is hidden on self-hosted / other deployments
- Gates the `/mcp` delegation route by including `$MCP` in the `requestValid` derived — when the flag is off, the route falls through to the existing "Invalid request" screen

The flag can be overridden per-deployment via the canister `feature_flags` deploy arg, or at runtime via `window.__featureFlags.MCP` / `?feature_flag_MCP=true` / localStorage, consistent with all other flags. E2e tests are unaffected because they run against `id.ai` where the flag auto-enables.

## Test plan

- [ ] On `id.ai` / `beta.id.ai`: MCP card still visible in Settings; `/mcp` flow works normally
- [ ] On a self-hosted deployment (no domain match): MCP card absent from Settings; `/mcp` shows "Invalid request"
- [ ] Operator can force-enable via `feature_flags = opt vec { ("MCP", true) }` in deploy args
- [ ] Developer can toggle via browser console: `window.__featureFlags.MCP.set(true/false)`
- [ ] Existing e2e tests for MCP pass (flag auto-on for `id.ai` test origin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHcuf29nw3agmxeXvXd23G)_