### PR TITLE
feat(be): scope OpenID anchor lookup by sso_domain (chunked re-key migration)

### DIFF
--- a/src/internet_identity/src/anchor_management.rs
+++ b/src/internet_identity/src/anchor_management.rs
@@ -1,5 +1,5 @@
 use crate::archive::{archive_operation, device_diff};
-use crate::openid::{OpenIdCredential, OpenIdCredentialKey};
+use crate::openid::{OpenIdCredential, OpenIdCredentialKey, OpenIdCredentialLookupKey};
 use crate::storage::anchor::{Anchor, AnchorError, Device};
 use crate::storage::Storage;
 use crate::{state, stats::activity_stats};
@@ -200,10 +200,10 @@ pub fn identity_properties_replace(
 
 pub fn check_openid_credential_is_unique<M: Memory + Clone>(
     storage: &Storage<M>,
-    openid_credential_key: &OpenIdCredentialKey,
+    openid_credential_lookup_key: &OpenIdCredentialLookupKey,
 ) -> Result<(), AnchorError> {
     if storage
-        .lookup_anchor_with_openid_credential(openid_credential_key)
+        .lookup_anchor_with_openid_credential(openid_credential_lookup_key)
         .is_some()
     {
         return Err(AnchorError::OpenIdCredentialAlreadyRegistered);
@@ -239,7 +239,9 @@ pub fn add_openid_credential(
     openid_credential: OpenIdCredential,
     now_ns: u64,
 ) -> Result<Operation, AnchorError> {
-    storage_borrow(|storage| check_openid_credential_is_unique(storage, &openid_credential.key()))?;
+    storage_borrow(|storage| {
+        check_openid_credential_is_unique(storage, &openid_credential.lookup_key())
+    })?;
 
     add_openid_credential_skip_checks(anchor, openid_credential, now_ns)
 }

--- a/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
+++ b/src/internet_identity/src/anchor_management/registration/registration_flow_v2.rs
@@ -276,7 +276,7 @@ fn validate_identity_data<M: Memory + Clone>(
                 )
             })?;
 
-            check_openid_credential_is_unique(storage, &credential.key())
+            check_openid_credential_is_unique(storage, &credential.lookup_key())
                 .map_err(|err| IdRegFinishError::InvalidAuthnMethod(err.to_string()))?;
 
             let name = openid_registration_data.name.clone();

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -188,6 +188,102 @@ fn init_sso_credential_migration_timer() {
     });
 }
 
+// ---- OpenID credential key migration (temporary, PR 1 of the SSO domain key
+// stack) ----
+//
+// The OpenID credential index key grew an `sso_domain` component so the same
+// `(iss, sub, aud)` verified through different SSO domains resolves to distinct
+// credentials. Existing index entries were written under the legacy
+// `(iss, sub, aud)` key and must be re-keyed. The `sso_domain` for each was
+// already stamped onto the stored credential by the #4013 backfill, so this
+// migration needs no upgrade arg — it reads the stamp off the credential. Doing
+// all entries synchronously in `post_upgrade` would blow the instruction limit
+// on II's production canister, so the work is batched via an interval timer,
+// same convention as the prior migrations (#4013, #3784, #3713).
+
+/// How long to wait between migration batches.
+const OPENID_KEY_MIGRATION_BATCH_BACKOFF_SECONDS: Duration = Duration::from_secs(1);
+
+/// Maximum number of index keys to examine per batch (= per ingress message).
+/// Matches the 2 000-per-batch convention used for previous migrations.
+const OPENID_KEY_MIGRATION_BATCH_SIZE: u64 = 2_000;
+
+thread_local! {
+    // TODO: Remove these after the data migration is complete.
+    static OPENID_KEY_MIGRATION_CURSOR: RefCell<Option<StorableOpenIdCredentialKey>> = const { RefCell::new(None) };
+    static OPENID_KEY_MIGRATION_DONE: RefCell<bool> = const { RefCell::new(false) };
+    static OPENID_KEY_MIGRATION_REKEYED: RefCell<u64> = const { RefCell::new(0) };
+    static OPENID_KEY_MIGRATION_ERRORS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+    static OPENID_KEY_MIGRATION_TIMER_ID: RefCell<Option<TimerId>> = const { RefCell::new(None) };
+}
+
+/// Temporary hidden endpoint: returns any per-entry errors encountered during
+/// the OpenID credential key migration.
+#[update(hidden = true)]
+fn list_openid_key_migration_errors() -> Vec<String> {
+    OPENID_KEY_MIGRATION_ERRORS.with_borrow(|errors| errors.clone())
+}
+
+/// Temporary hidden endpoint: returns `(rekeyed_entries, is_done)` so
+/// monitoring can track migration progress.
+#[query(hidden = true)]
+fn openid_key_migration_status() -> (u64, bool) {
+    (
+        OPENID_KEY_MIGRATION_REKEYED.with_borrow(|c| *c),
+        OPENID_KEY_MIGRATION_DONE.with_borrow(|d| *d),
+    )
+}
+
+/// Process one batch of the OpenID credential key migration. Bound to the
+/// interval timer set up in [`init_openid_key_migration_timer`]; clears the
+/// timer once the migration signals completion.
+fn run_openid_key_migration_batch() {
+    if OPENID_KEY_MIGRATION_DONE.with_borrow(|done| *done) {
+        return;
+    }
+
+    let cursor = OPENID_KEY_MIGRATION_CURSOR.with_borrow(|cursor| cursor.clone());
+    let outcome = state::storage_borrow_mut(|storage| {
+        storage.migrate_openid_credential_keys_batch(cursor, OPENID_KEY_MIGRATION_BATCH_SIZE)
+    });
+
+    OPENID_KEY_MIGRATION_REKEYED.with_borrow_mut(|count| {
+        *count = count.saturating_add(outcome.rekeyed);
+    });
+    if !outcome.errors.is_empty() {
+        OPENID_KEY_MIGRATION_ERRORS.with_borrow_mut(|errors| errors.extend(outcome.errors));
+    }
+    if let Some(next_cursor) = outcome.next_cursor {
+        OPENID_KEY_MIGRATION_CURSOR.replace(Some(next_cursor));
+    }
+
+    if outcome.is_done {
+        OPENID_KEY_MIGRATION_DONE.replace(true);
+        OPENID_KEY_MIGRATION_TIMER_ID.with_borrow_mut(|id_slot| {
+            if let Some(timer_id) = id_slot.take() {
+                ic_cdk_timers::clear_timer(timer_id);
+            }
+        });
+        let rekeyed = OPENID_KEY_MIGRATION_REKEYED.with_borrow(|c| *c);
+        ic_cdk::println!("OpenID credential key migration COMPLETED ({rekeyed} entries re-keyed).");
+    }
+}
+
+/// Start the interval timer driving [`run_openid_key_migration_batch`]. Safe to
+/// call from both `init` (the first batch will immediately see an empty index
+/// and mark the migration done) and `post_upgrade`.
+fn init_openid_key_migration_timer() {
+    let timer_id = ic_cdk_timers::set_timer_interval(
+        OPENID_KEY_MIGRATION_BATCH_BACKOFF_SECONDS,
+        run_openid_key_migration_batch,
+    );
+    OPENID_KEY_MIGRATION_TIMER_ID.with_borrow_mut(|id_slot| {
+        if let Some(old_id) = id_slot.replace(timer_id) {
+            ic_cdk_timers::clear_timer(old_id);
+        }
+    });
+}
+
 #[update]
 async fn init_salt() {
     state::init_salt().await;
@@ -904,6 +1000,13 @@ fn initialize(maybe_arg: Option<InternetIdentityInit>) {
     // signals done (immediately, when no `sso_credential_migration` arg was
     // supplied).
     init_sso_credential_migration_timer();
+
+    // Kick off the OpenID credential key batch migration that folds
+    // `sso_domain` into the index key. Examines at most
+    // `OPENID_KEY_MIGRATION_BATCH_SIZE` index keys per tick so each batch fits
+    // in one ingress message; timer self-clears once the scan reaches the end
+    // of the index (immediately, on a fresh canister with no credentials).
+    init_openid_key_migration_timer();
 }
 
 fn apply_install_arg(maybe_arg: Option<InternetIdentityInit>) {
@@ -1578,7 +1681,7 @@ mod openid_api {
 
         let prepared: Result<OpenIdPrepareDelegationResponse, OpenIdDelegationError> = async {
             let anchor_number = state::storage_borrow(|storage| {
-                storage.lookup_anchor_with_openid_credential(&openid_credential.key())
+                storage.lookup_anchor_with_openid_credential(&openid_credential.lookup_key())
             })
             .ok_or(OpenIdDelegationError::NoSuchAnchor)?;
 
@@ -1596,7 +1699,7 @@ mod openid_api {
 
             // Checking again because the association could've changed during the .await
             let still_anchor_number = state::storage_borrow(|storage| {
-                storage.lookup_anchor_with_openid_credential(&openid_credential.key())
+                storage.lookup_anchor_with_openid_credential(&openid_credential.lookup_key())
             })
             .ok_or(OpenIdDelegationError::NoSuchAnchor)?;
 
@@ -1638,7 +1741,7 @@ mod openid_api {
         };
 
         let delegation = match state::storage_borrow(|storage| {
-            storage.lookup_anchor_with_openid_credential(&openid_credential.key())
+            storage.lookup_anchor_with_openid_credential(&openid_credential.lookup_key())
         }) {
             Some(anchor_number) => {
                 openid_credential.get_jwt_delegation(session_key, expiration, anchor_number)

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -35,10 +35,22 @@ pub use crate::single_flight_cache::Cached;
 
 pub const OPENID_SESSION_DURATION_NS: u64 = 30 * MINUTE_NS;
 
+/// Public key of an OpenID credential: `(iss, sub, aud)`. This is the shape
+/// exposed on the candid interface (`openid_credential_remove`, `AuthorizationKey`)
+/// and the input to the delegation seed — both unchanged by the `sso_domain`
+/// work, so principals and the public API stay stable.
 pub type OpenIdCredentialKey = (Iss, Sub, Aud);
+/// Internal storage-index key: the public key plus the credential's stored
+/// `sso_domain` (`None` for direct providers like Google / Microsoft / Apple,
+/// `Some(domain)` for SSO credentials). Used ONLY to key the credential lookup
+/// index (see `StorableOpenIdCredentialKey` and the re-key migration) so the
+/// same `(iss, sub, aud)` verified through different SSO domains resolves to
+/// distinct anchors. It deliberately never feeds the delegation seed.
+pub type OpenIdCredentialLookupKey = (Iss, Sub, Aud, Option<SsoDomain>);
 pub type Iss = String;
 pub type Sub = String;
 pub type Aud = String;
+pub type SsoDomain = String;
 
 #[derive(PartialEq, Eq, CandidType, Deserialize, Clone, Debug)]
 pub enum OpenIDJWTVerificationError {
@@ -104,6 +116,18 @@ pub struct OpenIdCredential {
 impl OpenIdCredential {
     pub fn key(&self) -> OpenIdCredentialKey {
         (self.iss.clone(), self.sub.clone(), self.aud.clone())
+    }
+
+    /// Internal storage-index key: the public key plus the stored `sso_domain`.
+    /// Used only to look the credential up in / write it to the anchor index;
+    /// never fed into the delegation seed.
+    pub fn lookup_key(&self) -> OpenIdCredentialLookupKey {
+        (
+            self.iss.clone(),
+            self.sub.clone(),
+            self.aud.clone(),
+            self.sso_domain.clone(),
+        )
     }
 
     pub fn principal(&self, anchor_number: AnchorNumber) -> Principal {
@@ -464,6 +488,11 @@ pub(super) fn replace_issuer_placeholders(
 /// same user at the same provider with different OIDC clients derives distinct
 /// principals — this is the security property that makes SSO safe.
 ///
+/// `sso_domain` deliberately does NOT participate: anchor isolation against a rogue SSO
+/// domain happens at the lookup index (which anchor a login resolves to), and the seed
+/// already includes `anchor_number`, so the derived principal is transitively
+/// domain-separated. Keeping the seed on `(iss, sub, aud)` means no principal shift.
+///
 /// # Arguments
 ///
 /// * `(iss, sub, aud)`: The key of the `OpenIdCredential` to derive the `Hash` from
@@ -549,6 +578,28 @@ mod tests {
             143, 79, 158, 224, 218, 125, 157, 169, 98, 43, 205, 227, 243, 123, 173, 255, 132, 83,
             81, 139, 161, 18, 224, 243, 4, 129, 26, 123, 229, 242, 200, 189,
         ]
+    }
+
+    /// The delegation seed is derived from `(iss, sub, aud)` and the anchor
+    /// number only — `sso_domain` must not influence it, so an SSO credential
+    /// and an otherwise identical direct-provider credential on the same anchor
+    /// derive the same principal. This pins the behavior-preserving invariant:
+    /// the `sso_domain` work never shifts a principal.
+    #[test]
+    fn delegation_seed_is_independent_of_sso_domain() {
+        let anchor_number = 10_000u64;
+        let key: OpenIdCredentialKey = (
+            "https://accounts.google.com".to_string(),
+            "sub-123".to_string(),
+            "client-456".to_string(),
+        );
+
+        // The seed function's signature has no `sso_domain` parameter; two
+        // credentials that differ only by `sso_domain` share this same key and
+        // therefore the same seed.
+        let seed_a = calculate_delegation_seed(&key, anchor_number);
+        let seed_b = calculate_delegation_seed(&key, anchor_number);
+        assert_eq!(seed_a, seed_b);
     }
 
     #[test]

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -105,7 +105,7 @@ use identity_jose::jwk::Jwk;
 use internet_identity_interface::archive::types::BufferedEntry;
 
 use crate::delegation::check_frontend_length;
-use crate::openid::OpenIdCredentialKey;
+use crate::openid::OpenIdCredentialLookupKey;
 use crate::state::PersistentState;
 use crate::stats::event_stats::AggregationKey;
 use crate::stats::event_stats::{EventData, EventKey};
@@ -312,6 +312,26 @@ pub struct SsoCredentialMigrationBatchOutcome {
     /// Last index key examined this batch; pass back as `cursor` of the next
     /// batch to resume the scan where this one left off. `None` when the
     /// batch examined no keys.
+    pub next_cursor: Option<StorableOpenIdCredentialKey>,
+}
+
+/// Outcome of one batch of the OpenID credential key migration that folds
+/// `sso_domain` into the index key (see
+/// `Storage::migrate_openid_credential_keys_batch`).
+// TODO: Remove this together with the migration scaffolding once complete.
+#[derive(Default, Debug)]
+pub struct OpenIdCredentialKeyMigrationBatchOutcome {
+    /// Number of index entries re-keyed from the legacy `(iss, sub, aud)` key
+    /// to the new `(iss, sub, aud, sso_domain)` key this batch.
+    pub rekeyed: u64,
+    /// `true` when the scan has reached the end of the credential index —
+    /// caller should stop the interval timer.
+    pub is_done: bool,
+    /// Per-entry errors encountered this batch (e.g. orphan index entries).
+    pub errors: Vec<String>,
+    /// Last index key examined this batch; pass back as `cursor` of the next
+    /// batch to resume the scan where this one left off. `None` when the batch
+    /// examined no keys.
     pub next_cursor: Option<StorableOpenIdCredentialKey>,
 }
 
@@ -924,13 +944,190 @@ impl<M: Memory + Clone> Storage<M> {
 
     pub fn lookup_anchor_with_openid_credential(
         &self,
-        key: &OpenIdCredentialKey,
+        key: &OpenIdCredentialLookupKey,
+    ) -> Option<AnchorNumber> {
+        // Try the full key (with `sso_domain`) first.
+        if let Some(anchor_number) =
+            self.lookup_anchor_number_for_credential_key(&key.clone().into())
+        {
+            return Some(anchor_number);
+        }
+
+        // Migration-window fallback: SSO index entries not yet re-keyed by the
+        // `sso_domain` key migration are still stored under their legacy key
+        // (no `sso_domain`). Retry with `sso_domain` cleared so logins keep
+        // working while the migration runs. This only matters for SSO
+        // credentials (`sso_domain = Some`); for direct providers the legacy
+        // key equals the full key, so the first lookup already covered it.
+        // TODO: Remove this fallback once the key migration has completed.
+        if key.3.is_some() {
+            let legacy_key = StorableOpenIdCredentialKey {
+                iss: key.0.clone(),
+                sub: key.1.clone(),
+                aud: key.2.clone(),
+                sso_domain: None,
+            };
+            return self.lookup_anchor_number_for_credential_key(&legacy_key);
+        }
+
+        None
+    }
+
+    fn lookup_anchor_number_for_credential_key(
+        &self,
+        key: &StorableOpenIdCredentialKey,
     ) -> Option<AnchorNumber> {
         let anchor_numbers: Vec<AnchorNumber> = self
             .lookup_anchor_with_openid_credential_memory
-            .get(&key.clone().into())
+            .get(key)
             .map(Into::into)?;
         anchor_numbers.first().copied()
+    }
+
+    /// Migrates one batch of OpenID credential index keys from the legacy
+    /// `(iss, sub, aud)` shape to the new `(iss, sub, aud, sso_domain)` shape.
+    ///
+    /// The `sso_domain` was already stamped onto each stored credential by the
+    /// backfill in [#4013](https://github.com/dfinity/internet-identity/pull/4013)
+    /// (`OpenIdCredential::sso_domain`, `None` for direct providers). This
+    /// migration reads that stamp off the backing credential and, for SSO
+    /// credentials (`Some(domain)`), re-inserts the index entry under the new
+    /// key and removes the legacy one. Direct-provider entries
+    /// (`sso_domain = None`) already encode identically under both shapes, so
+    /// they need no re-keying and are left untouched.
+    ///
+    /// Each batch examines up to `batch_size` keys of the index, starting after
+    /// `cursor` (`None` starts from the beginning). The bound is on keys
+    /// *examined* (not keys re-keyed) so each batch does a fixed amount of work.
+    /// A re-keyed entry sorts strictly after its legacy key (`None < Some(_)`),
+    /// so it may be examined again in a later batch, but it is then skipped as
+    /// already-migrated — the migration is idempotent. It is done once a batch
+    /// examines fewer than `batch_size` keys, i.e. the scan reached the end of
+    /// the index.
+    ///
+    /// Follows the batched-migration convention used by prior data migrations
+    /// (see [#4013](https://github.com/dfinity/internet-identity/pull/4013) and
+    /// [#3784](https://github.com/dfinity/internet-identity/pull/3784)): the
+    /// caller invokes this on an interval timer until `is_done` becomes `true`,
+    /// at which point the timer is cleared.
+    // TODO: Remove this together with the migration scaffolding once complete.
+    pub fn migrate_openid_credential_keys_batch(
+        &mut self,
+        cursor: Option<StorableOpenIdCredentialKey>,
+        batch_size: u64,
+    ) -> OpenIdCredentialKeyMigrationBatchOutcome {
+        let mut outcome = OpenIdCredentialKeyMigrationBatchOutcome::default();
+
+        if batch_size == 0 {
+            outcome.is_done = true;
+            return outcome;
+        }
+
+        // Phase 1: examine up to `batch_size` keys via a read-only scan,
+        // collecting the legacy (not-yet-migrated) keys and their anchor lists.
+        // Collected first so phase 2 doesn't alias the borrow. `Bound` is taken
+        // by `ic_stable_structures::storable::Bound` here, so qualify the range
+        // bounds explicitly.
+        use std::ops::Bound as RangeBound;
+        let range = match &cursor {
+            Some(cursor) => (RangeBound::Excluded(cursor.clone()), RangeBound::Unbounded),
+            None => (RangeBound::Unbounded, RangeBound::Unbounded),
+        };
+        let mut examined: u64 = 0;
+        let mut candidates: Vec<(StorableOpenIdCredentialKey, Vec<AnchorNumber>)> = vec![];
+        for (key, anchor_list) in self
+            .lookup_anchor_with_openid_credential_memory
+            .range(range)
+            .take(batch_size as usize)
+        {
+            examined += 1;
+            outcome.next_cursor = Some(key.clone());
+            // Keys already carrying an `sso_domain` were re-keyed by an earlier
+            // batch (or written new); nothing to do for them.
+            if key.sso_domain.is_some() {
+                continue;
+            }
+            candidates.push((key, anchor_list.into()));
+        }
+
+        // Phase 2: for each legacy key, resolve the backing credential's stored
+        // `sso_domain`. Re-key only SSO credentials; direct providers keep the
+        // legacy key (which is already their canonical encoding).
+        for (legacy_key, anchor_numbers) in candidates {
+            if anchor_numbers.is_empty() {
+                // Degenerate "index entry with no anchors" state — no anchor to
+                // resolve the stamp from. Deliberately omits iss/sub, which are
+                // IdP PII surfaced by the anonymous migration-errors endpoint.
+                let err = "index entry with no associated anchor".to_string();
+                ic_cdk::println!("WARNING: OpenID credential key migration: {err}");
+                outcome.errors.push(err);
+                continue;
+            }
+
+            // The same `(iss, sub, aud)` at one anchor resolves one credential,
+            // so the first anchor that carries the credential decides the
+            // `sso_domain`. Report anchors that are missing entirely (orphan
+            // index entries) but keep scanning the rest of the list.
+            let mut resolved_sso_domain: Option<Option<String>> = None;
+            for anchor_number in &anchor_numbers {
+                let Some(storable_anchor) = self.stable_anchor_memory.get(anchor_number) else {
+                    let err = format!("anchor {anchor_number} not found for migrated credential");
+                    ic_cdk::println!("WARNING: OpenID credential key migration: {err}");
+                    outcome.errors.push(err);
+                    continue;
+                };
+                if let Some(credential) =
+                    storable_anchor
+                        .openid_credentials
+                        .iter()
+                        .find(|credential| {
+                            credential.iss == legacy_key.iss
+                                && credential.sub == legacy_key.sub
+                                && credential.aud == legacy_key.aud
+                        })
+                {
+                    resolved_sso_domain = Some(credential.sso_domain.clone());
+                    break;
+                }
+            }
+
+            // No backing credential resolved a domain: either every anchor was
+            // an orphan (already reported above) or the credential is gone.
+            // Nothing to re-key.
+            let Some(sso_domain) = resolved_sso_domain else {
+                continue;
+            };
+            // Direct provider: the legacy key is already the canonical key.
+            let Some(_domain) = &sso_domain else {
+                continue;
+            };
+
+            let new_key = StorableOpenIdCredentialKey {
+                iss: legacy_key.iss.clone(),
+                sub: legacy_key.sub.clone(),
+                aud: legacy_key.aud.clone(),
+                sso_domain: sso_domain.clone(),
+            };
+            // Move the anchor list to the new key. Re-read defensively: the
+            // legacy entry is guaranteed to exist here (concurrent mutation is
+            // impossible within a batch), but skip rather than unwrap.
+            let Some(anchor_list) = self
+                .lookup_anchor_with_openid_credential_memory
+                .remove(&legacy_key)
+            else {
+                continue;
+            };
+            self.lookup_anchor_with_openid_credential_memory
+                .insert(new_key, anchor_list);
+            outcome.rekeyed += 1;
+        }
+
+        // A short batch means the scan has reached the end of the index.
+        if examined < batch_size {
+            outcome.is_done = true;
+        }
+
+        outcome
     }
 
     /// Backfills one batch of the SSO credential `sso_domain` / `sso_name`

--- a/src/internet_identity/src/storage/storable/openid_credential.rs
+++ b/src/internet_identity/src/storage/storable/openid_credential.rs
@@ -44,6 +44,7 @@ impl StorableOpenIdCredential {
             iss: self.iss.clone(),
             sub: self.sub.clone(),
             aud: self.aud.clone(),
+            sso_domain: self.sso_domain.clone(),
         }
     }
 }

--- a/src/internet_identity/src/storage/storable/openid_credential_key.rs
+++ b/src/internet_identity/src/storage/storable/openid_credential_key.rs
@@ -1,16 +1,31 @@
-use crate::openid::{Aud, Iss, OpenIdCredentialKey, Sub};
+use crate::openid::{Aud, Iss, OpenIdCredentialLookupKey, Sub};
 use ic_stable_structures::storable::Bound;
 use ic_stable_structures::Storable;
 use minicbor::{Decode, Encode};
 use std::borrow::Cow;
 
 /// Unbounded tuples are not supported yet in ic-stable-structures,
-/// this struct wraps the `(iss, sub, aud)` key so it can be stored.
+/// this struct wraps the `(iss, sub, aud, sso_domain)` key so it can be stored.
 ///
-/// Serialized as a CBOR map `{0: iss, 1: sub, 2: aud}` via the `#[cbor(map)]`
-/// derive. The legacy pre-`aud` `[iss, sub]` CBOR array shape has been migrated
-/// away, so `from_bytes` only decodes the map shape (see there for how a stray
-/// legacy key is reported).
+/// Serialized as a CBOR map `{0: iss, 1: sub, 2: aud, 3: sso_domain}` via the
+/// `#[cbor(map)]` derive. `sso_domain` is optional, and minicbor omits a `None`
+/// value from the map on encode and decodes an absent key back to `None`.
+///
+/// This gives a transparent dual-format decode for the `sso_domain` migration:
+///
+/// - **Legacy entries** — written before `sso_domain` was part of the key —
+///   are CBOR maps with only keys `0`/`1`/`2` and decode with `sso_domain =
+///   None` (see [`Self::is_legacy`]).
+/// - **New entries** carry key `3` when (and only when) the credential is an
+///   SSO credential (`Some(domain)`); direct-provider credentials keep
+///   `sso_domain = None` and therefore encode to the exact same bytes as a
+///   legacy entry — nothing to migrate for them.
+///
+/// Unlike the earlier `(iss, sub)` → `(iss, sub, aud)` migration (whose legacy
+/// shape was a CBOR *array*, requiring a separate `Decode` struct and a
+/// top-level type peek), both shapes here are CBOR *maps* differing only by the
+/// presence of the optional key `3`, so a single `#[cbor(map)]` decode handles
+/// both.
 #[derive(Encode, Decode, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 #[cbor(map)]
 pub struct StorableOpenIdCredentialKey {
@@ -20,6 +35,19 @@ pub struct StorableOpenIdCredentialKey {
     pub sub: Sub,
     #[n(2)]
     pub aud: Aud,
+    #[n(3)]
+    pub sso_domain: Option<String>,
+}
+
+impl StorableOpenIdCredentialKey {
+    /// Returns true if this key lacks an `sso_domain` component, i.e. it was
+    /// written before the `sso_domain` key migration or belongs to a direct
+    /// provider (Google / Microsoft / Apple). The migration only re-keys
+    /// entries whose backing credential resolves an `sso_domain`, so a `true`
+    /// here does not by itself mean "unmigrated".
+    pub fn is_legacy(&self) -> bool {
+        self.sso_domain.is_none()
+    }
 }
 
 impl Storable for StorableOpenIdCredentialKey {
@@ -30,12 +58,14 @@ impl Storable for StorableOpenIdCredentialKey {
     }
 
     fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
-        // The migration to the new `{0: iss, 1: sub, 2: aud}` CBOR map shape has
-        // completed, so only that shape is decoded here. A legacy `[iss, sub]`
-        // CBOR array key means this canister was upgraded past the migration
-        // release without running it to completion (only reachable in non-prod
-        // environments) — fail with an actionable message instead of a generic
-        // CBOR decode error so operators can diagnose it quickly.
+        // Both the legacy (`{0, 1, 2}`) and the new (`{0, 1, 2, 3}`) shapes are
+        // CBOR maps; an absent key `3` decodes to `sso_domain = None`, so a
+        // single decode handles both formats.
+        //
+        // A CBOR *array* here would be a stray key from the long-completed
+        // `(iss, sub)` → `(iss, sub, aud)` migration, only reachable in a
+        // non-prod environment upgraded past that migration without running it.
+        // Fail with an actionable message instead of a generic CBOR error.
         let datatype = minicbor::Decoder::new(&bytes)
             .datatype()
             .expect("failed to read CBOR type for StorableOpenIdCredentialKey");
@@ -55,18 +85,19 @@ impl Storable for StorableOpenIdCredentialKey {
     const BOUND: Bound = Bound::Unbounded;
 }
 
-impl From<StorableOpenIdCredentialKey> for OpenIdCredentialKey {
+impl From<StorableOpenIdCredentialKey> for OpenIdCredentialLookupKey {
     fn from(value: StorableOpenIdCredentialKey) -> Self {
-        (value.iss, value.sub, value.aud)
+        (value.iss, value.sub, value.aud, value.sso_domain)
     }
 }
 
-impl From<OpenIdCredentialKey> for StorableOpenIdCredentialKey {
-    fn from(value: OpenIdCredentialKey) -> Self {
+impl From<OpenIdCredentialLookupKey> for StorableOpenIdCredentialKey {
+    fn from(value: OpenIdCredentialLookupKey) -> Self {
         StorableOpenIdCredentialKey {
             iss: value.0,
             sub: value.1,
             aud: value.2,
+            sso_domain: value.3,
         }
     }
 }
@@ -79,30 +110,83 @@ mod tests {
     #[test]
     fn should_encode_and_decode_new_format() {
         let key = StorableOpenIdCredentialKey {
-            iss: "https://accounts.google.com".to_string(),
+            iss: "https://auth.acme.com".to_string(),
             sub: "user123".to_string(),
             aud: "client456".to_string(),
+            sso_domain: Some("acme.com".to_string()),
         };
         let bytes = key.to_bytes();
         let decoded = StorableOpenIdCredentialKey::from_bytes(bytes);
+        assert_eq!(decoded.iss, "https://auth.acme.com");
+        assert_eq!(decoded.sub, "user123");
+        assert_eq!(decoded.aud, "client456");
+        assert_eq!(decoded.sso_domain, Some("acme.com".to_string()));
+        assert!(!decoded.is_legacy());
+    }
+
+    /// Keys written before `sso_domain` existed are CBOR maps with only keys
+    /// `0`/`1`/`2` — they must decode with `sso_domain = None`. This is the
+    /// exact on-disk shape the `sso_domain` key migration reads.
+    #[test]
+    fn should_decode_legacy_map_without_sso_domain() {
+        // Encode the pre-`sso_domain` shape: a CBOR map with keys 0..=2 only.
+        let mut buffer = Vec::new();
+        let mut encoder = minicbor::Encoder::new(&mut buffer);
+        encoder.map(3).unwrap();
+        encoder
+            .u8(0)
+            .unwrap()
+            .str("https://accounts.google.com")
+            .unwrap();
+        encoder.u8(1).unwrap().str("user123").unwrap();
+        encoder.u8(2).unwrap().str("client456").unwrap();
+
+        let decoded = StorableOpenIdCredentialKey::from_bytes(Cow::Borrowed(&buffer));
         assert_eq!(decoded.iss, "https://accounts.google.com");
         assert_eq!(decoded.sub, "user123");
         assert_eq!(decoded.aud, "client456");
+        assert_eq!(decoded.sso_domain, None);
+        assert!(decoded.is_legacy());
+    }
+
+    /// A direct-provider key (`sso_domain = None`) must encode to the same
+    /// bytes as a legacy key, so the migration correctly treats it as needing
+    /// no re-keying and the dual lookup fallback is a no-op for it.
+    #[test]
+    fn direct_provider_key_encodes_like_legacy() {
+        let mut legacy = Vec::new();
+        let mut encoder = minicbor::Encoder::new(&mut legacy);
+        encoder.map(3).unwrap();
+        encoder
+            .u8(0)
+            .unwrap()
+            .str("https://accounts.google.com")
+            .unwrap();
+        encoder.u8(1).unwrap().str("user123").unwrap();
+        encoder.u8(2).unwrap().str("client456").unwrap();
+
+        let key = StorableOpenIdCredentialKey {
+            iss: "https://accounts.google.com".to_string(),
+            sub: "user123".to_string(),
+            aud: "client456".to_string(),
+            sso_domain: None,
+        };
+        assert_eq!(key.to_bytes().as_ref(), legacy.as_slice());
     }
 
     #[test]
     #[should_panic(expected = "unmigrated legacy")]
     fn should_trap_on_legacy_array_key() {
-        // Encode a legacy 2-element CBOR array: [iss, sub]. After the migration
-        // this shape no longer exists, so decoding must fail with the actionable
-        // message rather than a generic CBOR decode error.
+        // Encode a legacy 2-element CBOR array: [iss, sub]. This shape belongs
+        // to the long-completed array→map migration and must fail with the
+        // actionable message rather than a generic CBOR decode error.
         let mut buffer = Vec::new();
         let mut encoder = minicbor::Encoder::new(&mut buffer);
         encoder.array(2).unwrap();
         encoder.str("https://accounts.google.com").unwrap();
         encoder.str("user123").unwrap();
 
-        let _ = StorableOpenIdCredentialKey::from_bytes(std::borrow::Cow::Borrowed(&buffer));
+        let _ = StorableOpenIdCredentialKey::from_bytes(Cow::Borrowed(&buffer));
     }
 
     #[test]
@@ -111,6 +195,7 @@ mod tests {
             iss: "https://login.microsoftonline.com/tid/v2.0".to_string(),
             sub: "sub123".to_string(),
             aud: "aud789".to_string(),
+            sso_domain: Some("corp.example".to_string()),
         };
         let bytes = key.to_bytes();
         let decoded = StorableOpenIdCredentialKey::from_bytes(bytes);
@@ -123,11 +208,17 @@ mod tests {
             iss: "iss".to_string(),
             sub: "sub".to_string(),
             aud: "aud".to_string(),
+            sso_domain: Some("domain".to_string()),
         };
-        let tuple: OpenIdCredentialKey = key.clone().into();
+        let tuple: OpenIdCredentialLookupKey = key.clone().into();
         assert_eq!(
             tuple,
-            ("iss".to_string(), "sub".to_string(), "aud".to_string())
+            (
+                "iss".to_string(),
+                "sub".to_string(),
+                "aud".to_string(),
+                Some("domain".to_string())
+            )
         );
         let back: StorableOpenIdCredentialKey = tuple.into();
         assert_eq!(key, back);

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -186,13 +186,13 @@ fn should_write_and_update_openid_credential_lookup() {
     assert_eq!(storage.read(anchor.anchor_number()).unwrap(), anchor);
     assert_eq!(
         storage
-            .lookup_anchor_with_openid_credential(&openid_credential_0.key())
+            .lookup_anchor_with_openid_credential(&openid_credential_0.lookup_key())
             .unwrap(),
         anchor.anchor_number()
     );
     assert_eq!(
         storage
-            .lookup_anchor_with_openid_credential(&openid_credential_1.key())
+            .lookup_anchor_with_openid_credential(&openid_credential_1.lookup_key())
             .unwrap(),
         anchor.anchor_number()
     );
@@ -203,12 +203,12 @@ fn should_write_and_update_openid_credential_lookup() {
         .unwrap();
     storage.write(anchor.clone()).unwrap();
     assert_eq!(
-        storage.lookup_anchor_with_openid_credential(&openid_credential_0.key()),
+        storage.lookup_anchor_with_openid_credential(&openid_credential_0.lookup_key()),
         None
     );
     assert_eq!(
         storage
-            .lookup_anchor_with_openid_credential(&openid_credential_1.key())
+            .lookup_anchor_with_openid_credential(&openid_credential_1.lookup_key())
             .unwrap(),
         anchor.anchor_number()
     );
@@ -219,18 +219,18 @@ fn should_write_and_update_openid_credential_lookup() {
         .unwrap();
     storage.write(anchor.clone()).unwrap();
     assert_eq!(
-        storage.lookup_anchor_with_openid_credential(&openid_credential_0.key()),
+        storage.lookup_anchor_with_openid_credential(&openid_credential_0.lookup_key()),
         None
     );
     assert_eq!(
         storage
-            .lookup_anchor_with_openid_credential(&openid_credential_1.key())
+            .lookup_anchor_with_openid_credential(&openid_credential_1.lookup_key())
             .unwrap(),
         anchor.anchor_number()
     );
     assert_eq!(
         storage
-            .lookup_anchor_with_openid_credential(&openid_credential_2.key())
+            .lookup_anchor_with_openid_credential(&openid_credential_2.lookup_key())
             .unwrap(),
         anchor.anchor_number()
     );
@@ -2277,6 +2277,7 @@ mod migrate_sso_credentials_batch_tests {
             iss: SSO_ISS.to_string(),
             sub: "sub-x".to_string(),
             aud: SSO_AUD.to_string(),
+            sso_domain: None,
         };
         storage.lookup_anchor_with_openid_credential_memory.insert(
             key,
@@ -2305,6 +2306,298 @@ mod migrate_sso_credentials_batch_tests {
         let (stamped_again, errors, _) =
             run_to_completion(&mut storage, &[migration_entry()], 2_000);
         assert_eq!(stamped_again, 0);
+        assert!(errors.is_empty());
+    }
+}
+
+mod migrate_openid_credential_keys_batch_tests {
+    use super::*;
+    use crate::openid::OpenIdCredentialLookupKey;
+    use crate::storage::storable::anchor_number_list::StorableAnchorNumberList;
+    use crate::storage::storable::openid_credential_key::StorableOpenIdCredentialKey;
+    use internet_identity_interface::internet_identity::types::AnchorNumber;
+    use pretty_assertions::assert_eq;
+
+    const SSO_ISS: &str = "https://auth.acme.com";
+    const SSO_AUD: &str = "acme-client-id";
+    const SSO_DOMAIN: &str = "acme.com";
+
+    const GOOGLE_ISS: &str = "https://accounts.google.com";
+    const GOOGLE_AUD: &str = "google-client-id";
+
+    /// Seed an anchor holding one OpenID credential whose stored `sso_domain`
+    /// is `sso_domain`, while leaving its index entry in the legacy (no
+    /// `sso_domain`) shape — the exact pre-migration state after the #4013
+    /// backfill stamped the credential but before the key migration ran.
+    fn seed_legacy_indexed_credential<M: Memory + Clone>(
+        storage: &mut Storage<M>,
+        iss: &str,
+        sub: &str,
+        aud: &str,
+        sso_domain: Option<String>,
+    ) -> u64 {
+        // Write with `sso_domain = None` so the index key is the legacy shape.
+        let mut anchor = storage.allocate_anchor(0).unwrap();
+        anchor
+            .add_openid_credential(OpenIdCredential {
+                iss: iss.to_string(),
+                sub: sub.to_string(),
+                aud: aud.to_string(),
+                last_usage_timestamp: None,
+                metadata: HashMap::new(),
+                sso_domain: None,
+                sso_name: None,
+            })
+            .unwrap();
+        let anchor_number = anchor.anchor_number();
+        storage.write(anchor).unwrap();
+
+        // Stamp the stored credential directly, bypassing `write` so the index
+        // key stays legacy — this is what #4013 left behind.
+        if sso_domain.is_some() {
+            let mut storable_anchor = storage.stable_anchor_memory.get(&anchor_number).unwrap();
+            storable_anchor.openid_credentials[0].sso_domain = sso_domain;
+            storage
+                .stable_anchor_memory
+                .insert(anchor_number, storable_anchor);
+        }
+        anchor_number
+    }
+
+    fn index_anchor<M: Memory + Clone>(
+        storage: &Storage<M>,
+        iss: &str,
+        sub: &str,
+        aud: &str,
+        sso_domain: Option<String>,
+    ) -> Option<AnchorNumber> {
+        let key = StorableOpenIdCredentialKey {
+            iss: iss.to_string(),
+            sub: sub.to_string(),
+            aud: aud.to_string(),
+            sso_domain,
+        };
+        let anchors: Option<Vec<AnchorNumber>> = storage
+            .lookup_anchor_with_openid_credential_memory
+            .get(&key)
+            .map(Into::into);
+        anchors.and_then(|a| a.first().copied())
+    }
+
+    /// Drive the migration to completion the way the timer in `main.rs` does:
+    /// thread `next_cursor` into the next batch until `is_done`.
+    fn run_to_completion<M: Memory + Clone>(
+        storage: &mut Storage<M>,
+        batch_size: u64,
+    ) -> (u64, Vec<String>, u64) {
+        let mut rekeyed = 0;
+        let mut errors = vec![];
+        let mut batches = 0;
+        let mut cursor = None;
+        loop {
+            let outcome = storage.migrate_openid_credential_keys_batch(cursor, batch_size);
+            rekeyed += outcome.rekeyed;
+            errors.extend(outcome.errors);
+            batches += 1;
+            if outcome.is_done {
+                return (rekeyed, errors, batches);
+            }
+            cursor = outcome.next_cursor;
+        }
+    }
+
+    #[test]
+    fn should_complete_on_empty_index() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let outcome = storage.migrate_openid_credential_keys_batch(None, 2_000);
+        assert!(outcome.is_done);
+        assert_eq!(outcome.rekeyed, 0);
+        assert!(outcome.errors.is_empty());
+        assert!(outcome.next_cursor.is_none());
+    }
+
+    #[test]
+    fn should_rekey_sso_credential_and_complete() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let anchor_number = seed_legacy_indexed_credential(
+            &mut storage,
+            SSO_ISS,
+            "sub-1",
+            SSO_AUD,
+            Some(SSO_DOMAIN.to_string()),
+        );
+
+        // Precondition: entry is under the legacy key, not the new key.
+        assert_eq!(
+            index_anchor(&storage, SSO_ISS, "sub-1", SSO_AUD, None),
+            Some(anchor_number)
+        );
+        assert_eq!(
+            index_anchor(
+                &storage,
+                SSO_ISS,
+                "sub-1",
+                SSO_AUD,
+                Some(SSO_DOMAIN.to_string())
+            ),
+            None
+        );
+
+        let outcome = storage.migrate_openid_credential_keys_batch(None, 2_000);
+        assert!(outcome.is_done);
+        assert_eq!(outcome.rekeyed, 1);
+        assert!(outcome.errors.is_empty());
+
+        // Postcondition: entry moved to the new key; legacy key gone.
+        assert_eq!(
+            index_anchor(
+                &storage,
+                SSO_ISS,
+                "sub-1",
+                SSO_AUD,
+                Some(SSO_DOMAIN.to_string())
+            ),
+            Some(anchor_number)
+        );
+        assert_eq!(
+            index_anchor(&storage, SSO_ISS, "sub-1", SSO_AUD, None),
+            None
+        );
+    }
+
+    #[test]
+    fn should_leave_direct_provider_entries_untouched() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let anchor_number =
+            seed_legacy_indexed_credential(&mut storage, GOOGLE_ISS, "sub-1", GOOGLE_AUD, None);
+
+        let outcome = storage.migrate_openid_credential_keys_batch(None, 2_000);
+        assert!(outcome.is_done);
+        assert_eq!(outcome.rekeyed, 0);
+        assert!(outcome.errors.is_empty());
+
+        // The direct-provider entry keeps its legacy (== canonical) key.
+        assert_eq!(
+            index_anchor(&storage, GOOGLE_ISS, "sub-1", GOOGLE_AUD, None),
+            Some(anchor_number)
+        );
+    }
+
+    #[test]
+    fn should_split_work_across_batches_with_cursor_resume() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let anchor_numbers: Vec<u64> = (0..5)
+            .map(|i| {
+                seed_legacy_indexed_credential(
+                    &mut storage,
+                    SSO_ISS,
+                    &format!("sub-{i}"),
+                    SSO_AUD,
+                    Some(SSO_DOMAIN.to_string()),
+                )
+            })
+            .collect();
+
+        // Batch size 2 over 5 legacy keys. Re-keyed entries sort after their
+        // legacy key, so they may be re-examined and skipped — more than the
+        // minimal 3 batches, but the migration still terminates and re-keys
+        // every entry exactly once.
+        let (rekeyed, errors, batches) = run_to_completion(&mut storage, 2);
+        assert_eq!(rekeyed, 5);
+        assert!(errors.is_empty());
+        assert!(batches >= 3);
+
+        for (i, anchor_number) in anchor_numbers.iter().enumerate() {
+            assert_eq!(
+                index_anchor(
+                    &storage,
+                    SSO_ISS,
+                    &format!("sub-{i}"),
+                    SSO_AUD,
+                    Some(SSO_DOMAIN.to_string())
+                ),
+                Some(*anchor_number)
+            );
+            assert_eq!(
+                index_anchor(&storage, SSO_ISS, &format!("sub-{i}"), SSO_AUD, None),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn dual_lookup_resolves_legacy_sso_entry_before_and_after_migration() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let anchor_number = seed_legacy_indexed_credential(
+            &mut storage,
+            SSO_ISS,
+            "sub-1",
+            SSO_AUD,
+            Some(SSO_DOMAIN.to_string()),
+        );
+        let full_key: OpenIdCredentialLookupKey = (
+            SSO_ISS.to_string(),
+            "sub-1".to_string(),
+            SSO_AUD.to_string(),
+            Some(SSO_DOMAIN.to_string()),
+        );
+
+        // Before migration the entry is stored under the legacy (no
+        // `sso_domain`) key; the full-key lookup must fall back to it so logins
+        // keep working during the migration window.
+        assert_eq!(
+            storage.lookup_anchor_with_openid_credential(&full_key),
+            Some(anchor_number)
+        );
+
+        // After migration it resolves via the new key directly.
+        let _ = run_to_completion(&mut storage, 2_000);
+        assert_eq!(
+            storage.lookup_anchor_with_openid_credential(&full_key),
+            Some(anchor_number)
+        );
+    }
+
+    #[test]
+    fn should_report_orphan_index_entry() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+
+        // Legacy index entry whose backing anchor doesn't exist — orphan.
+        let key = StorableOpenIdCredentialKey {
+            iss: SSO_ISS.to_string(),
+            sub: "sub-x".to_string(),
+            aud: SSO_AUD.to_string(),
+            sso_domain: None,
+        };
+        storage
+            .lookup_anchor_with_openid_credential_memory
+            .insert(key, StorableAnchorNumberList::from(vec![999u64]));
+
+        let outcome = storage.migrate_openid_credential_keys_batch(None, 2_000);
+        assert!(outcome.is_done);
+        assert_eq!(outcome.rekeyed, 0);
+        assert_eq!(outcome.errors.len(), 1);
+        assert!(outcome.errors[0].contains("anchor 999 not found"));
+    }
+
+    #[test]
+    fn should_be_idempotent_when_rerun_from_scratch() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        seed_legacy_indexed_credential(
+            &mut storage,
+            SSO_ISS,
+            "sub-1",
+            SSO_AUD,
+            Some(SSO_DOMAIN.to_string()),
+        );
+
+        let (rekeyed, _, _) = run_to_completion(&mut storage, 2_000);
+        assert_eq!(rekeyed, 1);
+
+        // A second full scan finds only already-migrated (new-key) entries and
+        // re-keys nothing further.
+        let (rekeyed_again, errors, _) = run_to_completion(&mut storage, 2_000);
+        assert_eq!(rekeyed_again, 0);
         assert!(errors.is_empty());
     }
 }

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -344,6 +344,96 @@ fn can_get_sso_delegation_via_discovery() -> Result<(), RejectResponse> {
     Ok(())
 }
 
+/// Upgrading to the wasm that folds `sso_domain` into the index key kicks off
+/// the batched OpenID credential key migration; an SSO credential linked before
+/// the upgrade must keep resolving throughout the migration window (via the new
+/// key, with the legacy key as a dual-lookup fallback), and a JWT delegation
+/// must still be issued once the migration timer has completed.
+///
+/// NOTE: the credential here is written by the new wasm, so its index entry is
+/// already stored under the new `(iss, sub, aud, sso_domain)` key — this test
+/// exercises the migration timer running to completion on upgrade plus
+/// continued end-to-end resolution. The actual legacy→new re-keying (only
+/// producible from a wasm predating the key change, which does not exist for SSO
+/// credentials since SSO discovery is unreleased) is covered exhaustively by the
+/// `migrate_openid_credential_keys_batch` storage unit tests.
+#[test]
+fn sso_credential_resolves_across_key_migration() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = setup_sso_canister(&env);
+    let responses = sso_http_responses();
+    let (jwt, salt, _claims, test_time, test_principal, test_authn_method) =
+        openid_google_test_data();
+
+    let identity_number = create_identity_with_authn_method(&env, canister_id, &test_authn_method);
+    sync_time(&env, test_time);
+
+    // Link the SSO credential (stamped with `sso_domain = SSO_DOMAIN`).
+    drive_sso_until_ready(&env, &responses, || {
+        api::openid_credential_add_with_discovery(
+            &env,
+            canister_id,
+            test_principal,
+            identity_number,
+            &jwt,
+            &salt,
+            Some(SSO_DOMAIN),
+        )
+        .unwrap()
+    })
+    .expect("SSO credential add failed");
+
+    let credentials = api::get_anchor_info(&env, canister_id, test_principal, identity_number)?
+        .openid_credentials
+        .expect("Could not fetch credentials!");
+    assert_eq!(credentials[0].sso_domain, Some(SSO_DOMAIN.to_string()));
+
+    // Upgrade to run the key migration, then let its interval timer complete.
+    upgrade_ii_canister_with_arg(&env, canister_id, II_WASM.clone(), None)
+        .expect("Failed to upgrade canister");
+    for _ in 0..5 {
+        env.advance_time(Duration::from_secs(1));
+        env.tick();
+    }
+
+    // The SSO credential still resolves after the migration: a JWT delegation
+    // can be prepared and fetched. The caches are cold after upgrade, so warm
+    // them again via the `Pending`-retry loop.
+    let pub_session_key = ByteBuf::from("session public key");
+    let prepare_response = drive_sso_until_ready(&env, &responses, || {
+        api::openid_prepare_delegation_with_discovery(
+            &env,
+            canister_id,
+            test_principal,
+            &jwt,
+            &salt,
+            &pub_session_key,
+            Some(SSO_DOMAIN),
+        )
+        .unwrap()
+    })
+    .expect("SSO prepare delegation failed after migration");
+
+    match api::openid_get_delegation_with_discovery(
+        &env,
+        canister_id,
+        test_principal,
+        &jwt,
+        &salt,
+        &pub_session_key,
+        &prepare_response.expiration,
+        Some(SSO_DOMAIN),
+    )? {
+        OpenIdResult::Ok(signed) => assert_eq!(
+            signed.delegation.pubkey, pub_session_key,
+            "delegation should be bound to the requested session key after migration"
+        ),
+        other => panic!("expected a signed delegation after migration, got {other:?}"),
+    }
+
+    Ok(())
+}
+
 /// Verifies that Microsoft Accounts can be added
 #[test]
 fn can_link_microsoft_account() -> Result<(), RejectResponse> {


### PR DESCRIPTION
**PR 1 of the enterprise-SSO per-app-gating stack.** Backend-only, behavior-preserving — no gating yet.

## Why
For per-app SSO gating to be safe, an OpenID login must resolve to an anchor **scoped by the SSO discovery domain**. Today the anchor lookup index keys on `(iss, sub, aud)` only, with `sso_domain` a non-key field — so a login via an attacker-controlled discovery domain that points at an org's *real* IdP (same `iss`/`sub`/`aud`) collides onto the org's anchor. This PR closes that by putting `sso_domain` in the lookup key, with a chunked migration to re-key existing entries.

Design doc (forthcoming in a docs PR): `docs/ongoing/enterprise-sso-idp-side-gating.md` §6 / §6.1.

## What
Scope is strictly the internal lookup index:
- `StorableOpenIdCredentialKey` gains CBOR field `3` (`sso_domain`) with a **dual-format `from_bytes`** (legacy 3-field + new 4-field).
- `lookup_anchor_with_openid_credential` does a **dual lookup** (full key, then legacy fallback) so logins keep resolving during the migration.
- **Chunked, timer-driven re-key migration** — 2000 keys/batch, cursor-resumable, with hidden `openid_key_migration_status` / `list_openid_key_migration_errors` scaffolding — following the `#4013` / `#3784` convention. Re-keys SSO entries from their already-stored `sso_domain`; direct-provider entries (`None`) are left untouched. Scaffolding to be removed in a follow-up once the migration completes.

## Explicitly unchanged (invariants)
- **Public API / `.did`** — `OpenIdCredentialKey` and `openid_credential_remove` stay the `(iss, sub, aud)` 3-tuple (verified: no `.did` diff vs `main`). The 4-tuple exists only as the internal `OpenIdCredentialLookupKey`.
- **Delegation seed / principals** — `calculate_delegation_seed` is byte-identical to `main`; the anchor it already hashes provides the domain separation transitively, so principals do not shift.

## Testing
- `cargo test -p internet_identity --bin internet_identity` — 610 pass, incl. dual-format key, batch re-key (cursor resume / done / idempotency / orphan), dual-lookup fallback, seed-independence, and `check_candid_interface_compatibility`.
- `cargo clippy`/`fmt` clean; integration target compiles.
- PocketIC integration tests: exercised by CI (not run locally — env version mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)