### PR TITLE
Show redirect message on MCP sign-in success screen

### DIFF
--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -72,7 +72,7 @@
     | { kind: "authorize" }
     | { kind: "untrusted" }
     | { kind: "connecting" }
-    | { kind: "close" }
+    | { kind: "close"; redirecting: boolean }
     | { kind: "invalid" };
 
   // The phase the page opens on: a returning user with a previously-used
@@ -207,7 +207,7 @@
         // navigation below never replaces the document (a 204 or attachment
         // response) or when the user comes Back to a bfcache-restored page —
         // rather than stranding them on the connecting spinner.
-        phase = { kind: "close" };
+        phase = { kind: "close", redirecting: finishUrl !== undefined };
         if (finishUrl !== undefined) {
           // The trusted server asked to finish the flow on its side (already
           // validated same-origin with the callback): hand it the tab.
@@ -291,7 +291,7 @@
 {:else if phase.kind === "connecting" && mcpServer !== undefined}
   <McpConnectingView mcpServer={mcpServer.host} />
 {:else if phase.kind === "close"}
-  <McpCloseWindowView />
+  <McpCloseWindowView redirecting={phase.redirecting} />
 {/if}
 
 <ManageHandoff

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpCloseWindowView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpCloseWindowView.svelte
@@ -2,12 +2,23 @@
   import { CheckIcon } from "@lucide/svelte";
   import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
   import { t } from "$lib/stores/locale.store";
+
+  interface Props {
+    /** Whether the tab is being redirected back to the agent — true when the
+     *  trusted server returned a `finish_url`. When false this is the resting
+     *  screen and there's nothing to redirect to. */
+    redirecting: boolean;
+  }
+
+  const { redirecting }: Props = $props();
 </script>
 
 <!--
-  Centered, card-less "you're done" page. Once the MCP server has accepted the
-  delegation there's nothing actionable here; the user just closes the tab and
-  returns to their MCP client.
+  Centered, card-less success page shown once the MCP server's session key has
+  been registered with the backend. When the trusted server returned a
+  `finish_url` the tab is being sent back to the agent to finish the flow, so we
+  say a redirect is underway; otherwise there's nothing to redirect to and this
+  is the resting screen, so we just confirm the sign-in.
 -->
 <div class="flex flex-col items-center gap-5 px-6 text-center">
   <FeaturedIcon size="lg" variant="success">
@@ -17,6 +28,10 @@
     {$t`You're signed in`}
   </h1>
   <p class="text-text-tertiary text-base">
-    {$t`You can close this window.`}
+    {#if redirecting}
+      {$t`Redirecting back to the agent…`}
+    {:else}
+      {$t`You can return to your agent.`}
+    {/if}
   </p>
 </div>

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpCloseWindowView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpCloseWindowView.svelte
@@ -2,6 +2,7 @@
   import { CheckIcon } from "@lucide/svelte";
   import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
   import { t } from "$lib/stores/locale.store";
+  import { onMount } from "svelte";
 
   interface Props {
     /** Whether the tab is being redirected back to the agent — true when the
@@ -11,14 +12,29 @@
   }
 
   const { redirecting }: Props = $props();
+
+  // A successful redirect replaces the document (and unmounts this view) within
+  // a moment. If we're still mounted after a few seconds the navigation never
+  // took — a `finish_url` that doesn't replace the document (204/attachment) or
+  // a bfcache back-navigation to this restored page — so reveal a way out
+  // rather than leaving the user on a "Redirecting…" message that never ends.
+  let redirectStalled = $state(false);
+  onMount(() => {
+    if (!redirecting) {
+      return;
+    }
+    const timer = setTimeout(() => (redirectStalled = true), 5000);
+    return () => clearTimeout(timer);
+  });
 </script>
 
 <!--
   Centered, card-less success page shown once the MCP server's session key has
   been registered with the backend. When the trusted server returned a
   `finish_url` the tab is being sent back to the agent to finish the flow, so we
-  say a redirect is underway; otherwise there's nothing to redirect to and this
-  is the resting screen, so we just confirm the sign-in.
+  say a redirect is underway (with a fallback hint if it stalls); otherwise
+  there's nothing to redirect to and this is the resting screen, so we just
+  confirm the sign-in.
 -->
 <div class="flex flex-col items-center gap-5 px-6 text-center">
   <FeaturedIcon size="lg" variant="success">
@@ -27,11 +43,18 @@
   <h1 class="text-text-primary text-2xl font-medium">
     {$t`You're signed in`}
   </h1>
-  <p class="text-text-tertiary text-base">
-    {#if redirecting}
-      {$t`Redirecting back to the agent…`}
-    {:else}
-      {$t`You can return to your agent.`}
+  <div class="flex flex-col items-center gap-1">
+    <p class="text-text-tertiary text-base">
+      {#if redirecting}
+        {$t`Redirecting back to the agent…`}
+      {:else}
+        {$t`You can return to your agent.`}
+      {/if}
+    </p>
+    {#if redirecting && redirectStalled}
+      <p class="text-text-tertiary text-sm">
+        {$t`If nothing happens, you can return to your agent.`}
+      </p>
     {/if}
-  </p>
+  </div>
 </div>


### PR DESCRIPTION
# Motivation

The terminal MCP sign-in success screen (`McpCloseWindowView`) told the user "You can close this window." That framing doesn't fit the flow: after the session key is registered, the tab is either redirected back to the agent (when the trusted server returns a `finish_url`) or it comes to rest on this screen. The copy should reflect what's actually happening in each case.

# Changes

- `McpCloseWindowView` now takes a `redirecting` prop and shows conditional secondary text:
  - **Redirect case** (server returned a `finish_url`): `Redirecting back to the agent…`
  - **Resting case** (no `finish_url`): `You can return to your agent.` — no false promise of a redirect that won't fire.
- **Stall fallback**: since `+page.svelte` sets the `close` phase *before* `window.location.assign` (so users aren't stranded on the spinner when the navigation never replaces the document — a 204/attachment `finish_url`, or a bfcache back-navigation), the view starts a 5s timer on mount while redirecting. A successful redirect unmounts the view and clears the timer; if it stalls, the timer reveals a hint: `If nothing happens, you can return to your agent.`
- `+page.svelte` sets `redirecting` on the terminal `close` phase from whether `mcpAuthorize` returned a `finish_url`, and passes it to the view.
- Updated the component comment to describe the current session-key registration flow (previously it referenced the old delegation-delivery flow and claimed there was no redirect).

The CLI close-window screen is intentionally left unchanged: it returns to the terminal via a loopback callback, so "close this window" is still correct there.

# Tests

Copy/UI-only change. Existing e2e tests assert the unchanged "You're signed in" heading in both the redirect and no-redirect scenarios and continue to pass. Locale catalogs are regenerated by the build's `lingui extract` step, which picks up the new source strings.
