### PR TITLE
fix(fe): gate read-only access UI behind a feature flag (default off)

### DIFF
--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -152,6 +152,18 @@ export const EMAIL_RECOVERY_SETUP = createFeatureFlagStore(
   enableOnIdAiDomains("EMAIL_RECOVERY_SETUP"),
 );
 
+/// Gates the read-only ("queries-only") access option in the sign-in flows
+/// (`/continue`, `/cli`, `/mcp`). Kept OFF by default — including on id.ai /
+/// beta.id.ai — because a queries-only delegation carries `permissions =
+/// "queries"` in its canister-signed message, and no released agent stack
+/// (`ic-agent` / `ic-transport-types` / `@icp-sdk/core`) round-trips that
+/// field yet: the field is dropped when the delegation is re-serialized into
+/// the request envelope, so the replica recomputes a different hash and
+/// canister-signature verification fails ("sig not found in the signature
+/// tree"). With the flag off, all flows send full access. Flip this on once
+/// the agent stack preserves the delegation `permissions` field.
+export const READ_ONLY_MODE = createFeatureFlagStore("READ_ONLY_MODE", false);
+
 export default {
   DOMAIN_COMPATIBILITY,
   HARDWARE_KEY_TEST,
@@ -161,4 +173,5 @@ export default {
   MIN_GUIDED_UPGRADE,
   EMAIL_RECOVERY,
   EMAIL_RECOVERY_SETUP,
+  READ_ONLY_MODE,
 } as Record<string, FeatureFlagStore>;

--- a/src/frontend/src/routes/(new-styling)/authorize/views/ContinueView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/ContinueView.svelte
@@ -100,7 +100,10 @@
   >(null);
   let accounts = $state<AccountInfo[]>();
   let isAuthenticatingDefault = $state(false);
-  // Authorizations default to full access; "Read-only mode" is the opt-in.
+  // When READ_ONLY_MODE is enabled, authorizations default to full access and
+  // "Read-only mode" is the opt-in. While the flag is off (the current
+  // default), the toggle below is hidden and `effectiveAccessLevel` forces
+  // full access, so this state is never surfaced to the user.
   let accessLevel: AccessLevel = $state("full-access");
   // While the read-only feature is flagged off, the toggle is hidden and every
   // authorization is full access regardless of the (unreachable) toggle state.

--- a/src/frontend/src/routes/(new-styling)/authorize/views/ContinueView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/ContinueView.svelte
@@ -34,6 +34,7 @@
   import { slide, fade, scale } from "svelte/transition";
   import AccessLevelToggle from "$lib/components/ui/AccessLevelToggle.svelte";
   import type { AccessLevel } from "$lib/utils/accessLevel";
+  import { READ_ONLY_MODE } from "$lib/state/featureFlags";
   import Dialog from "$lib/components/ui/Dialog.svelte";
   import EditAccount from "$lib/components/views/EditAccount.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
@@ -101,6 +102,11 @@
   let isAuthenticatingDefault = $state(false);
   // Authorizations default to full access; "Read-only mode" is the opt-in.
   let accessLevel: AccessLevel = $state("full-access");
+  // While the read-only feature is flagged off, the toggle is hidden and every
+  // authorization is full access regardless of the (unreachable) toggle state.
+  const effectiveAccessLevel: AccessLevel = $derived(
+    $READ_ONLY_MODE ? accessLevel : "full-access",
+  );
   let isMultipleAccountsEnabled = $state(
     readToggle($lastUsedIdentitiesStore.selected!.identityNumber),
   );
@@ -196,7 +202,7 @@
               .then(throwCanisterError)
               .then((account) => account.account_number[0])
           : Promise.resolve(defaultAccountNumber);
-      onAuthorize(accountNumberPromise, accessLevel);
+      onAuthorize(accountNumberPromise, effectiveAccessLevel);
     } catch (error) {
       handleError(error);
     } finally {
@@ -211,7 +217,7 @@
       if (!$isAuthenticatedStore) {
         await authLastUsedFlow.authenticate($lastUsedIdentitiesStore.selected!);
       }
-      onAuthorize(Promise.resolve(accountNumber), accessLevel);
+      onAuthorize(Promise.resolve(accountNumber), effectiveAccessLevel);
     } catch (error) {
       handleError(error);
     } finally {
@@ -573,12 +579,14 @@
       </button>
     </Tooltip>
   </div>
-  <AccessLevelToggle
-    bind:accessLevel
-    prompt="read-only"
-    disabled={isAuthenticatingDefault}
-    class="mt-4"
-  />
+  {#if $READ_ONLY_MODE}
+    <AccessLevelToggle
+      bind:accessLevel
+      prompt="read-only"
+      disabled={isAuthenticatingDefault}
+      class="mt-4"
+    />
+  {/if}
 </div>
 
 {#if authLastUsedFlow.systemOverlay}

--- a/src/frontend/src/routes/(new-styling)/cli/views/CliAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/views/CliAuthorizeView.svelte
@@ -3,6 +3,7 @@
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import AccessLevelToggle from "$lib/components/ui/AccessLevelToggle.svelte";
   import type { AccessLevel } from "$lib/utils/accessLevel";
+  import { READ_ONLY_MODE } from "$lib/state/featureFlags";
   import CliHeader from "../components/CliHeader.svelte";
   import TerminalBlock from "../components/TerminalBlock.svelte";
   import { Trans } from "$lib/components/locale";
@@ -22,11 +23,16 @@
   // user's behalf, so it gets query-only access unless the user opts into
   // full access by checking the "Full access" box.
   let accessLevel: AccessLevel = $state("read-only");
+  // While the read-only feature is flagged off, the toggle is hidden and CLI
+  // access is full (the toggle's read-only default is unreachable).
+  const effectiveAccessLevel: AccessLevel = $derived(
+    $READ_ONLY_MODE ? accessLevel : "full-access",
+  );
 
   const handleClick = async () => {
     busy = true;
     try {
-      await onAuthorize(accessLevel);
+      await onAuthorize(effectiveAccessLevel);
     } finally {
       busy = false;
     }
@@ -73,12 +79,14 @@
       {/if}
     </p>
 
-    <AccessLevelToggle
-      bind:accessLevel
-      prompt="full-access"
-      disabled={busy}
-      class="mt-4"
-    />
+    {#if $READ_ONLY_MODE}
+      <AccessLevelToggle
+        bind:accessLevel
+        prompt="full-access"
+        disabled={busy}
+        class="mt-4"
+      />
+    {/if}
 
     <button
       class="btn btn-primary btn-xl mt-6 w-full"

--- a/src/frontend/src/routes/(new-styling)/cli/views/CliAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/views/CliAuthorizeView.svelte
@@ -19,9 +19,11 @@
   const { domain, onAuthorize }: Props = $props();
 
   let busy = $state(false);
-  // CLI access defaults to read-only: a linked CLI usually reads on the
-  // user's behalf, so it gets query-only access unless the user opts into
-  // full access by checking the "Full access" box.
+  // When READ_ONLY_MODE is enabled, CLI access defaults to read-only (a linked
+  // CLI usually reads on the user's behalf, so it gets query-only access unless
+  // the user opts into full access via the "Full access" box). While the flag
+  // is off (the current default), the toggle is hidden and `effectiveAccessLevel`
+  // forces full access, so this default is unreachable.
   let accessLevel: AccessLevel = $state("read-only");
   // While the read-only feature is flagged off, the toggle is hidden and CLI
   // access is full (the toggle's read-only default is unreachable).

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -28,9 +28,11 @@
 
   const { mcpServerHost, requestedTtlSeconds, onAuthorize }: Props = $props();
 
-  // MCP connections default to read-only (opt-out): the server can read on the
-  // user's behalf across their apps, but its per-app delegations are query-only
-  // unless the user opts into full access by unchecking.
+  // When READ_ONLY_MODE is enabled, MCP connections default to read-only
+  // (opt-out): the server can read across the user's apps, but its per-app
+  // delegations are query-only unless the user unchecks. While the flag is off
+  // (the current default), the toggle is hidden and `effectiveAccessLevel`
+  // forces full access, so this default is unreachable.
   let accessLevel: AccessLevel = $state("read-only");
   // While the read-only feature is flagged off, the toggle is hidden and the
   // connection is full access (the toggle's read-only default is unreachable).

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -5,6 +5,7 @@
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import AccessLevelToggle from "$lib/components/ui/AccessLevelToggle.svelte";
   import type { AccessLevel } from "$lib/utils/accessLevel";
+  import { READ_ONLY_MODE } from "$lib/state/featureFlags";
   import { ChevronDownIcon } from "@lucide/svelte";
   import { t } from "$lib/stores/locale.store";
   import { AuthLastUsedFlow } from "$lib/flows/authLastUsedFlow.svelte";
@@ -31,6 +32,11 @@
   // user's behalf across their apps, but its per-app delegations are query-only
   // unless the user opts into full access by unchecking.
   let accessLevel: AccessLevel = $state("read-only");
+  // While the read-only feature is flagged off, the toggle is hidden and the
+  // connection is full access (the toggle's read-only default is unreachable).
+  const effectiveAccessLevel: AccessLevel = $derived(
+    $READ_ONLY_MODE ? accessLevel : "full-access",
+  );
 
   // Connecting authorizes this agent for the user's identity — no account is
   // chosen here (accounts are app-specific; the MCP server is the connector, not
@@ -109,7 +115,7 @@
         sessionStore.reset();
         await authLastUsedFlow.authenticate(selected);
       }
-      onAuthorize(selectedTtlSeconds, accessLevel);
+      onAuthorize(selectedTtlSeconds, effectiveAccessLevel);
     } catch (error) {
       handleError(error);
     } finally {
@@ -156,12 +162,14 @@
         </button>
       </Select>
     </div>
-    <AccessLevelToggle
-      bind:accessLevel
-      prompt="read-only"
-      disabled={isAuthorizing}
-      class="mb-6"
-    />
+    {#if $READ_ONLY_MODE}
+      <AccessLevelToggle
+        bind:accessLevel
+        prompt="read-only"
+        disabled={isAuthorizing}
+        class="mb-6"
+      />
+    {/if}
     <button
       class="btn btn-primary w-full gap-2"
       onclick={handleAllowAccess}

--- a/src/frontend/tests/e2e-playwright/routes/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/index.spec.ts
@@ -36,11 +36,12 @@ test("Authorize by signing in with an existing passkey", async ({
     await authPage
       .getByRole("button", { name: "Sign in with passkey" })
       .click();
-    // Authorizations default to full access: the "Read-only mode" checkbox
-    // is the opt-in and must start unticked.
+    // The read-only feature is flagged off, so the access-level toggle is
+    // hidden and authorizations are full access (a queries-only delegation
+    // would fail closed in every current agent — see the READ_ONLY_MODE flag).
     await expect(
       authPage.getByRole("checkbox", { name: "Read-only mode" }),
-    ).not.toBeChecked();
+    ).toHaveCount(0);
     await authPage
       .getByRole("button", { name: "Continue", exact: true })
       .click();

--- a/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
@@ -143,12 +143,12 @@ test("Generic CLI sign-in posts a two-hop delegation chain to the loopback callb
   await addVirtualAuthenticator(page);
   await page.goto(await cli.resolveAuthorizeUrl(page));
   await signUp(page);
-  // CLI access defaults to read-only: the "Full access" checkbox is the
-  // opt-in and must start unticked. (A flipped default here silently grants
-  // update-capable sessions.)
-  await expect(
-    page.getByRole("checkbox", { name: "Full access" }),
-  ).not.toBeChecked();
+  // The read-only feature is flagged off, so the access-level toggle is
+  // hidden and CLI sign-in is full access (a queries-only delegation would
+  // fail closed in every current agent — see the READ_ONLY_MODE flag).
+  await expect(page.getByRole("checkbox", { name: "Full access" })).toHaveCount(
+    0,
+  );
   await page.getByRole("button", { name: "Continue", exact: true }).click();
 
   const body = await cli.receivedDelegation;

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -243,12 +243,12 @@ test("Allow access posts a two-hop delegation chain", async ({ page, mcp }) => {
   await mcp.trustServer(page);
 
   await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
-  // MCP connections default to read-only: the "Read-only mode" checkbox must
-  // start ticked, so the server's per-app delegations are queries-only unless
-  // the user opts out.
+  // The read-only feature is flagged off, so the access-level toggle is
+  // hidden and the connection is full access (a queries-only delegation would
+  // fail closed in every current agent — see the READ_ONLY_MODE flag).
   await expect(
     page.getByRole("checkbox", { name: "Read-only mode" }),
-  ).toBeChecked();
+  ).toHaveCount(0);
   await page.getByRole("button", { name: "Allow access" }).click();
 
   const body = await mcp.receivedDelegation;


### PR DESCRIPTION
# Motivation

Read-only mode (#4016) is broken end-to-end with today's agent stack. A read-only ("queries-only") delegation is a canister signature over a representation-independent hash that **includes** `permissions = "queries"`. No released agent (`ic-agent` / `ic-transport-types`, checked through 0.47.3; `@icp-sdk/core`) has a `permissions` field on its `Delegation` wire type, and there is no `#[serde(flatten)]` catch-all — so the field is **dropped** when the delegation is re-serialized into the request envelope. The replica then recomputes the hash over `{pubkey, expiration, targets}` (no `permissions`), which the II canister never signed, and canister-signature verification fails:

```
invalid delegation chain: A canister signature in the delegation chain
could not be verified: sig not found in the signature tree
```

This surfaced as **MCP connections in read-only mode failing**: the read-only grant makes the MCP server mint queries-only per-app delegations, which its agent can't use. The same fails-closed applies to read-only `/continue` and `/cli` sessions.

Rather than revert the feature, gate the UI off until the agent stack preserves the delegation `permissions` field (agent-side field preservation is enough to un-break verification; the field doesn't need to be semantically interpreted by the agent — enforcement stays the replica's job).

# Changes

- New `READ_ONLY_MODE` feature flag in `src/frontend/src/lib/state/featureFlags.ts`, **off by default everywhere** (including `id.ai` / `beta.id.ai` — no domain override). Documented with the reason and the flip condition.
- `AccessLevelToggle` is hidden in all three flows (`ContinueView`, `CliAuthorizeView`, `McpAuthorizeView`) when the flag is off.
- Each flow computes an `effectiveAccessLevel` that is forced to `full-access` while the flag is off. This is the load-bearing part: `/cli` and `/mcp` default their (now-hidden) toggle to read-only, so simply hiding it would otherwise leave them minting the unusable queries-only delegations. With the flag off, every flow sends full access.
- e2e assertions updated to verify the toggle is absent by default (`toHaveCount(0)`).

The backend capability, the candid `Permissions` type, and all delegation tests from #4016 are unchanged and remain in place — re-enabling read-only is a one-line flip of the flag default once agents preserve the field.

# Tests

- `tsc --noEmit` / `svelte-check`: 0 errors.
- `eslint`, `prettier`: clean.
- Frontend unit tests pass (18), including the `toPermissionsArg` mapping and the `/cli` + `/mcp` authorize-helper argument tests (unaffected — they exercise the mapping directly, below the flag).
- e2e specs (`cli`, `mcp`, `authorize`) updated to assert the access-level toggle is not rendered while the flag is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gHRjyFYqumMxAMwbPRLuN

---
_Generated by [Claude Code](https://claude.ai/code/session_018gHRjyFYqumMxAMwbPRLuN)_