### PR TITLE
feat(fe): unify add-identity copy, single cross-device link, layered pairing modal

### DIFF
--- a/src/frontend/src/lib/components/wizards/addAccessMethod/AddAccessMethodWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/AddAccessMethodWizard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Dialog from "$lib/components/ui/Dialog.svelte";
   import SystemOverlayBackdrop from "$lib/components/utils/SystemOverlayBackdrop.svelte";
   import { AddAccessMethodFlow } from "$lib/flows/addAccessMethodFlow.svelte.js";
   import type {
@@ -74,12 +75,7 @@
   };
 </script>
 
-{#if isContinueOnAnotherDeviceVisible}
-  <ConfirmAccessMethodWizard
-    onConfirm={handleOtherDeviceRegistered}
-    {onError}
-  />
-{:else if addAccessMethodFlow.view === "chooseMethod"}
+{#if addAccessMethodFlow.view === "chooseMethod"}
   <AddAccessMethod
     createPasskey={handleCreatePasskey}
     continueOnAnotherDevice={() => (isContinueOnAnotherDeviceVisible = true)}
@@ -94,6 +90,19 @@
     goBack={addAccessMethodFlow.chooseMethod}
     {openIdCredentials}
   />
+{/if}
+
+<!-- Cross-device pairing is layered on top of the chooser as its own modal,
+     leaving the chooser mounted underneath. Closing it (X / Esc / backdrop)
+     only flips this flag back, returning the user to the "Add access method"
+     chooser rather than tearing down the whole (parent) dialog. -->
+{#if isContinueOnAnotherDeviceVisible}
+  <Dialog onClose={() => (isContinueOnAnotherDeviceVisible = false)}>
+    <ConfirmAccessMethodWizard
+      onConfirm={handleOtherDeviceRegistered}
+      {onError}
+    />
+  </Dialog>
 {/if}
 
 {#if addAccessMethodFlow.isSystemOverlayVisible}

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -173,25 +173,15 @@
   </div>
   <div class="flex flex-row items-center justify-between gap-4">
     <p class="text-text-tertiary text-sm">
-      {$t`Have a passkey on another device?`}
+      {$t`Add identity from another device`}
     </p>
-    <div class="flex items-center gap-2">
-      <button
-        onclick={continueOnAnotherDevice}
-        disabled={authenticatingProviderId !== undefined || isCreatingPasskey}
-        class="text-text-primary text-sm font-semibold outline-0 hover:underline focus-visible:underline"
-      >
-        {$t`URL`}
-      </button>
-      <span class="text-text-tertiary text-sm" aria-hidden="true">|</span>
-      <button
-        onclick={continueOnAnotherDevice}
-        disabled={authenticatingProviderId !== undefined || isCreatingPasskey}
-        class="text-text-primary text-sm font-semibold outline-0 hover:underline focus-visible:underline"
-      >
-        {$t`Scan QR`}
-      </button>
-    </div>
+    <button
+      onclick={continueOnAnotherDevice}
+      disabled={authenticatingProviderId !== undefined || isCreatingPasskey}
+      class="text-text-primary text-sm font-semibold outline-0 hover:underline focus-visible:underline"
+    >
+      {$t`URL | QR Code`}
+    </button>
   </div>
 </div>
 

--- a/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/addAccessMethod/views/AddAccessMethod.svelte
@@ -173,7 +173,7 @@
   </div>
   <div class="flex flex-row items-center justify-between gap-4">
     <p class="text-text-tertiary text-sm">
-      {$t`Add identity from another device`}
+      {$t`Add this identity to another device`}
     </p>
     <button
       onclick={continueOnAnotherDevice}

--- a/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/AuthWizard.svelte
@@ -480,15 +480,10 @@
      wizard's view changes. Prevents remount races between captcha and
      post-captcha views when SvelteKit navigation interleaves with the
      Dialog's onNavigate outro-pause. -->
-{#if authFlow.view === "chooseMethod" && !inDialog && !isElevated && authFlow.captcha === undefined && !isContinueFromAnotherDeviceVisible}
+{#if authFlow.view === "chooseMethod" && !inDialog && !isElevated && authFlow.captcha === undefined}
   {@render pickerBlock()}
 {:else}
-  {@const dialogOnClose =
-    authFlow.captcha !== undefined
-      ? undefined
-      : isContinueFromAnotherDeviceVisible
-        ? () => (isContinueFromAnotherDeviceVisible = false)
-        : reset}
+  {@const dialogOnClose = authFlow.captcha !== undefined ? undefined : reset}
   <!-- When the wizard is nested inside a parent Dialog, pass through
        and render content directly into the parent — avoids stacking
        two <dialog> elements (Safari renders both visibly, focus and
@@ -498,13 +493,22 @@
   <Dialog onClose={dialogOnClose} passthrough={inDialog}>
     {#if authFlow.captcha !== undefined}
       <SolveCaptcha {...authFlow.captcha} />
-    {:else if isContinueFromAnotherDeviceVisible}
-      <ContinueOnAnotherDeviceView onRegistered={handleRegistered} {onError} />
     {:else if authFlow.view === "chooseMethod"}
       {@render pickerBlock()}
     {:else}
       {@render activeView()}
     {/if}
+  </Dialog>
+{/if}
+
+<!-- Cross-device pairing is layered on top of the picker as its own
+     modal, leaving the picker mounted underneath. Closing it (X, Escape,
+     or backdrop) only flips this flag back, returning the user to the
+     "Add existing identity" picker rather than tearing down the whole
+     (parent) dialog — which is what a shared passthrough close would do. -->
+{#if isContinueFromAnotherDeviceVisible}
+  <Dialog onClose={() => (isContinueFromAnotherDeviceVisible = false)}>
+    <ContinueOnAnotherDeviceView onRegistered={handleRegistered} {onError} />
   </Dialog>
 {/if}
 

--- a/src/frontend/src/lib/components/wizards/auth/SignUpHero.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/SignUpHero.svelte
@@ -12,7 +12,7 @@
 <h2
   class="text-text-primary mb-1.5 self-center text-center text-[28px] leading-[1.1] font-medium tracking-tight"
 >
-  {$t`Sign up`}
+  {$t`Create new identity`}
 </h2>
 
 <p

--- a/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/PickAuthenticationMethod.svelte
@@ -29,10 +29,10 @@
     // Override the switch-mode CTA button label (e.g. "Create" instead
     // of the default "Sign up" / "Sign in").
     switchModeAction?: string;
-    // Override the primary passkey-button label. Used by surfaces that
-    // need different wording than the default mode-derived copy (e.g.
-    // /manage's "add existing identity" dialog uses "Select one of its
-    // passkeys" instead of "Sign in with passkey").
+    // Override the primary passkey-button label. The add-identity
+    // "Add existing identity" (signin) surfaces set this to "Select a
+    // passkey" instead of the default mode-derived "Sign in with passkey".
+    // Sign-up surfaces keep the default ("Create with passkey").
     passkeyLabel?: string;
   }
 
@@ -59,20 +59,20 @@
       (mode === "signin"
         ? $t`Sign in with passkey`
         : mode === "signup"
-          ? $t`Sign up with passkey`
+          ? $t`Create with passkey`
           : $t`Continue with passkey`),
   );
   const providerLabel = (name: string) =>
     mode === "signin"
       ? $t`Sign in with ${name}`
       : mode === "signup"
-        ? $t`Sign up with ${name}`
+        ? $t`Create with ${name}`
         : $t`Continue with ${name}`;
   const ssoLabel = $derived(
     mode === "signin"
       ? $t`Sign in with SSO`
       : mode === "signup"
-        ? $t`Sign up with SSO`
+        ? $t`Create with SSO`
         : $t`Continue with SSO`,
   );
 
@@ -171,25 +171,15 @@
   {#if continueOnAnotherDevice !== undefined && showLostAccess}
     <div class="flex flex-row items-center justify-between gap-4">
       <p class="text-text-tertiary text-sm">
-        {$t`Have a passkey on another device?`}
+        {$t`Add identity from another device`}
       </p>
-      <div class="flex items-center gap-2">
-        <button
-          onclick={continueOnAnotherDevice}
-          disabled={authenticatingProviderId !== undefined}
-          class="text-text-primary text-sm font-semibold outline-0 hover:underline focus-visible:underline"
-        >
-          {$t`URL`}
-        </button>
-        <span class="text-text-tertiary text-sm" aria-hidden="true">|</span>
-        <button
-          onclick={continueOnAnotherDevice}
-          disabled={authenticatingProviderId !== undefined}
-          class="text-text-primary text-sm font-semibold outline-0 hover:underline focus-visible:underline"
-        >
-          {$t`Scan QR`}
-        </button>
-      </div>
+      <button
+        onclick={continueOnAnotherDevice}
+        disabled={authenticatingProviderId !== undefined}
+        class="text-text-primary text-sm font-semibold outline-0 hover:underline focus-visible:underline"
+      >
+        {$t`URL | QR Code`}
+      </button>
     </div>
   {/if}
   {#if showLostAccess}

--- a/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/ContinueOnNewDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/confirmAccessMethod/views/ContinueOnNewDevice.svelte
@@ -25,7 +25,7 @@
 <div class="mt-4 flex flex-col gap-8">
   <div>
     <h1 class="text-text-primary mb-3 text-2xl font-medium sm:text-center">
-      {$t`Continue on another device`}
+      {$t`Add this identity to another device`}
     </h1>
     <p
       class="text-text-tertiary text-base font-medium text-balance sm:text-center"

--- a/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ContinueFromExistingDevice.svelte
+++ b/src/frontend/src/lib/components/wizards/registerAccessMethod/views/ContinueFromExistingDevice.svelte
@@ -25,14 +25,14 @@
 <div class="mt-4 flex flex-col gap-8">
   <div>
     <h1 class="text-text-primary mb-3 text-xl font-medium sm:text-center">
-      {$t`Can't find your identity?`}
+      {$t`Add identity from another device`}
     </h1>
     <p
       class="text-text-tertiary text-base font-medium text-balance sm:text-center"
     >
       <Trans>
         Use a device that already holds your identity to scan or open the URL.
-        This will link your identity to this device.
+        This will add your identity to this device.
       </Trans>
     </p>
   </div>

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -361,7 +361,7 @@
                 }}
                 bind:mode={inlinePickerMode}
                 passkeyLabel={inlinePickerMode === "signin"
-                  ? $t`Select one of its passkeys`
+                  ? $t`Select a passkey`
                   : undefined}
               >
                 {#snippet children(presenting)}
@@ -409,7 +409,7 @@
       }}
       bind:mode={authDialogMode}
       passkeyLabel={authDialogMode === "signin"
-        ? $t`Select one of its passkeys`
+        ? $t`Select a passkey`
         : undefined}
     >
       {#if authDialogMode === "signup"}

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -371,14 +371,14 @@
                 }}
                 bind:mode={authDialogMode}
                 passkeyLabel={authDialogMode === "signin"
-                  ? $t`Select one of its passkeys`
+                  ? $t`Select a passkey`
                   : undefined}
               >
                 <h1
                   class="text-text-primary my-2 self-start text-2xl font-medium"
                 >
                   {authDialogMode === "signup"
-                    ? $t`Add a new identity`
+                    ? $t`Create new identity`
                     : $t`Add existing identity`}
                 </h1>
                 <p class="text-text-secondary mb-6 self-start text-sm">

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -469,12 +469,12 @@
       }}
       bind:mode={authDialogMode}
       passkeyLabel={authDialogMode === "signin"
-        ? $t`Select one of its passkeys`
+        ? $t`Select a passkey`
         : undefined}
     >
       <h1 class="text-text-primary my-2 self-start text-2xl font-medium">
         {authDialogMode === "signup"
-          ? $t`Add a new identity`
+          ? $t`Create new identity`
           : $t`Add existing identity`}
       </h1>
       <p class="text-text-secondary mb-6 self-start text-sm">

--- a/src/frontend/tests/e2e-playwright-chrome-extension/chromeExtension.spec.ts
+++ b/src/frontend/tests/e2e-playwright-chrome-extension/chromeExtension.spec.ts
@@ -22,7 +22,7 @@ authorizeTest.describe("Authorize from chrome extension", () => {
       .getByRole("button", { name: "Create", exact: true })
       .click();
     await authorizePage.page
-      .getByRole("button", { name: "Sign up with passkey" })
+      .getByRole("button", { name: "Create with passkey" })
       .click();
     await authorizePage.page.getByLabel("Identity name").fill("Extension User");
     await authorizePage.page

--- a/src/frontend/tests/e2e-playwright/fixtures/identity.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/identity.ts
@@ -224,9 +224,9 @@ export class IdentityWizard {
     // WebAuthn flow; no intermediate Use existing / Create new dialog.
     // The button label varies by surface: /authorize landing keeps the
     // default "Sign in with passkey", while / and /manage / /authorize
-    // header dialogs override to "Select one of its passkeys".
+    // header dialogs override to "Select a passkey".
     const selectPasskey = this.#page.getByRole("button", {
-      name: "Select one of its passkeys",
+      name: "Select a passkey",
     });
     const signInWithPasskey = this.#page.getByRole("button", {
       name: "Sign in with passkey",
@@ -258,7 +258,7 @@ export class IdentityWizard {
         await signUpToggle.click();
       }
       await this.#page
-        .getByRole("button", { name: "Sign up with passkey" })
+        .getByRole("button", { name: "Create with passkey" })
         .click();
     }
     // Only the homepage flow navigates to /manage after registration.
@@ -285,7 +285,7 @@ export class IdentityWizard {
    * sits behind an "Add identity" / "Switch identity" CTA on the
    * welcome-back state and on `/authorize` / `/manage`. The picker may
    * be in mode="both" ("Continue with passkey") or in a mode-specific
-   * variant ("Sign in with passkey" / "Sign up with passkey") depending
+   * variant ("Sign in with passkey" / "Create with passkey") depending
    * on which surface rendered it. Callers handle the variants
    * themselves; this method just makes sure a picker is on screen.
    */
@@ -303,10 +303,10 @@ export class IdentityWizard {
       name: "Sign in with passkey",
     });
     const selectPasskey = this.#page.getByRole("button", {
-      name: "Select one of its passkeys",
+      name: "Select a passkey",
     });
     const signUpWithPasskey = this.#page.getByRole("button", {
-      name: "Sign up with passkey",
+      name: "Create with passkey",
     });
     await switchIdentity
       .or(addIdentity)

--- a/src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts
@@ -106,7 +106,7 @@ test("Should issue delegation when derivationOrigin is properly configured in /.
   // Create a new identity in II
   await addVirtualAuthenticator(authPage);
   await authPage.getByRole("button", { name: "Create", exact: true }).click();
-  await authPage.getByRole("button", { name: "Sign up with passkey" }).click();
+  await authPage.getByRole("button", { name: "Create with passkey" }).click();
   await authPage.getByLabel("Identity name").fill("John Doe");
   await authPage.getByRole("button", { name: "Create identity" }).click();
   await expect(

--- a/src/frontend/tests/e2e-playwright/routes/authorize/auth-disambiguation.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/auth-disambiguation.spec.ts
@@ -23,7 +23,7 @@ test.describe("AuthWizardView heading and subtitle", () => {
         .getByRole("button", { name: "Create", exact: true })
         .click();
       await authPage
-        .getByRole("button", { name: "Sign up with passkey" })
+        .getByRole("button", { name: "Create with passkey" })
         .click();
       await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
       await authPage.getByRole("button", { name: "Create identity" }).click();
@@ -66,7 +66,7 @@ test.describe("AuthWizardView heading and subtitle", () => {
         .getByRole("button", { name: "Create", exact: true })
         .click();
       await authPage
-        .getByRole("button", { name: "Sign up with passkey" })
+        .getByRole("button", { name: "Create with passkey" })
         .click();
       await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
       await authPage.getByRole("button", { name: "Create identity" }).click();
@@ -154,7 +154,7 @@ test.describe("IdentityNotConnectedDialog at /authorize", () => {
         .getByRole("button", { name: "Create", exact: true })
         .click();
       await authPage
-        .getByRole("button", { name: "Sign up with passkey" })
+        .getByRole("button", { name: "Create with passkey" })
         .click();
       await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
       await authPage.getByRole("button", { name: "Create identity" }).click();
@@ -395,12 +395,12 @@ test.describe("IdentityAlreadyLinkedDialog at /authorize (sign-up path)", () => 
       // The sign-up modal (parent dialog) is still visible; user can
       // proceed with passkey sign-up instead of auto-signing-in.
       await expect(
-        authPage.getByRole("button", { name: "Sign up with passkey" }),
+        authPage.getByRole("button", { name: "Create with passkey" }),
       ).toBeVisible();
 
       await addVirtualAuthenticator(authPage);
       await authPage
-        .getByRole("button", { name: "Sign up with passkey" })
+        .getByRole("button", { name: "Create with passkey" })
         .click();
       await authPage.getByLabel("Identity name").fill("New User");
       await authPage.getByRole("button", { name: "Create identity" }).click();

--- a/src/frontend/tests/e2e-playwright/routes/authorize/continue.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/continue.spec.ts
@@ -115,9 +115,7 @@ test.describe("multiple identities", () => {
       await authPage.getByRole("button", { name: "Add identity" }).click();
       // Sign-in dialog renders the mode="signin" picker; clicking it
       // goes straight to existing-passkey WebAuthn.
-      await authPage
-        .getByRole("button", { name: "Select one of its passkeys" })
-        .click();
+      await authPage.getByRole("button", { name: "Select a passkey" }).click();
       await authPage
         .getByRole("button", { name: "Continue", exact: true })
         .click();

--- a/src/frontend/tests/e2e-playwright/routes/authorize/delegationTtl.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/delegationTtl.spec.ts
@@ -17,7 +17,7 @@ test("Delegation maxTimeToLive: 1 min", async ({ page }) => {
   // Create new identity and authenticate
   await addVirtualAuthenticator(authPage);
   await authPage.getByRole("button", { name: "Create", exact: true }).click();
-  await authPage.getByRole("button", { name: "Sign up with passkey" }).click();
+  await authPage.getByRole("button", { name: "Create with passkey" }).click();
   await authPage.getByLabel("Identity name").fill("Test User");
   await authPage.getByRole("button", { name: "Create identity" }).click();
   await authPage.getByRole("button", { name: "Continue", exact: true }).click();
@@ -51,7 +51,7 @@ test("Delegation maxTimeToLive: 1 day", async ({ page }) => {
   // Create new identity and authenticate
   await addVirtualAuthenticator(authPage);
   await authPage.getByRole("button", { name: "Create", exact: true }).click();
-  await authPage.getByRole("button", { name: "Sign up with passkey" }).click();
+  await authPage.getByRole("button", { name: "Create with passkey" }).click();
   await authPage.getByLabel("Identity name").fill("Test User");
   await authPage.getByRole("button", { name: "Create identity" }).click();
   await authPage.getByRole("button", { name: "Continue", exact: true }).click();
@@ -84,7 +84,7 @@ test("Delegation maxTimeToLive: 2 months", async ({ page }) => {
   // Create new identity and authenticate
   await addVirtualAuthenticator(authPage);
   await authPage.getByRole("button", { name: "Create", exact: true }).click();
-  await authPage.getByRole("button", { name: "Sign up with passkey" }).click();
+  await authPage.getByRole("button", { name: "Create with passkey" }).click();
   await authPage.getByLabel("Identity name").fill("Test User");
   await authPage.getByRole("button", { name: "Create identity" }).click();
   await authPage.getByRole("button", { name: "Continue", exact: true }).click();

--- a/src/frontend/tests/e2e-playwright/routes/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/index.spec.ts
@@ -17,9 +17,7 @@ test("Authorize by registering a new passkey", async ({ page }) => {
   await authorize(page, async (authPage) => {
     await addVirtualAuthenticator(authPage);
     await authPage.getByRole("button", { name: "Create", exact: true }).click();
-    await authPage
-      .getByRole("button", { name: "Sign up with passkey" })
-      .click();
+    await authPage.getByRole("button", { name: "Create with passkey" }).click();
     await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
     await authPage.getByRole("button", { name: "Create identity" }).click();
     await authPage
@@ -74,15 +72,13 @@ test("Authorize by signing in from another device", async ({
     const principal = await authorize(page, async (authPage) => {
       // Switch to current device and start "Continue from another device" flow to get link.
       // The cancel→QR auto-transition was removed; use the explicit
-      // "Scan QR" CTA on the "Have a passkey on another device?" row.
+      // "URL | QR Code" CTA on the "Add identity from another device" row.
       await addVirtualAuthenticator(authPage);
-      await authPage
-        .getByRole("button", { name: "Scan QR", exact: true })
-        .click();
+      await authPage.getByRole("button", { name: "URL | QR Code" }).click();
       await authPage
         .getByRole("heading", {
           level: 1,
-          name: "Can't find your identity?",
+          name: "Add identity from another device",
         })
         .waitFor();
       const linkToPair = `https://${await authPage.getByLabel("Pairing link").innerText()}`;
@@ -270,7 +266,7 @@ test("Authorize with ICRC-29", async ({ page }) => {
         .getByRole("button", { name: "Create", exact: true })
         .click();
       await authPage
-        .getByRole("button", { name: "Sign up with passkey" })
+        .getByRole("button", { name: "Create with passkey" })
         .click();
       await authPage.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
       await authPage.getByRole("button", { name: "Create identity" }).click();
@@ -295,7 +291,7 @@ test("App logo doesn't appear when app is not known", async ({ page }) => {
         .getByRole("button", { name: "Create", exact: true })
         .click();
       await authPage
-        .getByRole("button", { name: "Sign up with passkey" })
+        .getByRole("button", { name: "Create with passkey" })
         .click();
       await authPage.getByLabel("Identity name").fill("John Doe");
       await authPage.getByRole("button", { name: "Create identity" }).click();

--- a/src/frontend/tests/e2e-playwright/routes/authorize/legacy.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/legacy.spec.ts
@@ -30,7 +30,7 @@ import {
             .getByRole("button", { name: "Create", exact: true })
             .click();
           await authPage
-            .getByRole("button", { name: "Sign up with passkey" })
+            .getByRole("button", { name: "Create with passkey" })
             .click();
           await authPage.getByLabel("Identity name").fill("Test");
           await authPage

--- a/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
@@ -35,7 +35,7 @@ const signUp = async (page: Page): Promise<void> => {
     await page.getByRole("button", { name: "Create new identity" }).click();
   } else {
     await signUpToggle.click();
-    await page.getByRole("button", { name: "Sign up with passkey" }).click();
+    await page.getByRole("button", { name: "Create with passkey" }).click();
   }
   await page.getByLabel("Identity name").fill("Test User");
   await page.getByRole("button", { name: "Create identity" }).click();

--- a/src/frontend/tests/e2e-playwright/routes/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/index.spec.ts
@@ -13,7 +13,7 @@ test.describe("First visit", () => {
     // The homepage's empty-state picker renders in sign-in mode; toggle
     // to sign-up via the picker CTA, which opens the sign-up dialog.
     await page.getByRole("button", { name: "Create", exact: true }).click();
-    await page.getByRole("button", { name: "Sign up with passkey" }).click();
+    await page.getByRole("button", { name: "Create with passkey" }).click();
     await page.getByLabel("Identity name").fill(DEFAULT_USER_NAME);
     await page.getByRole("button", { name: "Create identity" }).click();
     await page.waitForURL(II_URL + "/manage");
@@ -33,9 +33,7 @@ test.describe("First visit", () => {
     await addAuthenticatorForIdentity(page, identities[0].identityNumber);
     await page.goto(II_URL);
     // Sign-in mode picker goes directly to existing-passkey WebAuthn.
-    await page
-      .getByRole("button", { name: "Select one of its passkeys" })
-      .click();
+    await page.getByRole("button", { name: "Select a passkey" }).click();
     await managePage.assertVisible();
   });
 
@@ -59,15 +57,15 @@ test.describe("First visit", () => {
       await newDevicePage.goto(II_URL);
       // No existing passkeys on the new device. The cancel→QR auto
       // transition was removed; reach the cross-device flow via the
-      // explicit "Scan QR" CTA on the "Have a passkey on another
-      // device?" row.
+      // explicit "URL | QR Code" CTA on the "Add identity from another
+      // device" row.
       await newDevicePage
-        .getByRole("button", { name: "Scan QR", exact: true })
+        .getByRole("button", { name: "URL | QR Code" })
         .click();
       await newDevicePage
         .getByRole("heading", {
           level: 1,
-          name: "Can't find your identity?",
+          name: "Add identity from another device",
         })
         .waitFor();
       const linkToPair = `https://${await newDevicePage.getByLabel("Pairing link").innerText()}`;
@@ -79,7 +77,7 @@ test.describe("First visit", () => {
       );
       await existingDevicePage.goto(linkToPair);
       await existingDevicePage
-        .getByRole("button", { name: "Select one of its passkeys" })
+        .getByRole("button", { name: "Select a passkey" })
         .click();
 
       // Switch to new device and get confirmation code
@@ -547,9 +545,7 @@ test.describe("Last used identities listed", () => {
     // Now sign in through the welcome-back "Add identity" entry point;
     // the sign-in dialog opens with the mode="signin" picker.
     await page.getByRole("button", { name: "Add identity" }).click();
-    await page
-      .getByRole("button", { name: "Select one of its passkeys" })
-      .click();
+    await page.getByRole("button", { name: "Select a passkey" }).click();
     await managePage.assertVisible();
   });
 
@@ -571,7 +567,7 @@ test.describe("Last used identities listed", () => {
     await addVirtualAuthenticator(page);
     await page.getByRole("button", { name: "Add identity" }).click();
     await page.getByRole("button", { name: "Create", exact: true }).click();
-    await page.getByRole("button", { name: "Sign up with passkey" }).click();
+    await page.getByRole("button", { name: "Create with passkey" }).click();
     await page.getByLabel("Identity name").fill(SECONDARY_USER_NAME);
     await page.getByRole("button", { name: "Create identity" }).click();
     await managePage.assertVisible();

--- a/src/frontend/tests/e2e-playwright/routes/manage/access.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/manage/access.spec.ts
@@ -197,6 +197,56 @@ test.describe("Access methods", () => {
     await manageAccessPage.assertPasskeyCount(16);
   });
 
+  test("returns to the chooser when the cross-device dialog is closed", async ({
+    page,
+  }) => {
+    // Open the "Add access method" chooser.
+    await page
+      .getByRole("main")
+      .getByRole("button", { name: "Add new" })
+      .click();
+    await expect(
+      page.getByRole("heading", { name: "Add access method" }),
+    ).toBeVisible();
+
+    // Open the cross-device pairing modal via the single "URL | QR Code" link.
+    await page.getByRole("button", { name: "URL | QR Code" }).click();
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Add this identity to another device",
+      }),
+    ).toBeVisible();
+
+    // The pairing modal is layered on top of the chooser; closing it returns
+    // to the chooser rather than tearing down the whole add-access dialog.
+    // Both <dialog>s match getByRole("dialog") (the pairing one is nested),
+    // so target the innermost via .last().
+    const pairingDialog = page
+      .getByRole("dialog")
+      .filter({
+        has: page.getByRole("heading", {
+          name: "Add this identity to another device",
+        }),
+      })
+      .last();
+    await pairingDialog.getByRole("button", { name: "Close" }).click();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Add this identity to another device",
+      }),
+    ).toBeHidden();
+    // The chooser is still open — the dialog was not torn down.
+    await expect(
+      page.getByRole("heading", { name: "Add access method" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Continue with passkey" }),
+    ).toBeVisible();
+  });
+
   test.describe("can remove a legacy passkey", () => {
     const LEGACY_PASSKEY_NAME = "pre-upgrade-passkey";
 

--- a/src/frontend/tests/e2e-playwright/routes/manage/identities.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/manage/identities.spec.ts
@@ -132,7 +132,7 @@ test.describe("Sign out confirmation", () => {
     // No identities left — should see the inline auth picker (the
     // homepage's empty state renders it in sign-in mode).
     await expect(
-      page.getByRole("button", { name: "Select one of its passkeys" }),
+      page.getByRole("button", { name: "Select a passkey" }),
     ).toBeVisible();
   });
 });

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -24,7 +24,7 @@ const signUp = async (page: Page): Promise<void> => {
     await page.getByRole("button", { name: "Create new identity" }).click();
   } else {
     await signUpToggle.click();
-    await page.getByRole("button", { name: "Sign up with passkey" }).click();
+    await page.getByRole("button", { name: "Create with passkey" }).click();
   }
   await page.getByLabel("Identity name").fill("Test User");
   await page.getByRole("button", { name: "Create identity" }).click();


### PR DESCRIPTION
Stacked on top of #4043 (base branch is that PR's branch, so this diff shows only the delta). Polishes the three add-identity surfaces — landing, `/manage/access`, and `/authorize` add-identity — so the new terminology is consistent and the cross-device pairing modal behaves sensibly.

## What changed

### 1. Consistent terminology across the three flows
- **Sign up → "Create new identity"**: `SignUpHero` heading, and the `/authorize` + `/manage` header add-identity dialogs (were "Add a new identity"). In the picker, sign-up labels become **"Create with passkey"** / "Create with &lt;provider&gt;" / "Create with SSO" (default for `mode="signup"`, so /cli, /mcp and the /authorize landing get it too).
- **Sign in → "Add existing identity" / "Select a passkey"**: the sign-in passkey CTA override **"Select one of its passkeys" → "Select a passkey"** on the `/`, `/manage` and `/authorize` header dialogs. (The default `"Sign in with passkey"` is kept for the /authorize landing / cli / mcp surfaces.)

### 2. One cross-device link instead of two
The duplicated `URL | Scan QR` pair (two buttons doing the same thing) collapses to a **single "URL | QR Code" link**. The row prompt is direction-specific:
- Add-identity flows (auth picker): **"Add identity from another device"** (you're adding an existing identity *to this* device).
- `/manage/access` chooser: **"Add this identity to another device"** (you're extending the current identity *to another* device).

### 3. Closing the pairing modal returns to the picker/chooser (all three flows)
Previously, in the parent-dialog surfaces the cross-device view shared the parent dialog's close button, so closing it tore down the whole dialog. It now renders as **its own modal layered on top of the picker/chooser** (which stays mounted underneath); closing it via X / Esc / backdrop only dismisses the pairing modal and returns to the **"Add existing identity"** picker (add-identity flows) or the **"Add access method"** chooser (`/manage/access`).

### 4. Pairing modal copy
- Add-identity pairing modal (`ContinueFromExistingDevice`): heading **"Can't find your identity?" → "Add identity from another device"**; body **"…This will link your identity to this device." → "…This will add your identity to this device."**
- `/manage/access` pairing modal (`ContinueOnNewDevice`): heading **"Continue on another device" → "Add this identity to another device"**.

### Tests
- Updated Playwright specs/fixtures to the new labels and the single `URL | QR Code` cross-device link.
- Added an e2e test (`routes/manage/access.spec.ts`) that opens the `/manage/access` cross-device modal and asserts that **closing it returns to the "Add access method" chooser** rather than tearing down the whole dialog.

## Validation
`prettier --check`, `eslint --max-warnings 0`, and `svelte-check` all pass on the changed files (svelte-check run with an `icp` stub since the IC CLI isn't present in the sandbox; the remaining check errors are unrelated demo subprojects). The new e2e test will run in CI.

## Notes
- The sign-up↔sign-in footer toggle button is still "Sign in" (paired with "Already have an identity?"); left as-is from #4043, easy to switch to "Add existing" if you want.
- Stacked on #4043 — needs retargeting to `main` once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)