### PR TITLE
fix(fe): correct CITADEL dapp explorer URL

### DIFF
--- a/src/frontend/src/lib/legacy/flows/dappsExplorer/dapps.json
+++ b/src/frontend/src/lib/legacy/flows/dappsExplorer/dapps.json
@@ -657,7 +657,7 @@
   },
   {
     "name": "CITADEL",
-    "website": "https://ttxba-fqaaa-aaaaa-qgi4q-cai.icp.io",
+    "website": "https://ttxba-fqaaa-aaaaa-qgi4q-cai.icp0.io",
     "logo": "citadel_logo.svg"
   }
 ]


### PR DESCRIPTION
# Motivation

The CITADEL entry in the dapps explorer pointed to `https://ttxba-fqaaa-aaaaa-qgi4q-cai.icp.io`, which is the wrong domain. Canister frontends are served from `icp0.io`, not `icp.io`, so the link was broken.

# Changes

- Fixed the CITADEL `website` URL in `src/frontend/src/lib/legacy/flows/dappsExplorer/dapps.json` from `.icp.io` to `.icp0.io`.

# Tests

- No functional/test changes; this is a one-line data correction. The corrected URL `https://ttxba-fqaaa-aaaaa-qgi4q-cai.icp0.io` is the valid canister frontend domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWsEvEkAdWsf7gXxwPV6fd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWsEvEkAdWsf7gXxwPV6fd)_