### PR TITLE
fix(fe): auto-advance the MCP untrusted screen once the server is trusted

### DIFF
--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -157,6 +157,68 @@
     }
   });
 
+  // Auto-advance the untrusted screen once the user trusts this server. The
+  // "Manage trusted server" button hands the session to a Settings tab where the
+  // user sets the trusted server; when they come back to this tab, re-read the
+  // synced config and — if this server's origin is now trusted — move straight
+  // to the connect screen, so they don't have to restart the connect ("then try
+  // again" happens for them). Same unblock as switching to an identity that
+  // already trusts the server. Re-checking when the tab regains focus/visibility
+  // (rather than polling) is enough: the trusted server is set in another tab, so
+  // regaining focus here is exactly the moment the synced config may have
+  // changed. The read reuses the actor the untrusted screen already holds
+  // (reaching it authenticated the identity); minting still waits for an explicit
+  // "Allow access" on the connect screen.
+  $effect(() => {
+    if (phase.kind !== "untrusted" || mcpServer === undefined) {
+      return;
+    }
+    const server = mcpServer;
+    let checking = false;
+    const recheck = (): void => {
+      if (checking || document.visibilityState !== "visible") {
+        return;
+      }
+      const authenticated = get(authenticationStore);
+      if (authenticated === undefined) {
+        return;
+      }
+      const identityNumber = authenticated.identityNumber;
+      checking = true;
+      void (async () => {
+        try {
+          const config = await readMcpConfig(
+            authenticated.actor,
+            identityNumber,
+          );
+          // Only act if the user is still on the untrusted screen for the same
+          // identity this config was read (and signed) as: a late resolve mustn't
+          // yank them off a screen they've since moved to (navigated away), and —
+          // since the untrusted screen is reachable again for a different identity
+          // after a switch — applying a stale read must not unblock the wrong one.
+          if (
+            phase.kind === "untrusted" &&
+            get(authenticationStore)?.identityNumber === identityNumber &&
+            isOriginTrusted(config, server.origin)
+          ) {
+            phase = { kind: "authorize" };
+          }
+        } catch {
+          // Couldn't read the config (e.g. a transient error or an expired
+          // session): leave the user on the untrusted screen to retry manually.
+        } finally {
+          checking = false;
+        }
+      })();
+    };
+    document.addEventListener("visibilitychange", recheck);
+    window.addEventListener("focus", recheck);
+    return () => {
+      document.removeEventListener("visibilitychange", recheck);
+      window.removeEventListener("focus", recheck);
+    };
+  });
+
   // Invoked by the reused account picker once it has authenticated the selected
   // identity and resolved the chosen account. Connecting mints a short-lived
   // registration delegation for the server's per-connect key (rooted at a

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -181,9 +181,14 @@ test("Trusting the server in the Settings tab auto-advances the untrusted screen
   });
 
   // The now-trusted server unblocks the connect screen with no manual retry.
-  await expect(
-    page.getByRole("button", { name: "Allow access" }),
-  ).toBeVisible();
+  // Advancing hinges on the re-check's on-chain config read (a canister
+  // round-trip kicked off by the events above), which can outlast the default
+  // 5s expect timeout on a slow replica — `test.slow()` only scales the overall
+  // test timeout, not per-assertion ones — so give it the same headroom as the
+  // other canister-bound waits in this file.
+  await expect(page.getByRole("button", { name: "Allow access" })).toBeVisible({
+    timeout: 15_000,
+  });
 });
 
 test("After trusting the server, the connect screen shows", async ({

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -118,6 +118,74 @@ test("Manage trusted server hands the session to a new Settings tab", async ({
   ).toBeVisible({ timeout: 10_000 });
 });
 
+test("Trusting the server in the Settings tab auto-advances the untrusted screen", async ({
+  page,
+  mcp,
+}) => {
+  // The whole point of the untrusted screen: set the server as trusted in the
+  // handed-off Settings tab, come back, and the connect flow picks up where it
+  // was blocked — no manual retry. Trust lives on-chain (synced), so both the
+  // Settings write and this tab's re-read are real canister round-trips.
+  test.slow();
+  await addVirtualAuthenticator(page);
+  await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
+  await signUp(page);
+  await allowAccess(page);
+  await expect(
+    page.getByRole("heading", { name: "This MCP server isn't trusted yet" }),
+  ).toBeVisible();
+
+  // Hand the session to a new Settings tab and set this very server as trusted.
+  const settingsPagePromise = page.context().waitForEvent("page");
+  await page.getByRole("button", { name: "Manage trusted server" }).click();
+  const settingsPage = await settingsPagePromise;
+  await settingsPage.waitForURL("**/manage/settings**", { timeout: 15_000 });
+  // Mock this origin's RFC 9728 metadata so the Settings "Trust this server"
+  // probe verifies locally and fast (it's advisory — activation happens
+  // regardless — but without a mock it would hit the real network and stall).
+  // Routes are per-page, so this new tab needs its own.
+  await settingsPage.route(
+    `${mcp.mcpOrigin}/.well-known/oauth-protected-resource**`,
+    (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          "access-control-allow-origin": "*",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          authorization_servers: [mcp.mcpOrigin],
+          resource: `${mcp.mcpOrigin}/mcp`,
+        }),
+      }),
+  );
+  // The URL box only appears once the master toggle is on.
+  await settingsPage
+    .getByRole("switch", { name: "Trusted MCP server" })
+    .check();
+  await settingsPage.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
+  await settingsPage.getByRole("button", { name: "Trust this server" }).click();
+  await expect(
+    settingsPage.getByRole("button", { name: "Remove this server" }),
+  ).toBeVisible();
+
+  // Back on the original tab. In a real browser, returning to a backgrounded tab
+  // fires `visibilitychange`/`focus` — which is what the /mcp page listens for to
+  // re-check trust. Playwright keeps every page permanently foreground (so
+  // `bringToFront()` fires no such event and `visibilityState` stays "visible"),
+  // so dispatch the events the page listens for to stand in for the tab return;
+  // the page's `visibilityState === "visible"` guard is satisfied either way.
+  await page.evaluate(() => {
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("focus"));
+  });
+
+  // The now-trusted server unblocks the connect screen with no manual retry.
+  await expect(
+    page.getByRole("button", { name: "Allow access" }),
+  ).toBeVisible();
+});
+
 test("After trusting the server, the connect screen shows", async ({
   page,
   mcp,


### PR DESCRIPTION
# Motivation

When a `/mcp` connect request lands on the **"This MCP server isn't trusted yet"** screen, we point the user to Settings to set this server as their trusted MCP server. The "Manage trusted server" button hands the session to a new Settings tab so they don't have to sign in again.

But after the user set the server as trusted over there and came back to the connect tab, that tab stayed stuck on the untrusted screen — the only way forward was a full manual retry. It should notice the server is now trusted and proceed automatically.

# Changes

- `src/frontend/src/routes/(new-styling)/mcp/+page.svelte`: while the `untrusted` phase is showing, re-verify trust whenever the tab regains focus/visibility (`visibilitychange` / `focus`) — exactly the moment the user returns from the handed-off Settings tab. If the identity now trusts the server's origin (re-read from the synced on-chain config), the page advances to the connect (`authorize`) screen, the same unblock as switching to an identity that already trusts the server, and matching the screen's own "then try again" copy.
  - The re-check reuses the actor the untrusted screen already holds (reaching it authenticated the identity) and is bound to the identity whose config was read, so a late-resolving read can't unblock a different identity's screen after a switch.
  - Minting the registration delegation still waits for an explicit "Allow access" on the connect screen — consent is unchanged.
  - Listeners are registered only while on the untrusted screen and torn down when leaving it.

# Tests

- Added an e2e test (`src/frontend/tests/e2e-playwright/routes/mcp.spec.ts`): sign up → connect → untrusted screen → hand off to the Settings tab and trust this very server → return to the connect tab → it auto-advances to the connect screen with no manual retry.
  - Playwright keeps every page permanently foreground, so `bringToFront()` fires no `visibilitychange`/`focus` event; the test dispatches those events to stand in for the tab return (the page's `visibilityState === "visible"` guard is satisfied either way). Also mocks the Settings RFC 9728 metadata probe on the new tab so it resolves locally.
- `npm run check` (tsc + svelte-check), ESLint, and Prettier all pass on the changed files.
- The full Playwright e2e suite requires a local IC replica with deployed canisters, which wasn't run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eCeRzAEuZx6ZvPLXr8GX6

---
_Generated by [Claude Code](https://claude.ai/code/session_014eCeRzAEuZx6ZvPLXr8GX6)_