### PR TITLE
fix(fe,be): drop connect-time account selection; let the agent list app accounts

### DIFF
--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -471,7 +471,6 @@ pub fn mcp_set_access(
     sender: Principal,
     identity_number: IdentityNumber,
     mcp_server_origin: FrontendHostname,
-    account_number: Option<AccountNumber>,
     enabled: bool,
 ) -> Result<Result<(), String>, RejectResponse> {
     call_candid_as(
@@ -480,7 +479,7 @@ pub fn mcp_set_access(
         RawEffectivePrincipal::None,
         sender,
         "mcp_set_access",
-        (identity_number, mcp_server_origin, account_number, enabled),
+        (identity_number, mcp_server_origin, enabled),
     )
     .map(|(x,)| x)
 }
@@ -491,14 +490,29 @@ pub fn mcp_access_enabled(
     sender: Principal,
     identity_number: IdentityNumber,
     mcp_server_origin: FrontendHostname,
-    account_number: Option<AccountNumber>,
 ) -> Result<bool, RejectResponse> {
     query_candid_as(
         env,
         canister_id,
         sender,
         "mcp_access_enabled",
-        (identity_number, mcp_server_origin, account_number),
+        (identity_number, mcp_server_origin),
+    )
+    .map(|(x,)| x)
+}
+
+pub fn mcp_get_accounts(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+    target_origin: FrontendHostname,
+) -> Result<Result<Vec<AccountInfo>, AccountDelegationError>, RejectResponse> {
+    query_candid_as(
+        env,
+        canister_id,
+        sender,
+        "mcp_get_accounts",
+        (target_origin,),
     )
     .map(|(x,)| x)
 }

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -1129,7 +1129,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'mcp_access_enabled' : IDL.Func(
-        [UserNumber, FrontendHostname, IDL.Opt(AccountNumber)],
+        [UserNumber, FrontendHostname],
         [IDL.Bool],
         ['query'],
       ),
@@ -1138,6 +1138,16 @@ export const idlFactory = ({ IDL }) => {
         [
           IDL.Variant({
             'Ok' : SignedDelegation,
+            'Err' : AccountDelegationError,
+          }),
+        ],
+        ['query'],
+      ),
+    'mcp_get_accounts' : IDL.Func(
+        [FrontendHostname],
+        [
+          IDL.Variant({
+            'Ok' : IDL.Vec(AccountInfo),
             'Err' : AccountDelegationError,
           }),
         ],
@@ -1160,7 +1170,7 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'mcp_set_access' : IDL.Func(
-        [UserNumber, FrontendHostname, IDL.Opt(AccountNumber), IDL.Bool],
+        [UserNumber, FrontendHostname, IDL.Bool],
         [IDL.Variant({ 'Ok' : IDL.Null, 'Err' : IDL.Text })],
         [],
       ),

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1145,10 +1145,10 @@ export type LookupByRegistrationIdError = { 'InvalidRegistrationId' : string };
 export interface McpConfig { 'url' : [] | [string], 'enabled' : boolean }
 /**
  * Result of mcp_prepare_account_delegation. Carries the account_number the
- * canister resolved (the anchor's default account at target_origin) so the MCP
- * server can thread the same account into mcp_get_account_delegation — the
- * default is mutable, so re-resolving it in `get` could otherwise diverge and
- * yield NoSuchDelegation.
+ * canister used (the one named in the request, or the anchor's default account
+ * at target_origin when none was named) so the MCP server can thread the same
+ * account into mcp_get_account_delegation — the default is mutable, so
+ * re-resolving it in `get` could otherwise diverge and yield NoSuchDelegation.
  */
 export interface McpPrepareDelegation {
   'user_key' : UserKey,
@@ -2056,21 +2056,27 @@ export interface _SERVICE {
     [] | [DeviceKeyWithAnchor]
   >,
   /**
-   * Whether the anchor has MCP access enabled for the (mcp_server_origin,
-   * account_number) pair.
+   * Whether the anchor has MCP access enabled at mcp_server_origin.
    */
-  'mcp_access_enabled' : ActorMethod<
-    [UserNumber, FrontendHostname, [] | [AccountNumber]],
-    boolean
-  >,
+  'mcp_access_enabled' : ActorMethod<[UserNumber, FrontendHostname], boolean>,
   /**
-   * account_number must be the value returned by the matching
-   * mcp_prepare_account_delegation, so `get` reads the same account `prepare`
-   * signed for (the default account at target_origin is mutable).
+   * Fetch the delegation prepared above; the anchor is recovered from caller().
+   * account_number and expiration must be the values returned by the matching
+   * mcp_prepare_account_delegation, else this returns NoSuchDelegation.
    */
   'mcp_get_account_delegation' : ActorMethod<
     [FrontendHostname, [] | [AccountNumber], SessionKey, Timestamp],
     { 'Ok' : SignedDelegation } |
+      { 'Err' : AccountDelegationError }
+  >,
+  /**
+   * Called by the MCP server (anchor recovered from caller()): list the anchor's
+   * accounts at target_origin so the agent can pick which account_number to
+   * request a delegation for via mcp_prepare_account_delegation.
+   */
+  'mcp_get_accounts' : ActorMethod<
+    [FrontendHostname],
+    { 'Ok' : Array<AccountInfo> } |
       { 'Err' : AccountDelegationError }
   >,
   /**
@@ -2082,13 +2088,16 @@ export interface _SERVICE {
    */
   'mcp_get_config' : ActorMethod<[UserNumber], McpConfig>,
   /**
-   * Called by the MCP server, authorized by caller() == the anchor's principal
-   * for the (account, origin) it was bound to. Mints a <=5-minute delegation
-   * for the anchor's default account at target_origin. Anchor recovered from
-   * the caller.
-   * account_number names one of the anchor's accounts at target_origin to act
-   * as; null uses the anchor's default account there. The resolved account is
-   * returned in McpPrepareDelegation to thread into mcp_get_account_delegation.
+   * Called by the MCP server, authorized by caller() == the principal bound for
+   * its anchor at the connect-time mcp_server_origin; the anchor is recovered
+   * from the caller. Mints a per-app delegation at target_origin. account_number
+   * names one of the anchor's accounts there to act as (discover them with
+   * mcp_get_accounts), and null uses the anchor's default account there; an
+   * account_number that isn't the anchor's at target_origin is rejected as
+   * Unauthorized. max_ttl is the requested lifetime in ns, defaulting to and
+   * capped at 5 minutes. The resolved account_number is returned in
+   * McpPrepareDelegation so it can be threaded into mcp_get_account_delegation
+   * (the default account at an origin is mutable).
    */
   'mcp_prepare_account_delegation' : ActorMethod<
     [FrontendHostname, [] | [AccountNumber], SessionKey, [] | [bigint]],
@@ -2097,13 +2106,15 @@ export interface _SERVICE {
   >,
   /**
    * Enable/disable the backend /mcp delegation path for an anchor at a given
-   * MCP server origin and account (null account = unreserved default).
-   * Enabling binds the principal II derives for that (account, origin) pair;
-   * disabling unbinds exactly that principal. The origin comes from the
-   * connect request, so each user trusts the MCP server they choose.
+   * MCP server origin. Enabling binds the principal II derives for the anchor
+   * at that origin; disabling unbinds exactly that principal. No account is
+   * chosen here (accounts are per-origin and the connector isn't an app) — the
+   * app account is selected per call on mcp_prepare_account_delegation. The
+   * origin comes from the connect request, so each user trusts the MCP server
+   * they choose.
    */
   'mcp_set_access' : ActorMethod<
-    [UserNumber, FrontendHostname, [] | [AccountNumber], boolean],
+    [UserNumber, FrontendHostname, boolean],
     { 'Ok' : null } |
       { 'Err' : string }
   >,

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -10,7 +10,6 @@
   import { t } from "$lib/stores/locale.store";
   import { handleError } from "$lib/components/utils/error";
   import { toaster } from "$lib/components/utils/toaster";
-  import { remapToLegacyDomain } from "$lib/utils/iiConnection";
   import { parseMcpServerUrl } from "$lib/utils/mcpServer";
   import { readMcpConfig, isOriginTrusted } from "$lib/utils/mcpConfig";
   import { get } from "svelte/store";
@@ -44,13 +43,6 @@
   // rather than a silent CSP block at submit time.
   const mcpServer = $derived(
     params.kind === "valid" ? parseMcpServerUrl(params.callback) : undefined,
-  );
-
-  // Origin used for canister account calls: remap a gateway origin
-  // (*.icp0.io / *.icp.net) to *.ic0.app so the derived principal matches the
-  // one /authorize derives for that origin.
-  const effectiveOrigin = $derived(
-    mcpServer !== undefined ? remapToLegacyDomain(mcpServer.origin) : undefined,
   );
 
   const requestValid = $derived(
@@ -177,10 +169,7 @@
   // Invoked by the reused account picker once it has authenticated the selected
   // identity and resolved the chosen account. Connecting performs the opt-in
   // (`mcp_set_access`) and delivers the standing delegation to the MCP server.
-  const handleAuthorize = (
-    accountNumberPromise: Promise<bigint | undefined>,
-    ttlMinutes: number,
-  ): void => {
+  const handleAuthorize = (ttlMinutes: number): void => {
     const server = mcpServer;
     if (params.kind !== "valid" || server === undefined) {
       return;
@@ -212,7 +201,6 @@
           phase = { kind: "untrusted" };
           return;
         }
-        const accountNumber = await accountNumberPromise;
         // On success `mcpAuthorize` navigates the browser to the MCP server,
         // which redirects back here with a status — so a resolved promise means
         // the chain was built and submitted, not that we stay on this page.
@@ -220,7 +208,6 @@
           authenticated,
           publicKey: request.publicKey,
           mcpServerOrigin: server.origin,
-          accountNumber,
           ttlMinutes,
           callback: request.callback,
           state: request.state,
@@ -289,11 +276,9 @@
       </AuthWizard>
     </AuthPanel>
   </div>
-{:else if phase.kind === "authorize" && mcpServer !== undefined && effectiveOrigin !== undefined && $lastUsedIdentitiesStore.selected !== undefined}
+{:else if phase.kind === "authorize" && mcpServer !== undefined && $lastUsedIdentitiesStore.selected !== undefined}
   <McpAuthorizeView
     mcpServerHost={mcpServer.host}
-    {effectiveOrigin}
-    displayOrigin={mcpServer.origin}
     requestedTtlMinutes={params.kind === "valid" ? params.ttlMinutes : 60}
     onAuthorize={handleAuthorize}
   />

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -169,7 +169,7 @@
   // Invoked by the reused account picker once it has authenticated the selected
   // identity and resolved the chosen account. Connecting performs the opt-in
   // (`mcp_set_access`) and delivers the standing delegation to the MCP server.
-  const handleAuthorize = (ttlMinutes: number): void => {
+  const handleAuthorize = (ttlSeconds: number): void => {
     const server = mcpServer;
     if (params.kind !== "valid" || server === undefined) {
       return;
@@ -208,7 +208,7 @@
           authenticated,
           publicKey: request.publicKey,
           mcpServerOrigin: server.origin,
-          ttlMinutes,
+          ttlSeconds,
           callback: request.callback,
           state: request.state,
         });
@@ -279,7 +279,7 @@
 {:else if phase.kind === "authorize" && mcpServer !== undefined && $lastUsedIdentitiesStore.selected !== undefined}
   <McpAuthorizeView
     mcpServerHost={mcpServer.host}
-    requestedTtlMinutes={params.kind === "valid" ? params.ttlMinutes : 60}
+    requestedTtlSeconds={params.kind === "valid" ? params.ttlSeconds : 3600}
     onAuthorize={handleAuthorize}
   />
 {:else if phase.kind === "untrusted" && mcpServer !== undefined}

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.ts
@@ -3,6 +3,10 @@ import { fromBase64URL } from "$lib/utils/utils";
 
 /** Default delegation lifetime in seconds when the request omits `ttl`. */
 const DEFAULT_TTL_SECONDS = 60 * 60;
+/** Shortest TTL honoured: a request asking for less is clamped up to this, so a
+ *  too-short value (e.g. a server still sending minutes-as-seconds) can't mint a
+ *  uselessly-brief session. */
+const MIN_TTL_SECONDS = 10 * 60;
 /** Largest TTL the request can ask for: the backend caps a delegation at 30 days
  *  (`MAX_EXPIRATION_PERIOD_NS`), so anything larger is clamped to this. */
 const MAX_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -30,7 +34,7 @@ export type McpParams =
       /** Opaque value echoed back to the MCP server so it can tie the delivered
        *  delegation to the request it started (CSRF protection). */
       state: string;
-      /** Requested delegation lifetime in seconds (clamped to the 30-day cap). */
+      /** Requested delegation lifetime in seconds (clamped to [10 min, 30 days]). */
       ttlSeconds: number;
     }
   | { kind: "invalid" };
@@ -90,9 +94,10 @@ const parseState = (raw: string | null): string | undefined => {
 };
 
 // `ttl` is a lifetime in seconds. Any positive value is accepted and clamped to
-// the allowed range (the backend caps at 30 days regardless); an omitted `ttl`
-// uses the default, and a malformed one (non-numeric or <= 0) invalidates the
-// request.
+// the allowed range — at least 10 minutes, at most 30 days (the backend cap) —
+// so the exact requested duration is honoured within those bounds. An omitted
+// `ttl` uses the default, and a malformed one (non-numeric or <= 0) invalidates
+// the request.
 const parseTtl = (raw: string | null): number | undefined => {
   if (raw === null) {
     return DEFAULT_TTL_SECONDS;
@@ -101,7 +106,10 @@ const parseTtl = (raw: string | null): number | undefined => {
   if (!Number.isFinite(parsed) || parsed <= 0) {
     return undefined;
   }
-  return Math.min(Math.floor(parsed), MAX_TTL_SECONDS);
+  return Math.min(
+    Math.max(Math.floor(parsed), MIN_TTL_SECONDS),
+    MAX_TTL_SECONDS,
+  );
 };
 
 export const load: PageLoad = ({

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.ts
@@ -1,17 +1,21 @@
 import type { PageLoad } from "./$types";
 import { fromBase64URL } from "$lib/utils/utils";
 
-/** Default delegation lifetime in minutes when the request omits `ttl`. */
-const DEFAULT_TTL_MINUTES = 60;
+/** Default delegation lifetime in seconds when the request omits `ttl`. */
+const DEFAULT_TTL_SECONDS = 60 * 60;
+/** Largest TTL the request can ask for: the backend caps a delegation at 30 days
+ *  (`MAX_EXPIRATION_PERIOD_NS`), so anything larger is clamped to this. */
+const MAX_TTL_SECONDS = 30 * 24 * 60 * 60;
 
 /**
  * The `/mcp` request, parsed from the URL fragment the MCP server redirects the
  * browser to. `valid` carries the validated request — the session public key to
  * delegate to, the callback to post the delegation back to, the single-use
- * `state` echoed back to the MCP server, and the delegation TTL. The MCP server
- * the user connects is identified by the callback's origin (each user trusts
- * whichever server they connect), and the account is chosen in the picker.
- * `invalid` means the fragment was missing or malformed.
+ * `state` echoed back to the MCP server, and the delegation TTL (`ttl`, in
+ * seconds). The MCP server the user connects is identified by the callback's
+ * origin (each user trusts whichever server they connect); no account is chosen
+ * here (it's per-app, picked server-side at delegation time). `invalid` means
+ * the fragment was missing or malformed.
  *
  * Whether the callback origin is one the connect flow accepts (https only — MCP
  * connections are to remote servers) is checked in the page component, which
@@ -26,7 +30,8 @@ export type McpParams =
       /** Opaque value echoed back to the MCP server so it can tie the delivered
        *  delegation to the request it started (CSRF protection). */
       state: string;
-      ttlMinutes: number;
+      /** Requested delegation lifetime in seconds (clamped to the 30-day cap). */
+      ttlSeconds: number;
     }
   | { kind: "invalid" };
 
@@ -84,15 +89,19 @@ const parseState = (raw: string | null): string | undefined => {
   return raw;
 };
 
+// `ttl` is a lifetime in seconds. Any positive value is accepted and clamped to
+// the allowed range (the backend caps at 30 days regardless); an omitted `ttl`
+// uses the default, and a malformed one (non-numeric or <= 0) invalidates the
+// request.
 const parseTtl = (raw: string | null): number | undefined => {
   if (raw === null) {
-    return DEFAULT_TTL_MINUTES;
+    return DEFAULT_TTL_SECONDS;
   }
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     return undefined;
   }
-  return Math.floor(parsed);
+  return Math.min(Math.floor(parsed), MAX_TTL_SECONDS);
 };
 
 export const load: PageLoad = ({
@@ -109,18 +118,18 @@ export const load: PageLoad = ({
   const publicKey = parseBase64Url(params.get("public_key"));
   const callback = parseCallback(params.get("callback"));
   const state = parseState(params.get("state"));
-  const ttlMinutes = parseTtl(params.get("ttl"));
+  const ttlSeconds = parseTtl(params.get("ttl"));
 
   if (
     publicKey === undefined ||
     callback === undefined ||
     state === undefined ||
-    ttlMinutes === undefined
+    ttlSeconds === undefined
   ) {
     return { params: { kind: "invalid" }, status };
   }
   return {
-    params: { kind: "valid", publicKey, callback, state, ttlMinutes },
+    params: { kind: "valid", publicKey, callback, state, ttlSeconds },
     status,
   };
 };

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.ts
@@ -5,11 +5,14 @@ import { fromBase64URL } from "$lib/utils/utils";
 const DEFAULT_TTL_SECONDS = 60 * 60;
 /** Shortest TTL honoured: a request asking for less is clamped up to this, so a
  *  too-short value (e.g. a server still sending minutes-as-seconds) can't mint a
- *  uselessly-brief session. */
+ *  uselessly-brief session. Matches the smallest duration the picker offers. In
+ *  practice it shouldn't fire — the server is expected to send a sensible value
+ *  (e.g. `ttl=3600` for 1 hour) — but it bounds a misbehaving caller. */
 const MIN_TTL_SECONDS = 10 * 60;
-/** Largest TTL the request can ask for: the backend caps a delegation at 30 days
- *  (`MAX_EXPIRATION_PERIOD_NS`), so anything larger is clamped to this. */
-const MAX_TTL_SECONDS = 30 * 24 * 60 * 60;
+/** Largest TTL the request can ask for, matching the longest duration the picker
+ *  offers (1 week). Well within the backend's 30-day delegation cap
+ *  (`MAX_EXPIRATION_PERIOD_NS`), so the backend never clamps further. */
+const MAX_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 /**
  * The `/mcp` request, parsed from the URL fragment the MCP server redirects the
@@ -34,7 +37,7 @@ export type McpParams =
       /** Opaque value echoed back to the MCP server so it can tie the delivered
        *  delegation to the request it started (CSRF protection). */
       state: string;
-      /** Requested delegation lifetime in seconds (clamped to [10 min, 30 days]). */
+      /** Requested delegation lifetime in seconds (clamped to [10 min, 1 week]). */
       ttlSeconds: number;
     }
   | { kind: "invalid" };
@@ -94,10 +97,9 @@ const parseState = (raw: string | null): string | undefined => {
 };
 
 // `ttl` is a lifetime in seconds. Any positive value is accepted and clamped to
-// the allowed range — at least 10 minutes, at most 30 days (the backend cap) —
-// so the exact requested duration is honoured within those bounds. An omitted
-// `ttl` uses the default, and a malformed one (non-numeric or <= 0) invalidates
-// the request.
+// the allowed range — at least 10 minutes, at most 1 week — so the exact
+// requested duration is honoured within those bounds. An omitted `ttl` uses the
+// default, and a malformed one (non-numeric or <= 0) invalidates the request.
 const parseTtl = (raw: string | null): number | undefined => {
   if (raw === null) {
     return DEFAULT_TTL_SECONDS;

--- a/src/frontend/src/routes/(new-styling)/mcp/load.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/load.test.ts
@@ -3,7 +3,7 @@ import { load, type McpParams } from "./+page";
 
 const HOUR = 60 * 60;
 const MIN_TTL = 10 * 60;
-const MAX_TTL = 30 * 24 * 60 * 60;
+const MAX_TTL = 7 * 24 * 60 * 60;
 
 // A complete, valid fragment with an optional `ttl`. `public_key` is any
 // base64url-decodable string; the callback is an accepted https origin.
@@ -53,7 +53,7 @@ describe("/mcp load: ttl parsing", () => {
     }
   });
 
-  it("clamps an above-cap value down to 30 days", () => {
+  it("clamps an above-cap value down to 1 week", () => {
     const params = loadTtl(String(MAX_TTL + 1));
     expect(params.kind).toBe("valid");
     if (params.kind === "valid") {

--- a/src/frontend/src/routes/(new-styling)/mcp/load.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/load.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { load, type McpParams } from "./+page";
+
+const HOUR = 60 * 60;
+const MIN_TTL = 10 * 60;
+const MAX_TTL = 30 * 24 * 60 * 60;
+
+// A complete, valid fragment with an optional `ttl`. `public_key` is any
+// base64url-decodable string; the callback is an accepted https origin.
+const fragment = (ttl?: string): string => {
+  const params = new URLSearchParams();
+  params.set("public_key", "AAAA");
+  params.set("callback", "https://mcp.example.com/cb");
+  params.set("state", "opaque-state");
+  if (ttl !== undefined) {
+    params.set("ttl", ttl);
+  }
+  return params.toString();
+};
+
+// `load` is synchronous here; the `PageLoad` signature widens the return to
+// MaybePromise<void | ...>, so narrow it back for the assertions.
+const loadTtl = (ttl?: string): McpParams =>
+  (
+    load({
+      url: new URL(`https://id.ai/mcp#${fragment(ttl)}`),
+    } as Parameters<typeof load>[0]) as { params: McpParams }
+  ).params;
+
+describe("/mcp load: ttl parsing", () => {
+  it("defaults to 1 hour when ttl is omitted", () => {
+    const params = loadTtl();
+    expect(params.kind).toBe("valid");
+    if (params.kind === "valid") {
+      expect(params.ttlSeconds).toBe(HOUR);
+    }
+  });
+
+  it("honours an in-range value exactly", () => {
+    const params = loadTtl(String(2 * HOUR));
+    expect(params.kind).toBe("valid");
+    if (params.kind === "valid") {
+      expect(params.ttlSeconds).toBe(2 * HOUR);
+    }
+  });
+
+  it("clamps a below-floor value up to 10 minutes", () => {
+    // 60s — what a server still sending minutes-as-seconds would emit.
+    const params = loadTtl("60");
+    expect(params.kind).toBe("valid");
+    if (params.kind === "valid") {
+      expect(params.ttlSeconds).toBe(MIN_TTL);
+    }
+  });
+
+  it("clamps an above-cap value down to 30 days", () => {
+    const params = loadTtl(String(MAX_TTL + 1));
+    expect(params.kind).toBe("valid");
+    if (params.kind === "valid") {
+      expect(params.ttlSeconds).toBe(MAX_TTL);
+    }
+  });
+
+  it("rejects a non-numeric ttl", () => {
+    expect(loadTtl("abc").kind).toBe("invalid");
+  });
+
+  it("rejects a non-positive ttl", () => {
+    expect(loadTtl("0").kind).toBe("invalid");
+    expect(loadTtl("-5").kind).toBe("invalid");
+  });
+});

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -17,8 +17,8 @@ interface McpAuthorizeInput {
    *  always an https origin. Connecting binds the agent to this origin and the
    *  standing delegation acts as the user's identity there. */
   mcpServerOrigin: string;
-  /** Lifetime in minutes. */
-  ttlMinutes: number;
+  /** Lifetime in seconds (already clamped to the 30-day backend cap). */
+  ttlSeconds: number;
   /** Callback URL (on the MCP server origin) the delegation chain is
    *  form-POSTed to. */
   callback: string;
@@ -50,7 +50,7 @@ export const mcpAuthorize = async ({
   authenticated,
   publicKey,
   mcpServerOrigin,
-  ttlMinutes,
+  ttlSeconds,
   callback,
   state,
 }: McpAuthorizeInput): Promise<void> => {
@@ -60,7 +60,7 @@ export const mcpAuthorize = async ({
   // *.icp.net) to *.ic0.app so the principal matches the one /authorize derives
   // for that origin.
   const effectiveOrigin = remapToLegacyDomain(mcpServerOrigin);
-  const maxTimeToLiveNanos = BigInt(ttlMinutes) * BigInt(60) * BigInt(1e9);
+  const maxTimeToLiveNanos = BigInt(ttlSeconds) * BigInt(1e9);
 
   // Connecting is the opt-in: authorize this agent for the anchor at the MCP
   // server origin so II honors the server's later on-demand per-app delegation

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -17,7 +17,7 @@ interface McpAuthorizeInput {
    *  always an https origin. Connecting binds the agent to this origin and the
    *  standing delegation acts as the user's identity there. */
   mcpServerOrigin: string;
-  /** Lifetime in seconds (already clamped to the 30-day backend cap). */
+  /** Lifetime in seconds (already clamped to [10 min, 30-day backend cap]). */
   ttlSeconds: number;
   /** Callback URL (on the MCP server origin) the delegation chain is
    *  form-POSTed to. */

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -17,7 +17,7 @@ interface McpAuthorizeInput {
    *  always an https origin. Connecting binds the agent to this origin and the
    *  standing delegation acts as the user's identity there. */
   mcpServerOrigin: string;
-  /** Lifetime in seconds (already clamped to [10 min, 30-day backend cap]). */
+  /** Lifetime in seconds (already clamped to [10 min, 1 week]). */
   ttlSeconds: number;
   /** Callback URL (on the MCP server origin) the delegation chain is
    *  form-POSTed to. */

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -14,14 +14,9 @@ interface McpAuthorizeInput {
   publicKey: string;
   /** The MCP server origin, taken from the connect request's callback (e.g.
    *  "https://mcp.id.ai"). MCP connections are to remote servers, so this is
-   *  always an https origin. The standing delegation acts as the user's account
-   *  at this origin, so each user trusts whichever server they connect. */
+   *  always an https origin. Connecting binds the agent to this origin and the
+   *  standing delegation acts as the user's identity there. */
   mcpServerOrigin: string;
-  /** The account to connect as, chosen in the picker. `undefined` is the
-   *  unreserved default account. Bound by `mcp_set_access` and carried by the
-   *  standing delegation, so enable/disable derive the *same* principal even if
-   *  the user later changes their default account for this origin. */
-  accountNumber: bigint | undefined;
   /** Lifetime in minutes. */
   ttlMinutes: number;
   /** Callback URL (on the MCP server origin) the delegation chain is
@@ -39,13 +34,12 @@ interface McpAuthorizeInput {
  * redirects the browser back to `/mcp` with a `status` so this page keeps
  * owning the UI.
  *
- * The chain is derived for the account the user picked at the MCP server
- * origin (`accountNumber`, or the unreserved default when omitted) — so the
- * MCP server acts as the same account a normal `/authorize` sign-in to that
- * origin would use, not the legacy anchor-seed principal a blind `null`
- * produces. Binding to a specific account (rather than re-resolving the
- * mutable default each call) keeps enable and disable deriving the same
- * principal.
+ * Connecting authorizes the agent for the user's identity, not for a specific
+ * account: it binds the principal II derives for the anchor at the MCP server
+ * origin (`mcp_set_access`), which is the same principal the standing delegation
+ * below carries. No account is chosen here — the MCP server origin is the
+ * connector, not an app, and accounts are per-origin; the server selects an app
+ * account per call later via `mcp_prepare_account_delegation`.
  *
  * The canister only ever signs a delegation to a freshly-generated,
  * non-extractable browser key — never to the public_key from the URL fragment
@@ -56,32 +50,26 @@ export const mcpAuthorize = async ({
   authenticated,
   publicKey,
   mcpServerOrigin,
-  accountNumber,
   ttlMinutes,
   callback,
   state,
 }: McpAuthorizeInput): Promise<void> => {
   const { identityNumber, actor } = authenticated;
 
-  // The delegation acts as the user's chosen account at the MCP server origin.
-  // Remap a gateway origin (*.icp0.io / *.icp.net) to *.ic0.app so the principal
-  // matches the one /authorize derives for that origin.
+  // Bind and sign at the MCP server origin. Remap a gateway origin (*.icp0.io /
+  // *.icp.net) to *.ic0.app so the principal matches the one /authorize derives
+  // for that origin.
   const effectiveOrigin = remapToLegacyDomain(mcpServerOrigin);
   const maxTimeToLiveNanos = BigInt(ttlMinutes) * BigInt(60) * BigInt(1e9);
 
-  // Candid `opt AccountNumber`: `[]` is the unreserved default account.
-  const accountOpt: [] | [bigint] =
-    accountNumber === undefined ? [] : [accountNumber];
-
-  // Connecting the MCP server is the opt-in: enable MCP access for this anchor at
-  // (mcp_server_origin, account) so II authorizes the server's later on-demand
-  // per-app delegation calls. The backend binds the principal it derives for this
-  // (account, origin) pair — exactly the principal the standing delegation below
-  // carries — and re-derives the same principal to revoke. Idempotent.
+  // Connecting is the opt-in: authorize this agent for the anchor at the MCP
+  // server origin so II honors the server's later on-demand per-app delegation
+  // calls. The backend binds the principal it derives for the anchor at this
+  // origin — exactly the principal the standing delegation below carries — and
+  // re-derives the same principal to revoke. Idempotent.
   const accessResult = await actor.mcp_set_access(
     identityNumber,
     effectiveOrigin,
-    accountOpt,
     true,
   );
   if ("Err" in accessResult) {
@@ -95,11 +83,13 @@ export const mcpAuthorize = async ({
     ephemeralIdentity.getPublicKey().toDer(),
   );
 
+  // The standing delegation is for the identity's default account at the MCP
+  // server origin (`[]`) — the same principal `mcp_set_access` bound above.
   const { user_key, expiration } = await actor
     .prepare_account_delegation(
       identityNumber,
       effectiveOrigin,
-      accountOpt,
+      [],
       ephemeralPublicKey,
       [maxTimeToLiveNanos],
     )
@@ -110,7 +100,7 @@ export const mcpAuthorize = async ({
       .get_account_delegation(
         identityNumber,
         effectiveOrigin,
-        accountOpt,
+        [],
         ephemeralPublicKey,
         expiration,
       )

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -6,8 +6,9 @@
   import { ChevronDownIcon } from "@lucide/svelte";
   import { t } from "$lib/stores/locale.store";
   import { AuthLastUsedFlow } from "$lib/flows/authLastUsedFlow.svelte";
-  import { isAuthenticatedStore } from "$lib/stores/authentication.store";
+  import { authenticationStore } from "$lib/stores/authentication.store";
   import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
+  import { sessionStore } from "$lib/stores/session.store";
   import { handleError } from "$lib/components/utils/error";
 
   interface Props {
@@ -26,8 +27,8 @@
   // Connecting authorizes this agent for the user's identity — no account is
   // chosen here (accounts are app-specific; the MCP server is the connector, not
   // an app). The identity switcher (shown by the layout) is how the user picks
-  // which identity. The connect screen can show before sign-in, so authenticate
-  // the selected identity on "Allow access" if it isn't already.
+  // which identity, and it only *selects* (it doesn't sign in). So "Allow access"
+  // authenticates the selected identity unless it's already the live session.
   const authLastUsedFlow = new AuthLastUsedFlow();
   const selectedIdentityNumber = $derived(
     $lastUsedIdentitiesStore.selected?.identityNumber,
@@ -82,7 +83,11 @@
     }
     isAuthorizing = true;
     try {
-      if (!$isAuthenticatedStore) {
+      // Authenticate unless the live session is already the selected identity.
+      // The switcher only selects, so a session for a *different* identity must
+      // not be reused — that would connect as the wrong anchor.
+      if ($authenticationStore?.identityNumber !== selected.identityNumber) {
+        sessionStore.reset();
         await authLastUsedFlow.authenticate(selected);
       }
       onAuthorize(selectedTtlMinutes);

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -44,13 +44,20 @@
   const HOUR = 60 * MINUTE;
   const DAY = 24 * HOUR;
   const WEEK = 7 * DAY;
-  // Session-duration presets (seconds), spanning the offered range: 10 minutes
-  // (the shortest, also the request's floor) to 1 week (the longest).
-  const PRESETS = [10 * MINUTE, HOUR, 8 * HOUR, DAY, WEEK];
+  // The session durations the picker offers, each with its label, spanning the
+  // allowed range: 10 minutes (the shortest, also the request's floor) to 1 week
+  // (the longest). `$derived` so the labels re-translate when the locale changes.
+  const presets = $derived([
+    { value: 10 * MINUTE, label: $t`10 minutes` },
+    { value: HOUR, label: $t`1 hour` },
+    { value: 8 * HOUR, label: $t`8 hours` },
+    { value: DAY, label: $t`1 day` },
+    { value: WEEK, label: $t`1 week` },
+  ]);
 
-  // Compact label for an arbitrary duration: the request can ask for any number
-  // of seconds within [10 min, 1 week], so the selected value isn't always one
-  // of the presets.
+  // Compact label for an off-preset duration: the request can ask for any number
+  // of seconds within [10 min, 1 week], so the selected value isn't always one of
+  // the presets (e.g. a 2-hour request shows "2h").
   const formatTtl = (seconds: number): string => {
     const parts: string[] = [];
     const d = Math.floor(seconds / DAY);
@@ -64,32 +71,20 @@
     return parts.length > 0 ? parts.join(" ") : "0s";
   };
 
-  const labelFor = (seconds: number): string => {
-    switch (seconds) {
-      case 10 * MINUTE:
-        return $t`10 minutes`;
-      case HOUR:
-        return $t`1 hour`;
-      case 8 * HOUR:
-        return $t`8 hours`;
-      case DAY:
-        return $t`1 day`;
-      case WEEK:
-        return $t`1 week`;
-      default:
-        return formatTtl(seconds);
-    }
-  };
-
   // Honor the exact requested duration (already clamped to the cap); the user can
   // still override it with one of the presets before connecting.
   let selectedTtlSeconds = $state(requestedTtlSeconds);
   const options = $derived(
-    PRESETS.map((seconds) => ({
-      value: seconds,
-      label: labelFor(seconds),
-      selected: seconds === selectedTtlSeconds,
+    presets.map((preset) => ({
+      ...preset,
+      selected: preset.value === selectedTtlSeconds,
     })),
+  );
+  // The trigger shows the selected preset's label, or the compact format when the
+  // selection is an off-preset (honoured) duration.
+  const selectedLabel = $derived(
+    presets.find((preset) => preset.value === selectedTtlSeconds)?.label ??
+      formatTtl(selectedTtlSeconds),
   );
 
   const handleAllowAccess = async (): Promise<void> => {
@@ -148,7 +143,7 @@
           class="btn btn-secondary btn-sm gap-2"
           disabled={isAuthorizing}
         >
-          <span>{labelFor(selectedTtlSeconds)}</span>
+          <span>{selectedLabel}</span>
           <ChevronDownIcon class="size-4" />
         </button>
       </Select>

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -14,15 +14,15 @@
   interface Props {
     /** Hostname of the MCP server (display, e.g. mcp.id.ai). */
     mcpServerHost: string;
-    /** Session duration the request asked for (minutes); used as the initial
-     *  selection when it matches a preset, otherwise we default to 1 hour. */
-    requestedTtlMinutes: number;
+    /** Session duration the request asked for (seconds, already clamped to the
+     *  30-day cap); the initial selection, which the user can change. */
+    requestedTtlSeconds: number;
     /** Called once the selected identity is authenticated, with the chosen
-     *  session duration, to connect. */
-    onAuthorize: (ttlMinutes: number) => void;
+     *  session duration (seconds), to connect. */
+    onAuthorize: (ttlSeconds: number) => void;
   }
 
-  const { mcpServerHost, requestedTtlMinutes, onAuthorize }: Props = $props();
+  const { mcpServerHost, requestedTtlSeconds, onAuthorize }: Props = $props();
 
   // Connecting authorizes this agent for the user's identity — no account is
   // chosen here (accounts are app-specific; the MCP server is the connector, not
@@ -40,39 +40,56 @@
   });
   let isAuthorizing = $state(false);
 
-  const HOUR = 60;
+  const MINUTE = 60;
+  const HOUR = 60 * MINUTE;
   const DAY = 24 * HOUR;
-  // Session-duration presets (minutes). The backend caps a standing delegation
+  const WEEK = 7 * DAY;
+  const MONTH = 30 * DAY;
+  // Session-duration presets (seconds). The backend caps a standing delegation
   // at 30 days, so that's the longest offered.
-  const PRESETS = [HOUR, 8 * HOUR, DAY, 7 * DAY, 30 * DAY];
+  const PRESETS = [HOUR, 8 * HOUR, DAY, WEEK, MONTH];
 
-  const labelFor = (minutes: number): string => {
-    switch (minutes) {
+  // Compact label for an arbitrary duration: the request can ask for any number
+  // of seconds (within the 30-day cap), so the selected value isn't always one
+  // of the presets.
+  const formatTtl = (seconds: number): string => {
+    const parts: string[] = [];
+    const d = Math.floor(seconds / DAY);
+    const h = Math.floor((seconds % DAY) / HOUR);
+    const m = Math.floor((seconds % HOUR) / MINUTE);
+    const s = seconds % MINUTE;
+    if (d > 0) parts.push(`${d}d`);
+    if (h > 0) parts.push(`${h}h`);
+    if (m > 0) parts.push(`${m}m`);
+    if (s > 0) parts.push(`${s}s`);
+    return parts.length > 0 ? parts.join(" ") : "0s";
+  };
+
+  const labelFor = (seconds: number): string => {
+    switch (seconds) {
       case HOUR:
         return $t`1 hour`;
       case 8 * HOUR:
         return $t`8 hours`;
       case DAY:
         return $t`1 day`;
-      case 7 * DAY:
+      case WEEK:
         return $t`1 week`;
-      case 30 * DAY:
+      case MONTH:
         return $t`30 days`;
       default:
-        return $t`1 hour`;
+        return formatTtl(seconds);
     }
   };
 
-  // Start from the requested duration when it's one of the presets; otherwise
-  // default to 1 hour. The user can change it before connecting.
-  let selectedTtlMinutes = $state(
-    PRESETS.includes(requestedTtlMinutes) ? requestedTtlMinutes : HOUR,
-  );
+  // Honor the exact requested duration (already clamped to the cap); the user can
+  // still override it with one of the presets before connecting.
+  let selectedTtlSeconds = $state(requestedTtlSeconds);
   const options = $derived(
-    PRESETS.map((minutes) => ({
-      value: minutes,
-      label: labelFor(minutes),
-      selected: minutes === selectedTtlMinutes,
+    PRESETS.map((seconds) => ({
+      value: seconds,
+      label: labelFor(seconds),
+      selected: seconds === selectedTtlSeconds,
     })),
   );
 
@@ -90,7 +107,7 @@
         sessionStore.reset();
         await authLastUsedFlow.authenticate(selected);
       }
-      onAuthorize(selectedTtlMinutes);
+      onAuthorize(selectedTtlSeconds);
     } catch (error) {
       handleError(error);
     } finally {
@@ -122,11 +139,11 @@
       </span>
       <Select
         {options}
-        onChange={(value) => (selectedTtlMinutes = value)}
+        onChange={(value) => (selectedTtlSeconds = value)}
         align="end"
       >
         <button type="button" class="btn btn-secondary btn-sm gap-2">
-          <span>{labelFor(selectedTtlMinutes)}</span>
+          <span>{labelFor(selectedTtlSeconds)}</span>
           <ChevronDownIcon class="size-4" />
         </button>
       </Select>

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -15,7 +15,7 @@
     /** Hostname of the MCP server (display, e.g. mcp.id.ai). */
     mcpServerHost: string;
     /** Session duration the request asked for (seconds, already clamped to
-     *  [10 min, 30 days]); the initial selection, which the user can change. */
+     *  [10 min, 1 week]); the initial selection, which the user can change. */
     requestedTtlSeconds: number;
     /** Called once the selected identity is authenticated, with the chosen
      *  session duration (seconds), to connect. */
@@ -44,13 +44,12 @@
   const HOUR = 60 * MINUTE;
   const DAY = 24 * HOUR;
   const WEEK = 7 * DAY;
-  const MONTH = 30 * DAY;
-  // Session-duration presets (seconds). The backend caps a standing delegation
-  // at 30 days, so that's the longest offered.
-  const PRESETS = [HOUR, 8 * HOUR, DAY, WEEK, MONTH];
+  // Session-duration presets (seconds), spanning the offered range: 10 minutes
+  // (the shortest, also the request's floor) to 1 week (the longest).
+  const PRESETS = [10 * MINUTE, HOUR, 8 * HOUR, DAY, WEEK];
 
   // Compact label for an arbitrary duration: the request can ask for any number
-  // of seconds (within the 30-day cap), so the selected value isn't always one
+  // of seconds within [10 min, 1 week], so the selected value isn't always one
   // of the presets.
   const formatTtl = (seconds: number): string => {
     const parts: string[] = [];
@@ -67,6 +66,8 @@
 
   const labelFor = (seconds: number): string => {
     switch (seconds) {
+      case 10 * MINUTE:
+        return $t`10 minutes`;
       case HOUR:
         return $t`1 hour`;
       case 8 * HOUR:
@@ -75,8 +76,6 @@
         return $t`1 day`;
       case WEEK:
         return $t`1 week`;
-      case MONTH:
-        return $t`30 days`;
       default:
         return formatTtl(seconds);
     }

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -142,7 +142,13 @@
         onChange={(value) => (selectedTtlSeconds = value)}
         align="end"
       >
-        <button type="button" class="btn btn-secondary btn-sm gap-2">
+        <!-- Disabled while connecting: a disabled button dispatches no click, so
+             the Select can't open once the user has committed to "Allow access". -->
+        <button
+          type="button"
+          class="btn btn-secondary btn-sm gap-2"
+          disabled={isAuthorizing}
+        >
           <span>{labelFor(selectedTtlSeconds)}</span>
           <ChevronDownIcon class="size-4" />
         </button>

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -1,36 +1,43 @@
 <script lang="ts">
   import AuthPanel from "$lib/components/layout/AuthPanel.svelte";
-  import ContinueView from "../../authorize/views/ContinueView.svelte";
   import McpHero from "../components/McpHero.svelte";
   import Select from "$lib/components/ui/Select.svelte";
+  import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { ChevronDownIcon } from "@lucide/svelte";
   import { t } from "$lib/stores/locale.store";
+  import { AuthLastUsedFlow } from "$lib/flows/authLastUsedFlow.svelte";
+  import { isAuthenticatedStore } from "$lib/stores/authentication.store";
+  import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
+  import { handleError } from "$lib/components/utils/error";
 
   interface Props {
     /** Hostname of the MCP server (display, e.g. mcp.id.ai). */
     mcpServerHost: string;
-    /** Origin used for canister account calls (gateway origins remapped). */
-    effectiveOrigin: string;
-    /** The MCP server origin, shown to the user and used for the app lookup. */
-    displayOrigin: string;
     /** Session duration the request asked for (minutes); used as the initial
      *  selection when it matches a preset, otherwise we default to 1 hour. */
     requestedTtlMinutes: number;
-    /** Receives the chosen account (resolved after sign-in) and the chosen
-     *  session duration, then connects. */
-    onAuthorize: (
-      accountNumber: Promise<bigint | undefined>,
-      ttlMinutes: number,
-    ) => void;
+    /** Called once the selected identity is authenticated, with the chosen
+     *  session duration, to connect. */
+    onAuthorize: (ttlMinutes: number) => void;
   }
 
-  const {
-    mcpServerHost,
-    effectiveOrigin,
-    displayOrigin,
-    requestedTtlMinutes,
-    onAuthorize,
-  }: Props = $props();
+  const { mcpServerHost, requestedTtlMinutes, onAuthorize }: Props = $props();
+
+  // Connecting authorizes this agent for the user's identity — no account is
+  // chosen here (accounts are app-specific; the MCP server is the connector, not
+  // an app). The identity switcher (shown by the layout) is how the user picks
+  // which identity. The connect screen can show before sign-in, so authenticate
+  // the selected identity on "Allow access" if it isn't already.
+  const authLastUsedFlow = new AuthLastUsedFlow();
+  const selectedIdentityNumber = $derived(
+    $lastUsedIdentitiesStore.selected?.identityNumber,
+  );
+  $effect(() => {
+    if (selectedIdentityNumber !== undefined) {
+      authLastUsedFlow.init([selectedIdentityNumber]);
+    }
+  });
+  let isAuthorizing = $state(false);
 
   const HOUR = 60;
   const DAY = 24 * HOUR;
@@ -67,49 +74,67 @@
       selected: minutes === selectedTtlMinutes,
     })),
   );
+
+  const handleAllowAccess = async (): Promise<void> => {
+    const selected = $lastUsedIdentitiesStore.selected;
+    if (selected === undefined) {
+      return;
+    }
+    isAuthorizing = true;
+    try {
+      if (!$isAuthenticatedStore) {
+        await authLastUsedFlow.authenticate(selected);
+      }
+      onAuthorize(selectedTtlMinutes);
+    } catch (error) {
+      handleError(error);
+    } finally {
+      isAuthorizing = false;
+    }
+  };
 </script>
 
 <!--
-  The MCP connect screen reuses the regular continue-with-ii account picker
-  (multi-account toggle, add/edit account, account list) so the user binds a
-  specific, stable account — the same principal that enable and disable derive.
-  The MCP-specific consent (which server, what it can do, and for how long, with
-  a user-chosen session duration) replaces the picker's app header via `header`.
+  The MCP connect screen is a consent step: it authorizes the agent for the
+  user's identity and lets the user choose the session duration. There is no
+  account picker — accounts are per-app and the MCP server origin is just the
+  connector; the server selects an app account per call later.
 -->
 <div class="flex w-full justify-center max-sm:flex-1 sm:max-w-110">
   <AuthPanel>
-    <ContinueView
-      {effectiveOrigin}
-      {displayOrigin}
-      onAuthorize={(account) => onAuthorize(account, selectedTtlMinutes)}
-      continueLabel={$t`Allow access`}
+    <McpHero mcpServer={mcpServerHost} />
+    <h1 class="text-text-primary mt-2 text-2xl font-medium">
+      {$t`Connect ${mcpServerHost}`}
+    </h1>
+    <p class="text-text-tertiary mt-1 text-base text-pretty">
+      {$t`Let ${mcpServerHost} act on your behalf across your apps. You'll need to reconnect when this access expires.`}
+    </p>
+    <div
+      class="border-border-tertiary mt-4 mb-6 flex flex-row items-center justify-between gap-3 border-t pt-4"
     >
-      {#snippet header()}
-        <McpHero mcpServer={mcpServerHost} />
-        <h1 class="text-text-primary mt-2 text-2xl font-medium">
-          {$t`Connect ${mcpServerHost}`}
-        </h1>
-        <p class="text-text-tertiary mt-1 text-base text-pretty">
-          {$t`Let ${mcpServerHost} act on your behalf across your apps. You'll need to reconnect when this access expires.`}
-        </p>
-        <div
-          class="border-border-tertiary mt-4 mb-6 flex flex-row items-center justify-between gap-3 border-t pt-4"
-        >
-          <span class="text-text-secondary text-sm font-medium">
-            {$t`Access expires after`}
-          </span>
-          <Select
-            {options}
-            onChange={(value) => (selectedTtlMinutes = value)}
-            align="end"
-          >
-            <button type="button" class="btn btn-secondary btn-sm gap-2">
-              <span>{labelFor(selectedTtlMinutes)}</span>
-              <ChevronDownIcon class="size-4" />
-            </button>
-          </Select>
-        </div>
-      {/snippet}
-    </ContinueView>
+      <span class="text-text-secondary text-sm font-medium">
+        {$t`Access expires after`}
+      </span>
+      <Select
+        {options}
+        onChange={(value) => (selectedTtlMinutes = value)}
+        align="end"
+      >
+        <button type="button" class="btn btn-secondary btn-sm gap-2">
+          <span>{labelFor(selectedTtlMinutes)}</span>
+          <ChevronDownIcon class="size-4" />
+        </button>
+      </Select>
+    </div>
+    <button
+      class="btn btn-primary w-full gap-2"
+      onclick={handleAllowAccess}
+      disabled={isAuthorizing || selectedIdentityNumber === undefined}
+    >
+      {#if isAuthorizing}
+        <ProgressRing class="size-5" />
+      {/if}
+      <span>{$t`Allow access`}</span>
+    </button>
   </AuthPanel>
 </div>

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -14,8 +14,8 @@
   interface Props {
     /** Hostname of the MCP server (display, e.g. mcp.id.ai). */
     mcpServerHost: string;
-    /** Session duration the request asked for (seconds, already clamped to the
-     *  30-day cap); the initial selection, which the user can change. */
+    /** Session duration the request asked for (seconds, already clamped to
+     *  [10 min, 30 days]); the initial selection, which the user can change. */
     requestedTtlSeconds: number;
     /** Called once the selected identity is authenticated, with the chosen
      *  session duration (seconds), to connect. */

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -55,7 +55,7 @@ export type McpFixture = {
   /** Builds the `/mcp` authorize URL with the request params in the fragment. */
   buildAuthorizeUrl: (opts: {
     app: string;
-    ttlMinutes?: number;
+    ttlSeconds?: number;
     callbackUrl?: string;
   }) => string;
 };
@@ -158,7 +158,7 @@ export const test = base.extend<{ mcp: McpFixture }>({
 
     const buildAuthorizeUrl = (opts: {
       app: string;
-      ttlMinutes?: number;
+      ttlSeconds?: number;
       callbackUrl?: string;
     }): string => {
       const fragment = new URLSearchParams();
@@ -166,8 +166,8 @@ export const test = base.extend<{ mcp: McpFixture }>({
       fragment.set("callback", opts.callbackUrl ?? callbackUrl);
       fragment.set("state", state);
       fragment.set("app", opts.app);
-      if (opts.ttlMinutes !== undefined) {
-        fragment.set("ttl", String(opts.ttlMinutes));
+      if (opts.ttlSeconds !== undefined) {
+        fragment.set("ttl", String(opts.ttlSeconds));
       }
       return `${II_URL}/mcp#${fragment.toString()}`;
     };

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -293,7 +293,9 @@ test("Identity switcher shows while signing in and hides on the success screen",
 
 test("Requested TTL within bounds is honoured", async ({ page, mcp }) => {
   test.slow();
-  const ttlMinutes = 60;
+  // A non-preset value (2 hours), in seconds, to exercise that an arbitrary
+  // requested TTL is honoured exactly — not snapped to a dropdown preset.
+  const ttlSeconds = 2 * 60 * 60;
   await addVirtualAuthenticator(page);
   await mcp.installInterceptor(page);
   await page.goto(II_URL);
@@ -302,11 +304,11 @@ test("Requested TTL within bounds is honoured", async ({ page, mcp }) => {
   await mcp.trustServer(page);
 
   const before = Date.now();
-  await page.goto(mcp.buildAuthorizeUrl({ app: APP, ttlMinutes }));
+  await page.goto(mcp.buildAuthorizeUrl({ app: APP, ttlSeconds }));
   await page.getByRole("button", { name: "Allow access" }).click();
 
   const expMillis = expirationMillis(await mcp.receivedDelegation);
-  const requestedMillis = ttlMinutes * 60 * 1000;
+  const requestedMillis = ttlSeconds * 1000;
   expect(expMillis - before).toBeGreaterThanOrEqual(requestedMillis - 60_000);
   expect(expMillis - before).toBeLessThanOrEqual(requestedMillis + 60_000);
 });

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -3,9 +3,9 @@ import { test } from "../fixtures";
 import { addVirtualAuthenticator, II_URL } from "../utils";
 
 /** A target app passed in the request. It is ignored by the connect flow (the
- *  delegation acts as the user's chosen account at the MCP-server origin the
- *  request's callback identifies), but kept to exercise that the param is
- *  tolerated. */
+ *  delegation acts as the user's identity at the MCP-server origin the request's
+ *  callback identifies; the app account is chosen server-side per call), but kept
+ *  to exercise that the param is tolerated. */
 const APP = "nice-name.com";
 
 const signUp = async (page: Page): Promise<void> => {
@@ -311,9 +311,9 @@ test("Requested TTL within bounds is honoured", async ({ page, mcp }) => {
   expect(expMillis - before).toBeLessThanOrEqual(requestedMillis + 60_000);
 });
 
-// The browser /mcp flow issues the standing credential for the user's chosen
-// account at the MCP *server* origin the callback identifies (not a per-request
-// app); per-app delegations are minted server-side by the
-// `mcp_prepare/get_account_delegation` canister methods. Principal-derivation
-// parity for those is canister logic, covered by the integration tests
-// (tests/integration/mcp.rs), not here.
+// The browser /mcp flow issues the standing credential for the user's identity
+// at the MCP *server* origin the callback identifies (not a per-request app, and
+// no account is chosen at connect); per-app delegations are minted server-side by
+// the `mcp_prepare/get_account_delegation` canister methods, with the app account
+// chosen there. Principal-derivation parity for those is canister logic, covered
+// by the integration tests (tests/integration/mcp.rs), not here.

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1079,10 +1079,10 @@ type PrepareAccountDelegation = record {
 };
 
 // Result of mcp_prepare_account_delegation. Carries the account_number the
-// canister resolved (the anchor's default account at target_origin) so the MCP
-// server can thread the same account into mcp_get_account_delegation — the
-// default is mutable, so re-resolving it in `get` could otherwise diverge and
-// yield NoSuchDelegation.
+// canister used (the one named in the request, or the anchor's default account
+// at target_origin when none was named) so the MCP server can thread the same
+// account into mcp_get_account_delegation — the default is mutable, so
+// re-resolving it in `get` could otherwise diverge and yield NoSuchDelegation.
 type McpPrepareDelegation = record {
     user_key : UserKey;
     expiration : Timestamp;
@@ -1791,23 +1791,22 @@ service : (opt InternetIdentityInit) -> {
     ) -> (variant { Ok : SignedDelegation; Err : AccountDelegationError }) query;
 
     // Enable/disable the backend /mcp delegation path for an anchor at a given
-    // MCP server origin and account (null account = unreserved default).
-    // Enabling binds the principal II derives for that (account, origin) pair;
-    // disabling unbinds exactly that principal. The origin comes from the
-    // connect request, so each user trusts the MCP server they choose.
+    // MCP server origin. Enabling binds the principal II derives for the anchor
+    // at that origin; disabling unbinds exactly that principal. No account is
+    // chosen here (accounts are per-origin and the connector isn't an app) — the
+    // app account is selected per call on mcp_prepare_account_delegation. The
+    // origin comes from the connect request, so each user trusts the MCP server
+    // they choose.
     mcp_set_access : (
         anchor_number : UserNumber,
         mcp_server_origin : FrontendHostname,
-        account_number : opt AccountNumber, // Null is unreserved default account
         enabled : bool
     ) -> (variant { Ok; Err : text });
 
-    // Whether the anchor has MCP access enabled for the (mcp_server_origin,
-    // account_number) pair.
+    // Whether the anchor has MCP access enabled at mcp_server_origin.
     mcp_access_enabled : (
         anchor_number : UserNumber,
-        mcp_server_origin : FrontendHostname,
-        account_number : opt AccountNumber // Null is unreserved default account
+        mcp_server_origin : FrontendHostname
     ) -> (bool) query;
 
     // Read the identity's synced trusted-MCP-server config (master toggle + the
@@ -1825,13 +1824,16 @@ service : (opt InternetIdentityInit) -> {
         config : McpConfig
     ) -> (variant { Ok; Err : text });
 
-    // Called by the MCP server, authorized by caller() == the anchor's principal
-    // for the (account, origin) it was bound to. Mints a <=5-minute delegation
-    // for the anchor's default account at target_origin. Anchor recovered from
-    // the caller.
-    // account_number names one of the anchor's accounts at target_origin to act
-    // as; null uses the anchor's default account there. The resolved account is
-    // returned in McpPrepareDelegation to thread into mcp_get_account_delegation.
+    // Called by the MCP server, authorized by caller() == the principal bound for
+    // its anchor at the connect-time mcp_server_origin; the anchor is recovered
+    // from the caller. Mints a per-app delegation at target_origin. account_number
+    // names one of the anchor's accounts there to act as (discover them with
+    // mcp_get_accounts), and null uses the anchor's default account there; an
+    // account_number that isn't the anchor's at target_origin is rejected as
+    // Unauthorized. max_ttl is the requested lifetime in ns, defaulting to and
+    // capped at 5 minutes. The resolved account_number is returned in
+    // McpPrepareDelegation so it can be threaded into mcp_get_account_delegation
+    // (the default account at an origin is mutable).
     mcp_prepare_account_delegation : (
         target_origin : FrontendHostname,
         account_number : opt AccountNumber,
@@ -1839,15 +1841,22 @@ service : (opt InternetIdentityInit) -> {
         max_ttl : opt nat64
     ) -> (variant { Ok : McpPrepareDelegation; Err : AccountDelegationError });
 
-    // account_number must be the value returned by the matching
-    // mcp_prepare_account_delegation, so `get` reads the same account `prepare`
-    // signed for (the default account at target_origin is mutable).
+    // Fetch the delegation prepared above; the anchor is recovered from caller().
+    // account_number and expiration must be the values returned by the matching
+    // mcp_prepare_account_delegation, else this returns NoSuchDelegation.
     mcp_get_account_delegation : (
         target_origin : FrontendHostname,
         account_number : opt AccountNumber,
         session_key : SessionKey,
         expiration : Timestamp
     ) -> (variant { Ok : SignedDelegation; Err : AccountDelegationError }) query;
+
+    // Called by the MCP server (anchor recovered from caller()): list the anchor's
+    // accounts at target_origin so the agent can pick which account_number to
+    // request a delegation for via mcp_prepare_account_delegation.
+    mcp_get_accounts : (
+        target_origin : FrontendHostname
+    ) -> (variant { Ok : vec AccountInfo; Err : AccountDelegationError }) query;
 
     prepare_session_delegation : (
         anchor_number : UserNumber,

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -618,35 +618,30 @@ fn get_account_delegation(
 }
 
 /// Enable or disable the backend `/mcp` delegation path for `anchor_number` at
-/// `mcp_server_origin`, for the given account (the unreserved default when
-/// `account_number` is `None`). Enabling binds the principal II derives for that
-/// `(account, origin)` pair — the principal the MCP server's standing delegation
-/// carries — so it can later fetch per-app delegations as this anchor; disabling
-/// unbinds exactly that principal. The origin comes from the connect request, so
-/// each user trusts the MCP server they choose.
+/// `mcp_server_origin`. Enabling binds the principal II derives for the anchor at
+/// that origin — the principal the MCP server's standing delegation carries — so
+/// it can later fetch per-app delegations as this anchor; disabling unbinds
+/// exactly that principal. No account is chosen here (accounts are per-origin and
+/// the connector isn't an app); the app account is selected per call on
+/// `mcp_prepare_account_delegation`. The origin comes from the connect request,
+/// so each user trusts the MCP server they choose.
 #[update]
 fn mcp_set_access(
     anchor_number: AnchorNumber,
     mcp_server_origin: FrontendHostname,
-    account_number: Option<AccountNumber>,
     enabled: bool,
 ) -> Result<(), String> {
     check_authz_and_record_activity(anchor_number).map_err(|err| format!("Unauthorized: {err}"))?;
-    mcp::set_mcp_access(anchor_number, mcp_server_origin, account_number, enabled)
+    mcp::set_mcp_access(anchor_number, mcp_server_origin, enabled)
 }
 
-/// Whether `anchor_number` has MCP access enabled for the
-/// `(mcp_server_origin, account_number)` pair.
+/// Whether `anchor_number` has MCP access enabled at `mcp_server_origin`.
 #[query]
-fn mcp_access_enabled(
-    anchor_number: AnchorNumber,
-    mcp_server_origin: FrontendHostname,
-    account_number: Option<AccountNumber>,
-) -> bool {
+fn mcp_access_enabled(anchor_number: AnchorNumber, mcp_server_origin: FrontendHostname) -> bool {
     if check_session_authorization(anchor_number).is_err() {
         return false;
     }
-    mcp::is_mcp_access_enabled(anchor_number, mcp_server_origin, account_number)
+    mcp::is_mcp_access_enabled(anchor_number, mcp_server_origin)
 }
 
 /// Read `anchor_number`'s synced trusted-MCP-server config (master toggle +
@@ -674,9 +669,13 @@ fn mcp_set_config(anchor_number: AnchorNumber, config: McpConfig) -> Result<(), 
     Ok(())
 }
 
-/// Called by the MCP server (authorized by `caller()` == the anchor's principal
-/// at `mcp_server_origin`): prepare a ≤5-minute delegation for the anchor's
-/// default account at `target_origin`.
+/// Called by the MCP server (authorized by `caller()` == the principal bound for
+/// its anchor at the connect-time `mcp_server_origin`): prepare a per-app
+/// delegation at `target_origin` for `account_number` — one of the anchor's
+/// accounts there (discover them with `mcp_get_accounts`), or the anchor's
+/// default account when `None`. `max_ttl` is the requested lifetime in ns,
+/// defaulting to and capped at 5 minutes. The resolved `account_number` is
+/// returned in `McpPrepareDelegation` to thread into `mcp_get_account_delegation`.
 #[update]
 async fn mcp_prepare_account_delegation(
     target_origin: FrontendHostname,
@@ -687,6 +686,10 @@ async fn mcp_prepare_account_delegation(
     mcp::prepare_account_delegation(target_origin, account_number, session_key, max_ttl).await
 }
 
+/// Fetch the delegation prepared by `mcp_prepare_account_delegation`. The anchor
+/// is recovered from `caller()`; `account_number` and `expiration` must be the
+/// values returned by the matching prepare call, or this returns
+/// `NoSuchDelegation`.
 #[query]
 fn mcp_get_account_delegation(
     target_origin: FrontendHostname,
@@ -695,6 +698,16 @@ fn mcp_get_account_delegation(
     expiration: Timestamp,
 ) -> Result<SignedDelegation, AccountDelegationError> {
     mcp::get_account_delegation(target_origin, account_number, session_key, expiration)
+}
+
+/// Called by the MCP server (anchor recovered from `caller()`): list the anchor's
+/// accounts at `target_origin` so the agent can pick which `account_number` to
+/// request a delegation for.
+#[query]
+fn mcp_get_accounts(
+    target_origin: FrontendHostname,
+) -> Result<Vec<AccountInfo>, AccountDelegationError> {
+    mcp::get_accounts(target_origin)
 }
 
 #[update]

--- a/src/internet_identity/src/mcp.rs
+++ b/src/internet_identity/src/mcp.rs
@@ -1,24 +1,24 @@
 //! Backend `/mcp` delegation path: lets an MCP server the user chooses to trust
-//! act as one of the user's accounts at any app, without a per-app browser flow.
+//! act on the user's behalf at any app, without a per-app browser flow.
 //!
-//! At connect time the MCP server obtains (via the `/mcp` browser delegation
-//! flow) a standing delegation `anchor -> MCP server key`, issued for the MCP
-//! server's own origin and a specific account the user picks. Its principal is
-//! therefore the principal II derives for that `(account, origin)` pair. When
-//! the anchor enables MCP access for that pair, we record `that principal ->
-//! anchor` in the reverse index (see [`crate::storage`]). The MCP server then
-//! calls [`prepare_account_delegation`] / [`get_account_delegation`] *as that
+//! At connect time the user authorizes the MCP server for their identity: II
+//! records `the principal it derives for the anchor at the MCP server's origin
+//! -> anchor` in the reverse index (see [`crate::storage`]). No account is
+//! chosen at connect — the MCP server's own origin is just the connector, and
+//! accounts are per-origin. The MCP server then calls [`get_accounts`] /
+//! [`prepare_account_delegation`] / [`get_account_delegation`] *as that
 //! principal*; we recover the anchor from `caller()` via the index, so no
 //! `anchor_number` parameter is needed — being the right caller is the
 //! authorization. The trusted origin comes from the connect request, so each
-//! user trusts the server they choose. Issued per-app delegations are capped at
-//! 5 minutes.
+//! user trusts the server they choose. Which app account the server acts as is
+//! chosen per call against the *target app* origin (discover them with
+//! [`get_accounts`]). Issued per-app delegations are capped at 5 minutes.
 
 use candid::Principal;
 use ic_cdk::caller;
 use internet_identity_interface::internet_identity::types::{
-    AccountNumber, AnchorNumber, FrontendHostname, McpConfig, McpPrepareDelegation, SessionKey,
-    SignedDelegation, Timestamp,
+    AccountInfo, AccountNumber, AnchorNumber, FrontendHostname, McpConfig, McpPrepareDelegation,
+    SessionKey, SignedDelegation, Timestamp,
 };
 
 use crate::{
@@ -63,64 +63,37 @@ fn default_account_number(
     default_account(anchor_number, origin).account_number
 }
 
-/// The anchor's account `account_number` at `origin` — or the synthetic default
-/// (the unreserved account) when `account_number` is `None` or the account
-/// can't be read.
-fn account_for(
-    anchor_number: AnchorNumber,
-    account_number: Option<AccountNumber>,
-    origin: &FrontendHostname,
-) -> Account {
-    let Some(account_number) = account_number else {
-        return Account::synthetic(anchor_number, origin.clone());
-    };
-    storage_borrow(|storage| {
-        let known_app_num = storage.lookup_application_number_with_origin(origin);
-        storage
-            .read_account(ReadAccountParams {
-                account_number: Some(account_number),
-                anchor_number,
-                origin,
-                known_app_num,
-            })
-            .unwrap_or_else(|| Account::synthetic(anchor_number, origin.clone()))
-    })
-}
-
-/// The principal II derives for `anchor_number`'s `account_number` at `origin` —
-/// the principal the MCP server's standing delegation carries.
-fn mcp_principal_for(
-    anchor_number: AnchorNumber,
-    account_number: Option<AccountNumber>,
-    origin: &FrontendHostname,
-) -> Principal {
-    let seed = account_for(anchor_number, account_number, origin).calculate_seed();
+/// The MCP server's standing-delegation principal for `anchor_number` at
+/// `origin`: the principal II derives for the anchor's synthetic account at that
+/// origin (seed = anchor + origin). No account is chosen at connect — the
+/// connector isn't an app — and the synthetic seed is stable, so enable and
+/// disable always derive the same principal.
+fn mcp_principal_for(anchor_number: AnchorNumber, origin: &FrontendHostname) -> Principal {
+    let seed = Account::synthetic(anchor_number, origin.clone()).calculate_seed();
     Principal::self_authenticating(der_encode_canister_sig_key(seed.to_vec()))
 }
 
-/// Enable or disable MCP access for `anchor_number` at `mcp_server_origin` for
-/// `account_number` (the unreserved default when `None`): bind/unbind the
-/// principal II derives for that `(account, origin)` pair in the reverse index.
-/// The caller must already be authorized for `anchor_number` (checked by the
-/// canister method). Disabling re-derives the same principal from the supplied
-/// origin+account, so it always unbinds exactly what enabling bound.
+/// Enable or disable MCP access for `anchor_number` at `mcp_server_origin`:
+/// bind/unbind the principal II derives for the anchor at that origin in the
+/// reverse index. The caller must already be authorized for `anchor_number`
+/// (checked by the canister method). Disabling re-derives the same principal, so
+/// it always unbinds exactly what enabling bound.
 pub fn set_mcp_access(
     anchor_number: AnchorNumber,
     mcp_server_origin: FrontendHostname,
-    account_number: Option<AccountNumber>,
     enabled: bool,
 ) -> Result<(), String> {
-    let principal = mcp_principal_for(anchor_number, account_number, &mcp_server_origin);
+    let principal = mcp_principal_for(anchor_number, &mcp_server_origin);
     storage_borrow_mut(|storage| {
         if enabled {
             // Surface a cross-anchor collision instead of silently no-op'ing, so
-            // the caller learns the (account, origin) pair couldn't be bound.
+            // the caller learns the origin couldn't be bound.
             storage
                 .set_anchor_mcp_principal(principal, anchor_number)
                 .map_err(|existing| {
                     format!(
                         "MCP access could not be enabled: the principal for this \
-                         (account, origin) is already bound to identity {existing}."
+                         origin is already bound to identity {existing}."
                     )
                 })
         } else {
@@ -154,14 +127,12 @@ pub fn set_mcp_config(anchor_number: AnchorNumber, config: McpConfig) {
     storage_borrow_mut(|storage| storage.write_mcp_config(anchor_number, stored));
 }
 
-/// Whether `anchor_number` has MCP access enabled for the
-/// `(mcp_server_origin, account_number)` pair.
+/// Whether `anchor_number` has MCP access enabled at `mcp_server_origin`.
 pub fn is_mcp_access_enabled(
     anchor_number: AnchorNumber,
     mcp_server_origin: FrontendHostname,
-    account_number: Option<AccountNumber>,
 ) -> bool {
-    let principal = mcp_principal_for(anchor_number, account_number, &mcp_server_origin);
+    let principal = mcp_principal_for(anchor_number, &mcp_server_origin);
     storage_borrow(|storage| storage.lookup_anchor_with_mcp_principal(principal))
         == Some(anchor_number)
 }
@@ -172,13 +143,29 @@ fn caller_anchor() -> Result<AnchorNumber, AccountDelegationError> {
         .ok_or(AccountDelegationError::Unauthorized(caller()))
 }
 
+/// `mcp_get_accounts`: list the calling MCP server's anchor's accounts at
+/// `target_origin`, so the agent can discover which `account_number` values it
+/// may request a delegation for via [`prepare_account_delegation`]. Authorized
+/// like prepare/get — the anchor is recovered from `caller()`, never passed.
+pub fn get_accounts(
+    target_origin: FrontendHostname,
+) -> Result<Vec<AccountInfo>, AccountDelegationError> {
+    let anchor_number = caller_anchor()?;
+    Ok(
+        account_management::get_accounts_for_origin(anchor_number, &target_origin)
+            .iter()
+            .map(|account| account.to_info())
+            .collect(),
+    )
+}
+
 /// `mcp_prepare_account_delegation`: mint a ≤5-minute account delegation for the
 /// calling MCP server at `target_origin`, as `account_number` — one of the
-/// anchor's accounts at that origin when given explicitly, or the anchor's
-/// default account there when `None`. (Accounts are per-origin, so this is an
-/// account at `target_origin`, the app being acted on — not the account the user
-/// picked at the MCP server's own origin when connecting; an `account_number`
-/// that isn't the anchor's at `target_origin` is rejected as `Unauthorized`.)
+/// anchor's accounts at that origin when given explicitly (discover them with
+/// [`get_accounts`]), or the anchor's default account there when `None`.
+/// (Accounts are per-origin, so this is an account at `target_origin`, the app
+/// being acted on; no account is chosen at connect. An `account_number` that
+/// isn't the anchor's at `target_origin` is rejected as `Unauthorized`.)
 ///
 /// Returns the resolved `account_number` so the server can thread the *same*
 /// account into [`get_account_delegation`]: the default account at an origin is

--- a/src/internet_identity/tests/integration/mcp.rs
+++ b/src/internet_identity/tests/integration/mcp.rs
@@ -1,15 +1,16 @@
 //! Integration tests for the backend `/mcp` delegation path: an MCP server the
-//! user chooses to trust, acting as the principal II derives for an anchor's
-//! chosen account at that server's origin, fetches per-app account delegations
-//! without a per-app browser flow. The anchor is recovered from `caller()` via
-//! the opt-in index.
+//! user authorizes for their identity fetches per-app account delegations
+//! without a per-app browser flow. No account is chosen at connect (the
+//! connector isn't an app); the server is bound to the principal II derives for
+//! the anchor at the server's origin, recovered from `caller()` via the opt-in
+//! index, and picks the app account per call against the target origin.
 
 use candid::Principal;
 use canister_tests::{
     api::internet_identity::api_v2::{
-        create_account, mcp_access_enabled, mcp_get_account_delegation, mcp_get_config,
-        mcp_prepare_account_delegation, mcp_set_access, mcp_set_config, prepare_account_delegation,
-        set_default_account, AccountDelegationParams,
+        create_account, mcp_access_enabled, mcp_get_account_delegation, mcp_get_accounts,
+        mcp_get_config, mcp_prepare_account_delegation, mcp_set_access, mcp_set_config,
+        prepare_account_delegation, set_default_account, AccountDelegationParams,
     },
     flows,
     framework::{
@@ -75,7 +76,6 @@ fn mcp_mints_per_app_delegation_authorized_by_caller() -> Result<(), RejectRespo
         principal_1(),
         anchor,
         MCP_ORIGIN.to_string(),
-        None,
         true,
     )
     .unwrap()
@@ -85,8 +85,7 @@ fn mcp_mints_per_app_delegation_authorized_by_caller() -> Result<(), RejectRespo
         canister_id,
         principal_1(),
         anchor,
-        MCP_ORIGIN.to_string(),
-        None
+        MCP_ORIGIN.to_string()
     )
     .unwrap());
 
@@ -164,7 +163,6 @@ fn mcp_delegation_ttl_capped_at_5_minutes() -> Result<(), RejectResponse> {
         principal_1(),
         anchor,
         MCP_ORIGIN.to_string(),
-        None,
         true,
     )
     .unwrap()
@@ -250,7 +248,6 @@ fn mcp_disabling_access_revokes_the_caller() -> Result<(), RejectResponse> {
         principal_1(),
         anchor,
         MCP_ORIGIN.to_string(),
-        None,
         true,
     )
     .unwrap()
@@ -273,7 +270,6 @@ fn mcp_disabling_access_revokes_the_caller() -> Result<(), RejectResponse> {
         principal_1(),
         anchor,
         MCP_ORIGIN.to_string(),
-        None,
         false,
     )
     .unwrap()
@@ -283,8 +279,7 @@ fn mcp_disabling_access_revokes_the_caller() -> Result<(), RejectResponse> {
         canister_id,
         principal_1(),
         anchor,
-        MCP_ORIGIN.to_string(),
-        None
+        MCP_ORIGIN.to_string()
     )
     .unwrap());
     match mcp_prepare_account_delegation(&env, canister_id, mcp, target, None, session_key, None)
@@ -318,7 +313,6 @@ fn mcp_get_uses_prepared_account_despite_default_change() -> Result<(), RejectRe
         principal_1(),
         anchor,
         MCP_ORIGIN.to_string(),
-        None,
         true,
     )
     .unwrap()
@@ -412,7 +406,6 @@ fn mcp_prepares_for_an_explicitly_named_account() -> Result<(), RejectResponse> 
         principal_1(),
         anchor,
         MCP_ORIGIN.to_string(),
-        None,
         true,
     )
     .unwrap()
@@ -458,6 +451,73 @@ fn mcp_prepares_for_an_explicitly_named_account() -> Result<(), RejectResponse> 
     )
     .unwrap()
     .is_ok());
+
+    Ok(())
+}
+
+/// The agent discovers the anchor's accounts at an app via `mcp_get_accounts`
+/// (authorized as the bound MCP principal) and then prepares a delegation for
+/// one of them — closing the loop with no out-of-band knowledge. An unrelated
+/// principal cannot list.
+#[test]
+fn mcp_lists_accounts_then_prepares_for_one() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_with_mcp(&env);
+    let anchor = flows::register_anchor(&env, canister_id);
+    let mcp = mcp_server_principal(&env, canister_id, anchor);
+    let target = "https://some-app.com".to_string();
+
+    mcp_set_access(
+        &env,
+        canister_id,
+        principal_1(),
+        anchor,
+        MCP_ORIGIN.to_string(),
+        true,
+    )
+    .unwrap()
+    .unwrap();
+
+    // The user holds a named account at the target app (created via their device).
+    let created = create_account(
+        &env,
+        canister_id,
+        principal_1(),
+        anchor,
+        target.clone(),
+        "work".to_string(),
+    )
+    .unwrap()
+    .unwrap()
+    .account_number;
+    assert!(created.is_some());
+
+    // The agent lists the anchor's accounts at the app as the bound MCP principal.
+    let accounts = mcp_get_accounts(&env, canister_id, mcp, target.clone())
+        .unwrap()
+        .unwrap();
+    assert!(accounts.iter().any(|a| a.account_number == created));
+
+    // It can then prepare a delegation for a listed account.
+    let prepared = mcp_prepare_account_delegation(
+        &env,
+        canister_id,
+        mcp,
+        target.clone(),
+        created,
+        ByteBuf::from("k"),
+        None,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(prepared.account_number, created);
+
+    // A principal that isn't bound to the anchor cannot list.
+    match mcp_get_accounts(&env, canister_id, principal_2(), target).unwrap() {
+        Err(AccountDelegationError::Unauthorized(p)) => assert_eq!(p, principal_2()),
+        Ok(_) => panic!("expected Unauthorized, got Ok"),
+        Err(e) => panic!("expected Unauthorized, got {e:?}"),
+    }
 
     Ok(())
 }


### PR DESCRIPTION
# Motivation

Follow-up cleanup to #4052. Three problems with the merged MCP feature:

1. **The connect-time account picker was conceptually wrong — and inert.** The `/mcp` connect screen reused the full `/authorize` account picker (`ContinueView`) keyed on the *MCP server* origin and threaded the chosen account into `mcp_set_access` + the standing delegation. But accounts are **per-origin** (`read_account` → `find_account_reference` validates an account against its origin), and the MCP server origin is just the connector, not an app the user has accounts at. The picked `account_number` only selected which opaque reverse-index key got bound — it had **zero downstream effect** on what the server acts as at any app (that's chosen separately by `mcp_prepare_account_delegation`'s `target_origin`/`account_number`). It also left two unrelated `account_number` parameters sharing a name, and a silent `Account::synthetic` fallback that masked an invalid account as `Ok`.

2. **The multi-account story was half-built.** The agent can already request a delegation for a specific app/account (`mcp_prepare_account_delegation` takes `account_number`), but it had **no way to discover** which accounts the user has at an app: `get_accounts` is gated by `check_session_authorization`, which the MCP-server principal doesn't satisfy.

3. **Stale/contradictory/incomplete API docs**, surfaced by an adversarial audit: a contradictory stacked comment on `mcp_prepare_account_delegation` (old "default account" prose above the new `account_number` block), undocumented `max_ttl`/`expiration`, a missing doc on `mcp_get_account_delegation`, and connect-flow comments describing the now-removed "chosen account."

# Changes

**Remove connect-time account selection (end to end).** Accounts are chosen per app at delegation time, never at connect.
- Backend: `mcp_set_access` / `mcp_access_enabled` drop `account_number`; the bound principal is the anchor's synthetic principal at the MCP server origin (stable: anchor + origin). `mcp_principal_for` collapses accordingly; the `account_for` helper (and its silent synthetic fallback) is deleted.
- Frontend: the connect screen replaces `ContinueView` with a plain consent step (hero + "Connect <host>" + session-duration select + one "Allow access" that authenticates the selected identity). `mcpAuthorize` no longer takes an account; the standing delegation uses the identity's default account at the server origin.
- candid (`mcp_set_access`/`mcp_access_enabled` lose the param) + regenerated bindings + tests follow. This is a **breaking `.did` change** to those two methods.

**Add `mcp_get_accounts(target_origin)`** — a query authorized via `caller_anchor()` (same pattern as the other `mcp_*` methods) that lists the anchor's accounts at the target app, so the agent can discover the `account_number`s it may then pass to `mcp_prepare_account_delegation`. This completes the "list accounts → request a per-account delegation" flow.

**Overhaul the MCP API docs:** collapse the contradictory `mcp_prepare_account_delegation` comment into one accurate block, document `max_ttl` and `expiration`, add the missing `mcp_get_account_delegation` doc, fix the `McpPrepareDelegation` and `main.rs` docs, and correct the connect-flow comments in `mcp.rs`, the integration-test module doc, and the e2e comments.

# Tests

- Backend: `cargo check`/`clippy` (wasm) clean; candid `service_equal` compatibility test passes against the regenerated `.did`. New integration test `mcp_lists_accounts_then_prepares_for_one` lists as the bound MCP principal, prepares for a listed account, and asserts an unbound principal gets `Unauthorized`. Existing per-account/threading tests retained; all `mcp_set_access`/`mcp_access_enabled` calls updated to drop the account arg.
- Frontend: `npm run check` (svelte-check + tsc) — 0 errors; eslint + prettier clean.
- e2e `/mcp` connect specs unaffected functionally (they click "Allow access" directly); only their comments were corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGvgPmEVcgyUP2mAnwnDcj)_