### PR TITLE
feat(fe): revamp MCP settings into an AI access card

### DIFF
--- a/src/frontend/src/lib/components/ui/HoldToConfirm.svelte
+++ b/src/frontend/src/lib/components/ui/HoldToConfirm.svelte
@@ -11,6 +11,7 @@
     duration?: number;
     label: string;
     completed?: boolean;
+    variant?: "secondary" | "primary";
     onComplete?: () => void;
     class?: string;
   }
@@ -19,6 +20,7 @@
     duration = 2500,
     label,
     completed = false,
+    variant = "secondary",
     onComplete,
     class: className,
     ...props
@@ -71,10 +73,10 @@
     controller.cancel();
   }}
   class={[
-    "bg-bg-primary focus-visible:ring-offset-bg-primary focus-visible:ring-focus-ring relative box-border flex h-12 w-full touch-none items-center justify-center overflow-hidden rounded-md border px-4.5 text-base font-semibold outline-none select-none not-disabled:cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-2",
-    completed
-      ? "border-border-brand text-text-primary-inversed"
-      : "border-border-secondary text-text-primary",
+    "focus-visible:ring-offset-bg-primary focus-visible:ring-focus-ring relative box-border flex h-12 w-full touch-none items-center justify-center overflow-hidden rounded-md border px-4.5 text-base font-semibold outline-none select-none not-disabled:cursor-pointer focus-visible:ring-2 focus-visible:ring-offset-2",
+    completed || variant === "primary"
+      ? "bg-bg-brand-solid border-border-brand text-text-primary-inversed"
+      : "bg-bg-primary border-border-secondary text-text-primary",
     "transition-colors duration-200",
     className,
   ]}
@@ -83,7 +85,11 @@
     aria-hidden="true"
     class={[
       "absolute inset-0 origin-left",
-      completed ? "bg-bg-brand-solid" : "bg-bg-primary_hover",
+      completed
+        ? "bg-bg-brand-solid"
+        : variant === "primary"
+          ? "bg-bg-brand-solid_hover"
+          : "bg-bg-primary_hover",
     ]}
     style="width: {progress * 100}%"
   ></span>

--- a/src/frontend/src/lib/components/ui/HoldToConfirm.svelte
+++ b/src/frontend/src/lib/components/ui/HoldToConfirm.svelte
@@ -11,6 +11,7 @@
     duration?: number;
     label: string;
     completed?: boolean;
+    disabled?: boolean;
     variant?: "secondary" | "primary";
     onComplete?: () => void;
     class?: string;
@@ -20,11 +21,14 @@
     duration = 2500,
     label,
     completed = false,
+    disabled = false,
     variant = "secondary",
     onComplete,
     class: className,
     ...props
   }: Props = $props();
+
+  const inactive = $derived(completed || disabled);
 
   let progress = $state(0);
 
@@ -48,22 +52,22 @@
 <button
   {...props}
   type="button"
-  disabled={completed}
+  disabled={inactive}
   aria-label={completed ? $t`Confirmed` : label}
   onmousedown={() => {
-    if (!completed) controller.start();
+    if (!inactive) controller.start();
   }}
   onmouseup={() => controller.cancel()}
   onmouseleave={() => controller.cancel()}
   ontouchstart={(e) => {
-    if (completed) return;
+    if (inactive) return;
     e.preventDefault();
     controller.start();
   }}
   ontouchend={() => controller.cancel()}
   ontouchcancel={() => controller.cancel()}
   onkeydown={(e) => {
-    if (e.code !== "Space" || e.repeat || completed) return;
+    if (e.code !== "Space" || e.repeat || inactive) return;
     e.preventDefault();
     controller.start();
   }}
@@ -77,6 +81,7 @@
     completed || variant === "primary"
       ? "bg-bg-brand-solid border-border-brand text-text-primary-inversed"
       : "bg-bg-primary border-border-secondary text-text-primary",
+    disabled && !completed && "opacity-60",
     "transition-colors duration-200",
     className,
   ]}

--- a/src/frontend/src/lib/components/ui/Input.svelte
+++ b/src/frontend/src/lib/components/ui/Input.svelte
@@ -12,10 +12,6 @@
     size?: Size;
     error?: string | Snippet;
     errorBorder?: boolean;
-    /** Adornment rendered at the trailing edge, vertically centered inside the
-     *  input field. Give the input trailing padding (e.g. `inputClass="pe-11"`)
-     *  so its text doesn't run under it. */
-    trailing?: Snippet;
   };
 
   const id = $props.id();
@@ -29,7 +25,6 @@
     size = "md",
     error,
     errorBorder = error !== undefined,
-    trailing,
     ...restProps
   }: Props = $props();
 </script>
@@ -59,13 +54,6 @@
         inputClass,
       ]}
     />
-    {#if trailing !== undefined}
-      <div
-        class="pointer-events-none absolute inset-y-0 inset-e-3 flex items-center"
-      >
-        {@render trailing()}
-      </div>
-    {/if}
   </div>
   {#if error !== undefined || hint !== undefined}
     <div

--- a/src/frontend/src/lib/components/ui/Input.svelte
+++ b/src/frontend/src/lib/components/ui/Input.svelte
@@ -12,6 +12,10 @@
     size?: Size;
     error?: string | Snippet;
     errorBorder?: boolean;
+    /** Adornment rendered at the trailing edge, vertically centered inside the
+     *  input field. Give the input trailing padding (e.g. `inputClass="pe-11"`)
+     *  so its text doesn't run under it. */
+    trailing?: Snippet;
   };
 
   const id = $props.id();
@@ -25,6 +29,7 @@
     size = "md",
     error,
     errorBorder = error !== undefined,
+    trailing,
     ...restProps
   }: Props = $props();
 </script>
@@ -54,6 +59,13 @@
         inputClass,
       ]}
     />
+    {#if trailing !== undefined}
+      <div
+        class="pointer-events-none absolute inset-y-0 inset-e-3 flex items-center"
+      >
+        {@render trailing()}
+      </div>
+    {/if}
   </div>
   {#if error !== undefined || hint !== undefined}
     <div

--- a/src/frontend/src/lib/utils/mcpConfig.ts
+++ b/src/frontend/src/lib/utils/mcpConfig.ts
@@ -95,6 +95,13 @@ export const setMcpTrustedServer = (
   url: string,
 ): Promise<McpConfig> => updateConfig(actor, identityNumber, { url });
 
+export const trustAndEnableMcp = (
+  actor: ActorSubclass<_SERVICE>,
+  identityNumber: bigint,
+  url: string,
+): Promise<McpConfig> =>
+  updateConfig(actor, identityNumber, { url, enabled: true });
+
 /** Forget the trusted server URL (synced). */
 export const clearMcpTrustedServer = (
   actor: ActorSubclass<_SERVICE>,

--- a/src/frontend/src/lib/utils/mcpConfig.ts
+++ b/src/frontend/src/lib/utils/mcpConfig.ts
@@ -101,3 +101,15 @@ export const clearMcpTrustedServer = (
   identityNumber: bigint,
 ): Promise<McpConfig> =>
   updateConfig(actor, identityNumber, { url: undefined });
+
+/**
+ * Forget the trusted server URL and turn the feature off in a single write.
+ * Removing the only trusted server leaves an enabled config with nothing to
+ * gate, so the two are cleared together — atomically, and without a transient
+ * on-chain "enabled but no URL" state.
+ */
+export const clearAndDisableMcp = (
+  actor: ActorSubclass<_SERVICE>,
+  identityNumber: bigint,
+): Promise<McpConfig> =>
+  updateConfig(actor, identityNumber, { url: undefined, enabled: false });

--- a/src/frontend/src/lib/utils/mcpConfig.ts
+++ b/src/frontend/src/lib/utils/mcpConfig.ts
@@ -102,12 +102,6 @@ export const clearMcpTrustedServer = (
 ): Promise<McpConfig> =>
   updateConfig(actor, identityNumber, { url: undefined });
 
-/**
- * Forget the trusted server URL and turn the feature off in a single write.
- * Removing the only trusted server leaves an enabled config with nothing to
- * gate, so the two are cleared together — atomically, and without a transient
- * on-chain "enabled but no URL" state.
- */
 export const clearAndDisableMcp = (
   actor: ActorSubclass<_SERVICE>,
   identityNumber: bigint,

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -186,12 +186,12 @@
             </Tooltip>
           {:else if verifyState === "unverified" && parsedUrl !== undefined}
             <Tooltip
-              label={$t`Couldn't reach this connector`}
-              description={$t`We couldn't reach this URL to confirm it, but you can still trust it.`}
+              label={$t`Couldn't validate MCP support`}
+              description={$t`We couldn't validate MCP support at this URL, but you can still trust it.`}
             >
               <span
                 class="border-border-secondary text-fg-tertiary pointer-events-auto flex size-5 items-center justify-center rounded-full border"
-                aria-label={$t`Couldn't reach this connector`}
+                aria-label={$t`Couldn't validate MCP support`}
               >
                 <TriangleAlertIcon class="size-3" />
               </span>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -161,47 +161,56 @@
       </li>
     </ul>
 
-    <Input
-      bind:value={urlInput}
-      oninput={handleInput}
-      onblur={handleBlur}
-      label={$t`Connector URL`}
-      placeholder="https://mcp.example.com/mcp"
-      aria-label={$t`MCP server URL`}
-      error={errorText}
-      disabled={saving}
-      autocomplete="off"
-      autocapitalize="off"
-      spellcheck={false}
-      inputClass="pe-11 font-mono text-sm"
-    >
-      {#snippet trailing()}
-        {#if verifyState === "checking"}
-          <ProgressRing class="text-fg-tertiary size-5" />
-        {:else if verifyState === "ok"}
-          <Tooltip label={$t`Reachable MCP server`}>
-            <span
-              class="bg-bg-success-primary text-fg-success-primary pointer-events-auto flex size-5 items-center justify-center rounded-full"
-              aria-label={$t`Reachable MCP server`}
+    <div class="flex flex-col gap-1.5">
+      <span class="text-text-secondary text-sm font-medium">
+        {$t`Connector URL`}
+      </span>
+      <!-- The verify indicator is centered inside the field, so it's wrapped
+           with the input (not the label) in the positioning context. -->
+      <div class="relative">
+        <Input
+          bind:value={urlInput}
+          oninput={handleInput}
+          onblur={handleBlur}
+          placeholder="https://mcp.example.com/mcp"
+          aria-label={$t`MCP server URL`}
+          error={errorText}
+          disabled={saving}
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck={false}
+          inputClass="pe-11 font-mono text-sm"
+        />
+        <div
+          class="pointer-events-none absolute inset-y-0 inset-e-3 flex items-center"
+        >
+          {#if verifyState === "checking"}
+            <ProgressRing class="text-fg-tertiary size-5" />
+          {:else if verifyState === "ok"}
+            <Tooltip label={$t`Reachable MCP server`}>
+              <span
+                class="bg-bg-success-primary text-fg-success-primary pointer-events-auto flex size-5 items-center justify-center rounded-full"
+                aria-label={$t`Reachable MCP server`}
+              >
+                <CheckIcon class="size-3.5" />
+              </span>
+            </Tooltip>
+          {:else if verifyState === "unverified" && parsedUrl !== undefined}
+            <Tooltip
+              label={$t`Couldn't reach this connector`}
+              description={$t`We couldn't reach this URL to confirm it, but you can still trust it.`}
             >
-              <CheckIcon class="size-3.5" />
-            </span>
-          </Tooltip>
-        {:else if verifyState === "unverified" && parsedUrl !== undefined}
-          <Tooltip
-            label={$t`Couldn't reach this connector`}
-            description={$t`We couldn't reach this URL to confirm it, but you can still trust it.`}
-          >
-            <span
-              class="border-border-secondary text-fg-tertiary pointer-events-auto flex size-5 items-center justify-center rounded-full border"
-              aria-label={$t`Couldn't reach this connector`}
-            >
-              <TriangleAlertIcon class="size-3" />
-            </span>
-          </Tooltip>
-        {/if}
-      {/snippet}
-    </Input>
+              <span
+                class="border-border-secondary text-fg-tertiary pointer-events-auto flex size-5 items-center justify-center rounded-full border"
+                aria-label={$t`Couldn't reach this connector`}
+              >
+                <TriangleAlertIcon class="size-3" />
+              </span>
+            </Tooltip>
+          {/if}
+        </div>
+      </div>
+    </div>
 
     <HoldToConfirm
       label={$t`Hold to continue`}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -161,26 +161,21 @@
       </li>
     </ul>
 
-    <div class="relative">
-      <Input
-        bind:value={urlInput}
-        oninput={handleInput}
-        onblur={handleBlur}
-        label={$t`Connector URL`}
-        placeholder="https://mcp.example.com/mcp"
-        aria-label={$t`MCP server URL`}
-        error={errorText}
-        disabled={saving}
-        autocomplete="off"
-        autocapitalize="off"
-        spellcheck={false}
-        inputClass="pe-11 font-mono text-sm"
-      />
-
-      <span
-        class="pointer-events-none absolute inset-e-3 top-8 flex size-6 items-center justify-center"
-        aria-hidden={verifyState !== "ok" && verifyState !== "unverified"}
-      >
+    <Input
+      bind:value={urlInput}
+      oninput={handleInput}
+      onblur={handleBlur}
+      label={$t`Connector URL`}
+      placeholder="https://mcp.example.com/mcp"
+      aria-label={$t`MCP server URL`}
+      error={errorText}
+      disabled={saving}
+      autocomplete="off"
+      autocapitalize="off"
+      spellcheck={false}
+      inputClass="pe-11 font-mono text-sm"
+    >
+      {#snippet trailing()}
         {#if verifyState === "checking"}
           <ProgressRing class="text-fg-tertiary size-5" />
         {:else if verifyState === "ok"}
@@ -205,8 +200,8 @@
             </span>
           </Tooltip>
         {/if}
-      </span>
-    </div>
+      {/snippet}
+    </Input>
 
     <HoldToConfirm
       label={$t`Hold to continue`}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -40,18 +40,21 @@
     clearTimeout(debounceTimer);
   });
 
+  const normalizeUrl = (value: string): string =>
+    value.trim().replace(/\/+$/, "");
+
   const verify = async (url: string) => {
     verifyState = "checking";
     parsedUrl = url;
     const ok = await probeMcpServer(url);
-    if (!destroyed && urlInput.trim() === url) {
+    if (!destroyed && normalizeUrl(urlInput) === url) {
       verifyState = ok ? "ok" : "unverified";
     }
   };
 
   const handleInput = () => {
     clearTimeout(debounceTimer);
-    const trimmed = urlInput.trim();
+    const trimmed = normalizeUrl(urlInput);
     if (trimmed === "") {
       verifyState = "idle";
       parsedUrl = undefined;
@@ -88,7 +91,7 @@
   );
 
   const handleBlur = () => {
-    const trimmed = urlInput.trim();
+    const trimmed = normalizeUrl(urlInput);
     if (trimmed === "") return;
     if (parseMcpServerUrl(trimmed) === undefined) {
       verifyState = "invalid";

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+  import { TriangleAlertIcon, RotateCwIcon, CheckIcon } from "@lucide/svelte";
+  import Dialog from "$lib/components/ui/Dialog.svelte";
+  import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
+  import HoldToConfirm from "$lib/components/ui/HoldToConfirm.svelte";
+  import Input from "$lib/components/ui/Input.svelte";
+  import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
+  import Tooltip from "$lib/components/ui/Tooltip.svelte";
+  import McpIcon from "$lib/components/icons/McpIcon.svelte";
+  import { t } from "$lib/stores/locale.store";
+  import { parseMcpServerUrl, probeMcpServer } from "$lib/utils/mcpServer";
+
+  interface Props {
+    onClose: () => void;
+    onSave: (url: string) => void;
+    saving: boolean;
+  }
+
+  const { onClose, onSave, saving }: Props = $props();
+
+  // Verify state:
+  //  - "idle": nothing entered yet (or the user cleared it)
+  //  - "typing": input has content but hasn't been parsed as https yet
+  //  - "checking": a parsed https URL is being probed
+  //  - "ok": the probe succeeded — server speaks MCP
+  //  - "unverified": couldn't confirm it's an MCP server (advisory, still savable)
+  //  - "invalid": the URL isn't a valid https URL
+  type VerifyState =
+    | "idle"
+    | "typing"
+    | "checking"
+    | "ok"
+    | "unverified"
+    | "invalid";
+
+  let urlInput = $state("");
+  let verifyState = $state<VerifyState>("idle");
+  // The parsed URL from the most recent successful parse — what we actually
+  // save. Kept in sync with `urlInput` via the debounced verify.
+  let parsedUrl = $state<string | undefined>(undefined);
+
+  // Debounce the auto-verify so it doesn't fire on every keystroke. Cancelled
+  // if the user edits again before it starts, and a stale probe result won't
+  // land: `verify` guards on `parsed.url === urlInput` before assigning.
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const verify = async (url: string) => {
+    verifyState = "checking";
+    parsedUrl = url;
+    const ok = await probeMcpServer(url);
+    if (urlInput.trim() === url) {
+      verifyState = ok ? "ok" : "unverified";
+    }
+  };
+
+  const handleInput = () => {
+    clearTimeout(debounceTimer);
+    const trimmed = urlInput.trim();
+    if (trimmed === "") {
+      verifyState = "idle";
+      parsedUrl = undefined;
+      return;
+    }
+    const parsed = parseMcpServerUrl(trimmed);
+    if (parsed === undefined) {
+      verifyState = "typing";
+      parsedUrl = undefined;
+      return;
+    }
+    verifyState = "typing";
+    parsedUrl = undefined;
+    debounceTimer = setTimeout(() => {
+      void verify(parsed.url);
+    }, 500);
+  };
+
+  // Confirming is allowed as soon as the URL parses — the probe is advisory,
+  // matching the pre-revamp behaviour (a server that can't be probed for CORS
+  // reasons is still trustable). "checking" isn't confirmable because the
+  // parsed URL isn't stored yet.
+  const canConfirm = $derived(
+    !saving &&
+      parsedUrl !== undefined &&
+      (verifyState === "ok" || verifyState === "unverified"),
+  );
+
+  const handleConfirm = () => {
+    if (parsedUrl === undefined) return;
+    onSave(parsedUrl);
+  };
+
+  const errorText = $derived(
+    verifyState === "invalid"
+      ? $t`Enter a valid https URL (for example https://mcp.example.com/mcp).`
+      : undefined,
+  );
+
+  const handleBlur = () => {
+    const trimmed = urlInput.trim();
+    if (trimmed === "") return;
+    if (parseMcpServerUrl(trimmed) === undefined) {
+      verifyState = "invalid";
+    }
+  };
+</script>
+
+<Dialog {onClose} width="wider">
+  <div class="flex flex-col gap-5">
+    <FeaturedIcon size="lg" variant="info" class="self-start">
+      <McpIcon class="size-6" />
+    </FeaturedIcon>
+
+    <div class="flex flex-col gap-2">
+      <h2 class="text-text-primary text-xl font-medium">
+        {$t`Add AI access`}
+      </h2>
+      <p class="text-text-tertiary text-sm text-pretty">
+        {$t`To let AI ask questions and perform actions across your apps, add an MCP connector you trust.`}
+      </p>
+    </div>
+
+    <ul class="flex flex-col gap-4">
+      <li class="flex flex-row items-start gap-3">
+        <TriangleAlertIcon
+          class="text-fg-warning-primary mt-0.5 size-4.5 shrink-0"
+          aria-hidden="true"
+        />
+        <div class="flex flex-col gap-0.5 text-sm">
+          <span class="text-text-primary font-semibold">
+            {$t`Only add trusted connectors`}
+          </span>
+          <span class="text-text-tertiary">
+            {$t`Make sure the URL is from a source you trust.`}
+          </span>
+        </div>
+      </li>
+      <li class="flex flex-row items-start gap-3">
+        <RotateCwIcon
+          class="text-fg-secondary mt-0.5 size-4.5 shrink-0"
+          aria-hidden="true"
+        />
+        <div class="flex flex-col gap-0.5 text-sm">
+          <span class="text-text-primary font-semibold">
+            {$t`Revoke access anytime`}
+          </span>
+          <span class="text-text-tertiary">
+            {$t`Remove the connector to revoke AI access.`}
+          </span>
+        </div>
+      </li>
+    </ul>
+
+    <div class="relative">
+      <Input
+        bind:value={urlInput}
+        oninput={handleInput}
+        onblur={handleBlur}
+        label={$t`Connector URL`}
+        placeholder="https://mcp.example.com/mcp"
+        aria-label={$t`MCP server URL`}
+        error={errorText}
+        disabled={saving}
+        autocomplete="off"
+        autocapitalize="off"
+        spellcheck={false}
+        inputClass="pe-11 font-mono text-sm"
+      />
+
+      <span
+        class="pointer-events-none absolute inset-e-3 top-8 flex size-6 items-center justify-center"
+        aria-hidden={verifyState !== "ok" && verifyState !== "unverified"}
+      >
+        {#if verifyState === "checking"}
+          <ProgressRing class="text-fg-tertiary size-5" />
+        {:else if verifyState === "ok"}
+          <Tooltip label={$t`Reachable MCP server`}>
+            <span
+              class="bg-bg-success-primary text-fg-success-primary pointer-events-auto flex size-5 items-center justify-center rounded-full"
+              aria-label={$t`Reachable MCP server`}
+            >
+              <CheckIcon class="size-3.5" />
+            </span>
+          </Tooltip>
+        {:else if verifyState === "unverified" && parsedUrl !== undefined}
+          <Tooltip
+            label={$t`Couldn't verify this server`}
+            description={$t`We couldn't confirm this URL speaks MCP, but you can still trust it.`}
+          >
+            <span
+              class="border-border-secondary text-fg-tertiary pointer-events-auto flex size-5 items-center justify-center rounded-full border"
+              aria-label={$t`Couldn't verify this server`}
+            >
+              <TriangleAlertIcon class="size-3" />
+            </span>
+          </Tooltip>
+        {/if}
+      </span>
+    </div>
+
+    <HoldToConfirm
+      label={$t`Hold to continue`}
+      onComplete={handleConfirm}
+      class={canConfirm ? "" : "pointer-events-none opacity-60"}
+    />
+  </div>
+</Dialog>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import { TriangleAlertIcon, RotateCwIcon, CheckIcon } from "@lucide/svelte";
   import Dialog from "$lib/components/ui/Dialog.svelte";
   import FeaturedIcon from "$lib/components/ui/FeaturedIcon.svelte";
@@ -32,12 +33,18 @@
   let parsedUrl = $state<string | undefined>(undefined);
 
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  let destroyed = false;
+
+  onDestroy(() => {
+    destroyed = true;
+    clearTimeout(debounceTimer);
+  });
 
   const verify = async (url: string) => {
     verifyState = "checking";
     parsedUrl = url;
     const ok = await probeMcpServer(url);
-    if (urlInput.trim() === url) {
+    if (!destroyed && urlInput.trim() === url) {
       verifyState = ok ? "ok" : "unverified";
     }
   };
@@ -197,8 +204,8 @@
     <HoldToConfirm
       label={$t`Hold to continue`}
       variant="primary"
+      disabled={!canConfirm}
       onComplete={handleConfirm}
-      class={canConfirm ? "" : "pointer-events-none opacity-60"}
     />
   </div>
 </Dialog>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -7,6 +7,7 @@
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
   import McpIcon from "$lib/components/icons/McpIcon.svelte";
+  import { Trans } from "$lib/components/locale";
   import { t } from "$lib/stores/locale.store";
   import { parseMcpServerUrl, probeMcpServer } from "$lib/utils/mcpServer";
 
@@ -115,14 +116,24 @@
         {$t`Add AI access`}
       </h2>
       <p class="text-text-tertiary text-sm text-pretty">
-        {$t`To let AI ask questions and perform actions across your apps, add an MCP connector you trust.`}
+        <Trans>
+          To let AI ask questions and perform actions across your apps, add an
+          <a
+            href="https://modelcontextprotocol.io/docs/getting-started/intro"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-text-primary font-semibold hover:underline focus-visible:underline"
+          >
+            MCP connector
+          </a> you trust.
+        </Trans>
       </p>
     </div>
 
-    <ul class="flex flex-col gap-4">
+    <ul class="my-2 flex flex-col gap-5">
       <li class="flex flex-row items-start gap-3">
         <TriangleAlertIcon
-          class="text-fg-warning-primary mt-0.5 size-4.5 shrink-0"
+          class="text-fg-secondary mt-0.5 size-4.5 shrink-0"
           aria-hidden="true"
         />
         <div class="flex flex-col gap-0.5 text-sm">
@@ -183,12 +194,12 @@
           </Tooltip>
         {:else if verifyState === "unverified" && parsedUrl !== undefined}
           <Tooltip
-            label={$t`Couldn't verify this server`}
-            description={$t`We couldn't confirm this URL speaks MCP, but you can still trust it.`}
+            label={$t`Couldn't reach this connector`}
+            description={$t`We couldn't reach this URL to confirm it, but you can still trust it.`}
           >
             <span
               class="border-border-secondary text-fg-tertiary pointer-events-auto flex size-5 items-center justify-center rounded-full border"
-              aria-label={$t`Couldn't verify this server`}
+              aria-label={$t`Couldn't reach this connector`}
             >
               <TriangleAlertIcon class="size-3" />
             </span>
@@ -199,6 +210,7 @@
 
     <HoldToConfirm
       label={$t`Hold to continue`}
+      variant="primary"
       onComplete={handleConfirm}
       class={canConfirm ? "" : "pointer-events-none opacity-60"}
     />

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -19,13 +19,6 @@
 
   const { onClose, onSave, saving }: Props = $props();
 
-  // Verify state:
-  //  - "idle": nothing entered yet (or the user cleared it)
-  //  - "typing": input has content but hasn't been parsed as https yet
-  //  - "checking": a parsed https URL is being probed
-  //  - "ok": the probe succeeded — server speaks MCP
-  //  - "unverified": couldn't confirm it's an MCP server (advisory, still savable)
-  //  - "invalid": the URL isn't a valid https URL
   type VerifyState =
     | "idle"
     | "typing"
@@ -36,13 +29,8 @@
 
   let urlInput = $state("");
   let verifyState = $state<VerifyState>("idle");
-  // The parsed URL from the most recent successful parse — what we actually
-  // save. Kept in sync with `urlInput` via the debounced verify.
   let parsedUrl = $state<string | undefined>(undefined);
 
-  // Debounce the auto-verify so it doesn't fire on every keystroke. Cancelled
-  // if the user edits again before it starts, and a stale probe result won't
-  // land: `verify` guards on `parsed.url === urlInput` before assigning.
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
   const verify = async (url: string) => {
@@ -75,10 +63,6 @@
     }, 500);
   };
 
-  // Confirming is allowed as soon as the URL parses — the probe is advisory,
-  // matching the pre-revamp behaviour (a server that can't be probed for CORS
-  // reasons is still trustable). "checking" isn't confirmable because the
-  // parsed URL isn't stored yet.
   const canConfirm = $derived(
     !saving &&
       parsedUrl !== undefined &&
@@ -165,8 +149,6 @@
       <span class="text-text-secondary text-sm font-medium">
         {$t`Connector URL`}
       </span>
-      <!-- The verify indicator is centered inside the field, so it's wrapped
-           with the input (not the label) in the positioning context. -->
       <div class="relative">
         <Input
           bind:value={urlInput}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpAddConnectorDialog.svelte
@@ -14,11 +14,10 @@
 
   interface Props {
     onClose: () => void;
-    onSave: (url: string) => void;
-    saving: boolean;
+    onSave: (url: string) => Promise<void>;
   }
 
-  const { onClose, onSave, saving }: Props = $props();
+  const { onClose, onSave }: Props = $props();
 
   type VerifyState =
     | "idle"
@@ -31,6 +30,7 @@
   let urlInput = $state("");
   let verifyState = $state<VerifyState>("idle");
   let parsedUrl = $state<string | undefined>(undefined);
+  let saving = $state(false);
 
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
   let destroyed = false;
@@ -79,9 +79,14 @@
       (verifyState === "ok" || verifyState === "unverified"),
   );
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     if (parsedUrl === undefined) return;
-    onSave(parsedUrl);
+    saving = true;
+    try {
+      await onSave(parsedUrl);
+    } finally {
+      saving = false;
+    }
   };
 
   const errorText = $derived(
@@ -208,7 +213,7 @@
       label={$t`Hold to continue`}
       variant="primary"
       disabled={!canConfirm}
-      onComplete={handleConfirm}
+      onComplete={() => void handleConfirm()}
     />
   </div>
 </Dialog>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -12,7 +12,6 @@
   import {
     readMcpConfig,
     setMcpEnabled,
-    setMcpTrustedServer,
     trustAndEnableMcp,
     clearAndDisableMcp,
   } from "$lib/utils/mcpConfig";
@@ -34,10 +33,7 @@
   // True until the initial config read completes, so the toggle doesn't flicker
   // off-then-on and writes can't race the load.
   let loaded = $state(false);
-  let saving = $state(false);
-
   let showAdd = $state(false);
-  let enableOnSave = $state(false);
 
   const hostOf = (url: string): string => {
     try {
@@ -71,7 +67,6 @@
     const next = enabled;
     if (next && trusted === undefined) {
       enabled = false;
-      enableOnSave = true;
       showAdd = true;
       return;
     }
@@ -86,40 +81,21 @@
     }
   };
 
-  const openAdd = () => {
-    enableOnSave = !enabled;
-    showAdd = true;
-  };
-
   const handleAddClose = () => {
     showAdd = false;
-    enableOnSave = false;
   };
 
   const handleAddSave = async (url: string) => {
-    const enableNow = enableOnSave;
-    saving = true;
     try {
-      if (enableNow) {
-        await trustAndEnableMcp($authenticatedStore.actor, identityNumber, url);
-        enabled = true;
-      } else {
-        await setMcpTrustedServer(
-          $authenticatedStore.actor,
-          identityNumber,
-          url,
-        );
-      }
+      await trustAndEnableMcp($authenticatedStore.actor, identityNumber, url);
+      enabled = true;
       trusted = url;
       showAdd = false;
-      enableOnSave = false;
     } catch {
       toaster.error({
         title: $t`Couldn't save your trusted server. Please try again.`,
         duration: 4000,
       });
-    } finally {
-      saving = false;
     }
   };
 
@@ -226,23 +202,11 @@
             </button>
           </Tooltip>
         </div>
-      {:else}
-        <button
-          class="btn btn-secondary btn-sm w-full sm:w-auto"
-          onclick={openAdd}
-          disabled={saving}
-        >
-          {$t`Add connector`}
-        </button>
       {/if}
     </div>
   {/if}
 </section>
 
 {#if showAdd}
-  <McpAddConnectorDialog
-    onClose={handleAddClose}
-    onSave={handleAddSave}
-    {saving}
-  />
+  <McpAddConnectorDialog onClose={handleAddClose} onSave={handleAddSave} />
 {/if}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -236,9 +236,7 @@
 
   {#if enabled}
     <div class="border-border-tertiary mt-5 border-t pt-4">
-      <p
-        class="text-text-tertiary mb-3 text-xs font-semibold tracking-wider uppercase"
-      >
+      <p class="text-text-tertiary mb-3 text-xs font-semibold">
         {$t`Trusted connectors`}
       </p>
 
@@ -253,7 +251,7 @@
             <GlobeIcon class="size-4.5" />
           </span>
 
-          <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div class="flex min-w-0 flex-1 flex-col gap-1.5">
             <div class="flex flex-row flex-wrap items-center gap-x-2 gap-y-1">
               <span class="text-text-primary truncate text-sm font-semibold">
                 {hostOf(trusted)}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -1,20 +1,12 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import {
-    PlusIcon,
-    XIcon,
-    RotateCwIcon,
-    TriangleAlertIcon,
-  } from "@lucide/svelte";
+  import { GlobeIcon, Trash2Icon } from "@lucide/svelte";
   import McpIcon from "$lib/components/icons/McpIcon.svelte";
-  import Input from "$lib/components/ui/Input.svelte";
   import Badge from "$lib/components/ui/Badge.svelte";
   import Toggle from "$lib/components/ui/Toggle.svelte";
   import Tooltip from "$lib/components/ui/Tooltip.svelte";
-  import Ellipsis from "$lib/components/utils/Ellipsis.svelte";
   import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { toaster } from "$lib/components/utils/toaster";
-  import { Trans } from "$lib/components/locale";
   import { t } from "$lib/stores/locale.store";
   import { authenticatedStore } from "$lib/stores/authentication.store";
   import {
@@ -23,7 +15,7 @@
     setMcpTrustedServer,
     clearMcpTrustedServer,
   } from "$lib/utils/mcpConfig";
-  import { parseMcpServerUrl, probeMcpServer } from "$lib/utils/mcpServer";
+  import McpAddConnectorDialog from "./McpAddConnectorDialog.svelte";
 
   interface Props {
     identityNumber: bigint;
@@ -41,15 +33,13 @@
   // True until the initial config read completes, so the toggle doesn't flicker
   // off-then-on and writes can't race the load.
   let loaded = $state(false);
-  // A canister write (toggle / add / remove) is in flight.
+  // A canister write (toggle / clear) is in flight.
   let saving = $state(false);
 
-  let urlInput = $state("");
-  let error = $state<string | undefined>();
-  // Live MCP status of the trusted server: undefined while unknown / in flight,
-  // true when it verified as MCP, false when it couldn't be.
-  let verified = $state<boolean | undefined>(undefined);
-  let checking = $state(false);
+  // When true, the Add dialog is open. `enableOnSave` means confirming will
+  // also flip the master toggle on (the "turning on with no server yet" path).
+  let showAdd = $state(false);
+  let enableOnSave = $state(false);
 
   const hostOf = (url: string): string => {
     try {
@@ -59,32 +49,6 @@
     }
   };
 
-  // Probe the trusted server for a real MCP endpoint. Best-effort and advisory:
-  // a server we can't reach/read (e.g. CORS) shows as unverified but stays
-  // active. Guard against a stale result if the entry changed while in flight.
-  // `notify` surfaces a success toast for explicit checks (add / re-check), not
-  // the silent check on page load.
-  const verify = async (options?: { notify?: boolean }) => {
-    const url = trusted;
-    if (url === undefined) {
-      return;
-    }
-    checking = true;
-    const ok = await probeMcpServer(url);
-    if (trusted === url) {
-      verified = ok;
-      if (ok && options?.notify === true) {
-        toaster.success({
-          title: $t`Verified ${hostOf(url)} as an MCP server.`,
-          duration: 4000,
-        });
-      }
-    }
-    checking = false;
-  };
-
-  // Load the synced config when the section opens, then verify a server that is
-  // already set (and enabled).
   onMount(() => {
     void (async () => {
       try {
@@ -102,9 +66,6 @@
       } finally {
         loaded = true;
       }
-      if (enabled && trusted !== undefined) {
-        void verify();
-      }
     })();
   });
 
@@ -113,14 +74,26 @@
       return;
     }
     const next = event.currentTarget.checked;
+    // Turning on with no trusted server yet: don't write anything. Open the
+    // Add dialog and let its confirm flip the master toggle atomically after
+    // the URL is saved. Revert the visual toggle immediately so it doesn't
+    // flash on while the dialog is up.
+    if (next && trusted === undefined) {
+      event.currentTarget.checked = false;
+      enableOnSave = true;
+      showAdd = true;
+      return;
+    }
     const previous = enabled;
     enabled = next; // optimistic; reverted below if the write fails
     saving = true;
     try {
       await setMcpEnabled($authenticatedStore.actor, identityNumber, next);
-      // Re-check a previously-set server when re-enabling.
-      if (next && trusted !== undefined) {
-        void verify({ notify: true });
+      if (!next) {
+        toaster.info({
+          title: $t`AI access is off.`,
+          duration: 4000,
+        });
       }
     } catch {
       enabled = previous;
@@ -133,26 +106,47 @@
     }
   };
 
-  const handleAdd = async () => {
-    error = undefined;
-    const parsed = parseMcpServerUrl(urlInput);
-    if (parsed === undefined) {
-      error = $t`Enter a valid https URL (for example https://mcp.example.com/mcp).`;
-      return;
-    }
+  const openAdd = () => {
+    enableOnSave = !enabled;
+    showAdd = true;
+  };
+
+  const handleAddClose = () => {
+    showAdd = false;
+    enableOnSave = false;
+  };
+
+  // Save the URL from the Add dialog. If we entered via "toggle on with no
+  // server", also flip the master toggle in the same canister round-trip so
+  // the two writes can't disagree.
+  const handleAddSave = async (url: string) => {
     saving = true;
     try {
-      await setMcpTrustedServer(
-        $authenticatedStore.actor,
-        identityNumber,
-        parsed.url,
-      );
-      // Activate (verification is advisory): the server is trusted even if the
-      // probe can't confirm it speaks MCP.
-      trusted = parsed.url;
-      urlInput = "";
-      verified = undefined;
-      await verify({ notify: true });
+      if (enableOnSave) {
+        await setMcpTrustedServer(
+          $authenticatedStore.actor,
+          identityNumber,
+          url,
+        );
+        await setMcpEnabled($authenticatedStore.actor, identityNumber, true);
+        trusted = url;
+        enabled = true;
+      } else {
+        await setMcpTrustedServer(
+          $authenticatedStore.actor,
+          identityNumber,
+          url,
+        );
+        trusted = url;
+      }
+      showAdd = false;
+      enableOnSave = false;
+      toaster.success({
+        title: enabled
+          ? $t`You're all set. AI access is on with ${hostOf(url)}.`
+          : $t`${hostOf(url)} has been added.`,
+        duration: 4000,
+      });
     } catch {
       toaster.error({
         title: $t`Couldn't save your trusted server. Please try again.`,
@@ -163,19 +157,27 @@
     }
   };
 
-  const handleKeydown = (event: KeyboardEvent) => {
-    if (event.key === "Enter" && !checking && !saving) {
-      event.preventDefault();
-      void handleAdd();
-    }
-  };
-
+  // Removing the only trusted server. If MCP was enabled, turn it off too:
+  // an enabled config with no URL can't gate anything, so the two writes are
+  // paired.
   const handleRemove = async () => {
+    if (trusted === undefined) return;
+    const previousHost = hostOf(trusted);
+    const wasEnabled = enabled;
     saving = true;
     try {
       await clearMcpTrustedServer($authenticatedStore.actor, identityNumber);
       trusted = undefined;
-      verified = undefined;
+      if (wasEnabled) {
+        await setMcpEnabled($authenticatedStore.actor, identityNumber, false);
+        enabled = false;
+      }
+      toaster.info({
+        title: wasEnabled
+          ? $t`${previousHost} was removed. AI access is now off.`
+          : $t`${previousHost} was removed.`,
+        duration: 4000,
+      });
     } catch {
       toaster.error({
         title: $t`Couldn't remove the server. Please try again.`,
@@ -188,30 +190,38 @@
 </script>
 
 <section
-  class="border-border-secondary bg-bg-secondary flex flex-col gap-4 rounded-xl border p-4 sm:p-5"
+  class="border-border-secondary bg-bg-secondary flex flex-col rounded-xl border p-4 sm:p-5"
 >
   <div class="flex flex-row items-start gap-3 sm:gap-4">
     <span
-      class="border-border-tertiary text-fg-secondary bg-bg-primary flex size-10 shrink-0 items-center justify-center rounded-lg border"
+      class="border-border-tertiary text-fg-secondary bg-bg-primary flex size-12 shrink-0 items-center justify-center rounded-lg border"
       aria-hidden="true"
     >
-      <McpIcon class="size-5" />
+      <McpIcon class="size-5.5" />
     </span>
 
-    <div
-      class="flex min-h-[2.5rem] min-w-0 flex-1 flex-row flex-wrap items-center gap-x-2 gap-y-1"
-    >
-      <h3 id={titleId} class="text-text-primary text-base font-semibold">
-        {$t`Trusted MCP server`}
-      </h3>
-      {#if enabled && trusted !== undefined}
-        <Badge color="success" size="sm" dot>
-          {$t`Enabled on all your devices`}
+    <div class="flex min-w-0 flex-1 flex-col gap-1">
+      <div
+        class="flex min-h-[1.5rem] flex-row flex-wrap items-center gap-x-2 gap-y-1"
+      >
+        <h3 id={titleId} class="text-text-primary text-base font-semibold">
+          {$t`AI access`}
+        </h3>
+        <Badge color="surface" size="sm">
+          {$t`Preview`}
         </Badge>
-      {/if}
+        {#if enabled && trusted !== undefined}
+          <Badge color="success" size="sm" dot>
+            {$t`Enabled on all devices`}
+          </Badge>
+        {/if}
+      </div>
+      <p class="text-text-tertiary text-sm">
+        {$t`Ask questions and perform actions across your apps by chatting with AI.`}
+      </p>
     </div>
 
-    <div class="flex h-10 shrink-0 items-center">
+    <div class="flex h-6 shrink-0 items-center">
       {#if loaded}
         <Toggle
           checked={enabled}
@@ -225,112 +235,77 @@
     </div>
   </div>
 
-  <div
-    class="border-fg-warning-primary bg-bg-warning-primary text-fg-warning-primary flex flex-row items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium"
-  >
-    <TriangleAlertIcon class="size-4 shrink-0" />
-    <span>
-      {$t`Internet Identity MCP connectors are in preview. Use this feature at your own risk.`}
-    </span>
-  </div>
-
   {#if enabled}
-    <p class="text-text-tertiary text-sm">
-      <Trans>
-        Set the URL of an MCP server you trust. You will be able to add MCP
-        connectors to your AI agents that will then act on your behalf across
-        apps. This setting syncs across your devices.
-      </Trans>
-    </p>
-
-    {#if trusted !== undefined}
-      <div
-        class="border-border-secondary bg-bg-primary flex flex-row items-center gap-2 rounded-lg border px-3 py-2.5 sm:gap-3 sm:px-4"
+    <div class="border-border-tertiary mt-5 border-t pt-4">
+      <p
+        class="text-text-tertiary mb-3 text-xs font-semibold tracking-wider uppercase"
       >
-        <span class="text-text-primary min-w-0 flex-1 text-sm font-medium">
-          <Ellipsis text={trusted} position="middle" />
-        </span>
+        {$t`Trusted connectors`}
+      </p>
 
-        {#if !checking}
-          <Tooltip
-            label={verified === true
-              ? $t`Verified MCP server`
-              : verified === false
-                ? $t`Couldn't verify this server`
-                : $t`Not checked yet`}
-          >
-            <span
-              class={[
-                "size-2.5 shrink-0 rounded-full",
-                verified === true
-                  ? "bg-fg-success-primary"
-                  : verified === false
-                    ? "bg-fg-error-primary"
-                    : "bg-fg-quaternary",
-              ]}
-            ></span>
-          </Tooltip>
-        {/if}
-
-        <Tooltip label={$t`Re-check connection`}>
-          <button
-            class="btn btn-tertiary btn-sm btn-icon shrink-0"
-            onclick={() => void verify({ notify: true })}
-            disabled={checking}
-            aria-label={$t`Re-check connection`}
-          >
-            {#if checking}
-              <ProgressRing class="size-5" />
-            {:else}
-              <RotateCwIcon class="size-5" />
-            {/if}
-          </button>
-        </Tooltip>
-
-        <Tooltip label={$t`Remove this server`}>
-          <button
-            class="btn btn-tertiary btn-sm btn-icon shrink-0"
-            onclick={handleRemove}
-            disabled={saving}
-            aria-label={$t`Remove this server`}
-          >
-            <XIcon class="size-5" />
-          </button>
-        </Tooltip>
-      </div>
-
-      {#if verified === false && !checking}
-        <p class="text-text-tertiary text-sm">
-          {$t`Couldn't verify an MCP server at this URL. Please check the URL and that the server is running and retry.`}
-        </p>
-      {/if}
-    {:else}
-      <div class="flex flex-col gap-2 sm:flex-row sm:items-start">
-        <Input
-          bind:value={urlInput}
-          onkeydown={handleKeydown}
-          class="w-full min-w-0 sm:flex-1"
-          placeholder="https://mcp.example.com/mcp"
-          aria-label={$t`MCP server URL`}
-          {error}
-          disabled={saving}
-          autocomplete="off"
-          autocapitalize="off"
-          spellcheck={false}
-        />
-        <button
-          class="btn btn-secondary h-11 w-full sm:w-auto sm:shrink-0"
-          onclick={handleAdd}
-          disabled={urlInput.trim() === "" || saving}
+      {#if trusted !== undefined}
+        <div
+          class="border-border-tertiary bg-bg-primary flex flex-row items-center gap-3 rounded-lg border px-3 py-3 sm:px-4"
         >
-          {#if saving}
-            <ProgressRing class="size-5" />
-          {:else}
-            <PlusIcon class="size-5" />
-          {/if}
-          <span>{$t`Trust this server`}</span>
+          <span
+            class="border-border-secondary bg-bg-secondary text-fg-tertiary flex size-10 shrink-0 items-center justify-center rounded-md border"
+            aria-hidden="true"
+          >
+            <GlobeIcon class="size-4.5" />
+          </span>
+
+          <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+            <div class="flex flex-row flex-wrap items-center gap-x-2 gap-y-1">
+              <span class="text-text-primary truncate text-sm font-semibold">
+                {hostOf(trusted)}
+              </span>
+              <Tooltip
+                label={$t`Custom connector`}
+                description={$t`You added this server yourself. Only keep it if you fully trust it.`}
+              >
+                <span
+                  class="border-border-secondary text-text-tertiary inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold"
+                >
+                  {$t`Custom`}
+                </span>
+              </Tooltip>
+            </div>
+            <span
+              class="text-text-tertiary truncate font-mono text-xs"
+              title={trusted}
+            >
+              {trusted}
+            </span>
+          </div>
+
+          <Tooltip label={$t`Remove this server`}>
+            <button
+              class="btn btn-tertiary btn-sm btn-icon shrink-0"
+              onclick={handleRemove}
+              disabled={saving}
+              aria-label={$t`Remove this server`}
+            >
+              <Trash2Icon class="size-4.5" />
+            </button>
+          </Tooltip>
+        </div>
+      {:else}
+        <button
+          class="btn btn-secondary btn-sm w-full sm:w-auto"
+          onclick={openAdd}
+          disabled={saving}
+        >
+          {$t`Add connector`}
         </button>
-      </div>
-    {/if}
+      {/if}
+    </div>
   {/if}
 </section>
+
+{#if showAdd}
+  <McpAddConnectorDialog
+    onClose={handleAddClose}
+    onSave={handleAddSave}
+    {saving}
+  />
+{/if}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -77,10 +77,6 @@
     }
     try {
       await setMcpEnabled($authenticatedStore.actor, identityNumber, next);
-      toaster.info({
-        title: next ? $t`AI access is on.` : $t`AI access is off.`,
-        duration: 4000,
-      });
     } catch {
       enabled = !next;
       toaster.error({

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -158,10 +158,10 @@
 >
   <div class="flex flex-row items-start gap-3 sm:gap-4">
     <span
-      class="border-border-tertiary text-fg-secondary bg-bg-primary flex size-12 shrink-0 items-center justify-center rounded-lg border"
+      class="border-border-tertiary text-fg-secondary bg-bg-primary flex size-10 shrink-0 items-center justify-center rounded-lg border"
       aria-hidden="true"
     >
-      <BotIcon class="size-5.5" />
+      <BotIcon class="size-5" />
     </span>
 
     <div class="flex min-w-0 flex-1 flex-col gap-1">

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -13,7 +13,7 @@
     readMcpConfig,
     setMcpEnabled,
     setMcpTrustedServer,
-    clearMcpTrustedServer,
+    clearAndDisableMcp,
   } from "$lib/utils/mcpConfig";
   import McpAddConnectorDialog from "./McpAddConnectorDialog.svelte";
 
@@ -157,28 +157,27 @@
     }
   };
 
-  // Removing the only trusted server. If MCP was enabled, turn it off too:
-  // an enabled config with no URL can't gate anything, so the two writes are
-  // paired.
+  // Removing the only trusted server also turns the feature off: an enabled
+  // config with no URL can't gate anything. Both are cleared in one atomic
+  // write, and the UI collapses optimistically so no "add connector" state
+  // flashes between the two — reverted together if the write fails.
   const handleRemove = async () => {
     if (trusted === undefined) return;
+    const previousUrl = trusted;
     const previousHost = hostOf(trusted);
-    const wasEnabled = enabled;
+    const previousEnabled = enabled;
+    trusted = undefined;
+    enabled = false;
     saving = true;
     try {
-      await clearMcpTrustedServer($authenticatedStore.actor, identityNumber);
-      trusted = undefined;
-      if (wasEnabled) {
-        await setMcpEnabled($authenticatedStore.actor, identityNumber, false);
-        enabled = false;
-      }
+      await clearAndDisableMcp($authenticatedStore.actor, identityNumber);
       toaster.info({
-        title: wasEnabled
-          ? $t`${previousHost} was removed. AI access is now off.`
-          : $t`${previousHost} was removed.`,
+        title: $t`${previousHost} was removed. AI access is now off.`,
         duration: 4000,
       });
     } catch {
+      trusted = previousUrl;
+      enabled = previousEnabled;
       toaster.error({
         title: $t`Couldn't remove the server. Please try again.`,
         duration: 4000,
@@ -261,7 +260,7 @@
               </span>
               <Tooltip
                 label={$t`Custom connector`}
-                description={$t`You added this server yourself. Only keep it if you fully trust it.`}
+                description={$t`You added this connector yourself. Only keep it if you fully trust it.`}
               >
                 <span
                   class="border-border-secondary text-text-tertiary inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold"
@@ -278,7 +277,7 @@
             </span>
           </div>
 
-          <Tooltip label={$t`Remove this server`}>
+          <Tooltip label={$t`Remove`}>
             <button
               class="btn btn-tertiary btn-sm btn-icon shrink-0"
               onclick={handleRemove}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -220,21 +220,9 @@
           </span>
 
           <div class="flex min-w-0 flex-1 flex-col gap-1.5">
-            <div class="flex flex-row flex-wrap items-center gap-x-2 gap-y-1">
-              <span class="text-text-primary truncate text-sm font-semibold">
-                {hostOf(trusted)}
-              </span>
-              <Tooltip
-                label={$t`Custom connector`}
-                description={$t`You added this connector yourself. Only keep it if you fully trust it.`}
-              >
-                <span
-                  class="border-border-secondary text-text-tertiary inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold"
-                >
-                  {$t`Custom`}
-                </span>
-              </Tooltip>
-            </div>
+            <span class="text-text-primary truncate text-sm font-semibold">
+              {hostOf(trusted)}
+            </span>
             <span
               class="text-text-tertiary truncate font-mono text-xs"
               title={trusted}

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -33,11 +33,8 @@
   // True until the initial config read completes, so the toggle doesn't flicker
   // off-then-on and writes can't race the load.
   let loaded = $state(false);
-  // A canister write (toggle / clear) is in flight.
   let saving = $state(false);
 
-  // When true, the Add dialog is open. `enableOnSave` means confirming will
-  // also flip the master toggle on (the "turning on with no server yet" path).
   let showAdd = $state(false);
   let enableOnSave = $state(false);
 
@@ -74,10 +71,6 @@
       return;
     }
     const next = event.currentTarget.checked;
-    // Turning on with no trusted server yet: don't write anything. Open the
-    // Add dialog and let its confirm flip the master toggle atomically after
-    // the URL is saved. Revert the visual toggle immediately so it doesn't
-    // flash on while the dialog is up.
     if (next && trusted === undefined) {
       event.currentTarget.checked = false;
       enableOnSave = true;
@@ -116,9 +109,6 @@
     enableOnSave = false;
   };
 
-  // Save the URL from the Add dialog. If we entered via "toggle on with no
-  // server", also flip the master toggle in the same canister round-trip so
-  // the two writes can't disagree.
   const handleAddSave = async (url: string) => {
     saving = true;
     try {
@@ -157,10 +147,6 @@
     }
   };
 
-  // Removing the only trusted server also turns the feature off: an enabled
-  // config with no URL can't gate anything. Both are cleared in one atomic
-  // write, and the UI collapses optimistically so no "add connector" state
-  // flashes between the two — reverted together if the write fails.
   const handleRemove = async () => {
     if (trusted === undefined) return;
     const previousUrl = trusted;

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -112,22 +112,11 @@
   const handleAddSave = async (url: string) => {
     saving = true;
     try {
+      await setMcpTrustedServer($authenticatedStore.actor, identityNumber, url);
+      trusted = url;
       if (enableOnSave) {
-        await setMcpTrustedServer(
-          $authenticatedStore.actor,
-          identityNumber,
-          url,
-        );
         await setMcpEnabled($authenticatedStore.actor, identityNumber, true);
-        trusted = url;
         enabled = true;
-      } else {
-        await setMcpTrustedServer(
-          $authenticatedStore.actor,
-          identityNumber,
-          url,
-        );
-        trusted = url;
       }
       showAdd = false;
       enableOnSave = false;

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -113,12 +113,6 @@
       trusted = url;
       showAdd = false;
       enableOnSave = false;
-      toaster.success({
-        title: enableNow
-          ? $t`You're all set. AI access is on with ${hostOf(url)}.`
-          : $t`${hostOf(url)} has been added.`,
-        duration: 4000,
-      });
     } catch {
       toaster.error({
         title: $t`Couldn't save your trusted server. Please try again.`,
@@ -132,16 +126,11 @@
   const handleRemove = async () => {
     if (trusted === undefined) return;
     const previousUrl = trusted;
-    const previousHost = hostOf(trusted);
     const previousEnabled = enabled;
     trusted = undefined;
     enabled = false;
     try {
       await clearAndDisableMcp($authenticatedStore.actor, identityNumber);
-      toaster.info({
-        title: $t`${previousHost} was removed. AI access is now off.`,
-        duration: 4000,
-      });
     } catch {
       trusted = previousUrl;
       enabled = previousEnabled;

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { GlobeIcon, Trash2Icon } from "@lucide/svelte";
+  import { BotIcon, Trash2Icon } from "@lucide/svelte";
   import McpIcon from "$lib/components/icons/McpIcon.svelte";
   import Badge from "$lib/components/ui/Badge.svelte";
   import Toggle from "$lib/components/ui/Toggle.svelte";
@@ -165,7 +165,7 @@
       class="border-border-tertiary text-fg-secondary bg-bg-primary flex size-12 shrink-0 items-center justify-center rounded-lg border"
       aria-hidden="true"
     >
-      <McpIcon class="size-5.5" />
+      <BotIcon class="size-5.5" />
     </span>
 
     <div class="flex min-w-0 flex-1 flex-col gap-1">
@@ -216,7 +216,7 @@
             class="border-border-secondary bg-bg-secondary text-fg-tertiary flex size-10 shrink-0 items-center justify-center rounded-md border"
             aria-hidden="true"
           >
-            <GlobeIcon class="size-4.5" />
+            <McpIcon class="size-4.5" />
           </span>
 
           <div class="flex min-w-0 flex-1 flex-col gap-1.5">

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -67,36 +67,26 @@
     })();
   });
 
-  const handleToggle = async (event: Event) => {
-    if (!(event.currentTarget instanceof HTMLInputElement)) {
-      return;
-    }
-    const next = event.currentTarget.checked;
+  const handleToggle = async () => {
+    const next = enabled;
     if (next && trusted === undefined) {
-      event.currentTarget.checked = false;
+      enabled = false;
       enableOnSave = true;
       showAdd = true;
       return;
     }
-    const previous = enabled;
-    enabled = next; // optimistic; reverted below if the write fails
-    saving = true;
     try {
       await setMcpEnabled($authenticatedStore.actor, identityNumber, next);
-      if (!next) {
-        toaster.info({
-          title: $t`AI access is off.`,
-          duration: 4000,
-        });
-      }
+      toaster.info({
+        title: next ? $t`AI access is on.` : $t`AI access is off.`,
+        duration: 4000,
+      });
     } catch {
-      enabled = previous;
+      enabled = !next;
       toaster.error({
         title: $t`Couldn't save your change. Please try again.`,
         duration: 4000,
       });
-    } finally {
-      saving = false;
     }
   };
 
@@ -111,9 +101,10 @@
   };
 
   const handleAddSave = async (url: string) => {
+    const enableNow = enableOnSave;
     saving = true;
     try {
-      if (enableOnSave) {
+      if (enableNow) {
         await trustAndEnableMcp($authenticatedStore.actor, identityNumber, url);
         enabled = true;
       } else {
@@ -127,7 +118,7 @@
       showAdd = false;
       enableOnSave = false;
       toaster.success({
-        title: enabled
+        title: enableNow
           ? $t`You're all set. AI access is on with ${hostOf(url)}.`
           : $t`${hostOf(url)} has been added.`,
         duration: 4000,
@@ -149,7 +140,6 @@
     const previousEnabled = enabled;
     trusted = undefined;
     enabled = false;
-    saving = true;
     try {
       await clearAndDisableMcp($authenticatedStore.actor, identityNumber);
       toaster.info({
@@ -163,8 +153,6 @@
         title: $t`Couldn't remove the server. Please try again.`,
         duration: 4000,
       });
-    } finally {
-      saving = false;
     }
   };
 </script>
@@ -204,9 +192,8 @@
     <div class="flex h-6 shrink-0 items-center">
       {#if loaded}
         <Toggle
-          checked={enabled}
+          bind:checked={enabled}
           onchange={handleToggle}
-          disabled={saving}
           aria-labelledby={titleId}
         />
       {:else}
@@ -260,7 +247,6 @@
             <button
               class="btn btn-tertiary btn-sm btn-icon shrink-0"
               onclick={handleRemove}
-              disabled={saving}
               aria-label={$t`Remove this server`}
             >
               <Trash2Icon class="size-4.5" />

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -13,6 +13,7 @@
     readMcpConfig,
     setMcpEnabled,
     setMcpTrustedServer,
+    trustAndEnableMcp,
     clearAndDisableMcp,
   } from "$lib/utils/mcpConfig";
   import McpAddConnectorDialog from "./McpAddConnectorDialog.svelte";
@@ -112,12 +113,17 @@
   const handleAddSave = async (url: string) => {
     saving = true;
     try {
-      await setMcpTrustedServer($authenticatedStore.actor, identityNumber, url);
-      trusted = url;
       if (enableOnSave) {
-        await setMcpEnabled($authenticatedStore.actor, identityNumber, true);
+        await trustAndEnableMcp($authenticatedStore.actor, identityNumber, url);
         enabled = true;
+      } else {
+        await setMcpTrustedServer(
+          $authenticatedStore.actor,
+          identityNumber,
+          url,
+        );
       }
+      trusted = url;
       showAdd = false;
       enableOnSave = false;
       toaster.success({

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -60,9 +60,6 @@ const insecureFetch: typeof fetch = (url, options = {}) =>
 const permissionsString = (permissions: Permissions): string =>
   "queries" in permissions ? "queries" : "all";
 
-/** Press-and-hold a HoldToConfirm button until it fires its `onComplete`. The
- *  in-app component's default duration is 2.5 s; give it a little extra so the
- *  first animation frame after mousedown doesn't cut it. */
 const holdConfirm = async (page: Page, name: string): Promise<void> => {
   const button = page.getByRole("button", { name });
   await button.waitFor({ state: "visible" });
@@ -397,10 +394,6 @@ export const test = base.extend<{ mcp: McpFixture }>({
       }
       await page.locator('a[href="/manage/settings"]').click();
       await page.waitForURL(`${II_URL}/manage/settings`);
-      // Toggling AI access on with no server yet opens the Add-connector
-      // dialog; fill the URL there and hold the confirm button to save.
-      // A trusted-server row (carrying the Remove button) appears once the
-      // write to the canister lands.
       await page.getByRole("switch", { name: "AI access" }).check();
       await page.getByLabel("MCP server URL").fill(`${MCP_SERVER_ORIGIN}/mcp`);
       await holdConfirm(page, "Hold to continue");

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -60,6 +60,22 @@ const insecureFetch: typeof fetch = (url, options = {}) =>
 const permissionsString = (permissions: Permissions): string =>
   "queries" in permissions ? "queries" : "all";
 
+/** Press-and-hold a HoldToConfirm button until it fires its `onComplete`. The
+ *  in-app component's default duration is 2.5 s; give it a little extra so the
+ *  first animation frame after mousedown doesn't cut it. */
+const holdConfirm = async (page: Page, name: string): Promise<void> => {
+  const button = page.getByRole("button", { name });
+  await button.waitFor({ state: "visible" });
+  const box = await button.boundingBox();
+  if (box === null) {
+    throw new Error(`hold target "${name}" has no bounding box`);
+  }
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.waitForTimeout(2800);
+  await page.mouse.up();
+};
+
 /** The outcome the connect reports once the server redeems the registration
  *  delegation: the state echo, the session grant's expiration (ns since epoch,
  *  as a decimal string — the value overflows JSON numbers), and the session's
@@ -381,11 +397,13 @@ export const test = base.extend<{ mcp: McpFixture }>({
       }
       await page.locator('a[href="/manage/settings"]').click();
       await page.waitForURL(`${II_URL}/manage/settings`);
-      // The URL box only appears once the master toggle is on; the remove button
-      // appears once the trusted server is saved to the canister.
-      await page.getByRole("switch", { name: "Trusted MCP server" }).check();
+      // Toggling AI access on with no server yet opens the Add-connector
+      // dialog; fill the URL there and hold the confirm button to save.
+      // A trusted-server row (carrying the Remove button) appears once the
+      // write to the canister lands.
+      await page.getByRole("switch", { name: "AI access" }).check();
       await page.getByLabel("MCP server URL").fill(`${MCP_SERVER_ORIGIN}/mcp`);
-      await page.getByRole("button", { name: "Trust this server" }).click();
+      await holdConfirm(page, "Hold to continue");
       await page
         .getByRole("button", { name: "Remove this server" })
         .waitFor({ state: "visible" });

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -6,7 +6,7 @@ import {
 import { Actor, HttpAgent } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
 import { Agent as UndiciAgent } from "undici";
-import { test as base, type Page } from "@playwright/test";
+import { expect, test as base, type Page } from "@playwright/test";
 import { readCanisterId } from "@dfinity/internet-identity-vite-plugins/utils";
 import { idlFactory as internet_identity_idl } from "$lib/generated/internet_identity_idl";
 import type {
@@ -62,7 +62,7 @@ const permissionsString = (permissions: Permissions): string =>
 
 const holdConfirm = async (page: Page, name: string): Promise<void> => {
   const button = page.getByRole("button", { name });
-  await button.waitFor({ state: "visible" });
+  await expect(button).toBeEnabled();
   const box = await button.boundingBox();
   if (box === null) {
     throw new Error(`hold target "${name}" has no bounding box`);

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -394,7 +394,7 @@ export const test = base.extend<{ mcp: McpFixture }>({
       }
       await page.locator('a[href="/manage/settings"]').click();
       await page.waitForURL(`${II_URL}/manage/settings`);
-      await page.getByRole("switch", { name: "AI access" }).check();
+      await page.getByRole("switch", { name: "AI access" }).click();
       await page.getByLabel("MCP server URL").fill(`${MCP_SERVER_ORIGIN}/mcp`);
       await holdConfirm(page, "Hold to continue");
       await page

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -6,7 +6,7 @@ import {
 import { Actor, HttpAgent } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
 import { Agent as UndiciAgent } from "undici";
-import { expect, test as base, type Page } from "@playwright/test";
+import { test as base, type Page } from "@playwright/test";
 import { readCanisterId } from "@dfinity/internet-identity-vite-plugins/utils";
 import { idlFactory as internet_identity_idl } from "$lib/generated/internet_identity_idl";
 import type {
@@ -15,7 +15,7 @@ import type {
 } from "$lib/generated/internet_identity_types";
 import { toBase64URL } from "../../../src/lib/utils/utils";
 import { AUTH_CALLBACKS_PATH } from "../../../src/lib/utils/authCallbacks";
-import { II_URL } from "../utils";
+import { holdToConfirm, II_URL } from "../utils";
 import { DEFAULT_HOST } from "./identity";
 
 /** What the MCP server stand-in does on its next redemption. */
@@ -59,19 +59,6 @@ const insecureFetch: typeof fetch = (url, options = {}) =>
 
 const permissionsString = (permissions: Permissions): string =>
   "queries" in permissions ? "queries" : "all";
-
-const holdConfirm = async (page: Page, name: string): Promise<void> => {
-  const button = page.getByRole("button", { name });
-  await expect(button).toBeEnabled();
-  const box = await button.boundingBox();
-  if (box === null) {
-    throw new Error(`hold target "${name}" has no bounding box`);
-  }
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-  await page.mouse.down();
-  await page.waitForTimeout(2800);
-  await page.mouse.up();
-};
 
 /** The outcome the connect reports once the server redeems the registration
  *  delegation: the state echo, the session grant's expiration (ns since epoch,
@@ -396,7 +383,7 @@ export const test = base.extend<{ mcp: McpFixture }>({
       await page.waitForURL(`${II_URL}/manage/settings`);
       await page.getByRole("switch", { name: "AI access" }).click();
       await page.getByLabel("MCP server URL").fill(`${MCP_SERVER_ORIGIN}/mcp`);
-      await holdConfirm(page, "Hold to continue");
+      await holdToConfirm(page, "Hold to continue");
       await page
         .getByRole("button", { name: "Remove this server" })
         .waitFor({ state: "visible" });

--- a/src/frontend/tests/e2e-playwright/routes/authorize/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/index.spec.ts
@@ -113,6 +113,9 @@ test("Authorize by signing in from another device", async ({
         .getByRole("heading", { level: 1, name: "Authorize new device" })
         .waitFor();
       await holdToConfirm(otherDevicePage);
+      await otherDevicePage
+        .getByRole("heading", { level: 1, name: "Enter the code" })
+        .waitFor();
       for (let i = 0; i < confirmationCodeArray.length; i++) {
         const code = confirmationCodeArray[i];
         await otherDevicePage.getByLabel(`Code input ${i}`).fill(code);

--- a/src/frontend/tests/e2e-playwright/routes/index.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/index.spec.ts
@@ -95,6 +95,9 @@ test.describe("First visit", () => {
         .getByRole("heading", { level: 1, name: "Authorize new device" })
         .waitFor();
       await holdToConfirm(existingDevicePage);
+      await existingDevicePage
+        .getByRole("heading", { level: 1, name: "Enter the code" })
+        .waitFor();
       for (let i = 0; i < confirmationCodeArray.length; i++) {
         const code = confirmationCodeArray[i];
         await existingDevicePage.getByLabel(`Code input ${i}`).fill(code);

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -170,7 +170,7 @@ test("Trusting the server in the Settings tab auto-advances the untrusted screen
         }),
       }),
   );
-  await settingsPage.getByRole("switch", { name: "AI access" }).check();
+  await settingsPage.getByRole("switch", { name: "AI access" }).click();
   await settingsPage.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
   await holdSettingsConfirm(settingsPage, "Hold to continue");
   await expect(
@@ -280,7 +280,7 @@ test("Adding a trusted server in Settings unlocks the connect screen", async ({
   }
   await page.locator('a[href="/manage/settings"]').click();
   await page.waitForURL(II_URL + "/manage/settings");
-  await page.getByRole("switch", { name: "AI access" }).check();
+  await page.getByRole("switch", { name: "AI access" }).click();
   await page.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
   await holdSettingsConfirm(page, "Hold to continue");
   await expect(
@@ -524,6 +524,9 @@ test("Removing the trusted server in Settings blocks connecting", async ({
   await expect(
     page.getByRole("switch", { name: "AI access" }),
   ).not.toBeChecked();
+  await expect(
+    page.getByText(/was removed\. AI access is now off/),
+  ).toBeVisible();
 
   // Trust is re-verified against the synced config at connect time, so with no
   // trusted server the connect lands on the untrusted screen.
@@ -549,11 +552,7 @@ test("Disabling the master toggle blocks connecting (URL stays saved)", async ({
   // the config is no longer `enabled`, so trust is off.
   const toggle = page.getByRole("switch", { name: "AI access" });
   await toggle.uncheck();
-  // The toggle flips the UI optimistically but disables itself while the
-  // canister write is in flight (`disabled={saving}`), re-enabling only once
-  // the write resolves. Wait for that before navigating, so the connect below
-  // reads the persisted (disabled) config rather than racing the write.
-  await expect(toggle).toBeEnabled();
+  await expect(page.getByText("AI access is off.")).toBeVisible();
 
   await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
   await allowAccess(page);

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -7,6 +7,22 @@ import { addVirtualAuthenticator, II_URL } from "../utils";
  *  server-side per call), but kept to exercise that the param is tolerated. */
 const APP = "nice-name.com";
 
+/** Press-and-hold the named HoldToConfirm button until it fires its
+ *  `onComplete`. Mirrors the fixture-local helper; kept inline here so specs
+ *  that drive the Settings UI directly don't need to reach into the fixture. */
+const holdSettingsConfirm = async (page: Page, name: string): Promise<void> => {
+  const button = page.getByRole("button", { name });
+  await button.waitFor({ state: "visible" });
+  const box = await button.boundingBox();
+  if (box === null) {
+    throw new Error(`hold target "${name}" has no bounding box`);
+  }
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.waitForTimeout(2800);
+  await page.mouse.up();
+};
+
 const signUp = async (page: Page): Promise<void> => {
   const continueWithPasskey = page.getByRole("button", {
     name: "Continue with passkey",
@@ -111,10 +127,10 @@ test("Manage trusted server hands the session to a new Settings tab", async ({
   const settingsPage = await settingsPagePromise;
   await settingsPage.waitForURL("**/manage/settings**", { timeout: 15_000 });
 
-  // The handed-off session means Settings opens authenticated: the trusted
-  // server section heading is shown and no sign-in screen appears.
+  // The handed-off session means Settings opens authenticated: the AI-access
+  // section heading is shown and no sign-in screen appears.
   await expect(
-    settingsPage.getByRole("heading", { name: "Trusted MCP server" }),
+    settingsPage.getByRole("heading", { name: "AI access" }),
   ).toBeVisible({ timeout: 10_000 });
 });
 
@@ -159,12 +175,11 @@ test("Trusting the server in the Settings tab auto-advances the untrusted screen
         }),
       }),
   );
-  // The URL box only appears once the master toggle is on.
-  await settingsPage
-    .getByRole("switch", { name: "Trusted MCP server" })
-    .check();
+  // Toggling AI access on with no server opens the Add-connector dialog;
+  // fill the URL and hold the confirm to save.
+  await settingsPage.getByRole("switch", { name: "AI access" }).check();
   await settingsPage.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
-  await settingsPage.getByRole("button", { name: "Trust this server" }).click();
+  await holdSettingsConfirm(settingsPage, "Hold to continue");
   await expect(
     settingsPage.getByRole("button", { name: "Remove this server" }),
   ).toBeVisible();
@@ -272,12 +287,13 @@ test("Adding a trusted server in Settings unlocks the connect screen", async ({
   }
   await page.locator('a[href="/manage/settings"]').click();
   await page.waitForURL(II_URL + "/manage/settings");
-  // The URL box only appears once the master toggle is on.
-  await page.getByRole("switch", { name: "Trusted MCP server" }).check();
+  // Toggling AI access on with no server opens the Add-connector dialog;
+  // fill the URL and hold the confirm to save.
+  await page.getByRole("switch", { name: "AI access" }).check();
   await page.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
-  await page.getByRole("button", { name: "Trust this server" }).click();
-  // Once a server is trusted the input is replaced by the server row, which
-  // carries a remove button — a unique assertion that it was added.
+  await holdSettingsConfirm(page, "Hold to continue");
+  // Once a server is trusted the URL input is gone (dialog closed), and the
+  // server row carries a remove button — a unique assertion it was added.
   await expect(
     page.getByRole("button", { name: "Remove this server" }),
   ).toBeVisible();
@@ -512,13 +528,15 @@ test("Removing the trusted server in Settings blocks connecting", async ({
   await page.waitForURL(II_URL + "/manage");
   await mcp.trustServer(page); // leaves the page on Settings, server trusted
 
-  // Remove the server: the server row (and its Remove button) give way to the
-  // URL input again — the revoke path the fixture's add-only helper never hits.
+  // Remove the server: the row disappears and, because removing the only
+  // trusted server also disables the feature, the AI-access toggle flips off.
   await page.getByRole("button", { name: "Remove this server" }).click();
-  await expect(page.getByLabel("MCP server URL")).toBeVisible();
   await expect(
     page.getByRole("button", { name: "Remove this server" }),
   ).toHaveCount(0);
+  await expect(
+    page.getByRole("switch", { name: "AI access" }),
+  ).not.toBeChecked();
 
   // Trust is re-verified against the synced config at connect time, so with no
   // trusted server the connect lands on the untrusted screen.
@@ -542,7 +560,7 @@ test("Disabling the master toggle blocks connecting (URL stays saved)", async ({
 
   // Turn the feature off for this identity. The URL stays saved on-chain, but
   // the config is no longer `enabled`, so trust is off.
-  const toggle = page.getByRole("switch", { name: "Trusted MCP server" });
+  const toggle = page.getByRole("switch", { name: "AI access" });
   await toggle.uncheck();
   // The toggle flips the UI optimistically but disables itself while the
   // canister write is in flight (`disabled={saving}`), re-enabling only once

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -1,24 +1,11 @@
 import { expect, type Page } from "@playwright/test";
 import { test } from "../fixtures";
-import { addVirtualAuthenticator, II_URL } from "../utils";
+import { addVirtualAuthenticator, holdToConfirm, II_URL } from "../utils";
 
 /** A target app passed in the request. It is ignored by the connect flow (the
  *  session is registered for the user's identity; the app account is chosen
  *  server-side per call), but kept to exercise that the param is tolerated. */
 const APP = "nice-name.com";
-
-const holdSettingsConfirm = async (page: Page, name: string): Promise<void> => {
-  const button = page.getByRole("button", { name });
-  await expect(button).toBeEnabled();
-  const box = await button.boundingBox();
-  if (box === null) {
-    throw new Error(`hold target "${name}" has no bounding box`);
-  }
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-  await page.mouse.down();
-  await page.waitForTimeout(2800);
-  await page.mouse.up();
-};
 
 const signUp = async (page: Page): Promise<void> => {
   const continueWithPasskey = page.getByRole("button", {
@@ -172,7 +159,7 @@ test("Trusting the server in the Settings tab auto-advances the untrusted screen
   );
   await settingsPage.getByRole("switch", { name: "AI access" }).click();
   await settingsPage.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
-  await holdSettingsConfirm(settingsPage, "Hold to continue");
+  await holdToConfirm(settingsPage, "Hold to continue");
   await expect(
     settingsPage.getByRole("button", { name: "Remove this server" }),
   ).toBeVisible();
@@ -282,7 +269,7 @@ test("Adding a trusted server in Settings unlocks the connect screen", async ({
   await page.waitForURL(II_URL + "/manage/settings");
   await page.getByRole("switch", { name: "AI access" }).click();
   await page.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
-  await holdSettingsConfirm(page, "Hold to continue");
+  await holdToConfirm(page, "Hold to continue");
   await expect(
     page.getByRole("button", { name: "Remove this server" }),
   ).toBeVisible();

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -9,7 +9,7 @@ const APP = "nice-name.com";
 
 const holdSettingsConfirm = async (page: Page, name: string): Promise<void> => {
   const button = page.getByRole("button", { name });
-  await button.waitFor({ state: "visible" });
+  await expect(button).toBeEnabled();
   const box = await button.boundingBox();
   if (box === null) {
     throw new Error(`hold target "${name}" has no bounding box`);

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -517,16 +517,20 @@ test("Removing the trusted server in Settings blocks connecting", async ({
   await page.waitForURL(II_URL + "/manage");
   await mcp.trustServer(page); // leaves the page on Settings, server trusted
 
-  await page.getByRole("button", { name: "Remove this server" }).click();
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.url().includes("/call") &&
+        response.request().method() === "POST",
+    ),
+    page.getByRole("button", { name: "Remove this server" }).click(),
+  ]);
   await expect(
     page.getByRole("button", { name: "Remove this server" }),
   ).toHaveCount(0);
   await expect(
     page.getByRole("switch", { name: "AI access" }),
   ).not.toBeChecked();
-  await expect(
-    page.getByText(/was removed\. AI access is now off/),
-  ).toBeVisible();
 
   // Trust is re-verified against the synced config at connect time, so with no
   // trusted server the connect lands on the untrusted screen.

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -551,8 +551,14 @@ test("Disabling the master toggle blocks connecting (URL stays saved)", async ({
   // Turn the feature off for this identity. The URL stays saved on-chain, but
   // the config is no longer `enabled`, so trust is off.
   const toggle = page.getByRole("switch", { name: "AI access" });
-  await toggle.uncheck();
-  await expect(page.getByText("AI access is off.")).toBeVisible();
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.url().includes("/call") &&
+        response.request().method() === "POST",
+    ),
+    toggle.uncheck(),
+  ]);
 
   await page.goto(mcp.buildAuthorizeUrl({ app: APP }));
   await allowAccess(page);

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -7,9 +7,6 @@ import { addVirtualAuthenticator, II_URL } from "../utils";
  *  server-side per call), but kept to exercise that the param is tolerated. */
 const APP = "nice-name.com";
 
-/** Press-and-hold the named HoldToConfirm button until it fires its
- *  `onComplete`. Mirrors the fixture-local helper; kept inline here so specs
- *  that drive the Settings UI directly don't need to reach into the fixture. */
 const holdSettingsConfirm = async (page: Page, name: string): Promise<void> => {
   const button = page.getByRole("button", { name });
   await button.waitFor({ state: "visible" });
@@ -127,8 +124,6 @@ test("Manage trusted server hands the session to a new Settings tab", async ({
   const settingsPage = await settingsPagePromise;
   await settingsPage.waitForURL("**/manage/settings**", { timeout: 15_000 });
 
-  // The handed-off session means Settings opens authenticated: the AI-access
-  // section heading is shown and no sign-in screen appears.
   await expect(
     settingsPage.getByRole("heading", { name: "AI access" }),
   ).toBeVisible({ timeout: 10_000 });
@@ -175,8 +170,6 @@ test("Trusting the server in the Settings tab auto-advances the untrusted screen
         }),
       }),
   );
-  // Toggling AI access on with no server opens the Add-connector dialog;
-  // fill the URL and hold the confirm to save.
   await settingsPage.getByRole("switch", { name: "AI access" }).check();
   await settingsPage.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
   await holdSettingsConfirm(settingsPage, "Hold to continue");
@@ -287,13 +280,9 @@ test("Adding a trusted server in Settings unlocks the connect screen", async ({
   }
   await page.locator('a[href="/manage/settings"]').click();
   await page.waitForURL(II_URL + "/manage/settings");
-  // Toggling AI access on with no server opens the Add-connector dialog;
-  // fill the URL and hold the confirm to save.
   await page.getByRole("switch", { name: "AI access" }).check();
   await page.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
   await holdSettingsConfirm(page, "Hold to continue");
-  // Once a server is trusted the URL input is gone (dialog closed), and the
-  // server row carries a remove button — a unique assertion it was added.
   await expect(
     page.getByRole("button", { name: "Remove this server" }),
   ).toBeVisible();
@@ -528,8 +517,6 @@ test("Removing the trusted server in Settings blocks connecting", async ({
   await page.waitForURL(II_URL + "/manage");
   await mcp.trustServer(page); // leaves the page on Settings, server trusted
 
-  // Remove the server: the row disappears and, because removing the only
-  // trusted server also disables the feature, the AI-access toggle flips off.
   await page.getByRole("button", { name: "Remove this server" }).click();
   await expect(
     page.getByRole("button", { name: "Remove this server" }),

--- a/src/frontend/tests/e2e-playwright/utils.ts
+++ b/src/frontend/tests/e2e-playwright/utils.ts
@@ -289,13 +289,13 @@ export const openIiTab = async (page: Page): Promise<Page> => {
 // and mobile contexts) — the component's listener fires on any synthetic
 // event. The controller releases itself at the 2500ms duration, so no
 // matching mouseup is needed.
-export const holdToConfirm = async (page: Page): Promise<void> => {
-  await page
-    .getByRole("button", { name: "Hold to confirm" })
-    .dispatchEvent("mousedown");
-  await page
-    .getByRole("heading", { level: 1, name: "Enter the code" })
-    .waitFor();
+export const holdToConfirm = async (
+  page: Page,
+  name = "Hold to confirm",
+): Promise<void> => {
+  const button = page.getByRole("button", { name });
+  await expect(button).toBeEnabled();
+  await button.dispatchEvent("mousedown");
 };
 
 /**


### PR DESCRIPTION
The trusted-MCP-server settings section used a plain inline URL box and framed the feature around "Trusted MCP server". The new design reframes it as an **AI access** card and moves adding a connector into a focused dialog, so the settings page reads clearly and the risky "add a server" step gets its own guardrails.

## Changes

- Renamed the section to **AI access** with a **Preview** badge and updated copy ("Ask questions and perform actions across your apps by chatting with AI.").
- Replaced the inline URL input with a list-style **Trusted connectors** row: globe icon, host name, a **Custom** pill (with an explanatory tooltip), the URL in monospace, and a remove button.
- Added a dedicated **Add connector** dialog: featured MCP icon, safety tips (only add trusted connectors / revoke access anytime), a link to the MCP docs on "MCP connector", a URL field with a debounced verification indicator (checking → reachable → "Couldn't reach this connector", the last one advisory and still savable), and a **hold-to-confirm** action styled as the primary button.
- Added a `variant` prop to the shared `HoldToConfirm` component so the dialog's action can use the primary (white) style without affecting the confirmation-code wizard.
- Reworked the toggle flow: turning AI access on with no connector yet opens the dialog and pairs the two on-chain writes. Removing the only connector clears the URL **and** disables the feature in a single atomic write, with the UI collapsing optimistically so no stray "Add connector" button appears in between.

The on-chain data model (a single trusted URL per identity), the backend, and the locale catalog are unchanged.

## Tests

- Updated the Playwright fixture and `mcp.spec.ts` selectors for the new UI (AI access heading/switch, hold-to-confirm add flow, removal now disables the feature).
- `svelte-check` clean, MCP unit tests pass (`mcpConfig`, `mcpServer`), eslint clean, production `vite build` succeeds.
