### PR TITLE
fix(fe): initialize analytics before components mount so early funnel events aren't dropped

### DIFF
--- a/src/frontend/src/hooks.client.ts
+++ b/src/frontend/src/hooks.client.ts
@@ -3,7 +3,13 @@ import featureFlags from "$lib/state/featureFlags";
 import { authenticationStore } from "$lib/stores/authentication.store";
 import { mintSession } from "$lib/stores/session-delegation.store";
 import { sessionStore } from "$lib/stores/session.store";
-import { initGlobals, canisterId, agentOptions } from "$lib/globals";
+import {
+  initGlobals,
+  canisterId,
+  agentOptions,
+  frontendCanisterConfig,
+} from "$lib/globals";
+import { initAnalytics } from "$lib/utils/analytics/analytics";
 import { localeStore } from "$lib/stores/locale.store";
 import { getLocaleDirection } from "$lib/constants/locale.constants";
 
@@ -45,6 +51,14 @@ const overrideFeatureFlags = () => {
 
 export const init: ClientInit = async () => {
   await initGlobals();
+  // Initialize analytics here, in the client `init` hook, so the tracker exists
+  // before any component mounts. Svelte runs a child component's `onMount`
+  // before its parent's, so initializing in the root layout's `onMount` (as it
+  // was previously) happened *after* page `onMount`s had already fired their
+  // first events (e.g. the `/mcp` funnel's `start-mcp-authorize`), which were
+  // then dropped for lack of a tracker. `initGlobals` has populated the config
+  // by this point.
+  initAnalytics(frontendCanisterConfig.analytics_config[0]?.[0]);
   // Initialize them after globals so canister config can be used for defaults
   Object.values(featureFlags).forEach((flag) => flag.initialize());
   overrideFeatureFlags();

--- a/src/frontend/src/lib/utils/analytics/analytics.test.ts
+++ b/src/frontend/src/lib/utils/analytics/analytics.test.ts
@@ -54,12 +54,18 @@ describe("analytics init ordering", () => {
 
     initAnalytics(ENABLED_CONFIG);
 
-    // The queued hits are flushed, in order, to the freshly-built tracker.
+    // The queued hits are flushed to the freshly-built tracker: exactly one of
+    // each, no extras, and in the order they were emitted (event, then
+    // pageView).
     expect(plausibleFactory).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(trackEvent).toHaveBeenCalledWith("start-mcp-authorize", {
       props: undefined,
     });
     expect(trackPageview).toHaveBeenCalledTimes(1);
+    expect(trackEvent.mock.invocationCallOrder[0]).toBeLessThan(
+      trackPageview.mock.invocationCallOrder[0],
+    );
   });
 
   it("sends events directly once initialized", () => {
@@ -81,8 +87,12 @@ describe("analytics init ordering", () => {
     expect(plausibleFactory).not.toHaveBeenCalled();
     expect(trackEvent).not.toHaveBeenCalled();
 
-    // Subsequent events are also dropped, not queued.
+    // Subsequent events are dropped, not queued. Prove they were not merely
+    // withheld pending a later init: bringing analytics up (enabled) afterwards
+    // builds a tracker but must flush nothing, so `trackEvent` stays uncalled.
     analytics.event("mcp-authorize--confirmed");
+    initAnalytics(ENABLED_CONFIG);
+    expect(plausibleFactory).toHaveBeenCalledTimes(1);
     expect(trackEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/src/lib/utils/analytics/analytics.test.ts
+++ b/src/frontend/src/lib/utils/analytics/analytics.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnalyticsConfig } from "$lib/generated/internet_identity_types";
+
+// Mock the Plausible tracker: `initAnalytics` calls the default export to build
+// a tracker exposing `trackEvent` / `trackPageview`, which we spy on.
+const { plausibleFactory, trackEvent, trackPageview } = vi.hoisted(() => ({
+  plausibleFactory: vi.fn(),
+  trackEvent: vi.fn(),
+  trackPageview: vi.fn(),
+}));
+
+vi.mock("plausible-tracker", () => ({ default: plausibleFactory }));
+
+// Keep `withAuthorizationOrigin` deterministic and free of app deps: an empty
+// channel store means no `authorizationOrigin` is added to props.
+vi.mock("$lib/stores/channelStore", async () => {
+  const { writable } = await import("svelte/store");
+  return { establishedChannelStore: writable(undefined) };
+});
+
+// A config that `convertToPlausibleConfig` accepts (opt fields are `[] | [v]`).
+const ENABLED_CONFIG = {
+  Plausible: {
+    domain: ["identity.internetcomputer.org"],
+    track_localhost: [],
+    hash_mode: [],
+    api_host: [],
+  },
+} as unknown as AnalyticsConfig;
+
+let analytics: typeof import("./analytics").analytics;
+let initAnalytics: typeof import("./analytics").initAnalytics;
+
+beforeEach(async () => {
+  // Fresh module state (the tracker / queue / initialized flag are module-level).
+  vi.resetModules();
+  plausibleFactory.mockReset().mockReturnValue({ trackEvent, trackPageview });
+  trackEvent.mockReset();
+  trackPageview.mockReset();
+  ({ analytics, initAnalytics } = await import("./analytics"));
+});
+
+describe("analytics init ordering", () => {
+  it("queues events fired before init and flushes them once initialized", () => {
+    // Emitted before the tracker exists — as the /mcp page's onMount does,
+    // before the client `init` hook has created the tracker.
+    analytics.event("start-mcp-authorize");
+    analytics.pageView();
+
+    // Nothing sent yet: the tracker isn't built until init.
+    expect(plausibleFactory).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(trackPageview).not.toHaveBeenCalled();
+
+    initAnalytics(ENABLED_CONFIG);
+
+    // The queued hits are flushed, in order, to the freshly-built tracker.
+    expect(plausibleFactory).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith("start-mcp-authorize", {
+      props: undefined,
+    });
+    expect(trackPageview).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends events directly once initialized", () => {
+    initAnalytics(ENABLED_CONFIG);
+    analytics.event("mcp-authorize--confirmed");
+
+    expect(trackEvent).toHaveBeenCalledWith("mcp-authorize--confirmed", {
+      props: undefined,
+    });
+  });
+
+  it("drops pre-init events when analytics is disabled (no unbounded queue)", () => {
+    analytics.event("start-mcp-authorize");
+
+    // Init with no config = analytics disabled: no tracker is built, so the
+    // queued event is discarded rather than sent or retained.
+    initAnalytics(undefined);
+
+    expect(plausibleFactory).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
+
+    // Subsequent events are also dropped, not queued.
+    analytics.event("mcp-authorize--confirmed");
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/lib/utils/analytics/analytics.ts
+++ b/src/frontend/src/lib/utils/analytics/analytics.ts
@@ -6,6 +6,31 @@ import { get } from "svelte/store";
 
 let tracker: undefined | ReturnType<typeof Plausible>;
 
+// Whether `initAnalytics` has run yet — regardless of its outcome. Lets us tell
+// "analytics not initialized yet" (queue events) apart from "initialized but
+// disabled" (no tracker configured → drop events), so a deployment with
+// analytics off doesn't accumulate a queue forever.
+let initialized = false;
+
+// Events emitted before the tracker exists are queued here and flushed on init.
+// This matters because Svelte runs a *child* component's `onMount` before its
+// parent's: a page's `onMount` (e.g. the `/mcp` funnel firing
+// `start-mcp-authorize` / `mcp-authorize--request-received`) runs before the
+// root layout — or the client `init` hook — has created the tracker. Without
+// this queue those early events hit `tracker === undefined` and were silently
+// dropped, so the top of the connect funnel never reached Plausible. Bounded so
+// that if init never brings up a tracker (analytics disabled, or a stuck init)
+// the queue can't grow without limit.
+type QueuedHit =
+  | { kind: "pageView" }
+  | {
+      kind: "event";
+      name: string;
+      props?: Record<string, string | number | boolean>;
+    };
+const MAX_QUEUED_HITS = 50;
+let queuedHits: QueuedHit[] = [];
+
 const convertToPlausibleConfig = (
   config: AnalyticsConfig | undefined,
 ): PlausibleInitOptions | undefined => {
@@ -31,33 +56,66 @@ const removeUndefinedFields = (obj: Record<string, unknown | undefined>) => {
 };
 
 export const initAnalytics = (config: AnalyticsConfig | undefined) => {
-  if (config === undefined) {
-    return;
+  const plausibleConfig =
+    config === undefined ? undefined : convertToPlausibleConfig(config);
+  if (plausibleConfig !== undefined) {
+    tracker = Plausible(plausibleConfig);
   }
-  const plausibleConfig = convertToPlausibleConfig(config);
-  if (plausibleConfig === undefined) {
-    return;
+  initialized = true;
+  // Flush anything emitted before the tracker existed. If analytics is disabled
+  // (no tracker was configured) the queue is simply discarded.
+  const pending = queuedHits;
+  queuedHits = [];
+  if (tracker !== undefined) {
+    for (const hit of pending) {
+      if (hit.kind === "pageView") {
+        tracker.trackPageview();
+      } else {
+        tracker.trackEvent(hit.name, { props: hit.props });
+      }
+    }
   }
-  tracker = Plausible(plausibleConfig);
+};
+
+// The `authorizationOrigin` property is resolved at emit time (when it is
+// meaningful), so it is captured here and carried through the queue if the
+// event has to wait for init.
+const withAuthorizationOrigin = (
+  props?: Record<string, string | number | boolean>,
+): Record<string, string | number | boolean> | undefined => {
+  let authorizationOrigin: string | undefined;
+  try {
+    authorizationOrigin = get(establishedChannelStore).origin;
+  } catch {
+    // Context not available yet
+  }
+  return authorizationOrigin !== undefined
+    ? { ...props, authorizationOrigin }
+    : props;
+};
+
+// Queue a hit only while analytics is still coming up. Once initialized without
+// a tracker (analytics disabled), hits are dropped rather than accumulated.
+const enqueue = (hit: QueuedHit): void => {
+  if (!initialized && queuedHits.length < MAX_QUEUED_HITS) {
+    queuedHits.push(hit);
+  }
 };
 
 export const analytics = {
   pageView: () => {
-    tracker?.trackPageview();
+    if (tracker === undefined) {
+      enqueue({ kind: "pageView" });
+      return;
+    }
+    tracker.trackPageview();
   },
   event: (name: string, props?: Record<string, string | number | boolean>) => {
-    let authorizationOrigin: string | undefined;
-    try {
-      authorizationOrigin = get(establishedChannelStore).origin;
-    } catch {
-      // Context not available yet
+    const eventProps = withAuthorizationOrigin(props);
+    if (tracker === undefined) {
+      enqueue({ kind: "event", name, props: eventProps });
+      return;
     }
-
-    tracker?.trackEvent(name, {
-      props:
-        authorizationOrigin !== undefined
-          ? { ...props, authorizationOrigin }
-          : props,
-    });
+    tracker.trackEvent(name, { props: eventProps });
   },
 };

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { initAnalytics } from "$lib/utils/analytics/analytics";
-  import { frontendCanisterConfig, getPrimaryOrigin } from "$lib/globals";
+  import { getPrimaryOrigin } from "$lib/globals";
   import { onMount } from "svelte";
   import { page } from "$app/state";
 
@@ -59,9 +58,6 @@
       childList: true,
       subtree: true,
     });
-
-    // Initialize analytics
-    initAnalytics(frontendCanisterConfig.analytics_config[0]?.[0]);
   });
 </script>
 


### PR DESCRIPTION
# Motivation

Analytics events emitted from a page's `onMount` were being **silently dropped** in production. Concretely, the `/mcp` connect funnel's first two events — `start-mcp-authorize` and `mcp-authorize--request-received` — never reached Plausible, so the top of the connect funnel was permanently invisible (only `mcp-authorize--confirmed`/`--success`, fired later on user interaction, showed up).

Root cause is an initialization-order race:

- The Plausible tracker is created by `initAnalytics(...)`, which ran in the **root layout's `onMount`**.
- Svelte runs a **child** component's `onMount` before its **parent's**. The `/mcp` page is a child of the root layout, so the page's `onMount` runs *before* the layout's.
- `analytics.event` / `analytics.pageView` were `tracker?.trackEvent(...)` with **no queue**. Any event emitted in the page's `onMount` therefore hit `tracker === undefined` and was dropped. Events fired later (button clicks, etc.) worked because the tracker existed by then.

This was verified against the deployed prod bundle (`id.ai`): the page `onMount` is `Bo.init(), … Bo.trigger(RequestReceived|RequestInvalid)`, while `initAnalytics` sits in the layout `onMount` after it — and the observed Plausible data matched exactly (early events at 0, later events present).

# Changes

- **`hooks.client.ts`** — call `initAnalytics(frontendCanisterConfig.analytics_config[0]?.[0])` in the client `init` hook, immediately after `initGlobals()` populates the config. `init` runs before any component mounts, so the tracker exists before the `/mcp` page's `onMount` fires its first events.
- **`routes/+layout.svelte`** — remove the now-redundant `initAnalytics(...)` call from the layout's `onMount` (and the imports it solely used), avoiding a double-init.
- **`lib/utils/analytics/analytics.ts`** — add a small, **bounded** pre-init queue as a guard: events emitted before the tracker exists are buffered and flushed on init (in order), so no early event is lost regardless of mount ordering. Once init runs *without* a tracker (analytics disabled, e.g. beta's `analytics_config = null`), events are dropped rather than accumulated, so a disabled deployment can't grow the queue. `authorizationOrigin` is still resolved at emit time and carried through the queue.

Behaviour is otherwise unchanged: same events, same props, same tracker config.

# Tests

- New `lib/utils/analytics/analytics.test.ts`: covers (1) events fired before init are queued and flushed on init, in order; (2) events after init are sent directly; (3) with analytics disabled, pre-init and subsequent events are dropped, not queued.
- Full analytics suite (new + existing `Funnel.test.ts`) passes (20 tests); `tsc` + `svelte-check` report 0 errors; ESLint and Prettier clean.
- Note: the end-to-end confirmation (a `start-mcp-authorize` XHR firing on `/mcp` load before the tracker would previously have existed) is a browser-runtime check; the unit test asserts the equivalent queue-and-flush invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbjCCqTjsMn57fczTNGaKf

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbjCCqTjsMn57fczTNGaKf)_