### PR TITLE
fix(be): bound the MCP registration index (per-anchor cap, GC, URL hash)

### DIFF
--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -687,8 +687,7 @@ fn mcp_get_config(anchor_number: AnchorNumber) -> McpConfig {
 #[update]
 fn mcp_set_config(anchor_number: AnchorNumber, config: McpConfig) -> Result<(), String> {
     check_authz_and_record_activity(anchor_number).map_err(|err| format!("Unauthorized: {err}"))?;
-    mcp::set_mcp_config(anchor_number, config);
-    Ok(())
+    mcp::set_mcp_config(anchor_number, config)
 }
 
 /// Called by the MCP server, signed with its registered session key: prepare a

--- a/src/internet_identity/src/mcp.rs
+++ b/src/internet_identity/src/mcp.rs
@@ -216,7 +216,7 @@ pub fn set_mcp_config(anchor_number: AnchorNumber, config: McpConfig) -> Result<
     }
     storage_borrow_mut(|storage| {
         let old = storage.read_mcp_config(anchor_number);
-        let pending_registrations = old.pending_registrations.clone();
+        let pending_registration = old.pending_registration.clone();
         let revoke = !config.enabled || config.url != old.url;
         let session_principal = if revoke {
             if let Some(bytes) = &old.session_principal {
@@ -241,7 +241,7 @@ pub fn set_mcp_config(anchor_number: AnchorNumber, config: McpConfig) -> Result<
                 enabled: config.enabled,
                 url: config.url,
                 session_principal,
-                pending_registrations,
+                pending_registration,
             },
         );
     });

--- a/src/internet_identity/src/mcp.rs
+++ b/src/internet_identity/src/mcp.rs
@@ -52,6 +52,13 @@ use crate::{
 /// Maximum lifetime of an MCP-minted per-app account delegation: 1 hour.
 const MCP_MAX_EXPIRATION_PERIOD_NS: u64 = 60 * 60 * 1_000_000_000;
 
+/// Longest trusted-server URL `set_mcp_config` accepts. Generous for a real MCP
+/// endpoint (host + path) while bounding the one per-anchor config entry that
+/// stores it verbatim (for display / re-probing). The per-connect registration
+/// index never stores the URL verbatim — it stores a `SHA-256` hash — so this
+/// is the only place URL length affects stored size.
+pub(crate) const MCP_TRUSTED_URL_MAX_BYTES: usize = 2048;
+
 /// Bounds for the MCP session grant lifetime: 10 minutes to 30 days.
 /// Out-of-range requests are clamped (mirroring the frontend), not rejected.
 /// `pub(crate)` because `mcp_registration` applies the same clamp *before*
@@ -193,9 +200,23 @@ pub fn get_mcp_config(anchor_number: AnchorNumber) -> McpConfig {
 /// is deliberately an exact string compare: it needs no URL parsing in the
 /// canister, and erring towards revoking on any edit (even a path-only one)
 /// is the safe direction — the agent just reconnects.
-pub fn set_mcp_config(anchor_number: AnchorNumber, config: McpConfig) {
+///
+/// Rejects a trusted URL longer than [`MCP_TRUSTED_URL_MAX_BYTES`]: nothing
+/// legitimate needs a multi-KiB URL, and the bound keeps the stored config
+/// entry small. The anchor's pending-registration bookkeeping is carried over
+/// untouched — a config edit doesn't reset it (in-flight registrations are
+/// invalidated at redemption by the URL-hash check, and pruned by expiry).
+pub fn set_mcp_config(anchor_number: AnchorNumber, config: McpConfig) -> Result<(), String> {
+    if let Some(url) = &config.url {
+        if url.len() > MCP_TRUSTED_URL_MAX_BYTES {
+            return Err(format!(
+                "MCP configuration failed: trusted server URL must be at most {MCP_TRUSTED_URL_MAX_BYTES} bytes."
+            ));
+        }
+    }
     storage_borrow_mut(|storage| {
         let old = storage.read_mcp_config(anchor_number);
+        let pending_registrations = old.pending_registrations.clone();
         let revoke = !config.enabled || config.url != old.url;
         let session_principal = if revoke {
             if let Some(bytes) = &old.session_principal {
@@ -220,9 +241,11 @@ pub fn set_mcp_config(anchor_number: AnchorNumber, config: McpConfig) {
                 enabled: config.enabled,
                 url: config.url,
                 session_principal,
+                pending_registrations,
             },
         );
     });
+    Ok(())
 }
 
 /// A live MCP session: proof that the current `caller()` is the MCP server

--- a/src/internet_identity/src/mcp_registration.rs
+++ b/src/internet_identity/src/mcp_registration.rs
@@ -56,14 +56,16 @@
 //! shares the canister's stable memory with all other data: a redemption after
 //! expiry prunes its own entry, but the common cases — a successful redemption
 //! (entry retained for multi-use) and a connect that is never redeemed — would
-//! otherwise never be reclaimed. So [`prepare`] enforces a per-anchor cap on
-//! live entries, prunes the calling anchor's expired ones, and runs a bounded
-//! amortized sweep of other anchors' expired ones; and the trusted URL is
+//! otherwise never be reclaimed. So [`prepare`] keeps at most one entry per
+//! anchor (a new connect supersedes the anchor's prior in-flight registration,
+//! evicting its entry — an anchor trusts one server and holds one session, so
+//! an earlier pending registration is a superseded attempt at the same
+//! connection) and runs a bounded amortized sweep of *other* anchors' expired
+//! entries (whose owners minted and never returned); and the trusted URL is
 //! stored hashed so a large URL can't inflate an entry.
 
 use crate::authz_utils::check_authorization;
 use crate::delegation::{add_delegation_signature, der_encode_canister_sig_key};
-use crate::storage::storable::mcp_config::StorablePendingRegistration;
 use crate::storage::storable::mcp_registration::StorableMcpRegistration;
 use crate::{mcp, state, update_root_hash};
 use candid::Principal;
@@ -96,16 +98,6 @@ pub const MCP_REGISTRATION_DELEGATION_TTL_NS: u64 = 5 * 60 * 1_000_000_000;
 /// falling through to the clamp minimum) so an omitted argument has a
 /// documented, unsurprising meaning.
 pub const DEFAULT_MCP_GRANT_TTL_NS: u64 = 60 * 60 * 1_000_000_000;
-
-/// Most in-flight registration delegations one anchor may hold at once.
-/// Enforced at [`prepare`], which prunes the anchor's expired entries first, so
-/// this bounds *live* (unexpired) entries. Generous for real use — a connect
-/// mints one and they expire in [`MCP_REGISTRATION_DELEGATION_TTL_NS`] — while
-/// capping how much a single actor can write to the (shared-memory)
-/// registration index: a burst of `prepare` calls can hold at most this many
-/// entries per anchor, and minting more requires new anchors (rate-limited and
-/// costly to create).
-const MAX_PENDING_REGISTRATIONS_PER_ANCHOR: usize = 10;
 
 /// How many registration-index entries a single [`prepare`] scans for expired
 /// ones to reclaim — a bounded, amortized *global* GC (the per-anchor prune
@@ -197,10 +189,11 @@ fn trusted_url(anchor_number: AnchorNumber) -> Result<String, String> {
 ///
 /// Bounds on the registration index (which shares the canister's stable memory
 /// with all other data) are enforced here, on the write path:
-///  - each anchor may hold at most [`MAX_PENDING_REGISTRATIONS_PER_ANCHOR`]
-///    unexpired entries at once (this anchor's expired entries are pruned first,
-///    then the cap is checked), so a single actor can't flood the index;
-///  - a bounded, amortized sweep reclaims a window of *any* anchor's expired
+///  - at most one entry per anchor: this connect supersedes the anchor's prior
+///    in-flight registration (its entry is evicted), so a single actor can't
+///    flood the index — an anchor trusts one server and holds one session, so an
+///    earlier pending registration is a superseded attempt at the same connect;
+///  - a bounded, amortized sweep reclaims a window of *other* anchors' expired
 ///    entries, so entries whose owner never returns to redeem don't accumulate;
 ///  - the trusted URL is stored hashed, so a large URL can't amplify an entry.
 pub async fn prepare(
@@ -217,9 +210,9 @@ pub async fn prepare(
         return Err("MCP registration failed: empty registration key.".to_string());
     }
     // Fail fast (before drawing randomness) if no trusted server is configured.
-    // Re-checked authoritatively below under the same borrow that updates the
-    // pending list, since the `raw_rand` await can interleave a concurrent
-    // config change.
+    // Re-checked authoritatively below under the same borrow that supersedes the
+    // pending registration, since the `raw_rand` await can interleave a
+    // concurrent config change.
     trusted_url(anchor_number)?;
 
     // Effective (defaulted + clamped) grant lifetime, stored so the grant runs
@@ -229,19 +222,22 @@ pub async fn prepare(
     let read_only = read_only_from(permissions);
     let nonce = crate::random_salt().await;
 
-    // No further await below: the read-modify-write of this anchor's pending
-    // list, the signature, and the index insert all run in one message turn, so
-    // nothing interleaves between them.
+    // No further await below: reading the config, superseding the anchor's prior
+    // pending registration, the signature, and the index insert all run in one
+    // message turn, so nothing interleaves between them.
     let now = time();
     let expiration = now.saturating_add(MCP_REGISTRATION_DELEGATION_TTL_NS);
     let seed = mcp_registration_seed(&nonce);
     let user_key = der_encode_canister_sig_key(seed.to_vec());
     let p_reg = Principal::self_authenticating(&user_key);
 
-    // Read the config, require an enabled trusted server, prune this anchor's
-    // expired pending registrations (reclaiming each from the index), and
-    // enforce the per-anchor cap — all before minting anything, so an over-cap
-    // request costs no signature. Yields the trusted URL hash to store.
+    // Read the config, require an enabled trusted server, and *supersede* the
+    // anchor's prior in-flight registration: an anchor trusts one server and
+    // holds one session, so an earlier pending registration is a superseded
+    // attempt at the same connection — evict its index entry and repoint the
+    // config at this one. That keeps the registration index bounded to one entry
+    // per anchor without any cap/reject path. Yields the trusted URL hash to
+    // store.
     let trusted_url_hash = state::storage_borrow_mut(|storage| {
         let mut config = storage.read_mcp_config(anchor_number);
         let url =
@@ -252,32 +248,12 @@ pub async fn prepare(
                         .to_string(),
                 ),
             };
-        // Per-anchor GC: drop expired pending entries and remove them from the
-        // index. Bounded by the cap, so it's O(cap) work.
-        let mut pending = config.pending_registrations.take().unwrap_or_default();
-        pending.retain(|entry| {
-            if entry.expires_at_ns > now {
-                return true;
-            }
-            if let Ok(principal) = Principal::try_from_slice(&entry.principal) {
+        if let Some(previous) = config.pending_registration.take() {
+            if let Ok(principal) = Principal::try_from_slice(&previous) {
                 storage.remove_mcp_registration(principal);
             }
-            false
-        });
-        if pending.len() >= MAX_PENDING_REGISTRATIONS_PER_ANCHOR {
-            // Persist the prune even when refusing, so reclaimed slots aren't lost.
-            config.pending_registrations = Some(pending);
-            storage.write_mcp_config(anchor_number, config);
-            return Err(
-                "MCP registration failed: too many pending registrations for this identity; retry shortly."
-                    .to_string(),
-            );
         }
-        pending.push(StorablePendingRegistration {
-            principal: p_reg.as_slice().to_vec(),
-            expires_at_ns: expiration,
-        });
-        config.pending_registrations = Some(pending);
+        config.pending_registration = Some(p_reg.as_slice().to_vec());
         storage.write_mcp_config(anchor_number, config);
         Ok(hash_trusted_url(&url))
     })?;

--- a/src/internet_identity/src/mcp_registration.rs
+++ b/src/internet_identity/src/mcp_registration.rs
@@ -50,11 +50,20 @@
 //! re-binds. That is bounded by the same facts that bound a grant: the chain is
 //! only ever delivered to the trusted server's declared callback, only the
 //! holder of `X`'s private key can redeem it, and the anchor holds at most one
-//! session at a time (a re-registration replaces the previous grant). The index
-//! entry is retained until a lookup finds it expired, then pruned.
+//! session at a time (a re-registration replaces the previous grant).
+//!
+//! The index is kept bounded on the *write* path (see [`prepare`]), since it
+//! shares the canister's stable memory with all other data: a redemption after
+//! expiry prunes its own entry, but the common cases — a successful redemption
+//! (entry retained for multi-use) and a connect that is never redeemed — would
+//! otherwise never be reclaimed. So [`prepare`] enforces a per-anchor cap on
+//! live entries, prunes the calling anchor's expired ones, and runs a bounded
+//! amortized sweep of other anchors' expired ones; and the trusted URL is
+//! stored hashed so a large URL can't inflate an entry.
 
 use crate::authz_utils::check_authorization;
 use crate::delegation::{add_delegation_signature, der_encode_canister_sig_key};
+use crate::storage::storable::mcp_config::StorablePendingRegistration;
 use crate::storage::storable::mcp_registration::StorableMcpRegistration;
 use crate::{mcp, state, update_root_hash};
 use candid::Principal;
@@ -87,6 +96,36 @@ pub const MCP_REGISTRATION_DELEGATION_TTL_NS: u64 = 5 * 60 * 1_000_000_000;
 /// falling through to the clamp minimum) so an omitted argument has a
 /// documented, unsurprising meaning.
 pub const DEFAULT_MCP_GRANT_TTL_NS: u64 = 60 * 60 * 1_000_000_000;
+
+/// Most in-flight registration delegations one anchor may hold at once.
+/// Enforced at [`prepare`], which prunes the anchor's expired entries first, so
+/// this bounds *live* (unexpired) entries. Generous for real use — a connect
+/// mints one and they expire in [`MCP_REGISTRATION_DELEGATION_TTL_NS`] — while
+/// capping how much a single actor can write to the (shared-memory)
+/// registration index: a burst of `prepare` calls can hold at most this many
+/// entries per anchor, and minting more requires new anchors (rate-limited and
+/// costly to create).
+const MAX_PENDING_REGISTRATIONS_PER_ANCHOR: usize = 10;
+
+/// How many registration-index entries a single [`prepare`] scans for expired
+/// ones to reclaim — a bounded, amortized *global* GC (the per-anchor prune
+/// only reclaims the caller's own entries). Kept small so the work per write is
+/// O(1) in the index size; a fresh random start each call (see [`prepare`])
+/// spreads coverage across the whole keyspace over successive writes.
+const MCP_REGISTRATION_GC_SCAN_BUDGET: usize = 20;
+
+/// Bytes of the per-connect nonce reused as the random start key for the global
+/// GC sweep (a principal is at most 29 bytes). The nonce is already drawn for
+/// the seed; reusing it as a sweep start reveals nothing (which entries a sweep
+/// visits is not secret) and saves a second `raw_rand`.
+const GC_START_KEY_LEN: usize = 29;
+
+/// `SHA-256` of a trusted server URL, as stored on the registration index entry
+/// and re-derived at redemption. Only equality is ever needed, so a hash both
+/// suffices and bounds the entry size regardless of URL length.
+fn hash_trusted_url(url: &str) -> Vec<u8> {
+    Sha256::digest(url.as_bytes()).to_vec()
+}
 
 /// The effective session-grant lifetime for a requested `max_ttl`: the
 /// documented default when omitted, clamped to `mcp::register`'s [10 min,
@@ -150,10 +189,20 @@ fn trusted_url(anchor_number: AnchorNumber) -> Result<String, String> {
 /// (`Y` = the frontend's ephemeral, browser-held registration key — see the
 /// module doc for why the canister never delegates to a link-supplied key).
 /// `P_reg` is derived from a fresh random nonce, and the whole consent (anchor,
-/// read-only choice, resolved grant lifetime, trusted server URL) is recorded
-/// on the index entry keyed by `P_reg`, so [`register_v2`] recovers it
-/// server-side. Authenticated as the user (full authorization) — only the
-/// consenting user can create a registration delegation for their anchor.
+/// read-only choice, resolved grant lifetime, and a *hash* of the trusted
+/// server URL) is recorded on the index entry keyed by `P_reg`, so
+/// [`register_v2`] recovers it server-side. Authenticated as the user (full
+/// authorization) — only the consenting user can create a registration
+/// delegation for their anchor.
+///
+/// Bounds on the registration index (which shares the canister's stable memory
+/// with all other data) are enforced here, on the write path:
+///  - each anchor may hold at most [`MAX_PENDING_REGISTRATIONS_PER_ANCHOR`]
+///    unexpired entries at once (this anchor's expired entries are pruned first,
+///    then the cap is checked), so a single actor can't flood the index;
+///  - a bounded, amortized sweep reclaims a window of *any* anchor's expired
+///    entries, so entries whose owner never returns to redeem don't accumulate;
+///  - the trusted URL is stored hashed, so a large URL can't amplify an entry.
 pub async fn prepare(
     anchor_number: AnchorNumber,
     registration_key: SessionKey,
@@ -167,7 +216,11 @@ pub async fn prepare(
     if registration_key.is_empty() {
         return Err("MCP registration failed: empty registration key.".to_string());
     }
-    let url = trusted_url(anchor_number)?;
+    // Fail fast (before drawing randomness) if no trusted server is configured.
+    // Re-checked authoritatively below under the same borrow that updates the
+    // pending list, since the `raw_rand` await can interleave a concurrent
+    // config change.
+    trusted_url(anchor_number)?;
 
     // Effective (defaulted + clamped) grant lifetime, stored so the grant runs
     // exactly this long; and a fresh random nonce (raw_rand) that makes P_reg
@@ -176,8 +229,58 @@ pub async fn prepare(
     let read_only = read_only_from(permissions);
     let nonce = crate::random_salt().await;
 
-    let expiration = time().saturating_add(MCP_REGISTRATION_DELEGATION_TTL_NS);
+    // No further await below: the read-modify-write of this anchor's pending
+    // list, the signature, and the index insert all run in one message turn, so
+    // nothing interleaves between them.
+    let now = time();
+    let expiration = now.saturating_add(MCP_REGISTRATION_DELEGATION_TTL_NS);
     let seed = mcp_registration_seed(&nonce);
+    let user_key = der_encode_canister_sig_key(seed.to_vec());
+    let p_reg = Principal::self_authenticating(&user_key);
+
+    // Read the config, require an enabled trusted server, prune this anchor's
+    // expired pending registrations (reclaiming each from the index), and
+    // enforce the per-anchor cap — all before minting anything, so an over-cap
+    // request costs no signature. Yields the trusted URL hash to store.
+    let trusted_url_hash = state::storage_borrow_mut(|storage| {
+        let mut config = storage.read_mcp_config(anchor_number);
+        let url =
+            match (config.enabled, config.url.as_ref()) {
+                (true, Some(url)) => url.clone(),
+                _ => return Err(
+                    "MCP registration failed: no trusted MCP server is enabled for this identity."
+                        .to_string(),
+                ),
+            };
+        // Per-anchor GC: drop expired pending entries and remove them from the
+        // index. Bounded by the cap, so it's O(cap) work.
+        let mut pending = config.pending_registrations.take().unwrap_or_default();
+        pending.retain(|entry| {
+            if entry.expires_at_ns > now {
+                return true;
+            }
+            if let Ok(principal) = Principal::try_from_slice(&entry.principal) {
+                storage.remove_mcp_registration(principal);
+            }
+            false
+        });
+        if pending.len() >= MAX_PENDING_REGISTRATIONS_PER_ANCHOR {
+            // Persist the prune even when refusing, so reclaimed slots aren't lost.
+            config.pending_registrations = Some(pending);
+            storage.write_mcp_config(anchor_number, config);
+            return Err(
+                "MCP registration failed: too many pending registrations for this identity; retry shortly."
+                    .to_string(),
+            );
+        }
+        pending.push(StorablePendingRegistration {
+            principal: p_reg.as_slice().to_vec(),
+            expires_at_ns: expiration,
+        });
+        config.pending_registrations = Some(pending);
+        storage.write_mcp_config(anchor_number, config);
+        Ok(hash_trusted_url(&url))
+    })?;
 
     state::signature_map_mut(|sigs| {
         // No queries-only restriction on the registration delegation itself: it
@@ -189,9 +292,8 @@ pub async fn prepare(
 
     // Record the whole consent, keyed by P_reg, so register_v2 recovers it
     // server-side — the server passes only its session key, and the anchor
-    // number is never disclosed to it.
-    let user_key = der_encode_canister_sig_key(seed.to_vec());
-    let p_reg = Principal::self_authenticating(&user_key);
+    // number is never disclosed to it. The trusted URL is stored *hashed*, so a
+    // large URL can't amplify this per-connect entry.
     state::storage_borrow_mut(|storage| {
         storage.insert_mcp_registration(
             p_reg,
@@ -199,10 +301,15 @@ pub async fn prepare(
                 anchor_number,
                 read_only,
                 grant_ttl_ns,
-                trusted_url: url,
+                trusted_url_hash,
                 expires_at_ns: expiration,
             },
         );
+        // Amortized global GC: reclaim a bounded window of any anchor's expired
+        // entries (an owner may have minted and never returned), from a random
+        // start so successive prepares cover the whole keyspace.
+        let start = Principal::from_slice(&nonce[..GC_START_KEY_LEN]);
+        storage.sweep_expired_mcp_registrations(now, start, MCP_REGISTRATION_GC_SCAN_BUDGET);
     });
 
     Ok(PrepareMcpRegistrationDelegation {
@@ -315,9 +422,9 @@ pub fn register_v2(session_key: SessionKey) -> Result<McpRegistrationV2, String>
 
     // The trusted server the user consented to must still be the anchor's
     // current one — otherwise a switch or disable since consent has invalidated
-    // this delegation.
+    // this delegation. Compared by URL hash (the entry stores only the hash).
     match trusted_url(entry.anchor_number) {
-        Ok(current_url) if current_url == entry.trusted_url => {}
+        Ok(current_url) if hash_trusted_url(&current_url) == entry.trusted_url_hash => {}
         _ => return Err(NOT_AUTHORIZED.to_string()),
     }
 

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -200,7 +200,13 @@ const MCP_CONFIG_MEMORY_INDEX: u8 = 26u8;
 // const DEPRECATED_LOOKUP_MCP_PRINCIPAL_READ_ONLY_MEMORY_INDEX: u8 = 27u8;
 // const DEPRECATED_MCP_ACCESS_MEMORY_INDEX: u8 = 28u8;
 const MCP_GRANT_MEMORY_INDEX: u8 = 29u8;
-const MCP_REGISTRATION_MEMORY_INDEX: u8 = 30u8;
+// Index 30 held the first registration index, whose value stored the trusted
+// server URL verbatim. It is abandoned in favour of index 31, whose value
+// stores only a hash of that URL (see [`StorableMcpRegistration`]). Registration
+// entries are short-lived preview state (re-created on the next connect), so the
+// region is abandoned rather than migrated, matching the retired MCP indexes above.
+// const DEPRECATED_MCP_REGISTRATION_URL_MEMORY_INDEX: u8 = 30u8;
+const MCP_REGISTRATION_MEMORY_INDEX: u8 = 31u8;
 
 const ANCHOR_MEMORY_ID: MemoryId = MemoryId::new(ANCHOR_MEMORY_INDEX);
 const ARCHIVE_BUFFER_MEMORY_ID: MemoryId = MemoryId::new(ARCHIVE_BUFFER_MEMORY_INDEX);
@@ -1157,6 +1163,36 @@ impl<M: Memory + Clone> Storage<M> {
     /// its short lifetime, so a successful redemption *retains* the entry).
     pub fn remove_mcp_registration(&mut self, principal: Principal) {
         self.mcp_registration_memory.remove(&principal);
+    }
+
+    /// Reclaim up to `budget` expired registration entries, scanning a bounded
+    /// window of the index that begins at `start`. Returns the number removed.
+    ///
+    /// This is the amortized *global* GC of the registration index: `prepare`
+    /// prunes the calling anchor's own entries synchronously, but an anchor that
+    /// mints an entry and never returns would otherwise leave it until it
+    /// expired and then forever (nothing else looks it up). Scanning a bounded
+    /// window keeps the work per write O(`budget`) rather than O(index size); a
+    /// fresh random `start` on each call gives amortized coverage of the whole
+    /// keyspace over successive writes, so expired entries anywhere are reclaimed
+    /// without any single call scanning the whole map.
+    pub fn sweep_expired_mcp_registrations(
+        &mut self,
+        now_ns: u64,
+        start: Principal,
+        budget: usize,
+    ) -> usize {
+        let expired: Vec<Principal> = self
+            .mcp_registration_memory
+            .range(start..)
+            .take(budget)
+            .filter(|(_, entry)| entry.expires_at_ns <= now_ns)
+            .map(|(principal, _)| principal)
+            .collect();
+        for principal in &expired {
+            self.mcp_registration_memory.remove(principal);
+        }
+        expired.len()
     }
 
     /// Read `anchor_number`'s synced trusted-MCP-server config. Returns the

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -1165,8 +1165,9 @@ impl<M: Memory + Clone> Storage<M> {
         self.mcp_registration_memory.remove(&principal);
     }
 
-    /// Reclaim up to `budget` expired registration entries, scanning a bounded
-    /// window of the index that begins at `start`. Returns the number removed.
+    /// Reclaim expired registration entries, inspecting up to `budget` entries in
+    /// one bounded window that begins at `start` and wraps around to the lowest
+    /// key. Returns the number removed.
     ///
     /// This is the amortized *global* GC of the registration index: `prepare`
     /// prunes the calling anchor's own entries synchronously, but an anchor that
@@ -1175,7 +1176,10 @@ impl<M: Memory + Clone> Storage<M> {
     /// window keeps the work per write O(`budget`) rather than O(index size); a
     /// fresh random `start` on each call gives amortized coverage of the whole
     /// keyspace over successive writes, so expired entries anywhere are reclaimed
-    /// without any single call scanning the whole map.
+    /// without any single call scanning the whole map. Wrapping (`start..` then
+    /// `..start`) means every call inspects a full `budget`-sized window even
+    /// when `start` lands near the top of the keyspace, keeping the reclamation
+    /// rate independent of where `start` falls.
     pub fn sweep_expired_mcp_registrations(
         &mut self,
         now_ns: u64,
@@ -1185,6 +1189,7 @@ impl<M: Memory + Clone> Storage<M> {
         let expired: Vec<Principal> = self
             .mcp_registration_memory
             .range(start..)
+            .chain(self.mcp_registration_memory.range(..start))
             .take(budget)
             .filter(|(_, entry)| entry.expires_at_ns <= now_ns)
             .map(|(principal, _)| principal)

--- a/src/internet_identity/src/storage/storable/mcp_config.rs
+++ b/src/internet_identity/src/storage/storable/mcp_config.rs
@@ -43,7 +43,9 @@ pub struct StorableMcpConfig {
     /// ones (removing them from the registration index too) and refuses to mint
     /// a new one once this list is at the per-anchor cap — so a single anchor
     /// can't flood the registration index. Kept small (bounded by that cap).
-    /// `None` on configs written before this field existed, decoded as empty.
+    /// A config written before this field existed decodes with it set to `None`
+    /// (the `#[cbor(map)]` derive maps an absent key 3 to `None`); callers treat
+    /// `None` and an empty list identically.
     #[n(3)]
     pub pending_registrations: Option<Vec<StorablePendingRegistration>>,
 }

--- a/src/internet_identity/src/storage/storable/mcp_config.rs
+++ b/src/internet_identity/src/storage/storable/mcp_config.rs
@@ -12,6 +12,12 @@ use std::borrow::Cow;
 ///
 /// `Default` is the disabled, no-server state, returned for anchors that have
 /// never written a config.
+///
+/// It also carries the anchor's in-flight *registration delegations*
+/// ([`pending_registrations`](StorableMcpConfig::pending_registrations)) — the
+/// per-anchor state that bounds how many an anchor can hold at once. This rides
+/// the config entry (which already exists per anchor) rather than a separate
+/// map, so it adds no new per-anchor growth surface.
 #[derive(Encode, Decode, Clone, Default, Debug, Eq, PartialEq)]
 #[cbor(map)]
 pub struct StorableMcpConfig {
@@ -31,6 +37,31 @@ pub struct StorableMcpConfig {
     /// `mcp_register` replaces the previous grant through it.
     #[cbor(n(2), with = "minicbor::bytes")]
     pub session_principal: Option<Vec<u8>>,
+    /// The anchor's in-flight MCP registration delegations (see
+    /// `prepare_mcp_registration_delegation`): the registration principal
+    /// `P_reg` of each and the delegation's expiry. `prepare` prunes the expired
+    /// ones (removing them from the registration index too) and refuses to mint
+    /// a new one once this list is at the per-anchor cap — so a single anchor
+    /// can't flood the registration index. Kept small (bounded by that cap).
+    /// `None` on configs written before this field existed, decoded as empty.
+    #[n(3)]
+    pub pending_registrations: Option<Vec<StorablePendingRegistration>>,
+}
+
+/// One of an anchor's in-flight MCP registration delegations, tracked on its
+/// [`StorableMcpConfig`] to bound how many the anchor can hold at once and to
+/// let `prepare` reclaim the anchor's own expired ones synchronously.
+#[derive(Encode, Decode, Clone, Debug, Eq, PartialEq)]
+#[cbor(map)]
+pub struct StorablePendingRegistration {
+    /// Raw bytes of the registration principal `P_reg` (the key of the
+    /// registration index entry this tracks).
+    #[cbor(n(0), with = "minicbor::bytes")]
+    pub principal: Vec<u8>,
+    /// Expiry (ns since epoch) of the registration delegation, copied from the
+    /// index entry so `prepare` can prune without a per-entry lookup.
+    #[n(1)]
+    pub expires_at_ns: u64,
 }
 
 impl Storable for StorableMcpConfig {
@@ -57,6 +88,16 @@ mod tests {
             enabled: true,
             url: Some("https://mcp.example.com/mcp".to_string()),
             session_principal: Some(vec![1, 2, 3, 4]),
+            pending_registrations: Some(vec![
+                StorablePendingRegistration {
+                    principal: vec![7; 29],
+                    expires_at_ns: 42,
+                },
+                StorablePendingRegistration {
+                    principal: vec![8; 29],
+                    expires_at_ns: 43,
+                },
+            ]),
         };
         let decoded = StorableMcpConfig::from_bytes(config.to_bytes());
         assert_eq!(decoded, config);
@@ -81,6 +122,30 @@ mod tests {
         assert!(decoded.enabled);
         assert_eq!(decoded.url, Some("https://mcp.example.com/mcp".to_string()));
         assert_eq!(decoded.session_principal, None);
+        // A field added later (key 3) is likewise absent -> empty.
+        assert_eq!(decoded.pending_registrations, None);
+    }
+
+    /// Configs written before the `pending_registrations` field existed are
+    /// CBOR maps without key 3 — they must decode with the field `None`.
+    #[test]
+    fn should_decode_config_without_pending_registrations() {
+        // Encode the pre-`pending_registrations` shape: a map with keys 0..=2.
+        let mut buffer = Vec::new();
+        let mut encoder = minicbor::Encoder::new(&mut buffer);
+        encoder.map(3).unwrap();
+        encoder.u8(0).unwrap().bool(true).unwrap();
+        encoder
+            .u8(1)
+            .unwrap()
+            .str("https://mcp.example.com/mcp")
+            .unwrap();
+        encoder.u8(2).unwrap().bytes(&[5; 29]).unwrap();
+
+        let decoded = StorableMcpConfig::from_bytes(Cow::Borrowed(&buffer));
+        assert!(decoded.enabled);
+        assert_eq!(decoded.session_principal, Some(vec![5; 29]));
+        assert_eq!(decoded.pending_registrations, None);
     }
 
     /// Rollback safety: bytes written by the new encoder (with key 2 present)
@@ -95,6 +160,7 @@ mod tests {
             enabled: true,
             url: Some("https://mcp.example.com/mcp".to_string()),
             session_principal: Some(vec![5; 29]),
+            pending_registrations: None,
         };
         let decoded = StorableMcpConfig::from_bytes(config.to_bytes());
         assert!(decoded.enabled);

--- a/src/internet_identity/src/storage/storable/mcp_config.rs
+++ b/src/internet_identity/src/storage/storable/mcp_config.rs
@@ -13,11 +13,11 @@ use std::borrow::Cow;
 /// `Default` is the disabled, no-server state, returned for anchors that have
 /// never written a config.
 ///
-/// It also carries the anchor's in-flight *registration delegations*
-/// ([`pending_registrations`](StorableMcpConfig::pending_registrations)) — the
-/// per-anchor state that bounds how many an anchor can hold at once. This rides
-/// the config entry (which already exists per anchor) rather than a separate
-/// map, so it adds no new per-anchor growth surface.
+/// It also carries the anchor's current in-flight *registration delegation*
+/// ([`pending_registration`](StorableMcpConfig::pending_registration)) — the
+/// per-anchor pointer that keeps the registration index bounded to one entry
+/// per anchor. This rides the config entry (which already exists per anchor)
+/// rather than a separate map, so it adds no new per-anchor growth surface.
 #[derive(Encode, Decode, Clone, Default, Debug, Eq, PartialEq)]
 #[cbor(map)]
 pub struct StorableMcpConfig {
@@ -37,33 +37,18 @@ pub struct StorableMcpConfig {
     /// `mcp_register` replaces the previous grant through it.
     #[cbor(n(2), with = "minicbor::bytes")]
     pub session_principal: Option<Vec<u8>>,
-    /// The anchor's in-flight MCP registration delegations (see
-    /// `prepare_mcp_registration_delegation`): the registration principal
-    /// `P_reg` of each and the delegation's expiry. `prepare` prunes the expired
-    /// ones (removing them from the registration index too) and refuses to mint
-    /// a new one once this list is at the per-anchor cap — so a single anchor
-    /// can't flood the registration index. Kept small (bounded by that cap).
-    /// A config written before this field existed decodes with it set to `None`
-    /// (the `#[cbor(map)]` derive maps an absent key 3 to `None`); callers treat
-    /// `None` and an empty list identically.
-    #[n(3)]
-    pub pending_registrations: Option<Vec<StorablePendingRegistration>>,
-}
-
-/// One of an anchor's in-flight MCP registration delegations, tracked on its
-/// [`StorableMcpConfig`] to bound how many the anchor can hold at once and to
-/// let `prepare` reclaim the anchor's own expired ones synchronously.
-#[derive(Encode, Decode, Clone, Debug, Eq, PartialEq)]
-#[cbor(map)]
-pub struct StorablePendingRegistration {
-    /// Raw bytes of the registration principal `P_reg` (the key of the
-    /// registration index entry this tracks).
-    #[cbor(n(0), with = "minicbor::bytes")]
-    pub principal: Vec<u8>,
-    /// Expiry (ns since epoch) of the registration delegation, copied from the
-    /// index entry so `prepare` can prune without a per-entry lookup.
-    #[n(1)]
-    pub expires_at_ns: u64,
+    /// Raw principal bytes of the anchor's current in-flight registration
+    /// delegation `P_reg` (the key of its registration-index entry), or `None`
+    /// when none is pending. An anchor trusts one server and holds one session,
+    /// so at most one registration is in flight: a new
+    /// `prepare_mcp_registration_delegation` supersedes the previous one,
+    /// evicting the entry this points at before minting the next — which keeps
+    /// the registration index bounded to one entry per anchor (a single actor
+    /// can't flood it). A config written before this field existed decodes with
+    /// it set to `None` (the `#[cbor(map)]` derive maps an absent key 3 to
+    /// `None`).
+    #[cbor(n(3), with = "minicbor::bytes")]
+    pub pending_registration: Option<Vec<u8>>,
 }
 
 impl Storable for StorableMcpConfig {
@@ -90,16 +75,7 @@ mod tests {
             enabled: true,
             url: Some("https://mcp.example.com/mcp".to_string()),
             session_principal: Some(vec![1, 2, 3, 4]),
-            pending_registrations: Some(vec![
-                StorablePendingRegistration {
-                    principal: vec![7; 29],
-                    expires_at_ns: 42,
-                },
-                StorablePendingRegistration {
-                    principal: vec![8; 29],
-                    expires_at_ns: 43,
-                },
-            ]),
+            pending_registration: Some(vec![7; 29]),
         };
         let decoded = StorableMcpConfig::from_bytes(config.to_bytes());
         assert_eq!(decoded, config);
@@ -124,15 +100,15 @@ mod tests {
         assert!(decoded.enabled);
         assert_eq!(decoded.url, Some("https://mcp.example.com/mcp".to_string()));
         assert_eq!(decoded.session_principal, None);
-        // A field added later (key 3) is likewise absent -> empty.
-        assert_eq!(decoded.pending_registrations, None);
+        // A field added later (key 3) is likewise absent -> None.
+        assert_eq!(decoded.pending_registration, None);
     }
 
-    /// Configs written before the `pending_registrations` field existed are
+    /// Configs written before the `pending_registration` field existed are
     /// CBOR maps without key 3 — they must decode with the field `None`.
     #[test]
-    fn should_decode_config_without_pending_registrations() {
-        // Encode the pre-`pending_registrations` shape: a map with keys 0..=2.
+    fn should_decode_config_without_pending_registration() {
+        // Encode the pre-`pending_registration` shape: a map with keys 0..=2.
         let mut buffer = Vec::new();
         let mut encoder = minicbor::Encoder::new(&mut buffer);
         encoder.map(3).unwrap();
@@ -147,22 +123,21 @@ mod tests {
         let decoded = StorableMcpConfig::from_bytes(Cow::Borrowed(&buffer));
         assert!(decoded.enabled);
         assert_eq!(decoded.session_principal, Some(vec![5; 29]));
-        assert_eq!(decoded.pending_registrations, None);
+        assert_eq!(decoded.pending_registration, None);
     }
 
-    /// Rollback safety: bytes written by the new encoder (with key 2 present)
-    /// must remain decodable when the unknown key is skipped — minicbor's
-    /// `#[cbor(map)]` derive ignores unknown map keys, which is what a
-    /// rolled-back (pre-`session_principal`) wasm relies on. Cheaply
-    /// approximated here by decoding new-encoder bytes and checking the
-    /// pre-existing fields survive untouched.
+    /// Rollback safety: bytes written by the new encoder (with the later keys
+    /// present) must remain decodable when the unknown keys are skipped —
+    /// minicbor's `#[cbor(map)]` derive ignores unknown map keys, which is what
+    /// a rolled-back (older) wasm relies on. Cheaply approximated here by
+    /// decoding new-encoder bytes and checking the pre-existing fields survive.
     #[test]
-    fn should_keep_preexisting_fields_when_session_principal_present() {
+    fn should_keep_preexisting_fields_when_later_keys_present() {
         let config = StorableMcpConfig {
             enabled: true,
             url: Some("https://mcp.example.com/mcp".to_string()),
             session_principal: Some(vec![5; 29]),
-            pending_registrations: None,
+            pending_registration: Some(vec![6; 29]),
         };
         let decoded = StorableMcpConfig::from_bytes(config.to_bytes());
         assert!(decoded.enabled);

--- a/src/internet_identity/src/storage/storable/mcp_registration.rs
+++ b/src/internet_identity/src/storage/storable/mcp_registration.rs
@@ -14,12 +14,14 @@ use std::borrow::Cow;
 /// session key the MCP server generates. Because `P_reg` is derived from a
 /// random per-connect nonce (not from the consent), the consent can't be
 /// re-derived and so is stored here in full: the anchor to bind to, the
-/// read-only choice, the resolved grant lifetime, and the trusted server URL
-/// consented to. `mcp_register_v2` takes *only* the session key and recovers
-/// all of this from the entry — so the server can neither name a different
-/// anchor nor alter the access level or lifetime, and never learns the anchor
-/// number. The stored URL lets `mcp_register_v2` reject a delegation whose
-/// trusted server was switched or disabled since consent.
+/// read-only choice, the resolved grant lifetime, and a hash of the trusted
+/// server URL consented to. `mcp_register_v2` takes *only* the session key and
+/// recovers all of this from the entry — so the server can neither name a
+/// different anchor nor alter the access level or lifetime, and never learns
+/// the anchor number. The stored URL hash lets `mcp_register_v2` reject a
+/// delegation whose trusted server was switched or disabled since consent
+/// (equality is all the check needs, so a hash suffices and bounds the entry
+/// size).
 ///
 /// The entry is retained after a successful redemption (the delegation is
 /// multi-use within its short lifetime; a retry re-binds), and removed once a
@@ -44,12 +46,15 @@ pub struct StorableMcpRegistration {
     /// the grant for exactly this long.
     #[n(2)]
     pub grant_ttl_ns: u64,
-    /// The trusted server URL the user consented to (the anchor's synced config
-    /// at `prepare`). `mcp_register_v2` requires it to still equal the anchor's
-    /// current trusted URL, so switching or disabling the trusted server between
-    /// consent and redemption invalidates the delegation.
-    #[n(3)]
-    pub trusted_url: String,
+    /// `SHA-256` of the trusted server URL the user consented to (the anchor's
+    /// synced config at `prepare`). `mcp_register_v2` requires it to still equal
+    /// the hash of the anchor's current trusted URL, so switching or disabling
+    /// the trusted server between consent and redemption invalidates the
+    /// delegation. Stored as a fixed-size hash rather than the URL verbatim: the
+    /// comparison only needs equality, and hashing caps the per-connect entry at
+    /// 32 bytes so a large (attacker-set) trusted URL can't amplify it.
+    #[cbor(n(3), with = "minicbor::bytes")]
+    pub trusted_url_hash: Vec<u8>,
     /// Expiration of the *registration delegation itself* (nanoseconds since the
     /// epoch), short by design. Past this the entry authorizes nothing; it also
     /// bounds how long a stale entry lingers before it can be pruned.
@@ -77,15 +82,12 @@ mod tests {
 
     #[test]
     fn should_roundtrip_through_storable() {
-        for (read_only, trusted_url) in [
-            (false, "https://mcp.example.com/mcp".to_string()),
-            (true, "https://other.example.com/sse".to_string()),
-        ] {
+        for (read_only, trusted_url_hash) in [(false, vec![0xab; 32]), (true, vec![0x12; 32])] {
             let entry = StorableMcpRegistration {
                 anchor_number: 10_000,
                 read_only,
                 grant_ttl_ns: 24 * 60 * 60 * 1_000_000_000,
-                trusted_url,
+                trusted_url_hash,
                 expires_at_ns: 1_234_567_890_000_000_000,
             };
             let decoded = StorableMcpRegistration::from_bytes(entry.to_bytes());

--- a/src/internet_identity/tests/integration/mcp.rs
+++ b/src/internet_identity/tests/integration/mcp.rs
@@ -1941,68 +1941,65 @@ fn mcp_prepare_registration_delegation_rejects_empty_key() -> Result<(), RejectR
     Ok(())
 }
 
-/// A single anchor can hold only so many *live* registration delegations at
-/// once: `prepare` prunes the anchor's expired entries, then refuses once the
-/// per-anchor cap is reached. This bounds how much one actor can write to the
-/// registration index (which shares the canister's stable memory with all other
-/// data). Once the in-flight ones expire, `prepare` reclaims them and admits new
-/// requests again.
+/// A new `prepare` supersedes the anchor's prior in-flight registration, so the
+/// registration index holds at most one entry per anchor: the previous `P_reg`
+/// entry is evicted and can no longer be redeemed, while the latest one can.
+/// This bounds how much a single actor can write to the index (which shares the
+/// canister's stable memory with all other data) — an anchor trusts one server
+/// and holds one session, so an earlier pending registration is a superseded
+/// attempt at the same connection.
 #[test]
-fn mcp_prepare_registration_delegation_is_capped_per_anchor() -> Result<(), RejectResponse> {
-    // Mirrors `MAX_PENDING_REGISTRATIONS_PER_ANCHOR` in `mcp_registration.rs`.
-    const MAX_PENDING: usize = 10;
-
+fn mcp_prepare_registration_delegation_supersedes_previous() -> Result<(), RejectResponse> {
     let env = env();
     let canister_id = install_with_mcp(&env);
     let anchor = flows::register_anchor(&env, canister_id);
     trust_mcp_server(&env, canister_id, principal_1(), anchor);
 
-    // Fill the per-anchor budget: each prepare mints a distinct `P_reg` entry
-    // (the seed comes from a fresh random nonce, not the registration key).
-    for i in 0..MAX_PENDING {
-        prepare_mcp_registration_delegation(
+    // Mint three registration delegations for the same anchor in a row. Each
+    // gets a distinct `P_reg` (the seed comes from a fresh random nonce), and
+    // each `prepare` evicts the previous anchor's entry.
+    let mut p_regs = Vec::new();
+    for i in 0..3 {
+        let prepared = prepare_mcp_registration_delegation(
             &env,
             canister_id,
             principal_1(),
             anchor,
             ByteBuf::from(format!("browser registration key Y {i}")),
-            Some(true),
+            Some(false),
             Some(GRANT_TTL_NS),
         )
         .unwrap()
-        .expect("prepares up to the cap must succeed");
+        .expect("each prepare must succeed (there is no cap/reject path)");
+        p_regs.push(Principal::self_authenticating(&prepared.user_key));
     }
 
-    // One past the cap is refused.
-    let over_cap = prepare_mcp_registration_delegation(
+    // Only the latest registration is redeemable; the two it superseded were
+    // evicted, so redeeming them is rejected (their entry is gone).
+    for superseded in &p_regs[..2] {
+        let redeemed = mcp_register_v2(
+            &env,
+            canister_id,
+            *superseded,
+            ByteBuf::from("mcp server session key S"),
+        )
+        .unwrap();
+        assert!(
+            matches!(&redeemed, Err(message) if message.contains("not authorized")),
+            "a superseded registration must no longer be redeemable: {redeemed:?}"
+        );
+    }
+    let latest = mcp_register_v2(
         &env,
         canister_id,
-        principal_1(),
-        anchor,
-        ByteBuf::from("browser registration key Y over"),
-        Some(true),
-        Some(GRANT_TTL_NS),
+        p_regs[2],
+        ByteBuf::from("mcp server session key S"),
     )
     .unwrap();
     assert!(
-        matches!(&over_cap, Err(message) if message.contains("too many pending registrations")),
-        "a prepare past the per-anchor cap must be rejected: {over_cap:?}"
+        latest.is_ok(),
+        "the latest registration must still be redeemable: {latest:?}"
     );
-
-    // Past the ~5-minute registration lifetime, the in-flight entries are
-    // expired; the next prepare prunes them (freeing the budget) and succeeds.
-    env.advance_time(Duration::from_secs(6 * 60));
-    prepare_mcp_registration_delegation(
-        &env,
-        canister_id,
-        principal_1(),
-        anchor,
-        ByteBuf::from("browser registration key Y after expiry"),
-        Some(true),
-        Some(GRANT_TTL_NS),
-    )
-    .unwrap()
-    .expect("once the pending entries expire, prepare must succeed again");
 
     Ok(())
 }

--- a/src/internet_identity/tests/integration/mcp.rs
+++ b/src/internet_identity/tests/integration/mcp.rs
@@ -1940,3 +1940,108 @@ fn mcp_prepare_registration_delegation_rejects_empty_key() -> Result<(), RejectR
 
     Ok(())
 }
+
+/// A single anchor can hold only so many *live* registration delegations at
+/// once: `prepare` prunes the anchor's expired entries, then refuses once the
+/// per-anchor cap is reached. This bounds how much one actor can write to the
+/// registration index (which shares the canister's stable memory with all other
+/// data). Once the in-flight ones expire, `prepare` reclaims them and admits new
+/// requests again.
+#[test]
+fn mcp_prepare_registration_delegation_is_capped_per_anchor() -> Result<(), RejectResponse> {
+    // Mirrors `MAX_PENDING_REGISTRATIONS_PER_ANCHOR` in `mcp_registration.rs`.
+    const MAX_PENDING: usize = 10;
+
+    let env = env();
+    let canister_id = install_with_mcp(&env);
+    let anchor = flows::register_anchor(&env, canister_id);
+    trust_mcp_server(&env, canister_id, principal_1(), anchor);
+
+    // Fill the per-anchor budget: each prepare mints a distinct `P_reg` entry
+    // (the seed comes from a fresh random nonce, not the registration key).
+    for i in 0..MAX_PENDING {
+        prepare_mcp_registration_delegation(
+            &env,
+            canister_id,
+            principal_1(),
+            anchor,
+            ByteBuf::from(format!("browser registration key Y {i}")),
+            Some(true),
+            Some(GRANT_TTL_NS),
+        )
+        .unwrap()
+        .expect("prepares up to the cap must succeed");
+    }
+
+    // One past the cap is refused.
+    let over_cap = prepare_mcp_registration_delegation(
+        &env,
+        canister_id,
+        principal_1(),
+        anchor,
+        ByteBuf::from("browser registration key Y over"),
+        Some(true),
+        Some(GRANT_TTL_NS),
+    )
+    .unwrap();
+    assert!(
+        matches!(&over_cap, Err(message) if message.contains("too many pending registrations")),
+        "a prepare past the per-anchor cap must be rejected: {over_cap:?}"
+    );
+
+    // Past the ~5-minute registration lifetime, the in-flight entries are
+    // expired; the next prepare prunes them (freeing the budget) and succeeds.
+    env.advance_time(Duration::from_secs(6 * 60));
+    prepare_mcp_registration_delegation(
+        &env,
+        canister_id,
+        principal_1(),
+        anchor,
+        ByteBuf::from("browser registration key Y after expiry"),
+        Some(true),
+        Some(GRANT_TTL_NS),
+    )
+    .unwrap()
+    .expect("once the pending entries expire, prepare must succeed again");
+
+    Ok(())
+}
+
+/// `mcp_set_config` rejects a trusted URL past the length cap. Nothing
+/// legitimate needs a multi-KiB URL, and the bound keeps the stored config
+/// entry small — the registration index stores only a *hash* of the URL, so
+/// this is the only place URL length affects stored size. A normal URL is
+/// unaffected.
+#[test]
+fn mcp_set_config_rejects_overlong_trusted_url() -> Result<(), RejectResponse> {
+    // Mirrors `MCP_TRUSTED_URL_MAX_BYTES` in `mcp.rs`.
+    const MAX_URL_BYTES: usize = 2048;
+
+    let env = env();
+    let canister_id = install_with_mcp(&env);
+    let anchor = flows::register_anchor(&env, canister_id);
+
+    let overlong = format!("https://mcp.example.com/{}", "a".repeat(MAX_URL_BYTES));
+    let rejected = mcp_set_config(
+        &env,
+        canister_id,
+        principal_1(),
+        anchor,
+        McpConfig {
+            enabled: true,
+            url: Some(overlong),
+        },
+    )
+    .unwrap();
+    assert!(
+        matches!(&rejected, Err(message) if message.contains("at most")),
+        "an over-long trusted URL must be rejected: {rejected:?}"
+    );
+
+    // A normal-length URL is accepted (and the end-to-end connect keeps working:
+    // `mcp_register_v2` re-derives and compares the URL hash — see the happy-path
+    // test — so hashing the stored URL is transparent to redemption).
+    trust_mcp_server(&env, canister_id, principal_1(), anchor);
+
+    Ok(())
+}


### PR DESCRIPTION
# Motivation

The `mcp_registration` index written by `prepare_mcp_registration_delegation` (MCP v2 backend) grows without bound:

- a successful `mcp_register_v2` **retains** its entry (the delegation is multi-use), and a connect that is never redeemed leaves one behind;
- the only removal path — an expired lookup inside `register_v2` — is effectively **unreachable**, because an expired delegation chain is rejected at ingress before the update ever executes.

That index shares the canister's single stable-memory pool with all identity data (anchors, accounts, …), and it stored the trusted server URL **verbatim**. So a single authenticated anchor could both **flood** it (unbounded entries, one per `prepare`) and **inflate** it (a large trusted URL, up to the ~2 MiB ingress limit), competing for the memory that new-anchor registration and every other write depends on — i.e. a canister-wide write-availability risk with MCP registration as the injection point.

This is **not yet released to production** (no release tag contains the MCP v2 backend), so this lands the fix before the v2 backend ships.

# Changes

All bounds are enforced on the **write path**, in `mcp_registration::prepare`:

- **At most one registration entry per anchor (supersede).** A new `prepare` evicts the anchor's prior in-flight registration entry and repoints the config at the new one. An anchor trusts exactly one server and holds exactly one session, so an earlier pending registration is a superseded attempt at the *same* connection — evicting it loses nothing (a redeemed one would be replaced at the grant level anyway; an unredeemed one is abandoned), and "newest wins" mirrors the one-session invariant. The pointer rides the anchor's existing `StorableMcpConfig` (`pending_registration: Option<Vec<u8>>`), so there's no new per-anchor growth surface and no cap/reject path.
- **Bounded amortized global GC**: each `prepare` scans a small window (`MCP_REGISTRATION_GC_SCAN_BUDGET = 20`) of the index, wrapping from a random start (`start..` then `..start`), and reclaims expired entries — so entries whose owner minted and never returned don't accumulate, without any call scanning the whole map.
- **Store `SHA-256(trusted_url)`** on the registration entry instead of the URL verbatim (redemption only needs equality), and **cap the config URL length** (`MCP_TRUSTED_URL_MAX_BYTES = 2048`) in `mcp_set_config`.
- The registration index moves to a **fresh memory id** (its value format changed); entries are short-lived preview state re-created on the next connect, so the old region is abandoned rather than migrated — matching the already-retired MCP indices.

**No candid / public-signature changes.** **No display impact:** the Settings UI shows the verbatim config URL (unchanged); only the internal registration entry is hashed.

# Tests

- Storable unit tests updated + added: hashed-URL round-trip; config round-trip with the `pending_registration` pointer; back-compat decode of a config written before the field (decodes to `None`).
- New integration tests: `mcp_prepare_registration_delegation_supersedes_previous` (three prepares in a row → only the latest entry is redeemable; the two it superseded are evicted) and `mcp_set_config_rejects_overlong_trusted_url`.
- Full MCP integration suite (35 tests) green against a freshly built wasm — including the existing `register_v2` / config-change tests, which now exercise the hashed-URL comparison.
- `cargo fmt`, `cargo clippy -D warnings` (wasm target + test target), and `cargo build --target wasm32` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)