### PR TITLE
fix(fe): pass SSO discovery domain when switching to an SSO method

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/+page.svelte
@@ -271,9 +271,13 @@
               ? lastUsedAuthMethod.sso.loginHint
               : undefined;
         let jwt: string;
+        let ssoDiscoveryPromise:
+          | ReturnType<typeof discoverSsoConfig>
+          | undefined;
         if (ssoDomain !== undefined) {
+          ssoDiscoveryPromise = discoverSsoConfig(ssoDomain);
           jwt = await requestWithPopup(
-            discoverSsoConfig(ssoDomain).then((ssoResult) => ({
+            ssoDiscoveryPromise.then((ssoResult) => ({
               clientId: ssoResult.clientId,
               authURL: ssoResult.discovery.authorization_endpoint,
               authScope: selectAuthScopes(
@@ -298,11 +302,17 @@
             { nonce: session.nonce, mediation: "optional", loginHint },
           );
         }
-        const { iss: jwtIss, sub, loginHint: jwtLoginHint } = decodeJWT(jwt);
+        const {
+          iss: jwtIss,
+          sub,
+          loginHint: jwtLoginHint,
+          email: jwtEmail,
+        } = decodeJWT(jwt);
         const { identity, identityNumber } = await authenticateWithJWT({
           canisterId,
           session,
           jwt,
+          discoveryDomain: ssoDomain,
         });
         // The OAuth popup lets the user pick any account — if they choose one
         // linked to a different anchor, the JWT authenticates to that anchor.
@@ -318,13 +328,32 @@
           identityNumber,
           authMethod: { openid: { iss: jwtIss, sub } },
         });
+        const ssoName =
+          ssoDiscoveryPromise !== undefined
+            ? (await ssoDiscoveryPromise).name
+            : undefined;
         lastUsedIdentitiesStore.addLastUsedIdentity({
           identityNumber,
           name: data.identityInfo.name[0],
           createdAtMillis,
-          authMethod: {
-            openid: { iss: jwtIss, sub, loginHint: jwtLoginHint, metadata },
-          },
+          authMethod:
+            ssoDomain !== undefined
+              ? {
+                  sso: {
+                    domain: ssoDomain,
+                    name: ssoName,
+                    email: jwtEmail,
+                    loginHint: jwtLoginHint,
+                  },
+                }
+              : {
+                  openid: {
+                    iss: jwtIss,
+                    sub,
+                    loginHint: jwtLoginHint,
+                    metadata,
+                  },
+                },
         });
       }
       switchingAccessMethodKey = undefined;

--- a/src/frontend/tests/e2e-playwright/routes/manage/access.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/manage/access.spec.ts
@@ -388,7 +388,9 @@ test.describe("Access methods", () => {
         .getByRole("main")
         .getByRole("listitem")
         .filter({ hasText: "Passkey" });
-      await expect(passkeyItem.getByText("Active")).toBeVisible();
+      await expect(
+        passkeyItem.getByText("Active", { exact: true }),
+      ).toBeVisible();
 
       // Switch to the SSO method via More options → Switch → Continue. The
       // canister rejects the JWT as "Authorization invalid" if the handler

--- a/src/frontend/tests/e2e-playwright/routes/manage/access.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/manage/access.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "../../fixtures";
 import { createActorForCredential, II_URL } from "../../utils";
 import { DEFAULT_PASSKEY_NAME } from "../../fixtures/manageAccessPage";
+import { SSO_DISCOVERY_DOMAIN, SSO_OPENID_PORT } from "../../fixtures/sso";
 import { ECDSAKeyIdentity } from "@icp-sdk/core/identity";
 import { LEGACY_II_URL } from "$lib/config";
 
@@ -344,6 +345,100 @@ test.describe("Access methods", () => {
       await manageAccessPage
         .findPasskey(LEGACY_PASSKEY_NAME)
         .assertRemoveDisabled();
+    });
+  });
+
+  test.describe("with an SSO method", () => {
+    const ssoEmail = "switch-sso@example.com";
+
+    test.use({
+      openIdConfig: {
+        defaultPort: SSO_OPENID_PORT,
+        createUsers: [{ claims: { email: ssoEmail } }],
+      },
+    });
+
+    test("can link an SSO method and switch to it", async ({
+      page,
+      manageAccessPage,
+      openSsoPopup,
+      signInWithOpenId,
+      openIdUsers,
+    }) => {
+      // Link the SSO method via the Add access method dialog. The SSO entry
+      // button (aria-label "Continue with SSO") routes the wizard to the
+      // SignInWithSso view, where `openSsoPopup` fills the domain, waits
+      // for canister-side discovery, and clicks Continue.
+      await manageAccessPage.add(async () => {
+        const popup = await openSsoPopup(page);
+        const closed = popup.waitForEvent("close", { timeout: 15_000 });
+        await signInWithOpenId(popup, openIdUsers[0].id);
+        await closed;
+      });
+
+      // The linked SSO credential renders as its own list item — pick it
+      // out by the email claim we set on the test IdP user.
+      const ssoItem = page
+        .getByRole("main")
+        .getByRole("listitem")
+        .filter({ hasText: ssoEmail });
+      await expect(ssoItem).toBeVisible();
+      // The passkey is still the active method.
+      const passkeyItem = page
+        .getByRole("main")
+        .getByRole("listitem")
+        .filter({ hasText: "Passkey" });
+      await expect(passkeyItem.getByText("Active")).toBeVisible();
+
+      // Switch to the SSO method via More options → Switch → Continue. The
+      // canister rejects the JWT as "Authorization invalid" if the handler
+      // omits the SSO discovery domain (regression guard for the prior bug).
+      await ssoItem.getByRole("button", { name: "More options" }).click();
+      await page.getByRole("menuitem", { name: "Switch" }).click();
+      const switchDialog = page.getByRole("dialog").filter({
+        has: page.getByRole("heading", { name: "Switch access method" }),
+      });
+      await expect(switchDialog).toBeVisible();
+      const switchPopupPromise = page.context().waitForEvent("page");
+      await switchDialog.getByRole("button", { name: "Continue" }).click();
+      const switchPopup = await switchPopupPromise;
+      const switchPopupClosed = switchPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(switchPopup, openIdUsers[0].id);
+      await switchPopupClosed;
+
+      // Success toast + Active badge flips to the SSO item.
+      await expect(switchDialog).toBeHidden();
+      await expect(page.getByRole("status")).toContainText(
+        "Successfully switched access method",
+      );
+      await expect(ssoItem.getByText("Active", { exact: true })).toBeVisible();
+      await expect(
+        passkeyItem.getByText("Active", { exact: true }),
+      ).toBeHidden();
+
+      // Last-used entry must be tagged as `sso` so a subsequent "last used"
+      // sign-in re-authenticates via the SSO branch (not the configured
+      // OpenID branch, which would have no discovery domain).
+      const lastUsedRaw = await page.evaluate(() =>
+        localStorage.getItem("ii-last-used-identities"),
+      );
+      expect(lastUsedRaw).not.toBeNull();
+      const lastUsed = JSON.parse(lastUsedRaw!) as {
+        data: Record<string, { authMethod: Record<string, unknown> }>;
+      };
+      const entries = Object.values(lastUsed.data);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.authMethod).toHaveProperty("sso");
+      expect(entries[0]?.authMethod).not.toHaveProperty("openid");
+      const sso = (entries[0]!.authMethod as { sso: Record<string, unknown> })
+        .sso;
+      expect(sso).toMatchObject({
+        domain: SSO_DISCOVERY_DOMAIN,
+        email: ssoEmail,
+      });
+      expect(sso.loginHint).toEqual(expect.any(String));
     });
   });
 

--- a/src/frontend/tests/e2e-playwright/routes/manage/access.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/manage/access.spec.ts
@@ -392,6 +392,13 @@ test.describe("Access methods", () => {
         passkeyItem.getByText("Active", { exact: true }),
       ).toBeVisible();
 
+      // Drop the IdP's session cookie from the link popup so the switch
+      // popup re-prompts for sign-in; otherwise the IdP silently reuses
+      // the existing session and `signInWithOpenId` can't find its
+      // "Sign-in" heading. II's session lives in localStorage and on
+      // `id.ai`, so clearing `localhost` cookies leaves it untouched.
+      await page.context().clearCookies({ domain: "localhost" });
+
       // Switch to the SSO method via More options → Switch → Continue. The
       // canister rejects the JWT as "Authorization invalid" if the handler
       // omits the SSO discovery domain (regression guard for the prior bug).


### PR DESCRIPTION
On /manage/access, switching the active access method to an SSO method (More options → Switch → Continue) failed with "Authorization invalid". The switch handler extracted `ssoDomain` to fetch the JWT, but dropped it before calling `authenticateWithJWT`, so the subsequent `openid_prepare_delegation` / `openid_get_delegation` calls ran without a discovery domain and the canister had no JWKS to verify the JWT against.

Sign-in, account-link, and signup paths thread `discoveryDomain` through correctly (see [`authFlow.svelte.ts:542`](../blob/main/src/frontend/src/lib/flows/authFlow.svelte.ts#L542), [`authFlow.svelte.ts:816`](../blob/main/src/frontend/src/lib/flows/authFlow.svelte.ts#L816)); only the switch path was missing it.

While in the same block, the lastUsed-identity entry written after a successful switch always recorded `authMethod: { openid: { iss, sub, ... } }`, even when the switched-to method was SSO — that would have made the next "last used" sign-in go down the configured-OpenID branch and miss the domain. The sign-in flows record SSO as `authMethod: { sso: { domain, name, email, loginHint } }`; this PR matches that shape.

## Changes

- Pass `discoveryDomain: ssoDomain` to `authenticateWithJWT` in `handleSwitchConfirmed`.
- Cache the `discoverSsoConfig` promise so its `name` field can be reused without re-running discovery, then store the lastUsed entry as `sso` (with `domain`, `name`, `email`, `loginHint`) when the method is SSO, falling back to `openid` for configured providers.

## Tests

- `npm run check` (svelte-check + tsc): 0 errors.
- `npm run lint`: 0 problems.
- New Playwright spec `tests/e2e-playwright/routes/manage/access.spec.ts` — describe `"Access methods > with an SSO method"` — signs in with a passkey, links an SSO method via the Add access method dialog, then exercises More options → Switch → Continue on the SSO item. Asserts (a) the success toast fires, (b) the Active badge moves to the SSO item, and (c) the lastUsed entry is tagged as `sso` (with `domain`, `email`, `loginHint`) so a subsequent "last used" sign-in routes through the SSO branch. Local e2e run was skipped (port 8000 was held by a parallel worktree's `icp network`); relying on this PR's `canister-tests / e2e-playwright` CI job to verify.