### PR TITLE
chore(fe): update OISY Wallet description in dapp explorer

### DIFF
--- a/src/frontend/src/lib/legacy/flows/dappsExplorer/dapps.json
+++ b/src/frontend/src/lib/legacy/flows/dappsExplorer/dapps.json
@@ -82,7 +82,7 @@
   },
   {
     "name": "OISY Wallet",
-    "oneLiner": "One wallet for ICP, Bitcoin and Ethereum. No private keys to lose.",
+    "oneLiner": "One wallet for your digital wealth: crypto, stocks, commodities and collectibles. With encrypted notes and tools to earn, borrow, and trade. Private and tamperproof. Invisible if you need it to be.",
     "website": "https://oisy.com",
     "authOrigins": ["https://oisy.com"],
     "logo": "oisy_logo.svg",

--- a/src/frontend/src/lib/legacy/flows/dappsExplorer/dapps.json
+++ b/src/frontend/src/lib/legacy/flows/dappsExplorer/dapps.json
@@ -82,7 +82,7 @@
   },
   {
     "name": "OISY Wallet",
-    "oneLiner": "One wallet for your digital wealth: crypto, stocks, commodities and collectibles. With encrypted notes and tools to earn, borrow, and trade. Private and tamperproof. Invisible if you need it to be.",
+    "oneLiner": "One wallet for your digital wealth: crypto, stocks, commodities, and collectibles. With encrypted notes and tools to earn, borrow, and trade. Private and tamperproof. Invisible if you need it to be.",
     "website": "https://oisy.com",
     "authOrigins": ["https://oisy.com"],
     "logo": "oisy_logo.svg",


### PR DESCRIPTION
# Motivation

The OISY Wallet entry in the dapp explorer carried an outdated one-liner ("One wallet for ICP, Bitcoin and Ethereum. No private keys to lose."). This updates it to the current description that better reflects the product's positioning.

# Changes

- Updated the `oneLiner` field for the `OISY Wallet` entry in `src/frontend/src/lib/legacy/flows/dappsExplorer/dapps.json` to:

  > One wallet for your digital wealth: crypto, stocks, commodities and collectibles. With encrypted notes and tools to earn, borrow, and trade. Private and tamperproof. Invisible if you need it to be.

  This `dapps.json` is the single source of truth (imported via `dapps.ts`), so the new copy shows up both in the legacy dapps explorer and the new-styling authenticated home page, which both render the `oneLiner` field.

# Tests

- Validated that `dapps.json` remains well-formed JSON.
- The existing `dapps.test.ts` suite only asserts on `logo`, `website`, and `authOrigins` — none of which are touched — so no test changes are required; only the display copy changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pZMhcPCwgqawn2ujdiRCV

---
_Generated by [Claude Code](https://claude.ai/code/session_013pZMhcPCwgqawn2ujdiRCV)_