### PR TITLE
chore(be): remove the v1 mcp_register API

### DIFF
--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -478,31 +478,6 @@ fn permissions_arg(read_only: Option<bool>) -> Option<Permissions> {
     })
 }
 
-pub fn mcp_register(
-    env: &PocketIc,
-    canister_id: CanisterId,
-    sender: Principal,
-    identity_number: IdentityNumber,
-    session_key: SessionKey,
-    grant_ttl_ns: u64,
-    read_only: Option<bool>,
-) -> Result<Result<McpRegistration, String>, RejectResponse> {
-    call_candid_as(
-        env,
-        canister_id,
-        RawEffectivePrincipal::None,
-        sender,
-        "mcp_register",
-        (
-            identity_number,
-            session_key,
-            grant_ttl_ns,
-            permissions_arg(read_only),
-        ),
-    )
-    .map(|(x,)| x)
-}
-
 pub fn prepare_mcp_registration_delegation(
     env: &PocketIc,
     canister_id: CanisterId,

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -637,7 +637,6 @@ export const idlFactory = ({ IDL }) => {
     'account_number' : IDL.Opt(AccountNumber),
     'expiration' : Timestamp,
   });
-  const McpRegistration = IDL.Record({ 'expiration' : Timestamp });
   const JWT = IDL.Text;
   const Salt = IDL.Vec(IDL.Nat8);
   const OpenIdCredentialAddError = IDL.Variant({
@@ -1177,11 +1176,6 @@ export const idlFactory = ({ IDL }) => {
             'Err' : AccountDelegationError,
           }),
         ],
-        [],
-      ),
-    'mcp_register' : IDL.Func(
-        [UserNumber, SessionKey, IDL.Nat64, IDL.Opt(Permissions)],
-        [IDL.Variant({ 'Ok' : McpRegistration, 'Err' : IDL.Text })],
         [],
       ),
     'mcp_register_v2' : IDL.Func(

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1163,12 +1163,6 @@ export interface McpPrepareDelegation {
   'account_number' : [] | [AccountNumber],
   'expiration' : Timestamp,
 }
-/**
- * Result of mcp_register: the expiration (ns since epoch) of the MCP session
- * grant just registered. Every server-facing mcp_* call returns Unauthorized
- * once it passes; the server reconnects through a new consent flow.
- */
-export interface McpRegistration { 'expiration' : Timestamp }
 export interface PrepareMcpRegistrationDelegation {
   'user_key' : UserKey,
   'expiration' : Timestamp,
@@ -2129,25 +2123,6 @@ export interface _SERVICE {
     [FrontendHostname, [] | [AccountNumber], SessionKey, [] | [bigint]],
     { 'Ok' : McpPrepareDelegation } |
       { 'Err' : AccountDelegationError }
-  >,
-  /**
-   * Register the trusted MCP server's session key for the anchor: grant the
-   * key's self-authenticating principal access to the server-facing mcp_*
-   * methods until the grant expires (grant_ttl_ns clamped to [10 min, 30
-   * days]). Called by the /mcp connect flow after user consent, with a key
-   * the frontend fetched from the *trusted* server's callback — never taken
-   * from the unauthenticated connect link. No account is chosen here
-   * (accounts are per-origin and the connector isn't an app) — the app
-   * account is selected per call on mcp_prepare_delegation.
-   *
-   * At most one session per identity: registering replaces any previous
-   * grant. Requires the identity's MCP config to be enabled with a trusted
-   * server set, so every session stays revocable via mcp_set_config.
-   */
-  'mcp_register' : ActorMethod<
-    [UserNumber, SessionKey, bigint, [] | [Permissions]],
-    { 'Ok' : McpRegistration } |
-      { 'Err' : string }
   >,
   'mcp_register_v2' : ActorMethod<
     [SessionKey],

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -38,8 +38,8 @@ interface McpAuthorizeInput {
 
 /**
  * Connects the MCP server by minting a short-lived *registration delegation
- * chain* and handing it to the server, instead of fetching the server's key
- * and calling `mcp_register` on its behalf. The flow:
+ * chain* and handing it to the server to redeem, rather than binding a key II
+ * merely fetched from the server. The flow:
  *
  *  1. Generate an ephemeral registration key `Y` for this connect; its private
  *     half never leaves this page.

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -38,8 +38,8 @@ interface McpAuthorizeInput {
 
 /**
  * Connects the MCP server by minting a short-lived *registration delegation
- * chain* and handing it to the server to redeem, rather than binding a key II
- * merely fetched from the server. The flow:
+ * chain* and handing it to the server to redeem, rather than binding a key
+ * that II merely fetched from the server. The flow:
  *
  *  1. Generate an ephemeral registration key `Y` for this connect; its private
  *     half never leaves this page.

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1124,13 +1124,6 @@ type McpConfig = record {
     url : opt text;
 };
 
-// Result of mcp_register: the expiration (ns since epoch) of the MCP session
-// grant just registered. Every server-facing mcp_* call returns Unauthorized
-// once it passes; the server reconnects through a new consent flow.
-type McpRegistration = record {
-    expiration : Timestamp;
-};
-
 // Result of prepare_mcp_registration_delegation: the canister-signature public
 // key the registration delegation is rooted at (P_reg), and the (short)
 // expiration of that delegation. The frontend fetches the signed delegation via
@@ -1837,28 +1830,6 @@ service : (opt InternetIdentityInit) -> {
         // the omitted/`null` case, which means unrestricted).
         permissions : opt Permissions
     ) -> (variant { Ok : SignedDelegation; Err : AccountDelegationError }) query;
-
-    // Register the trusted MCP server's session key for the anchor: grant the
-    // key's self-authenticating principal access to the server-facing mcp_*
-    // methods until the grant expires (grant_ttl_ns clamped to [10 min, 30
-    // days]). Called by the /mcp connect flow after user consent, with a key
-    // the frontend fetched from the *trusted* server's callback — never taken
-    // from the unauthenticated connect link. No account is chosen here
-    // (accounts are per-origin and the connector isn't an app) — the app
-    // account is selected per call on mcp_prepare_delegation.
-    //
-    // At most one session per identity: registering replaces any previous
-    // grant. Requires the identity's MCP config to be enabled with a trusted
-    // server set, so every session stays revocable via mcp_set_config.
-    mcp_register : (
-        anchor_number : UserNumber,
-        session_key : SessionKey,
-        grant_ttl_ns : nat64,
-        // `opt (queries)` makes every per-app delegation this session later
-        // mints queries-only (read-only, chosen once for the whole session).
-        // Omitted (`null`) or `opt (all)` means full, update-capable access.
-        permissions : opt Permissions
-    ) -> (variant { Ok : McpRegistration; Err : text });
 
     // Read the identity's synced trusted-MCP-server config (master toggle + the
     // trusted server URL). Persisted on-chain, so it follows the identity across

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -637,34 +637,6 @@ fn get_account_delegation(
     }
 }
 
-/// Register the trusted MCP server's session key for `anchor_number`: grant
-/// the key's self-authenticating principal access to the server-facing
-/// `mcp_*` methods until the grant expires (`grant_ttl_ns` clamped to
-/// [10 min, 30 days]). Called by the `/mcp` connect flow after user consent,
-/// with a key the frontend fetched from the *trusted* server's callback —
-/// never taken from the unauthenticated connect link. No account is chosen
-/// here (accounts are per-origin and the connector isn't an app); the app
-/// account is selected per call on `mcp_prepare_delegation`.
-///
-/// At most one session per identity: registering replaces any previous grant.
-/// Requires the identity's MCP config to be enabled with a trusted server set,
-/// so every session stays revocable via `mcp_set_config`. `permissions` sets
-/// the session's read-only restriction: `opt (queries)` makes every per-app
-/// delegation it later mints queries-only; omitted (`null`) or `opt (all)`
-/// means full, update-capable access.
-#[update]
-fn mcp_register(
-    anchor_number: AnchorNumber,
-    session_key: SessionKey,
-    grant_ttl_ns: u64,
-    permissions: Option<Permissions>,
-) -> Result<McpRegistration, String> {
-    check_authz_and_record_activity(anchor_number).map_err(|err| format!("Unauthorized: {err}"))?;
-    // The grant persists a bool; derive it from the requested permissions.
-    let read_only = DelegationAccess::from(permissions) == DelegationAccess::ReadOnly;
-    mcp::register(anchor_number, session_key, grant_ttl_ns, read_only)
-}
-
 /// Read `anchor_number`'s synced trusted-MCP-server config (master toggle +
 /// trusted server URL). Persisted on-chain, so it follows the identity across
 /// devices. Read by the Settings UI and by the `/mcp` connect flow, which

--- a/src/internet_identity/src/mcp.rs
+++ b/src/internet_identity/src/mcp.rs
@@ -98,12 +98,13 @@ fn default_account_number(
     default_account(anchor_number, origin).account_number
 }
 
-/// `mcp_register`: register the trusted MCP server's session key for
-/// `anchor_number`, granting its self-authenticating principal access to the
-/// server-facing `mcp_*` methods until the grant expires. The caller must
-/// already be authorized for `anchor_number` (checked by the canister
-/// method); the key itself comes from the trusted server's callback, fetched
-/// by the II frontend after user consent — never from the connect link.
+/// Register the trusted MCP server's session key for `anchor_number`, granting
+/// its self-authenticating principal access to the server-facing `mcp_*`
+/// methods until the grant expires. Internal grant-binding shared by the
+/// connect path: [`crate::mcp_registration::register_v2`] calls it once it has
+/// recovered the consent (anchor, read-only choice, grant lifetime) for the
+/// redeeming registration principal, so the anchor and consent here are
+/// recovered server-side, never taken from the connecting server.
 ///
 /// `grant_ttl_ns` is clamped to [10 min, 30 days]. `read_only` restricts every
 /// per-app delegation this session mints to query calls (chosen at connect,

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -255,8 +255,8 @@ const OPENID_JWKS_CACHE_MEMORY_ID: MemoryId = MemoryId::new(OPENID_JWKS_CACHE_ME
 
 /// MCP session grants: maps an MCP server's session-key principal to the
 /// grant ([`StorableMcpGrant`]: the anchor that registered it, the expiry, and
-/// whether its per-app delegations are read-only). Written by the authenticated
-/// `mcp_register` method; the server-facing `mcp_*` methods authorize a caller
+/// whether its per-app delegations are read-only). Written by the connect flow
+/// (`mcp_register_v2`); the server-facing `mcp_*` methods authorize a caller
 /// by looking up its grant here (and checking expiry), recovering the anchor
 /// without an `anchor_number` parameter. Bounded at one entry per anchor via
 /// [`StorableMcpConfig::session_principal`].

--- a/src/internet_identity/src/storage/storable/mcp_config.rs
+++ b/src/internet_identity/src/storage/storable/mcp_config.rs
@@ -34,7 +34,7 @@ pub struct StorableMcpConfig {
     /// when no session is registered. The grant map is keyed by principal, so
     /// this forward pointer is what lets a config change revoke the active
     /// session in O(1) — and what enforces at most one session per identity:
-    /// `mcp_register` replaces the previous grant through it.
+    /// `mcp_register_v2` replaces the previous grant through it.
     #[cbor(n(2), with = "minicbor::bytes")]
     pub session_principal: Option<Vec<u8>>,
     /// Raw principal bytes of the anchor's current in-flight registration

--- a/src/internet_identity/src/storage/storable/mcp_grant.rs
+++ b/src/internet_identity/src/storage/storable/mcp_grant.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 
 /// An active MCP session grant: the value of the grant map (see
 /// [`crate::storage`]), keyed by the MCP server's session-key principal.
-/// Written by the authenticated `mcp_register` method; the server-facing
+/// Written by the connect flow (`mcp_register_v2`); the server-facing
 /// `mcp_*` methods authorize a caller by looking up its grant and checking it
 /// has not expired. At most one live grant exists per anchor — registering a
 /// new session replaces the previous one through
@@ -23,7 +23,7 @@ pub struct StorableMcpGrant {
     #[n(1)]
     pub expires_at_ns: u64,
     /// Whether the per-app delegations this session mints are restricted to
-    /// query calls (queries-only). Chosen once at connect (`mcp_register`) and
+    /// query calls (queries-only). Chosen once at connect (`mcp_register_v2`) and
     /// applied to every delegation the session mints — read-only is a property
     /// of the whole MCP session, not a per-call flag. Both `prepare` and `get`
     /// read it, since the access level is folded into the delegation signature.

--- a/src/internet_identity/src/storage/storable/mcp_grant.rs
+++ b/src/internet_identity/src/storage/storable/mcp_grant.rs
@@ -23,10 +23,12 @@ pub struct StorableMcpGrant {
     #[n(1)]
     pub expires_at_ns: u64,
     /// Whether the per-app delegations this session mints are restricted to
-    /// query calls (queries-only). Chosen once at connect (`mcp_register_v2`) and
-    /// applied to every delegation the session mints — read-only is a property
-    /// of the whole MCP session, not a per-call flag. Both `prepare` and `get`
-    /// read it, since the access level is folded into the delegation signature.
+    /// query calls (queries-only). Chosen once at connect: recorded by
+    /// `prepare_mcp_registration_delegation` and written onto the grant when
+    /// `mcp_register_v2` binds it, then applied to every delegation the session
+    /// mints — read-only is a property of the whole MCP session, not a per-call
+    /// flag. Both `prepare` and `get` read it, since the access level is folded
+    /// into the delegation signature.
     #[n(2)]
     pub read_only: bool,
 }

--- a/src/internet_identity/tests/integration/delegation_ingress.rs
+++ b/src/internet_identity/tests/integration/delegation_ingress.rs
@@ -35,8 +35,8 @@
 use candid::{Encode, Principal};
 use canister_tests::api::internet_identity::api_v2::{
     get_account_delegation_with_read_only, mcp_get_delegation, mcp_prepare_delegation,
-    mcp_register, mcp_set_config, prepare_account_delegation_with_read_only,
-    AccountDelegationParams,
+    mcp_register_v2, mcp_set_config, prepare_account_delegation_with_read_only,
+    prepare_mcp_registration_delegation, AccountDelegationParams,
 };
 use canister_tests::flows;
 use canister_tests::framework::*;
@@ -148,20 +148,25 @@ fn mint_mcp_delegation(
     .unwrap()
     .unwrap();
 
-    // Register the MCP server's own session key, with the read-only choice —
+    // Register the MCP server's own session key through the connect path (mint a
+    // registration delegation, then redeem it), with the read-only choice —
     // read-only is a property of the whole session.
     let server_key = ByteBuf::from("mcp server session key");
-    mcp_register(
+    let prepared = prepare_mcp_registration_delegation(
         env,
         canister_id,
         principal_1(),
         anchor,
-        server_key.clone(),
-        GRANT_TTL_NS,
+        ByteBuf::from("browser registration key Y"),
         Some(read_only),
+        Some(GRANT_TTL_NS),
     )
     .unwrap()
     .unwrap();
+    let p_reg = Principal::self_authenticating(&prepared.user_key);
+    mcp_register_v2(env, canister_id, p_reg, server_key.clone())
+        .unwrap()
+        .unwrap();
     let mcp = Principal::self_authenticating(&server_key);
 
     let McpPrepareDelegation {

--- a/src/internet_identity/tests/integration/mcp.rs
+++ b/src/internet_identity/tests/integration/mcp.rs
@@ -2,8 +2,9 @@
 //! authorizes for their identity fetches per-app account delegations without a
 //! per-app browser flow. No account is chosen at connect (the connector isn't
 //! an app); the server's own session-key principal is registered as a grant
-//! via `mcp_register`, recovered from `caller()` on every server-facing call
-//! (checking expiry), and the app account is picked per call against the
+//! via `mcp_register_v2` (the connect flow), recovered from `caller()` on every
+//! server-facing call (checking expiry), and the app account is picked per call
+//! against the
 //! target origin. At most one session exists per identity, and changing the
 //! synced config (disable, or a different trusted URL) revokes it.
 
@@ -11,7 +12,7 @@ use candid::Principal;
 use canister_tests::{
     api::internet_identity::api_v2::{
         create_account, get_mcp_registration_delegation, mcp_get_accounts, mcp_get_config,
-        mcp_get_delegation, mcp_prepare_delegation, mcp_register, mcp_register_v2, mcp_set_config,
+        mcp_get_delegation, mcp_prepare_delegation, mcp_register_v2, mcp_set_config,
         prepare_account_delegation, prepare_mcp_registration_delegation, set_default_account,
         AccountDelegationParams,
     },
@@ -66,12 +67,47 @@ fn trust_mcp_server(
     .unwrap();
 }
 
-/// Register `session_key` as the anchor's MCP session (called as the user,
-/// like the `/mcp` connect flow does after consent) and return the session
-/// principal the server now calls with — the self-authenticating principal of
-/// the key, exactly as the canister derives it — plus the grant expiration.
-/// Registers an unrestricted (not read-only) session; the read-only path has
-/// its own test.
+/// Register `session_key` as the anchor's MCP session through the connect path:
+/// mint a registration delegation as the user (`prepare_mcp_registration_delegation`),
+/// then redeem it as the registration principal with the server's session key
+/// (`mcp_register_v2`) — exactly what the `/mcp` flow does after consent.
+/// `read_only` fixes the whole session's access level. Returns the session
+/// principal the server now calls with (the self-authenticating principal of the
+/// key, exactly as the canister derives it) plus the grant expiration.
+///
+/// The anchor must already trust a server (a precondition of `prepare`); callers
+/// set that up with [`trust_mcp_server`] first.
+fn register_session_with_access(
+    env: &PocketIc,
+    canister_id: Principal,
+    sender: Principal,
+    anchor: AnchorNumber,
+    session_key: &ByteBuf,
+    grant_ttl_ns: u64,
+    read_only: bool,
+) -> (Principal, u64) {
+    let prepared = prepare_mcp_registration_delegation(
+        env,
+        canister_id,
+        sender,
+        anchor,
+        ByteBuf::from("browser registration key Y (register_session helper)"),
+        Some(read_only),
+        Some(grant_ttl_ns),
+    )
+    .unwrap()
+    .unwrap();
+    let p_reg = Principal::self_authenticating(&prepared.user_key);
+    let registration = mcp_register_v2(env, canister_id, p_reg, session_key.clone())
+        .unwrap()
+        .unwrap();
+    (
+        Principal::self_authenticating(session_key),
+        registration.expiration,
+    )
+}
+
+/// [`register_session_with_access`] for an unrestricted (not read-only) session.
 fn register_session(
     env: &PocketIc,
     canister_id: Principal,
@@ -80,20 +116,14 @@ fn register_session(
     session_key: &ByteBuf,
     grant_ttl_ns: u64,
 ) -> (Principal, u64) {
-    let registration = mcp_register(
+    register_session_with_access(
         env,
         canister_id,
         sender,
         anchor,
-        session_key.clone(),
+        session_key,
         grant_ttl_ns,
-        None,
-    )
-    .unwrap()
-    .unwrap();
-    (
-        Principal::self_authenticating(session_key),
-        registration.expiration,
+        false,
     )
 }
 
@@ -597,103 +627,13 @@ fn mcp_registration_replaces_previous_session() -> Result<(), RejectResponse> {
     Ok(())
 }
 
-/// Registration requires a live trusted-server config (enabled + URL set) —
-/// that coupling is what makes config-driven revocation cover every session —
-/// and is gated to the identity itself.
+/// One key serves one identity: redeeming a registration delegation with a
+/// session key that already has a live grant for another anchor is rejected
+/// (without echoing whose it is). Once that grant expires the key can be
+/// re-registered by the other anchor — and the first anchor's stale config
+/// pointer must not damage the new owner's session.
 #[test]
-fn mcp_register_requires_enabled_config() -> Result<(), RejectResponse> {
-    let env = env();
-    let canister_id = install_with_mcp(&env);
-    let anchor = flows::register_anchor(&env, canister_id);
-    let session_key = ByteBuf::from("mcp server session key");
-
-    // No config written at all.
-    assert!(mcp_register(
-        &env,
-        canister_id,
-        principal_1(),
-        anchor,
-        session_key.clone(),
-        GRANT_TTL_NS,
-        None
-    )
-    .unwrap()
-    .is_err());
-
-    // Disabled config with a URL.
-    mcp_set_config(
-        &env,
-        canister_id,
-        principal_1(),
-        anchor,
-        McpConfig {
-            enabled: false,
-            url: Some(format!("{MCP_ORIGIN}/mcp")),
-        },
-    )
-    .unwrap()
-    .unwrap();
-    assert!(mcp_register(
-        &env,
-        canister_id,
-        principal_1(),
-        anchor,
-        session_key.clone(),
-        GRANT_TTL_NS,
-        None
-    )
-    .unwrap()
-    .is_err());
-
-    // Enabled config without a URL.
-    mcp_set_config(
-        &env,
-        canister_id,
-        principal_1(),
-        anchor,
-        McpConfig {
-            enabled: true,
-            url: None,
-        },
-    )
-    .unwrap()
-    .unwrap();
-    assert!(mcp_register(
-        &env,
-        canister_id,
-        principal_1(),
-        anchor,
-        session_key.clone(),
-        GRANT_TTL_NS,
-        None
-    )
-    .unwrap()
-    .is_err());
-
-    // An unrelated caller cannot register a session for the anchor even with a
-    // live config.
-    trust_mcp_server(&env, canister_id, principal_1(), anchor);
-    assert!(mcp_register(
-        &env,
-        canister_id,
-        principal_2(),
-        anchor,
-        session_key,
-        GRANT_TTL_NS,
-        None
-    )
-    .unwrap()
-    .is_err());
-
-    Ok(())
-}
-
-/// One key serves one identity: a session key with a live grant for another
-/// anchor is rejected (without echoing whose it is). Once that grant expires
-/// the key can be re-registered by the other anchor — and the first anchor's
-/// stale config pointer must not damage the new owner's session.
-#[test]
-fn mcp_register_rejects_a_key_registered_to_another_identity() -> Result<(), RejectResponse> {
+fn mcp_register_v2_rejects_a_key_registered_to_another_identity() -> Result<(), RejectResponse> {
     let env = env();
     let canister_id = install_with_mcp(&env);
     let anchor_1 = flows::register_anchor(&env, canister_id);
@@ -714,19 +654,24 @@ fn mcp_register_rejects_a_key_registered_to_another_identity() -> Result<(), Rej
         GRANT_MIN_TTL_NS,
     );
 
-    // While that grant is live, anchor 2 cannot register the same key — and
-    // the error must not leak whose it is.
-    let err = mcp_register(
+    // While that grant is live, anchor 2 cannot bind the same key: it mints its
+    // own registration delegation, but redeeming it with the shared key is
+    // rejected — and the error must not leak whose it is.
+    let prepared_2 = prepare_mcp_registration_delegation(
         &env,
         canister_id,
         principal_2(),
         anchor_2,
-        shared_key.clone(),
-        GRANT_TTL_NS,
-        None,
+        ByteBuf::from("browser registration key Y (anchor 2)"),
+        Some(false),
+        Some(GRANT_TTL_NS),
     )
     .unwrap()
-    .unwrap_err();
+    .unwrap();
+    let p_reg_2 = Principal::self_authenticating(&prepared_2.user_key);
+    let err = mcp_register_v2(&env, canister_id, p_reg_2, shared_key.clone())
+        .unwrap()
+        .unwrap_err();
     assert!(!err.contains(&anchor_1.to_string()));
 
     // Once anchor 1's grant expires, anchor 2 can take the key over.
@@ -1142,7 +1087,7 @@ fn mcp_config_is_gated_to_the_identity() -> Result<(), RejectResponse> {
 /// `read_only = true` makes every per-app delegation the session mints
 /// queries-only (it carries `permissions = "queries"`), while an unrestricted
 /// session's delegations carry no `permissions` field. The choice is made once
-/// at `mcp_register` and stored on the grant — there is no per-call variant.
+/// at connect and stored on the grant — there is no per-call variant.
 #[test]
 fn mcp_read_only_grant_mints_queries_only_delegations() -> Result<(), RejectResponse> {
     let env = env();
@@ -1153,20 +1098,17 @@ fn mcp_read_only_grant_mints_queries_only_delegations() -> Result<(), RejectResp
 
     trust_mcp_server(&env, canister_id, principal_1(), anchor);
 
-    // Register a read-only session (read_only = Some(true)).
+    // Register a read-only session.
     let server_key = ByteBuf::from("mcp server session key");
-    mcp_register(
+    let (mcp, _) = register_session_with_access(
         &env,
         canister_id,
         principal_1(),
         anchor,
-        server_key.clone(),
+        &server_key,
         GRANT_TTL_NS,
-        Some(true),
-    )
-    .unwrap()
-    .unwrap();
-    let mcp = Principal::self_authenticating(&server_key);
+        true,
+    );
 
     // Every delegation the session mints is queries-only.
     let prepared = mcp_prepare_delegation(
@@ -1399,18 +1341,15 @@ fn mcp_read_only_grant_stays_queries_only_across_upgrade() -> Result<(), RejectR
 
     trust_mcp_server(&env, canister_id, principal_1(), anchor);
     let server_key = ByteBuf::from("mcp server session key");
-    mcp_register(
+    let (mcp, _) = register_session_with_access(
         &env,
         canister_id,
         principal_1(),
         anchor,
-        server_key.clone(),
+        &server_key,
         GRANT_TTL_NS,
-        Some(true),
-    )
-    .unwrap()
-    .unwrap();
-    let mcp = Principal::self_authenticating(&server_key);
+        true,
+    );
 
     upgrade_ii_canister(&env, canister_id, II_WASM.clone());
 
@@ -1885,29 +1824,82 @@ fn mcp_registration_delegation_expires() -> Result<(), RejectResponse> {
     Ok(())
 }
 
-/// `prepare` requires a live trusted-server config: it records the trusted URL
-/// on the entry (and there is nothing to connect without one), so no
-/// registration delegation can be minted for an identity that trusts no server.
+/// `prepare` requires a live trusted-server config (enabled *and* a URL set):
+/// it records the trusted URL on the entry, and there is nothing to connect
+/// without one, so no registration delegation can be minted for an identity
+/// that trusts no server. It is also authenticated as the identity, so an
+/// unrelated caller cannot mint one for someone else's anchor. (This coupling
+/// to the config is what keeps every session config-revocable.)
 #[test]
 fn mcp_prepare_registration_delegation_requires_trusted_server() -> Result<(), RejectResponse> {
     let env = env();
     let canister_id = install_with_mcp(&env);
     let anchor = flows::register_anchor(&env, canister_id);
-    // No trust_mcp_server: the anchor's config is the disabled default.
 
-    let result = prepare_mcp_registration_delegation(
+    let prepare = |sender: Principal| {
+        prepare_mcp_registration_delegation(
+            &env,
+            canister_id,
+            sender,
+            anchor,
+            ByteBuf::from("browser registration key Y"),
+            Some(true),
+            Some(GRANT_TTL_NS),
+        )
+        .unwrap()
+    };
+
+    // No config at all: the disabled, no-server default.
+    let none = prepare(principal_1());
+    assert!(
+        matches!(&none, Err(message) if message.contains("no trusted MCP server")),
+        "prepare with no config must be rejected: {none:?}"
+    );
+
+    // MCP disabled, even with a URL set.
+    mcp_set_config(
         &env,
         canister_id,
         principal_1(),
         anchor,
-        ByteBuf::from("browser registration key Y"),
-        Some(true),
-        Some(GRANT_TTL_NS),
+        McpConfig {
+            enabled: false,
+            url: Some(format!("{MCP_ORIGIN}/mcp")),
+        },
     )
+    .unwrap()
     .unwrap();
+    let disabled = prepare(principal_1());
     assert!(
-        matches!(&result, Err(message) if message.contains("no trusted MCP server")),
-        "prepare without a trusted server must be rejected: {result:?}"
+        matches!(&disabled, Err(message) if message.contains("no trusted MCP server")),
+        "prepare with MCP disabled must be rejected: {disabled:?}"
+    );
+
+    // Enabled, but no trusted URL set.
+    mcp_set_config(
+        &env,
+        canister_id,
+        principal_1(),
+        anchor,
+        McpConfig {
+            enabled: true,
+            url: None,
+        },
+    )
+    .unwrap()
+    .unwrap();
+    let no_url = prepare(principal_1());
+    assert!(
+        matches!(&no_url, Err(message) if message.contains("no trusted MCP server")),
+        "prepare with no trusted URL must be rejected: {no_url:?}"
+    );
+
+    // With a live trusted server, an unrelated caller still cannot prepare for
+    // the anchor: prepare is authenticated as the identity.
+    trust_mcp_server(&env, canister_id, principal_1(), anchor);
+    assert!(
+        prepare(principal_2()).is_err(),
+        "an unrelated caller must not mint a registration delegation for the anchor"
     );
 
     Ok(())
@@ -1915,7 +1907,7 @@ fn mcp_prepare_registration_delegation_requires_trusted_server() -> Result<(), R
 
 /// An empty registration key is rejected at `prepare`: delegating to an empty
 /// `Y` would make the signed message degenerate/predictable (mirrors
-/// `mcp_register`'s empty-session-key check).
+/// `mcp::register`'s empty-session-key check).
 #[test]
 fn mcp_prepare_registration_delegation_rejects_empty_key() -> Result<(), RejectResponse> {
     let env = env();

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -672,10 +672,12 @@ pub struct McpConfig {
     pub url: Option<String>,
 }
 
-/// Result of the MCP connect flow (`mcp_register_v2`): the expiration
-/// (nanoseconds since the epoch) of the MCP session grant just registered.
-/// Every server-facing `mcp_*` call returns `Unauthorized` once it passes; the
-/// server reconnects through a new consent flow.
+/// Result of the internal MCP grant-binding (`mcp::register`): the expiration
+/// (nanoseconds since the epoch) of the MCP session grant just registered. The
+/// connect flow's `mcp_register_v2` invokes that helper and surfaces the same
+/// expiration to the server as `McpRegistrationV2`. Every server-facing
+/// `mcp_*` call returns `Unauthorized` once that expiry passes; the server
+/// reconnects through a new consent flow.
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct McpRegistration {
     pub expiration: Timestamp,

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -672,10 +672,10 @@ pub struct McpConfig {
     pub url: Option<String>,
 }
 
-/// Result of `mcp_register`: the expiration (nanoseconds since the epoch) of
-/// the MCP session grant just registered. Every server-facing `mcp_*` call
-/// returns `Unauthorized` once it passes; the server reconnects through a new
-/// consent flow.
+/// Result of the MCP connect flow (`mcp_register_v2`): the expiration
+/// (nanoseconds since the epoch) of the MCP session grant just registered.
+/// Every server-facing `mcp_*` call returns `Unauthorized` once it passes; the
+/// server reconnects through a new consent flow.
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
 pub struct McpRegistration {
     pub expiration: Timestamp,


### PR DESCRIPTION
# Motivation

id.ai has switched to the v2 MCP registration-delegation connect flow
(`prepare_mcp_registration_delegation` + `get_mcp_registration_delegation` +
`mcp_register_v2`). The legacy v1 `mcp_register` endpoint — where the II
frontend fetched the server's key and bound it directly — is no longer used by
any client, so it is dead surface area on the canister interface and should go.

Removing it shrinks the public API to the single, safer registration path: the
server redeems a browser-assembled delegation chain and passes only its own
session key, so it never supplies any consented value and never learns the
anchor number.

# Changes

Removed the v1 endpoint and everything that existed only to serve it:

- **Canister**: deleted the `#[update] fn mcp_register(...)` endpoint in
  `main.rs`.
- **Candid**: removed the `mcp_register` method and the `McpRegistration`
  record type from `internet_identity.did` (no remaining candid endpoint
  references the type). Verified by the `check_candid_interface_compatibility`
  test.
- **Generated bindings**: removed the `mcp_register` func/method and the
  orphaned `McpRegistration` entry from `internet_identity_idl.js` and
  `internet_identity_types.d.ts`.
- **Test API**: removed the `mcp_register(...)` binding from
  `canister_tests/.../api_v2.rs`.

Retained on purpose (v2 depends on them):

- the internal grant-binding `mcp::register(...)`, which `mcp_register_v2`
  calls once it has recovered the consent server-side;
- the Rust `McpRegistration` interface type, which `mcp::register` returns.

Doc comments that referenced the removed endpoint were updated to point at the
connect flow / `mcp_register_v2` / `mcp::register`.

# Tests

- Ported v1-only behavioral coverage onto the v2 flow rather than deleting it:
  the integration test helper now does `prepare_mcp_registration_delegation` +
  `mcp_register_v2`, and the cross-identity key-reuse guard, the
  trusted-server-required check, the empty-key rejection, and the read-only
  session tests all exercise the v2 path.
- `check_candid_interface_compatibility`: passes (exported candid matches the
  trimmed `.did`).
- `cargo fmt` clean; confirmed no unused imports left in `main.rs` after the
  endpoint removal.
- The full MCP integration suite was run green against a freshly built wasm in
  the prior iteration of this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbjCCqTjsMn57fczTNGaKf)_