### PR TITLE
fix(scripts): hide HSM PIN entry in make-upgrade-proposal

### DIFF
--- a/scripts/make-upgrade-proposal
+++ b/scripts/make-upgrade-proposal
@@ -1106,7 +1106,7 @@ dry_run_proposal() {
       --use-hsm \
       --key-id "01" \
       --slot 0 \
-      --pin "$(read -p 'HSM PIN? '; echo "$REPLY")" \
+      --pin "$(read -sp 'HSM PIN? '; echo >&2; echo "$REPLY")" \
       --nns-url "https://ic0.app" \
       propose-to-change-nns-canister \
       --proposer "$(read -p 'NEURON ID? '; echo "$REPLY")" \
@@ -1128,7 +1128,7 @@ dry_run_proposal() {
       --use-hsm \
       --key-id "01" \
       --slot 0 \
-      --pin "$(read -p 'HSM PIN? '; echo "$REPLY")" \
+      --pin "$(read -sp 'HSM PIN? '; echo >&2; echo "$REPLY")" \
       --nns-url "https://ic0.app" \
       propose-to-change-nns-canister \
       --proposer "$(read -p 'NEURON ID? '; echo "$REPLY")" \
@@ -1186,7 +1186,7 @@ make_backend_proposal() {
     --use-hsm \
     --key-id "01" \
     --slot 0 \
-    --pin "$(read -p 'HSM PIN? '; echo "$REPLY")" \
+    --pin "$(read -sp 'HSM PIN? '; echo >&2; echo "$REPLY")" \
     --nns-url "https://ic0.app" \
     propose-to-change-nns-canister \
     --proposer "$(read -p 'NEURON ID? '; echo "$REPLY")" \
@@ -1211,7 +1211,7 @@ make_frontend_proposal() {
     --use-hsm \
     --key-id "01" \
     --slot 0 \
-    --pin "$(read -p 'HSM PIN? '; echo "$REPLY")" \
+    --pin "$(read -sp 'HSM PIN? '; echo >&2; echo "$REPLY")" \
     --nns-url "https://ic0.app" \
     propose-to-change-nns-canister \
     --proposer "$(read -p 'NEURON ID? '; echo "$REPLY")" \


### PR DESCRIPTION
## Problem
`scripts/make-upgrade-proposal` prompts for the HSM PIN four times (twice in `dry_run_proposal`, once each in `make_backend_proposal` / `make_frontend_proposal`) using `read -p 'HSM PIN? '`. Plain `read` echoes input to the terminal, so the PIN is visible on-screen while the operator types it and remains in scrollback.

## Changes
Switch the four prompts to `read -sp` (silent) and emit a newline to stderr afterwards so the next line of output doesn't glue itself to the prompt.

```bash
--pin "$(read -sp 'HSM PIN? '; echo >&2; echo "$REPLY")" \
```

## Tests
Verified the prompt behavior in a bash subshell:

```
$ bash -c 'pin="$(read -sp "HSM PIN? "; echo >&2; echo "$REPLY")"; echo "captured: [$pin]"'
HSM PIN?
captured: [hunter2]
```

Prompt appears, typed characters are not echoed, cursor advances after Enter, and the value is captured correctly.