### PR TITLE
feat(fe): connect via registration delegation (phase 3 — frontend + e2e)

### DIFF
--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -41,13 +41,13 @@ sequenceDiagram
     M-->>F: {"callbacks": [...]} — link's callback must exact-match
     note over F: generate ephemeral key Y (browser-held)
     F->>C: prepare_mcp_registration_delegation(anchor, Y, permissions, ttl)
-    C-->>F: {user_key, expiration} — P_reg derived, only the anchor stored
-    F->>C: get_mcp_registration_delegation(anchor, Y, permissions, ttl, expiration)
+    C-->>F: {user_key, expiration} — P_reg from a random nonce, consent stored
+    F->>C: get_mcp_registration_delegation(anchor, Y, user_key, expiration)
     C-->>F: SignedDelegation — the P_reg to Y hop (inert without Y)
     note over F: sign the second hop Y to X locally — full chain never transits the IC
-    F->>U: navigate tab to callback#delegation, state, permissions, ttl
+    F->>U: navigate tab to callback#delegation, state
     U->>M: your connect page reads the fragment, ships it to your backend
-    M->>C: mcp_register_v2(S, permissions, ttl) — signed via the chain, echoing the consent
+    M->>C: mcp_register_v2(S) — signed via the chain; consent recovered server-side
     C-->>M: {expiration, permissions} — grant bound: S's principal to anchor
     note over U,M: your page owns the tab now — finish your flow (e.g. OAuth code redirect)
     end
@@ -140,42 +140,35 @@ https://<II_ORIGIN>/mcp#registration_key=<base64url DER public key>&callback=<de
 ## 3. Receive and redeem the registration delegation
 
 **a) Delivery.** After the user consents, II mints a canister-signed
-delegation `P_reg -> Y` (where `P_reg` is a registration principal **derived
-from the user's consent** — the anchor, the access level, the grant TTL, and
-the trusted server URL; nothing is stored — and `Y` is an ephemeral key the
-II frontend holds; you never construct or see either), extends it
-browser-side with a second, browser-signed hop `Y -> X` to your registration
-key, and navigates the connecting tab to your declared callback with the
-full chain **plus the consent tuple** in the **URL fragment**:
+delegation `P_reg -> Y` (where `P_reg` is a registration principal seeded
+from a **fresh random nonce** — not from the consent — and `Y` is an
+ephemeral key the II frontend holds; you never construct or see either),
+extends it browser-side with a second, browser-signed hop `Y -> X` to your
+registration key, and navigates the connecting tab to your declared callback
+with the full chain in the **URL fragment**:
 
 ```
-https://<your-origin>/mcp/connect#delegation=<URL-encoded chain JSON>&state=<state>&permissions=<queries|all>&ttl=<ns>
+https://<your-origin>/mcp/connect#delegation=<URL-encoded chain JSON>&state=<state>
 ```
 
-- `permissions` — the access level the user chose: `queries` (read-only)
-  or `all`.
-- `ttl` — the consented grant lifetime, in **nanoseconds**, as a decimal
-  string (it overflows 32-bit ints; parse as a 64-bit/bigint).
-
-These are the values you **echo verbatim to `mcp_register_v2`** (§3c). You
-can't gain anything by editing them: they are folded into `P_reg`'s
-derivation, so an altered echo derives a different principal and the
-redemption is rejected. Note the fragment does **not** carry the user's
-anchor (identity) number: II recovers it server-side from the registration
-delegation, so a connected server never learns it. The fragment is never
-sent in the HTTP request, so the chain stays out of your access logs and any
-intermediary's. Your callback page reads it client-side and ships it to your
-backend over a same-origin request:
+The whole consent — the anchor, the access level, the grant lifetime, and
+the trusted server URL — is **recorded canister-side** on the registration
+entry keyed by `P_reg` at consent time. You carry none of it: the fragment
+holds only the chain and your `state`, and redemption (§3c) passes only your
+session key. So the server can't name a different anchor, upgrade the access
+level, or stretch the lifetime — it never handles any of those values — and
+it **never learns the user's anchor (identity) number**. The fragment is
+never sent in the HTTP request, so the chain stays out of your access logs
+and any intermediary's. Your callback page reads it client-side and ships it
+to your backend over a same-origin request:
 
 ```js
 const params = new URLSearchParams(location.hash.slice(1));
 const delegation = params.get("delegation"); // chain JSON
 const state = params.get("state");
-const permissions = params.get("permissions");
-const ttl = params.get("ttl");
 // Clear the fragment, keeping any query string your declared callback carries.
 history.replaceState(null, "", location.pathname + location.search);
-// POST { delegation, state, permissions, ttl } to your backend, same-origin
+// POST { delegation, state } to your backend, same-origin
 ```
 
 **b) The chain format** is agent-js `DelegationChain.toJSON()`: an object
@@ -200,9 +193,7 @@ P_reg`), call:
 
 ```candid
 mcp_register_v2 : (
-    session_key : blob,           // DER public key of your session key S
-    permissions : opt Permissions, // echo the fragment's `permissions`
-    max_ttl : opt nat64           // echo the fragment's `ttl` (ns)
+    session_key : blob            // DER public key of your session key S
   ) -> (variant { Ok : McpRegistrationV2; Err : text });
 
 type McpRegistrationV2 = record {
@@ -211,30 +202,32 @@ type McpRegistrationV2 = record {
 };
 ```
 
-echoing the fragment's `permissions` and `ttl` alongside the DER public key
-of your **session key `S`**. You do **not** pass the anchor — the canister
-recovers it from the registration delegation (keyed by `caller() == P_reg`),
-so you never handle the user's identity number. On `Ok`, the grant is live:
-`S`'s self-authenticating principal is bound to the consenting user's
-identity until `expiration`, with the access level the user chose (see
-[Read-only sessions](#read-only-sessions)). This response is synchronous and
-authoritative — there is no separate completion notification to wait for or
-tolerate missing.
+You pass **only** the DER public key of your **session key `S`** — no
+anchor, no access level, no lifetime. The canister looks up the registration
+entry keyed by `caller() == P_reg` and recovers the entire consent from it
+(the anchor to bind, the access level, and the grant lifetime), so you never
+handle any of those values and never learn the user's identity number. On
+`Ok`, the grant is live: `S`'s self-authenticating principal is bound to the
+consenting user's identity until `expiration`, with the access level the user
+chose (see [Read-only sessions](#read-only-sessions)). The response echoes
+back the effective `permissions` and `expiration` so you know exactly what
+was granted. This response is synchronous and authoritative — there is no
+separate completion notification to wait for or tolerate missing.
 
 Semantics to build against:
 
 - **Redeem immediately.** The registration delegation lives 5 minutes —
   sized to cover the browser hops plus the IC's permitted clock drift, not
   a queue. Expired delegations get a clean `Err`.
-- **Echo the consent exactly.** The canister stores only the anchor at
-  consent; the access level and lifetime are re-derived, not stored. It
-  recovers the anchor from your `caller()` (`P_reg`), then re-derives `P_reg`
-  from `(recovered anchor, permissions, max_ttl, current trusted-server URL)`
-  and redeems only if it lands exactly on `caller()`. You cannot upgrade the
-  access level or stretch the TTL — an altered value derives a different
-  principal and gets a clean `Err`. The same mechanism means a consent-time
-  config change (the user switching or disabling the trusted server)
-  invalidates an in-flight delegation.
+- **The consent is fixed at consent time.** The canister records the whole
+  consent (anchor, access level, grant lifetime, trusted-server URL) on the
+  registration entry when the user consents, and recovers it at redemption
+  from the entry keyed by your `caller()` (`P_reg`). You pass none of it, so
+  there is nothing to alter — you cannot upgrade the access level or stretch
+  the TTL. Redemption also requires the recorded trusted-server URL to still
+  equal the anchor's current one, so a config change between consent and
+  redemption (the user switching or disabling the trusted server) invalidates
+  an in-flight delegation with a clean `Err`.
 - **Retry-safe, replace-not-add.** Within its 5-minute lifetime the
   delegation redeems repeatedly: a retry of the same call (same chain, same
   `S` — e.g. after a network timeout) just re-binds `S`, and the user's
@@ -347,15 +340,14 @@ uninstall/delete, and even `canister_status` and cycles reads are update
 calls), so that entire class of tools is inert under the default session. You
 don't choose this per call and can't widen it; it's fixed for the session.
 
-You learn the level at delivery (the fragment's `permissions`) and have it
-confirmed synchronously: it is the `permissions` field of `mcp_register_v2`'s
-`Ok` response (`queries` = read-only, `all` = full). The `permissions` field
-on any `SignedDelegation` you later mint carries the same value, as a
-cross-check. If your server needs update access and the session is read-only,
-tell the user to reconnect with read-only off instead of surfacing raw IC
-rejections. (You echo the level, but you can't choose it — it is folded into
-the registration principal's derivation from the consent screen, so an
-altered echo fails to redeem.)
+You learn the level synchronously at redemption: it is the `permissions`
+field of `mcp_register_v2`'s `Ok` response (`queries` = read-only, `all` =
+full). The `permissions` field on any `SignedDelegation` you later mint
+carries the same value, as a cross-check. If your server needs update access
+and the session is read-only, tell the user to reconnect with read-only off
+instead of surfacing raw IC rejections. (You never pass the level — it is
+recorded canister-side at consent and recovered at redemption, so there is
+nothing for the server to choose or alter.)
 
 ## 4. Calling Internet Identity
 

--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -41,7 +41,7 @@ sequenceDiagram
     M-->>F: {"callbacks": [...]} — link's callback must exact-match
     note over F: generate ephemeral key Y (browser-held)
     F->>C: prepare_mcp_registration_delegation(anchor, Y, permissions, ttl)
-    C-->>F: {user_key, expiration} — P_reg derived; only the anchor is stored
+    C-->>F: {user_key, expiration} — P_reg derived, only the anchor stored
     F->>C: get_mcp_registration_delegation(anchor, Y, permissions, ttl, expiration)
     C-->>F: SignedDelegation — the P_reg to Y hop (inert without Y)
     note over F: sign the second hop Y to X locally — full chain never transits the IC

--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -1,12 +1,12 @@
 # MCP server guide: connecting to Internet Identity
 
 This documents the protocol an MCP server implements to act on an Internet
-Identity user's behalf. At connect, II mints a **single-use registration
-delegation** that your server redeems to bind its **session key** to the
-user's identity (a _grant_, up to 30 days, revocable in II Settings at any
-time); the server then signs `mcp_*` canister calls with that key. The
-registration delegation is the only delegation chain your server ever
-handles, and it is redeemed exactly once, at connect. Per-app delegations
+Identity user's behalf. At connect, II mints a **short-lived registration
+delegation** (5 minutes) that your server redeems to bind its **session
+key** to the user's identity (a _grant_, up to 30 days, revocable in II
+Settings at any time); the server then signs `mcp_*` canister calls with
+that key. The registration delegation is the only delegation chain your
+server ever handles, and it is redeemed at connect. Per-app delegations
 (up to 1 hour) are minted on demand through `mcp_prepare_delegation` /
 `mcp_get_delegation`.
 
@@ -41,13 +41,13 @@ sequenceDiagram
     M-->>F: {"callbacks": [...]} — link's callback must exact-match
     note over F: generate ephemeral key Y (browser-held)
     F->>C: prepare_mcp_registration_delegation(anchor, Y, permissions, ttl)
-    C-->>F: {user_key, expiration} — consent recorded under P_reg
-    F->>C: get_mcp_registration_delegation(anchor, Y, expiration)
+    C-->>F: {user_key, expiration} — P_reg derived from the consent, nothing stored
+    F->>C: get_mcp_registration_delegation(anchor, Y, permissions, ttl, expiration)
     C-->>F: SignedDelegation — the P_reg to Y hop (inert without Y)
     note over F: sign the second hop Y to X locally — full chain never transits the IC
-    F->>U: navigate tab to callback#delegation, state
+    F->>U: navigate tab to callback#delegation, state, anchor, permissions, ttl
     U->>M: your connect page reads the fragment, ships it to your backend
-    M->>C: mcp_register_v2(session key S) — signed via the P_reg to Y to X chain
+    M->>C: mcp_register_v2(anchor, S, permissions, ttl) — signed via the chain, echoing the consent
     C-->>M: {expiration, permissions} — grant bound: S's principal to anchor
     note over U,M: your page owns the tab now — finish your flow (e.g. OAuth code redirect)
     end
@@ -124,8 +124,8 @@ https://<II_ORIGIN>/mcp#registration_key=<base64url DER public key>&callback=<de
   key material travels in the link; the corresponding private key stays on
   your server and is what lets you — and only you — redeem the delegation
   chain. Mint a fresh `X` per attempt and bind it to that attempt's `state`:
-  the chain you receive is single-use, so a stale `X` has nothing left to
-  redeem.
+  the chain you receive expires within 5 minutes, and a failed connect is
+  restarted with a fresh link, never by re-driving the old one.
 - `callback` — one of the URLs you declared in §1, verbatim. The user must
   have set your origin as their trusted MCP server in II Settings (matching
   is by **origin**; the callback is then matched against your declared list).
@@ -140,28 +140,42 @@ https://<II_ORIGIN>/mcp#registration_key=<base64url DER public key>&callback=<de
 ## 3. Receive and redeem the registration delegation
 
 **a) Delivery.** After the user consents, II mints a canister-signed
-delegation `P_reg -> Y` (where `P_reg` is a registration principal derived
-from the user's consent and `Y` is an ephemeral key the II frontend holds —
-you never construct or see either), extends it browser-side with a second,
-browser-signed hop `Y -> X` to your registration key, and navigates the
-connecting tab to your declared callback with the full chain in the **URL
-fragment**:
+delegation `P_reg -> Y` (where `P_reg` is a registration principal **derived
+from the user's consent** — the anchor, the access level, the grant TTL, and
+the trusted server URL; nothing is stored — and `Y` is an ephemeral key the
+II frontend holds; you never construct or see either), extends it
+browser-side with a second, browser-signed hop `Y -> X` to your registration
+key, and navigates the connecting tab to your declared callback with the
+full chain **plus the consent tuple** in the **URL fragment**:
 
 ```
-https://<your-origin>/mcp/connect#delegation=<URL-encoded chain JSON>&state=<state>
+https://<your-origin>/mcp/connect#delegation=<URL-encoded chain JSON>&state=<state>&anchor=<number>&permissions=<queries|all>&ttl=<ns>
 ```
 
-The fragment is never sent in the HTTP request, so the chain stays out of
-your access logs and any intermediary's. Your callback page reads it
-client-side and ships it to your backend over a same-origin request:
+- `anchor` — the user's identity (anchor) number, as a decimal string.
+- `permissions` — the access level the user chose: `queries` (read-only)
+  or `all`.
+- `ttl` — the consented grant lifetime, in **nanoseconds**, as a decimal
+  string (it overflows 32-bit ints; parse as a 64-bit/bigint).
+
+These are the values you **echo verbatim to `mcp_register_v2`** (§3c). You
+can't gain anything by editing them: they are folded into `P_reg`'s
+derivation, so an altered echo derives a different principal and the
+redemption is rejected. The fragment is never sent in the HTTP request, so
+the chain stays out of your access logs and any intermediary's. Your
+callback page reads it client-side and ships it to your backend over a
+same-origin request:
 
 ```js
 const params = new URLSearchParams(location.hash.slice(1));
 const delegation = params.get("delegation"); // chain JSON
 const state = params.get("state");
+const anchor = params.get("anchor");
+const permissions = params.get("permissions");
+const ttl = params.get("ttl");
 // Clear the fragment, keeping any query string your declared callback carries.
 history.replaceState(null, "", location.pathname + location.search);
-// POST { delegation, state } to your backend, same-origin
+// POST { delegation, state, anchor, permissions, ttl } to your backend, same-origin
 ```
 
 **b) The chain format** is agent-js `DelegationChain.toJSON()`: an object
@@ -185,8 +199,12 @@ const identity = DelegationIdentity.fromDelegation(registrationKeyX, chain);
 P_reg`), call:
 
 ```candid
-mcp_register_v2 : (session_key : blob)
-  -> (variant { Ok : McpRegistrationV2; Err : text });
+mcp_register_v2 : (
+    anchor_number : nat64,        // echo the fragment's `anchor`
+    session_key : blob,           // DER public key of your session key S
+    permissions : opt Permissions, // echo: queries / all
+    max_ttl : opt nat64           // echo the fragment's `ttl` (ns)
+  ) -> (variant { Ok : McpRegistrationV2; Err : text });
 
 type McpRegistrationV2 = record {
     expiration : nat64;        // grant expiry, ns since epoch
@@ -194,9 +212,10 @@ type McpRegistrationV2 = record {
 };
 ```
 
-with the DER public key of your **session key `S`**. On `Ok`, the grant is
-live: `S`'s self-authenticating principal is bound to the consenting user's
-identity until `expiration`, with the access level the user chose (see
+echoing the fragment's consent tuple alongside the DER public key of your
+**session key `S`**. On `Ok`, the grant is live: `S`'s self-authenticating
+principal is bound to the consenting user's identity until `expiration`,
+with the access level the user chose (see
 [Read-only sessions](#read-only-sessions)). This response is synchronous and
 authoritative — there is no separate completion notification to wait for or
 tolerate missing.
@@ -206,23 +225,33 @@ Semantics to build against:
 - **Redeem immediately.** The registration delegation lives 5 minutes —
   sized to cover the browser hops plus the IC's permitted clock drift, not
   a queue. Expired delegations get a clean `Err`.
-- **Single-use, retry-safe.** The delegation binds one `S`. A retry of the
-  same call (same chain, same `S` — e.g. after a network timeout) is served
-  idempotently with the current grant; presenting a used delegation with a
-  *different* `S` is rejected. A failed connect is restarted with a fresh
-  `X`, fresh `state`, and a new link — never by re-driving the old one.
-- **Consent is fixed at consent time.** The anchor, the read-only choice, and
-  the grant TTL were recorded when the user consented; `mcp_register_v2`
-  takes none of them as arguments, so you cannot alter them — you only
-  supply the key to bind.
+- **Echo the consent exactly.** The canister stores nothing at consent:
+  it re-derives `P_reg` from your presented `(anchor_number, permissions,
+max_ttl)` and the user's current trusted-server config, and redeems only
+  if the derivation lands exactly on `caller()`. You cannot upgrade the
+  access level, stretch the TTL, or bind a different anchor — any altered
+  value derives a different principal and gets a clean `Err`. The same
+  mechanism means a consent-time config change (the user switching or
+  disabling the trusted server) invalidates an in-flight delegation.
+- **Retry-safe, replace-not-add.** Within its 5-minute lifetime the
+  delegation redeems repeatedly: a retry of the same call (same chain, same
+  `S` — e.g. after a network timeout) just re-binds `S`, and the user's
+  identity only ever holds **one** session — a redemption with a different
+  `S` replaces the previous grant rather than adding a session. A failed
+  connect is restarted with a fresh `X`, fresh `state`, and a new link —
+  never by re-driving the old one.
 - **Check `state` before redeeming.** Only redeem a delegation delivered
   with a `state` you issued and haven't consumed; consume it atomically on
   first use.
 - The chain is **inert to anyone without `X`'s private key**, authenticates
-  nothing but this one `mcp_register_v2` call, and grants no access by
-  itself. Discard it after redemption.
+  nothing but `mcp_register_v2` for the consented tuple, and grants no
+  access by itself. Discard it after redemption.
+- **The anchor number is user data.** The fragment (and your `mcp_register_v2`
+  call) identifies the user by their II anchor number — a stable, unique
+  identifier for their whole identity. Store and log it with the same care
+  as any user identifier.
 
-**d) Finish on your own page.** After delivery, the tab is on *your* origin,
+**d) Finish on your own page.** After delivery, the tab is on _your_ origin,
 on a page you serve — there is no redirect-back channel to ask II for.
 Verify the redemption result and continue your flow from there (show a
 "connected" state, or redirect onward — e.g. hand an OAuth code back to an
@@ -245,7 +274,7 @@ page closing the loop:
    PKCE, create a pending auth `{code_challenge, oauth_state, resource}`,
    mint a **fresh registration keypair `X`** and a fresh, single-use
    `connect_state` for it, set an initiator cookie (`sid`, `HttpOnly;
-   Secure; SameSite=Lax`) referencing the pending auth, and 302 the browser
+Secure; SameSite=Lax`) referencing the pending auth, and 302 the browser
    to the II connect link (§2).
 2. The consenting browser arrives at your declared callback (§3a) carrying
    the delegation and `connect_state`; the page ships both to your backend
@@ -273,8 +302,8 @@ delivered only to the consenting browser (the victim's), and that browser
 does not hold the attacker's `sid` cookie, so the delivery is refused,
 nothing is redeemed, and no code is minted. Conversely the attacker's
 browser holds `sid` but never receives the delegation. Only the legitimate
-same-browser flow holds both proofs — *initiator* (`sid`) and *consenter*
-(the delegation, single-use and redeemable only with your `X`) — so a code
+same-browser flow holds both proofs — _initiator_ (`sid`) and _consenter_
+(the delegation, short-lived and redeemable only with your `X`) — so a code
 can never be minted for an identity other than the one operating the
 initiating client. No side-channel secret or "exactly one request, never
 retried" discipline is needed; the delegation itself is the consent-bound
@@ -311,7 +340,7 @@ middleware, and return proper AS error codes (`invalid_client`,
 
 At consent the user picks an access level, and **the connect screen defaults to
 read-only** — so unless the user deliberately opts out, you get a read-only
-session. II records the level at consent time and applies it to _every_ per-app
+session. II fixes the level at consent time and applies it to _every_ per-app
 delegation your session mints: a read-only session's delegations carry
 `permissions = "queries"`, so the IC rejects update calls made through them at
 ingress — enforcement is protocol-level, not up to the target app. This
@@ -320,13 +349,15 @@ uninstall/delete, and even `canister_status` and cycles reads are update
 calls), so that entire class of tools is inert under the default session. You
 don't choose this per call and can't widen it; it's fixed for the session.
 
-You learn the level synchronously: it is the `permissions` field of
-`mcp_register_v2`'s `Ok` response (`queries` = read-only, `all` = full). The
-`permissions` field on any `SignedDelegation` you later mint carries the same
-value, as a cross-check. If your server needs update access and the session is
-read-only, tell the user to reconnect with read-only off instead of surfacing
-raw IC rejections. (You never pass the level yourself — it is recorded from
-the consent screen when the delegation is prepared, before you are involved.)
+You learn the level at delivery (the fragment's `permissions`) and have it
+confirmed synchronously: it is the `permissions` field of `mcp_register_v2`'s
+`Ok` response (`queries` = read-only, `all` = full). The `permissions` field
+on any `SignedDelegation` you later mint carries the same value, as a
+cross-check. If your server needs update access and the session is read-only,
+tell the user to reconnect with read-only off instead of surfacing raw IC
+rejections. (You echo the level, but you can't choose it — it is folded into
+the registration principal's derivation from the consent screen, so an
+altered echo fails to redeem.)
 
 ## 4. Calling Internet Identity
 

--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -192,9 +192,9 @@ tolerate missing.
 
 Semantics to build against:
 
-- **Redeem immediately.** The registration delegation lives ~90 seconds —
-  enough for the browser hops, not for a queue. Expired delegations get a
-  clean `Err`.
+- **Redeem immediately.** The registration delegation lives 5 minutes —
+  sized to cover the browser hops plus the IC's permitted clock drift, not
+  a queue. Expired delegations get a clean `Err`.
 - **Single-use, retry-safe.** The delegation binds one `S`. A retry of the
   same call (same chain, same `S` — e.g. after a network timeout) is served
   idempotently with the current grant; presenting a used delegation with a

--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -47,7 +47,7 @@ sequenceDiagram
     note over F: sign the second hop Y to X locally — full chain never transits the IC
     F->>U: navigate tab to callback#delegation, state
     U->>M: your connect page reads the fragment, ships it to your backend
-    M->>C: mcp_register_v2(S) — signed via the chain; consent recovered server-side
+    M->>C: mcp_register_v2(S) — signed via the chain, consent recovered server-side
     C-->>M: {expiration, permissions} — grant bound: S's principal to anchor
     note over U,M: your page owns the tab now — finish your flow (e.g. OAuth code redirect)
     end

--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -153,7 +153,8 @@ client-side and ships it to your backend over a same-origin request:
 const params = new URLSearchParams(location.hash.slice(1));
 const delegation = params.get("delegation"); // chain JSON
 const state = params.get("state");
-history.replaceState(null, "", location.pathname); // clear the fragment
+// Clear the fragment, keeping any query string your declared callback carries.
+history.replaceState(null, "", location.pathname + location.search);
 // POST { delegation, state } to your backend, same-origin
 ```
 

--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -13,8 +13,10 @@ handles, and it is redeemed exactly once, at connect. Per-app delegations
 Your server generates **two keypairs per connection**:
 
 - the **registration key `X`** — per connect attempt; its public key rides
-  the connect link, and II mints the registration delegation for it. Its
-  private key is what makes the delegation redeemable by you alone.
+  the connect link, and the registration chain's final, browser-signed hop
+  targets it. Its private key is what makes the chain redeemable by you
+  alone. (The chain's canister-signed hop targets an ephemeral key the II
+  frontend holds — see §3b — but you never handle that key.)
 - the **session key `S`** — the long-lived key the grant is bound to; you
   sign all subsequent `mcp_*` calls with it.
 
@@ -37,13 +39,15 @@ sequenceDiagram
     C-->>F: enabled + trusted URL (verify callback origin)
     F->>M: GET /.well-known/ii-auth-callbacks
     M-->>F: {"callbacks": [...]} — link's callback must exact-match
-    F->>C: prepare_mcp_registration_delegation(anchor, X, permissions, ttl)
+    note over F: generate ephemeral key Y (browser-held)
+    F->>C: prepare_mcp_registration_delegation(anchor, Y, permissions, ttl)
     C-->>F: {user_key, expiration} — consent recorded under P_reg
-    F->>C: get_mcp_registration_delegation(anchor, X, expiration)
-    C-->>F: SignedDelegation — the P_reg to X chain
+    F->>C: get_mcp_registration_delegation(anchor, Y, expiration)
+    C-->>F: SignedDelegation — the P_reg to Y hop (inert without Y)
+    note over F: sign the second hop Y to X locally — full chain never transits the IC
     F->>U: navigate tab to callback#delegation, state
     U->>M: your connect page reads the fragment, ships it to your backend
-    M->>C: mcp_register_v2(session key S) — signed via the P_reg to X chain
+    M->>C: mcp_register_v2(session key S) — signed via the P_reg to Y to X chain
     C-->>M: {expiration, permissions} — grant bound: S's principal to anchor
     note over U,M: your page owns the tab now — finish your flow (e.g. OAuth code redirect)
     end
@@ -118,10 +122,10 @@ https://<II_ORIGIN>/mcp#registration_key=<base64url DER public key>&callback=<de
   minted per connect attempt** (Ed25519 recommended, e.g. agent-js
   `Ed25519KeyIdentity`), DER-encoded, base64url without padding. Only public
   key material travels in the link; the corresponding private key stays on
-  your server and is what lets you — and only you — redeem the delegation.
-  Never reuse an `X` across connect attempts: II rejects a second
-  registration for a key whose previous one is still live, and the
-  delegation for it is single-use.
+  your server and is what lets you — and only you — redeem the delegation
+  chain. Mint a fresh `X` per attempt and bind it to that attempt's `state`:
+  the chain you receive is single-use, so a stale `X` has nothing left to
+  redeem.
 - `callback` — one of the URLs you declared in §1, verbatim. The user must
   have set your origin as their trusted MCP server in II Settings (matching
   is by **origin**; the callback is then matched against your declared list).
@@ -136,9 +140,11 @@ https://<II_ORIGIN>/mcp#registration_key=<base64url DER public key>&callback=<de
 ## 3. Receive and redeem the registration delegation
 
 **a) Delivery.** After the user consents, II mints a canister-signed
-delegation `P_reg -> X` (where `P_reg` is a registration principal derived
-from the user's consent — you never construct it) and navigates the
-connecting tab to your declared callback with the chain in the **URL
+delegation `P_reg -> Y` (where `P_reg` is a registration principal derived
+from the user's consent and `Y` is an ephemeral key the II frontend holds —
+you never construct or see either), extends it browser-side with a second,
+browser-signed hop `Y -> X` to your registration key, and navigates the
+connecting tab to your declared callback with the full chain in the **URL
 fragment**:
 
 ```
@@ -159,10 +165,14 @@ history.replaceState(null, "", location.pathname + location.search);
 ```
 
 **b) The chain format** is agent-js `DelegationChain.toJSON()`: an object
-`{"delegations": [{"delegation": {"pubkey": "<hex>", "expiration": "<hex ns>"},
-"signature": "<hex>"}], "publicKey": "<hex>"}` with hex-encoded fields, where
-`publicKey` is `P_reg`'s DER key and the single delegation is to your `X`.
-With agent-js, reconstruction is two calls:
+`{"delegations": [ ... ], "publicKey": "<hex>"}` with hex-encoded fields,
+where `publicKey` is `P_reg`'s DER key and `delegations` carries **two
+hops** — the canister-signed `P_reg -> Y` and the browser-signed `Y -> X` to
+your registration key. The split is deliberate: what the II canister signs
+transits the IC (replicas, boundary nodes) and must be inert on its own, so
+it targets the browser-held `Y`; the redeemable chain is assembled only in
+the consenting browser and reaches you only via the fragment. You never
+handle `Y` — with agent-js, reconstruction is the same two calls:
 
 ```js
 import { DelegationChain, DelegationIdentity } from "@icp-sdk/core/identity";

--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -279,12 +279,22 @@ model only ever identifies your origin, not the OAuth client.)
 
 Advertise what you actually implement (`authorization_endpoint`,
 `response_types_supported: ["code"]`, `grant_types_supported` containing
-`authorization_code`, plus `refresh_token` only if you issue them), don't
-rewrite clients' requested grant types at registration, persist DCR client
-registrations across deploys (clients cache their `client_id`), exempt
-`/oauth/*` and `/.well-known/*` from bearer-token middleware, and return proper
-AS error codes (`invalid_client`, `invalid_request`) from the authorize
-endpoint.
+`authorization_code`, plus `refresh_token` only if you issue them). At DCR,
+handle requested `grant_types` by **intersecting them with what you support
+and returning the resulting set in the registration response** (RFC 7591
+makes the response authoritative — a client that asked for `refresh_token`
+must be able to see it wasn't granted). Two failure modes to avoid: rejecting
+a registration because the requested set isn't exactly yours, or replacing it
+with a server default that drops `authorization_code` — clients request
+`["authorization_code", "refresh_token"]` optimistically and must come away
+able to run the code flow. Never echo a grant type you don't implement; if
+the intersection loses `authorization_code` (or is empty), fail with
+`invalid_client_metadata` instead of registering a client that can't complete
+any flow, and keep the response consistent with `grant_types_supported`.
+Persist DCR client registrations across deploys (clients cache their
+`client_id`), exempt `/oauth/*` and `/.well-known/*` from bearer-token
+middleware, and return proper AS error codes (`invalid_client`,
+`invalid_request`) from the authorize endpoint.
 
 ### Read-only sessions
 

--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -41,13 +41,13 @@ sequenceDiagram
     M-->>F: {"callbacks": [...]} — link's callback must exact-match
     note over F: generate ephemeral key Y (browser-held)
     F->>C: prepare_mcp_registration_delegation(anchor, Y, permissions, ttl)
-    C-->>F: {user_key, expiration} — P_reg derived from the consent, nothing stored
+    C-->>F: {user_key, expiration} — P_reg derived; only the anchor is stored
     F->>C: get_mcp_registration_delegation(anchor, Y, permissions, ttl, expiration)
     C-->>F: SignedDelegation — the P_reg to Y hop (inert without Y)
     note over F: sign the second hop Y to X locally — full chain never transits the IC
-    F->>U: navigate tab to callback#delegation, state, anchor, permissions, ttl
+    F->>U: navigate tab to callback#delegation, state, permissions, ttl
     U->>M: your connect page reads the fragment, ships it to your backend
-    M->>C: mcp_register_v2(anchor, S, permissions, ttl) — signed via the chain, echoing the consent
+    M->>C: mcp_register_v2(S, permissions, ttl) — signed via the chain, echoing the consent
     C-->>M: {expiration, permissions} — grant bound: S's principal to anchor
     note over U,M: your page owns the tab now — finish your flow (e.g. OAuth code redirect)
     end
@@ -149,10 +149,9 @@ key, and navigates the connecting tab to your declared callback with the
 full chain **plus the consent tuple** in the **URL fragment**:
 
 ```
-https://<your-origin>/mcp/connect#delegation=<URL-encoded chain JSON>&state=<state>&anchor=<number>&permissions=<queries|all>&ttl=<ns>
+https://<your-origin>/mcp/connect#delegation=<URL-encoded chain JSON>&state=<state>&permissions=<queries|all>&ttl=<ns>
 ```
 
-- `anchor` — the user's identity (anchor) number, as a decimal string.
 - `permissions` — the access level the user chose: `queries` (read-only)
   or `all`.
 - `ttl` — the consented grant lifetime, in **nanoseconds**, as a decimal
@@ -161,21 +160,22 @@ https://<your-origin>/mcp/connect#delegation=<URL-encoded chain JSON>&state=<sta
 These are the values you **echo verbatim to `mcp_register_v2`** (§3c). You
 can't gain anything by editing them: they are folded into `P_reg`'s
 derivation, so an altered echo derives a different principal and the
-redemption is rejected. The fragment is never sent in the HTTP request, so
-the chain stays out of your access logs and any intermediary's. Your
-callback page reads it client-side and ships it to your backend over a
-same-origin request:
+redemption is rejected. Note the fragment does **not** carry the user's
+anchor (identity) number: II recovers it server-side from the registration
+delegation, so a connected server never learns it. The fragment is never
+sent in the HTTP request, so the chain stays out of your access logs and any
+intermediary's. Your callback page reads it client-side and ships it to your
+backend over a same-origin request:
 
 ```js
 const params = new URLSearchParams(location.hash.slice(1));
 const delegation = params.get("delegation"); // chain JSON
 const state = params.get("state");
-const anchor = params.get("anchor");
 const permissions = params.get("permissions");
 const ttl = params.get("ttl");
 // Clear the fragment, keeping any query string your declared callback carries.
 history.replaceState(null, "", location.pathname + location.search);
-// POST { delegation, state, anchor, permissions, ttl } to your backend, same-origin
+// POST { delegation, state, permissions, ttl } to your backend, same-origin
 ```
 
 **b) The chain format** is agent-js `DelegationChain.toJSON()`: an object
@@ -200,9 +200,8 @@ P_reg`), call:
 
 ```candid
 mcp_register_v2 : (
-    anchor_number : nat64,        // echo the fragment's `anchor`
     session_key : blob,           // DER public key of your session key S
-    permissions : opt Permissions, // echo: queries / all
+    permissions : opt Permissions, // echo the fragment's `permissions`
     max_ttl : opt nat64           // echo the fragment's `ttl` (ns)
   ) -> (variant { Ok : McpRegistrationV2; Err : text });
 
@@ -212,10 +211,12 @@ type McpRegistrationV2 = record {
 };
 ```
 
-echoing the fragment's consent tuple alongside the DER public key of your
-**session key `S`**. On `Ok`, the grant is live: `S`'s self-authenticating
-principal is bound to the consenting user's identity until `expiration`,
-with the access level the user chose (see
+echoing the fragment's `permissions` and `ttl` alongside the DER public key
+of your **session key `S`**. You do **not** pass the anchor — the canister
+recovers it from the registration delegation (keyed by `caller() == P_reg`),
+so you never handle the user's identity number. On `Ok`, the grant is live:
+`S`'s self-authenticating principal is bound to the consenting user's
+identity until `expiration`, with the access level the user chose (see
 [Read-only sessions](#read-only-sessions)). This response is synchronous and
 authoritative — there is no separate completion notification to wait for or
 tolerate missing.
@@ -225,14 +226,15 @@ Semantics to build against:
 - **Redeem immediately.** The registration delegation lives 5 minutes —
   sized to cover the browser hops plus the IC's permitted clock drift, not
   a queue. Expired delegations get a clean `Err`.
-- **Echo the consent exactly.** The canister stores nothing at consent:
-  it re-derives `P_reg` from your presented `(anchor_number, permissions,
-max_ttl)` and the user's current trusted-server config, and redeems only
-  if the derivation lands exactly on `caller()`. You cannot upgrade the
-  access level, stretch the TTL, or bind a different anchor — any altered
-  value derives a different principal and gets a clean `Err`. The same
-  mechanism means a consent-time config change (the user switching or
-  disabling the trusted server) invalidates an in-flight delegation.
+- **Echo the consent exactly.** The canister stores only the anchor at
+  consent; the access level and lifetime are re-derived, not stored. It
+  recovers the anchor from your `caller()` (`P_reg`), then re-derives `P_reg`
+  from `(recovered anchor, permissions, max_ttl, current trusted-server URL)`
+  and redeems only if it lands exactly on `caller()`. You cannot upgrade the
+  access level or stretch the TTL — an altered value derives a different
+  principal and gets a clean `Err`. The same mechanism means a consent-time
+  config change (the user switching or disabling the trusted server)
+  invalidates an in-flight delegation.
 - **Retry-safe, replace-not-add.** Within its 5-minute lifetime the
   delegation redeems repeatedly: a retry of the same call (same chain, same
   `S` — e.g. after a network timeout) just re-binds `S`, and the user's
@@ -244,12 +246,8 @@ max_ttl)` and the user's current trusted-server config, and redeems only
   with a `state` you issued and haven't consumed; consume it atomically on
   first use.
 - The chain is **inert to anyone without `X`'s private key**, authenticates
-  nothing but `mcp_register_v2` for the consented tuple, and grants no
+  nothing but `mcp_register_v2` for the consented values, and grants no
   access by itself. Discard it after redemption.
-- **The anchor number is user data.** The fragment (and your `mcp_register_v2`
-  call) identifies the user by their II anchor number — a stable, unique
-  identifier for their whole identity. Store and log it with the same care
-  as any user identifier.
 
 **d) Finish on your own page.** After delivery, the tab is on _your_ origin,
 on a page you serve — there is no redirect-back channel to ask II for.

--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -1,11 +1,22 @@
 # MCP server guide: connecting to Internet Identity
 
 This documents the protocol an MCP server implements to act on an Internet
-Identity user's behalf. The user registers the server's **session key** with
-the II canister (a _grant_, up to 30 days, revocable in II Settings at any
-time); the server then signs `mcp_*` canister calls with that key — no
-delegation chains are delivered or handled. Per-app delegations (up to 1 hour)
-are minted on demand through `mcp_prepare_delegation` / `mcp_get_delegation`.
+Identity user's behalf. At connect, II mints a **single-use registration
+delegation** that your server redeems to bind its **session key** to the
+user's identity (a _grant_, up to 30 days, revocable in II Settings at any
+time); the server then signs `mcp_*` canister calls with that key. The
+registration delegation is the only delegation chain your server ever
+handles, and it is redeemed exactly once, at connect. Per-app delegations
+(up to 1 hour) are minted on demand through `mcp_prepare_delegation` /
+`mcp_get_delegation`.
+
+Your server generates **two keypairs per connection**:
+
+- the **registration key `X`** — per connect attempt; its public key rides
+  the connect link, and II mints the registration delegation for it. Its
+  private key is what makes the delegation redeemable by you alone.
+- the **session key `S`** — the long-lived key the grant is bound to; you
+  sign all subsequent `mcp_*` calls with it.
 
 ## Lifecycle at a glance
 
@@ -20,20 +31,21 @@ sequenceDiagram
 
     rect rgb(244, 244, 250)
     note over U,C: Phase 1 — connect handshake (once per session)
-    M->>U: redirect to /mcp#callback, state, ttl
+    M->>U: redirect to /mcp#registration_key, callback, state, ttl
     U->>F: open /mcp, authenticate and consent (pick TTL)
     F->>C: mcp_get_config(anchor)
     C-->>F: enabled + trusted URL (verify callback origin)
-    F->>M: POST callback {state}
-    M-->>F: 200 {public_key} — fresh keypair for this connection
-    F->>C: mcp_register(anchor, session_key, ttl) [user-authenticated]
-    C-->>F: {expiration} — grant bound: principal to anchor
-    F-)M: POST callback {state, expiration} (best effort)
-    alt key response carried finish_url
-        F->>M: browser navigates to finish_url — finish your flow (e.g. OAuth code redirect)
-    else
-        F-->>U: "You're signed in"
-    end
+    F->>M: GET /.well-known/ii-auth-callbacks
+    M-->>F: {"callbacks": [...]} — link's callback must exact-match
+    F->>C: prepare_mcp_registration_delegation(anchor, X, permissions, ttl)
+    C-->>F: {user_key, expiration} — consent recorded under P_reg
+    F->>C: get_mcp_registration_delegation(anchor, X, expiration)
+    C-->>F: SignedDelegation — the P_reg to X chain
+    F->>U: navigate tab to callback#delegation, state
+    U->>M: your connect page reads the fragment, ships it to your backend
+    M->>C: mcp_register_v2(session key S) — signed via the P_reg to X chain
+    C-->>M: {expiration, permissions} — grant bound: S's principal to anchor
+    note over U,M: your page owns the tab now — finish your flow (e.g. OAuth code redirect)
     end
 
     rect rgb(240, 248, 244)
@@ -55,98 +67,156 @@ sequenceDiagram
     end
     M->>C: mcp_* (signed by session key)
     C-->>M: Err Unauthorized(principal)
-    note over M: session over → prompt a fresh connect with a new key
+    note over M: session over → prompt a fresh connect with new keys
     end
 ```
 
-## 1. Connect link
+## 1. Declare your callbacks
+
+II delivers the registration delegation only to a callback **you declare**.
+Host an allow-list at a fixed well-known path on your origin:
+
+```
+GET https://<your-origin>/.well-known/ii-auth-callbacks
+
+200 Content-Type: application/json
+{"callbacks": ["https://<your-origin>/mcp/connect"]}
+```
+
+Requirements — II's fetch is strict and fails the connect (closed) on any
+violation:
+
+- **Same origin only.** Every entry must be an absolute URL on this origin
+  (a declared cross-origin entry is rejected, never honoured). Different
+  origins are separate trusted-server entries, each with its own file.
+- **Exact match, no normalization.** The connect link's `callback` must equal
+  a declared entry byte-for-byte — declare the exact string you put in links
+  (no trailing-slash or case slack, query strings allowed but must match).
+- **No fragments** in entries (II appends its own).
+- Served as `application/json`, at most 8 KiB, **without redirects** (II
+  refuses to follow any — an open redirect at this path must not let a third
+  party serve your list), and with **CORS** headers that let II read it
+  (`Access-Control-Allow-Origin: <II origin>` or `*`; the fetch carries no
+  credentials). It is fetched with `cache: no-store` at every connect, so
+  changes take effect immediately.
+- **List only clean endpoints** you fully control — no reflecting routes, no
+  user-content paths, nothing that redirects. The list is a security
+  boundary: anything on it can receive registration delegations.
+
+The name is deliberately not MCP-specific: it is a general auth-callback
+allow-list that other II flows can reuse.
+
+## 2. Connect link
 
 Send the user's browser to:
 
 ```
-https://<II_ORIGIN>/mcp#callback=<https URL on your origin>&state=<opaque>&ttl=<seconds>
+https://<II_ORIGIN>/mcp#registration_key=<base64url DER public key>&callback=<declared URL>&state=<opaque>&ttl=<seconds>
 ```
 
-- `callback` — an https URL on your origin. The user must have set your origin
-  as their trusted MCP server in II Settings (matching is by **origin**).
+- `registration_key` — the public key of a **fresh registration keypair `X`,
+  minted per connect attempt** (Ed25519 recommended, e.g. agent-js
+  `Ed25519KeyIdentity`), DER-encoded, base64url without padding. Only public
+  key material travels in the link; the corresponding private key stays on
+  your server and is what lets you — and only you — redeem the delegation.
+  Never reuse an `X` across connect attempts: II rejects a second
+  registration for a key whose previous one is still live, and the
+  delegation for it is single-use.
+- `callback` — one of the URLs you declared in §1, verbatim. The user must
+  have set your origin as their trusted MCP server in II Settings (matching
+  is by **origin**; the callback is then matched against your declared list).
 - `state` — unguessable, single-use, bound server-side to this pending
-  connection. Treat a mismatch as a hard reject.
+  connection. It comes back alongside the delegation; treat a mismatch as a
+  hard reject.
 - `ttl` — optional requested grant lifetime in seconds. Default 3600, clamped
   to [600, 2 592 000] (10 min – 30 days). The user can override it in the
-  consent UI, so treat it as a suggestion; the authoritative value arrives in
-  the completion notification.
+  consent UI, so treat it as a suggestion; the authoritative value is the
+  `expiration` returned by `mcp_register_v2`.
 
-No key material travels in the link: II never registers anything taken from
-the (attacker-craftable) fragment.
+## 3. Receive and redeem the registration delegation
 
-## 2. Callback endpoint
-
-Your callback answers JSON POSTs from the II frontend. Enable CORS: answer
-`OPTIONS` preflights and set `Access-Control-Allow-Origin: <II origin>` (or
-`*`; no credentials are used), `Access-Control-Allow-Headers: content-type`,
-`Access-Control-Allow-Methods: POST`.
-
-**a) Key request** — after user consent, II's frontend asks for your session
-public key:
+**a) Delivery.** After the user consents, II mints a canister-signed
+delegation `P_reg -> X` (where `P_reg` is a registration principal derived
+from the user's consent — you never construct it) and navigates the
+connecting tab to your declared callback with the chain in the **URL
+fragment**:
 
 ```
-POST <callback>            Content-Type: application/json
-{"state": "<state>"}
+https://<your-origin>/mcp/connect#delegation=<URL-encoded chain JSON>&state=<state>
 ```
 
-Respond:
+The fragment is never sent in the HTTP request, so the chain stays out of
+your access logs and any intermediary's. Your callback page reads it
+client-side and ships it to your backend over a same-origin request:
 
-```
-200 {"public_key": "<base64url, unpadded, DER-encoded public key>",
-     "finish_url": "<optional: absolute https URL on your origin>"}
-```
-
-Generate a **fresh keypair per user-connection** — Ed25519 recommended (e.g.
-agent-js `Ed25519KeyIdentity`). The registered principal is
-`self_authenticating(DER)`; one principal serves at most one identity, so a
-key reused across users makes the second registration fail. An unknown,
-already-used, or expired `state` must get a non-2xx response — the connect
-flow then errors out and **nothing is registered**.
-
-`finish_url` asks II to hand the connecting tab back to you once the session
-is registered (see (c) below). It must be an **absolute https URL on the same
-origin as the callback** — anything else fails the connect before anything is
-registered. Omit it (`null` and `""` also count as omitted) and the II tab
-simply shows its own success screen.
-
-**b) Completion notification** — best effort, after II registers the key
-(distinguish from (a) by the `expiration` field):
-
-```
-POST <callback>
-{"state": "<state>",
- "expiration": "<grant expiry, ns since epoch, decimal string>",
- "permissions": "queries" | "all"}
+```js
+const params = new URLSearchParams(location.hash.slice(1));
+const delegation = params.get("delegation"); // chain JSON
+const state = params.get("state");
+history.replaceState(null, "", location.pathname); // clear the fragment
+// POST { delegation, state } to your backend, same-origin
 ```
 
-Respond with any 2xx; mark the connection live and store `expiration` (a
-string because u64 nanoseconds overflow JSON numbers) and `permissions` (the
-session's access level — `"queries"` = read-only, `"all"` = full; see
-[Read-only sessions](#read-only-sessions)). You must tolerate never receiving
-this call (e.g. network failure after registration succeeded): fall back to
-attempting a signed call — success means you are registered — and to reading
-the access level off any minted delegation's `permissions` field.
+**b) The chain format** is agent-js `DelegationChain.toJSON()`: an object
+`{"delegations": [{"delegation": {"pubkey": "<hex>", "expiration": "<hex ns>"},
+"signature": "<hex>"}], "publicKey": "<hex>"}` with hex-encoded fields, where
+`publicKey` is `P_reg`'s DER key and the single delegation is to your `X`.
+With agent-js, reconstruction is two calls:
 
-**c) Finish redirect** — only if your key response carried `finish_url`:
-after registering the session and sending (b), II navigates the connecting
-tab to your `finish_url`. Use it to complete a flow of your own around the
-connect; without it the II tab finishes on its own and never redirects.
+```js
+import { DelegationChain, DelegationIdentity } from "@icp-sdk/core/identity";
 
-- **Ordering:** II awaits (b) before navigating, so you normally hear about
-  the registration first — but (b) is best effort, so the browser can arrive
-  without it. Treat arrival at `finish_url` as a UX signal, not as proof of
-  registration: verify via (b), or by making a signed `mcp_get_accounts` call
-  and checking for the `Ok` variant. (Check the candid result, not the
-  transport status: an unregistered key gets `Err Unauthorized(principal)`
-  delivered inside a _successful_ query response.)
-- Tie the request to the pending connection via the `finish_url` query — II
-  passes the URL through untouched, which is exactly how the one-time
-  `finish_secret` reaches `/oauth/finish` (see "Consent-Bound Completion").
+const chain = DelegationChain.fromJSON(JSON.parse(delegation));
+const identity = DelegationIdentity.fromDelegation(registrationKeyX, chain);
+```
+
+**c) Redemption.** Using that identity (so the canister sees `caller() ==
+P_reg`), call:
+
+```candid
+mcp_register_v2 : (session_key : blob)
+  -> (variant { Ok : McpRegistrationV2; Err : text });
+
+type McpRegistrationV2 = record {
+    expiration : nat64;        // grant expiry, ns since epoch
+    permissions : Permissions; // queries = read-only, all = full
+};
+```
+
+with the DER public key of your **session key `S`**. On `Ok`, the grant is
+live: `S`'s self-authenticating principal is bound to the consenting user's
+identity until `expiration`, with the access level the user chose (see
+[Read-only sessions](#read-only-sessions)). This response is synchronous and
+authoritative — there is no separate completion notification to wait for or
+tolerate missing.
+
+Semantics to build against:
+
+- **Redeem immediately.** The registration delegation lives ~90 seconds —
+  enough for the browser hops, not for a queue. Expired delegations get a
+  clean `Err`.
+- **Single-use, retry-safe.** The delegation binds one `S`. A retry of the
+  same call (same chain, same `S` — e.g. after a network timeout) is served
+  idempotently with the current grant; presenting a used delegation with a
+  *different* `S` is rejected. A failed connect is restarted with a fresh
+  `X`, fresh `state`, and a new link — never by re-driving the old one.
+- **Consent is fixed at consent time.** The anchor, the read-only choice, and
+  the grant TTL were recorded when the user consented; `mcp_register_v2`
+  takes none of them as arguments, so you cannot alter them — you only
+  supply the key to bind.
+- **Check `state` before redeeming.** Only redeem a delegation delivered
+  with a `state` you issued and haven't consumed; consume it atomically on
+  first use.
+- The chain is **inert to anyone without `X`'s private key**, authenticates
+  nothing but this one `mcp_register_v2` call, and grants no access by
+  itself. Discard it after redemption.
+
+**d) Finish on your own page.** After delivery, the tab is on *your* origin,
+on a page you serve — there is no redirect-back channel to ask II for.
+Verify the redemption result and continue your flow from there (show a
+"connected" state, or redirect onward — e.g. hand an OAuth code back to an
+MCP client). A 2xx from your own endpoint is not proof of registration; the
+canister's `Ok` is.
 
 ### Serving MCP clients over OAuth
 
@@ -157,70 +227,52 @@ metadata and RFC 8414 AS metadata, with RFC 7591 dynamic client registration.
 The RFC 8628 device grant is **not** part of that profile — no current client
 uses it, and it adds a device-code phishing surface with none of the PKCE
 binding the rest of the flow relies on, so prefer to omit it. The II connect
-slots into the code flow as your "identity provider" leg, with `finish_url`
-closing the loop:
+slots into the code flow as your "identity provider" leg, with your connect
+page closing the loop:
 
 1. `GET /oauth/authorize` — validate `client_id` + exact `redirect_uri` +
-   PKCE, create a pending auth `{code_challenge, oauth_state, resource}`, set
-   an initiator cookie (`sid`, `HttpOnly; Secure; SameSite=Lax`) referencing
-   it, and 302 the browser to the II connect link (§1) with a fresh,
-   single-use `connect_state` as the link's `state`.
-2. Your callback (§2a) answers the key request with a fresh keypair **and a
-   `finish_url` carrying a one-time `finish_secret` in its query** (see
-   "Consent-Bound Completion" below). Mint the keypair and `finish_secret`
-   and mark `connect_state` consumed in one atomic step, on the _first_ POST
-   for that `connect_state`; reject any later POST for it.
-3. `GET <finish_url>` — mint the authorization code only once the browser
-   proves it is both the initiator (the `sid` cookie) and the consenter (the
-   matching `finish_secret`), and the session is provably registered (see
-   (c)); then 302 to the client's `redirect_uri` with `code` + the client's
-   original `state`.
+   PKCE, create a pending auth `{code_challenge, oauth_state, resource}`,
+   mint a **fresh registration keypair `X`** and a fresh, single-use
+   `connect_state` for it, set an initiator cookie (`sid`, `HttpOnly;
+   Secure; SameSite=Lax`) referencing the pending auth, and 302 the browser
+   to the II connect link (§2).
+2. The consenting browser arrives at your declared callback (§3a) carrying
+   the delegation and `connect_state`; the page ships both to your backend
+   (the same-origin request carries the `sid` cookie).
+3. Bind before you redeem: accept the delivery only if the request carries
+   the `sid` cookie of the pending auth **and** the matching, unconsumed
+   `connect_state`. Then redeem (§3c) and, on `Ok`, mint the authorization
+   code and 302 to the client's `redirect_uri` with `code` + the client's
+   original `state`. If the initiator binding is missing, refuse and redeem
+   nothing.
 4. `POST /oauth/token` — exchange code + PKCE verifier for a bearer token.
    Bound its lifetime by the grant — never issue a token that outlives the
    grant. Refresh tokens are **optional**: they enable silent renewal but only
    pay off alongside server-side persistence (a restart wipes them too) and add
    no security over the grant, which is the hard, user-revocable ceiling either
    way. Without them the client re-runs the browser flow when the token
-   expires; the `error="invalid_token"` challenge (below) lets it prompt inline.
+   expires; the `error="invalid_token"` challenge lets it prompt inline.
 
-**Consent-Bound Completion: bind the code to whoever actually consented.** The
-`connect_state` in the II link travels back to the client in the redirect, and
-a cookie alone binds only `authorize`↔`finish` to one browser — neither binds
-the code to the browser that performed the II consent. Without that binding a
-split-browser takeover remains: an attacker registers a client (open DCR) with
-their own `redirect_uri` + PKCE, starts `/oauth/authorize`, lifts the resulting
-II connect link, and phishes it to a victim who already trusts your origin —
-II's consent screen names only **your server's origin**, never the OAuth
-client, so nothing warns the victim. The victim consents (registering _their_
-session under the attacker's pending auth); the attacker, still holding the
-`sid` cookie, completes `/oauth/finish` and redeems a token for the victim's
-identity.
+**Consent-Bound Completion is structural in this flow.** The classic
+split-browser takeover — an attacker registers a client (open DCR), starts
+`/oauth/authorize`, lifts the II connect link, and phishes it to a victim who
+already trusts your origin (II's consent screen names only **your server's
+origin**, never the OAuth client) — is broken at step 3: the delegation is
+delivered only to the consenting browser (the victim's), and that browser
+does not hold the attacker's `sid` cookie, so the delivery is refused,
+nothing is redeemed, and no code is minted. Conversely the attacker's
+browser holds `sid` but never receives the delegation. Only the legitimate
+same-browser flow holds both proofs — *initiator* (`sid`) and *consenter*
+(the delegation, single-use and redeemable only with your `X`) — so a code
+can never be minted for an identity other than the one operating the
+initiating client. No side-channel secret or "exactly one request, never
+retried" discipline is needed; the delegation itself is the consent-bound
+credential.
 
-Close it by requiring **two independent proofs** at `/oauth/finish` before
-minting a code: the `sid` cookie (proves _initiator_) **and** the
-`finish_secret` (proves _consenter_ — it is disclosed only in the key-request
-response, which runs in the consenting browser, and rides through to
-`/oauth/finish` inside `finish_url`). Because `connect_state` is single-use, the
-key request — and thus the `finish_secret` — reaches exactly one browser; only
-in the legitimate same-browser flow can one user-agent hold both proofs, so a
-code can never be minted for an identity other than the one operating the
-initiating client. This rests on II issuing **exactly one key request per
-connect and never auto-retrying it**: II drops the link's `state` after parsing
-and issues a single, non-retried `fetch`, so a failed connect must restart at
-`/oauth/authorize` with a new `connect_state` — never re-drive the same one. Do
-not add a client- or server-side retry of the key request.
-
-Two supporting requirements keep the proof intact. Treat the session as
-**registered only on proof of an on-chain grant** — a signed `mcp_get_accounts`
-returning `Ok` (see (c)), never a bare completion POST, which any
-`connect_state`-knower can forge. And keep `finish_secret` **leak-free**: carry
-it in the query string (not a path segment), set `Referrer-Policy: no-referrer`
-on `/oauth/finish`, and keep it out of logs, metrics, and error bodies.
-
-Consent-Bound Completion closes this for every client transport, including
-loopback. It does **not** by itself close the _same-browser_ variant (the
-attacker induces the victim's own browser to both initiate and consent) toward
-a **hosted** `redirect_uri`; that residual needs hosted-redirect allow-listing.
+This closes the takeover for every client transport, including loopback. It
+does **not** by itself close the _same-browser_ variant (the attacker induces
+the victim's own browser to both initiate and consent) toward a **hosted**
+`redirect_uri`; that residual needs hosted-redirect allow-listing.
 Loopback/native clients — whose redirect resolves on the consenter's own
 machine — are safe either way. (II cannot help with any of this: its trust
 model only ever identifies your origin, not the OAuth client.)
@@ -238,7 +290,7 @@ endpoint.
 
 At consent the user picks an access level, and **the connect screen defaults to
 read-only** — so unless the user deliberately opts out, you get a read-only
-session. II records the level on the grant and applies it to _every_ per-app
+session. II records the level at consent time and applies it to _every_ per-app
 delegation your session mints: a read-only session's delegations carry
 `permissions = "queries"`, so the IC rejects update calls made through them at
 ingress — enforcement is protocol-level, not up to the target app. This
@@ -247,17 +299,15 @@ uninstall/delete, and even `canister_status` and cycles reads are update
 calls), so that entire class of tools is inert under the default session. You
 don't choose this per call and can't widen it; it's fixed for the session.
 
-To know the level up front — rather than discovering it through an opaque
-ingress rejection — read the `permissions` field of the completion notification
-(§2b): `"queries"` = read-only, `"all"` = full. That POST is best-effort, so if
-it never arrives, fall back to inspecting the `permissions` field on the first
-`SignedDelegation` you mint (`queries` = read-only, absent = full). Either way,
-if your server needs update access and the session is read-only, tell the user
-to reconnect with read-only off instead of surfacing raw IC rejections. (You
-never pass the level yourself — `mcp_register` takes it as an `opt permissions`
-argument the II frontend fills from the consent screen.)
+You learn the level synchronously: it is the `permissions` field of
+`mcp_register_v2`'s `Ok` response (`queries` = read-only, `all` = full). The
+`permissions` field on any `SignedDelegation` you later mint carries the same
+value, as a cross-check. If your server needs update access and the session is
+read-only, tell the user to reconnect with read-only off instead of surfacing
+raw IC rejections. (You never pass the level yourself — it is recorded from
+the consent screen when the delegation is prepared, before you are involved.)
 
-## 3. Calling Internet Identity
+## 4. Calling Internet Identity
 
 Sign directly with the session key (a plain identity, no `DelegationChain`):
 
@@ -315,14 +365,14 @@ app's `ii-alternative-origins` (a web search or a direct fetch) and retry with
 the declared derivation origin as `target_origin`. Resolving it automatically is
 a planned enhancement, not current behavior.
 
-## 4. Session lifecycle
+## 5. Session lifecycle
 
 - **One active session per user identity.** A new connect (any agent, any
   device) replaces the previous grant immediately; the old key starts getting
   `Unauthorized`.
 - **Expiry:** at the grant's `expiration` every call returns
-  `Unauthorized(<your principal>)`. Reconnect via a fresh connect link with a
-  fresh keypair.
+  `Unauthorized(<your principal>)`. Reconnect via a fresh connect link — with
+  a fresh registration keypair `X` and a fresh session keypair `S`.
 - **Revocation:** the user can revoke at any time in II Settings (toggling MCP
   off or changing the trusted URL). Indistinguishable from expiry on your
   side. Treat any `Unauthorized` as "session over → offer reconnect"; do not

--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -271,9 +271,9 @@ page closing the loop:
 1. `GET /oauth/authorize` — validate `client_id` + exact `redirect_uri` +
    PKCE, create a pending auth `{code_challenge, oauth_state, resource}`,
    mint a **fresh registration keypair `X`** and a fresh, single-use
-   `connect_state` for it, set an initiator cookie (`sid`, `HttpOnly;
-Secure; SameSite=Lax`) referencing the pending auth, and 302 the browser
-   to the II connect link (§2).
+   `connect_state` for it, set an initiator cookie
+   (`sid`, `HttpOnly; Secure; SameSite=Lax`) referencing the pending auth,
+   and 302 the browser to the II connect link (§2).
 2. The consenting browser arrives at your declared callback (§3a) carrying
    the delegation and `connect_state`; the page ships both to your backend
    (the same-origin request carries the `sid` cookie).

--- a/src/frontend/src/lib/utils/accessLevel.ts
+++ b/src/frontend/src/lib/utils/accessLevel.ts
@@ -19,13 +19,6 @@ export const toPermissionsArg = (accessLevel: AccessLevel): [Permissions] => [
   accessLevel === "read-only" ? { queries: null } : { all: null },
 ];
 
-/** The wire string for this access level (`"queries"` / `"all"`), matching
- *  the protocol's `permissions` values. Used where the access level travels
- *  outside candid — e.g. the `/mcp` delivery fragment, whose value the MCP
- *  server echoes back as the `permissions` argument of `mcp_register_v2`. */
-export const toPermissionsString = (accessLevel: AccessLevel): string =>
-  accessLevel === "read-only" ? "queries" : "all";
-
 /** Whether an access-level toggle's checkbox is ticked: the box offers
  *  `prompt` as the opt-in, so it is ticked exactly when the current level
  *  *is* the prompted one. */

--- a/src/frontend/src/lib/utils/accessLevel.ts
+++ b/src/frontend/src/lib/utils/accessLevel.ts
@@ -19,14 +19,6 @@ export const toPermissionsArg = (accessLevel: AccessLevel): [Permissions] => [
   accessLevel === "read-only" ? { queries: null } : { all: null },
 ];
 
-/** The access level as the ICP permission string (`"queries"` / `"all"`) — the
- *  same vocabulary a minted delegation's `permissions` field uses. Sent to the
- *  MCP server in the connect completion notification so it learns the session's
- *  access level up front, without minting a probe delegation to inspect it. */
-export const toPermissionsString = (
-  accessLevel: AccessLevel,
-): "queries" | "all" => (accessLevel === "read-only" ? "queries" : "all");
-
 /** Whether an access-level toggle's checkbox is ticked: the box offers
  *  `prompt` as the opt-in, so it is ticked exactly when the current level
  *  *is* the prompted one. */

--- a/src/frontend/src/lib/utils/accessLevel.ts
+++ b/src/frontend/src/lib/utils/accessLevel.ts
@@ -19,6 +19,13 @@ export const toPermissionsArg = (accessLevel: AccessLevel): [Permissions] => [
   accessLevel === "read-only" ? { queries: null } : { all: null },
 ];
 
+/** The wire string for this access level (`"queries"` / `"all"`), matching
+ *  the protocol's `permissions` values. Used where the access level travels
+ *  outside candid — e.g. the `/mcp` delivery fragment, whose value the MCP
+ *  server echoes back as the `permissions` argument of `mcp_register_v2`. */
+export const toPermissionsString = (accessLevel: AccessLevel): string =>
+  accessLevel === "read-only" ? "queries" : "all";
+
 /** Whether an access-level toggle's checkbox is ticked: the box offers
  *  `prompt` as the opt-in, so it is ticked exactly when the current level
  *  *is* the prompted one. */

--- a/src/frontend/src/lib/utils/utils.ts
+++ b/src/frontend/src/lib/utils/utils.ts
@@ -285,6 +285,21 @@ export const throwCanisterError = <
   return response.Ok as Promise<S>;
 };
 
+/** Sibling of {@link throwCanisterError} for methods whose candid error is a
+ *  plain `text` (e.g. the `mcp_*` family) rather than a variant record —
+ *  {@link CanisterError} wraps variants, so it doesn't fit those. Unwraps `Ok`
+ *  and throws the `Err` string as an `Error`. Transport/replica failures
+ *  reject the call itself, so a catch can still distinguish them from
+ *  canister-reported errors. */
+export const throwTextCanisterError = <T>(
+  response: { Ok: T } | { Err: string },
+): T => {
+  if ("Err" in response) {
+    throw new Error(response.Err);
+  }
+  return response.Ok;
+};
+
 // Helper that normalizes ArrayBuffer-like inputs.
 // Given a Uint8Array or an ArrayBuffer, always return an ArrayBuffer corresponding
 // exactly to the view's bytes (respects byteOffset/byteLength for typed arrays).

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -217,7 +217,8 @@
           callback,
           state: request.state,
           // The server's public per-connect key `X` from the link (validated
-          // base64url in `load`); II mints a `P_reg -> X` delegation for it.
+          // base64url in `load`); the browser-signed final hop of the
+          // registration chain targets it.
           registrationKey: fromBase64URL(request.registrationKey),
         });
         mcpAuthorizeFunnel.trigger(McpAuthorizeEvents.Success);

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -12,6 +12,7 @@
   import { handleError } from "$lib/components/utils/error";
   import { toaster } from "$lib/components/utils/toaster";
   import { parseMcpServerUrl } from "$lib/utils/mcpServer";
+  import { fromBase64URL } from "$lib/utils/utils";
   import { readMcpConfig, isOriginTrusted } from "$lib/utils/mcpConfig";
   import { matchDeclaredCallback } from "$lib/utils/authCallbacks";
   import { get } from "svelte/store";
@@ -36,12 +37,12 @@
 
   // The MCP server the user is connecting is identified by the origin of the
   // request's callback: each user trusts whichever (remote) server they connect.
-  // The connect flow fetches the server's session key from that callback and
-  // reports completion to it — once the callback has been matched against the
-  // allow-list the server declares on its origin (see `matchDeclaredCallback`
-  // in `handleAuthorize`). MCP is remote-only, so only https callbacks are
-  // accepted (a plain-http or loopback callback is rejected). A disallowed (or
-  // unparsable) callback yields `undefined` → the invalid screen.
+  // The connect flow delivers the registration delegation to that callback —
+  // once it has been matched against the allow-list the server declares on its
+  // origin (see `matchDeclaredCallback` in `handleAuthorize`). MCP is
+  // remote-only, so only https callbacks are accepted (a plain-http or loopback
+  // callback is rejected). A disallowed (or unparsable) callback yields
+  // `undefined` → the invalid screen.
   const mcpServer = $derived(
     params.kind === "valid" ? parseMcpServerUrl(params.callback) : undefined,
   );
@@ -84,12 +85,12 @@
   // is the identity's synced (on-chain) config, which can only be read once
   // authenticated — so we show the connect screen optimistically and verify it
   // against the canister at connect time (`handleAuthorize`), moving to the
-  // untrusted screen if it isn't. The terminal `close` phase is reached from
-  // `handleAuthorize` once the session is registered — the whole flow runs on
-  // this page. There is no redirect-back unless the *trusted server* asks for
-  // one: a `finish_url` in its key response (validated same-origin with the
-  // callback) sends the tab there instead of the close screen, letting the
-  // server finish its own flow (e.g. hand an OAuth code to an MCP client).
+  // untrusted screen if it isn't. Once the registration delegation is minted,
+  // `handleAuthorize` hands the tab to the server's declared callback
+  // (carrying the delegation in the fragment): the server redeems it and
+  // finishes its own flow (e.g. hands an OAuth code to an MCP client). The
+  // terminal `close` phase is set first so the page is truthful if that
+  // navigation never replaces the document or the user comes Back to it.
   const initialPhase = (): Phase => {
     if (!requestValid) {
       return { kind: "invalid" };
@@ -157,10 +158,10 @@
   });
 
   // Invoked by the reused account picker once it has authenticated the selected
-  // identity and resolved the chosen account. Connecting fetches the server's
-  // session key from its callback and registers it with the backend
-  // (`mcp_register`, with the chosen access level) — the whole flow completes
-  // on this page.
+  // identity and resolved the chosen account. Connecting mints a single-use
+  // registration delegation for the server's per-connect key (recording the
+  // anchor and chosen access level on the backend) and hands the tab to the
+  // server's declared callback, which redeems it (`mcp_register_v2`).
   const handleAuthorize = (
     ttlSeconds: number,
     accessLevel: AccessLevel,
@@ -171,10 +172,9 @@
     }
     const request = params;
     mcpAuthorizeFunnel.trigger(McpAuthorizeEvents.Confirmed);
-    // Show a loading screen while we verify trust and (if trusted) fetch the
-    // server's key, register it, and notify the server: the picker's own button
-    // spinner stops once it hands off here, and those steps span several
-    // network round trips.
+    // Show a loading screen while we verify trust and (if trusted) mint the
+    // registration delegation: the picker's own button spinner stops once it
+    // hands off here, and those steps span several canister round trips.
     phase = { kind: "connecting" };
     void (async () => {
       try {
@@ -197,7 +197,7 @@
           phase = { kind: "untrusted" };
           return;
         }
-        // Contact the trusted server only at a callback it *declares*: the
+        // Deliver to the trusted server only at a callback it *declares*: the
         // server hosts an allow-list at a fixed well-known path on its origin
         // (/.well-known/ii-auth-callbacks), and the link's callback must
         // exact-match a declared entry. The (attacker-craftable) link only
@@ -205,30 +205,31 @@
         // point II at an arbitrary path on the trusted origin (a planted
         // file, a reflecting or redirecting route). An undeclared callback,
         // or an unreachable/invalid allow-list, throws: the connect fails
-        // closed into the catch below, before anything is registered.
+        // closed into the catch below, before anything is minted.
         const callback = await matchDeclaredCallback(
           server.origin,
           request.callback,
         );
-        const finishUrl = await mcpAuthorize({
+        const deliveryUrl = await mcpAuthorize({
           authenticated,
           ttlSeconds,
           accessLevel,
           callback,
           state: request.state,
+          // The server's public per-connect key `X` from the link (validated
+          // base64url in `load`); II mints a `P_reg -> X` delegation for it.
+          registrationKey: fromBase64URL(request.registrationKey),
         });
         mcpAuthorizeFunnel.trigger(McpAuthorizeEvents.Success);
-        // The session is registered either way: reach the terminal close
+        // The registration delegation is minted: reach the terminal close
         // screen first, so the page is in the truthful state even when the
-        // navigation below never replaces the document (a 204 or attachment
-        // response) or when the user comes Back to a bfcache-restored page —
-        // rather than stranding them on the connecting spinner.
-        phase = { kind: "close", redirecting: finishUrl !== undefined };
-        if (finishUrl !== undefined) {
-          // The trusted server asked to finish the flow on its side (already
-          // validated same-origin with the callback): hand it the tab.
-          window.location.assign(finishUrl);
-        }
+        // navigation below never replaces the document or the user comes Back
+        // to a bfcache-restored page — rather than stranding them on the
+        // connecting spinner. Then hand the tab to the server's declared
+        // callback with the delegation in the fragment; the server redeems it
+        // (mcp_register_v2) and finishes its own flow.
+        phase = { kind: "close", redirecting: true };
+        window.location.assign(deliveryUrl);
       } catch (error) {
         // Return to the connect screen so the user can retry.
         mcpAuthorizeFunnel.trigger(McpAuthorizeEvents.Error);

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -158,10 +158,11 @@
   });
 
   // Invoked by the reused account picker once it has authenticated the selected
-  // identity and resolved the chosen account. Connecting mints a single-use
-  // registration delegation for the server's per-connect key (recording the
-  // anchor and chosen access level on the backend) and hands the tab to the
-  // server's declared callback, which redeems it (`mcp_register_v2`).
+  // identity and resolved the chosen account. Connecting mints a short-lived
+  // registration delegation for the server's per-connect key (rooted at a
+  // principal derived from the anchor and the chosen access level, so neither
+  // can be altered) and hands the tab to the server's declared callback, which
+  // redeems it (`mcp_register_v2`).
   const handleAuthorize = (
     ttlSeconds: number,
     accessLevel: AccessLevel,

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -160,9 +160,10 @@
   // Invoked by the reused account picker once it has authenticated the selected
   // identity and resolved the chosen account. Connecting mints a short-lived
   // registration delegation for the server's per-connect key (rooted at a
-  // principal derived from the anchor and the chosen access level, so neither
-  // can be altered) and hands the tab to the server's declared callback, which
-  // redeems it (`mcp_register_v2`).
+  // principal `P_reg` seeded from a fresh random nonce; the whole consent —
+  // anchor, access level, grant lifetime — is recorded canister-side, so the
+  // server can't alter it) and hands the tab to the server's declared callback,
+  // which redeems it (`mcp_register_v2`).
   const handleAuthorize = (
     ttlSeconds: number,
     accessLevel: AccessLevel,

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.ts
@@ -1,6 +1,5 @@
 import type { PageLoad } from "./$types";
 import { z } from "zod";
-import { fromBase64URL } from "$lib/utils/utils";
 
 /** Default grant lifetime in seconds when the request omits `ttl`. */
 const DEFAULT_TTL_SECONDS = 60 * 60;
@@ -65,55 +64,31 @@ export type McpParams =
  * `z.string()` treats absence as invalid.
  */
 const McpRequestSchema = z.object({
-  // The server's registration public key `X` (DER, base64url). Kept verbatim
-  // as the base64url string (decoded to bytes at connect time); this just
-  // validates it is present and actually base64url-decodable, so a malformed
-  // key invalidates the request up front rather than throwing mid-connect.
-  registration_key: z.string().refine((raw) => {
-    try {
-      return fromBase64URL(raw).length > 0;
-    } catch {
-      return false;
-    }
-  }),
-  // Structural callback check: must be an absolute http(s) URL. The stricter
-  // "is this an origin the connect flow accepts" check (https only) happens in
-  // the component, alongside the consent UI — keeping this `load` minimal
-  // since it also runs at prerender.
-  callback: z.string().refine((raw) => {
-    try {
-      const url = new URL(raw);
-      return url.protocol === "https:" || url.protocol === "http:";
-    } catch {
-      return false;
-    }
-  }),
+  // The server's registration public key `X` (DER, base64url), surfaced
+  // verbatim (decoded to bytes at connect time). Zod's `base64url` check
+  // rejects a key with out-of-alphabet characters up front — so a malformed
+  // key invalidates the request rather than throwing mid-connect — and
+  // `.min(1)` rejects a present-but-empty one.
+  registration_key: z.base64url().min(1),
+  // Structural callback check: an absolute http(s) URL. The stricter "is this
+  // an origin the connect flow accepts" gate (https only) runs in the
+  // component, alongside the consent UI — keeping this `load` minimal since it
+  // also runs at prerender.
+  callback: z.url({ protocol: /^https?$/ }),
   state: z.string().min(1),
-  // `ttl` is a lifetime in seconds. Any positive value is accepted and clamped
-  // to the allowed range — at least 10 minutes, at most 30 days — so the exact
-  // requested duration is honoured within those bounds. An omitted `ttl` uses
-  // the default, and a malformed one (non-numeric or <= 0) invalidates the
-  // request.
-  ttl: z
-    .string()
-    .nullable()
-    .transform((raw, ctx) => {
-      if (raw === null) {
-        return DEFAULT_TTL_SECONDS;
-      }
-      const parsed = Number(raw);
-      if (!Number.isFinite(parsed) || parsed <= 0) {
-        ctx.addIssue({
-          code: "custom",
-          message: "ttl must be a positive number of seconds",
-        });
-        return z.NEVER;
-      }
-      return Math.min(
-        Math.max(Math.floor(parsed), MIN_TTL_SECONDS),
-        MAX_TTL_SECONDS,
-      );
-    }),
+  // `ttl` is a lifetime in seconds: coerced from the string, required to be a
+  // positive integer, then clamped to the allowed range (at least 10 minutes,
+  // at most 30 days) so the exact requested duration is honoured within those
+  // bounds. An omitted `ttl` uses the default; a malformed one (non-numeric or
+  // <= 0) invalidates the request.
+  ttl: z.coerce
+    .number()
+    .int()
+    .positive()
+    .transform((seconds) =>
+      Math.min(Math.max(seconds, MIN_TTL_SECONDS), MAX_TTL_SECONDS),
+    )
+    .default(DEFAULT_TTL_SECONDS),
 });
 
 export const load: PageLoad = ({ url }): { params: McpParams } => {
@@ -131,7 +106,9 @@ export const load: PageLoad = ({ url }): { params: McpParams } => {
     registration_key: params.get("registration_key"),
     callback: params.get("callback"),
     state: params.get("state"),
-    ttl: params.get("ttl"),
+    // Absent (`null` from `URLSearchParams.get`) becomes `undefined` so the
+    // schema's `.default()` applies; a present value is coerced and validated.
+    ttl: params.get("ttl") ?? undefined,
   });
   if (!request.success) {
     return { params: { kind: "invalid" } };

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.ts
@@ -24,7 +24,7 @@ const MAX_TTL_SECONDS = 30 * 24 * 60 * 60;
  * delivered delegation to the connect it started, and the requested
  * session-grant TTL (`ttl`, in seconds). The MCP server the user connects is
  * identified by the callback's *origin* (each user trusts whichever server they
- * connect); II mints a single-use registration delegation chain (rooted at a
+ * connect); II mints a short-lived registration delegation chain (rooted at a
  * canister-signed hop to a browser-held key, extended locally to `X`) and
  * delivers it to the callback only after it exact-matches the allow-list the
  * server declares at a fixed well-known path on that origin (see

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.ts
@@ -1,4 +1,5 @@
 import type { PageLoad } from "./$types";
+import { z } from "zod";
 import { fromBase64URL } from "$lib/utils/utils";
 
 /** Default grant lifetime in seconds when the request omits `ttl`. */
@@ -57,69 +58,61 @@ export type McpParams =
   | { kind: "invalid" };
 
 /**
- * Structural callback check: must be an absolute http(s) URL. The stricter
- * "is this an origin the connect flow accepts" check (https only) happens in
- * the component, alongside the consent UI — keeping this `load` minimal since
- * it also runs at prerender.
+ * The whole fragment, validated and normalized in one schema. Absent params
+ * arrive as `null` (from `URLSearchParams.get`), so any field typed plain
+ * `z.string()` treats absence as invalid.
  */
-const parseCallback = (raw: string | null): string | undefined => {
-  if (raw === null || raw === "") {
-    return undefined;
-  }
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    return undefined;
-  }
-  if (url.protocol !== "https:" && url.protocol !== "http:") {
-    return undefined;
-  }
-  return raw;
-};
-
-const parseState = (raw: string | null): string | undefined => {
-  if (raw === null || raw === "") {
-    return undefined;
-  }
-  return raw;
-};
-
-// The server's registration public key `X` (DER, base64url). Kept verbatim as
-// the base64url string (decoded to bytes at connect time); this just validates
-// it is present and actually base64url-decodable, so a malformed key
-// invalidates the request up front rather than throwing mid-connect.
-const parseRegistrationKey = (raw: string | null): string | undefined => {
-  if (raw === null || raw === "") {
-    return undefined;
-  }
-  try {
-    if (fromBase64URL(raw).length === 0) {
-      return undefined;
+const McpRequestSchema = z.object({
+  // The server's registration public key `X` (DER, base64url). Kept verbatim
+  // as the base64url string (decoded to bytes at connect time); this just
+  // validates it is present and actually base64url-decodable, so a malformed
+  // key invalidates the request up front rather than throwing mid-connect.
+  registration_key: z.string().refine((raw) => {
+    try {
+      return fromBase64URL(raw).length > 0;
+    } catch {
+      return false;
     }
-  } catch {
-    return undefined;
-  }
-  return raw;
-};
-
-// `ttl` is a lifetime in seconds. Any positive value is accepted and clamped to
-// the allowed range — at least 10 minutes, at most 30 days — so the exact
-// requested duration is honoured within those bounds. An omitted `ttl` uses the
-// default, and a malformed one (non-numeric or <= 0) invalidates the request.
-const parseTtl = (raw: string | null): number | undefined => {
-  if (raw === null) {
-    return DEFAULT_TTL_SECONDS;
-  }
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return undefined;
-  }
-  return Math.min(
-    Math.max(Math.floor(parsed), MIN_TTL_SECONDS),
-    MAX_TTL_SECONDS,
-  );
-};
+  }),
+  // Structural callback check: must be an absolute http(s) URL. The stricter
+  // "is this an origin the connect flow accepts" check (https only) happens in
+  // the component, alongside the consent UI — keeping this `load` minimal
+  // since it also runs at prerender.
+  callback: z.string().refine((raw) => {
+    try {
+      const url = new URL(raw);
+      return url.protocol === "https:" || url.protocol === "http:";
+    } catch {
+      return false;
+    }
+  }),
+  state: z.string().min(1),
+  // `ttl` is a lifetime in seconds. Any positive value is accepted and clamped
+  // to the allowed range — at least 10 minutes, at most 30 days — so the exact
+  // requested duration is honoured within those bounds. An omitted `ttl` uses
+  // the default, and a malformed one (non-numeric or <= 0) invalidates the
+  // request.
+  ttl: z
+    .string()
+    .nullable()
+    .transform((raw, ctx) => {
+      if (raw === null) {
+        return DEFAULT_TTL_SECONDS;
+      }
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        ctx.addIssue({
+          code: "custom",
+          message: "ttl must be a positive number of seconds",
+        });
+        return z.NEVER;
+      }
+      return Math.min(
+        Math.max(Math.floor(parsed), MIN_TTL_SECONDS),
+        MAX_TTL_SECONDS,
+      );
+    }),
+});
 
 export const load: PageLoad = ({ url }): { params: McpParams } => {
   // The MCP server redirects the browser here with the request in the URL
@@ -132,20 +125,23 @@ export const load: PageLoad = ({ url }): { params: McpParams } => {
   // (attacker-craftable) link.
   const params = new URLSearchParams(url.hash.slice(1));
 
-  const registrationKey = parseRegistrationKey(params.get("registration_key"));
-  const callback = parseCallback(params.get("callback"));
-  const state = parseState(params.get("state"));
-  const ttlSeconds = parseTtl(params.get("ttl"));
-
-  if (
-    registrationKey === undefined ||
-    callback === undefined ||
-    state === undefined ||
-    ttlSeconds === undefined
-  ) {
+  const request = McpRequestSchema.safeParse({
+    registration_key: params.get("registration_key"),
+    callback: params.get("callback"),
+    state: params.get("state"),
+    ttl: params.get("ttl"),
+  });
+  if (!request.success) {
     return { params: { kind: "invalid" } };
   }
+  const { registration_key, callback, state, ttl } = request.data;
   return {
-    params: { kind: "valid", registrationKey, callback, state, ttlSeconds },
+    params: {
+      kind: "valid",
+      registrationKey: registration_key,
+      callback,
+      state,
+      ttlSeconds: ttl,
+    },
   };
 };

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.ts
@@ -24,7 +24,8 @@ const MAX_TTL_SECONDS = 30 * 24 * 60 * 60;
  * delivered delegation to the connect it started, and the requested
  * session-grant TTL (`ttl`, in seconds). The MCP server the user connects is
  * identified by the callback's *origin* (each user trusts whichever server they
- * connect); II mints a single-use registration delegation `P_reg -> X` and
+ * connect); II mints a single-use registration delegation chain (rooted at a
+ * canister-signed hop to a browser-held key, extended locally to `X`) and
  * delivers it to the callback only after it exact-matches the allow-list the
  * server declares at a fixed well-known path on that origin (see
  * `matchDeclaredCallback`), so a crafted link can't point II at an arbitrary
@@ -42,9 +43,10 @@ export type McpParams =
   | {
       kind: "valid";
       /** The MCP server's registration public key `X` (DER, base64url) for this
-       *  connect. II mints a single-use `P_reg -> X` delegation for it, so the
-       *  server can bind its long-lived session key by redeeming that chain
-       *  (`mcp_register_v2`) — nothing secret rides this public key. */
+       *  connect. The registration chain's browser-signed final hop targets
+       *  it, so the server can bind its long-lived session key by redeeming
+       *  that chain (`mcp_register_v2`) — nothing secret rides this public
+       *  key. */
       registrationKey: string;
       callback: string;
       /** Opaque value the server issued for this connect; delivered back
@@ -120,9 +122,9 @@ export const load: PageLoad = ({ url }): { params: McpParams } => {
   // II's request logs; the address-bar copy is cleared in `+page.svelte` via
   // `replaceState`). Reading `url.hash` relies on this universal `load`
   // re-running client-side; with `adapter-static` it's empty during prerender.
-  // The `registration_key` is the server's *public* per-connect key `X`; II
-  // mints a `P_reg -> X` delegation for it, so no secret key material rides the
-  // (attacker-craftable) link.
+  // The `registration_key` is the server's *public* per-connect key `X`; the
+  // browser-signed hop of the registration chain targets it, so no secret key
+  // material rides the (attacker-craftable) link.
   const params = new URLSearchParams(url.hash.slice(1));
 
   const request = McpRequestSchema.safeParse({

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.ts
@@ -1,4 +1,5 @@
 import type { PageLoad } from "./$types";
+import { fromBase64URL } from "$lib/utils/utils";
 
 /** Default grant lifetime in seconds when the request omits `ttl`. */
 const DEFAULT_TTL_SECONDS = 60 * 60;
@@ -15,18 +16,22 @@ const MAX_TTL_SECONDS = 30 * 24 * 60 * 60;
 
 /**
  * The `/mcp` request, parsed from the URL fragment the MCP server redirects the
- * browser to. `valid` carries the validated request — the callback on the MCP
- * server the connect flow talks to, the single-use `state` included in those
- * requests so the server can tie them to the connect it started, and the
- * requested session-grant TTL (`ttl`, in seconds). The MCP server the user
- * connects is identified by the callback's *origin* (each user trusts whichever
- * server they connect); the callback itself is only honoured after it
- * exact-matches the allow-list the server declares at a fixed well-known path
- * on that origin (see `matchDeclaredCallback`), so a crafted link can't point
- * II at an arbitrary path on the trusted origin — the link only selects among
- * the server-declared callbacks. No key material travels in the fragment, and
- * no account is chosen here (it's per-app, picked server-side at delegation
- * time). `invalid` means the fragment was missing or malformed.
+ * browser to. `valid` carries the validated request — the MCP server's
+ * registration public key (`registration_key`, the per-connect key `X` the
+ * server generated for this browser session), the callback identifying the
+ * server, the single-use `state` the server echoes back so it can tie the
+ * delivered delegation to the connect it started, and the requested
+ * session-grant TTL (`ttl`, in seconds). The MCP server the user connects is
+ * identified by the callback's *origin* (each user trusts whichever server they
+ * connect); II mints a single-use registration delegation `P_reg -> X` and
+ * delivers it to the callback only after it exact-matches the allow-list the
+ * server declares at a fixed well-known path on that origin (see
+ * `matchDeclaredCallback`), so a crafted link can't point II at an arbitrary
+ * path on the trusted origin — the link only selects among the server-declared
+ * callbacks. The only key material in the fragment is the server's own public
+ * `registration_key` (never a secret), and no account is chosen here (it's
+ * per-app, picked server-side at delegation time). `invalid` means the fragment
+ * was missing or malformed.
  *
  * Whether the callback origin is one the connect flow accepts (https only — MCP
  * connections are to remote servers) is checked in the page component, which
@@ -35,10 +40,15 @@ const MAX_TTL_SECONDS = 30 * 24 * 60 * 60;
 export type McpParams =
   | {
       kind: "valid";
+      /** The MCP server's registration public key `X` (DER, base64url) for this
+       *  connect. II mints a single-use `P_reg -> X` delegation for it, so the
+       *  server can bind its long-lived session key by redeeming that chain
+       *  (`mcp_register_v2`) — nothing secret rides this public key. */
+      registrationKey: string;
       callback: string;
-      /** Opaque value the server issued for this connect; included in the
-       *  key-request and completion calls so the server can tie them to the
-       *  request it started (CSRF protection). */
+      /** Opaque value the server issued for this connect; delivered back
+       *  alongside the registration delegation so the server can tie it to the
+       *  connect it started (CSRF protection). */
       state: string;
       /** Requested session-grant lifetime in seconds (clamped to
        *  [10 min, 30 days]). */
@@ -75,6 +85,24 @@ const parseState = (raw: string | null): string | undefined => {
   return raw;
 };
 
+// The server's registration public key `X` (DER, base64url). Kept verbatim as
+// the base64url string (decoded to bytes at connect time); this just validates
+// it is present and actually base64url-decodable, so a malformed key
+// invalidates the request up front rather than throwing mid-connect.
+const parseRegistrationKey = (raw: string | null): string | undefined => {
+  if (raw === null || raw === "") {
+    return undefined;
+  }
+  try {
+    if (fromBase64URL(raw).length === 0) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return raw;
+};
+
 // `ttl` is a lifetime in seconds. Any positive value is accepted and clamped to
 // the allowed range — at least 10 minutes, at most 30 days — so the exact
 // requested duration is honoured within those bounds. An omitted `ttl` uses the
@@ -99,16 +127,18 @@ export const load: PageLoad = ({ url }): { params: McpParams } => {
   // II's request logs; the address-bar copy is cleared in `+page.svelte` via
   // `replaceState`). Reading `url.hash` relies on this universal `load`
   // re-running client-side; with `adapter-static` it's empty during prerender.
-  // A legacy `public_key` param is ignored: the session key is fetched from
-  // the trusted server's callback, never taken from the (attacker-craftable)
-  // link.
+  // The `registration_key` is the server's *public* per-connect key `X`; II
+  // mints a `P_reg -> X` delegation for it, so no secret key material rides the
+  // (attacker-craftable) link.
   const params = new URLSearchParams(url.hash.slice(1));
 
+  const registrationKey = parseRegistrationKey(params.get("registration_key"));
   const callback = parseCallback(params.get("callback"));
   const state = parseState(params.get("state"));
   const ttlSeconds = parseTtl(params.get("ttl"));
 
   if (
+    registrationKey === undefined ||
     callback === undefined ||
     state === undefined ||
     ttlSeconds === undefined
@@ -116,6 +146,6 @@ export const load: PageLoad = ({ url }): { params: McpParams } => {
     return { params: { kind: "invalid" } };
   }
   return {
-    params: { kind: "valid", callback, state, ttlSeconds },
+    params: { kind: "valid", registrationKey, callback, state, ttlSeconds },
   };
 };

--- a/src/frontend/src/routes/(new-styling)/mcp/load.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/load.test.ts
@@ -5,11 +5,16 @@ const HOUR = 60 * 60;
 const MIN_TTL = 10 * 60;
 const MAX_TTL = 30 * 24 * 60 * 60;
 
+// A valid base64url registration key (the server's public per-connect key `X`).
+const REGISTRATION_KEY = "cmVnaXN0cmF0aW9uLWtleQ";
+
 // A complete, valid fragment with an optional `ttl`. The callback is an
-// accepted https origin; no key material travels in the fragment (the
-// server's session key is fetched from the callback after consent).
+// accepted https origin; the only key material is the server's *public*
+// registration key (II mints a `P_reg -> X` delegation for it — nothing secret
+// travels in the fragment).
 const fragment = (ttl?: string): string => {
   const params = new URLSearchParams();
+  params.set("registration_key", REGISTRATION_KEY);
   params.set("callback", "https://mcp.example.com/cb");
   params.set("state", "opaque-state");
   if (ttl !== undefined) {
@@ -74,19 +79,44 @@ describe("/mcp load: ttl parsing", () => {
 });
 
 describe("/mcp load: request validation", () => {
+  it("surfaces the registration key verbatim on a valid request", () => {
+    const parsed = loadTtl();
+    expect(parsed.kind).toBe("valid");
+    if (parsed.kind === "valid") {
+      expect(parsed.registrationKey).toBe(REGISTRATION_KEY);
+    }
+  });
+
+  it("rejects a fragment without a registration_key", () => {
+    const params = new URLSearchParams(fragment());
+    params.delete("registration_key");
+    expect(loadParams(params.toString()).kind).toBe("invalid");
+  });
+
+  it("rejects a present-but-empty or undecodable registration_key", () => {
+    const empty = new URLSearchParams(fragment());
+    empty.set("registration_key", "");
+    expect(loadParams(empty.toString()).kind).toBe("invalid");
+
+    const garbage = new URLSearchParams(fragment());
+    // `*` is outside the base64url alphabet, so decoding throws → invalid.
+    garbage.set("registration_key", "***not-base64***");
+    expect(loadParams(garbage.toString()).kind).toBe("invalid");
+  });
+
   it("rejects a fragment without a callback", () => {
-    const params = new URLSearchParams();
-    params.set("state", "opaque-state");
+    const params = new URLSearchParams(fragment());
+    params.delete("callback");
     expect(loadParams(params.toString()).kind).toBe("invalid");
   });
 
   it("rejects a fragment without a state", () => {
-    const params = new URLSearchParams();
-    params.set("callback", "https://mcp.example.com/cb");
+    const params = new URLSearchParams(fragment());
+    params.delete("state");
     expect(loadParams(params.toString()).kind).toBe("invalid");
   });
 
-  it("tolerates (and ignores) a legacy public_key param", () => {
+  it("tolerates (and ignores) an unknown extra param", () => {
     const params = new URLSearchParams(fragment());
     params.set("public_key", "AAAA");
     const parsed = loadParams(params.toString());

--- a/src/frontend/src/routes/(new-styling)/mcp/load.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/load.test.ts
@@ -10,8 +10,9 @@ const REGISTRATION_KEY = "cmVnaXN0cmF0aW9uLWtleQ";
 
 // A complete, valid fragment with an optional `ttl`. The callback is an
 // accepted https origin; the only key material is the server's *public*
-// registration key (II mints a `P_reg -> X` delegation for it — nothing secret
-// travels in the fragment).
+// registration key `X` (II mints a two-hop `P_reg -> Y -> X` chain rooted at
+// it — a canister-signed `P_reg -> Y` extended browser-side to `X` — nothing
+// secret travels in the fragment).
 const fragment = (ttl?: string): string => {
   const params = new URLSearchParams();
   params.set("registration_key", REGISTRATION_KEY);

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
@@ -42,8 +42,7 @@ const makeActor = () => {
       (
         _anchor: bigint,
         requestedKey: Uint8Array,
-        _permissions: [{ queries: null } | { all: null }],
-        _maxTtl: [bigint],
+        _userKey: Uint8Array,
         _expiration: bigint,
       ): Promise<
         | {
@@ -113,8 +112,8 @@ describe("mcpAuthorize registration-delegation minting", () => {
     await authorize(actor, "read-only");
 
     // Minted for the identity and a browser-generated ephemeral key Y, with
-    // the user-chosen grant TTL and the read-only access level (folded into
-    // the derived registration principal, never into the signature).
+    // the user-chosen grant TTL and the read-only access level (recorded on
+    // the registration entry, never into the signature).
     expect(actor.prepare_mcp_registration_delegation).toHaveBeenCalledWith(
       IDENTITY_NUMBER,
       expect.any(Uint8Array),
@@ -156,17 +155,17 @@ describe("mcpAuthorize registration-delegation minting", () => {
     );
   });
 
-  it("fetches the certified delegation with the same consent parameters", async () => {
+  it("fetches the certified delegation by handing back the user_key prepare returned", async () => {
     const actor = makeActor();
     await authorize(actor, "read-only");
 
-    // `get` re-derives the seed from its arguments (nothing is stored), so it
-    // takes the exact consent tuple prepare folded, plus prepare's expiration.
+    // `get` recovers the seed from `user_key` (no consent params), so it is
+    // called with the browser key Y, the user_key prepare returned, and the
+    // expiration.
     expect(actor.get_mcp_registration_delegation).toHaveBeenCalledWith(
       IDENTITY_NUMBER,
       browserKeyOf(actor),
-      [{ queries: null }],
-      [BigInt(TTL_SECONDS) * BigInt(1_000_000_000)],
+      USER_KEY,
       actor.expiration,
     );
   });
@@ -186,38 +185,35 @@ describe("mcpAuthorize delivery URL", () => {
     expect(fragment.get("state")).toBe(STATE);
   });
 
-  it("carries the echoed consent (permissions, ttl) the server passes to mcp_register_v2", async () => {
-    // The derivation authenticates the echo (a tampered value fails to
-    // redeem), but the server needs the plain values to echo: the access level
-    // as its wire string and the grant TTL in nanoseconds.
-    const url = await authorize(makeActor(), "read-only");
-
-    const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
-    expect(fragment.get("permissions")).toBe("queries");
-    expect(fragment.get("ttl")).toBe(
-      (BigInt(TTL_SECONDS) * BigInt(1_000_000_000)).toString(),
-    );
-  });
-
-  it("never delivers the anchor number to the server", async () => {
-    // The canister recovers the anchor server-side from the registration
-    // entry, so it must not ride the fragment (the server never learns it).
-    const url = await authorize(makeActor(), "read-only");
-
-    const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
-    expect(fragment.get("anchor")).toBeNull();
-    // No delivered value *is* the anchor (the delegation blob is hex and may
-    // contain the digits incidentally, so check param values, not substrings).
-    for (const value of fragment.values()) {
-      expect(value).not.toBe(IDENTITY_NUMBER.toString());
+  it("delivers only the delegation and state — no consent params", async () => {
+    // The server passes nothing but its session key to mcp_register_v2; the
+    // canister recovers the whole consent from the entry. So the fragment
+    // carries only the chain and the state echo — no anchor, permissions, or
+    // ttl (checked for both access levels, since neither should surface).
+    for (const level of ["read-only", "full-access"] as const) {
+      const url = await authorize(makeActor(), level);
+      const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
+      expect([...fragment.keys()].sort()).toEqual(["delegation", "state"]);
+      // Belt-and-suspenders: the anchor number appears as no param value (the
+      // delegation blob is hex and may contain the digits incidentally, so
+      // check values, not substrings).
+      for (const value of fragment.values()) {
+        expect(value).not.toBe(IDENTITY_NUMBER.toString());
+      }
     }
   });
 
-  it("marks a full-access connect as such in the echoed consent", async () => {
-    const url = await authorize(makeActor(), "full-access");
+  it("marks a full-access connect as such to prepare (never in the fragment)", async () => {
+    const actor = makeActor();
+    await authorize(actor, "full-access");
 
-    const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
-    expect(fragment.get("permissions")).toBe("all");
+    // The access level reaches the canister via prepare, not the fragment.
+    expect(actor.prepare_mcp_registration_delegation).toHaveBeenCalledWith(
+      IDENTITY_NUMBER,
+      expect.any(Uint8Array),
+      [{ all: null }],
+      [BigInt(TTL_SECONDS) * BigInt(1_000_000_000)],
+    );
   });
 
   it("carries a reconstructable two-hop P_reg -> Y -> X chain", async () => {

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
@@ -15,8 +15,8 @@ const CALLBACK = `${MCP_ORIGIN}/mcp/connect`;
 const STATE = "opaque-state";
 const TTL_SECONDS = 3600;
 
-/** The MCP server's per-connect registration public key `X` (DER). II mints a
- *  `P_reg -> X` delegation for it — nothing secret rides this. */
+/** The MCP server's per-connect registration public key `X` (DER), from the
+ *  link. The browser-signed final hop targets it — the canister never sees it. */
 const REGISTRATION_KEY = new Uint8Array(44).fill(9);
 /** `P_reg`'s DER public key, returned by the mocked prepare call — the chain's
  *  public key, and what makes the server's redemption `caller() == P_reg`. */
@@ -26,9 +26,11 @@ const expirationNanos = (): bigint =>
   BigInt(Date.now() + 60 * 60 * 1000) * BigInt(1_000_000);
 
 /** Fake actor recording the exact candid arguments the flow sends. `prepare`
- *  returns `P_reg`'s key + an expiration; `get` returns a well-formed (but
- *  arbitrary) signed `P_reg -> X` delegation — the chain is only assembled and
- *  serialized on the frontend, never verified, so the bytes needn't be real. */
+ *  returns `P_reg`'s key + an expiration; `get` echoes back a well-formed
+ *  signed delegation for whatever key was requested (the browser-generated
+ *  `Y`, unknown to the test up front) — the chain is only assembled and
+ *  serialized on the frontend, never verified, so the signature needn't be
+ *  real. */
 const makeActor = () => {
   const expiration = expirationNanos();
   return {
@@ -36,19 +38,43 @@ const makeActor = () => {
     prepare_mcp_registration_delegation: vi
       .fn()
       .mockResolvedValue({ Ok: { user_key: USER_KEY, expiration } }),
-    get_mcp_registration_delegation: vi.fn().mockResolvedValue({
-      Ok: {
-        delegation: {
-          pubkey: Array.from(REGISTRATION_KEY),
-          expiration,
-          targets: [],
-          permissions: [],
-        },
-        signature: Array.from(new Uint8Array(64).fill(1)),
-      },
-    }),
+    get_mcp_registration_delegation: vi.fn(
+      (
+        _anchor: bigint,
+        requestedKey: Uint8Array,
+      ): Promise<
+        | {
+            Ok: {
+              delegation: {
+                pubkey: number[];
+                expiration: bigint;
+                targets: never[];
+                permissions: never[];
+              };
+              signature: number[];
+            };
+          }
+        | { Err: string }
+      > =>
+        Promise.resolve({
+          Ok: {
+            delegation: {
+              pubkey: Array.from(requestedKey),
+              expiration,
+              targets: [],
+              permissions: [],
+            },
+            signature: Array.from(new Uint8Array(64).fill(1)),
+          },
+        }),
+    ),
   };
 };
+
+/** The browser-generated registration key `Y` the flow sent to `prepare` —
+ *  readable only after the flow ran. */
+const browserKeyOf = (actor: ReturnType<typeof makeActor>): Uint8Array =>
+  actor.prepare_mcp_registration_delegation.mock.calls[0][1] as Uint8Array;
 
 const authorize = (
   actor: ReturnType<typeof makeActor>,
@@ -83,15 +109,36 @@ describe("mcpAuthorize registration-delegation minting", () => {
     const actor = makeActor();
     await authorize(actor, "read-only");
 
-    // Minted for the identity and the server's registration key, with the
-    // user-chosen grant TTL and the read-only access level (recorded on the
-    // index entry by the backend, never folded into the signature).
+    // Minted for the identity and a browser-generated ephemeral key Y, with
+    // the user-chosen grant TTL and the read-only access level (recorded on
+    // the index entry by the backend, never folded into the signature).
     expect(actor.prepare_mcp_registration_delegation).toHaveBeenCalledWith(
       IDENTITY_NUMBER,
-      REGISTRATION_KEY,
+      expect.any(Uint8Array),
       [{ queries: null }],
       [BigInt(TTL_SECONDS) * BigInt(1_000_000_000)],
     );
+  });
+
+  it("never sends the link's key X to the canister", async () => {
+    // The canister-signed hop must be inert to a transport-level observer:
+    // it targets the browser-held Y, never the (attacker-craftable) link's X.
+    const actor = makeActor();
+    await authorize(actor, "read-only");
+
+    const browserKey = browserKeyOf(actor);
+    expect(browserKey.length).toBeGreaterThan(0);
+    expect(toHex(browserKey)).not.toBe(toHex(REGISTRATION_KEY));
+    const [, getKey] = actor.get_mcp_registration_delegation.mock.calls[0];
+    expect(toHex(getKey as Uint8Array)).toBe(toHex(browserKey));
+  });
+
+  it("generates a fresh Y per connect attempt", async () => {
+    const first = makeActor();
+    await authorize(first, "read-only");
+    const second = makeActor();
+    await authorize(second, "read-only");
+    expect(toHex(browserKeyOf(first))).not.toBe(toHex(browserKeyOf(second)));
   });
 
   it("passes full access explicitly (never relies on the backend default)", async () => {
@@ -100,7 +147,7 @@ describe("mcpAuthorize registration-delegation minting", () => {
 
     expect(actor.prepare_mcp_registration_delegation).toHaveBeenCalledWith(
       IDENTITY_NUMBER,
-      REGISTRATION_KEY,
+      expect.any(Uint8Array),
       [{ all: null }],
       [BigInt(TTL_SECONDS) * BigInt(1_000_000_000)],
     );
@@ -112,7 +159,7 @@ describe("mcpAuthorize registration-delegation minting", () => {
 
     expect(actor.get_mcp_registration_delegation).toHaveBeenCalledWith(
       IDENTITY_NUMBER,
-      REGISTRATION_KEY,
+      browserKeyOf(actor),
       actor.expiration,
     );
   });
@@ -132,8 +179,9 @@ describe("mcpAuthorize delivery URL", () => {
     expect(fragment.get("state")).toBe(STATE);
   });
 
-  it("carries a reconstructable P_reg -> X delegation chain", async () => {
-    const url = await authorize(makeActor(), "read-only");
+  it("carries a reconstructable two-hop P_reg -> Y -> X chain", async () => {
+    const actor = makeActor();
+    const url = await authorize(actor, "read-only");
 
     const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
     const delegation = fragment.get("delegation");
@@ -143,11 +191,20 @@ describe("mcpAuthorize delivery URL", () => {
     const chain = DelegationChain.fromJSON(JSON.parse(delegation));
     // Its public key is P_reg's DER key, so the redemption is caller() == P_reg.
     expect(toHex(new Uint8Array(chain.publicKey))).toBe(toHex(USER_KEY));
-    expect(chain.delegations).toHaveLength(1);
-    // The delegated-to key is the server's registration key X.
-    expect(toHex(new Uint8Array(chain.delegations[0].delegation.pubkey))).toBe(
+    expect(chain.delegations).toHaveLength(2);
+    const [canisterHop, browserHop] = chain.delegations;
+    // Hop 1 (canister-signed) targets the browser-held Y...
+    expect(toHex(new Uint8Array(canisterHop.delegation.pubkey))).toBe(
+      toHex(browserKeyOf(actor)),
+    );
+    // ...hop 2 (browser-signed) targets the server's X, expiring no later
+    // than the canister hop.
+    expect(toHex(new Uint8Array(browserHop.delegation.pubkey))).toBe(
       toHex(REGISTRATION_KEY),
     );
+    expect(
+      browserHop.delegation.expiration <= canisterHop.delegation.expiration,
+    ).toBe(true);
   });
 });
 

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
@@ -186,21 +186,34 @@ describe("mcpAuthorize delivery URL", () => {
     expect(fragment.get("state")).toBe(STATE);
   });
 
-  it("carries the consent tuple the server must echo to mcp_register_v2", async () => {
+  it("carries the echoed consent (permissions, ttl) the server passes to mcp_register_v2", async () => {
     // The derivation authenticates the echo (a tampered value fails to
-    // redeem), but the server needs the plain values to echo: the anchor, the
-    // access level as its wire string, and the grant TTL in nanoseconds.
+    // redeem), but the server needs the plain values to echo: the access level
+    // as its wire string and the grant TTL in nanoseconds.
     const url = await authorize(makeActor(), "read-only");
 
     const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
-    expect(fragment.get("anchor")).toBe(IDENTITY_NUMBER.toString());
     expect(fragment.get("permissions")).toBe("queries");
     expect(fragment.get("ttl")).toBe(
       (BigInt(TTL_SECONDS) * BigInt(1_000_000_000)).toString(),
     );
   });
 
-  it("marks a full-access connect as such in the consent tuple", async () => {
+  it("never delivers the anchor number to the server", async () => {
+    // The canister recovers the anchor server-side from the registration
+    // entry, so it must not ride the fragment (the server never learns it).
+    const url = await authorize(makeActor(), "read-only");
+
+    const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
+    expect(fragment.get("anchor")).toBeNull();
+    // No delivered value *is* the anchor (the delegation blob is hex and may
+    // contain the digits incidentally, so check param values, not substrings).
+    for (const value of fragment.values()) {
+      expect(value).not.toBe(IDENTITY_NUMBER.toString());
+    }
+  });
+
+  it("marks a full-access connect as such in the echoed consent", async () => {
     const url = await authorize(makeActor(), "full-access");
 
     const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
@@ -42,6 +42,9 @@ const makeActor = () => {
       (
         _anchor: bigint,
         requestedKey: Uint8Array,
+        _permissions: [{ queries: null } | { all: null }],
+        _maxTtl: [bigint],
+        _expiration: bigint,
       ): Promise<
         | {
             Ok: {
@@ -110,8 +113,8 @@ describe("mcpAuthorize registration-delegation minting", () => {
     await authorize(actor, "read-only");
 
     // Minted for the identity and a browser-generated ephemeral key Y, with
-    // the user-chosen grant TTL and the read-only access level (recorded on
-    // the index entry by the backend, never folded into the signature).
+    // the user-chosen grant TTL and the read-only access level (folded into
+    // the derived registration principal, never into the signature).
     expect(actor.prepare_mcp_registration_delegation).toHaveBeenCalledWith(
       IDENTITY_NUMBER,
       expect.any(Uint8Array),
@@ -130,7 +133,7 @@ describe("mcpAuthorize registration-delegation minting", () => {
     expect(browserKey.length).toBeGreaterThan(0);
     expect(toHex(browserKey)).not.toBe(toHex(REGISTRATION_KEY));
     const [, getKey] = actor.get_mcp_registration_delegation.mock.calls[0];
-    expect(toHex(getKey as Uint8Array)).toBe(toHex(browserKey));
+    expect(toHex(getKey)).toBe(toHex(browserKey));
   });
 
   it("generates a fresh Y per connect attempt", async () => {
@@ -153,13 +156,17 @@ describe("mcpAuthorize registration-delegation minting", () => {
     );
   });
 
-  it("fetches the certified delegation for the expiration prepare returned", async () => {
+  it("fetches the certified delegation with the same consent parameters", async () => {
     const actor = makeActor();
     await authorize(actor, "read-only");
 
+    // `get` re-derives the seed from its arguments (nothing is stored), so it
+    // takes the exact consent tuple prepare folded, plus prepare's expiration.
     expect(actor.get_mcp_registration_delegation).toHaveBeenCalledWith(
       IDENTITY_NUMBER,
       browserKeyOf(actor),
+      [{ queries: null }],
+      [BigInt(TTL_SECONDS) * BigInt(1_000_000_000)],
       actor.expiration,
     );
   });
@@ -177,6 +184,27 @@ describe("mcpAuthorize delivery URL", () => {
     expect(url.startsWith(`${CALLBACK}#`)).toBe(true);
     const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
     expect(fragment.get("state")).toBe(STATE);
+  });
+
+  it("carries the consent tuple the server must echo to mcp_register_v2", async () => {
+    // The derivation authenticates the echo (a tampered value fails to
+    // redeem), but the server needs the plain values to echo: the anchor, the
+    // access level as its wire string, and the grant TTL in nanoseconds.
+    const url = await authorize(makeActor(), "read-only");
+
+    const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
+    expect(fragment.get("anchor")).toBe(IDENTITY_NUMBER.toString());
+    expect(fragment.get("permissions")).toBe("queries");
+    expect(fragment.get("ttl")).toBe(
+      (BigInt(TTL_SECONDS) * BigInt(1_000_000_000)).toString(),
+    );
+  });
+
+  it("marks a full-access connect as such in the consent tuple", async () => {
+    const url = await authorize(makeActor(), "full-access");
+
+    const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
+    expect(fragment.get("permissions")).toBe("all");
   });
 
   it("carries a reconstructable two-hop P_reg -> Y -> X chain", async () => {

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.test.ts
@@ -2,25 +2,53 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ActorSubclass } from "@icp-sdk/core/agent";
 import type { _SERVICE } from "$lib/generated/internet_identity_types";
 import type { Authenticated } from "$lib/stores/authentication.store";
-import { fromBase64URL, toBase64URL } from "$lib/utils/utils";
+import { DelegationChain } from "@icp-sdk/core/identity";
+import { toHex } from "$lib/utils/utils";
 import { mcpAuthorize } from "./utils";
 
 const IDENTITY_NUMBER = BigInt(42);
 const MCP_ORIGIN = "https://mcp.id.ai";
-const CALLBACK = `${MCP_ORIGIN}/callback`;
+/** The trusted server's declared connect callback (exact-matched by the caller
+ *  against the server's /.well-known/ii-auth-callbacks allow-list): where the
+ *  caller delivers the registration delegation. */
+const CALLBACK = `${MCP_ORIGIN}/mcp/connect`;
+const STATE = "opaque-state";
 const TTL_SECONDS = 3600;
-/** The server's session public key, returned by the mocked key-request fetch. */
-const SERVER_PUBKEY = toBase64URL(new Uint8Array(32).fill(7));
+
+/** The MCP server's per-connect registration public key `X` (DER). II mints a
+ *  `P_reg -> X` delegation for it — nothing secret rides this. */
+const REGISTRATION_KEY = new Uint8Array(44).fill(9);
+/** `P_reg`'s DER public key, returned by the mocked prepare call — the chain's
+ *  public key, and what makes the server's redemption `caller() == P_reg`. */
+const USER_KEY = new Uint8Array(62).fill(3);
 
 const expirationNanos = (): bigint =>
   BigInt(Date.now() + 60 * 60 * 1000) * BigInt(1_000_000);
 
-/** Fake actor recording the exact candid arguments the flow sends. */
-const makeActor = () => ({
-  mcp_register: vi
-    .fn()
-    .mockResolvedValue({ Ok: { expiration: expirationNanos() } }),
-});
+/** Fake actor recording the exact candid arguments the flow sends. `prepare`
+ *  returns `P_reg`'s key + an expiration; `get` returns a well-formed (but
+ *  arbitrary) signed `P_reg -> X` delegation — the chain is only assembled and
+ *  serialized on the frontend, never verified, so the bytes needn't be real. */
+const makeActor = () => {
+  const expiration = expirationNanos();
+  return {
+    expiration,
+    prepare_mcp_registration_delegation: vi
+      .fn()
+      .mockResolvedValue({ Ok: { user_key: USER_KEY, expiration } }),
+    get_mcp_registration_delegation: vi.fn().mockResolvedValue({
+      Ok: {
+        delegation: {
+          pubkey: Array.from(REGISTRATION_KEY),
+          expiration,
+          targets: [],
+          permissions: [],
+        },
+        signature: Array.from(new Uint8Array(64).fill(1)),
+      },
+    }),
+  };
+};
 
 const authorize = (
   actor: ReturnType<typeof makeActor>,
@@ -34,33 +62,15 @@ const authorize = (
     ttlSeconds: TTL_SECONDS,
     accessLevel,
     callback: CALLBACK,
-    state: "opaque-state",
+    state: STATE,
+    registrationKey: REGISTRATION_KEY,
   });
 
-/** Mocks the two callback requests of the connect flow: the key request (no
- *  `expiration` in the body) answers with `keyBody`; the completion
- *  notification (carries `expiration`) just succeeds. The canister arguments
- *  to `mcp_register` — and the returned `finish_url` — are what's under test. */
-const stubFetch = (keyBody: Record<string, unknown>): void => {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn((_url: string, init?: RequestInit) => {
-      const body = JSON.parse((init?.body as string) ?? "{}") as {
-        expiration?: string;
-      };
-      const response =
-        body.expiration !== undefined
-          ? new Response("{}", { status: 200 })
-          : new Response(JSON.stringify(keyBody), { status: 200 });
-      return Promise.resolve(response);
-    }),
-  );
-};
-
 beforeEach(() => {
-  // Default stand-in server: answers the key request with its pubkey and no
-  // `finish_url`. Tests exercising `finish_url` re-stub with one included.
-  stubFetch({ public_key: SERVER_PUBKEY });
+  // The v2 connect makes no network calls of its own — delivery is by
+  // navigation. Stub fetch so any accidental call is observable (and asserted
+  // against below), rather than hitting the real network.
+  vi.stubGlobal("fetch", vi.fn());
 });
 
 afterEach(() => {
@@ -68,308 +78,101 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("mcpAuthorize access-level wiring", () => {
-  it("registers the session queries-only when read-only", async () => {
+describe("mcpAuthorize registration-delegation minting", () => {
+  it("prepares the delegation for the server's key with the chosen TTL and read-only", async () => {
     const actor = makeActor();
     await authorize(actor, "read-only");
 
-    // The session key comes from the trusted server's callback (not the link),
-    // and read-only is persisted on the grant via the permissions argument.
-    expect(actor.mcp_register).toHaveBeenCalledWith(
+    // Minted for the identity and the server's registration key, with the
+    // user-chosen grant TTL and the read-only access level (recorded on the
+    // index entry by the backend, never folded into the signature).
+    expect(actor.prepare_mcp_registration_delegation).toHaveBeenCalledWith(
       IDENTITY_NUMBER,
-      fromBase64URL(SERVER_PUBKEY),
-      BigInt(TTL_SECONDS) * BigInt(1_000_000_000),
+      REGISTRATION_KEY,
       [{ queries: null }],
+      [BigInt(TTL_SECONDS) * BigInt(1_000_000_000)],
     );
   });
 
-  it("registers full access explicitly (never relies on the backend default)", async () => {
+  it("passes full access explicitly (never relies on the backend default)", async () => {
     const actor = makeActor();
     await authorize(actor, "full-access");
 
-    expect(actor.mcp_register).toHaveBeenCalledWith(
+    expect(actor.prepare_mcp_registration_delegation).toHaveBeenCalledWith(
       IDENTITY_NUMBER,
-      fromBase64URL(SERVER_PUBKEY),
-      BigInt(TTL_SECONDS) * BigInt(1_000_000_000),
+      REGISTRATION_KEY,
       [{ all: null }],
+      [BigInt(TTL_SECONDS) * BigInt(1_000_000_000)],
     );
   });
-});
 
-describe("mcpAuthorize completion notification", () => {
-  /** The body of the completion POST (the callback fetch that carries
-   *  `expiration`), parsed from the recorded fetch calls. */
-  const completionBody = (): { expiration: string; permissions: string } => {
-    const call = vi
-      .mocked(fetch)
-      .mock.calls.find(([, init]) =>
-        ((init?.body as string) ?? "").includes("expiration"),
-      );
-    if (call === undefined) throw new Error("no completion POST was sent");
-    return JSON.parse(call[1]?.body as string);
-  };
+  it("fetches the certified delegation for the expiration prepare returned", async () => {
+    const actor = makeActor();
+    await authorize(actor, "read-only");
 
-  it("reports the access level so the server learns read-only up front", async () => {
+    expect(actor.get_mcp_registration_delegation).toHaveBeenCalledWith(
+      IDENTITY_NUMBER,
+      REGISTRATION_KEY,
+      actor.expiration,
+    );
+  });
+
+  it("makes no network request of its own (delivery is by navigation)", async () => {
     await authorize(makeActor(), "read-only");
-    expect(completionBody().permissions).toBe("queries");
-  });
-
-  it("reports full access as `all`", async () => {
-    await authorize(makeActor(), "full-access");
-    expect(completionBody().permissions).toBe("all");
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
   });
 });
 
-describe("mcpAuthorize finish_url handling", () => {
-  it("resolves undefined when the server sends no finish_url", async () => {
-    await expect(authorize(makeActor(), "read-only")).resolves.toBeUndefined();
+describe("mcpAuthorize delivery URL", () => {
+  it("targets the declared callback and carries the state echo", async () => {
+    const url = await authorize(makeActor(), "read-only");
+
+    expect(url.startsWith(`${CALLBACK}#`)).toBe(true);
+    const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
+    expect(fragment.get("state")).toBe(STATE);
   });
 
-  it("treats a null or empty finish_url as absent (common optional serializations)", async () => {
-    // serde `Option::None`, Go string zero-values, and Python `None` all
-    // serialize an omitted optional as null (or ""): those connects must
-    // succeed without a redirect, not hard-fail.
-    for (const finish_url of [null, ""]) {
-      const actor = makeActor();
-      stubFetch({ public_key: SERVER_PUBKEY, finish_url });
-      await expect(authorize(actor, "read-only")).resolves.toBeUndefined();
-      expect(actor.mcp_register).toHaveBeenCalledOnce();
-    }
-  });
+  it("carries a reconstructable P_reg -> X delegation chain", async () => {
+    const url = await authorize(makeActor(), "read-only");
 
-  it("returns the finish_url when it is on the callback's origin", async () => {
-    // The finish redirect lets the server complete a flow of its own (e.g.
-    // hand an OAuth code to an MCP client) after the session is registered.
-    const finishUrl = `${MCP_ORIGIN}/oauth/finish?sid=abc123`;
-    stubFetch({ public_key: SERVER_PUBKEY, finish_url: finishUrl });
-    const actor = makeActor();
+    const fragment = new URLSearchParams(url.slice(url.indexOf("#") + 1));
+    const delegation = fragment.get("delegation");
+    if (delegation === null) throw new Error("no delegation in the fragment");
 
-    await expect(authorize(actor, "read-only")).resolves.toBe(finishUrl);
-    // The session was registered and the completion notification still sent
-    // (key request + completion = two callback fetches) before any navigation.
-    expect(actor.mcp_register).toHaveBeenCalledOnce();
-    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
-  });
-
-  it("rejects a cross-origin finish_url before registering anything", async () => {
-    // II only ever navigates to the trusted origin: a finish_url elsewhere
-    // fails the connect — and fails it up front, so no session materializes.
-    stubFetch({
-      public_key: SERVER_PUBKEY,
-      finish_url: "https://evil.example.com/finish",
-    });
-    const actor = makeActor();
-
-    await expect(authorize(actor, "read-only")).rejects.toThrow(
-      /not on the server's own origin/,
+    // The server round-trips the chain out of the fragment exactly like this.
+    const chain = DelegationChain.fromJSON(JSON.parse(delegation));
+    // Its public key is P_reg's DER key, so the redemption is caller() == P_reg.
+    expect(toHex(new Uint8Array(chain.publicKey))).toBe(toHex(USER_KEY));
+    expect(chain.delegations).toHaveLength(1);
+    // The delegated-to key is the server's registration key X.
+    expect(toHex(new Uint8Array(chain.delegations[0].delegation.pubkey))).toBe(
+      toHex(REGISTRATION_KEY),
     );
-    expect(actor.mcp_register).not.toHaveBeenCalled();
-  });
-
-  it("rejects a plain-http finish_url on the same host", async () => {
-    // Origin comparison includes the scheme: the same host over http is a
-    // different origin than the https callback. This pins the https-only
-    // invariant against refactors that would compare hostnames instead.
-    stubFetch({
-      public_key: SERVER_PUBKEY,
-      finish_url: `http://${new URL(MCP_ORIGIN).host}/finish`,
-    });
-    const actor = makeActor();
-
-    await expect(authorize(actor, "read-only")).rejects.toThrow(
-      /not on the server's own origin/,
-    );
-    expect(actor.mcp_register).not.toHaveBeenCalled();
-  });
-
-  it("rejects a scheme with no comparable origin (javascript:)", async () => {
-    // javascript:/data: URLs parse but have an opaque ("null") origin, which
-    // can never equal the https callback's origin.
-    stubFetch({
-      public_key: SERVER_PUBKEY,
-      finish_url: "javascript:alert(1)",
-    });
-    const actor = makeActor();
-
-    await expect(authorize(actor, "read-only")).rejects.toThrow(
-      /not on the server's own origin/,
-    );
-    expect(actor.mcp_register).not.toHaveBeenCalled();
-  });
-
-  it("rejects a malformed finish_url before registering anything", async () => {
-    // Relative paths included: finish_url must be an absolute URL.
-    stubFetch({ public_key: SERVER_PUBKEY, finish_url: "/oauth/finish" });
-    const actor = makeActor();
-
-    await expect(authorize(actor, "read-only")).rejects.toThrow(
-      /not a valid URL/,
-    );
-    expect(actor.mcp_register).not.toHaveBeenCalled();
-  });
-
-  it("rejects a non-string finish_url before registering anything", async () => {
-    // Present but not a string (e.g. a number or object) is a misbehaving
-    // server, not an omitted optional — fail the connect up front.
-    for (const finish_url of [42, { url: "https://mcp.id.ai" }, true]) {
-      const actor = makeActor();
-      stubFetch({ public_key: SERVER_PUBKEY, finish_url });
-      await expect(authorize(actor, "read-only")).rejects.toThrow(
-        /not a string/,
-      );
-      expect(actor.mcp_register).not.toHaveBeenCalled();
-    }
   });
 });
 
 describe("mcpAuthorize failure paths", () => {
-  it("rejects a key response without a usable public_key, registering nothing", async () => {
-    // Missing key and non-string key are both a misbehaving (or wrong) server;
-    // the connect must abort before anything binds to the identity.
-    for (const keyBody of [
-      {},
-      { public_key: 42 },
-      { public_key: null },
-    ] as Record<string, unknown>[]) {
-      const actor = makeActor();
-      stubFetch(keyBody);
-      await expect(authorize(actor, "read-only")).rejects.toThrow(
-        /missing `public_key`/,
-      );
-      expect(actor.mcp_register).not.toHaveBeenCalled();
-    }
-  });
-
-  it("propagates an mcp_register refusal and sends no completion POST", async () => {
-    // A backend refusal (untrusted config, key bound to another identity, ...)
-    // fails the connect: the error surfaces to the caller, and the server must
-    // NOT be told the session is live — no completion POST follows the key
-    // request.
+  it("propagates a prepare refusal and never fetches the delegation", async () => {
     const actor = makeActor();
-    actor.mcp_register.mockResolvedValue({
-      Err: "MCP is not enabled for this identity",
+    actor.prepare_mcp_registration_delegation.mockResolvedValue({
+      Err: "MCP registration failed: 2vxsx-fae could not be authenticated.",
     });
 
     await expect(authorize(actor, "full-access")).rejects.toThrow(
-      /not enabled for this identity/,
+      /could not be authenticated/,
     );
-    // Exactly one callback fetch: the key request. No completion.
-    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+    // Aborted before the certified delegation is even fetched.
+    expect(actor.get_mcp_registration_delegation).not.toHaveBeenCalled();
   });
 
-  it("still resolves (best effort) when the completion POST fails", async () => {
-    // The completion notification is advisory: the session is already
-    // registered, so a network failure on the POST must not fail the connect —
-    // and a finish_url from the key response must still be handed back for
-    // navigation.
-    const finishUrl = `${MCP_ORIGIN}/oauth/finish?sid=xyz`;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn((_url: string, init?: RequestInit) => {
-        const body = JSON.parse((init?.body as string) ?? "{}") as {
-          expiration?: string;
-        };
-        // Key request succeeds; completion POST dies on the network.
-        return body.expiration === undefined
-          ? Promise.resolve(
-              new Response(
-                JSON.stringify({
-                  public_key: SERVER_PUBKEY,
-                  finish_url: finishUrl,
-                }),
-                { status: 200 },
-              ),
-            )
-          : Promise.reject(new TypeError("network down"));
-      }),
-    );
+  it("propagates a get refusal", async () => {
     const actor = makeActor();
-
-    await expect(authorize(actor, "read-only")).resolves.toBe(finishUrl);
-    expect(actor.mcp_register).toHaveBeenCalledOnce();
-    // Both fetches were attempted: key request + the failed completion.
-    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
-  });
-});
-
-describe("callback fetch hardening", () => {
-  it("issues both callback requests with redirect: error and credentials: omit", async () => {
-    // A 307/308 from the server must not silently re-POST the single-use
-    // `state` (key request) or the completion payload to a redirected origin,
-    // and no ambient credentials ride these cross-origin calls.
-    stubFetch({
-      public_key: SERVER_PUBKEY,
-      finish_url: `${MCP_ORIGIN}/oauth/finish`,
+    actor.get_mcp_registration_delegation.mockResolvedValue({
+      Err: "MCP registration failed: no such delegation.",
     });
-    await authorize(makeActor(), "read-only");
-
-    const calls = vi.mocked(fetch).mock.calls;
-    expect(calls.length).toBeGreaterThanOrEqual(2); // key request + completion
-    for (const [, init] of calls) {
-      expect(init).toMatchObject({ redirect: "error", credentials: "omit" });
-    }
-  });
-});
-
-// Two properties the server-side H3 mitigation ("Consent-Bound Completion")
-// relies on from the II frontend. They hold today; these tests pin them so a
-// future refactor of the connect flow can't silently regress them.
-//   P1  — the key request is issued exactly once per connect and never
-//         auto-retried (a single-use connect-state means a retry would either
-//         brick the user or reopen the attacker race; recovery is a fresh
-//         connect, not a retry).
-//   P2  — finish_url (which carries the server's one-time finish_secret) is
-//         never written to a log/telemetry sink by the frontend.
-describe("H3 preconditions the fix depends on", () => {
-  /** Callback POSTs that are key requests (no `expiration` in the body), as
-   *  opposed to the completion notification (which carries `expiration`). */
-  const keyRequestCount = (): number =>
-    vi.mocked(fetch).mock.calls.filter(([, init]) => {
-      const body = JSON.parse((init?.body as string) ?? "{}") as {
-        expiration?: string;
-      };
-      return body.expiration === undefined;
-    }).length;
-
-  it("P1: issues exactly one key request per connect", async () => {
-    await authorize(makeActor(), "read-only");
-    expect(keyRequestCount()).toBe(1);
-  });
-
-  it("P1: does not retry the key request (or register) when the server rejects it", async () => {
-    // A rejected key request aborts the connect; there is no retry loop, and
-    // nothing is registered — the only recovery is a fresh /oauth/authorize
-    // (new connect-state), never a retry of the same one.
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() => Promise.resolve(new Response("", { status: 403 }))),
-    );
-    const actor = makeActor();
 
     await expect(authorize(actor, "read-only")).rejects.toThrow(
-      /rejected the connect request/,
+      /no such delegation/,
     );
-    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
-    expect(actor.mcp_register).not.toHaveBeenCalled();
-  });
-
-  it("P2: never writes finish_url (which carries finish_secret) to the console", async () => {
-    const SECRET = "fs-DO-NOT-LOG-9f83k2";
-    stubFetch({
-      public_key: SERVER_PUBKEY,
-      finish_url: `${MCP_ORIGIN}/oauth/finish?fs=${SECRET}`,
-    });
-    const methods = ["log", "info", "warn", "error", "debug"] as const;
-    const spies = methods.map((m) =>
-      vi.spyOn(console, m).mockImplementation(() => undefined),
-    );
-
-    // Returns the finish_url to the caller (which navigates to it) — but must
-    // not emit it to any console sink along the way.
-    await expect(authorize(makeActor(), "read-only")).resolves.toContain(
-      SECRET,
-    );
-    const logged = spies.flatMap((s) => s.mock.calls.flat()).join(" ");
-    expect(logged).not.toContain(SECRET);
   });
 });

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -90,7 +90,8 @@ export const mcpAuthorize = async ({
   // hop targets this browser-held key — never the link-supplied `X` — so the
   // delegation that transits the IC is inert to any transport-level observer:
   // only this page holds `priv(Y)`. Fresh per attempt so each connect signs its
-  // own second hop (`P_reg` itself is derived from the consent, not from `Y`).
+  // own second hop (`P_reg` is seeded canister-side from a fresh random nonce —
+  // not from `Y` and not from the consent).
   const registrationIdentity = await ECDSAKeyIdentity.generate({
     extractable: false,
   });

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -1,8 +1,4 @@
-import {
-  toPermissionsArg,
-  toPermissionsString,
-  type AccessLevel,
-} from "$lib/utils/accessLevel";
+import { toPermissionsArg, type AccessLevel } from "$lib/utils/accessLevel";
 import type { Authenticated } from "$lib/stores/authentication.store";
 import type { PublicKey } from "@icp-sdk/core/agent";
 import { DelegationChain, ECDSAKeyIdentity } from "@icp-sdk/core/identity";
@@ -18,8 +14,8 @@ interface McpAuthorizeInput {
   ttlSeconds: number;
   /** Whether the whole session is read-only: when read-only, every per-app
    *  delegation the server later mints is restricted to query calls. Chosen
-   *  once at connect and folded into the registration principal's derivation,
-   *  so the server cannot upgrade a read-only session to full access. */
+   *  once at connect and recorded on the registration entry by `prepare`, so
+   *  the server cannot upgrade a read-only session to full access. */
   accessLevel: AccessLevel;
   /** The trusted server's declared connect callback: exact-matched by the
    *  caller against the allow-list the server hosts at a fixed well-known
@@ -48,28 +44,24 @@ interface McpAuthorizeInput {
  *  1. Generate an ephemeral registration key `Y` for this connect; its private
  *     half never leaves this page.
  *  2. `prepare_mcp_registration_delegation` — authenticated as the user, mint a
- *     short-lived canister-signed delegation `P_reg -> Y`. `P_reg` is *derived*
- *     from the consent tuple (this anchor, the read-only choice, the grant TTL,
- *     the trusted server URL); the canister stores only the anchor (keyed by
- *     `P_reg`) so it can recover it at redemption, while the read-only choice
- *     and TTL are re-derived and compared rather than trusted from a
- *     `register_v2` argument the server invents.
+ *     short-lived canister-signed delegation `P_reg -> Y`. `P_reg` is derived
+ *     from a fresh random nonce, and the whole consent (this anchor, the
+ *     read-only choice, the grant TTL, the trusted server URL) is recorded on
+ *     the index entry keyed by `P_reg`, so the server recovers it at redemption
+ *     rather than being trusted to supply it.
  *  3. `get_mcp_registration_delegation` — fetch the certified `P_reg -> Y`
- *     delegation (passing the same consent parameters, which determine the
- *     derivation), then extend the chain *locally* with a second hop `Y -> X`
- *     signed by `priv(Y)`, where `X` is the server's per-connect registration
- *     key from the link.
- *  4. Deliver the full chain — with the echoed consent (`permissions`, `ttl`)
- *     alongside — to the trusted server over a URL fragment (a top-level
- *     navigation to the callback it declared — see `matchDeclaredCallback`).
- *     The server, holding `X`'s private key, redeems it by calling
- *     `mcp_register_v2` with its long-lived session key `S`, echoing those two
- *     values; the backend recovers the anchor from the registration entry
- *     (so the anchor is never delivered to or seen by the server), re-derives
- *     `P_reg` from (recovered anchor, echoed values, current config) and binds
- *     `S` only if it lands exactly on `caller()`. II never binds a key it
- *     merely received, and an altered echo (upgraded access, stretched TTL)
- *     derives a different principal and is rejected.
+ *     delegation (handing back the `user_key` prepare returned, which the
+ *     canister uses to recover the seed), then extend the chain *locally* with
+ *     a second hop `Y -> X` signed by `priv(Y)`, where `X` is the server's
+ *     per-connect registration key from the link.
+ *  4. Deliver the full chain to the trusted server over a URL fragment (a
+ *     top-level navigation to the callback it declared — see
+ *     `matchDeclaredCallback`). The server, holding `X`'s private key, redeems
+ *     it by calling `mcp_register_v2` with only its long-lived session key `S`;
+ *     the backend recovers the entire consent (anchor, read-only choice, grant
+ *     lifetime) from the registration entry keyed by `caller()`. II never binds
+ *     a key it merely received, the server passes no consented value (so it
+ *     can't alter any), and it never learns the anchor number.
  *
  * The two-hop shape is load-bearing: what the canister signs transits the IC
  * (the `get` query response passes the answering replica and API boundary
@@ -106,11 +98,11 @@ export const mcpAuthorize = async ({
     registrationIdentity.getPublicKey().toDer(),
   );
 
-  // The session-grant lifetime the user chose (the backend clamps again). The
-  // access level and TTL are folded into `P_reg`'s derivation, so `get` takes
-  // them too (the seed is re-derived from arguments; the canister stores only
-  // the anchor). A backend refusal (MCP disabled, unauthenticated, ...) throws
-  // here and fails the connect before anything is delivered.
+  // The session-grant lifetime and the read-only choice go to `prepare`, which
+  // records the whole consent on the index entry keyed by `P_reg` (the server
+  // recovers it at redemption). A backend refusal (MCP disabled,
+  // unauthenticated, ...) throws here and fails the connect before anything is
+  // delivered.
   const grantTtlNanos = BigInt(ttlSeconds) * BigInt(1e9);
   const { user_key, expiration } = await actor
     .prepare_mcp_registration_delegation(
@@ -121,12 +113,13 @@ export const mcpAuthorize = async ({
     )
     .then(throwTextCanisterError);
 
+  // `get` recovers the seed from `user_key` (the value `prepare` returned), so
+  // it needs neither the consent params nor a deterministic re-derivation.
   const signed = await actor
     .get_mcp_registration_delegation(
       identityNumber,
       browserKey,
-      toPermissionsArg(accessLevel),
-      [grantTtlNanos],
+      user_key,
       expiration,
     )
     .then(throwTextCanisterError);
@@ -152,17 +145,13 @@ export const mcpAuthorize = async ({
 
   // Deliver over the fragment (never sent to the server in the HTTP request):
   // the trusted server's endpoint reads it client-side, reconstructs the chain,
-  // and redeems it. The echoed consent rides along — `permissions`
-  // ("queries"/"all") and `ttl` (grant lifetime in ns) are what the server must
-  // pass back to `mcp_register_v2` (the derivation authenticates the echo; a
-  // tampered value simply fails to redeem). The anchor is deliberately *not*
-  // delivered: the canister recovers it server-side from the registration
-  // entry, so the server never learns the user's II anchor number. `state`
-  // lets the server correlate.
+  // and redeems it with `mcp_register_v2(session_key)` — nothing else. The
+  // whole consent (anchor, read-only choice, grant lifetime) is recovered
+  // server-side from the registration entry, so the server passes only its own
+  // key and never learns any of it; only `state` rides along, so the server can
+  // correlate the delivery with the connect it started.
   const fragment = new URLSearchParams();
   fragment.set("delegation", JSON.stringify(chain.toJSON()));
   fragment.set("state", state);
-  fragment.set("permissions", toPermissionsString(accessLevel));
-  fragment.set("ttl", grantTtlNanos.toString());
   return `${callback}#${fragment.toString()}`;
 };

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -1,10 +1,7 @@
-import {
-  toPermissionsArg,
-  toPermissionsString,
-  type AccessLevel,
-} from "$lib/utils/accessLevel";
+import { toPermissionsArg, type AccessLevel } from "$lib/utils/accessLevel";
 import type { Authenticated } from "$lib/stores/authentication.store";
-import { fromBase64URL } from "$lib/utils/utils";
+import { DelegationChain } from "@icp-sdk/core/identity";
+import { transformSignedDelegation } from "$lib/utils/utils";
 
 interface McpAuthorizeInput {
   authenticated: Authenticated;
@@ -13,103 +10,53 @@ interface McpAuthorizeInput {
   ttlSeconds: number;
   /** Whether the whole session is read-only: when read-only, every per-app
    *  delegation the server later mints is restricted to query calls. Chosen
-   *  once at connect and passed to `mcp_register`, which persists it on the
-   *  grant — read-only is a property of the session, not a per-call flag. */
+   *  once at connect and recorded on the registration delegation's index entry,
+   *  so the server cannot upgrade a read-only session to full access. */
   accessLevel: AccessLevel;
   /** The trusted server's declared connect callback: exact-matched by the
    *  caller against the allow-list the server hosts at a fixed well-known
    *  path on its (trusted) origin (see `matchDeclaredCallback`) — the
    *  (attacker-craftable) connect link only ever selects among the entries
-   *  the server declares. Always https (the trusted origin is). The connect
-   *  flow talks to it twice: once to fetch the server's session public key,
-   *  once to report completion. */
+   *  the server declares. Always https (the trusted origin is). This is where
+   *  II delivers the registration delegation (a top-level navigation carrying
+   *  it in the fragment). */
   callback: string;
-  /** Opaque value the server issued for this connect, included in both
-   *  callback requests so the server can tie them to the request it started. */
+  /** Opaque value the server issued for this connect, delivered back alongside
+   *  the registration delegation so the server can tie it to the connect it
+   *  started. */
   state: string;
+  /** The MCP server's registration public key `X` (DER) for this connect. II
+   *  mints a single-use `P_reg -> X` delegation for it; nothing secret. */
+  registrationKey: Uint8Array;
 }
 
-/** The key-request response: the server's session public key for this
- *  connection (DER-encoded, base64url), plus an optional `finish_url` the
- *  browser should be sent to once the session is registered — this is how a
- *  server completes a flow of its own around the connect (e.g. minting the
- *  OAuth authorization code for an MCP client and redirecting back to it).
- *
- *  `finish_url` is only honoured on the *callback's* origin — the trusted
- *  server the user consented to, per their synced config. It arrives over the
- *  same origin-attested channel as the key (the callback response, never the
- *  connect link), and the same-origin requirement keeps the invariant that II
- *  only ever navigates to the trusted origin; where the server redirects from
- *  there is its own (standard OAuth) responsibility. Origin equality also
- *  rules out non-https schemes (`javascript:` etc. have no matching origin).
- *  A `finish_url` that fails these checks fails the connect — before anything
- *  is registered — rather than silently completing without the redirect. */
-const parseKeyResponse = (
-  body: unknown,
-  callback: string,
-): { sessionKey: Uint8Array; finishUrl: string | undefined } => {
-  if (
-    typeof body !== "object" ||
-    body === null ||
-    !("public_key" in body) ||
-    typeof body.public_key !== "string"
-  ) {
-    throw new Error("The MCP server's key response is missing `public_key`.");
-  }
-  const sessionKey = fromBase64URL(body.public_key);
-  // `null` and `""` count as absent, not as errors: they're how common server
-  // stacks serialize an omitted optional (serde `Option::None`, a Go string
-  // zero-value, Python `None`), and "no redirect" is the only thing an absent
-  // value can mean — there's nothing to navigate to, so nothing to fail.
-  if (
-    !("finish_url" in body) ||
-    body.finish_url === undefined ||
-    body.finish_url === null ||
-    body.finish_url === ""
-  ) {
-    return { sessionKey, finishUrl: undefined };
-  }
-  if (typeof body.finish_url !== "string") {
-    throw new Error("The MCP server's `finish_url` is not a string.");
-  }
-  let finishUrl;
-  try {
-    finishUrl = new URL(body.finish_url);
-  } catch {
-    throw new Error("The MCP server's `finish_url` is not a valid URL.");
-  }
-  if (finishUrl.origin !== new URL(callback).origin) {
-    throw new Error(
-      "The MCP server's `finish_url` is not on the server's own origin.",
-    );
-  }
-  return { sessionKey, finishUrl: finishUrl.href };
-};
-
 /**
- * Connects the MCP server by registering its session key with the backend:
- * fetch the server's session public key from its callback, register it via
- * `mcp_register` (binding the key's principal to the identity with the
- * user-chosen expiry and access level), and report completion back to the
- * callback. No delegation is minted for the server itself — its capability is
- * the grant, which the backend checks on every `mcp_*` call and which Settings
- * revokes via `mcp_set_config`. A read-only `accessLevel` makes every per-app
- * delegation the session later mints query-only.
+ * Connects the MCP server by minting a single-use *registration delegation* and
+ * handing it to the server, instead of fetching the server's key and calling
+ * `mcp_register` on its behalf. The flow:
  *
- * The key is fetched over an origin-attested channel: this code only ever
- * contacts the *trusted* origin's callback (verified against the synced
- * config by the caller), and the server only answers for a `state` it issued.
- * Nothing from the unauthenticated connect link is ever registered — an
- * attacker-crafted link yields no key (unknown state) and so registers
- * nothing, preserving the property that a session only materializes with the
- * trusted server's cooperation.
+ *  1. `prepare_mcp_registration_delegation` — authenticated as the user, mint a
+ *     short-lived canister-signed delegation `P_reg -> X` (where `X` is the
+ *     server's per-connect registration key from the link) and record the
+ *     consent (this anchor, the read-only choice, the grant TTL) on an index
+ *     entry keyed by `P_reg`. The anchor and access level live on that entry,
+ *     never in an argument the server controls.
+ *  2. `get_mcp_registration_delegation` — fetch the certified `P_reg -> X`
+ *     delegation and assemble the chain.
+ *  3. Deliver the chain to the trusted server over a URL fragment (a top-level
+ *     navigation to the callback it declared — see `matchDeclaredCallback`).
+ *     The server, holding `X`'s private key, redeems the chain by calling
+ *     `mcp_register_v2` with its long-lived session key `S`; the backend binds
+ *     `S` to the recorded anchor with the recorded access level. II never binds
+ *     a key it merely received, and the registration delegation is single-use.
  *
- * A resolved promise means the session is registered and the server was (best
- * effort) notified. Resolves with the server's validated `finish_url` when it
- * supplied one in the key response (the caller then navigates the tab there,
- * letting the server finish a flow of its own — e.g. hand an OAuth code back
- * to an MCP client), and with `undefined` otherwise (the page stays put and
- * shows the terminal screen itself).
+ * Nothing is delivered anywhere but a callback the trusted origin declares
+ * (the origin is verified against the synced config, and the callback against
+ * the server's allow-list, by the caller), and the fragment carries only the
+ * server's own public key material — no secret. Resolves with the delivery URL
+ * the caller should navigate the tab to; the server's callback finishes the
+ * flow on its side (e.g. redeeming the chain and handing an OAuth code back to
+ * an MCP client).
  */
 export const mcpAuthorize = async ({
   authenticated,
@@ -117,77 +64,48 @@ export const mcpAuthorize = async ({
   accessLevel,
   callback,
   state,
-}: McpAuthorizeInput): Promise<string | undefined> => {
+  registrationKey,
+}: McpAuthorizeInput): Promise<string> => {
   const { identityNumber, actor } = authenticated;
 
-  // Ask the trusted server for its session public key for this connect. A
-  // non-2xx answer (e.g. a state it never issued) aborts before anything is
-  // registered. `redirect: "error"` makes a 307/308 a hard failure rather than
-  // silently re-POSTing the single-use `state` to a redirected origin; `omit`
-  // keeps ambient credentials off this cross-origin call (mirrors the
-  // fail-closed fetches elsewhere, e.g. validateDerivationOrigin).
-  const keyResponse = await fetch(callback, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ state }),
-    redirect: "error",
-    credentials: "omit",
-  });
-  if (!keyResponse.ok) {
-    throw new Error(
-      `The MCP server rejected the connect request (HTTP ${keyResponse.status}).`,
-    );
-  }
-  // Parsing also validates any `finish_url` (same-origin with the trusted
-  // callback), so a misbehaving response aborts here — nothing registered.
-  const { sessionKey, finishUrl } = parseKeyResponse(
-    await keyResponse.json(),
-    callback,
-  );
-
-  // One authenticated call registers the session: the backend binds the key's
-  // self-authenticating principal to the identity (replacing any previous
-  // session — at most one at a time) until the chosen expiry, and persists the
-  // access level so every per-app delegation this session mints inherits it.
+  // The session-grant lifetime the user chose (the backend clamps again). The
+  // access level is recorded on the index entry, not folded into the signature.
   const grantTtlNanos = BigInt(ttlSeconds) * BigInt(1e9);
-  const result = await actor.mcp_register(
+  const prepared = await actor.prepare_mcp_registration_delegation(
     identityNumber,
-    sessionKey,
-    grantTtlNanos,
+    registrationKey,
     toPermissionsArg(accessLevel),
+    [grantTtlNanos],
   );
-  if ("Err" in result) {
-    throw new Error(result.Err);
+  if ("Err" in prepared) {
+    // A backend refusal (MCP disabled, unauthenticated, a duplicate in-flight
+    // key, ...) fails the connect before anything is delivered.
+    throw new Error(prepared.Err);
   }
-  const { expiration } = result.Ok;
+  const { user_key, expiration } = prepared.Ok;
 
-  // Tell the server its session is live: when it expires (ns since epoch, as a
-  // string — the value overflows JSON numbers) and the access level the user
-  // chose (`permissions`, "queries" | "all"), so it learns read-only up front
-  // instead of inferring it from a minted delegation. Best effort: on failure
-  // the server discovers success on its first signed call, and can still read
-  // the access level off any delegation's `permissions`. Sent (and awaited)
-  // before any `finish_url` navigation, so the server normally hears about the
-  // registration before the browser arrives — but a server must not rely on
-  // that ordering, since this notification can fail while the navigation still
-  // happens.
-  try {
-    await fetch(callback, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        state,
-        expiration: expiration.toString(),
-        permissions: toPermissionsString(accessLevel),
-      }),
-      // Same fail-closed posture as the key request: never let a redirect
-      // forward the completion payload to another origin.
-      redirect: "error",
-      credentials: "omit",
-    });
-  } catch {
-    // Deliberately ignored; see above.
+  const signed = await actor.get_mcp_registration_delegation(
+    identityNumber,
+    registrationKey,
+    expiration,
+  );
+  if ("Err" in signed) {
+    throw new Error(signed.Err);
   }
 
-  return finishUrl;
+  // Assemble the `P_reg -> X` chain the server will redeem. `user_key` is
+  // `P_reg`'s DER public key, so the server's `mcp_register_v2` call is seen by
+  // the backend as `caller() == P_reg`.
+  const chain = DelegationChain.fromDelegations(
+    [transformSignedDelegation(signed.Ok)],
+    new Uint8Array(user_key),
+  );
+
+  // Deliver over the fragment (never sent to the server in the HTTP request):
+  // the trusted server's endpoint reads it client-side, reconstructs the chain,
+  // and redeems it. `state` rides along so the server can correlate.
+  const fragment = new URLSearchParams();
+  fragment.set("delegation", JSON.stringify(chain.toJSON()));
+  fragment.set("state", state);
+  return `${callback}#${fragment.toString()}`;
 };

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -1,7 +1,10 @@
 import { toPermissionsArg, type AccessLevel } from "$lib/utils/accessLevel";
 import type { Authenticated } from "$lib/stores/authentication.store";
 import { DelegationChain } from "@icp-sdk/core/identity";
-import { transformSignedDelegation } from "$lib/utils/utils";
+import {
+  throwTextCanisterError,
+  transformSignedDelegation,
+} from "$lib/utils/utils";
 
 interface McpAuthorizeInput {
   authenticated: Authenticated;
@@ -70,34 +73,31 @@ export const mcpAuthorize = async ({
 
   // The session-grant lifetime the user chose (the backend clamps again). The
   // access level is recorded on the index entry, not folded into the signature.
+  // A backend refusal (MCP disabled, unauthenticated, a duplicate in-flight
+  // key, ...) throws here and fails the connect before anything is delivered.
   const grantTtlNanos = BigInt(ttlSeconds) * BigInt(1e9);
-  const prepared = await actor.prepare_mcp_registration_delegation(
-    identityNumber,
-    registrationKey,
-    toPermissionsArg(accessLevel),
-    [grantTtlNanos],
-  );
-  if ("Err" in prepared) {
-    // A backend refusal (MCP disabled, unauthenticated, a duplicate in-flight
-    // key, ...) fails the connect before anything is delivered.
-    throw new Error(prepared.Err);
-  }
-  const { user_key, expiration } = prepared.Ok;
+  const { user_key, expiration } = await actor
+    .prepare_mcp_registration_delegation(
+      identityNumber,
+      registrationKey,
+      toPermissionsArg(accessLevel),
+      [grantTtlNanos],
+    )
+    .then(throwTextCanisterError);
 
-  const signed = await actor.get_mcp_registration_delegation(
-    identityNumber,
-    registrationKey,
-    expiration,
-  );
-  if ("Err" in signed) {
-    throw new Error(signed.Err);
-  }
+  const signed = await actor
+    .get_mcp_registration_delegation(
+      identityNumber,
+      registrationKey,
+      expiration,
+    )
+    .then(throwTextCanisterError);
 
   // Assemble the `P_reg -> X` chain the server will redeem. `user_key` is
   // `P_reg`'s DER public key, so the server's `mcp_register_v2` call is seen by
   // the backend as `caller() == P_reg`.
   const chain = DelegationChain.fromDelegations(
-    [transformSignedDelegation(signed.Ok)],
+    [transformSignedDelegation(signed)],
     new Uint8Array(user_key),
   );
 

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -57,15 +57,17 @@ interface McpAuthorizeInput {
  *     derivation), then extend the chain *locally* with a second hop `Y -> X`
  *     signed by `priv(Y)`, where `X` is the server's per-connect registration
  *     key from the link.
- *  4. Deliver the full chain — with the consent tuple alongside — to the
- *     trusted server over a URL fragment (a top-level navigation to the
- *     callback it declared — see `matchDeclaredCallback`). The server, holding
- *     `X`'s private key, redeems it by calling `mcp_register_v2` with its
- *     long-lived session key `S`, echoing the tuple; the backend re-derives
- *     `P_reg` from the echoed tuple and binds `S` only if it lands exactly on
- *     `caller()`. II never binds a key it merely received, and any altered
- *     echo (upgraded access, stretched TTL, different anchor) derives a
- *     different principal and is rejected.
+ *  4. Deliver the full chain — with the echoed consent (`permissions`, `ttl`)
+ *     alongside — to the trusted server over a URL fragment (a top-level
+ *     navigation to the callback it declared — see `matchDeclaredCallback`).
+ *     The server, holding `X`'s private key, redeems it by calling
+ *     `mcp_register_v2` with its long-lived session key `S`, echoing those two
+ *     values; the backend recovers the anchor from the registration entry
+ *     (so the anchor is never delivered to or seen by the server), re-derives
+ *     `P_reg` from (recovered anchor, echoed values, current config) and binds
+ *     `S` only if it lands exactly on `caller()`. II never binds a key it
+ *     merely received, and an altered echo (upgraded access, stretched TTL)
+ *     derives a different principal and is rejected.
  *
  * The two-hop shape is load-bearing: what the canister signs transits the IC
  * (the `get` query response passes the answering replica and API boundary
@@ -148,14 +150,16 @@ export const mcpAuthorize = async ({
 
   // Deliver over the fragment (never sent to the server in the HTTP request):
   // the trusted server's endpoint reads it client-side, reconstructs the chain,
-  // and redeems it. The consent tuple rides along — `anchor`, `permissions`
-  // ("queries"/"all") and `ttl` (grant lifetime in ns) are what the server
-  // must echo to `mcp_register_v2` (the derivation authenticates the echo; a
-  // tampered value simply fails to redeem). `state` lets the server correlate.
+  // and redeems it. The echoed consent rides along — `permissions`
+  // ("queries"/"all") and `ttl` (grant lifetime in ns) are what the server must
+  // pass back to `mcp_register_v2` (the derivation authenticates the echo; a
+  // tampered value simply fails to redeem). The anchor is deliberately *not*
+  // delivered: the canister recovers it server-side from the registration
+  // entry, so the server never learns the user's II anchor number. `state`
+  // lets the server correlate.
   const fragment = new URLSearchParams();
   fragment.set("delegation", JSON.stringify(chain.toJSON()));
   fragment.set("state", state);
-  fragment.set("anchor", identityNumber.toString());
   fragment.set("permissions", toPermissionsString(accessLevel));
   fragment.set("ttl", grantTtlNanos.toString());
   return `${callback}#${fragment.toString()}`;

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -1,6 +1,7 @@
 import { toPermissionsArg, type AccessLevel } from "$lib/utils/accessLevel";
 import type { Authenticated } from "$lib/stores/authentication.store";
-import { DelegationChain } from "@icp-sdk/core/identity";
+import type { PublicKey } from "@icp-sdk/core/agent";
+import { DelegationChain, ECDSAKeyIdentity } from "@icp-sdk/core/identity";
 import {
   throwTextCanisterError,
   transformSignedDelegation,
@@ -28,38 +29,48 @@ interface McpAuthorizeInput {
    *  the registration delegation so the server can tie it to the connect it
    *  started. */
   state: string;
-  /** The MCP server's registration public key `X` (DER) for this connect. II
-   *  mints a single-use `P_reg -> X` delegation for it; nothing secret. */
+  /** The MCP server's registration public key `X` (DER) for this connect, from
+   *  the link. The *browser-signed* final hop of the registration chain targets
+   *  it (see `mcpAuthorize` — the canister never delegates to it directly);
+   *  nothing secret. */
   registrationKey: Uint8Array;
 }
 
 /**
- * Connects the MCP server by minting a single-use *registration delegation* and
- * handing it to the server, instead of fetching the server's key and calling
- * `mcp_register` on its behalf. The flow:
+ * Connects the MCP server by minting a single-use *registration delegation
+ * chain* and handing it to the server, instead of fetching the server's key
+ * and calling `mcp_register` on its behalf. The flow:
  *
- *  1. `prepare_mcp_registration_delegation` — authenticated as the user, mint a
- *     short-lived canister-signed delegation `P_reg -> X` (where `X` is the
- *     server's per-connect registration key from the link) and record the
+ *  1. Generate an ephemeral registration key `Y` for this connect; its private
+ *     half never leaves this page.
+ *  2. `prepare_mcp_registration_delegation` — authenticated as the user, mint a
+ *     short-lived canister-signed delegation `P_reg -> Y` and record the
  *     consent (this anchor, the read-only choice, the grant TTL) on an index
  *     entry keyed by `P_reg`. The anchor and access level live on that entry,
  *     never in an argument the server controls.
- *  2. `get_mcp_registration_delegation` — fetch the certified `P_reg -> X`
- *     delegation and assemble the chain.
- *  3. Deliver the chain to the trusted server over a URL fragment (a top-level
- *     navigation to the callback it declared — see `matchDeclaredCallback`).
- *     The server, holding `X`'s private key, redeems the chain by calling
- *     `mcp_register_v2` with its long-lived session key `S`; the backend binds
- *     `S` to the recorded anchor with the recorded access level. II never binds
- *     a key it merely received, and the registration delegation is single-use.
+ *  3. `get_mcp_registration_delegation` — fetch the certified `P_reg -> Y`
+ *     delegation, then extend the chain *locally* with a second hop `Y -> X`
+ *     signed by `priv(Y)`, where `X` is the server's per-connect registration
+ *     key from the link.
+ *  4. Deliver the full chain to the trusted server over a URL fragment (a
+ *     top-level navigation to the callback it declared — see
+ *     `matchDeclaredCallback`). The server, holding `X`'s private key, redeems
+ *     it by calling `mcp_register_v2` with its long-lived session key `S`; the
+ *     backend binds `S` to the recorded anchor with the recorded access level.
+ *     II never binds a key it merely received, and the chain is single-use.
  *
- * Nothing is delivered anywhere but a callback the trusted origin declares
- * (the origin is verified against the synced config, and the callback against
- * the server's allow-list, by the caller), and the fragment carries only the
- * server's own public key material — no secret. Resolves with the delivery URL
- * the caller should navigate the tab to; the server's callback finishes the
- * flow on its side (e.g. redeeming the chain and handing an OAuth code back to
- * an MCP client).
+ * The two-hop shape is load-bearing: what the canister signs transits the IC
+ * (the `get` query response passes the answering replica and API boundary
+ * nodes), so it must be inert on its own — it delegates to the browser-held
+ * `Y`, never to the link-supplied `X` an attacker could have planted. The only
+ * redeemable artifact, the full `P_reg -> Y -> X` chain, is assembled inside
+ * this page and leaves it exclusively via the fragment navigation to the
+ * declared callback. Nothing is delivered anywhere but a callback the trusted
+ * origin declares (the origin is verified against the synced config, and the
+ * callback against the server's allow-list, by the caller). Resolves with the
+ * delivery URL the caller should navigate the tab to; the server's callback
+ * finishes the flow on its side (e.g. redeeming the chain and handing an OAuth
+ * code back to an MCP client).
  */
 export const mcpAuthorize = async ({
   authenticated,
@@ -71,34 +82,53 @@ export const mcpAuthorize = async ({
 }: McpAuthorizeInput): Promise<string> => {
   const { identityNumber, actor } = authenticated;
 
+  // The ephemeral registration key `Y` for this connect. The canister-signed
+  // hop targets this browser-held key — never the link-supplied `X` — so the
+  // delegation that transits the IC is inert to any transport-level observer:
+  // only this page holds `priv(Y)`. Fresh per attempt, which also keeps
+  // `P_reg` per-connect-unique (and retries collision-free).
+  const registrationIdentity = await ECDSAKeyIdentity.generate({
+    extractable: false,
+  });
+  const browserKey = new Uint8Array(
+    registrationIdentity.getPublicKey().toDer(),
+  );
+
   // The session-grant lifetime the user chose (the backend clamps again). The
   // access level is recorded on the index entry, not folded into the signature.
-  // A backend refusal (MCP disabled, unauthenticated, a duplicate in-flight
-  // key, ...) throws here and fails the connect before anything is delivered.
+  // A backend refusal (MCP disabled, unauthenticated, ...) throws here and
+  // fails the connect before anything is delivered.
   const grantTtlNanos = BigInt(ttlSeconds) * BigInt(1e9);
   const { user_key, expiration } = await actor
     .prepare_mcp_registration_delegation(
       identityNumber,
-      registrationKey,
+      browserKey,
       toPermissionsArg(accessLevel),
       [grantTtlNanos],
     )
     .then(throwTextCanisterError);
 
   const signed = await actor
-    .get_mcp_registration_delegation(
-      identityNumber,
-      registrationKey,
-      expiration,
-    )
+    .get_mcp_registration_delegation(identityNumber, browserKey, expiration)
     .then(throwTextCanisterError);
 
-  // Assemble the `P_reg -> X` chain the server will redeem. `user_key` is
-  // `P_reg`'s DER public key, so the server's `mcp_register_v2` call is seen by
-  // the backend as `caller() == P_reg`.
-  const chain = DelegationChain.fromDelegations(
+  // Hop 1, canister-signed: `P_reg -> Y`. `user_key` is `P_reg`'s DER public
+  // key, so the server's eventual `mcp_register_v2` call is seen by the
+  // backend as `caller() == P_reg`.
+  const canisterHop = DelegationChain.fromDelegations(
     [transformSignedDelegation(signed)],
     new Uint8Array(user_key),
+  );
+
+  // Hop 2, signed here with `priv(Y)`: extend the chain to the server's `X`
+  // from the link, with the same expiration as the canister hop. Only now does
+  // a redeemable chain exist — inside this page — and it leaves only via the
+  // fragment navigation below.
+  const chain = await DelegationChain.create(
+    registrationIdentity,
+    { toDer: () => registrationKey } as unknown as PublicKey,
+    new Date(Number(expiration / BigInt(1_000_000))),
+    { previous: canisterHop },
   );
 
   // Deliver over the fragment (never sent to the server in the HTTP request):

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -92,12 +92,10 @@ export const mcpAuthorize = async ({
   // only this page holds `priv(Y)`. Fresh per attempt so each connect signs its
   // own second hop (`P_reg` is seeded canister-side from a fresh random nonce —
   // not from `Y` and not from the consent).
-  const registrationIdentity = await ECDSAKeyIdentity.generate({
+  const browserIdentity = await ECDSAKeyIdentity.generate({
     extractable: false,
   });
-  const browserKey = new Uint8Array(
-    registrationIdentity.getPublicKey().toDer(),
-  );
+  const browserKey = new Uint8Array(browserIdentity.getPublicKey().toDer());
 
   // The session-grant lifetime and the read-only choice go to `prepare`, which
   // records the whole consent on the index entry keyed by `P_reg` (the server
@@ -138,7 +136,7 @@ export const mcpAuthorize = async ({
   // a redeemable chain exist — inside this page — and it leaves only via the
   // fragment navigation below.
   const chain = await DelegationChain.create(
-    registrationIdentity,
+    browserIdentity,
     { toDer: () => registrationKey } as unknown as PublicKey,
     new Date(Number(expiration / BigInt(1_000_000))),
     { previous: canisterHop },

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -1,4 +1,8 @@
-import { toPermissionsArg, type AccessLevel } from "$lib/utils/accessLevel";
+import {
+  toPermissionsArg,
+  toPermissionsString,
+  type AccessLevel,
+} from "$lib/utils/accessLevel";
 import type { Authenticated } from "$lib/stores/authentication.store";
 import type { PublicKey } from "@icp-sdk/core/agent";
 import { DelegationChain, ECDSAKeyIdentity } from "@icp-sdk/core/identity";
@@ -14,7 +18,7 @@ interface McpAuthorizeInput {
   ttlSeconds: number;
   /** Whether the whole session is read-only: when read-only, every per-app
    *  delegation the server later mints is restricted to query calls. Chosen
-   *  once at connect and recorded on the registration delegation's index entry,
+   *  once at connect and folded into the registration principal's derivation,
    *  so the server cannot upgrade a read-only session to full access. */
   accessLevel: AccessLevel;
   /** The trusted server's declared connect callback: exact-matched by the
@@ -37,27 +41,31 @@ interface McpAuthorizeInput {
 }
 
 /**
- * Connects the MCP server by minting a single-use *registration delegation
+ * Connects the MCP server by minting a short-lived *registration delegation
  * chain* and handing it to the server, instead of fetching the server's key
  * and calling `mcp_register` on its behalf. The flow:
  *
  *  1. Generate an ephemeral registration key `Y` for this connect; its private
  *     half never leaves this page.
  *  2. `prepare_mcp_registration_delegation` — authenticated as the user, mint a
- *     short-lived canister-signed delegation `P_reg -> Y` and record the
- *     consent (this anchor, the read-only choice, the grant TTL) on an index
- *     entry keyed by `P_reg`. The anchor and access level live on that entry,
- *     never in an argument the server controls.
+ *     short-lived canister-signed delegation `P_reg -> Y`. Nothing is stored:
+ *     `P_reg` is *derived* from the consent tuple (this anchor, the read-only
+ *     choice, the grant TTL, the trusted server URL), so only that exact tuple
+ *     ever redeems it — never an argument the server invents.
  *  3. `get_mcp_registration_delegation` — fetch the certified `P_reg -> Y`
- *     delegation, then extend the chain *locally* with a second hop `Y -> X`
+ *     delegation (passing the same consent parameters, which determine the
+ *     derivation), then extend the chain *locally* with a second hop `Y -> X`
  *     signed by `priv(Y)`, where `X` is the server's per-connect registration
  *     key from the link.
- *  4. Deliver the full chain to the trusted server over a URL fragment (a
- *     top-level navigation to the callback it declared — see
- *     `matchDeclaredCallback`). The server, holding `X`'s private key, redeems
- *     it by calling `mcp_register_v2` with its long-lived session key `S`; the
- *     backend binds `S` to the recorded anchor with the recorded access level.
- *     II never binds a key it merely received, and the chain is single-use.
+ *  4. Deliver the full chain — with the consent tuple alongside — to the
+ *     trusted server over a URL fragment (a top-level navigation to the
+ *     callback it declared — see `matchDeclaredCallback`). The server, holding
+ *     `X`'s private key, redeems it by calling `mcp_register_v2` with its
+ *     long-lived session key `S`, echoing the tuple; the backend re-derives
+ *     `P_reg` from the echoed tuple and binds `S` only if it lands exactly on
+ *     `caller()`. II never binds a key it merely received, and any altered
+ *     echo (upgraded access, stretched TTL, different anchor) derives a
+ *     different principal and is rejected.
  *
  * The two-hop shape is load-bearing: what the canister signs transits the IC
  * (the `get` query response passes the answering replica and API boundary
@@ -95,8 +103,9 @@ export const mcpAuthorize = async ({
   );
 
   // The session-grant lifetime the user chose (the backend clamps again). The
-  // access level is recorded on the index entry, not folded into the signature.
-  // A backend refusal (MCP disabled, unauthenticated, ...) throws here and
+  // access level and TTL are folded into `P_reg`'s derivation, so `get` takes
+  // them too (the seed is re-derived from arguments; nothing is stored). A
+  // backend refusal (MCP disabled, unauthenticated, ...) throws here and
   // fails the connect before anything is delivered.
   const grantTtlNanos = BigInt(ttlSeconds) * BigInt(1e9);
   const { user_key, expiration } = await actor
@@ -109,7 +118,13 @@ export const mcpAuthorize = async ({
     .then(throwTextCanisterError);
 
   const signed = await actor
-    .get_mcp_registration_delegation(identityNumber, browserKey, expiration)
+    .get_mcp_registration_delegation(
+      identityNumber,
+      browserKey,
+      toPermissionsArg(accessLevel),
+      [grantTtlNanos],
+      expiration,
+    )
     .then(throwTextCanisterError);
 
   // Hop 1, canister-signed: `P_reg -> Y`. `user_key` is `P_reg`'s DER public
@@ -133,9 +148,15 @@ export const mcpAuthorize = async ({
 
   // Deliver over the fragment (never sent to the server in the HTTP request):
   // the trusted server's endpoint reads it client-side, reconstructs the chain,
-  // and redeems it. `state` rides along so the server can correlate.
+  // and redeems it. The consent tuple rides along — `anchor`, `permissions`
+  // ("queries"/"all") and `ttl` (grant lifetime in ns) are what the server
+  // must echo to `mcp_register_v2` (the derivation authenticates the echo; a
+  // tampered value simply fails to redeem). `state` lets the server correlate.
   const fragment = new URLSearchParams();
   fragment.set("delegation", JSON.stringify(chain.toJSON()));
   fragment.set("state", state);
+  fragment.set("anchor", identityNumber.toString());
+  fragment.set("permissions", toPermissionsString(accessLevel));
+  fragment.set("ttl", grantTtlNanos.toString());
   return `${callback}#${fragment.toString()}`;
 };

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -48,10 +48,12 @@ interface McpAuthorizeInput {
  *  1. Generate an ephemeral registration key `Y` for this connect; its private
  *     half never leaves this page.
  *  2. `prepare_mcp_registration_delegation` — authenticated as the user, mint a
- *     short-lived canister-signed delegation `P_reg -> Y`. Nothing is stored:
- *     `P_reg` is *derived* from the consent tuple (this anchor, the read-only
- *     choice, the grant TTL, the trusted server URL), so only that exact tuple
- *     ever redeems it — never an argument the server invents.
+ *     short-lived canister-signed delegation `P_reg -> Y`. `P_reg` is *derived*
+ *     from the consent tuple (this anchor, the read-only choice, the grant TTL,
+ *     the trusted server URL); the canister stores only the anchor (keyed by
+ *     `P_reg`) so it can recover it at redemption, while the read-only choice
+ *     and TTL are re-derived and compared rather than trusted from a
+ *     `register_v2` argument the server invents.
  *  3. `get_mcp_registration_delegation` — fetch the certified `P_reg -> Y`
  *     delegation (passing the same consent parameters, which determine the
  *     derivation), then extend the chain *locally* with a second hop `Y -> X`
@@ -95,8 +97,8 @@ export const mcpAuthorize = async ({
   // The ephemeral registration key `Y` for this connect. The canister-signed
   // hop targets this browser-held key — never the link-supplied `X` — so the
   // delegation that transits the IC is inert to any transport-level observer:
-  // only this page holds `priv(Y)`. Fresh per attempt, which also keeps
-  // `P_reg` per-connect-unique (and retries collision-free).
+  // only this page holds `priv(Y)`. Fresh per attempt so each connect signs its
+  // own second hop (`P_reg` itself is derived from the consent, not from `Y`).
   const registrationIdentity = await ECDSAKeyIdentity.generate({
     extractable: false,
   });
@@ -106,9 +108,9 @@ export const mcpAuthorize = async ({
 
   // The session-grant lifetime the user chose (the backend clamps again). The
   // access level and TTL are folded into `P_reg`'s derivation, so `get` takes
-  // them too (the seed is re-derived from arguments; nothing is stored). A
-  // backend refusal (MCP disabled, unauthenticated, ...) throws here and
-  // fails the connect before anything is delivered.
+  // them too (the seed is re-derived from arguments; the canister stores only
+  // the anchor). A backend refusal (MCP disabled, unauthenticated, ...) throws
+  // here and fails the connect before anything is delivered.
   const grantTtlNanos = BigInt(ttlSeconds) * BigInt(1e9);
   const { user_key, expiration } = await actor
     .prepare_mcp_registration_delegation(

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpCloseWindowView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpCloseWindowView.svelte
@@ -5,19 +5,19 @@
   import { onMount } from "svelte";
 
   interface Props {
-    /** Whether the tab is being redirected back to the agent — true when the
-     *  trusted server returned a `finish_url`. When false this is the resting
-     *  screen and there's nothing to redirect to. */
+    /** Whether the tab is being handed to the trusted server (to redeem the
+     *  registration delegation and finish the flow). When false this is the
+     *  resting screen and there's nothing to redirect to. */
     redirecting: boolean;
   }
 
   const { redirecting }: Props = $props();
 
-  // A successful redirect replaces the document (and unmounts this view) within
+  // A successful hand-off replaces the document (and unmounts this view) within
   // a moment. If we're still mounted after a few seconds the navigation never
-  // took — a `finish_url` that doesn't replace the document (204/attachment) or
-  // a bfcache back-navigation to this restored page — so reveal a way out
-  // rather than leaving the user on a "Redirecting…" message that never ends.
+  // took — a server endpoint that doesn't replace the document, or a bfcache
+  // back-navigation to this restored page — so reveal a way out rather than
+  // leaving the user on a "Redirecting…" message that never ends.
   let redirectStalled = $state(false);
   onMount(() => {
     if (!redirecting) {
@@ -29,12 +29,11 @@
 </script>
 
 <!--
-  Centered, card-less success page shown once the MCP server's session key has
-  been registered with the backend. When the trusted server returned a
-  `finish_url` the tab is being sent back to the agent to finish the flow, so we
-  say a redirect is underway (with a fallback hint if it stalls); otherwise
-  there's nothing to redirect to and this is the resting screen, so we just
-  confirm the sign-in.
+  Centered, card-less success page shown once the registration delegation has
+  been minted. The tab is then handed to the server's declared callback —
+  where the server redeems the delegation and finishes the flow — so we say a
+  redirect is underway (with a fallback hint if it stalls); when there's nothing
+  to redirect to this is the resting screen, so we just confirm the sign-in.
 -->
 <div class="flex flex-col items-center gap-5 px-6 text-center">
   <FeaturedIcon size="lg" variant="success">

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpCloseWindowView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpCloseWindowView.svelte
@@ -45,7 +45,7 @@
   <div class="flex flex-col items-center gap-1">
     <p class="text-text-tertiary text-base">
       {#if redirecting}
-        {$t`Redirecting back to the agent…`}
+        {$t`Taking you to the server to finish connecting…`}
       {:else}
         {$t`You can return to your agent.`}
       {/if}

--- a/src/frontend/src/routes/(new-styling)/mcp/views/McpConnectingView.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/views/McpConnectingView.svelte
@@ -13,10 +13,10 @@
 </script>
 
 <!--
-  Shown after the user confirms (and has authenticated) while the server's
-  session key is fetched and registered with the backend — i.e. between
-  "Allow access" and the terminal screen. Gives the otherwise-blank gap a
-  loading state, like the /authorize redirect screen.
+  Shown after the user confirms (and has authenticated) while the registration
+  delegation is minted — i.e. between "Allow access" and the tab being handed
+  to the trusted server. Gives the otherwise-blank gap a loading state, like
+  the /authorize redirect screen.
 -->
 <div class="flex w-full justify-center max-sm:flex-1 sm:max-w-110">
   <AuthPanel>

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -75,9 +75,10 @@ export type McpCompletion = {
  * long-lived session key `S` it wants bound to the anchor. It declares its
  * connect callback in the auth-callback allow-list it hosts at
  * `/.well-known/ii-auth-callbacks`; II exact-matches the link's callback
- * against that list, mints a single-use `P_reg -> X` delegation, and hands it
- * to the declared callback over a top-level navigation (the delegation in the
- * URL fragment). There's no real HTTP server: `page.route` intercepts the
+ * against that list, mints a single-use registration chain — a canister-signed
+ * `P_reg -> Y` hop to a browser-held ephemeral key, extended browser-side with
+ * a `Y -> X` hop — and hands it to the declared callback over a top-level
+ * navigation (the chain in the URL fragment). There's no real HTTP server: `page.route` intercepts the
  * navigation and serves a page that reads the fragment and POSTs it to a
  * fixture endpoint; that handler — holding `X`'s private key — reconstructs the
  * chain and redeems it by calling `mcp_register_v2(pub(S))` as the server
@@ -220,7 +221,7 @@ export const test = base.extend<{ mcp: McpFixture }>({
       nextOutcome = outcome;
     };
 
-    // Redeem the delivered `P_reg -> X` chain exactly as the server would:
+    // Redeem the delivered `P_reg -> Y -> X` chain exactly as the server would:
     // reconstruct the chain, sign as X (which the server holds), and bind S via
     // `mcp_register_v2`. `caller()` is `P_reg`, so the backend recovers the
     // anchor and access level from the index entry `prepare` recorded.

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -153,6 +153,10 @@ const connectPageHtml = (redeemPath: string): string => `<!doctype html>
     const params = new URLSearchParams(location.hash.slice(1));
     const delegation = params.get("delegation");
     const state = params.get("state");
+    // Clear the fragment once parsed (keeping the query string — the declared
+    // callback may carry one) so the delegation doesn't linger in the address
+    // bar / history — what the server guide tells real servers to do.
+    history.replaceState(null, "", location.pathname + location.search);
     if (!delegation || !state) {
       el.textContent = "Missing delegation";
       return;

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -1,10 +1,24 @@
-import { Ed25519KeyIdentity } from "@icp-sdk/core/identity";
+import {
+  DelegationChain,
+  DelegationIdentity,
+  Ed25519KeyIdentity,
+} from "@icp-sdk/core/identity";
+import { Actor, HttpAgent } from "@icp-sdk/core/agent";
+import { Principal } from "@icp-sdk/core/principal";
+import { Agent as UndiciAgent } from "undici";
 import { test as base, type Page } from "@playwright/test";
+import { readCanisterId } from "@dfinity/internet-identity-vite-plugins/utils";
+import { idlFactory as internet_identity_idl } from "$lib/generated/internet_identity_idl";
+import type {
+  _SERVICE,
+  Permissions,
+} from "$lib/generated/internet_identity_types";
 import { toBase64URL } from "../../../src/lib/utils/utils";
 import { AUTH_CALLBACKS_PATH } from "../../../src/lib/utils/authCallbacks";
 import { II_URL } from "../utils";
+import { DEFAULT_HOST } from "./identity";
 
-/** What the MCP server stand-in does on its next callback request. */
+/** What the MCP server stand-in does on its next redemption. */
 type McpOutcome = "success" | "error";
 
 /**
@@ -15,10 +29,39 @@ type McpOutcome = "success" | "error";
  */
 const MCP_SERVER_ORIGIN = "https://mcp.id.ai";
 
-/** The completion notification the connect flow POSTs once the session is
- *  registered: the state echo, the grant expiration (ns since epoch, as a
- *  decimal string — the value overflows JSON numbers), and the session's
- *  access level (`permissions`: "queries" = read-only, "all" = full). */
+/** The server-chosen path of its connect callback page — any path works, as
+ *  long as the server declares the full URL in its auth-callback allow-list
+ *  (see `AUTH_CALLBACKS_PATH`). Deliberately not a well-known path: the server
+ *  owns its own routing under the declared-callbacks model. */
+const CONNECT_CALLBACK_PATH = "/mcp/connect";
+
+/** A fixture-internal endpoint the connect page POSTs the delivered fragment
+ *  to. Same-origin with the server (no CORS preflight); it stands in for the
+ *  server's backend, which holds `X`'s private key and redeems the chain. */
+const REDEEM_PATH = "/__ii_mcp_redeem";
+
+/** The II backend canister (exposes `mcp_register_v2`). Read once at module
+ *  load, like `test_app` in `utils.ts`. */
+const II_CANISTER_ID = Principal.fromText(
+  readCanisterId({ canisterName: "internet_identity" }),
+);
+
+/** Self-signed-cert tolerant fetch for the redeeming agent — same setup as
+ *  `utils.ts` / `emailRecovery.ts`. */
+const insecureUndici = new UndiciAgent({
+  connect: { rejectUnauthorized: false },
+});
+const insecureFetch: typeof fetch = (url, options = {}) =>
+  fetch(url, { dispatcher: insecureUndici, ...options } as RequestInit);
+
+const permissionsString = (permissions: Permissions): string =>
+  "queries" in permissions ? "queries" : "all";
+
+/** The outcome the connect reports once the server redeems the registration
+ *  delegation: the state echo, the session grant's expiration (ns since epoch,
+ *  as a decimal string — the value overflows JSON numbers), and the session's
+ *  access level (`permissions`: "queries" = read-only, "all" = full), all read
+ *  off `mcp_register_v2`'s response. */
 export type McpCompletion = {
   state: string;
   expiration: string;
@@ -26,43 +69,39 @@ export type McpCompletion = {
 };
 
 /**
- * Stands in for a remote MCP server. Unlike the CLI loopback fixture there's
- * no real HTTP server: the callback is a public https origin, and the connect
- * flow talks to it with JSON `fetch`es. We intercept those with `page.route`
- * (which catches them before the network, so no server or DNS for `mcp.id.ai`
- * is needed) and answer exactly like a real MCP server would: the well-known
- * auth-callback allow-list (`/.well-known/ii-auth-callbacks`) declares this
- * connection's callback, the key request (`{state}`) gets this connection's
- * session public key, and the completion notification (`{state, expiration}`)
- * gets a 200. A request with a state the server never issued gets a 403 —
- * nothing is registered then.
- *
- * `completion` resolves with the completion body once the flow reports the
- * session registered.
+ * Stands in for a remote MCP server in the *registration-delegation* connect
+ * flow. The server generates two keys per browser session: a per-connect
+ * registration key `X` (its public key rides the connect link) and the
+ * long-lived session key `S` it wants bound to the anchor. It declares its
+ * connect callback in the auth-callback allow-list it hosts at
+ * `/.well-known/ii-auth-callbacks`; II exact-matches the link's callback
+ * against that list, mints a single-use `P_reg -> X` delegation, and hands it
+ * to the declared callback over a top-level navigation (the delegation in the
+ * URL fragment). There's no real HTTP server: `page.route` intercepts the
+ * navigation and serves a page that reads the fragment and POSTs it to a
+ * fixture endpoint; that handler — holding `X`'s private key — reconstructs the
+ * chain and redeems it by calling `mcp_register_v2(pub(S))` as the server
+ * would, then resolves `completion`.
  */
 export type McpFixture = {
-  publicKey: string;
+  /** The server's registration public key `X` (DER, base64url) — what rides
+   *  the connect link. */
+  registrationKey: string;
   state: string;
   mcpOrigin: string;
   callbackUrl: string;
-  /** Where the stand-in sends the browser after the connect once
-   *  `enableFinishRedirect()` is called: a landing page on its own origin,
-   *  like a real server completing its own (e.g. OAuth) flow. Its query
-   *  carries the one-time `finish_secret` (as a real server's would) so a
-   *  test can assert that secret never leaks to a log/telemetry sink. */
+  /** Where the server's connect page sends the browser after a successful
+   *  redemption once `enableFinishRedirect()` is called: a landing page on its
+   *  own origin, like a real server completing its own (e.g. OAuth) flow. */
   finishUrl: string;
-  /** The one-time secret embedded in `finishUrl`'s query (the `fs` param):
-   *  the H3 "Consent-Bound Completion" credential the server delivers only to
-   *  the consenting browser. Exposed so the leak test can grep for it. */
-  finishSecret: string;
   completion: Promise<McpCompletion>;
   /** Every completion received so far, in order (for multi-connect tests). */
   completions: McpCompletion[];
-  /** Sets what the MCP server stand-in does on its next callback request. */
+  /** Sets what the server stand-in does on its next redemption. */
   setNextOutcome: (outcome: McpOutcome) => void;
-  /** Makes the key response carry `finish_url`, so the connect flow hands the
-   *  tab back to the server (at `finishUrl`) instead of showing the close
-   *  screen. Off by default — most tests assert the close screen. */
+  /** Makes the server's connect page hand the tab back to the server (at
+   *  `finishUrl`) after a successful redemption, instead of just showing its
+   *  connected state. Off by default. */
   enableFinishRedirect: () => void;
   /**
    * Trusts this fixture's MCP origin for the signed-up identity by driving the
@@ -74,8 +113,10 @@ export type McpFixture = {
    */
   trustServer: (page: Page) => Promise<void>;
   /**
-   * Installs the callback interceptor on `page`. Must be called before the
-   * flow contacts the server (i.e. before "Allow access").
+   * Installs the server stand-in on `page`: the auth-callback allow-list, the
+   * declared connect callback (serves the fragment-reading page), the redeem
+   * endpoint, and the finish landing. Must be called before the flow delivers
+   * the delegation (i.e. before "Allow access").
    */
   installInterceptor: (page: Page) => Promise<void>;
   /** Builds the `/mcp` authorize URL with the request params in the fragment. */
@@ -86,33 +127,78 @@ export type McpFixture = {
   }) => string;
 };
 
-// The connect flow's requests (the allow-list GET and the callback POSTs) are
-// cross-origin JSON `fetch`es, so the stand-in must answer the CORS preflight
-// and mark its responses readable — exactly what a real MCP server has to do.
+// The auth-callback allow-list is fetched cross-origin by the II frontend, so
+// its response must carry CORS headers to be readable — part of the server's
+// contract. The redeem POST is same-origin with the served connect page, so it
+// isn't preflighted; the headers are applied to the fixture's JSON responses
+// defensively either way.
 const CORS_HEADERS = {
   "access-control-allow-origin": "*",
   "access-control-allow-methods": "GET, POST",
   "access-control-allow-headers": "content-type",
 };
 
+/** The page served at the declared connect callback. Reads the delivered
+ *  delegation + state from the fragment (never sent to the server in the HTTP
+ *  request) and ships them to the redeem endpoint; on success it either lands
+ *  on its "connected" state or, if the server asked for it, navigates onward to
+ *  its own finish URL. */
+const connectPageHtml = (redeemPath: string): string => `<!doctype html>
+<meta charset="utf-8" />
+<title>MCP connect</title>
+<h1 id="status">Connecting…</h1>
+<script>
+  (async () => {
+    const el = document.getElementById("status");
+    const params = new URLSearchParams(location.hash.slice(1));
+    const delegation = params.get("delegation");
+    const state = params.get("state");
+    if (!delegation || !state) {
+      el.textContent = "Missing delegation";
+      return;
+    }
+    try {
+      const res = await fetch(${JSON.stringify(redeemPath)}, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ delegation, state }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data.ok) {
+        if (data.finishUrl) {
+          location.assign(data.finishUrl);
+          return;
+        }
+        el.textContent = "Connected";
+      } else {
+        el.textContent = "Connection failed";
+      }
+    } catch {
+      el.textContent = "Connection failed";
+    }
+  })();
+</script>`;
+
 export const test = base.extend<{ mcp: McpFixture }>({
   // eslint-disable-next-line no-empty-pattern -- playwright fixtures require the destructure
   mcp: async ({}, use) => {
-    const identity = Ed25519KeyIdentity.generate();
-    const publicKey = toBase64URL(
-      new Uint8Array(identity.getPublicKey().toDer()),
+    // The server's two per-session keys: X (registration key, public part rides
+    // the link) and S (the long-lived session key it wants bound).
+    const registrationIdentity = Ed25519KeyIdentity.generate();
+    const sessionIdentity = Ed25519KeyIdentity.generate();
+    const registrationKey = toBase64URL(
+      new Uint8Array(registrationIdentity.getPublicKey().toDer()),
     );
-    // Opaque value the MCP server puts in the request and the frontend sends
-    // back in its callback requests so the server can tie them to the request
-    // it started.
+    const sessionKey = new Uint8Array(sessionIdentity.getPublicKey().toDer());
+
+    // Opaque value the server puts in the link and the connect page echoes back
+    // with the delegation, so the server can tie it to the connect it started.
     const state = toBase64URL(crypto.getRandomValues(new Uint8Array(32)));
-    const callbackUrl = `${MCP_SERVER_ORIGIN}/callback`;
-    // A distinctive one-time secret in the finish URL's query, standing in for
-    // the H3 `finish_secret` the server delivers only to the consenting
-    // browser. Kept greppable so the leak test can assert it never reaches a
-    // console/telemetry/outbound sink other than the finish navigation itself.
-    const finishSecret = "fs-DO-NOT-LEAK-7f2a91c4";
-    const finishUrl = `${MCP_SERVER_ORIGIN}/oauth/finish?sid=fixture&fs=${finishSecret}`;
+    // The link's callback: the server's connect page, declared in the
+    // allow-list it hosts at /.well-known/ii-auth-callbacks. II honours it
+    // only after exact-matching it against that list.
+    const callbackUrl = `${MCP_SERVER_ORIGIN}${CONNECT_CALLBACK_PATH}`;
+    const finishUrl = `${MCP_SERVER_ORIGIN}/oauth/finish?sid=fixture`;
 
     let finishRedirect = false;
     const enableFinishRedirect = (): void => {
@@ -130,83 +216,121 @@ export const test = base.extend<{ mcp: McpFixture }>({
       nextOutcome = outcome;
     };
 
+    // Redeem the delivered `P_reg -> X` chain exactly as the server would:
+    // reconstruct the chain, sign as X (which the server holds), and bind S via
+    // `mcp_register_v2`. `caller()` is `P_reg`, so the backend recovers the
+    // anchor and access level from the index entry `prepare` recorded.
+    const redeem = async (delegationJson: string): Promise<McpCompletion> => {
+      const chain = DelegationChain.fromJSON(JSON.parse(delegationJson));
+      const identity = DelegationIdentity.fromDelegation(
+        registrationIdentity,
+        chain,
+      );
+      const agent = await HttpAgent.create({
+        host: DEFAULT_HOST,
+        shouldFetchRootKey: true,
+        verifyQuerySignatures: false,
+        fetch: insecureFetch,
+        identity,
+      });
+      const actor = Actor.createActor<_SERVICE>(internet_identity_idl, {
+        agent,
+        canisterId: II_CANISTER_ID,
+      });
+      const result = await actor.mcp_register_v2(sessionKey);
+      if ("Err" in result) {
+        throw new Error(result.Err);
+      }
+      return {
+        state,
+        expiration: result.Ok.expiration.toString(),
+        permissions: permissionsString(result.Ok.permissions),
+      };
+    };
+
     const installInterceptor = async (page: Page): Promise<void> => {
       await page.route(`${MCP_SERVER_ORIGIN}/**`, async (route) => {
         const request = route.request();
+        const { pathname } = new URL(request.url());
+
         if (request.method() === "OPTIONS") {
-          // CORS preflight for the JSON POSTs.
           await route.fulfill({ status: 204, headers: CORS_HEADERS });
           return;
         }
-        if (request.method() === "GET") {
-          // The server-declared auth-callback allow-list: II fetches it and
-          // exact-matches the link's callback against it before contacting
-          // the callback. Served with CORS (a cross-origin JSON GET) and the
-          // application/json content type II requires.
-          if (new URL(request.url()).pathname === AUTH_CALLBACKS_PATH) {
+
+        // The connect page delivers the fragment here. Redeem it (the server's
+        // backend role), or fail on an "error" outcome / a state it never issued.
+        if (request.method() === "POST" && pathname === REDEEM_PATH) {
+          if (nextOutcome === "error") {
+            await route.fulfill({ status: 500, headers: CORS_HEADERS });
+            return;
+          }
+          let body: { delegation?: unknown; state?: unknown } = {};
+          try {
+            body = JSON.parse(request.postData() ?? "{}") as typeof body;
+          } catch {
+            // Leave `body` empty; the checks below reject the request.
+          }
+          if (typeof body.delegation !== "string" || body.state !== state) {
+            await route.fulfill({ status: 403, headers: CORS_HEADERS });
+            return;
+          }
+          try {
+            const received = await redeem(body.delegation);
+            completions.push(received);
+            resolveCompletion(received);
             await route.fulfill({
               status: 200,
               headers: { ...CORS_HEADERS, "content-type": "application/json" },
-              body: JSON.stringify({ callbacks: [callbackUrl] }),
+              body: JSON.stringify({
+                ok: true,
+                finishUrl: finishRedirect ? finishUrl : null,
+              }),
             });
-            return;
-          }
-          // A navigation to the finish URL: the browser was handed back to
-          // the server after the connect. Serve the landing page.
-          if (request.url() === finishUrl) {
+          } catch (error) {
             await route.fulfill({
-              status: 200,
-              headers: { "content-type": "text/html" },
-              body: "<h1>Connection complete</h1>",
+              status: 502,
+              headers: { ...CORS_HEADERS, "content-type": "application/json" },
+              body: JSON.stringify({ ok: false, error: String(error) }),
             });
-            return;
           }
-          await route.fulfill({ status: 404 });
           return;
         }
-        let body: Record<string, unknown> = {};
-        try {
-          body = JSON.parse(request.postData() ?? "{}") as Record<
-            string,
-            unknown
-          >;
-        } catch {
-          // Leave `body` empty; the state check below rejects the request.
-        }
-        if (nextOutcome === "error" || body.state !== state) {
-          // On an "error" outcome, or a state this server never issued (a real
-          // MCP server must reject that), answer 403 — the flow errors out and
-          // nothing is registered.
-          await route.fulfill({ status: 403, headers: CORS_HEADERS });
-          return;
-        }
-        if (typeof body.expiration === "string") {
-          // Completion notification: the session is registered.
-          const received = {
-            state,
-            expiration: body.expiration,
-            permissions: String(body.permissions),
-          };
-          completions.push(received);
-          resolveCompletion(received);
+
+        if (request.method() === "GET" && pathname === AUTH_CALLBACKS_PATH) {
+          // The server-declared auth-callback allow-list: II fetches it and
+          // exact-matches the link's callback against it before delivering
+          // anything. Served with CORS (a cross-origin JSON GET) and the
+          // application/json content type II requires.
           await route.fulfill({
             status: 200,
             headers: { ...CORS_HEADERS, "content-type": "application/json" },
-            body: "{}",
+            body: JSON.stringify({ callbacks: [callbackUrl] }),
           });
           return;
         }
-        // Key request: serve this connection's session public key, plus the
-        // finish redirect when enabled — exactly the response shape a real
-        // server completing its own flow (e.g. OAuth) would send.
-        await route.fulfill({
-          status: 200,
-          headers: { ...CORS_HEADERS, "content-type": "application/json" },
-          body: JSON.stringify({
-            public_key: publicKey,
-            ...(finishRedirect ? { finish_url: finishUrl } : {}),
-          }),
-        });
+
+        if (request.method() === "GET" && pathname === CONNECT_CALLBACK_PATH) {
+          // The declared connect callback: II delivers the delegation here.
+          await route.fulfill({
+            status: 200,
+            headers: { "content-type": "text/html" },
+            body: connectPageHtml(REDEEM_PATH),
+          });
+          return;
+        }
+
+        if (request.method() === "GET" && request.url() === finishUrl) {
+          // The server's own landing page after it finishes its flow.
+          await route.fulfill({
+            status: 200,
+            headers: { "content-type": "text/html" },
+            body: "<h1>Connection complete</h1>",
+          });
+          return;
+        }
+
+        await route.fulfill({ status: 404 });
       });
     };
 
@@ -214,8 +338,8 @@ export const test = base.extend<{ mcp: McpFixture }>({
       // The trusted server is the identity's synced (on-chain) config, set via
       // Settings — so seed it the way a user would. Mock this origin's RFC 9728
       // metadata first so the Settings probe verifies fast and clean (the probe
-      // is advisory; activation happens regardless). The narrow well-known
-      // pattern doesn't collide with the callback interceptor's `/**` route.
+      // is advisory; activation happens regardless). Registered after the
+      // connect interceptor so this narrower route wins for its exact path.
       await page.route(
         `${MCP_SERVER_ORIGIN}/.well-known/oauth-protected-resource**`,
         (route) =>
@@ -257,6 +381,7 @@ export const test = base.extend<{ mcp: McpFixture }>({
       callbackUrl?: string;
     }): string => {
       const fragment = new URLSearchParams();
+      fragment.set("registration_key", registrationKey);
       fragment.set("callback", opts.callbackUrl ?? callbackUrl);
       fragment.set("state", state);
       fragment.set("app", opts.app);
@@ -267,12 +392,11 @@ export const test = base.extend<{ mcp: McpFixture }>({
     };
 
     await use({
-      publicKey,
+      registrationKey,
       state,
       mcpOrigin: MCP_SERVER_ORIGIN,
       callbackUrl,
       finishUrl,
-      finishSecret,
       completion,
       completions,
       setNextOutcome,

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -89,12 +89,13 @@ export type McpCompletion = {
  * against that list, mints a short-lived registration chain — a canister-signed
  * `P_reg -> Y` hop to a browser-held ephemeral key, extended browser-side with
  * a `Y -> X` hop — and hands it to the declared callback over a top-level
- * navigation (the chain plus the consent tuple in the URL fragment). There's
- * no real HTTP server: `page.route` intercepts the navigation and serves a
- * page that reads the fragment and POSTs it to a fixture endpoint; that
- * handler — holding `X`'s private key — reconstructs the chain and redeems it
- * by calling `mcp_register_v2` as the server would, echoing the delivered
- * consent tuple (anchor, permissions, ttl) alongside `pub(S)`, then resolves
+ * navigation (the chain plus the echoed consent — permissions, ttl — in the
+ * URL fragment; the anchor is not delivered). There's no real HTTP server:
+ * `page.route` intercepts the navigation and serves a page that reads the
+ * fragment and POSTs it to a fixture endpoint; that handler — holding `X`'s
+ * private key — reconstructs the chain and redeems it by calling
+ * `mcp_register_v2` as the server would, echoing the delivered permissions and
+ * ttl alongside `pub(S)` (the canister recovers the anchor), then resolves
  * `completion`.
  */
 export type McpFixture = {
@@ -153,11 +154,12 @@ const CORS_HEADERS = {
 };
 
 /** The page served at the declared connect callback. Reads the delivered
- *  delegation + state + consent tuple (anchor, permissions, ttl — what the
- *  server must echo to `mcp_register_v2`) from the fragment (never sent to the
- *  server in the HTTP request) and ships them to the redeem endpoint; on
- *  success it either lands on its "connected" state or, if the server asked
- *  for it, navigates onward to its own finish URL. */
+ *  delegation + state + echoed consent (permissions, ttl — what the server
+ *  passes to `mcp_register_v2`; the anchor is NOT delivered, the canister
+ *  recovers it) from the fragment (never sent to the server in the HTTP
+ *  request) and ships them to the redeem endpoint; on success it either lands
+ *  on its "connected" state or, if the server asked for it, navigates onward to
+ *  its own finish URL. */
 const connectPageHtml = (redeemPath: string): string => `<!doctype html>
 <meta charset="utf-8" />
 <title>MCP connect</title>
@@ -168,14 +170,13 @@ const connectPageHtml = (redeemPath: string): string => `<!doctype html>
     const params = new URLSearchParams(location.hash.slice(1));
     const delegation = params.get("delegation");
     const state = params.get("state");
-    const anchor = params.get("anchor");
     const permissions = params.get("permissions");
     const ttl = params.get("ttl");
     // Clear the fragment once parsed (keeping the query string — the declared
     // callback may carry one) so the delegation doesn't linger in the address
     // bar / history — what the server guide tells real servers to do.
     history.replaceState(null, "", location.pathname + location.search);
-    if (!delegation || !state || !anchor || !permissions || !ttl) {
+    if (!delegation || !state || !permissions || !ttl) {
       el.textContent = "Missing delegation";
       return;
     }
@@ -183,7 +184,7 @@ const connectPageHtml = (redeemPath: string): string => `<!doctype html>
       const res = await fetch(${JSON.stringify(redeemPath)}, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ delegation, state, anchor, permissions, ttl }),
+        body: JSON.stringify({ delegation, state, permissions, ttl }),
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok && data.ok) {
@@ -240,13 +241,13 @@ export const test = base.extend<{ mcp: McpFixture }>({
 
     // Redeem the delivered `P_reg -> Y -> X` chain exactly as the server would:
     // reconstruct the chain, sign as X (which the server holds), and bind S via
-    // `mcp_register_v2`, echoing the delivered consent tuple. `caller()` is
-    // `P_reg`, and the backend re-derives the principal from the echoed tuple
-    // (plus the anchor's current trusted-server config) and matches it against
-    // `caller()` — an altered echo simply fails to redeem.
+    // `mcp_register_v2`, echoing the delivered consent (permissions, ttl).
+    // `caller()` is `P_reg`; the backend recovers the anchor from the
+    // registration entry (never delivered here) and re-derives the principal
+    // from (recovered anchor, echoed values, current config), matching it
+    // against `caller()` — an altered echo simply fails to redeem.
     const redeem = async (delivered: {
       delegation: string;
-      anchor: string;
       permissions: string;
       ttl: string;
     }): Promise<McpCompletion> => {
@@ -267,7 +268,6 @@ export const test = base.extend<{ mcp: McpFixture }>({
         canisterId: II_CANISTER_ID,
       });
       const result = await actor.mcp_register_v2(
-        BigInt(delivered.anchor),
         sessionKey,
         permissionsArg(delivered.permissions),
         [BigInt(delivered.ttl)],
@@ -302,7 +302,6 @@ export const test = base.extend<{ mcp: McpFixture }>({
           let body: {
             delegation?: unknown;
             state?: unknown;
-            anchor?: unknown;
             permissions?: unknown;
             ttl?: unknown;
           } = {};
@@ -314,7 +313,6 @@ export const test = base.extend<{ mcp: McpFixture }>({
           if (
             typeof body.delegation !== "string" ||
             body.state !== state ||
-            typeof body.anchor !== "string" ||
             typeof body.permissions !== "string" ||
             typeof body.ttl !== "string"
           ) {
@@ -324,7 +322,6 @@ export const test = base.extend<{ mcp: McpFixture }>({
           try {
             const received = await redeem({
               delegation: body.delegation,
-              anchor: body.anchor,
               permissions: body.permissions,
               ttl: body.ttl,
             });

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -57,6 +57,17 @@ const insecureFetch: typeof fetch = (url, options = {}) =>
 const permissionsString = (permissions: Permissions): string =>
   "queries" in permissions ? "queries" : "all";
 
+/** The candid `opt Permissions` argument for a wire permissions string as
+ *  delivered in the fragment ("queries" / "all") — what the server echoes back
+ *  to `mcp_register_v2`. Anything else is echoed as an empty opt; the backend's
+ *  derive-and-compare then rejects the redemption (never silently defaults). */
+const permissionsArg = (wire: string): [] | [Permissions] =>
+  wire === "queries"
+    ? [{ queries: null }]
+    : wire === "all"
+      ? [{ all: null }]
+      : [];
+
 /** The outcome the connect reports once the server redeems the registration
  *  delegation: the state echo, the session grant's expiration (ns since epoch,
  *  as a decimal string — the value overflows JSON numbers), and the session's
@@ -75,14 +86,16 @@ export type McpCompletion = {
  * long-lived session key `S` it wants bound to the anchor. It declares its
  * connect callback in the auth-callback allow-list it hosts at
  * `/.well-known/ii-auth-callbacks`; II exact-matches the link's callback
- * against that list, mints a single-use registration chain — a canister-signed
+ * against that list, mints a short-lived registration chain — a canister-signed
  * `P_reg -> Y` hop to a browser-held ephemeral key, extended browser-side with
  * a `Y -> X` hop — and hands it to the declared callback over a top-level
- * navigation (the chain in the URL fragment). There's no real HTTP server: `page.route` intercepts the
- * navigation and serves a page that reads the fragment and POSTs it to a
- * fixture endpoint; that handler — holding `X`'s private key — reconstructs the
- * chain and redeems it by calling `mcp_register_v2(pub(S))` as the server
- * would, then resolves `completion`.
+ * navigation (the chain plus the consent tuple in the URL fragment). There's
+ * no real HTTP server: `page.route` intercepts the navigation and serves a
+ * page that reads the fragment and POSTs it to a fixture endpoint; that
+ * handler — holding `X`'s private key — reconstructs the chain and redeems it
+ * by calling `mcp_register_v2` as the server would, echoing the delivered
+ * consent tuple (anchor, permissions, ttl) alongside `pub(S)`, then resolves
+ * `completion`.
  */
 export type McpFixture = {
   /** The server's registration public key `X` (DER, base64url) — what rides
@@ -140,10 +153,11 @@ const CORS_HEADERS = {
 };
 
 /** The page served at the declared connect callback. Reads the delivered
- *  delegation + state from the fragment (never sent to the server in the HTTP
- *  request) and ships them to the redeem endpoint; on success it either lands
- *  on its "connected" state or, if the server asked for it, navigates onward to
- *  its own finish URL. */
+ *  delegation + state + consent tuple (anchor, permissions, ttl — what the
+ *  server must echo to `mcp_register_v2`) from the fragment (never sent to the
+ *  server in the HTTP request) and ships them to the redeem endpoint; on
+ *  success it either lands on its "connected" state or, if the server asked
+ *  for it, navigates onward to its own finish URL. */
 const connectPageHtml = (redeemPath: string): string => `<!doctype html>
 <meta charset="utf-8" />
 <title>MCP connect</title>
@@ -154,11 +168,14 @@ const connectPageHtml = (redeemPath: string): string => `<!doctype html>
     const params = new URLSearchParams(location.hash.slice(1));
     const delegation = params.get("delegation");
     const state = params.get("state");
+    const anchor = params.get("anchor");
+    const permissions = params.get("permissions");
+    const ttl = params.get("ttl");
     // Clear the fragment once parsed (keeping the query string — the declared
     // callback may carry one) so the delegation doesn't linger in the address
     // bar / history — what the server guide tells real servers to do.
     history.replaceState(null, "", location.pathname + location.search);
-    if (!delegation || !state) {
+    if (!delegation || !state || !anchor || !permissions || !ttl) {
       el.textContent = "Missing delegation";
       return;
     }
@@ -166,7 +183,7 @@ const connectPageHtml = (redeemPath: string): string => `<!doctype html>
       const res = await fetch(${JSON.stringify(redeemPath)}, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ delegation, state }),
+        body: JSON.stringify({ delegation, state, anchor, permissions, ttl }),
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok && data.ok) {
@@ -223,10 +240,17 @@ export const test = base.extend<{ mcp: McpFixture }>({
 
     // Redeem the delivered `P_reg -> Y -> X` chain exactly as the server would:
     // reconstruct the chain, sign as X (which the server holds), and bind S via
-    // `mcp_register_v2`. `caller()` is `P_reg`, so the backend recovers the
-    // anchor and access level from the index entry `prepare` recorded.
-    const redeem = async (delegationJson: string): Promise<McpCompletion> => {
-      const chain = DelegationChain.fromJSON(JSON.parse(delegationJson));
+    // `mcp_register_v2`, echoing the delivered consent tuple. `caller()` is
+    // `P_reg`, and the backend re-derives the principal from the echoed tuple
+    // (plus the anchor's current trusted-server config) and matches it against
+    // `caller()` — an altered echo simply fails to redeem.
+    const redeem = async (delivered: {
+      delegation: string;
+      anchor: string;
+      permissions: string;
+      ttl: string;
+    }): Promise<McpCompletion> => {
+      const chain = DelegationChain.fromJSON(JSON.parse(delivered.delegation));
       const identity = DelegationIdentity.fromDelegation(
         registrationIdentity,
         chain,
@@ -242,7 +266,12 @@ export const test = base.extend<{ mcp: McpFixture }>({
         agent,
         canisterId: II_CANISTER_ID,
       });
-      const result = await actor.mcp_register_v2(sessionKey);
+      const result = await actor.mcp_register_v2(
+        BigInt(delivered.anchor),
+        sessionKey,
+        permissionsArg(delivered.permissions),
+        [BigInt(delivered.ttl)],
+      );
       if ("Err" in result) {
         throw new Error(result.Err);
       }
@@ -270,18 +299,35 @@ export const test = base.extend<{ mcp: McpFixture }>({
             await route.fulfill({ status: 500, headers: CORS_HEADERS });
             return;
           }
-          let body: { delegation?: unknown; state?: unknown } = {};
+          let body: {
+            delegation?: unknown;
+            state?: unknown;
+            anchor?: unknown;
+            permissions?: unknown;
+            ttl?: unknown;
+          } = {};
           try {
             body = JSON.parse(request.postData() ?? "{}") as typeof body;
           } catch {
             // Leave `body` empty; the checks below reject the request.
           }
-          if (typeof body.delegation !== "string" || body.state !== state) {
+          if (
+            typeof body.delegation !== "string" ||
+            body.state !== state ||
+            typeof body.anchor !== "string" ||
+            typeof body.permissions !== "string" ||
+            typeof body.ttl !== "string"
+          ) {
             await route.fulfill({ status: 403, headers: CORS_HEADERS });
             return;
           }
           try {
-            const received = await redeem(body.delegation);
+            const received = await redeem({
+              delegation: body.delegation,
+              anchor: body.anchor,
+              permissions: body.permissions,
+              ttl: body.ttl,
+            });
             completions.push(received);
             resolveCompletion(received);
             await route.fulfill({

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -60,17 +60,6 @@ const insecureFetch: typeof fetch = (url, options = {}) =>
 const permissionsString = (permissions: Permissions): string =>
   "queries" in permissions ? "queries" : "all";
 
-/** The candid `opt Permissions` argument for a wire permissions string as
- *  delivered in the fragment ("queries" / "all") — what the server echoes back
- *  to `mcp_register_v2`. Anything else is echoed as an empty opt; the backend's
- *  derive-and-compare then rejects the redemption (never silently defaults). */
-const permissionsArg = (wire: string): [] | [Permissions] =>
-  wire === "queries"
-    ? [{ queries: null }]
-    : wire === "all"
-      ? [{ all: null }]
-      : [];
-
 /** The outcome the connect reports once the server redeems the registration
  *  delegation: the state echo, the session grant's expiration (ns since epoch,
  *  as a decimal string — the value overflows JSON numbers), and the session's
@@ -92,14 +81,13 @@ export type McpCompletion = {
  * against that list, mints a short-lived registration chain — a canister-signed
  * `P_reg -> Y` hop to a browser-held ephemeral key, extended browser-side with
  * a `Y -> X` hop — and hands it to the declared callback over a top-level
- * navigation (the chain plus the echoed consent — permissions, ttl — in the
- * URL fragment; the anchor is not delivered). There's no real HTTP server:
- * `page.route` intercepts the navigation and serves a page that reads the
- * fragment and POSTs it to a fixture endpoint; that handler — holding `X`'s
- * private key — reconstructs the chain and redeems it by calling
- * `mcp_register_v2` as the server would, echoing the delivered permissions and
- * ttl alongside `pub(S)` (the canister recovers the anchor), then resolves
- * `completion`.
+ * navigation (only the chain and the `state` echo in the URL fragment; no
+ * consent is delivered — the canister recovers it all from the entry). There's
+ * no real HTTP server: `page.route` intercepts the navigation and serves a
+ * page that reads the fragment and POSTs it to a fixture endpoint; that
+ * handler — holding `X`'s private key — reconstructs the chain and redeems it
+ * by calling `mcp_register_v2(pub(S))` as the server would, with no consent
+ * arguments, then resolves `completion`.
  */
 export type McpFixture = {
   /** The server's registration public key `X` (DER, base64url) — what rides
@@ -157,11 +145,10 @@ const CORS_HEADERS = {
 };
 
 /** The page served at the declared connect callback. Reads the delivered
- *  delegation + state + echoed consent (permissions, ttl — what the server
- *  passes to `mcp_register_v2`; the anchor is NOT delivered, the canister
- *  recovers it) from the fragment (never sent to the server in the HTTP
- *  request) and ships them to the redeem endpoint; on success it either lands
- *  on its "connected" state or, if the server asked for it, navigates onward to
+ *  delegation + state from the fragment (never sent to the server in the HTTP
+ *  request) and ships them to the redeem endpoint; no consent is delivered —
+ *  the canister recovers it all from the entry. On success it either lands on
+ *  its "connected" state or, if the server asked for it, navigates onward to
  *  its own finish URL. */
 const connectPageHtml = (redeemPath: string): string => `<!doctype html>
 <meta charset="utf-8" />
@@ -173,13 +160,11 @@ const connectPageHtml = (redeemPath: string): string => `<!doctype html>
     const params = new URLSearchParams(location.hash.slice(1));
     const delegation = params.get("delegation");
     const state = params.get("state");
-    const permissions = params.get("permissions");
-    const ttl = params.get("ttl");
     // Clear the fragment once parsed (keeping the query string — the declared
     // callback may carry one) so the delegation doesn't linger in the address
     // bar / history — what the server guide tells real servers to do.
     history.replaceState(null, "", location.pathname + location.search);
-    if (!delegation || !state || !permissions || !ttl) {
+    if (!delegation || !state) {
       el.textContent = "Missing delegation";
       return;
     }
@@ -187,7 +172,7 @@ const connectPageHtml = (redeemPath: string): string => `<!doctype html>
       const res = await fetch(${JSON.stringify(redeemPath)}, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ delegation, state, permissions, ttl }),
+        body: JSON.stringify({ delegation, state }),
       });
       const data = await res.json().catch(() => ({}));
       if (res.ok && data.ok) {
@@ -244,17 +229,12 @@ export const test = base.extend<{ mcp: McpFixture }>({
 
     // Redeem the delivered `P_reg -> Y -> X` chain exactly as the server would:
     // reconstruct the chain, sign as X (which the server holds), and bind S via
-    // `mcp_register_v2`, echoing the delivered consent (permissions, ttl).
-    // `caller()` is `P_reg`; the backend recovers the anchor from the
-    // registration entry (never delivered here) and re-derives the principal
-    // from (recovered anchor, echoed values, current config), matching it
-    // against `caller()` — an altered echo simply fails to redeem.
-    const redeem = async (delivered: {
-      delegation: string;
-      permissions: string;
-      ttl: string;
-    }): Promise<McpCompletion> => {
-      const chain = DelegationChain.fromJSON(JSON.parse(delivered.delegation));
+    // `mcp_register_v2(pub(S))` — no consent arguments. `caller()` is `P_reg`;
+    // the backend recovers the whole consent (anchor, read-only, TTL) from the
+    // registration entry keyed by `caller()`, so the server neither delivers
+    // nor passes any of it. The access level comes back in the result.
+    const redeem = async (delegationJson: string): Promise<McpCompletion> => {
+      const chain = DelegationChain.fromJSON(JSON.parse(delegationJson));
       const identity = DelegationIdentity.fromDelegation(
         registrationIdentity,
         chain,
@@ -270,11 +250,7 @@ export const test = base.extend<{ mcp: McpFixture }>({
         agent,
         canisterId: II_CANISTER_ID,
       });
-      const result = await actor.mcp_register_v2(
-        sessionKey,
-        permissionsArg(delivered.permissions),
-        [BigInt(delivered.ttl)],
-      );
+      const result = await actor.mcp_register_v2(sessionKey);
       if ("Err" in result) {
         throw new Error(result.Err);
       }
@@ -305,29 +281,18 @@ export const test = base.extend<{ mcp: McpFixture }>({
           let body: {
             delegation?: unknown;
             state?: unknown;
-            permissions?: unknown;
-            ttl?: unknown;
           } = {};
           try {
             body = JSON.parse(request.postData() ?? "{}") as typeof body;
           } catch {
             // Leave `body` empty; the checks below reject the request.
           }
-          if (
-            typeof body.delegation !== "string" ||
-            body.state !== state ||
-            typeof body.permissions !== "string" ||
-            typeof body.ttl !== "string"
-          ) {
+          if (typeof body.delegation !== "string" || body.state !== state) {
             await route.fulfill({ status: 403, headers: CORS_HEADERS });
             return;
           }
           try {
-            const received = await redeem({
-              delegation: body.delegation,
-              permissions: body.permissions,
-              ttl: body.ttl,
-            });
+            const received = await redeem(body.delegation);
             completions.push(received);
             resolveCompletion(received);
             await route.fulfill({

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -52,7 +52,10 @@ const insecureUndici = new UndiciAgent({
   connect: { rejectUnauthorized: false },
 });
 const insecureFetch: typeof fetch = (url, options = {}) =>
-  fetch(url, { dispatcher: insecureUndici, ...options } as RequestInit);
+  // Spread the caller's options first, then pin the dispatcher, so this
+  // fixture's self-signed-tolerant agent is authoritative and can't be
+  // silently overridden (defensive — the callers here never pass a dispatcher).
+  fetch(url, { ...options, dispatcher: insecureUndici } as RequestInit);
 
 const permissionsString = (permissions: Permissions): string =>
   "queries" in permissions ? "queries" : "all";

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -42,7 +42,7 @@ test("Invalid params show the error screen", async ({ page }) => {
 test("A non-https callback is rejected", async ({ page, mcp }) => {
   // MCP connections are to remote servers only, so callbacks must be https. A
   // plain-http (or loopback) origin is rejected up front, before the connect
-  // flow would talk to it.
+  // flow would deliver anything to it.
   await page.goto(
     mcp.buildAuthorizeUrl({
       app: APP,
@@ -61,7 +61,8 @@ test("Signing up to an untrusted server prompts to add it in settings", async ({
   // A fresh sign-up trusts no MCP server yet. The connect screen shows
   // optimistically, but at connect time — after the user authenticates — II
   // verifies the server against the identity's synced config and, finding it
-  // untrusted, shows the screen pointing to Settings rather than connecting.
+  // untrusted, shows the screen pointing to Settings rather than minting the
+  // registration delegation.
   await addVirtualAuthenticator(page);
   await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
   await signUp(page);
@@ -219,7 +220,7 @@ test("Returning user lands on the connect screen immediately", async ({
   ).toBeVisible();
 });
 
-test("Allow access registers the server's session key", async ({
+test("Allow access mints a registration delegation the server redeems", async ({
   page,
   mcp,
 }) => {
@@ -240,60 +241,43 @@ test("Allow access registers the server's session key", async ({
   ).toBeChecked();
   await page.getByRole("button", { name: "Allow access" }).click();
 
-  // The connect flow fetched the server's session key, registered it with the
-  // backend, and reported completion: the state echo, the grant expiration
-  // (ns since epoch as a decimal string), and the access level the user chose.
-  // No delegation chain travels anywhere.
+  // II minted a single-use P_reg -> X delegation and handed it to the trusted
+  // server's declared callback (in the fragment). The server redeemed it via
+  // mcp_register_v2, binding its session key: the completion reports the state
+  // echo, the grant expiration (ns since epoch as a decimal string), and the
+  // access level. The private registration key never left the server.
   const completion = await mcp.completion;
   expect(completion.state).toBe(mcp.state);
   expect(completion.expiration).toMatch(/^\d+$/);
   expect(expirationMillis(completion.expiration)).toBeGreaterThan(Date.now());
-  // Left at the read-only default, the server is told so up front via the
-  // completion's `permissions` field ("queries"). The full-access path (after
-  // unchecking the toggle) has its own test below.
+  // Left at the read-only default, the grant is queries-only. The full-access
+  // path (after unchecking the toggle) has its own test below.
   expect(completion.permissions).toBe("queries");
-  await expect(
-    page.getByRole("heading", { name: "You're signed in" }),
-  ).toBeVisible();
+  // The tab landed on the server's connect page, which shows its connected
+  // state once the redemption succeeds.
+  await expect(page.getByRole("heading", { name: "Connected" })).toBeVisible();
 });
 
-test("An undeclared callback path fails the connect: nothing contacts it, nothing registers", async ({
+test("An undeclared callback path fails the connect: nothing is delivered to it", async ({
   page,
   mcp,
 }) => {
   test.slow();
   await addVirtualAuthenticator(page);
   await mcp.installInterceptor(page);
-  // An attacker-controlled path on the *trusted* origin that, if II ever fetched
-  // it, would hand back a key of the attacker's choosing (the reported phishing
-  // vector: a planted/echoing path on the trusted origin). It is NOT in the
-  // allow-list the server declares at /.well-known/ii-auth-callbacks, so the
-  // connect must fail closed before contacting it. Registered after the
-  // fixture's catch-all so it would win for this exact path if contacted.
+  // An attacker-controlled path on the *trusted* origin. If II ever delivered
+  // the delegation there (the reported phishing vector: a planted/echoing path
+  // on the trusted origin), this navigation target would be hit. It is NOT in
+  // the allow-list the server declares at /.well-known/ii-auth-callbacks, so
+  // the connect must fail closed before delivering anything. Registered after
+  // the fixture's catch-all so it would win for this exact path.
   let attackerPathHit = false;
   await page.route(`${mcp.mcpOrigin}/attacker-echo`, async (route) => {
-    // A CORS-correct stub. If a regression ever fetched this path, the actual
-    // request (not the preflight) flips the flag, so the failure is a clean
-    // assertion rather than a stall on a rejected preflight.
-    if (route.request().method() === "OPTIONS") {
-      await route.fulfill({
-        status: 204,
-        headers: {
-          "access-control-allow-origin": "*",
-          "access-control-allow-methods": "POST",
-          "access-control-allow-headers": "content-type",
-        },
-      });
-      return;
-    }
     attackerPathHit = true;
     await route.fulfill({
       status: 200,
-      headers: {
-        "access-control-allow-origin": "*",
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({ public_key: "AAAA" }),
+      headers: { "content-type": "text/html" },
+      body: "<h1>ATTACKER</h1>",
     });
   });
   await page.goto(II_URL);
@@ -312,29 +296,27 @@ test("An undeclared callback path fails the connect: nothing contacts it, nothin
   await page.getByRole("button", { name: "Allow access" }).click();
 
   // The link's callback only selects among the server-declared entries: an
-  // undeclared one fails the connect. The failure surfaces and the user is
-  // back on the connect screen — never the success screen.
+  // undeclared one fails the connect before the delegation is even minted.
+  // The failure surfaces and the user is back on the connect screen.
   await expect(page.getByText(/does not declare this callback/)).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Allow access" }),
   ).toBeVisible();
-  await expect(
-    page.getByRole("heading", { name: "You're signed in" }),
-  ).toHaveCount(0);
-  // The attacker path was never contacted, and no session was registered.
+  // The attacker path was never navigated to, and nothing was redeemed.
   expect(attackerPathHit).toBe(false);
   expect(mcp.completions).toHaveLength(0);
 });
 
-test("A finish_url from the server hands the tab back to it after connecting", async ({
+test("A finish redirect hands the tab onward after connecting", async ({
   page,
   mcp,
 }) => {
   test.slow();
   await addVirtualAuthenticator(page);
-  // The server asks for the browser back after the connect (its key response
-  // carries `finish_url`) — how a real server completes its own flow, e.g.
-  // minting the OAuth code for an MCP client and redirecting back to it.
+  // The server asks for the browser back after a successful redemption — how a
+  // real server completes its own flow, e.g. minting the OAuth code for an MCP
+  // client and redirecting back to it. This is the server's connect page's own
+  // decision now, made after it redeems the delegation.
   mcp.enableFinishRedirect();
   await mcp.installInterceptor(page);
   await page.goto(II_URL);
@@ -345,80 +327,17 @@ test("A finish_url from the server hands the tab back to it after connecting", a
   await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
   await page.getByRole("button", { name: "Allow access" }).click();
 
-  // The session registers and completion is reported like any connect...
+  // The session registers like any connect...
   const completion = await mcp.completion;
   expect(completion.state).toBe(mcp.state);
-  // ...but instead of II's close screen, the tab lands on the server's
-  // finish URL.
+  // ...and then the server's connect page hands the tab to its finish URL.
   await page.waitForURL(mcp.finishUrl);
   await expect(
     page.getByRole("heading", { name: "Connection complete" }),
   ).toBeVisible();
 });
 
-test("The finish_secret never leaks to logs, errors, or other requests", async ({
-  page,
-  mcp,
-}) => {
-  test.slow();
-  // The server's key response carries a finish_url whose query holds a one-time
-  // finish_secret (the H3 "Consent-Bound Completion" credential the server hands
-  // only to the consenting browser). II must navigate the tab to that URL and
-  // surface the secret nowhere else: not to the console, not through an uncaught
-  // error, and not on any outbound request but the finish navigation itself.
-  // Anything else would leak the credential to a log/telemetry sink an attacker
-  // (or a bug report) could read — which is exactly what P2 forbids. This covers
-  // the +page.svelte funnel/error surface the utils unit test can't reach.
-  await addVirtualAuthenticator(page);
-  mcp.enableFinishRedirect();
-  const secret = mcp.finishSecret;
-
-  // Attach the observers before anything loads, so nothing is missed. The
-  // finish navigation (a GET to /oauth/finish) is the one place the secret is
-  // meant to appear, so it's excluded; every other request — URL and body — is
-  // inspected.
-  const consoleLeaks: string[] = [];
-  page.on("console", (msg) => {
-    if (msg.text().includes(secret)) consoleLeaks.push(msg.text());
-  });
-  const errorLeaks: string[] = [];
-  page.on("pageerror", (error) => {
-    if (error.message.includes(secret)) errorLeaks.push(error.message);
-  });
-  const requestLeaks: string[] = [];
-  page.on("request", (request) => {
-    const url = request.url();
-    if (url.includes("/oauth/finish")) {
-      return;
-    }
-    if (url.includes(secret) || (request.postData() ?? "").includes(secret)) {
-      requestLeaks.push(`${request.method()} ${url}`);
-    }
-  });
-
-  await mcp.installInterceptor(page);
-  await page.goto(II_URL);
-  await signUp(page);
-  await page.waitForURL(II_URL + "/manage");
-  await mcp.trustServer(page);
-
-  await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
-  await page.getByRole("button", { name: "Allow access" }).click();
-
-  // Drive the full connect through to the finish navigation — the secret has
-  // now flowed through the key response, +page.svelte, and the redirect.
-  await mcp.completion;
-  await page.waitForURL(mcp.finishUrl);
-  await expect(
-    page.getByRole("heading", { name: "Connection complete" }),
-  ).toBeVisible();
-
-  expect(consoleLeaks).toEqual([]);
-  expect(errorLeaks).toEqual([]);
-  expect(requestLeaks).toEqual([]);
-});
-
-test("Identity switcher shows while signing in and hides on the success screen", async ({
+test("Identity switcher shows while signing in and hides once connecting", async ({
   page,
   mcp,
 }) => {
@@ -437,9 +356,8 @@ test("Identity switcher shows while signing in and hides on the success screen",
   await expect(switcher).toBeVisible();
 
   await allow.click();
-  await expect(
-    page.getByRole("heading", { name: "You're signed in" }),
-  ).toBeVisible();
+  // Once connecting, the switcher is gone — and it stays gone as the tab is
+  // handed to the server's declared callback (a different origin entirely).
   await expect(switcher).toBeHidden();
 });
 
@@ -465,7 +383,7 @@ test("Requested TTL within bounds is honoured", async ({ page, mcp }) => {
   expect(expMillis - before).toBeLessThanOrEqual(requestedMillis + 60_000);
 });
 
-test("A connect failure returns to the connect screen instead of stranding the user", async ({
+test("A failed redemption surfaces on the server's page and registers nothing", async ({
   page,
   mcp,
 }) => {
@@ -477,24 +395,20 @@ test("A connect failure returns to the connect screen instead of stranding the u
   await page.waitForURL(II_URL + "/manage");
   await mcp.trustServer(page);
 
-  // The server rejects the key request (a `state` it never issued, a transient
-  // 5xx, ...). The connect must surface the error and return to the connect
-  // screen — not hang on the connecting spinner, and never reach the success
-  // screen — so the user can retry (handleAuthorize's catch re-opens authorize).
+  // The server rejects the redemption (a transient failure on its side, a
+  // state it can't correlate, ...). II has already delivered the delegation and
+  // handed the tab to the server; the failure surfaces on the server's connect
+  // page, and no session grant is created.
   mcp.setNextOutcome("error");
   await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
   await page.getByRole("button", { name: "Allow access" }).click();
 
-  // The failure is surfaced...
-  await expect(page.getByText(/rejected the connect request/)).toBeVisible();
-  // ...the connect screen is back (retry is possible)...
+  // The server's connect page reports the failure...
   await expect(
-    page.getByRole("button", { name: "Allow access" }),
+    page.getByRole("heading", { name: "Connection failed" }),
   ).toBeVisible();
-  // ...and no session was reported as registered.
-  await expect(
-    page.getByRole("heading", { name: "You're signed in" }),
-  ).toHaveCount(0);
+  // ...and nothing was registered (no completion reached the server).
+  expect(mcp.completions).toHaveLength(0);
 });
 
 test("Removing the trusted server in Settings blocks connecting", async ({
@@ -558,7 +472,8 @@ test("Unchecking read-only mode connects with full access", async ({
   mcp,
 }) => {
   // The read-only default (queries-only) connect is covered by "Allow access
-  // registers the server's session key"; this exercises the opt-out path.
+  // mints a registration delegation the server redeems"; this exercises the
+  // opt-out path.
   test.slow();
   await addVirtualAuthenticator(page);
   await mcp.installInterceptor(page);
@@ -573,16 +488,19 @@ test("Unchecking read-only mode connects with full access", async ({
   await readOnly.uncheck();
 
   await page.getByRole("button", { name: "Allow access" }).click();
-  // Unchecking the toggle switches the session to full access, which the
-  // server is told up front via the completion's `permissions` field.
+  // Unchecking the toggle switches the session to full access, recorded on the
+  // registration delegation's index entry and reflected in the grant the server
+  // gets back from mcp_register_v2.
   const completion = await mcp.completion;
   expect(completion.permissions).toBe("all");
 });
 
-// The browser /mcp flow registers the MCP server's session key for the user's
-// identity (fetched from the callback the request identifies — not a
-// per-request app, and no account is chosen at connect); per-app delegations
-// are minted server-side by the `mcp_prepare/get_delegation` canister methods,
-// with the app account chosen there. Grant semantics (expiry, revocation,
-// replacement) are canister logic, covered by the integration tests
-// (tests/integration/mcp.rs), not here.
+// The browser /mcp flow mints a single-use registration delegation (P_reg -> X)
+// and hands it to the trusted server, which redeems it (`mcp_register_v2`) to
+// bind its long-lived session key `S` to the user's identity — no per-request
+// app, and no account chosen at connect. Per-app delegations are minted
+// server-side by the `mcp_prepare/get_delegation` canister methods, with the
+// app account chosen there. Grant semantics (expiry, revocation, replacement)
+// and the registration delegation's single-use/idempotency guarantees are
+// canister logic, covered by the integration tests (tests/integration/mcp.rs),
+// not here.

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -241,7 +241,7 @@ test("Allow access mints a registration delegation the server redeems", async ({
   ).toBeChecked();
   await page.getByRole("button", { name: "Allow access" }).click();
 
-  // II minted a single-use P_reg -> X delegation and handed it to the trusted
+  // II minted a single-use P_reg -> Y -> X registration chain and handed it to the trusted
   // server's declared callback (in the fragment). The server redeemed it via
   // mcp_register_v2, binding its session key: the completion reports the state
   // echo, the grant expiration (ns since epoch as a decimal string), and the
@@ -495,7 +495,7 @@ test("Unchecking read-only mode connects with full access", async ({
   expect(completion.permissions).toBe("all");
 });
 
-// The browser /mcp flow mints a single-use registration delegation (P_reg -> X)
+// The browser /mcp flow mints a single-use registration chain (P_reg -> Y -> X)
 // and hands it to the trusted server, which redeems it (`mcp_register_v2`) to
 // bind its long-lived session key `S` to the user's identity — no per-request
 // app, and no account chosen at connect. Per-app delegations are minted

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -241,11 +241,12 @@ test("Allow access mints a registration delegation the server redeems", async ({
   ).toBeChecked();
   await page.getByRole("button", { name: "Allow access" }).click();
 
-  // II minted a single-use P_reg -> Y -> X registration chain and handed it to the trusted
-  // server's declared callback (in the fragment). The server redeemed it via
-  // mcp_register_v2, binding its session key: the completion reports the state
-  // echo, the grant expiration (ns since epoch as a decimal string), and the
-  // access level. The private registration key never left the server.
+  // II minted a short-lived P_reg -> Y -> X registration chain and handed it
+  // (plus the consent tuple) to the trusted server's declared callback (in the
+  // fragment). The server redeemed it via mcp_register_v2, echoing the tuple
+  // and binding its session key: the completion reports the state echo, the
+  // grant expiration (ns since epoch as a decimal string), and the access
+  // level. The private registration key never left the server.
   const completion = await mcp.completion;
   expect(completion.state).toBe(mcp.state);
   expect(completion.expiration).toMatch(/^\d+$/);
@@ -488,19 +489,21 @@ test("Unchecking read-only mode connects with full access", async ({
   await readOnly.uncheck();
 
   await page.getByRole("button", { name: "Allow access" }).click();
-  // Unchecking the toggle switches the session to full access, recorded on the
-  // registration delegation's index entry and reflected in the grant the server
+  // Unchecking the toggle switches the session to full access, folded into the
+  // registration principal's derivation and reflected in the grant the server
   // gets back from mcp_register_v2.
   const completion = await mcp.completion;
   expect(completion.permissions).toBe("all");
 });
 
-// The browser /mcp flow mints a single-use registration chain (P_reg -> Y -> X)
-// and hands it to the trusted server, which redeems it (`mcp_register_v2`) to
-// bind its long-lived session key `S` to the user's identity — no per-request
-// app, and no account chosen at connect. Per-app delegations are minted
-// server-side by the `mcp_prepare/get_delegation` canister methods, with the
-// app account chosen there. Grant semantics (expiry, revocation, replacement)
-// and the registration delegation's single-use/idempotency guarantees are
-// canister logic, covered by the integration tests (tests/integration/mcp.rs),
-// not here.
+// The browser /mcp flow mints a short-lived registration chain (P_reg -> Y -> X)
+// and hands it to the trusted server, which redeems it (`mcp_register_v2`,
+// echoing the delivered consent tuple) to bind its long-lived session key `S`
+// to the user's identity — no per-request app, and no account chosen at
+// connect. Per-app delegations are minted server-side by the
+// `mcp_prepare/get_delegation` canister methods, with the app account chosen
+// there. Grant semantics (expiry, revocation, replacement) and the
+// registration delegation's derive-and-compare guarantees (altered echoes
+// rejected, config changes invalidating in-flight delegations) are canister
+// logic, covered by the integration tests (tests/integration/mcp.rs), not
+// here.

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -242,11 +242,12 @@ test("Allow access mints a registration delegation the server redeems", async ({
   await page.getByRole("button", { name: "Allow access" }).click();
 
   // II minted a short-lived P_reg -> Y -> X registration chain and handed it
-  // (plus the consent tuple) to the trusted server's declared callback (in the
-  // fragment). The server redeemed it via mcp_register_v2, echoing the tuple
-  // and binding its session key: the completion reports the state echo, the
-  // grant expiration (ns since epoch as a decimal string), and the access
-  // level. The private registration key never left the server.
+  // to the trusted server's declared callback (in the fragment; no consent
+  // rides along). The server redeemed it via mcp_register_v2 with only its
+  // session key, and the canister recovered the whole consent from the entry
+  // to bind that key: the completion reports the state echo, the grant
+  // expiration (ns since epoch as a decimal string), and the access level.
+  // The private registration key never left the server.
   const completion = await mcp.completion;
   expect(completion.state).toBe(mcp.state);
   expect(completion.expiration).toMatch(/^\d+$/);
@@ -489,21 +490,23 @@ test("Unchecking read-only mode connects with full access", async ({
   await readOnly.uncheck();
 
   await page.getByRole("button", { name: "Allow access" }).click();
-  // Unchecking the toggle switches the session to full access, folded into the
-  // registration principal's derivation and reflected in the grant the server
-  // gets back from mcp_register_v2.
+  // Unchecking the toggle switches the session to full access, recorded on the
+  // registration entry at prepare and reflected in the grant the server gets
+  // back from mcp_register_v2.
   const completion = await mcp.completion;
   expect(completion.permissions).toBe("all");
 });
 
 // The browser /mcp flow mints a short-lived registration chain (P_reg -> Y -> X)
-// and hands it to the trusted server, which redeems it (`mcp_register_v2`,
-// echoing the delivered consent tuple) to bind its long-lived session key `S`
-// to the user's identity — no per-request app, and no account chosen at
-// connect. Per-app delegations are minted server-side by the
+// and hands it to the trusted server, which redeems it (`mcp_register_v2`, with
+// only its session key) to bind its long-lived session key `S` to the user's
+// identity — no per-request app, and no account chosen at connect. The whole
+// consent (anchor, read-only choice, grant lifetime) is recorded canister-side
+// at prepare and recovered from the entry at redemption, so the server delivers
+// and passes none of it. Per-app delegations are minted server-side by the
 // `mcp_prepare/get_delegation` canister methods, with the app account chosen
-// there. Grant semantics (expiry, revocation, replacement) and the
-// registration delegation's derive-and-compare guarantees (altered echoes
-// rejected, config changes invalidating in-flight delegations) are canister
+// there. Grant semantics (expiry, revocation, replacement) and the registration
+// delegation's stored-consent guarantees (the server can't alter the consent it
+// never handles, config changes invalidating in-flight delegations) are canister
 // logic, covered by the integration tests (tests/integration/mcp.rs), not
 // here.


### PR DESCRIPTION
# Motivation

Third and final PR of the MCP *registration delegation* refinement, following
#4092 (phase-2 backend, **now merged**). It migrates the browser `/mcp` connect
flow — and its e2e coverage — to the new handshake, so the frontend and the
tests that exercise it land together.

Before, the connect flow fetched the MCP server's session key from a callback
and called `mcp_register` on the server's behalf, then POSTed a completion
notification back. That put II in the position of registering a key it merely
received, and leaned on an out-of-band completion channel (plus a `finish_url`
in the key response) to hand the flow back to the server.

The registration-delegation model removes that. II mints a **short-lived
registration chain `P_reg -> Y -> X`**: the canister signs `P_reg -> Y` for an
**ephemeral browser-held key `Y`**, and the II frontend extends the chain
locally with a browser-signed hop `Y -> X` to the server's per-connect
registration key `X` (from the link). The two-hop shape is load-bearing: what
the canister signs transits the IC (the `get` query response passes the
answering replica and API boundary nodes) and must be inert on its own — the
redeemable chain is assembled only in the consenting browser and reaches the
server exclusively via a fragment navigation to a callback it **declares** in
its `/.well-known/ii-auth-callbacks` allow-list (#4091). The server redeems it
(`mcp_register_v2`) to bind its own long-lived session key `S`. Per phase-2,
the canister records the **whole consent** (anchor, read-only choice, grant
lifetime, trusted URL) on the registration entry and recovers it server-side,
so the flow delivers **only the chain and the `state` echo** in the fragment —
no anchor, no permissions, no ttl. The server passes only its session key to
`mcp_register_v2`, so there is nothing for it to alter and it never learns the
anchor.

> Now based on `main` (phase-2 #4092 has merged); this is the last PR in the stack.

# Changes

**Frontend connect flow**
- `mcp/+page.ts`: the connect link carries a required `registration_key`
  (the server's public per-connect key `X`), validated with a single Zod
  schema (whole-fragment `safeParse`, per review).
- `mcp/utils.ts`: `mcpAuthorize` generates a non-extractable ECDSA `Y`,
  calls `prepare_mcp_registration_delegation` for `Y` (with the consent
  params, which `prepare` records on the entry) then
  `get_mcp_registration_delegation` handing back the returned `user_key`
  (the link's `X` never reaches the canister; `get` recovers the seed from
  `user_key`), extends the chain browser-side via
  `DelegationChain.create(..., { previous })`, and returns the **delivery
  URL**: declared callback + `#delegation=…&state=…`. No consent value and no
  anchor is delivered (the canister recovers all of it). Canister errors are
  unwrapped via a `throwTextCanisterError` helper (the `mcp_*` family's candid
  error is `text`, which `CanisterError`'s variant wrapper doesn't fit).
- `mcp/+page.svelte`: `handleAuthorize` exact-matches the link's callback
  against the server's declared allow-list (`matchDeclaredCallback`), mints
  the chain, then hands the tab to the delivery URL.
- Removed the dead `finish_url` / completion-POST machinery.
- The close-view copy says the tab is being taken to the server to finish
  connecting.

**Tests**
- `mcp/load.test.ts`, `mcp/utils.test.ts`: v2 params; the two-hop chain shape
  (hop 1 targets the browser key, hop 2 the link's `X`, hop-2 expiry bounded
  by hop 1); that the canister never sees `X`; fresh `Y` per attempt; that
  `get` is called with the returned `user_key`; that the delivery fragment
  carries **only** `delegation` + `state` for both access levels (no anchor,
  no permissions, no ttl); no network calls of II's own; error propagation.
- `tests/e2e-playwright/fixtures/mcp.ts`: the MCP server stand-in generates
  `X` + `S`, declares its connect page in the allow-list, serves that page
  (reads the delivered fragment — chain + state — clears it, POSTs it to a
  fixture endpoint), and — as the server backend holding `priv(X)` —
  reconstructs the chain and redeems via `mcp_register_v2(session_key)` (no
  consent arguments), reading the granted level off the response, against the
  local replica.
- `tests/e2e-playwright/routes/mcp.spec.ts`: all `/mcp` tests on the v2 flow;
  an undeclared callback path fails the connect without being contacted.

**Docs**
- `docs/mcp-server-guide.md`: rewritten for the declared-callbacks +
  registration-chain contract (allow-list requirements, link format, two-hop
  chain format and why, the fragment carrying only the chain + state, and
  redemption passing only the session key with the whole consent recovered
  server-side — the 5-minute window and replace-not-add multi-use, a note that
  the anchor is recovered server-side and never delivered, structural
  Consent-Bound Completion in the OAuth section, DCR `grant_types`
  clarification).

# Tests

- `tsc`, `svelte-check` (0 errors), ESLint (`--max-warnings 0`), Prettier pass
  locally; `vitest` unit suites (authCallbacks + mcp) pass.
- The Playwright e2e suite requires a replica + browser and validates in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbjCCqTjsMn57fczTNGaKf