### PR TITLE
chore: bump PocketIC 9.0.3 → 15.0.0

### DIFF
--- a/.github/workflows/canister-tests.yml
+++ b/.github/workflows/canister-tests.yml
@@ -261,7 +261,7 @@ jobs:
       - name: Install PocketIC server
         uses: dfinity/pocketic@main
         with:
-          pocket-ic-server-version: "9.0.3"
+          pocket-ic-server-version: "15.0.0"
       - name: "Run VC issuer canister tests"
         working-directory: demos/vc_issuer
         run: |
@@ -374,7 +374,7 @@ jobs:
       - name: Install PocketIC server
         uses: dfinity/pocketic@main
         with:
-          pocket-ic-server-version: "9.0.3"
+          pocket-ic-server-version: "15.0.0"
 
       - name: "Download II wasm"
         uses: actions/download-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.20"
+version = "0.10.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8037a01ec09d6c06883a38bad4f47b8d06158ad360b841e0ae5707c9884dfaf6"
+checksum = "1347fd6b24f5ad23e4ab16d49551a03d396410dcb086e8f969c21efdf4b1dbd8"
 dependencies = [
  "anyhow",
  "binread",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.20"
+version = "0.10.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb45f4d5eff3805598ee633dd80f8afb306c023249d34b5b7dfdc2080ea1df2e"
+checksum = "ad381629d2d2940899c3a784ccd4fe59e255b5714e7520f016f839f07d2236e7"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1598,7 +1598,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1753,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "ic-management-canister-types"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7e5b8a0f7c3b320d9450ac950547db4f24a31601b5d398f9680b64427455d2"
+checksum = "3149217e24186df3f13dc45eee14cdb3e5cad07d0b2b67bd53555c1c55462957"
 dependencies = [
  "candid",
  "serde",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.40.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e7706e55836e8104c98149ec0796d20d5213fef972ac01b544657d410f1883"
+checksum = "4a775244756a5d97ff19b08071a946a4b4896904e35deb036bf215e80f2e703d"
 dependencies = [
  "candid",
  "hex",
@@ -1858,7 +1858,7 @@ dependencies = [
  "serde_cbor",
  "serde_repr",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2957,9 +2957,9 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "9.0.2"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e523c23bda9dc26ae989aab647b8bd805b54c72a3f2f00d668830d8b490c9c8"
+checksum = "4fe796a5fbeb08244338f5eb30f2de91fa12152ea2b5176f9da20fecd20b1ced"
 dependencies = [
  "backoff",
  "base64 0.13.1",
@@ -2971,8 +2971,8 @@ dependencies = [
  "ic-transport-types",
  "reqwest",
  "schemars",
+ "semver",
  "serde",
- "serde_bytes",
  "serde_cbor",
  "serde_json",
  "sha2 0.10.9",
@@ -2980,7 +2980,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -3130,7 +3130,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -3151,7 +3151,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4208,11 +4208,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4228,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4434,7 +4434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ ic-metrics-encoder = "1"
 ic-stable-structures = "0.6"
 ic-verifiable-credentials = { git = "https://github.com/dfinity/verifiable-credentials-sdk", rev = "b74c746ea5361af3da207a2c957be4a951f7a72c" }
 ic-canister-sig-creation = "1.1"
-pocket-ic = "9.0.2"
+pocket-ic = "15"
 pretty_assertions = "1.4.1"
 proptest = "1"
 base64 = "0.22"

--- a/demos/vc_issuer/Cargo.lock
+++ b/demos/vc_issuer/Cargo.lock
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.17"
+version = "0.10.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaac522d18020d5fbc8320ecb12a9b13b2137ae31133da2d42fa256a825507c4"
+checksum = "1347fd6b24f5ad23e4ab16d49551a03d396410dcb086e8f969c21efdf4b1dbd8"
 dependencies = [
  "anyhow",
  "binread",
@@ -419,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.17"
+version = "0.10.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1b4fddbd462182050989068d53604a91a3d0f117c3c8316c6818023df00add"
+checksum = "ad381629d2d2940899c3a784ccd4fe59e255b5714e7520f016f839f07d2236e7"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "ic-management-canister-types"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f3af3543f6d0cbdecd2dcdfd4737ada2bd42d935cc787eec22090c96492c76"
+checksum = "3149217e24186df3f13dc45eee14cdb3e5cad07d0b2b67bd53555c1c55462957"
 dependencies = [
  "candid",
  "serde",
@@ -1655,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.40.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e7706e55836e8104c98149ec0796d20d5213fef972ac01b544657d410f1883"
+checksum = "4a775244756a5d97ff19b08071a946a4b4896904e35deb036bf215e80f2e703d"
 dependencies = [
  "candid",
  "hex",
@@ -1668,7 +1668,7 @@ dependencies = [
  "serde_cbor",
  "serde_repr",
  "sha2 0.10.9",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1932,16 +1932,6 @@ name = "ipnet"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
-
-[[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -2412,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "9.0.2"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e523c23bda9dc26ae989aab647b8bd805b54c72a3f2f00d668830d8b490c9c8"
+checksum = "4fe796a5fbeb08244338f5eb30f2de91fa12152ea2b5176f9da20fecd20b1ced"
 dependencies = [
  "backoff",
  "base64 0.13.1",
@@ -2426,8 +2416,8 @@ dependencies = [
  "ic-transport-types",
  "reqwest",
  "schemars",
+ "semver",
  "serde",
- "serde_bytes",
  "serde_cbor",
  "serde_json",
  "sha2 0.10.9",
@@ -2435,7 +2425,7 @@ dependencies = [
  "strum 0.26.3",
  "strum_macros 0.26.4",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -2788,9 +2778,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3472,11 +3462,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3492,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3647,20 +3637,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
  "futures-util",
  "http 1.1.0",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]

--- a/demos/vc_issuer/Cargo.toml
+++ b/demos/vc_issuer/Cargo.toml
@@ -37,6 +37,6 @@ include_dir = "0.7"
 assert_matches = "1.5"
 candid_parser = "0.1"
 ic-http-certification = "2.6"
-pocket-ic = "9.0.2"
+pocket-ic = "15"
 ic-response-verification = "2.6"
 canister_tests = { path = "../../src/canister_tests" }

--- a/scripts/test-canisters.sh
+++ b/scripts/test-canisters.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-POCKET_IC_SERVER_VERSION=9.0.3
+POCKET_IC_SERVER_VERSION=15.0.0
 POCKET_IC_SERVER_PATH="pocket-ic"
 PREVIOUS_II_WASM_PATH="internet_identity_previous.wasm.gz"
 PREVIOUS_ARCHIVE_WASM_PATH="archive_previous.wasm.gz"

--- a/src/archive/tests/tests.rs
+++ b/src/archive/tests/tests.rs
@@ -51,9 +51,11 @@ fn should_expose_status() -> Result<(), RejectResponse> {
     let canister_id = install_archive_canister(&env, ARCHIVE_WASM.clone());
     let status = api::status(&env, canister_id)?;
     // The point of this test is that an anonymous caller can read the status
-    // (the `?` above). The exact cycle balance is a PocketIC default — newer
-    // versions fund freshly-created canisters — so assert the status exposes a
-    // funded balance rather than a hard-coded value.
+    // (the `?` above). The exact cycle balance is a PocketIC default: newer
+    // versions fund freshly-created canisters, so assert the status exposes a
+    // funded balance rather than a hard-coded value. `cycles` is a `candid::Nat`;
+    // we compare against the `0u8` primitive via `Nat: PartialOrd<u8>` because
+    // constructing an owned `Nat` for the comparison trips `clippy::cmp_owned`.
     assert!(status.canister_status.cycles > 0u8);
     Ok(())
 }

--- a/src/archive/tests/tests.rs
+++ b/src/archive/tests/tests.rs
@@ -50,7 +50,11 @@ fn should_expose_status() -> Result<(), RejectResponse> {
     let env = env();
     let canister_id = install_archive_canister(&env, ARCHIVE_WASM.clone());
     let status = api::status(&env, canister_id)?;
-    assert_eq!(status.canister_status.cycles, 0u8);
+    // The point of this test is that an anonymous caller can read the status
+    // (the `?` above). The exact cycle balance is a PocketIC default — newer
+    // versions fund freshly-created canisters — so assert the status exposes a
+    // funded balance rather than a hard-coded value.
+    assert!(status.canister_status.cycles > 0u8);
     Ok(())
 }
 

--- a/src/internet_identity/tests/integration/archive_integration.rs
+++ b/src/internet_identity/tests/integration/archive_integration.rs
@@ -58,12 +58,20 @@ mod deployment_tests {
         });
         let ii_canister = setup_ii(&env, arg);
         env.add_cycles(ii_canister, 150_000_000_000);
+        let balance_before = env.cycle_balance(ii_canister);
 
         let result = ii_api::deploy_archive(&env, ii_canister, &ARCHIVE_WASM)
             .expect("archive deployment failed");
 
         assert!(matches!(result, DeployArchiveResult::Success(_)));
-        assert_eq!(env.cycle_balance(ii_canister), 50_000_000_000);
+        // Deploying the archive spends exactly `canister_creation_cycles_cost`
+        // (100B) to create it. Assert the delta rather than an absolute balance:
+        // the latter is base-dependent, since newer PocketIC versions fund newly
+        // created canisters (II included) by default.
+        assert_eq!(
+            env.cycle_balance(ii_canister),
+            balance_before - 100_000_000_000
+        );
     }
 
     #[test]

--- a/src/internet_identity/tests/integration/archive_integration.rs
+++ b/src/internet_identity/tests/integration/archive_integration.rs
@@ -45,6 +45,10 @@ mod deployment_tests {
 
     #[test]
     fn should_deploy_archive_with_cycles() {
+        // Charged to create the archive canister. Kept in one place so the init
+        // arg and the post-deploy assertion below cannot drift apart.
+        const ARCHIVE_CREATION_CYCLES_COST: u64 = 100_000_000_000; // current cost in application subnets
+
         let env = env();
         let arg = Some(InternetIdentityInit {
             archive_config: Some(ArchiveConfig {
@@ -53,7 +57,7 @@ mod deployment_tests {
                 polling_interval_ns: 0,
                 entries_fetch_limit: 0,
             }),
-            canister_creation_cycles_cost: Some(100_000_000_000), // current cost in application subnets
+            canister_creation_cycles_cost: Some(ARCHIVE_CREATION_CYCLES_COST),
             ..InternetIdentityInit::default()
         });
         let ii_canister = setup_ii(&env, arg);
@@ -64,14 +68,16 @@ mod deployment_tests {
             .expect("archive deployment failed");
 
         assert!(matches!(result, DeployArchiveResult::Success(_)));
-        // Deploying the archive spends exactly `canister_creation_cycles_cost`
-        // (100B) to create it. Assert the delta rather than an absolute balance:
-        // the latter is base-dependent, since newer PocketIC versions fund newly
-        // created canisters (II included) by default.
-        assert_eq!(
-            env.cycle_balance(ii_canister),
-            balance_before - 100_000_000_000
-        );
+        // Deploying the archive spends exactly `canister_creation_cycles_cost` to
+        // create it. Assert the delta rather than an absolute balance: the latter
+        // is base-dependent, since newer PocketIC versions fund newly created
+        // canisters (II included) by default. A checked subtraction gives a clear
+        // failure if the deploy unexpectedly failed to spend cycles.
+        let balance_after = env.cycle_balance(ii_canister);
+        let spent = balance_before
+            .checked_sub(balance_after)
+            .expect("archive deployment did not decrease the II cycle balance");
+        assert_eq!(spent, ARCHIVE_CREATION_CYCLES_COST as u128);
     }
 
     #[test]

--- a/src/internet_identity/tests/integration/attributes.rs
+++ b/src/internet_identity/tests/integration/attributes.rs
@@ -1222,13 +1222,14 @@ fn icrc3_test_vectors() {
     let expected_value: serde_json::Value = serde_json::from_str(&expected_raw)
         .unwrap_or_else(|e| panic!("failed to parse {}: {e}", snapshot_path.display()));
 
-    // Strip `certificate_cbor_hex` from both sides before comparing: the CBOR
-    // certificate's BLS signature is not stable across PocketIC versions /
-    // platforms, while the canister-produced `message_hex` and
-    // `signed_message_hex` bytes are fully deterministic and are what dapps
-    // actually rely on.
-    let generated_stable = serialize_snapshot_pretty(&strip_cert(&snapshot));
-    let expected_stable = serialize_snapshot_pretty(&strip_cert(&expected_value));
+    // Strip the environment-dependent fields from both sides before comparing:
+    // the per-vector CBOR certificate's BLS signature, the subnet `root_key_hex`,
+    // and the `canister_sig_pk_hex` (which embeds the PocketIC-assigned canister
+    // id) all vary across PocketIC versions / platforms. The canister-produced
+    // `message_hex` and `signed_message_hex` bytes are fully deterministic and
+    // are what dapps actually rely on.
+    let generated_stable = serialize_snapshot_pretty(&strip_unstable(&snapshot));
+    let expected_stable = serialize_snapshot_pretty(&strip_unstable(&expected_value));
 
     assert_eq!(
         generated_stable, expected_stable,
@@ -1248,11 +1249,20 @@ fn serialize_snapshot_pretty(value: &serde_json::Value) -> String {
     String::from_utf8(buf).expect("serde_json produced non-UTF8 output")
 }
 
-fn strip_cert(value: &serde_json::Value) -> serde_json::Value {
+fn strip_unstable(value: &serde_json::Value) -> serde_json::Value {
     let mut cloned = value.clone();
+    if let Some(obj) = cloned.as_object_mut() {
+        // Top-level environment-dependent fields: the subnet root key and the
+        // canister signature public key (which embeds the PocketIC-assigned
+        // canister id) both vary across PocketIC versions / platforms.
+        obj.remove("root_key_hex");
+        obj.remove("canister_sig_pk_hex");
+    }
     if let Some(vectors) = cloned.get_mut("vectors").and_then(|v| v.as_array_mut()) {
         for vector in vectors {
             if let Some(obj) = vector.as_object_mut() {
+                // The CBOR certificate embeds the subnet's BLS signature, which
+                // is non-deterministic across runs.
                 obj.remove("certificate_cbor_hex");
             }
         }


### PR DESCRIPTION
# Motivation

Bump the PocketIC test harness to v15 — the first version whose bundled replica implements the request-delegation `permissions` extension (dfinity/ic#10449). This is a prerequisite for adding integration tests that exercise **read-only (queries-only) delegation enforcement** end-to-end (follow-up to #4016). Landing the bump on its own keeps that dependency/infra change reviewable in isolation, separate from the feature work.

# Changes

- **`Cargo.toml`**: `pocket-ic` `"9.0.2"` → `"15"`. This transitively bumps `candid` 0.10.20→0.10.31, `ic-management-canister-types` 0.3.3→0.5.0, and `ic-transport-types` 0.40→0.45 across the workspace (i.e. it touches the II canister's own dependency tree). The canister and the test framework compile with **no code changes**.
- **`demos/vc_issuer/Cargo.toml`**: same `pocket-ic` `"9.0.2"` → `"15"` bump (it pins pocket-ic directly *and* path-depends on `canister_tests`, so it must move in lockstep to avoid a two-version collision), plus the `Cargo.lock` refresh.
- **`scripts/test-canisters.sh`**: `POCKET_IC_SERVER_VERSION` 9.0.3 → 15.0.0 (same release-asset name; download mechanism unchanged).
- **`.github/workflows/canister-tests.yml`**: the two `dfinity/pocketic` action pins 9.0.3 → 15.0.0.
- **Test adaptations for v15's cycle-funding behavior** (v15 funds freshly-created canisters with a default balance; no production code is affected):
  - `archive::should_expose_status`: assert the status exposes a funded balance (`> 0`) instead of a hard-coded `0`.
  - `should_deploy_archive_with_cycles`: assert the *delta* spent on archive creation (exactly `canister_creation_cycles_cost`) rather than an absolute, base-dependent post-deploy balance.
  - `icrc3_test_vectors`: also strip the environment-dependent top-level `root_key_hex` and `canister_sig_pk_hex` (the latter embeds the PocketIC-assigned canister id) before comparing. The deterministic `message_hex` / `signed_message_hex` bytes are byte-identical — no II-side change.

The E2E Playwright launcher pin (`icp-cli-network-launcher` v12, see the in-file comment about dfinity/ic#10226) is intentionally **left untouched** — that's a separate pocket-ic build used only by the browser suite.

# Tests

- `cargo check` across `internet_identity` + `canister_tests` (incl. tests): clean, no porting needed.
- Full `delegation` integration suite (**37 tests**) passes locally against `pocket-ic-server 15.0.0`.
- The three adapted tests above pass locally against `pocket-ic-server 15.0.0`.
- CI runs the complete canister-tests suite on v15.

> Note for the follow-up enforcement tests: round-tripping an II canister-signature delegation through the replica's ingress validation may interact with dfinity/ic#10226 (strict `subnet_type` cert check). That will be verified when the enforcement-test harness (`make_live` + `ic-agent`) is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gHRjyFYqumMxAMwbPRLuN

---
_Generated by [Claude Code](https://claude.ai/code/session_018gHRjyFYqumMxAMwbPRLuN)_