### PR TITLE
feat(be): expose live MCP session count in metrics

### DIFF
--- a/src/internet_identity/src/http/metrics.rs
+++ b/src/internet_identity/src/http/metrics.rs
@@ -78,7 +78,7 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
         w.encode_gauge(
             "internet_identity_mcp_live_session_count",
             storage.count_live_mcp_grants(time()) as f64,
-            "Number of live (non-expired) MCP session grants: the currently-authorized MCP sessions.",
+            "Number of live (non-expired) MCP session grants: the currently-authorized MCP sessions. Computed by scanning the grant map at scrape time (O(n) in stored grants).",
         )?;
         if let Some(registration_rates) = storage.registration_rates.registration_rates() {
             w.gauge_vec(

--- a/src/internet_identity/src/http/metrics.rs
+++ b/src/internet_identity/src/http/metrics.rs
@@ -70,6 +70,16 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             storage.get_total_application_count() as f64,
             "Number of total applications registered in this canister.",
         )?;
+        w.encode_gauge(
+            "internet_identity_mcp_session_count",
+            storage.mcp_grant_count() as f64,
+            "Number of MCP session grants stored (live grants plus not-yet-removed expired residue).",
+        )?;
+        w.encode_gauge(
+            "internet_identity_mcp_live_session_count",
+            storage.count_live_mcp_grants(time()) as f64,
+            "Number of live (non-expired) MCP session grants: the currently-authorized MCP sessions.",
+        )?;
         if let Some(registration_rates) = storage.registration_rates.registration_rates() {
             w.gauge_vec(
                 "internet_identity_registrations_per_second",

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -1138,6 +1138,26 @@ impl<M: Memory + Clone> Storage<M> {
         self.mcp_grant_memory.remove(&principal);
     }
 
+    /// Total number of MCP session grant entries currently stored — live
+    /// grants plus any expired residue that has not been superseded or
+    /// removed yet (grants are replaced per anchor on re-registration and
+    /// dropped on the config change that revokes them, but an expired grant
+    /// whose anchor never returns lingers until then). O(1).
+    pub fn mcp_grant_count(&self) -> u64 {
+        self.mcp_grant_memory.len()
+    }
+
+    /// Number of *live* (non-expired at `now_ns`) MCP session grants: the
+    /// currently-authorized MCP sessions, at most one per anchor. Scans the
+    /// grant map and filters by `expires_at_ns`, since the map may also hold
+    /// expired residue (see [`Self::mcp_grant_count`]); O(n) in stored grants.
+    pub fn count_live_mcp_grants(&self, now_ns: u64) -> u64 {
+        self.mcp_grant_memory
+            .iter()
+            .filter(|(_, grant)| grant.expires_at_ns > now_ns)
+            .count() as u64
+    }
+
     /// Look up the pending MCP registration entry keyed by `principal` (the
     /// registration principal `P_reg`). Callers check `expires_at_ns`; the map
     /// itself never authorizes anything.

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -1152,10 +1152,12 @@ impl<M: Memory + Clone> Storage<M> {
     /// grant map and filters by `expires_at_ns`, since the map may also hold
     /// expired residue (see [`Self::mcp_grant_count`]); O(n) in stored grants.
     pub fn count_live_mcp_grants(&self, now_ns: u64) -> u64 {
+        // Accumulate directly into a `u64`: `Iterator::count` returns `usize`,
+        // which is 32-bit on wasm32 and would wrap in a release build.
         self.mcp_grant_memory
             .iter()
             .filter(|(_, grant)| grant.expires_at_ns > now_ns)
-            .count() as u64
+            .fold(0u64, |acc, _| acc + 1)
     }
 
     /// Look up the pending MCP registration entry keyed by `principal` (the

--- a/src/internet_identity/tests/integration/mcp.rs
+++ b/src/internet_identity/tests/integration/mcp.rs
@@ -18,8 +18,8 @@ use canister_tests::{
     },
     flows,
     framework::{
-        device_data_2, env, install_ii_canister_with_arg, principal_1, principal_2, time,
-        upgrade_ii_canister, verify_delegation, II_WASM,
+        assert_metric, device_data_2, env, get_metrics, install_ii_canister_with_arg, principal_1,
+        principal_2, time, upgrade_ii_canister, verify_delegation, II_WASM,
     },
 };
 use internet_identity_interface::internet_identity::types::{
@@ -2031,6 +2031,64 @@ fn mcp_set_config_rejects_overlong_trusted_url() -> Result<(), RejectResponse> {
     // `mcp_register_v2` re-derives and compares the URL hash — see the happy-path
     // test — so hashing the stored URL is transparent to redemption).
     trust_mcp_server(&env, canister_id, principal_1(), anchor);
+
+    Ok(())
+}
+
+/// The metrics endpoint exposes the number of live (non-expired) MCP session
+/// grants. Registering sessions raises the live count; letting the grants
+/// expire drops it back to zero — the metric filters by expiry at scrape time,
+/// so no pruning call is needed — while the total entry count still reflects
+/// the not-yet-removed expired residue.
+#[test]
+fn mcp_live_session_count_metric() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_with_mcp(&env);
+    let anchor_1 = flows::register_anchor(&env, canister_id);
+    let anchor_2 = flows::register_anchor_with(&env, canister_id, principal_2(), &device_data_2());
+    trust_mcp_server(&env, canister_id, principal_1(), anchor_1);
+    trust_mcp_server(&env, canister_id, principal_2(), anchor_2);
+
+    // No sessions registered yet.
+    let metrics = get_metrics(&env, canister_id);
+    assert_metric(&metrics, "internet_identity_mcp_live_session_count", 0f64);
+    assert_metric(&metrics, "internet_identity_mcp_session_count", 0f64);
+
+    // One anchor registers a session -> one live session.
+    register_session(
+        &env,
+        canister_id,
+        principal_1(),
+        anchor_1,
+        &ByteBuf::from("session key anchor 1"),
+        GRANT_TTL_NS,
+    );
+    let metrics = get_metrics(&env, canister_id);
+    assert_metric(&metrics, "internet_identity_mcp_live_session_count", 1f64);
+    assert_metric(&metrics, "internet_identity_mcp_session_count", 1f64);
+
+    // A second anchor registers -> two live sessions.
+    register_session(
+        &env,
+        canister_id,
+        principal_2(),
+        anchor_2,
+        &ByteBuf::from("session key anchor 2"),
+        GRANT_TTL_NS,
+    );
+    let metrics = get_metrics(&env, canister_id);
+    assert_metric(&metrics, "internet_identity_mcp_live_session_count", 2f64);
+    assert_metric(&metrics, "internet_identity_mcp_session_count", 2f64);
+
+    // Let both grants expire (GRANT_TTL_NS is one day). The live count filters
+    // by expiry at scrape time, so it drops to zero on the next query without
+    // any pruning; the total still counts the two expired entries (the grant
+    // map has no periodic GC).
+    env.advance_time(Duration::from_nanos(GRANT_TTL_NS) + Duration::from_secs(1));
+    env.tick();
+    let metrics = get_metrics(&env, canister_id);
+    assert_metric(&metrics, "internet_identity_mcp_live_session_count", 0f64);
+    assert_metric(&metrics, "internet_identity_mcp_session_count", 2f64);
 
     Ok(())
 }


### PR DESCRIPTION
# Motivation

MCP session grants (registered via the `/mcp` connect flow, `mcp_register_v2`)
are the currently-authorized MCP sessions on the canister, but their count was
not observable from outside. Exposing it in the Prometheus metrics lets us
monitor how many MCP sessions are live over time (adoption, and — together
with the total — how much expired residue accumulates in the grant map, which
informs whether periodic grant-map GC is ever needed).

# Changes

Added two gauges to the canister metrics endpoint (`http_request` → Prometheus
text; no candid/interface change):

- **`internet_identity_mcp_live_session_count`** — live (non-expired) MCP
  session grants: the currently-authorized sessions, at most one per anchor.
  Computed by scanning the grant map and filtering by `expires_at_ns` against
  the current time at scrape time.
- **`internet_identity_mcp_session_count`** — total grant entries stored (live
  plus not-yet-removed expired residue), for context. O(1) via the map length.

Backed by two `Storage` helpers:

- `count_live_mcp_grants(now_ns)` — the filtered live count (O(n) in stored
  grants).
- `mcp_grant_count()` — the total entry count (O(1)).

# Tests

- New integration test `mcp::mcp_live_session_count_metric`: registers MCP
  sessions for two anchors and asserts both gauges track them (0 → 1 → 2),
  then advances time past the grant lifetime and asserts the live count drops
  to `0` on the next scrape (the metric filters by expiry, no pruning call
  needed) while the total still reports `2` (the grant map has no periodic GC).
- Full metric suite green (`cargo test --test integration metric`, 16 passed)
  and full MCP suite green (35 passed) against a freshly built wasm.
- `cargo fmt` clean; clippy clean on the canister (wasm32) and the tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbjCCqTjsMn57fczTNGaKf)_