### PR TITLE
fix(be): require a bare authority when sso_allow_any_domain opens the gate

### DIFF
--- a/src/internet_identity/src/openid/sso.rs
+++ b/src/internet_identity/src/openid/sso.rs
@@ -250,7 +250,45 @@ fn is_explicitly_allowlisted(domain: &str) -> bool {
 }
 
 pub fn is_allowed_discovery_domain(domain: &str) -> bool {
-    sso_allow_any_domain() || is_explicitly_allowlisted(domain)
+    // An explicitly allowlisted domain is admin-curated and trusted verbatim.
+    // The `sso_allow_any_domain` flag, by contrast, makes the domain
+    // caller-controlled, and `domain` is later interpolated into a discovery
+    // URL (`{scheme}://{domain}/.well-known/...`). Require it to be a bare
+    // authority so the flag means "any *domain*", not "any string that happens
+    // to parse inside a URL": inputs carrying userinfo (`evil.com@127.0.0.1`), a
+    // path (`host/..`), a query, or a fragment could otherwise change the
+    // effective request target.
+    is_explicitly_allowlisted(domain) || (sso_allow_any_domain() && is_bare_authority(domain))
+}
+
+/// True if `domain` is a bare URL authority — a host, optionally `host:port`,
+/// and nothing else: no scheme, userinfo, path, query, or fragment. It is
+/// parsed the same way it is later used (as the authority of an `https`
+/// discovery URL) and required to round-trip exactly, so anything the URL
+/// parser would reinterpret — embedded userinfo/path/query/fragment, stripped
+/// control characters, an injected scheme — is rejected. (A redundant
+/// `:443`/`:80` default port is normalized away by the parser and thus rejected
+/// too; real discovery domains don't carry one.)
+fn is_bare_authority(domain: &str) -> bool {
+    let Ok(url) = url::Url::parse(&format!("https://{domain}")) else {
+        return false;
+    };
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !matches!(url.path(), "" | "/")
+    {
+        return false;
+    }
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    let authority = match url.port() {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    };
+    authority == domain.to_ascii_lowercase()
 }
 
 /// True if `host` (the `host:port` portion of a URL) matches an allowlist
@@ -617,6 +655,47 @@ mod tests {
         assert_eq!(scheme_for_allowlisted_host("127.0.0.1:8080"), "https");
         // Non-loopback hosts are always https regardless.
         assert_eq!(scheme_for_allowlisted_host("evil.example.com"), "https");
+    }
+
+    #[test]
+    fn allow_any_domain_rejects_non_authority() {
+        reset();
+        TEST_ALLOW_ANY.with_borrow_mut(|b| *b = true);
+
+        // Bare authorities pass: host, sub-host, and explicit (non-default)
+        // port, case-insensitively.
+        assert!(is_allowed_discovery_domain("example.com"));
+        assert!(is_allowed_discovery_domain("sub.example.com"));
+        assert!(is_allowed_discovery_domain("example.com:8443"));
+        assert!(is_allowed_discovery_domain("Example.COM"));
+
+        // Anything that isn't a bare host[:port] is rejected even with the flag
+        // on, so the caller-controlled value can't reshape the interpolated
+        // discovery URL (`{scheme}://{domain}/.well-known/...`).
+        for bad in [
+            "evil.com@127.0.0.1",    // userinfo — real host is 127.0.0.1
+            "user:pass@example.com", // userinfo
+            "example.com/..",        // path traversal
+            "example.com/foo",       // path
+            "example.com?x=1",       // query
+            "example.com#frag",      // fragment
+            "https://example.com",   // injected scheme
+            "example.com:443",       // redundant default port (normalized away)
+            "exa mple.com",          // whitespace in host
+            "",                      // empty
+        ] {
+            assert!(
+                !is_allowed_discovery_domain(bad),
+                "expected `{bad}` to be rejected even with sso_allow_any_domain on",
+            );
+        }
+
+        // The bare-authority check only gates the flag path: an explicitly
+        // allowlisted entry is admin-curated and trusted verbatim, so it is
+        // accepted even if it wouldn't pass `is_bare_authority` on its own.
+        TEST_ALLOWED.with_borrow_mut(|d| *d = vec!["example.com/weird".to_string()]);
+        assert!(!is_bare_authority("example.com/weird"));
+        assert!(is_allowed_discovery_domain("example.com/weird"));
     }
 
     #[test]


### PR DESCRIPTION
Addresses the unresolved Copilot review comment on #4045 ([discussion](https://github.com/dfinity/internet-identity/pull/4045#discussion_r3444755122)).

Stacked on `feat/sso-allow-any-domain` so the diff is just this fix (can also be cherry-picked as a single commit).

## Problem

With `sso_allow_any_domain` enabled, `is_allowed_discovery_domain` accepted any *string*, not just a syntactically valid `host` / `host:port`. That value is later interpolated into a discovery URL (`format!("{scheme}://{domain}/.well-known/...")`), so inputs carrying userinfo (`evil.com@127.0.0.1`), a path (`example.com/..`), a query, or a fragment could change the effective request target — i.e. the flag meant "any string that happens to parse in a URL" rather than "any *domain*".

## Fix

- `is_allowed_discovery_domain` now gates the **flag path** on a new `is_bare_authority` check: the domain is parsed the same way it's later used (as the authority of an `https` URL) and required to round-trip exactly, rejecting anything with a scheme, userinfo, path, query, or fragment (and, as a side effect of the round-trip, stripped control characters and a redundant `:443`/`:80` default port — real discovery domains don't carry one).
- The **explicit allowlist path** is unchanged: admin-curated `sso_discoverable_domains` entries stay trusted verbatim and bypass the new check.
- The strict-`https` posture is untouched — this only narrows what the domain gate accepts.

## Tests

- New unit test `openid::sso::allow_any_domain_rejects_non_authority` covering accepted bare authorities (host, sub-host, `host:port`, case-insensitive) and rejected non-authorities (userinfo, path, query, fragment, injected scheme, default-port, whitespace, empty), plus the allowlist short-circuit.
- The `is_bare_authority` logic was additionally verified against the exact `url` 2.5 crate semantics in an isolated harness, since the full backend crate can't be compiled in this environment (a transitive git dependency is outside the session's egress scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZpyWEEopJBAVKBo2KACiV)_