### PR TITLE
fix(ci): use icp-cli syntax for identity import in deploy-rc

### DIFF
--- a/.github/workflows/deploy-rc.yml
+++ b/.github/workflows/deploy-rc.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           key_pem=$(mktemp)
           printenv "ICP_DEPLOY_KEY" > "$key_pem"
-          icp identity import --disable-encryption --force default "$key_pem"
+          icp identity import --force --from-pem "$key_pem" default
           rm "$key_pem"
 
       - name: "Deploy Release Candidate"


### PR DESCRIPTION
## Problem
The scheduled `Deploy Release Candidate` workflow has been failing every Tuesday since the `dfx → icp-cli` migration (#3801) — ~10 consecutive weeks. The latest failure: https://github.com/dfinity/internet-identity/actions/runs/28048752169.

The `Install key` step runs:

```bash
icp identity import --disable-encryption --force default "$key_pem"
```

That's dfx's argument layout, not icp-cli's. icp-cli errors out:

```
error: unexpected argument '--disable-encryption' found

Usage: icp identity import [OPTIONS] <--from-pem <FILE>|--read-seed-phrase|--from-seed-file <FILE>> <NAME>
```

Two issues with the old line:
- `--disable-encryption` isn't a flag in `icp identity import` — icp-cli doesn't encrypt PEMs at rest the way dfx did (the deploy step already sets `ICP_WARNING=-mainnet_plaintext_identity` to suppress the related warning).
- The PEM path must be passed as `--from-pem <FILE>`; the trailing positional is the identity **name** (`default`).

## Changes
Switch to the icp-cli layout in [.github/workflows/deploy-rc.yml](.github/workflows/deploy-rc.yml):

```bash
icp identity import --force --from-pem "$key_pem" default
```

No other steps change.

## Tests
Can't fully validate locally — the step needs `secrets.DFX_DEPLOY_KEY` and write access to the RC canister, neither of which exists outside the upstream runner. Real validation is either:
- Letting next Tuesday's cron run, or
- Triggering the workflow manually via `workflow_dispatch` after merge.