### PR TITLE
fix(fe): show correct SSO error when a domain isn't allowlisted

### DIFF
--- a/src/frontend/src/lib/components/wizards/auth/views/SignInWithSso.svelte
+++ b/src/frontend/src/lib/components/wizards/auth/views/SignInWithSso.svelte
@@ -96,9 +96,18 @@
   ): string | undefined => {
     if (e instanceof DomainNotConfiguredError) {
       if (e.reason === "timeout") {
-        return $t`${domainInput} took too long to respond. Try again in a moment.`;
+        // The domain IS on II's allowlist, but discovery never resolved.
+        // A failed or unreachable discovery fetch surfaces here too — the
+        // canister keeps reporting `Pending` until we time out — so this is
+        // the case where pointing the SSO admin at the discovery endpoint
+        // actually helps.
+        return $t`Couldn't load SSO settings from ${domainInput}. Ask your SSO admin to check that /.well-known/ii-openid-configuration is reachable.`;
       }
-      return $t`Couldn't load SSO settings from ${domainInput}. Ask your SSO admin to check that /.well-known/ii-openid-configuration is reachable.`;
+      // `rejected` is the canister's `NotAllowed`: the domain isn't on II's
+      // SSO allowlist, so no discovery was ever attempted. Telling the user
+      // to check the discovery endpoint would be misleading — the domain
+      // simply isn't set up for SSO with II yet.
+      return $t`SSO is not available for "${domainInput}" yet. Ask an II admin to register this domain.`;
     }
     if (e instanceof OAuthProviderError) {
       // `unsupported_response_type` = the SSO app is code-only; II needs
@@ -117,12 +126,6 @@
         return $t`${domainInput}'s SSO returned "${e.error}": ${e.errorDescription}`;
       }
       return $t`${domainInput}'s SSO returned error "${e.error}".`;
-    }
-    if (e instanceof Error) {
-      const msg = e.message;
-      if (msg.toLowerCase().includes("canary allowlist")) {
-        return $t`SSO is not available for "${domainInput}" yet. Ask an II admin to register this domain.`;
-      }
     }
     return undefined;
   };

--- a/src/frontend/src/lib/locales/de.po
+++ b/src/frontend/src/lib/locales/de.po
@@ -37,9 +37,6 @@ msgstr "{displayName}-Konto"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "{domainInput} hat /.well-known/ii-openid-configuration nicht veröffentlicht (HTTP {0})."
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} hat zu lange für eine Antwort gebraucht. Versuchen Sie es in einem Moment erneut."
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "Die /.well-known/ii-openid-configuration von {domainInput} ist fehlerhaft."
 

--- a/src/frontend/src/lib/locales/en.po
+++ b/src/frontend/src/lib/locales/en.po
@@ -37,9 +37,6 @@ msgstr "{displayName} account"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} took too long to respond. Try again in a moment."
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 

--- a/src/frontend/src/lib/locales/es.po
+++ b/src/frontend/src/lib/locales/es.po
@@ -37,9 +37,6 @@ msgstr "Cuenta de {displayName}"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "{domainInput} no publicó /.well-known/ii-openid-configuration (HTTP {0})."
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} tardó demasiado en responder. Inténtalo de nuevo en un momento."
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "El /.well-known/ii-openid-configuration de {domainInput} está mal formado."
 

--- a/src/frontend/src/lib/locales/fr.po
+++ b/src/frontend/src/lib/locales/fr.po
@@ -37,9 +37,6 @@ msgstr "Compte {displayName}"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "{domainInput} n’a pas publié /.well-known/ii-openid-configuration (HTTP {0})."
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} a mis trop de temps à répondre. Réessayez dans un instant."
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "Le fichier /.well-known/ii-openid-configuration de {domainInput} est mal formé."
 

--- a/src/frontend/src/lib/locales/id.po
+++ b/src/frontend/src/lib/locales/id.po
@@ -37,9 +37,6 @@ msgstr "Akun {displayName}"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "{domainInput} tidak mempublikasikan /.well-known/ii-openid-configuration (HTTP {0})."
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} terlalu lama merespons. Coba lagi sebentar lagi."
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "/.well-known/ii-openid-configuration milik {domainInput} tidak valid."
 

--- a/src/frontend/src/lib/locales/it.po
+++ b/src/frontend/src/lib/locales/it.po
@@ -37,9 +37,6 @@ msgstr "Account {displayName}"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "{domainInput} non ha pubblicato /.well-known/ii-openid-configuration (HTTP {0})."
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} ha impiegato troppo tempo a rispondere. Riprova tra un momento."
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "Il file /.well-known/ii-openid-configuration di {domainInput} è malformato."
 

--- a/src/frontend/src/lib/locales/nl.po
+++ b/src/frontend/src/lib/locales/nl.po
@@ -37,9 +37,6 @@ msgstr "{displayName}-account"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "{domainInput} heeft /.well-known/ii-openid-configuration niet gepubliceerd (HTTP {0})."
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} duurde te lang om te reageren. Probeer het over een moment opnieuw."
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "De /.well-known/ii-openid-configuration van {domainInput} is ongeldig."
 

--- a/src/frontend/src/lib/locales/pl.po
+++ b/src/frontend/src/lib/locales/pl.po
@@ -37,9 +37,6 @@ msgstr "Konto {displayName}"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "{domainInput} nie opublikował /.well-known/ii-openid-configuration (HTTP {0})."
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} zbyt długo nie odpowiadał. Spróbuj ponownie za chwilę."
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "Plik /.well-known/ii-openid-configuration domeny {domainInput} jest nieprawidłowy."
 

--- a/src/frontend/src/lib/locales/ru.po
+++ b/src/frontend/src/lib/locales/ru.po
@@ -37,9 +37,6 @@ msgstr "Аккаунт {displayName}"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "Домен {domainInput} не опубликовал /.well-known/ii-openid-configuration (HTTP {0})."
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} слишком долго не отвечал. Попробуйте снова через некоторое время."
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "Файл /.well-known/ii-openid-configuration домена {domainInput} имеет неверный формат."
 

--- a/src/frontend/src/lib/locales/uk.po
+++ b/src/frontend/src/lib/locales/uk.po
@@ -37,9 +37,6 @@ msgstr "Обліковий запис {displayName}"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "{domainInput} не опублікував /.well-known/ii-openid-configuration (HTTP {0})."
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} не відповів вчасно. Спробуйте ще раз за мить."
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "Файл /.well-known/ii-openid-configuration домену {domainInput} має неправильний формат."
 

--- a/src/frontend/src/lib/locales/ur.po
+++ b/src/frontend/src/lib/locales/ur.po
@@ -37,9 +37,6 @@ msgstr "{displayName} اکاؤنٹ"
 msgid "{domainInput} didn't publish /.well-known/ii-openid-configuration (HTTP {0})."
 msgstr "{domainInput} نے /.well-known/ii-openid-configuration شائع نہیں کیا (HTTP {0})۔"
 
-msgid "{domainInput} took too long to respond. Try again in a moment."
-msgstr "{domainInput} کو جواب دینے میں بہت زیادہ وقت لگا۔ تھوڑی دیر بعد دوبارہ کوشش کریں۔"
-
 msgid "{domainInput}'s /.well-known/ii-openid-configuration is malformed."
 msgstr "{domainInput} کی /.well-known/ii-openid-configuration درست شکل میں نہیں ہے۔"
 


### PR DESCRIPTION
## Problem

On id.ai, typing an SSO domain that isn't on the canister's discovery allowlist (e.g. `beta.dfinity.org` against the production canister, whose allowlist is `["dfinity.org"]`) shows:

> Couldn't load SSO settings from beta.dfinity.org. Ask your SSO admin to check that /.well-known/ii-openid-configuration is reachable.

This is the wrong message. When a domain isn't allowlisted, the canister rejects it at the allowlist gate (`get_sso_discovery` → `NotAllowed`) and **never even attempts** the `/.well-known/ii-openid-configuration` fetch — so advising the admin to check that endpoint's reachability is misleading.

## Root cause

`discoverSsoConfig` maps the canister's `NotAllowed` to `DomainNotConfiguredError("rejected")`. In `SignInWithSso.svelte`, the error mapper had the two `DomainNotConfiguredError` reasons mapped to semantically-mismatched copy:

- `rejected` (not allowlisted) → "...check that /.well-known/ii-openid-configuration is reachable." ❌
- `timeout` (allowlisted, but discovery never resolved) → "took too long to respond." 

The correct "domain isn't registered for SSO" copy already existed, but only inside a dead `canary allowlist` string-match branch that nothing ever triggers (no error in the codebase carries that text).

## Fix

- **`rejected`** now reports that SSO isn't available for the domain yet, reusing the message previously stranded in the dead branch.
- The **`/.well-known/ii-openid-configuration` reachability advice** moves to the **`timeout`** case — the one situation where the domain *is* allowlisted but discovery never resolved (a failed/unreachable fetch surfaces as a timeout because the canister keeps reporting `Pending`), so checking that endpoint actually helps.
- Removed the now-dead `canary allowlist` branch and the orphaned `took too long to respond` catalog entry across all locales.

Both messages I now use already existed as msgids, so existing translations carry over and no new untranslated strings are introduced.

## Testing

No automated tests assert on these UI strings (verified). The change is a 1:1 remapping of which existing message is shown for each `DomainNotConfiguredError` reason, plus removal of dead code. Manual verification on a deployment where the typed domain is off the allowlist will now show "SSO is not available for ... yet. Ask an II admin to register this domain." instead of the endpoint-reachability message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgPmHHcAwFqjo2j64KXr7G

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgPmHHcAwFqjo2j64KXr7G)_