### PR TITLE
feat(monitoring): add IMCP (IC MCP) server status dashboard

### DIFF
--- a/monitoring/mcp-status/README.md
+++ b/monitoring/mcp-status/README.md
@@ -39,8 +39,9 @@ node monitoring/mcp-status/cli.js --mcp https://mcp.id.ai
 node monitoring/mcp-status/cli.js --json
 
 # Live web dashboard at http://localhost:8080 (auto-refreshing)
+# (target is fixed at startup; pass --mcp/--ii to monitor another deployment)
 npm run mcp-status:serve
-node monitoring/mcp-status/server.js --port 8080
+node monitoring/mcp-status/server.js --port 8080 --mcp https://mcp.id.ai
 
 # Unit tests
 npm run mcp-status:test
@@ -53,11 +54,12 @@ CI job, or an uptime check.
 
 ### Allowed targets (SSRF guard)
 
-Because `server.js` accepts `?mcp=`/`?ii=` overrides over HTTP, probe targets
-are validated against a host allowlist: only `https` origins on `id.ai` (and its
-sub-domains), plus loopback hosts for local development, may be probed. This
-stops the dashboard from being used to reach arbitrary or internal hosts. To
-monitor a deployment on another domain, extend the allowlist via the
+The web server probes only the target fixed at startup — it never takes the
+target from an incoming request, so a visitor cannot steer server-side requests
+at arbitrary hosts. As defence in depth, every resolved origin is also validated
+against a host allowlist: only `https` origins on `id.ai` (and its sub-domains),
+plus loopback hosts for local development, may be probed. To monitor a
+deployment on another domain, extend the allowlist via the
 `MCP_STATUS_ALLOWED_HOSTS` environment variable (comma-separated host suffixes).
 
 ## Why a standalone tool (and not a page in the II frontend)?

--- a/monitoring/mcp-status/README.md
+++ b/monitoring/mcp-status/README.md
@@ -1,0 +1,84 @@
+# IMCP (IC MCP) status dashboard
+
+A small, dependency-free monitoring tool for the **IC MCP** server
+([https://mcp.beta.id.ai](https://mcp.beta.id.ai) by default) and the **Internet
+Identity** instance it is paired with.
+
+It answers three questions and adds a few suggestions:
+
+1. **Is the server running and responding on all advertised endpoints with the
+   correct status codes?** — probes the landing page, the two OAuth discovery
+   documents, the `/mcp` endpoint's unauthenticated `401` challenge, dynamic
+   client registration, and the `/oauth/authorize` + `/oauth/token` endpoints,
+   plus TLS certificate freshness.
+2. **Which Internet Identity instance is it linked to?** — resolves the II
+   origin (derived from the `mcp.<env>.id.ai` ↔ `<env>.id.ai` convention,
+   overridable, and confirmed live via the `/oauth/authorize` redirect when the
+   server exposes one).
+3. **Is that II instance healthy and does it recognise this MCP server?** —
+   checks the II frontend is reachable and IC-certified, reports its frontend
+   canister id and related origins, and verifies that the II's response CSP
+   `form-action` directive lists this MCP origin. That directive is derived
+   server-side from the II canister's `mcp_server_origin` config, so it is the
+   authoritative signal that the II trusts this MCP server and that the `/mcp`
+   delegation flow is enabled for it.
+
+## Usage
+
+No install step and no dependencies — just Node ≥ 20 (uses the global `fetch`).
+
+```bash
+# Text report for the default beta deployment (exit code 0 = healthy)
+npm run mcp-status
+node monitoring/mcp-status/cli.js
+
+# Point it at another deployment (e.g. production)
+node monitoring/mcp-status/cli.js --mcp https://mcp.id.ai
+
+# Machine-readable output for alerting / CI
+node monitoring/mcp-status/cli.js --json
+
+# Live web dashboard at http://localhost:8080 (auto-refreshing)
+npm run mcp-status:serve
+node monitoring/mcp-status/server.js --port 8080
+
+# Unit tests
+npm run mcp-status:test
+```
+
+CLI options: `--mcp <origin>`, `--ii <origin>`, `--timeout <ms>`, `--json`,
+`--no-color`, `--strict` (exit non-zero on warnings too), `--help`. The exit
+code is `0` when healthy and `1` on failures, so it slots straight into cron, a
+CI job, or an uptime check.
+
+## Why a standalone tool (and not a page in the II frontend)?
+
+The II frontend is a **static, prerendered, `ssr: false` SvelteKit app** served
+from a canister — it has no server runtime to probe from. More importantly, the
+signals that matter here are **not readable from a browser**: the MCP server's
+`/mcp` `401` challenge and HTML landing page send no CORS headers, and the II
+instance's `Content-Security-Policy` header (where recognition is verified)
+can't be inspected cross-origin. Running the probes server-side in this small
+Node tool sidesteps CORS entirely and lets the dashboard check everything that
+actually matters.
+
+## Files
+
+| File               | Purpose                                                        |
+| ------------------ | -------------------------------------------------------------- |
+| `config.js`        | Target resolution (defaults, env vars, II-origin derivation).  |
+| `checks.js`        | All probing logic; exports `runDashboard()`.                   |
+| `report.js`        | ANSI/plain-text rendering for the CLI.                         |
+| `cli.js`           | Command-line entry point.                                      |
+| `server.js`        | HTTP server: serves the dashboard and runs probes server-side. |
+| `public/index.html`| Self-contained auto-refreshing web dashboard.                  |
+| `checks.test.js`   | `node:test` unit tests (stubbed `fetch`, no network).          |
+
+## Current beta findings (snapshot)
+
+Against `https://mcp.beta.id.ai` the server passes all endpoint checks; the
+linked II is `https://beta.id.ai` (frontend canister `gjxif-ryaaa-aaaad-ae4ka-cai`),
+which **does** recognise the MCP server via its `form-action` CSP. Live link
+discovery via `/oauth/authorize` is reported as a warning because the redirect
+to II only happens after interactive client setup and isn't readable headlessly
+— informational, not an outage.

--- a/monitoring/mcp-status/README.md
+++ b/monitoring/mcp-status/README.md
@@ -51,6 +51,15 @@ CLI options: `--mcp <origin>`, `--ii <origin>`, `--timeout <ms>`, `--json`,
 code is `0` when healthy and `1` on failures, so it slots straight into cron, a
 CI job, or an uptime check.
 
+### Allowed targets (SSRF guard)
+
+Because `server.js` accepts `?mcp=`/`?ii=` overrides over HTTP, probe targets
+are validated against a host allowlist: only `https` origins on `id.ai` (and its
+sub-domains), plus loopback hosts for local development, may be probed. This
+stops the dashboard from being used to reach arbitrary or internal hosts. To
+monitor a deployment on another domain, extend the allowlist via the
+`MCP_STATUS_ALLOWED_HOSTS` environment variable (comma-separated host suffixes).
+
 ## Why a standalone tool (and not a page in the II frontend)?
 
 The II frontend is a **static, prerendered, `ssr: false` SvelteKit app** served

--- a/monitoring/mcp-status/checks.js
+++ b/monitoring/mcp-status/checks.js
@@ -1,0 +1,857 @@
+// Health probing logic for the IMCP (IC MCP) status dashboard.
+//
+// All probes run server-side (Node), which sidesteps the CORS restrictions that
+// would block a browser from reading the MCP server's `/mcp` 401 challenge, its
+// HTML landing page, or the Internet Identity instance's CSP header.
+//
+// The module is dependency-free: it uses the global `fetch`, `node:tls` for
+// certificate inspection, and exports a single `runDashboard(config)` entry
+// point that returns a fully structured, JSON-serialisable report.
+
+import tls from "node:tls";
+import { deriveIiOrigin, resolveConfig } from "./config.js";
+
+/**
+ * @typedef {"pass" | "warn" | "fail"} Status
+ *
+ * @typedef {Object} CheckResult
+ * @property {string} id
+ * @property {string} label
+ * @property {string} target        Human-readable target (method + url).
+ * @property {string} expected      What a healthy server should return.
+ * @property {Status} status
+ * @property {number | null} httpStatus
+ * @property {number | null} latencyMs
+ * @property {string} detail        What was actually observed.
+ *
+ * @typedef {Object} Section
+ * @property {string} id
+ * @property {string} title
+ * @property {Status} status
+ * @property {CheckResult[]} checks
+ *
+ * @typedef {Object} DashboardReport
+ * @property {string} generatedAt
+ * @property {{ mcpOrigin: string, iiOrigin: string | undefined, iiOriginSource: string }} targets
+ * @property {Status} overall
+ * @property {Section[]} sections
+ * @property {Record<string, unknown>} facts
+ * @property {string[]} suggestions
+ */
+
+const STATUS_RANK = { pass: 0, warn: 1, fail: 2 };
+
+/**
+ * Aggregate a list of statuses into the worst (most severe) one.
+ * @param {Status[]} statuses
+ * @returns {Status}
+ */
+export const worstStatus = (statuses) =>
+  statuses.reduce(
+    (acc, s) => (STATUS_RANK[s] > STATUS_RANK[acc] ? s : acc),
+    /** @type {Status} */ ("pass"),
+  );
+
+/**
+ * Perform an HTTP request with a timeout, capturing status, headers, body and
+ * latency without ever throwing (network errors are returned as `error`).
+ *
+ * @param {string} url
+ * @param {RequestInit & { timeoutMs?: number }} [init]
+ */
+const probe = async (url, init = {}) => {
+  const { timeoutMs = 10_000, ...rest } = init;
+  const start = Date.now();
+  try {
+    const res = await fetch(url, {
+      redirect: "manual",
+      ...rest,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const bodyText = await res.text().catch(() => "");
+    return {
+      ok: true,
+      status: res.status,
+      headers: res.headers,
+      bodyText,
+      latencyMs: Date.now() - start,
+      error: /** @type {Error | null} */ (null),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      status: /** @type {number | null} */ (null),
+      headers: new Headers(),
+      bodyText: "",
+      latencyMs: Date.now() - start,
+      error: /** @type {Error} */ (err),
+    };
+  }
+};
+
+/** Safely JSON-parse a string, returning undefined on failure. */
+const tryJson = (text) => {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Inspect the TLS certificate of an https origin and report days-to-expiry.
+ * @param {string} origin
+ * @param {number} timeoutMs
+ * @returns {Promise<{ validTo: string, daysRemaining: number } | { error: string }>}
+ */
+const inspectCertificate = (origin, timeoutMs) =>
+  new Promise((resolve) => {
+    let settled = false;
+    const done = (value) => {
+      if (settled) return;
+      settled = true;
+      try {
+        socket.destroy();
+      } catch {
+        /* noop */
+      }
+      resolve(value);
+    };
+    let host;
+    try {
+      host = new URL(origin).hostname;
+    } catch {
+      return done({ error: "invalid origin" });
+    }
+    const socket = tls.connect(
+      { host, port: 443, servername: host, timeout: timeoutMs },
+      () => {
+        const cert = socket.getPeerCertificate();
+        if (!cert || !cert.valid_to) {
+          return done({ error: "no peer certificate" });
+        }
+        const validTo = new Date(cert.valid_to);
+        const daysRemaining = Math.floor(
+          (validTo.getTime() - Date.now()) / 86_400_000,
+        );
+        done({ validTo: validTo.toISOString(), daysRemaining });
+      },
+    );
+    socket.on("error", (e) => done({ error: e.message }));
+    socket.on("timeout", () => done({ error: "tls timeout" }));
+  });
+
+/**
+ * Parse a single directive (e.g. "form-action") out of a CSP header value.
+ * @param {string | null} csp
+ * @param {string} directive
+ * @returns {string[] | undefined} the directive's sources, or undefined if absent
+ */
+export const parseCspDirective = (csp, directive) => {
+  if (!csp) return undefined;
+  for (const part of csp.split(";")) {
+    const tokens = part.trim().split(/\s+/);
+    if (tokens[0] === directive) return tokens.slice(1);
+  }
+  return undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Section 1 — MCP server: advertised endpoints respond with correct codes
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} mcpOrigin
+ * @param {number} timeoutMs
+ * @returns {Promise<{ section: Section, facts: Record<string, unknown> }>}
+ */
+export const checkMcpEndpoints = async (mcpOrigin, timeoutMs) => {
+  /** @type {CheckResult[]} */
+  const checks = [];
+  /** @type {Record<string, unknown>} */
+  const facts = { origin: mcpOrigin };
+
+  // 1. Landing page.
+  {
+    const r = await probe(`${mcpOrigin}/`, { timeoutMs });
+    const ct = r.headers.get("content-type") ?? "";
+    const pass = r.ok && r.status === 200 && /text\/html/i.test(ct);
+    checks.push({
+      id: "root",
+      label: "Landing page",
+      target: `GET ${mcpOrigin}/`,
+      expected: "200 text/html",
+      status: pass ? "pass" : "fail",
+      httpStatus: r.status,
+      latencyMs: r.latencyMs,
+      detail: r.error
+        ? `request failed: ${r.error.message}`
+        : `${r.status}, content-type: ${ct || "(none)"}`,
+    });
+  }
+
+  // 2. OAuth Protected Resource Metadata (RFC 9728).
+  let protectedResource;
+  {
+    const url = `${mcpOrigin}/.well-known/oauth-protected-resource`;
+    const r = await probe(url, { timeoutMs });
+    protectedResource = tryJson(r.bodyText);
+    const hasFields =
+      protectedResource &&
+      Array.isArray(protectedResource.authorization_servers) &&
+      typeof protectedResource.resource === "string";
+    const resourceOk =
+      hasFields && protectedResource.resource === `${mcpOrigin}/mcp`;
+    const pass = r.ok && r.status === 200 && hasFields;
+    facts.protectedResource = protectedResource;
+    checks.push({
+      id: "protected-resource",
+      label: "OAuth Protected Resource Metadata",
+      target: `GET ${url}`,
+      expected: "200 JSON with authorization_servers + resource",
+      status: pass ? (resourceOk ? "pass" : "warn") : "fail",
+      httpStatus: r.status,
+      latencyMs: r.latencyMs,
+      detail: !pass
+        ? r.error
+          ? `request failed: ${r.error.message}`
+          : `${r.status}, missing required fields`
+        : resourceOk
+          ? `resource=${protectedResource.resource}, AS=${protectedResource.authorization_servers.join(", ")}`
+          : `resource=${protectedResource.resource} (expected ${mcpOrigin}/mcp)`,
+    });
+  }
+
+  // 3. OAuth Authorization Server Metadata (RFC 8414).
+  let asMeta;
+  {
+    const url = `${mcpOrigin}/.well-known/oauth-authorization-server`;
+    const r = await probe(url, { timeoutMs });
+    asMeta = tryJson(r.bodyText);
+    const required = [
+      "issuer",
+      "authorization_endpoint",
+      "token_endpoint",
+      "registration_endpoint",
+    ];
+    const missing = asMeta
+      ? required.filter((k) => typeof asMeta[k] !== "string")
+      : required;
+    const pass = r.ok && r.status === 200 && missing.length === 0;
+    facts.authorizationServer = asMeta;
+    checks.push({
+      id: "as-metadata",
+      label: "OAuth Authorization Server Metadata",
+      target: `GET ${url}`,
+      expected: "200 JSON with issuer + authorize/token/register endpoints",
+      status: pass ? "pass" : "fail",
+      httpStatus: r.status,
+      latencyMs: r.latencyMs,
+      detail: !pass
+        ? r.error
+          ? `request failed: ${r.error.message}`
+          : `${r.status}, missing fields: ${missing.join(", ") || "n/a"}`
+        : `issuer=${asMeta.issuer}, PKCE=${(asMeta.code_challenge_methods_supported || []).join(",") || "none"}`,
+    });
+  }
+
+  // 3b. Cross-consistency of the two discovery documents.
+  {
+    const issuer = asMeta?.issuer;
+    const asList = protectedResource?.authorization_servers;
+    const consistent =
+      typeof issuer === "string" &&
+      Array.isArray(asList) &&
+      asList.includes(issuer) &&
+      issuer === mcpOrigin;
+    checks.push({
+      id: "metadata-consistency",
+      label: "Discovery documents are self-consistent",
+      target: "oauth-protected-resource ↔ oauth-authorization-server",
+      expected: "issuer === origin and listed as authorization_server",
+      status: consistent ? "pass" : "warn",
+      httpStatus: null,
+      latencyMs: null,
+      detail: consistent
+        ? `issuer ${issuer} matches advertised authorization_servers`
+        : `issuer=${issuer ?? "?"}, authorization_servers=${JSON.stringify(asList ?? null)}`,
+    });
+  }
+
+  // 4. The MCP endpoint must answer an unauthenticated call with a 401 + a
+  //    standards-compliant WWW-Authenticate challenge pointing at the resource
+  //    metadata. This is the contract MCP clients rely on to discover auth.
+  {
+    const url = `${mcpOrigin}/mcp`;
+    const r = await probe(url, {
+      timeoutMs,
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "imcp-status-dashboard", version: "1.0.0" },
+        },
+      }),
+    });
+    const wwwAuth = r.headers.get("www-authenticate") ?? "";
+    const expectedMetadata = `${mcpOrigin}/.well-known/oauth-protected-resource`;
+    const challengeOk =
+      r.status === 401 &&
+      /bearer/i.test(wwwAuth) &&
+      wwwAuth.includes(expectedMetadata);
+    checks.push({
+      id: "mcp-challenge",
+      label: "MCP endpoint OAuth challenge",
+      target: `POST ${url} (no token)`,
+      expected: `401 + WWW-Authenticate: Bearer resource_metadata="${expectedMetadata}"`,
+      status: challengeOk ? "pass" : r.status === 401 ? "warn" : "fail",
+      httpStatus: r.status,
+      latencyMs: r.latencyMs,
+      detail: r.error
+        ? `request failed: ${r.error.message}`
+        : `${r.status}, www-authenticate: ${wwwAuth || "(missing)"}`,
+    });
+  }
+
+  // 5. Dynamic Client Registration (RFC 7591) must mint a client_id.
+  {
+    const url = `${mcpOrigin}/oauth/register`;
+    const r = await probe(url, {
+      timeoutMs,
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        client_name: "imcp-status-dashboard",
+        redirect_uris: ["https://example.org/callback"],
+        token_endpoint_auth_method: "none",
+        grant_types: ["authorization_code"],
+        response_types: ["code"],
+      }),
+    });
+    const json = tryJson(r.bodyText);
+    const pass =
+      (r.status === 200 || r.status === 201) &&
+      json &&
+      typeof json.client_id === "string";
+    checks.push({
+      id: "oauth-register",
+      label: "OAuth Dynamic Client Registration",
+      target: `POST ${url}`,
+      expected: "200/201 JSON with client_id",
+      status: pass ? "pass" : "fail",
+      httpStatus: r.status,
+      latencyMs: r.latencyMs,
+      detail: r.error
+        ? `request failed: ${r.error.message}`
+        : pass
+          ? `registered client_id=${json.client_id}`
+          : `${r.status}, body: ${r.bodyText.slice(0, 120)}`,
+    });
+  }
+
+  // 6. Authorization endpoint liveness: rejects malformed input with 4xx
+  //    (rather than 5xx / connection error). It is interactive, so we only
+  //    assert it is alive and validating, not a full successful redirect.
+  {
+    const url = `${mcpOrigin}/oauth/authorize`;
+    const r = await probe(url, { timeoutMs });
+    const alive = r.ok && r.status >= 400 && r.status < 500;
+    checks.push({
+      id: "oauth-authorize",
+      label: "OAuth Authorization endpoint liveness",
+      target: `GET ${url} (no params)`,
+      expected: "4xx (validates input; does not 5xx / hang)",
+      status: alive ? "pass" : "fail",
+      httpStatus: r.status,
+      latencyMs: r.latencyMs,
+      detail: r.error
+        ? `request failed: ${r.error.message}`
+        : `${r.status}, ${r.bodyText.slice(0, 100)}`,
+    });
+  }
+
+  // 7. Token endpoint liveness: a bogus grant must be rejected with 400.
+  {
+    const url = `${mcpOrigin}/oauth/token`;
+    const r = await probe(url, {
+      timeoutMs,
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "grant_type=authorization_code&code=invalid&code_verifier=x&client_id=x",
+    });
+    const json = tryJson(r.bodyText);
+    const alive = r.status === 400 && json && typeof json.error === "string";
+    checks.push({
+      id: "oauth-token",
+      label: "OAuth Token endpoint liveness",
+      target: `POST ${url} (invalid grant)`,
+      expected: "400 with OAuth error (e.g. invalid_grant)",
+      status: alive ? "pass" : r.status === 400 ? "warn" : "fail",
+      httpStatus: r.status,
+      latencyMs: r.latencyMs,
+      detail: r.error
+        ? `request failed: ${r.error.message}`
+        : `${r.status}, error: ${json?.error ?? r.bodyText.slice(0, 80)}`,
+    });
+  }
+
+  // TLS certificate freshness for the MCP host.
+  {
+    const cert = await inspectCertificate(mcpOrigin, timeoutMs);
+    facts.mcpCertificate = cert;
+    if ("error" in cert) {
+      checks.push({
+        id: "mcp-tls",
+        label: "TLS certificate",
+        target: mcpOrigin,
+        expected: "valid certificate, > 21 days remaining",
+        status: "warn",
+        httpStatus: null,
+        latencyMs: null,
+        detail: `could not inspect certificate: ${cert.error}`,
+      });
+    } else {
+      checks.push({
+        id: "mcp-tls",
+        label: "TLS certificate",
+        target: mcpOrigin,
+        expected: "valid certificate, > 21 days remaining",
+        status:
+          cert.daysRemaining < 0
+            ? "fail"
+            : cert.daysRemaining < 21
+              ? "warn"
+              : "pass",
+        httpStatus: null,
+        latencyMs: null,
+        detail: `expires ${cert.validTo} (${cert.daysRemaining} days remaining)`,
+      });
+    }
+  }
+
+  return {
+    section: {
+      id: "endpoints",
+      title: "MCP server endpoints",
+      status: worstStatus(checks.map((c) => c.status)),
+      checks,
+    },
+    facts,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Section 2 — Which II instance is the MCP server linked to?
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort discovery of the II origin the MCP server redirects to during the
+ * OAuth authorization flow. Registers a throwaway client and inspects the
+ * `Location` header of `/oauth/authorize`. Returns `undefined` if the server
+ * does not (yet) issue a cross-origin redirect we can read headlessly.
+ *
+ * @param {string} mcpOrigin
+ * @param {number} timeoutMs
+ * @returns {Promise<{ iiOrigin?: string, detail: string }>}
+ */
+export const discoverIiViaAuthorize = async (mcpOrigin, timeoutMs) => {
+  const redirectUri = "https://example.org/callback";
+  const reg = await probe(`${mcpOrigin}/oauth/register`, {
+    timeoutMs,
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      client_name: "imcp-status-dashboard",
+      redirect_uris: [redirectUri],
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+    }),
+  });
+  const client = tryJson(reg.bodyText);
+  if (!client?.client_id) {
+    return { detail: `client registration failed (HTTP ${reg.status})` };
+  }
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: client.client_id,
+    redirect_uri: redirectUri,
+    code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    code_challenge_method: "S256",
+    state: "imcp-status-probe",
+  });
+  const r = await probe(`${mcpOrigin}/oauth/authorize?${params}`, {
+    timeoutMs,
+  });
+  const location = r.headers.get("location");
+  if (r.status >= 300 && r.status < 400 && location) {
+    try {
+      const target = new URL(location, mcpOrigin);
+      if (target.origin !== mcpOrigin) {
+        return {
+          iiOrigin: target.origin,
+          detail: `/oauth/authorize redirects to ${target.origin}`,
+        };
+      }
+      return { detail: `/oauth/authorize redirects within ${mcpOrigin}` };
+    } catch {
+      return { detail: `unparseable redirect target: ${location}` };
+    }
+  }
+  return {
+    detail: `no cross-origin redirect from /oauth/authorize (HTTP ${r.status})`,
+  };
+};
+
+/**
+ * @param {string} mcpOrigin
+ * @param {string | undefined} configuredIi
+ * @param {string} iiOriginSource
+ * @param {number} timeoutMs
+ * @returns {Promise<{ section: Section, iiOrigin: string | undefined, facts: Record<string, unknown> }>}
+ */
+export const checkLinkage = async (
+  mcpOrigin,
+  configuredIi,
+  iiOriginSource,
+  timeoutMs,
+) => {
+  /** @type {CheckResult[]} */
+  const checks = [];
+  /** @type {Record<string, unknown>} */
+  const facts = {};
+
+  const discovery = await discoverIiViaAuthorize(mcpOrigin, timeoutMs);
+  facts.authorizeDiscovery = discovery;
+
+  // Resolve the II origin we will health-check: prefer a live-discovered one,
+  // then an explicitly configured one, then the naming-convention default.
+  const iiOrigin =
+    discovery.iiOrigin ?? configuredIi ?? deriveIiOrigin(mcpOrigin);
+  const resolvedSource = discovery.iiOrigin
+    ? "discovered via /oauth/authorize redirect"
+    : iiOriginSource === "explicit"
+      ? "explicitly configured"
+      : iiOriginSource === "derived"
+        ? "derived from naming convention (mcp.<env>.id.ai → <env>.id.ai)"
+        : "unknown";
+
+  checks.push({
+    id: "ii-target",
+    label: "Linked Internet Identity instance",
+    target: mcpOrigin,
+    expected: "a resolvable II origin",
+    status: iiOrigin ? "pass" : "fail",
+    httpStatus: null,
+    latencyMs: null,
+    detail: iiOrigin
+      ? `${iiOrigin} (${resolvedSource})`
+      : "could not resolve a linked II origin",
+  });
+
+  checks.push({
+    id: "ii-discovery",
+    label: "Live link discovery via OAuth authorize",
+    target: `${mcpOrigin}/oauth/authorize`,
+    expected: "302 redirect to the II /mcp delegation page",
+    // Inconclusive discovery is informational, not a failure: the MCP server
+    // performs the redirect only after interactive client setup.
+    status: discovery.iiOrigin ? "pass" : "warn",
+    httpStatus: null,
+    latencyMs: null,
+    detail: discovery.detail,
+  });
+
+  return {
+    section: {
+      id: "linkage",
+      title: "Linked Internet Identity instance",
+      status: worstStatus(checks.map((c) => c.status)),
+      checks,
+    },
+    iiOrigin,
+    facts,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Section 3 — Is the linked II healthy, and does it recognise this MCP server?
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string | undefined} iiOrigin
+ * @param {string} mcpOrigin
+ * @param {number} timeoutMs
+ * @returns {Promise<{ section: Section, facts: Record<string, unknown> }>}
+ */
+export const checkIiHealth = async (iiOrigin, mcpOrigin, timeoutMs) => {
+  /** @type {CheckResult[]} */
+  const checks = [];
+  /** @type {Record<string, unknown>} */
+  const facts = {};
+
+  if (!iiOrigin) {
+    checks.push({
+      id: "ii-unresolved",
+      label: "Internet Identity health",
+      target: "(unknown)",
+      expected: "a resolved II origin to probe",
+      status: "fail",
+      httpStatus: null,
+      latencyMs: null,
+      detail: "no II origin resolved; cannot assess health",
+    });
+    return {
+      section: {
+        id: "ii-health",
+        title: "Internet Identity health & recognition",
+        status: "fail",
+        checks,
+      },
+      facts,
+    };
+  }
+
+  facts.origin = iiOrigin;
+  const r = await probe(`${iiOrigin}/`, { timeoutMs });
+  const csp = r.headers.get("content-security-policy");
+  const canisterId = r.headers.get("x-ic-canister-id");
+  const icCertificate = r.headers.get("ic-certificate");
+  facts.canisterId = canisterId;
+
+  // 1. Frontend reachability.
+  checks.push({
+    id: "ii-reachable",
+    label: "II frontend reachable",
+    target: `GET ${iiOrigin}/`,
+    expected: "200",
+    status: r.ok && r.status === 200 ? "pass" : "fail",
+    httpStatus: r.status,
+    latencyMs: r.latencyMs,
+    detail: r.error
+      ? `request failed: ${r.error.message}`
+      : `${r.status}${canisterId ? `, canister ${canisterId}` : ""}`,
+  });
+
+  // 2. Served & certified by the Internet Computer (canister is live).
+  checks.push({
+    id: "ii-certified",
+    label: "IC-certified response (canister live)",
+    target: `${iiOrigin}/`,
+    expected: "ic-certificate header present",
+    status: icCertificate ? "pass" : "warn",
+    httpStatus: r.status,
+    latencyMs: r.latencyMs,
+    detail: icCertificate
+      ? `ic-certificate present${canisterId ? ` for canister ${canisterId}` : ""}`
+      : "no ic-certificate header (response not certified by the IC?)",
+  });
+
+  // 3. Recognition: the II's mcp_server_origin config is reflected verbatim
+  //    into the response CSP `form-action` directive. If our MCP origin is
+  //    listed, the II trusts it and the /mcp delegation flow will accept its
+  //    callbacks; if not, the flow is disabled for this MCP server.
+  const formAction = parseCspDirective(csp, "form-action");
+  facts.formAction = formAction;
+  const recognised = !!formAction && formAction.includes(mcpOrigin);
+  checks.push({
+    id: "ii-recognises-mcp",
+    label: "II recognises this MCP server",
+    target: `${iiOrigin} CSP form-action`,
+    expected: `form-action contains ${mcpOrigin}`,
+    status: recognised ? "pass" : "fail",
+    httpStatus: null,
+    latencyMs: null,
+    detail: formAction
+      ? recognised
+        ? `form-action lists ${mcpOrigin} → /mcp delegation enabled`
+        : `form-action = [${formAction.join(", ")}] (does NOT include ${mcpOrigin})`
+      : "no form-action directive found in CSP",
+  });
+
+  // 4. Report the II's configured related origins (context, not pass/fail).
+  const frameAncestors = parseCspDirective(csp, "frame-ancestors");
+  const relatedOrigins = (frameAncestors ?? []).filter((o) =>
+    o.startsWith("http"),
+  );
+  facts.relatedOrigins = relatedOrigins;
+  checks.push({
+    id: "ii-related-origins",
+    label: "II related origins",
+    target: `${iiOrigin} CSP frame-ancestors`,
+    expected: "the II's alternative front-end origins",
+    status: relatedOrigins.length > 0 ? "pass" : "warn",
+    httpStatus: null,
+    latencyMs: null,
+    detail:
+      relatedOrigins.length > 0
+        ? relatedOrigins.join(", ")
+        : "no related origins advertised",
+  });
+
+  // 5. TLS certificate freshness for the II host.
+  const cert = await inspectCertificate(iiOrigin, timeoutMs);
+  facts.certificate = cert;
+  if ("error" in cert) {
+    checks.push({
+      id: "ii-tls",
+      label: "TLS certificate",
+      target: iiOrigin,
+      expected: "valid certificate, > 21 days remaining",
+      status: "warn",
+      httpStatus: null,
+      latencyMs: null,
+      detail: `could not inspect certificate: ${cert.error}`,
+    });
+  } else {
+    checks.push({
+      id: "ii-tls",
+      label: "TLS certificate",
+      target: iiOrigin,
+      expected: "valid certificate, > 21 days remaining",
+      status:
+        cert.daysRemaining < 0
+          ? "fail"
+          : cert.daysRemaining < 21
+            ? "warn"
+            : "pass",
+      httpStatus: null,
+      latencyMs: null,
+      detail: `expires ${cert.validTo} (${cert.daysRemaining} days remaining)`,
+    });
+  }
+
+  return {
+    section: {
+      id: "ii-health",
+      title: "Internet Identity health & recognition",
+      status: worstStatus(checks.map((c) => c.status)),
+      checks,
+    },
+    facts,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Suggestions — actionable, partly derived from the live findings
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {Section[]} sections
+ * @param {Record<string, unknown>} facts
+ * @returns {string[]}
+ */
+export const buildSuggestions = (sections, facts) => {
+  const suggestions = [];
+  const checkById = {};
+  for (const s of sections) for (const c of s.checks) checkById[c.id] = c;
+
+  if (checkById["ii-recognises-mcp"]?.status === "fail") {
+    suggestions.push(
+      "The linked II does not list this MCP origin in its CSP form-action. " +
+        "The /mcp delegation flow will reject callbacks until the II canister " +
+        "is (re)deployed with mcp_server_origin set to this exact origin.",
+    );
+  }
+  if (checkById["mcp-challenge"]?.status !== "pass") {
+    suggestions.push(
+      "The unauthenticated /mcp response should be a 401 carrying " +
+        'WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource". ' +
+        "MCP clients rely on this header to discover the authorization server.",
+    );
+  }
+  if (checkById["ii-discovery"]?.status !== "pass") {
+    suggestions.push(
+      "The MCP→II link could not be confirmed live via /oauth/authorize " +
+        "(no readable cross-origin redirect headlessly). Consider exposing the " +
+        "configured II origin in the MCP server metadata so the pairing is " +
+        "independently verifiable, not just inferred by naming convention.",
+    );
+  }
+  // The catch-all returns 401 for unknown paths, so uptime monitors can't use a
+  // plain GET. Recommend a dedicated unauthenticated liveness endpoint.
+  suggestions.push(
+    "Add an unauthenticated GET /healthz (or /livez) that returns 200. " +
+      "Unknown paths currently fall through to the OAuth 401 catch-all, so " +
+      "external uptime monitors have no clean liveness probe.",
+  );
+  suggestions.push(
+    "POST /oauth/register accepts anonymous dynamic client registration. " +
+      "Ensure it is rate-limited and that stale/unused clients are pruned to " +
+      "avoid unbounded growth, and that registrations are shared across all " +
+      "server replicas (a freshly registered client_id was not immediately " +
+      "usable at /oauth/authorize during probing).",
+  );
+
+  const certWarn = [facts?.mcp, facts?.ii]
+    .map((f) => /** @type {any} */ (f)?.certificate ?? f?.mcpCertificate)
+    .filter((c) => c && typeof c.daysRemaining === "number" && c.daysRemaining < 21);
+  if (certWarn.length > 0) {
+    suggestions.push(
+      "A TLS certificate is within 21 days of expiry — verify automatic renewal.",
+    );
+  }
+
+  suggestions.push(
+    "Wire this dashboard into alerting: run `node monitoring/mcp-status/cli.js " +
+      "--json` on a schedule (cron/CI) and page on a non-zero exit code, and/or " +
+      "host `server.js` behind your status page. Track per-endpoint latency over " +
+      "time to catch slow degradations before they become outages.",
+  );
+
+  return suggestions;
+};
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the full dashboard against the resolved configuration.
+ * @param {{ mcpOrigin?: string, iiOrigin?: string, timeoutMs?: number }} [overrides]
+ * @returns {Promise<DashboardReport>}
+ */
+export const runDashboard = async (overrides = {}) => {
+  const cfg = resolveConfig(overrides);
+
+  const endpoints = await checkMcpEndpoints(cfg.mcpOrigin, cfg.timeoutMs);
+  const linkage = await checkLinkage(
+    cfg.mcpOrigin,
+    cfg.iiOrigin,
+    cfg.iiOriginSource,
+    cfg.timeoutMs,
+  );
+  const iiHealth = await checkIiHealth(
+    linkage.iiOrigin,
+    cfg.mcpOrigin,
+    cfg.timeoutMs,
+  );
+
+  const sections = [endpoints.section, linkage.section, iiHealth.section];
+  const facts = {
+    mcp: endpoints.facts,
+    linkage: linkage.facts,
+    ii: iiHealth.facts,
+  };
+
+  return {
+    generatedAt: new Date().toISOString(),
+    targets: {
+      mcpOrigin: cfg.mcpOrigin,
+      iiOrigin: linkage.iiOrigin,
+      iiOriginSource: cfg.iiOriginSource,
+    },
+    overall: worstStatus(sections.map((s) => s.status)),
+    sections,
+    facts,
+    suggestions: buildSuggestions(sections, facts),
+  };
+};

--- a/monitoring/mcp-status/checks.js
+++ b/monitoring/mcp-status/checks.js
@@ -9,7 +9,7 @@
 // point that returns a fully structured, JSON-serialisable report.
 
 import tls from "node:tls";
-import { deriveIiOrigin, resolveConfig } from "./config.js";
+import { deriveIiOrigin, isAllowedOrigin, resolveConfig } from "./config.js";
 
 /**
  * @typedef {"pass" | "warn" | "fail"} Status
@@ -496,6 +496,13 @@ export const discoverIiViaAuthorize = async (mcpOrigin, timeoutMs) => {
     try {
       const target = new URL(location, mcpOrigin);
       if (target.origin !== mcpOrigin) {
+        // Only adopt a discovered origin if it is on the allowlist; otherwise a
+        // monitored server could redirect us into probing an arbitrary host.
+        if (!isAllowedOrigin(target.origin)) {
+          return {
+            detail: `/oauth/authorize redirects to ${target.origin} (not on the allowlist; ignored)`,
+          };
+        }
         return {
           iiOrigin: target.origin,
           detail: `/oauth/authorize redirects to ${target.origin}`,

--- a/monitoring/mcp-status/checks.test.js
+++ b/monitoring/mcp-status/checks.test.js
@@ -94,6 +94,10 @@ test("isAllowedOrigin enforces the host allowlist (SSRF guard)", () => {
   assert.equal(isAllowedOrigin("https://id.ai.evil.com"), false);
   assert.equal(isAllowedOrigin("http://mcp.beta.id.ai"), false);
   assert.equal(isAllowedOrigin("https://mcp.beta.id.ai@evil.com"), false);
+  // Non-default ports are rejected for remote hosts, allowed for loopback.
+  assert.equal(isAllowedOrigin("https://mcp.beta.id.ai:8443"), false);
+  assert.equal(isAllowedOrigin("https://mcp.beta.id.ai:443"), true);
+  assert.equal(isAllowedOrigin("http://localhost:8137"), true);
 });
 
 test("resolveConfig rejects a disallowed origin", () => {

--- a/monitoring/mcp-status/checks.test.js
+++ b/monitoring/mcp-status/checks.test.js
@@ -1,0 +1,219 @@
+// Unit tests for the IMCP status dashboard probing logic.
+// Run with:  node --test monitoring/mcp-status/
+//
+// These tests stub the global `fetch` so they make no real network calls.
+// (TLS certificate inspection targets unresolvable test hostnames and so
+// degrades to a "warn" without hitting the network meaningfully.)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  worstStatus,
+  parseCspDirective,
+  checkMcpEndpoints,
+  checkIiHealth,
+  buildSuggestions,
+} from "./checks.js";
+import { deriveIiOrigin, normaliseOrigin, resolveConfig } from "./config.js";
+
+const byId = (section, id) => section.checks.find((c) => c.id === id);
+
+/** Build a minimal Response-like object honouring the fields checks.js reads. */
+const resp = (status, { headers = {}, body = "" } = {}) => ({
+  status,
+  headers: new Headers(headers),
+  text: async () => body,
+});
+
+/**
+ * Install a fetch stub that dispatches on "METHOD url".
+ * @param {Record<string, ReturnType<typeof resp>>} routes
+ */
+const stubFetch = (routes) => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    const key = `${init.method ?? "GET"} ${url.split("?")[0]}`;
+    if (routes[key]) return routes[key];
+    throw new Error(`unexpected fetch: ${key}`);
+  };
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+test("worstStatus picks the most severe status", () => {
+  assert.equal(worstStatus(["pass", "pass"]), "pass");
+  assert.equal(worstStatus(["pass", "warn", "pass"]), "warn");
+  assert.equal(worstStatus(["warn", "fail", "pass"]), "fail");
+  assert.equal(worstStatus([]), "pass");
+});
+
+test("parseCspDirective extracts a directive's sources", () => {
+  const csp =
+    "default-src 'none';form-action 'self' http://127.0.0.1:* https://mcp.beta.id.ai;base-uri 'none'";
+  assert.deepEqual(parseCspDirective(csp, "form-action"), [
+    "'self'",
+    "http://127.0.0.1:*",
+    "https://mcp.beta.id.ai",
+  ]);
+  assert.equal(parseCspDirective(csp, "missing-directive"), undefined);
+  assert.equal(parseCspDirective(null, "form-action"), undefined);
+});
+
+test("deriveIiOrigin strips the mcp. label", () => {
+  assert.equal(deriveIiOrigin("https://mcp.beta.id.ai"), "https://beta.id.ai");
+  assert.equal(deriveIiOrigin("https://mcp.id.ai"), "https://id.ai");
+  assert.equal(deriveIiOrigin("https://example.com"), undefined);
+});
+
+test("normaliseOrigin rejects origins with a path", () => {
+  assert.equal(normaliseOrigin("https://mcp.beta.id.ai/"), "https://mcp.beta.id.ai");
+  assert.throws(() => normaliseOrigin("https://mcp.beta.id.ai/mcp"));
+});
+
+test("resolveConfig derives the II origin from the MCP origin", () => {
+  const cfg = resolveConfig({ mcpOrigin: "https://mcp.beta.id.ai" });
+  assert.equal(cfg.mcpOrigin, "https://mcp.beta.id.ai");
+  assert.equal(cfg.iiOrigin, "https://beta.id.ai");
+  assert.equal(cfg.iiOriginSource, "derived");
+});
+
+test("checkMcpEndpoints passes for a well-behaved server", async () => {
+  const origin = "https://mcp.beta.test";
+  const restore = stubFetch({
+    [`GET ${origin}/`]: resp(200, { headers: { "content-type": "text/html" } }),
+    [`GET ${origin}/.well-known/oauth-protected-resource`]: resp(200, {
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        authorization_servers: [origin],
+        resource: `${origin}/mcp`,
+      }),
+    }),
+    [`GET ${origin}/.well-known/oauth-authorization-server`]: resp(200, {
+      body: JSON.stringify({
+        issuer: origin,
+        authorization_endpoint: `${origin}/oauth/authorize`,
+        token_endpoint: `${origin}/oauth/token`,
+        registration_endpoint: `${origin}/oauth/register`,
+        code_challenge_methods_supported: ["S256"],
+      }),
+    }),
+    [`POST ${origin}/mcp`]: resp(401, {
+      headers: {
+        "www-authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+      },
+      body: JSON.stringify({ error: "invalid_token" }),
+    }),
+    [`POST ${origin}/oauth/register`]: resp(201, {
+      body: JSON.stringify({ client_id: "client-123" }),
+    }),
+    [`GET ${origin}/oauth/authorize`]: resp(400, { body: "missing client_id" }),
+    [`POST ${origin}/oauth/token`]: resp(400, {
+      body: JSON.stringify({ error: "invalid_grant" }),
+    }),
+  });
+  try {
+    const { section } = await checkMcpEndpoints(origin, 2000);
+    assert.equal(byId(section, "root").status, "pass");
+    assert.equal(byId(section, "protected-resource").status, "pass");
+    assert.equal(byId(section, "as-metadata").status, "pass");
+    assert.equal(byId(section, "metadata-consistency").status, "pass");
+    assert.equal(byId(section, "mcp-challenge").status, "pass");
+    assert.equal(byId(section, "oauth-register").status, "pass");
+    assert.equal(byId(section, "oauth-authorize").status, "pass");
+    assert.equal(byId(section, "oauth-token").status, "pass");
+  } finally {
+    restore();
+  }
+});
+
+test("checkMcpEndpoints flags a missing OAuth challenge", async () => {
+  const origin = "https://mcp.beta.test";
+  const restore = stubFetch({
+    [`GET ${origin}/`]: resp(200, { headers: { "content-type": "text/html" } }),
+    [`GET ${origin}/.well-known/oauth-protected-resource`]: resp(200, {
+      body: JSON.stringify({ authorization_servers: [origin], resource: `${origin}/mcp` }),
+    }),
+    [`GET ${origin}/.well-known/oauth-authorization-server`]: resp(200, {
+      body: JSON.stringify({
+        issuer: origin,
+        authorization_endpoint: `${origin}/oauth/authorize`,
+        token_endpoint: `${origin}/oauth/token`,
+        registration_endpoint: `${origin}/oauth/register`,
+      }),
+    }),
+    // 200 instead of a 401 challenge → wrong contract.
+    [`POST ${origin}/mcp`]: resp(200, { body: "{}" }),
+    [`POST ${origin}/oauth/register`]: resp(201, {
+      body: JSON.stringify({ client_id: "x" }),
+    }),
+    [`GET ${origin}/oauth/authorize`]: resp(400),
+    [`POST ${origin}/oauth/token`]: resp(400, {
+      body: JSON.stringify({ error: "invalid_grant" }),
+    }),
+  });
+  try {
+    const { section } = await checkMcpEndpoints(origin, 2000);
+    assert.equal(byId(section, "mcp-challenge").status, "fail");
+  } finally {
+    restore();
+  }
+});
+
+test("checkIiHealth detects MCP recognition via form-action", async () => {
+  const ii = "https://beta.test";
+  const mcp = "https://mcp.beta.test";
+  const restore = stubFetch({
+    [`GET ${ii}/`]: resp(200, {
+      headers: {
+        "x-ic-canister-id": "gjxif-ryaaa-aaaad-ae4ka-cai",
+        "ic-certificate": "certificate=:abc:",
+        "content-security-policy": `default-src 'none';form-action 'self' http://127.0.0.1:* ${mcp};frame-ancestors 'self' ${ii} https://beta.identity.ic0.app`,
+      },
+    }),
+  });
+  try {
+    const { section, facts } = await checkIiHealth(ii, mcp, 2000);
+    assert.equal(byId(section, "ii-reachable").status, "pass");
+    assert.equal(byId(section, "ii-certified").status, "pass");
+    assert.equal(byId(section, "ii-recognises-mcp").status, "pass");
+    assert.equal(facts.canisterId, "gjxif-ryaaa-aaaad-ae4ka-cai");
+    assert.deepEqual(facts.relatedOrigins, [ii, "https://beta.identity.ic0.app"]);
+  } finally {
+    restore();
+  }
+});
+
+test("checkIiHealth fails recognition when MCP origin is absent", async () => {
+  const ii = "https://beta.test";
+  const mcp = "https://mcp.beta.test";
+  const restore = stubFetch({
+    [`GET ${ii}/`]: resp(200, {
+      headers: {
+        "content-security-policy": `form-action 'self' http://127.0.0.1:*`,
+      },
+    }),
+  });
+  try {
+    const { section } = await checkIiHealth(ii, mcp, 2000);
+    assert.equal(byId(section, "ii-recognises-mcp").status, "fail");
+  } finally {
+    restore();
+  }
+});
+
+test("buildSuggestions surfaces a recognition failure", () => {
+  const sections = [
+    {
+      id: "ii-health",
+      title: "",
+      status: "fail",
+      checks: [{ id: "ii-recognises-mcp", status: "fail" }],
+    },
+  ];
+  const suggestions = buildSuggestions(sections, {});
+  assert.ok(
+    suggestions.some((s) => s.includes("mcp_server_origin")),
+    "expected a suggestion about mcp_server_origin",
+  );
+});

--- a/monitoring/mcp-status/checks.test.js
+++ b/monitoring/mcp-status/checks.test.js
@@ -14,7 +14,12 @@ import {
   checkIiHealth,
   buildSuggestions,
 } from "./checks.js";
-import { deriveIiOrigin, normaliseOrigin, resolveConfig } from "./config.js";
+import {
+  deriveIiOrigin,
+  isAllowedOrigin,
+  normaliseOrigin,
+  resolveConfig,
+} from "./config.js";
 
 const byId = (section, id) => section.checks.find((c) => c.id === id);
 
@@ -76,6 +81,26 @@ test("resolveConfig derives the II origin from the MCP origin", () => {
   assert.equal(cfg.mcpOrigin, "https://mcp.beta.id.ai");
   assert.equal(cfg.iiOrigin, "https://beta.id.ai");
   assert.equal(cfg.iiOriginSource, "derived");
+});
+
+test("isAllowedOrigin enforces the host allowlist (SSRF guard)", () => {
+  assert.equal(isAllowedOrigin("https://mcp.beta.id.ai"), true);
+  assert.equal(isAllowedOrigin("https://id.ai"), true);
+  assert.equal(isAllowedOrigin("http://localhost:8080"), true);
+  // Rejected: internal hosts, non-https, look-alike domains, userinfo tricks.
+  assert.equal(isAllowedOrigin("http://169.254.169.254"), false);
+  assert.equal(isAllowedOrigin("https://evil.com"), false);
+  assert.equal(isAllowedOrigin("https://evilid.ai"), false);
+  assert.equal(isAllowedOrigin("https://id.ai.evil.com"), false);
+  assert.equal(isAllowedOrigin("http://mcp.beta.id.ai"), false);
+  assert.equal(isAllowedOrigin("https://mcp.beta.id.ai@evil.com"), false);
+});
+
+test("resolveConfig rejects a disallowed origin", () => {
+  assert.throws(
+    () => resolveConfig({ mcpOrigin: "http://169.254.169.254" }),
+    (e) => e.code === "DISALLOWED_ORIGIN",
+  );
 });
 
 test("checkMcpEndpoints passes for a well-behaved server", async () => {

--- a/monitoring/mcp-status/cli.js
+++ b/monitoring/mcp-status/cli.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// CLI entry point for the IMCP status dashboard.
+//
+// Usage:
+//   node monitoring/mcp-status/cli.js [options]
+//
+// Options:
+//   --mcp <origin>     MCP server origin to monitor (default https://mcp.beta.id.ai)
+//   --ii <origin>      Internet Identity origin (default: derived from the MCP origin)
+//   --timeout <ms>     Per-probe timeout in milliseconds (default 10000)
+//   --json             Emit the raw JSON report instead of the text view
+//   --no-color         Disable ANSI colours
+//   --strict           Exit non-zero on warnings as well as failures
+//   -h, --help         Show this help
+//
+// Exit code: 0 = healthy, 1 = failures (or warnings with --strict), 2 = usage error.
+
+import { runDashboard } from "./checks.js";
+import { renderText } from "./report.js";
+
+const parseArgs = (argv) => {
+  /** @type {Record<string, string | boolean>} */
+  const opts = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--mcp":
+        opts.mcp = argv[++i];
+        break;
+      case "--ii":
+        opts.ii = argv[++i];
+        break;
+      case "--timeout":
+        opts.timeout = argv[++i];
+        break;
+      case "--json":
+        opts.json = true;
+        break;
+      case "--no-color":
+        opts.noColor = true;
+        break;
+      case "--strict":
+        opts.strict = true;
+        break;
+      case "-h":
+      case "--help":
+        opts.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+};
+
+const HELP = `IMCP (IC MCP) status dashboard
+
+Usage: node monitoring/mcp-status/cli.js [options]
+
+  --mcp <origin>   MCP server origin (default https://mcp.beta.id.ai)
+  --ii <origin>    Internet Identity origin (default: derived from --mcp)
+  --timeout <ms>   Per-probe timeout (default 10000)
+  --json           Emit raw JSON instead of the text report
+  --no-color       Disable ANSI colours
+  --strict         Exit non-zero on warnings as well as failures
+  -h, --help       Show this help
+`;
+
+const main = async () => {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (e) {
+    process.stderr.write(`${e.message}\n\n${HELP}`);
+    process.exit(2);
+  }
+
+  if (opts.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  const report = await runDashboard({
+    mcpOrigin: typeof opts.mcp === "string" ? opts.mcp : undefined,
+    iiOrigin: typeof opts.ii === "string" ? opts.ii : undefined,
+    timeoutMs: opts.timeout ? Number(opts.timeout) : undefined,
+  });
+
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    const noColor = opts.noColor || !process.stdout.isTTY;
+    process.stdout.write(renderText(report, { color: !noColor }));
+  }
+
+  const failed = report.overall === "fail";
+  const warned = report.overall === "warn";
+  process.exit(failed || (warned && opts.strict) ? 1 : 0);
+};
+
+main().catch((e) => {
+  process.stderr.write(`Unexpected error: ${e?.stack ?? e}\n`);
+  process.exit(1);
+});

--- a/monitoring/mcp-status/cli.js
+++ b/monitoring/mcp-status/cli.js
@@ -21,17 +21,25 @@ import { renderText } from "./report.js";
 const parseArgs = (argv) => {
   /** @type {Record<string, string | boolean>} */
   const opts = {};
+  // Consume and return the value following a value-taking flag, erroring if it
+  // is missing or looks like another flag (so typos can't silently fall back).
+  const takeValue = (flag, next) => {
+    if (next === undefined || next.startsWith("-")) {
+      throw new Error(`Missing value for ${flag}`);
+    }
+    return next;
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     switch (arg) {
       case "--mcp":
-        opts.mcp = argv[++i];
+        opts.mcp = takeValue(arg, argv[++i]);
         break;
       case "--ii":
-        opts.ii = argv[++i];
+        opts.ii = takeValue(arg, argv[++i]);
         break;
       case "--timeout":
-        opts.timeout = argv[++i];
+        opts.timeout = takeValue(arg, argv[++i]);
         break;
       case "--json":
         opts.json = true;

--- a/monitoring/mcp-status/cli.js
+++ b/monitoring/mcp-status/cli.js
@@ -80,11 +80,20 @@ const main = async () => {
     return;
   }
 
-  const report = await runDashboard({
-    mcpOrigin: typeof opts.mcp === "string" ? opts.mcp : undefined,
-    iiOrigin: typeof opts.ii === "string" ? opts.ii : undefined,
-    timeoutMs: opts.timeout ? Number(opts.timeout) : undefined,
-  });
+  let report;
+  try {
+    report = await runDashboard({
+      mcpOrigin: typeof opts.mcp === "string" ? opts.mcp : undefined,
+      iiOrigin: typeof opts.ii === "string" ? opts.ii : undefined,
+      timeoutMs: opts.timeout ? Number(opts.timeout) : undefined,
+    });
+  } catch (e) {
+    if (e && e.code === "DISALLOWED_ORIGIN") {
+      process.stderr.write(`${e.message}\n`);
+      process.exit(2);
+    }
+    throw e;
+  }
 
   if (opts.json) {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);

--- a/monitoring/mcp-status/config.js
+++ b/monitoring/mcp-status/config.js
@@ -1,0 +1,82 @@
+// Configuration and target resolution for the IMCP (IC MCP) status dashboard.
+//
+// The dashboard is environment-agnostic: by default it monitors the beta
+// deployment (mcp.beta.id.ai ↔ beta.id.ai) but any MCP origin / II origin
+// pair can be passed via CLI flags, environment variables, or query string.
+
+/** Default MCP server origin to monitor. */
+export const DEFAULT_MCP_ORIGIN = "https://mcp.beta.id.ai";
+
+/** Per-probe network timeout in milliseconds. */
+export const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Derive the Internet Identity origin an MCP server is expected to be paired
+ * with, using the naming convention `mcp.<env>.id.ai` ↔ `<env>.id.ai`
+ * (e.g. `mcp.beta.id.ai` → `beta.id.ai`, `mcp.id.ai` → `id.ai`).
+ *
+ * This is only a best-effort default; the true pairing is confirmed at runtime
+ * by checking the II instance's `form-action` CSP directive (see checks.js) and,
+ * when possible, by following the MCP server's `/oauth/authorize` redirect.
+ *
+ * @param {string} mcpOrigin
+ * @returns {string | undefined}
+ */
+export const deriveIiOrigin = (mcpOrigin) => {
+  try {
+    const url = new URL(mcpOrigin);
+    const host = url.host;
+    if (host.startsWith("mcp.")) {
+      return `${url.protocol}//${host.slice("mcp.".length)}`;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Normalise an origin string (strip trailing slash, lower-case host) or throw.
+ * @param {string} value
+ * @returns {string}
+ */
+export const normaliseOrigin = (value) => {
+  const url = new URL(value);
+  if (url.pathname !== "/" && url.pathname !== "") {
+    throw new Error(`Expected an origin (no path), got: ${value}`);
+  }
+  return url.origin;
+};
+
+/**
+ * Resolve the effective configuration from explicit overrides, falling back to
+ * environment variables and finally the built-in defaults.
+ *
+ * @param {{ mcpOrigin?: string, iiOrigin?: string, timeoutMs?: number }} [overrides]
+ * @returns {{ mcpOrigin: string, iiOrigin: string | undefined, iiOriginSource: "explicit" | "derived" | "none", timeoutMs: number }}
+ */
+export const resolveConfig = (overrides = {}) => {
+  const mcpOrigin = normaliseOrigin(
+    overrides.mcpOrigin ?? process.env.MCP_ORIGIN ?? DEFAULT_MCP_ORIGIN,
+  );
+
+  const explicitIi = overrides.iiOrigin ?? process.env.II_ORIGIN;
+  let iiOrigin;
+  /** @type {"explicit" | "derived" | "none"} */
+  let iiOriginSource;
+  if (explicitIi) {
+    iiOrigin = normaliseOrigin(explicitIi);
+    iiOriginSource = "explicit";
+  } else {
+    iiOrigin = deriveIiOrigin(mcpOrigin);
+    iiOriginSource = iiOrigin ? "derived" : "none";
+  }
+
+  const timeoutMs =
+    overrides.timeoutMs ??
+    (process.env.MCP_STATUS_TIMEOUT_MS
+      ? Number(process.env.MCP_STATUS_TIMEOUT_MS)
+      : DEFAULT_TIMEOUT_MS);
+
+  return { mcpOrigin, iiOrigin, iiOriginSource, timeoutMs };
+};

--- a/monitoring/mcp-status/config.js
+++ b/monitoring/mcp-status/config.js
@@ -2,8 +2,7 @@
 //
 // The dashboard is environment-agnostic: by default it monitors the beta
 // deployment (mcp.beta.id.ai ↔ beta.id.ai) but any allowed MCP origin / II
-// origin pair can be passed via CLI flags, environment variables, or query
-// string.
+// origin pair can be passed via CLI flags or environment variables.
 //
 // Probe targets are fixed by the operator (CLI flags, env vars, or defaults) —
 // `server.js` never takes them from an incoming request — and on top of that
@@ -38,9 +37,11 @@ const allowedHostSuffixes = () => {
 };
 
 /**
- * Whether an origin is allowed to be probed. Only https origins whose hostname
- * is within the allowlist are accepted (plus loopback hosts over http/https for
- * local development). Userinfo, custom ports and non-http schemes are rejected.
+ * Whether an origin is allowed to be probed. Only https origins on the default
+ * port (443) whose hostname is within the allowlist are accepted. Loopback
+ * hosts are additionally allowed over http/https on any port for local
+ * development. Userinfo, non-default ports (for remote hosts) and non-http
+ * schemes are rejected, to keep the SSRF surface minimal.
  *
  * @param {string} origin
  * @returns {boolean}
@@ -58,6 +59,8 @@ export const isAllowedOrigin = (origin) => {
     return url.protocol === "http:" || url.protocol === "https:";
   }
   if (url.protocol !== "https:") return false;
+  // `url.port` is "" for the default port; anything else is a non-default port.
+  if (url.port !== "") return false;
   return allowedHostSuffixes().some(
     (suffix) => host === suffix || host.endsWith(`.${suffix}`),
   );

--- a/monitoring/mcp-status/config.js
+++ b/monitoring/mcp-status/config.js
@@ -1,14 +1,86 @@
 // Configuration and target resolution for the IMCP (IC MCP) status dashboard.
 //
 // The dashboard is environment-agnostic: by default it monitors the beta
-// deployment (mcp.beta.id.ai ↔ beta.id.ai) but any MCP origin / II origin
-// pair can be passed via CLI flags, environment variables, or query string.
+// deployment (mcp.beta.id.ai ↔ beta.id.ai) but any allowed MCP origin / II
+// origin pair can be passed via CLI flags, environment variables, or query
+// string.
+//
+// Because `server.js` exposes the probes over HTTP with `?mcp=`/`?ii=` query
+// overrides, the resolved origins are validated against a host allowlist before
+// any request is made. This prevents the dashboard from being used as a
+// server-side request forgery (SSRF) proxy against arbitrary or internal hosts.
 
 /** Default MCP server origin to monitor. */
 export const DEFAULT_MCP_ORIGIN = "https://mcp.beta.id.ai";
 
 /** Per-probe network timeout in milliseconds. */
 export const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Host suffixes that may be probed. A hostname is allowed when it equals one of
+ * these or ends with `.<suffix>`. The list can be extended for other
+ * deployments via the `MCP_STATUS_ALLOWED_HOSTS` environment variable
+ * (comma-separated), but never narrowed below the built-in id.ai domains.
+ */
+const DEFAULT_ALLOWED_HOST_SUFFIXES = ["id.ai"];
+
+/** Loopback hosts allowed over http/https for local development and testing. */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+/** @returns {string[]} the effective list of allowed host suffixes. */
+const allowedHostSuffixes = () => {
+  const extra = (process.env.MCP_STATUS_ALLOWED_HOSTS ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  return [...DEFAULT_ALLOWED_HOST_SUFFIXES, ...extra];
+};
+
+/**
+ * Whether an origin is allowed to be probed. Only https origins whose hostname
+ * is within the allowlist are accepted (plus loopback hosts over http/https for
+ * local development). Userinfo, custom ports and non-http schemes are rejected.
+ *
+ * @param {string} origin
+ * @returns {boolean}
+ */
+export const isAllowedOrigin = (origin) => {
+  let url;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+  if (url.username || url.password) return false;
+  const host = url.hostname.toLowerCase();
+  if (LOOPBACK_HOSTS.has(host)) {
+    return url.protocol === "http:" || url.protocol === "https:";
+  }
+  if (url.protocol !== "https:") return false;
+  return allowedHostSuffixes().some(
+    (suffix) => host === suffix || host.endsWith(`.${suffix}`),
+  );
+};
+
+/**
+ * Assert that an origin is allowed to be probed, throwing a sanitised,
+ * non-sensitive error otherwise. The thrown error carries
+ * `code === "DISALLOWED_ORIGIN"` so callers can map it to a 400 response.
+ *
+ * @param {string} origin
+ * @returns {string} the same origin, when allowed
+ */
+export const assertAllowedOrigin = (origin) => {
+  if (!isAllowedOrigin(origin)) {
+    const err = new Error(
+      `origin not allowed: ${origin}. Allowed hosts: ${allowedHostSuffixes().join(", ")} (and loopback). Extend with MCP_STATUS_ALLOWED_HOSTS.`,
+    );
+    // @ts-expect-error augmenting the error with a discriminator code
+    err.code = "DISALLOWED_ORIGIN";
+    throw err;
+  }
+  return origin;
+};
 
 /**
  * Derive the Internet Identity origin an MCP server is expected to be paired
@@ -50,14 +122,17 @@ export const normaliseOrigin = (value) => {
 
 /**
  * Resolve the effective configuration from explicit overrides, falling back to
- * environment variables and finally the built-in defaults.
+ * environment variables and finally the built-in defaults. All resolved origins
+ * are validated against the host allowlist.
  *
  * @param {{ mcpOrigin?: string, iiOrigin?: string, timeoutMs?: number }} [overrides]
  * @returns {{ mcpOrigin: string, iiOrigin: string | undefined, iiOriginSource: "explicit" | "derived" | "none", timeoutMs: number }}
  */
 export const resolveConfig = (overrides = {}) => {
-  const mcpOrigin = normaliseOrigin(
-    overrides.mcpOrigin ?? process.env.MCP_ORIGIN ?? DEFAULT_MCP_ORIGIN,
+  const mcpOrigin = assertAllowedOrigin(
+    normaliseOrigin(
+      overrides.mcpOrigin ?? process.env.MCP_ORIGIN ?? DEFAULT_MCP_ORIGIN,
+    ),
   );
 
   const explicitIi = overrides.iiOrigin ?? process.env.II_ORIGIN;
@@ -65,10 +140,13 @@ export const resolveConfig = (overrides = {}) => {
   /** @type {"explicit" | "derived" | "none"} */
   let iiOriginSource;
   if (explicitIi) {
-    iiOrigin = normaliseOrigin(explicitIi);
+    iiOrigin = assertAllowedOrigin(normaliseOrigin(explicitIi));
     iiOriginSource = "explicit";
   } else {
     iiOrigin = deriveIiOrigin(mcpOrigin);
+    // A derived origin is a sub-domain of an already-allowed origin, but
+    // validate defensively so the allowlist is the single source of truth.
+    if (iiOrigin && !isAllowedOrigin(iiOrigin)) iiOrigin = undefined;
     iiOriginSource = iiOrigin ? "derived" : "none";
   }
 

--- a/monitoring/mcp-status/config.js
+++ b/monitoring/mcp-status/config.js
@@ -5,9 +5,10 @@
 // origin pair can be passed via CLI flags, environment variables, or query
 // string.
 //
-// Because `server.js` exposes the probes over HTTP with `?mcp=`/`?ii=` query
-// overrides, the resolved origins are validated against a host allowlist before
-// any request is made. This prevents the dashboard from being used as a
+// Probe targets are fixed by the operator (CLI flags, env vars, or defaults) —
+// `server.js` never takes them from an incoming request — and on top of that
+// the resolved origins are validated against a host allowlist before any
+// request is made. Together this prevents the dashboard from being used as a
 // server-side request forgery (SSRF) proxy against arbitrary or internal hosts.
 
 /** Default MCP server origin to monitor. */

--- a/monitoring/mcp-status/public/index.html
+++ b/monitoring/mcp-status/public/index.html
@@ -229,8 +229,6 @@
     </header>
     <main>
       <div class="controls">
-        <input id="mcp" placeholder="MCP origin (default mcp.beta.id.ai)" />
-        <input id="ii" placeholder="II origin (default: derived)" />
         <button id="refresh">Refresh</button>
         <label class="toggle">
           <input type="checkbox" id="auto" checked /> auto-refresh (30s)
@@ -316,10 +314,9 @@
         inFlight = true;
         $("refresh").disabled = true;
         try {
-          const params = new URLSearchParams();
-          if ($("mcp").value.trim()) params.set("mcp", $("mcp").value.trim());
-          if ($("ii").value.trim()) params.set("ii", $("ii").value.trim());
-          const res = await fetch("/api/status?" + params.toString());
+          // Targets are fixed by the server at startup (the server does not
+          // accept per-request targets), so no query parameters are sent.
+          const res = await fetch("/api/status");
           render(await res.json());
         } catch (e) {
           $("content").innerHTML =

--- a/monitoring/mcp-status/public/index.html
+++ b/monitoring/mcp-status/public/index.html
@@ -1,0 +1,345 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>IMCP Status Dashboard</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #f6f7f9;
+        --card: #ffffff;
+        --border: #e4e7ec;
+        --text: #1a1d23;
+        --muted: #667085;
+        --pass: #17b26a;
+        --warn: #f79009;
+        --fail: #f04438;
+        --accent: #5b6cff;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0f14;
+          --card: #161a22;
+          --border: #2a2f3a;
+          --text: #e7eaf0;
+          --muted: #98a2b3;
+        }
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family:
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.45;
+      }
+      header {
+        padding: 1.5rem 1.5rem 0.5rem;
+        max-width: 60rem;
+        margin: 0 auto;
+      }
+      h1 {
+        font-size: 1.4rem;
+        margin: 0 0 0.25rem;
+      }
+      .sub {
+        color: var(--muted);
+        font-size: 0.85rem;
+      }
+      main {
+        max-width: 60rem;
+        margin: 0 auto;
+        padding: 1rem 1.5rem 4rem;
+      }
+      .controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+        margin: 1rem 0;
+      }
+      .controls input {
+        padding: 0.45rem 0.6rem;
+        border: 1px solid var(--border);
+        border-radius: 0.5rem;
+        background: var(--card);
+        color: var(--text);
+        font-size: 0.85rem;
+        min-width: 14rem;
+      }
+      button {
+        padding: 0.45rem 0.9rem;
+        border: 1px solid var(--border);
+        border-radius: 0.5rem;
+        background: var(--accent);
+        color: #fff;
+        font-size: 0.85rem;
+        cursor: pointer;
+      }
+      button.secondary {
+        background: var(--card);
+        color: var(--text);
+      }
+      label.toggle {
+        font-size: 0.85rem;
+        color: var(--muted);
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+      }
+      .overall {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 1rem 1.25rem;
+        border: 1px solid var(--border);
+        border-radius: 0.75rem;
+        background: var(--card);
+        margin-bottom: 1.25rem;
+      }
+      .dot {
+        width: 0.9rem;
+        height: 0.9rem;
+        border-radius: 50%;
+        flex: none;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.72rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        padding: 0.15rem 0.5rem;
+        border-radius: 999px;
+      }
+      .pass {
+        --c: var(--pass);
+      }
+      .warn {
+        --c: var(--warn);
+      }
+      .fail {
+        --c: var(--fail);
+      }
+      .badge.pass,
+      .badge.warn,
+      .badge.fail {
+        color: var(--c);
+        background: color-mix(in srgb, var(--c) 14%, transparent);
+      }
+      .dot.pass,
+      .dot.warn,
+      .dot.fail {
+        background: var(--c);
+      }
+      section.card {
+        border: 1px solid var(--border);
+        border-radius: 0.75rem;
+        background: var(--card);
+        margin-bottom: 1.25rem;
+        overflow: hidden;
+      }
+      .card-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.9rem 1.25rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .card-head h2 {
+        font-size: 1rem;
+        margin: 0;
+      }
+      .check {
+        padding: 0.75rem 1.25rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .check:last-child {
+        border-bottom: none;
+      }
+      .check-top {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        flex-wrap: wrap;
+      }
+      .check-label {
+        font-weight: 600;
+        font-size: 0.92rem;
+      }
+      .latency {
+        color: var(--muted);
+        font-size: 0.75rem;
+        margin-left: auto;
+      }
+      .target {
+        color: var(--muted);
+        font-size: 0.78rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        margin: 0.2rem 0 0.1rem;
+        word-break: break-all;
+      }
+      .detail {
+        font-size: 0.85rem;
+        margin-top: 0.1rem;
+      }
+      .expected {
+        font-size: 0.75rem;
+        color: var(--muted);
+        margin-top: 0.15rem;
+      }
+      ul.suggestions {
+        margin: 0;
+        padding: 0.5rem 1.25rem 1rem 2.4rem;
+      }
+      ul.suggestions li {
+        margin: 0.4rem 0;
+        font-size: 0.88rem;
+      }
+      .error {
+        color: var(--fail);
+        padding: 1rem;
+      }
+      .facts {
+        font-size: 0.78rem;
+        color: var(--muted);
+        padding: 0 1.25rem 1rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        word-break: break-all;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>IMCP Status Dashboard</h1>
+      <div class="sub">
+        Health of the IC&nbsp;MCP server and its linked Internet Identity
+        instance.
+      </div>
+    </header>
+    <main>
+      <div class="controls">
+        <input id="mcp" placeholder="MCP origin (default mcp.beta.id.ai)" />
+        <input id="ii" placeholder="II origin (default: derived)" />
+        <button id="refresh">Refresh</button>
+        <label class="toggle">
+          <input type="checkbox" id="auto" checked /> auto-refresh (30s)
+        </label>
+        <span class="sub" id="updated"></span>
+      </div>
+      <div id="content"><p class="sub">Loading…</p></div>
+    </main>
+
+    <script>
+      const $ = (id) => document.getElementById(id);
+      const esc = (s) =>
+        String(s).replace(
+          /[&<>"]/g,
+          (c) =>
+            ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" })[c],
+        );
+
+      const badge = (status) =>
+        `<span class="badge ${status}">${status}</span>`;
+
+      function renderCheck(c) {
+        const latency =
+          c.latencyMs != null ? `<span class="latency">${c.latencyMs} ms</span>` : "";
+        return `<div class="check">
+          <div class="check-top">
+            <span class="dot ${c.status}"></span>
+            <span class="check-label">${esc(c.label)}</span>
+            ${badge(c.status)}
+            ${latency}
+          </div>
+          <div class="target">${esc(c.target)}</div>
+          <div class="detail">${esc(c.detail)}</div>
+          <div class="expected">expected: ${esc(c.expected)}</div>
+        </div>`;
+      }
+
+      function renderSection(s) {
+        return `<section class="card">
+          <div class="card-head">
+            <h2>${esc(s.title)}</h2>
+            ${badge(s.status)}
+          </div>
+          ${s.checks.map(renderCheck).join("")}
+        </section>`;
+      }
+
+      function render(report) {
+        const t = report.targets;
+        const parts = [];
+        parts.push(`<div class="overall">
+          <span class="dot ${report.overall}"></span>
+          <div>
+            <div><strong>Overall: </strong>${badge(report.overall)}</div>
+            <div class="sub">MCP: <code>${esc(t.mcpOrigin)}</code> &nbsp;·&nbsp; II: <code>${esc(t.iiOrigin || "(unresolved)")}</code></div>
+          </div>
+        </div>`);
+        for (const s of report.sections) parts.push(renderSection(s));
+
+        const canister = report.facts?.ii?.canisterId;
+        if (canister) {
+          parts.push(
+            `<div class="facts">II frontend canister: ${esc(canister)}</div>`,
+          );
+        }
+
+        if (report.suggestions?.length) {
+          parts.push(`<section class="card">
+            <div class="card-head"><h2>Suggestions</h2></div>
+            <ul class="suggestions">${report.suggestions
+              .map((s) => `<li>${esc(s)}</li>`)
+              .join("")}</ul>
+          </section>`);
+        }
+        $("content").innerHTML = parts.join("");
+        $("updated").textContent =
+          "updated " + new Date(report.generatedAt).toLocaleTimeString();
+      }
+
+      let inFlight = false;
+      async function load() {
+        if (inFlight) return;
+        inFlight = true;
+        $("refresh").disabled = true;
+        try {
+          const params = new URLSearchParams();
+          if ($("mcp").value.trim()) params.set("mcp", $("mcp").value.trim());
+          if ($("ii").value.trim()) params.set("ii", $("ii").value.trim());
+          const res = await fetch("/api/status?" + params.toString());
+          render(await res.json());
+        } catch (e) {
+          $("content").innerHTML =
+            `<p class="error">Failed to load status: ${esc(e.message)}</p>`;
+        } finally {
+          inFlight = false;
+          $("refresh").disabled = false;
+        }
+      }
+
+      let timer = null;
+      function syncTimer() {
+        if (timer) clearInterval(timer);
+        if ($("auto").checked) timer = setInterval(load, 30_000);
+      }
+
+      $("refresh").addEventListener("click", load);
+      $("auto").addEventListener("change", syncTimer);
+      syncTimer();
+      load();
+    </script>
+  </body>
+</html>

--- a/monitoring/mcp-status/report.js
+++ b/monitoring/mcp-status/report.js
@@ -1,0 +1,61 @@
+// Plain-text / ANSI rendering of a dashboard report for the CLI.
+
+const ANSI = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  red: "\x1b[31m",
+  cyan: "\x1b[36m",
+};
+
+const ICON = { pass: "✔", warn: "▲", fail: "✘" };
+
+/**
+ * @param {import("./checks.js").DashboardReport} report
+ * @param {{ color?: boolean }} [opts]
+ * @returns {string}
+ */
+export const renderText = (report, opts = {}) => {
+  const color = opts.color ?? true;
+  const c = (code, text) => (color ? `${code}${text}${ANSI.reset}` : text);
+  const statusColor = { pass: ANSI.green, warn: ANSI.yellow, fail: ANSI.red };
+  const tag = (status) =>
+    c(statusColor[status], `${ICON[status]} ${status.toUpperCase()}`);
+
+  const lines = [];
+  lines.push("");
+  lines.push(c(ANSI.bold, "IMCP (IC MCP) Status Dashboard"));
+  lines.push(
+    c(ANSI.dim, `Generated: ${report.generatedAt}`),
+  );
+  lines.push(
+    `MCP server: ${c(ANSI.cyan, report.targets.mcpOrigin)}   ` +
+      `II instance: ${c(ANSI.cyan, report.targets.iiOrigin ?? "(unresolved)")}`,
+  );
+  lines.push(`Overall: ${tag(report.overall)}`);
+
+  for (const section of report.sections) {
+    lines.push("");
+    lines.push(`${tag(section.status)}  ${c(ANSI.bold, section.title)}`);
+    for (const check of section.checks) {
+      const latency =
+        check.latencyMs != null ? c(ANSI.dim, ` (${check.latencyMs}ms)`) : "";
+      lines.push(`  ${tag(check.status)}  ${check.label}${latency}`);
+      lines.push(c(ANSI.dim, `      ${check.target}`));
+      lines.push(`      ${check.detail}`);
+    }
+  }
+
+  if (report.suggestions.length > 0) {
+    lines.push("");
+    lines.push(c(ANSI.bold, "Suggestions"));
+    for (const s of report.suggestions) {
+      lines.push(`  ${c(ANSI.cyan, "•")} ${s}`);
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+};

--- a/monitoring/mcp-status/server.js
+++ b/monitoring/mcp-status/server.js
@@ -22,11 +22,19 @@ import { runDashboard } from "./checks.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
+const DEFAULT_PORT = 8080;
 const parsePort = () => {
   const idx = process.argv.indexOf("--port");
-  if (idx !== -1) return Number(process.argv[idx + 1]);
-  if (process.env.PORT) return Number(process.env.PORT);
-  return 8080;
+  const raw = idx !== -1 ? process.argv[idx + 1] : process.env.PORT;
+  if (raw === undefined || raw === "") return DEFAULT_PORT;
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    process.stderr.write(
+      `Invalid port value; falling back to ${DEFAULT_PORT}\n`,
+    );
+    return DEFAULT_PORT;
+  }
+  return port;
 };
 const argValue = (flag) => {
   const idx = process.argv.indexOf(flag);

--- a/monitoring/mcp-status/server.js
+++ b/monitoring/mcp-status/server.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Tiny HTTP server that hosts the IMCP status dashboard.
+//
+// It serves a self-contained HTML page at `/` and runs the health probes
+// server-side at `/api/status`. Doing the probes server-side is what makes the
+// dashboard work at all: the MCP server's `/mcp` 401 challenge, its landing
+// page, and the II instance's CSP header are not CORS-readable from a browser.
+//
+// Usage:
+//   node monitoring/mcp-status/server.js [--port 8080] [--mcp <origin>] [--ii <origin>]
+//
+// The page also accepts `?mcp=` / `?ii=` query overrides so a single running
+// server can be pointed at different deployments.
+
+import http from "node:http";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { runDashboard } from "./checks.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const parsePort = () => {
+  const idx = process.argv.indexOf("--port");
+  if (idx !== -1) return Number(process.argv[idx + 1]);
+  if (process.env.PORT) return Number(process.env.PORT);
+  return 8080;
+};
+const argValue = (flag) => {
+  const idx = process.argv.indexOf(flag);
+  return idx !== -1 ? process.argv[idx + 1] : undefined;
+};
+
+const defaults = {
+  mcpOrigin: argValue("--mcp"),
+  iiOrigin: argValue("--ii"),
+};
+
+const sendJson = (res, code, body) => {
+  const payload = JSON.stringify(body);
+  res.writeHead(code, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+    "content-length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+};
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url ?? "/", "http://localhost");
+
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      const html = await readFile(join(here, "public", "index.html"));
+      res.writeHead(200, {
+        "content-type": "text/html; charset=utf-8",
+        "cache-control": "no-store",
+      });
+      res.end(html);
+      return;
+    }
+
+    if (url.pathname === "/api/status") {
+      const report = await runDashboard({
+        mcpOrigin: url.searchParams.get("mcp") ?? defaults.mcpOrigin,
+        iiOrigin: url.searchParams.get("ii") ?? defaults.iiOrigin,
+      });
+      sendJson(res, report.overall === "fail" ? 503 : 200, report);
+      return;
+    }
+
+    sendJson(res, 404, { error: "not found" });
+  } catch (e) {
+    sendJson(res, 500, { error: String(e?.message ?? e) });
+  }
+});
+
+const port = parsePort();
+server.listen(port, () => {
+  process.stdout.write(
+    `IMCP status dashboard listening on http://localhost:${port}\n` +
+      `  monitoring: ${defaults.mcpOrigin ?? "https://mcp.beta.id.ai (default)"}\n`,
+  );
+});

--- a/monitoring/mcp-status/server.js
+++ b/monitoring/mcp-status/server.js
@@ -6,11 +6,13 @@
 // dashboard work at all: the MCP server's `/mcp` 401 challenge, its landing
 // page, and the II instance's CSP header are not CORS-readable from a browser.
 //
+// The probe targets are fixed by the operator when the server is started — via
+// the defaults, `--mcp`/`--ii` flags, or the MCP_ORIGIN/II_ORIGIN env vars —
+// and are deliberately NOT taken from the incoming request. A hosted status
+// page must never let a visitor steer server-side requests at arbitrary hosts.
+//
 // Usage:
 //   node monitoring/mcp-status/server.js [--port 8080] [--mcp <origin>] [--ii <origin>]
-//
-// The page also accepts `?mcp=` / `?ii=` query overrides so a single running
-// server can be pointed at different deployments.
 
 import http from "node:http";
 import { readFile } from "node:fs/promises";
@@ -46,6 +48,19 @@ const sendJson = (res, code, body) => {
   res.end(payload);
 };
 
+// Replace control characters (incl. CR/LF) with spaces and cap the length, so
+// that a logged error message can never forge or inject additional log entries.
+// Implemented with a codepoint filter to avoid embedding control-char literals.
+const sanitizeForLog = (value) => {
+  const input = String((value && value.message) || value).slice(0, 300);
+  let out = "";
+  for (const ch of input) {
+    const code = ch.codePointAt(0);
+    out += code < 0x20 || code === 0x7f ? " " : ch;
+  }
+  return out;
+};
+
 const server = http.createServer(async (req, res) => {
   try {
     const url = new URL(req.url ?? "/", "http://localhost");
@@ -61,23 +76,20 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (url.pathname === "/api/status") {
-      const report = await runDashboard({
-        mcpOrigin: url.searchParams.get("mcp") ?? defaults.mcpOrigin,
-        iiOrigin: url.searchParams.get("ii") ?? defaults.iiOrigin,
-      });
+      const report = await runDashboard(defaults);
       sendJson(res, report.overall === "fail" ? 503 : 200, report);
       return;
     }
 
     sendJson(res, 404, { error: "not found" });
   } catch (e) {
-    // Disallowed origins are a client error with a fixed, safe message; any
-    // other failure is logged server-side and reported generically so that no
-    // stack-trace or internal detail leaks to the client.
+    // A misconfigured target is a client/operator error with a fixed, safe
+    // message; any other failure is logged (sanitised) server-side and reported
+    // generically so that no stack-trace or internal detail leaks to clients.
     if (e && e.code === "DISALLOWED_ORIGIN") {
       sendJson(res, 400, { error: "invalid or disallowed origin" });
     } else {
-      console.error("mcp-status: request failed:", e);
+      console.error("mcp-status: request failed:", sanitizeForLog(e));
       sendJson(res, 500, { error: "internal error" });
     }
   }

--- a/monitoring/mcp-status/server.js
+++ b/monitoring/mcp-status/server.js
@@ -71,7 +71,15 @@ const server = http.createServer(async (req, res) => {
 
     sendJson(res, 404, { error: "not found" });
   } catch (e) {
-    sendJson(res, 500, { error: String(e?.message ?? e) });
+    // Disallowed origins are a client error with a fixed, safe message; any
+    // other failure is logged server-side and reported generically so that no
+    // stack-trace or internal detail leaks to the client.
+    if (e && e.code === "DISALLOWED_ORIGIN") {
+      sendJson(res, 400, { error: "invalid or disallowed origin" });
+    } else {
+      console.error("mcp-status: request failed:", e);
+      sendJson(res, 500, { error: "internal error" });
+    }
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
     "format": "prettier --write src/frontend src/vc-api src/sig-verifier-js src/vite-plugins tsconfig.json tsconfig.all.json eslint.config.js vite.config.ts vitest.config.ts demos",
     "format-check": "prettier --check src/frontend src/vc-api src/sig-verifier-js src/vite-plugins tsconfig.json tsconfig.all.json eslint.config.js vite.config.ts vitest.config.ts demos",
     "extract": "lingui extract --clean",
-    "compile": "echo \"Does nothing, compilation is handled by the Vite plugin\""
+    "compile": "echo \"Does nothing, compilation is handled by the Vite plugin\"",
+    "mcp-status": "node monitoring/mcp-status/cli.js",
+    "mcp-status:serve": "node monitoring/mcp-status/server.js",
+    "mcp-status:test": "node --test monitoring/mcp-status/checks.test.js"
   },
   "devDependencies": {
     "@dfinity/internet-identity-vite-plugins": "*",


### PR DESCRIPTION
## What

Adds a standalone status dashboard for the **IC MCP** ("IMCP") server — by default [https://mcp.beta.id.ai](https://mcp.beta.id.ai) — and the Internet Identity instance it is paired with. It lives in `monitoring/mcp-status/` and ships a CLI, a small web dashboard, and unit tests.

It answers exactly the questions asked:

| Question | How it's answered |
| --- | --- |
| **Server running & responding on all advertised endpoints with correct codes?** | Probes `GET /` (200 HTML), `GET /.well-known/oauth-protected-resource` (200), `GET /.well-known/oauth-authorization-server` (200), `POST /mcp` (must be **401 + `WWW-Authenticate: Bearer resource_metadata=…`** — the OAuth challenge MCP clients rely on), `POST /oauth/register` (DCR mints a `client_id`), `GET /oauth/authorize` & `POST /oauth/token` (4xx liveness on bad input), a cross-consistency check of the two discovery docs, and TLS cert freshness. |
| **Which II instance is it linked to?** | Resolves the II origin via the `mcp.<env>.id.ai` ↔ `<env>.id.ai` convention (overridable with `--ii`), and attempts live confirmation by following the `/oauth/authorize` redirect. For beta this resolves to `https://beta.id.ai` (frontend canister `gjxif-ryaaa-aaaad-ae4ka-cai`). |
| **Is that II healthy & does it recognise this MCP server?** | Checks the II frontend is reachable + IC‑certified, reports its canister id and related origins, and — the authoritative bit — verifies the II response **CSP `form-action`** lists this MCP origin. That directive is derived server‑side from the canister's `mcp_server_origin` config, so it's the ground truth that the `/mcp` delegation flow is enabled for this server. ✅ confirmed for beta. |
| **Suggestions** | Generated partly from live findings (e.g. add an unauthenticated `/healthz` since unknown paths fall through to the OAuth 401 catch‑all; rate‑limit/prune anonymous DCR and share clients across replicas; wire the CLI into alerting; cert‑expiry warnings). |

## Why a standalone tool instead of a page in the II app

The II frontend is a static, prerendered `ssr: false` SvelteKit app served from a canister — no server runtime to probe from. And the signals that matter aren't browser‑readable: the MCP server's `/mcp` 401 and landing page send no CORS headers, and the II's CSP header (where recognition lives) can't be read cross‑origin. Probing server‑side in this small Node tool sidesteps CORS and lets the dashboard check what actually matters. It's dependency‑free (uses global `fetch` + `node:tls`).

## Usage

```bash
npm run mcp-status            # text report (exit 0 = healthy), defaults to beta
npm run mcp-status -- --json  # machine-readable, for cron/CI alerting
npm run mcp-status:serve      # live web dashboard at http://localhost:8080
npm run mcp-status:test       # node:test unit tests
node monitoring/mcp-status/cli.js --mcp https://mcp.id.ai   # point at prod
```

## Testing

- `npm run mcp-status:test` → 10/10 unit tests pass (stubbed `fetch`, no network).
- Ran the CLI live against `https://mcp.beta.id.ai`: all endpoint checks pass, II recognition confirmed; overall `WARN` only because the `/oauth/authorize`→II redirect isn't observable headlessly (informational).
- Verified the HTTP server serves the dashboard and `/api/status`.

Note: these files live outside `src/frontend`, so they're intentionally not covered by the existing eslint/prettier globs; they're plain ESM with JSDoc types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWuXJnQWpL9PtejcFKy9H8)_