### PR TITLE
chore: consolidate Dependabot into one weekly version PR + grouped security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,20 @@
 version: 2
+
+# Non-major version updates for every ecosystem are consolidated into a single
+# weekly pull request via `multi-ecosystem-groups`. Security updates are handled
+# separately per ecosystem via `groups` with `applies-to: security-updates`, so
+# advisory-driven bumps arrive as one grouped PR per ecosystem (across all
+# directories) instead of one PR per dependency.
+multi-ecosystem-groups:
+  weekly-version-updates:
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Etc/UTC
+    labels:
+      - dependencies
+
 updates:
   # ── cargo ──────────────────────────────────────────────
   - package-ecosystem: cargo
@@ -20,21 +36,14 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+    patterns:
+      - "*"
+    multi-ecosystem-group: weekly-version-updates
     groups:
-      cargo-all:
+      cargo-security:
+        applies-to: security-updates
         patterns:
           - "*"
-        update-types:
-          - minor
-          - patch
-        exclude-patterns:
-          - pocket-ic
-      pocket-ic:
-        patterns:
-          - pocket-ic
-        update-types:
-          - minor
-          - patch
 
   # ── npm ────────────────────────────────────────────────
   - package-ecosystem: npm
@@ -63,21 +72,14 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+    patterns:
+      - "*"
+    multi-ecosystem-group: weekly-version-updates
     groups:
-      npm-all:
+      npm-security:
+        applies-to: security-updates
         patterns:
           - "*"
-        update-types:
-          - minor
-          - patch
-        exclude-patterns:
-          - "@dfinity/*"
-      agent-js:
-        patterns:
-          - "@dfinity/*"
-        update-types:
-          - minor
-          - patch
 
   # ── github-actions ─────────────────────────────────────
   - package-ecosystem: github-actions
@@ -95,13 +97,14 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+    patterns:
+      - "*"
+    multi-ecosystem-group: weekly-version-updates
     groups:
-      actions-all:
+      actions-security:
+        applies-to: security-updates
         patterns:
           - "*"
-        update-types:
-          - minor
-          - patch
 
   # ── docker ─────────────────────────────────────────────
   - package-ecosystem: docker
@@ -119,3 +122,11 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+    patterns:
+      - "*"
+    multi-ecosystem-group: weekly-version-updates
+    groups:
+      docker-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Problem

Dependabot opens far too many PRs. The bulk of the individual noise (postcss, tar, dompurify, immutable, brace-expansion, undici, js-yaml, `@vitest/browser`, …) is Dependabot **security updates** — they are advisory-driven and, by default, open **one PR per dependency**, ignoring the existing `groups:` config. The weekly *version* updates were already grouped; the security stream was not.

## Fix

Two independent levers:

1. **`multi-ecosystem-groups` (`weekly-version-updates`)** — consolidates non-major version updates across `cargo` / `npm` / `github-actions` / `docker` into a **single weekly PR**.
2. **Per-ecosystem `groups` with `applies-to: security-updates`** — batches security updates into **one PR per ecosystem across all directories** ([grouped security updates](https://github.blog/changelog/2024-03-28-dependabot-grouped-security-updates-generally-available/), GA'd 2024-03-28).

## Behavior change

The previous per-ecosystem version sub-groups (`pocket-ic` split out of cargo, `agent-js`/`@dfinity/*` split out of npm) are dropped — non-major version updates now all land in the single weekly PR.

## Notes for reviewer

- `multi-ecosystem-groups` is a newer Dependabot feature. Please confirm Dependabot's config validation passes on the default branch after merge — Dependabot ignores the entire file if it fails to parse. The `applies-to: security-updates` grouping is GA and well-established.
- `version-update:semver-major` remains ignored, which also gates major-version *security* fixes. Flagging so reviewers can decide whether security fixes should be allowed to go major.
