### PR TITLE
Always show Read-only mode in the MCP connect flow

### DIFF
--- a/src/frontend/src/lib/state/featureFlags.ts
+++ b/src/frontend/src/lib/state/featureFlags.ts
@@ -152,16 +152,19 @@ export const EMAIL_RECOVERY_SETUP = createFeatureFlagStore(
   enableOnIdAiDomains("EMAIL_RECOVERY_SETUP"),
 );
 
-/// Gates the read-only ("queries-only") access option in the sign-in flows
-/// (`/continue`, `/cli`, `/mcp`). Kept OFF by default — including on id.ai /
-/// beta.id.ai — because a queries-only delegation carries `permissions =
-/// "queries"` in its canister-signed message, and no released agent stack
-/// (`ic-agent` / `ic-transport-types` / `@icp-sdk/core`) round-trips that
-/// field yet: the field is dropped when the delegation is re-serialized into
-/// the request envelope, so the replica recomputes a different hash and
-/// canister-signature verification fails ("sig not found in the signature
-/// tree"). With the flag off, all flows send full access. Flip this on once
-/// the agent stack preserves the delegation `permissions` field.
+/// Gates the read-only ("queries-only") access option in the `/continue` and
+/// `/cli` sign-in flows. (The `/mcp` flow always offers it, ungated: there the
+/// choice is persisted with the access grant and applies to the per-app
+/// delegations the server later obtains, while its standing delegation stays
+/// full access.) Kept OFF by default — including on id.ai / beta.id.ai —
+/// because a queries-only delegation carries `permissions = "queries"` in its
+/// canister-signed message, and no released agent stack (`ic-agent` /
+/// `ic-transport-types` / `@icp-sdk/core`) round-trips that field yet: the
+/// field is dropped when the delegation is re-serialized into the request
+/// envelope, so the replica recomputes a different hash and canister-signature
+/// verification fails ("sig not found in the signature tree"). With the flag
+/// off, these two flows send full access. Flip this on once the agent stack
+/// preserves the delegation `permissions` field.
 export const READ_ONLY_MODE = createFeatureFlagStore("READ_ONLY_MODE", false);
 
 export default {

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpAuthorizeView.svelte
@@ -5,7 +5,6 @@
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import AccessLevelToggle from "$lib/components/ui/AccessLevelToggle.svelte";
   import type { AccessLevel } from "$lib/utils/accessLevel";
-  import { READ_ONLY_MODE } from "$lib/state/featureFlags";
   import { ChevronDownIcon } from "@lucide/svelte";
   import { t } from "$lib/stores/locale.store";
   import { AuthLastUsedFlow } from "$lib/flows/authLastUsedFlow.svelte";
@@ -28,17 +27,10 @@
 
   const { mcpServerHost, requestedTtlSeconds, onAuthorize }: Props = $props();
 
-  // When READ_ONLY_MODE is enabled, MCP connections default to read-only
-  // (opt-out): the server can read across the user's apps, but its per-app
-  // delegations are query-only unless the user unchecks. While the flag is off
-  // (the current default), the toggle is hidden and `effectiveAccessLevel`
-  // forces full access, so this default is unreachable.
+  // MCP connections default to read-only (opt-out): the server can read across
+  // the user's apps, but its per-app delegations are query-only unless the user
+  // unchecks "Read-only mode" to grant full access.
   let accessLevel: AccessLevel = $state("read-only");
-  // While the read-only feature is flagged off, the toggle is hidden and the
-  // connection is full access (the toggle's read-only default is unreachable).
-  const effectiveAccessLevel: AccessLevel = $derived(
-    $READ_ONLY_MODE ? accessLevel : "full-access",
-  );
 
   // Connecting authorizes this agent for the user's identity — no account is
   // chosen here (accounts are app-specific; the MCP server is the connector, not
@@ -117,7 +109,7 @@
         sessionStore.reset();
         await authLastUsedFlow.authenticate(selected);
       }
-      onAuthorize(selectedTtlSeconds, effectiveAccessLevel);
+      onAuthorize(selectedTtlSeconds, accessLevel);
     } catch (error) {
       handleError(error);
     } finally {
@@ -164,14 +156,12 @@
         </button>
       </Select>
     </div>
-    {#if $READ_ONLY_MODE}
-      <AccessLevelToggle
-        bind:accessLevel
-        prompt="read-only"
-        disabled={isAuthorizing}
-        class="mb-6"
-      />
-    {/if}
+    <AccessLevelToggle
+      bind:accessLevel
+      prompt="read-only"
+      disabled={isAuthorizing}
+      class="mb-6"
+    />
     <button
       class="btn btn-primary w-full gap-2"
       onclick={handleAllowAccess}

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -243,12 +243,15 @@ test("Allow access posts a two-hop delegation chain", async ({ page, mcp }) => {
   await mcp.trustServer(page);
 
   await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
-  // The read-only feature is flagged off, so the access-level toggle is
-  // hidden and the connection is full access (a queries-only delegation would
-  // fail closed in every current agent — see the READ_ONLY_MODE flag).
+  // The MCP flow always shows the access-level toggle, defaulting to read-only
+  // (opt-out): the "Read-only mode" box is shown checked. That choice is
+  // persisted with the access grant and applies to the per-app delegations the
+  // server later obtains; the standing delegation posted here stays full access
+  // (so the server can still call the update prepare endpoint), so this two-hop
+  // chain is unaffected by the toggle.
   await expect(
     page.getByRole("checkbox", { name: "Read-only mode" }),
-  ).toHaveCount(0);
+  ).toBeChecked();
   await page.getByRole("button", { name: "Allow access" }).click();
 
   const body = await mcp.receivedDelegation;


### PR DESCRIPTION
# Motivation

The `READ_ONLY_MODE` front-end feature flag gates the read-only ("queries-only") access-level toggle across the `/continue`, `/cli`, and `/mcp` sign-in flows, and is off by default. We want the "Read-only mode" toggle to be permanently available in the MCP connect flow, while keeping the flag in place for the other flows.

Unlike the other flows, showing read-only in the MCP flow does not require the flag's release condition: the read-only choice is persisted with the access grant (`mcp_set_access`) and only applies to the per-app delegations the server later obtains. The standing delegation posted at connect time always stays full access (so the server can still call the update `prepare` endpoint), so it never carries the `permissions = "queries"` field that current agent stacks fail to round-trip.

# Changes

- `mcp/views/McpAuthorizeView.svelte`: removed the `READ_ONLY_MODE` import, dropped the `effectiveAccessLevel` derived indirection, and removed the `{#if $READ_ONLY_MODE}` wrapper so the `AccessLevelToggle` ("Read-only mode") is always rendered. The connection now uses the toggle's `accessLevel` directly (defaulting to read-only, opt-out).
- `lib/state/featureFlags.ts`: the `READ_ONLY_MODE` flag is retained (still used by `/continue` and `/cli`); updated its doc comment to note that `/mcp` is no longer gated and explain why.
- No changes to the other flows (`/continue`, `/cli`) — the flag still gates them.

# Tests

- Updated `tests/e2e-playwright/routes/mcp.spec.ts`: the "Allow access posts a two-hop delegation chain" test previously asserted the toggle was absent (`toHaveCount(0)`); it now asserts the "Read-only mode" checkbox is shown and checked by default (`toBeChecked()`). The two-hop delegation assertion is unchanged, since the standing delegation stays full access regardless of the toggle.
- `npm run check` (`tsc` + `svelte-check`): passes with 0 errors.
- `npm run lint:eslint` on the changed files: passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKKV4dmEp3tjAZKJjuLB4w)_