### PR TITLE
feat(fe): plausible analytics for verified-email consent + remove

### DIFF
--- a/src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte
+++ b/src/frontend/src/lib/components/settings/VerifiedEmailsPanel.svelte
@@ -12,6 +12,7 @@
   import { handleError } from "$lib/components/utils/error";
   import { nanosToMillis } from "$lib/utils/time";
   import { throwCanisterError } from "$lib/utils/utils";
+  import { analytics } from "$lib/utils/analytics/analytics";
   import type {
     EmailChallengeDnsInput,
     EmailChallengeSubmitDkimLeafArg,
@@ -82,6 +83,7 @@
       handleError(err);
       return;
     }
+    analytics.event("verified-email-removed");
     removingAddress = undefined;
     void invalidateAll();
     toaster.success({

--- a/src/frontend/src/lib/utils/analytics/verifiedEmailConsentFunnel.ts
+++ b/src/frontend/src/lib/utils/analytics/verifiedEmailConsentFunnel.ts
@@ -1,0 +1,35 @@
+import { Funnel } from "./Funnel";
+
+/**
+ * Verified-email **consent / share** flow events. The user is signed in
+ * and a relying party has requested `email` / `verified_email` on the
+ * authorize / attribute-consent screen. Complements
+ * {@link setupVerifiedEmailFunnel}, which measures *binding* an
+ * address; this funnel measures whether that address ever gets shared
+ * with a dapp.
+ *
+ * Funnel shape:
+ *
+ * start-verified-email-consent    (INIT — consent view resolves with
+ *                                  verified_email/email in the request)
+ *   verified-email-consent-empty-state-shown   (no addresses bound yet)
+ *     verified-email-consent-verify-clicked    (user opens the inline wizard)
+ *     | verified-email-consent-skipped         (user dismisses with "Skip for now")
+ *   verified-email-consent-denied-all          (clicked the "Deny all" link)
+ *   verified-email-consent-shared              (clicked Continue with at
+ *                                               least one email-shaped
+ *                                               attribute selected, with
+ *                                               `source = unscoped | openid | sso`)
+ * end-verified-email-consent       (CLOSE — terminal state, carries `duration-…`)
+ */
+export const VerifiedEmailConsentEvents = {
+  EmptyStateShown: "verified-email-consent-empty-state-shown",
+  VerifyClicked: "verified-email-consent-verify-clicked",
+  Skipped: "verified-email-consent-skipped",
+  DeniedAll: "verified-email-consent-denied-all",
+  Shared: "verified-email-consent-shared",
+} as const;
+
+export const verifiedEmailConsentFunnel = new Funnel<
+  typeof VerifiedEmailConsentEvents
+>("verified-email-consent");

--- a/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import type {
     AttributeConsent,
     AttributeConsentContext,
@@ -25,6 +26,10 @@
   } from "$lib/generated/internet_identity_types";
   import { MailPlusIcon } from "@lucide/svelte";
   import { t } from "$lib/stores/locale.store";
+  import {
+    verifiedEmailConsentFunnel,
+    VerifiedEmailConsentEvents,
+  } from "$lib/utils/analytics/verifiedEmailConsentFunnel";
   import AttributePicker from "./AttributePicker.svelte";
   import {
     type MergedGroup,
@@ -176,10 +181,19 @@
       });
     }
     displayGroups = groups;
+    const emailRequested = ctx.requestedKeys.some(isEmailKey);
+    if (emailRequested) {
+      verifiedEmailConsentFunnel.init({ variant });
+      if (groups.length === 0) {
+        verifiedEmailConsentFunnel.trigger(
+          VerifiedEmailConsentEvents.EmptyStateShown,
+        );
+      }
+    }
     return {
       effectiveOrigin: ctx.effectiveOrigin,
       requestedKeys: ctx.requestedKeys,
-      emailRequested: ctx.requestedKeys.some(isEmailKey),
+      emailRequested,
       recoveryAddresses: ctx.recoveryAddresses,
       verifiedAddresses: ctx.verifiedAddresses,
     };
@@ -259,9 +273,34 @@
     await refetchGroups(requestedKeys, address);
   };
 
-  const handleSkip = () => onConsent({ attributes: [] });
+  const handleOpenVerifyWizard = () => {
+    verifiedEmailConsentFunnel.trigger(
+      VerifiedEmailConsentEvents.VerifyClicked,
+    );
+    showVerifyWizard = true;
+  };
+
+  // Catches the abandon path — user closes the tab / navigates away
+  // without skip / deny / continue. Funnel.close() is idempotent so
+  // overlapping with the explicit terminal calls above is safe.
+  onDestroy(() => verifiedEmailConsentFunnel.close());
+
+  const sourceForKey = (key: string): "unscoped" | "openid" | "sso" => {
+    const scope = extractScope(key);
+    if (scope === undefined) return "unscoped";
+    if (scope.startsWith("openid:")) return "openid";
+    if (scope.startsWith("sso:")) return "sso";
+    return "unscoped";
+  };
+
+  const handleSkip = () => {
+    verifiedEmailConsentFunnel.trigger(VerifiedEmailConsentEvents.Skipped);
+    verifiedEmailConsentFunnel.close();
+    onConsent({ attributes: [] });
+  };
 
   const handleDenyAll = (groups: MergedGroup[]) => {
+    verifiedEmailConsentFunnel.trigger(VerifiedEmailConsentEvents.DeniedAll);
     for (const group of groups) {
       selections.set(groupId(group), { checked: false, selectedIndex: 0 });
     }
@@ -273,18 +312,22 @@
       if (selection === undefined || !selection.checked) return [];
       return group.options[selection.selectedIndex].originals;
     });
-    const sharedEmail = attributes.find((attr) => {
+    const sharedEmailAttr = attributes.find((attr) => {
       const name = extractAttributeName(attr.key);
       return name === "email" || name === "verified_email";
-    })?.displayValue;
-    if (sharedEmail !== undefined) {
+    });
+    if (sharedEmailAttr !== undefined) {
+      verifiedEmailConsentFunnel.trigger(VerifiedEmailConsentEvents.Shared, {
+        source: sourceForKey(sharedEmailAttr.key),
+      });
       const { effectiveOrigin } = await prepared;
       lastSharedEmailsStore.set(
         $authenticatedStore.identityNumber,
         effectiveOrigin,
-        sharedEmail,
+        sharedEmailAttr.displayValue,
       );
     }
+    verifiedEmailConsentFunnel.close();
     onConsent({ attributes });
   };
 
@@ -383,7 +426,7 @@
       </p>
       <button
         class="btn btn-primary btn-xl mb-3 w-full"
-        onclick={() => (showVerifyWizard = true)}
+        onclick={handleOpenVerifyWizard}
       >
         {$t`Verify an email address`}
       </button>
@@ -458,7 +501,7 @@
               }}
               onVerifyNew={group.name === "email" ||
               group.name === "verified_email"
-                ? () => (showVerifyWizard = true)
+                ? handleOpenVerifyWizard
                 : undefined}
             />
           {/if}

--- a/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
@@ -276,7 +276,9 @@
   const handleOpenVerifyWizard = () => {
     void prepared.then(({ emailRequested }) => {
       if (emailRequested) {
-        verifiedEmailConsentFunnel.trigger(VerifiedEmailConsentEvents.VerifyClicked);
+        verifiedEmailConsentFunnel.trigger(
+          VerifiedEmailConsentEvents.VerifyClicked,
+        );
       }
     });
     showVerifyWizard = true;

--- a/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/AttributeConsentView.svelte
@@ -274,9 +274,11 @@
   };
 
   const handleOpenVerifyWizard = () => {
-    verifiedEmailConsentFunnel.trigger(
-      VerifiedEmailConsentEvents.VerifyClicked,
-    );
+    void prepared.then(({ emailRequested }) => {
+      if (emailRequested) {
+        verifiedEmailConsentFunnel.trigger(VerifiedEmailConsentEvents.VerifyClicked);
+      }
+    });
     showVerifyWizard = true;
   };
 


### PR DESCRIPTION
The verified-email setup funnel already had Plausible events, but nothing measured the value-realization side: when a relying party requests a verified email on the consent screen, do users actually share one — and if not, why not? Likewise, removing a verified email on `/manage/shareable-info` was silent.

## Changes

- New `verified-email-consent` funnel ([`verifiedEmailConsentFunnel.ts`](src/frontend/src/lib/utils/analytics/verifiedEmailConsentFunnel.ts)) with events:
  - `start-verified-email-consent` *(prop: `variant = openid | normal`)* — fires when the consent view resolves with an email-shaped key in the request
  - `verified-email-consent-empty-state-shown` — user has no addresses bound yet
  - `verified-email-consent-verify-clicked` — opened the inline verify wizard (from either the empty-state CTA or the per-row "verify new" affordance)
  - `verified-email-consent-skipped` — clicked "Skip for now"
  - `verified-email-consent-denied-all` — clicked the "Deny all" link
  - `verified-email-consent-shared` *(prop: `source = unscoped | openid | sso`)* — clicked Continue with an email attribute selected
  - `end-verified-email-consent` — every terminal action + an `onDestroy` for the abandon path (Funnel.close() is idempotent)
- One-shot `verified-email-removed` event in `VerifiedEmailsPanel.handleRemove` after a successful remove.

No new Plausible funnels show up in the dashboard automatically — these are raw goals/events. The dashboard funnels mirror what was done for "Recovery Emails Setup" / "Recovery Email Recover": create them in Plausible → Funnels once goals appear.

## Tests

Tested via existing checks — no new tests added (analytics call sites are exercised by the wizard's existing e2e flows):

- `npm run check` — typecheck clean (the new file + edited components have no errors).
- `npx svelte-check` — 0 errors.
- `npx eslint` on the three changed files — 0 warnings.
- `npx vitest run src/frontend/src/lib/utils/analytics/` — 17/17 pass (existing `Funnel.test.ts`).
- `npm run format-check` — clean.