### PR TITLE
docs(be,fe): push notifications PoC design

### DIFF
--- a/docs/push-api.md
+++ b/docs/push-api.md
@@ -1,0 +1,137 @@
+# Push notifications — II interface and dApp integration
+
+The Candid surface a dApp sends through, and the steps to integrate one.
+
+Design rationale lives in [push-notifications.md](push-notifications.md); this
+document is reference material and assumes you have read at least
+[how it works, in plain terms](push-notifications.md#how-it-works-in-plain-terms).
+
+## dApp developer integration
+
+
+
+One-time setup (~15 min): serve `.well-known/ii-push-senders`, call
+`push_register_sender(origin)` from the backend. Steady state: hand the client
+library a campaign — it chunks, paces, retries and reports:
+
+```rust
+// Non-sensitive app: show the content.
+push.broadcast(
+    PushContent::Display { title, body },
+    PushDelivery { urgency: High, ttl_seconds: 3600, topic: Some("balance") },
+    &my_user_principals,        // library chunks + paces these
+).await?;
+
+// E2E app: send nothing sensitive; content is revealed on tap.
+push.broadcast(
+    PushContent::Hidden { category: Some(Message) },
+    PushDelivery { urgency: High, ttl_seconds: 3600, topic: None },
+    &my_user_principals,
+).await?;
+```
+
+Under the hood the library splits the audience into ≤ ~1000-target chunks,
+calls `push_send` per chunk, **paces on `ready` / `retry_after_ms`**, retries
+with a stable `chunk_id`, and aggregates per-target results into campaign
+status. The dApp sees a campaign API; II sees paced, bounded chunks. No keys,
+no crypto, no Web Push knowledge, and no per-user state beyond the principals
+from auth (the library owns campaign status). Delivery is best-effort with no
+receipts; the only per-user signal is `NoConsent`.
+
+
+## The Candid interface
+
+The exact API a dApp's backend calls, written in Candid (the IC's interface
+language). There is a single send entry point, `push_send`: it carries a
+shared `default_alert` plus a list of recipients, each of which may override
+that alert with its own — so the same call does both "same text for everyone"
+and "different text per user." The rest are the types it uses; skim the
+comments — each explains what the field is for.
+
+```candid
+type PushCategory = variant { Message; Transfer; Update; Generic };
+
+// The content variant is what makes end-to-end encryption possible later
+// (see the end-to-end-encryption section below). Display content is read by II
+// and shown verbatim — fine for non-sensitive notifications, but II sees it.
+// Hidden content is never sent to II at all: the payload carries no message
+// text, so an E2E sender structurally cannot leak content. The service
+// worker renders an II-controlled generic string keyed by category, and the
+// real message is revealed on tap-through when the app decrypts it.
+type PushContent = variant {
+  Display : record {             // II-visible; transport-encrypted only, NOT E2E
+    title : text;                // ≤ 64 bytes
+    body : text;                 // ≤ 256 bytes
+  };
+  Hidden : record {              // content-free; E2E-safe by construction
+    category : opt PushCategory; // maps to II-controlled copy ("New message", …)
+  };
+  Dismiss;                       // close the shown notification named by notification_id; renders nothing
+};
+
+type PushAlert = record {
+  content : PushContent;
+  url : opt text;                // tap-through target; must be same-origin as sender
+  notification_id : opt text;    // dApp's id for this notification (maps to the Web Notification `tag`):
+                                 // reuse it to UPDATE the shown one, or pair with Dismiss to close it
+};
+
+type PushUrgency = variant { VeryLow; Low; Normal; High };
+
+type PushDelivery = record {     // RFC 8030 relay headers; plaintext, relay-visible
+  urgency : opt PushUrgency;     // default Normal; also orders II's drain
+  ttl_seconds : opt nat32;       // default ~4h; 0 = only if online now; clamped to a max
+  topic : opt text;              // ≤ 32 chars base64url; collapse key
+};
+
+type PushRejection = variant {
+  NoConsent;                     // unknown target OR not consented to *your* origin (merged on purpose)
+  AlertInvalid : text;
+};
+
+type PushResult = record {
+  admitted : nat32;              // accepted into the in-flight buffer for delivery (NOT delivered)
+  rejected : vec record { index : nat32; reason : PushRejection };
+  ready : bool;                  // false → II is at capacity; stop and retry after retry_after_ms
+  retry_after_ms : opt nat32;    // Layer-1 backpressure hint
+};
+
+// One recipient. `alert` is an optional per-recipient override; when null the
+// recipient uses the chunk's shared `default_alert`. This is how one endpoint
+// covers both cases: broadcast = shared default + all overrides null;
+// personalized = per-recipient overrides. `null` costs ~1 byte, so broadcast
+// stays compact (the content isn't repeated per recipient).
+type PushRecipient = record {
+  target : principal;            // in-app principal
+  alert : opt PushAlert;         // override; falls back to default_alert
+};
+
+service : {
+  push_register_sender : (origin : text) -> (variant { Ok; Err : text });
+  push_deregister_sender : (origin : text) -> (variant { Ok; Err : text });
+
+  // Submit ONE chunk (≤ ~1000 recipients, ≤ 2 MB). II admits what it has
+  // capacity for (Layer 1) and returns per-recipient rejections plus a
+  // backpressure signal. Each recipient's effective alert is its own override
+  // or, if null, `default_alert`; if both are null it is rejected
+  // (AlertInvalid). The client library owns the campaign, chunking, pacing,
+  // retry, status, templating and prioritization — II holds no campaign state.
+  push_send : (
+    chunk_id : blob,             // per-chunk idempotency (short-lived heap dedup)
+    delivery : PushDelivery,     // shared across the chunk (urgency / ttl / topic)
+    default_alert : opt PushAlert, // shared alert for recipients that don't override
+    recipients : vec PushRecipient
+  ) -> (PushResult);
+}
+```
+
+The `content` / `PushDelivery` split mirrors the trust boundaries. `Display`
+content is transport-encrypted (the relay can't read it) but **II can** —
+acceptable for non-sensitive notifications. `Hidden` content is never sent to
+II, which is what preserves end-to-end encryption. `PushDelivery` fields are
+plaintext RFC 8030 headers the relay sees. A sender that wants E2E chooses the
+`Hidden` variant and, by construction, has no field to put message text in.
+`push_send` returns as soon as the chunk is admitted (or rejected) — it does
+**not** wait for delivery; "admitted" means "accepted into II's in-flight
+buffer", nothing more.
+

--- a/docs/push-api.md
+++ b/docs/push-api.md
@@ -1,25 +1,18 @@
 # Push notifications — II interface and dApp integration
 
-The Candid surface a dApp sends through, and the steps to integrate one.
+The Candid surface a dApp sends through, and how to integrate one. Reference material
+— rationale is in [push-notifications.md](push-notifications.md).
 
-Design rationale lives in [push-notifications.md](push-notifications.md); this
-document is reference material and assumes you have read at least
-[how it works, in plain terms](push-notifications.md#how-it-works-in-plain-terms).
+## Integrating a dApp
 
-## dApp developer integration
+Setup is one step: serve `.well-known/ii-push-senders` listing your backend canister
+principal. II verifies the file itself (on first consent, or on your first send), so
+there's no registration call to remember — `push_send` just returns `SenderUnverified`
+until it does, and the client library retries until a correctly published file
+resolves. (`push_register_sender` only forces an immediate re-check after you edit the
+file.)
 
-
-
-One-time setup: serve `.well-known/ii-push-senders` listing your backend canister
-principal. That is the whole of it — II verifies the file itself, on first consent
-or on your first send, so there is no registration call to remember. `push_send`
-returns `SenderUnverified` until it has, and the client library surfaces the hint
-and retries, so a correctly published file resolves on its own.
-(`push_register_sender(origin)` exists to force an immediate re-read after you edit
-the file, rather than waiting for the TTL.)
-
-Steady state: hand the client library a campaign — it chunks, paces, retries and
-reports:
+Then hand the client library a campaign; it chunks, paces, retries and reports:
 
 ```rust
 // Non-sensitive app: show the content.
@@ -37,23 +30,18 @@ push.broadcast(
 ).await?;
 ```
 
-Under the hood the library splits the audience into ≤ ~1000-target chunks,
-calls `push_send` per chunk, **paces on `ready` / `retry_after_ms`**, retries
-with a stable `chunk_id`, and aggregates per-target results into campaign
-status. The dApp sees a campaign API; II sees paced, bounded chunks. No keys,
-no crypto, no Web Push knowledge, and no per-user state beyond the principals
-from auth (the library owns campaign status). Delivery is best-effort with no
-receipts; the only per-user signal is `NoConsent`.
+The library splits the audience into ≤1000-target chunks, calls `push_send` per chunk,
+paces on `ready`/`retry_after_ms`, retries with a stable `chunk_id`, and aggregates
+results into campaign status. The dApp handles no keys, no crypto, no Web Push, and no
+per-user state. Delivery is best-effort with no receipts — the only per-user signal is
+`NoConsent`.
 
 
 ## The Candid interface
 
-The exact API a dApp's backend calls, written in Candid (the IC's interface
-language). There is a single send entry point, `push_send`: it carries a
-shared `default_alert` plus a list of recipients, each of which may override
-that alert with its own — so the same call does both "same text for everyone"
-and "different text per user." The rest are the types it uses; skim the
-comments — each explains what the field is for.
+One send entry point, `push_send`: a shared `default_alert` plus recipients that may
+each override it, so the same call does broadcast and per-user text. The inline
+comments cover the rest.
 
 ```candid
 type PushCategory = variant { Message; Transfer; Update; Generic };
@@ -132,13 +120,9 @@ service : {
 }
 ```
 
-The `content` / `PushDelivery` split mirrors the trust boundaries. `Display`
-content is transport-encrypted (the relay can't read it) but **II can** —
-acceptable for non-sensitive notifications. `Hidden` content is never sent to
-II, which is what preserves end-to-end encryption. `PushDelivery` fields are
-plaintext RFC 8030 headers the relay sees. A sender that wants E2E chooses the
-`Hidden` variant and, by construction, has no field to put message text in.
-`push_send` returns as soon as the chunk is admitted (or rejected) — it does
-**not** wait for delivery; "admitted" means "accepted into II's in-flight
-buffer", nothing more.
+The `content`/`PushDelivery` split mirrors the trust boundaries: `Display` is
+transport-encrypted but II-readable (fine for non-sensitive text); `Hidden` never
+reaches II (preserving E2E — an E2E sender simply has no field for message text);
+`PushDelivery` headers are plaintext the relay sees. `push_send` returns on admission,
+not delivery — "admitted" means "in II's buffer", nothing more.
 

--- a/docs/push-api.md
+++ b/docs/push-api.md
@@ -10,9 +10,16 @@ document is reference material and assumes you have read at least
 
 
 
-One-time setup (~15 min): serve `.well-known/ii-push-senders`, call
-`push_register_sender(origin)` from the backend. Steady state: hand the client
-library a campaign — it chunks, paces, retries and reports:
+One-time setup: serve `.well-known/ii-push-senders` listing your backend canister
+principal. That is the whole of it — II verifies the file itself, on first consent
+or on your first send, so there is no registration call to remember. `push_send`
+returns `SenderUnverified` until it has, and the client library surfaces the hint
+and retries, so a correctly published file resolves on its own.
+(`push_register_sender(origin)` exists to force an immediate re-read after you edit
+the file, rather than waiting for the TTL.)
+
+Steady state: hand the client library a campaign — it chunks, paces, retries and
+reports:
 
 ```rust
 // Non-sensitive app: show the content.

--- a/docs/push-client-library.md
+++ b/docs/push-client-library.md
@@ -144,6 +144,7 @@ is internal. A dApp author should never have to know what a chunk is.
 | Failure                            | What the library must do                                        |
 | ---------------------------------- | --------------------------------------------------------------- |
 | `ready = false`                    | back off with jitter; do **not** advance the cursor             |
+| `SenderUnverified`                 | surface the hint once, then retry with backoff — self-heals     |
 | `drain_epoch` moved (II upgraded)  | rewind to the oldest unconfirmed chunk and re-send              |
 | Its own host restarts mid-campaign | resume from `cursor`; re-send anything `InFlight`               |
 | `NoConsent` for a target           | mark terminal, stop retrying, surface to the dApp               |
@@ -153,4 +154,25 @@ is internal. A dApp author should never have to know what a chunk is.
 Because retries and epoch-recovery both re-send chunks, **duplicate delivery is
 expected by design** — which is the other half of why `msg_id` dedup on the
 device is a v1 requirement, not a nicety.
+
+### Sender verification is the library's job, not the dApp's
+
+A dApp should never write registration logic. Its only obligation is to publish
+`/.well-known/ii-push-senders` listing its backend canister; everything after that
+belongs here.
+
+On `SenderUnverified` the library logs the hint II returned — which names the file
+to publish and the principal to list — exactly once per origin, then keeps retrying
+with backoff. II verifies in the background, so a correctly published file makes
+the condition clear itself with no further action, and a missing one produces one
+actionable log line instead of a silent failure.
+
+The only case worth an explicit call is a developer who has just fixed their file
+and does not want to wait: expose `forceReverify()` over
+`push_register_sender(origin)`, which bypasses II's negative cache. It is a
+convenience, not part of the normal path.
+
+The failure this avoids is worth naming, because it is the one a dApp would
+otherwise hit on day one: publish the file, forget the setup call, and every send
+fails with an authorization error that looks like a bug in II.
 

--- a/docs/push-client-library.md
+++ b/docs/push-client-library.md
@@ -1,33 +1,22 @@
 # Push notifications — the dApp-side client library
 
-The helper a dApp runs to feed II a large send at a pace II can accept,
-retry safely, and keep the durable campaign state that lets II stay stateless.
+The helper a dApp runs to feed II a large send at a pace it accepts, retry safely, and
+hold the durable campaign state that keeps II stateless. Reference material — rationale
+is in [push-notifications.md](push-notifications.md).
 
-Design rationale lives in [push-notifications.md](push-notifications.md); this
-document is reference material and assumes you have read at least
-[how it works, in plain terms](push-notifications.md#how-it-works-in-plain-terms).
+Because II stores nothing per send, the durable coordination is a library the dApp
+runs: it keeps the list, sends it in paced pieces, retries failures, tracks who was
+notified, and personalises text. The dApp calls one "notify these users" method.
 
-
-
-> _In short: because II stores nothing per send, a small library on the dApp's
-> side keeps the list, sends it to II in paced pieces, retries failures, tracks
-> who got notified, and personalizes text. The dApp calls one simple
-> "notify these users" method; the library handles the rest._
-
-Since II is stateless for campaigns, the durable coordination is a library the
-dApp runs. This is where the heavy list and its bookkeeping live — where the
-volume originates.
-
-Security is unaffected by moving this out: II re-validates sender-origin,
-consent and origin-pinning on **every** chunk, so a buggy or malicious library
-cannot fake consent, target another dApp's users, or exceed admission limits —
-it can only mismanage its own campaign. **The library is a convenience, never a
-control.**
+Moving this out costs no security: II re-validates sender-origin, consent and
+origin-pinning on **every** chunk, so a buggy or malicious library can only mismanage
+its own campaign — never fake consent, target another dApp's users, or exceed limits.
+**The library is a convenience, never a control.**
 
 ### Where it runs, and the one real choice
 
-The library must live somewhere with durable state and a scheduler, because it
-owns a campaign that outlives any single call. Two viable hosts:
+It needs durable state and a scheduler, since a campaign outlives any single call. Two
+hosts:
 
 |                 | dApp **canister** (recommended)                 | dApp **web2 backend**                       |
 | --------------- | ----------------------------------------------- | ------------------------------------------- |
@@ -37,10 +26,9 @@ owns a campaign that outlives any single call. Two viable hosts:
 | Sender identity | its own canister principal — registers directly | needs a canister to call on its behalf      |
 | Fits            | on-chain apps, the default                      | apps whose audience already lives off-chain |
 
-The canister host is the recommended shape: it is the only one that can attach
-cycles (relevant if sender-pays ever lands) and the only one whose sender
-identity is a principal II can register directly. A web2 backend still needs a
-small companion canister to be the registered sender, so it ends up running both.
+Prefer the canister: it's the only host that can attach cycles (for a future
+sender-pays) and whose principal II can register directly. A web2 backend needs a
+companion canister as the registered sender anyway, so it runs both.
 
 ### State it must keep
 
@@ -66,15 +54,12 @@ Target {                              // one row per recipient
 }
 ```
 
-Two things worth being precise about, because they are where implementations go
-wrong:
+Two things implementations get wrong:
 
-- **`status = Admitted` means "II accepted it into its buffer", not
-  "delivered".** There are no delivery receipts. The library must not present
-  `Admitted` to the dApp as "the user got it"; the honest label is "sent".
-- **`cursor` + `last_drain_epoch` together are the recovery state.** On restart,
-  or when II's `drain_epoch` moves, everything `InFlight`/`Admitted` since that
-  epoch is suspect and must be re-sent (see below).
+- **`Admitted` means "in II's buffer", not "delivered"** — there are no receipts, so
+  present it to the dApp as "sent", never "the user got it".
+- **`cursor` + `last_drain_epoch` are the recovery state** — on restart or when II's
+  `drain_epoch` moves, everything `InFlight`/`Admitted` since that epoch must be re-sent.
 
 ### The send loop
 
@@ -126,8 +111,8 @@ status(campaign_id) -> { total, sent, no_consent, pending, state }
 pause(campaign_id) / resume(campaign_id) / cancel(campaign_id)
 ```
 
-Everything else — chunking, pacing, retry, epoch recovery, backoff, templating —
-is internal. A dApp author should never have to know what a chunk is.
+Everything else — chunking, pacing, retry, epoch recovery, backoff, templating — is
+internal; a dApp author never needs to know what a chunk is.
 
 - **Templating / personalization** — expand `template + per-user data` into a
   per-recipient `alert` override entirely client-side. **II never sees a
@@ -157,22 +142,13 @@ device is a v1 requirement, not a nicety.
 
 ### Sender verification is the library's job, not the dApp's
 
-A dApp should never write registration logic. Its only obligation is to publish
-`/.well-known/ii-push-senders` listing its backend canister; everything after that
-belongs here.
+The dApp's only obligation is to publish `/.well-known/ii-push-senders`; registration
+logic belongs here. On `SenderUnverified`, log the hint II returns (the file and
+principal) once per origin, then retry with backoff — II verifies in the background, so
+a correct file self-heals and a missing one gives one actionable log line instead of a
+silent failure. Expose `forceReverify()` (over `push_register_sender`) for a developer
+who just fixed their file and doesn't want to wait.
 
-On `SenderUnverified` the library logs the hint II returned — which names the file
-to publish and the principal to list — exactly once per origin, then keeps retrying
-with backoff. II verifies in the background, so a correctly published file makes
-the condition clear itself with no further action, and a missing one produces one
-actionable log line instead of a silent failure.
-
-The only case worth an explicit call is a developer who has just fixed their file
-and does not want to wait: expose `forceReverify()` over
-`push_register_sender(origin)`, which bypasses II's negative cache. It is a
-convenience, not part of the normal path.
-
-The failure this avoids is worth naming, because it is the one a dApp would
-otherwise hit on day one: publish the file, forget the setup call, and every send
-fails with an authorization error that looks like a bug in II.
+This avoids the day-one failure: publish the file, forget the setup call, and every
+send fails with an error that looks like an II bug.
 

--- a/docs/push-client-library.md
+++ b/docs/push-client-library.md
@@ -1,0 +1,156 @@
+# Push notifications — the dApp-side client library
+
+The helper a dApp runs to feed II a large send at a pace II can accept,
+retry safely, and keep the durable campaign state that lets II stay stateless.
+
+Design rationale lives in [push-notifications.md](push-notifications.md); this
+document is reference material and assumes you have read at least
+[how it works, in plain terms](push-notifications.md#how-it-works-in-plain-terms).
+
+
+
+> _In short: because II stores nothing per send, a small library on the dApp's
+> side keeps the list, sends it to II in paced pieces, retries failures, tracks
+> who got notified, and personalizes text. The dApp calls one simple
+> "notify these users" method; the library handles the rest._
+
+Since II is stateless for campaigns, the durable coordination is a library the
+dApp runs. This is where the heavy list and its bookkeeping live — where the
+volume originates.
+
+Security is unaffected by moving this out: II re-validates sender-origin,
+consent and origin-pinning on **every** chunk, so a buggy or malicious library
+cannot fake consent, target another dApp's users, or exceed admission limits —
+it can only mismanage its own campaign. **The library is a convenience, never a
+control.**
+
+### Where it runs, and the one real choice
+
+The library must live somewhere with durable state and a scheduler, because it
+owns a campaign that outlives any single call. Two viable hosts:
+
+|                 | dApp **canister** (recommended)                 | dApp **web2 backend**                       |
+| --------------- | ----------------------------------------------- | ------------------------------------------- |
+| Durability      | stable memory, survives upgrades                | whatever the backend already has            |
+| Scheduling      | `ic_cdk_timers`                                 | cron / job runner                           |
+| Calls II via    | inter-canister call (**can attach cycles**)     | ingress (**cannot attach cycles**)          |
+| Sender identity | its own canister principal — registers directly | needs a canister to call on its behalf      |
+| Fits            | on-chain apps, the default                      | apps whose audience already lives off-chain |
+
+The canister host is the recommended shape: it is the only one that can attach
+cycles (relevant if sender-pays ever lands) and the only one whose sender
+identity is a principal II can register directly. A web2 backend still needs a
+small companion canister to be the registered sender, so it ends up running both.
+
+### State it must keep
+
+Per campaign, durable:
+
+```
+Campaign {
+  campaign_id       : text            // dApp-chosen, unique
+  default_alert     : PushAlert       // shared text, if any
+  delivery          : PushDelivery    // urgency / ttl / topic for the campaign
+  created_at        : nanos
+  state             : Building | Sending | Paused | Done | Failed
+  cursor            : nat64           // index of the next unsent target
+  last_drain_epoch  : nat64           // II's epoch as of the last confirmed chunk
+}
+
+Target {                              // one row per recipient
+  principal   : Principal             // the user's in-app principal for THIS origin
+  alert       : opt PushAlert         // personalization override, else default
+  status      : Pending | InFlight | Admitted | NoConsent | Invalid | Dropped
+  chunk_id    : opt blob              // which chunk carried it
+  attempts    : nat8
+}
+```
+
+Two things worth being precise about, because they are where implementations go
+wrong:
+
+- **`status = Admitted` means "II accepted it into its buffer", not
+  "delivered".** There are no delivery receipts. The library must not present
+  `Admitted` to the dApp as "the user got it"; the honest label is "sent".
+- **`cursor` + `last_drain_epoch` together are the recovery state.** On restart,
+  or when II's `drain_epoch` moves, everything `InFlight`/`Admitted` since that
+  epoch is suspect and must be re-sent (see below).
+
+### The send loop
+
+```
+for each batch of ≤1000 targets from cursor:
+    chunk_id = hash(campaign_id, cursor)        # deterministic → idempotent retry
+    r = push_send(chunk_id, delivery, default_alert, recipients)
+
+    if r.drain_epoch != last_drain_epoch:       # II was upgraded
+        rewind cursor to the oldest unconfirmed chunk
+        last_drain_epoch = r.drain_epoch
+        continue
+
+    mark r.rejected targets by reason           # NoConsent → terminal, not retry
+    mark the rest Admitted; advance cursor
+
+    if !r.ready:
+        sleep(r.retry_after_ms + jitter)        # jitter is not optional
+```
+
+Details that matter:
+
+- **`chunk_id` must be deterministic** — derive it from
+  `(campaign_id, cursor)`, never from a random value or a timestamp. That is
+  what makes a retry idempotent instead of a duplicate. Fix it at **16 bytes**;
+  II's dedup set is bounded and LRU-evicted, so oversized or unbounded ids are
+  rejected.
+- **Jittered exponential backoff, always.** A bare `retry_after_ms` makes every
+  rejected sender retry at the same instant, and after an II upgrade every
+  client with lost chunks retries simultaneously — a thundering herd precisely
+  when II is least able to absorb it.
+- **Pipeline no more than a few chunks.** The output queue between two canisters
+  is 500 deep, and the point of pacing is to absorb inter-canister latency, not
+  to race II's admission control.
+- **`NoConsent` is terminal.** It means the user revoked or never granted; retrying
+  it wastes admission budget forever. Distinguish it from capacity rejections,
+  which _are_ retryable.
+- **Chunk by bytes as well as by count.** ≤1000 targets _and_ under the
+  size ceiling — with heavy per-recipient personalization the byte bound binds
+  first. II enforces both server-side; hitting them is a client bug.
+
+### What it owes the dApp
+
+The public surface should be small enough that the common case is one call:
+
+```
+notify(campaign_id, targets, default_alert, delivery) -> CampaignHandle
+status(campaign_id) -> { total, sent, no_consent, pending, state }
+pause(campaign_id) / resume(campaign_id) / cancel(campaign_id)
+```
+
+Everything else — chunking, pacing, retry, epoch recovery, backoff, templating —
+is internal. A dApp author should never have to know what a chunk is.
+
+- **Templating / personalization** — expand `template + per-user data` into a
+  per-recipient `alert` override entirely client-side. **II never sees a
+  template**, which is what keeps personalization off II's storage.
+- **Prioritization** — the library decides which campaign or segment goes first.
+  Note this is _campaign_ ordering, distinct from per-message `urgency`, which
+  rides the relay header and contributes to II's drain order.
+- **Status/reporting** — aggregate per-chunk results into campaign progress,
+  labelled honestly: `sent` (admitted), `no_consent`, `pending`. Not
+  "delivered" — nothing in this design can tell the dApp that.
+
+### Failure modes the library is responsible for
+
+| Failure                            | What the library must do                                        |
+| ---------------------------------- | --------------------------------------------------------------- |
+| `ready = false`                    | back off with jitter; do **not** advance the cursor             |
+| `drain_epoch` moved (II upgraded)  | rewind to the oldest unconfirmed chunk and re-send              |
+| Its own host restarts mid-campaign | resume from `cursor`; re-send anything `InFlight`               |
+| `NoConsent` for a target           | mark terminal, stop retrying, surface to the dApp               |
+| Call trapped / rejected            | retry the _same_ `chunk_id`; never mint a new one               |
+| Campaign outlives its own deadline | `ttl_seconds` already bounds it II-side; mark `Dropped` locally |
+
+Because retries and epoch-recovery both re-send chunks, **duplicate delivery is
+expected by design** — which is the other half of why `msg_id` dedup on the
+device is a v1 requirement, not a nicety.
+

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1,0 +1,890 @@
+# Push notifications — design
+
+Internet Identity hosts a single Web Push pipeline that any dApp can send
+through. The user grants notification permission to id.ai **once**, subscribes
+per device, and consents per dApp; every consented dApp then delivers
+notifications via II rather than running its own service worker, VAPID
+keypair, and subscription.
+
+The value is a **single permission + delivery hub**, not an install: the user
+allows notifications for their identity provider once, and every consented
+dApp reaches them through it — instead of each dApp prompting for its own
+notification permission (which browsers increasingly bury) and running its own
+push stack. Installing II as a PWA is **optional** on Android and desktop
+(Web Push works in a plain tab there) and only **required on iOS Safari**,
+where it also earns its keep as "install one app, get every dApp's
+notifications." This doc captures the design across the two paths that decide
+scalability — **dApp → II** and **II → device** — plus the security model and
+the open items.
+
+## What does the user experience?
+
+### How does a user turn notifications on? (first time signing into a dApp)
+
+1. On the dApp (e.g. `oisy.com`), the user clicks **Sign in with Internet
+   Identity**. II opens at `/authorize`.
+2. The user authenticates as usual (passkey, or an existing session for a
+   returning user).
+3. **Continue screen** (`ContinueView`): "Continue to `<dApp>`" with the
+   account picker and a **Continue** button. There is no notification toggle
+   here — the account choice is the only decision.
+4. The user taps **Continue**.
+5. **Notifications opt-in screen** (`NotifOptInView`): a preview illustration
+   of what a notification looks like (an "Example" lock-screen stack), the
+   heading "Let `<dApp>` notify you", two short reasons (instant alerts /
+   reachable anytime), and two buttons — **Enable notifications** and **Maybe
+   later**.
+6a. **Enable** → the browser shows its **native permission prompt**
+    ("`id.ai` wants to show notifications — Allow / Block"). This dialog is
+    the browser's own and cannot be restyled. On **Allow**, II subscribes the
+    device and records consent for this dApp, then redirects to the dApp. No
+    app install is required (Android/desktop); iOS Safari is the exception.
+6b. **Maybe later** → II redirects straight to the dApp; nothing is enabled.
+
+The permission prompt appears only the first time the user enables
+notifications on this browser; for later dApps the opt-in screen simply
+records consent (no second prompt).
+
+### What happens when a notification is sent?
+
+7. The dApp's backend/frontend calls `notify_user` (later, a batch endpoint).
+8. The notification arrives on every device the user enabled — **even with the
+   tab closed / browser not running** (on Android). It shows the dApp's origin
+   as the source and the dApp's title/body as the text.
+9. The user **taps** it. II's `/notify` screen appears briefly — "Opening
+   `<dApp>`" with the app's logo — then forwards to the dApp (the specific
+   page if the dApp deep-linked, otherwise its home).
+
+### How does a user manage or turn them off?
+
+10. In **II → Settings**, the user sees **Notifications on this device**
+    (a toggle to turn the whole device on/off) and **Allowed apps** — every
+    dApp that can notify them, each with a remove button. Revoking an app
+    stops its notifications immediately.
+
+## Status
+
+Built today (PoC on `feat/push-notifications-poc`):
+
+- Device subscribe/unsubscribe, `/authorize` opt-in, per-dApp consent.
+- Single `notify_user(principal, alert)` update call.
+- RFC 8291 payload encryption + RFC 8292 VAPID JWT signing, both in-canister.
+- VAPID private key generated via `raw_rand` and persisted in stable memory.
+  This is not the ideal custody model, and we do it only because the ideal
+  one is unavailable: VAPID/Web Push mandate ECDSA on the **P-256
+  (secp256r1)** curve, but the IC's threshold ECDSA currently supports **only
+  secp256k1** — so we cannot let the subnet hold the key via `sign_with_ecdsa`
+  and must generate and store it ourselves. It follows the same posture as the
+  anchor salt (node operators could extract it; the blast radius is spam, not
+  identity). If P-256 threshold ECDSA lands on the IC, the key moves off
+  storage entirely — see the security and open-items sections below.
+- Notification click routes through the consent-gated `/notify` redirect.
+
+Proposed (this doc):
+
+- Chunked `push_send` with two-layer flow control (II admission + client
+  pacing), sender registry, a stateless-for-campaigns II (transient heap
+  buffer, storage O(users)), a durable client library, and delivery through a
+  trusted web2 gateway (with direct per-device outcalls as the documented
+  alternative/fallback). No cycles charging in v1 (the real costs — storage and
+  outcalls — are controlled by design, not billing) — parked as a future
+  exploration.
+
+## How does it work, in plain terms?
+
+Read this first; the sections after it just add detail.
+
+- **A dApp never talks to phones directly.** It tells II "notify these users,"
+  and II handles the actual delivery. The dApp only knows its users by an
+  opaque per-app id, so it can't reach anyone it wasn't given.
+- **II already knows how to reach each user.** When a user turns notifications
+  on, their browser hands II the keys needed to deliver to that device; when
+  they sign into a dApp and opt in, II records that the dApp is allowed. So II
+  keeps two small per-user facts: *which devices* and *which apps are allowed*.
+- **II seals every message.** It encrypts (using device key-pair generated during subscription. Standard web-push api.) the text so only the user's own
+  device can read it (Google/Apple/Mozilla just forward sealed bytes, the browser makes sure to decrypt it), and it
+  signs the request so those push services trust that it really came from II (VAPID JWT which is per audience and can be cached so that we don't have to generate it every time).
+- **Big sends are streamed, not dumped.** To notify 10,000 users, the dApp uses
+  a small helper **library** that feeds II the list in bite-size batches at a
+  pace II can handle. II refuses more than it can take (so nobody can flood
+  it), and the library slows down when asked. The big list lives with the
+  dApp — **II stores almost nothing per send**, which matters because storage
+  is II's resource we want to protect.
+- **How II sends the final messages.** II hands the sealed messages to a small
+  **trusted helper server (the "gateway")** that makes the many little
+  per-device sends on II's behalf over ordinary internet — far cheaper and
+  faster than the canister making each call itself. (Having the canister call
+  each push service directly is the documented fallback, but one network call
+  per device gets expensive at scale, so it isn't the default.) Either way II
+  does the sealing; the helper only forwards messages it can't read.
+- **Tapping a notification** opens II briefly ("Opening \<app\>…") and forwards
+  the user to the app — only ever to the app that sent it.
+
+Everything below is the same story with the exact mechanisms and edge cases.
+
+## Architecture
+
+```
+┌─ dApp side ────────────────────────┐        ┌─ II ────────────────────────────────┐
+│ client library (durable):          │        │ Layer 1 — admission control         │
+│  owns the campaign + status         │ chunk  │  per-origin bucket + global cap,    │
+│  chunks (≤1000, ≤2MB)               │──────▶ │  O(1) reject → protects II          │
+│  templating / personalization       │        │        │ admit                       │
+│  prioritization                     │ ◀──────│        ▼                            │
+│  Layer 2 — pacing (cooperative):    │ ready/ │  transient HEAP buffer (small)      │
+│  send on `ready`, back off,         │ retry  │        │ seal: encrypt + VAPID sign  │
+│  retry, track per-target status     │        │        ▼ fast drain                 │
+└────────────────────────────────────┘        │  few batched outcalls ──▶ gateway   │
+                                               │  (direct per-device = alt/fallback) │
+                                               └─────────────────────────────────────┘
+                                                        │ (gateway fans out off-chain)
+                                                        ▼
+                                              FCM / Mozilla / APNs relays
+                                                        ▼
+                                    device SW decrypts → showNotification
+                                                        │ tap
+                                                        ▼
+                          II /notify?origin=…&to=… → consent-gated redirect → dApp
+```
+
+Two costs drive the architecture, and it is built to control **both**:
+
+- **Stable storage** — the hard constraint. It is limited and must not grow
+  with how many notifications are sent. So the durable campaign lives in the
+  dApp's client library, and II keeps only user-scoped data (subscriptions,
+  consent) plus a small transient working set — its storage stays flat with
+  volume.
+- **HTTPS outcalls** — genuinely expensive and rate-bounded (one call per
+  device adds up fast in both cycles and throughput). So delivery is batched
+  through the gateway, turning thousands of per-device outcalls into a handful.
+
+Raw compute is the cheap part (the crypto is microseconds of local work and
+stays in-canister); storage and outcalls are the two things worth engineering
+around.
+
+## dApp → II
+
+### Sending to thousands of users: chunked send + two-layer flow control
+
+> *In short: the dApp streams the audience to II in small batches ("chunks");
+> II refuses more than it can handle, and the dApp slows down when told to.
+> Two separate safeguards — one on each side — keep this safe and smooth.*
+
+A campaign of any size is delivered as a series of **bounded chunks** — a chunk
+is just a bite-size batch of targets (≤ ~1000 targets, ≤ 2 MB per call). This is deliberate: II must never be asked to hold a
+whole campaign, because that is the storage that scales with volume. Two
+independent control layers make this safe and smooth — and they must not be
+confused:
+
+- **Layer 1 — II admission control (mandatory, adversarial).** This is the
+  security boundary and assumes a hostile client. II enforces a per-origin
+  token bucket (notifications-per-window) plus a global cap on its transient
+  buffer. Over capacity, `push_send` **rejects the chunk** (`ready = false` +
+  `retry_after_ms`). The reject is O(1). The guarantee: **II never holds more
+  than its bounded buffer, no matter what the client does** — a client that
+  ignores backpressure just collects cheap rejections. This is the anti-spam
+  property, and it lives entirely on II.
+- **Layer 2 — client pacing (cooperative, efficiency only).** The client
+  library reads the same `ready` / `retry_after_ms` signal and paces so it
+  doesn't waste calls getting rejected: send the next chunk when II is ready,
+  back off when it isn't, retry, track status. This is a good-citizen layer,
+  **not** a security layer. If a client skips it, nothing breaks for II
+  (Layer 1 holds); the client just delivers slower.
+
+The rule to remember: **II protects itself; the client optimizes itself.**
+Never rely on client pacing to prevent spam — that is always Layer 1's job.
+
+Both "same text for everyone" and "different text per user" go through the
+**one** `push_send` call: it takes a shared `default_alert` plus a list of
+recipients, each able to override the default with its own alert. Broadcast =
+set the default and leave every override empty (the content isn't repeated, so
+~1000 recipients fit well under 2 MB); personalized = give each recipient its
+own alert, rendered client-side by the library's templating (II never holds a
+template); a mix of the two works too.
+
+### The Candid interface
+
+The exact API a dApp's backend calls, written in Candid (the IC's interface
+language). There is a single send entry point, `push_send`: it carries a
+shared `default_alert` plus a list of recipients, each of which may override
+that alert with its own — so the same call does both "same text for everyone"
+and "different text per user." The rest are the types it uses; skim the
+comments — each explains what the field is for.
+
+```candid
+type PushCategory = variant { Message; Transfer; Update; Generic };
+
+// The content variant is what makes end-to-end encryption possible later
+// (see the end-to-end-encryption section below). Display content is read by II
+// and shown verbatim — fine for non-sensitive notifications, but II sees it.
+// Hidden content is never sent to II at all: the payload carries no message
+// text, so an E2E sender structurally cannot leak content. The service
+// worker renders an II-controlled generic string keyed by category, and the
+// real message is revealed on tap-through when the app decrypts it.
+type PushContent = variant {
+  Display : record {             // II-visible; transport-encrypted only, NOT E2E
+    title : text;                // ≤ 64 bytes
+    body : text;                 // ≤ 256 bytes
+  };
+  Hidden : record {              // content-free; E2E-safe by construction
+    category : opt PushCategory; // maps to II-controlled copy ("New message", …)
+  };
+  Dismiss;                       // close the shown notification named by notification_id; renders nothing
+};
+
+type PushAlert = record {
+  content : PushContent;
+  url : opt text;                // tap-through target; must be same-origin as sender
+  notification_id : opt text;    // dApp's id for this notification (maps to the Web Notification `tag`):
+                                 // reuse it to UPDATE the shown one, or pair with Dismiss to close it
+};
+
+type PushUrgency = variant { VeryLow; Low; Normal; High };
+
+type PushDelivery = record {     // RFC 8030 relay headers; plaintext, relay-visible
+  urgency : opt PushUrgency;     // default Normal; also orders II's drain
+  ttl_seconds : opt nat32;       // default ~4h; 0 = only if online now; clamped to a max
+  topic : opt text;              // ≤ 32 chars base64url; collapse key
+};
+
+type PushRejection = variant {
+  NoConsent;                     // unknown target OR not consented to *your* origin (merged on purpose)
+  AlertInvalid : text;
+};
+
+type PushResult = record {
+  admitted : nat32;              // accepted into the in-flight buffer for delivery (NOT delivered)
+  rejected : vec record { index : nat32; reason : PushRejection };
+  ready : bool;                  // false → II is at capacity; stop and retry after retry_after_ms
+  retry_after_ms : opt nat32;    // Layer-1 backpressure hint
+};
+
+// One recipient. `alert` is an optional per-recipient override; when null the
+// recipient uses the chunk's shared `default_alert`. This is how one endpoint
+// covers both cases: broadcast = shared default + all overrides null;
+// personalized = per-recipient overrides. `null` costs ~1 byte, so broadcast
+// stays compact (the content isn't repeated per recipient).
+type PushRecipient = record {
+  target : principal;            // in-app principal
+  alert : opt PushAlert;         // override; falls back to default_alert
+};
+
+service : {
+  push_register_sender : (origin : text) -> (variant { Ok; Err : text });
+  push_deregister_sender : (origin : text) -> (variant { Ok; Err : text });
+
+  // Submit ONE chunk (≤ ~1000 recipients, ≤ 2 MB). II admits what it has
+  // capacity for (Layer 1) and returns per-recipient rejections plus a
+  // backpressure signal. Each recipient's effective alert is its own override
+  // or, if null, `default_alert`; if both are null it is rejected
+  // (AlertInvalid). The client library owns the campaign, chunking, pacing,
+  // retry, status, templating and prioritization — II holds no campaign state.
+  push_send : (
+    chunk_id : blob,             // per-chunk idempotency (short-lived heap dedup)
+    delivery : PushDelivery,     // shared across the chunk (urgency / ttl / topic)
+    default_alert : opt PushAlert, // shared alert for recipients that don't override
+    recipients : vec PushRecipient,
+  ) -> (PushResult);
+}
+```
+
+The `content` / `PushDelivery` split mirrors the trust boundaries. `Display`
+content is transport-encrypted (the relay can't read it) but **II can** —
+acceptable for non-sensitive notifications. `Hidden` content is never sent to
+II, which is what preserves end-to-end encryption. `PushDelivery` fields are
+plaintext RFC 8030 headers the relay sees. A sender that wants E2E chooses the
+`Hidden` variant and, by construction, has no field to put message text in.
+`push_send` returns as soon as the chunk is admitted (or rejected) — it does
+**not** wait for delivery; "admitted" means "accepted into II's in-flight
+buffer", nothing more.
+
+### How does II know which users to send to?
+
+The dApp only knows its users by their in-app principal (II's privacy model).
+`PRINCIPAL_INDEX` resolves `principal → (anchor, origin_hash)`, and the index
+entry **pins the origin** — a principal belonging to another dApp's consent
+resolves to a different `origin_hash` and is rejected. dApp A physically
+cannot target dApp B's users even with stolen principals. Audiences larger
+than one chunk are split across paced `push_send` calls by the client library,
+not by server-side routing.
+
+### How does II verify the sender is really that dApp?
+
+One call has one `caller()`, so the per-user `caller == in_app_principal`
+model does not batch. Senders authenticate at the **origin** level:
+
+1. The dApp serves `/.well-known/ii-push-senders` listing its backend
+   canister principal(s).
+2. The backend calls `push_register_sender(origin)`; II fetches the file via
+   HTTPS outcall (with a transform for consensus) and verifies
+   `caller ∈ senders`, storing `origin_hash → {principals, verified_at}`.
+3. II re-verifies on a TTL (~weekly, lazy) and deregisters when the file
+   disappears. This reuses the existing outcall / DoH machinery; IC custom
+   domains also carry a `_canister-id` DNS TXT record as a second path.
+
+### Admission control (Layer 1): stopping one dApp from flooding II
+
+> *In short: II tracks how much each app is sending and simply says "not right
+> now, try again in N ms" once an app goes over its share. This is what stops
+> spam, and it works even if the sender ignores every hint.*
+
+The mandatory guard, assuming a hostile client. Enforced on every `push_send`,
+independent of client behavior:
+
+- **Per-origin token bucket** in notifications-per-window — one origin can't
+  spam and can't starve others. Denominated in notifications, not calls, so it
+  can't be gamed by slicing a send into many small chunks.
+- **Global cap** on the in-flight buffer — protects II/the subnet as a whole.
+- **O(1) reject** when over capacity (`ready = false` + `retry_after_ms`), so
+  absorbing a flood is itself cheap.
+
+Because the queue lives on the client, the only II storage a sender can
+pressure is the bounded in-flight buffer — which admission control caps
+directly. That, plus the fast drain (below), is what lets II sustain high
+throughput on a *small* buffer.
+
+### What does this cost, and who pays?
+
+Two real costs, controlled by the design; not charged to the dApp in v1:
+
+- **Stable storage — the hard constraint.** Kept **O(users)** (subscriptions +
+  consent), never O(notification volume), because the campaign state lives in
+  the client library. This is the cost that would otherwise grow without bound,
+  so it's the one the whole "stateless II" shape is built around.
+- **HTTPS outcalls — expensive and bounded.** Minimized by batching delivery
+  through the gateway (a handful of calls instead of one per device). Real
+  enough to design against, which is why the gateway exists.
+- **Compute (the crypto)** is the cheap part and stays in-canister.
+
+On charging: **no cycles charging in v1.** Cycles can only be attached by
+canister senders, and adding per-notification fees brings real complexity
+(accept/refund, fee tuning) for a v1 whose abuse surface is already bounded by
+admission control. Attached-cycle or prepaid-balance pricing is parked as a
+future exploration — worth revisiting to offset the outcall/storage cost at
+scale, or as an extra abuse lever. See Future exploration.
+
+## II's state model: stateless for campaigns
+
+> *In short: II accepts a chunk, briefly holds it in memory (not durable
+> storage), seals and sends it, then forgets it. The durable list lives with
+> the dApp, so II's storage doesn't grow as more notifications are sent.*
+
+II holds **no campaign queue in stable (durable) memory**. `push_send` is
+cheap:
+authenticate the sender, dedup `chunk_id`, run admission control (Layer 1),
+per-target resolve + consent-check, then admit the survivors into a small
+**transient heap buffer** and return `{admitted, rejected, ready,
+retry_after_ms}`. It does not wait for delivery — one message cannot do
+1000 × devices encryptions and outcalls (per-message instruction limit +
+outcall-concurrency cap).
+
+A timer (`ic_cdk_timers`, ~1s) drains the heap buffer:
+
+- One `raw_rand` per tick; ChaCha20 derives per-message ephemeral seeds.
+- Resolves each anchor's devices **now** (they change between admit and drain)
+  and re-checks consent (may have been revoked since).
+- Forces `content` attribution to the sender origin (unspoofable).
+- RFC 8291 encrypts per device; attaches the per-audience VAPID JWT
+  (cached, ≤ 12h).
+- Drains **fast** to the gateway in a few batched outcalls (see below). Fast
+  drain is what lets the buffer stay small while admitting at high throughput.
+- `410 Gone` deletes the subscription. No retries in v1 (retries are a client
+  concern; see the client library).
+
+`PushDelivery` integrates into the buffer, not just the headers:
+
+- **topic** — key the buffer entry by `(origin_hash, anchor, topic)`; an
+  un-drained entry with the same key is **replaced**, collapsing rapid updates
+  (savings scale with buffer depth). The relay collapses in-flight duplicates
+  too.
+- **ttl_seconds** — at drain, if `admitted_at + ttl` has passed, **skip** the
+  outcall (the relay would drop it anyway).
+- **urgency** — sets the header *and* orders the drain (`High` first).
+
+**Durability lives on the client, not in II.** The in-flight buffer is heap,
+not stable memory — so it costs no persistent storage and is simply lost on
+upgrade. That is fine: the client library is the source of truth and re-sends
+any chunk it hasn't seen acknowledged. Consequently the only new **stable**
+regions are user-scoped and volume-independent: the sender registry
+(`OriginSha256 → sender`) alongside the existing subscription and consent maps.
+`chunk_id` dedup is a short-lived heap set. Timers don't survive upgrades —
+re-arm in `post_upgrade` and `init`.
+
+## Delivering to devices
+
+The relay API is one POST per subscription endpoint (RFC 8030) — there is no
+multi-recipient send, so reaching N devices is fundamentally N sends. The
+design routes those sends through a **trusted web2 gateway**. Doing them as
+per-device outcalls straight from the canister ("direct") is the documented
+**alternative** — kept for context and as a possible low-volume or
+fully-on-chain fallback, but not the shipping path.
+
+### The delivery path: a trusted web2 gateway
+
+II encrypts and signs as usual, then hands the **fully-sealed, ready-to-send
+messages** to a small trusted helper server, which makes the many little sends
+over ordinary (free) internet instead of on-chain:
+
+```
+[ { endpoint, headers, authorization:<vapid jwt+pubkey>, body:<ciphertext> }, … ]
+```
+
+- **The VAPID key and encryption stay on II** — moving either would require
+  giving the gateway the VAPID private key (push to all users) or the device
+  keys + plaintext (read all notifications). RFC 8291 has no encrypt-once mode,
+  so II produces the N ciphertexts regardless; the gateway saves **outcall
+  count, not crypto**.
+- The gateway is **stateless** — no keys, no subscriptions, no plaintext at
+  rest; it only sees in-transit ciphertext + endpoints + timing.
+- II batches sealed bundles into ~2 MB chunks: ~25 outcalls instead of ~13k
+  (~500× fewer; cycles drop to cents).
+- II authenticates to the gateway with a bearer token (IC outcalls have no
+  stable source IP). The gateway must return a **deterministic ack** or the
+  outcall's response-consensus fails; per-device results cannot return through
+  this channel.
+- **The gateway's cheapness sets II's admission capacity.** II's throughput is
+  bounded by how fast it drains its (small) buffer; a fast, cheap batched
+  drain empties the buffer quickly, so II recovers capacity and admits the next
+  chunk sooner. Fast drain → high sustained throughput on a *small* buffer →
+  flat storage. This is why the gateway hop is a scaling primitive, not just a
+  cost optimization.
+
+Trust delta — the deliberate cost of this path: the gateway can **drop, delay,
+or replay** captured bundles, but cannot read content or forge new sends.
+Confidentiality and authenticity stay on-chain; only **liveness** moves off — a
+real, narrow concession for a trust-minimizing service. Its replay capability
+is why message-level replay protection (below) is a should-have here.
+
+### The alternative: direct per-device outcalls
+
+II could instead make one HTTPS outcall per device straight to the push
+service — fully on-chain, nothing extra to run or trust. Why it isn't the
+default: a 10k-user broadcast is ~13k outcalls (~1T cycles, ~$1–2 per blast)
+and takes minutes to drain at a safe in-flight rate; that per-device outcall
+cost and the throughput ceiling are exactly what the gateway removes. It stays
+viable for low volume, a fully-on-chain deployment, or as a fallback if the
+gateway is unavailable.
+
+## The dApp-side client library
+
+> *In short: because II stores nothing per send, a small library on the dApp's
+> side keeps the list, sends it to II in paced pieces, retries failures, tracks
+> who got notified, and personalizes text. The dApp calls one simple
+> "notify these users" method; the library handles the rest.*
+
+Since II is stateless for campaigns, the durable coordination is a library the
+dApp runs (in its own canister for on-chain durability, or its backend). This
+is where the heavy list and its bookkeeping live — where the volume originates.
+Responsibilities:
+
+- **Campaign store** — the target list and per-target status (pending / sent /
+  `NoConsent` / to-retry). This is the durable state that II deliberately does
+  not hold.
+- **Chunking** — split the audience into `push_send` chunks (≤ ~1000 targets,
+  ≤ 2 MB), enforced client-side against the message-size bound.
+- **Pacing (Layer 2)** — send on `ready`, back off on `retry_after_ms`,
+  pipeline a few chunks within the caller's output-queue limit. Absorbs
+  inter-canister latency so a large campaign completes over seconds-to-minutes
+  without ever blocking II.
+- **Retry** — resend chunks that were rejected for capacity or lost to an
+  upgrade; `chunk_id` makes resends idempotent.
+- **Status/reporting** — aggregate per-chunk results into campaign progress
+  for the dApp. (Delivery itself is best-effort with no receipts; the only
+  per-user signal is `NoConsent`.)
+- **Templating / personalization** — expand `template + per-user data` into a
+  per-recipient `alert` override, entirely client-side. II never sees a
+  template.
+- **Prioritization** — schedule which campaign/segment goes first. (Per-message
+  `urgency` still rides the relay header; campaign ordering is the library's.)
+
+Security is unaffected by moving this out: II re-validates sender-origin,
+consent and origin-pinning on **every** chunk, so a buggy or malicious library
+cannot fake consent, target another dApp's users, or exceed admission limits —
+it can only mismanage its own campaign.
+
+## On the device: rendering and tap-through
+
+- **Subscribe** (Settings): request permission, `pushManager.subscribe` with
+  II's VAPID public key, store `(anchor, endpoint_hash) → {p256dh, auth}`. No
+  PWA install is needed on Android or desktop — this works in a plain tab;
+  iOS Safari is the exception (it only allows Web Push for an installed
+  home-screen app). The optional install adds an app icon / standalone window
+  and slightly better attribution.
+- **Consent** (`/authorize`): `push_grant_consent(anchor, origin)`.
+- **Render**: the service worker branches on `content` — `Display` shows the
+  supplied `title`/`body`; `Hidden` shows an II-controlled generic string
+  keyed by `category` ("New message from `<origin>`"), never app-supplied text.
+- **Click**: the service worker opens
+  `/notify?origin=<sender>&to=<deep-link>`; the page validates and redirects
+  (see below), otherwise it fails closed. This prevents the redirect endpoint
+  from being abused as an open redirect. For `Hidden` (E2E) notifications this
+  tap-through is also the content-reveal path: the app opens and decrypts the
+  message in its own context.
+
+### Shared devices and multiple identities
+
+A browser has **one** physical push endpoint, but a person may sign into
+several identities on it and devices get shared. The rule is: **enabling and
+consent are per identity, never per device.** Turning notifications on for one
+identity never implies anything for another that happens to share the same
+browser — each identity must separately enable notifications and grant its own
+per-origin consent. We do not infer consent from a shared endpoint.
+
+What that means in practice:
+
+- **One endpoint, independent rows.** The subscription is stored as `(anchor,
+  endpoint_hash) → {p256dh, auth}`, so the same physical endpoint can appear
+  under several anchors as separate rows. II delivers to an anchor's row only
+  if *that* anchor enabled it; identity B's senders reach the device only after
+  B itself opted in.
+- **Isolation is at the consent layer, not the transport.** Once two identities
+  on the device have both enabled, the device physically receives pushes for
+  both — there is only one endpoint, so they cannot be separated in transit.
+  The service worker renders by **sender origin**, not by which II identity, and
+  never reveals that the two identities live on the same device.
+- **Disabling is per identity.** Turning notifications off for one identity
+  removes only that anchor's rows; the browser subscription stays alive for the
+  others. The SW calls `pushManager.unsubscribe()` only when **no** identity on
+  the device still wants notifications.
+- **Rotation re-registers lazily.** When the endpoint rotates
+  (`pushsubscriptionchange`), every anchor that held the old endpoint needs its
+  row updated, but the SW can only act for the currently-signed-in identity —
+  so each identity re-registers the next time it authenticates.
+
+### Can the app choose where the notification opens?
+
+The app may set `alert.url` to send the user to a specific page rather than
+the origin root. `/notify` honors it under two constraints, both enforced
+client-side:
+
+- **The target's origin must equal the sender's origin.** The sender origin
+  is `alert.hostname`, which the backend forces to the consented origin and a
+  dApp cannot spoof. So a notification can deep-link anywhere within the
+  sender's own site (`https://app.com/thread/42`) but never to another
+  origin — not `evil.com`, and not another consented dApp.
+- **The sender origin must be in the anchor's consent list** (session-delegation
+  check). A hand-crafted `/notify?origin=…&to=…` therefore also fails closed.
+
+No target → redirect to the sender origin's root. Because the check keys off
+the backend-forced `hostname`, this is entirely front-end; no backend or
+Candid change is required. (A backend `alert.url`-origin validation at send
+time is a nice defense-in-depth follow-up but not required for safety.)
+
+### Can a notification be updated or dismissed after it's shown?
+
+Yes, via a dApp-chosen `notification_id`, which the service worker maps to the
+Web Notification `tag`:
+
+- **Update / replace** — send again with the same `notification_id`; the device
+  replaces the shown notification in place rather than stacking a second (e.g.
+  "Order shipped" → "Order delivered", or a live score ticking up).
+- **Dismiss** — send `content = Dismiss` with that `notification_id`; the SW
+  finds notifications with the matching tag and calls `.close()`, showing
+  nothing new.
+
+This is complementary to the `topic` delivery header, and the two act at
+different stages: `topic` collapses *undelivered* messages at the relay
+(before they reach the device), while `notification_id` updates or dismisses an
+*already-delivered* one on the device.
+
+Caveats:
+
+- **`userVisibleOnly` fights a silent dismiss.** Browsers require every push to
+  show *something*; a pure "close and show nothing" push can trigger the
+  browser's generic "site updated in background" notification and, if abused, a
+  permission penalty. So **update-with-a-new-state is the robust pattern**;
+  pure dismiss is best-effort.
+- It only works if the device is online to receive the follow-up and the
+  notification is still present (the user may have dismissed it already).
+- This is **explicit, opt-in** grouping the dApp controls — the opposite of the
+  automatic hostname-collapse we rejected. Notifications without a
+  `notification_id` never replace each other.
+
+## Security model
+
+- **Origin pinning** — a sender can only target anchors that consented to
+  *its* origin; cross-dApp targeting is impossible even with leaked principals.
+- **Attribution** — II forces `alert.hostname` to the consented origin; a
+  dApp cannot spoof who sent a notification.
+- **Content is dApp-controlled (Display mode)** — `title`/`body` are free-form,
+  delivered under II's service worker. Attribution is shown and lengths are
+  capped, but a compromised dApp could send misleading text within its own
+  attribution. Inherent to any notification relay; a documented posture, not a
+  bug. `Hidden` mode avoids it entirely — no app text reaches the SW.
+- **Transport confidentiality** — every payload is RFC 8291 encrypted to each
+  device; no relay or gateway can read it. Note this is *transport*
+  encryption: for `Display` content II itself sees plaintext (it does the
+  encryption). Keeping content from II-the-service is the `Hidden` variant
+  today (and, later, the vetKeys-sealed path); see the next section.
+- **Coarse rejections** — the dApp learns only about its own relationship with
+  a target (`NoConsent`), never device counts or II state.
+- **Redirect-screen icon** — the `/notify` screen shows the app logo only from
+  II's curated dApp registry, with a neutral globe fallback. Arbitrary or
+  remote icons are deliberately not fetched: doing so would render
+  attacker-controlled imagery inside II's trusted chrome and leak the fetch to
+  the dApp. If arbitrary-app icons are ever wanted, the least-bad path is a
+  vetted icon supplied at sender-registration, not a per-notification URL.
+- **VAPID key** — in stable memory today (same posture as the anchor salt;
+  node operators could extract it, blast radius is spam, not identity). P-256
+  threshold ECDSA would remove it from storage but is not yet available on the
+  IC (only secp256k1 is).
+
+## End-to-end-encrypted apps
+
+Some apps (e.g. a chat using vetKeys) encrypt content so that only the
+recipient can read it — the app backend cannot. Our `Display` path is **not**
+E2E: II receives plaintext `title`/`body` and briefly holds it. The `Hidden`
+variant lets these apps use II-hosted push without ever handing content to II.
+
+**Correcting an earlier overstatement.** It is tempting to say II can *never*
+show decrypted content. That is too strong. The honest constraint is about
+*who* decrypts and *where*, and it comes with a trust dial the user is already
+turning:
+
+- **II-the-service decrypts** — the canister and its node operators see
+  plaintext. That is just `Display` relabeled: fine for non-sensitive content,
+  not E2E.
+- **II's service worker decrypts on the user's own device**, using a key it
+  legitimately obtains and that II-the-service never sees in the clear. This
+  **is** viable. It asks the user to trust II's *client code* running as them
+  on their device — which is only a small step past the trust they already
+  place in II by signing in with it (and exactly the trust the `Display` path
+  already assumes). This is the basis for showing real content in an
+  E2E-friendly way.
+
+So there is a spectrum, from no trust to full trust in II for content:
+
+| Approach | Who decrypts | In-notification | Trust in II for content |
+| --- | --- | --- | --- |
+| `Hidden` (ships first) | the app, after tap | generic ("New message") | none — II never touches content |
+| Design A — vetKeys-sealed | II's **SW**, on device | full, real text | II's client code + IC vetKD threshold |
+| Design B — dApp-fetch | II's **SW**, on device | full, real text | II's client code (+ the dApp) |
+| `Display` | II-the-service | full | full — II reads it |
+| App's own SW (not II-hosted) | the app's own SW | full | none — II isn't in the loop |
+
+### Baseline that ships first: `Hidden` + tap-through
+
+A content-hidden notification ("New message from `<origin>`") plus
+**tap-through reveal** — the user taps, the app opens, the app decrypts and
+shows the message in its own context. This is the industry-standard E2E
+notification UX (Signal, iMessage with previews off), and the `/notify`
+redirect we already have is exactly the reveal path. II never sees a byte of
+content and stores no plaintext.
+
+Framed honestly, `Hidden` is a **deliberate lesser experience that is what
+enables E2E and push together at all.** The user gives up the lock-screen
+preview (they see "New message," not the text) — a real downgrade versus
+`Display`. But it needs zero extra trust in II and ships today, so it is the
+right first step; the richer designs below are how the real text gets onto the
+lock screen later.
+
+### Design A — vetKeys-sealed content, decrypted in II's SW (preferred richer path)
+
+II provides the encryption service so the app never hands plaintext to
+II-the-service, yet the real text still reaches the lock screen:
+
+- II derives a vetKeys (IBE) identity per `(user, origin)`. The dApp fetches
+  II's master public key once and **encrypts the content to that identity
+  offline** — no round-trip, recipient needn't be online. It sends only the
+  *ciphertext* to II via `push_send`, as opaque bytes II cannot read.
+- II delivers as usual (RFC 8291 wraps the opaque bytes). On the device, II's
+  SW authenticates **as the user** to II's canister and requests the vetKD
+  decryption key. vetKD returns it **encrypted to the SW's transport key**, so
+  no node operator sees the key in the clear; the SW decrypts the content and
+  shows the **real text**.
+- **What II-the-service sees:** in the honest flow, nothing — not the content,
+  not the key in clear. Plaintext exists only inside the user's SW, and II
+  stores none of it.
+- **The trust that remains:** II's canister *controls the vetKD
+  authorization*, so a malicious/compromised II could authorize itself to
+  derive a user's key and decrypt. That is the same class of trust the user
+  already extends to II for their delegations — not a new kind. No single node
+  can derive the key (threshold); II's client code is assumed honest (if it
+  weren't, the user's identity is already lost). A small, coherent increment
+  over `Hidden`.
+- **Cost:** vetKeys integration in II and a derive-key call per render; the
+  dApp does IBE encryption. No change to the send/admission model — II still
+  just carries bytes it can't read.
+
+### Design B — dApp keeps the keys, II's SW fetches + decrypts (alternative)
+
+The push is a bare wake; on receipt II's SW calls an endpoint **on the dApp's
+side** to obtain the content, then renders it. Genuinely E2E only if that
+endpoint hands back *ciphertext* the SW can decrypt — which forces one of two
+uncomfortable choices:
+
+- **Endpoint returns plaintext.** Then the dApp *backend* can decrypt, so it is
+  "trust the dApp backend," not strict E2E. Simple, no vetKeys; fine for apps
+  that don't need backend-blind encryption.
+- **Endpoint returns ciphertext + the SW holds the key.** The recipient's key
+  lives in the dApp's client (cross-origin from II's SW), so the dApp must
+  *provision a key into II's SW* — now II's SW holds dApp secrets, a real added
+  surface (II's code could exfiltrate them).
+
+Either way it also needs a way for the SW to authenticate to the dApp as the
+user (it has no delegation to the dApp) and a **fetch per notification**
+(latency, dApp serving load, offline-delivery gaps). More moving parts and a
+murkier trust story than A; documented as the fallback for apps that prefer to
+own the crypto or are content with backend-readable content.
+
+### Recommendation
+
+- **Ship `Hidden` first** — zero extra trust, works today.
+- **Plan for Design A (vetKeys)** as the way to put real content on the lock
+  screen while keeping II-the-service blind to it — the trust increment is
+  small and of a kind the user already accepts.
+- **Design B** stays the documented alternative for backend-trusted apps or
+  teams that don't want vetKeys.
+- **App runs its own SW** remains the strict, II-uninvolved option for teams
+  that want rich previews with II entirely out of the loop.
+
+Forward-compat is already in the interface: an E2E sender picks `Hidden` today
+and has no field to leak content through. Design A slots in later as an opaque
+**ciphertext arm** of `PushContent` (II still just carries bytes it can't
+read) plus a vetKD derive-and-decrypt branch in the SW render path — no change
+to send, admission, or storage.
+
+## Open items
+
+Must-fix before a real deployment:
+
+- **`pushsubscriptionchange`** — browsers rotate/invalidate subscriptions; the
+  service worker must re-subscribe and re-register with II, or delivery
+  silently erodes over weeks. Invisible in short-lived testing.
+- **Sender deregistration & re-verification TTL** — bound the window after a
+  sender principal is compromised or a domain changes hands.
+- **Buffer sizing & drain fairness** — tune the admission bucket + global cap,
+  and drain the transient buffer **round-robin across origins** so one origin's
+  chunk can't starve another's. (Admission control itself is designed, above;
+  this is the tuning.)
+- **Observability** — in-flight buffer depth (canary for stuck timers /
+  backpressure), drain lag, admission reject rate per origin, per-origin
+  outcall success / 410 / drop counts.
+
+Must-decide (design, not code):
+
+- **iOS reality** — iOS Safari is the one platform where a PWA install is
+  *mandatory* for Web Push (Android/desktop work in a plain tab). It is also
+  flakier and more throttled; "best-effort" is weakest there. Set expectations
+  in dApp docs, and surface the "Add to Home Screen" hint only on iOS.
+
+Known-deferred:
+
+- **Device-level replay / `msg_id`** — note this internal `msg_id` is a
+  *different* thing from the dApp-facing `notification_id` used to
+  update/dismiss (above): `msg_id` is II-generated and suppresses exact
+  duplicates (show at most once); `notification_id` is dApp-chosen and
+  *replaces* the shown notification. Same-looking, opposite behavior — keep
+  them as separate fields. There are two replay layers, handled separately.
+  **dApp→II replay** (a resent/duplicated chunk) is solved by the `chunk_id`
+  idempotency key. **relay/gateway→device replay** (a captured
+  `(jwt, ciphertext, endpoint)` re-POSTed) is *not* solved: Web Push has no
+  built-in protection — VAPID's JWT is a time-bounded bearer token and
+  AES-GCM's freshness gives tamper-detection, not anti-replay, so a captured
+  push re-decrypts and shows again. The fix is a `msg_id` plus a small SW
+  dedup set, wired as follows (note it is **not** a Candid field — the dApp
+  does not supply it):
+  - **On send (in the canister):** II assigns a unique `msg_id` **once per
+    admitted message** (per target) and includes it in the JSON *before* RFC
+    8291 encryption (`alert_to_json` in `push/api.rs`). It must be **stable
+    across delivery retries** — the same logical message always carries the
+    same `msg_id` — so that both a retried send and a replayed captured
+    ciphertext are recognized as duplicates, while genuinely distinct
+    notifications get distinct ids.
+  - **On receive (service worker):** the SW reads `msg_id` from the decrypted
+    payload, keeps a bounded set of recently-seen ids (IndexedDB/Cache), and
+    drops any it has already shown.
+  It is a **hard prerequisite**, not a nicety, for two later features and must
+  land before either:
+  - **outcall retries** — a retry is itself a replay; without dedup, retry
+    logic manufactures duplicate banners.
+  - **the gateway** — a compromised gateway is inherently replay-capable, so
+    `msg_id` + SW dedup should land together with the gateway (the chosen
+    delivery path) to neutralize that power.
+  Today's practical risk is low (TLS gates capture; blast radius is a
+  duplicate banner, not credential theft).
+- **VAPID key → P-256 threshold ECDSA** — the key is in stable memory only
+  because the IC's threshold ECDSA is secp256k1-only while Web Push requires
+  P-256 (secp256r1). When P-256 tECDSA ships, migrate to `sign_with_ecdsa` so
+  the key never exists in storage. Migration invalidates existing
+  subscriptions (the derived public key changes), so it pairs with the
+  re-enable UX below.
+- **VAPID rotation** — rotating invalidates every subscription at once; needs
+  a "re-enable on your devices" UX if ever required.
+- **Stale-subscription GC**, and cleanup hooks on device/anchor removal.
+
+Explicitly rejected:
+
+- **On-device `tag`-based collapsing by hostname** — a dApp sends distinct
+  notifications that must not replace each other on the device. Collapsing is
+  opt-in per send via `topic`, never automatic per origin.
+
+## dApp developer integration
+
+One-time setup (~15 min): serve `.well-known/ii-push-senders`, call
+`push_register_sender(origin)` from the backend. Steady state: hand the client
+library a campaign — it chunks, paces, retries and reports:
+
+```rust
+// Non-sensitive app: show the content.
+push.broadcast(
+    PushContent::Display { title, body },
+    PushDelivery { urgency: High, ttl_seconds: 3600, topic: Some("balance") },
+    &my_user_principals,        // library chunks + paces these
+).await?;
+
+// E2E app: send nothing sensitive; content is revealed on tap.
+push.broadcast(
+    PushContent::Hidden { category: Some(Message) },
+    PushDelivery { urgency: High, ttl_seconds: 3600, topic: None },
+    &my_user_principals,
+).await?;
+```
+
+Under the hood the library splits the audience into ≤ ~1000-target chunks,
+calls `push_send` per chunk, **paces on `ready` / `retry_after_ms`**, retries
+with a stable `chunk_id`, and aggregates per-target results into campaign
+status. The dApp sees a campaign API; II sees paced, bounded chunks. No keys,
+no crypto, no Web Push knowledge, and no per-user state beyond the principals
+from auth (the library owns campaign status). Delivery is best-effort with no
+receipts; the only per-user signal is `NoConsent`.
+
+## Feasibility and scale
+
+| Metric | Gateway (chosen) | Direct (alternative) |
+| --- | --- | --- |
+| App → II for 10k users | ~10 paced chunks (client-driven) | ~10 paced chunks |
+| Outcalls per 10k blast | ~25 | ~13k |
+| II **stable storage** | O(users) — flat with volume | O(users) — flat with volume |
+| II in-flight buffer | one chunk (heap, transient) | one chunk (heap, transient) |
+| Full-delivery latency | seconds | minutes |
+| Main costs | storage + ~25 outcalls | storage + ~13k outcalls |
+
+App → II is feasible either way: the client library streams bounded chunks, II
+admits what it has capacity for, and its **stable storage stays flat regardless
+of volume**. The two rows above are why the **gateway is the chosen delivery
+path** — a faster, cheaper drain recycles II's small buffer sooner, which is
+what raises admission throughput. Direct delivery works and is fully on-chain,
+but its per-device outcall cost and slower drain are exactly what the gateway
+removes, so it stays as the alternative/fallback.
+
+## Future exploration
+
+Deliberately out of v1, kept here so the door stays open:
+
+- **Cycles-based charging.** Attach cycles per notification (canister senders
+  only — ingress calls can't carry cycles), or a prepaid per-origin balance
+  (which would also let off-chain senders pay). Dropped from v1 because the
+  design already controls the real costs (storage via the stateless model,
+  outcalls via the gateway) and admission control bounds abuse — so billing
+  adds complexity without solving an immediate problem. Worth revisiting at
+  scale to make senders pay for the outcalls/storage they drive, or as an extra
+  fairness/abuse lever. Retrofitting payment later is possible (the endpoint
+  would check attached cycles or a prepaid balance) but easier to design in
+  than bolt on, so keep the option visible.
+- **Off-chain senders** (a web2 backend calling via ingress) — needs a
+  self-auth challenge flow for sender identity and, if paid, the prepaid
+  balance above.
+- **Delivery receipts / analytics** — Web Push has none; any per-user delivery
+  signal would have to come from the app itself, and per-origin aggregates are
+  the most II can offer without a per-user tracking surface.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1245,11 +1245,27 @@ Three levels, and they differ in what authority the worker needs:
   is worth having for its own sake: it works even if II's backend is unreachable or
   misbehaving, so a user can always stop the noise from the notification itself.
   Device-wide, though — every dApp, not one.
-- **Stop this app — one extra tap.** `push_revoke_consent` is authorized by the
-  anchor, and the worker holds no authority for it, so this is a navigation into
-  II's settings deep-linked to that app's row. Arguably where it belongs anyway:
-  revoking one app is worth confirming, and it lands the user somewhere they can
-  see everything else they have granted.
+- **Stop this app — a deep link into II's settings.** `push_revoke_consent` is
+  authorized by the anchor and the worker holds no authority for it, so this action
+  navigates rather than acting:
+
+  ```
+  actions: [{ action: "unsubscribe", title: "Turn off" }]
+  → clients.openWindow(`${II_ORIGIN}/manage/settings?app=<origin>`)
+  ```
+
+  The destination already exists — `PushNotificationsSection` on `/manage/settings`
+  lists every consented origin and revokes per app via `push_revoke_consent`. Two
+  small additions are needed: the action itself, and having the page accept the
+  origin so the user lands on that app's row rather than scanning a list. II owns
+  the label; the sender cannot rename or omit it.
+
+  Landing on an authenticated route means the user may have to sign in first. That
+  is correct rather than unfortunate — revoking a permission deserves proof of who
+  is asking, they have just demonstrated they hold the identity by tapping a
+  notification addressed to it, and it is the same Continue screen they already know
+  from opting in. It also puts them somewhere they can see every other app they have
+  granted, which a silent one-tap revoke would not.
 - **Stop this app, silently — needs new machinery.** II could seal a short-lived
   capability token scoped to `(anchor, origin)` into the payload and accept it back
   on a token-authorized revoke. That buys one saved tap for a replay window, token

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -34,16 +34,28 @@ the open items.
    heading "Let `<dApp>` notify you", two short reasons (instant alerts /
    reachable anytime), and two buttons — **Enable notifications** and **Maybe
    later**.
-   6a. **Enable** → the browser shows its **native permission prompt**
-   ("`id.ai` wants to show notifications — Allow / Block"). This dialog is
-   the browser's own and cannot be restyled. On **Allow**, II subscribes the
-   device and records consent for this dApp, then redirects to the dApp. No
-   app install is required (Android/desktop); iOS Safari is the exception.
+   6a. **Enable** → if this browser has not granted permission yet, it shows
+   its **native permission prompt** ("`id.ai` wants to show notifications —
+   Allow / Block"). This dialog is the browser's own and cannot be restyled.
+   On **Allow** — or straight away, when permission was granted earlier — II
+   subscribes the device and records consent for this dApp, then redirects to
+   the dApp. No app install is required (Android/desktop); iOS Safari is the
+   exception.
    6b. **Maybe later** → II redirects straight to the dApp; nothing is enabled.
 
-The permission prompt appears only the first time the user enables
-notifications on this browser; for later dApps the opt-in screen simply
-records consent (no second prompt).
+Two separate things are being asked, and only one of them repeats.
+
+II's opt-in screen **is** shown for each new dApp, because consent is recorded
+per origin and no dApp inherits another's. It appears once per dApp per
+device: a device that has not subscribed yet sees it again even for a dApp
+already enabled on another device, with copy that asks about this device
+rather than repeating the original pitch.
+
+The **browser's** permission prompt is the part that does not come back. It is
+granted to `id.ai`, not to the dApp, and every dApp's notifications are
+delivered through that one origin — so once the user has allowed it, the
+browser has nothing left to ask, and later opt-ins complete without a second
+dialog.
 
 ### What happens when a notification is sent?
 
@@ -53,59 +65,70 @@ records consent (no second prompt).
 8. The notification arrives on every device the user enabled — **even with the
    tab closed / browser not running** (on Android). It shows the dApp's origin
    as the source and the dApp's title/body as the text.
-9. The user **taps** it. II's `/notify` screen appears briefly — "Opening
-   `<dApp>`" with the app's logo — then forwards to the dApp (the specific
-   page if the dApp deep-linked, otherwise its home).
+9. The user **taps** it. When the dApp supplied a deep link — the normal case —
+   the service worker opens that URL directly and II is not visited at all. The
+   dApp lands the user on the page the notification was about, signing them in
+   on the way with the ICRC-167 top-level redirect if the session has lapsed,
+   which is the usual state when a notification is what brought them back.
+   Only a notification with no deep link falls back to II's `/notify` screen
+   ("Opening `<dApp>`" with the app's logo), which resolves the sender's origin
+   behind a consent gate and forwards to the dApp's home.
 
 ### How does a user manage or turn them off?
 
-10. In **II → Settings**, the user sees **Notifications on this device**
+10. Either from the browser or from II.
+
+    In **II → Settings**, the user sees **Notifications on this device**
     (a toggle to turn the whole device on/off) and **Allowed apps** — every
     dApp that can notify them, each with a remove button. Revoking an app
     stops its notifications immediately.
 
+    The **browser's own site settings** can also block notifications for
+    `id.ai`, which silences every dApp at once and cannot be overridden from
+    inside II — the permission belongs to the browser, not to us. II can only
+    observe the result: a blocked permission makes the opt-in screen
+    unofferable, so it is skipped rather than shown as a button that cannot
+    work. Re-enabling has to happen in the browser too; that is the one path
+    II cannot offer a control for.
+
 ## Status
 
-Built today (PoC on `feat/push-notifications-poc`):
+### Built today (PoC on `feat/push-notifications-poc`)
 
-- Device subscribe/unsubscribe, `/authorize` opt-in, per-dApp consent.
-- Single `notify_user(principal, alert)` update call — a one-shot for one
-  recipient. It does **not** answer scale; the design supersedes it with the
-  chunked `push_send` + client library described under "Proposed" below, and
-  everything in this doc about throughput, cost, and delivery assumes that
-  path, not this call.
-- RFC 8291 payload encryption + RFC 8292 VAPID JWT signing, both in-canister.
-- VAPID private key generated via `raw_rand` and persisted in stable memory.
-  This is not the ideal custody model, and we do it only because the ideal
-  one is unavailable: VAPID/Web Push mandate ECDSA on the **P-256
-  (secp256r1)** curve, but the IC's threshold ECDSA currently supports **only
-  secp256k1** — so we cannot let the subnet hold the key via `sign_with_ecdsa`
-  and must generate and store it ourselves. Custody posture matches the anchor
-  salt (node operators could extract it), but the blast radius is **not** just
-  spam — see the [security model](#security-model). If P-256 threshold ECDSA
-  ever lands, the key moves off storage entirely.
-- Notification click routes through the consent-gated `/notify` redirect.
+An inventory, not an explanation — each line links to the section that covers
+it. The last four exist because building the PoC proved they had to.
 
-Also built since, because using the PoC forced them:
+- **Per-device subscribe/unsubscribe, `/authorize` opt-in, per-dApp consent** —
+  [the user flow](#how-does-a-user-turn-notifications-on-first-time-signing-into-a-dapp),
+  [consent lifecycle](#consent-lifecycle-it-must-not-outlive-the-sender).
+- **`notify_user(principal, alert)`** — one recipient per call. It does **not**
+  answer scale, and everything in this doc about throughput, cost and delivery
+  assumes the chunked `push_send` that supersedes it:
+  [chunked send and flow control](#sending-to-thousands-of-users-chunked-send--two-layer-flow-control).
+- **RFC 8291 payload encryption and RFC 8292 VAPID signing, both in-canister** —
+  [delivering to devices](#delivering-to-devices).
+- **VAPID key generated with `raw_rand`, held in stable memory** — not the
+  custody model we would choose. Web Push mandates P-256, the IC's threshold
+  ECDSA is secp256k1 only, so the subnet cannot hold the key for us:
+  [what that risks](#security-model),
+  [what changes if P-256 lands](#ic-capabilities-to-re-evaluate).
+- **Tap opens the dApp's deep link directly**, falling back to the consent-gated
+  `/notify` redirect when the sender supplied no target —
+  [where a notification opens](#can-the-app-choose-where-the-notification-opens),
+  [landing signed in](#can-the-tap-land-the-user-already-signed-in).
+- **Sender authorization by origin** — a registry keyed by origin hash. The
+  original `caller() == in_app_principal` rule could never match an
+  inter-canister call, so it admitted only self-sends:
+  [how II verifies a sender](#how-does-ii-verify-the-sender-is-really-that-dapp).
+- **Send-time `alert.url` validation** — what makes opening the deep link
+  directly safe:
+  [where a notification opens](#can-the-app-choose-where-the-notification-opens).
+- **`msg_id` dedup in the service worker, and `410`/`404` row cleanup** —
+  [duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
+- **VAPID key rotation in the browser** — a subscription bound to a superseded
+  key is resubscribed rather than failing forever.
 
-- **Sender authorization by origin.** `notify_user` originally required
-  `caller() == in_app_principal`, which cannot work: that principal is a
-  canister-signature principal derived from II's seed, so only the recipient's
-  own browser can present it — an inter-canister call always arrives as the
-  calling canister's principal. It admitted only self-sends, i.e. the one case
-  the endpoint is not for. A sender registry keyed by origin hash now authorizes
-  sends, with self-sends still allowed (the recipient asking to be notified needs
-  nothing further). `push_register_sender` is controller-only until the
-  `.well-known` verification below exists.
-- **`msg_id` + service-worker dedup**, and **`410`/`404` row cleanup** — see
-  [Duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
-- **Send-time `alert.url` validation**, which is what lets a tap open the deep
-  link directly.
-- **VAPID key rotation handling** in the browser: an existing subscription bound
-  to a superseded key is replaced rather than failing forever.
-
-What it still deliberately does **not** have, so it isn't mistaken for a
-shippable subset:
+### Not built, so the PoC isn't mistaken for a shippable subset
 
 - No `push_send`, so no batching, no chunking, and no client library — a send is
   one `notify_user` per recipient.
@@ -120,7 +143,7 @@ shippable subset:
   stale row until a relay reports it gone.
 - Integration and E2E test coverage is thin (unit tests only).
 
-Proposed (this doc):
+### Proposed (the rest of this doc)
 
 - Chunked `push_send` with two-layer flow control (II admission + client
   pacing), a sender registry, a stateless-for-campaigns II (transient heap
@@ -156,8 +179,7 @@ Read this first; the sections after it just add detail.
   a small helper **library** that feeds II the list in bite-sized batches at a
   pace II can handle. II refuses more than it can take (so nobody can flood
   it), and the library slows down when asked. The big list lives with the
-  dApp — **II stores almost nothing per send**, which matters because storage
-  is II's resource we want to protect.
+  dApp — **II stores almost nothing per send**.
 - **How II sends the final messages.** II hands the sealed messages to a small
   **trusted helper server (the "gateway")** that makes the many little
   per-device sends on II's behalf over ordinary internet — far cheaper and
@@ -165,8 +187,10 @@ Read this first; the sections after it just add detail.
   each push service directly is the documented fallback, but one network call
   per device gets expensive at scale, so it isn't the default.) Either way II
   does the sealing; the helper only forwards messages it can't read.
-- **Tapping a notification** opens II briefly ("Opening \<app\>…") and forwards
-  the user to the app — only ever to the app that sent it.
+- **Tapping a notification** goes straight to the app's own deep link, which
+  signs the user in on arrival if their session has lapsed. Only a notification
+  without a deep link detours through II ("Opening \<app\>…"). Either way the
+  destination is only ever the app that sent it.
 
 Everything below is the same story with the exact mechanisms and edge cases.
 
@@ -192,7 +216,8 @@ Everything below is the same story with the exact mechanisms and edge cases.
                                     device SW decrypts → showNotification
                                                         │ tap
                                                         ▼
-                          II /notify?origin=…&to=… → consent-gated redirect → dApp
+                    deep link → dApp (signs in on arrival if the session lapsed)
+                          └── none → II /notify?origin=… → consent-gated → dApp home
 ```
 
 Three resources drive the architecture, and it is built to control all three:
@@ -203,8 +228,8 @@ Three resources drive the architecture, and it is built to control all three:
   for email recovery, JWKS and discovery for OIDC sign-in). One naive blast is
   ~13k outcalls, which would starve login. So delivery is batched through the
   gateway: ~25 outcalls instead of ~13k.
-- **Stable storage** — limited on every deployment (500 GiB per canister,
-  2 GiB per message, 8 GiB per upgrade) and it must not grow with how many
+- **Stable storage** — limited on every deployment (500 GiB per canister;
+  512 MiB touched per message, 2 GiB per upgrade) and it must not grow with how many
   notifications are sent. So the durable campaign lives in the dApp's client
   library and II keeps only user-scoped data plus a small transient working
   set.
@@ -480,33 +505,54 @@ outcall, execution and storage fees are waived. On any application subnet
 (self-hosted, fork, test net) they are fully charged, and the formula is:
 
 ```
-outcall cycles = (3_000_000 + 60_000·n)·n              ← per-call base
+replicated     = (3_000_000 + 60_000·n)·n              ← per-call base
                + (400·request_bytes + 800·max_response_bytes)·n
+
+non-replicated =  3_000_000 + 60_000·n                 ← base, one node only
+               +  400·request_bytes + 800·max_response_bytes
 ```
 
-At n = 34: base 171.4 M, 13,600 per request byte, 27,200 per reserved response
-byte. Worked example, a 10k-user broadcast (~13k device-messages) on a 34-node
-**application** subnet:
+The whole `·n` disappears from the per-byte terms, which is where the money is.
+At n = 34 replicated: base 171.4 M, 13,600 per request byte, 27,200 per reserved
+response byte. Non-replicated: base 5.04 M, 400 and 800. Worked example, a
+10k-user broadcast (~13k device-messages) on a 34-node **application** subnet:
 
-| Path                   | Outcalls | Cycles | ≈ USD  |
-| ---------------------- | -------- | ------ | ------ |
-| Direct, one per device | ~13,000  | ~2.8 T | ~$3.80 |
-| Gateway, ~2 MB batches | ~25      | ~0.7 T | ~$0.95 |
+| Path                                       | Outcalls | Cycles  | ≈ USD  |
+| ------------------------------------------ | -------- | ------- | ------ |
+| Direct, one per device, replicated         | ~13,000  | ~2.8 T  | ~$3.80 |
+| Gateway, ~2 MB batches, replicated         | ~25      | ~0.7 T  | ~$0.95 |
+| **Gateway, ~2 MB batches, non-replicated** | ~25      | ~0.02 T | ~$0.03 |
 
-Two things to read off that table. The gateway cuts outcall **count** ~500× but
-**cycles only ~4×**, because the per-byte fee is charged on the same sealed
-bytes either way — batching amortizes the base fee, not the payload. And
-`max_response_bytes` is charged whether used or not (at 1 KB it exceeds the
-request fee for small direct sends), so always set it tight. **The gateway's
-real justification is in-flight slots and drain latency, not cycles.**
+Three things to read off that table. Batching alone cuts outcall **count** ~500×
+but **cycles only ~4×**, because the per-byte fee is charged on the same sealed
+bytes either way — batching amortizes the base fee, not the payload. Dropping
+replication is what actually cuts the payload cost, by the full factor of n
+(~34×). And `max_response_bytes` is charged whether used or not, so always set it
+tight.
+
+Note what this does to the gateway's rationale. Once the batch handoff is
+non-replicated the cycle saving is ~44× against direct-replicated, but the honest
+justification is still **in-flight outcall slots and drain latency** — 13k
+concurrent outcalls would starve login on a subnet capped at 3,000 in flight,
+and that is a scheduling limit no pricing change touches.
+
+One cost belongs to a variant not described yet, and it is large enough to
+mention here rather than let it surprise anyone later. Everything above assumes
+II can read a notification's text, because it does the sealing. Some apps cannot
+accept that — a messenger should not hand its message bodies to II — so
+[End-to-end-encrypted apps](#end-to-end-encrypted-apps) sets out a variant where
+the content is encrypted such that only the user's own device can read it, and II
+forwards bytes it cannot see. Doing that needs a per-user key, and the IC's way
+to derive one is **vetKD**.
 
 **vetKD is charged on every deployment**, system subnets included:
-`vetkd_derive_key` is ~26.2 B cycles (~$0.036) per call. A derive _per
-notification render_ would be ~$357 per 10k blast — so the E2E design in
-[End-to-end-encrypted apps](#end-to-end-encrypted-apps) must derive **once per
-`(user, origin)`** and cache in the service worker, with a per-anchor rate
-limit. Because the service worker calls in over ingress, which carries no
-cycles, **II pays** — making an uncached derive a user-triggerable drain.
+`vetkd_derive_key` is ~26.2 B cycles (~$0.036) per call. That is fine once per
+user and ruinous per message: a derive _per notification render_ would be ~$357
+per 10k blast. So that design must derive **once per `(user, origin)`** and cache
+the result in the service worker, with a per-anchor rate limit. And the bill lands
+on II, not the app — the service worker calls in over ingress, which carries no
+cycles — so an uncached derive is a **user-triggerable drain**, not merely an
+inefficiency.
 
 On charging senders: **no cycles charging in v1.** Cycles can only be attached
 by canister senders, and per-notification fees bring real complexity
@@ -545,9 +591,29 @@ A timer (`ic_cdk_timers`, ~1s) drains the heap buffer:
   `ic-cdk-timers` documents that under load "timeouts may result in duplicate
   execution", and the drain is not idempotent.
 - Works a **bounded slice** (target 100–300 device-messages, tuned from a real
-  measurement), not a whole chunk. Sealing costs real instructions and this
-  canister also serves every login on the network; a whole 1000-recipient chunk
-  is a large fraction of an execution round.
+  measurement), not a whole chunk.
+
+  What costs instructions is **RFC 8291 encryption, and within it the elliptic
+  curve**: per device-message II generates an ephemeral P-256 keypair and does an
+  **ECDH** against that device's `p256dh`, so two scalar multiplications — one
+  fixed-base for the ephemeral public key, one **variable-base** for the shared
+  secret, which is the expensive one because the device's key differs every time
+  and nothing precomputes. HKDF-SHA256 and AES-128-GCM beside it are noise. The
+  RFC 8292 VAPID **signature** is not part of this budget at all: it is per
+  audience and cached up to 12h, so it amortises to nothing however many messages
+  are sent. Nor can the ECDH be amortised — RFC 8291 has no encrypt-once mode, so
+  the cost is strictly per device.
+
+  Two different ceilings follow, and only one of them is the platform's. The slice
+  is kept to a small fraction of a message's instruction budget because this
+  canister serves every login on the network, and spending most of a round sealing
+  notifications surfaces as login latency — see
+  [Push must never degrade authentication](#push-must-never-degrade-authentication).
+  The per-message instruction limit sits well above that as a hard wall, and
+  crossing it is worse than slow: the tick traps, the trap rolls back the tick's
+  heap mutations, and the same slice is retried and traps again — a permanently
+  wedged drain rather than a degraded one. That asymmetry is why the slice must be
+  set from a measured per-seal cost rather than an estimate.
 - One `raw_rand` per tick; ChaCha20 derives per-message ephemeral seeds. (Note
   the per-tick seed means the subnet's random tape, if observed, reveals that
   tick's ephemeral scalars — see the [security model](#security-model).)
@@ -615,6 +681,93 @@ grow it with attacker-chosen keys until the heap is exhausted (heap exhaustion
 traps the canister, which takes authentication down with it). Timers don't
 survive upgrades — re-arm in `post_upgrade` and `init`.
 
+### How big is the buffer, and how many origins can it serve at once?
+
+**Sizing one entry.** A buffer entry is per _recipient_, not per device — devices
+are resolved at drain, not at admit. Recipient-scoped fields are small: anchor
+(8 B), interned origin (4 B), `topic` (≤ 32 B), `msg_id` (16 B), `admitted_at`
+(8 B), `ttl` (4 B), urgency and attempt counter (2 B). Call it **~200 B** with
+Rust `String`/collection overhead.
+
+The text is the variable. `PushTarget.alert` is an _override_ that falls back to
+`default_alert`, so a broadcast stores one copy of title + body + url for the
+whole chunk and entries point at it. Fully personalized sends cannot: `title`
+(≤ 64 B) + `body` (≤ 256 B) + `url` (~256 B) plus string headers lands each entry
+near **~1 KB**. That five-fold difference is a reason to keep `default_alert` the
+common path, not merely a convenience.
+
+**Memory is not the constraint — by three orders of magnitude.** The heap ceiling
+is 4 GiB. A full 1,000-recipient chunk is ~200 KB broadcast, ~1 MB personalized.
+Even a hundred concurrent full chunks — 100,000 recipients in flight — is ~20 MB
+broadcast or ~100 MB personalized. Nothing about that is close to a limit.
+
+**Drain rate is the constraint.** At the drain's own target of 100–300
+device-messages per ~1s tick, take 200/s. With ~2 devices per user that is ~100
+recipients/s, and everything downstream follows from it:
+
+| Work                            | Device-messages | Time to drain at 200/s |
+| ------------------------------- | --------------- | ---------------------- |
+| One 1,000-recipient chunk       | ~2,000          | ~10 s                  |
+| One 10k-user blast (10 chunks)  | ~20,000         | ~100 s                 |
+| 5 origins blasting 10k at once  | ~100,000        | ~8 min                 |
+| 10 origins blasting 10k at once | ~200,000        | ~17 min                |
+| 50 origins blasting 10k at once | ~1,000,000      | ~83 min                |
+
+The rate is a fixed pie shared by every origin: II drains 200/s in total, not per
+sender. So concurrency does not degrade gracefully into slower delivery for the
+noisy origin — it degrades into slower delivery for _everyone_, which is why
+Layer 1 has to divide the rate rather than merely cap the buffer.
+
+**Which fixes the buffer size.** Depth should be the drain rate multiplied by the
+worst in-buffer latency worth accepting, not whatever the heap allows. Capping
+queue latency at 60 s gives 200/s × 60 = 12,000 device-messages ≈ 6,000
+recipients ≈ **~6 MB personalized, ~1.2 MB broadcast**. A buffer sized to memory
+instead would happily accept _hours_ of backlog and report `admitted` for
+messages whose `ttl` will expire before they are sent — the failure mode is a
+lying success, not an out-of-memory.
+
+So express the admission ceiling in **seconds of drain backlog**, with per-origin
+fair share as `total_rate / active_origins`; and set `ttl_seconds` defaults with
+the queue depth in mind, since a 60 s queue against the ~4 h default TTL is
+comfortable while a 1 h queue is not.
+
+**Everything above scales linearly with one unmeasured number.** The 200/s slice
+is this design's own target, not an observation. What has to be measured before
+these figures mean anything: instructions for one RFC 8291 seal (the P-256 ECDH
+dominates), how large a slice fits in a safe fraction of an execution round on a
+canister that also serves every login, and whether the ~1s timer holds under
+load. Measure those three and every row in that table moves together.
+
+### The way to lift that ceiling is a separate canister
+
+Note what the 200/s is actually a limit on. It is not the crypto and it is not the
+platform — it is **co-tenancy with authentication**. The slice is small because
+this canister serves every login on the network, so the only reason push cannot
+spend its whole execution round sealing is that logins are sharing that round.
+
+Which suggests the structural fix: run push in its **own canister**. It could then
+spend a full round on sealing — plausibly the same order as the 10–20× headroom
+between the self-imposed budget and the instruction limit — while keeping the
+trust boundary exactly where it is today. Still an IC canister under the same
+controllers, still no plaintext leaving the platform, so this buys throughput
+without the concession that moving sealing to the gateway would demand. It also
+turns [Push must never degrade authentication](#push-must-never-degrade-authentication)
+from a discipline that has to be maintained into a property that holds by
+construction.
+
+The real cost is state ownership. Subscriptions and consent are anchor-scoped, so
+a push canister has to **own** those maps rather than calling II per send —
+otherwise the load just moved back, with inter-canister latency added. Then
+`/authorize`'s opt-in becomes one inter-canister write at consent time, which is
+rare and cheap, and the service worker still lives on II's origin because that is
+where the notification permission is granted. What is genuinely new is
+two-canister upgrade coordination, and deciding where the VAPID key lives.
+
+Not proposed as the shipping path here, because it changes which canister holds
+user-scoped state and that deserves its own review. But it is the honest answer to
+"the throughput number looks low", and it is a better answer than moving crypto
+off-platform.
+
 ## Delivering to devices
 
 The relay API is one POST per subscription endpoint (RFC 8030) — there is no
@@ -642,17 +795,25 @@ being charged). Three consequences the rest of this section is built around:
   subscription just died). No transform can manufacture agreement about which
   POST was first; a transform can only collapse everything to one deterministic
   value. So `410`-driven subscription cleanup is **not implementable under
-  replicated outcalls** — see
+  replicated outcalls** — which is one of the reasons the next bullet is the
+  design, not a future option. See
   [stale-subscription cleanup](#stale-subscription-cleanup).
-- **Non-replicated outcalls change this.** `is_replicated = false` (in the
-  management-canister interface, on mainnet since 2025-08-04) has **one** node
-  make the request: no consensus, no transform, no 34× fan-out, and roughly two
-  orders of magnitude cheaper. The IC docs recommend it specifically for
-  rate-limited APIs, which is exactly Web Push. It is marked experimental and its
-  API may still change, so this doc does not build the shipping path on it — but
-  it is the single most consequential capability to re-evaluate, because it
-  removes the duplicate-delivery problem _and_ restores per-device status on the
-  direct path. See
+- **So II's outcall to the gateway is non-replicated, and that is the design.**
+  `is_replicated = false` (management-canister interface, on mainnet since
+  2025-08-04) has **one** node make the request: no consensus on the response, no
+  transform, no 34× fan-out, and roughly two orders of magnitude cheaper. The IC
+  docs recommend it precisely for rate-limited APIs, which is what Web Push is.
+  Applied to the one call II actually makes — the batch handoff to the gateway —
+  it removes all three consequences above: the gateway receives one copy of each
+  batch instead of 34, needs no idempotency window, and may return real per-device
+  status instead of a deterministic ack.
+
+  Two things this does not buy. The flag is marked **experimental** and its API
+  may still change, so the interface should be isolated behind one call site that
+  can be reverted to replicated with a transform. And a single node's reply is
+  **not consensus-verified** — for a trusted gateway that is no new concession,
+  since a dishonest gateway could always lie about delivery, but it does mean
+  status coming back is evidence rather than proof. See
   [IC capabilities to re-evaluate](#ic-capabilities-to-re-evaluate).
 
 ### The delivery path: a trusted web2 gateway
@@ -670,20 +831,35 @@ over ordinary (free) internet instead of on-chain:
   keys + plaintext (read all notifications). RFC 8291 has no encrypt-once mode,
   so II produces the N ciphertexts regardless; the gateway saves **outcall
   count, not crypto**.
+
+  It is worth being precise about why offloading the sealing is not merely
+  disallowed but useless, because the instinct to move expensive work to a server
+  with no instruction limit is a good one. The cost splits in the wrong place: the
+  **ECDH that derives the content key is the expensive half, and the AES-128-GCM
+  that uses it is noise**. Deriving the key and being able to decrypt are the same
+  capability, so the only part of the sealing that can be handed to the gateway is
+  the part that was already free. It would also defeat
+  [End-to-end-encrypted apps](#end-to-end-encrypted-apps) outright: that design
+  exists so *II* cannot read content, and a web2 relay holding plaintext is
+  strictly worse than the thing it was built to avoid.
 - The gateway holds **no keys, no subscriptions, and no plaintext at rest** — it
-  sees in-transit ciphertext, endpoints and timing. It is _not_, however,
-  stateless: it must keep a short **idempotency window keyed on batch id** so the
-  34 identical copies of each batch (replication, above) forward once rather than
-  34 times. "Keyless and no plaintext at rest" is the accurate claim; "stateless"
-  is not.
+  sees in-transit ciphertext, endpoints and timing. Because II sends each batch
+  with a **non-replicated** outcall (below), the gateway receives one copy rather
+  than 34 and needs no idempotency window to collapse them, so it is genuinely
+  stateless. Under replicated outcalls it would have had to keep a short window
+  keyed on batch id, and "stateless" would have been the wrong word.
 - II batches sealed bundles into **~1.5 MB** chunks: ~25 outcalls instead of
   ~13k. The 2 MB outcall ceiling counts **headers too**, so targeting exactly
   2 MB leaves no room for the VAPID `Authorization` headers each bundle carries.
 - II authenticates to the gateway with a bearer token (IC outcalls have no stable
-  source IP — replicated requests arrive from all 34 node addresses, and IPv4
-  destinations via a shared proxy pool). The gateway must return a
-  **deterministic ack**, so per-device results cannot come back through this
-  channel.
+  source IP — a non-replicated request comes from whichever node executed it, and
+  IPv4 destinations go via a shared proxy pool). Because the response is not put
+  to consensus, it does **not** have to be deterministic — so per-device results
+  _can_ come back through this channel, which is what makes `410`-driven
+  [stale-subscription cleanup](#stale-subscription-cleanup) implementable. Trust
+  that status only as far as the gateway is already trusted: it is a single
+  unverified reply, so treat a reported `410` as grounds to retire a subscription
+  opportunistically, never as an authority to delete user state on one word.
 - **The gateway sets II's admission capacity.** Throughput is bounded by how fast
   the small buffer drains; a batched drain empties it quickly, so II recovers
   capacity and admits the next chunk sooner. Fast drain → high sustained
@@ -1592,17 +1768,19 @@ Must-fix before a real deployment:
   client-side durability story does not work without it. See
   [II's state model](#iis-state-model-stateless-for-campaigns).
 - **Stale-subscription cleanup.** <a id="stale-subscription-cleanup"></a>
-  `404`/`410` row removal is **built** on the direct path; what follows still
-  applies to the gateway, where per-device status cannot come back at all.
-  Promoted from deferred, because on the _chosen_ path it is not merely missing
-  but structurally impossible: `410 Gone` cannot return through the gateway's
-  deterministic ack, and browsers rotate endpoints continuously. Left alone, the
-  subscription table grows monotonically — O(devices ever registered), not
-  O(users) — and II pays forever to send to dead endpoints. Options: have the
-  gateway expose dead endpoints via a separate authenticated **pull** that II
-  fetches (deterministic by construction), add a `push_gateway_report` update
-  the gateway calls, or fall back to TTL-based GC keyed on last successful
-  delivery. Pairs with `pushsubscriptionchange` below.
+  `404`/`410` row removal is **built** on the direct path. On the gateway path it
+  became possible only once the batch handoff went **non-replicated**: with no
+  consensus on the response, the gateway is no longer confined to a deterministic
+  ack and can return per-device status inline. Under replicated outcalls this was
+  structurally impossible, not merely unbuilt. It still has to be built, and it
+  still matters — browsers rotate endpoints continuously, so left alone the
+  subscription table grows as O(devices ever registered) rather than O(users) and
+  II pays forever to send to dead endpoints. Treat the returned status as
+  evidence, not proof: it is one unverified reply from a trusted party, so retire
+  a subscription opportunistically on a reported `410` rather than deleting user
+  state on a single word. A separate authenticated **pull**, a
+  `push_gateway_report` update, or TTL-based GC keyed on last successful delivery
+  all remain viable as corroboration. Pairs with `pushsubscriptionchange` below.
 - **`pushsubscriptionchange`** — browsers rotate/invalidate subscriptions; the
   service worker must re-subscribe and re-register with II, or delivery
   silently erodes over weeks. Invisible in short-lived testing.
@@ -1676,15 +1854,18 @@ Explicitly rejected:
 Platform features that would change decisions in this doc. Worth re-checking
 before implementation, because two of them postdate the design:
 
-- **Non-replicated outcalls (`is_replicated = false`)** — on mainnet since
-  2025-08-04, marked experimental. Removes the *n*× fan-out and restores
-  per-device delivery status, which would fix duplicate delivery and `410`
-  cleanup on the direct path and weaken the gateway's rationale to in-flight
-  slots alone. **The single highest-value thing to evaluate.**
-- **Per-node outcall results.** A newer management-canister API returning
-  per-node responses would contradict this doc's claim that per-device results
-  cannot come back. Unverified whether it is enabled on mainnet — settle by
-  calling it or checking release notes.
+- ~~**Non-replicated outcalls (`is_replicated = false`)**~~ — **adopted**: the
+  batch handoff to the gateway uses it, which is what makes `410` cleanup
+  possible there and drops the payload cost by the full factor of *n*. Still
+  marked experimental, so what remains to watch is the API changing under us —
+  keep it behind one call site that can revert to replicated plus a transform.
+  Field-tested outside II: multidex's price oracle has run on it since
+  2025-08-04, which is where the ~*n*× figure was measured.
+- **Per-node outcall results.** A management-canister API returning per-node
+  responses would give per-device status back on a *replicated* path, which is now
+  only interesting as a way to stop depending on an experimental flag. Unverified
+  whether it is enabled on mainnet — settle by calling it or checking release
+  notes.
 - **P-256 (secp256r1) threshold ECDSA** — would move the VAPID key out of
   storage entirely via `sign_with_ecdsa`. Requested since 2024 with **no public
   roadmap item or timeline**, so treat it as "if it ever ships", not "when".
@@ -1776,17 +1957,17 @@ receipts; the only per-user signal is `NoConsent`.
 
 ## Feasibility and scale
 
-| Metric                               | Gateway (chosen)                     | Direct (alternative)    |
-| ------------------------------------ | ------------------------------------ | ----------------------- |
-| App → II for 10k users               | ~10 paced chunks (client-driven)     | ~10 paced chunks        |
-| Outcalls per 10k blast               | ~25                                  | ~13k                    |
-| Requests actually reaching relays    | ~13k (gateway fans out off-chain)    | ~13k × 34 (replication) |
-| Per-device status (`410`) observable | no (deterministic ack)               | no under replication    |
-| II **stable storage**                | O(users × origins), flat with volume | same                    |
-| II in-flight buffer                  | bounded, transient heap              | same                    |
-| Full-delivery latency, 10k blast     | tens of seconds                      | minutes                 |
-| Cycles, 34-node **paying** subnet    | ~0.7 T (~$0.95)                      | ~2.8 T (~$3.80)         |
-| Cycles, canonical II (system subnet) | fee-waived                           | fee-waived              |
+| Metric                               | Gateway (chosen)                                                   | Direct (alternative)    |
+| ------------------------------------ | ------------------------------------------------------------------ | ----------------------- |
+| App → II for 10k users               | ~10 paced chunks (client-driven)                                   | ~10 paced chunks        |
+| Outcalls per 10k blast               | ~25                                                                | ~13k                    |
+| Requests actually reaching relays    | ~13k (gateway fans out off-chain)                                  | ~13k × 34 (replication) |
+| Per-device status (`410`) observable | yes — non-replicated handoff, so the ack need not be deterministic | no under replication    |
+| II **stable storage**                | O(users × origins), flat with volume                               | same                    |
+| II in-flight buffer                  | bounded, transient heap                                            | same                    |
+| Full-delivery latency, 10k blast     | tens of seconds                                                    | minutes                 |
+| Cycles, 34-node **paying** subnet    | ~0.02 T (~$0.03) non-replicated; ~0.7 T (~$0.95) if replicated     | ~2.8 T (~$3.80)         |
+| Cycles, canonical II (system subnet) | fee-waived                                                         | fee-waived              |
 
 **Throughput has a global ceiling, and it is shared.** The buffer drains only as
 fast as its outcalls resolve, and outcalls take seconds. At a bounded slice per
@@ -1823,7 +2004,7 @@ At 10M users × 2 devices × 10 consented dApps that is roughly **6 GB + 1 GB +
 1.2 GB ≈ 8 GB**, against a 500 GiB per-canister limit but sharing a 2 TiB subnet
 with anchor data — and **before** any dead rows, which is why
 [stale-subscription cleanup](#stale-subscription-cleanup) is a must-fix rather
-than housekeeping. Note also the 8 GiB stable-memory-per-upgrade ceiling, which
+than housekeeping. Note also the 2 GiB stable-memory-per-upgrade ceiling, which
 bounds how large these maps can get before upgrades become a problem.
 
 ## Stable memory regions

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1,13 +1,7 @@
 # Push notifications — design
 
-Start with [How it works, in plain terms](#how-it-works-in-plain-terms). Then:
-**reviewing** → [Goals](#goals-and-non-goals) · [Architecture](#architecture) ·
-[Alternatives](#alternatives-considered) · [Security](#security-model) ·
-[Open items](#open-items); **implementing** → [dApp → II](#dapp--ii) ·
-[state model](#iis-state-model-stateless-for-campaigns) ·
-[delivery](#delivering-to-devices) ·
-[Scaling](#scaling); **integrating** → [push-api.md](push-api.md),
-[push-client-library.md](push-client-library.md); **today** → [Status](#status).
+Start with [How it works, in plain terms](#how-it-works-in-plain-terms). **Reviewing:**
+[Goals](#goals-and-non-goals) · [Architecture](#architecture) · [Alternatives](#alternatives-considered) · [Security](#security-model) · [Open items](#open-items). **Implementing:** [dApp → II](#dapp--ii) · [state model](#iis-state-model-stateless-for-campaigns) · [delivery](#delivering-to-devices) · [Scaling](#scaling). **Integrating:** [push-api.md](push-api.md) · [push-client-library.md](push-client-library.md).
 
 ## Context and scope
 
@@ -123,31 +117,20 @@ would be the real fix — out of scope here.
 8. The notification arrives on every device the user enabled — **even with the
    tab closed / browser not running** (on Android). It shows the dApp's origin
    as the source and the dApp's title/body as the text.
-9. The user **taps** it. When the dApp supplied a deep link — the normal case —
-   the service worker opens that URL directly and II is not visited at all. The
-   dApp lands the user on the page the notification was about, signing them in
-   on the way with the ICRC-167 top-level redirect if the session has lapsed,
-   which is the usual state when a notification is what brought them back.
-   Only a notification with no deep link falls back to II's `/notify` screen
-   ("Opening `<dApp>`" with the app's logo), which resolves the sender's origin
-   behind a consent gate and forwards to the dApp's home.
+9. The user **taps** it. With a deep link (the normal case) the service worker opens
+   that URL directly — II isn't visited — landing them on the page it was about and
+   signing them in via the ICRC-167 redirect if their session lapsed. A link-less
+   notification instead detours through II's `/notify` screen, which resolves the
+   sender behind a consent gate and forwards to the dApp's home.
 
 ### Managing them, and turning them off
 
-10. Either from the browser or from II.
-
-    In **II → Settings**, the user sees **Notifications on this device**
-    (a toggle to turn the whole device on/off) and **Allowed apps** — every
-    dApp that can notify them, each with a remove button. Revoking an app
-    stops its notifications immediately.
-
-    The **browser's own site settings** can also block notifications for
-    `id.ai`, which silences every dApp at once and cannot be overridden from
-    inside II — the permission belongs to the browser, not to us. II can only
-    observe the result: a blocked permission makes the opt-in screen
-    unofferable, so it is skipped rather than shown as a button that cannot
-    work. Re-enabling has to happen in the browser too; that is the one path
-    II cannot offer a control for.
+10. From either the browser or II. In **II → Settings**, a device toggle plus an
+    **Allowed apps** list, each with a remove button that stops that app immediately.
+    The **browser's own site settings** can also block `id.ai` — which silences every
+    dApp at once and can't be overridden from inside II, since the permission belongs
+    to the browser. II only observes the result: a blocked permission makes the opt-in
+    unofferable, so it's skipped rather than shown as a dead button.
 
 ## dApp → II
 
@@ -934,8 +917,8 @@ global ceiling:**
   the shared rate. The [separate-canister split](#the-way-to-lift-that-ceiling-is-a-separate-canister)
   is the one move that lifts 3–4.
 
-Delivery time is linear in blast size and shared across dApps — it crosses the
-one-hour budget at ~720k messages, beyond which some notifications outlive their TTL:
+Delivery time is linear in blast size and shared across dApps, crossing the one-hour
+budget at ~720k messages:
 
 ```mermaid
 xychart-beta

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -12,10 +12,9 @@ and a security model. If you only read one section, read
   [II's state model](#iis-state-model-stateless-for-campaigns) →
   [Delivering to devices](#delivering-to-devices) →
   [Push must never degrade authentication](#push-must-never-degrade-authentication).
-- **Integrating a dApp?**
-  [dApp developer integration](#dapp-developer-integration) →
-  [The Candid interface](#the-candid-interface) →
-  [The dApp-side client library](#the-dapp-side-client-library).
+- **Integrating a dApp?** Reference material lives in separate files:
+  [push-api.md](push-api.md) (Candid + integration steps) and
+  [push-client-library.md](push-client-library.md) (the client library).
 - **Wondering what exists today?** [Status](#status), at the end.
 
 ## Context and scope
@@ -63,8 +62,9 @@ serve as reference material.
   sending more notifications must not make it larger.
 - **A tap lands the user where the notification was about**, in the sending app,
   signed in.
-- **There is a path for apps that cannot let II read their content** — a
-  messenger should not hand message bodies to its identity provider.
+- **End-to-end encryption is possible** for apps that can't let II see message
+  text — a messenger shouldn't hand its message bodies to its identity provider.
+  See [End-to-end-encrypted apps](#end-to-end-encrypted-apps).
 
 ### Non-goals
 
@@ -123,117 +123,64 @@ Everything below is the same story with the exact mechanisms and edge cases.
 
 ## Architecture
 
-```
-┌─ dApp side ────────────────────────┐        ┌─ II ────────────────────────────────┐
-│ client library (durable):          │        │ Layer 1 — admission control         │
-│  owns the campaign + status         │ chunk  │  per-origin bucket + global cap,    │
-│  chunks (≤1000 targets)             │──────▶ │  hard caps + reject → protects II   │
-│  templating / personalization       │        │        │ admit                       │
-│  prioritization                     │ ◀──────│        ▼                            │
-│  Layer 2 — pacing (cooperative):    │ ready/ │  transient HEAP buffer (small)      │
-│  send on `ready`, back off,         │ retry  │        │ seal: encrypt + VAPID sign  │
-│  retry, track per-target status     │        │        ▼ fast drain                 │
-└────────────────────────────────────┘        │  few batched outcalls ──▶ gateway   │
-                                               │  (direct per-device = alt/fallback) │
-                                               └─────────────────────────────────────┘
-                                                        │ (gateway fans out off-chain)
-                                                        ▼
-                                              FCM / Mozilla / APNs relays
-                                                        ▼
-                                    device SW decrypts → showNotification
-                                                        │ tap
-                                                        ▼
-                    deep link → dApp (signs in on arrival if the session lapsed)
-                          └── none → II /notify?origin=… → consent-gated → dApp home
+```mermaid
+sequenceDiagram
+    participant Lib as dApp client library<br/>(durable campaign)
+    participant II as II canister
+    participant GW as Trusted gateway
+    participant Relay as FCM / Mozilla / APNs
+    participant SW as Device service worker
+
+    Lib->>II: push_send(chunk ≤1000)
+    Note over II: Layer 1 — admit or reject<br/>(per-origin + global cap)
+    II-->>Lib: {ready, retry_after, drain_epoch}
+    Note over II: seal per device<br/>(RFC 8291 + VAPID), heap buffer
+    II->>GW: batched, non-replicated outcalls (~25)
+    GW->>Relay: one POST per device
+    Relay->>SW: encrypted payload
+    Note over SW: decrypt → showNotification
+    SW->>Lib: tap → deep link (signs in if session lapsed)
 ```
 
-Three resources drive the architecture, and it is built to control all three:
+Three limits shape everything and bind on every deployment:
 
-- **In-flight HTTPS outcalls** — the binding constraint, and it is _shared_.
-  The subnet allows 3000 outcalls in flight **across every canister on it**,
-  and II already spends from that budget on its own authentication paths (DoH
-  for email recovery, JWKS and discovery for OIDC sign-in). One naive blast is
-  ~13k outcalls, which would starve login. So delivery is batched through the
-  gateway: ~25 outcalls instead of ~13k.
-- **Stable storage** — limited on every deployment (500 GiB per canister;
-  512 MiB touched per message, 2 GiB per upgrade) and it must not grow with how many
-  notifications are sent. So the durable campaign lives in the dApp's client
-  library and II keeps only user-scoped data plus a small transient working
-  set.
-- **Instructions per message and per round** — the crypto is _not_ free at
-  chunk scale (see the sealing budget below), and II serves every login on the
-  network from this same canister. So the drain works in bounded slices rather
-  than whole chunks.
+| Limit | Consequence in this design |
+| --- | --- |
+| **In-flight outcalls** — 3000 subnet-wide, shared with II's own login paths | batch through the gateway (~25 outcalls, not ~13k) so a blast can't starve sign-in |
+| **Stable storage** — 500 GiB/canister, must not grow with volume | durable campaign lives in the dApp's library; II keeps only user-scoped rows + a transient buffer |
+| **Instructions/round** — this canister also serves every login | drain in bounded slices, never whole chunks |
 
-Cycles are a real cost too, but how much they matter depends on the deployment
-— see [Deployment assumptions](#deployment-assumptions). The three limits above
-bind everywhere regardless of who pays.
-
-## Deployment assumptions
-
-Numbers in this doc depend on where II runs, so state the deployment before
-quoting a cost:
-
-- **Canonical II** (`rdmx6-jaaaa-aaaaa-aaadq-cai`) runs on subnet `uzr34…`,
-  which is a **system subnet with 34 nodes**. On a system subnet the IC waives
-  execution, ingress, xnet, storage and HTTPS-outcall fees, so those are
-  effectively free _for this deployment_. Chain-key fees (threshold ECDSA,
-  vetKD) are **still charged**.
-- **Any other deployment** — a self-hosted II, a fork, or a test network —
-  runs on an application subnet where **every fee applies**. This is a
-  first-class case: the design must be viable when cycles are really being
-  spent, and a self-hoster needs the cost model to budget with.
-- **Capacity limits apply everywhere**, priced or not: the 3000 in-flight
-  outcall cap, per-message and per-round instruction limits, the 500-deep
-  output queue per canister pair, 2 MB message ceilings, and the 30 s outcall
-  timeout.
-- **Outcall replication.** A replicated outcall is executed by **every node**,
-  so the target receives _n_ requests, not one (n = 34 on II's subnet). This
-  matters for both cost and correctness — see
-  [Delivering to devices](#delivering-to-devices).
-
-Rule of thumb for this doc: design to the **paying** case and treat the fee
-waiver as a property of one deployment, not a premise of the design.
+Cycles are waived on canonical II (system subnet `uzr34…`) but fully charged on any self-hosted or forked deployment — so the design targets the **paying** case and treats the waiver as one deployment's property, not a premise.
 
 ## The user experience
 
 ### Turning notifications on (first time signing into a dApp)
 
-1. On the dApp (e.g. `oisy.com`), the user clicks **Sign in with Internet
-   Identity**. II opens at `/authorize`.
-2. The user authenticates as usual (passkey, or an existing session for a
-   returning user).
-3. **Continue screen** (`ContinueView`): "Continue to `<dApp>`" with the
-   account picker and a **Continue** button. There is no notification toggle
-   here — the account choice is the only decision.
-4. The user taps **Continue**.
-5. **Notifications opt-in screen** (`NotifOptInView`): a preview illustration
-   of what a notification looks like (an "Example" lock-screen stack), the
-   heading "Let `<dApp>` notify you", two short reasons (instant alerts /
-   reachable anytime), and two buttons — **Enable notifications** and **Maybe
-   later**.
-   6a. **Enable** → if this browser has not granted permission yet, it shows
-   its **native permission prompt** ("`id.ai` wants to show notifications —
-   Allow / Block"). This dialog is the browser's own and cannot be restyled.
-   On **Allow** — or straight away, when permission was granted earlier — II
-   subscribes the device and records consent for this dApp, then redirects to
-   the dApp. No app install is required (Android/desktop); iOS Safari is the
-   exception.
-   6b. **Maybe later** → II redirects straight to the dApp; nothing is enabled.
+```mermaid
+flowchart TD
+    A[Sign in with II on the dApp] --> B[Authenticate]
+    B --> C[Continue screen]
+    C --> D[Notifications opt-in screen]
+    D -->|Maybe later| Z[Redirect to dApp — nothing enabled]
+    D -->|Enable| E{Browser permission<br/>already granted?}
+    E -->|No| F[Native browser prompt<br/>Allow / Block]
+    E -->|Yes| G[Subscribe device + record consent]
+    F -->|Allow| G
+    F -->|Block| Z
+    G --> H[Redirect to dApp]
+```
 
-Two separate things are being asked, and only one of them repeats.
+Two grants, and only one repeats:
 
-II's opt-in screen **is** shown for each new dApp, because consent is recorded
-per origin and no dApp inherits another's. It appears once per dApp per
-device: a device that has not subscribed yet sees it again even for a dApp
-already enabled on another device, with copy that asks about this device
-rather than repeating the original pitch.
+- **II's opt-in screen** shows once per dApp per device — consent is per origin,
+  nothing is inherited.
+- **The browser's permission prompt** is granted to `id.ai` once and never returns;
+  every dApp delivers through that one origin.
 
-The **browser's** permission prompt is the part that does not come back. It is
-granted to `id.ai`, not to the dApp, and every dApp's notifications are
-delivered through that one origin — so once the user has allowed it, the
-browser has nothing left to ask, and later opt-ins complete without a second
-dialog.
+No install needed on Android/desktop. iOS is a degraded path: Web Push works only
+in an installed home-screen PWA, so consent is granted in the tab but the
+subscription is created later from II's own installed app. A native II app on APNs
+would be the real fix — out of scope here.
 
 ### What happens when a notification is sent
 
@@ -348,84 +295,39 @@ not by server-side routing.
 
 ### How II verifies the sender is really that dApp
 
-One call has one `caller()`, so the per-user `caller == in_app_principal`
-model does not batch. Senders authenticate at the **origin** level:
-
-The only thing a dApp must do is **publish the file**:
+Sends are authenticated at the **origin**, not per user. A dApp's only setup step
+is to publish a file; II verifies it and shows its `name` as the notification
+title (so no dApp can wear another's name).
 
 ```
 https://myapp.com/.well-known/ii-push-senders
-{ "senders": ["abcde-fghij-...-cai"] }
+{ "senders": ["abcde-…-cai"], "name": "MULTI/DEX" }
 ```
 
-Registration itself should be automatic. Requiring an explicit setup call is
-boilerplate that adds no security — the file is the proof, and II can go and read
-it whenever it needs to.
+II verifies on first consent (preferred) or on a send (returns `SenderUnverified`,
+never blocking the call), storing `origin_hash → {principals, name}`. Every send
+then requires `caller` to be a listed principal. Revoke by removing the file — II
+drops the sender on its ~weekly re-check.
 
-1. **On first consent.** When a user opts in for an origin in `/authorize`, II has
-   the origin and no registry row yet, so it fetches and verifies then. This is the
-   preferred trigger: it is user-paced, and by the time the dApp sends anything the
-   row already exists.
-2. **On a send, as a backstop.** If a row is still missing, II starts verification
-   and returns `SenderUnverified` with a hint naming the file to publish and the
-   principal to list. It does **not** block the send on an outcall — `push_send`
-   stays a cheap, no-await admission call, and the dApp's library retries.
-3. **`push_register_sender(origin)` stays**, as "check me again now": it forces a
-   re-read, bypassing the negative cache below, for a developer who has just fixed
-   their file and does not want to wait for the TTL.
+> **Self-serve verification is a launch blocker.** The PoC registers senders by
+> hand (controller-only). "Any dApp can send through II" is false while onboarding
+> means a DFINITY support ticket, so the `.well-known` check must ship in v1.
 
-Verification itself is unchanged in substance: II fetches over an HTTPS outcall
-with a transform so replicas agree, then checks that the calling — or, for the
-consent-time path, the claimed — canister is listed, and stores
-`origin_hash → {principals, verified_at}`.
+<details><summary>Verification detail</summary>
 
-**Only ever fetch for origins a user has already consented to.** Without that gate
-any canister could make II fetch a URL of its choosing by naming an arbitrary
-origin, which is an SSRF and DoS amplifier of exactly the kind the
-[endpoint allowlist](#open-items) exists to prevent. Consent requires a real user
-completing the II opt-in for that origin, so the fetchable set is bounded by
-grants that already happened — and it costs nothing, because a send to a user who
-has not consented is refused regardless. Add negative caching per origin so a
-misconfigured file is not re-fetched on every send, and a cap on concurrent
-verifications so a burst of new origins cannot crowd out authentication's outcall
-budget.
+- **Fetch only for origins a user already consented to** — otherwise any canister
+  could make II fetch an arbitrary URL (SSRF/DoS). Add per-origin negative caching
+  and a concurrent-verification cap.
+- **The proof needs both halves** — a published file *and* a canister it names — so
+  an impersonator needs the origin's content and the canister.
+- **`name` fallback** is the bare host, not the full URL. Cap length, reject
+  control/RTL characters: a name is a homograph surface a host isn't.
+- **`push_register_sender(origin)`** forces an immediate re-check after editing the
+  file, bypassing the negative cache.
+- Reuses the DoH/outcall machinery; a `_canister-id` DNS TXT record is a second
+  proof path for custom domains.
 
-The proof still needs **both halves** — a published file and a canister that the
-file names — so an impersonator needs control of the origin's content *and* of the
-canister. Making the check implicit changes when II reads the file, not what it
-proves.
-
-The proof needs **both halves**, which is what makes it a proof: publishing the
-file registers nothing on its own, and calling without the file is refused. A
-would-be impersonator needs control of the origin's content *and* of the canister.
-
-Then, per send: II hashes the claimed origin, requires `caller` to be the
-registered principal, and forces attribution to that origin so a dApp cannot label
-its notification as another app.
-
-To revoke, the dApp removes itself from the file. II re-verifies on a lazy TTL
-(~weekly) and deregisters when the entry or the file is gone, so no II call is
-needed to stop being a sender. That TTL is also what bounds the exposure if a
-domain changes hands — the old canister keeps sending until re-verification
-catches up, which is the window
-[sender deregistration & re-verification TTL](#open-items) exists to shorten.
-
-This reuses the existing outcall / DoH machinery; IC custom domains also carry a
-`_canister-id` DNS TXT record as a second proof path.
-
-The registry itself is permanent; only step 2's **write path** is provisional. The
-PoC has a controller register senders by hand, because without the `.well-known`
-check self-registration would let any canister claim any origin — and consent is
-per origin, so that would let a stranger's notification arrive wearing a consented
-app's name. The lookup in step 2 and the check on every send stay either way;
-verification changes who may write a row, not whether the row exists.
-
-**Treat the missing verification as a launch blocker, not a hardening step.** This
-document's premise is that any dApp can send through II and needs no push
-infrastructure of its own. An operator-maintained registry contradicts it: a dApp
-would trade a push stack for a support ticket, and adoption would be gated on
-someone at DFINITY inserting a row. Self-serve registration is what makes the goal
-true, so it belongs in the first shippable version rather than after it.
+</details>
 
 ### Admission control (Layer 1): stopping one dApp from flooding II
 
@@ -465,8 +367,9 @@ throughput on a _small_ buffer.
 
 ### What this costs, and who pays
 
-Costs split into what is _always_ scarce and what depends on the deployment
-(see [Deployment assumptions](#deployment-assumptions)).
+Costs split into what is _always_ scarce (outcall slots, storage, instructions)
+and cycles, which are waived on canonical II but charged on any self-hosted or
+forked deployment.
 
 **Always scarce, on every deployment:**
 
@@ -476,7 +379,7 @@ Costs split into what is _always_ scarce and what depends on the deployment
   `(anchor, endpoint)`, consent and the principal index per `(anchor, origin)`.
   Never O(notification volume), because campaign state lives in the client
   library. That is the invariant the "stateless II" shape buys; see the
-  [bytes-per-user table](#what-this-actually-costs-per-user).
+  [bytes-per-user table](#storage-can-ii-store-the-data).
 - **Instructions** — sealing is not free at chunk scale; the drain must work in
   bounded slices.
 
@@ -757,142 +660,77 @@ per-device outcalls straight from the canister ("direct") is the documented
 **alternative** — kept for context and as a possible low-volume or
 fully-on-chain fallback, but not the shipping path.
 
-### First, the constraint that shapes both paths: outcall replication
+### The outcall to the gateway is non-replicated
 
-A replicated HTTPS outcall is executed by **every node in the subnet** — 34 on
-II's. The target sees 34 requests, and the replicas' responses must be
-_byte-identical_ or response-consensus fails (the call then errors while still
-being charged). Three consequences the rest of this section is built around:
+**Decision:** II's batch handoff uses `is_replicated = false` (mainnet since
+2025-08-04). One node makes the call — no 34× fan-out, no response consensus,
+~2 orders of magnitude cheaper — which is why the gateway can stay stateless,
+return real per-device status, and enable `410` cleanup.
 
-- **Duplicate delivery is the default, not an edge case.** RFC 8030 has no
-  idempotency key, so 34 POSTs of the same push are 34 distinct messages to the
-  relay and up to 34 banners on the device. `Topic` collapses _undelivered_
-  duplicates, so an offline device may collapse to one — an online device does
-  not. This is why `msg_id` + service-worker dedup is a v1 requirement rather
-  than a later hardening step.
-- **Per-device status cannot survive consensus.** The 34 POSTs legitimately get
-  _different_ answers (the first may get `201`, later ones `429`, or `410` if the
-  subscription just died). No transform can manufacture agreement about which
-  POST was first; a transform can only collapse everything to one deterministic
-  value. So `410`-driven subscription cleanup is **not implementable under
-  replicated outcalls** — which is one of the reasons the next bullet is the
-  design, not a future option. See
-  [stale-subscription cleanup](#stale-subscription-cleanup).
-- **So II's outcall to the gateway is non-replicated, and that is the design.**
-  `is_replicated = false` (management-canister interface, on mainnet since
-  2025-08-04) has **one** node make the request: no consensus on the response, no
-  transform, no 34× fan-out, and roughly two orders of magnitude cheaper. The IC
-  docs recommend it precisely for rate-limited APIs, which is what Web Push is.
-  Applied to the one call II actually makes — the batch handoff to the gateway —
-  it removes all three consequences above: the gateway receives one copy of each
-  batch instead of 34, needs no idempotency window, and may return real per-device
-  status instead of a deterministic ack.
+Two caveats: the flag is **experimental**, so isolate it behind one call site that
+can revert to replicated + transform; and a single node's reply isn't
+consensus-verified, so returned status is evidence, not proof (no new concession —
+a trusted gateway could always lie).
 
-  Two things this does not buy. The flag is marked **experimental** and its API
-  may still change, so the interface should be isolated behind one call site that
-  can be reverted to replicated with a transform. And a single node's reply is
-  **not consensus-verified** — for a trusted gateway that is no new concession,
-  since a dishonest gateway could always lie about delivery, but it does mean
-  status coming back is evidence rather than proof. See
-  [IC capabilities to re-evaluate](#ic-capabilities-to-re-evaluate).
+<details><summary>Why replicated outcalls don't work here</summary>
+
+A replicated outcall runs on every node (34 on II's subnet), so the target sees 34
+identical POSTs and responses must be byte-identical or consensus fails. That
+breaks Web Push two ways:
+
+- **Duplicate delivery** — RFC 8030 has no idempotency key, so 34 POSTs = up to 34
+  banners. (`msg_id` + SW dedup is a v1 requirement regardless, as a belt-and-braces.)
+- **Per-device status can't survive consensus** — the 34 POSTs legitimately get
+  different answers (`201`, `429`, `410`), and a transform can only collapse them to
+  one value. So `410`-driven [cleanup](#stale-subscription-cleanup) is impossible
+  under replication.
+
+</details>
 
 ### The delivery path: a trusted web2 gateway
 
-II encrypts and signs as usual, then hands the **fully-sealed, ready-to-send
-messages** to a small trusted helper server, which makes the many little sends
-over ordinary (free) internet instead of on-chain:
+II seals every message, then hands the ready-to-send bundles to a small trusted
+helper that fans them out over ordinary internet:
 
+```mermaid
+flowchart LR
+    II[II canister<br/>seals: RFC 8291 + VAPID] -->|~25 batched<br/>non-replicated outcalls| GW[Gateway<br/>no keys, no plaintext]
+    GW -->|1 POST/device| R[FCM / Mozilla / APNs]
+    R --> D[Device]
+    II -.->|"direct: ~13k outcalls<br/>(alt / fallback)"| R
 ```
-[ { endpoint, headers, authorization:<vapid jwt+pubkey>, body:<ciphertext> }, … ]
-```
 
-- **The VAPID key and encryption stay on II** — moving either would require
-  giving the gateway the VAPID private key (push to all users) or the device
-  keys + plaintext (read all notifications). RFC 8291 has no encrypt-once mode,
-  so II produces the N ciphertexts regardless; the gateway saves **outcall
-  count, not crypto**.
+**Why a gateway, not direct:** in-flight outcall slots, not cycles. A 10k-user
+blast is ~13k direct outcalls against the subnet's 3000 shared slots — it would
+starve login. The gateway needs ~25. This holds even on the fee-waived deployment,
+which is why it's the real reason (cycles only differ ~4×).
 
-  It is worth being precise about why offloading the sealing is not merely
-  disallowed but useless, because the instinct to move expensive work to a server
-  with no instruction limit is a good one. The cost splits in the wrong place: the
-  **ECDH that derives the content key is the expensive half, and the AES-128-GCM
-  that uses it is noise**. Deriving the key and being able to decrypt are the same
-  capability, so the only part of the sealing that can be handed to the gateway is
-  the part that was already free. It would also defeat
-  [End-to-end-encrypted apps](#end-to-end-encrypted-apps) outright: that design
-  exists so *II* cannot read content, and a web2 relay holding plaintext is
-  strictly worse than the thing it was built to avoid.
-- The gateway holds **no keys, no subscriptions, and no plaintext at rest** — it
-  sees in-transit ciphertext, endpoints and timing. Because II sends each batch
-  with a **non-replicated** outcall (below), the gateway receives one copy rather
-  than 34 and needs no idempotency window to collapse them, so it is genuinely
-  stateless. Under replicated outcalls it would have had to keep a short window
-  keyed on batch id, and "stateless" would have been the wrong word.
-- II batches sealed bundles into **~1.5 MB** chunks: ~25 outcalls instead of
-  ~13k. The 2 MB outcall ceiling counts **headers too**, so targeting exactly
-  2 MB leaves no room for the VAPID `Authorization` headers each bundle carries.
-- II authenticates to the gateway with a bearer token (IC outcalls have no stable
-  source IP — a non-replicated request comes from whichever node executed it, and
-  IPv4 destinations go via a shared proxy pool). Because the response is not put
-  to consensus, it does **not** have to be deterministic — so per-device results
-  _can_ come back through this channel, which is what makes `410`-driven
-  [stale-subscription cleanup](#stale-subscription-cleanup) implementable. Trust
-  that status only as far as the gateway is already trusted: it is a single
-  unverified reply, so treat a reported `410` as grounds to retire a subscription
-  opportunistically, never as an authority to delete user state on one word.
-- **The gateway sets II's admission capacity.** Throughput is bounded by how fast
-  the small buffer drains; a batched drain empties it quickly, so II recovers
-  capacity and admits the next chunk sooner. Fast drain → high sustained
-  throughput on a _small_ buffer → flat storage.
+**What stays on II:** all crypto. The gateway sees ciphertext, endpoints and timing
+— never keys or plaintext. Sealing can't be offloaded: the ECDH that derives the
+content key *is* the ability to decrypt, so the only movable part is the AES that
+was already free.
 
-**Why the gateway, stated correctly.** Its justification is **in-flight outcall
-slots and drain latency — not cycles.** Direct delivery would spend ~13k of the
-subnet's 3000 shared in-flight slots' worth of work per blast, starving II's own
-authentication outcalls; the gateway needs ~25. On a paying deployment it also
-saves cycles, but only ~4× (the per-byte fee applies to the same sealed bytes
-either way) — not the "cents" a naive call-count comparison suggests. The slot
-argument holds on _every_ deployment, including the fee-waived one, which is why
-it is the real reason.
+<details><summary>Trust delta — the deliberate cost</summary>
 
-Trust delta — the deliberate cost of this path. The gateway can **drop, delay,
-or replay** bundles. It **cannot read content**. But it **can forge sends**: each
-bundle carries a VAPID `Authorization` token, relays authenticate on that token
-alone and never validate the body, and the token is cached for up to 12 h. So a
-compromised gateway can harvest `(endpoint, token)` pairs and POST arbitrary
-bytes to those devices for the token's lifetime — including after being rotated
-out of the path. Those bytes won't decrypt, so the browser shows its generic
-"site updated in background" notification attributed to `id.ai` — which at volume
-burns the shared notification permission (see
-[shared fate](#shared-fate-one-permission-for-every-dapp)). Mitigations: scope
-credentials **per batch** so they expire with it, cut the JWT cache to minutes,
-and note that the bearer token in canister state is extractable by node
-operators, so this replay capability is not the gateway operator's alone.
-
-Only **liveness and this bounded forgery window** move off-chain;
-confidentiality stays on. Which also means the gateway is a **single point of
-failure**, and the doc must say what happens when it fails — see
+The gateway can **drop, delay or replay**, and **forge sends**: each bundle carries
+a VAPID token relays accept without validating the body, cached ≤12 h. A compromised
+gateway can harvest `(endpoint, token)` pairs and POST junk that won't decrypt — the
+browser then shows its generic "site updated" notice attributed to `id.ai`, burning
+the [shared permission](#shared-fate-one-permission-for-every-dapp). Mitigations:
+scope credentials per batch, cut the JWT cache to minutes. The token is also
+extractable from canister state by node operators, so this isn't the operator's
+alone. It's a **single point of failure** — see
 [Operating it](#operating-it-controls-alerts-and-rollout).
+
+</details>
 
 ### The alternative: direct per-device outcalls
 
-II could instead make one HTTPS outcall per device straight to the push service
-— fully on-chain, nothing extra to run or trust. Why it isn't the default:
-
-- **It would consume the shared in-flight outcall budget.** ~13k outcalls per
-  10k-user blast against a 3000-slot subnet-wide cap that II's own login paths
-  draw on. This is the disqualifying reason.
-- **Cost** on a paying deployment: ~2.8 T cycles (~$3.80) per blast at n = 34,
-  versus ~0.7 T through the gateway.
-- **Replication makes it worse, not just slower**: 34 POSTs per device, and no
-  usable per-device status (above).
-
-It stays viable for low volume or a deliberately fully-on-chain deployment. Note
-that "fallback if the gateway is unavailable" is only true with caveats: under
-replicated outcalls the direct path delivers duplicates and cannot observe
-`410`, so failing over to it is a degraded mode, not a transparent one.
-**`is_replicated = false` would change this assessment substantially** — it
-removes the fan-out and restores per-device status, making direct delivery a
-genuine peer of the gateway on correctness, still bounded by in-flight slots.
+One outcall per device, fully on-chain, nothing extra to trust — but ~13k outcalls
+per blast against the 3000-slot cap **disqualifies it as the default**. Viable for
+low volume or a deliberately all-on-chain deployment. With `is_replicated = false`
+it becomes a genuine peer of the gateway on correctness (no fan-out, per-device
+status restored), still bounded by in-flight slots.
 
 ## The dApp-side client library
 
@@ -1259,7 +1097,7 @@ dApp running its own service worker is same-origin with its own session, so
 Centralising the pipeline on II removes that: the worker that receives the tap is
 not the worker that could act. Worth listing alongside shared fate and content
 visibility in
-[alternatives considered](#ii-hosts-the-pipeline-rather-than-each-dapp-running-its-own)
+[alternatives considered](#a1)
 as part of what the single permission is bought with.
 
 #### One action II should always add: turning it off
@@ -1292,9 +1130,15 @@ Three levels, and they differ in what authority the worker needs:
   navigates rather than acting:
 
   ```
-  actions: [{ action: "unsubscribe", title: "Turn off" }]
+  actions: [{ action: "ii-manage", title: "Manage" }]
   → clients.openWindow(`${II_ORIGIN}/manage/settings?app=<origin>`)
   ```
+
+  **"Manage", not "Unsubscribe"**, for two reasons. Chrome already renders its own
+  unsubscribe affordance on a notification, and a second one competing beside it
+  reads as a mistake rather than a feature. And the button navigates rather than
+  revoking, so a label promising otherwise would be a lie — the honest word for
+  "opens the place where you can turn this off" is not "off".
 
   The destination already exists — `PushNotificationsSection` on `/manage/settings`
   lists every consented origin and revokes per app via `push_revoke_consent`. Two
@@ -1315,8 +1159,8 @@ Three levels, and they differ in what authority the worker needs:
   first version.
 
 So: ship the device-level switch, since it costs nothing and cannot fail, and make
-the per-app one a deep link. II must own both labels — a sender that could rename
-"Turn off notifications" would defeat the point.
+the per-app one a deep link. II must own both labels — a sender able to rename them
+would defeat the point.
 
 ### Updating or dismissing a notification already shown
 
@@ -1350,63 +1194,37 @@ Caveats:
 
 ## Alternatives considered
 
-### II hosts the pipeline, rather than each dApp running its own
+| # | Decision | Rejected alternative | Why |
+| --- | --- | --- | --- |
+| 1 | [II hosts the pipeline](#a1) | Each dApp runs its own | The permission is the scarce resource, not the plumbing — a dApp can't win the *n*th prompt |
+| 2 | [II hosts the service worker](#a2) | Each dApp hosts its own | Same decision as #1 — Web Push binds the subscription to the SW's origin |
+| 3 | [Gateway delivery](#the-delivery-path-a-trusted-web2-gateway) | Direct per-device outcalls | 13k in-flight outcalls would starve login; gateway → ~25 |
+| 4 | [Sealing stays on II](#action-buttons-navigation-only-never-silent-work) | Gateway seals | Deriving the key = ability to decrypt; useless to move. Real lever is a [separate canister](#the-way-to-lift-that-ceiling-is-a-separate-canister) |
+| 5 | [vetKeys-sealed E2E](#recommendation) | dApp holds the keys | See E2E section |
 
-The alternative is the status quo: every dApp prompts for its own notification
-permission, runs its own service worker, holds its own VAPID keypair, and stores
-its own subscriptions. It has real advantages — no shared-fate coupling, no new
-responsibility for II, no trusted gateway, and each dApp's notification content
-never leaves it.
+<h4 id="a1">1. II hosts the pipeline</h4>
 
-Rejected because the permission is the scarce resource, not the plumbing. A user
-declines the *n*th notification prompt far more often than the first, browsers
-increasingly bury the prompt, and iOS Safari requires a PWA install per site — so
-the per-dApp model works in principle and almost never happens in practice. One
-permission at the identity provider is the only version of this that a user
-actually says yes to, and it is the one thing a dApp genuinely cannot build for
-itself.
+The status quo — every dApp runs its own permission prompt, service worker, VAPID
+keypair and subscriptions — has real merits (no shared fate, no gateway, content
+never leaves the dApp). Rejected anyway: users decline repeat prompts, browsers
+bury them, iOS needs a PWA install per site, so the per-dApp model almost never
+happens in practice. One permission at the identity provider is the only version
+users say yes to, and the one thing a dApp can't build itself.
 
-The cost of that choice is paid throughout this document and should be read as its
-price, not as incidental complexity: II becomes a shared-fate dependency (see
-[Shared fate: one permission for every dApp](#shared-fate-one-permission-for-every-dapp)),
-II sees notification content unless the app opts into
-[end-to-end encryption](#end-to-end-encrypted-apps), a canister whose real job is
-authentication now carries a delivery pipeline — hence
-[Push must never degrade authentication](#push-must-never-degrade-authentication) —
-and notification **action buttons can only navigate, never act**, because the
-worker that receives the tap belongs to II rather than to the app holding the
-user's session (see
-[action buttons](#action-buttons-navigation-only-never-silent-work)).
+Its price, paid throughout this doc:
+[shared fate](#shared-fate-one-permission-for-every-dapp), II sees content absent
+[E2E](#end-to-end-encrypted-apps), a delivery pipeline inside an auth canister
+([must not degrade login](#push-must-never-degrade-authentication)), and
+[action buttons can only navigate](#action-buttons-navigation-only-never-silent-work).
+In exchange it buys one thing no per-dApp design can:
+[an off-switch no sender can remove](#one-action-ii-should-always-add-turning-it-off).
 
-The same property cuts the other way once, and it is worth weighing against the
-list above: because II composes the notification, **it can attach an off-switch no
-sender can remove or relabel** — a guarantee no per-dApp design can make, since an
-app that owned its notifications would never add that button. See
-[one action II should always add](#one-action-ii-should-always-add-turning-it-off).
+<h4 id="a2">2. II hosts the service worker</h4>
 
-### II hosts the service worker, rather than each dApp hosting one
-
-Web Push binds a subscription to the origin whose service worker created it. Had
-each dApp hosted its own, each would need its own permission grant, and the single
-prompt above would be impossible — the two decisions are the same decision. It
-also means notifications arrive attributed to `id.ai` rather than to the dApp,
-which the UX compensates for by naming the sending app in the body and title, and
-which the security model has to defend by forcing attribution to the sender origin
-at send time.
-
-### Decisions argued where they arise
-
-Three further alternatives are weighed in place rather than here, because each
-needs its surrounding detail to make sense:
-
-- **Gateway versus direct per-device outcalls** —
-  [the delivery path](#the-delivery-path-a-trusted-web2-gateway) and
-  [the alternative](#the-alternative-direct-per-device-outcalls).
-- **Where the sealing runs.** Moving it to the gateway is not merely disallowed
-  but useless, and the alternative that does help is a separate canister — see
-  [the way to lift that ceiling](#the-way-to-lift-that-ceiling-is-a-separate-canister).
-- **Two E2E designs**, vetKeys-sealed versus dApp-held keys, with a
-  [recommendation](#recommendation).
+Web Push binds a subscription to the SW's origin, so a per-dApp SW would need a
+per-dApp permission — making #1 impossible. Cost: notifications arrive attributed
+to `id.ai`, which the UX fixes by naming the app and the security model defends by
+forcing sender-origin attribution at send time.
 
 ## Security model
 
@@ -1890,7 +1708,7 @@ Must-fix before a real deployment:
   intent is worse than a cap that says no.
 
   Against the row sizes in
-  [what this actually costs per user](#what-this-actually-costs-per-user), 20
+  [what this actually costs per user](#storage-can-ii-store-the-data), 20
   subscriptions plus 100 consents (each consent also costing a principal-index
   row, so 140 B a piece) is **~19.5 KB per anchor** on typical endpoints and
   **~35 KB** on worst-case ones. 20 is chosen rather than 10 because a real user
@@ -2112,53 +1930,77 @@ What a dApp must do to send its first notification — register as a sender for 
 origin, serve the callback allow-list, shape its deep links — is in
 [push-api.md](push-api.md#dapp-developer-integration).
 
-## Feasibility and scale
+## Scaling
 
-| Metric                               | Gateway (chosen)                                                   | Direct (alternative)    |
-| ------------------------------------ | ------------------------------------------------------------------ | ----------------------- |
-| App → II for 10k users               | ~10 paced chunks (client-driven)                                   | ~10 paced chunks        |
-| Outcalls per 10k blast               | ~25                                                                | ~13k                    |
-| Requests actually reaching relays    | ~13k (gateway fans out off-chain)                                  | ~13k × 34 (replication) |
-| Per-device status (`410`) observable | yes — non-replicated handoff, so the ack need not be deterministic | no under replication    |
-| II **stable storage**                | O(users × origins), flat with volume                               | same                    |
-| II in-flight buffer                  | bounded, transient heap                                            | same                    |
-| Full-delivery latency, 10k blast     | tens of seconds                                                    | minutes                 |
-| Cycles, 34-node **paying** subnet    | ~0.02 T (~$0.03) non-replicated; ~0.7 T (~$0.95) if replicated     | ~2.8 T (~$3.80)         |
-| Cycles, canonical II (system subnet) | fee-waived                                                         | fee-waived              |
+Two questions: **how fast can II push**, and **can II store the data**. The honest
+answer to the first is per-stage — a send crosses six stages and only two actually
+bound scale.
 
-**Throughput has a global ceiling and it is shared across all dApps** — the single
-most important capacity fact here, worked through in
-[buffer size, and how many origins it serves at once](#buffer-size-and-how-many-origins-it-serves-at-once).
-It must be published, and derived from a measurement rather than from this doc's
-estimates.
+### Where the bottleneck is, stage by stage
 
-App → II is feasible either way. Direct delivery stays fully on-chain and viable at
-low volume, but under replicated outcalls it multiplies every POST by the subnet
-size and cannot observe `410`, so it is a degraded fallback rather than a
-transparent one.
+```mermaid
+flowchart LR
+    A[1. dApp→II<br/>admit] --> B[2. heap<br/>buffer]
+    B --> C[3. seal<br/>ECDH/msg]
+    C --> D[4. outcall<br/>→ gateway]
+    D --> E[5. gateway<br/>→ relays]
+    E --> F[6. device]
+    C:::bottleneck
+    D:::bottleneck
+    classDef bottleneck fill:#c0392b,color:#fff
+```
 
-## What this actually costs per user
+| Stage | Hard limit | Elastic? | Push it → |
+| --- | --- | --- | --- |
+| 1. Admit (`push_send`) | Layer-1 per-origin + global bucket | client-paced | bigger bucket = weaker flood protection |
+| 2. Heap buffer | 4 GiB heap | not the limit | oversizing accepts backlog whose TTL expires — a lying success |
+| **3. Seal** | instructions/round, **shared with every login** | **no** | bigger slice → login latency |
+| **4. Outcall → gateway** | 3000 in-flight subnet-wide, 500-deep queue | **no** | more in flight → starves II's own auth outcalls |
+| 5. Gateway → relays | web2, horizontally scalable | yes | relay per-app rate limits (FCM etc.) |
+| 6. Storage | 537 GB/canister | O(users × origins) | [see below](#storage-can-ii-store-the-data) |
 
-Storage is O(users × origins), not O(users) — worth being concrete, since the
-"flat with volume" claim is about _notification volume_ only:
+**The binding constraint is stages 3–4 — II's own execution round, shared with
+every sign-in on the network.** That caps sustained throughput at *low hundreds of
+device-messages/second across all dApps combined* (≈ tens of millions/day). So:
 
-| Row             | Key                       | Size                                                        | Grows with       |
-| --------------- | ------------------------- | ----------------------------------------------------------- | ---------------- |
-| Subscription    | `(anchor, endpoint_hash)` | ~300 B typical (endpoint URL dominates), ~1.1 KB worst case | users × devices  |
-| Consent         | `(anchor, origin_hash)`   | ~60 B                                                       | users × dApps    |
-| Principal index | `principal`               | ~80 B                                                       | users × dApps    |
-| Sender registry | `origin_hash`             | ~100 B                                                      | registered dApps |
+- **Total users isn't the limit** — a large consented base costs storage, not throughput.
+- **Simultaneous blasts are** — N origins each blasting 10k serialise through one
+  drain; [Layer 1](#admission-control-layer-1-stopping-one-dapp-from-flooding-ii)
+  divides the shared rate rather than letting one starve the rest.
+- The [separate-canister split](#the-way-to-lift-that-ceiling-is-a-separate-canister)
+  is the one move that lifts stages 3–4, by not sharing the round with login.
 
-At 10M users × 2 devices × 10 consented dApps: 20M subscription rows ≈ **6 GB**,
-100M consent rows ≈ **6 GB**, 100M principal-index rows ≈ **8 GB** — about
-**20 GB** in total, or ~2 KB per anchor. The two 100M-row maps dominate, because
-every consent costs a principal-index row as well; devices are the cheap axis.
+> The stage-3 number is this design's **estimate**, not a measurement. One RFC 8291
+> seal is dominated by a P-256 ECDH; measure it before trusting any throughput
+> figure — every number above scales off it.
 
-That is against a 500 GiB (537 GB) per-canister limit while sharing a 2 TiB subnet
-with anchor data, and it is **before** any dead rows — which is why
-[stale-subscription cleanup](#stale-subscription-cleanup) is a must-fix rather
-than housekeeping. Note also the 2 GiB stable-memory-per-upgrade ceiling, which
-bounds how large these maps can get before upgrades become a problem.
+Gateway vs direct, per 10k-user blast:
+
+| | Gateway (chosen) | Direct (alt) |
+| --- | --- | --- |
+| Outcalls | ~25 | ~13k |
+| Per-device `410` status | yes (non-replicated) | no under replication |
+| Latency | tens of seconds | minutes |
+| Cycles (paying subnet) | ~0.02 T (~$0.03) | ~2.8 T (~$3.80) |
+
+### Storage: can II store the data
+
+Storage is **O(users × origins)** — flat with notification *volume*, but it grows
+with users and the apps they consent to.
+
+| Row | Key | Size | Grows with |
+| --- | --- | --- | --- |
+| Subscription | `(anchor, endpoint_hash)` | ~300 B (~1.1 KB worst) | users × devices |
+| Consent | `(anchor, origin_hash)` | ~60 B | users × dApps |
+| Principal index | `principal` | ~80 B | users × dApps |
+| Sender registry | `origin_hash` | ~100 B | registered dApps |
+
+**At 10M users × 2 devices × 10 dApps ≈ 20 GB** (~2 KB/anchor) against a 537 GB
+per-canister limit. The two 100M-row maps dominate — every consent costs a
+principal-index row too, so consents are the expensive axis, not devices. This is
+before dead rows, which is why [stale-subscription cleanup](#stale-subscription-cleanup)
+is a must-fix. The 2 GiB stable-memory-per-upgrade ceiling bounds how large the maps
+can get before upgrades become a problem.
 
 ## Stable memory regions
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1960,8 +1960,12 @@ flowchart LR
 | 6. Storage | 537 GB/canister | O(users × origins) | [see below](#storage-can-ii-store-the-data) |
 
 **The binding constraint is stages 3–4 — II's own execution round, shared with
-every sign-in on the network.** That caps sustained throughput at *low hundreds of
-device-messages/second across all dApps combined* (≈ tens of millions/day). So:
+every sign-in on the network.** It sets a single global ceiling:
+
+> **≈ 200 device-messages/second — ≈ 720k/hour — ≈ 17M/day — across every dApp
+> combined.** (Estimated; see the caveat below.)
+
+So:
 
 - **Total users isn't the limit** — a large consented base costs storage, not throughput.
 - **Simultaneous blasts are** — N origins each blasting 10k serialise through one

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1680,9 +1680,27 @@ Must-fix before a real deployment:
   chosen path; it does not remove the need for the allowlist, because one POST at
   a victim of the caller's choosing is still one too many.
 - **Per-anchor caps.** Cap subscription rows at **20** and consent rows at
-  **100** per anchor, with LRU eviction. Nothing bounds either today, ingress is
-  free to the caller, and II pays the stable-memory cost — a direct attack on the
-  resource this design calls a hard constraint.
+  **100** per anchor. Nothing bounds either today, ingress is free to the caller,
+  and II pays the stable-memory cost — a direct attack on the resource this design
+  calls a hard constraint.
+
+  Read the units carefully. 100 consents really is 100 distinct dApps. But 20
+  subscriptions is 20 **endpoints**, not 20 browsers: a browser resubscribing with
+  the same endpoint overwrites in place, but a browser that _rotates_ its endpoint
+  (expiry, cleared storage, `pushsubscriptionchange`) produces a new row and leaves
+  the old one behind until cleanup, and two profiles on one machine are two rows.
+  So the live-device budget is under 20, and the slack is there for stale
+  rotations — which is why 20 rather than 10.
+
+  **The two maps need different eviction, and neither wants plain LRU.**
+  Subscriptions are machine state and safe to reclaim, but evict **known-dead rows
+  first** — ones that already returned `404`/`410` — and only fall back to
+  recency, or a weekly-use laptop gets dropped while a dead rotated endpoint
+  survives. Consent is not machine state: silently evicting one **reverses a
+  decision the user made**, with no signal, so an app they allowed simply stops
+  reaching them. Refuse the 101st with an error the UI can explain instead, and let
+  the user revoke something if they want room. A cap that quietly discards user
+  intent is worse than a cap that says no.
 
   Against the row sizes in
   [what this actually costs per user](#what-this-actually-costs-per-user), 20
@@ -1969,9 +1987,10 @@ the same virtual memory and corrupts both.
 What each is for, since the names alone do not say:
 
 - **Subscriptions** hold exactly what RFC 8291 needs to seal for one device — the
-  relay `endpoint` plus that device's `p256dh` public key and `auth` secret. One
-  row per browser that ran `pushManager.subscribe()`; a browser resubscribing
-  overwrites in place. The endpoint URL is what makes this the largest row.
+  relay `endpoint` plus that device's `p256dh` public key and `auth` secret. One row
+  per _endpoint_, which is not quite one per browser: resubscribing with the same
+  endpoint overwrites in place, but a rotated endpoint is a new row and leaves the
+  old one behind until cleanup. The endpoint URL is what makes this the largest row.
 - **Consent** is presence-as-grant: the key existing means this user allowed this
   dApp on this identity, and revoking deletes it.
 - **The principal index** is the reverse lookup `notify_user` cannot work without.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -86,23 +86,39 @@ Built today (PoC on `feat/push-notifications-poc`):
   ever lands, the key moves off storage entirely.
 - Notification click routes through the consent-gated `/notify` redirect.
 
-What the PoC deliberately does **not** have, so it isn't mistaken for a
+Also built since, because using the PoC forced them:
+
+- **Sender authorization by origin.** `notify_user` originally required
+  `caller() == in_app_principal`, which cannot work: that principal is a
+  canister-signature principal derived from II's seed, so only the recipient's
+  own browser can present it — an inter-canister call always arrives as the
+  calling canister's principal. It admitted only self-sends, i.e. the one case
+  the endpoint is not for. A sender registry keyed by origin hash now authorizes
+  sends, with self-sends still allowed (the recipient asking to be notified needs
+  nothing further). `push_register_sender` is controller-only until the
+  `.well-known` verification below exists.
+- **`msg_id` + service-worker dedup**, and **`410`/`404` row cleanup** — see
+  [Duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
+- **Send-time `alert.url` validation**, which is what lets a tap open the deep
+  link directly.
+- **VAPID key rotation handling** in the browser: an existing subscription bound
+  to a superseded key is replaced rather than failing forever.
+
+What it still deliberately does **not** have, so it isn't mistaken for a
 shippable subset:
 
-- **`notify_user` requires `caller() == in_app_principal`.** That principal is a
-  canister-signature principal, so it can only appear as `caller()` on an
-  _ingress_ message carrying the user's own delegation — a dApp **backend cannot
-  call it at all**. The PoC therefore demonstrates _delivery_, not _sending_:
-  the only party who can currently notify a user is a browser tab holding that
-  user's live session. Backend-initiated sends need the sender registry and
-  `push_send` from the design below.
+- No `push_send`, so no batching, no chunking, and no client library — a send is
+  one `notify_user` per recipient.
 - No rate limiting or admission control of any kind — `notify_user` is unmetered.
-- No endpoint validation beyond an `https://` prefix, and no per-anchor caps on
-  subscription or consent rows.
+- No `.well-known/ii-push-senders` verification: senders are registered by an
+  operator, so nothing yet proves a canister owns the origin it sends as.
+- No endpoint host allowlist, and no per-anchor caps on subscription or consent
+  rows.
 - `Display` content only — no `Hidden`, which is the variant the design
   recommends shipping first for E2E apps.
-- No `msg_id`, no `410` cleanup, no `pushsubscriptionchange` handling.
-- Integration and E2E test coverage is thin (unit tests for the crypto only).
+- No `pushsubscriptionchange` handling, so a rotated endpoint still leaves a
+  stale row until a relay reports it gone.
+- Integration and E2E test coverage is thin (unit tests only).
 
 Proposed (this doc):
 
@@ -111,10 +127,10 @@ Proposed (this doc):
   buffer, storage O(users × origins)), a durable client library, and delivery
   through a trusted web2 gateway (with direct per-device outcalls as the
   documented alternative/fallback).
-- Promoted to v1 requirements by review: `msg_id` + device dedup, a
-  `drain_epoch` acknowledgment signal, an endpoint host allowlist, per-anchor
-  caps, drain isolation and non-reentrancy, and a reserved outcall budget that
-  protects sign-in.
+- Promoted to v1 requirements by review, and still outstanding: a `drain_epoch`
+  acknowledgment signal, an endpoint host allowlist, per-anchor caps, drain
+  isolation and non-reentrancy, and a reserved outcall budget that protects
+  sign-in. (`msg_id` + device dedup was also promoted, and is now built.)
 - No cycles charging to senders in v1 — but a deployment that pays fees needs a
   cycle budget with a circuit breaker regardless. Sender charging is parked as a
   future exploration.
@@ -871,22 +887,38 @@ device is a v1 requirement, not a nicety.
 
 ## On the device: rendering and tap-through
 
-- **Subscribe** (Settings): request permission, `pushManager.subscribe` with
-  II's VAPID public key, store `(anchor, endpoint_hash) → {p256dh, auth}`. No
+- **Subscribe** (Settings, or the `/authorize` opt-in): request permission,
+  `pushManager.subscribe` with II's VAPID public key, store
+  `(anchor, endpoint_hash) → {endpoint, p256dh, auth}`. A browser allows one
+  subscription per service worker, permanently bound to the key it was created
+  with, so `subscribe` **refuses a different key**: an existing subscription is
+  reused when its key still matches and replaced when it doesn't. Otherwise
+  every browser that subscribed under a previous VAPID key could never
+  re-enable. No
   PWA install is needed on Android or desktop — this works in a plain tab;
   iOS Safari is the exception (it only allows Web Push for an installed
   home-screen app). The optional install adds an app icon / standalone window
   and slightly better attribution.
-- **Consent** (`/authorize`): `push_grant_consent(anchor, origin)`.
+- **Consent** (`/authorize`): `push_grant_consent(anchor, origin)`. Asked once
+  per `(identity, origin)` **per device** — the answer is remembered locally,
+  which matches what it commits to, since a subscription belongs to one browser.
+  Consent itself is shared by all of the identity's devices, so on a second
+  device only the subscription is missing and the screen says so ("Also notify
+  you on this device?") rather than repeating the first-run ask.
 - **Render**: the service worker branches on `content` — `Display` shows the
   supplied `title`/`body`; `Hidden` shows an II-controlled generic string
   keyed by `category` ("New message from `<origin>`"), never app-supplied text.
-- **Click**: the service worker opens
-  `/notify?origin=<sender>&to=<deep-link>`; the page validates and redirects
-  (see below), otherwise it fails closed. This prevents the redirect endpoint
-  from being abused as an open redirect. For `Hidden` (E2E) notifications this
-  tap-through is also the content-reveal path: the app opens and decrypts the
-  message in its own context.
+- **Click**: with a deep link, the service worker opens it **directly**. II
+  validated at send time that `alert.url` is on the consented origin (see
+  [the deep-link question](#can-the-app-choose-where-the-notification-opens)),
+  so there is nothing left to check on the device — and routing through II
+  would add a second visit in the middle of a journey the user expects to be
+  one step. Without a deep link it opens `/notify?origin=<sender>`, which
+  resolves the sender's own origin, shows which app is opening, and fails
+  closed if it cannot verify the sender.
+
+  For `Hidden` (E2E) notifications this tap-through is also the content-reveal
+  path: the app opens and decrypts the message in its own context.
 
 ### Shared devices and multiple identities
 
@@ -921,23 +953,35 @@ endpoint_hash) → {endpoint, p256dh, auth, created_at}` — the endpoint URL
 
 ### Can the app choose where the notification opens?
 
-The app may set `alert.url` to send the user to a specific page rather than
-the origin root. `/notify` honors it under two constraints, both enforced
-client-side:
+The app may set `alert.url` to send the user to a specific page rather than the
+origin root. **II validates it at send time** and refuses the send otherwise:
 
-- **The target's origin must equal the sender's origin.** The sender origin is
-  **II-derived**, not a field on `PushAlert`: the backend forces it to this
-  sender's consented origin and stamps it into the delivered payload, so a dApp
-  cannot set or spoof it. A notification can therefore deep-link anywhere within
-  the sender's own site (`https://app.com/thread/42`) but never to another
-  origin — not `evil.com`, and not another consented dApp.
-- **The sender origin must be in the anchor's consent list** (session-delegation
-  check). A hand-crafted `/notify?origin=…&to=…` therefore also fails closed.
+- **The target must be on the sender's own application.** The sender origin is
+  II-derived, not a field on `PushAlert`: the backend forces it to this sender's
+  consented origin, so a dApp cannot set or spoof it. A notification can
+  deep-link anywhere within the sender's own site
+  (`https://app.com/thread/42`) but never to another origin — not `evil.com`,
+  and not another consented dApp.
+- **Both sides are canonicalised** before comparing, because consent is recorded
+  against the _effective_ origin (already remapped to the legacy boundary
+  domain) while a dApp's links use whichever domain the user is browsing.
+  Without that, every real deep link is refused. It stays safe rather than
+  loose: only the same subdomain collapses, and that subdomain is the canister
+  id, so two different canisters can never normalise to one origin.
+- **Only `https`, or `http` on loopback** — the secure-context rule browsers
+  use. `javascript:` and `data:` URLs report their origin as the string
+  `"null"`, so without a scheme check two of them compare equal, pass an
+  origin test, and reach a navigation.
 
-No target → redirect to the sender origin's root. Because the check keys off
-the backend-forced `hostname`, this is entirely front-end; no backend or
-Candid change is required. (A backend `alert.url`-origin validation at send
-time is a nice defense-in-depth follow-up but not required for safety.)
+Validating on the send side rather than on the device is what lets the service
+worker open the link directly, removing a hop from the tap-through. It is also
+simply the better place: this is the only party that knows authoritatively which
+origin the user consented to, whereas the device-side check sat on a publicly
+craftable URL and every future consumer of `alert.url` would have had to repeat
+it.
+
+No target → the tap opens `/notify?origin=<sender>`, which resolves the sender's
+origin from the anchor's consent list and fails closed if it cannot.
 
 ### Can the tap land the user already signed in?
 
@@ -987,6 +1031,38 @@ One consistency requirement: push consent keys on the `effectiveOrigin` (see
 sign-in derives the identity from the callback origin or its `derivationOrigin`.
 They must agree, or the principal that was notified is not the principal the
 user comes back with.
+
+**Notifications should link straight at the sign-in route**, not at the app.
+Sending them to the app means it boots, discovers it has no usable session and
+bounces — a visible flash on the way to a redirect that was always going to
+happen. Linking direct makes the journey tap → Internet Identity → the page.
+
+Four things this cost to get right, all learned the hard way:
+
+- **The sign-in route must be its own URL.** The flow journals state per route,
+  so running it on the app root interleaves that journal with the app's whole
+  boot path. The symptom is landing signed out with nothing explaining why.
+- **Do not short-circuit on `isAuthenticated()` there.** A delegation can sit in
+  storage while the app considers the session over — an app that ends its
+  session when every tab closes is in exactly that state when a notification
+  arrives. Forwarding on it returns the user to an app that then signs them out.
+  Calling `signIn()` unconditionally is correct: it starts the redirect on the
+  first pass and completes from journaled state on the return one.
+- **A loopback callback needs II's `dev_csp`.** Establishing the flow fetches
+  the callback origin's allow-list, and that fetch is `connect-src`-bound, which
+  production CSP limits to `https:`. So a dApp on `http://localhost` can only do
+  this against an II deployed with the dev CSP — which is why the honest advice
+  for a demo is to serve the dApp over https.
+- **Chrome will ask the user.** A public II origin fetching an allow-list from a
+  loopback address is a local-network request, which Chrome gates behind a
+  permission prompt ("access other apps and services on this device"). Expected
+  on a local setup, absent once both sides are public https.
+
+Finally, the route is a page on the dApp's origin and **cannot be supplied by
+II or by the auth client**. The client is headless, and the redirect is a
+top-level navigation onto the relying party's own origin — which is also what
+generates the session key. So the realistic goal is making that page invisible
+(the app's own background and no decision on it), not removing it.
 
 ### What about apps with no URL routing (e.g. Caffeine)?
 
@@ -1305,26 +1381,47 @@ service worker drops out-of-order updates rather than applying them.
 
 ## Duplicate and replay suppression (`msg_id`)
 
-Promoted to a **v1 requirement**. Three independent mechanisms make duplicates
-the norm rather than the exception:
+**Built.** Four independent mechanisms make duplicates the norm rather than the
+exception, and the fourth is the one that showed up first in practice:
 
 1. **Replicated outcalls** — 34 POSTs per push, no idempotency key in RFC 8030.
 2. **Timer duplicate execution** — `ic-cdk-timers` documents that under load
    "timeouts may result in duplicate execution", and the drain is not idempotent.
 3. **Client retries and `drain_epoch` recovery** — by design, per the client
    library.
+4. **Accumulated subscription rows.** The fan-out sends one push per stored row,
+   browsers rotate endpoints, and nothing removed a row — so one browser ended up
+   behind two rows that both still delivered. This is what actually produced
+   duplicate banners during testing, before any of the above did.
 
-Design: II assigns a `msg_id` **once per admitted message**, stable across
-delivery retries, included in the JSON _before_ RFC 8291 encryption (so it is not
-a Candid field and no dApp supplies it). The service worker drops ids it has
-already shown.
+II assigns a `msg_id` **once per admitted message**, stable across delivery
+retries, included in the JSON _before_ RFC 8291 encryption — so it is not a
+Candid field, no dApp supplies it, and no relay or gateway can read or forge it.
+The service worker keeps a bounded set of ids it has shown and drops repeats.
 
-**Use a monotonic window, not a bounded recency set.** A bounded set of
-recently-seen ids is defeatable by construction: the attacker controls eviction
-pressure, so flooding a device with fresh notifications flushes the set and a
-replayed capture then looks new (clearing site data does the same). Keep a
-per-origin high-water mark and reject anything at or below it, and bind `msg_id`
-to a short validity window so an old capture fails on age alone.
+Two implementation notes that are easy to get wrong:
+
+- **The seen-set cannot live in a variable.** A service worker is killed between
+  pushes, so an in-memory set forgets exactly what it needs to remember. It is
+  held in the Cache API, bounded and pruned oldest-first.
+- **A payload with no id is always shown.** Failing open matters: dropping a
+  real notification is worse than showing a duplicate, and it keeps an older
+  canister working against a newer worker.
+
+Cause as well as symptom: the drain now **removes a subscription when the relay
+answers `404`/`410`**. That is the only signal a row is dead, and without it rows
+only accumulate while every future send pays for a target that can never receive.
+`pushsubscriptionchange` is still missing, so a rotated endpoint lingers until a
+relay reports it gone — self-healing now rather than permanent.
+
+**Still to harden: a monotonic window rather than a bounded recency set.** What
+is built collapses accidental duplicates, which is what the symptom was. It does
+not resist a deliberate replay: a bounded set means eviction, and the attacker
+controls the pressure, so flooding a device with fresh notifications flushes the
+set and a replayed capture then looks new (clearing site data does the same).
+The hardened form keeps a per-origin high-water mark, rejects anything at or
+below it, and binds `msg_id` to a short validity window so an old capture fails
+on age alone.
 
 Note `msg_id` is a **different thing** from the dApp-facing `notification_id`:
 `msg_id` is II-generated and suppresses exact duplicates (show at most once);
@@ -1487,12 +1584,16 @@ Must-fix before a real deployment:
   attempt counter, a stuck-buffer watchdog, and a claim step before the first
   `await`. Without these, one malformed row wedges the feature globally and
   overlapping ticks double-send.
-- **`msg_id` + device-side dedup.** Promoted from deferred — see
+- ~~**`msg_id` + device-side dedup.**~~ **Built** — see
   [Duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
+  What remains is hardening it against deliberate replay (monotonic window
+  instead of a bounded set), not the duplicate-suppression itself.
 - **An acknowledgment signal (`drain_epoch`).** Promoted from implicit — the
   client-side durability story does not work without it. See
   [II's state model](#iis-state-model-stateless-for-campaigns).
 - **Stale-subscription cleanup.** <a id="stale-subscription-cleanup"></a>
+  `404`/`410` row removal is **built** on the direct path; what follows still
+  applies to the gateway, where per-device status cannot come back at all.
   Promoted from deferred, because on the _chosen_ path it is not merely missing
   but structurally impossible: `410 Gone` cannot return through the gateway's
   deterministic ack, and browsers rotate endpoints continuously. Left alone, the

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -351,14 +351,50 @@ not by server-side routing.
 One call has one `caller()`, so the per-user `caller == in_app_principal`
 model does not batch. Senders authenticate at the **origin** level:
 
-1. The dApp serves `/.well-known/ii-push-senders` listing its backend
-   canister principal(s).
-2. The backend calls `push_register_sender(origin)`; II fetches the file via
-   HTTPS outcall (with a transform for consensus) and verifies
-   `caller ∈ senders`, storing `origin_hash → {principals, verified_at}`.
-3. II re-verifies on a TTL (~weekly, lazy) and deregisters when the file
-   disappears. This reuses the existing outcall / DoH machinery; IC custom
-   domains also carry a `_canister-id` DNS TXT record as a second path.
+Registering, once per dApp. The order matters — the file has to exist before the
+call, because II fetches it during the call:
+
+1. The dApp **publishes** `https://myapp.com/.well-known/ii-push-senders`, listing
+   its backend canister principal(s).
+2. That **backend canister calls** `push_register_sender("https://myapp.com")`. It
+   must be the canister making the call: `caller()` is what is being claimed.
+3. **II fetches the file** over an HTTPS outcall, with a transform so every replica
+   agrees on the bytes.
+4. **II checks `caller() ∈ senders`.** On success it stores
+   `origin_hash → {principals, verified_at}`. If the file is absent, unparseable,
+   or does not list the caller, the call is refused and nothing is stored.
+
+The proof needs **both halves**, which is what makes it a proof: publishing the
+file registers nothing on its own, and calling without the file is refused. A
+would-be impersonator needs control of the origin's content *and* of the canister.
+
+Then, per send: II hashes the claimed origin, requires `caller` to be the
+registered principal, and forces attribution to that origin so a dApp cannot label
+its notification as another app.
+
+To revoke, the dApp removes itself from the file. II re-verifies on a lazy TTL
+(~weekly) and deregisters when the entry or the file is gone, so no II call is
+needed to stop being a sender. That TTL is also what bounds the exposure if a
+domain changes hands — the old canister keeps sending until re-verification
+catches up, which is the window
+[sender deregistration & re-verification TTL](#open-items) exists to shorten.
+
+This reuses the existing outcall / DoH machinery; IC custom domains also carry a
+`_canister-id` DNS TXT record as a second proof path.
+
+The registry itself is permanent; only step 2's **write path** is provisional. The
+PoC has a controller register senders by hand, because without the `.well-known`
+check self-registration would let any canister claim any origin — and consent is
+per origin, so that would let a stranger's notification arrive wearing a consented
+app's name. The lookup in step 2 and the check on every send stay either way;
+verification changes who may write a row, not whether the row exists.
+
+**Treat the missing verification as a launch blocker, not a hardening step.** This
+document's premise is that any dApp can send through II and needs no push
+infrastructure of its own. An operator-maintained registry contradicts it: a dApp
+would trade a push stack for a support ticket, and adoption would be gated on
+someone at DFINITY inserting a row. Self-serve registration is what makes the goal
+true, so it belongs in the first shippable version rather than after it.
 
 ### Admission control (Layer 1): stopping one dApp from flooding II
 
@@ -1575,6 +1611,14 @@ to send, admission, or storage.
 
 Must-fix before a real deployment:
 
+- **`.well-known/ii-push-senders` verification**, so a dApp can register itself.
+  Specified in
+  [how II verifies the sender](#how-ii-verifies-the-sender-is-really-that-dapp)
+  but not built: today a controller inserts registry rows by hand. That is a
+  blocker for the goal rather than a rough edge — "any dApp can send through II"
+  is not true while onboarding means asking someone at DFINITY to add a row, and a
+  dApp would have traded a push stack for a support ticket. Pairs with the
+  deregistration and re-verification TTL below.
 - **Endpoint host allowlist.** The push endpoint is attacker-supplied. Validate
   it against the known push services at subscribe time (and **re-validate at
   drain**, so pre-existing rows can't bypass a tightened list), reject explicit

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -918,17 +918,18 @@ flowchart LR
     classDef bn fill:#c0392b,color:#fff
 ```
 
-| Stage | Hard limit | Elastic? | Push it → |
-| --- | --- | --- | --- |
-| 1. Admit | Layer-1 bucket | client-paced | bigger bucket = weaker flood protection |
-| 2. Heap buffer | 4 GiB | not the limit | oversizing accepts backlog whose TTL expires |
-| **3. Seal** | instructions/round, **shared with login** | **no** | bigger slice → login latency |
-| **4. Outcall** | 3000 in-flight, 500-deep queue | **no** | more in flight → starves auth outcalls |
-| 5. → relays | web2 | yes | relay per-app rate limits |
-| 6. Storage | 537 GB | O(users×origins) | [below](#storage-can-ii-store-the-data) |
+| Stage | What happens | Can it scale? |
+| --- | --- | --- |
+| 1. Admit the send | II accepts the chunk into its buffer | Yes — the client just paces; raising the limit only weakens flood protection |
+| 2. Hold in buffer | the chunk waits in memory to be sent | Yes — 4 GiB is far more than needed; memory is never the limit |
+| **3. Encrypt** | II encrypts each message for its device (elliptic-curve crypto, one per device) | **No — the bottleneck.** This is CPU-heavy, and II may only spend a slice of each execution round on it before sign-in slows |
+| **4. Send to the gateway** | II makes the outbound HTTPS calls | **No — the bottleneck.** Only ~3,000 calls can be in flight across the whole subnet, and II's own login calls draw from the same pool |
+| 5. Gateway → relays | the gateway fans out to FCM/Apple/Mozilla | Yes — ordinary web2, limited only by each relay's per-app rate |
+| 6. Store per-user rows | subscriptions and consent persist | Grows with users × apps, not with volume — [Storage below](#storage-can-ii-store-the-data) |
 
-**Stages 3–4 bind — II's execution round, shared with every login. The single
-global ceiling:**
+**Both bottlenecks are the same root cause: II shares its execution round and its
+outcall budget with every sign-in on the network, so push only ever gets a slice.**
+That slice is the ceiling:
 
 > **≈ 200 device-msg/s ≈ 720k/hour ≈ 17M/day, across every dApp combined.**
 > (Estimate — one RFC 8291 seal is dominated by a P-256 ECDH; measure it, every

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -307,32 +307,47 @@ come from a measured per-seal cost, not an estimate.
 
 </details>
 
-`PushDelivery` shapes the buffer: **topic** replaces an un-drained same-key entry
-(collapses rapid updates); **ttl** skips the outcall once expired; **urgency** is
-one drain-order input, never the sole key — it's sender-supplied and everyone sets
-`High`, so origin fairness (round-robin) outranks it, with age/TTL preventing
-starvation.
+The three delivery fields a sender sets also shape how the buffer behaves:
 
-**Durability needs `drain_epoch`.** The buffer is heap, lost on upgrade; the client
-re-sends unacknowledged chunks — but `admitted` means "buffered", returned before
-an upgrade that would drop it, so today a client can't tell. A `drain_epoch`
-counter (bumped in `post_upgrade`) + `push_chunk_status(chunk_id)` closes it,
-making delivery explicitly **at-least-once** (hence `msg_id` ships with it). The
-only new **stable** regions are the user-scoped, volume-independent sender/subscription/consent
-maps; `chunk_id` dedup is a bounded heap set.
+- **`topic`** collapses rapid updates. If a newer notification with the same topic
+  arrives before the previous one has been sent, it replaces it in the buffer — so a
+  value that changes several times a second doesn't pile up into several notifications.
+- **`ttl`** lets a notification expire. If it has waited longer than its time-to-live
+  when II reaches it, II drops it rather than sending — the relay would drop it anyway.
+- **`urgency`** influences send order but never decides it alone. Senders set it
+  themselves, and in practice everyone marks everything `High`, so if urgency ruled the
+  queue one sender could jump ahead of everyone else forever. Instead II takes turns
+  between apps, weighing urgency and age only within a single app's turn.
+
+**What happens if II is upgraded mid-send.** The buffer lives in working memory, which
+an upgrade wipes, so anything still in it is lost. The intent is that the sender's
+library re-sends whatever wasn't confirmed — but II replies `admitted` the moment a
+chunk enters the buffer, which is *before* an upgrade could drop it, so a sender that
+got `admitted` has no way to know its messages vanished and never re-sends. The fix is
+a counter (`drain_epoch`) that changes whenever II restarts: the library watches it and
+re-sends anything from before the change. That makes delivery **at-least-once** — it
+may arrive twice, but never zero times — which is exactly why `msg_id`
+duplicate-suppression is part of v1. The only permanent storage this adds is the
+per-user maps (who's subscribed, who consented, which senders are registered), and none
+of it grows with how many notifications are sent.
 
 ### Buffer size, and how many origins it serves at once
+
+First, the unit. A **device-message** is one sealed notification sent to one device.
+A user with two devices counts as two, because that's two actual sends — so a 1,000-
+recipient send is roughly 2,000 device-messages, and it's the device-message count,
+not the recipient count, that the pipeline is really moving.
 
 An entry is **per recipient** (~200 B + text; ~1 KB personalized vs one shared copy
 for a broadcast — a reason to keep `default_alert` the common path). **Memory isn't
 the constraint** (4 GiB heap; 100k recipients in flight ≈ 20–100 MB). **Drain rate
-is**, and it's a *shared pie* — ~200 device-msg/s total across all origins:
+is**, and it's shared across every app — about **200 device-messages a second, total**:
 
-| Work | Device-msgs | Drain time |
+| Send | Device-messages | Time to deliver all of them |
 | --- | --- | --- |
-| 1k-recipient chunk | ~2k | ~10 s |
-| 10k blast | ~20k | ~100 s |
-| 10 origins × 10k | ~200k | ~17 min |
+| One 1,000-recipient chunk | ~2,000 | ~10 s |
+| One 10k-user blast | ~20,000 | ~100 s |
+| 10 apps each blasting 10k at once | ~200,000 | ~17 min |
 
 So the buffer depth should be **drain rate × acceptable latency** (60 s → ~6 MB),
 not what the heap allows — a memory-sized buffer accepts hours of backlog and

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -20,8 +20,6 @@ and a security model. If you only read one section, read
 
 ## Context and scope
 
-
-
 A dApp on the IC that wants to reach a user who is not currently looking at it
 has no good option. Web Push is the browser-native answer, but doing it yourself
 means prompting for your own notification permission, running your own service
@@ -49,8 +47,6 @@ and the client-library internals are here to show the design is buildable, not t
 serve as reference material.
 
 ## Goals and non-goals
-
-
 
 ### Goals
 
@@ -90,8 +86,6 @@ serve as reference material.
 
 ## How it works, in plain terms
 
-
-
 The whole design, in six bullets. Everything after this adds detail to one of
 them.
 
@@ -128,8 +122,6 @@ them.
 Everything below is the same story with the exact mechanisms and edge cases.
 
 ## Architecture
-
-
 
 ```
 ┌─ dApp side ────────────────────────┐        ┌─ II ────────────────────────────────┐
@@ -179,8 +171,6 @@ bind everywhere regardless of who pays.
 
 ## Deployment assumptions
 
-
-
 Numbers in this doc depend on where II runs, so state the deployment before
 quoting a cost:
 
@@ -206,8 +196,6 @@ Rule of thumb for this doc: design to the **paying** case and treat the fee
 waiver as a property of one deployment, not a premise of the design.
 
 ## The user experience
-
-
 
 ### Turning notifications on (first time signing into a dApp)
 
@@ -282,8 +270,6 @@ dialog.
     II cannot offer a control for.
 
 ## dApp → II
-
-
 
 ### Sending to thousands of users: chunked send + two-layer flow control
 
@@ -492,8 +478,6 @@ the rate bucket — see
 
 ## II's state model: stateless for campaigns
 
-
-
 > _In short: II accepts a chunk, briefly holds it in memory (not durable
 > storage), seals and sends it, then forgets it. The durable list lives with
 > the dApp, so II's storage doesn't grow as more notifications are sent._
@@ -699,8 +683,6 @@ off-platform.
 
 ## Delivering to devices
 
-
-
 The relay API is one POST per subscription endpoint (RFC 8030) — there is no
 multi-recipient send, so reaching N devices is fundamentally N sends. The
 design routes those sends through a **trusted web2 gateway**. Doing them as
@@ -858,8 +840,6 @@ lives, which is what lets II stay stateless per send. See
 [II's state model](#iis-state-model-stateless-for-campaigns).
 
 ## On the device: rendering and tap-through
-
-
 
 - **Subscribe** (Settings, or the `/authorize` opt-in): request permission,
   `pushManager.subscribe` with II's VAPID public key, store
@@ -1126,7 +1106,6 @@ Caveats:
 
 ## Alternatives considered
 
-
 ### II hosts the pipeline, rather than each dApp running its own
 
 The alternative is the status quo: every dApp prompts for its own notification
@@ -1176,8 +1155,6 @@ needs its surrounding detail to make sense:
   [recommendation](#recommendation).
 
 ## Security model
-
-
 
 - **Origin pinning** — a sender can only target anchors that consented to
   _its_ origin; cross-dApp targeting is impossible even with leaked principals.
@@ -1357,8 +1334,6 @@ the sender.
 
 ## Privacy
 
-
-
 The doc's confidentiality story is about _content_. Metadata is a separate
 exposure and, for a notification hub, arguably the more sensitive one — `Hidden`
 protects the message text and does nothing for any of this.
@@ -1390,16 +1365,15 @@ operators each learn.
 
 ## Delivery semantics: what is actually guaranteed
 
-
-
 "Best-effort" is not a guarantee, and several features silently depend on which
 one holds. Stated explicitly:
 
-- **At-least-once, not at-most-once.** Retries, `drain_epoch` recovery, and
-  replicated outcalls all duplicate. `chunk_id` makes _chunk_ resends idempotent;
-  `msg_id` + device dedup is what makes duplicates invisible to the user.
-- **Unordered.** Nothing in the pipeline preserves order: replication, per-relay
-  queueing, and urgency's contribution to drain order all reorder freely.
+- **At-least-once, not at-most-once.** Retries and `drain_epoch` recovery both
+  duplicate; the non-replicated handoff removes the *n*×-fan-out source but not
+  these. `chunk_id` makes _chunk_ resends idempotent; `msg_id` + device dedup is
+  what makes duplicates invisible to the user.
+- **Unordered.** Nothing in the pipeline preserves order: per-relay queueing and
+  urgency's contribution to drain order both reorder freely.
 - **No delivery receipts.** The only per-target signal is `NoConsent`, returned
   at admission. `admitted` means "in II's buffer", never "on the device".
 
@@ -1412,14 +1386,15 @@ service worker drops out-of-order updates rather than applying them.
 
 ## Duplicate and replay suppression (`msg_id`)
 
-
-
 **Built.** Four independent mechanisms make duplicates the norm rather than the
 exception, and the fourth is the one that showed up first in practice:
 
 1. **Replicated outcalls** — 34 POSTs per push, no idempotency key in RFC 8030.
-2. **Timer duplicate execution** — `ic-cdk-timers` documents that under load
-   "timeouts may result in duplicate execution", and the drain is not idempotent.
+   The non-replicated handoff removes this one, which is why it is no longer the
+   headline reason.
+2. **Timer duplicate execution** — see
+   [II's state model](#iis-state-model-stateless-for-campaigns), where the drain's
+   claim-before-`await` step exists for exactly this.
 3. **Client retries and `drain_epoch` recovery** — by design, per the client
    library.
 4. **Accumulated subscription rows.** The fan-out sends one push per stored row,
@@ -1462,8 +1437,6 @@ Note `msg_id` is a **different thing** from the dApp-facing `notification_id`:
 shape, opposite behavior — keep them separate fields.
 
 ## End-to-end-encrypted apps
-
-
 
 Some apps (e.g. a chat using vetKeys) encrypt content so that only the
 recipient can read it — the app backend cannot. Our `Display` path is **not**
@@ -1539,14 +1512,11 @@ II-the-service, yet the real text still reaches the lock screen:
 - **Availability:** vetKeys is **live on mainnet** (since mid-2025), not a
   future capability — `vetkd_public_key` / `vetkd_derive_key` on curve
   `bls12_381_g2`, with IBE supported. So this design is buildable today.
-- **Cost — and this is the binding constraint.** `vetkd_derive_key` is
-  ~26.2 B cycles (**~$0.036 per call**) and chain-key fees are charged on
-  **every** deployment, system subnets included. So a derive _per notification
-  render_ would be **~$357 per 10k-notification blast** — roughly 400× the
-  entire outcall cost of the same blast, and the most expensive thing in the
-  whole design. Worse, the service worker calls in over **ingress, which carries
-  no cycles**, so **II pays** — making an uncached derive a user-triggerable
-  cycle drain.
+- **Cost — and this is the binding constraint.** Priced in
+  [what this costs, and who pays](#what-this-costs-and-who-pays): a derive per
+  notification render would be **~$357 per 10k blast**, roughly 400× the entire
+  outcall cost of the same blast and the most expensive thing in the design, and
+  II is the one billed.
 
   Therefore: derive **once per `(user, origin)`**, cache the key in the service
   worker, and rate-limit the derive endpoint per anchor. The per-`(user, origin)`
@@ -1600,8 +1570,6 @@ read) plus a vetKD derive-and-decrypt branch in the SW render path — no change
 to send, admission, or storage.
 
 ## Open items
-
-
 
 Must-fix before a real deployment:
 
@@ -1712,8 +1680,6 @@ Explicitly rejected:
 
 ## IC capabilities to re-evaluate
 
-
-
 Platform features that would change decisions in this doc. Worth re-checking
 before implementation, because two of them postdate the design:
 
@@ -1741,8 +1707,6 @@ before implementation, because two of them postdate the design:
 
 ## Push must never degrade authentication
 
-
-
 The invariant, stated separately because it is the one that makes this feature
 unshippable if violated: **no volume of push traffic may reduce the availability
 of sign-in.**
@@ -1767,8 +1731,6 @@ measurement, a cycle floor, and **authentication p99 latency as a monitored
 signal** with push throttling as the automatic response.
 
 ## Operating it: controls, alerts and rollout
-
-
 
 Metrics alone are not operability. Missing today:
 
@@ -1800,8 +1762,6 @@ origin, serve the callback allow-list, shape its deep links — is in
 
 ## Feasibility and scale
 
-
-
 | Metric                               | Gateway (chosen)                                                   | Direct (alternative)    |
 | ------------------------------------ | ------------------------------------------------------------------ | ----------------------- |
 | App → II for 10k users               | ~10 paced chunks (client-driven)                                   | ~10 paced chunks        |
@@ -1814,28 +1774,18 @@ origin, serve the callback allow-list, shape its deep links — is in
 | Cycles, 34-node **paying** subnet    | ~0.02 T (~$0.03) non-replicated; ~0.7 T (~$0.95) if replicated     | ~2.8 T (~$3.80)         |
 | Cycles, canonical II (system subnet) | fee-waived                                                         | fee-waived              |
 
-**Throughput has a global ceiling, and it is shared.** The buffer drains only as
-fast as its outcalls resolve, and outcalls take seconds. At a bounded slice per
-tick this puts II's sustained rate in the low hundreds of device-messages per
-second **across all dApps combined** — so a single 10k-user blast occupies the
-global budget for tens of seconds, during which every other origin sees
-`ready = false`. For a system positioned as the notification hub for every dApp
-on the network, this number is the most important capacity fact in the design and
-must be published — and derived from a real measurement, not from the estimates
-in this doc.
+**Throughput has a global ceiling and it is shared across all dApps** — the single
+most important capacity fact here, worked through in
+[buffer size, and how many origins it serves at once](#buffer-size-and-how-many-origins-it-serves-at-once).
+It must be published, and derived from a measurement rather than from this doc's
+estimates.
 
-App → II is feasible either way: the client library streams bounded chunks, II
-admits what it has capacity for, and its storage stays flat with volume. The
-**gateway is the chosen delivery path** because it turns ~13k in-flight outcalls
-into ~25, and that budget is shared with sign-in — a faster drain also recycles
-the small buffer sooner, raising admission throughput. Direct delivery remains
-fully on-chain and viable at low volume, but under replicated outcalls it also
-multiplies every POST by the subnet size and cannot observe `410`, so it is a
-degraded fallback rather than a transparent one.
+App → II is feasible either way. Direct delivery stays fully on-chain and viable at
+low volume, but under replicated outcalls it multiplies every POST by the subnet
+size and cannot observe `410`, so it is a degraded fallback rather than a
+transparent one.
 
 ## What this actually costs per user
-
-
 
 Storage is O(users × origins), not O(users) — worth being concrete, since the
 "flat with volume" claim is about _notification volume_ only:
@@ -1856,8 +1806,6 @@ bounds how large these maps can get before upgrades become a problem.
 
 ## Stable memory regions
 
-
-
 New regions must claim an unused `MemoryId`. Because nothing in the code forces
 this check, record allocations here and verify against `storage.rs` before
 adding one — a duplicate index silently interleaves two `StableBTreeMap`s into
@@ -1867,16 +1815,18 @@ the same virtual memory and corrupts both.
 | ----- | ------------------------------------- |
 | …     | (existing regions — see `storage.rs`) |
 | 31    | MCP registration                      |
-| 32    | push consent                          |
-| 33    | push principal index                  |
-| 34    | push subscriptions                    |
-| 35    | push sender registry (proposed)       |
+| 32    | SSO stable-id index                   |
+| 33    | push subscriptions                    |
+| 34    | push consent                          |
+| 35    | push principal index                  |
+| 36    | push sender registry                  |
 
-A test asserting all indices are distinct is cheap and worth having.
+This is not hypothetical. An earlier revision of the PoC claimed 32, which `main`
+had meanwhile taken for the SSO stable-id index; the two `StableBTreeMap`s
+interleaved and the canister trapped inside the B-tree on the first read. A test
+asserting all indices are distinct is cheap and worth having.
 
 ## Future exploration
-
-
 
 Deliberately out of v1, kept here so the door stays open:
 
@@ -1897,8 +1847,6 @@ Deliberately out of v1, kept here so the door stays open:
   signal would have to come from the app itself, and per-origin aggregates are
   the most II can offer without a per-user tracking surface.
 ## Status
-
-
 
 ### Built today (PoC on `feat/push-notifications-poc`)
 
@@ -1942,26 +1890,14 @@ it. The last four exist because building the PoC proved they had to.
 - No rate limiting or admission control of any kind — `notify_user` is unmetered.
 - No `.well-known/ii-push-senders` verification: senders are registered by an
   operator, so nothing yet proves a canister owns the origin it sends as.
-- No endpoint host allowlist, and no per-anchor caps on subscription or consent
-  rows.
 - `Display` content only — no `Hidden`, which is the variant the design
   recommends shipping first for E2E apps.
-- No `pushsubscriptionchange` handling, so a rotated endpoint still leaves a
-  stale row until a relay reports it gone.
 - Integration and E2E test coverage is thin (unit tests only).
 
-### Proposed (designed above, not yet built)
+Everything else the PoC lacks is a work item rather than a design gap, and is
+listed once in [Open items](#open-items) — endpoint allowlist, per-anchor caps,
+`drain_epoch`, drain isolation, `pushsubscriptionchange`, the reserved outcall
+budget for authentication. This section deliberately does not restate them.
 
-- Chunked `push_send` with two-layer flow control (II admission + client
-  pacing), a sender registry, a stateless-for-campaigns II (transient heap
-  buffer, storage O(users × origins)), a durable client library, and delivery
-  through a trusted web2 gateway (with direct per-device outcalls as the
-  documented alternative/fallback).
-- Promoted to v1 requirements by review, and still outstanding: a `drain_epoch`
-  acknowledgment signal, an endpoint host allowlist, per-anchor caps, drain
-  isolation and non-reentrancy, and a reserved outcall budget that protects
-  sign-in. (`msg_id` + device dedup was also promoted, and is now built.)
-- No cycles charging to senders in v1 — but a deployment that pays fees needs a
-  cycle budget with a circuit breaker regardless. Sender charging is parked as a
-  future exploration.
+The rest of this document is the proposal, so there is no separate list of it.
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1067,6 +1067,39 @@ Sending them to the app means it boots, discovers it has no usable session and
 bounces — a visible flash on the way to a redirect that was always going to
 happen. Linking direct makes the journey tap → Internet Identity → the page.
 
+**Two journeys, and they want opposite things.** With a reusable session it is tap
+→ the page, and anything shown in between is pure friction. Without one it is up to
+three page loads and two interactions:
+
+```
+tap → /sign-in         (load)
+    → II /authorize     (load, possibly a passkey prompt)
+    → Continue          (a tap)
+    → /sign-in          (load)
+    → the page
+```
+
+The temptation is to soften that with an interstitial offering the user something
+to do. Resist putting it on II, for two reasons. The notification's own action
+buttons already _are_ that surface — a body tap for the destination, a reserved
+button for turning it off (see
+[action buttons](#action-buttons-navigation-only-never-silent-work)) — so the
+controls exist without spending a screen. And **only the dApp knows whether it has
+a session**; II cannot see across the origin boundary, so II would have to show its
+screen unconditionally, taxing the fast path to serve the slow one.
+
+If a waiting screen is wanted, it belongs on the dApp's sign-in route, shown only
+when a redirect is actually needed: reusable session → forward, render nothing;
+otherwise → the app's own branded "Signing you in", which is a fine place for a
+_Turn off notifications_ link because there is genuinely a moment to fill.
+
+And note which lever matters. The ugly journey is not a design problem to style
+away, it is a **session-lifetime** one: an app whose session survives a tab close
+takes the instant path most of the time and reaches the slow one rarely. Of the
+three loads, only II's Continue tap is irreducible — issuing a delegation silently
+on navigation would let any site obtain one by redirecting the user to II, so that
+tap _is_ the authorization.
+
 Four things this cost to get right, all learned the hard way:
 
 - **The sign-in route must be its own URL.** The flow journals state per route,

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -871,14 +871,12 @@ PoC's job was to prove the shape, not to be complete).
 
 ## Push must never degrade authentication
 
-The unshippable-if-violated invariant: **no volume of push may reduce sign-in
-availability.** II authenticates every user, and push shares three resources with
-that job — the in-flight outcall budget (push holds a quota well below 3000 and
-**fails closed**, not competing; the 500-deep queue can otherwise fail II's *own*
-auth outcalls synchronously), instructions/round (small drain slice), and cycles
-(push spend must never approach the freezing threshold). Enforce with a push-only
-semaphore, a measured slice, a cycle floor, and **auth p99 as a monitored signal**
-that auto-throttles push.
+Non-negotiable: no amount of push traffic may slow or block sign-in. II authenticates
+every user, and push competes with that for three shared resources — outcall slots
+(stay well under the 3,000 cap and fail closed rather than compete), compute per round
+(small drain slices), and cycles (never spend toward the freezing threshold). Enforce a
+hard push quota that always yields to login, and auto-throttle push if sign-in latency
+climbs.
 
 ## Operating it: controls, alerts and rollout
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -342,20 +342,20 @@ not the recipient count, that the pipeline is really moving.
 An entry is **per recipient** (~200 B + text; ~1 KB personalized vs one shared copy
 for a broadcast — a reason to keep `default_alert` the common path). **Memory isn't
 the constraint** (4 GiB heap; 100k recipients in flight ≈ 20–100 MB). **Drain rate
-is**, and it's shared across every app — about **50 device-messages a second, total**
-(the central estimate derived below):
+is**, and it's shared across every app — about **29 device-messages a second, total**
+(the central figure derived below):
 
 | Send | Device-messages | Time to deliver all of them |
 | --- | --- | --- |
-| One 1,000-recipient chunk | ~2,000 | ~40 s |
-| One 10k-user blast | ~20,000 | ~6.5 min |
-| 10 apps each blasting 10k at once | ~200,000 | ~67 min |
+| One 1,000-recipient chunk | ~2,000 | ~70 s |
+| One 10k-user blast | ~20,000 | ~11.5 min |
+| 10 apps each blasting 10k at once | ~200,000 | ~1.9 h |
 
-So the buffer depth should be **drain rate × acceptable latency** (60 s → ~2 MB),
+So the buffer depth should be **drain rate × acceptable latency** (60 s → ~1 MB),
 not what the heap allows — a memory-sized buffer accepts hours of backlog and
 returns `admitted` for messages whose TTL expires first (a lying success). Express
 admission in *seconds of backlog*, fair-shared `total_rate / active_origins`. All of
-this scales off the ~50/s estimate — measure the per-seal cost first.
+this follows from the measured ~34.6 M-instruction seal (~29/s).
 
 ### The way to lift that ceiling is a separate canister
 
@@ -912,24 +912,29 @@ slice.** That slice is the ceiling, and it comes down to two numbers: the cost o
 seal, and the share of the canister we let push take —
 `device-msg/sec = (instructions/sec allotted to push) ÷ (instructions per seal)`:
 
-- **Cost of a seal** — one RFC 8291 message is dominated by a single P-256 variable-base
-  scalar multiplication (the ECDH against the device's key); HKDF and AES-GCM are noise
-  beside it. In Wasm that is an estimated **~20 M instructions**, range ~10–30 M. This is
-  the one number to measure first — every figure below scales off it.
+- **Cost of a seal** — **measured at ~34.6 M instructions** (canbench, against the exact
+  production `encrypt` and its pinned crate versions, built at the canister's release
+  profile). Two P-256 scalar multiplications dominate — the ephemeral keygen and the
+  ECDH against the device's key — with HKDF and AES-GCM negligible beside them. Every
+  figure below scales off this.
 - **Share of execution** — the drain is held to **~20 % of the canister**, a deliberate
   cap so sign-in keeps ~80 % of every round even mid-blast. On a canister sustaining a
   few billion instructions/sec that hands push **~1 B instructions/sec**.
 
-Plugging those in (M = million instructions; the central column is the planning number):
+With the seal cost pinned by measurement, the remaining lever is push's execution
+share, and throughput scales linearly with it — raising the share buys a proportional
+lift, straight into sign-in's headroom:
 
-| Seal cost | 10 M (optimistic) | **20 M (central)** | 30 M (conservative) |
-| --- | --- | --- | --- |
-| device-msg/sec | ~100 | **~50** | ~33 |
-| per hour | ~360k | **~180k** | ~120k |
-| per day | ~8.6M msg | **~4.3M msg** | ~2.9M msg |
+```mermaid
+xychart-beta
+    title "Hourly throughput vs push's execution share (seal = 34.6M ins)"
+    x-axis "Execution share of the canister" ["10%", "20%", "30%", "40%"]
+    y-axis "Device-messages / hour (thousands)" 0 --> 220
+    bar [52, 104, 156, 208]
+```
 
-> **≈ 50 device-msg/s ≈ 180k/hour ≈ 4.3M/day, across every dApp combined** — at a
-> deliberate 20 % execution share and ~20 M-instruction seal, both to confirm by measurement.
+> **≈ 29 device-msg/s ≈ 104k/hour ≈ 2.5M/day, across every dApp combined** — at a
+> deliberate 20 % execution share and the measured ~34.6 M-instruction seal.
 
 - **Users aren't the limit** — a large base costs storage, not throughput.
 - **Simultaneous blasts are** — N origins serialise through one drain;
@@ -938,15 +943,15 @@ Plugging those in (M = million instructions; the central column is the planning 
   is the one move that lifts 3–4.
 
 Delivery time is linear in blast size and shared across dApps, crossing the one-hour
-budget at ~180k messages:
+budget at ~105k messages:
 
 ```mermaid
 xychart-beta
-    title "Minutes to drain a blast (shared ~50 msg/s)"
-    x-axis "Notifications in the hour" [10k, 50k, 100k, 180k, 300k]
-    y-axis "Minutes to deliver" 0 --> 120
-    bar [3.3, 16.7, 33.3, 60, 100]
-    line [60, 60, 60, 60, 60]
+    title "Minutes to drain a blast (shared ~29 msg/s)"
+    x-axis "Notifications in the hour" [10k, 50k, 105k, 200k]
+    y-axis "Minutes to deliver" 0 --> 130
+    bar [5.7, 28.7, 60, 114.9]
+    line [60, 60, 60, 60]
 ```
 
 ### Storage: can II store the data

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -218,62 +218,34 @@ would be the real fix — out of scope here.
 
 ## dApp → II
 
-### Sending to thousands of users: chunked send + two-layer flow control
+### Sending to thousands: chunked send + two-layer flow control
 
-> _In short: the dApp streams the audience to II in small batches ("chunks");
-> II refuses more than it can handle, and the dApp slows down when told to.
-> Two separate safeguards — one on each side — keep this safe and smooth._
+A campaign is delivered as **bounded chunks** (≤~1000 targets, under the message
+size ceiling) — II must never hold a whole campaign, that's the storage that scales
+with volume. Two control layers, not to be confused:
 
-A campaign of any size is delivered as a series of **bounded chunks** — a chunk
-is just a bite-sized batch of targets (≤ ~1000 targets, and under the message
-size ceiling). This is deliberate: II must never be asked to hold a whole
-campaign, because that is the storage that scales with volume. Two independent
-control layers make this safe and smooth — and they must not be confused:
+- **Layer 1 — II admission (mandatory, adversarial).** Hard `recipients.len()`
+  ceiling + per-origin token bucket + global buffer cap. Over capacity, `push_send`
+  rejects (`ready=false`, `retry_after_ms`). **II never holds more than its bounded
+  buffer, whatever the client does** — this is the anti-spam property.
+- **Layer 2 — client pacing (cooperative, efficiency only).** The library reads the
+  same signal and paces; skipping it just delivers slower. Never an anti-spam layer.
 
-- **Layer 1 — II admission control (mandatory, adversarial).** This is the
-  security boundary and assumes a hostile client. II enforces a hard
-  `recipients.len()` ceiling (see below), a per-origin token bucket
-  (notifications-per-window) plus a global cap on its transient buffer. Over
-  capacity, `push_send` **rejects the chunk** (`ready = false` +
-  `retry_after_ms`). The guarantee: **II never holds more than its bounded
-  buffer, no matter what the client does**. This is the anti-spam property, and
-  it lives entirely on II.
+The rule: **II protects itself; the client optimizes itself.**
 
-  Two honest caveats about how cheap that reject is:
-  - The **policy decision** is O(1), but it happens _after_ the message has been
-    admitted into a block and its payload Candid-decoded. A rejected 2 MB chunk
-    still costs a consensus round and a 2 MB decode, so absorbing a flood is
-    cheap _per decision_, not free. Cap the accepted message size well below
-    2 MB so the pre-decision cost is bounded too.
-  - **`inspect_message` cannot help here.** It is not invoked for
-    inter-canister calls, and `push_send` is called by dApp _canisters_. It
-    only ever filters ingress. Any claim that push is rate-limited via
-    `canister_inspect_message` is wrong.
+<details><summary>Two caveats on Layer 1</summary>
 
-  **The ≤1000-recipient bound is enforced server-side**, before any
-  per-recipient work. It is not a client obligation: 2 MB of `PushRecipient`
-  with empty overrides is ~65,000 recipients, and doing per-recipient index and
-  consent lookups for that many in one message would exceed the instruction
-  limit and trap. The client-side chunking in the library is an _optimization
-  over_ this hard limit, never a substitute for it.
+- The reject is O(1) but happens *after* the 2 MB chunk is decoded — cap accepted
+  size well below 2 MB so the pre-decision cost is bounded.
+- `inspect_message` **can't** help — it isn't invoked for inter-canister calls, and
+  `push_send` is called by canisters. The ≤1000 bound is enforced server-side
+  (2 MB of recipients ≈ 65k, whose per-recipient lookups would trap).
 
-- **Layer 2 — client pacing (cooperative, efficiency only).** The client
-  library reads the same `ready` / `retry_after_ms` signal and paces so it
-  doesn't waste calls getting rejected: send the next chunk when II is ready,
-  back off when it isn't, retry, track status. This is a good-citizen layer,
-  **not** a security layer. If a client skips it, nothing breaks for II
-  (Layer 1 holds); the client just delivers slower.
+</details>
 
-The rule to remember: **II protects itself; the client optimizes itself.**
-Never rely on client pacing to prevent spam — that is always Layer 1's job.
-
-Both "same text for everyone" and "different text per user" go through the
-**one** `push_send` call: it takes a shared `default_alert` plus a list of
-recipients, each able to override the default with its own alert. Broadcast =
-set the default and leave every override empty (the content isn't repeated, so
-~1000 recipients fit well under 2 MB); personalized = give each recipient its
-own alert, rendered client-side by the library's templating (II never holds a
-template); a mix of the two works too.
+Broadcast and personalized share one `push_send`: a `default_alert` plus recipients
+that may override it. Broadcast = default + empty overrides; personalized = per-
+recipient alert (templated client-side, II holds no template).
 
 ### The Candid interface
 
@@ -367,259 +339,104 @@ throughput on a _small_ buffer.
 
 ### What this costs, and who pays
 
-Costs split into what is _always_ scarce (outcall slots, storage, instructions)
-and cycles, which are waived on canonical II but charged on any self-hosted or
-forked deployment.
+**Always scarce** (every deployment): outcall slots (3000 subnet-wide, shared with
+login — why the gateway exists), storage (kept O(users × origins), never O(volume)),
+instructions (bounded-slice drain).
 
-**Always scarce, on every deployment:**
+**Cycles** are waived on canonical II, charged elsewhere. The per-byte fee carries
+the `·n` replication factor, so non-replicated is where the money is — a 10k-user
+blast on a paying subnet:
 
-- **In-flight outcall slots** — 3000 subnet-wide, shared with II's own login
-  outcalls. The reason the gateway exists.
-- **Stable storage** — kept **O(users × origins)**: subscriptions are per
-  `(anchor, endpoint)`, consent and the principal index per `(anchor, origin)`.
-  Never O(notification volume), because campaign state lives in the client
-  library. That is the invariant the "stateless II" shape buys; see the
-  [bytes-per-user table](#storage-can-ii-store-the-data).
-- **Instructions** — sealing is not free at chunk scale; the drain must work in
-  bounded slices.
+| Path | Outcalls | Cycles | ≈ USD |
+| --- | --- | --- | --- |
+| Direct, replicated | ~13k | ~2.8 T | ~$3.80 |
+| Gateway, replicated | ~25 | ~0.7 T | ~$0.95 |
+| **Gateway, non-replicated** | ~25 | ~0.02 T | ~$0.03 |
 
-**Cycles — real, but deployment-dependent.** On canonical II (system subnet)
-outcall, execution and storage fees are waived. On any application subnet
-(self-hosted, fork, test net) they are fully charged, and the formula is:
+Batching cuts *count* ~500× but cycles only ~4× (per-byte fee is the same sealed
+bytes); dropping replication cuts the payload by ~34×. Set `max_response_bytes`
+tight — it's charged whether used or not. The gateway's real justification stays
+**outcall slots**, which no pricing change touches.
 
-```
-replicated     = (3_000_000 + 60_000·n)·n              ← per-call base
-               + (400·request_bytes + 800·max_response_bytes)·n
+**vetKD** (for [E2E](#end-to-end-encrypted-apps)) is charged everywhere: ~26.2 B
+cycles/call — fine once per user, ruinous per message (~$357/10k blast). So derive
+**once per `(user, origin)`**, cache in the SW, rate-limit per anchor; the bill
+lands on **II** (ingress carries no cycles), so an uncached derive is a
+user-triggerable drain.
 
-non-replicated =  3_000_000 + 60_000·n                 ← base, one node only
-               +  400·request_bytes + 800·max_response_bytes
-```
-
-The whole `·n` disappears from the per-byte terms, which is where the money is.
-At n = 34 replicated: base 171.4 M, 13,600 per request byte, 27,200 per reserved
-response byte. Non-replicated: base 5.04 M, 400 and 800. Worked example, a
-10k-user broadcast (~13k device-messages) on a 34-node **application** subnet:
-
-| Path                                       | Outcalls | Cycles  | ≈ USD  |
-| ------------------------------------------ | -------- | ------- | ------ |
-| Direct, one per device, replicated         | ~13,000  | ~2.8 T  | ~$3.80 |
-| Gateway, ~2 MB batches, replicated         | ~25      | ~0.7 T  | ~$0.95 |
-| **Gateway, ~2 MB batches, non-replicated** | ~25      | ~0.02 T | ~$0.03 |
-
-Three things to read off that table. Batching alone cuts outcall **count** ~500×
-but **cycles only ~4×**, because the per-byte fee is charged on the same sealed
-bytes either way — batching amortizes the base fee, not the payload. Dropping
-replication is what actually cuts the payload cost, by the full factor of n
-(~34×). And `max_response_bytes` is charged whether used or not, so always set it
-tight.
-
-Note what this does to the gateway's rationale. Once the batch handoff is
-non-replicated the cycle saving is ~44× against direct-replicated, but the honest
-justification is still **in-flight outcall slots and drain latency** — 13k
-concurrent outcalls would starve login on a subnet capped at 3,000 in flight,
-and that is a scheduling limit no pricing change touches.
-
-One cost belongs to a variant not described yet, and it is large enough to
-mention here rather than let it surprise anyone later. Everything above assumes
-II can read a notification's text, because it does the sealing. Some apps cannot
-accept that — a messenger should not hand its message bodies to II — so
-[End-to-end-encrypted apps](#end-to-end-encrypted-apps) sets out a variant where
-the content is encrypted such that only the user's own device can read it, and II
-forwards bytes it cannot see. Doing that needs a per-user key, and the IC's way
-to derive one is **vetKD**.
-
-**vetKD is charged on every deployment**, system subnets included:
-`vetkd_derive_key` is ~26.2 B cycles (~$0.036) per call. That is fine once per
-user and ruinous per message: a derive _per notification render_ would be ~$357
-per 10k blast. So that design must derive **once per `(user, origin)`** and cache
-the result in the service worker, with a per-anchor rate limit. And the bill lands
-on II, not the app — the service worker calls in over ingress, which carries no
-cycles — so an uncached derive is a **user-triggerable drain**, not merely an
-inefficiency.
-
-On charging senders: **no cycles charging in v1.** Cycles can only be attached
-by canister senders, and per-notification fees bring real complexity
-(accept/refund, fee tuning). Prepaid-balance or attached-cycle pricing is parked
-as a future exploration. But note what does _not_ follow from deferring
-charging: a rate limit multiplied by time is unbounded spend, so a deployment
-that pays fees needs a **cycle budget with a circuit breaker** independent of
-the rate bucket — see
-[Operating it](#operating-it-controls-alerts-and-rollout).
+**No sender charging in v1** — parked (accept/refund complexity). But a rate limit
+× time is unbounded spend, so a paying deployment needs a **cycle budget +
+circuit breaker** independent of the rate bucket.
 
 ## II's state model: stateless for campaigns
 
-> _In short: II accepts a chunk, briefly holds it in memory (not durable
-> storage), seals and sends it, then forgets it. The durable list lives with
-> the dApp, so II's storage doesn't grow as more notifications are sent._
+II holds **no campaign queue in stable memory** — it accepts a chunk into a
+transient heap buffer, seals and sends it, then forgets it. The durable list lives
+with the dApp, so II's storage doesn't grow with notification volume.
 
-II holds **no campaign queue in stable (durable) memory**. `push_send` is cheap:
-check the recipient-count ceiling, authenticate the sender, dedup `chunk_id`, run
-admission control (Layer 1), per-target resolve + consent-check, then admit the
-survivors into a small **transient heap buffer** and return
-`{admitted, rejected, ready, retry_after_ms, drain_epoch}`.
+`push_send` is a cheap, no-await admission call: count check, authenticate sender,
+dedup `chunk_id`, [Layer 1](#admission-control-layer-1-stopping-one-dapp-from-flooding-ii),
+per-target consent-check, admit survivors, return
+`{admitted, rejected, ready, retry_after_ms, drain_epoch}`. It can't send inline —
+a whole chunk is ~1000 seals + outcalls against the 500-deep output queue and the
+instruction budget.
 
-It does not wait for delivery, and cannot: sending a whole chunk inline would
-need ~1000 × devices seals and outcalls in one message. The binding limits there
-are the **500-deep output queue** to the management canister (which caps
-concurrent outcalls per message) and the subnet's 3000 in-flight cap — with
-instruction cost making a whole chunk a large fraction of an execution round on
-a canister that also serves every login. Hence the bounded-slice drain below.
+A ~1s timer drains the buffer in **bounded slices** (target 100–300 device-msgs,
+measured), each slice:
 
-A timer (`ic_cdk_timers`, ~1s) drains the heap buffer:
+- **claims** its entries before the first `await` (non-reentrant), or two ticks
+  double-send — `ic-cdk-timers` documents duplicate execution under load;
+- resolves each anchor's devices **now** via a **prefix range scan** on
+  `(anchor, endpoint_hash)` (never a full-map scan — that's O(all push users) and
+  traps at scale), re-checks consent, forces sender-origin attribution;
+- seals per device (RFC 8291) + attaches the cached VAPID JWT, assigns `msg_id`;
+- **isolates per-entry failure** — a trap rolls back the tick and the poison row
+  retries forever; needs a failure boundary, attempt counter, and a watchdog.
 
-- **Claims** the slice it is about to work on before the first `await`, marking
-  those entries in-flight. Every `await` ends a message execution and lets the
-  next tick interleave, so without a claim step two ticks send the same entries
-  twice. A `draining` flag makes ticks non-reentrant. This is not optional:
-  `ic-cdk-timers` documents that under load "timeouts may result in duplicate
-  execution", and the drain is not idempotent.
-- Works a **bounded slice** (target 100–300 device-messages, tuned from a real
-  measurement), not a whole chunk.
+<details><summary>Sealing cost, and the two ceilings</summary>
 
-  What costs instructions is **RFC 8291 encryption, and within it the elliptic
-  curve**: per device-message II generates an ephemeral P-256 keypair and does an
-  **ECDH** against that device's `p256dh`, so two scalar multiplications — one
-  fixed-base for the ephemeral public key, one **variable-base** for the shared
-  secret, which is the expensive one because the device's key differs every time
-  and nothing precomputes. HKDF-SHA256 and AES-128-GCM beside it are noise. The
-  RFC 8292 VAPID **signature** is not part of this budget at all: it is per
-  audience and cached up to 12h, so it amortises to nothing however many messages
-  are sent. Nor can the ECDH be amortised — RFC 8291 has no encrypt-once mode, so
-  the cost is strictly per device.
+The cost is RFC 8291's **ECDH** — a variable-base P-256 scalar mult per
+device-message (HKDF/AES are noise; the VAPID signature is cached, per audience,
+free). It can't be amortised: no encrypt-once mode. Two ceilings: the slice is a
+*small fraction* of the round because this canister serves every login (bigger →
+login latency); the per-message instruction limit is a *hard wall* above it, and
+crossing it traps → rolls back → retries the same slice forever. So the slice must
+come from a measured per-seal cost, not an estimate.
 
-  Two different ceilings follow, and only one of them is the platform's. The slice
-  is kept to a small fraction of a message's instruction budget because this
-  canister serves every login on the network, and spending most of a round sealing
-  notifications surfaces as login latency — see
-  [Push must never degrade authentication](#push-must-never-degrade-authentication).
-  The per-message instruction limit sits well above that as a hard wall, and
-  crossing it is worse than slow: the tick traps, the trap rolls back the tick's
-  heap mutations, and the same slice is retried and traps again — a permanently
-  wedged drain rather than a degraded one. That asymmetry is why the slice must be
-  set from a measured per-seal cost rather than an estimate.
-- One `raw_rand` per tick; ChaCha20 derives per-message ephemeral seeds. (Note
-  the per-tick seed means the subnet's random tape, if observed, reveals that
-  tick's ephemeral scalars — see the [security model](#security-model).)
-- Resolves each anchor's devices **now** (they change between admit and drain)
-  and re-checks consent (may have been revoked since). Device lookup must be a
-  **prefix range scan** over `(anchor, endpoint_hash)`, never a filtered scan of
-  the whole map — the latter is O(all users with push enabled) per notification
-  and traps once the map is large.
-- Forces attribution to the sender origin (unspoofable).
-- RFC 8291 encrypts per device; attaches the per-audience VAPID JWT
-  (cached, ≤ 12h).
-- Assigns a `msg_id` per admitted message, stable across retries, for
-  device-side replay/duplicate suppression. Not optional — see
-  [Duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
-- Drains to the gateway in a few batched outcalls (see below). A fast drain is
-  what lets the buffer stay small while admitting at high throughput.
-- **Isolates per-entry failure.** A trap inside the drain rolls back the tick's
-  heap mutations, leaving the buffer unchanged — so the next tick reprocesses
-  the same poison entry and traps again, forever, with `ready = false` returned
-  to _every_ origin. One malformed row would take the whole feature down until
-  an upgrade (which then silently discards the buffer). Each entry needs its own
-  failure boundary, an attempt counter with drop-and-count, and a watchdog that
-  clears the buffer if depth stays pinned across N ticks.
+</details>
 
-`PushDelivery` integrates into the buffer, not just the headers:
+`PushDelivery` shapes the buffer: **topic** replaces an un-drained same-key entry
+(collapses rapid updates); **ttl** skips the outcall once expired; **urgency** is
+one drain-order input, never the sole key — it's sender-supplied and everyone sets
+`High`, so origin fairness (round-robin) outranks it, with age/TTL preventing
+starvation.
 
-- **topic** — key the buffer entry by `(origin_hash, anchor, topic)`; an
-  un-drained entry with the same key is **replaced**, collapsing rapid updates
-  (savings scale with buffer depth). The relay collapses in-flight duplicates
-  too.
-- **ttl_seconds** — at drain, if `admitted_at + ttl` has passed, **skip** the
-  outcall (the relay would drop it anyway).
-- **urgency** — sets the RFC 8030 header, and contributes to drain order as
-  **one input among several**, never as the sole key. Ordering is: round-robin
-  across origins first, then within an origin's slice by urgency combined with
-  age and remaining TTL. Urgency is sender-supplied and unvalidated — every
-  sender will set `High` (both examples in this doc do) — so if it ordered the
-  whole buffer, one sender pinning `High` would starve every other origin's
-  `Normal` traffic indefinitely. Origin fairness outranks it; age and TTL stop
-  anything from sitting at the tail forever.
-
-**Durability lives on the client — but the client needs a signal to act on.**
-The in-flight buffer is heap, not stable memory, so it costs no persistent
-storage and is lost on upgrade. The intent is that the client library re-sends
-anything unacknowledged. **That requires an acknowledgment that today's
-interface does not provide:** `admitted` means "accepted into the buffer", it is
-returned _before_ any upgrade that would lose the buffer, and delivery itself
-carries no receipts. A client that received `admitted: 1000` therefore has no
-way to learn the messages were dropped and, by its own retry rule, never
-re-sends — so an upgrade mid-campaign silently loses every in-flight chunk while
-the campaign store marks them sent.
-
-Close it with a **`drain_epoch`** in `PushResult` (a counter bumped in
-`post_upgrade`) plus a `push_chunk_status(chunk_id)` query: a client that sees
-the epoch move re-sends anything it hasn't confirmed drained. This makes
-delivery explicitly **at-least-once**, which is why `msg_id` dedup ships with
-it rather than after it — see
-[Delivery semantics](#delivery-semantics-what-is-actually-guaranteed).
-
-Consequently the only new **stable** regions are user-scoped and
-volume-independent: the sender registry (`OriginSha256 → sender`) alongside the
-subscription and consent maps. `chunk_id` dedup is a heap set — **bounded by
-count with LRU eviction**, and `chunk_id` fixed at 16 bytes, so a sender cannot
-grow it with attacker-chosen keys until the heap is exhausted (heap exhaustion
-traps the canister, which takes authentication down with it). Timers don't
-survive upgrades — re-arm in `post_upgrade` and `init`.
+**Durability needs `drain_epoch`.** The buffer is heap, lost on upgrade; the client
+re-sends unacknowledged chunks — but `admitted` means "buffered", returned before
+an upgrade that would drop it, so today a client can't tell. A `drain_epoch`
+counter (bumped in `post_upgrade`) + `push_chunk_status(chunk_id)` closes it,
+making delivery explicitly **at-least-once** (hence `msg_id` ships with it). The
+only new **stable** regions are the user-scoped, volume-independent sender/subscription/consent
+maps; `chunk_id` dedup is a bounded heap set.
 
 ### Buffer size, and how many origins it serves at once
 
-**Sizing one entry.** A buffer entry is per _recipient_, not per device — devices
-are resolved at drain, not at admit. Recipient-scoped fields are small: anchor
-(8 B), interned origin (4 B), `topic` (≤ 32 B), `msg_id` (16 B), `admitted_at`
-(8 B), `ttl` (4 B), urgency and attempt counter (2 B). Call it **~200 B** with
-Rust `String`/collection overhead.
+An entry is **per recipient** (~200 B + text; ~1 KB personalized vs one shared copy
+for a broadcast — a reason to keep `default_alert` the common path). **Memory isn't
+the constraint** (4 GiB heap; 100k recipients in flight ≈ 20–100 MB). **Drain rate
+is**, and it's a *shared pie* — ~200 device-msg/s total across all origins:
 
-The text is the variable. `PushTarget.alert` is an _override_ that falls back to
-`default_alert`, so a broadcast stores one copy of title + body + url for the
-whole chunk and entries point at it. Fully personalized sends cannot: `title`
-(≤ 64 B) + `body` (≤ 256 B) + `url` (~256 B) plus string headers lands each entry
-near **~1 KB**. That five-fold difference is a reason to keep `default_alert` the
-common path, not merely a convenience.
+| Work | Device-msgs | Drain time |
+| --- | --- | --- |
+| 1k-recipient chunk | ~2k | ~10 s |
+| 10k blast | ~20k | ~100 s |
+| 10 origins × 10k | ~200k | ~17 min |
 
-**Memory is not the constraint — by three orders of magnitude.** The heap ceiling
-is 4 GiB. A full 1,000-recipient chunk is ~200 KB broadcast, ~1 MB personalized.
-Even a hundred concurrent full chunks — 100,000 recipients in flight — is ~20 MB
-broadcast or ~100 MB personalized. Nothing about that is close to a limit.
-
-**Drain rate is the constraint.** At the drain's own target of 100–300
-device-messages per ~1s tick, take 200/s. With ~2 devices per user that is ~100
-recipients/s, and everything downstream follows from it:
-
-| Work                            | Device-messages | Time to drain at 200/s |
-| ------------------------------- | --------------- | ---------------------- |
-| One 1,000-recipient chunk       | ~2,000          | ~10 s                  |
-| One 10k-user blast (10 chunks)  | ~20,000         | ~100 s                 |
-| 5 origins blasting 10k at once  | ~100,000        | ~8 min                 |
-| 10 origins blasting 10k at once | ~200,000        | ~17 min                |
-| 50 origins blasting 10k at once | ~1,000,000      | ~83 min                |
-
-The rate is a fixed pie shared by every origin: II drains 200/s in total, not per
-sender. So concurrency does not degrade gracefully into slower delivery for the
-noisy origin — it degrades into slower delivery for _everyone_, which is why
-Layer 1 has to divide the rate rather than merely cap the buffer.
-
-**Which fixes the buffer size.** Depth should be the drain rate multiplied by the
-worst in-buffer latency worth accepting, not whatever the heap allows. Capping
-queue latency at 60 s gives 200/s × 60 = 12,000 device-messages ≈ 6,000
-recipients ≈ **~6 MB personalized, ~1.2 MB broadcast**. A buffer sized to memory
-instead would happily accept _hours_ of backlog and report `admitted` for
-messages whose `ttl` will expire before they are sent — the failure mode is a
-lying success, not an out-of-memory.
-
-So express the admission ceiling in **seconds of drain backlog**, with per-origin
-fair share as `total_rate / active_origins`; and set `ttl_seconds` defaults with
-the queue depth in mind, since a 60 s queue against the ~4 h default TTL is
-comfortable while a 1 h queue is not.
-
-**Everything above scales linearly with one unmeasured number.** The 200/s slice
-is this design's own target, not an observation. What has to be measured before
-these figures mean anything: instructions for one RFC 8291 seal (the P-256 ECDH
-dominates), how large a slice fits in a safe fraction of an execution round on a
-canister that also serves every login, and whether the ~1s timer holds under
-load. Measure those three and every row in that table moves together.
+So the buffer depth should be **drain rate × acceptable latency** (60 s → ~6 MB),
+not what the heap allows — a memory-sized buffer accepts hours of backlog and
+returns `admitted` for messages whose TTL expires first (a lying success). Express
+admission in *seconds of backlog*, fair-shared `total_rate / active_origins`. All of
+this scales off the unmeasured ~200/s — measure the per-seal cost first.
 
 ### The way to lift that ceiling is a separate canister
 
@@ -844,168 +661,55 @@ origin from the anchor's consent list and fails closed if it cannot.
 
 ### Landing the user already signed in
 
-Yes — and it needs **no II-side changes**, because it composes out of the
-ICRC-167 URL transport (top-level redirect sign-in) that II already supports.
+Yes, with **no II-side changes** — it composes out of the ICRC-167 redirect
+transport II already supports.
 
-**The constraint that shapes it: II cannot push a signed-in session.** A
-delegation is bound to a session public key the _dApp's client_ generates, and
-II never sees the private half, so it cannot mint one unprompted. In the URL
-transport the request always arrives _at_ II (`message` + `callback` + `state`
-in the hash) and `channel.origin` is the callback's origin — the RP initiates,
-II only answers. So the notification's job is not to carry a session; it is to
-land the user on a page that _starts_ sign-in immediately.
+**II cannot push a signed-in session.** A delegation targets a session key the
+_dApp_ generates and II never sees, so the flow must *begin* on the dApp's origin —
+a notification cannot bounce through `id.ai` and have II sign the user in from
+there. This is the same property that stops II impersonating a user, so it's a
+guarantee, not a limitation.
 
-Spelled out, because the opposite is the natural assumption: **a notification
-cannot take the user to `id.ai` and have II sign them into the app from there.**
-II would have no session key to delegate to, and one it generated itself would
-have its private half in `id.ai`'s storage, which the dApp cannot read across
-origins — the delegation would be useless. The flow has to begin where that
-private key lives, which is the dApp's own origin. This is the same property that
-stops II impersonating a user to a dApp, so it is a guarantee rather than a
-limitation, and no amount of protocol work removes it.
-
-The standard guarded-route pattern does exactly that:
-
-1. The notification deep-links to a restricted page,
-   `https://app.com/thread/42`.
-2. That page checks `authClient.isAuthenticated()` on load; if not signed in it
-   redirects to `/sign-in?next=/thread/42`.
-3. `/sign-in`, **on page load** (not behind a click — the redirect unloads the
-   page), memoizes `next` and calls `signIn({ transport: "redirect" })`, which
-   top-level-redirects to II's `/authorize`.
-4. The user already has an II session — they just tapped a notification from
-   `id.ai` — and already consented to this origin at push opt-in, so this is the
-   Continue screen: one tap.
-5. II navigates back to the declared callback with the response in its fragment;
-   the client replays its journaled state, completes the delegation, reads the
-   memoized `next`, and forwards to `/thread/42` — signed in.
-
-What the dApp has to provide:
-
-- `transport: "redirect"` from a recent `@icp-sdk/auth`.
-- **`/.well-known/ii-auth-callbacks`** declaring the exact callback URL. II's
-  validation fails closed: redirects are not followed, no ambient credentials,
-  never cached, must be `application/json` under a size cap, **exact** string
-  match, same-origin, and no fragment — plus CORS headers so II can read it. So
-  a push-enabled dApp ends up hosting **two** well-known files, this one and
-  `ii-push-senders`.
-- A callback that is **protocol + host + path only** — the transport rejects a
-  callback carrying a query, fragment or credentials. That is why the
-  destination rides in memoized flow state rather than as `?next=` on the
-  callback itself.
-
-One consistency requirement: push consent keys on the `effectiveOrigin` (see
-[Which origin is authoritative](#which-origin-is-authoritative)), and this
-sign-in derives the identity from the callback origin or its `derivationOrigin`.
-They must agree, or the principal that was notified is not the principal the
-user comes back with.
-
-**Notifications should link straight at the sign-in route**, not at the app.
-Sending them to the app means it boots, discovers it has no usable session and
-bounces — a visible flash on the way to a redirect that was always going to
-happen. Linking direct makes the journey tap → Internet Identity → the page.
-
-**Two journeys, and they want opposite things.** With a reusable session it is tap
-→ the page, and anything shown in between is pure friction. Without one it is up to
-three page loads and two interactions:
-
-```
-tap → /sign-in         (load)
-    → II /authorize     (load, possibly a passkey prompt)
-    → Continue          (a tap)
-    → /sign-in          (load)
-    → the page
+```mermaid
+flowchart LR
+    N[Tap notification] --> S["/sign-in?next=…<br/>(dApp origin)"]
+    S -->|session reusable| P[Destination page — signed in]
+    S -->|not| A[II /authorize → Continue tap]
+    A --> S2["/sign-in return leg"] --> P
 ```
 
-The temptation is to soften that with an interstitial offering the user something
-to do. Resist putting it on II, for two reasons. The notification's own action
-buttons already _are_ that surface — a body tap for the destination, a reserved
-button for turning it off (see
-[action buttons](#action-buttons-navigation-only-never-silent-work)) — so the
-controls exist without spending a screen. And **only the dApp knows whether it has
-a session**; II cannot see across the origin boundary, so II would have to show its
-screen unconditionally, taxing the fast path to serve the slow one.
+Notifications link straight at the sign-in route (not the app, which would boot,
+find no session and bounce — a visible flash). The dApp provides `transport:
+"redirect"`, a `/.well-known/ii-auth-callbacks` file declaring the exact callback
+(protocol+host+path only — the destination rides in memoized flow state), and a
+callback origin whose identity derivation matches the push-consent `effectiveOrigin`.
 
-If a waiting screen is wanted, it belongs on the dApp's sign-in route, shown only
-when a redirect is actually needed: reusable session → forward, render nothing;
-otherwise → the app's own branded "Signing you in", which is a fine place for a
-_Turn off notifications_ link because there is genuinely a moment to fill.
+**This should be a library, not per-dApp code.** Building it by hand is ~70 lines
+of ICRC-167 plumbing, ~15 of them app-specific and two security-relevant (narrowing
+an attacker-supplied `next` to a same-origin fragment; landing in the app on
+failure not stranding). It belongs in `@icp-sdk/auth` as one call —
+`handleRedirectSignIn({ nextParam, reuseExistingSession, onArrive, onError })` —
+with hooks for an app's own session policy. Until it exists, tap-through is the one
+place "a dApp needs no push infrastructure" is false.
 
-And note which lever matters. The ugly journey is not a design problem to style
-away, it is a **session-lifetime** one: an app whose session survives a tab close
-takes the instant path most of the time and reaches the slow one rarely. Of the
-three loads, only II's Continue tap is irreducible — issuing a delegation silently
-on navigation would let any site obtain one by redirecting the user to II, so that
-tap _is_ the authorization.
+<details><summary>Lessons that shaped the helper's design</summary>
 
-Four things this cost to get right, all learned the hard way:
+- **Its own route** — the flow journals state per route; on the app root it
+  interleaves with boot and lands signed out.
+- **Reuse needs the app's staleness rule, not just `isAuthenticated()`** — a
+  delegation can be valid while the app considers the session dead (session ends on
+  last-tab-close, exactly a notification's state). Stamp liveness first (arrival =
+  presence), then reuse. An app that *deletes* its session on tab close always
+  re-auths; it should exempt push-consenting users.
+- **Only II's Continue tap is irreducible** — silent delegation issuance would let
+  any site obtain one by redirect. The ugly signed-out path is a session-lifetime
+  problem, not one to style away; don't add an II-side interstitial (only the dApp
+  knows if it has a session).
+- **Local dev:** a loopback callback needs II's `dev_csp` (the allow-list fetch is
+  `connect-src`-bound to `https:`), and Chrome prompts for local-network access —
+  both absent once both sides are public https.
 
-- **The sign-in route must be its own URL.** The flow journals state per route,
-  so running it on the app root interleaves that journal with the app's whole
-  boot path. The symptom is landing signed out with nothing explaining why.
-- **Reusing an existing session needs the app's own staleness rule, not just
-  `isAuthenticated()`.** A delegation can sit in storage while the app considers
-  the session over — an app that ends its session when every tab closes is in
-  exactly that state when a notification arrives, so forwarding on it returns the
-  user to an app that then signs them out. The fix is not to skip the check but to
-  record liveness first: **arriving from a notification is itself evidence the
-  user is present**, which is what such a rule is trying to measure. Stamp
-  whatever the app uses, then reuse the session if there is one and only redirect
-  otherwise.
-
-  An app that goes further and *deletes* its stored session on tab close cannot
-  reuse anything — a notification arrives long after that has run, so tap-through
-  will always re-authenticate. That is a legitimate posture, but it is a choice
-  being made about notifications, and it is worth making deliberately rather than
-  discovering it. Such an app should consider exempting users who granted push
-  consent: asking to be brought back later, and destroying the session that makes
-  returning cheap, are in tension.
-- **A loopback callback needs II's `dev_csp`.** Establishing the flow fetches
-  the callback origin's allow-list, and that fetch is `connect-src`-bound, which
-  production CSP limits to `https:`. So a dApp on `http://localhost` can only do
-  this against an II deployed with the dev CSP — which is why the honest advice
-  for a demo is to serve the dApp over https.
-- **Chrome will ask the user.** A public II origin fetching an allow-list from a
-  loopback address is a local-network request, which Chrome gates behind a
-  permission prompt ("access other apps and services on this device"). Expected
-  on a local setup, absent once both sides are public https.
-
-The **page** has to live on the dApp's origin and cannot be supplied by II: the
-client is headless, and the redirect is a top-level navigation onto the relying
-party's own origin, which is also what generates the session key. So the goal is
-making that page invisible — the app's own background, no decision on it — not
-removing it.
-
-**Its contents are a different matter, and should not be the dApp's problem.**
-The four lessons above were each learned by writing this route by hand, and every
-one of them is boilerplate that every dApp would reproduce identically. Building
-it once for the PoC came to ~70 lines of logic, of which perhaps 15 were actually
-about that app — and two of the rest were security-relevant: validating an
-attacker-supplied `next` down to a same-origin fragment, and landing the user in
-the app rather than stranding them when sign-in fails. Leaving each dApp to
-reimplement the first of those is how an open redirect gets shipped.
-
-Almost all of it belongs in `@icp-sdk/auth`, because it is ICRC-167 plumbing
-rather than anything to do with push: journaling the destination through
-`memoize` (required, since the callback may carry no query or fragment),
-validating it on the way back, running the two legs of `signIn`, reusing an
-existing session, and falling back into the app on failure. The shape wanted is
-one call the dApp mounts on its own page —
-
-```
-handleRedirectSignIn({ identityProvider, nextParam, reuseExistingSession: true,
-                       onArrive, onBeforeLeave, onError })
-```
-
-— where the app supplies only what is genuinely its own. `onArrive` and
-`onBeforeLeave` are what let an app with its own session policy participate
-without the library knowing anything about it: they are where the liveness stamp
-and the tab-close exemption above would go.
-
-This matters for a stated goal, not just ergonomics. This design claims a dApp
-needs no push infrastructure. Until that helper exists, tap-through is the place
-where the claim is false — the one part of adopting push that still asks a dApp
-to write subtle, security-relevant code of its own.
+</details>
 
 ### Apps with no URL routing (e.g. Caffeine)
 
@@ -1063,106 +767,40 @@ as "open the app" — no deep link, no authenticated landing. Worth stating plai
 to set expectations, and it pairs naturally with the `Hidden` content variant,
 which also shows a generic message and reveals context only after the tap.
 
-### Action buttons: navigation only, never silent work
+### Action buttons: navigate, never act
 
-Web Notifications lets a notification carry `actions` — buttons rendered on it,
-with `notificationclick` reporting which was pressed. Platforms show about two,
-and **Safari and iOS support none at all**, so anything built on them has to
-degrade to a plain notification rather than depend on them.
-
-**Every action here can only navigate.** The service worker belongs to II's
-origin, so `notificationclick` fires on II's origin, and II's worker holds no
-session for the dApp — the delegation lives in the dApp's own origin storage,
-which is unreachable cross-origin by design. It cannot call the dApp's backend as
-the user. So an "Add margin" button opens the app on the add-margin screen; it
-cannot add margin.
-
-That makes actions a straightforward extension of the deep link already specified:
+`actions` are extra buttons (`notificationclick` reports which); platforms show ~2,
+**Safari/iOS none**, so they must degrade. Every action here can only **navigate** —
+the SW is on II's origin and holds no dApp session, so "Add margin" opens the
+add-margin screen, it can't add margin. It's just an extension of the deep link:
 
 ```candid
-actions : opt vec record { id : text; title : text; url : text };   // ≤ 2
+actions : opt vec record { id : text; title : text; url : text };   // ≤ 2, same-origin
 ```
 
-Each `url` is validated same-origin against the sender at send time, exactly as
-`alert.url` is, and the worker maps `event.action` back to one. Cap the count at
-two because that is what platforms render, cap `title` short because buttons
-truncate, and leave `icon` out of a first version — fetching a cross-origin image
-to decorate a notification on II's origin raises the same concern as the app logo
-on the `/notify` screen. This composes with `Hidden` content, since the worker
-builds the notification after decrypting.
+**Cost of the hub:** silent actions. A dApp's own SW could Archive/Snooze via a
+`fetch` with no window; the II-hosted worker can't. Listed in
+[alternatives](#a1) as part of what the single permission buys.
 
-**Silent actions are the thing being given up, and it is a cost of the hub.** A
-dApp running its own service worker is same-origin with its own session, so
-"Archive", "Snooze" or "Mark read" work as a `fetch` with no window opened at all.
-Centralising the pipeline on II removes that: the worker that receives the tap is
-not the worker that could act. Worth listing alongside shared fate and content
-visibility in
-[alternatives considered](#a1)
-as part of what the single permission is bought with.
+**What it buys back: a sender-proof off-switch.** Because II composes every
+notification it can attach an off-switch no sender can remove or relabel — a
+guarantee no per-dApp design can make. It spends one of the two slots (worth it,
+since a sender's own actions only navigate anyway). Three levels:
 
-#### One action II should always add: turning it off
+- **Turn off on this device** — free, silent, today. `subscription.unsubscribe()`
+  needs no II call, works even if II's backend is down; endpoint then `410`s and
+  [cleanup](#stale-subscription-cleanup) reclaims it. Device-wide, not per-app.
+- **Stop this app** — `{ action: "ii-manage", title: "Manage" }` deep-links to
+  `/manage/settings?app=<origin>` (revoke is anchor-authorized, so it navigates).
+  **"Manage" not "Unsubscribe"**: Chrome already shows its own unsubscribe, and the
+  button navigates rather than revoking. Lands on the app's row where every other
+  grant is visible; the destination already exists in `PushNotificationsSection`.
+- **Stop this app silently** — would need a sealed capability token; not worth one
+  saved tap in v1.
 
-The same centralisation buys something a per-dApp design cannot offer. Because II
-owns the worker and composes the notification, **II can put an off-switch on every
-notification that the sender cannot remove, relabel or suppress.** An app that owned
-its own notifications would simply never ship that button. This is the strongest
-user-protection property available here, and it is available only because of the
-choice that costs silent actions.
+II owns both labels — a sender able to rename them would defeat the point.
 
-Note first what "overrides the default" cannot mean: `actions` are _additional_
-buttons, so the body tap stays the deep link. The real cost is a **slot** —
-platforms render about two — so reserving one for II leaves a sender one. Given
-that a sender's own actions can only navigate anyway, that is a good trade rather
-than a sacrifice.
-
-Three levels, and they differ in what authority the worker needs:
-
-- **Turn off on this device — free, silent, available today.**
-  `subscription.unsubscribe()` is a browser and push-service operation; the worker
-  needs no II call and no delegation. Delivery to this device stops at once, the
-  endpoint begins answering `410 Gone`, and
-  [stale-subscription cleanup](#stale-subscription-cleanup) reclaims the row. This
-  is worth having for its own sake: it works even if II's backend is unreachable or
-  misbehaving, so a user can always stop the noise from the notification itself.
-  Device-wide, though — every dApp, not one.
-- **Stop this app — a deep link into II's settings.** `push_revoke_consent` is
-  authorized by the anchor and the worker holds no authority for it, so this action
-  navigates rather than acting:
-
-  ```
-  actions: [{ action: "ii-manage", title: "Manage" }]
-  → clients.openWindow(`${II_ORIGIN}/manage/settings?app=<origin>`)
-  ```
-
-  **"Manage", not "Unsubscribe"**, for two reasons. Chrome already renders its own
-  unsubscribe affordance on a notification, and a second one competing beside it
-  reads as a mistake rather than a feature. And the button navigates rather than
-  revoking, so a label promising otherwise would be a lie — the honest word for
-  "opens the place where you can turn this off" is not "off".
-
-  The destination already exists — `PushNotificationsSection` on `/manage/settings`
-  lists every consented origin and revokes per app via `push_revoke_consent`. Two
-  small additions are needed: the action itself, and having the page accept the
-  origin so the user lands on that app's row rather than scanning a list. II owns
-  the label; the sender cannot rename or omit it.
-
-  Landing on an authenticated route means the user may have to sign in first. That
-  is correct rather than unfortunate — revoking a permission deserves proof of who
-  is asking, they have just demonstrated they hold the identity by tapping a
-  notification addressed to it, and it is the same Continue screen they already know
-  from opting in. It also puts them somewhere they can see every other app they have
-  granted, which a silent one-tap revoke would not.
-- **Stop this app, silently — needs new machinery.** II could seal a short-lived
-  capability token scoped to `(anchor, origin)` into the payload and accept it back
-  on a token-authorized revoke. That buys one saved tap for a replay window, token
-  expiry and a second authorization path into consent state. Not worth it in a
-  first version.
-
-So: ship the device-level switch, since it costs nothing and cannot fail, and make
-the per-app one a deep link. II must own both labels — a sender able to rename them
-would defeat the point.
-
-### Updating or dismissing a notification already shown
+### Updating or dismissing### Updating or dismissing a notification already shown
 
 Yes, via a dApp-chosen `notification_id`, which the service worker maps to the
 Web Notification `tag`:
@@ -1199,7 +837,7 @@ Caveats:
 | 1 | [II hosts the pipeline](#a1) | Each dApp runs its own | The permission is the scarce resource, not the plumbing — a dApp can't win the *n*th prompt |
 | 2 | [II hosts the service worker](#a2) | Each dApp hosts its own | Same decision as #1 — Web Push binds the subscription to the SW's origin |
 | 3 | [Gateway delivery](#the-delivery-path-a-trusted-web2-gateway) | Direct per-device outcalls | 13k in-flight outcalls would starve login; gateway → ~25 |
-| 4 | [Sealing stays on II](#action-buttons-navigation-only-never-silent-work) | Gateway seals | Deriving the key = ability to decrypt; useless to move. Real lever is a [separate canister](#the-way-to-lift-that-ceiling-is-a-separate-canister) |
+| 4 | [Sealing stays on II](#action-buttons-navigate-never-act) | Gateway seals | Deriving the key = ability to decrypt; useless to move. Real lever is a [separate canister](#the-way-to-lift-that-ceiling-is-a-separate-canister) |
 | 5 | [vetKeys-sealed E2E](#recommendation) | dApp holds the keys | See E2E section |
 
 <h4 id="a1">1. II hosts the pipeline</h4>
@@ -1215,9 +853,9 @@ Its price, paid throughout this doc:
 [shared fate](#shared-fate-one-permission-for-every-dapp), II sees content absent
 [E2E](#end-to-end-encrypted-apps), a delivery pipeline inside an auth canister
 ([must not degrade login](#push-must-never-degrade-authentication)), and
-[action buttons can only navigate](#action-buttons-navigation-only-never-silent-work).
+[action buttons can only navigate](#action-buttons-navigate-never-act).
 In exchange it buys one thing no per-dApp design can:
-[an off-switch no sender can remove](#one-action-ii-should-always-add-turning-it-off).
+[an off-switch no sender can remove](#action-buttons-navigate-never-act).
 
 <h4 id="a2">2. II hosts the service worker</h4>
 
@@ -1228,98 +866,27 @@ forcing sender-origin attribution at send time.
 
 ## Security model
 
-- **Origin pinning** — a sender can only target anchors that consented to
-  _its_ origin; cross-dApp targeting is impossible even with leaked principals.
-  Note what "its origin" means when alternative origins are in play — see
-  [Which origin is authoritative](#which-origin-is-authoritative).
-- **Attribution** — the sender origin shown on the notification is II-derived,
-  not dApp-supplied: II forces it to the consented origin and stamps it into the
-  payload, so a dApp **cannot choose a different origin's name**. Two limits on
-  how far that goes:
-  - It does not stop an attacker from _registering a confusable origin_.
-    `https://аpp.com` (Cyrillic а) or `https://app.com.evil.co` will pass
-    `.well-known` verification on a domain the attacker owns and then be
-    stamped as attribution verbatim. Origins must be **canonicalized** —
-    punycode, lowercased, default port stripped — at both registration and
-    consent, and confusable/mixed-script labels rejected. Without that,
-    `https://app.com`, `https://App.com` and `https://app.com:443` are three
-    distinct buckets with identical-looking lock-screen labels.
-  - It does not stop the _content_ from impersonating someone. `body` is
-    free-form; Unicode bidi controls (`U+202E`) or leading newlines can push the
-    real origin out of the visible line and render a convincing "Internet
-    Identity: verify your recovery phrase" banner. Strip bidi controls and
-    collapse whitespace in `title`/`body`, and render attribution as its own
-    non-injectable element rather than concatenated into the body string. This
-    matters more here than for a generic relay: the notification carries II's
-    permission, II's service worker, and an `id.ai` interstitial on tap — the
-    highest-credibility surface in the system for a recovery-phrase phish.
-- **Content is dApp-controlled (Display mode)** — `title`/`body` are free-form,
-  delivered under II's service worker, with lengths capped and attribution shown.
-  A compromised dApp can still send misleading text within its own attribution;
-  that is inherent to any notification relay and is a documented posture.
-  `Hidden` mode avoids it entirely — no app text reaches the SW.
-- **Transport confidentiality** — every payload is RFC 8291 encrypted to each
-  device, so **no relay or gateway can read it**. Two scope limits: this is
-  _transport_ encryption, so for `Display` content II itself sees plaintext (it
-  does the encryption); and because the drain draws one `raw_rand` per tick and
-  derives per-message ephemeral seeds from it, an observer of the subnet's random
-  tape can recompute that tick's ephemeral scalars. So the honest claim is "no
-  relay, gateway or network observer can read it" — **not** "only that device
-  can". Deriving each seed from `raw_rand ‖ msg_id` would stop one tape
-  observation from yielding a whole tick. Keeping content from II-the-service
-  altogether is the `Hidden` variant today (and, later, the vetKeys-sealed
-  path); see the next section.
-- **Coarse rejections** — the dApp learns only about its own relationship with
-  a target (`NoConsent`), never device counts or II state. One leak to close:
-  `ready` / `retry_after_ms` reflect _aggregate_ load from other senders, so a
-  sender that probes them learns something about II's global state. Randomize
-  `retry_after_ms` per caller.
-- **Error strings are a channel too** — reject reasons returned to senders must
-  be a fixed enum, never free-form text echoing caller input, and endpoint URLs
-  must never reach canister logs (an endpoint plus a valid VAPID token is a
-  push capability, and a stable per-device identifier besides).
-- **Redirect-screen icon** — the `/notify` screen shows the app logo only from
-  II's curated dApp registry, with a neutral globe fallback. Arbitrary or
-  remote icons are deliberately not fetched: doing so would render
-  attacker-controlled imagery inside II's trusted chrome and leak the fetch to
-  the dApp. If arbitrary-app icons are ever wanted, the least-bad path is a
-  vetted icon supplied at sender-registration, not a per-notification URL.
-- **VAPID key** — in stable memory today, the same custody posture as the anchor
-  salt: node operators could extract it. But **the blast radius is larger than
-  "spam"**, and the anchor-salt analogy undersells it. The _same_ stable memory
-  holds every device's `p256dh` and `auth` secrets, so an attacker who can read
-  it gets both halves: the device secrets let them produce a valid RFC 8291
-  ciphertext, and the VAPID key lets them sign a valid request. They can then
-  deliver **arbitrary, fully-readable notifications to any subscribed device,
-  attributed to any origin the user actually consented to** — which means the
-  forged notification's tap-through passes `/notify`'s consent gate and
-  deep-links into the real dApp. Salt exposure lets someone _compute
-  identifiers_ (passive); this lets someone _write into the user's trusted
-  notification surface wearing another app's name_ (active). That is
-  phishing capability, not spam.
+| Threat | Defence |
+| --- | --- |
+| **Cross-dApp targeting** | Origin pinning — a sender reaches only anchors that consented to *its* origin, even with leaked principals |
+| **Spoofed attribution** | II derives and stamps the origin; a dApp can't wear another's name. Must also **canonicalize** origins (punycode/case/port, reject mixed-script) and strip bidi/whitespace from `title`/`body`, rendering attribution as a non-injectable element — this is the highest-credibility surface for a recovery-phrase phish |
+| **Relay/gateway reads content** | RFC 8291 encrypted per device. Scope: *transport* only — II sees `Display` plaintext (it seals); `Hidden`/vetKeys keep it from II too |
+| **Probing II state** | Rejections are coarse (`NoConsent` only); randomize `retry_after_ms` (it reflects aggregate load); reject reasons a fixed enum; endpoint URLs never logged |
+| **`/notify` icon** | curated registry only + globe fallback — never fetch arbitrary/remote icons into II's chrome |
 
-  Mitigations worth doing regardless of custody: derive per-device transport
-  secrets so extracting one does not yield the other, and keep a signed
-  monotonic per-endpoint counter of pushes II issued so a service worker can
-  flag pushes II did not send. Note there is currently **no detection story** —
-  II cannot observe pushes it did not originate — and **no rotation story**:
-  abandoning the leaked VAPID key invalidates every subscription signed under it,
-  so the "re-enable on your devices" UX is a prerequisite for having a recovery
-  path at all, not a later nicety. (A _planned_ key change does not need it — see
-  [VAPID rotation](#open-items) — but a compromise does, because the point is to
-  stop honouring the old key immediately.)
+**The VAPID-key risk is larger than "spam".** The same stable memory holds the
+VAPID key *and* every device's `p256dh`/`auth`, so an attacker reading it can forge
+**fully-readable notifications to any device, attributed to any consented origin** —
+whose tap-through then passes `/notify` and deep-links into the real dApp. That's
+phishing capability, not spam, and there's currently **no detection or rotation
+story**. Mitigate: per-device transport secrets (extracting one ≠ the other), a
+signed per-endpoint counter so a SW can flag pushes II didn't send. Real fix:
+[P-256 threshold ECDSA](#ic-capabilities-to-re-evaluate) removes the stored key
+entirely.
 
-  P-256 threshold ECDSA would remove the key from storage entirely and delete this
-  whole risk rather than mitigating it, but the IC supports only secp256k1 today
-  (see [IC capabilities to re-evaluate](#ic-capabilities-to-re-evaluate)).
-
-- **VAPID key initialization must not race.** Generating the key lazily on first
-  use puts an `await` on `raw_rand` between the "is it set?" check and the
-  write, so two concurrent first callers can both generate and the later write
-  wins. A browser that already subscribed with the losing public key is
-  **permanently undeliverable**, silently, with no error surfaced anywhere.
-  Initialize eagerly in `init`/`post_upgrade` behind a guard, or re-check after
-  the `await` and adopt whatever was stored.
+**Key init must not race** — a lazy `await raw_rand` between check and write lets
+two callers generate; the loser's subscribers become silently undeliverable.
+Initialize eagerly behind a guard.
 
 ### Shared fate: one permission for every dApp
 
@@ -1645,204 +1212,36 @@ to send, admission, or storage.
 
 ## Open items
 
-Must-fix before a real deployment:
+**Blockers** (before any real deployment):
 
-- **`.well-known/ii-push-senders` verification**, so a dApp can register itself.
-  Specified in
-  [how II verifies the sender](#how-ii-verifies-the-sender-is-really-that-dapp)
-  but not built: today a controller inserts registry rows by hand. That is a
-  blocker for the goal rather than a rough edge — "any dApp can send through II"
-  is not true while onboarding means asking someone at DFINITY to add a row, and a
-  dApp would have traded a push stack for a support ticket. Pairs with the
-  deregistration and re-verification TTL below.
-- **Endpoint host allowlist.** The endpoint is a URL the **caller** supplies. A
-  browser gets it from its push service — `fcm.googleapis.com`,
-  `updates.push.services.mozilla.com`, `web.push.apple.com` — and passes it to
-  `push_subscribe_device`, but that call arrives over ingress and nothing proves
-  the string came from a push service. So a caller can subscribe with
-  `https://victim.example.com/something-expensive`, and every later send to that
-  anchor becomes traffic aimed wherever they chose: **reflection**, and **SSRF**
-  from the sending party's network position.
+| Item | Why |
+| --- | --- |
+| `.well-known/ii-push-senders` verification | self-serve registration; controller-by-hand today makes "any dApp" false — see [verification](#how-ii-verifies-the-sender-is-really-that-dapp) |
+| Endpoint host allowlist | endpoint is caller-supplied → SSRF/reflection. Allowlist known push hosts, re-validate at drain, **II validates not the gateway** |
+| Per-anchor caps | 20 subscriptions / 100 consents, anti-griefing not a storage bound. Evict dead rows first for subs; **refuse** (never silently evict) a consent |
+| Reserved outcall budget for auth | push must not spend login's slots — [detail](#push-must-never-degrade-authentication) |
+| Drain isolation & non-reentrancy | per-entry failure boundary, attempt counter, watchdog, claim-before-await, or one poison row wedges the feature |
+| `drain_epoch` ack signal | client durability doesn't work without it — [state model](#iis-state-model-stateless-for-campaigns) |
+| <a id="stale-subscription-cleanup"></a>Stale-subscription cleanup | `404`/`410` removal; possible on the gateway path only via the non-replicated handoff. Treat `410` as evidence, retire opportunistically |
+| Redirect-sign-in helper in `@icp-sdk/auth` | tap-through is the last place a dApp writes security-relevant code by hand — [shape](#landing-the-user-already-signed-in) |
+| `pushsubscriptionchange` | SW must re-subscribe + re-register or delivery erodes over weeks |
+| Sender deregistration & re-verification TTL | bound the window after a compromised sender / domain hand-off |
+| Origin canonicalization | punycode, lowercase, strip port, reject mixed-script, at registration and consent |
+| Input validation & caps | `title`≤64, `body`≤256, `topic`≤32, `url` bounded, `chunk_id` 16 B — validate, never trap; fixed error enum |
+| Cycle budget + freezing guard | per-origin/global daily burn cap + circuit breaker; disable push before spend nears the freezing threshold (past it, **logins fail while the frontend still loads**) |
+| Buffer sizing & drain fairness | round-robin across origins; urgency/age only within a slice |
+| Observability | buffer depth, drain lag, per-origin reject/410 counts, and **auth-path p99** (the signal push is stealing from login) |
 
-  Validate the host against the known push services at subscribe time, and
-  **re-validate at drain** so rows written before the list was tightened cannot
-  keep using it. Reject non-`https`, explicit ports, `userinfo`, and
-  private/loopback/link-local hosts.
+**Decisions (design, not code):**
 
-  **II must be the validator, not the gateway.** On the chosen path II never POSTs
-  to the endpoint at all — it hands the endpoint to the gateway, which makes the
-  per-device sends. That relocates the abuse rather than removing it, and makes it
-  worse in one respect: the gateway is an ordinary server that may sit where
-  private addresses are reachable, whereas replica outcalls egress through a proxy.
-  If the gateway were the only place this is checked, II would be handing an
-  attacker-chosen URL to a component it has already declared trusted, and a buggy
-  or compromised gateway would turn that into clean SSRF. Check before handing it
-  over.
+- **Apps without URL routing** (Caffeine) — confirm whether a builder-sandbox app can address a destination; if not, tap-through degrades to "open the app" — [detail](#apps-with-no-url-routing-eg-caffeine).
+- **iOS** — PWA install mandatory for Web Push, flakier and more throttled; a native app on APNs is the real fix, out of scope.
 
-  On the direct per-device alternative, II does POST itself, and under replicated
-  outcalls that carries an *n*× multiplier — one free ingress call becoming 34
-  POSTs at the victim. The non-replicated handoff removes the multiplier from the
-  chosen path; it does not remove the need for the allowlist, because one POST at
-  a victim of the caller's choosing is still one too many.
-- **Per-anchor caps.** Cap subscription rows at **20** and consent rows at
-  **100** per anchor. Nothing bounds either today, ingress is free to the caller,
-  and II pays the stable-memory cost — a direct attack on the resource this design
-  calls a hard constraint.
+**Deferred:** replay layering (`chunk_id` for dApp→II, `msg_id` for relay→device); cleanup hooks on device/anchor removal; metadata-privacy mitigations ([Privacy](#privacy)).
 
-  Read the units carefully. 100 consents really is 100 distinct dApps. But 20
-  subscriptions is 20 **endpoints**, not 20 browsers: a browser resubscribing with
-  the same endpoint overwrites in place, but a browser that _rotates_ its endpoint
-  (expiry, cleared storage, `pushsubscriptionchange`) produces a new row and leaves
-  the old one behind until cleanup, and two profiles on one machine are two rows.
-  So the live-device budget is under 20, and the slack is there for stale
-  rotations — which is why 20 rather than 10.
+**VAPID rotation — never as maintenance.** A planned migration to a subnet-held key needs no user-visible event (dual-key, let the fleet age over); only compromise recovery invalidates everything and needs the "re-enable" UX. End state: [subnet holds the key](#ic-capabilities-to-re-evaluate).
 
-  **The two maps need different eviction, and neither wants plain LRU.**
-  Subscriptions are machine state and safe to reclaim, but evict **known-dead rows
-  first** — ones that already returned `404`/`410` — and only fall back to
-  recency, or a weekly-use laptop gets dropped while a dead rotated endpoint
-  survives. Consent is not machine state: silently evicting one **reverses a
-  decision the user made**, with no signal, so an app they allowed simply stops
-  reaching them. Refuse the 101st with an error the UI can explain instead, and let
-  the user revoke something if they want room. A cap that quietly discards user
-  intent is worse than a cap that says no.
-
-  Against the row sizes in
-  [what this actually costs per user](#storage-can-ii-store-the-data), 20
-  subscriptions plus 100 consents (each consent also costing a principal-index
-  row, so 140 B a piece) is **~19.5 KB per anchor** on typical endpoints and
-  **~35 KB** on worst-case ones. 20 is chosen rather than 10 because a real user
-  plausibly has 4–5 devices and browsers rotate endpoints, so stale rows
-  accumulate between cleanups; 10 would start evicting live devices. The
-  worst-case figure is dominated by the endpoint URL at ~1.1 KB — 22 of those
-  35 KB — so bounding endpoint length is a bigger lever on the ceiling than the
-  row count is.
-
-  **Read the cap as anti-griefing, not as a storage bound.** If all 10M anchors
-  saturated it, that is 200–360 GB against a 537 GB canister limit, on a subnet
-  shared with anchor data — so the cap stops one anchor from mining II's storage,
-  while aggregate growth stays bounded by real usage (~20 GB) plus
-  [stale-subscription cleanup](#stale-subscription-cleanup). It buys roughly 10×
-  headroom over expected usage, which is the right order for a limit nobody
-  legitimate should ever reach.
-- **Reserved outcall budget for authentication.** See
-  [Push must never degrade authentication](#push-must-never-degrade-authentication).
-- **Drain isolation and non-reentrancy.** Per-entry failure boundaries, an
-  attempt counter, a stuck-buffer watchdog, and a claim step before the first
-  `await`. Without these, one malformed row wedges the feature globally and
-  overlapping ticks double-send.
-- ~~**`msg_id` + device-side dedup.**~~ **Built** — see
-  [Duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
-  What remains is hardening it against deliberate replay (monotonic window
-  instead of a bounded set), not the duplicate-suppression itself.
-- **An acknowledgment signal (`drain_epoch`).** Promoted from implicit — the
-  client-side durability story does not work without it. See
-  [II's state model](#iis-state-model-stateless-for-campaigns).
-- **Stale-subscription cleanup.** <a id="stale-subscription-cleanup"></a>
-  `404`/`410` row removal is **built** on the direct path. On the gateway path it
-  became possible only once the batch handoff went **non-replicated**: with no
-  consensus on the response, the gateway is no longer confined to a deterministic
-  ack and can return per-device status inline. Under replicated outcalls this was
-  structurally impossible, not merely unbuilt. It still has to be built, and it
-  still matters — browsers rotate endpoints continuously, so left alone the
-  subscription table grows as O(devices ever registered) rather than O(users) and
-  II pays forever to send to dead endpoints. Treat the returned status as
-  evidence, not proof: it is one unverified reply from a trusted party, so retire
-  a subscription opportunistically on a reported `410` rather than deleting user
-  state on a single word. A separate authenticated **pull**, a
-  `push_gateway_report` update, or TTL-based GC keyed on last successful delivery
-  all remain viable as corroboration. Pairs with `pushsubscriptionchange` below.
-- **A redirect-sign-in helper in `@icp-sdk/auth`.** Tap-through is the last place
-  a dApp still writes subtle security-relevant code by hand — see
-  [landing the user already signed in](#landing-the-user-already-signed-in) for
-  the shape. Not II-side work, and not push-specific, but it is on the critical
-  path for "a dApp needs no push infrastructure" being true, so it belongs on this
-  list rather than in someone else's backlog.
-- **`pushsubscriptionchange`** — browsers rotate/invalidate subscriptions; the
-  service worker must re-subscribe and re-register with II, or delivery
-  silently erodes over weeks. Invisible in short-lived testing.
-- **Sender deregistration & re-verification TTL** — bound the window after a
-  sender principal is compromised or a domain changes hands, and make
-  re-verification resistant to being used as a deregistration primitive (see
-  [Consent lifecycle](#consent-lifecycle-it-must-not-outlive-the-sender)).
-- **Origin canonicalization** — punycode, lowercase, strip default port, reject
-  confusable/mixed-script labels, at registration _and_ consent.
-- **Input validation and caps** — `title` ≤ 64, `body` ≤ 256, `topic` ≤ 32,
-  `notification_id` ≤ 64, `url` bounded, `chunk_id` fixed at 16 bytes, origins
-  ≤ 255 bytes **validated rather than trapped on**. Reject with a fixed error
-  enum; never return free-form text echoing caller input.
-- **Cycle budget + freezing-threshold guard** (deployments that pay fees) — a
-  per-origin and global daily burn cap with a circuit breaker, independent of
-  the rate bucket, plus a floor that disables push before spend can approach the
-  freezing threshold. Past that threshold a canister stops serving updates while
-  still serving queries, which for II means **logins fail while the frontend
-  still loads**.
-- **Buffer sizing & drain fairness** — tune the admission bucket, global cap and
-  per-origin reservations, and drain **round-robin across origins** with urgency
-  and age only _within_ an origin's slice.
-- **Observability** — in-flight buffer depth (canary for stuck timers /
-  backpressure), drain lag, admission reject rate per origin, per-origin
-  outcall success / 410 / drop counts, and **authentication-path p99 latency**
-  (the signal that push is stealing from login).
-
-Must-decide (design, not code):
-
-- **App platforms without URL routing** — confirm whether Caffeine-built apps
-  can address a destination at all, in the builder sandbox _and_ published. If
-  not, deep-linking and signed-in tap-through are both unavailable there and
-  notifications degrade to "open the app". See
-  [What about apps with no URL routing](#apps-with-no-url-routing-eg-caffeine).
-- **iOS reality** — iOS Safari is the one platform where a PWA install is
-  _mandatory_ for Web Push (Android/desktop work in a plain tab). It is also
-  flakier and more throttled; "best-effort" is weakest there. Set expectations
-  in dApp docs, and surface the "Add to Home Screen" hint only on iOS.
-
-Known-deferred:
-
-- **Replay layering.** The two replay surfaces are handled separately.
-  **dApp→II replay** (a resent or duplicated chunk) is solved by the `chunk_id`
-  idempotency key. **relay/gateway→device replay** (a captured
-  `(jwt, ciphertext, endpoint)` re-POSTed) has no protection in Web Push itself
-  — VAPID's JWT is a time-bounded bearer token and AES-GCM gives
-  tamper-detection, not anti-replay — so it is handled by `msg_id`, now a v1
-  requirement rather than a deferred item. Note the earlier framing that "TLS
-  gates capture, so the practical risk is low" does **not** hold on the chosen
-  path: the gateway legitimately receives the sealed bundle, so replay needs no
-  network interception at all.
-- **VAPID rotation — the design intent is never to rotate.** There is no expiry
-  and no hygiene schedule; a rotation is an incident, not maintenance. Two cases,
-  and they want opposite mechanisms:
-
-  **Planned migration** (today's stored key → a subnet-held one, if P-256
-  threshold ECDSA ever ships) needs no user-visible event at all. A subscription
-  is bound to the `applicationServerKey` it was created with, so II can retain the
-  old private key for devices already on it while issuing new subscriptions under
-  the new one. Endpoints churn on their own as browsers rotate them, so the fleet
-  migrates without anyone being asked to re-enable anything. Support both keys at
-  verify time, stop issuing the old one, and let it age out.
-
-  **Compromise recovery** cannot do that, because the whole point is to stop
-  honouring the leaked key — so it does invalidate every subscription under it at
-  once, and it is the case that genuinely needs the "re-enable on your devices"
-  UX. Build that UX for the incident, not for the migration; deferring it means
-  having no recovery path, which is the actual argument for it.
-
-  The end state we want is **the subnet holding the key**, so that there is no
-  stored secret to leak and this open item mostly disappears — see
-  [IC capabilities to re-evaluate](#ic-capabilities-to-re-evaluate).
-- **Cleanup hooks** on device/anchor removal.
-- **Metadata-privacy mitigations** — endpoint blinding, batch shuffling/padding,
-  per-origin VAPID subkeys. See [Privacy](#privacy).
-
-Explicitly rejected:
-
-- **On-device `tag`-based collapsing by hostname** — a dApp sends distinct
-  notifications that must not replace each other on the device. Collapsing is
-  opt-in per send via `topic`, never automatic per origin.
-- **Reusing one RFC 8291 ephemeral key across recipients in a batch.** It would
-  roughly halve sealing cost, and the RFC does not forbid it — but it links
-  recipients cryptographically and makes one leaked transient key expose the
-  whole batch. Not worth it.
+**Rejected:** per-origin `tag` collapsing (collapsing is opt-in via `topic`); reusing one RFC 8291 ephemeral key across a batch (halves cost but links recipients and makes one leaked key expose the batch).
 
 ## IC capabilities to re-evaluate
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -351,18 +351,49 @@ not by server-side routing.
 One call has one `caller()`, so the per-user `caller == in_app_principal`
 model does not batch. Senders authenticate at the **origin** level:
 
-Registering, once per dApp. The order matters — the file has to exist before the
-call, because II fetches it during the call:
+The only thing a dApp must do is **publish the file**:
 
-1. The dApp **publishes** `https://myapp.com/.well-known/ii-push-senders`, listing
-   its backend canister principal(s).
-2. That **backend canister calls** `push_register_sender("https://myapp.com")`. It
-   must be the canister making the call: `caller()` is what is being claimed.
-3. **II fetches the file** over an HTTPS outcall, with a transform so every replica
-   agrees on the bytes.
-4. **II checks `caller() ∈ senders`.** On success it stores
-   `origin_hash → {principals, verified_at}`. If the file is absent, unparseable,
-   or does not list the caller, the call is refused and nothing is stored.
+```
+https://myapp.com/.well-known/ii-push-senders
+{ "senders": ["abcde-fghij-...-cai"] }
+```
+
+Registration itself should be automatic. Requiring an explicit setup call is
+boilerplate that adds no security — the file is the proof, and II can go and read
+it whenever it needs to.
+
+1. **On first consent.** When a user opts in for an origin in `/authorize`, II has
+   the origin and no registry row yet, so it fetches and verifies then. This is the
+   preferred trigger: it is user-paced, and by the time the dApp sends anything the
+   row already exists.
+2. **On a send, as a backstop.** If a row is still missing, II starts verification
+   and returns `SenderUnverified` with a hint naming the file to publish and the
+   principal to list. It does **not** block the send on an outcall — `push_send`
+   stays a cheap, no-await admission call, and the dApp's library retries.
+3. **`push_register_sender(origin)` stays**, as "check me again now": it forces a
+   re-read, bypassing the negative cache below, for a developer who has just fixed
+   their file and does not want to wait for the TTL.
+
+Verification itself is unchanged in substance: II fetches over an HTTPS outcall
+with a transform so replicas agree, then checks that the calling — or, for the
+consent-time path, the claimed — canister is listed, and stores
+`origin_hash → {principals, verified_at}`.
+
+**Only ever fetch for origins a user has already consented to.** Without that gate
+any canister could make II fetch a URL of its choosing by naming an arbitrary
+origin, which is an SSRF and DoS amplifier of exactly the kind the
+[endpoint allowlist](#open-items) exists to prevent. Consent requires a real user
+completing the II opt-in for that origin, so the fetchable set is bounded by
+grants that already happened — and it costs nothing, because a send to a user who
+has not consented is refused regardless. Add negative caching per origin so a
+misconfigured file is not re-fetched on every send, and a cap on concurrent
+verifications so a burst of new origins cannot crowd out authentication's outcall
+budget.
+
+The proof still needs **both halves** — a published file and a canister that the
+file names — so an impersonator needs control of the origin's content *and* of the
+canister. Making the check implicit changes when II reads the file, not what it
+proves.
 
 The proof needs **both halves**, which is what makes it a proof: publishing the
 file registers nothing on its own, and calling without the file is refused. A

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1063,12 +1063,23 @@ Four things this cost to get right, all learned the hard way:
 - **The sign-in route must be its own URL.** The flow journals state per route,
   so running it on the app root interleaves that journal with the app's whole
   boot path. The symptom is landing signed out with nothing explaining why.
-- **Do not short-circuit on `isAuthenticated()` there.** A delegation can sit in
-  storage while the app considers the session over — an app that ends its
-  session when every tab closes is in exactly that state when a notification
-  arrives. Forwarding on it returns the user to an app that then signs them out.
-  Calling `signIn()` unconditionally is correct: it starts the redirect on the
-  first pass and completes from journaled state on the return one.
+- **Reusing an existing session needs the app's own staleness rule, not just
+  `isAuthenticated()`.** A delegation can sit in storage while the app considers
+  the session over — an app that ends its session when every tab closes is in
+  exactly that state when a notification arrives, so forwarding on it returns the
+  user to an app that then signs them out. The fix is not to skip the check but to
+  record liveness first: **arriving from a notification is itself evidence the
+  user is present**, which is what such a rule is trying to measure. Stamp
+  whatever the app uses, then reuse the session if there is one and only redirect
+  otherwise.
+
+  An app that goes further and *deletes* its stored session on tab close cannot
+  reuse anything — a notification arrives long after that has run, so tap-through
+  will always re-authenticate. That is a legitimate posture, but it is a choice
+  being made about notifications, and it is worth making deliberately rather than
+  discovering it. Such an app should consider exempting users who granted push
+  consent: asking to be brought back later, and destroying the session that makes
+  returning cheap, are in tension.
 - **A loopback callback needs II's `dev_csp`.** Establishing the flow fetches
   the callback origin's allow-list, and that fetch is `connect-src`-bound, which
   production CSP limits to `https:`. So a dApp on `http://localhost` can only do
@@ -1079,11 +1090,42 @@ Four things this cost to get right, all learned the hard way:
   permission prompt ("access other apps and services on this device"). Expected
   on a local setup, absent once both sides are public https.
 
-Finally, the route is a page on the dApp's origin and **cannot be supplied by
-II or by the auth client**. The client is headless, and the redirect is a
-top-level navigation onto the relying party's own origin — which is also what
-generates the session key. So the realistic goal is making that page invisible
-(the app's own background and no decision on it), not removing it.
+The **page** has to live on the dApp's origin and cannot be supplied by II: the
+client is headless, and the redirect is a top-level navigation onto the relying
+party's own origin, which is also what generates the session key. So the goal is
+making that page invisible — the app's own background, no decision on it — not
+removing it.
+
+**Its contents are a different matter, and should not be the dApp's problem.**
+The four lessons above were each learned by writing this route by hand, and every
+one of them is boilerplate that every dApp would reproduce identically. Building
+it once for the PoC came to ~70 lines of logic, of which perhaps 15 were actually
+about that app — and two of the rest were security-relevant: validating an
+attacker-supplied `next` down to a same-origin fragment, and landing the user in
+the app rather than stranding them when sign-in fails. Leaving each dApp to
+reimplement the first of those is how an open redirect gets shipped.
+
+Almost all of it belongs in `@icp-sdk/auth`, because it is ICRC-167 plumbing
+rather than anything to do with push: journaling the destination through
+`memoize` (required, since the callback may carry no query or fragment),
+validating it on the way back, running the two legs of `signIn`, reusing an
+existing session, and falling back into the app on failure. The shape wanted is
+one call the dApp mounts on its own page —
+
+```
+handleRedirectSignIn({ identityProvider, nextParam, reuseExistingSession: true,
+                       onArrive, onBeforeLeave, onError })
+```
+
+— where the app supplies only what is genuinely its own. `onArrive` and
+`onBeforeLeave` are what let an app with its own session policy participate
+without the library knowing anything about it: they are where the liveness stamp
+and the tab-close exemption above would go.
+
+This matters for a stated goal, not just ergonomics. This design claims a dApp
+needs no push infrastructure. Until that helper exists, tap-through is the place
+where the claim is false — the one part of adopting push that still asks a dApp
+to write subtle, security-relevant code of its own.
 
 ### Apps with no URL routing (e.g. Caffeine)
 
@@ -1747,6 +1789,12 @@ Must-fix before a real deployment:
   state on a single word. A separate authenticated **pull**, a
   `push_gateway_report` update, or TTL-based GC keyed on last successful delivery
   all remain viable as corroboration. Pairs with `pushsubscriptionchange` below.
+- **A redirect-sign-in helper in `@icp-sdk/auth`.** Tap-through is the last place
+  a dApp still writes subtle security-relevant code by hand — see
+  [landing the user already signed in](#landing-the-user-already-signed-in) for
+  the shape. Not II-side work, and not push-specific, but it is on the critical
+  path for "a dApp needs no push infrastructure" being true, so it belongs on this
+  list rather than in someone else's backlog.
 - **`pushsubscriptionchange`** — browsers rotate/invalidate subscriptions; the
   service worker must re-subscribe and re-register with II, or delivery
   silently erodes over weeks. Invisible in short-lived testing.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -69,7 +69,7 @@ sequenceDiagram
     SW->>Lib: tap → deep link (signs in if session lapsed)
 ```
 
-Three limits bind on every deployment:
+Three limits shape the design, and they bind on every deployment:
 
 | Limit | Consequence in this design |
 | --- | --- |
@@ -242,9 +242,9 @@ client library paces itself in response.
 
 ### What this costs, and who pays
 
-Three things are scarce on every deployment: outcall slots (3000 subnet-wide, shared
-with login — the reason the gateway exists), storage (kept O(users × origins), never
-O(volume)), and instructions (which force the bounded-slice drain).
+We care about three costs on every deployment: outcall slots (3000 subnet-wide,
+shared with login — the reason the gateway exists), storage (kept O(users × origins),
+never O(volume)), and instructions (which force the bounded-slice drain).
 
 Cycles are the fourth cost, but only where they're charged — waived on canonical II,
 real everywhere else. The per-byte fee carries the `·n` replication factor, so

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1,92 +1,42 @@
 # Push notifications — design
 
-**How to read this.** It is long because it covers two independent scaling paths
-and a security model. If you only read one section, read
-[How it works, in plain terms](#how-it-works-in-plain-terms). Then:
-
-- **Reviewing the design?** [Goals and non-goals](#goals-and-non-goals) →
-  [Architecture](#architecture) →
-  [Alternatives considered](#alternatives-considered) →
-  [Security model](#security-model) → [Open items](#open-items).
-- **Implementing it on II?** [dApp → II](#dapp--ii) →
-  [II's state model](#iis-state-model-stateless-for-campaigns) →
-  [Delivering to devices](#delivering-to-devices) →
-  [Push must never degrade authentication](#push-must-never-degrade-authentication).
-- **Integrating a dApp?** Reference material lives in separate files:
-  [push-api.md](push-api.md) (Candid + integration steps) and
-  [push-client-library.md](push-client-library.md) (the client library).
-- **Wondering what exists today?** [Status](#status), at the end.
+Start with [How it works, in plain terms](#how-it-works-in-plain-terms). Then:
+**reviewing** → [Goals](#goals-and-non-goals) · [Architecture](#architecture) ·
+[Alternatives](#alternatives-considered) · [Security](#security-model) ·
+[Open items](#open-items); **implementing** → [dApp → II](#dapp--ii) ·
+[state model](#iis-state-model-stateless-for-campaigns) ·
+[delivery](#delivering-to-devices) ·
+[Scaling](#scaling); **integrating** → [push-api.md](push-api.md),
+[push-client-library.md](push-client-library.md); **today** → [Status](#status).
 
 ## Context and scope
 
-A dApp on the IC that wants to reach a user who is not currently looking at it
-has no good option. Web Push is the browser-native answer, but doing it yourself
-means prompting for your own notification permission, running your own service
-worker, holding your own VAPID keypair, and storing your own subscription
-endpoints — per dApp. Browsers increasingly bury that permission prompt, users
-decline it more often the more times they see it, and on iOS Safari it requires
-the site to be installed as a PWA at all. The result is that almost no dApp does
-it, and users get nothing.
+A dApp that wants to reach a user who isn't looking at it has no good option: doing
+Web Push yourself means your own permission prompt, service worker, VAPID keypair and
+subscription storage — **per dApp**. Browsers bury repeat prompts, users decline them,
+and iOS needs a PWA install. So almost no dApp does it.
 
-Internet Identity is already the one origin every user of these apps has a
-relationship with, and already holds per-user state they have consented to. That
-makes it the one place where the permission can be asked **once** and reused.
+II is already the one origin every user of these apps has a relationship with. So it
+hosts a single Web Push pipeline: grant permission to `id.ai` **once**, subscribe per
+device, consent per dApp. PWA install stays optional except on iOS Safari.
 
-So: II hosts a single Web Push pipeline that any dApp can send through. The user
-grants notification permission to `id.ai` once, subscribes per device, and
-consents per dApp; a consented dApp then delivers through II rather than running
-a push stack of its own. Installing II as a PWA stays **optional** on Android and
-desktop, and is **required only on iOS Safari** — where "install one app, get
-every dApp's notifications" is a better trade than installing each dApp.
-
-This document covers the design of the two paths that decide whether it scales —
-**dApp → II** and **II → device** — the security and privacy model, and the open
-items. It is a design document, not an integration guide: the Candid interface
-and the client-library internals are here to show the design is buildable, not to
-serve as reference material.
+This doc covers the two scaling paths (**dApp → II**, **II → device**), the
+security/privacy model, and open items. Design doc, not an integration guide — the Candid surface and library internals live in [separate files](push-api.md).
 
 ## Goals and non-goals
 
-### Goals
+**Goals:** one permission across all consented dApps; a dApp needs **no push
+infrastructure**; consent per dApp + per device, revocable; a 10k-user broadcast is
+normal (and must never degrade auth); II's durable storage doesn't grow with volume;
+a tap lands where the notification was about, signed in; **E2E possible** for apps
+that can't let II read content ([E2E](#end-to-end-encrypted-apps)).
 
-- **One permission, many apps.** A user allows notifications once, for their
-  identity provider, and every consented dApp reaches them through it.
-- **A dApp needs no push infrastructure.** No service worker, no VAPID keypair,
-  no subscription storage, no relay accounts.
-- **Consent is per dApp and per device, and revocable.** Revoking one dApp stops
-  its notifications immediately and affects no other.
-- **A 10k-user broadcast is a normal operation**, not an incident — with the
-  explicit constraint that it must never degrade authentication, which is what
-  this canister actually exists to do.
-- **II's durable storage does not grow with volume.** Storage is user-scoped;
-  sending more notifications must not make it larger.
-- **A tap lands the user where the notification was about**, in the sending app,
-  signed in.
-- **End-to-end encryption is possible** for apps that can't let II see message
-  text — a messenger shouldn't hand its message bodies to its identity provider.
-  See [End-to-end-encrypted apps](#end-to-end-encrypted-apps).
-
-### Non-goals
-
-- **Not a messaging product.** No inbox, no history, no unread state, no
-  read receipts. II forgets a notification once it is handed off.
-- **Not exactly-once delivery.** Delivery is explicitly at-least-once, which is
-  why device-side deduplication ships with it rather than after it.
-- **Not guaranteed delivery.** The relays are best-effort and a device that never
-  comes online never receives; no part of this promises otherwise.
-- **Not per-notification billing, in v1.** Charging senders cycles is parked, not
-  designed — which has consequences for abuse limits, covered below.
-- **Not a way to reach "all II users".** There is no audience except users who
-  consented to a specific dApp; a sender cannot discover or address anyone else.
-- **Not universal browser support.** Web Push is browser-scoped. Browsers without
-  it (some vendor forks ship none) are out of reach, and that is not something
-  this design can fix.
-- **Not a replacement for in-app notification UI.** This reaches users who are
-  away; what an app shows a user who is present is the app's business.
+**Non-goals:** not a messaging product (no inbox/history/receipts); not exactly-once
+(at-least-once + device dedup); not guaranteed delivery (relays are best-effort); no
+per-notification billing in v1; no "reach all II users" (only consenters); not
+universal (Web Push is browser-scoped); not a replacement for in-app UI.
 
 ## How it works, in plain terms
-
-The whole design in six points; everything after adds detail.
 
 1. **A dApp never talks to phones.** It tells II "notify these users" (by opaque
    per-app id — it can't reach anyone it wasn't given); II delivers.
@@ -125,7 +75,7 @@ sequenceDiagram
     SW->>Lib: tap → deep link (signs in if session lapsed)
 ```
 
-Three limits shape everything and bind on every deployment:
+Three limits bind on every deployment:
 
 | Limit | Consequence in this design |
 | --- | --- |
@@ -402,74 +352,43 @@ this scales off the unmeasured ~200/s — measure the per-seal cost first.
 
 ### The way to lift that ceiling is a separate canister
 
-Note what the 200/s is actually a limit on. It is not the crypto and it is not the
-platform — it is **co-tenancy with authentication**. The slice is small because
-this canister serves every login on the network, so the only reason push cannot
-spend its whole execution round sealing is that logins are sharing that round.
+The 200/s limit is **co-tenancy with authentication** — the slice is small only
+because this canister serves every login. So run push in its **own canister**: it
+could spend a full round sealing (the ~10–20× headroom), keeping the trust boundary
+(same controllers, no plaintext off-platform) and turning "must not degrade login"
+into a property that holds by construction.
 
-Which suggests the structural fix: run push in its **own canister**. It could then
-spend a full round on sealing — plausibly the same order as the 10–20× headroom
-between the self-imposed budget and the instruction limit — while keeping the
-trust boundary exactly where it is today. Still an IC canister under the same
-controllers, still no plaintext leaving the platform, so this buys throughput
-without the concession that moving sealing to the gateway would demand. It also
-turns [Push must never degrade authentication](#push-must-never-degrade-authentication)
-from a discipline that has to be maintained into a property that holds by
-construction.
-
-The real cost is state ownership. Subscriptions and consent are anchor-scoped, so
-a push canister has to **own** those maps rather than calling II per send —
-otherwise the load just moved back, with inter-canister latency added. Then
-`/authorize`'s opt-in becomes one inter-canister write at consent time, which is
-rare and cheap, and the service worker still lives on II's origin because that is
-where the notification permission is granted. What is genuinely new is
-two-canister upgrade coordination, and deciding where the VAPID key lives.
-
-Not proposed as the shipping path here, because it changes which canister holds
-user-scoped state and that deserves its own review. But it is the honest answer to
-"the throughput number looks low", and it is a better answer than moving crypto
-off-platform.
+Cost: state ownership. The push canister must **own** the subscription/consent maps
+(else the load just moves back with added latency), making `/authorize` opt-in one
+inter-canister write. New: two-canister upgrade coordination, and where the VAPID
+key lives. Not the shipping path — it deserves its own review — but the honest
+answer to "the throughput looks low", better than moving crypto off-platform.
 
 ## Delivering to devices
 
-The relay API is one POST per subscription endpoint (RFC 8030) — there is no
-multi-recipient send, so reaching N devices is fundamentally N sends. The
-design routes those sends through a **trusted web2 gateway**. Doing them as
-per-device outcalls straight from the canister ("direct") is the documented
-**alternative** — kept for context and as a possible low-volume or
-fully-on-chain fallback, but not the shipping path.
+The relay API is one POST per endpoint (RFC 8030) — reaching N devices is N sends.
+The design routes them through a **trusted gateway**; per-device outcalls straight
+from the canister ("direct") are the documented low-volume/on-chain **alternative**.
 
 ### The outcall to the gateway is non-replicated
 
-**Decision:** II's batch handoff uses `is_replicated = false` (mainnet since
-2025-08-04). One node makes the call — no 34× fan-out, no response consensus,
-~2 orders of magnitude cheaper — which is why the gateway can stay stateless,
-return real per-device status, and enable `410` cleanup.
-
-Two caveats: the flag is **experimental**, so isolate it behind one call site that
-can revert to replicated + transform; and a single node's reply isn't
-consensus-verified, so returned status is evidence, not proof (no new concession —
-a trusted gateway could always lie).
+**Decision:** the batch handoff uses `is_replicated = false` (mainnet since
+2025-08-04). One node calls — no 34× fan-out, no response consensus, ~2 orders
+cheaper — which is what lets the gateway stay stateless, return per-device status,
+and enable `410` cleanup. Caveats: **experimental** (isolate behind one revertible
+call site), and a single node's reply isn't consensus-verified (status is evidence,
+not proof — no new concession).
 
 <details><summary>Why replicated outcalls don't work here</summary>
 
-A replicated outcall runs on every node (34 on II's subnet), so the target sees 34
-identical POSTs and responses must be byte-identical or consensus fails. That
-breaks Web Push two ways:
-
-- **Duplicate delivery** — RFC 8030 has no idempotency key, so 34 POSTs = up to 34
-  banners. (`msg_id` + SW dedup is a v1 requirement regardless, as a belt-and-braces.)
-- **Per-device status can't survive consensus** — the 34 POSTs legitimately get
-  different answers (`201`, `429`, `410`), and a transform can only collapse them to
-  one value. So `410`-driven [cleanup](#stale-subscription-cleanup) is impossible
-  under replication.
+Replicated = every node POSTs (34×), responses must be byte-identical or consensus
+fails. That gives **duplicate delivery** (RFC 8030 has no idempotency key) and makes
+**per-device status unrecoverable** (the 34 answers differ; a transform collapses
+them to one) — so `410` [cleanup](#stale-subscription-cleanup) is impossible.
 
 </details>
 
 ### The delivery path: a trusted web2 gateway
-
-II seals every message, then hands the ready-to-send bundles to a small trusted
-helper that fans them out over ordinary internet:
 
 ```mermaid
 flowchart LR
@@ -486,20 +405,17 @@ which is why it's the real reason (cycles only differ ~4×).
 
 **What stays on II:** all crypto. The gateway sees ciphertext, endpoints and timing
 — never keys or plaintext. Sealing can't be offloaded: the ECDH that derives the
-content key *is* the ability to decrypt, so the only movable part is the AES that
-was already free.
+content key *is* the ability to decrypt.
 
 <details><summary>Trust delta — the deliberate cost</summary>
 
-The gateway can **drop, delay or replay**, and **forge sends**: each bundle carries
-a VAPID token relays accept without validating the body, cached ≤12 h. A compromised
-gateway can harvest `(endpoint, token)` pairs and POST junk that won't decrypt — the
-browser then shows its generic "site updated" notice attributed to `id.ai`, burning
-the [shared permission](#shared-fate-one-permission-for-every-dapp). Mitigations:
-scope credentials per batch, cut the JWT cache to minutes. The token is also
-extractable from canister state by node operators, so this isn't the operator's
-alone. It's a **single point of failure** — see
-[Operating it](#operating-it-controls-alerts-and-rollout).
+The gateway can **drop, delay, replay**, and **forge sends** (the VAPID token, cached
+≤12 h, is accepted without body validation) — a compromised one can POST junk that
+won't decrypt, triggering the browser's "site updated" notice attributed to `id.ai`
+and burning the [shared permission](#shared-fate-one-permission-for-every-dapp).
+Mitigate: per-batch credentials, minutes-long JWT cache. The token is also
+node-operator-extractable from canister state. **Gateway = single point of failure**
+([Operating it](#operating-it-controls-alerts-and-rollout)).
 
 </details>
 
@@ -555,87 +471,64 @@ endpoint. So:
   identity still wants notifications.
 - On rotation, each identity re-registers next time it authenticates.
 
-### Where a notification opens### Where a notification opens
+### Where a notification opens
 
-The app may set `alert.url` to send the user to a specific page rather than the
-origin root. **II validates it at send time** and refuses the send otherwise:
+`alert.url` deep-links within the sender's own app; **II validates it at send time**
+and refuses otherwise:
 
-- **The target must be on the sender's own application.** The sender origin is
-  II-derived, not a field on `PushAlert`: the backend forces it to this sender's
-  consented origin, so a dApp cannot set or spoof it. A notification can
-  deep-link anywhere within the sender's own site
-  (`https://app.com/thread/42`) but never to another origin — not `evil.com`,
-  and not another consented dApp.
-- **Both sides are canonicalised** before comparing, because consent is recorded
-  against the _effective_ origin (already remapped to the legacy boundary
-  domain) while a dApp's links use whichever domain the user is browsing.
-  Without that, every real deep link is refused. It stays safe rather than
-  loose: only the same subdomain collapses, and that subdomain is the canister
-  id, so two different canisters can never normalise to one origin.
-- **Only `https`, or `http` on loopback** — the secure-context rule browsers
-  use. `javascript:` and `data:` URLs report their origin as the string
-  `"null"`, so without a scheme check two of them compare equal, pass an
-  origin test, and reach a navigation.
+- **Same-origin only.** The sender origin is II-derived (not a `PushAlert` field), so
+  a link can go anywhere on `app.com` but never to `evil.com` or another consented
+  dApp.
+- **Both sides canonicalised** — consent keys the *effective* origin, links use
+  whichever domain is browsed; without this every real deep link is refused. Safe:
+  only the same canister-id subdomain collapses.
+- **`https`, or `http` on loopback** only — `javascript:`/`data:` report origin
+  `"null"` and would compare equal without a scheme check.
 
-Validating on the send side rather than on the device is what lets the service
-worker open the link directly, removing a hop from the tap-through. It is also
-simply the better place: this is the only party that knows authoritatively which
-origin the user consented to, whereas the device-side check sat on a publicly
-craftable URL and every future consumer of `alert.url` would have had to repeat
-it.
-
-No target → the tap opens `/notify?origin=<sender>`, which resolves the sender's
-origin from the anchor's consent list and fails closed if it cannot.
+Validating on send (not device) removes a tap-through hop and puts the check on the
+only party that authoritatively knows the consented origin. No target → `/notify?origin=`
+resolves the sender and fails closed.
 
 ### Landing the user already signed in
 
-Yes, with **no II-side changes** — it composes out of the ICRC-167 redirect
-transport II already supports.
-
-**II cannot push a signed-in session.** A delegation targets a session key the
-_dApp_ generates and II never sees, so the flow must *begin* on the dApp's origin —
-a notification cannot bounce through `id.ai` and have II sign the user in from
-there. This is the same property that stops II impersonating a user, so it's a
-guarantee, not a limitation.
+Yes, **no II-side changes** — it composes out of the ICRC-167 redirect transport.
+**II cannot push a signed-in session** (the delegation targets a key the dApp
+generates and II never sees), so the flow must *begin* on the dApp's origin — a
+notification can't bounce through `id.ai` and be signed in from there. Same property
+that stops II impersonating a user.
 
 ```mermaid
 flowchart LR
     N[Tap notification] --> S["/sign-in?next=…<br/>(dApp origin)"]
-    S -->|session reusable| P[Destination page — signed in]
+    S -->|session reusable| P[Destination — signed in]
     S -->|not| A[II /authorize → Continue tap]
-    A --> S2["/sign-in return leg"] --> P
+    A --> S2[return leg] --> P
 ```
 
-Notifications link straight at the sign-in route (not the app, which would boot,
-find no session and bounce — a visible flash). The dApp provides `transport:
-"redirect"`, a `/.well-known/ii-auth-callbacks` file declaring the exact callback
-(protocol+host+path only — the destination rides in memoized flow state), and a
-callback origin whose identity derivation matches the push-consent `effectiveOrigin`.
+Notifications link at the sign-in route (not the app, which would boot, find no
+session and flash). The dApp provides `transport: "redirect"`, a
+`/.well-known/ii-auth-callbacks` (callback is protocol+host+path only; destination
+rides in memoized state), and a callback origin whose derivation matches the
+consent `effectiveOrigin`.
 
-**This should be a library, not per-dApp code.** Building it by hand is ~70 lines
-of ICRC-167 plumbing, ~15 of them app-specific and two security-relevant (narrowing
-an attacker-supplied `next` to a same-origin fragment; landing in the app on
-failure not stranding). It belongs in `@icp-sdk/auth` as one call —
-`handleRedirectSignIn({ nextParam, reuseExistingSession, onArrive, onError })` —
-with hooks for an app's own session policy. Until it exists, tap-through is the one
-place "a dApp needs no push infrastructure" is false.
+**This should be a library.** By hand it's ~70 lines of ICRC-167 plumbing, two of
+them security-relevant (narrow an attacker-supplied `next` to a same-origin
+fragment; land in the app on failure). Belongs in `@icp-sdk/auth` as
+`handleRedirectSignIn({ nextParam, reuseExistingSession, onArrive, onError })`.
+Until then, tap-through is the one place "a dApp needs no push infrastructure" is false.
 
-<details><summary>Lessons that shaped the helper's design</summary>
+<details><summary>Lessons that shaped it</summary>
 
-- **Its own route** — the flow journals state per route; on the app root it
-  interleaves with boot and lands signed out.
-- **Reuse needs the app's staleness rule, not just `isAuthenticated()`** — a
-  delegation can be valid while the app considers the session dead (session ends on
-  last-tab-close, exactly a notification's state). Stamp liveness first (arrival =
-  presence), then reuse. An app that *deletes* its session on tab close always
-  re-auths; it should exempt push-consenting users.
-- **Only II's Continue tap is irreducible** — silent delegation issuance would let
-  any site obtain one by redirect. The ugly signed-out path is a session-lifetime
-  problem, not one to style away; don't add an II-side interstitial (only the dApp
-  knows if it has a session).
-- **Local dev:** a loopback callback needs II's `dev_csp` (the allow-list fetch is
-  `connect-src`-bound to `https:`), and Chrome prompts for local-network access —
-  both absent once both sides are public https.
+- **Own route** — the flow journals state per route; on the app root it lands signed out.
+- **Reuse needs the app's staleness rule, not `isAuthenticated()`** — a delegation
+  can be valid while the app considers the session dead (last-tab-close). Stamp
+  liveness first (arrival = presence). An app that *deletes* its session on tab close
+  should exempt push-consenting users.
+- **Only II's Continue tap is irreducible** — silent issuance would let any site get
+  a delegation by redirect. Don't add an II-side interstitial (only the dApp knows if
+  it has a session).
+- **Local dev:** loopback callback needs `dev_csp`; Chrome prompts for local-network
+  access — both gone once public https.
 
 </details>
 
@@ -690,33 +583,15 @@ II owns both labels — a sender able to rename them would defeat the point.
 
 ### Updating or dismissing a notification already shown
 
-Yes, via a dApp-chosen `notification_id`, which the service worker maps to the
-Web Notification `tag`:
+Via a dApp-chosen `notification_id` mapped to the Web Notification `tag`: send again
+with the same id to **replace** in place ("Order shipped"→"delivered"); send
+`content = Dismiss` to **close** it. Complementary to `topic` (which collapses
+*undelivered* messages at the relay) — this acts on *delivered* ones.
 
-- **Update / replace** — send again with the same `notification_id`; the device
-  replaces the shown notification in place rather than stacking a second (e.g.
-  "Order shipped" → "Order delivered", or a live score ticking up).
-- **Dismiss** — send `content = Dismiss` with that `notification_id`; the SW
-  finds notifications with the matching tag and calls `.close()`, showing
-  nothing new.
-
-This is complementary to the `topic` delivery header, and the two act at
-different stages: `topic` collapses _undelivered_ messages at the relay
-(before they reach the device), while `notification_id` updates or dismisses an
-_already-delivered_ one on the device.
-
-Caveats:
-
-- **`userVisibleOnly` fights a silent dismiss.** Browsers require every push to
-  show _something_; a pure "close and show nothing" push can trigger the
-  browser's generic "site updated in background" notification and, if abused, a
-  permission penalty. So **update-with-a-new-state is the robust pattern**;
-  pure dismiss is best-effort.
-- It only works if the device is online to receive the follow-up and the
-  notification is still present (the user may have dismissed it already).
-- This is **explicit, opt-in** grouping the dApp controls — the opposite of the
-  automatic hostname-collapse we rejected. Notifications without a
-  `notification_id` never replace each other.
+Caveats: `userVisibleOnly` means a pure silent dismiss can trigger the browser's
+"site updated" notice, so **update-with-new-state is robust, pure dismiss
+best-effort**; only works if the device is online and the notification still present.
+Explicit opt-in — no `notification_id` means notifications never replace each other.
 
 ## Alternatives considered
 
@@ -817,80 +692,48 @@ as `app.com` — intentional, document it.
 
 ### Consent lifecycle: it must not outlive the sender
 
-Consent rows keyed only by `(anchor, origin_hash)` carry no reference to _which
-sender_ was registered for that origin. That makes consent survive events it
-should not:
+Consent keyed only by `(anchor, origin_hash)` carries no sender reference, so it
+survives events it shouldn't: a domain expires, someone buys it, serves their own
+`.well-known`, registers — and **every prior consenter is reachable**, attributed as
+the old brand. Fix: stamp consent with the **sender registration epoch**;
+invalidate when the registered principals change or the sender deregisters; expire
+after long no-delivery; surface "this app re-registered — re-confirm?".
 
-- A dApp shuts down, its domain expires, someone else buys it, serves their own
-  `.well-known/ii-push-senders`, and registers. **Every user who ever consented
-  to that origin is immediately reachable** — attributed as the old brand, with
-  tap-through deep-linking into the new owner's site.
-- Sender deregistration and re-verification TTLs do not bound this, because they
-  govern _sender verification_, not _consent validity_.
-
-Fixes: stamp each consent row with the **sender registration epoch**; invalidate
-consent when the registered principal set for an origin changes or the sender is
-deregistered, requiring a fresh opt-in; expire consent after a long period with
-no delivery; and surface "this app re-registered — re-confirm?" in Settings.
-
-Relatedly, `.well-known` re-verification must not become a **deregistration
-primitive**: a competitor who can cause a single 404 or timeout on a sender's
-`.well-known` during one lazy re-verify would silently strip its notification
-capability. Require K consecutive failures across a multi-day window, and never
-deregister on a 5xx or timeout — only on a well-formed file that no longer lists
-the sender.
+Also: re-verification must not be a **deregistration primitive** — a single induced
+404 shouldn't strip capability. Require K failures over days, never deregister on
+5xx/timeout, only on a well-formed file that no longer lists the sender.
 
 ## Privacy
 
-The doc's confidentiality story is about _content_. Metadata is a separate
-exposure and, for a notification hub, arguably the more sensitive one — `Hidden`
-protects the message text and does nothing for any of this.
+Confidentiality covers *content*; **metadata is the bigger exposure for a
+notification hub, and `Hidden` does nothing for it.** New here isn't the
+anchor↔origin link (II already stores that) but the **temporal** dimension and an
+**off-chain, device-linkable** identifier:
 
-**What is genuinely new here.** II already stores which origins an anchor uses
-(`StorableApplication`), so the anchor↔origin association is not new. What this
-feature adds is the **temporal** dimension — _when_ each app notified each user,
-continuously — and the **off-chain export** of a device-linkable identifier.
+- **The gateway sees a join key.** Grouping bundles by `endpoint` reveals, per
+  device: which origins notify it, when, sizes, and cleartext `Urgency`/`Topic`.
+  Since one browser = one endpoint across identities, this **links a user's anchors
+  and dApps** — the exact linkage per-origin derivation prevents. No decryption.
+- **Relays too:** one shared VAPID key lets FCM/APNs isolate II traffic and count
+  per-user dApp diversity. Per-dApp keys were an unlinkability property this design
+  removes.
 
-- **The gateway sees a join key.** Every bundle is
-  `{endpoint, headers, authorization, body}`. Grouping by `endpoint` yields, per
-  physical device: the set of sender origins notifying it, exact timestamps,
-  message sizes, and `Urgency`/`Topic` in cleartext headers. Because one browser
-  has one endpoint shared across a user's identities, that set links **a user's
-  anchors to each other and their dApps to each other** — precisely the linkage
-  per-origin principal derivation exists to prevent. No decryption required.
-- **The relays get it too, and more easily than before.** All II-mediated push
-  carries **one shared VAPID public key**, so FCM/APNs/Mozilla can isolate II
-  traffic and count per-user dApp diversity trivially. Per-dApp VAPID keys — which
-  this design frames as a burden it removes — were an unlinkability property.
-- **Timing is content.** "Which dApp notified this user at 03:00" is sensitive
-  even when the body is opaque.
-
-Mitigations to evaluate: give the gateway per-batch pseudonymous endpoint handles
-rather than raw endpoints; shuffle and pad batches so per-origin timing is not
-directly readable; and consider per-origin VAPID subkeys to restore relay-side
-unlinkability. At minimum, state plainly what the gateway, the relays and node
-operators each learn.
+Mitigations to evaluate: per-batch pseudonymous endpoint handles, batch
+shuffling/padding, per-origin VAPID subkeys. At minimum, state what the gateway,
+relays and node operators each learn.
 
 ## Delivery semantics: what is actually guaranteed
 
-"Best-effort" is not a guarantee, and several features silently depend on which
-one holds. Stated explicitly:
+- **At-least-once** — retries and `drain_epoch` duplicate; `chunk_id` makes chunk
+  resends idempotent, `msg_id` + device dedup hides the rest.
+- **Unordered** — per-relay queueing and urgency reorder freely.
+- **No receipts** — the only per-target signal is `NoConsent` at admission;
+  `admitted` ≠ "on the device".
 
-- **At-least-once, not at-most-once.** Retries and `drain_epoch` recovery both
-  duplicate; the non-replicated handoff removes the *n*×-fan-out source but not
-  these. `chunk_id` makes _chunk_ resends idempotent; `msg_id` + device dedup is
-  what makes duplicates invisible to the user.
-- **Unordered.** Nothing in the pipeline preserves order: per-relay queueing and
-  urgency's contribution to drain order both reorder freely.
-- **No delivery receipts.** The only per-target signal is `NoConsent`, returned
-  at admission. `admitted` means "in II's buffer", never "on the device".
-
-The ordering gap has teeth, because `notification_id` update/replace is defined
-in terms of it: "Order delivered" can land before "Order shipped" and leave the
-**stale** text on the lock screen permanently, and a `Dismiss` can arrive before
-the notification it dismisses and then be a no-op forever. Fix: carry a
-**monotonic sequence number per `(origin, anchor, notification_id)`** so the
-service worker drops out-of-order updates rather than applying them.
+The ordering gap has teeth: `notification_id` replace is order-dependent, so "Order
+delivered" can land before "shipped" and leave stale text forever, and a `Dismiss`
+can precede its notification. Fix: a **monotonic sequence per `(origin, anchor,
+notification_id)`** so the SW drops out-of-order updates.
 
 ## Duplicate and replay suppression (`msg_id`)
 
@@ -924,10 +767,6 @@ that (a messenger), the axis is *who decrypts and where*:
 | **Design B** — dApp-fetch | II's SW, on device | real text | II client code (+ dApp) |
 | `Display` | II service | full | full |
 | App's own SW | app's SW | full | none (II not in loop) |
-
-Key correction: "II can never show decrypted content" is too strong. II's *service
-worker* decrypting on the user's own device — with a key II-the-service never sees
-in clear — is viable, and only a small step past the trust of signing in with II.
 
 **Ship `Hidden` first** — content-hidden notification + tap-through reveal (the
 industry-standard E2E UX; `/notify` is the reveal path). Zero extra trust, today.
@@ -995,83 +834,42 @@ fetch per notification. Murkier than A; the fallback for backend-trusted apps.
 
 ## IC capabilities to re-evaluate
 
-Platform features that would change decisions in this doc. Worth re-checking
-before implementation, because two of them postdate the design:
-
-- ~~**Non-replicated outcalls (`is_replicated = false`)**~~ — **adopted**: the
-  batch handoff to the gateway uses it, which is what makes `410` cleanup
-  possible there and drops the payload cost by the full factor of *n*. Still
-  marked experimental, so what remains to watch is the API changing under us —
-  keep it behind one call site that can revert to replicated plus a transform.
-  Field-tested outside II: multidex's price oracle has run on it since
-  2025-08-04, which is where the ~*n*× figure was measured.
-- **Per-node outcall results.** A management-canister API returning per-node
-  responses would give per-device status back on a *replicated* path, which is now
-  only interesting as a way to stop depending on an experimental flag. Unverified
-  whether it is enabled on mainnet — settle by calling it or checking release
-  notes.
-- **P-256 (secp256r1) threshold ECDSA** — **the end state this design wants.** It
-  moves the VAPID key out of storage entirely via `sign_with_ecdsa`: the subnet
-  signs, there is no stored secret to extract, and the custody caveat that runs
-  through the security model goes away rather than being mitigated. Requested
-  since 2024 with **no public roadmap item or timeline**, so treat it as "if it
-  ever ships", not "when" — which is why the stored key is the design and not a
-  placeholder. Migrating changes the public key, but does **not** require a
-  fleet-wide re-enable: run both keys and let old subscriptions age out, per
-  [VAPID rotation](#open-items).
-- **vetKeys** — already live; see
-  [Design A](#end-to-end-encrypted-apps).
-  Client libraries are still pre-1.0 and the JS package was renamed, so pin
-  deliberately.
+- ~~**Non-replicated outcalls**~~ — **adopted** (batch handoff); still experimental,
+  so keep it behind one revertible call site. Field-tested on multidex's oracle.
+- **Per-node outcall results** — would give per-device status on a *replicated* path;
+  only interesting to stop depending on the experimental flag. Verify on mainnet.
+- **P-256 threshold ECDSA** — **the end state.** Moves the VAPID key out of storage
+  (subnet signs, no stored secret), deleting the custody caveat rather than mitigating
+  it. No roadmap, so the stored key is the design, not a placeholder. Migration is
+  dual-key, no fleet re-enable.
+- **vetKeys** — live; [Design A](#end-to-end-encrypted-apps). Pin the pre-1.0 client.
 
 ## Push must never degrade authentication
 
-The invariant, stated separately because it is the one that makes this feature
-unshippable if violated: **no volume of push traffic may reduce the availability
-of sign-in.**
-
-II is not a dedicated push canister. It authenticates every user of the network,
-and push shares three resources with that job:
-
-- **The in-flight outcall budget** (3000, subnet-wide). II's own auth paths spend
-  from it: DoH for email recovery, JWKS and discovery for OIDC. Push must hold a
-  quota well below the cap and **fail closed** — return `ready = false` — rather
-  than compete. Note the queue to the management canister is also 500-deep per
-  canister pair, so a burst can exhaust the queue and make II's _own_ auth
-  outcalls fail synchronously.
-- **Instructions per round.** A drain slice must be a small fraction of a round,
-  never a whole chunk.
-- **Cycles** (on paying deployments), because the freezing threshold is shared:
-  push spend must never be able to push II toward the state where updates stop
-  and only queries serve.
-
-Concretely: a semaphore with a push-only quota, a drain slice sized from
-measurement, a cycle floor, and **authentication p99 latency as a monitored
-signal** with push throttling as the automatic response.
+The unshippable-if-violated invariant: **no volume of push may reduce sign-in
+availability.** II authenticates every user, and push shares three resources with
+that job — the in-flight outcall budget (push holds a quota well below 3000 and
+**fails closed**, not competing; the 500-deep queue can otherwise fail II's *own*
+auth outcalls synchronously), instructions/round (small drain slice), and cycles
+(push spend must never approach the freezing threshold). Enforce with a push-only
+semaphore, a measured slice, a cycle floor, and **auth p99 as a monitored signal**
+that auto-throttles push.
 
 ## Operating it: controls, alerts and rollout
 
-Metrics alone are not operability. Missing today:
+Missing today:
 
-- **A per-origin kill switch.** `push_deregister_sender` is authenticated by the
-  _dApp_, so there is no operator-side way to silence an abusive sender. Needs an
-  operator-gated `push_set_origin_enabled(origin, bool)` plus a **global feature
-  flag** in persistent state to disable push entirely without an upgrade.
-- **Alert thresholds and ownership** — on buffer depth (stuck-timer canary),
-  drain lag, per-origin reject rate, and auth-path p99. Define who is paged.
-- **Gateway operations** — who runs it, how many independent instances (≥2 with
-  distinct operators), health probes, automatic switchover, and what happens to
-  batches already handed over when one dies. Since the gateway is the shipping
-  path and the direct path is a degraded fallback, **gateway down = push down**;
-  that needs to be an explicit, accepted statement rather than an implication.
-- **Rollout and rollback.** Rollback is an upgrade, which discards the in-flight
-  buffer — so a rollback silently drops in-flight campaigns unless `drain_epoch`
-  is in place first.
-- **A load test.** Every throughput and cost number in this doc is derived, not
-  measured. Before deployment: run a 10k-recipient campaign against a local
-  replica while measuring authentication latency, and measure the real
-  instruction cost of one seal with `performance_counter` (II already runs
-  P-256 in `dnssec/`, so this is a short exercise).
+- **Per-origin kill switch** — `push_deregister_sender` is dApp-authenticated, so
+  there's no operator way to silence an abusive sender. Need operator-gated
+  `push_set_origin_enabled` + a global feature flag to disable push without an upgrade.
+- **Alerts + ownership** on buffer depth, drain lag, per-origin reject rate, auth p99.
+- **Gateway ops** — who runs it, ≥2 independent instances, health/switchover.
+  **Gateway down = push down** (direct is a degraded fallback) — state it explicitly.
+- **Rollback discards the buffer** — silently drops in-flight campaigns unless
+  `drain_epoch` lands first.
+- **A load test** — every throughput/cost number here is derived. Run a 10k campaign
+  against a local replica measuring auth latency, and measure one seal's real cost
+  with `performance_counter`.
 
 ## dApp developer integration
 
@@ -1081,9 +879,8 @@ origin, serve the callback allow-list, shape its deep links — is in
 
 ## Scaling
 
-Two questions: **how fast can II push**, and **can II store the data**. The honest
-answer to the first is per-stage — a send crosses six stages and only two actually
-bound scale.
+Two questions: **how fast can II push** (per-stage — six stages, two bind), and
+**can II store the data**.
 
 ### Where the bottleneck is, stage by stage
 
@@ -1135,8 +932,8 @@ xychart-beta
 
 ### Storage: can II store the data
 
-Storage is **O(users × origins)** — flat with notification *volume*, but it grows
-with users and the apps they consent to.
+Storage is **O(users × origins)** — flat with notification *volume*, grows with
+users × consented apps.
 
 | Row | Key | Size | Grows with |
 | --- | --- | --- | --- |
@@ -1168,24 +965,15 @@ cheap.)
 
 ## Future exploration
 
-Deliberately out of v1, kept here so the door stays open:
+- **Cycles-based charging** — per-notification cycles (canister senders) or a prepaid
+  per-origin balance (also lets off-chain senders pay). Out of v1: the design already
+  controls storage and outcalls and admission bounds abuse, so billing adds complexity
+  without solving a present problem. Retrofittable, kept visible.
+- **Off-chain senders** (web2 via ingress) — needs a self-auth challenge and, if paid,
+  the prepaid balance.
+- **Delivery receipts** — Web Push has none; per-origin aggregates are the most II can
+  offer without per-user tracking.
 
-- **Cycles-based charging.** Attach cycles per notification (canister senders
-  only — ingress calls can't carry cycles), or a prepaid per-origin balance
-  (which would also let off-chain senders pay). Dropped from v1 because the
-  design already controls the real costs (storage via the stateless model,
-  outcalls via the gateway) and admission control bounds abuse — so billing
-  adds complexity without solving an immediate problem. Worth revisiting at
-  scale to make senders pay for the outcalls/storage they drive, or as an extra
-  fairness/abuse lever. Retrofitting payment later is possible (the endpoint
-  would check attached cycles or a prepaid balance) but easier to design in
-  than bolt on, so keep the option visible.
-- **Off-chain senders** (a web2 backend calling via ingress) — needs a
-  self-auth challenge flow for sender identity and, if paid, the prepaid
-  balance above.
-- **Delivery receipts / analytics** — Web Push has none; any per-user delivery
-  signal would have to come from the app itself, and per-origin aggregates are
-  the most II can offer without a per-user tracking surface.
 ## Status
 
 ### Built today (PoC on `feat/push-notifications-poc`)
@@ -1204,21 +992,8 @@ the PoC proved it necessary.
 - **`msg_id` dedup + `410`/`404` cleanup**, **`alert.url` validation**, **browser
   VAPID-key resubscribe**
 
-### Not built, so the PoC isn't mistaken for a shippable subset
+### Not built (so the PoC isn't mistaken for shippable)
 
-- No `push_send`, so no batching, no chunking, and no client library — a send is
-  one `notify_user` per recipient.
-- No rate limiting or admission control of any kind — `notify_user` is unmetered.
-- No `.well-known/ii-push-senders` verification: senders are registered by an
-  operator, so nothing yet proves a canister owns the origin it sends as.
-- `Display` content only — no `Hidden`, which is the variant the design
-  recommends shipping first for E2E apps.
-- Integration and E2E test coverage is thin (unit tests only).
-
-Everything else the PoC lacks is a work item rather than a design gap, and is
-listed once in [Open items](#open-items) — endpoint allowlist, per-anchor caps,
-`drain_epoch`, drain isolation, `pushsubscriptionchange`, the reserved outcall
-budget for authentication. This section deliberately does not restate them.
-
-The rest of this document is the proposal, so there is no separate list of it.
-
+No `push_send` (one `notify_user` per recipient), no rate limiting, no `.well-known`
+verification (operator-registered), `Display` only (no `Hidden`), thin test coverage.
+Everything else is a work item listed once in [Open items](#open-items).

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -271,10 +271,9 @@ tight — it's charged whether used or not. The gateway's real justification sta
 **outcall slots**, which no pricing change touches.
 
 **vetKD** (for [E2E](#end-to-end-encrypted-apps)) is charged everywhere: ~26.2 B
-cycles/call — fine once per user, ruinous per message (~$357/10k blast). So derive
-**once per `(user, origin)`**, cache in the SW, rate-limit per anchor; the bill
-lands on **II** (ingress carries no cycles), so an uncached derive is a
-user-triggerable drain.
+cycles/call — fine once per user, ruinous per message (~$357/10k blast). Derive
+**once per `(user, origin)`** and cache in the SW. (It's also a DoS vector — the
+bill lands on II — see [Security](#security-model).)
 
 **No sender charging in v1** — parked (accept/refund complexity). But a rate limit
 × time is unbounded spend, so a paying deployment needs a **cycle budget +
@@ -550,38 +549,45 @@ authenticated landing. Pairs naturally with `Hidden` content.
 
 ### Action buttons: navigate, never act
 
-`actions` are extra buttons (`notificationclick` reports which); platforms show ~2,
-**Safari/iOS none**, so they must degrade. Every action here can only **navigate** —
-the SW is on II's origin and holds no dApp session, so "Add margin" opens the
-add-margin screen, it can't add margin. It's just an extension of the deep link:
+A notification can carry up to about two action buttons (Safari and iOS show none,
+so anything built on them has to degrade gracefully). Here, every button can only
+navigate — never act. The service worker runs on II's origin and has no session for
+the dApp, so an "Add margin" button can open the add-margin screen, but it cannot
+actually add margin. In other words, an action is just another deep link:
 
 ```candid
 actions : opt vec record { id : text; title : text; url : text };   // ≤ 2, same-origin
 ```
 
-**Cost of the hub:** silent actions. A dApp's own SW could Archive/Snooze via a
-`fetch` with no window; the II-hosted worker can't. Listed in
-[alternatives](#a1) as part of what the single permission buys.
+Losing silent actions is a genuine cost of centralising on II. A dApp that ran its
+own service worker could Archive or Snooze with a background fetch and no window
+opened; because our worker lives on II's origin instead, it can't. This is one of
+the trade-offs the single permission buys, alongside the others in
+[alternatives](#a1).
 
-**What it buys back: a sender-proof off-switch.** Because II composes every
-notification it can attach an off-switch no sender can remove or relabel — a
-guarantee no per-dApp design can make. It spends one of the two slots (worth it,
-since a sender's own actions only navigate anyway). Three levels:
+In return, II can do something no per-dApp design can: put an off-switch on every
+notification that the sender is unable to remove or relabel, because II composes the
+notification itself. It costs one of the two button slots, which is a good trade
+given a sender's own actions could only navigate anyway. There are three levels:
 
-- **Turn off on this device** — free, silent, today. `subscription.unsubscribe()`
-  needs no II call, works even if II's backend is down; endpoint then `410`s and
-  [cleanup](#stale-subscription-cleanup) reclaims it. Device-wide, not per-app.
-- **Stop this app** — `{ action: "ii-manage", title: "Manage" }` deep-links to
-  `/manage/settings?app=<origin>` (revoke is anchor-authorized, so it navigates).
-  **"Manage" not "Unsubscribe"**: Chrome already shows its own unsubscribe, and the
-  button navigates rather than revoking. Lands on the app's row where every other
-  grant is visible; the destination already exists in `PushNotificationsSection`.
-- **Stop this app silently** — would need a sealed capability token; not worth one
-  saved tap in v1.
+- **Turn off on this device.** Free and immediate: `subscription.unsubscribe()`
+  needs no call to II and works even if II's backend is down. The endpoint then
+  returns `410` and [cleanup](#stale-subscription-cleanup) reclaims the row. This is
+  device-wide, though, not per-app.
+- **Stop a single app.** Revoking consent is authorised by the anchor, which the
+  worker can't do itself, so the button navigates:
+  `{ action: "ii-manage", title: "Manage" }` opens `/manage/settings?app=<origin>`.
+  We call it "Manage" rather than "Unsubscribe" for two reasons — Chrome already
+  shows its own unsubscribe control, and the button navigates rather than revoking,
+  so a stronger word would overpromise. It lands the user on that app's row, where
+  they can see everything else they've granted; the page already exists.
+- **Stop a single app silently** would need a sealed capability token in the
+  payload, which isn't worth the one saved tap for now.
 
-II owns both labels — a sender able to rename them would defeat the point.
+Either way II owns the labels — a sender that could rename "Manage" or "Turn off"
+would defeat the whole point.
 
-### Updating or dismissing a notification already shown
+### Updating or dismissing a notification already shown### Updating or dismissing a notification already shown
 
 Via a dApp-chosen `notification_id` mapped to the Web Notification `tag`: send again
 with the same id to **replace** in place ("Order shipped"→"delivered"); send
@@ -636,6 +642,7 @@ forcing sender-origin attribution at send time.
 | **Relay/gateway reads content** | RFC 8291 encrypted per device. Scope: *transport* only — II sees `Display` plaintext (it seals); `Hidden`/vetKeys keep it from II too |
 | **Probing II state** | Rejections are coarse (`NoConsent` only); randomize `retry_after_ms` (it reflects aggregate load); reject reasons a fixed enum; endpoint URLs never logged |
 | **`/notify` icon** | curated registry only + globe fallback — never fetch arbitrary/remote icons into II's chrome |
+| **vetKD derive drain** | the SW triggers a derive over ingress (no cycles attached), so the bill lands on II — an uncached derive is a user-triggerable cycle drain. Derive once per `(user, origin)`, cache in the SW, rate-limit per anchor |
 
 **The VAPID-key risk is larger than "spam".** The same stable memory holds the
 VAPID key *and* every device's `p256dh`/`auth`, so an attacker reading it can forge

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -577,7 +577,7 @@ given a sender's own actions could only navigate anyway. There are three levels:
 Either way II owns the labels — a sender that could rename "Manage" or "Turn off"
 would defeat the whole point.
 
-### Updating or dismissing a notification already shown### Updating or dismissing a notification already shown
+### Updating or dismissing a notification already shown
 
 Via a dApp-chosen `notification_id` mapped to the Web Notification `tag`: send again
 with the same id to **replace** in place ("Order shipped"→"delivered"); send

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1231,13 +1231,15 @@ needs its surrounding detail to make sense:
   monotonic per-endpoint counter of pushes II issued so a service worker can
   flag pushes II did not send. Note there is currently **no detection story** —
   II cannot observe pushes it did not originate — and **no rotation story**:
-  rotating the VAPID key invalidates every subscription at once, so the
-  "re-enable on your devices" UX is a prerequisite for having a recovery path
-  at all, not a later nicety.
+  abandoning the leaked VAPID key invalidates every subscription signed under it,
+  so the "re-enable on your devices" UX is a prerequisite for having a recovery
+  path at all, not a later nicety. (A _planned_ key change does not need it — see
+  [VAPID rotation](#open-items) — but a compromise does, because the point is to
+  stop honouring the old key immediately.)
 
-  P-256 threshold ECDSA would remove the key from storage entirely, but the IC
-  supports only secp256k1 today (see
-  [IC capabilities to re-evaluate](#ic-capabilities-to-re-evaluate)).
+  P-256 threshold ECDSA would remove the key from storage entirely and delete this
+  whole risk rather than mitigating it, but the IC supports only secp256k1 today
+  (see [IC capabilities to re-evaluate](#ic-capabilities-to-re-evaluate)).
 
 - **VAPID key initialization must not race.** Generating the key lazily on first
   use puts an `await` on `raw_rand` between the "is it set?" check and the
@@ -1680,9 +1682,27 @@ Known-deferred:
   gates capture, so the practical risk is low" does **not** hold on the chosen
   path: the gateway legitimately receives the sealed bundle, so replay needs no
   network interception at all.
-- **VAPID rotation** — rotating invalidates every subscription at once; needs
-  a "re-enable on your devices" UX. Note this UX is also the only recovery path
-  from a VAPID key compromise, so deferring it means deferring recovery.
+- **VAPID rotation — the design intent is never to rotate.** There is no expiry
+  and no hygiene schedule; a rotation is an incident, not maintenance. Two cases,
+  and they want opposite mechanisms:
+
+  **Planned migration** (today's stored key → a subnet-held one, if P-256
+  threshold ECDSA ever ships) needs no user-visible event at all. A subscription
+  is bound to the `applicationServerKey` it was created with, so II can retain the
+  old private key for devices already on it while issuing new subscriptions under
+  the new one. Endpoints churn on their own as browsers rotate them, so the fleet
+  migrates without anyone being asked to re-enable anything. Support both keys at
+  verify time, stop issuing the old one, and let it age out.
+
+  **Compromise recovery** cannot do that, because the whole point is to stop
+  honouring the leaked key — so it does invalidate every subscription under it at
+  once, and it is the case that genuinely needs the "re-enable on your devices"
+  UX. Build that UX for the incident, not for the migration; deferring it means
+  having no recovery path, which is the actual argument for it.
+
+  The end state we want is **the subnet holding the key**, so that there is no
+  stored secret to leak and this open item mostly disappears — see
+  [IC capabilities to re-evaluate](#ic-capabilities-to-re-evaluate).
 - **Cleanup hooks** on device/anchor removal.
 - **Metadata-privacy mitigations** — endpoint blinding, batch shuffling/padding,
   per-origin VAPID subkeys. See [Privacy](#privacy).
@@ -1714,11 +1734,15 @@ before implementation, because two of them postdate the design:
   only interesting as a way to stop depending on an experimental flag. Unverified
   whether it is enabled on mainnet — settle by calling it or checking release
   notes.
-- **P-256 (secp256r1) threshold ECDSA** — would move the VAPID key out of
-  storage entirely via `sign_with_ecdsa`. Requested since 2024 with **no public
-  roadmap item or timeline**, so treat it as "if it ever ships", not "when".
-  Migration invalidates existing subscriptions (the public key changes), so it
-  pairs with the re-enable UX.
+- **P-256 (secp256r1) threshold ECDSA** — **the end state this design wants.** It
+  moves the VAPID key out of storage entirely via `sign_with_ecdsa`: the subnet
+  signs, there is no stored secret to extract, and the custody caveat that runs
+  through the security model goes away rather than being mitigated. Requested
+  since 2024 with **no public roadmap item or timeline**, so treat it as "if it
+  ever ships", not "when" — which is why the stored key is the design and not a
+  placeholder. Migrating changes the public key, but does **not** require a
+  fleet-wide re-enable: run both keys and let old subscriptions age out, per
+  [VAPID rotation](#open-items).
 - **vetKeys** — already live; see
   [Design A](#design-a--vetkeys-sealed-content-decrypted-in-iis-sw-preferred-richer-path).
   Client libraries are still pre-1.0 and the JS package was renamed, so pin

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1650,12 +1650,35 @@ Must-fix before a real deployment:
   is not true while onboarding means asking someone at DFINITY to add a row, and a
   dApp would have traded a push stack for a support ticket. Pairs with the
   deregistration and re-verification TTL below.
-- **Endpoint host allowlist.** The push endpoint is attacker-supplied. Validate
-  it against the known push services at subscribe time (and **re-validate at
-  drain**, so pre-existing rows can't bypass a tightened list), reject explicit
-  ports, userinfo and non-`https` schemes, and reject private/loopback/link-local
-  hosts. Without this, II is an SSRF and DDoS reflector with an *n*× multiplier —
-  a free ingress call turns into 34 POSTs at a victim of the caller's choosing.
+- **Endpoint host allowlist.** The endpoint is a URL the **caller** supplies. A
+  browser gets it from its push service — `fcm.googleapis.com`,
+  `updates.push.services.mozilla.com`, `web.push.apple.com` — and passes it to
+  `push_subscribe_device`, but that call arrives over ingress and nothing proves
+  the string came from a push service. So a caller can subscribe with
+  `https://victim.example.com/something-expensive`, and every later send to that
+  anchor becomes traffic aimed wherever they chose: **reflection**, and **SSRF**
+  from the sending party's network position.
+
+  Validate the host against the known push services at subscribe time, and
+  **re-validate at drain** so rows written before the list was tightened cannot
+  keep using it. Reject non-`https`, explicit ports, `userinfo`, and
+  private/loopback/link-local hosts.
+
+  **II must be the validator, not the gateway.** On the chosen path II never POSTs
+  to the endpoint at all — it hands the endpoint to the gateway, which makes the
+  per-device sends. That relocates the abuse rather than removing it, and makes it
+  worse in one respect: the gateway is an ordinary server that may sit where
+  private addresses are reachable, whereas replica outcalls egress through a proxy.
+  If the gateway were the only place this is checked, II would be handing an
+  attacker-chosen URL to a component it has already declared trusted, and a buggy
+  or compromised gateway would turn that into clean SSRF. Check before handing it
+  over.
+
+  On the direct per-device alternative, II does POST itself, and under replicated
+  outcalls that carries an *n*× multiplier — one free ingress call becoming 34
+  POSTs at the victim. The non-replicated handoff removes the multiplier from the
+  chosen path; it does not remove the need for the allowlist, because one POST at
+  a victim of the caller's choosing is still one too many.
 - **Per-anchor caps.** Cap subscription rows at **20** and consent rows at
   **100** per anchor, with LRU eviction. Nothing bounds either today, ingress is
   free to the caller, and II pays the stable-memory cost — a direct attack on the

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1,166 +1,96 @@
 # Push notifications — design
 
-Internet Identity hosts a single Web Push pipeline that any dApp can send
-through. The user grants notification permission to id.ai **once**, subscribes
-per device, and consents per dApp; every consented dApp then delivers
-notifications via II rather than running its own service worker, VAPID
-keypair, and subscription.
+**How to read this.** It is long because it covers two independent scaling paths
+and a security model. If you only read one section, read
+[How it works, in plain terms](#how-it-works-in-plain-terms). Then:
 
-The value is a **single permission + delivery hub**, not an install: the user
-allows notifications for their identity provider once, and every consented
-dApp reaches them through it — instead of each dApp prompting for its own
-notification permission (which browsers increasingly bury) and running its own
-push stack. Installing II as a PWA is **optional** on Android and desktop
-(Web Push works in a plain tab there) and only **required on iOS Safari**,
-where it also earns its keep as "install one app, get every dApp's
-notifications." This doc captures the design across the two paths that decide
-scalability — **dApp → II** and **II → device** — plus the security model and
-the open items.
+- **Reviewing the design?** [Goals and non-goals](#goals-and-non-goals) →
+  [Architecture](#architecture) →
+  [Alternatives considered](#alternatives-considered) →
+  [Security model](#security-model) → [Open items](#open-items).
+- **Implementing it on II?** [dApp → II](#dapp--ii) →
+  [II's state model](#iis-state-model-stateless-for-campaigns) →
+  [Delivering to devices](#delivering-to-devices) →
+  [Push must never degrade authentication](#push-must-never-degrade-authentication).
+- **Integrating a dApp?**
+  [dApp developer integration](#dapp-developer-integration) →
+  [The Candid interface](#the-candid-interface) →
+  [The dApp-side client library](#the-dapp-side-client-library).
+- **Wondering what exists today?** [Status](#status), at the end.
 
-## What does the user experience?
+## Context and scope
 
-### How does a user turn notifications on? (first time signing into a dApp)
 
-1. On the dApp (e.g. `oisy.com`), the user clicks **Sign in with Internet
-   Identity**. II opens at `/authorize`.
-2. The user authenticates as usual (passkey, or an existing session for a
-   returning user).
-3. **Continue screen** (`ContinueView`): "Continue to `<dApp>`" with the
-   account picker and a **Continue** button. There is no notification toggle
-   here — the account choice is the only decision.
-4. The user taps **Continue**.
-5. **Notifications opt-in screen** (`NotifOptInView`): a preview illustration
-   of what a notification looks like (an "Example" lock-screen stack), the
-   heading "Let `<dApp>` notify you", two short reasons (instant alerts /
-   reachable anytime), and two buttons — **Enable notifications** and **Maybe
-   later**.
-   6a. **Enable** → if this browser has not granted permission yet, it shows
-   its **native permission prompt** ("`id.ai` wants to show notifications —
-   Allow / Block"). This dialog is the browser's own and cannot be restyled.
-   On **Allow** — or straight away, when permission was granted earlier — II
-   subscribes the device and records consent for this dApp, then redirects to
-   the dApp. No app install is required (Android/desktop); iOS Safari is the
-   exception.
-   6b. **Maybe later** → II redirects straight to the dApp; nothing is enabled.
+A dApp on the IC that wants to reach a user who is not currently looking at it
+has no good option. Web Push is the browser-native answer, but doing it yourself
+means prompting for your own notification permission, running your own service
+worker, holding your own VAPID keypair, and storing your own subscription
+endpoints — per dApp. Browsers increasingly bury that permission prompt, users
+decline it more often the more times they see it, and on iOS Safari it requires
+the site to be installed as a PWA at all. The result is that almost no dApp does
+it, and users get nothing.
 
-Two separate things are being asked, and only one of them repeats.
+Internet Identity is already the one origin every user of these apps has a
+relationship with, and already holds per-user state they have consented to. That
+makes it the one place where the permission can be asked **once** and reused.
 
-II's opt-in screen **is** shown for each new dApp, because consent is recorded
-per origin and no dApp inherits another's. It appears once per dApp per
-device: a device that has not subscribed yet sees it again even for a dApp
-already enabled on another device, with copy that asks about this device
-rather than repeating the original pitch.
+So: II hosts a single Web Push pipeline that any dApp can send through. The user
+grants notification permission to `id.ai` once, subscribes per device, and
+consents per dApp; a consented dApp then delivers through II rather than running
+a push stack of its own. Installing II as a PWA stays **optional** on Android and
+desktop, and is **required only on iOS Safari** — where "install one app, get
+every dApp's notifications" is a better trade than installing each dApp.
 
-The **browser's** permission prompt is the part that does not come back. It is
-granted to `id.ai`, not to the dApp, and every dApp's notifications are
-delivered through that one origin — so once the user has allowed it, the
-browser has nothing left to ask, and later opt-ins complete without a second
-dialog.
+This document covers the design of the two paths that decide whether it scales —
+**dApp → II** and **II → device** — the security and privacy model, and the open
+items. It is a design document, not an integration guide: the Candid interface
+and the client-library internals are here to show the design is buildable, not to
+serve as reference material.
 
-### What happens when a notification is sent?
+## Goals and non-goals
 
-7. The dApp's backend tells II to notify the user. At any real scale this runs
-   through the dApp's client library and the chunked `push_send` endpoint (see
-   below); the PoC has a simpler one-shot `notify_user` for a single recipient.
-8. The notification arrives on every device the user enabled — **even with the
-   tab closed / browser not running** (on Android). It shows the dApp's origin
-   as the source and the dApp's title/body as the text.
-9. The user **taps** it. When the dApp supplied a deep link — the normal case —
-   the service worker opens that URL directly and II is not visited at all. The
-   dApp lands the user on the page the notification was about, signing them in
-   on the way with the ICRC-167 top-level redirect if the session has lapsed,
-   which is the usual state when a notification is what brought them back.
-   Only a notification with no deep link falls back to II's `/notify` screen
-   ("Opening `<dApp>`" with the app's logo), which resolves the sender's origin
-   behind a consent gate and forwards to the dApp's home.
 
-### How does a user manage or turn them off?
+### Goals
 
-10. Either from the browser or from II.
+- **One permission, many apps.** A user allows notifications once, for their
+  identity provider, and every consented dApp reaches them through it.
+- **A dApp needs no push infrastructure.** No service worker, no VAPID keypair,
+  no subscription storage, no relay accounts.
+- **Consent is per dApp and per device, and revocable.** Revoking one dApp stops
+  its notifications immediately and affects no other.
+- **A 10k-user broadcast is a normal operation**, not an incident — with the
+  explicit constraint that it must never degrade authentication, which is what
+  this canister actually exists to do.
+- **II's durable storage does not grow with volume.** Storage is user-scoped;
+  sending more notifications must not make it larger.
+- **A tap lands the user where the notification was about**, in the sending app,
+  signed in.
+- **There is a path for apps that cannot let II read their content** — a
+  messenger should not hand message bodies to its identity provider.
 
-    In **II → Settings**, the user sees **Notifications on this device**
-    (a toggle to turn the whole device on/off) and **Allowed apps** — every
-    dApp that can notify them, each with a remove button. Revoking an app
-    stops its notifications immediately.
+### Non-goals
 
-    The **browser's own site settings** can also block notifications for
-    `id.ai`, which silences every dApp at once and cannot be overridden from
-    inside II — the permission belongs to the browser, not to us. II can only
-    observe the result: a blocked permission makes the opt-in screen
-    unofferable, so it is skipped rather than shown as a button that cannot
-    work. Re-enabling has to happen in the browser too; that is the one path
-    II cannot offer a control for.
+- **Not a messaging product.** No inbox, no history, no unread state, no
+  read receipts. II forgets a notification once it is handed off.
+- **Not exactly-once delivery.** Delivery is explicitly at-least-once, which is
+  why device-side deduplication ships with it rather than after it.
+- **Not guaranteed delivery.** The relays are best-effort and a device that never
+  comes online never receives; no part of this promises otherwise.
+- **Not per-notification billing, in v1.** Charging senders cycles is parked, not
+  designed — which has consequences for abuse limits, covered below.
+- **Not a way to reach "all II users".** There is no audience except users who
+  consented to a specific dApp; a sender cannot discover or address anyone else.
+- **Not universal browser support.** Web Push is browser-scoped. Browsers without
+  it (some vendor forks ship none) are out of reach, and that is not something
+  this design can fix.
+- **Not a replacement for in-app notification UI.** This reaches users who are
+  away; what an app shows a user who is present is the app's business.
 
-## Status
+## How it works, in plain terms
 
-### Built today (PoC on `feat/push-notifications-poc`)
 
-An inventory, not an explanation — each line links to the section that covers
-it. The last four exist because building the PoC proved they had to.
-
-- **Per-device subscribe/unsubscribe, `/authorize` opt-in, per-dApp consent** —
-  [the user flow](#how-does-a-user-turn-notifications-on-first-time-signing-into-a-dapp),
-  [consent lifecycle](#consent-lifecycle-it-must-not-outlive-the-sender).
-- **`notify_user(principal, alert)`** — one recipient per call. It does **not**
-  answer scale, and everything in this doc about throughput, cost and delivery
-  assumes the chunked `push_send` that supersedes it:
-  [chunked send and flow control](#sending-to-thousands-of-users-chunked-send--two-layer-flow-control).
-- **RFC 8291 payload encryption and RFC 8292 VAPID signing, both in-canister** —
-  [delivering to devices](#delivering-to-devices).
-- **VAPID key generated with `raw_rand`, held in stable memory** — not the
-  custody model we would choose. Web Push mandates P-256, the IC's threshold
-  ECDSA is secp256k1 only, so the subnet cannot hold the key for us:
-  [what that risks](#security-model),
-  [what changes if P-256 lands](#ic-capabilities-to-re-evaluate).
-- **Tap opens the dApp's deep link directly**, falling back to the consent-gated
-  `/notify` redirect when the sender supplied no target —
-  [where a notification opens](#can-the-app-choose-where-the-notification-opens),
-  [landing signed in](#can-the-tap-land-the-user-already-signed-in).
-- **Sender authorization by origin** — a registry keyed by origin hash. The
-  original `caller() == in_app_principal` rule could never match an
-  inter-canister call, so it admitted only self-sends:
-  [how II verifies a sender](#how-does-ii-verify-the-sender-is-really-that-dapp).
-- **Send-time `alert.url` validation** — what makes opening the deep link
-  directly safe:
-  [where a notification opens](#can-the-app-choose-where-the-notification-opens).
-- **`msg_id` dedup in the service worker, and `410`/`404` row cleanup** —
-  [duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
-- **VAPID key rotation in the browser** — a subscription bound to a superseded
-  key is resubscribed rather than failing forever.
-
-### Not built, so the PoC isn't mistaken for a shippable subset
-
-- No `push_send`, so no batching, no chunking, and no client library — a send is
-  one `notify_user` per recipient.
-- No rate limiting or admission control of any kind — `notify_user` is unmetered.
-- No `.well-known/ii-push-senders` verification: senders are registered by an
-  operator, so nothing yet proves a canister owns the origin it sends as.
-- No endpoint host allowlist, and no per-anchor caps on subscription or consent
-  rows.
-- `Display` content only — no `Hidden`, which is the variant the design
-  recommends shipping first for E2E apps.
-- No `pushsubscriptionchange` handling, so a rotated endpoint still leaves a
-  stale row until a relay reports it gone.
-- Integration and E2E test coverage is thin (unit tests only).
-
-### Proposed (the rest of this doc)
-
-- Chunked `push_send` with two-layer flow control (II admission + client
-  pacing), a sender registry, a stateless-for-campaigns II (transient heap
-  buffer, storage O(users × origins)), a durable client library, and delivery
-  through a trusted web2 gateway (with direct per-device outcalls as the
-  documented alternative/fallback).
-- Promoted to v1 requirements by review, and still outstanding: a `drain_epoch`
-  acknowledgment signal, an endpoint host allowlist, per-anchor caps, drain
-  isolation and non-reentrancy, and a reserved outcall budget that protects
-  sign-in. (`msg_id` + device dedup was also promoted, and is now built.)
-- No cycles charging to senders in v1 — but a deployment that pays fees needs a
-  cycle budget with a circuit breaker regardless. Sender charging is parked as a
-  future exploration.
-
-## How does it work, in plain terms?
-
-Read this first; the sections after it just add detail.
+The whole design, in six bullets. Everything after this adds detail to one of
+them.
 
 - **A dApp never talks to phones directly.** It tells II "notify these users,"
   and II handles the actual delivery. The dApp only knows its users by an
@@ -195,6 +125,7 @@ Read this first; the sections after it just add detail.
 Everything below is the same story with the exact mechanisms and edge cases.
 
 ## Architecture
+
 
 ```
 ┌─ dApp side ────────────────────────┐        ┌─ II ────────────────────────────────┐
@@ -244,6 +175,7 @@ bind everywhere regardless of who pays.
 
 ## Deployment assumptions
 
+
 Numbers in this doc depend on where II runs, so state the deployment before
 quoting a cost:
 
@@ -268,7 +200,83 @@ quoting a cost:
 Rule of thumb for this doc: design to the **paying** case and treat the fee
 waiver as a property of one deployment, not a premise of the design.
 
+## The user experience
+
+
+### Turning notifications on (first time signing into a dApp)
+
+1. On the dApp (e.g. `oisy.com`), the user clicks **Sign in with Internet
+   Identity**. II opens at `/authorize`.
+2. The user authenticates as usual (passkey, or an existing session for a
+   returning user).
+3. **Continue screen** (`ContinueView`): "Continue to `<dApp>`" with the
+   account picker and a **Continue** button. There is no notification toggle
+   here — the account choice is the only decision.
+4. The user taps **Continue**.
+5. **Notifications opt-in screen** (`NotifOptInView`): a preview illustration
+   of what a notification looks like (an "Example" lock-screen stack), the
+   heading "Let `<dApp>` notify you", two short reasons (instant alerts /
+   reachable anytime), and two buttons — **Enable notifications** and **Maybe
+   later**.
+   6a. **Enable** → if this browser has not granted permission yet, it shows
+   its **native permission prompt** ("`id.ai` wants to show notifications —
+   Allow / Block"). This dialog is the browser's own and cannot be restyled.
+   On **Allow** — or straight away, when permission was granted earlier — II
+   subscribes the device and records consent for this dApp, then redirects to
+   the dApp. No app install is required (Android/desktop); iOS Safari is the
+   exception.
+   6b. **Maybe later** → II redirects straight to the dApp; nothing is enabled.
+
+Two separate things are being asked, and only one of them repeats.
+
+II's opt-in screen **is** shown for each new dApp, because consent is recorded
+per origin and no dApp inherits another's. It appears once per dApp per
+device: a device that has not subscribed yet sees it again even for a dApp
+already enabled on another device, with copy that asks about this device
+rather than repeating the original pitch.
+
+The **browser's** permission prompt is the part that does not come back. It is
+granted to `id.ai`, not to the dApp, and every dApp's notifications are
+delivered through that one origin — so once the user has allowed it, the
+browser has nothing left to ask, and later opt-ins complete without a second
+dialog.
+
+### What happens when a notification is sent
+
+7. The dApp's backend tells II to notify the user. At any real scale this runs
+   through the dApp's client library and the chunked `push_send` endpoint (see
+   below); the PoC has a simpler one-shot `notify_user` for a single recipient.
+8. The notification arrives on every device the user enabled — **even with the
+   tab closed / browser not running** (on Android). It shows the dApp's origin
+   as the source and the dApp's title/body as the text.
+9. The user **taps** it. When the dApp supplied a deep link — the normal case —
+   the service worker opens that URL directly and II is not visited at all. The
+   dApp lands the user on the page the notification was about, signing them in
+   on the way with the ICRC-167 top-level redirect if the session has lapsed,
+   which is the usual state when a notification is what brought them back.
+   Only a notification with no deep link falls back to II's `/notify` screen
+   ("Opening `<dApp>`" with the app's logo), which resolves the sender's origin
+   behind a consent gate and forwards to the dApp's home.
+
+### Managing them, and turning them off
+
+10. Either from the browser or from II.
+
+    In **II → Settings**, the user sees **Notifications on this device**
+    (a toggle to turn the whole device on/off) and **Allowed apps** — every
+    dApp that can notify them, each with a remove button. Revoking an app
+    stops its notifications immediately.
+
+    The **browser's own site settings** can also block notifications for
+    `id.ai`, which silences every dApp at once and cannot be overridden from
+    inside II — the permission belongs to the browser, not to us. II can only
+    observe the result: a blocked permission makes the opt-in screen
+    unofferable, so it is skipped rather than shown as a button that cannot
+    work. Re-enabling has to happen in the browser too; that is the one path
+    II cannot offer a control for.
+
 ## dApp → II
+
 
 ### Sending to thousands of users: chunked send + two-layer flow control
 
@@ -423,7 +431,7 @@ plaintext RFC 8030 headers the relay sees. A sender that wants E2E chooses the
 **not** wait for delivery; "admitted" means "accepted into II's in-flight
 buffer", nothing more.
 
-### How does II know which users to send to?
+### How II knows which users to send to
 
 The dApp only knows its users by their in-app principal (II's privacy model).
 `PRINCIPAL_INDEX` resolves `principal → (anchor, origin_hash)`, and the index
@@ -433,7 +441,7 @@ cannot target dApp B's users even with stolen principals. Audiences larger
 than one chunk are split across paced `push_send` calls by the client library,
 not by server-side routing.
 
-### How does II verify the sender is really that dApp?
+### How II verifies the sender is really that dApp
 
 One call has one `caller()`, so the per-user `caller == in_app_principal`
 model does not batch. Senders authenticate at the **origin** level:
@@ -483,7 +491,7 @@ pressure is the bounded in-flight buffer — which admission control caps
 directly. That, plus the fast drain (below), is what lets II sustain high
 throughput on a _small_ buffer.
 
-### What does this cost, and who pays?
+### What this costs, and who pays
 
 Costs split into what is _always_ scarce and what depends on the deployment
 (see [Deployment assumptions](#deployment-assumptions)).
@@ -496,7 +504,7 @@ Costs split into what is _always_ scarce and what depends on the deployment
   `(anchor, endpoint)`, consent and the principal index per `(anchor, origin)`.
   Never O(notification volume), because campaign state lives in the client
   library. That is the invariant the "stateless II" shape buys; see the
-  [bytes-per-user table](#what-does-this-actually-cost-per-user).
+  [bytes-per-user table](#what-this-actually-costs-per-user).
 - **Instructions** — sealing is not free at chunk scale; the drain must work in
   bounded slices.
 
@@ -564,6 +572,7 @@ the rate bucket — see
 [Operating it](#operating-it-controls-alerts-and-rollout).
 
 ## II's state model: stateless for campaigns
+
 
 > _In short: II accepts a chunk, briefly holds it in memory (not durable
 > storage), seals and sends it, then forgets it. The durable list lives with
@@ -681,7 +690,7 @@ grow it with attacker-chosen keys until the heap is exhausted (heap exhaustion
 traps the canister, which takes authentication down with it). Timers don't
 survive upgrades — re-arm in `post_upgrade` and `init`.
 
-### How big is the buffer, and how many origins can it serve at once?
+### Buffer size, and how many origins it serves at once
 
 **Sizing one entry.** A buffer entry is per _recipient_, not per device — devices
 are resolved at drain, not at admit. Recipient-scoped fields are small: anchor
@@ -769,6 +778,7 @@ user-scoped state and that deserves its own review. But it is the honest answer 
 off-platform.
 
 ## Delivering to devices
+
 
 The relay API is one POST per subscription endpoint (RFC 8030) — there is no
 multi-recipient send, so reaching N devices is fundamentally N sends. The
@@ -915,6 +925,7 @@ removes the fan-out and restores per-device status, making direct delivery a
 genuine peer of the gateway on correctness, still bounded by in-flight slots.
 
 ## The dApp-side client library
+
 
 > _In short: because II stores nothing per send, a small library on the dApp's
 > side keeps the list, sends it to II in paced pieces, retries failures, tracks
@@ -1063,6 +1074,7 @@ device is a v1 requirement, not a nicety.
 
 ## On the device: rendering and tap-through
 
+
 - **Subscribe** (Settings, or the `/authorize` opt-in): request permission,
   `pushManager.subscribe` with II's VAPID public key, store
   `(anchor, endpoint_hash) → {endpoint, p256dh, auth}`. A browser allows one
@@ -1086,7 +1098,7 @@ device is a v1 requirement, not a nicety.
   keyed by `category` ("New message from `<origin>`"), never app-supplied text.
 - **Click**: with a deep link, the service worker opens it **directly**. II
   validated at send time that `alert.url` is on the consented origin (see
-  [the deep-link question](#can-the-app-choose-where-the-notification-opens)),
+  [the deep-link question](#where-a-notification-opens)),
   so there is nothing left to check on the device — and routing through II
   would add a second visit in the middle of a journey the user expects to be
   one step. Without a deep link it opens `/notify?origin=<sender>`, which
@@ -1127,7 +1139,7 @@ endpoint_hash) → {endpoint, p256dh, auth, created_at}` — the endpoint URL
   row updated, but the SW can only act for the currently-signed-in identity —
   so each identity re-registers the next time it authenticates.
 
-### Can the app choose where the notification opens?
+### Where a notification opens
 
 The app may set `alert.url` to send the user to a specific page rather than the
 origin root. **II validates it at send time** and refuses the send otherwise:
@@ -1159,7 +1171,7 @@ it.
 No target → the tap opens `/notify?origin=<sender>`, which resolves the sender's
 origin from the anchor's consent list and fails closed if it cannot.
 
-### Can the tap land the user already signed in?
+### Landing the user already signed in
 
 Yes — and it needs **no II-side changes**, because it composes out of the
 ICRC-167 URL transport (top-level redirect sign-in) that II already supports.
@@ -1240,7 +1252,7 @@ top-level navigation onto the relying party's own origin — which is also what
 generates the session key. So the realistic goal is making that page invisible
 (the app's own background and no decision on it), not removing it.
 
-### What about apps with no URL routing (e.g. Caffeine)?
+### Apps with no URL routing (e.g. Caffeine)
 
 **This is a hard prerequisite that some app platforms do not currently meet, and
 it needs checking before we promise notifications to them.**
@@ -1296,7 +1308,7 @@ as "open the app" — no deep link, no authenticated landing. Worth stating plai
 to set expectations, and it pairs naturally with the `Hidden` content variant,
 which also shows a generic message and reveals context only after the tap.
 
-### Can a notification be updated or dismissed after it's shown?
+### Updating or dismissing a notification already shown
 
 Yes, via a dApp-chosen `notification_id`, which the service worker maps to the
 Web Notification `tag`:
@@ -1326,7 +1338,58 @@ Caveats:
   automatic hostname-collapse we rejected. Notifications without a
   `notification_id` never replace each other.
 
+## Alternatives considered
+
+### II hosts the pipeline, rather than each dApp running its own
+
+The alternative is the status quo: every dApp prompts for its own notification
+permission, runs its own service worker, holds its own VAPID keypair, and stores
+its own subscriptions. It has real advantages — no shared-fate coupling, no new
+responsibility for II, no trusted gateway, and each dApp's notification content
+never leaves it.
+
+Rejected because the permission is the scarce resource, not the plumbing. A user
+declines the *n*th notification prompt far more often than the first, browsers
+increasingly bury the prompt, and iOS Safari requires a PWA install per site — so
+the per-dApp model works in principle and almost never happens in practice. One
+permission at the identity provider is the only version of this that a user
+actually says yes to, and it is the one thing a dApp genuinely cannot build for
+itself.
+
+The cost of that choice is paid throughout this document and should be read as its
+price, not as incidental complexity: II becomes a shared-fate dependency (see
+[Shared fate: one permission for every dApp](#shared-fate-one-permission-for-every-dapp)),
+II sees notification content unless the app opts into
+[end-to-end encryption](#end-to-end-encrypted-apps), and a canister whose real job
+is authentication now carries a delivery pipeline — hence
+[Push must never degrade authentication](#push-must-never-degrade-authentication).
+
+### II hosts the service worker, rather than each dApp hosting one
+
+Web Push binds a subscription to the origin whose service worker created it. Had
+each dApp hosted its own, each would need its own permission grant, and the single
+prompt above would be impossible — the two decisions are the same decision. It
+also means notifications arrive attributed to `id.ai` rather than to the dApp,
+which the UX compensates for by naming the sending app in the body and title, and
+which the security model has to defend by forcing attribution to the sender origin
+at send time.
+
+### Decisions argued where they arise
+
+Three further alternatives are weighed in place rather than here, because each
+needs its surrounding detail to make sense:
+
+- **Gateway versus direct per-device outcalls** —
+  [the delivery path](#the-delivery-path-a-trusted-web2-gateway) and
+  [the alternative](#the-alternative-direct-per-device-outcalls).
+- **Where the sealing runs.** Moving it to the gateway is not merely disallowed
+  but useless, and the alternative that does help is a separate canister — see
+  [the way to lift that ceiling](#the-way-to-lift-that-ceiling-is-a-separate-canister).
+- **Two E2E designs**, vetKeys-sealed versus dApp-held keys, with a
+  [recommendation](#recommendation).
+
 ## Security model
+
 
 - **Origin pinning** — a sender can only target anchors that consented to
   _its_ origin; cross-dApp targeting is impossible even with leaked principals.
@@ -1506,6 +1569,7 @@ the sender.
 
 ## Privacy
 
+
 The doc's confidentiality story is about _content_. Metadata is a separate
 exposure and, for a notification hub, arguably the more sensitive one — `Hidden`
 protects the message text and does nothing for any of this.
@@ -1537,6 +1601,7 @@ operators each learn.
 
 ## Delivery semantics: what is actually guaranteed
 
+
 "Best-effort" is not a guarantee, and several features silently depend on which
 one holds. Stated explicitly:
 
@@ -1556,6 +1621,7 @@ the notification it dismisses and then be a no-op forever. Fix: carry a
 service worker drops out-of-order updates rather than applying them.
 
 ## Duplicate and replay suppression (`msg_id`)
+
 
 **Built.** Four independent mechanisms make duplicates the norm rather than the
 exception, and the fourth is the one that showed up first in practice:
@@ -1605,6 +1671,7 @@ Note `msg_id` is a **different thing** from the dApp-facing `notification_id`:
 shape, opposite behavior — keep them separate fields.
 
 ## End-to-end-encrypted apps
+
 
 Some apps (e.g. a chat using vetKeys) encrypt content so that only the
 recipient can read it — the app backend cannot. Our `Display` path is **not**
@@ -1742,6 +1809,7 @@ to send, admission, or storage.
 
 ## Open items
 
+
 Must-fix before a real deployment:
 
 - **Endpoint host allowlist.** The push endpoint is attacker-supplied. Validate
@@ -1814,7 +1882,7 @@ Must-decide (design, not code):
   can address a destination at all, in the builder sandbox _and_ published. If
   not, deep-linking and signed-in tap-through are both unavailable there and
   notifications degrade to "open the app". See
-  [What about apps with no URL routing](#what-about-apps-with-no-url-routing-eg-caffeine).
+  [What about apps with no URL routing](#apps-with-no-url-routing-eg-caffeine).
 - **iOS reality** — iOS Safari is the one platform where a PWA install is
   _mandatory_ for Web Push (Android/desktop work in a plain tab). It is also
   flakier and more throttled; "best-effort" is weakest there. Set expectations
@@ -1851,6 +1919,7 @@ Explicitly rejected:
 
 ## IC capabilities to re-evaluate
 
+
 Platform features that would change decisions in this doc. Worth re-checking
 before implementation, because two of them postdate the design:
 
@@ -1878,6 +1947,7 @@ before implementation, because two of them postdate the design:
 
 ## Push must never degrade authentication
 
+
 The invariant, stated separately because it is the one that makes this feature
 unshippable if violated: **no volume of push traffic may reduce the availability
 of sign-in.**
@@ -1903,6 +1973,7 @@ signal** with push throttling as the automatic response.
 
 ## Operating it: controls, alerts and rollout
 
+
 Metrics alone are not operability. Missing today:
 
 - **A per-origin kill switch.** `push_deregister_sender` is authenticated by the
@@ -1926,6 +1997,7 @@ Metrics alone are not operability. Missing today:
   P-256 in `dnssec/`, so this is a short exercise).
 
 ## dApp developer integration
+
 
 One-time setup (~15 min): serve `.well-known/ii-push-senders`, call
 `push_register_sender(origin)` from the backend. Steady state: hand the client
@@ -1956,6 +2028,7 @@ from auth (the library owns campaign status). Delivery is best-effort with no
 receipts; the only per-user signal is `NoConsent`.
 
 ## Feasibility and scale
+
 
 | Metric                               | Gateway (chosen)                                                   | Direct (alternative)    |
 | ------------------------------------ | ------------------------------------------------------------------ | ----------------------- |
@@ -1988,7 +2061,8 @@ fully on-chain and viable at low volume, but under replicated outcalls it also
 multiplies every POST by the subnet size and cannot observe `410`, so it is a
 degraded fallback rather than a transparent one.
 
-## What does this actually cost per user?
+## What this actually costs per user
+
 
 Storage is O(users × origins), not O(users) — worth being concrete, since the
 "flat with volume" claim is about _notification volume_ only:
@@ -2009,6 +2083,7 @@ bounds how large these maps can get before upgrades become a problem.
 
 ## Stable memory regions
 
+
 New regions must claim an unused `MemoryId`. Because nothing in the code forces
 this check, record allocations here and verify against `storage.rs` before
 adding one — a duplicate index silently interleaves two `StableBTreeMap`s into
@@ -2026,6 +2101,7 @@ the same virtual memory and corrupts both.
 A test asserting all indices are distinct is cheap and worth having.
 
 ## Future exploration
+
 
 Deliberately out of v1, kept here so the door stays open:
 
@@ -2045,3 +2121,71 @@ Deliberately out of v1, kept here so the door stays open:
 - **Delivery receipts / analytics** — Web Push has none; any per-user delivery
   signal would have to come from the app itself, and per-origin aggregates are
   the most II can offer without a per-user tracking surface.
+## Status
+
+
+### Built today (PoC on `feat/push-notifications-poc`)
+
+An inventory, not an explanation — each line links to the section that covers
+it. The last four exist because building the PoC proved they had to.
+
+- **Per-device subscribe/unsubscribe, `/authorize` opt-in, per-dApp consent** —
+  [the user flow](#turning-notifications-on-first-time-signing-into-a-dapp),
+  [consent lifecycle](#consent-lifecycle-it-must-not-outlive-the-sender).
+- **`notify_user(principal, alert)`** — one recipient per call. It does **not**
+  answer scale, and everything in this doc about throughput, cost and delivery
+  assumes the chunked `push_send` that supersedes it:
+  [chunked send and flow control](#sending-to-thousands-of-users-chunked-send--two-layer-flow-control).
+- **RFC 8291 payload encryption and RFC 8292 VAPID signing, both in-canister** —
+  [delivering to devices](#delivering-to-devices).
+- **VAPID key generated with `raw_rand`, held in stable memory** — not the
+  custody model we would choose. Web Push mandates P-256, the IC's threshold
+  ECDSA is secp256k1 only, so the subnet cannot hold the key for us:
+  [what that risks](#security-model),
+  [what changes if P-256 lands](#ic-capabilities-to-re-evaluate).
+- **Tap opens the dApp's deep link directly**, falling back to the consent-gated
+  `/notify` redirect when the sender supplied no target —
+  [where a notification opens](#where-a-notification-opens),
+  [landing signed in](#landing-the-user-already-signed-in).
+- **Sender authorization by origin** — a registry keyed by origin hash. The
+  original `caller() == in_app_principal` rule could never match an
+  inter-canister call, so it admitted only self-sends:
+  [how II verifies a sender](#how-ii-verifies-the-sender-is-really-that-dapp).
+- **Send-time `alert.url` validation** — what makes opening the deep link
+  directly safe:
+  [where a notification opens](#where-a-notification-opens).
+- **`msg_id` dedup in the service worker, and `410`/`404` row cleanup** —
+  [duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
+- **VAPID key rotation in the browser** — a subscription bound to a superseded
+  key is resubscribed rather than failing forever.
+
+### Not built, so the PoC isn't mistaken for a shippable subset
+
+- No `push_send`, so no batching, no chunking, and no client library — a send is
+  one `notify_user` per recipient.
+- No rate limiting or admission control of any kind — `notify_user` is unmetered.
+- No `.well-known/ii-push-senders` verification: senders are registered by an
+  operator, so nothing yet proves a canister owns the origin it sends as.
+- No endpoint host allowlist, and no per-anchor caps on subscription or consent
+  rows.
+- `Display` content only — no `Hidden`, which is the variant the design
+  recommends shipping first for E2E apps.
+- No `pushsubscriptionchange` handling, so a rotated endpoint still leaves a
+  stale row until a relay reports it gone.
+- Integration and E2E test coverage is thin (unit tests only).
+
+### Proposed (designed above, not yet built)
+
+- Chunked `push_send` with two-layer flow control (II admission + client
+  pacing), a sender registry, a stateless-for-campaigns II (transient heap
+  buffer, storage O(users × origins)), a durable client library, and delivery
+  through a trusted web2 gateway (with direct per-device outcalls as the
+  documented alternative/fallback).
+- Promoted to v1 requirements by review, and still outstanding: a `drain_epoch`
+  acknowledgment signal, an endpoint host allowlist, per-anchor caps, drain
+  isolation and non-reentrancy, and a reserved outcall budget that protects
+  sign-in. (`msg_id` + device dedup was also promoted, and is now built.)
+- No cycles charging to senders in v1 — but a deployment that pays fees needs a
+  cycle budget with a circuit breaker regardless. Sender charging is parked as a
+  future exploration.
+

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -111,9 +111,8 @@ would be the real fix — out of scope here.
 
 ### What happens when a notification is sent
 
-7. The dApp's backend tells II to notify the user. At any real scale this runs
-   through the dApp's client library and the chunked `push_send` endpoint (see
-   below); the PoC has a simpler one-shot `notify_user` for a single recipient.
+7. The dApp's backend tells II to notify the user, through the client library and
+   the chunked `push_send` endpoint (below).
 8. The notification arrives on every device the user enabled — **even with the
    tab closed / browser not running** (on Android). It shows the dApp's origin
    as the source and the dApp's title/body as the text.
@@ -204,10 +203,6 @@ never blocking the call), storing `origin_hash → {principals, name}`. Every se
 then requires `caller` to be a listed principal. Revoke by removing the file — II
 drops the sender on its ~weekly re-check.
 
-> **Self-serve verification is a launch blocker.** The PoC registers senders by
-> hand (controller-only). "Any dApp can send through II" is false while onboarding
-> means a DFINITY support ticket, so the `.well-known` check must ship in v1.
-
 <details><summary>Verification detail</summary>
 
 - **Fetch only for origins a user already consented to** — otherwise any canister
@@ -226,18 +221,24 @@ drops the sender on its ~weekly re-check.
 
 ### Admission control (Layer 1): stopping one dApp from flooding II
 
-The mandatory guard on every `push_send`, assuming a hostile client:
+This is the mandatory guard, and it assumes a hostile sender. It puts a limit on three
+things:
 
-- **Hard `recipients.len()` ceiling** (~1000) + accepted-payload cap well below 2 MB.
-- **Per-operator token bucket** in **device-messages** (a 5-device recipient costs 5),
-  bucketed by **eTLD+1 not bare origin** (else `a1…a1000.evil.com` = 1000 buckets).
-- **Global buffer cap with per-origin reservations** underneath — a large sender at
-  its limit can't starve small ones (a plain FCFS cap wouldn't guarantee that).
-- **A push outcall budget** well below the 3000 cap, yielding to auth outcalls.
-- **Reject** over capacity (`ready=false` + jittered `retry_after_ms`).
+- **How much one call can carry** — up to ~1000 recipients, and a payload well under
+  2 MB. A larger campaign isn't rejected; the client library just splits it across more
+  calls. There's no cap on total campaign size — the limit is on rate, not volume.
+- **How fast one dApp can send** — a rate limit counted in *device-messages* (a
+  recipient with five devices counts as five, because that's five actual sends). It's
+  applied per registered domain, not per origin, so a dApp can't multiply its quota by
+  spinning up `a1.evil.com … a1000.evil.com`.
+- **How much of II push can ever take** — push draws on a slice of the outcall budget
+  well below the subnet's cap, and always yields to sign-in. Each origin also has a
+  reserved share of the buffer, so one large sender running flat-out can't crowd out
+  smaller ones.
 
-The only II storage a sender can pressure is the bounded buffer, which this caps
-directly.
+When II is over capacity it simply rejects the call — `ready = false` plus a
+`retry_after_ms` hint (jittered, so rejected senders don't retry in lockstep) — and the
+client library paces itself in response.
 
 ### What this costs, and who pays
 
@@ -738,20 +739,19 @@ notification_id)`** so the SW drops out-of-order updates.
 
 ## Duplicate and replay suppression (`msg_id`)
 
-**Built.** Duplicates come from four sources: replicated outcalls (removed by the
+Duplicates are the norm, from four sources: replicated outcalls (removed by the
 non-replicated handoff), timer duplicate execution (claim-before-`await`), client
-retries + `drain_epoch`, and **accumulated subscription rows** — the one that actually
-produced duplicate banners in testing, when a rotated endpoint left two live rows for
-one browser.
+retries + `drain_epoch`, and **accumulated subscription rows** — a rotated endpoint
+leaving two live rows for one browser, which is the case most likely to reach a user.
 
 II assigns a `msg_id` **once per admitted message**, inside the payload *before*
-RFC 8291 encryption — so no dApp supplies it and no relay can read or forge it. The
-SW keeps a bounded seen-set (**in the Cache API**, since the worker is killed
-between pushes) and drops repeats; a payload with **no id is always shown**
-(failing open beats dropping a real notification). The drain now **removes a row on
-`404`/`410`**, the only signal a row is dead.
+RFC 8291 encryption, so no dApp supplies it and no relay can read or forge it. The
+service worker keeps a bounded seen-set (**in the Cache API**, since the worker is
+killed between pushes) and drops repeats; a payload with **no id is always shown**,
+because failing open beats dropping a real notification. The drain removes a row on
+`404`/`410`, the only signal that a row is dead.
 
-One thing left to harden: a bounded recency set can be flushed by flooding, after
+To harden it further: a bounded recency set can be flushed by flooding, after
 which a replayed capture looks new — so replace it with a per-origin high-water mark
 and a short `msg_id` validity window. Note that `msg_id` (II-generated, suppresses
 duplicates) is a different thing from `notification_id` (dApp-chosen, *replaces* a
@@ -807,7 +807,7 @@ fetch per notification. Murkier than A; the fallback for backend-trusted apps.
 
 | Item | Why |
 | --- | --- |
-| `.well-known/ii-push-senders` verification | self-serve registration; controller-by-hand today makes "any dApp" false — see [verification](#how-ii-verifies-the-sender-is-really-that-dapp) |
+| `.well-known/ii-push-senders` verification | self-serve registration — see [verification](#how-ii-verifies-the-sender-is-really-that-dapp) |
 | Endpoint host allowlist | endpoint is caller-supplied → SSRF/reflection. Allowlist known push hosts, re-validate at drain, **II validates not the gateway** |
 | Per-anchor caps | 20 subscriptions / 100 consents, anti-griefing not a storage bound. Evict dead rows first for subs; **refuse** (never silently evict) a consent |
 | Reserved outcall budget for auth | push must not spend login's slots — [detail](#push-must-never-degrade-authentication) |
@@ -953,16 +953,14 @@ can get before upgrades become a problem.
 ## Stable memory regions
 
 New regions must claim an unused `MemoryId` — a duplicate index silently interleaves
-two `StableBTreeMap`s and corrupts both. (This happened: a PoC revision claimed 32,
-already taken by SSO, and the canister trapped on first read. A distinctness test is
-cheap.)
+two `StableBTreeMap`s and corrupts both — a distinctness test is cheap and worth having.
 
 | Index | Region | Key → value |
 | --- | --- | --- |
 | 33 | push subscriptions | `(anchor, endpoint_sha256)` → `{endpoint, p256dh, auth}` — RFC 8291 seal inputs, one row per endpoint (rotations leave stale rows) |
 | 34 | push consent | `(anchor, origin_sha256)` → `{granted_at, origin}` — presence = grant |
 | 35 | push principal index | `in_app_principal` → `anchor` — reverse lookup `notify_user` needs; why a consent costs ~140 B |
-| 36 | push sender registry | `origin_sha256` → sender canister — controller-written until `.well-known` verification |
+| 36 | push sender registry | `origin_sha256` → sender canister (verified via `.well-known`) |
 
 ## Future exploration
 
@@ -974,27 +972,3 @@ cheap.)
   the prepaid balance.
 - **Delivery receipts** — Web Push has none; per-origin aggregates are the most II can
   offer without per-user tracking.
-
-## Status
-
-### Built today (PoC on `feat/push-notifications-poc`)
-
-Each line links to the section covering it; the last group exists because building
-the PoC proved it necessary.
-
-- Per-device subscribe/unsubscribe, `/authorize` opt-in, per-dApp consent
-- `notify_user(principal, alert)` — one recipient (superseded by chunked
-  [`push_send`](#sending-to-thousands-chunked-send--two-layer-flow-control))
-- RFC 8291 encryption + RFC 8292 VAPID signing, in-canister
-- VAPID key via `raw_rand` in stable memory ([risk](#security-model))
-- Tap → deep link directly, `/notify` fallback
-- **Sender authorization by origin** — the `caller() == in_app_principal` rule
-  never matched inter-canister calls
-- **`msg_id` dedup + `410`/`404` cleanup**, **`alert.url` validation**, **browser
-  VAPID-key resubscribe**
-
-### Not built (so the PoC isn't mistaken for shippable)
-
-No `push_send` (one `notify_user` per recipient), no rate limiting, no `.well-known`
-verification (operator-registered), `Display` only (no `Hidden`), thin test coverage.
-Everything else is a work item listed once in [Open items](#open-items).

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -47,7 +47,9 @@ records consent (no second prompt).
 
 ### What happens when a notification is sent?
 
-7. The dApp's backend/frontend calls `notify_user` (later, a batch endpoint).
+7. The dApp's backend tells II to notify the user. At any real scale this runs
+   through the dApp's client library and the chunked `push_send` endpoint (see
+   below); the PoC has a simpler one-shot `notify_user` for a single recipient.
 8. The notification arrives on every device the user enabled — **even with the
    tab closed / browser not running** (on Android). It shows the dApp's origin
    as the source and the dApp's title/body as the text.
@@ -67,7 +69,11 @@ records consent (no second prompt).
 Built today (PoC on `feat/push-notifications-poc`):
 
 - Device subscribe/unsubscribe, `/authorize` opt-in, per-dApp consent.
-- Single `notify_user(principal, alert)` update call.
+- Single `notify_user(principal, alert)` update call — a one-shot for one
+  recipient. It does **not** answer scale; the design supersedes it with the
+  chunked `push_send` + client library described under "Proposed" below, and
+  everything in this doc about throughput, cost, and delivery assumes that
+  path, not this call.
 - RFC 8291 payload encryption + RFC 8292 VAPID JWT signing, both in-canister.
 - VAPID private key generated via `raw_rand` and persisted in stable memory.
   This is not the ideal custody model, and we do it only because the ideal

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1017,6 +1017,15 @@ in the hash) and `channel.origin` is the callback's origin — the RP initiates,
 II only answers. So the notification's job is not to carry a session; it is to
 land the user on a page that _starts_ sign-in immediately.
 
+Spelled out, because the opposite is the natural assumption: **a notification
+cannot take the user to `id.ai` and have II sign them into the app from there.**
+II would have no session key to delegate to, and one it generated itself would
+have its private half in `id.ai`'s storage, which the dApp cannot read across
+origins — the delegation would be useless. The flow has to begin where that
+private key lives, which is the dApp's own origin. This is the same property that
+stops II impersonating a user to a dApp, so it is a guarantee rather than a
+limitation, and no amount of protocol work removes it.
+
 The standard guarded-route pattern does exactly that:
 
 1. The notification deep-links to a restricted page,

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -86,40 +86,23 @@ serve as reference material.
 
 ## How it works, in plain terms
 
-The whole design, in six bullets. Everything after this adds detail to one of
-them.
+The whole design in six points; everything after adds detail.
 
-- **A dApp never talks to phones directly.** It tells II "notify these users,"
-  and II handles the actual delivery. The dApp only knows its users by an
-  opaque per-app id, so it can't reach anyone it wasn't given.
-- **II already knows how to reach each user.** When a user turns notifications
-  on, their browser hands II the keys needed to deliver to that device; when
-  they sign into a dApp and opt in, II records that the dApp is allowed. So II
-  keeps two small per-user facts: _which devices_ and _which apps are allowed_.
-- **II seals every message.** It encrypts the text with the device's own key
-  (created when the device subscribed, using standard Web Push encryption) so
-  only that device can read it — Google/Apple/Mozilla just forward the sealed
-  bytes and the browser decrypts them. It also signs each request so those push
-  services trust it really came from II (a VAPID token, cached per push service
-  so II needn't re-sign every time).
-- **Big sends are streamed, not dumped.** To notify 10,000 users, the dApp uses
-  a small helper **library** that feeds II the list in bite-sized batches at a
-  pace II can handle. II refuses more than it can take (so nobody can flood
-  it), and the library slows down when asked. The big list lives with the
-  dApp — **II stores almost nothing per send**.
-- **How II sends the final messages.** II hands the sealed messages to a small
-  **trusted helper server (the "gateway")** that makes the many little
-  per-device sends on II's behalf over ordinary internet — far cheaper and
-  faster than the canister making each call itself. (Having the canister call
-  each push service directly is the documented fallback, but one network call
-  per device gets expensive at scale, so it isn't the default.) Either way II
-  does the sealing; the helper only forwards messages it can't read.
-- **Tapping a notification** goes straight to the app's own deep link, which
-  signs the user in on arrival if their session has lapsed. Only a notification
-  without a deep link detours through II ("Opening \<app\>…"). Either way the
-  destination is only ever the app that sent it.
-
-Everything below is the same story with the exact mechanisms and edge cases.
+1. **A dApp never talks to phones.** It tells II "notify these users" (by opaque
+   per-app id — it can't reach anyone it wasn't given); II delivers.
+2. **II already knows how to reach each user** — the browser hands it device keys on
+   enable, and it records which apps are allowed. Two per-user facts: devices, and
+   allowed apps.
+3. **II seals every message** with the device's own Web Push key (only that device
+   decrypts; relays just forward) and signs it (VAPID, cached).
+4. **Big sends are streamed**: a client library feeds II bite-sized batches; II
+   refuses more than it can take. The list lives with the dApp — II stores almost
+   nothing per send.
+5. **II hands the sealed messages to a trusted gateway** that does the many
+   per-device sends over ordinary internet (direct-from-canister is the fallback).
+   The gateway only forwards bytes it can't read.
+6. **A tap goes straight to the app's deep link**, signing the user in on arrival if
+   their session lapsed; only a link-less notification detours through II.
 
 ## Architecture
 
@@ -303,39 +286,18 @@ drops the sender on its ~weekly re-check.
 
 ### Admission control (Layer 1): stopping one dApp from flooding II
 
-> _In short: II tracks how much each app is sending and simply says "not right
-> now, try again in N ms" once an app goes over its share. This is what stops
-> spam, and it works even if the sender ignores every hint._
+The mandatory guard on every `push_send`, assuming a hostile client:
 
-The mandatory guard, assuming a hostile client. Enforced on every `push_send`,
-independent of client behavior:
+- **Hard `recipients.len()` ceiling** (~1000) + accepted-payload cap well below 2 MB.
+- **Per-operator token bucket** in **device-messages** (a 5-device recipient costs 5),
+  bucketed by **eTLD+1 not bare origin** (else `a1…a1000.evil.com` = 1000 buckets).
+- **Global buffer cap with per-origin reservations** underneath — a large sender at
+  its limit can't starve small ones (a plain FCFS cap wouldn't guarantee that).
+- **A push outcall budget** well below the 3000 cap, yielding to auth outcalls.
+- **Reject** over capacity (`ready=false` + jittered `retry_after_ms`).
 
-- **Hard `recipients.len()` ceiling** (~1000), checked before any per-recipient
-  work, and a hard accepted-payload cap well below 2 MB.
-- **Per-origin token bucket** denominated in **device-messages, not
-  recipients** — a recipient with five devices costs five sealed messages and
-  five outcall payloads, so counting recipients under-charges the real work.
-  Denominated per notification rather than per call, so it can't be gamed by
-  slicing a send into many small chunks.
-- **Bucket by registered operator (eTLD+1), not by bare origin.** An origin is
-  scheme+host+port and registration only requires serving a `.well-known`
-  file, so `a1.evil.com … a1000.evil.com` would otherwise be 1000 origins with
-  1000 full buckets. Per-origin buckets bound one _origin_, not one _operator_.
-- **Global cap** on the in-flight buffer — protects II/the subnet as a whole —
-  **with per-origin reservations underneath it**, so a large sender at its own
-  limit cannot consume the entire global budget and starve small senders. A
-  first-come-first-served global cap does not deliver the "can't starve others"
-  property on its own.
-- **A push-specific outcall budget** well below the subnet's 3000 in-flight cap,
-  yielding to II's own authentication outcalls. See
-  [Push must never degrade authentication](#push-must-never-degrade-authentication).
-- **Reject** when over capacity (`ready = false` + `retry_after_ms`, jittered
-  per caller so rejected clients don't retry in lockstep).
-
-Because the queue lives on the client, the only II storage a sender can
-pressure is the bounded in-flight buffer — which admission control caps
-directly. That, plus the fast drain (below), is what lets II sustain high
-throughput on a _small_ buffer.
+The only II storage a sender can pressure is the bounded buffer, which this caps
+directly.
 
 ### What this costs, and who pays
 
@@ -563,71 +525,37 @@ lives, which is what lets II stay stateless per send. See
 
 ## On the device: rendering and tap-through
 
-- **Subscribe** (Settings, or the `/authorize` opt-in): request permission,
-  `pushManager.subscribe` with II's VAPID public key, store
-  `(anchor, endpoint_hash) → {endpoint, p256dh, auth}`. A browser allows one
-  subscription per service worker, permanently bound to the key it was created
-  with, so `subscribe` **refuses a different key**: an existing subscription is
-  reused when its key still matches and replaced when it doesn't. Otherwise
-  every browser that subscribed under a previous VAPID key could never
-  re-enable. No
-  PWA install is needed on Android or desktop — this works in a plain tab;
-  iOS Safari is the exception (it only allows Web Push for an installed
-  home-screen app). The optional install adds an app icon / standalone window
-  and slightly better attribution.
-- **Consent** (`/authorize`): `push_grant_consent(anchor, origin)`. Asked once
-  per `(identity, origin)` **per device** — the answer is remembered locally,
-  which matches what it commits to, since a subscription belongs to one browser.
-  Consent itself is shared by all of the identity's devices, so on a second
-  device only the subscription is missing and the screen says so ("Also notify
-  you on this device?") rather than repeating the first-run ask.
-- **Render**: the service worker branches on `content` — `Display` shows the
-  supplied `title`/`body`; `Hidden` shows an II-controlled generic string
-  keyed by `category` ("New message from `<origin>`"), never app-supplied text.
-- **Click**: with a deep link, the service worker opens it **directly**. II
-  validated at send time that `alert.url` is on the consented origin (see
-  [the deep-link question](#where-a-notification-opens)),
-  so there is nothing left to check on the device — and routing through II
-  would add a second visit in the middle of a journey the user expects to be
-  one step. Without a deep link it opens `/notify?origin=<sender>`, which
-  resolves the sender's own origin, shows which app is opening, and fails
-  closed if it cannot verify the sender.
-
-  For `Hidden` (E2E) notifications this tap-through is also the content-reveal
-  path: the app opens and decrypts the message in its own context.
+- **Subscribe** (Settings or `/authorize` opt-in): request permission,
+  `pushManager.subscribe` with II's VAPID key, store `(anchor, endpoint_hash)`. A
+  browser binds one subscription per SW to one key, so `subscribe` refuses a
+  different key — reuse when it matches, replace when it doesn't (or subscribers
+  under an old key can never re-enable). No install on Android/desktop; iOS Safari
+  only allows Web Push for an installed home-screen app.
+- **Consent** (`push_grant_consent`): once per `(identity, origin)` per device.
+  Consent is shared across the identity's devices, so a second device is missing
+  only the subscription ("Also notify you on this device?").
+- **Render**: `Display` shows the supplied text; `Hidden` shows an II-controlled
+  generic string by `category`.
+- **Click**: with a deep link the SW opens it directly (II validated `alert.url`
+  is on the consented origin at send time); without one, `/notify?origin=` resolves
+  the sender and fails closed. For `Hidden`, the tap is the content-reveal.
 
 ### Shared devices and multiple identities
 
-A browser has **one** physical push endpoint, but a person may sign into
-several identities on it and devices get shared. The rule is: **enabling and
-consent are per identity, never per device.** Turning notifications on for one
-identity never implies anything for another that happens to share the same
-browser — each identity must separately enable notifications and grant its own
-per-origin consent. We do not infer consent from a shared endpoint.
+One browser has one endpoint, but several identities may share it. **Enabling and
+consent are per identity, never per device** — no consent is inferred from a shared
+endpoint. So:
 
-What that means in practice:
+- The same endpoint appears under several anchors as **independent rows**; II
+  delivers to an anchor's row only if that anchor enabled it.
+- Isolation is at the **consent layer**, not transport — once two identities enable,
+  the device physically receives both; the SW renders by **sender origin**, never
+  revealing they share a device.
+- Disabling removes only that anchor's rows; `unsubscribe()` fires only when no
+  identity still wants notifications.
+- On rotation, each identity re-registers next time it authenticates.
 
-- **One endpoint, independent rows.** The subscription is stored as `(anchor,
-endpoint_hash) → {endpoint, p256dh, auth, created_at}` — the endpoint URL
-  itself is part of the value, since it is the POST target — so the same
-  physical endpoint can appear under several anchors as separate rows. II
-  delivers to an anchor's row only if _that_ anchor enabled it; identity B's
-  senders reach the device only after B itself opted in.
-- **Isolation is at the consent layer, not the transport.** Once two identities
-  on the device have both enabled, the device physically receives pushes for
-  both — there is only one endpoint, so they cannot be separated in transit.
-  The service worker renders by **sender origin**, not by which II identity, and
-  never reveals that the two identities live on the same device.
-- **Disabling is per identity.** Turning notifications off for one identity
-  removes only that anchor's rows; the browser subscription stays alive for the
-  others. The SW calls `pushManager.unsubscribe()` only when **no** identity on
-  the device still wants notifications.
-- **Rotation re-registers lazily.** When the endpoint rotates
-  (`pushsubscriptionchange`), every anchor that held the old endpoint needs its
-  row updated, but the SW can only act for the currently-signed-in identity —
-  so each identity re-registers the next time it authenticates.
-
-### Where a notification opens
+### Where a notification opens### Where a notification opens
 
 The app may set `alert.url` to send the user to a specific page rather than the
 origin root. **II validates it at send time** and refuses the send otherwise:
@@ -713,59 +641,19 @@ place "a dApp needs no push infrastructure" is false.
 
 ### Apps with no URL routing (e.g. Caffeine)
 
-**This is a hard prerequisite that some app platforms do not currently meet, and
-it needs checking before we promise notifications to them.**
+Deep-linking and signed-in tap-through both assume **addressable URLs**.
+Caffeine-built apps were last seen fully stateful with no routing — so there's no
+address to point a notification at. **Confirm this before promising notifications
+there** (and check the builder sandbox separately from published apps).
 
-Everything above — deep-linking _and_ signed-in tap-through — assumes the app
-has **addressable URLs**. Caffeine-built apps were, last time anyone checked,
-fully stateful with no URL-based routing: there is no address to point a
-notification at. If that is still true, two things break, and the first is worse
-than the second:
+If routing is absent, such a platform needs: (1) an addressable destination — a
+single `/open?s=<token>` entry route restoring in-app state is the cheap fit; (2) a
+sign-in route in the project template; (3) an `isAuthenticated()` guard; (4)
+`/.well-known/ii-auth-callbacks`. The callback must be protocol+host+path only, so
+the destination rides in memoized flow state.
 
-- **Deep-linking breaks outright.** With nothing to put in `alert.url`, a
-  notification can only ever open the app's root, so the context the
-  notification was _about_ ("which message", "which order") is lost on arrival.
-  A notification that cannot say where it goes is a much weaker product than one
-  that can.
-- **Signed-in landing breaks**, because the guarded-route pattern needs two real
-  routes: the restricted page and the sign-in/callback page.
-
-What such a platform has to add, in dependency order:
-
-1. **Addressable destinations.** Either a real route per notifiable view, or —
-   cheaper and probably the right fit for a stateful app — a **single entry route
-   that takes an opaque state token** (`/open?s=<token>`) and restores the
-   in-app state from it. Notifications then carry that token. This is the
-   unavoidable one: without it, notifications are reduced to "something
-   happened, open the app".
-2. **A sign-in route in the project template.** A hardcoded page that constructs
-   the redirect `AuthClient` at page load, memoizes the destination, calls
-   `signIn()`, and forwards to the memoized destination on return. It is
-   boilerplate, which is exactly why it belongs in the template rather than in
-   each app.
-3. **A guard on restricted views** calling `isAuthenticated()` and bouncing to
-   that route.
-4. **`/.well-known/ii-auth-callbacks`** served from the app's origin, listing the
-   sign-in route exactly, with CORS.
-
-One constraint that shapes the template: the callback URL must be **protocol +
-host + path only** — no query string — so the destination cannot ride on the
-callback and must live in memoized flow state. A template that tries
-`callback=/sign-in?next=…` will be rejected by the transport.
-
-Open questions to confirm rather than assume:
-
-- Is routing still absent, or has it changed?
-- Does the **builder sandbox** differ from a **published** app? URL routing
-  inside a live-preview environment (possibly iframed) may be constrained in
-  ways the published app is not, so both need checking — a design that works
-  only when published is still workable, but it changes what can be
-  demonstrated.
-
-**Fallback if routing cannot be added:** notifications still function, but only
-as "open the app" — no deep link, no authenticated landing. Worth stating plainly
-to set expectations, and it pairs naturally with the `Hidden` content variant,
-which also shows a generic message and reveals context only after the tap.
+**Fallback:** notifications still work as "open the app" — no deep link, no
+authenticated landing. Pairs naturally with `Hidden` content.
 
 ### Action buttons: navigate, never act
 
@@ -800,7 +688,7 @@ since a sender's own actions only navigate anyway). Three levels:
 
 II owns both labels — a sender able to rename them would defeat the point.
 
-### Updating or dismissing### Updating or dismissing a notification already shown
+### Updating or dismissing a notification already shown
 
 Yes, via a dApp-chosen `notification_id`, which the service worker maps to the
 Web Notification `tag`:
@@ -838,7 +726,7 @@ Caveats:
 | 2 | [II hosts the service worker](#a2) | Each dApp hosts its own | Same decision as #1 — Web Push binds the subscription to the SW's origin |
 | 3 | [Gateway delivery](#the-delivery-path-a-trusted-web2-gateway) | Direct per-device outcalls | 13k in-flight outcalls would starve login; gateway → ~25 |
 | 4 | [Sealing stays on II](#action-buttons-navigate-never-act) | Gateway seals | Deriving the key = ability to decrypt; useless to move. Real lever is a [separate canister](#the-way-to-lift-that-ceiling-is-a-separate-canister) |
-| 5 | [vetKeys-sealed E2E](#recommendation) | dApp holds the keys | See E2E section |
+| 5 | [vetKeys-sealed E2E](#end-to-end-encrypted-apps) | dApp holds the keys | See E2E section |
 
 <h4 id="a1">1. II hosts the pipeline</h4>
 
@@ -914,39 +802,18 @@ II-side:
 
 ### Which origin is authoritative
 
-II lets one origin borrow another's identity derivation: a dApp served from
-`https://beta.app.com` may pass `derivationOrigin: https://app.com`, and if
-`https://app.com/.well-known/ii-alternative-origins` lists it, II derives the
-user's principal from `app.com`. That is what lets a beta site, a custom domain
-and a raw canister URL share one identity. It leaves two origins in play:
+With `derivationOrigin`, a dApp on `beta.app.com` can derive its principal from
+`app.com` (letting beta/custom-domain/canister-URL share one identity), leaving
+`effectiveOrigin` (`app.com`, what the principal derives from) and `displayOrigin`
+(`beta.app.com`, what the browser talks to) in play.
 
-- **`effectiveOrigin`** — what the principal is derived from (`app.com`).
-- **`displayOrigin`** — who the browser is actually talking to
-  (`beta.app.com`).
-
-**Decision: `effectiveOrigin` is authoritative for push** — consent rows,
-sender registration, and attribution all key on it. This is forced by the
-targeting model: the dApp addresses users by an in-app principal derived from
-`effectiveOrigin`, and `PRINCIPAL_INDEX` resolves that principal back to
-`(anchor, origin_hash)`, so consent must be keyed on the same origin or the
-lookup simply does not resolve. It is also the right trust boundary: if
-`app.com`'s `.well-known` is trusted enough to let those origins **share the
-user's identity**, letting them share push rights is the same trust, not a wider
-one.
-
-Three obligations follow, and skipping them is where this becomes a security
-problem:
-
-- **The opt-in screen must disclose the origin being granted.** Showing
-  "beta.app.com" while recording consent for `app.com` means the user consents to
-  something they were never shown, and Settings → Allowed apps then lists an
-  origin they don't recognize. When the two differ, show both.
-- **`.well-known/ii-push-senders` must live on the `effectiveOrigin`.** A
-  borrowing origin cannot register itself; the canonical origin must. Good
-  property — state it.
-- **Transitivity is intentional and must be documented.** One registration lets
-  _every_ origin listed in that alternative-origins file send as `app.com`, with
-  no separate opt-in.
+**Decision: `effectiveOrigin` is authoritative** — consent, registration and
+attribution all key on it. Forced by targeting (the in-app principal derives from
+it, so consent must match or the lookup fails) and the right trust boundary
+(sharing identity already implies sharing push). Three obligations: the opt-in must
+**disclose the origin granted** (show both when they differ); `.well-known` lives on
+the `effectiveOrigin`; and one registration lets **every** alternative origin send
+as `app.com` — intentional, document it.
 
 ### Consent lifecycle: it must not outlive the sender
 
@@ -1027,188 +894,71 @@ service worker drops out-of-order updates rather than applying them.
 
 ## Duplicate and replay suppression (`msg_id`)
 
-**Built.** Four independent mechanisms make duplicates the norm rather than the
-exception, and the fourth is the one that showed up first in practice:
+**Built.** Duplicates are the norm from four sources: replicated outcalls (removed
+by the non-replicated handoff), timer duplicate execution (claim-before-`await`),
+client retries + `drain_epoch`, and **accumulated subscription rows** — the one
+that actually produced duplicate banners in testing, when a rotated endpoint left
+two live rows for one browser.
 
-1. **Replicated outcalls** — 34 POSTs per push, no idempotency key in RFC 8030.
-   The non-replicated handoff removes this one, which is why it is no longer the
-   headline reason.
-2. **Timer duplicate execution** — see
-   [II's state model](#iis-state-model-stateless-for-campaigns), where the drain's
-   claim-before-`await` step exists for exactly this.
-3. **Client retries and `drain_epoch` recovery** — by design, per the client
-   library.
-4. **Accumulated subscription rows.** The fan-out sends one push per stored row,
-   browsers rotate endpoints, and nothing removed a row — so one browser ended up
-   behind two rows that both still delivered. This is what actually produced
-   duplicate banners during testing, before any of the above did.
+II assigns a `msg_id` **once per admitted message**, inside the payload *before*
+RFC 8291 encryption — so no dApp supplies it and no relay can read or forge it. The
+SW keeps a bounded seen-set (**in the Cache API**, since the worker is killed
+between pushes) and drops repeats; a payload with **no id is always shown**
+(failing open beats dropping a real notification). The drain now **removes a row on
+`404`/`410`**, the only signal a row is dead.
 
-II assigns a `msg_id` **once per admitted message**, stable across delivery
-retries, included in the JSON _before_ RFC 8291 encryption — so it is not a
-Candid field, no dApp supplies it, and no relay or gateway can read or forge it.
-The service worker keeps a bounded set of ids it has shown and drops repeats.
-
-Two implementation notes that are easy to get wrong:
-
-- **The seen-set cannot live in a variable.** A service worker is killed between
-  pushes, so an in-memory set forgets exactly what it needs to remember. It is
-  held in the Cache API, bounded and pruned oldest-first.
-- **A payload with no id is always shown.** Failing open matters: dropping a
-  real notification is worse than showing a duplicate, and it keeps an older
-  canister working against a newer worker.
-
-Cause as well as symptom: the drain now **removes a subscription when the relay
-answers `404`/`410`**. That is the only signal a row is dead, and without it rows
-only accumulate while every future send pays for a target that can never receive.
-`pushsubscriptionchange` is still missing, so a rotated endpoint lingers until a
-relay reports it gone — self-healing now rather than permanent.
-
-**Still to harden: a monotonic window rather than a bounded recency set.** What
-is built collapses accidental duplicates, which is what the symptom was. It does
-not resist a deliberate replay: a bounded set means eviction, and the attacker
-controls the pressure, so flooding a device with fresh notifications flushes the
-set and a replayed capture then looks new (clearing site data does the same).
-The hardened form keeps a per-origin high-water mark, rejects anything at or
-below it, and binds `msg_id` to a short validity window so an old capture fails
-on age alone.
-
-Note `msg_id` is a **different thing** from the dApp-facing `notification_id`:
-`msg_id` is II-generated and suppresses exact duplicates (show at most once);
-`notification_id` is dApp-chosen and _replaces_ a shown notification. Similar
-shape, opposite behavior — keep them separate fields.
+**To harden:** a bounded recency set can be flushed by flooding, so a replayed
+capture looks new — replace with a per-origin high-water mark + a short `msg_id`
+validity window. Note `msg_id` (II-generated, suppress duplicates) differs from
+`notification_id` (dApp-chosen, *replaces* a shown notification).
 
 ## End-to-end-encrypted apps
 
-Some apps (e.g. a chat using vetKeys) encrypt content so that only the
-recipient can read it — the app backend cannot. Our `Display` path is **not**
-E2E: II receives plaintext `title`/`body` and briefly holds it. The `Hidden`
-variant lets these apps use II-hosted push without ever handing content to II.
+The `Display` path is **not** E2E — II sees plaintext. For apps that can't allow
+that (a messenger), the axis is *who decrypts and where*:
 
-**Correcting an earlier overstatement.** It is tempting to say II can _never_
-show decrypted content. That is too strong. The honest constraint is about
-_who_ decrypts and _where_, and it comes with a trust dial the user is already
-turning:
+| Approach | Who decrypts | In-notification | Trust in II for content |
+| --- | --- | --- | --- |
+| **`Hidden`** (ships first) | the app, after tap | generic ("New message") | none |
+| **Design A** — vetKeys | II's SW, on device | real text | II client code + vetKD threshold |
+| **Design B** — dApp-fetch | II's SW, on device | real text | II client code (+ dApp) |
+| `Display` | II service | full | full |
+| App's own SW | app's SW | full | none (II not in loop) |
 
-- **II-the-service decrypts** — the canister and its node operators see
-  plaintext. That is just `Display` relabeled: fine for non-sensitive content,
-  not E2E.
-- **II's service worker decrypts on the user's own device**, using a key it
-  legitimately obtains and that II-the-service never sees in the clear. This
-  **is** viable. It asks the user to trust II's _client code_ running as them
-  on their device — which is only a small step past the trust they already
-  place in II by signing in with it (and exactly the trust the `Display` path
-  already assumes). This is the basis for showing real content in an
-  E2E-friendly way.
+Key correction: "II can never show decrypted content" is too strong. II's *service
+worker* decrypting on the user's own device — with a key II-the-service never sees
+in clear — is viable, and only a small step past the trust of signing in with II.
 
-So there is a spectrum, from no trust to full trust in II for content:
+**Ship `Hidden` first** — content-hidden notification + tap-through reveal (the
+industry-standard E2E UX; `/notify` is the reveal path). Zero extra trust, today.
+It's a deliberate lesser experience (no lock-screen preview) that's what makes E2E
++ push work at all.
 
-| Approach                     | Who decrypts           | In-notification         | Trust in II for content               |
-| ---------------------------- | ---------------------- | ----------------------- | ------------------------------------- |
-| `Hidden` (ships first)       | the app, after tap     | generic ("New message") | none — II never touches content       |
-| Design A — vetKeys-sealed    | II's **SW**, on device | full, real text         | II's client code + IC vetKD threshold |
-| Design B — dApp-fetch        | II's **SW**, on device | full, real text         | II's client code (+ the dApp)         |
-| `Display`                    | II-the-service         | full                    | full — II reads it                    |
-| App's own SW (not II-hosted) | the app's own SW       | full                    | none — II isn't in the loop           |
+<details><summary>Design A — vetKeys-sealed (preferred richer path)</summary>
 
-### Baseline that ships first: `Hidden` + tap-through
+II derives a vetKeys (IBE) identity per `(user, origin)`; the dApp encrypts to it
+offline and sends only ciphertext via `push_send`. On the device, II's SW
+authenticates as the user, gets the vetKD key (returned encrypted to the SW's
+transport key — no node sees it clear), decrypts, shows real text. II-the-service
+sees nothing; the residual trust is that II's canister controls the vetKD
+authorization — same class as delegations. vetKeys is **live on mainnet**.
 
-A content-hidden notification ("New message from `<origin>`") plus
-**tap-through reveal** — the user taps, the app opens, the app decrypts and
-shows the message in its own context. This is the industry-standard E2E
-notification UX (Signal, iMessage with previews off), and the `/notify`
-redirect we already have is exactly the reveal path. II never sees a byte of
-content and stores no plaintext.
+**Binding constraint: cost.** A derive per render is ~$357/10k blast (~400× the
+outcall cost), billed to II. So derive **once per `(user, origin)`**, cache in the
+SW, rate-limit per anchor — per-render derivation is a design error. Cross-subnet
+derive latency (seconds) is a second reason the cached path is the only viable one.
+Slots into `PushContent` later as an opaque ciphertext arm — no send/storage change.
 
-Framed honestly, `Hidden` is a **deliberate lesser experience that is what
-enables E2E and push together at all.** The user gives up the lock-screen
-preview (they see "New message," not the text) — a real downgrade versus
-`Display`. But it needs zero extra trust in II and ships today, so it is the
-right first step; the richer designs below are how the real text gets onto the
-lock screen later.
+</details>
 
-### Design A — vetKeys-sealed content, decrypted in II's SW (preferred richer path)
+<details><summary>Design B — dApp keeps the keys (alternative)</summary>
 
-II provides the encryption service so the app never hands plaintext to
-II-the-service, yet the real text still reaches the lock screen:
+Push is a bare wake; II's SW fetches content from the dApp. E2E only if the endpoint
+returns *ciphertext* — which forces either plaintext-from-backend (not strict E2E)
+or provisioning a dApp key into II's SW (added surface). Needs SW→dApp auth and a
+fetch per notification. Murkier than A; the fallback for backend-trusted apps.
 
-- II derives a vetKeys (IBE) identity per `(user, origin)`. The dApp fetches
-  II's master public key once and **encrypts the content to that identity
-  offline** — no round-trip, recipient needn't be online. It sends only the
-  _ciphertext_ to II via `push_send`, as opaque bytes II cannot read.
-- II delivers as usual (RFC 8291 wraps the opaque bytes). On the device, II's
-  SW authenticates **as the user** to II's canister and requests the vetKD
-  decryption key. vetKD returns it **encrypted to the SW's transport key**, so
-  no node operator sees the key in the clear; the SW decrypts the content and
-  shows the **real text**.
-- **What II-the-service sees:** in the honest flow, nothing — not the content,
-  not the key in clear. Plaintext exists only inside the user's SW, and II
-  stores none of it.
-- **The trust that remains:** II's canister _controls the vetKD
-  authorization_, so a malicious/compromised II could authorize itself to
-  derive a user's key and decrypt. That is the same class of trust the user
-  already extends to II for their delegations — not a new kind. No single node
-  can derive the key (threshold); II's client code is assumed honest (if it
-  weren't, the user's identity is already lost). A small, coherent increment
-  over `Hidden`.
-- **Availability:** vetKeys is **live on mainnet** (since mid-2025), not a
-  future capability — `vetkd_public_key` / `vetkd_derive_key` on curve
-  `bls12_381_g2`, with IBE supported. So this design is buildable today.
-- **Cost — and this is the binding constraint.** Priced in
-  [what this costs, and who pays](#what-this-costs-and-who-pays): a derive per
-  notification render would be **~$357 per 10k blast**, roughly 400× the entire
-  outcall cost of the same blast and the most expensive thing in the design, and
-  II is the one billed.
-
-  Therefore: derive **once per `(user, origin)`**, cache the key in the service
-  worker, and rate-limit the derive endpoint per anchor. The per-`(user, origin)`
-  identity scheme above already permits exactly this — the key is stable, so a
-  single derive covers every future notification from that origin. Treat
-  per-render derivation as a design error, not a tuning knob.
-
-- **Latency:** the production vetKD key lives on a different subnet, so each
-  derive is a cross-subnet round trip — seconds — inside a `push` event
-  handler's limited lifetime. Another reason the cached-key path is the only
-  viable one.
-- No change to the send/admission model — II still just carries bytes it can't
-  read.
-
-### Design B — dApp keeps the keys, II's SW fetches + decrypts (alternative)
-
-The push is a bare wake; on receipt II's SW calls an endpoint **on the dApp's
-side** to obtain the content, then renders it. Genuinely E2E only if that
-endpoint hands back _ciphertext_ the SW can decrypt — which forces one of two
-uncomfortable choices:
-
-- **Endpoint returns plaintext.** Then the dApp _backend_ can decrypt, so it is
-  "trust the dApp backend," not strict E2E. Simple, no vetKeys; fine for apps
-  that don't need backend-blind encryption.
-- **Endpoint returns ciphertext + the SW holds the key.** The recipient's key
-  lives in the dApp's client (cross-origin from II's SW), so the dApp must
-  _provision a key into II's SW_ — now II's SW holds dApp secrets, a real added
-  surface (II's code could exfiltrate them).
-
-Either way it also needs a way for the SW to authenticate to the dApp as the
-user (it has no delegation to the dApp) and a **fetch per notification**
-(latency, dApp serving load, offline-delivery gaps). More moving parts and a
-murkier trust story than A; documented as the fallback for apps that prefer to
-own the crypto or are content with backend-readable content.
-
-### Recommendation
-
-- **Ship `Hidden` first** — zero extra trust, works today.
-- **Plan for Design A (vetKeys)** as the way to put real content on the lock
-  screen while keeping II-the-service blind to it — the trust increment is
-  small and of a kind the user already accepts.
-- **Design B** stays the documented alternative for backend-trusted apps or
-  teams that don't want vetKeys.
-- **App runs its own SW** remains the strict, II-uninvolved option for teams
-  that want rich previews with II entirely out of the loop.
-
-Forward-compat is already in the interface: an E2E sender picks `Hidden` today
-and has no field to leak content through. Design A slots in later as an opaque
-**ciphertext arm** of `PushContent` (II still just carries bytes it can't
-read) plus a vetKD derive-and-decrypt branch in the SW render path — no change
-to send, admission, or storage.
+</details>
 
 ## Open items
 
@@ -1270,7 +1020,7 @@ before implementation, because two of them postdate the design:
   fleet-wide re-enable: run both keys and let old subscriptions age out, per
   [VAPID rotation](#open-items).
 - **vetKeys** — already live; see
-  [Design A](#design-a--vetkeys-sealed-content-decrypted-in-iis-sw-preferred-richer-path).
+  [Design A](#end-to-end-encrypted-apps).
   Client libraries are still pre-1.0 and the JS package was renamed, so pin
   deliberately.
 
@@ -1344,39 +1094,35 @@ flowchart LR
     C --> D[4. outcall<br/>→ gateway]
     D --> E[5. gateway<br/>→ relays]
     E --> F[6. device]
-    C:::bottleneck
-    D:::bottleneck
-    classDef bottleneck fill:#c0392b,color:#fff
+    C:::bn
+    D:::bn
+    classDef bn fill:#c0392b,color:#fff
 ```
 
 | Stage | Hard limit | Elastic? | Push it → |
 | --- | --- | --- | --- |
-| 1. Admit (`push_send`) | Layer-1 per-origin + global bucket | client-paced | bigger bucket = weaker flood protection |
-| 2. Heap buffer | 4 GiB heap | not the limit | oversizing accepts backlog whose TTL expires — a lying success |
-| **3. Seal** | instructions/round, **shared with every login** | **no** | bigger slice → login latency |
-| **4. Outcall → gateway** | 3000 in-flight subnet-wide, 500-deep queue | **no** | more in flight → starves II's own auth outcalls |
-| 5. Gateway → relays | web2, horizontally scalable | yes | relay per-app rate limits (FCM etc.) |
-| 6. Storage | 537 GB/canister | O(users × origins) | [see below](#storage-can-ii-store-the-data) |
+| 1. Admit | Layer-1 bucket | client-paced | bigger bucket = weaker flood protection |
+| 2. Heap buffer | 4 GiB | not the limit | oversizing accepts backlog whose TTL expires |
+| **3. Seal** | instructions/round, **shared with login** | **no** | bigger slice → login latency |
+| **4. Outcall** | 3000 in-flight, 500-deep queue | **no** | more in flight → starves auth outcalls |
+| 5. → relays | web2 | yes | relay per-app rate limits |
+| 6. Storage | 537 GB | O(users×origins) | [below](#storage-can-ii-store-the-data) |
 
-**The binding constraint is stages 3–4 — II's own execution round, shared with
-every sign-in on the network.** It sets a single global ceiling:
+**Stages 3–4 bind — II's execution round, shared with every login. The single
+global ceiling:**
 
-> **≈ 200 device-messages/second — ≈ 720k/hour — ≈ 17M/day — across every dApp
-> combined.** (Estimated; see the caveat below.)
+> **≈ 200 device-msg/s ≈ 720k/hour ≈ 17M/day, across every dApp combined.**
+> (Estimate — one RFC 8291 seal is dominated by a P-256 ECDH; measure it, every
+> number scales off it.)
 
-So:
+- **Users aren't the limit** — a large base costs storage, not throughput.
+- **Simultaneous blasts are** — N origins serialise through one drain;
+  [Layer 1](#admission-control-layer-1-stopping-one-dapp-from-flooding-ii) divides
+  the shared rate. The [separate-canister split](#the-way-to-lift-that-ceiling-is-a-separate-canister)
+  is the one move that lifts 3–4.
 
-- **Total users isn't the limit** — a large consented base costs storage, not throughput.
-- **Simultaneous blasts are** — N origins each blasting 10k serialise through one
-  drain; [Layer 1](#admission-control-layer-1-stopping-one-dapp-from-flooding-ii)
-  divides the shared rate rather than letting one starve the rest.
-- The [separate-canister split](#the-way-to-lift-that-ceiling-is-a-separate-canister)
-  is the one move that lifts stages 3–4, by not sharing the round with login.
-
-At the estimated ~200 device-msg/s shared drain, delivery time is linear in blast
-size — and because the rate is shared, the line is the **total across all dApps**.
-It crosses the one-hour budget at ~720k messages: beyond that, some notifications
-outlive their TTL before they are sent.
+Delivery time is linear in blast size and shared across dApps — it crosses the
+one-hour budget at ~720k messages, beyond which some notifications outlive their TTL:
 
 ```mermaid
 xychart-beta
@@ -1386,22 +1132,6 @@ xychart-beta
     bar [0.8, 8.3, 41.7, 60, 83.3]
     line [60, 60, 60, 60, 60]
 ```
-
-The flat line is the 60-minute budget; where the bars cross it is the ceiling. Two
-origins blasting at once share the same bars — the ceiling is not per-dApp.
-
-> The ~200 msg/s is this design's **estimate**, not a measurement. One RFC 8291
-> seal is dominated by a P-256 ECDH; measure it before trusting any figure — every
-> number here scales off it.
-
-Gateway vs direct, per 10k-user blast:
-
-| | Gateway (chosen) | Direct (alt) |
-| --- | --- | --- |
-| Outcalls | ~25 | ~13k |
-| Per-device `410` status | yes (non-replicated) | no under replication |
-| Latency | tens of seconds | minutes |
-| Cycles (paying subnet) | ~0.02 T (~$0.03) | ~2.8 T (~$3.80) |
 
 ### Storage: can II store the data
 
@@ -1424,42 +1154,17 @@ can get before upgrades become a problem.
 
 ## Stable memory regions
 
-New regions must claim an unused `MemoryId`. Because nothing in the code forces
-this check, record allocations here and verify against `storage.rs` before
-adding one — a duplicate index silently interleaves two `StableBTreeMap`s into
-the same virtual memory and corrupts both.
+New regions must claim an unused `MemoryId` — a duplicate index silently interleaves
+two `StableBTreeMap`s and corrupts both. (This happened: a PoC revision claimed 32,
+already taken by SSO, and the canister trapped on first read. A distinctness test is
+cheap.)
 
-| Index | Region               | Key → value                                                       |
-| ----- | -------------------- | ----------------------------------------------------------------- |
-| …     | (existing regions)   | see `storage.rs`                                                  |
-| 31    | MCP registration     | —                                                                 |
-| 32    | SSO stable-id index  | —                                                                 |
-| 33    | push subscriptions   | `(anchor, endpoint_sha256)` → `{endpoint, p256dh, auth, created}` |
-| 34    | push consent         | `(anchor, origin_sha256)` → `{granted_at, origin}`                |
-| 35    | push principal index | `in_app_principal` → `anchor`                                     |
-| 36    | push sender registry | `origin_sha256` → registered sender canister                      |
-
-What each is for, since the names alone do not say:
-
-- **Subscriptions** hold exactly what RFC 8291 needs to seal for one device — the
-  relay `endpoint` plus that device's `p256dh` public key and `auth` secret. One row
-  per _endpoint_, which is not quite one per browser: resubscribing with the same
-  endpoint overwrites in place, but a rotated endpoint is a new row and leaves the
-  old one behind until cleanup. The endpoint URL is what makes this the largest row.
-- **Consent** is presence-as-grant: the key existing means this user allowed this
-  dApp on this identity, and revoking deletes it.
-- **The principal index** is the reverse lookup `notify_user` cannot work without.
-  A dApp knows the user only by its per-origin `in_app_principal`, never the
-  anchor, so this resolves one to the other before the two maps above can be read.
-  Written on grant, cleared on revoke — and the reason a consent costs ~140 B
-  rather than ~60 B.
-- **The sender registry** records which canister may send as a given origin.
-  Controller-written only, because `.well-known` verification does not exist yet.
-
-This is not hypothetical. An earlier revision of the PoC claimed 32, which `main`
-had meanwhile taken for the SSO stable-id index; the two `StableBTreeMap`s
-interleaved and the canister trapped inside the B-tree on the first read. A test
-asserting all indices are distinct is cheap and worth having.
+| Index | Region | Key → value |
+| --- | --- | --- |
+| 33 | push subscriptions | `(anchor, endpoint_sha256)` → `{endpoint, p256dh, auth}` — RFC 8291 seal inputs, one row per endpoint (rotations leave stale rows) |
+| 34 | push consent | `(anchor, origin_sha256)` → `{granted_at, origin}` — presence = grant |
+| 35 | push principal index | `in_app_principal` → `anchor` — reverse lookup `notify_user` needs; why a consent costs ~140 B |
+| 36 | push sender registry | `origin_sha256` → sender canister — controller-written until `.well-known` verification |
 
 ## Future exploration
 
@@ -1485,38 +1190,19 @@ Deliberately out of v1, kept here so the door stays open:
 
 ### Built today (PoC on `feat/push-notifications-poc`)
 
-An inventory, not an explanation — each line links to the section that covers
-it. The last four exist because building the PoC proved they had to.
+Each line links to the section covering it; the last group exists because building
+the PoC proved it necessary.
 
-- **Per-device subscribe/unsubscribe, `/authorize` opt-in, per-dApp consent** —
-  [the user flow](#turning-notifications-on-first-time-signing-into-a-dapp),
-  [consent lifecycle](#consent-lifecycle-it-must-not-outlive-the-sender).
-- **`notify_user(principal, alert)`** — one recipient per call. It does **not**
-  answer scale, and everything in this doc about throughput, cost and delivery
-  assumes the chunked `push_send` that supersedes it:
-  [chunked send and flow control](#sending-to-thousands-of-users-chunked-send--two-layer-flow-control).
-- **RFC 8291 payload encryption and RFC 8292 VAPID signing, both in-canister** —
-  [delivering to devices](#delivering-to-devices).
-- **VAPID key generated with `raw_rand`, held in stable memory** — not the
-  custody model we would choose. Web Push mandates P-256, the IC's threshold
-  ECDSA is secp256k1 only, so the subnet cannot hold the key for us:
-  [what that risks](#security-model),
-  [what changes if P-256 lands](#ic-capabilities-to-re-evaluate).
-- **Tap opens the dApp's deep link directly**, falling back to the consent-gated
-  `/notify` redirect when the sender supplied no target —
-  [where a notification opens](#where-a-notification-opens),
-  [landing signed in](#landing-the-user-already-signed-in).
-- **Sender authorization by origin** — a registry keyed by origin hash. The
-  original `caller() == in_app_principal` rule could never match an
-  inter-canister call, so it admitted only self-sends:
-  [how II verifies a sender](#how-ii-verifies-the-sender-is-really-that-dapp).
-- **Send-time `alert.url` validation** — what makes opening the deep link
-  directly safe:
-  [where a notification opens](#where-a-notification-opens).
-- **`msg_id` dedup in the service worker, and `410`/`404` row cleanup** —
-  [duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
-- **VAPID key rotation in the browser** — a subscription bound to a superseded
-  key is resubscribed rather than failing forever.
+- Per-device subscribe/unsubscribe, `/authorize` opt-in, per-dApp consent
+- `notify_user(principal, alert)` — one recipient (superseded by chunked
+  [`push_send`](#sending-to-thousands-chunked-send--two-layer-flow-control))
+- RFC 8291 encryption + RFC 8292 VAPID signing, in-canister
+- VAPID key via `raw_rand` in stable memory ([risk](#security-model))
+- Tap → deep link directly, `/notify` fallback
+- **Sender authorization by origin** — the `caller() == in_app_principal` rule
+  never matched inter-canister calls
+- **`msg_id` dedup + `410`/`404` cleanup**, **`alert.url` validation**, **browser
+  VAPID-key resubscribe**
 
 ### Not built, so the PoC isn't mistaken for a shippable subset
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -425,8 +425,7 @@ The gateway can **drop, delay, replay**, and **forge sends** (the VAPID token, c
 won't decrypt, triggering the browser's "site updated" notice attributed to `id.ai`
 and burning the [shared permission](#shared-fate-one-permission-for-every-dapp).
 Mitigate: per-batch credentials, minutes-long JWT cache. The token is also
-node-operator-extractable from canister state. **Gateway = single point of failure**
-([Operating it](#operating-it-controls-alerts-and-rollout)).
+node-operator-extractable from canister state. **Gateway = single point of failure.**
 
 </details>
 
@@ -693,8 +692,7 @@ II-side:
   volume, with automatic suspension of an origin that exceeds it.
 - **Attributable throttling** — surface "app X was rate-limited" in Settings so
   blame lands on the sender rather than on II.
-- An **operator kill switch** per origin (see
-  [Operating it](#operating-it-controls-alerts-and-rollout)).
+- An **operator kill switch** per origin, to silence an abusive sender.
 
 ### Which origin is authoritative
 
@@ -877,22 +875,6 @@ every user, and push competes with that for three shared resources — outcall s
 (small drain slices), and cycles (never spend toward the freezing threshold). Enforce a
 hard push quota that always yields to login, and auto-throttle push if sign-in latency
 climbs.
-
-## Operating it: controls, alerts and rollout
-
-Missing today:
-
-- **Per-origin kill switch** — `push_deregister_sender` is dApp-authenticated, so
-  there's no operator way to silence an abusive sender. Need operator-gated
-  `push_set_origin_enabled` + a global feature flag to disable push without an upgrade.
-- **Alerts + ownership** on buffer depth, drain lag, per-origin reject rate, auth p99.
-- **Gateway ops** — who runs it, ≥2 independent instances, health/switchover.
-  **Gateway down = push down** (direct is a degraded fallback) — state it explicitly.
-- **Rollback discards the buffer** — silently drops in-flight campaigns unless
-  `drain_epoch` lands first.
-- **A load test** — every throughput/cost number here is derived. Run a 10k campaign
-  against a local replica measuring auth latency, and measure one seal's real cost
-  with `performance_counter`.
 
 ## dApp developer integration
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1970,9 +1970,26 @@ device-messages/second across all dApps combined* (≈ tens of millions/day). So
 - The [separate-canister split](#the-way-to-lift-that-ceiling-is-a-separate-canister)
   is the one move that lifts stages 3–4, by not sharing the round with login.
 
-> The stage-3 number is this design's **estimate**, not a measurement. One RFC 8291
-> seal is dominated by a P-256 ECDH; measure it before trusting any throughput
-> figure — every number above scales off it.
+At the estimated ~200 device-msg/s shared drain, delivery time is linear in blast
+size — and because the rate is shared, the line is the **total across all dApps**.
+It crosses the one-hour budget at ~720k messages: beyond that, some notifications
+outlive their TTL before they are sent.
+
+```mermaid
+xychart-beta
+    title "Minutes to drain a blast (shared ~200 msg/s)"
+    x-axis "Notifications in the hour" [10k, 100k, 500k, 720k, 1M]
+    y-axis "Minutes to deliver" 0 --> 90
+    bar [0.8, 8.3, 41.7, 60, 83.3]
+    line [60, 60, 60, 60, 60]
+```
+
+The flat line is the 60-minute budget; where the bars cross it is the ceiling. Two
+origins blasting at once share the same bars — the ceiling is not per-dApp.
+
+> The ~200 msg/s is this design's **estimate**, not a measurement. One RFC 8291
+> seal is dominated by a P-256 ECDH; measure it before trusting any figure — every
+> number here scales off it.
 
 Gateway vs direct, per 10k-user blast:
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1220,6 +1220,46 @@ visibility in
 [alternatives considered](#ii-hosts-the-pipeline-rather-than-each-dapp-running-its-own)
 as part of what the single permission is bought with.
 
+#### One action II should always add: turning it off
+
+The same centralisation buys something a per-dApp design cannot offer. Because II
+owns the worker and composes the notification, **II can put an off-switch on every
+notification that the sender cannot remove, relabel or suppress.** An app that owned
+its own notifications would simply never ship that button. This is the strongest
+user-protection property available here, and it is available only because of the
+choice that costs silent actions.
+
+Note first what "overrides the default" cannot mean: `actions` are _additional_
+buttons, so the body tap stays the deep link. The real cost is a **slot** —
+platforms render about two — so reserving one for II leaves a sender one. Given
+that a sender's own actions can only navigate anyway, that is a good trade rather
+than a sacrifice.
+
+Three levels, and they differ in what authority the worker needs:
+
+- **Turn off on this device — free, silent, available today.**
+  `subscription.unsubscribe()` is a browser and push-service operation; the worker
+  needs no II call and no delegation. Delivery to this device stops at once, the
+  endpoint begins answering `410 Gone`, and
+  [stale-subscription cleanup](#stale-subscription-cleanup) reclaims the row. This
+  is worth having for its own sake: it works even if II's backend is unreachable or
+  misbehaving, so a user can always stop the noise from the notification itself.
+  Device-wide, though — every dApp, not one.
+- **Stop this app — one extra tap.** `push_revoke_consent` is authorized by the
+  anchor, and the worker holds no authority for it, so this is a navigation into
+  II's settings deep-linked to that app's row. Arguably where it belongs anyway:
+  revoking one app is worth confirming, and it lands the user somewhere they can
+  see everything else they have granted.
+- **Stop this app, silently — needs new machinery.** II could seal a short-lived
+  capability token scoped to `(anchor, origin)` into the payload and accept it back
+  on a token-authorized revoke. That buys one saved tap for a replay window, token
+  expiry and a second authorization path into consent state. Not worth it in a
+  first version.
+
+So: ship the device-level switch, since it costs nothing and cannot fail, and make
+the per-app one a deep link. II must own both labels — a sender that could rename
+"Turn off notifications" would defeat the point.
+
 ### Updating or dismissing a notification already shown
 
 Yes, via a dApp-chosen `notification_id`, which the service worker maps to the
@@ -1279,6 +1319,12 @@ and notification **action buttons can only navigate, never act**, because the
 worker that receives the tap belongs to II rather than to the app holding the
 user's session (see
 [action buttons](#action-buttons-navigation-only-never-silent-work)).
+
+The same property cuts the other way once, and it is worth weighing against the
+list above: because II composes the notification, **it can attach an off-switch no
+sender can remove or relabel** — a guarantee no per-dApp design can make, since an
+app that owned its notifications would never add that button. See
+[one action II should always add](#one-action-ii-should-always-add-turning-it-off).
 
 ### II hosts the service worker, rather than each dApp hosting one
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -73,7 +73,7 @@ Three limits shape the design, and they bind on every deployment:
 
 | Limit | Consequence in this design |
 | --- | --- |
-| **In-flight outcalls** — 3000 subnet-wide, shared with II's own login paths | batch through the gateway (~25 outcalls, not ~13k) so a blast can't starve sign-in |
+| **In-flight outcalls** — 3000 subnet-wide, shared across every canister on the subnet | batch through the gateway (~25 outcalls, not ~13k) so a blast can't exhaust the subnet's shared outcall pool |
 | **Stable storage** — 500 GiB/canister, must not grow with volume | durable campaign lives in the dApp's library; II keeps only user-scoped rows + a transient buffer |
 | **Instructions/round** — this canister also serves every login | drain in bounded slices, never whole chunks |
 
@@ -231,8 +231,9 @@ things:
   recipient with five devices counts as five, because that's five actual sends). It's
   applied per registered domain, not per origin, so a dApp can't multiply its quota by
   spinning up `a1.evil.com … a1000.evil.com`.
-- **How much of II push can ever take** — push draws on a slice of the outcall budget
-  well below the subnet's cap, and always yields to sign-in. Each origin also has a
+- **How much of II push can ever take** — push draws only a slice of the outcall budget,
+  well below the subnet's cap, and its drain is scheduled behind sign-in — so a blast
+  neither exhausts the shared outcall pool nor slows logins. Each origin also has a
   reserved share of the buffer, so one large sender running flat-out can't crowd out
   smaller ones.
 
@@ -243,7 +244,7 @@ client library paces itself in response.
 ### What this costs, and who pays
 
 We care about three costs on every deployment: outcall slots (3000 subnet-wide,
-shared with login — the reason the gateway exists), storage (kept O(users × origins),
+shared across the subnet — the reason the gateway exists), storage (kept O(users × origins),
 never O(volume)), and instructions (which force the bounded-slice drain).
 
 Cycles are the fourth cost, but only where they're charged — waived on canonical II,
@@ -341,19 +342,20 @@ not the recipient count, that the pipeline is really moving.
 An entry is **per recipient** (~200 B + text; ~1 KB personalized vs one shared copy
 for a broadcast — a reason to keep `default_alert` the common path). **Memory isn't
 the constraint** (4 GiB heap; 100k recipients in flight ≈ 20–100 MB). **Drain rate
-is**, and it's shared across every app — about **200 device-messages a second, total**:
+is**, and it's shared across every app — about **50 device-messages a second, total**
+(the central estimate derived below):
 
 | Send | Device-messages | Time to deliver all of them |
 | --- | --- | --- |
-| One 1,000-recipient chunk | ~2,000 | ~10 s |
-| One 10k-user blast | ~20,000 | ~100 s |
-| 10 apps each blasting 10k at once | ~200,000 | ~17 min |
+| One 1,000-recipient chunk | ~2,000 | ~40 s |
+| One 10k-user blast | ~20,000 | ~6.5 min |
+| 10 apps each blasting 10k at once | ~200,000 | ~67 min |
 
-So the buffer depth should be **drain rate × acceptable latency** (60 s → ~6 MB),
+So the buffer depth should be **drain rate × acceptable latency** (60 s → ~2 MB),
 not what the heap allows — a memory-sized buffer accepts hours of backlog and
 returns `admitted` for messages whose TTL expires first (a lying success). Express
 admission in *seconds of backlog*, fair-shared `total_rate / active_origins`. All of
-this scales off the unmeasured ~200/s — measure the per-seal cost first.
+this scales off the ~50/s estimate — measure the per-seal cost first.
 
 ### The way to lift that ceiling is a separate canister
 
@@ -411,7 +413,7 @@ turn those into ~25 batched outcalls off-chain instead of ~13k on-chain.
 
 **Why a gateway, not direct:** in-flight outcall slots, not cycles. A 10k-user
 blast is ~13k direct outcalls against the subnet's 3000 shared slots — it would
-starve login. The gateway needs ~25. This holds even on the fee-waived deployment,
+exhaust the pool the whole subnet draws from. The gateway needs ~25. This holds even on the fee-waived deployment,
 which is why it's the real reason (cycles only differ ~4×).
 
 **What stays on II:** all crypto. The gateway sees ciphertext, endpoints and timing
@@ -616,7 +618,7 @@ Explicit opt-in — no `notification_id` means notifications never replace each 
 | --- | --- | --- | --- |
 | 1 | [II hosts the pipeline](#a1) | Each dApp runs its own | The permission is the scarce resource, not the plumbing — a dApp can't win the *n*th prompt |
 | 2 | [II hosts the service worker](#a2) | Each dApp hosts its own | Same decision as #1 — Web Push binds the subscription to the SW's origin |
-| 3 | [Gateway delivery](#the-delivery-path-a-trusted-web2-gateway) | Direct per-device outcalls | 13k in-flight outcalls would starve login; gateway → ~25 |
+| 3 | [Gateway delivery](#the-delivery-path-a-trusted-web2-gateway) | Direct per-device outcalls | 13k in-flight outcalls would drain the subnet's outcall pool; gateway → ~25 |
 | 4 | [Sealing stays on II](#action-buttons-navigate-never-act) | Gateway seals | Deriving the key = ability to decrypt; useless to move. Real lever is a [separate canister](#the-way-to-lift-that-ceiling-is-a-separate-canister) |
 | 5 | [vetKeys-sealed E2E](#end-to-end-encrypted-apps) | dApp holds the keys | See E2E section |
 
@@ -831,7 +833,7 @@ PoC's job was to prove the shape, not to be complete).
 | --- | --- |
 | Endpoint allowlist | Only real push-service endpoints (FCM, Apple, Mozilla) may be stored — no other host. The endpoint is where II POSTs each notification and the caller supplies it, so a fake one would aim II at any server the attacker likes. Re-check at send; II validates, not the gateway. |
 | Per-anchor caps | ~20 device subscriptions and ~100 app consents per identity, so one anchor can't mine II's storage. Reclaim dead subscriptions first; never silently drop a consent — refuse the next one instead. |
-| Reserved outcall budget | Push gets a fixed slice of the outcall budget and always yields to sign-in — [detail](#push-must-never-degrade-authentication). |
+| Reserved outcall budget | Push gets a fixed slice of the subnet outcall budget, and its drain is scheduled behind sign-in — [detail](#push-must-never-degrade-authentication). |
 | Robust drain loop | The timer emptying the buffer must survive one bad entry — otherwise a single malformed notification crashes the batch, rolls back, and retries forever, blocking everyone. Needs per-entry error handling with an attempt limit, a watchdog for a stuck buffer, and marking entries in-flight before the send so two ticks can't double-send. |
 | `drain_epoch` ack signal | A counter that changes when II is upgraded, so the client knows the buffer was wiped and re-sends — client durability doesn't work without it ([state model](#iis-state-model-stateless-for-campaigns)). |
 | <a id="stale-subscription-cleanup"></a>Stale-subscription cleanup | Remove a device row when its relay returns `404`/`410` (the endpoint is dead), or the table grows forever. Possible on the gateway path only because the handoff is non-replicated; treat a `410` as a hint, not proof. |
@@ -905,17 +907,36 @@ flowchart LR
 | 1. Admit the send | II accepts the chunk into its buffer | Yes — the client just paces; raising the limit only weakens flood protection |
 | 2. Hold in buffer | the chunk waits in memory to be sent | Yes — 4 GiB is far more than needed; memory is never the limit |
 | **3. Encrypt** | II encrypts each message for its device (elliptic-curve crypto, one per device) | **No — the bottleneck.** This is CPU-heavy, and II may only spend a slice of each execution round on it before sign-in slows |
-| **4. Send to the gateway** | II makes the outbound HTTPS calls | **No — the bottleneck.** Only ~3,000 calls can be in flight across the whole subnet, and II's own login calls draw from the same pool |
+| **4. Send to the gateway** | II makes the outbound HTTPS calls | **No — the bottleneck.** Only ~3,000 calls can be in flight across the whole subnet, shared with every other canister on it — which is exactly why delivery batches through the gateway |
 | 5. Gateway → relays | the gateway fans out to FCM/Apple/Mozilla | Yes — ordinary web2, limited only by each relay's per-app rate |
 | 6. Store per-user rows | subscriptions and consent persist | Grows with users × apps, not with volume — [Storage below](#storage-can-ii-store-the-data) |
 
-**Both bottlenecks are the same root cause: II shares its execution round and its
-outcall budget with every sign-in on the network, so push only ever gets a slice.**
-That slice is the ceiling:
+**The two bottlenecks have different roots. Encryption shares II's execution round
+with every sign-in — one canister, one instruction budget per round. Delivery shares
+the subnet's ~3,000-outcall cap with every canister on the subnet, which is why it
+batches through the gateway. Push yields on both fronts, so it only ever gets a
+slice.** That slice is the ceiling, and it comes down to two numbers: the cost of one
+seal, and the share of the canister we let push take —
+`device-msg/sec = (instructions/sec allotted to push) ÷ (instructions per seal)`:
 
-> **≈ 200 device-msg/s ≈ 720k/hour ≈ 17M/day, across every dApp combined.**
-> (Estimate — one RFC 8291 seal is dominated by a P-256 ECDH; measure it, every
-> number scales off it.)
+- **Cost of a seal** — one RFC 8291 message is dominated by a single P-256 variable-base
+  scalar multiplication (the ECDH against the device's key); HKDF and AES-GCM are noise
+  beside it. In Wasm that is an estimated **~20 M instructions**, range ~10–30 M. This is
+  the one number to measure first — every figure below scales off it.
+- **Share of execution** — the drain is held to **~20 % of the canister**, a deliberate
+  cap so sign-in keeps ~80 % of every round even mid-blast. On a canister sustaining a
+  few billion instructions/sec that hands push **~1 B instructions/sec**.
+
+Plugging those in — the central column is the planning number:
+
+| per seal | 10 M (optimistic) | **20 M (central)** | 30 M (conservative) |
+| --- | --- | --- | --- |
+| device-msg/sec | ~100 | **~50** | ~33 |
+| per hour | ~360k | **~180k** | ~120k |
+| per day | ~8.6M | **~4.3M** | ~2.9M |
+
+> **≈ 50 device-msg/s ≈ 180k/hour ≈ 4.3M/day, across every dApp combined** — at a
+> deliberate 20 % execution share and ~20 M-instruction seal, both to confirm by measurement.
 
 - **Users aren't the limit** — a large base costs storage, not throughput.
 - **Simultaneous blasts are** — N origins serialise through one drain;
@@ -924,14 +945,14 @@ That slice is the ceiling:
   is the one move that lifts 3–4.
 
 Delivery time is linear in blast size and shared across dApps, crossing the one-hour
-budget at ~720k messages:
+budget at ~180k messages:
 
 ```mermaid
 xychart-beta
-    title "Minutes to drain a blast (shared ~200 msg/s)"
-    x-axis "Notifications in the hour" [10k, 100k, 500k, 720k, 1M]
-    y-axis "Minutes to deliver" 0 --> 90
-    bar [0.8, 8.3, 41.7, 60, 83.3]
+    title "Minutes to drain a blast (shared ~50 msg/s)"
+    x-axis "Notifications in the hour" [10k, 50k, 100k, 180k, 300k]
+    y-axis "Minutes to deliver" 0 --> 120
+    bar [3.3, 16.7, 33.3, 60, 100]
     line [60, 60, 60, 60, 60]
 ```
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1579,10 +1579,29 @@ Must-fix before a real deployment:
   ports, userinfo and non-`https` schemes, and reject private/loopback/link-local
   hosts. Without this, II is an SSRF and DDoS reflector with an *n*× multiplier —
   a free ingress call turns into 34 POSTs at a victim of the caller's choosing.
-- **Per-anchor caps.** Cap subscription rows (~10) and consent rows (~100) per
-  anchor, with LRU eviction. Nothing bounds them today, ingress is free to the
-  caller, and II pays the stable-memory cost — a direct attack on the resource
-  this design calls a hard constraint.
+- **Per-anchor caps.** Cap subscription rows at **20** and consent rows at
+  **100** per anchor, with LRU eviction. Nothing bounds either today, ingress is
+  free to the caller, and II pays the stable-memory cost — a direct attack on the
+  resource this design calls a hard constraint.
+
+  Against the row sizes in
+  [what this actually costs per user](#what-this-actually-costs-per-user), 20
+  subscriptions plus 100 consents (each consent also costing a principal-index
+  row, so 140 B a piece) is **~19.5 KB per anchor** on typical endpoints and
+  **~35 KB** on worst-case ones. 20 is chosen rather than 10 because a real user
+  plausibly has 4–5 devices and browsers rotate endpoints, so stale rows
+  accumulate between cleanups; 10 would start evicting live devices. The
+  worst-case figure is dominated by the endpoint URL at ~1.1 KB — 22 of those
+  35 KB — so bounding endpoint length is a bigger lever on the ceiling than the
+  row count is.
+
+  **Read the cap as anti-griefing, not as a storage bound.** If all 10M anchors
+  saturated it, that is 200–360 GB against a 537 GB canister limit, on a subnet
+  shared with anchor data — so the cap stops one anchor from mining II's storage,
+  while aggregate growth stays bounded by real usage (~20 GB) plus
+  [stale-subscription cleanup](#stale-subscription-cleanup). It buys roughly 10×
+  headroom over expected usage, which is the right order for a limit nobody
+  legitimate should ever reach.
 - **Reserved outcall budget for authentication.** See
   [Push must never degrade authentication](#push-must-never-degrade-authentication).
 - **Drain isolation and non-reentrancy.** Per-entry failure boundaries, an
@@ -1797,9 +1816,13 @@ Storage is O(users × origins), not O(users) — worth being concrete, since the
 | Principal index | `principal`               | ~80 B                                                       | users × dApps    |
 | Sender registry | `origin_hash`             | ~100 B                                                      | registered dApps |
 
-At 10M users × 2 devices × 10 consented dApps that is roughly **6 GB + 1 GB +
-1.2 GB ≈ 8 GB**, against a 500 GiB per-canister limit but sharing a 2 TiB subnet
-with anchor data — and **before** any dead rows, which is why
+At 10M users × 2 devices × 10 consented dApps: 20M subscription rows ≈ **6 GB**,
+100M consent rows ≈ **6 GB**, 100M principal-index rows ≈ **8 GB** — about
+**20 GB** in total, or ~2 KB per anchor. The two 100M-row maps dominate, because
+every consent costs a principal-index row as well; devices are the cheap axis.
+
+That is against a 500 GiB (537 GB) per-canister limit while sharing a 2 TiB subnet
+with anchor data, and it is **before** any dead rows — which is why
 [stale-subscription cleanup](#stale-subscription-cleanup) is a must-fix rather
 than housekeeping. Note also the 2 GiB stable-memory-per-upgrade ceiling, which
 bounds how large these maps can get before upgrades become a problem.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -34,12 +34,12 @@ the open items.
    heading "Let `<dApp>` notify you", two short reasons (instant alerts /
    reachable anytime), and two buttons — **Enable notifications** and **Maybe
    later**.
-6a. **Enable** → the browser shows its **native permission prompt**
-    ("`id.ai` wants to show notifications — Allow / Block"). This dialog is
-    the browser's own and cannot be restyled. On **Allow**, II subscribes the
-    device and records consent for this dApp, then redirects to the dApp. No
-    app install is required (Android/desktop); iOS Safari is the exception.
-6b. **Maybe later** → II redirects straight to the dApp; nothing is enabled.
+   6a. **Enable** → the browser shows its **native permission prompt**
+   ("`id.ai` wants to show notifications — Allow / Block"). This dialog is
+   the browser's own and cannot be restyled. On **Allow**, II subscribes the
+   device and records consent for this dApp, then redirects to the dApp. No
+   app install is required (Android/desktop); iOS Safari is the exception.
+   6b. **Maybe later** → II redirects straight to the dApp; nothing is enabled.
 
 The permission prompt appears only the first time the user enables
 notifications on this browser; for later dApps the opt-in screen simply
@@ -80,21 +80,44 @@ Built today (PoC on `feat/push-notifications-poc`):
   one is unavailable: VAPID/Web Push mandate ECDSA on the **P-256
   (secp256r1)** curve, but the IC's threshold ECDSA currently supports **only
   secp256k1** — so we cannot let the subnet hold the key via `sign_with_ecdsa`
-  and must generate and store it ourselves. It follows the same posture as the
-  anchor salt (node operators could extract it; the blast radius is spam, not
-  identity). If P-256 threshold ECDSA lands on the IC, the key moves off
-  storage entirely — see the security and open-items sections below.
+  and must generate and store it ourselves. Custody posture matches the anchor
+  salt (node operators could extract it), but the blast radius is **not** just
+  spam — see the [security model](#security-model). If P-256 threshold ECDSA
+  ever lands, the key moves off storage entirely.
 - Notification click routes through the consent-gated `/notify` redirect.
+
+What the PoC deliberately does **not** have, so it isn't mistaken for a
+shippable subset:
+
+- **`notify_user` requires `caller() == in_app_principal`.** That principal is a
+  canister-signature principal, so it can only appear as `caller()` on an
+  _ingress_ message carrying the user's own delegation — a dApp **backend cannot
+  call it at all**. The PoC therefore demonstrates _delivery_, not _sending_:
+  the only party who can currently notify a user is a browser tab holding that
+  user's live session. Backend-initiated sends need the sender registry and
+  `push_send` from the design below.
+- No rate limiting or admission control of any kind — `notify_user` is unmetered.
+- No endpoint validation beyond an `https://` prefix, and no per-anchor caps on
+  subscription or consent rows.
+- `Display` content only — no `Hidden`, which is the variant the design
+  recommends shipping first for E2E apps.
+- No `msg_id`, no `410` cleanup, no `pushsubscriptionchange` handling.
+- Integration and E2E test coverage is thin (unit tests for the crypto only).
 
 Proposed (this doc):
 
 - Chunked `push_send` with two-layer flow control (II admission + client
-  pacing), sender registry, a stateless-for-campaigns II (transient heap
-  buffer, storage O(users)), a durable client library, and delivery through a
-  trusted web2 gateway (with direct per-device outcalls as the documented
-  alternative/fallback). No cycles charging in v1 (the real costs — storage and
-  outcalls — are controlled by design, not billing) — parked as a future
-  exploration.
+  pacing), a sender registry, a stateless-for-campaigns II (transient heap
+  buffer, storage O(users × origins)), a durable client library, and delivery
+  through a trusted web2 gateway (with direct per-device outcalls as the
+  documented alternative/fallback).
+- Promoted to v1 requirements by review: `msg_id` + device dedup, a
+  `drain_epoch` acknowledgment signal, an endpoint host allowlist, per-anchor
+  caps, drain isolation and non-reentrancy, and a reserved outcall budget that
+  protects sign-in.
+- No cycles charging to senders in v1 — but a deployment that pays fees needs a
+  cycle budget with a circuit breaker regardless. Sender charging is parked as a
+  future exploration.
 
 ## How does it work, in plain terms?
 
@@ -106,7 +129,7 @@ Read this first; the sections after it just add detail.
 - **II already knows how to reach each user.** When a user turns notifications
   on, their browser hands II the keys needed to deliver to that device; when
   they sign into a dApp and opt in, II records that the dApp is allowed. So II
-  keeps two small per-user facts: *which devices* and *which apps are allowed*.
+  keeps two small per-user facts: _which devices_ and _which apps are allowed_.
 - **II seals every message.** It encrypts the text with the device's own key
   (created when the device subscribed, using standard Web Push encryption) so
   only that device can read it — Google/Apple/Mozilla just forward the sealed
@@ -137,7 +160,7 @@ Everything below is the same story with the exact mechanisms and edge cases.
 ┌─ dApp side ────────────────────────┐        ┌─ II ────────────────────────────────┐
 │ client library (durable):          │        │ Layer 1 — admission control         │
 │  owns the campaign + status         │ chunk  │  per-origin bucket + global cap,    │
-│  chunks (≤1000, ≤2MB)               │──────▶ │  O(1) reject → protects II          │
+│  chunks (≤1000 targets)             │──────▶ │  hard caps + reject → protects II   │
 │  templating / personalization       │        │        │ admit                       │
 │  prioritization                     │ ◀──────│        ▼                            │
 │  Layer 2 — pacing (cooperative):    │ ready/ │  transient HEAP buffer (small)      │
@@ -156,43 +179,95 @@ Everything below is the same story with the exact mechanisms and edge cases.
                           II /notify?origin=…&to=… → consent-gated redirect → dApp
 ```
 
-Two costs drive the architecture, and it is built to control **both**:
+Three resources drive the architecture, and it is built to control all three:
 
-- **Stable storage** — the hard constraint. It is limited and must not grow
-  with how many notifications are sent. So the durable campaign lives in the
-  dApp's client library, and II keeps only user-scoped data (subscriptions,
-  consent) plus a small transient working set — its storage stays flat with
-  volume.
-- **HTTPS outcalls** — genuinely expensive and rate-bounded (one call per
-  device adds up fast in both cycles and throughput). So delivery is batched
-  through the gateway, turning thousands of per-device outcalls into a handful.
+- **In-flight HTTPS outcalls** — the binding constraint, and it is _shared_.
+  The subnet allows 3000 outcalls in flight **across every canister on it**,
+  and II already spends from that budget on its own authentication paths (DoH
+  for email recovery, JWKS and discovery for OIDC sign-in). One naive blast is
+  ~13k outcalls, which would starve login. So delivery is batched through the
+  gateway: ~25 outcalls instead of ~13k.
+- **Stable storage** — limited on every deployment (500 GiB per canister,
+  2 GiB per message, 8 GiB per upgrade) and it must not grow with how many
+  notifications are sent. So the durable campaign lives in the dApp's client
+  library and II keeps only user-scoped data plus a small transient working
+  set.
+- **Instructions per message and per round** — the crypto is _not_ free at
+  chunk scale (see the sealing budget below), and II serves every login on the
+  network from this same canister. So the drain works in bounded slices rather
+  than whole chunks.
 
-Raw compute is the cheap part (the crypto is microseconds of local work and
-stays in-canister); storage and outcalls are the two things worth engineering
-around.
+Cycles are a real cost too, but how much they matter depends on the deployment
+— see [Deployment assumptions](#deployment-assumptions). The three limits above
+bind everywhere regardless of who pays.
+
+## Deployment assumptions
+
+Numbers in this doc depend on where II runs, so state the deployment before
+quoting a cost:
+
+- **Canonical II** (`rdmx6-jaaaa-aaaaa-aaadq-cai`) runs on subnet `uzr34…`,
+  which is a **system subnet with 34 nodes**. On a system subnet the IC waives
+  execution, ingress, xnet, storage and HTTPS-outcall fees, so those are
+  effectively free _for this deployment_. Chain-key fees (threshold ECDSA,
+  vetKD) are **still charged**.
+- **Any other deployment** — a self-hosted II, a fork, or a test network —
+  runs on an application subnet where **every fee applies**. This is a
+  first-class case: the design must be viable when cycles are really being
+  spent, and a self-hoster needs the cost model to budget with.
+- **Capacity limits apply everywhere**, priced or not: the 3000 in-flight
+  outcall cap, per-message and per-round instruction limits, the 500-deep
+  output queue per canister pair, 2 MB message ceilings, and the 30 s outcall
+  timeout.
+- **Outcall replication.** A replicated outcall is executed by **every node**,
+  so the target receives _n_ requests, not one (n = 34 on II's subnet). This
+  matters for both cost and correctness — see
+  [Delivering to devices](#delivering-to-devices).
+
+Rule of thumb for this doc: design to the **paying** case and treat the fee
+waiver as a property of one deployment, not a premise of the design.
 
 ## dApp → II
 
 ### Sending to thousands of users: chunked send + two-layer flow control
 
-> *In short: the dApp streams the audience to II in small batches ("chunks");
+> _In short: the dApp streams the audience to II in small batches ("chunks");
 > II refuses more than it can handle, and the dApp slows down when told to.
-> Two separate safeguards — one on each side — keep this safe and smooth.*
+> Two separate safeguards — one on each side — keep this safe and smooth._
 
 A campaign of any size is delivered as a series of **bounded chunks** — a chunk
-is just a bite-sized batch of targets (≤ ~1000 targets, ≤ 2 MB per call). This is deliberate: II must never be asked to hold a
-whole campaign, because that is the storage that scales with volume. Two
-independent control layers make this safe and smooth — and they must not be
-confused:
+is just a bite-sized batch of targets (≤ ~1000 targets, and under the message
+size ceiling). This is deliberate: II must never be asked to hold a whole
+campaign, because that is the storage that scales with volume. Two independent
+control layers make this safe and smooth — and they must not be confused:
 
 - **Layer 1 — II admission control (mandatory, adversarial).** This is the
-  security boundary and assumes a hostile client. II enforces a per-origin
-  token bucket (notifications-per-window) plus a global cap on its transient
-  buffer. Over capacity, `push_send` **rejects the chunk** (`ready = false` +
-  `retry_after_ms`). The reject is O(1). The guarantee: **II never holds more
-  than its bounded buffer, no matter what the client does** — a client that
-  ignores backpressure just collects cheap rejections. This is the anti-spam
-  property, and it lives entirely on II.
+  security boundary and assumes a hostile client. II enforces a hard
+  `recipients.len()` ceiling (see below), a per-origin token bucket
+  (notifications-per-window) plus a global cap on its transient buffer. Over
+  capacity, `push_send` **rejects the chunk** (`ready = false` +
+  `retry_after_ms`). The guarantee: **II never holds more than its bounded
+  buffer, no matter what the client does**. This is the anti-spam property, and
+  it lives entirely on II.
+
+  Two honest caveats about how cheap that reject is:
+  - The **policy decision** is O(1), but it happens _after_ the message has been
+    admitted into a block and its payload Candid-decoded. A rejected 2 MB chunk
+    still costs a consensus round and a 2 MB decode, so absorbing a flood is
+    cheap _per decision_, not free. Cap the accepted message size well below
+    2 MB so the pre-decision cost is bounded too.
+  - **`inspect_message` cannot help here.** It is not invoked for
+    inter-canister calls, and `push_send` is called by dApp _canisters_. It
+    only ever filters ingress. Any claim that push is rate-limited via
+    `canister_inspect_message` is wrong.
+
+  **The ≤1000-recipient bound is enforced server-side**, before any
+  per-recipient work. It is not a client obligation: 2 MB of `PushRecipient`
+  with empty overrides is ~65,000 recipients, and doing per-recipient index and
+  consent lookups for that many in one message would exceed the instruction
+  limit and trap. The client-side chunking in the library is an _optimization
+  over_ this hard limit, never a substitute for it.
+
 - **Layer 2 — client pacing (cooperative, efficiency only).** The client
   library reads the same `ready` / `retry_after_ms` signal and paces so it
   doesn't waste calls getting rejected: send the next chunk when II is ready,
@@ -333,72 +408,153 @@ model does not batch. Senders authenticate at the **origin** level:
 
 ### Admission control (Layer 1): stopping one dApp from flooding II
 
-> *In short: II tracks how much each app is sending and simply says "not right
+> _In short: II tracks how much each app is sending and simply says "not right
 > now, try again in N ms" once an app goes over its share. This is what stops
-> spam, and it works even if the sender ignores every hint.*
+> spam, and it works even if the sender ignores every hint._
 
 The mandatory guard, assuming a hostile client. Enforced on every `push_send`,
 independent of client behavior:
 
-- **Per-origin token bucket** in notifications-per-window — one origin can't
-  spam and can't starve others. Denominated in notifications, not calls, so it
-  can't be gamed by slicing a send into many small chunks.
-- **Global cap** on the in-flight buffer — protects II/the subnet as a whole.
-- **O(1) reject** when over capacity (`ready = false` + `retry_after_ms`), so
-  absorbing a flood is itself cheap.
+- **Hard `recipients.len()` ceiling** (~1000), checked before any per-recipient
+  work, and a hard accepted-payload cap well below 2 MB.
+- **Per-origin token bucket** denominated in **device-messages, not
+  recipients** — a recipient with five devices costs five sealed messages and
+  five outcall payloads, so counting recipients under-charges the real work.
+  Denominated per notification rather than per call, so it can't be gamed by
+  slicing a send into many small chunks.
+- **Bucket by registered operator (eTLD+1), not by bare origin.** An origin is
+  scheme+host+port and registration only requires serving a `.well-known`
+  file, so `a1.evil.com … a1000.evil.com` would otherwise be 1000 origins with
+  1000 full buckets. Per-origin buckets bound one _origin_, not one _operator_.
+- **Global cap** on the in-flight buffer — protects II/the subnet as a whole —
+  **with per-origin reservations underneath it**, so a large sender at its own
+  limit cannot consume the entire global budget and starve small senders. A
+  first-come-first-served global cap does not deliver the "can't starve others"
+  property on its own.
+- **A push-specific outcall budget** well below the subnet's 3000 in-flight cap,
+  yielding to II's own authentication outcalls. See
+  [Push must never degrade authentication](#push-must-never-degrade-authentication).
+- **Reject** when over capacity (`ready = false` + `retry_after_ms`, jittered
+  per caller so rejected clients don't retry in lockstep).
 
 Because the queue lives on the client, the only II storage a sender can
 pressure is the bounded in-flight buffer — which admission control caps
 directly. That, plus the fast drain (below), is what lets II sustain high
-throughput on a *small* buffer.
+throughput on a _small_ buffer.
 
 ### What does this cost, and who pays?
 
-Two real costs, controlled by the design; not charged to the dApp in v1:
+Costs split into what is _always_ scarce and what depends on the deployment
+(see [Deployment assumptions](#deployment-assumptions)).
 
-- **Stable storage — the hard constraint.** Kept **O(users)** (subscriptions +
-  consent), never O(notification volume), because the campaign state lives in
-  the client library. This is the cost that would otherwise grow without bound,
-  so it's the one the whole "stateless II" shape is built around.
-- **HTTPS outcalls — expensive and bounded.** Minimized by batching delivery
-  through the gateway (a handful of calls instead of one per device). Real
-  enough to design against, which is why the gateway exists.
-- **Compute (the crypto)** is the cheap part and stays in-canister.
+**Always scarce, on every deployment:**
 
-On charging: **no cycles charging in v1.** Cycles can only be attached by
-canister senders, and adding per-notification fees brings real complexity
-(accept/refund, fee tuning) for a v1 whose abuse surface is already bounded by
-admission control. Attached-cycle or prepaid-balance pricing is parked as a
-future exploration — worth revisiting to offset the outcall/storage cost at
-scale, or as an extra abuse lever. See Future exploration.
+- **In-flight outcall slots** — 3000 subnet-wide, shared with II's own login
+  outcalls. The reason the gateway exists.
+- **Stable storage** — kept **O(users × origins)**: subscriptions are per
+  `(anchor, endpoint)`, consent and the principal index per `(anchor, origin)`.
+  Never O(notification volume), because campaign state lives in the client
+  library. That is the invariant the "stateless II" shape buys; see the
+  [bytes-per-user table](#what-does-this-actually-cost-per-user).
+- **Instructions** — sealing is not free at chunk scale; the drain must work in
+  bounded slices.
+
+**Cycles — real, but deployment-dependent.** On canonical II (system subnet)
+outcall, execution and storage fees are waived. On any application subnet
+(self-hosted, fork, test net) they are fully charged, and the formula is:
+
+```
+outcall cycles = (3_000_000 + 60_000·n)·n              ← per-call base
+               + (400·request_bytes + 800·max_response_bytes)·n
+```
+
+At n = 34: base 171.4 M, 13,600 per request byte, 27,200 per reserved response
+byte. Worked example, a 10k-user broadcast (~13k device-messages) on a 34-node
+**application** subnet:
+
+| Path                   | Outcalls | Cycles | ≈ USD  |
+| ---------------------- | -------- | ------ | ------ |
+| Direct, one per device | ~13,000  | ~2.8 T | ~$3.80 |
+| Gateway, ~2 MB batches | ~25      | ~0.7 T | ~$0.95 |
+
+Two things to read off that table. The gateway cuts outcall **count** ~500× but
+**cycles only ~4×**, because the per-byte fee is charged on the same sealed
+bytes either way — batching amortizes the base fee, not the payload. And
+`max_response_bytes` is charged whether used or not (at 1 KB it exceeds the
+request fee for small direct sends), so always set it tight. **The gateway's
+real justification is in-flight slots and drain latency, not cycles.**
+
+**vetKD is charged on every deployment**, system subnets included:
+`vetkd_derive_key` is ~26.2 B cycles (~$0.036) per call. A derive _per
+notification render_ would be ~$357 per 10k blast — so the E2E design in
+[End-to-end-encrypted apps](#end-to-end-encrypted-apps) must derive **once per
+`(user, origin)`** and cache in the service worker, with a per-anchor rate
+limit. Because the service worker calls in over ingress, which carries no
+cycles, **II pays** — making an uncached derive a user-triggerable drain.
+
+On charging senders: **no cycles charging in v1.** Cycles can only be attached
+by canister senders, and per-notification fees bring real complexity
+(accept/refund, fee tuning). Prepaid-balance or attached-cycle pricing is parked
+as a future exploration. But note what does _not_ follow from deferring
+charging: a rate limit multiplied by time is unbounded spend, so a deployment
+that pays fees needs a **cycle budget with a circuit breaker** independent of
+the rate bucket — see
+[Operating it](#operating-it-controls-alerts-and-rollout).
 
 ## II's state model: stateless for campaigns
 
-> *In short: II accepts a chunk, briefly holds it in memory (not durable
+> _In short: II accepts a chunk, briefly holds it in memory (not durable
 > storage), seals and sends it, then forgets it. The durable list lives with
-> the dApp, so II's storage doesn't grow as more notifications are sent.*
+> the dApp, so II's storage doesn't grow as more notifications are sent._
 
-II holds **no campaign queue in stable (durable) memory**. `push_send` is
-cheap:
-authenticate the sender, dedup `chunk_id`, run admission control (Layer 1),
-per-target resolve + consent-check, then admit the survivors into a small
-**transient heap buffer** and return `{admitted, rejected, ready,
-retry_after_ms}`. It does not wait for delivery — one message cannot do
-1000 × devices encryptions and outcalls (per-message instruction limit +
-outcall-concurrency cap).
+II holds **no campaign queue in stable (durable) memory**. `push_send` is cheap:
+check the recipient-count ceiling, authenticate the sender, dedup `chunk_id`, run
+admission control (Layer 1), per-target resolve + consent-check, then admit the
+survivors into a small **transient heap buffer** and return
+`{admitted, rejected, ready, retry_after_ms, drain_epoch}`.
+
+It does not wait for delivery, and cannot: sending a whole chunk inline would
+need ~1000 × devices seals and outcalls in one message. The binding limits there
+are the **500-deep output queue** to the management canister (which caps
+concurrent outcalls per message) and the subnet's 3000 in-flight cap — with
+instruction cost making a whole chunk a large fraction of an execution round on
+a canister that also serves every login. Hence the bounded-slice drain below.
 
 A timer (`ic_cdk_timers`, ~1s) drains the heap buffer:
 
-- One `raw_rand` per tick; ChaCha20 derives per-message ephemeral seeds.
+- **Claims** the slice it is about to work on before the first `await`, marking
+  those entries in-flight. Every `await` ends a message execution and lets the
+  next tick interleave, so without a claim step two ticks send the same entries
+  twice. A `draining` flag makes ticks non-reentrant. This is not optional:
+  `ic-cdk-timers` documents that under load "timeouts may result in duplicate
+  execution", and the drain is not idempotent.
+- Works a **bounded slice** (target 100–300 device-messages, tuned from a real
+  measurement), not a whole chunk. Sealing costs real instructions and this
+  canister also serves every login on the network; a whole 1000-recipient chunk
+  is a large fraction of an execution round.
+- One `raw_rand` per tick; ChaCha20 derives per-message ephemeral seeds. (Note
+  the per-tick seed means the subnet's random tape, if observed, reveals that
+  tick's ephemeral scalars — see the [security model](#security-model).)
 - Resolves each anchor's devices **now** (they change between admit and drain)
-  and re-checks consent (may have been revoked since).
-- Forces `content` attribution to the sender origin (unspoofable).
+  and re-checks consent (may have been revoked since). Device lookup must be a
+  **prefix range scan** over `(anchor, endpoint_hash)`, never a filtered scan of
+  the whole map — the latter is O(all users with push enabled) per notification
+  and traps once the map is large.
+- Forces attribution to the sender origin (unspoofable).
 - RFC 8291 encrypts per device; attaches the per-audience VAPID JWT
   (cached, ≤ 12h).
-- Drains **fast** to the gateway in a few batched outcalls (see below). Fast
-  drain is what lets the buffer stay small while admitting at high throughput.
-- `410 Gone` deletes the subscription. No retries in v1 (retries are a client
-  concern; see the client library).
+- Assigns a `msg_id` per admitted message, stable across retries, for
+  device-side replay/duplicate suppression. Not optional — see
+  [Duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
+- Drains to the gateway in a few batched outcalls (see below). A fast drain is
+  what lets the buffer stay small while admitting at high throughput.
+- **Isolates per-entry failure.** A trap inside the drain rolls back the tick's
+  heap mutations, leaving the buffer unchanged — so the next tick reprocesses
+  the same poison entry and traps again, forever, with `ready = false` returned
+  to _every_ origin. One malformed row would take the whole feature down until
+  an upgrade (which then silently discards the buffer). Each entry needs its own
+  failure boundary, an attempt counter with drop-and-count, and a watchdog that
+  clears the buffer if depth stays pinned across N ticks.
 
 `PushDelivery` integrates into the buffer, not just the headers:
 
@@ -408,16 +564,40 @@ A timer (`ic_cdk_timers`, ~1s) drains the heap buffer:
   too.
 - **ttl_seconds** — at drain, if `admitted_at + ttl` has passed, **skip** the
   outcall (the relay would drop it anyway).
-- **urgency** — sets the header *and* orders the drain (`High` first).
+- **urgency** — sets the RFC 8030 header, and contributes to drain order as
+  **one input among several**, never as the sole key. Ordering is: round-robin
+  across origins first, then within an origin's slice by urgency combined with
+  age and remaining TTL. Urgency is sender-supplied and unvalidated — every
+  sender will set `High` (both examples in this doc do) — so if it ordered the
+  whole buffer, one sender pinning `High` would starve every other origin's
+  `Normal` traffic indefinitely. Origin fairness outranks it; age and TTL stop
+  anything from sitting at the tail forever.
 
-**Durability lives on the client, not in II.** The in-flight buffer is heap,
-not stable memory — so it costs no persistent storage and is simply lost on
-upgrade. That is fine: the client library is the source of truth and re-sends
-any chunk it hasn't seen acknowledged. Consequently the only new **stable**
-regions are user-scoped and volume-independent: the sender registry
-(`OriginSha256 → sender`) alongside the existing subscription and consent maps.
-`chunk_id` dedup is a short-lived heap set. Timers don't survive upgrades —
-re-arm in `post_upgrade` and `init`.
+**Durability lives on the client — but the client needs a signal to act on.**
+The in-flight buffer is heap, not stable memory, so it costs no persistent
+storage and is lost on upgrade. The intent is that the client library re-sends
+anything unacknowledged. **That requires an acknowledgment that today's
+interface does not provide:** `admitted` means "accepted into the buffer", it is
+returned _before_ any upgrade that would lose the buffer, and delivery itself
+carries no receipts. A client that received `admitted: 1000` therefore has no
+way to learn the messages were dropped and, by its own retry rule, never
+re-sends — so an upgrade mid-campaign silently loses every in-flight chunk while
+the campaign store marks them sent.
+
+Close it with a **`drain_epoch`** in `PushResult` (a counter bumped in
+`post_upgrade`) plus a `push_chunk_status(chunk_id)` query: a client that sees
+the epoch move re-sends anything it hasn't confirmed drained. This makes
+delivery explicitly **at-least-once**, which is why `msg_id` dedup ships with
+it rather than after it — see
+[Delivery semantics](#delivery-semantics-what-is-actually-guaranteed).
+
+Consequently the only new **stable** regions are user-scoped and
+volume-independent: the sender registry (`OriginSha256 → sender`) alongside the
+subscription and consent maps. `chunk_id` dedup is a heap set — **bounded by
+count with LRU eviction**, and `chunk_id` fixed at 16 bytes, so a sender cannot
+grow it with attacker-chosen keys until the heap is exhausted (heap exhaustion
+traps the canister, which takes authentication down with it). Timers don't
+survive upgrades — re-arm in `post_upgrade` and `init`.
 
 ## Delivering to devices
 
@@ -427,6 +607,37 @@ design routes those sends through a **trusted web2 gateway**. Doing them as
 per-device outcalls straight from the canister ("direct") is the documented
 **alternative** — kept for context and as a possible low-volume or
 fully-on-chain fallback, but not the shipping path.
+
+### First, the constraint that shapes both paths: outcall replication
+
+A replicated HTTPS outcall is executed by **every node in the subnet** — 34 on
+II's. The target sees 34 requests, and the replicas' responses must be
+_byte-identical_ or response-consensus fails (the call then errors while still
+being charged). Three consequences the rest of this section is built around:
+
+- **Duplicate delivery is the default, not an edge case.** RFC 8030 has no
+  idempotency key, so 34 POSTs of the same push are 34 distinct messages to the
+  relay and up to 34 banners on the device. `Topic` collapses _undelivered_
+  duplicates, so an offline device may collapse to one — an online device does
+  not. This is why `msg_id` + service-worker dedup is a v1 requirement rather
+  than a later hardening step.
+- **Per-device status cannot survive consensus.** The 34 POSTs legitimately get
+  _different_ answers (the first may get `201`, later ones `429`, or `410` if the
+  subscription just died). No transform can manufacture agreement about which
+  POST was first; a transform can only collapse everything to one deterministic
+  value. So `410`-driven subscription cleanup is **not implementable under
+  replicated outcalls** — see
+  [stale-subscription cleanup](#stale-subscription-cleanup).
+- **Non-replicated outcalls change this.** `is_replicated = false` (in the
+  management-canister interface, on mainnet since 2025-08-04) has **one** node
+  make the request: no consensus, no transform, no 34× fan-out, and roughly two
+  orders of magnitude cheaper. The IC docs recommend it specifically for
+  rate-limited APIs, which is exactly Web Push. It is marked experimental and its
+  API may still change, so this doc does not build the shipping path on it — but
+  it is the single most consequential capability to re-evaluate, because it
+  removes the duplicate-delivery problem _and_ restores per-device status on the
+  direct path. See
+  [IC capabilities to re-evaluate](#ic-capabilities-to-re-evaluate).
 
 ### The delivery path: a trusted web2 gateway
 
@@ -443,73 +654,220 @@ over ordinary (free) internet instead of on-chain:
   keys + plaintext (read all notifications). RFC 8291 has no encrypt-once mode,
   so II produces the N ciphertexts regardless; the gateway saves **outcall
   count, not crypto**.
-- The gateway is **stateless** — no keys, no subscriptions, no plaintext at
-  rest; it only sees in-transit ciphertext + endpoints + timing.
-- II batches sealed bundles into ~2 MB chunks: ~25 outcalls instead of ~13k
-  (~500× fewer; cycles drop to cents).
-- II authenticates to the gateway with a bearer token (IC outcalls have no
-  stable source IP). The gateway must return a **deterministic ack** or the
-  outcall's response-consensus fails; per-device results cannot return through
-  this channel.
-- **The gateway's cheapness sets II's admission capacity.** II's throughput is
-  bounded by how fast it drains its (small) buffer; a fast, cheap batched
-  drain empties the buffer quickly, so II recovers capacity and admits the next
-  chunk sooner. Fast drain → high sustained throughput on a *small* buffer →
-  flat storage. This is why the gateway hop is a scaling primitive, not just a
-  cost optimization.
+- The gateway holds **no keys, no subscriptions, and no plaintext at rest** — it
+  sees in-transit ciphertext, endpoints and timing. It is _not_, however,
+  stateless: it must keep a short **idempotency window keyed on batch id** so the
+  34 identical copies of each batch (replication, above) forward once rather than
+  34 times. "Keyless and no plaintext at rest" is the accurate claim; "stateless"
+  is not.
+- II batches sealed bundles into **~1.5 MB** chunks: ~25 outcalls instead of
+  ~13k. The 2 MB outcall ceiling counts **headers too**, so targeting exactly
+  2 MB leaves no room for the VAPID `Authorization` headers each bundle carries.
+- II authenticates to the gateway with a bearer token (IC outcalls have no stable
+  source IP — replicated requests arrive from all 34 node addresses, and IPv4
+  destinations via a shared proxy pool). The gateway must return a
+  **deterministic ack**, so per-device results cannot come back through this
+  channel.
+- **The gateway sets II's admission capacity.** Throughput is bounded by how fast
+  the small buffer drains; a batched drain empties it quickly, so II recovers
+  capacity and admits the next chunk sooner. Fast drain → high sustained
+  throughput on a _small_ buffer → flat storage.
 
-Trust delta — the deliberate cost of this path: the gateway can **drop, delay,
-or replay** captured bundles, but cannot read content or forge new sends.
-Confidentiality and authenticity stay on-chain; only **liveness** moves off — a
-real, narrow concession for a trust-minimizing service. Its replay capability
-is why message-level replay protection (below) is a should-have here.
+**Why the gateway, stated correctly.** Its justification is **in-flight outcall
+slots and drain latency — not cycles.** Direct delivery would spend ~13k of the
+subnet's 3000 shared in-flight slots' worth of work per blast, starving II's own
+authentication outcalls; the gateway needs ~25. On a paying deployment it also
+saves cycles, but only ~4× (the per-byte fee applies to the same sealed bytes
+either way) — not the "cents" a naive call-count comparison suggests. The slot
+argument holds on _every_ deployment, including the fee-waived one, which is why
+it is the real reason.
+
+Trust delta — the deliberate cost of this path. The gateway can **drop, delay,
+or replay** bundles. It **cannot read content**. But it **can forge sends**: each
+bundle carries a VAPID `Authorization` token, relays authenticate on that token
+alone and never validate the body, and the token is cached for up to 12 h. So a
+compromised gateway can harvest `(endpoint, token)` pairs and POST arbitrary
+bytes to those devices for the token's lifetime — including after being rotated
+out of the path. Those bytes won't decrypt, so the browser shows its generic
+"site updated in background" notification attributed to `id.ai` — which at volume
+burns the shared notification permission (see
+[shared fate](#shared-fate-one-permission-for-every-dapp)). Mitigations: scope
+credentials **per batch** so they expire with it, cut the JWT cache to minutes,
+and note that the bearer token in canister state is extractable by node
+operators, so this replay capability is not the gateway operator's alone.
+
+Only **liveness and this bounded forgery window** move off-chain;
+confidentiality stays on. Which also means the gateway is a **single point of
+failure**, and the doc must say what happens when it fails — see
+[Operating it](#operating-it-controls-alerts-and-rollout).
 
 ### The alternative: direct per-device outcalls
 
-II could instead make one HTTPS outcall per device straight to the push
-service — fully on-chain, nothing extra to run or trust. Why it isn't the
-default: a 10k-user broadcast is ~13k outcalls (~1T cycles, ~$1–2 per blast)
-and takes minutes to drain at a safe in-flight rate; that per-device outcall
-cost and the throughput ceiling are exactly what the gateway removes. It stays
-viable for low volume, a fully-on-chain deployment, or as a fallback if the
-gateway is unavailable.
+II could instead make one HTTPS outcall per device straight to the push service
+— fully on-chain, nothing extra to run or trust. Why it isn't the default:
+
+- **It would consume the shared in-flight outcall budget.** ~13k outcalls per
+  10k-user blast against a 3000-slot subnet-wide cap that II's own login paths
+  draw on. This is the disqualifying reason.
+- **Cost** on a paying deployment: ~2.8 T cycles (~$3.80) per blast at n = 34,
+  versus ~0.7 T through the gateway.
+- **Replication makes it worse, not just slower**: 34 POSTs per device, and no
+  usable per-device status (above).
+
+It stays viable for low volume or a deliberately fully-on-chain deployment. Note
+that "fallback if the gateway is unavailable" is only true with caveats: under
+replicated outcalls the direct path delivers duplicates and cannot observe
+`410`, so failing over to it is a degraded mode, not a transparent one.
+**`is_replicated = false` would change this assessment substantially** — it
+removes the fan-out and restores per-device status, making direct delivery a
+genuine peer of the gateway on correctness, still bounded by in-flight slots.
 
 ## The dApp-side client library
 
-> *In short: because II stores nothing per send, a small library on the dApp's
+> _In short: because II stores nothing per send, a small library on the dApp's
 > side keeps the list, sends it to II in paced pieces, retries failures, tracks
 > who got notified, and personalizes text. The dApp calls one simple
-> "notify these users" method; the library handles the rest.*
+> "notify these users" method; the library handles the rest._
 
 Since II is stateless for campaigns, the durable coordination is a library the
-dApp runs (in its own canister for on-chain durability, or its backend). This
-is where the heavy list and its bookkeeping live — where the volume originates.
-Responsibilities:
-
-- **Campaign store** — the target list and per-target status (pending / sent /
-  `NoConsent` / to-retry). This is the durable state that II deliberately does
-  not hold.
-- **Chunking** — split the audience into `push_send` chunks (≤ ~1000 targets,
-  ≤ 2 MB), enforced client-side against the message-size bound.
-- **Pacing (Layer 2)** — send on `ready`, back off on `retry_after_ms`,
-  pipeline a few chunks within the caller's output-queue limit. Absorbs
-  inter-canister latency so a large campaign completes over seconds-to-minutes
-  without ever blocking II.
-- **Retry** — resend chunks that were rejected for capacity or lost to an
-  upgrade; `chunk_id` makes resends idempotent.
-- **Status/reporting** — aggregate per-chunk results into campaign progress
-  for the dApp. (Delivery itself is best-effort with no receipts; the only
-  per-user signal is `NoConsent`.)
-- **Templating / personalization** — expand `template + per-user data` into a
-  per-recipient `alert` override, entirely client-side. II never sees a
-  template.
-- **Prioritization** — schedule which campaign/segment goes first. (Per-message
-  `urgency` still rides the relay header; campaign ordering is the library's.)
+dApp runs. This is where the heavy list and its bookkeeping live — where the
+volume originates.
 
 Security is unaffected by moving this out: II re-validates sender-origin,
 consent and origin-pinning on **every** chunk, so a buggy or malicious library
 cannot fake consent, target another dApp's users, or exceed admission limits —
-it can only mismanage its own campaign.
+it can only mismanage its own campaign. **The library is a convenience, never a
+control.**
+
+### Where it runs, and the one real choice
+
+The library must live somewhere with durable state and a scheduler, because it
+owns a campaign that outlives any single call. Two viable hosts:
+
+|                 | dApp **canister** (recommended)                 | dApp **web2 backend**                       |
+| --------------- | ----------------------------------------------- | ------------------------------------------- |
+| Durability      | stable memory, survives upgrades                | whatever the backend already has            |
+| Scheduling      | `ic_cdk_timers`                                 | cron / job runner                           |
+| Calls II via    | inter-canister call (**can attach cycles**)     | ingress (**cannot attach cycles**)          |
+| Sender identity | its own canister principal — registers directly | needs a canister to call on its behalf      |
+| Fits            | on-chain apps, the default                      | apps whose audience already lives off-chain |
+
+The canister host is the recommended shape: it is the only one that can attach
+cycles (relevant if sender-pays ever lands) and the only one whose sender
+identity is a principal II can register directly. A web2 backend still needs a
+small companion canister to be the registered sender, so it ends up running both.
+
+### State it must keep
+
+Per campaign, durable:
+
+```
+Campaign {
+  campaign_id       : text            // dApp-chosen, unique
+  default_alert     : PushAlert       // shared text, if any
+  delivery          : PushDelivery    // urgency / ttl / topic for the campaign
+  created_at        : nanos
+  state             : Building | Sending | Paused | Done | Failed
+  cursor            : nat64           // index of the next unsent target
+  last_drain_epoch  : nat64           // II's epoch as of the last confirmed chunk
+}
+
+Target {                              // one row per recipient
+  principal   : Principal             // the user's in-app principal for THIS origin
+  alert       : opt PushAlert         // personalization override, else default
+  status      : Pending | InFlight | Admitted | NoConsent | Invalid | Dropped
+  chunk_id    : opt blob              // which chunk carried it
+  attempts    : nat8
+}
+```
+
+Two things worth being precise about, because they are where implementations go
+wrong:
+
+- **`status = Admitted` means "II accepted it into its buffer", not
+  "delivered".** There are no delivery receipts. The library must not present
+  `Admitted` to the dApp as "the user got it"; the honest label is "sent".
+- **`cursor` + `last_drain_epoch` together are the recovery state.** On restart,
+  or when II's `drain_epoch` moves, everything `InFlight`/`Admitted` since that
+  epoch is suspect and must be re-sent (see below).
+
+### The send loop
+
+```
+for each batch of ≤1000 targets from cursor:
+    chunk_id = hash(campaign_id, cursor)        # deterministic → idempotent retry
+    r = push_send(chunk_id, delivery, default_alert, recipients)
+
+    if r.drain_epoch != last_drain_epoch:       # II was upgraded
+        rewind cursor to the oldest unconfirmed chunk
+        last_drain_epoch = r.drain_epoch
+        continue
+
+    mark r.rejected targets by reason           # NoConsent → terminal, not retry
+    mark the rest Admitted; advance cursor
+
+    if !r.ready:
+        sleep(r.retry_after_ms + jitter)        # jitter is not optional
+```
+
+Details that matter:
+
+- **`chunk_id` must be deterministic** — derive it from
+  `(campaign_id, cursor)`, never from a random value or a timestamp. That is
+  what makes a retry idempotent instead of a duplicate. Fix it at **16 bytes**;
+  II's dedup set is bounded and LRU-evicted, so oversized or unbounded ids are
+  rejected.
+- **Jittered exponential backoff, always.** A bare `retry_after_ms` makes every
+  rejected sender retry at the same instant, and after an II upgrade every
+  client with lost chunks retries simultaneously — a thundering herd precisely
+  when II is least able to absorb it.
+- **Pipeline no more than a few chunks.** The output queue between two canisters
+  is 500 deep, and the point of pacing is to absorb inter-canister latency, not
+  to race II's admission control.
+- **`NoConsent` is terminal.** It means the user revoked or never granted; retrying
+  it wastes admission budget forever. Distinguish it from capacity rejections,
+  which _are_ retryable.
+- **Chunk by bytes as well as by count.** ≤1000 targets _and_ under the
+  size ceiling — with heavy per-recipient personalization the byte bound binds
+  first. II enforces both server-side; hitting them is a client bug.
+
+### What it owes the dApp
+
+The public surface should be small enough that the common case is one call:
+
+```
+notify(campaign_id, targets, default_alert, delivery) -> CampaignHandle
+status(campaign_id) -> { total, sent, no_consent, pending, state }
+pause(campaign_id) / resume(campaign_id) / cancel(campaign_id)
+```
+
+Everything else — chunking, pacing, retry, epoch recovery, backoff, templating —
+is internal. A dApp author should never have to know what a chunk is.
+
+- **Templating / personalization** — expand `template + per-user data` into a
+  per-recipient `alert` override entirely client-side. **II never sees a
+  template**, which is what keeps personalization off II's storage.
+- **Prioritization** — the library decides which campaign or segment goes first.
+  Note this is _campaign_ ordering, distinct from per-message `urgency`, which
+  rides the relay header and contributes to II's drain order.
+- **Status/reporting** — aggregate per-chunk results into campaign progress,
+  labelled honestly: `sent` (admitted), `no_consent`, `pending`. Not
+  "delivered" — nothing in this design can tell the dApp that.
+
+### Failure modes the library is responsible for
+
+| Failure                            | What the library must do                                        |
+| ---------------------------------- | --------------------------------------------------------------- |
+| `ready = false`                    | back off with jitter; do **not** advance the cursor             |
+| `drain_epoch` moved (II upgraded)  | rewind to the oldest unconfirmed chunk and re-send              |
+| Its own host restarts mid-campaign | resume from `cursor`; re-send anything `InFlight`               |
+| `NoConsent` for a target           | mark terminal, stop retrying, surface to the dApp               |
+| Call trapped / rejected            | retry the _same_ `chunk_id`; never mint a new one               |
+| Campaign outlives its own deadline | `ttl_seconds` already bounds it II-side; mark `Dropped` locally |
+
+Because retries and epoch-recovery both re-send chunks, **duplicate delivery is
+expected by design** — which is the other half of why `msg_id` dedup on the
+device is a v1 requirement, not a nicety.
 
 ## On the device: rendering and tap-through
 
@@ -542,10 +900,11 @@ per-origin consent. We do not infer consent from a shared endpoint.
 What that means in practice:
 
 - **One endpoint, independent rows.** The subscription is stored as `(anchor,
-  endpoint_hash) → {p256dh, auth}`, so the same physical endpoint can appear
-  under several anchors as separate rows. II delivers to an anchor's row only
-  if *that* anchor enabled it; identity B's senders reach the device only after
-  B itself opted in.
+endpoint_hash) → {endpoint, p256dh, auth, created_at}` — the endpoint URL
+  itself is part of the value, since it is the POST target — so the same
+  physical endpoint can appear under several anchors as separate rows. II
+  delivers to an anchor's row only if _that_ anchor enabled it; identity B's
+  senders reach the device only after B itself opted in.
 - **Isolation is at the consent layer, not the transport.** Once two identities
   on the device have both enabled, the device physically receives pushes for
   both — there is only one endpoint, so they cannot be separated in transit.
@@ -580,6 +939,55 @@ the backend-forced `hostname`, this is entirely front-end; no backend or
 Candid change is required. (A backend `alert.url`-origin validation at send
 time is a nice defense-in-depth follow-up but not required for safety.)
 
+### Can the tap land the user already signed in?
+
+Yes — and it needs **no II-side changes**, because it composes out of the
+ICRC-167 URL transport (top-level redirect sign-in) that II already supports.
+
+**The constraint that shapes it: II cannot push a signed-in session.** A
+delegation is bound to a session public key the _dApp's client_ generates, and
+II never sees the private half, so it cannot mint one unprompted. In the URL
+transport the request always arrives _at_ II (`message` + `callback` + `state`
+in the hash) and `channel.origin` is the callback's origin — the RP initiates,
+II only answers. So the notification's job is not to carry a session; it is to
+land the user on a page that _starts_ sign-in immediately.
+
+The standard guarded-route pattern does exactly that:
+
+1. The notification deep-links to a restricted page,
+   `https://app.com/thread/42`.
+2. That page checks `authClient.isAuthenticated()` on load; if not signed in it
+   redirects to `/sign-in?next=/thread/42`.
+3. `/sign-in`, **on page load** (not behind a click — the redirect unloads the
+   page), memoizes `next` and calls `signIn({ transport: "redirect" })`, which
+   top-level-redirects to II's `/authorize`.
+4. The user already has an II session — they just tapped a notification from
+   `id.ai` — and already consented to this origin at push opt-in, so this is the
+   Continue screen: one tap.
+5. II navigates back to the declared callback with the response in its fragment;
+   the client replays its journaled state, completes the delegation, reads the
+   memoized `next`, and forwards to `/thread/42` — signed in.
+
+What the dApp has to provide:
+
+- `transport: "redirect"` from a recent `@icp-sdk/auth`.
+- **`/.well-known/ii-auth-callbacks`** declaring the exact callback URL. II's
+  validation fails closed: redirects are not followed, no ambient credentials,
+  never cached, must be `application/json` under a size cap, **exact** string
+  match, same-origin, and no fragment — plus CORS headers so II can read it. So
+  a push-enabled dApp ends up hosting **two** well-known files, this one and
+  `ii-push-senders`.
+- A callback that is **protocol + host + path only** — the transport rejects a
+  callback carrying a query, fragment or credentials. That is why the
+  destination rides in memoized flow state rather than as `?next=` on the
+  callback itself.
+
+One consistency requirement: push consent keys on the `effectiveOrigin` (see
+[Which origin is authoritative](#which-origin-is-authoritative)), and this
+sign-in derives the identity from the callback origin or its `derivationOrigin`.
+They must agree, or the principal that was notified is not the principal the
+user comes back with.
+
 ### Can a notification be updated or dismissed after it's shown?
 
 Yes, via a dApp-chosen `notification_id`, which the service worker maps to the
@@ -593,14 +1001,14 @@ Web Notification `tag`:
   nothing new.
 
 This is complementary to the `topic` delivery header, and the two act at
-different stages: `topic` collapses *undelivered* messages at the relay
+different stages: `topic` collapses _undelivered_ messages at the relay
 (before they reach the device), while `notification_id` updates or dismisses an
-*already-delivered* one on the device.
+_already-delivered_ one on the device.
 
 Caveats:
 
 - **`userVisibleOnly` fights a silent dismiss.** Browsers require every push to
-  show *something*; a pure "close and show nothing" push can trigger the
+  show _something_; a pure "close and show nothing" push can trigger the
   browser's generic "site updated in background" notification and, if abused, a
   permission penalty. So **update-with-a-new-state is the robust pattern**;
   pure dismiss is best-effort.
@@ -613,32 +1021,259 @@ Caveats:
 ## Security model
 
 - **Origin pinning** — a sender can only target anchors that consented to
-  *its* origin; cross-dApp targeting is impossible even with leaked principals.
+  _its_ origin; cross-dApp targeting is impossible even with leaked principals.
+  Note what "its origin" means when alternative origins are in play — see
+  [Which origin is authoritative](#which-origin-is-authoritative).
 - **Attribution** — the sender origin shown on the notification is II-derived,
   not dApp-supplied: II forces it to the consented origin and stamps it into the
-  payload, so a dApp cannot spoof who sent a notification.
+  payload, so a dApp **cannot choose a different origin's name**. Two limits on
+  how far that goes:
+  - It does not stop an attacker from _registering a confusable origin_.
+    `https://аpp.com` (Cyrillic а) or `https://app.com.evil.co` will pass
+    `.well-known` verification on a domain the attacker owns and then be
+    stamped as attribution verbatim. Origins must be **canonicalized** —
+    punycode, lowercased, default port stripped — at both registration and
+    consent, and confusable/mixed-script labels rejected. Without that,
+    `https://app.com`, `https://App.com` and `https://app.com:443` are three
+    distinct buckets with identical-looking lock-screen labels.
+  - It does not stop the _content_ from impersonating someone. `body` is
+    free-form; Unicode bidi controls (`U+202E`) or leading newlines can push the
+    real origin out of the visible line and render a convincing "Internet
+    Identity: verify your recovery phrase" banner. Strip bidi controls and
+    collapse whitespace in `title`/`body`, and render attribution as its own
+    non-injectable element rather than concatenated into the body string. This
+    matters more here than for a generic relay: the notification carries II's
+    permission, II's service worker, and an `id.ai` interstitial on tap — the
+    highest-credibility surface in the system for a recovery-phrase phish.
 - **Content is dApp-controlled (Display mode)** — `title`/`body` are free-form,
-  delivered under II's service worker. Attribution is shown and lengths are
-  capped, but a compromised dApp could send misleading text within its own
-  attribution. Inherent to any notification relay; a documented posture, not a
-  bug. `Hidden` mode avoids it entirely — no app text reaches the SW.
+  delivered under II's service worker, with lengths capped and attribution shown.
+  A compromised dApp can still send misleading text within its own attribution;
+  that is inherent to any notification relay and is a documented posture.
+  `Hidden` mode avoids it entirely — no app text reaches the SW.
 - **Transport confidentiality** — every payload is RFC 8291 encrypted to each
-  device; no relay or gateway can read it. Note this is *transport*
-  encryption: for `Display` content II itself sees plaintext (it does the
-  encryption). Keeping content from II-the-service is the `Hidden` variant
-  today (and, later, the vetKeys-sealed path); see the next section.
+  device, so **no relay or gateway can read it**. Two scope limits: this is
+  _transport_ encryption, so for `Display` content II itself sees plaintext (it
+  does the encryption); and because the drain draws one `raw_rand` per tick and
+  derives per-message ephemeral seeds from it, an observer of the subnet's random
+  tape can recompute that tick's ephemeral scalars. So the honest claim is "no
+  relay, gateway or network observer can read it" — **not** "only that device
+  can". Deriving each seed from `raw_rand ‖ msg_id` would stop one tape
+  observation from yielding a whole tick. Keeping content from II-the-service
+  altogether is the `Hidden` variant today (and, later, the vetKeys-sealed
+  path); see the next section.
 - **Coarse rejections** — the dApp learns only about its own relationship with
-  a target (`NoConsent`), never device counts or II state.
+  a target (`NoConsent`), never device counts or II state. One leak to close:
+  `ready` / `retry_after_ms` reflect _aggregate_ load from other senders, so a
+  sender that probes them learns something about II's global state. Randomize
+  `retry_after_ms` per caller.
+- **Error strings are a channel too** — reject reasons returned to senders must
+  be a fixed enum, never free-form text echoing caller input, and endpoint URLs
+  must never reach canister logs (an endpoint plus a valid VAPID token is a
+  push capability, and a stable per-device identifier besides).
 - **Redirect-screen icon** — the `/notify` screen shows the app logo only from
   II's curated dApp registry, with a neutral globe fallback. Arbitrary or
   remote icons are deliberately not fetched: doing so would render
   attacker-controlled imagery inside II's trusted chrome and leak the fetch to
   the dApp. If arbitrary-app icons are ever wanted, the least-bad path is a
   vetted icon supplied at sender-registration, not a per-notification URL.
-- **VAPID key** — in stable memory today (same posture as the anchor salt;
-  node operators could extract it, blast radius is spam, not identity). P-256
-  threshold ECDSA would remove it from storage but is not yet available on the
-  IC (only secp256k1 is).
+- **VAPID key** — in stable memory today, the same custody posture as the anchor
+  salt: node operators could extract it. But **the blast radius is larger than
+  "spam"**, and the anchor-salt analogy undersells it. The _same_ stable memory
+  holds every device's `p256dh` and `auth` secrets, so an attacker who can read
+  it gets both halves: the device secrets let them produce a valid RFC 8291
+  ciphertext, and the VAPID key lets them sign a valid request. They can then
+  deliver **arbitrary, fully-readable notifications to any subscribed device,
+  attributed to any origin the user actually consented to** — which means the
+  forged notification's tap-through passes `/notify`'s consent gate and
+  deep-links into the real dApp. Salt exposure lets someone _compute
+  identifiers_ (passive); this lets someone _write into the user's trusted
+  notification surface wearing another app's name_ (active). That is
+  phishing capability, not spam.
+
+  Mitigations worth doing regardless of custody: derive per-device transport
+  secrets so extracting one does not yield the other, and keep a signed
+  monotonic per-endpoint counter of pushes II issued so a service worker can
+  flag pushes II did not send. Note there is currently **no detection story** —
+  II cannot observe pushes it did not originate — and **no rotation story**:
+  rotating the VAPID key invalidates every subscription at once, so the
+  "re-enable on your devices" UX is a prerequisite for having a recovery path
+  at all, not a later nicety.
+
+  P-256 threshold ECDSA would remove the key from storage entirely, but the IC
+  supports only secp256k1 today (see
+  [IC capabilities to re-evaluate](#ic-capabilities-to-re-evaluate)).
+
+- **VAPID key initialization must not race.** Generating the key lazily on first
+  use puts an `await` on `raw_rand` between the "is it set?" check and the
+  write, so two concurrent first callers can both generate and the later write
+  wins. A browser that already subscribed with the losing public key is
+  **permanently undeliverable**, silently, with no error surfaced anywhere.
+  Initialize eagerly in `init`/`post_upgrade` behind a guard, or re-check after
+  the `await` and adopt whatever was stored.
+
+### Shared fate: one permission for every dApp
+
+The value proposition — one notification permission covering every dApp — has a
+structural consequence that is a security property, not a UX detail: **the
+browser's permission belongs to `id.ai`, not to any dApp.** So the browser's
+abuse heuristics and the user's own Block button both target `id.ai`.
+
+A single hostile or careless consented sender can therefore end notifications
+for **every other dApp on that device**: spam at volume, `Dismiss`-only pushes,
+or malformed bodies each trip the browser's generic "site updated in background"
+notification, and Chrome's abusive-notification heuristics respond by revoking or
+quieting the origin. The user has no way to attribute which app caused it, and no
+II-side re-enable UX can undo a browser-level block.
+
+This is created by the single-permission design, so it has to be defended
+II-side:
+
+- A **per-origin budget on generic/contentless notifications**, not just on
+  volume, with automatic suspension of an origin that exceeds it.
+- **Attributable throttling** — surface "app X was rate-limited" in Settings so
+  blame lands on the sender rather than on II.
+- An **operator kill switch** per origin (see
+  [Operating it](#operating-it-controls-alerts-and-rollout)).
+
+### Which origin is authoritative
+
+II lets one origin borrow another's identity derivation: a dApp served from
+`https://beta.app.com` may pass `derivationOrigin: https://app.com`, and if
+`https://app.com/.well-known/ii-alternative-origins` lists it, II derives the
+user's principal from `app.com`. That is what lets a beta site, a custom domain
+and a raw canister URL share one identity. It leaves two origins in play:
+
+- **`effectiveOrigin`** — what the principal is derived from (`app.com`).
+- **`displayOrigin`** — who the browser is actually talking to
+  (`beta.app.com`).
+
+**Decision: `effectiveOrigin` is authoritative for push** — consent rows,
+sender registration, and attribution all key on it. This is forced by the
+targeting model: the dApp addresses users by an in-app principal derived from
+`effectiveOrigin`, and `PRINCIPAL_INDEX` resolves that principal back to
+`(anchor, origin_hash)`, so consent must be keyed on the same origin or the
+lookup simply does not resolve. It is also the right trust boundary: if
+`app.com`'s `.well-known` is trusted enough to let those origins **share the
+user's identity**, letting them share push rights is the same trust, not a wider
+one.
+
+Three obligations follow, and skipping them is where this becomes a security
+problem:
+
+- **The opt-in screen must disclose the origin being granted.** Showing
+  "beta.app.com" while recording consent for `app.com` means the user consents to
+  something they were never shown, and Settings → Allowed apps then lists an
+  origin they don't recognize. When the two differ, show both.
+- **`.well-known/ii-push-senders` must live on the `effectiveOrigin`.** A
+  borrowing origin cannot register itself; the canonical origin must. Good
+  property — state it.
+- **Transitivity is intentional and must be documented.** One registration lets
+  _every_ origin listed in that alternative-origins file send as `app.com`, with
+  no separate opt-in.
+
+### Consent lifecycle: it must not outlive the sender
+
+Consent rows keyed only by `(anchor, origin_hash)` carry no reference to _which
+sender_ was registered for that origin. That makes consent survive events it
+should not:
+
+- A dApp shuts down, its domain expires, someone else buys it, serves their own
+  `.well-known/ii-push-senders`, and registers. **Every user who ever consented
+  to that origin is immediately reachable** — attributed as the old brand, with
+  tap-through deep-linking into the new owner's site.
+- Sender deregistration and re-verification TTLs do not bound this, because they
+  govern _sender verification_, not _consent validity_.
+
+Fixes: stamp each consent row with the **sender registration epoch**; invalidate
+consent when the registered principal set for an origin changes or the sender is
+deregistered, requiring a fresh opt-in; expire consent after a long period with
+no delivery; and surface "this app re-registered — re-confirm?" in Settings.
+
+Relatedly, `.well-known` re-verification must not become a **deregistration
+primitive**: a competitor who can cause a single 404 or timeout on a sender's
+`.well-known` during one lazy re-verify would silently strip its notification
+capability. Require K consecutive failures across a multi-day window, and never
+deregister on a 5xx or timeout — only on a well-formed file that no longer lists
+the sender.
+
+## Privacy
+
+The doc's confidentiality story is about _content_. Metadata is a separate
+exposure and, for a notification hub, arguably the more sensitive one — `Hidden`
+protects the message text and does nothing for any of this.
+
+**What is genuinely new here.** II already stores which origins an anchor uses
+(`StorableApplication`), so the anchor↔origin association is not new. What this
+feature adds is the **temporal** dimension — _when_ each app notified each user,
+continuously — and the **off-chain export** of a device-linkable identifier.
+
+- **The gateway sees a join key.** Every bundle is
+  `{endpoint, headers, authorization, body}`. Grouping by `endpoint` yields, per
+  physical device: the set of sender origins notifying it, exact timestamps,
+  message sizes, and `Urgency`/`Topic` in cleartext headers. Because one browser
+  has one endpoint shared across a user's identities, that set links **a user's
+  anchors to each other and their dApps to each other** — precisely the linkage
+  per-origin principal derivation exists to prevent. No decryption required.
+- **The relays get it too, and more easily than before.** All II-mediated push
+  carries **one shared VAPID public key**, so FCM/APNs/Mozilla can isolate II
+  traffic and count per-user dApp diversity trivially. Per-dApp VAPID keys — which
+  this design frames as a burden it removes — were an unlinkability property.
+- **Timing is content.** "Which dApp notified this user at 03:00" is sensitive
+  even when the body is opaque.
+
+Mitigations to evaluate: give the gateway per-batch pseudonymous endpoint handles
+rather than raw endpoints; shuffle and pad batches so per-origin timing is not
+directly readable; and consider per-origin VAPID subkeys to restore relay-side
+unlinkability. At minimum, state plainly what the gateway, the relays and node
+operators each learn.
+
+## Delivery semantics: what is actually guaranteed
+
+"Best-effort" is not a guarantee, and several features silently depend on which
+one holds. Stated explicitly:
+
+- **At-least-once, not at-most-once.** Retries, `drain_epoch` recovery, and
+  replicated outcalls all duplicate. `chunk_id` makes _chunk_ resends idempotent;
+  `msg_id` + device dedup is what makes duplicates invisible to the user.
+- **Unordered.** Nothing in the pipeline preserves order: replication, per-relay
+  queueing, and urgency's contribution to drain order all reorder freely.
+- **No delivery receipts.** The only per-target signal is `NoConsent`, returned
+  at admission. `admitted` means "in II's buffer", never "on the device".
+
+The ordering gap has teeth, because `notification_id` update/replace is defined
+in terms of it: "Order delivered" can land before "Order shipped" and leave the
+**stale** text on the lock screen permanently, and a `Dismiss` can arrive before
+the notification it dismisses and then be a no-op forever. Fix: carry a
+**monotonic sequence number per `(origin, anchor, notification_id)`** so the
+service worker drops out-of-order updates rather than applying them.
+
+## Duplicate and replay suppression (`msg_id`)
+
+Promoted to a **v1 requirement**. Three independent mechanisms make duplicates
+the norm rather than the exception:
+
+1. **Replicated outcalls** — 34 POSTs per push, no idempotency key in RFC 8030.
+2. **Timer duplicate execution** — `ic-cdk-timers` documents that under load
+   "timeouts may result in duplicate execution", and the drain is not idempotent.
+3. **Client retries and `drain_epoch` recovery** — by design, per the client
+   library.
+
+Design: II assigns a `msg_id` **once per admitted message**, stable across
+delivery retries, included in the JSON _before_ RFC 8291 encryption (so it is not
+a Candid field and no dApp supplies it). The service worker drops ids it has
+already shown.
+
+**Use a monotonic window, not a bounded recency set.** A bounded set of
+recently-seen ids is defeatable by construction: the attacker controls eviction
+pressure, so flooding a device with fresh notifications flushes the set and a
+replayed capture then looks new (clearing site data does the same). Keep a
+per-origin high-water mark and reject anything at or below it, and bind `msg_id`
+to a short validity window so an old capture fails on age alone.
+
+Note `msg_id` is a **different thing** from the dApp-facing `notification_id`:
+`msg_id` is II-generated and suppresses exact duplicates (show at most once);
+`notification_id` is dApp-chosen and _replaces_ a shown notification. Similar
+shape, opposite behavior — keep them separate fields.
 
 ## End-to-end-encrypted apps
 
@@ -647,9 +1282,9 @@ recipient can read it — the app backend cannot. Our `Display` path is **not**
 E2E: II receives plaintext `title`/`body` and briefly holds it. The `Hidden`
 variant lets these apps use II-hosted push without ever handing content to II.
 
-**Correcting an earlier overstatement.** It is tempting to say II can *never*
+**Correcting an earlier overstatement.** It is tempting to say II can _never_
 show decrypted content. That is too strong. The honest constraint is about
-*who* decrypts and *where*, and it comes with a trust dial the user is already
+_who_ decrypts and _where_, and it comes with a trust dial the user is already
 turning:
 
 - **II-the-service decrypts** — the canister and its node operators see
@@ -657,7 +1292,7 @@ turning:
   not E2E.
 - **II's service worker decrypts on the user's own device**, using a key it
   legitimately obtains and that II-the-service never sees in the clear. This
-  **is** viable. It asks the user to trust II's *client code* running as them
+  **is** viable. It asks the user to trust II's _client code_ running as them
   on their device — which is only a small step past the trust they already
   place in II by signing in with it (and exactly the trust the `Display` path
   already assumes). This is the basis for showing real content in an
@@ -665,13 +1300,13 @@ turning:
 
 So there is a spectrum, from no trust to full trust in II for content:
 
-| Approach | Who decrypts | In-notification | Trust in II for content |
-| --- | --- | --- | --- |
-| `Hidden` (ships first) | the app, after tap | generic ("New message") | none — II never touches content |
-| Design A — vetKeys-sealed | II's **SW**, on device | full, real text | II's client code + IC vetKD threshold |
-| Design B — dApp-fetch | II's **SW**, on device | full, real text | II's client code (+ the dApp) |
-| `Display` | II-the-service | full | full — II reads it |
-| App's own SW (not II-hosted) | the app's own SW | full | none — II isn't in the loop |
+| Approach                     | Who decrypts           | In-notification         | Trust in II for content               |
+| ---------------------------- | ---------------------- | ----------------------- | ------------------------------------- |
+| `Hidden` (ships first)       | the app, after tap     | generic ("New message") | none — II never touches content       |
+| Design A — vetKeys-sealed    | II's **SW**, on device | full, real text         | II's client code + IC vetKD threshold |
+| Design B — dApp-fetch        | II's **SW**, on device | full, real text         | II's client code (+ the dApp)         |
+| `Display`                    | II-the-service         | full                    | full — II reads it                    |
+| App's own SW (not II-hosted) | the app's own SW       | full                    | none — II isn't in the loop           |
 
 ### Baseline that ships first: `Hidden` + tap-through
 
@@ -697,7 +1332,7 @@ II-the-service, yet the real text still reaches the lock screen:
 - II derives a vetKeys (IBE) identity per `(user, origin)`. The dApp fetches
   II's master public key once and **encrypts the content to that identity
   offline** — no round-trip, recipient needn't be online. It sends only the
-  *ciphertext* to II via `push_send`, as opaque bytes II cannot read.
+  _ciphertext_ to II via `push_send`, as opaque bytes II cannot read.
 - II delivers as usual (RFC 8291 wraps the opaque bytes). On the device, II's
   SW authenticates **as the user** to II's canister and requests the vetKD
   decryption key. vetKD returns it **encrypted to the SW's transport key**, so
@@ -706,30 +1341,51 @@ II-the-service, yet the real text still reaches the lock screen:
 - **What II-the-service sees:** in the honest flow, nothing — not the content,
   not the key in clear. Plaintext exists only inside the user's SW, and II
   stores none of it.
-- **The trust that remains:** II's canister *controls the vetKD
-  authorization*, so a malicious/compromised II could authorize itself to
+- **The trust that remains:** II's canister _controls the vetKD
+  authorization_, so a malicious/compromised II could authorize itself to
   derive a user's key and decrypt. That is the same class of trust the user
   already extends to II for their delegations — not a new kind. No single node
   can derive the key (threshold); II's client code is assumed honest (if it
   weren't, the user's identity is already lost). A small, coherent increment
   over `Hidden`.
-- **Cost:** vetKeys integration in II and a derive-key call per render; the
-  dApp does IBE encryption. No change to the send/admission model — II still
-  just carries bytes it can't read.
+- **Availability:** vetKeys is **live on mainnet** (since mid-2025), not a
+  future capability — `vetkd_public_key` / `vetkd_derive_key` on curve
+  `bls12_381_g2`, with IBE supported. So this design is buildable today.
+- **Cost — and this is the binding constraint.** `vetkd_derive_key` is
+  ~26.2 B cycles (**~$0.036 per call**) and chain-key fees are charged on
+  **every** deployment, system subnets included. So a derive _per notification
+  render_ would be **~$357 per 10k-notification blast** — roughly 400× the
+  entire outcall cost of the same blast, and the most expensive thing in the
+  whole design. Worse, the service worker calls in over **ingress, which carries
+  no cycles**, so **II pays** — making an uncached derive a user-triggerable
+  cycle drain.
+
+  Therefore: derive **once per `(user, origin)`**, cache the key in the service
+  worker, and rate-limit the derive endpoint per anchor. The per-`(user, origin)`
+  identity scheme above already permits exactly this — the key is stable, so a
+  single derive covers every future notification from that origin. Treat
+  per-render derivation as a design error, not a tuning knob.
+
+- **Latency:** the production vetKD key lives on a different subnet, so each
+  derive is a cross-subnet round trip — seconds — inside a `push` event
+  handler's limited lifetime. Another reason the cached-key path is the only
+  viable one.
+- No change to the send/admission model — II still just carries bytes it can't
+  read.
 
 ### Design B — dApp keeps the keys, II's SW fetches + decrypts (alternative)
 
 The push is a bare wake; on receipt II's SW calls an endpoint **on the dApp's
 side** to obtain the content, then renders it. Genuinely E2E only if that
-endpoint hands back *ciphertext* the SW can decrypt — which forces one of two
+endpoint hands back _ciphertext_ the SW can decrypt — which forces one of two
 uncomfortable choices:
 
-- **Endpoint returns plaintext.** Then the dApp *backend* can decrypt, so it is
+- **Endpoint returns plaintext.** Then the dApp _backend_ can decrypt, so it is
   "trust the dApp backend," not strict E2E. Simple, no vetKeys; fine for apps
   that don't need backend-blind encryption.
 - **Endpoint returns ciphertext + the SW holds the key.** The recipient's key
   lives in the dApp's client (cross-origin from II's SW), so the dApp must
-  *provision a key into II's SW* — now II's SW holds dApp secrets, a real added
+  _provision a key into II's SW_ — now II's SW holds dApp secrets, a real added
   surface (II's code could exfiltrate them).
 
 Either way it also needs a way for the SW to authenticate to the dApp as the
@@ -759,76 +1415,172 @@ to send, admission, or storage.
 
 Must-fix before a real deployment:
 
+- **Endpoint host allowlist.** The push endpoint is attacker-supplied. Validate
+  it against the known push services at subscribe time (and **re-validate at
+  drain**, so pre-existing rows can't bypass a tightened list), reject explicit
+  ports, userinfo and non-`https` schemes, and reject private/loopback/link-local
+  hosts. Without this, II is an SSRF and DDoS reflector with an *n*× multiplier —
+  a free ingress call turns into 34 POSTs at a victim of the caller's choosing.
+- **Per-anchor caps.** Cap subscription rows (~10) and consent rows (~100) per
+  anchor, with LRU eviction. Nothing bounds them today, ingress is free to the
+  caller, and II pays the stable-memory cost — a direct attack on the resource
+  this design calls a hard constraint.
+- **Reserved outcall budget for authentication.** See
+  [Push must never degrade authentication](#push-must-never-degrade-authentication).
+- **Drain isolation and non-reentrancy.** Per-entry failure boundaries, an
+  attempt counter, a stuck-buffer watchdog, and a claim step before the first
+  `await`. Without these, one malformed row wedges the feature globally and
+  overlapping ticks double-send.
+- **`msg_id` + device-side dedup.** Promoted from deferred — see
+  [Duplicate and replay suppression](#duplicate-and-replay-suppression-msg_id).
+- **An acknowledgment signal (`drain_epoch`).** Promoted from implicit — the
+  client-side durability story does not work without it. See
+  [II's state model](#iis-state-model-stateless-for-campaigns).
+- **Stale-subscription cleanup.** <a id="stale-subscription-cleanup"></a>
+  Promoted from deferred, because on the _chosen_ path it is not merely missing
+  but structurally impossible: `410 Gone` cannot return through the gateway's
+  deterministic ack, and browsers rotate endpoints continuously. Left alone, the
+  subscription table grows monotonically — O(devices ever registered), not
+  O(users) — and II pays forever to send to dead endpoints. Options: have the
+  gateway expose dead endpoints via a separate authenticated **pull** that II
+  fetches (deterministic by construction), add a `push_gateway_report` update
+  the gateway calls, or fall back to TTL-based GC keyed on last successful
+  delivery. Pairs with `pushsubscriptionchange` below.
 - **`pushsubscriptionchange`** — browsers rotate/invalidate subscriptions; the
   service worker must re-subscribe and re-register with II, or delivery
   silently erodes over weeks. Invisible in short-lived testing.
 - **Sender deregistration & re-verification TTL** — bound the window after a
-  sender principal is compromised or a domain changes hands.
-- **Buffer sizing & drain fairness** — tune the admission bucket + global cap,
-  and drain the transient buffer **round-robin across origins** so one origin's
-  chunk can't starve another's. (Admission control itself is designed, above;
-  this is the tuning.)
+  sender principal is compromised or a domain changes hands, and make
+  re-verification resistant to being used as a deregistration primitive (see
+  [Consent lifecycle](#consent-lifecycle-it-must-not-outlive-the-sender)).
+- **Origin canonicalization** — punycode, lowercase, strip default port, reject
+  confusable/mixed-script labels, at registration _and_ consent.
+- **Input validation and caps** — `title` ≤ 64, `body` ≤ 256, `topic` ≤ 32,
+  `notification_id` ≤ 64, `url` bounded, `chunk_id` fixed at 16 bytes, origins
+  ≤ 255 bytes **validated rather than trapped on**. Reject with a fixed error
+  enum; never return free-form text echoing caller input.
+- **Cycle budget + freezing-threshold guard** (deployments that pay fees) — a
+  per-origin and global daily burn cap with a circuit breaker, independent of
+  the rate bucket, plus a floor that disables push before spend can approach the
+  freezing threshold. Past that threshold a canister stops serving updates while
+  still serving queries, which for II means **logins fail while the frontend
+  still loads**.
+- **Buffer sizing & drain fairness** — tune the admission bucket, global cap and
+  per-origin reservations, and drain **round-robin across origins** with urgency
+  and age only _within_ an origin's slice.
 - **Observability** — in-flight buffer depth (canary for stuck timers /
   backpressure), drain lag, admission reject rate per origin, per-origin
-  outcall success / 410 / drop counts.
+  outcall success / 410 / drop counts, and **authentication-path p99 latency**
+  (the signal that push is stealing from login).
 
 Must-decide (design, not code):
 
 - **iOS reality** — iOS Safari is the one platform where a PWA install is
-  *mandatory* for Web Push (Android/desktop work in a plain tab). It is also
+  _mandatory_ for Web Push (Android/desktop work in a plain tab). It is also
   flakier and more throttled; "best-effort" is weakest there. Set expectations
   in dApp docs, and surface the "Add to Home Screen" hint only on iOS.
 
 Known-deferred:
 
-- **Device-level replay / `msg_id`** — note this internal `msg_id` is a
-  *different* thing from the dApp-facing `notification_id` used to
-  update/dismiss (above): `msg_id` is II-generated and suppresses exact
-  duplicates (show at most once); `notification_id` is dApp-chosen and
-  *replaces* the shown notification. Same-looking, opposite behavior — keep
-  them as separate fields. There are two replay layers, handled separately.
-  **dApp→II replay** (a resent/duplicated chunk) is solved by the `chunk_id`
+- **Replay layering.** The two replay surfaces are handled separately.
+  **dApp→II replay** (a resent or duplicated chunk) is solved by the `chunk_id`
   idempotency key. **relay/gateway→device replay** (a captured
-  `(jwt, ciphertext, endpoint)` re-POSTed) is *not* solved: Web Push has no
-  built-in protection — VAPID's JWT is a time-bounded bearer token and
-  AES-GCM's freshness gives tamper-detection, not anti-replay, so a captured
-  push re-decrypts and shows again. The fix is a `msg_id` plus a small SW
-  dedup set, wired as follows (note it is **not** a Candid field — the dApp
-  does not supply it):
-  - **On send (in the canister):** II assigns a unique `msg_id` **once per
-    admitted message** (per target) and includes it in the JSON *before* RFC
-    8291 encryption (`alert_to_json` in `push/api.rs`). It must be **stable
-    across delivery retries** — the same logical message always carries the
-    same `msg_id` — so that both a retried send and a replayed captured
-    ciphertext are recognized as duplicates, while genuinely distinct
-    notifications get distinct ids.
-  - **On receive (service worker):** the SW reads `msg_id` from the decrypted
-    payload, keeps a bounded set of recently-seen ids (IndexedDB/Cache), and
-    drops any it has already shown.
-  It is a **hard prerequisite**, not a nicety, for two later features and must
-  land before either:
-  - **outcall retries** — a retry is itself a replay; without dedup, retry
-    logic manufactures duplicate banners.
-  - **the gateway** — a compromised gateway is inherently replay-capable, so
-    `msg_id` + SW dedup should land together with the gateway (the chosen
-    delivery path) to neutralize that power.
-  Today's practical risk is low (TLS gates capture; blast radius is a
-  duplicate banner, not credential theft).
-- **VAPID key → P-256 threshold ECDSA** — the key is in stable memory only
-  because the IC's threshold ECDSA is secp256k1-only while Web Push requires
-  P-256 (secp256r1). When P-256 tECDSA ships, migrate to `sign_with_ecdsa` so
-  the key never exists in storage. Migration invalidates existing
-  subscriptions (the derived public key changes), so it pairs with the
-  re-enable UX below.
+  `(jwt, ciphertext, endpoint)` re-POSTed) has no protection in Web Push itself
+  — VAPID's JWT is a time-bounded bearer token and AES-GCM gives
+  tamper-detection, not anti-replay — so it is handled by `msg_id`, now a v1
+  requirement rather than a deferred item. Note the earlier framing that "TLS
+  gates capture, so the practical risk is low" does **not** hold on the chosen
+  path: the gateway legitimately receives the sealed bundle, so replay needs no
+  network interception at all.
 - **VAPID rotation** — rotating invalidates every subscription at once; needs
-  a "re-enable on your devices" UX if ever required.
-- **Stale-subscription GC**, and cleanup hooks on device/anchor removal.
+  a "re-enable on your devices" UX. Note this UX is also the only recovery path
+  from a VAPID key compromise, so deferring it means deferring recovery.
+- **Cleanup hooks** on device/anchor removal.
+- **Metadata-privacy mitigations** — endpoint blinding, batch shuffling/padding,
+  per-origin VAPID subkeys. See [Privacy](#privacy).
 
 Explicitly rejected:
 
 - **On-device `tag`-based collapsing by hostname** — a dApp sends distinct
   notifications that must not replace each other on the device. Collapsing is
   opt-in per send via `topic`, never automatic per origin.
+- **Reusing one RFC 8291 ephemeral key across recipients in a batch.** It would
+  roughly halve sealing cost, and the RFC does not forbid it — but it links
+  recipients cryptographically and makes one leaked transient key expose the
+  whole batch. Not worth it.
+
+## IC capabilities to re-evaluate
+
+Platform features that would change decisions in this doc. Worth re-checking
+before implementation, because two of them postdate the design:
+
+- **Non-replicated outcalls (`is_replicated = false`)** — on mainnet since
+  2025-08-04, marked experimental. Removes the *n*× fan-out and restores
+  per-device delivery status, which would fix duplicate delivery and `410`
+  cleanup on the direct path and weaken the gateway's rationale to in-flight
+  slots alone. **The single highest-value thing to evaluate.**
+- **Per-node outcall results.** A newer management-canister API returning
+  per-node responses would contradict this doc's claim that per-device results
+  cannot come back. Unverified whether it is enabled on mainnet — settle by
+  calling it or checking release notes.
+- **P-256 (secp256r1) threshold ECDSA** — would move the VAPID key out of
+  storage entirely via `sign_with_ecdsa`. Requested since 2024 with **no public
+  roadmap item or timeline**, so treat it as "if it ever ships", not "when".
+  Migration invalidates existing subscriptions (the public key changes), so it
+  pairs with the re-enable UX.
+- **vetKeys** — already live; see
+  [Design A](#design-a--vetkeys-sealed-content-decrypted-in-iis-sw-preferred-richer-path).
+  Client libraries are still pre-1.0 and the JS package was renamed, so pin
+  deliberately.
+
+## Push must never degrade authentication
+
+The invariant, stated separately because it is the one that makes this feature
+unshippable if violated: **no volume of push traffic may reduce the availability
+of sign-in.**
+
+II is not a dedicated push canister. It authenticates every user of the network,
+and push shares three resources with that job:
+
+- **The in-flight outcall budget** (3000, subnet-wide). II's own auth paths spend
+  from it: DoH for email recovery, JWKS and discovery for OIDC. Push must hold a
+  quota well below the cap and **fail closed** — return `ready = false` — rather
+  than compete. Note the queue to the management canister is also 500-deep per
+  canister pair, so a burst can exhaust the queue and make II's _own_ auth
+  outcalls fail synchronously.
+- **Instructions per round.** A drain slice must be a small fraction of a round,
+  never a whole chunk.
+- **Cycles** (on paying deployments), because the freezing threshold is shared:
+  push spend must never be able to push II toward the state where updates stop
+  and only queries serve.
+
+Concretely: a semaphore with a push-only quota, a drain slice sized from
+measurement, a cycle floor, and **authentication p99 latency as a monitored
+signal** with push throttling as the automatic response.
+
+## Operating it: controls, alerts and rollout
+
+Metrics alone are not operability. Missing today:
+
+- **A per-origin kill switch.** `push_deregister_sender` is authenticated by the
+  _dApp_, so there is no operator-side way to silence an abusive sender. Needs an
+  operator-gated `push_set_origin_enabled(origin, bool)` plus a **global feature
+  flag** in persistent state to disable push entirely without an upgrade.
+- **Alert thresholds and ownership** — on buffer depth (stuck-timer canary),
+  drain lag, per-origin reject rate, and auth-path p99. Define who is paged.
+- **Gateway operations** — who runs it, how many independent instances (≥2 with
+  distinct operators), health probes, automatic switchover, and what happens to
+  batches already handed over when one dies. Since the gateway is the shipping
+  path and the direct path is a degraded fallback, **gateway down = push down**;
+  that needs to be an explicit, accepted statement rather than an implication.
+- **Rollout and rollback.** Rollback is an upgrade, which discards the in-flight
+  buffer — so a rollback silently drops in-flight campaigns unless `drain_epoch`
+  is in place first.
+- **A load test.** Every throughput and cost number in this doc is derived, not
+  measured. Before deployment: run a 10k-recipient campaign against a local
+  replica while measuring authentication latency, and measure the real
+  instruction cost of one seal with `performance_counter` (II already runs
+  P-256 in `dnssec/`, so this is a short exercise).
 
 ## dApp developer integration
 
@@ -862,22 +1614,73 @@ receipts; the only per-user signal is `NoConsent`.
 
 ## Feasibility and scale
 
-| Metric | Gateway (chosen) | Direct (alternative) |
-| --- | --- | --- |
-| App → II for 10k users | ~10 paced chunks (client-driven) | ~10 paced chunks |
-| Outcalls per 10k blast | ~25 | ~13k |
-| II **stable storage** | O(users) — flat with volume | O(users) — flat with volume |
-| II in-flight buffer | one chunk (heap, transient) | one chunk (heap, transient) |
-| Full-delivery latency | seconds | minutes |
-| Main costs | storage + ~25 outcalls | storage + ~13k outcalls |
+| Metric                               | Gateway (chosen)                     | Direct (alternative)    |
+| ------------------------------------ | ------------------------------------ | ----------------------- |
+| App → II for 10k users               | ~10 paced chunks (client-driven)     | ~10 paced chunks        |
+| Outcalls per 10k blast               | ~25                                  | ~13k                    |
+| Requests actually reaching relays    | ~13k (gateway fans out off-chain)    | ~13k × 34 (replication) |
+| Per-device status (`410`) observable | no (deterministic ack)               | no under replication    |
+| II **stable storage**                | O(users × origins), flat with volume | same                    |
+| II in-flight buffer                  | bounded, transient heap              | same                    |
+| Full-delivery latency, 10k blast     | tens of seconds                      | minutes                 |
+| Cycles, 34-node **paying** subnet    | ~0.7 T (~$0.95)                      | ~2.8 T (~$3.80)         |
+| Cycles, canonical II (system subnet) | fee-waived                           | fee-waived              |
+
+**Throughput has a global ceiling, and it is shared.** The buffer drains only as
+fast as its outcalls resolve, and outcalls take seconds. At a bounded slice per
+tick this puts II's sustained rate in the low hundreds of device-messages per
+second **across all dApps combined** — so a single 10k-user blast occupies the
+global budget for tens of seconds, during which every other origin sees
+`ready = false`. For a system positioned as the notification hub for every dApp
+on the network, this number is the most important capacity fact in the design and
+must be published — and derived from a real measurement, not from the estimates
+in this doc.
 
 App → II is feasible either way: the client library streams bounded chunks, II
-admits what it has capacity for, and its **stable storage stays flat regardless
-of volume**. The two rows above are why the **gateway is the chosen delivery
-path** — a faster, cheaper drain recycles II's small buffer sooner, which is
-what raises admission throughput. Direct delivery works and is fully on-chain,
-but its per-device outcall cost and slower drain are exactly what the gateway
-removes, so it stays as the alternative/fallback.
+admits what it has capacity for, and its storage stays flat with volume. The
+**gateway is the chosen delivery path** because it turns ~13k in-flight outcalls
+into ~25, and that budget is shared with sign-in — a faster drain also recycles
+the small buffer sooner, raising admission throughput. Direct delivery remains
+fully on-chain and viable at low volume, but under replicated outcalls it also
+multiplies every POST by the subnet size and cannot observe `410`, so it is a
+degraded fallback rather than a transparent one.
+
+## What does this actually cost per user?
+
+Storage is O(users × origins), not O(users) — worth being concrete, since the
+"flat with volume" claim is about _notification volume_ only:
+
+| Row             | Key                       | Size                                                        | Grows with       |
+| --------------- | ------------------------- | ----------------------------------------------------------- | ---------------- |
+| Subscription    | `(anchor, endpoint_hash)` | ~300 B typical (endpoint URL dominates), ~1.1 KB worst case | users × devices  |
+| Consent         | `(anchor, origin_hash)`   | ~60 B                                                       | users × dApps    |
+| Principal index | `principal`               | ~80 B                                                       | users × dApps    |
+| Sender registry | `origin_hash`             | ~100 B                                                      | registered dApps |
+
+At 10M users × 2 devices × 10 consented dApps that is roughly **6 GB + 1 GB +
+1.2 GB ≈ 8 GB**, against a 500 GiB per-canister limit but sharing a 2 TiB subnet
+with anchor data — and **before** any dead rows, which is why
+[stale-subscription cleanup](#stale-subscription-cleanup) is a must-fix rather
+than housekeeping. Note also the 8 GiB stable-memory-per-upgrade ceiling, which
+bounds how large these maps can get before upgrades become a problem.
+
+## Stable memory regions
+
+New regions must claim an unused `MemoryId`. Because nothing in the code forces
+this check, record allocations here and verify against `storage.rs` before
+adding one — a duplicate index silently interleaves two `StableBTreeMap`s into
+the same virtual memory and corrupts both.
+
+| Index | Region                                |
+| ----- | ------------------------------------- |
+| …     | (existing regions — see `storage.rs`) |
+| 31    | MCP registration                      |
+| 32    | push consent                          |
+| 33    | push principal index                  |
+| 34    | push subscriptions                    |
+| 35    | push sender registry (proposed)       |
+
+A test asserting all indices are distinct is cheap and worth having.
 
 ## Future exploration
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -824,27 +824,29 @@ fetch per notification. Murkier than A; the fallback for backend-trusted apps.
 
 ## Open items
 
-**Blockers** (before any real deployment):
+These are decided by the design above; a production build has to implement them (the
+PoC's job was to prove the shape, not to be complete).
 
-| Item | Why |
+**Security and correctness the design requires:**
+
+| Requirement | What and why |
 | --- | --- |
-| `.well-known/ii-push-senders` verification | self-serve registration — see [verification](#how-ii-verifies-the-sender-is-really-that-dapp) |
-| Endpoint host allowlist | endpoint is caller-supplied → SSRF/reflection. Allowlist known push hosts, re-validate at drain, **II validates not the gateway** |
-| Per-anchor caps | 20 subscriptions / 100 consents, anti-griefing not a storage bound. Evict dead rows first for subs; **refuse** (never silently evict) a consent |
-| Reserved outcall budget for auth | push must not spend login's slots — [detail](#push-must-never-degrade-authentication) |
-| Drain isolation & non-reentrancy | per-entry failure boundary, attempt counter, watchdog, claim-before-await, or one poison row wedges the feature |
-| `drain_epoch` ack signal | client durability doesn't work without it — [state model](#iis-state-model-stateless-for-campaigns) |
-| <a id="stale-subscription-cleanup"></a>Stale-subscription cleanup | `404`/`410` removal; possible on the gateway path only via the non-replicated handoff. Treat `410` as evidence, retire opportunistically |
-| Redirect-sign-in helper in `@icp-sdk/auth` | tap-through is the last place a dApp writes security-relevant code by hand — [shape](#landing-the-user-already-signed-in) |
-| `pushsubscriptionchange` | SW must re-subscribe + re-register or delivery erodes over weeks |
-| Sender deregistration & re-verification TTL | bound the window after a compromised sender / domain hand-off |
-| Origin canonicalization | punycode, lowercase, strip port, reject mixed-script, at registration and consent |
-| Input validation & caps | `title`≤64, `body`≤256, `topic`≤32, `url` bounded, `chunk_id` 16 B — validate, never trap; fixed error enum |
-| Cycle budget + freezing guard | per-origin/global daily burn cap + circuit breaker; disable push before spend nears the freezing threshold (past it, **logins fail while the frontend still loads**) |
-| Buffer sizing & drain fairness | round-robin across origins; urgency/age only within a slice |
-| Observability | buffer depth, drain lag, per-origin reject/410 counts, and **auth-path p99** (the signal push is stealing from login) |
+| Endpoint allowlist | Only real push-service endpoints (FCM, Apple, Mozilla) may be stored — no other host. The endpoint is where II POSTs each notification and the caller supplies it, so a fake one would aim II at any server the attacker likes. Re-check at send; II validates, not the gateway. |
+| Per-anchor caps | ~20 device subscriptions and ~100 app consents per identity, so one anchor can't mine II's storage. Reclaim dead subscriptions first; never silently drop a consent — refuse the next one instead. |
+| Reserved outcall budget | Push gets a fixed slice of the outcall budget and always yields to sign-in — [detail](#push-must-never-degrade-authentication). |
+| Robust drain loop | The timer emptying the buffer must survive one bad entry — otherwise a single malformed notification crashes the batch, rolls back, and retries forever, blocking everyone. Needs per-entry error handling with an attempt limit, a watchdog for a stuck buffer, and marking entries in-flight before the send so two ticks can't double-send. |
+| `drain_epoch` ack signal | A counter that changes when II is upgraded, so the client knows the buffer was wiped and re-sends — client durability doesn't work without it ([state model](#iis-state-model-stateless-for-campaigns)). |
+| <a id="stale-subscription-cleanup"></a>Stale-subscription cleanup | Remove a device row when its relay returns `404`/`410` (the endpoint is dead), or the table grows forever. Possible on the gateway path only because the handoff is non-replicated; treat a `410` as a hint, not proof. |
+| Redirect-sign-in helper | Ship the tap-through sign-in as a library, so each dApp doesn't hand-write security-sensitive redirect code ([shape](#landing-the-user-already-signed-in)). |
+| `pushsubscriptionchange` | Browsers rotate a device's endpoint periodically; the service worker must re-subscribe and tell II, or delivery quietly dies over weeks. |
+| Sender re-verification | Re-check the `.well-known` file on a schedule and drop a sender once it's gone, bounding the damage if a sender is compromised or a domain changes hands. |
+| Origin canonicalization | Normalise origins (lowercase, strip default port, punycode, reject look-alike scripts) at registration and consent, so `app.com` and `App.com` aren't two apps and a look-alike can't impersonate one. |
+| Input validation | Bound every field (`title` ≤64, `body` ≤256, `topic` ≤32, `url`, 16-byte `chunk_id`) and reject bad input with a fixed error rather than trapping. |
+| Cycle budget + freezing guard | On a paying deployment, cap daily spend per app and globally with a circuit breaker, and cut push off before spend nears the freezing threshold — past it, logins fail while the page still loads. |
+| Fair draining | Take turns between apps when draining, ordering by urgency and age only within one app's turn, so no single sender monopolises the queue. |
+| Observability | Track buffer depth, drain lag, per-app rejects/`410`s, and **sign-in p99 latency** — the last is the alarm that push is stealing from login. |
 
-**Decisions (design, not code):**
+**Still to decide (need a call or a measurement):**
 
 - **Apps without URL routing** (Caffeine) — confirm whether a builder-sandbox app can address a destination; if not, tap-through degrades to "open the app" — [detail](#apps-with-no-url-routing-eg-caffeine).
 - **iOS** — PWA install mandatory for Web Push, flakier and more throttled; a native app on APNs is the real fix, out of scope.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -21,6 +21,7 @@ and a security model. If you only read one section, read
 ## Context and scope
 
 
+
 A dApp on the IC that wants to reach a user who is not currently looking at it
 has no good option. Web Push is the browser-native answer, but doing it yourself
 means prompting for your own notification permission, running your own service
@@ -48,6 +49,7 @@ and the client-library internals are here to show the design is buildable, not t
 serve as reference material.
 
 ## Goals and non-goals
+
 
 
 ### Goals
@@ -89,6 +91,7 @@ serve as reference material.
 ## How it works, in plain terms
 
 
+
 The whole design, in six bullets. Everything after this adds detail to one of
 them.
 
@@ -125,6 +128,7 @@ them.
 Everything below is the same story with the exact mechanisms and edge cases.
 
 ## Architecture
+
 
 
 ```
@@ -176,6 +180,7 @@ bind everywhere regardless of who pays.
 ## Deployment assumptions
 
 
+
 Numbers in this doc depend on where II runs, so state the deployment before
 quoting a cost:
 
@@ -201,6 +206,7 @@ Rule of thumb for this doc: design to the **paying** case and treat the fee
 waiver as a property of one deployment, not a premise of the design.
 
 ## The user experience
+
 
 
 ### Turning notifications on (first time signing into a dApp)
@@ -278,6 +284,7 @@ dialog.
 ## dApp → II
 
 
+
 ### Sending to thousands of users: chunked send + two-layer flow control
 
 > _In short: the dApp streams the audience to II in small batches ("chunks");
@@ -337,99 +344,11 @@ template); a mix of the two works too.
 
 ### The Candid interface
 
-The exact API a dApp's backend calls, written in Candid (the IC's interface
-language). There is a single send entry point, `push_send`: it carries a
-shared `default_alert` plus a list of recipients, each of which may override
-that alert with its own — so the same call does both "same text for everyone"
-and "different text per user." The rest are the types it uses; skim the
-comments — each explains what the field is for.
-
-```candid
-type PushCategory = variant { Message; Transfer; Update; Generic };
-
-// The content variant is what makes end-to-end encryption possible later
-// (see the end-to-end-encryption section below). Display content is read by II
-// and shown verbatim — fine for non-sensitive notifications, but II sees it.
-// Hidden content is never sent to II at all: the payload carries no message
-// text, so an E2E sender structurally cannot leak content. The service
-// worker renders an II-controlled generic string keyed by category, and the
-// real message is revealed on tap-through when the app decrypts it.
-type PushContent = variant {
-  Display : record {             // II-visible; transport-encrypted only, NOT E2E
-    title : text;                // ≤ 64 bytes
-    body : text;                 // ≤ 256 bytes
-  };
-  Hidden : record {              // content-free; E2E-safe by construction
-    category : opt PushCategory; // maps to II-controlled copy ("New message", …)
-  };
-  Dismiss;                       // close the shown notification named by notification_id; renders nothing
-};
-
-type PushAlert = record {
-  content : PushContent;
-  url : opt text;                // tap-through target; must be same-origin as sender
-  notification_id : opt text;    // dApp's id for this notification (maps to the Web Notification `tag`):
-                                 // reuse it to UPDATE the shown one, or pair with Dismiss to close it
-};
-
-type PushUrgency = variant { VeryLow; Low; Normal; High };
-
-type PushDelivery = record {     // RFC 8030 relay headers; plaintext, relay-visible
-  urgency : opt PushUrgency;     // default Normal; also orders II's drain
-  ttl_seconds : opt nat32;       // default ~4h; 0 = only if online now; clamped to a max
-  topic : opt text;              // ≤ 32 chars base64url; collapse key
-};
-
-type PushRejection = variant {
-  NoConsent;                     // unknown target OR not consented to *your* origin (merged on purpose)
-  AlertInvalid : text;
-};
-
-type PushResult = record {
-  admitted : nat32;              // accepted into the in-flight buffer for delivery (NOT delivered)
-  rejected : vec record { index : nat32; reason : PushRejection };
-  ready : bool;                  // false → II is at capacity; stop and retry after retry_after_ms
-  retry_after_ms : opt nat32;    // Layer-1 backpressure hint
-};
-
-// One recipient. `alert` is an optional per-recipient override; when null the
-// recipient uses the chunk's shared `default_alert`. This is how one endpoint
-// covers both cases: broadcast = shared default + all overrides null;
-// personalized = per-recipient overrides. `null` costs ~1 byte, so broadcast
-// stays compact (the content isn't repeated per recipient).
-type PushRecipient = record {
-  target : principal;            // in-app principal
-  alert : opt PushAlert;         // override; falls back to default_alert
-};
-
-service : {
-  push_register_sender : (origin : text) -> (variant { Ok; Err : text });
-  push_deregister_sender : (origin : text) -> (variant { Ok; Err : text });
-
-  // Submit ONE chunk (≤ ~1000 recipients, ≤ 2 MB). II admits what it has
-  // capacity for (Layer 1) and returns per-recipient rejections plus a
-  // backpressure signal. Each recipient's effective alert is its own override
-  // or, if null, `default_alert`; if both are null it is rejected
-  // (AlertInvalid). The client library owns the campaign, chunking, pacing,
-  // retry, status, templating and prioritization — II holds no campaign state.
-  push_send : (
-    chunk_id : blob,             // per-chunk idempotency (short-lived heap dedup)
-    delivery : PushDelivery,     // shared across the chunk (urgency / ttl / topic)
-    default_alert : opt PushAlert, // shared alert for recipients that don't override
-    recipients : vec PushRecipient
-  ) -> (PushResult);
-}
-```
-
-The `content` / `PushDelivery` split mirrors the trust boundaries. `Display`
-content is transport-encrypted (the relay can't read it) but **II can** —
-acceptable for non-sensitive notifications. `Hidden` content is never sent to
-II, which is what preserves end-to-end encryption. `PushDelivery` fields are
-plaintext RFC 8030 headers the relay sees. A sender that wants E2E chooses the
-`Hidden` variant and, by construction, has no field to put message text in.
-`push_send` returns as soon as the chunk is admitted (or rejected) — it does
-**not** wait for delivery; "admitted" means "accepted into II's in-flight
-buffer", nothing more.
+The full interface — `push_send`, the alert and delivery types, the result and
+rejection variants — is in [push-api.md](push-api.md#the-candid-interface). It is
+reference material rather than design argument, so it lives beside the
+integration guide. What matters here is the shape it implies, covered above and in
+[II's state model](#iis-state-model-stateless-for-campaigns).
 
 ### How II knows which users to send to
 
@@ -572,6 +491,7 @@ the rate bucket — see
 [Operating it](#operating-it-controls-alerts-and-rollout).
 
 ## II's state model: stateless for campaigns
+
 
 
 > _In short: II accepts a chunk, briefly holds it in memory (not durable
@@ -780,6 +700,7 @@ off-platform.
 ## Delivering to devices
 
 
+
 The relay API is one POST per subscription endpoint (RFC 8030) — there is no
 multi-recipient send, so reaching N devices is fundamentally N sends. The
 design routes those sends through a **trusted web2 gateway**. Doing them as
@@ -926,153 +847,18 @@ genuine peer of the gateway on correctness, still bounded by in-flight slots.
 
 ## The dApp-side client library
 
+A dApp does not call `push_send` in a loop; it drives II through a small client
+library that owns pacing, retry and durable campaign state — which is what keeps
+II's own storage flat. Its design, the send loop, the state it must keep and the
+failure modes it owns are specified in
+[push-client-library.md](push-client-library.md).
 
-> _In short: because II stores nothing per send, a small library on the dApp's
-> side keeps the list, sends it to II in paced pieces, retries failures, tracks
-> who got notified, and personalizes text. The dApp calls one simple
-> "notify these users" method; the library handles the rest._
-
-Since II is stateless for campaigns, the durable coordination is a library the
-dApp runs. This is where the heavy list and its bookkeeping live — where the
-volume originates.
-
-Security is unaffected by moving this out: II re-validates sender-origin,
-consent and origin-pinning on **every** chunk, so a buggy or malicious library
-cannot fake consent, target another dApp's users, or exceed admission limits —
-it can only mismanage its own campaign. **The library is a convenience, never a
-control.**
-
-### Where it runs, and the one real choice
-
-The library must live somewhere with durable state and a scheduler, because it
-owns a campaign that outlives any single call. Two viable hosts:
-
-|                 | dApp **canister** (recommended)                 | dApp **web2 backend**                       |
-| --------------- | ----------------------------------------------- | ------------------------------------------- |
-| Durability      | stable memory, survives upgrades                | whatever the backend already has            |
-| Scheduling      | `ic_cdk_timers`                                 | cron / job runner                           |
-| Calls II via    | inter-canister call (**can attach cycles**)     | ingress (**cannot attach cycles**)          |
-| Sender identity | its own canister principal — registers directly | needs a canister to call on its behalf      |
-| Fits            | on-chain apps, the default                      | apps whose audience already lives off-chain |
-
-The canister host is the recommended shape: it is the only one that can attach
-cycles (relevant if sender-pays ever lands) and the only one whose sender
-identity is a principal II can register directly. A web2 backend still needs a
-small companion canister to be the registered sender, so it ends up running both.
-
-### State it must keep
-
-Per campaign, durable:
-
-```
-Campaign {
-  campaign_id       : text            // dApp-chosen, unique
-  default_alert     : PushAlert       // shared text, if any
-  delivery          : PushDelivery    // urgency / ttl / topic for the campaign
-  created_at        : nanos
-  state             : Building | Sending | Paused | Done | Failed
-  cursor            : nat64           // index of the next unsent target
-  last_drain_epoch  : nat64           // II's epoch as of the last confirmed chunk
-}
-
-Target {                              // one row per recipient
-  principal   : Principal             // the user's in-app principal for THIS origin
-  alert       : opt PushAlert         // personalization override, else default
-  status      : Pending | InFlight | Admitted | NoConsent | Invalid | Dropped
-  chunk_id    : opt blob              // which chunk carried it
-  attempts    : nat8
-}
-```
-
-Two things worth being precise about, because they are where implementations go
-wrong:
-
-- **`status = Admitted` means "II accepted it into its buffer", not
-  "delivered".** There are no delivery receipts. The library must not present
-  `Admitted` to the dApp as "the user got it"; the honest label is "sent".
-- **`cursor` + `last_drain_epoch` together are the recovery state.** On restart,
-  or when II's `drain_epoch` moves, everything `InFlight`/`Admitted` since that
-  epoch is suspect and must be re-sent (see below).
-
-### The send loop
-
-```
-for each batch of ≤1000 targets from cursor:
-    chunk_id = hash(campaign_id, cursor)        # deterministic → idempotent retry
-    r = push_send(chunk_id, delivery, default_alert, recipients)
-
-    if r.drain_epoch != last_drain_epoch:       # II was upgraded
-        rewind cursor to the oldest unconfirmed chunk
-        last_drain_epoch = r.drain_epoch
-        continue
-
-    mark r.rejected targets by reason           # NoConsent → terminal, not retry
-    mark the rest Admitted; advance cursor
-
-    if !r.ready:
-        sleep(r.retry_after_ms + jitter)        # jitter is not optional
-```
-
-Details that matter:
-
-- **`chunk_id` must be deterministic** — derive it from
-  `(campaign_id, cursor)`, never from a random value or a timestamp. That is
-  what makes a retry idempotent instead of a duplicate. Fix it at **16 bytes**;
-  II's dedup set is bounded and LRU-evicted, so oversized or unbounded ids are
-  rejected.
-- **Jittered exponential backoff, always.** A bare `retry_after_ms` makes every
-  rejected sender retry at the same instant, and after an II upgrade every
-  client with lost chunks retries simultaneously — a thundering herd precisely
-  when II is least able to absorb it.
-- **Pipeline no more than a few chunks.** The output queue between two canisters
-  is 500 deep, and the point of pacing is to absorb inter-canister latency, not
-  to race II's admission control.
-- **`NoConsent` is terminal.** It means the user revoked or never granted; retrying
-  it wastes admission budget forever. Distinguish it from capacity rejections,
-  which _are_ retryable.
-- **Chunk by bytes as well as by count.** ≤1000 targets _and_ under the
-  size ceiling — with heavy per-recipient personalization the byte bound binds
-  first. II enforces both server-side; hitting them is a client bug.
-
-### What it owes the dApp
-
-The public surface should be small enough that the common case is one call:
-
-```
-notify(campaign_id, targets, default_alert, delivery) -> CampaignHandle
-status(campaign_id) -> { total, sent, no_consent, pending, state }
-pause(campaign_id) / resume(campaign_id) / cancel(campaign_id)
-```
-
-Everything else — chunking, pacing, retry, epoch recovery, backoff, templating —
-is internal. A dApp author should never have to know what a chunk is.
-
-- **Templating / personalization** — expand `template + per-user data` into a
-  per-recipient `alert` override entirely client-side. **II never sees a
-  template**, which is what keeps personalization off II's storage.
-- **Prioritization** — the library decides which campaign or segment goes first.
-  Note this is _campaign_ ordering, distinct from per-message `urgency`, which
-  rides the relay header and contributes to II's drain order.
-- **Status/reporting** — aggregate per-chunk results into campaign progress,
-  labelled honestly: `sent` (admitted), `no_consent`, `pending`. Not
-  "delivered" — nothing in this design can tell the dApp that.
-
-### Failure modes the library is responsible for
-
-| Failure                            | What the library must do                                        |
-| ---------------------------------- | --------------------------------------------------------------- |
-| `ready = false`                    | back off with jitter; do **not** advance the cursor             |
-| `drain_epoch` moved (II upgraded)  | rewind to the oldest unconfirmed chunk and re-send              |
-| Its own host restarts mid-campaign | resume from `cursor`; re-send anything `InFlight`               |
-| `NoConsent` for a target           | mark terminal, stop retrying, surface to the dApp               |
-| Call trapped / rejected            | retry the _same_ `chunk_id`; never mint a new one               |
-| Campaign outlives its own deadline | `ttl_seconds` already bounds it II-side; mark `Dropped` locally |
-
-Because retries and epoch-recovery both re-send chunks, **duplicate delivery is
-expected by design** — which is the other half of why `msg_id` dedup on the
-device is a v1 requirement, not a nicety.
+The one point that belongs in this document: the library is where the durable list
+lives, which is what lets II stay stateless per send. See
+[II's state model](#iis-state-model-stateless-for-campaigns).
 
 ## On the device: rendering and tap-through
+
 
 
 - **Subscribe** (Settings, or the `/authorize` opt-in): request permission,
@@ -1340,6 +1126,7 @@ Caveats:
 
 ## Alternatives considered
 
+
 ### II hosts the pipeline, rather than each dApp running its own
 
 The alternative is the status quo: every dApp prompts for its own notification
@@ -1389,6 +1176,7 @@ needs its surrounding detail to make sense:
   [recommendation](#recommendation).
 
 ## Security model
+
 
 
 - **Origin pinning** — a sender can only target anchors that consented to
@@ -1570,6 +1358,7 @@ the sender.
 ## Privacy
 
 
+
 The doc's confidentiality story is about _content_. Metadata is a separate
 exposure and, for a notification hub, arguably the more sensitive one — `Hidden`
 protects the message text and does nothing for any of this.
@@ -1602,6 +1391,7 @@ operators each learn.
 ## Delivery semantics: what is actually guaranteed
 
 
+
 "Best-effort" is not a guarantee, and several features silently depend on which
 one holds. Stated explicitly:
 
@@ -1621,6 +1411,7 @@ the notification it dismisses and then be a no-op forever. Fix: carry a
 service worker drops out-of-order updates rather than applying them.
 
 ## Duplicate and replay suppression (`msg_id`)
+
 
 
 **Built.** Four independent mechanisms make duplicates the norm rather than the
@@ -1671,6 +1462,7 @@ Note `msg_id` is a **different thing** from the dApp-facing `notification_id`:
 shape, opposite behavior — keep them separate fields.
 
 ## End-to-end-encrypted apps
+
 
 
 Some apps (e.g. a chat using vetKeys) encrypt content so that only the
@@ -1810,6 +1602,7 @@ to send, admission, or storage.
 ## Open items
 
 
+
 Must-fix before a real deployment:
 
 - **Endpoint host allowlist.** The push endpoint is attacker-supplied. Validate
@@ -1920,6 +1713,7 @@ Explicitly rejected:
 ## IC capabilities to re-evaluate
 
 
+
 Platform features that would change decisions in this doc. Worth re-checking
 before implementation, because two of them postdate the design:
 
@@ -1948,6 +1742,7 @@ before implementation, because two of them postdate the design:
 ## Push must never degrade authentication
 
 
+
 The invariant, stated separately because it is the one that makes this feature
 unshippable if violated: **no volume of push traffic may reduce the availability
 of sign-in.**
@@ -1974,6 +1769,7 @@ signal** with push throttling as the automatic response.
 ## Operating it: controls, alerts and rollout
 
 
+
 Metrics alone are not operability. Missing today:
 
 - **A per-origin kill switch.** `push_deregister_sender` is authenticated by the
@@ -1998,36 +1794,12 @@ Metrics alone are not operability. Missing today:
 
 ## dApp developer integration
 
-
-One-time setup (~15 min): serve `.well-known/ii-push-senders`, call
-`push_register_sender(origin)` from the backend. Steady state: hand the client
-library a campaign — it chunks, paces, retries and reports:
-
-```rust
-// Non-sensitive app: show the content.
-push.broadcast(
-    PushContent::Display { title, body },
-    PushDelivery { urgency: High, ttl_seconds: 3600, topic: Some("balance") },
-    &my_user_principals,        // library chunks + paces these
-).await?;
-
-// E2E app: send nothing sensitive; content is revealed on tap.
-push.broadcast(
-    PushContent::Hidden { category: Some(Message) },
-    PushDelivery { urgency: High, ttl_seconds: 3600, topic: None },
-    &my_user_principals,
-).await?;
-```
-
-Under the hood the library splits the audience into ≤ ~1000-target chunks,
-calls `push_send` per chunk, **paces on `ready` / `retry_after_ms`**, retries
-with a stable `chunk_id`, and aggregates per-target results into campaign
-status. The dApp sees a campaign API; II sees paced, bounded chunks. No keys,
-no crypto, no Web Push knowledge, and no per-user state beyond the principals
-from auth (the library owns campaign status). Delivery is best-effort with no
-receipts; the only per-user signal is `NoConsent`.
+What a dApp must do to send its first notification — register as a sender for its
+origin, serve the callback allow-list, shape its deep links — is in
+[push-api.md](push-api.md#dapp-developer-integration).
 
 ## Feasibility and scale
+
 
 
 | Metric                               | Gateway (chosen)                                                   | Direct (alternative)    |
@@ -2064,6 +1836,7 @@ degraded fallback rather than a transparent one.
 ## What this actually costs per user
 
 
+
 Storage is O(users × origins), not O(users) — worth being concrete, since the
 "flat with volume" claim is about _notification volume_ only:
 
@@ -2082,6 +1855,7 @@ than housekeeping. Note also the 2 GiB stable-memory-per-upgrade ceiling, which
 bounds how large these maps can get before upgrades become a problem.
 
 ## Stable memory regions
+
 
 
 New regions must claim an unused `MemoryId`. Because nothing in the code forces
@@ -2103,6 +1877,7 @@ A test asserting all indices are distinct is cheap and worth having.
 ## Future exploration
 
 
+
 Deliberately out of v1, kept here so the door stays open:
 
 - **Cycles-based charging.** Attach cycles per notification (canister senders
@@ -2122,6 +1897,7 @@ Deliberately out of v1, kept here so the door stays open:
   signal would have to come from the app itself, and per-origin aggregates are
   the most II can offer without a per-user tracking surface.
 ## Status
+
 
 
 ### Built today (PoC on `feat/push-notifications-poc`)

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -395,13 +395,19 @@ them to one) — so `410` [cleanup](#stale-subscription-cleanup) is impossible.
 
 ### The delivery path: a trusted web2 gateway
 
+Numbers below are for one 10k-user blast — about 13k devices, so ~13k messages to
+deliver:
+
 ```mermaid
 flowchart LR
-    II[II canister<br/>seals: RFC 8291 + VAPID] -->|~25 batched<br/>non-replicated outcalls| GW[Gateway<br/>no keys, no plaintext]
-    GW -->|1 POST/device| R[FCM / Mozilla / APNs]
-    R --> D[Device]
+    II[II canister<br/>seals ~13k messages] -->|~25 batched outcalls<br/>non-replicated| GW[Gateway<br/>no keys, no plaintext]
+    GW -->|~13k POSTs<br/>one per device| R[FCM / Mozilla / APNs]
+    R --> D[13k devices]
     II -.->|"direct: ~13k outcalls<br/>(alt / fallback)"| R
 ```
+
+II always produces one sealed message per device (~13k here); the gateway's job is to
+turn those into ~25 batched outcalls off-chain instead of ~13k on-chain.
 
 **Why a gateway, not direct:** in-flight outcall slots, not cycles. A 10k-user
 blast is ~13k direct outcalls against the subnet's 3000 shared slots — it would

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -107,11 +107,14 @@ Read this first; the sections after it just add detail.
   on, their browser hands II the keys needed to deliver to that device; when
   they sign into a dApp and opt in, II records that the dApp is allowed. So II
   keeps two small per-user facts: *which devices* and *which apps are allowed*.
-- **II seals every message.** It encrypts (using device key-pair generated during subscription. Standard web-push api.) the text so only the user's own
-  device can read it (Google/Apple/Mozilla just forward sealed bytes, the browser makes sure to decrypt it), and it
-  signs the request so those push services trust that it really came from II (VAPID JWT which is per audience and can be cached so that we don't have to generate it every time).
+- **II seals every message.** It encrypts the text with the device's own key
+  (created when the device subscribed, using standard Web Push encryption) so
+  only that device can read it — Google/Apple/Mozilla just forward the sealed
+  bytes and the browser decrypts them. It also signs each request so those push
+  services trust it really came from II (a VAPID token, cached per push service
+  so II needn't re-sign every time).
 - **Big sends are streamed, not dumped.** To notify 10,000 users, the dApp uses
-  a small helper **library** that feeds II the list in bite-size batches at a
+  a small helper **library** that feeds II the list in bite-sized batches at a
   pace II can handle. II refuses more than it can take (so nobody can flood
   it), and the library slows down when asked. The big list lives with the
   dApp — **II stores almost nothing per send**, which matters because storage
@@ -177,7 +180,7 @@ around.
 > Two separate safeguards — one on each side — keep this safe and smooth.*
 
 A campaign of any size is delivered as a series of **bounded chunks** — a chunk
-is just a bite-size batch of targets (≤ ~1000 targets, ≤ 2 MB per call). This is deliberate: II must never be asked to hold a
+is just a bite-sized batch of targets (≤ ~1000 targets, ≤ 2 MB per call). This is deliberate: II must never be asked to hold a
 whole campaign, because that is the storage that scales with volume. Two
 independent control layers make this safe and smooth — and they must not be
 confused:
@@ -289,7 +292,7 @@ service : {
     chunk_id : blob,             // per-chunk idempotency (short-lived heap dedup)
     delivery : PushDelivery,     // shared across the chunk (urgency / ttl / topic)
     default_alert : opt PushAlert, // shared alert for recipients that don't override
-    recipients : vec PushRecipient,
+    recipients : vec PushRecipient
   ) -> (PushResult);
 }
 ```
@@ -563,10 +566,11 @@ The app may set `alert.url` to send the user to a specific page rather than
 the origin root. `/notify` honors it under two constraints, both enforced
 client-side:
 
-- **The target's origin must equal the sender's origin.** The sender origin
-  is `alert.hostname`, which the backend forces to the consented origin and a
-  dApp cannot spoof. So a notification can deep-link anywhere within the
-  sender's own site (`https://app.com/thread/42`) but never to another
+- **The target's origin must equal the sender's origin.** The sender origin is
+  **II-derived**, not a field on `PushAlert`: the backend forces it to this
+  sender's consented origin and stamps it into the delivered payload, so a dApp
+  cannot set or spoof it. A notification can therefore deep-link anywhere within
+  the sender's own site (`https://app.com/thread/42`) but never to another
   origin — not `evil.com`, and not another consented dApp.
 - **The sender origin must be in the anchor's consent list** (session-delegation
   check). A hand-crafted `/notify?origin=…&to=…` therefore also fails closed.
@@ -610,8 +614,9 @@ Caveats:
 
 - **Origin pinning** — a sender can only target anchors that consented to
   *its* origin; cross-dApp targeting is impossible even with leaked principals.
-- **Attribution** — II forces `alert.hostname` to the consented origin; a
-  dApp cannot spoof who sent a notification.
+- **Attribution** — the sender origin shown on the notification is II-derived,
+  not dApp-supplied: II forces it to the consented origin and stamps it into the
+  payload, so a dApp cannot spoof who sent a notification.
 - **Content is dApp-controlled (Display mode)** — `title`/`body` are free-form,
   delivered under II's service worker. Attribution is shown and lengths are
   capped, but a compromised dApp could send misleading text within its own

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -153,32 +153,39 @@ would be the real fix — out of scope here.
 
 ### Sending to thousands: chunked send + two-layer flow control
 
-A campaign is delivered as **bounded chunks** (≤~1000 targets, under the message
-size ceiling) — II must never hold a whole campaign, that's the storage that scales
-with volume. Two control layers, not to be confused:
+A campaign is delivered as a stream of bounded chunks (up to ~1000 targets each,
+within the message-size limit). II never holds the whole campaign, because that is
+exactly the storage that would scale with volume. Two control layers keep this safe,
+and it's important not to confuse them:
 
-- **Layer 1 — II admission (mandatory, adversarial).** Hard `recipients.len()`
-  ceiling + per-origin token bucket + global buffer cap. Over capacity, `push_send`
-  rejects (`ready=false`, `retry_after_ms`). **II never holds more than its bounded
-  buffer, whatever the client does** — this is the anti-spam property.
-- **Layer 2 — client pacing (cooperative, efficiency only).** The library reads the
-  same signal and paces; skipping it just delivers slower. Never an anti-spam layer.
+- **Layer 1 is II's own admission control** — mandatory, and it assumes a hostile
+  client. It enforces a hard recipient ceiling, a per-origin token bucket, and a
+  global cap on its buffer; over capacity, `push_send` simply rejects the chunk
+  (`ready = false`, plus a `retry_after_ms` hint). The guarantee is that II never
+  holds more than its bounded buffer no matter what the client does. This is the
+  anti-spam property, and it lives entirely on II.
+- **Layer 2 is the client library pacing itself** — cooperative, and only about
+  efficiency. It reads the same `ready` signal and avoids wasting calls that would
+  be rejected. A client that skips it just delivers more slowly; nothing breaks for
+  II.
 
-The rule: **II protects itself; the client optimizes itself.**
+The short version: II protects itself, the client optimises itself — never rely on
+client pacing to prevent spam.
+
+A single `push_send` covers both broadcast and personalised sends: it takes a shared
+`default_alert` plus a list of recipients, each of which may override it. A broadcast
+sets the default and leaves the overrides empty; a personalised send gives each
+recipient its own alert, templated on the client side so II never holds a template.
 
 <details><summary>Two caveats on Layer 1</summary>
 
-- The reject is O(1) but happens *after* the 2 MB chunk is decoded — cap accepted
-  size well below 2 MB so the pre-decision cost is bounded.
-- `inspect_message` **can't** help — it isn't invoked for inter-canister calls, and
-  `push_send` is called by canisters. The ≤1000 bound is enforced server-side
-  (2 MB of recipients ≈ 65k, whose per-recipient lookups would trap).
+The reject is O(1), but it happens *after* the 2 MB chunk has been decoded, so cap
+the accepted size well below 2 MB to bound even the cost of refusing a flood. And
+`inspect_message` can't help here — it isn't invoked for inter-canister calls, and
+`push_send` is called by canisters. The ~1000 ceiling is enforced server-side, since
+2 MB of recipients is roughly 65,000, whose per-recipient lookups would trap.
 
 </details>
-
-Broadcast and personalized share one `push_send`: a `default_alert` plus recipients
-that may override it. Broadcast = default + empty overrides; personalized = per-
-recipient alert (templated client-side, II holds no template).
 
 ### The Candid interface
 
@@ -251,13 +258,13 @@ directly.
 
 ### What this costs, and who pays
 
-**Always scarce** (every deployment): outcall slots (3000 subnet-wide, shared with
-login — why the gateway exists), storage (kept O(users × origins), never O(volume)),
-instructions (bounded-slice drain).
+Three things are scarce on every deployment: outcall slots (3000 subnet-wide, shared
+with login — the reason the gateway exists), storage (kept O(users × origins), never
+O(volume)), and instructions (which force the bounded-slice drain).
 
-**Cycles** are waived on canonical II, charged elsewhere. The per-byte fee carries
-the `·n` replication factor, so non-replicated is where the money is — a 10k-user
-blast on a paying subnet:
+Cycles are the fourth cost, but only where they're charged — waived on canonical II,
+real everywhere else. The per-byte fee carries the `·n` replication factor, so
+non-replicated delivery is where the money is. For a 10k-user blast on a paying subnet:
 
 | Path | Outcalls | Cycles | ≈ USD |
 | --- | --- | --- | --- |
@@ -644,19 +651,21 @@ forcing sender-origin attribution at send time.
 | **`/notify` icon** | curated registry only + globe fallback — never fetch arbitrary/remote icons into II's chrome |
 | **vetKD derive drain** | the SW triggers a derive over ingress (no cycles attached), so the bill lands on II — an uncached derive is a user-triggerable cycle drain. Derive once per `(user, origin)`, cache in the SW, rate-limit per anchor |
 
-**The VAPID-key risk is larger than "spam".** The same stable memory holds the
-VAPID key *and* every device's `p256dh`/`auth`, so an attacker reading it can forge
-**fully-readable notifications to any device, attributed to any consented origin** —
-whose tap-through then passes `/notify` and deep-links into the real dApp. That's
-phishing capability, not spam, and there's currently **no detection or rotation
-story**. Mitigate: per-device transport secrets (extracting one ≠ the other), a
-signed per-endpoint counter so a SW can flag pushes II didn't send. Real fix:
-[P-256 threshold ECDSA](#ic-capabilities-to-re-evaluate) removes the stored key
+**The VAPID-key risk is larger than "spam".** The same stable memory holds the VAPID
+key and every device's `p256dh`/`auth` secrets, so an attacker who reads it can forge
+fully-readable notifications to any device, attributed to any origin the user actually
+consented to. The tap-through then passes `/notify` and deep-links into the real dApp,
+which makes this a phishing capability rather than spam — and there is no detection or
+rotation story today. The mitigations worth doing regardless of custody are per-device
+transport secrets, so that extracting one doesn't yield the other, and a signed
+per-endpoint counter so a service worker can flag pushes II never sent. The real fix is
+[P-256 threshold ECDSA](#ic-capabilities-to-re-evaluate), which removes the stored key
 entirely.
 
-**Key init must not race** — a lazy `await raw_rand` between check and write lets
-two callers generate; the loser's subscribers become silently undeliverable.
-Initialize eagerly behind a guard.
+One subtle bug to avoid: if the key is generated lazily, the `await raw_rand` between
+checking "is it set?" and writing it lets two concurrent first-callers both generate,
+and whichever loses leaves its subscribers silently undeliverable. Generate it eagerly,
+behind a guard.
 
 ### Shared fate: one permission for every dApp
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1858,15 +1858,31 @@ this check, record allocations here and verify against `storage.rs` before
 adding one — a duplicate index silently interleaves two `StableBTreeMap`s into
 the same virtual memory and corrupts both.
 
-| Index | Region                                |
-| ----- | ------------------------------------- |
-| …     | (existing regions — see `storage.rs`) |
-| 31    | MCP registration                      |
-| 32    | SSO stable-id index                   |
-| 33    | push subscriptions                    |
-| 34    | push consent                          |
-| 35    | push principal index                  |
-| 36    | push sender registry                  |
+| Index | Region               | Key → value                                                       |
+| ----- | -------------------- | ----------------------------------------------------------------- |
+| …     | (existing regions)   | see `storage.rs`                                                  |
+| 31    | MCP registration     | —                                                                 |
+| 32    | SSO stable-id index  | —                                                                 |
+| 33    | push subscriptions   | `(anchor, endpoint_sha256)` → `{endpoint, p256dh, auth, created}` |
+| 34    | push consent         | `(anchor, origin_sha256)` → `{granted_at, origin}`                |
+| 35    | push principal index | `in_app_principal` → `anchor`                                     |
+| 36    | push sender registry | `origin_sha256` → registered sender canister                      |
+
+What each is for, since the names alone do not say:
+
+- **Subscriptions** hold exactly what RFC 8291 needs to seal for one device — the
+  relay `endpoint` plus that device's `p256dh` public key and `auth` secret. One
+  row per browser that ran `pushManager.subscribe()`; a browser resubscribing
+  overwrites in place. The endpoint URL is what makes this the largest row.
+- **Consent** is presence-as-grant: the key existing means this user allowed this
+  dApp on this identity, and revoking deletes it.
+- **The principal index** is the reverse lookup `notify_user` cannot work without.
+  A dApp knows the user only by its per-origin `in_app_principal`, never the
+  anchor, so this resolves one to the other before the two maps above can be read.
+  Written on grant, cleared on revoke — and the reason a consent costs ~140 B
+  rather than ~60 B.
+- **The sender registry** records which canister may send as a given origin.
+  Controller-written only, because `.well-known` verification does not exist yet.
 
 This is not hypothetical. An earlier revision of the PoC claimed 32, which `main`
 had meanwhile taken for the SSO stable-id index; the two `StableBTreeMap`s

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -539,8 +539,6 @@ Until then, tap-through is the one place "a dApp needs no push infrastructure" i
 - **Only II's Continue tap is irreducible** — silent issuance would let any site get
   a delegation by redirect. Don't add an II-side interstitial (only the dApp knows if
   it has a session).
-- **Local dev:** loopback callback needs `dev_csp`; Chrome prompts for local-network
-  access — both gone once public https.
 
 </details>
 
@@ -860,7 +858,7 @@ PoC's job was to prove the shape, not to be complete).
 ## IC capabilities to re-evaluate
 
 - ~~**Non-replicated outcalls**~~ — **adopted** (batch handoff); still experimental,
-  so keep it behind one revertible call site. Field-tested on multidex's oracle.
+  so keep it behind one revertible call site.
 - **Per-node outcall results** — would give per-device status on a *replicated* path;
   only interesting to stop depending on the experimental flag. Verify on mainnet.
 - **P-256 threshold ECDSA** — **the end state.** Moves the VAPID key out of storage
@@ -877,11 +875,6 @@ every user, and push competes with that for three shared resources — outcall s
 (small drain slices), and cycles (never spend toward the freezing threshold). Enforce a
 hard push quota that always yields to login, and auto-throttle push if sign-in latency
 climbs.
-
-## dApp developer integration
-
-What a dApp does to send its first notification — publish the sender file, serve the
-callback allow-list, shape its deep links — is in [push-api.md](push-api.md#integrating-a-dapp).
 
 ## Scaling
 
@@ -927,13 +920,13 @@ seal, and the share of the canister we let push take —
   cap so sign-in keeps ~80 % of every round even mid-blast. On a canister sustaining a
   few billion instructions/sec that hands push **~1 B instructions/sec**.
 
-Plugging those in — the central column is the planning number:
+Plugging those in (M = million instructions; the central column is the planning number):
 
-| per seal | 10 M (optimistic) | **20 M (central)** | 30 M (conservative) |
+| Seal cost | 10 M (optimistic) | **20 M (central)** | 30 M (conservative) |
 | --- | --- | --- | --- |
 | device-msg/sec | ~100 | **~50** | ~33 |
 | per hour | ~360k | **~180k** | ~120k |
-| per day | ~8.6M | **~4.3M** | ~2.9M |
+| per day | ~8.6M msg | **~4.3M msg** | ~2.9M msg |
 
 > **≈ 50 device-msg/s ≈ 180k/hour ≈ 4.3M/day, across every dApp combined** — at a
 > deliberate 20 % execution share and ~20 M-instruction seal, both to confirm by measurement.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -988,6 +988,62 @@ sign-in derives the identity from the callback origin or its `derivationOrigin`.
 They must agree, or the principal that was notified is not the principal the
 user comes back with.
 
+### What about apps with no URL routing (e.g. Caffeine)?
+
+**This is a hard prerequisite that some app platforms do not currently meet, and
+it needs checking before we promise notifications to them.**
+
+Everything above — deep-linking _and_ signed-in tap-through — assumes the app
+has **addressable URLs**. Caffeine-built apps were, last time anyone checked,
+fully stateful with no URL-based routing: there is no address to point a
+notification at. If that is still true, two things break, and the first is worse
+than the second:
+
+- **Deep-linking breaks outright.** With nothing to put in `alert.url`, a
+  notification can only ever open the app's root, so the context the
+  notification was _about_ ("which message", "which order") is lost on arrival.
+  A notification that cannot say where it goes is a much weaker product than one
+  that can.
+- **Signed-in landing breaks**, because the guarded-route pattern needs two real
+  routes: the restricted page and the sign-in/callback page.
+
+What such a platform has to add, in dependency order:
+
+1. **Addressable destinations.** Either a real route per notifiable view, or —
+   cheaper and probably the right fit for a stateful app — a **single entry route
+   that takes an opaque state token** (`/open?s=<token>`) and restores the
+   in-app state from it. Notifications then carry that token. This is the
+   unavoidable one: without it, notifications are reduced to "something
+   happened, open the app".
+2. **A sign-in route in the project template.** A hardcoded page that constructs
+   the redirect `AuthClient` at page load, memoizes the destination, calls
+   `signIn()`, and forwards to the memoized destination on return. It is
+   boilerplate, which is exactly why it belongs in the template rather than in
+   each app.
+3. **A guard on restricted views** calling `isAuthenticated()` and bouncing to
+   that route.
+4. **`/.well-known/ii-auth-callbacks`** served from the app's origin, listing the
+   sign-in route exactly, with CORS.
+
+One constraint that shapes the template: the callback URL must be **protocol +
+host + path only** — no query string — so the destination cannot ride on the
+callback and must live in memoized flow state. A template that tries
+`callback=/sign-in?next=…` will be rejected by the transport.
+
+Open questions to confirm rather than assume:
+
+- Is routing still absent, or has it changed?
+- Does the **builder sandbox** differ from a **published** app? URL routing
+  inside a live-preview environment (possibly iframed) may be constrained in
+  ways the published app is not, so both need checking — a design that works
+  only when published is still workable, but it changes what can be
+  demonstrated.
+
+**Fallback if routing cannot be added:** notifications still function, but only
+as "open the app" — no deep link, no authenticated landing. Worth stating plainly
+to set expectations, and it pairs naturally with the `Hidden` content variant,
+which also shows a generic message and reveals context only after the tap.
+
 ### Can a notification be updated or dismissed after it's shown?
 
 Yes, via a dApp-chosen `notification_id`, which the service worker maps to the
@@ -1475,6 +1531,11 @@ Must-fix before a real deployment:
 
 Must-decide (design, not code):
 
+- **App platforms without URL routing** — confirm whether Caffeine-built apps
+  can address a destination at all, in the builder sandbox _and_ published. If
+  not, deep-linking and signed-in tap-through are both unavailable there and
+  notifications degrade to "open the app". See
+  [What about apps with no URL routing](#what-about-apps-with-no-url-routing-eg-caffeine).
 - **iOS reality** — iOS Safari is the one platform where a PWA install is
   _mandatory_ for Web Push (Android/desktop work in a plain tab). It is also
   flakier and more throttled; "best-effort" is weakest there. Set expectations

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1183,6 +1183,43 @@ as "open the app" — no deep link, no authenticated landing. Worth stating plai
 to set expectations, and it pairs naturally with the `Hidden` content variant,
 which also shows a generic message and reveals context only after the tap.
 
+### Action buttons: navigation only, never silent work
+
+Web Notifications lets a notification carry `actions` — buttons rendered on it,
+with `notificationclick` reporting which was pressed. Platforms show about two,
+and **Safari and iOS support none at all**, so anything built on them has to
+degrade to a plain notification rather than depend on them.
+
+**Every action here can only navigate.** The service worker belongs to II's
+origin, so `notificationclick` fires on II's origin, and II's worker holds no
+session for the dApp — the delegation lives in the dApp's own origin storage,
+which is unreachable cross-origin by design. It cannot call the dApp's backend as
+the user. So an "Add margin" button opens the app on the add-margin screen; it
+cannot add margin.
+
+That makes actions a straightforward extension of the deep link already specified:
+
+```candid
+actions : opt vec record { id : text; title : text; url : text };   // ≤ 2
+```
+
+Each `url` is validated same-origin against the sender at send time, exactly as
+`alert.url` is, and the worker maps `event.action` back to one. Cap the count at
+two because that is what platforms render, cap `title` short because buttons
+truncate, and leave `icon` out of a first version — fetching a cross-origin image
+to decorate a notification on II's origin raises the same concern as the app logo
+on the `/notify` screen. This composes with `Hidden` content, since the worker
+builds the notification after decrypting.
+
+**Silent actions are the thing being given up, and it is a cost of the hub.** A
+dApp running its own service worker is same-origin with its own session, so
+"Archive", "Snooze" or "Mark read" work as a `fetch` with no window opened at all.
+Centralising the pipeline on II removes that: the worker that receives the tap is
+not the worker that could act. Worth listing alongside shared fate and content
+visibility in
+[alternatives considered](#ii-hosts-the-pipeline-rather-than-each-dapp-running-its-own)
+as part of what the single permission is bought with.
+
 ### Updating or dismissing a notification already shown
 
 Yes, via a dApp-chosen `notification_id`, which the service worker maps to the
@@ -1235,9 +1272,13 @@ The cost of that choice is paid throughout this document and should be read as i
 price, not as incidental complexity: II becomes a shared-fate dependency (see
 [Shared fate: one permission for every dApp](#shared-fate-one-permission-for-every-dapp)),
 II sees notification content unless the app opts into
-[end-to-end encryption](#end-to-end-encrypted-apps), and a canister whose real job
-is authentication now carries a delivery pipeline — hence
-[Push must never degrade authentication](#push-must-never-degrade-authentication).
+[end-to-end encryption](#end-to-end-encrypted-apps), a canister whose real job is
+authentication now carries a delivery pipeline — hence
+[Push must never degrade authentication](#push-must-never-degrade-authentication) —
+and notification **action buttons can only navigate, never act**, because the
+worker that receives the tap belongs to II rather than to the app holding the
+user's session (see
+[action buttons](#action-buttons-navigation-only-never-silent-work)).
 
 ### II hosts the service worker, rather than each dApp hosting one
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -692,15 +692,17 @@ as `app.com` — intentional, document it.
 ### Consent lifecycle: it must not outlive the sender
 
 Consent keyed only by `(anchor, origin_hash)` carries no sender reference, so it
-survives events it shouldn't: a domain expires, someone buys it, serves their own
-`.well-known`, registers — and **every prior consenter is reachable**, attributed as
-the old brand. Fix: stamp consent with the **sender registration epoch**;
-invalidate when the registered principals change or the sender deregisters; expire
-after long no-delivery; surface "this app re-registered — re-confirm?".
+survives events it shouldn't. If a domain expires and someone else buys it, serves
+their own `.well-known`, and registers, every prior consenter is suddenly reachable —
+attributed as the old brand. The fix is to stamp each consent with the sender's
+registration epoch, invalidate it when the registered principals change or the sender
+deregisters, expire it after a long stretch with no delivery, and surface a "this app
+re-registered — re-confirm?" prompt.
 
-Also: re-verification must not be a **deregistration primitive** — a single induced
-404 shouldn't strip capability. Require K failures over days, never deregister on
-5xx/timeout, only on a well-formed file that no longer lists the sender.
+Re-verification also mustn't become a deregistration primitive: a single induced 404
+shouldn't strip a sender's capability. Require several failures over days, and only
+ever deregister on a well-formed file that no longer lists the sender — never on a
+5xx or a timeout.
 
 ## Privacy
 
@@ -736,11 +738,11 @@ notification_id)`** so the SW drops out-of-order updates.
 
 ## Duplicate and replay suppression (`msg_id`)
 
-**Built.** Duplicates are the norm from four sources: replicated outcalls (removed
-by the non-replicated handoff), timer duplicate execution (claim-before-`await`),
-client retries + `drain_epoch`, and **accumulated subscription rows** — the one
-that actually produced duplicate banners in testing, when a rotated endpoint left
-two live rows for one browser.
+**Built.** Duplicates come from four sources: replicated outcalls (removed by the
+non-replicated handoff), timer duplicate execution (claim-before-`await`), client
+retries + `drain_epoch`, and **accumulated subscription rows** — the one that actually
+produced duplicate banners in testing, when a rotated endpoint left two live rows for
+one browser.
 
 II assigns a `msg_id` **once per admitted message**, inside the payload *before*
 RFC 8291 encryption — so no dApp supplies it and no relay can read or forge it. The
@@ -749,10 +751,11 @@ between pushes) and drops repeats; a payload with **no id is always shown**
 (failing open beats dropping a real notification). The drain now **removes a row on
 `404`/`410`**, the only signal a row is dead.
 
-**To harden:** a bounded recency set can be flushed by flooding, so a replayed
-capture looks new — replace with a per-origin high-water mark + a short `msg_id`
-validity window. Note `msg_id` (II-generated, suppress duplicates) differs from
-`notification_id` (dApp-chosen, *replaces* a shown notification).
+One thing left to harden: a bounded recency set can be flushed by flooding, after
+which a replayed capture looks new — so replace it with a per-origin high-water mark
+and a short `msg_id` validity window. Note that `msg_id` (II-generated, suppresses
+duplicates) is a different thing from `notification_id` (dApp-chosen, *replaces* a
+shown notification).
 
 ## End-to-end-encrypted apps
 
@@ -872,9 +875,8 @@ Missing today:
 
 ## dApp developer integration
 
-What a dApp must do to send its first notification — register as a sender for its
-origin, serve the callback allow-list, shape its deep links — is in
-[push-api.md](push-api.md#dapp-developer-integration).
+What a dApp does to send its first notification — publish the sender file, serve the
+callback allow-list, shape its deep links — is in [push-api.md](push-api.md#integrating-a-dapp).
 
 ## Scaling
 


### PR DESCRIPTION
Design proposal for routing dApp → user push notifications through Internet Identity as a single permission + delivery hub. The doc settles the shape before code lands: what it is for, what it deliberately is not, the two paths that decide whether it scales, the security and privacy model, and what is still open. The implementation PoC is tracked separately in #4109.

Start with [How it works, in plain terms](https://github.com/dfinity/internet-identity/blob/docs/push-notifications-poc/docs/push-notifications.md#how-it-works-in-plain-terms) — the whole design in six bullets. The doc opens with a reading path routed by what you came for: reviewing, implementing, integrating, or just wanting to know what exists today.

Positions the doc takes:

- **II is the push hub.** The user grants notification permission to id.ai once and consents per dApp; every consented dApp delivers through II instead of running its own service worker + VAPID keypair + subscriptions. PWA install is optional on Android/desktop and required only on iOS Safari. The alternative — every dApp running its own pipeline — is now argued and rejected explicitly, because the scarce resource is the permission, not the plumbing: a user declines the *n*th prompt far more often than the first.
- **Two scalability paths.** dApp → II (chunked send with mandatory II-side admission control plus cooperative client-side pacing) and II → device (batched through a trusted web2 gateway, with direct per-device outcalls as the documented alternative).
- **II's handoff to the gateway is a non-replicated outcall.** This is the design, not a future option. It makes the gateway genuinely stateless (no idempotency window needed to collapse 34 duplicate copies), lets per-device status come back inline — which is what makes `410`-driven subscription cleanup possible at all — and drops the payload cost by the full factor of *n*: ~0.7 T → **~0.02 T** for a 10k-user blast.
- **Stateless for campaigns.** The durable campaign lives in a dApp-side client library; II keeps only user-scoped data (subscriptions, consent) plus a small transient buffer, so its stable storage stays flat regardless of send volume.
- **The buffer is now sized, not just called "small".** Entries are per recipient rather than per device (~200 B, or ~1 KB when every recipient gets different text). Memory is not the constraint by three orders of magnitude — drain rate is, and it is a pie shared by every origin, so ten origins blasting at once slows delivery for everyone rather than for the noisy one. Buffer depth should therefore be drain rate × acceptable queue latency (~6 MB at 60 s), because a memory-sized buffer would accept hours of backlog and report `admitted` for messages whose TTL expires first — a lying success rather than an out-of-memory.
- **Throughput is capped by a budget, not by the platform.** The cost is RFC 8291's ECDH, two scalar multiplications per device-message; the VAPID signature is cached per audience and irrelevant. The slice is kept small because this canister also serves every login on the network. Moving the sealing to the gateway is not merely disallowed but useless — deriving the content key and being able to decrypt are the same capability — so the alternative that would actually lift the ceiling is a separate push canister, recorded as needing its own review.
- **Targeting by in-app principal**, per-origin consent with origin pinning, and per-origin admission control (Layer 1).
- **Sender verification is automatic — a dApp's only obligation is publishing a file.** `origin_sha256 → sender canister` is what authorizes a send, because the original `caller() == in_app_principal` rule can never match an inter-canister call and so admitted only self-sends. But a dApp should not have to call a setup endpoint: it publishes `/.well-known/ii-push-senders` listing its backend canister, and II verifies that itself — on first consent (preferred: user-paced, so the row exists before the first send) or on first send as a backstop, returning `SenderUnverified` with an actionable hint without blocking on the outcall. `push_register_sender` remains only as "re-check me now" after editing the file, and the client library owns the retry so the dApp writes none of it. **The gate that makes this safe: only ever fetch for origins a user has already consented to** — otherwise any canister could make II fetch a URL of its choosing by naming an arbitrary origin, an SSRF/DoS amplifier of the kind the endpoint allowlist exists to prevent. Consent bounds the fetchable set to grants that already happened, and costs nothing since a send to a non-consenting user is refused anyway.
- **VAPID key custody.** Generated via `raw_rand` and held in stable memory today because IC threshold ECDSA is secp256k1-only while Web Push needs P-256; migrate to `sign_with_ecdsa` if P-256 threshold ECDSA ships.
- **E2E.** A `Hidden` content-hidden baseline that ships first (generic notification + tap-through reveal), plus two documented future paths for rich content on the lock screen — vetKeys-sealed (II's SW decrypts on-device, II-the-service stays blind) and dApp-fetch.
- **VAPID keys are never rotated as maintenance.** There is no expiry and no hygiene schedule; a rotation is an incident. A *planned* migration to a subnet-held key needs no user-visible event — a subscription is bound to the `applicationServerKey` it was created with, so II honours the old key for devices already on it while issuing new subscriptions under the new one, and the fleet migrates as endpoints churn. Only *compromise recovery* invalidates everything at once, and that is what the "re-enable on your devices" UX is for. **P-256 threshold ECDSA is the end state** — the subnet signs, no stored secret exists to extract, and the custody caveat is deleted rather than mitigated.
- **Per-anchor caps are sized at 20 subscriptions / 100 consents** (~19.5 KB per anchor typical, ~35 KB worst case, since every consent costs a principal-index row too). Read as anti-griefing, not a storage bound: all 10M anchors saturating it would be 200–360 GB against a 537 GB limit, so it stops one anchor mining II's storage while aggregate growth stays bounded by real usage plus stale-row cleanup.
- **Shared devices** bind push per identity, never per device — a shared endpoint under one identity implies no consent for another.

## Changes

- `docs/push-notifications.md` — the design doc.
- `docs/push-api.md` — **new.** The Candid interface and what a dApp must do to integrate.
- `docs/push-client-library.md` — **new.** The client library's design, send loop, the state it must keep, and the failure modes it owns.

The split follows the guidance in [Design Docs at Google](https://www.industrialempathy.com/posts/design-docs-at-google/): the Candid surface and the library internals are needed to show the design is buildable, but they are reference material rather than decision analysis, and reading through them to reach the next decision is what made the doc hard to follow. The design doc keeps a stub for each, carrying only the part that is a design argument.

The doc was also restructured to that post's shape, which it was missing three sections of: **context and scope** (why a dApp cannot solve this alone), **goals and non-goals** (the non-goals being the load-bearing half — not a messaging product, not exactly-once, not guaranteed delivery, no billing in v1, no way to address anyone who has not consented), and **alternatives considered**. "How it works, in plain terms" now actually comes first, as it always told the reader to read it first; build status moved to the end, being project tracking rather than design. All 13 question-phrased headings became statements, with every anchor link updated.

Corrections worth calling out for anyone who reviewed an earlier revision:

- Stable-memory limits were off by a column: **512 MiB touched per message and 2 GiB per upgrade**, not 2 GiB and 8 GiB. 500 GiB per canister was right.
- The opt-in description conflated two prompts. II's own opt-in screen **is** shown for each new dApp, once per dApp per device; the **browser's** permission dialog is the part that never returns, because it is granted to id.ai and every dApp is delivered through that one origin.
- Tapping a notification opens the dApp's deep link **directly**, and the dApp signs the user in on arrival; II's `/notify` screen is only the fallback when no target was supplied. Four places still described everything routing through `/notify`, including the architecture diagram.
- Notifications can be turned off from the **browser** as well as from II, and a browser-level block cannot be undone from inside II — which is also why the opt-in screen is skipped rather than shown when permission is already denied.

Further corrections, from a pass reviewing the doc for duplicated material:

- **The stable-memory index table was wrong in the dangerous direction** — it omitted the SSO stable-id index at 32 and shifted all three push indices down one. Following it would have reintroduced the collision that actually happened during the PoC: 32 was claimed after `main` had taken it, the two `StableBTreeMap`s interleaved, and the canister trapped inside the B-tree on first read. Corrected to 31–36 against `storage.rs`, with that history recorded under the table.
- **The storage estimate was understated ~2.5×.** Both 100M-row maps were priced as if they held ~17M rows: 10M users × 10 consented dApps is 100M consent rows (~6 GB, not 1 GB) and 100M principal-index rows (~8 GB, not 1.2 GB). Total ~20 GB, not ~8 GB. Still comfortable against the limit, but it changes which axis matters — consents are expensive because each costs two rows; devices are cheap.
- **Duplicated material removed** so each fact has one home: Status no longer restates five Open items, "Feasibility and scale" no longer re-derives the shared-throughput ceiling or the gateway rationale a third time, and the vetKD cost and the `ic-cdk-timers` duplicate-execution note are each stated once. Cross-reference links were deliberately left alone.

Supersedes the earlier `docs/push-notifications-poc.md` and `docs/push-notifications-flow.mmd`; the architecture diagram is now inline.

Two gaps are known and deliberately not yet addressed: the local-development constraint (a dApp backend cannot reach a mainnet II from a local replica, because inter-canister calls only route within one domain — every integrator will hit this), and per-category consent (consent is all-or-nothing per origin, so a venue cannot offer "liquidation alerts yes, every fill no").
