### PR TITLE
fix(fe): verified-email follow-ups (dialog symmetry, copy, mobile)

### DIFF
--- a/src/frontend/src/lib/components/settings/RemoveVerifiedEmail.svelte
+++ b/src/frontend/src/lib/components/settings/RemoveVerifiedEmail.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
-  import { Trash2Icon } from "@lucide/svelte";
+  import { TriangleAlertIcon } from "@lucide/svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { t } from "$lib/stores/locale.store";
   import { Trans } from "$lib/components/locale";
@@ -25,29 +25,31 @@
   };
 </script>
 
-<div class="flex flex-1 flex-col gap-2">
-  <FeaturedIcon variant="info" size="lg" class="mb-3">
-    <Trash2Icon class="size-5" />
-  </FeaturedIcon>
-  <h1 class="text-text-primary text-xl font-medium">
-    {$t`Forget this email?`}
-  </h1>
-  <p class="text-text-secondary mb-6 text-sm">
-    <Trans>
-      <strong class="text-text-primary break-all">{address}</strong> will no longer
-      be associated with your Internet Identity.
-    </Trans>
-  </p>
-  <div class="mt-auto flex flex-row items-stretch gap-3">
-    <button
-      class="btn btn-tertiary btn-lg flex-1"
-      onclick={onCancel}
-      disabled={isRemoving}
+<div class="flex flex-1 flex-col">
+  <div class="mb-8 flex flex-col">
+    <FeaturedIcon variant="warning" size="lg" class="mb-3">
+      <TriangleAlertIcon class="size-6" />
+    </FeaturedIcon>
+    <h1 class="text-text-primary mb-3 text-2xl font-medium">
+      {$t`Forget this email?`}
+    </h1>
+    <div
+      class={[
+        "flex flex-col gap-4",
+        "[&_p]:text-text-tertiary [&_p]:text-base [&_p]:font-medium",
+      ]}
     >
-      {$t`Cancel`}
-    </button>
+      <p>
+        <Trans>
+          <strong class="text-text-primary break-all">{address}</strong>
+          will no longer be associated with your Internet Identity.
+        </Trans>
+      </p>
+    </div>
+  </div>
+  <div class="mt-auto flex flex-col items-stretch gap-3">
     <button
-      class="btn btn-primary btn-lg btn-danger flex-1"
+      class="btn btn-primary btn-lg btn-danger"
       onclick={handleRemove}
       disabled={isRemoving}
     >
@@ -57,6 +59,13 @@
       {:else}
         <span>{$t`Remove`}</span>
       {/if}
+    </button>
+    <button
+      class="btn btn-tertiary btn-lg"
+      onclick={onCancel}
+      disabled={isRemoving}
+    >
+      {$t`Cancel`}
     </button>
   </div>
 </div>

--- a/src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte
+++ b/src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte
@@ -136,7 +136,7 @@
     >
       <MailIcon class="text-fg-secondary size-7" aria-hidden="true" />
       <p aria-hidden="true" class="text-text-tertiary text-sm">
-        {$t`No emails yet.`}
+        {$t`No emails yet`}
       </p>
       <span
         aria-hidden="true"

--- a/src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte
+++ b/src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte
@@ -117,13 +117,13 @@
     </div>
     {#if count > 0}
       <button
-        class="btn btn-primary btn-sm shrink-0"
+        class="btn btn-primary btn-sm max-sm:btn-icon shrink-0"
         onclick={() => (showAddWizard = true)}
         disabled={isFull}
         aria-label={$t`Add an email`}
       >
         <PlusIcon class="size-4" aria-hidden="true" />
-        <span>{$t`Add an email`}</span>
+        <span class="max-sm:hidden">{$t`Add an email`}</span>
       </button>
     {/if}
   </div>
@@ -153,13 +153,13 @@
         <li
           class="bg-bg-secondary border-border-secondary relative flex flex-row items-center gap-3 rounded-xl border px-4 py-3"
         >
-          <div class="flex min-w-0 flex-1 flex-col gap-1 overflow-hidden">
-            <div class="flex flex-row items-center gap-2.5">
-              <span
-                class="text-text-primary min-w-0 truncate text-sm font-semibold"
-              >
-                {entry.address}
-              </span>
+          <div class="flex min-w-0 flex-1 flex-col gap-1.5 overflow-hidden">
+            <span
+              class="text-text-primary min-w-0 truncate text-sm font-semibold"
+            >
+              {entry.address}
+            </span>
+            <div class="flex flex-row flex-wrap items-center gap-x-2.5 gap-y-1">
               <span
                 class="border-fg-success-primary bg-bg-success-primary text-text-success-primary inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium"
               >
@@ -169,18 +169,17 @@
                 ></span>
                 {$t`Verified`}
               </span>
+              <time
+                datetime={verifiedAt.toISOString()}
+                title={$formatDate(verifiedAt, {
+                  timeStyle: "short",
+                  dateStyle: "medium",
+                })}
+                class="text-text-tertiary text-sm"
+              >
+                {$formatRelative(verifiedAt, { style: "long" })}
+              </time>
             </div>
-            <time
-              datetime={verifiedAt.toISOString()}
-              title={$formatDate(verifiedAt, {
-                timeStyle: "short",
-                dateStyle: "medium",
-              })}
-              class="text-text-tertiary text-sm"
-            >
-              {$t`Verified`}
-              {$formatRelative(verifiedAt, { style: "long" })}
-            </time>
           </div>
           <button
             class="btn btn-tertiary btn-sm btn-icon relative z-10 shrink-0"

--- a/src/frontend/src/lib/components/wizards/setupEmailRecovery/views/EnterAddress.svelte
+++ b/src/frontend/src/lib/components/wizards/setupEmailRecovery/views/EnterAddress.svelte
@@ -87,9 +87,8 @@
       </div>
       <div class="text-text-warning-primary text-sm">
         <Trans>
-          Recovery is best kept as a private mailbox, separate from the
-          addresses you share with apps — that way, losing access to one doesn't
-          lock you out of the other.
+          Keep your recovery email private and separate from emails you share
+          with apps.
         </Trans>
       </div>
     </div>


### PR DESCRIPTION
Follow-ups on #4046 / #4056 surfaced after the two PRs landed: the "Forget this email?" dialog didn't match the recovery dialog's visual treatment, the setup-recovery wizard's "shareable email" warning was long-winded with an em-dash, and the shareable-info panel didn't respond well on mobile.

## Changes

- **`RemoveVerifiedEmail` dialog** — match `RemoveEmailRecovery`: amber `FeaturedIcon variant="warning"` + `TriangleAlertIcon` instead of the neutral info-style trash icon, `text-2xl` title, and stacked buttons (danger **Remove** on top, **Cancel** below) instead of side-by-side. Kept the verified-email-specific copy ("Forget this email?" / "…no longer be associated with your Internet Identity").
- **Setup-recovery wizard warning copy** — replaced the two-sentence em-dash explainer with: "Keep your recovery email private and separate from emails you share with apps."
- **`VerifiedEmailsPanel` mobile layout** — the heading's "Add an email" button collapses to an icon-only square below `sm` (text hidden via `max-sm:hidden`, `max-sm:btn-icon` for the squared padding). Each email card moves the "Verified" badge off the email row down next to the relative time, in a `flex-wrap` row so the time can drop under the badge on very narrow viewports. Removed the redundant "Verified" word that prefixed the relative time (the badge already says "Verified").

## Tests

- Manual: /manage/shareable-info renders correctly on mobile width; "Forget this email?" dialog now matches the recovery dialog's visual hierarchy.