### PR TITLE
fix(be): keep loopback http gated by explicit allowlist under sso_allow_any_domain

### DIFF
--- a/src/internet_identity/src/openid/sso.rs
+++ b/src/internet_identity/src/openid/sso.rs
@@ -298,8 +298,9 @@ struct DiscoveryDocument {
 #[cfg(not(test))]
 async fn discovery_fill(domain: String) -> Result<DiscoveredConfig, String> {
     // Hop 1: fetch /.well-known/ii-openid-configuration. Default to https; an
-    // allowlisted loopback host (the e2e provider, which can't serve TLS) may
-    // use http. The allowlist is the trust gate.
+    // explicitly allowlisted loopback host (the e2e provider, which can't serve
+    // TLS) may use http. The explicit allowlist is the trust gate — the
+    // `sso_allow_any_domain` flag opens the domain gate but never picks http.
     let hop1_scheme = scheme_for_allowlisted_host(&domain);
     let hop1_url = format!("{hop1_scheme}://{domain}/.well-known/ii-openid-configuration");
     let ii_config = fetch_ii_openid_configuration(hop1_url).await?;
@@ -480,12 +481,18 @@ fn host_with_port(url: &url::Url) -> Option<String> {
     })
 }
 
-/// Scheme for the hop-1 URL of an allowlisted domain: loopback (the e2e test
-/// provider) gets `http`, everything else `https`.
-#[cfg(not(test))]
+/// Scheme for the hop-1 URL. A loopback host (the e2e test provider, which
+/// can't serve TLS) gets `http`, but *only* when it's explicitly allowlisted;
+/// every other host gets `https`. Crucially, a loopback host that is reachable
+/// only because the `sso_allow_any_domain` flag opened the domain gate is *not*
+/// explicitly allowlisted, so it still gets `https`. This is what keeps the
+/// flag from becoming a plain-HTTP SSRF footgun: opening the domain gate must
+/// never let an un-allowlisted caller trigger an `http://` outcall to
+/// `localhost`/`127.0.0.1`. Consults the same explicit-allowlist gate as the
+/// hop-2 `https`-relaxation check ([`is_allowlisted_host`]).
 fn scheme_for_allowlisted_host(host: &str) -> &'static str {
     let bare = host.split(':').next().unwrap_or(host).to_ascii_lowercase();
-    if matches!(bare.as_str(), "localhost" | "127.0.0.1") {
+    if matches!(bare.as_str(), "localhost" | "127.0.0.1") && is_explicitly_allowlisted(host) {
         "http"
     } else {
         "https"
@@ -588,6 +595,28 @@ mod tests {
         // still consults it, so the flag does not bless arbitrary http hosts.
         assert!(is_explicitly_allowlisted("example.org"));
         assert!(!is_explicitly_allowlisted("not-allowed.com"));
+    }
+
+    #[test]
+    fn allow_any_domain_does_not_relax_https_for_loopback() {
+        reset();
+        // e2e setup: the loopback provider is explicitly allowlisted, so hop-1
+        // is allowed to use plain http (it can't serve TLS).
+        TEST_ALLOWED.with_borrow_mut(|d| *d = vec!["localhost:11107".to_string()]);
+        assert_eq!(scheme_for_allowlisted_host("localhost:11107"), "http");
+
+        // Flag on opens the *domain* gate for everything, loopback included...
+        TEST_ALLOW_ANY.with_borrow_mut(|b| *b = true);
+        assert!(is_allowed_discovery_domain("localhost"));
+        assert!(is_allowed_discovery_domain("127.0.0.1:8080"));
+        // ...but a loopback host reachable only via the flag (not on the
+        // explicit allowlist) still gets https: the flag must never trigger a
+        // plain-http outcall to localhost/127.0.0.1.
+        assert_eq!(scheme_for_allowlisted_host("localhost"), "https");
+        assert_eq!(scheme_for_allowlisted_host("localhost:9999"), "https");
+        assert_eq!(scheme_for_allowlisted_host("127.0.0.1:8080"), "https");
+        // Non-loopback hosts are always https regardless.
+        assert_eq!(scheme_for_allowlisted_host("evil.example.com"), "https");
     }
 
     #[test]


### PR DESCRIPTION
Addresses the review comment on #4045 (https://github.com/dfinity/internet-identity/pull/4045#discussion_r3444628094).

## Problem

Hop-1 of SSO discovery chooses its scheme via `scheme_for_allowlisted_host`, which keyed **only** on whether the host was loopback (`localhost` / `127.0.0.1`) — it never consulted the allowlist. That was safe only under the prior invariant that *every* domain reaching discovery was already explicitly allowlisted.

`sso_allow_any_domain` breaks that invariant: with the flag on, `is_allowed_discovery_domain` accepts **any** domain, so a non-allowlisted `localhost` / `127.0.0.1` now reaches hop-1 and gets a plain-`http://` outcall. That is an SSRF/footgun for staging deployments and contradicts the flag's stated "strict-`https` posture untouched" goal.

## Fix

Gate the loopback `http` downgrade on **explicit** allowlisting (the same gate hop-2 already uses), so the flag opens the *domain* gate but never relaxes `https`:

```rust
if matches!(bare.as_str(), "localhost" | "127.0.0.1") && is_explicitly_allowlisted(host) {
    "http"
} else {
    "https"
}
```

- A loopback host reachable *only* via the flag (not on the explicit allowlist) now gets `https` — no plain-HTTP outcall to loopback.
- The e2e provider `localhost:11107` stays on the explicit `sso_discoverable_domains` allowlist, so its `http` path is unaffected (no e2e regression).
- Adds regression unit test `allow_any_domain_does_not_relax_https_for_loopback`.

> Note: this is stacked on `feat/sso-allow-any-domain`; it can also just be cherry-picked as a single commit onto that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDnAektYFmpUWDHPLHypkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDnAektYFmpUWDHPLHypkQ)_