### PR TITLE
feat(fe): relabel logged-in auth dialog as "Add existing identity"

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -40,6 +40,13 @@
     onError: (error: unknown) => void;
     mode?: AuthMode;
     children?: Snippet<[boolean?]>;
+    // Optional copy overrides forwarded to PickAuthenticationMethod, used
+    // by logged-in surfaces (e.g. the "Add existing identity" dialog) where
+    // the default sign-in copy is misleading.
+    passkeyLabel?: string;
+    switchModeTitle?: string;
+    switchModeDescription?: string;
+    switchModeButtonLabel?: string;
   }
 
   let {
@@ -48,6 +55,10 @@
     onError,
     mode = $bindable("both"),
     children,
+    passkeyLabel,
+    switchModeTitle,
+    switchModeDescription,
+    switchModeButtonLabel,
   }: Props = $props();
 
   // Initial mode snapshot — restored when the wizard's own dialog closes
@@ -458,6 +469,10 @@
     {mode}
     onSwitchMode={switchModeAvailable ? toggleMode : undefined}
     withinDialog={inDialog || isElevated || inAuthPanel}
+    {passkeyLabel}
+    {switchModeTitle}
+    {switchModeDescription}
+    {switchModeButtonLabel}
   />
 {/snippet}
 

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -17,11 +17,20 @@
     mode?: "signin" | "signup" | "both";
     onSwitchMode?: () => void;
     withinDialog?: boolean;
+    // Override the primary passkey button label (used when the picker lives
+    // inside a logged-in surface where the default "Sign in with passkey"
+    // copy is misleading, e.g. "Select one of its passkeys").
+    passkeyLabel?: string;
     // Override the switch-mode CTA title (used when the picker lives
     // inside a logged-in surface where the default "New to Internet
-    // Identity?" copy is misleading). When set, the description line is
-    // suppressed and the title carries the full prompt on its own.
+    // Identity?" copy is misleading). When set without an accompanying
+    // switchModeDescription, the description line is suppressed and the
+    // title carries the full prompt on its own.
     switchModeTitle?: string;
+    // Optional description shown beneath switchModeTitle.
+    switchModeDescription?: string;
+    // Override the switch-mode CTA button label (e.g. "Create").
+    switchModeButtonLabel?: string;
   }
 
   const {
@@ -31,7 +40,10 @@
     mode = "both",
     onSwitchMode,
     withinDialog = false,
+    passkeyLabel: passkeyLabelOverride,
     switchModeTitle,
+    switchModeDescription,
+    switchModeButtonLabel,
   }: Props = $props();
 
   const showLostAccess = $derived(mode !== "signup");
@@ -40,11 +52,12 @@
   );
 
   const passkeyLabel = $derived(
-    mode === "signin"
-      ? $t`Sign in with passkey`
-      : mode === "signup"
-        ? $t`Sign up with passkey`
-        : $t`Continue with passkey`,
+    passkeyLabelOverride ??
+      (mode === "signin"
+        ? $t`Sign in with passkey`
+        : mode === "signup"
+          ? $t`Sign up with passkey`
+          : $t`Continue with passkey`),
   );
   const providerLabel = (name: string) =>
     mode === "signin"
@@ -185,7 +198,11 @@
               ? $t`Want a new identity?`
               : $t`Already have an identity?`)}
         </div>
-        {#if switchModeTitle === undefined}
+        {#if switchModeDescription !== undefined}
+          <div class="text-text-tertiary mt-1 text-xs">
+            {switchModeDescription}
+          </div>
+        {:else if switchModeTitle === undefined}
           <div class="text-text-tertiary mt-1 text-xs">
             {mode === "signin"
               ? $t`Create one in seconds.`
@@ -198,7 +215,8 @@
         disabled={authenticatingProviderId !== undefined}
         class="btn btn-secondary btn-sm shrink-0 gap-2"
       >
-        {mode === "signin" ? $t`Sign up` : $t`Sign in`}
+        {switchModeButtonLabel ??
+          (mode === "signin" ? $t`Sign up` : $t`Sign in`)}
         <ArrowRightIcon class="size-4 rtl:-scale-x-100" />
       </button>
     </div>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -468,9 +468,23 @@
         handleError(error);
       }}
       bind:mode={authDialogMode}
+      passkeyLabel={authDialogMode === "signin"
+        ? $t`Select one of its passkeys`
+        : undefined}
+      switchModeTitle={authDialogMode === "signin"
+        ? $t`Create a new identity`
+        : undefined}
+      switchModeDescription={authDialogMode === "signin"
+        ? $t`Create one in seconds.`
+        : undefined}
+      switchModeButtonLabel={authDialogMode === "signin"
+        ? $t`Create`
+        : undefined}
     >
       <h1 class="text-text-primary my-2 self-start text-2xl font-medium">
-        {authDialogMode === "signup" ? $t`Add a new identity` : $t`Sign in`}
+        {authDialogMode === "signup"
+          ? $t`Add a new identity`
+          : $t`Add existing identity`}
       </h1>
       <p class="text-text-secondary mb-6 self-start text-sm">
         {$t`Choose method to continue`}


### PR DESCRIPTION
## Summary

Updates the auth dialog opened from the logged-in manage surface ("Use another identity") so its copy matches the intended design:

- **Title** (signin mode): `Sign in` → **`Add existing identity`**
- **Primary passkey button**: → **`Select one of its passkeys`**
- **Switch-mode CTA**: → **`Create a new identity`** / `Create one in seconds.` with a **`Create`** button

## Implementation

Threads optional copy overrides (`passkeyLabel`, `switchModeTitle`, `switchModeDescription`, `switchModeButtonLabel`) through `AuthWizard` to `PickAuthenticationMethod`. Defaults preserve existing copy on all other auth surfaces (authorize, cli, mcp, landing page). Overrides are applied only in signin mode, so toggling to signup still shows `Add a new identity` with the standard sign-up copy.

### Files changed
- `PickAuthenticationMethod.svelte` — accept and apply the new optional overrides
- `AuthWizard.svelte` — forward overrides to the picker
- `manage/(authenticated)/+layout.svelte` — set the overrides + new title in signin mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKogHB5WfCFfmAfGQbpjyU)_