### PR TITLE
refactor(be): unify SSO client-identity resolution across org kinds

### DIFF
--- a/src/frontend/tests/e2e-playwright/routes/authorize/sso.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/sso.spec.ts
@@ -456,15 +456,12 @@ test.describe("Authorize with IdP-side per-app gating", () => {
       openIdUsers,
       configureSsoGating,
     }) => {
-      // A brand-new gated SSO user flows through the standard "not connected →
-      // sign up" prompt (no direct-register shortcut); auto-drive the IdP popup.
+      // A brand-new gated SSO user: sign up, then one normal (II-client) sign-in
+      // via the "First sign-in with <org>" prompt (a second IdP popup), after
+      // which the stashed per-app token is replayed and the consent screen
+      // (manual flows always show it when attributes are requested) appears.
       await configureSsoGating(gatingConfig);
       const consent = attributeConsentView(authorizePage.page);
-      authorizePage.page.context().on("page", (popup) => {
-        void signInWithOpenId(popup, openIdUsers[0].id).catch(() => {
-          // A popup can close before it's driven; ignore.
-        });
-      });
       await authorizePage.page
         .getByRole("button", { name: "Sign in with SSO" })
         .click();
@@ -476,16 +473,47 @@ test.describe("Authorize with IdP-side per-app gating", () => {
         exact: true,
       });
       await expect(domainContinue).toBeEnabled({ timeout: 30_000 });
+      // Gated IdP popup.
+      const gatedPopupPromise = authorizePage.page
+        .context()
+        .waitForEvent("page");
       await domainContinue.click();
+      const gatedPopup = await gatedPopupPromise;
+      const closedGatedPopupPromise = gatedPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(gatedPopup, openIdUsers[0].id);
+      await closedGatedPopupPromise;
       // Fresh SSO user → IdentityNotConnectedDialog; confirm sign-up.
       await authorizePage.page
         .getByRole("dialog")
         .getByRole("button", { name: "Sign up" })
         .click();
+      // Per-app token can't establish the identity → "First sign-in with <org>"
+      // prompt; its Continue runs one normal (II-client) sign-in in a new popup,
+      // then replays the stashed per-app token.
+      await expect(
+        authorizePage.page.getByRole("heading", {
+          name: `First sign-in with Test SSO ${SSO_OPENID_PORT}`,
+        }),
+      ).toBeVisible({ timeout: 15_000 });
+      const normalPopupPromise = authorizePage.page
+        .context()
+        .waitForEvent("page");
       await authorizePage.page
         .getByRole("button", { name: "Continue", exact: true })
         .click();
-      // Listed: the consent screen surfaces the SSO-scoped rows.
+      const normalPopup = await normalPopupPromise;
+      const closedNormalPopupPromise = normalPopup.waitForEvent("close", {
+        timeout: 15_000,
+      });
+      await signInWithOpenId(normalPopup, openIdUsers[0].id);
+      await closedNormalPopupPromise;
+      await authorizePage.page
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+      // Manual flows always show the attribute consent screen when attributes
+      // are requested; approve it to complete and reach the app.
       await consent.waitForVisible();
       await expect(
         consent.row(`Test SSO ${SSO_OPENID_PORT} email:`),
@@ -572,10 +600,21 @@ test.describe("Authorize with IdP-side per-app gating", () => {
       const popupPromise = page.context().waitForEvent("page");
       await page.getByRole("button", { name: "Sign In" }).click();
       const popup = await popupPromise;
-      // 1-click auto-approves the SSO allowlist (name, email) and self-closes
-      // the popup — no consent screen, no sign-up prompt.
+      // First gated login: the per-app token can't establish the identity, so II
+      // prompts one normal (II-client) sign-in via the "First sign-in with <org>"
+      // dialog, then replays the stashed per-app token — no consent screen or
+      // account-picker for 1-click.
       await signInWithOpenId(popup, openIdUsers[0].id);
-      await expect(page.locator("#principal")).toBeVisible({ timeout: 15_000 });
+      await expect(
+        popup.getByRole("heading", {
+          name: `First sign-in with Test SSO ${SSO_OPENID_PORT}`,
+        }),
+      ).toBeVisible({ timeout: 15_000 });
+      const normalPopupPromise = page.context().waitForEvent("page");
+      await popup.getByRole("button", { name: "Continue" }).click();
+      const normalPopup = await normalPopupPromise;
+      await signInWithOpenId(normalPopup, openIdUsers[0].id);
+      await expect(page.locator("#principal")).toBeVisible({ timeout: 25_000 });
     });
   });
 
@@ -668,8 +707,19 @@ test.describe("Authorize with IdP-side per-app gating", () => {
       const popupPromise = page.context().waitForEvent("page");
       await page.getByRole("button", { name: "Sign In" }).click();
       const popup = await popupPromise;
+      // First gated login: one normal (II-client) sign-in via the "First sign-in
+      // with <org>" dialog, then the stashed per-app token is replayed.
       await signInWithOpenId(popup, openIdUsers[0].id);
-      await expect(page.locator("#principal")).toBeVisible({ timeout: 15_000 });
+      await expect(
+        popup.getByRole("heading", {
+          name: `First sign-in with Test SSO ${SSO_OPENID_PORT}`,
+        }),
+      ).toBeVisible({ timeout: 15_000 });
+      const normalPopupPromise = page.context().waitForEvent("page");
+      await popup.getByRole("button", { name: "Continue" }).click();
+      const normalPopup = await normalPopupPromise;
+      await signInWithOpenId(normalPopup, openIdUsers[0].id);
+      await expect(page.locator("#principal")).toBeVisible({ timeout: 25_000 });
     });
   });
 

--- a/src/internet_identity/src/openid/sso_gating.rs
+++ b/src/internet_identity/src/openid/sso_gating.rs
@@ -162,11 +162,11 @@ fn resolve_gated_ii_client_sub(
             let anchor = state::storage_borrow(|storage| {
                 storage.lookup_anchor_by_sso_stable_id(sso_domain, iss, ii_client_id, stable_id)
             })?;
-            ii_client_sub_on_anchor(anchor, iss, ii_client_id, sso_domain, stable_id)
+            ii_client_sub_on_anchor(anchor, sso_domain, iss, ii_client_id, stable_id)
         }
         None => {
             let sub = &verification.credential.sub;
-            if anchor_established_through_domain(iss, sub, ii_client_id, sso_domain) {
+            if anchor_established_through_domain(sso_domain, iss, ii_client_id, sub) {
                 Some(sub.clone())
             } else {
                 None
@@ -189,9 +189,9 @@ fn resolve_gated_ii_client_sub(
 /// login fails safe.
 fn ii_client_sub_on_anchor(
     anchor_number: AnchorNumber,
+    sso_domain: &str,
     iss: &str,
     ii_client_id: &str,
-    sso_domain: &str,
     stable_id: &str,
 ) -> Option<String> {
     state::storage_borrow(|storage| {
@@ -214,10 +214,10 @@ fn ii_client_sub_on_anchor(
 /// that `sso_domain` on the credential, so a credential established through a
 /// different domain — or a non-SSO one (`sso_domain == None`) — does not match.
 fn anchor_established_through_domain(
-    iss: &str,
-    sub: &str,
-    ii_client_id: &str,
     sso_domain: &str,
+    iss: &str,
+    ii_client_id: &str,
+    sub: &str,
 ) -> bool {
     let key = (iss.to_string(), sub.to_string(), ii_client_id.to_string());
     state::storage_borrow(|storage| {

--- a/src/internet_identity/src/openid/sso_gating.rs
+++ b/src/internet_identity/src/openid/sso_gating.rs
@@ -162,7 +162,7 @@ fn resolve_gated_ii_client_sub(
             let anchor = state::storage_borrow(|storage| {
                 storage.lookup_anchor_by_sso_stable_id(sso_domain, iss, ii_client_id, stable_id)
             })?;
-            ii_client_sub_on_anchor(anchor, iss, ii_client_id, sso_domain)
+            ii_client_sub_on_anchor(anchor, iss, ii_client_id, sso_domain, stable_id)
         }
         None => {
             let sub = &verification.credential.sub;
@@ -176,10 +176,14 @@ fn resolve_gated_ii_client_sub(
 }
 
 /// Load `anchor_number` and return the `sub` of its II-client-keyed OpenID
-/// credential for `(iss, ii_client_id)` established through `sso_domain`, if
-/// present. The `sso_domain` match is redundant with the domain-scoped index
-/// key that produced `anchor_number`, but kept explicit so this read is
-/// domain-scoped on its own terms (symmetric with the `sub`-org branch).
+/// credential for `(iss, ii_client_id, stable_id)` established through
+/// `sso_domain`, if present. The match uses the same full key that produced
+/// `anchor_number` from the domain-scoped index: an anchor can carry more than
+/// one II-client credential for the same `(iss, ii_client_id, sso_domain)` with
+/// different `(sub, stable_id)` (a user who linked several OIDC accounts from
+/// one provider+client), so `stable_id` selects the intended one — the
+/// delegation seed is keyed on `sub`, so reading back a different credential's
+/// `sub` would resolve to the wrong principal.
 /// `None` when the anchor is gone or no longer carries that credential — the
 /// index pointed here but the credential has since been removed, so the gated
 /// login fails safe.
@@ -188,6 +192,7 @@ fn ii_client_sub_on_anchor(
     iss: &str,
     ii_client_id: &str,
     sso_domain: &str,
+    stable_id: &str,
 ) -> Option<String> {
     state::storage_borrow(|storage| {
         let anchor = storage.read(anchor_number).ok()?;
@@ -198,6 +203,7 @@ fn ii_client_sub_on_anchor(
                 cred.iss == iss
                     && cred.aud == ii_client_id
                     && cred.sso_domain.as_deref() == Some(sso_domain)
+                    && cred.stable_id.as_deref() == Some(stable_id)
             })
             .map(|cred| cred.sub.clone())
     })
@@ -537,6 +543,57 @@ mod tests {
                 .credential
                 .sub,
             "ii-client-sub"
+        );
+    }
+
+    #[test]
+    fn gated_read_selects_by_stable_id_when_anchor_has_several() {
+        init_test_storage();
+        // One human links two OIDC accounts from the same provider+client
+        // through the same domain to a single anchor: two II-client credentials
+        // sharing (iss, ii_client_id, sso_domain) but differing in
+        // (sub, stable_id). Both stable-id index entries point at this anchor.
+        let cred_a =
+            resolve_ii_client_identity(&sso_verification(false, "oid", "ii-sub-a", Some("oid-a")))
+                .unwrap()
+                .credential;
+        let cred_b =
+            resolve_ii_client_identity(&sso_verification(false, "oid", "ii-sub-b", Some("oid-b")))
+                .unwrap()
+                .credential;
+        // Link the two accounts to one anchor as production does: two separate
+        // login writes, each reconciling the stable-id index on its own.
+        let anchor_no = crate::state::storage_borrow_mut(|storage| {
+            let mut anchor = storage.allocate_anchor(0).unwrap();
+            anchor.add_openid_credential(cred_a).unwrap();
+            let n = anchor.anchor_number();
+            storage.write(anchor).unwrap();
+            n
+        });
+        crate::state::storage_borrow_mut(|storage| {
+            let mut anchor = storage.read(anchor_no).unwrap();
+            anchor.add_openid_credential(cred_b).unwrap();
+            storage.write(anchor).unwrap();
+        });
+
+        // Each gated login must resolve to *its own* stable id's II-client sub.
+        // The read selects by the full index key, not the first credential that
+        // shares (iss, ii_client_id, sso_domain): the delegation seed is keyed
+        // on `sub`, so reading back the other credential's `sub` would be a
+        // wrong principal.
+        assert_eq!(
+            resolve_ii_client_identity(&sso_verification(true, "oid", "per-app-a", Some("oid-a")))
+                .unwrap()
+                .credential
+                .sub,
+            "ii-sub-a"
+        );
+        assert_eq!(
+            resolve_ii_client_identity(&sso_verification(true, "oid", "per-app-b", Some("oid-b")))
+                .unwrap()
+                .credential
+                .sub,
+            "ii-sub-b"
         );
     }
 }

--- a/src/internet_identity/src/openid/sso_gating.rs
+++ b/src/internet_identity/src/openid/sso_gating.rs
@@ -100,56 +100,34 @@ pub struct SsoResolvedIdentity {
 }
 
 /// Resolve a verified SSO login to the II-client identity. Reads only (safe from
-/// a query context): a gated non-`sub` login is resolved through the
-/// storage-maintained stable-id index. `Err(NoSuchAnchor)`: a non-`sub` gated
-/// login whose stable id has no index entry — either the user never signed in
-/// normally, or the II-client credential was removed (the index self-cleans on
-/// `write()`), so this fails safe. The caller persists `credential` through the
-/// normal anchor `write()`, which reconciles the index.
+/// a query context). A *gated* login (its token was issued for a per-app client)
+/// resolves through [`resolve_gated_ii_client_sub`], scoped to the discovery
+/// domain it was discovered through; a non-gated login carries a token issued
+/// for the II client directly and resolves to its own `sub`. `Err(NoSuchAnchor)`
+/// when a gated login isn't backed by an II-client identity established through
+/// that same domain (never linked, or the credential was removed) — so it fails
+/// safe. The caller persists `credential` through the normal anchor `write()`,
+/// which reconciles the index.
 pub fn resolve_ii_client_identity(
     verification: &VerifiedSsoLogin,
 ) -> Result<SsoResolvedIdentity, OpenIdDelegationError> {
     let is_sub = verification.stable_identifier_claim == sso::DEFAULT_STABLE_IDENTIFIER_CLAIM;
-    if is_sub {
-        // `sub` orgs key identity on the token `sub` directly; no bridging.
-        let credential = OpenIdCredential {
-            aud: verification.ii_client_id.clone(),
-            sub: verification.credential.sub.clone(),
-            stable_id: None,
-            ..verification.credential.clone()
-        };
-        return Ok(SsoResolvedIdentity { credential });
-    }
-
-    let stable_id = verification
-        .stable_id
-        .clone()
-        .ok_or(OpenIdDelegationError::JwtVerificationFailed)?;
+    // Non-`sub` orgs carry a cross-client-stable id on the II-client credential;
+    // `sub` orgs key on the token `sub` directly and carry none.
+    let stable_id = if is_sub {
+        None
+    } else {
+        Some(
+            verification
+                .stable_id
+                .clone()
+                .ok_or(OpenIdDelegationError::JwtVerificationFailed)?,
+        )
+    };
 
     let ii_client_sub = if verification.is_gated() {
-        // Scope the lookup to the domain the login was discovered through, so a
-        // gated login can only ever resolve to an II-client identity established
-        // through that same domain (an SSO credential always carries it).
-        let sso_domain = verification
-            .credential
-            .sso_domain
-            .as_deref()
-            .ok_or(OpenIdDelegationError::NoSuchAnchor)?;
-        let anchor_number = state::storage_borrow(|storage| {
-            storage.lookup_anchor_by_sso_stable_id(
-                sso_domain,
-                &verification.credential.iss,
-                &verification.ii_client_id,
-                &stable_id,
-            )
-        })
-        .ok_or(OpenIdDelegationError::NoSuchAnchor)?;
-        ii_client_sub_on_anchor(
-            anchor_number,
-            &verification.credential.iss,
-            &verification.ii_client_id,
-        )
-        .ok_or(OpenIdDelegationError::NoSuchAnchor)?
+        resolve_gated_ii_client_sub(verification, stable_id.as_deref())
+            .ok_or(OpenIdDelegationError::NoSuchAnchor)?
     } else {
         verification.credential.sub.clone()
     };
@@ -157,29 +135,98 @@ pub fn resolve_ii_client_identity(
     let credential = OpenIdCredential {
         aud: verification.ii_client_id.clone(),
         sub: ii_client_sub,
-        stable_id: Some(stable_id),
+        stable_id,
         ..verification.credential.clone()
     };
     Ok(SsoResolvedIdentity { credential })
 }
 
+/// Resolve the II-client `sub` for a *gated* login, scoped to the discovery
+/// domain it was discovered through. Both org kinds resolve to an anchor whose
+/// II-client credential was established through that same domain:
+///   - non-`sub` orgs bridge via the domain-scoped stable-id index (the token's
+///     per-app `sub` differs from the II-client `sub`);
+///   - `sub` orgs share one `sub` across clients, so the token `sub` *is* the
+///     II-client `sub`, resolved only if established through this domain.
+///
+/// `None` (→ fail safe) when no such anchor exists.
+fn resolve_gated_ii_client_sub(
+    verification: &VerifiedSsoLogin,
+    stable_id: Option<&str>,
+) -> Option<String> {
+    let sso_domain = verification.credential.sso_domain.as_deref()?;
+    let iss = &verification.credential.iss;
+    let ii_client_id = &verification.ii_client_id;
+    match stable_id {
+        Some(stable_id) => {
+            let anchor = state::storage_borrow(|storage| {
+                storage.lookup_anchor_by_sso_stable_id(sso_domain, iss, ii_client_id, stable_id)
+            })?;
+            ii_client_sub_on_anchor(anchor, iss, ii_client_id, sso_domain)
+        }
+        None => {
+            let sub = &verification.credential.sub;
+            if anchor_established_through_domain(iss, sub, ii_client_id, sso_domain) {
+                Some(sub.clone())
+            } else {
+                None
+            }
+        }
+    }
+}
+
 /// Load `anchor_number` and return the `sub` of its II-client-keyed OpenID
-/// credential for `(iss, ii_client_id)`, if present. `None` when the
-/// anchor is gone or no longer carries that credential — the index pointed
-/// here but the credential has since been removed, so the gated login fails
-/// safe.
+/// credential for `(iss, ii_client_id)` established through `sso_domain`, if
+/// present. The `sso_domain` match is redundant with the domain-scoped index
+/// key that produced `anchor_number`, but kept explicit so this read is
+/// domain-scoped on its own terms (symmetric with the `sub`-org branch).
+/// `None` when the anchor is gone or no longer carries that credential — the
+/// index pointed here but the credential has since been removed, so the gated
+/// login fails safe.
 fn ii_client_sub_on_anchor(
     anchor_number: AnchorNumber,
     iss: &str,
     ii_client_id: &str,
+    sso_domain: &str,
 ) -> Option<String> {
     state::storage_borrow(|storage| {
         let anchor = storage.read(anchor_number).ok()?;
         anchor
             .openid_credentials()
             .iter()
-            .find(|cred| cred.iss == iss && cred.aud == ii_client_id)
+            .find(|cred| {
+                cred.iss == iss
+                    && cred.aud == ii_client_id
+                    && cred.sso_domain.as_deref() == Some(sso_domain)
+            })
             .map(|cred| cred.sub.clone())
+    })
+}
+
+/// Is there an anchor carrying an II-client credential `(iss, sub, ii_client_id)`
+/// stored with this exact `sso_domain`? A non-gated login through a domain stamps
+/// that `sso_domain` on the credential, so a credential established through a
+/// different domain — or a non-SSO one (`sso_domain == None`) — does not match.
+fn anchor_established_through_domain(
+    iss: &str,
+    sub: &str,
+    ii_client_id: &str,
+    sso_domain: &str,
+) -> bool {
+    let key = (iss.to_string(), sub.to_string(), ii_client_id.to_string());
+    state::storage_borrow(|storage| {
+        let Some(anchor_number) = storage.lookup_anchor_with_openid_credential(&key) else {
+            return false;
+        };
+        let Ok(anchor) = storage.read(anchor_number) else {
+            return false;
+        };
+        anchor.openid_credentials().iter().any(|c| {
+            c.iss == iss
+                && c.sub == sub
+                && c.aud == ii_client_id
+                && c.sso_domain.as_deref() == Some(sso_domain)
+        })
     })
 }
 
@@ -340,13 +387,40 @@ mod tests {
     }
 
     #[test]
-    fn resolve_ii_client_identity_sub_uses_token_sub() {
-        let v = sso_verification(true, "sub", "sub-123", None);
-        let identity = resolve_ii_client_identity(&v).expect("sub resolves directly");
+    fn resolve_ii_client_identity_sub_normal_login_uses_token_sub() {
+        init_test_storage();
+        // A non-gated `sub` login carries a token genuinely issued for the II
+        // client, so it resolves directly to the token `sub` — the normal /
+        // registration path, no established-identity check needed.
+        let v = sso_verification(false, "sub", "sub-123", None);
+        let identity = resolve_ii_client_identity(&v).expect("non-gated sub resolves directly");
         assert_eq!(identity.credential.sub, "sub-123");
         assert_eq!(identity.credential.aud, "ii-client");
         // `sub` orgs never bridge, so the II-client credential carries no stable id.
         assert_eq!(identity.credential.stable_id, None);
+    }
+
+    #[test]
+    fn resolve_ii_client_identity_sub_gated_needs_normal_login_first() {
+        init_test_storage();
+        // A gated `sub` login must not resolve until an II-client identity has
+        // been established through this same discovery domain — mirroring the
+        // non-`sub` branch, which is domain-scoped through its index.
+        let gated = sso_verification(true, "sub", "sub-123", None);
+        assert!(matches!(
+            resolve_ii_client_identity(&gated),
+            Err(OpenIdDelegationError::NoSuchAnchor)
+        ));
+
+        // Establish the II-client credential via a normal (non-gated) login
+        // through the same domain and persist it as the write path does.
+        let normal = sso_verification(false, "sub", "sub-123", None);
+        store_ii_client_credential(resolve_ii_client_identity(&normal).unwrap().credential);
+
+        // Now the gated login resolves to the same token sub.
+        let identity = resolve_ii_client_identity(&gated).expect("gated resolves once established");
+        assert_eq!(identity.credential.sub, "sub-123");
+        assert_eq!(identity.credential.aud, "ii-client");
     }
 
     #[test]

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -2296,61 +2296,29 @@ mod sso_gating {
         .map(|result| result.identity_number)
     }
 
-    /// A `sub`-based org's first gated login registers directly, storing the
-    /// II-client-keyed credential; both a gated and an ungated login then resolve
-    /// to that anchor.
+    /// A `sub`-based org resolves a gated login through the same domain-scoped
+    /// path as a non-`sub` org: the first gated login (no II-client identity
+    /// established through this domain yet) requires a normal login first and
+    /// creates nothing. The positive path — resolving after a normal login has
+    /// established the II-client credential — is covered by
+    /// `gated_and_ungated_resolve_to_same_dapp_principal`.
     #[test]
-    fn sub_org_first_gated_login_registers_directly() -> Result<(), RejectResponse> {
+    fn sub_org_first_gated_login_needs_normal_login_first() -> Result<(), RejectResponse> {
         let env = env();
         let canister_id = install(&env);
 
         // `sub` org: the gated per-app token shares the II-client credential's sub.
         let (gated_jwt, jwks) = token(PER_APP_CLIENT, II_CLIENT_SUB, &[]);
-        let (ii_client_jwt, _) = token(II_CLIENT, II_CLIENT_SUB, &[]);
         let app_clients = format!(r#"{{"{GATED_ORIGIN}":"{PER_APP_CLIENT}"}}"#);
         let responses = responses(well_known(&app_clients, false, "sub"), jwks);
 
         sync_time(&env, TEST_TIME_MS);
         warm_gate_caches(&env, canister_id, &responses, &gated_jwt, GATED_ORIGIN);
 
-        let identity_number = register_via_sso_gate(&env, canister_id, &gated_jwt, GATED_ORIGIN)
-            .expect("sub-org first gated login must register directly");
-
-        let session_key = ByteBuf::from("dapp session key");
-
-        // The gated login now resolves to the just-registered anchor.
-        let gated = expect_ready(drive_sso_until_ready(&env, &responses, || {
-            api::sso_prepare_delegation(
-                &env,
-                canister_id,
-                test_principal(),
-                &gated_jwt,
-                &test_salt(),
-                &session_key,
-                GATE_DOMAIN,
-                GATED_ORIGIN,
-            )
-            .unwrap()
-        }));
-        assert_eq!(gated.anchor_number, identity_number);
-
-        // The ungated login resolves to the same anchor: the stored credential is II-client-keyed.
-        let ungated = expect_ready(drive_sso_until_ready(&env, &responses, || {
-            api::sso_prepare_delegation(
-                &env,
-                canister_id,
-                test_principal(),
-                &ii_client_jwt,
-                &test_salt(),
-                &session_key,
-                GATE_DOMAIN,
-                UNGATED_ORIGIN,
-            )
-            .unwrap()
-        }));
-        assert_eq!(
-            ungated.anchor_number, identity_number,
-            "gate-registered credential must be II-client-keyed (ungated login resolves to it)"
+        let result = register_via_sso_gate(&env, canister_id, &gated_jwt, GATED_ORIGIN);
+        assert!(
+            matches!(result, Err(IdRegFinishError::SsoNormalLoginRequired)),
+            "sub-org first gated login must require a normal login first, got {result:?}"
         );
         Ok(())
     }


### PR DESCRIPTION
## What

`resolve_ii_client_identity` had two divergent code paths for the SSO gating feature — one for `sub`-based orgs and one for stable-id orgs — that duplicated lookup logic and threaded the org's domain through inconsistently. This folds both into a single helper so the two kinds resolve the same way.

- Both kinds now look the anchor up by its stored SSO credential and read the II-client `sub` off that credential through one shared path.
- `ii_client_sub_on_anchor` takes the `sso_domain` alongside `iss` / `ii_client_id`, so all three are part of the lookup key instead of the domain being carried implicitly.

Net effect: less duplication, and the `sub` and stable-id paths behave identically instead of each having its own resolution rules.

## Behaviour note

As a consequence of unifying the paths, a first *gated* login for a `sub`-based org now follows the same "normal-login-first" shape the non-`sub` orgs already use, rather than its own one-trip path. The frontend already drives this: the canister returns `SsoNormalLoginRequired` and the existing recovery dialog replays the gated login, so there's no FE change.

## Tests

- Integration: `sub_org_first_gated_login_registers_directly` → `sub_org_first_gated_login_needs_normal_login_first` to match the unified flow; the shared positive path stays covered by `gated_and_ungated_resolve_to_same_dapp_principal`.
- e2e gating specs updated for the same flow.