### PR TITLE
fix(fe): spell out off-preset session durations in the picker

### DIFF
--- a/src/frontend/src/lib/components/ui/SessionDurationSelect.svelte
+++ b/src/frontend/src/lib/components/ui/SessionDurationSelect.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import Select from "$lib/components/ui/Select.svelte";
   import { ChevronDownIcon } from "@lucide/svelte";
-  import { plural, t } from "$lib/stores/locale.store";
+  import { formatDuration, t } from "$lib/stores/locale.store";
   import {
     cappedSessionDurations,
-    sessionDurationParts,
-    type SessionDurationPart,
+    sessionDurationBreakdown,
   } from "$lib/utils/sessionDuration";
 
   type Align = "start" | "center" | "end";
@@ -48,28 +47,12 @@
     { value: 30 * DAY, label: $t`30 days` },
   ]);
 
-  // One unit of an off-preset duration, spelled out and pluralized in the
-  // current locale, e.g. `{ unit: "minute", value: 20 } -> "20 minutes"`.
-  const partLabel = ({ unit, value }: SessionDurationPart): string => {
-    switch (unit) {
-      case "day":
-        return $plural(value, { one: `# day`, other: `# days` });
-      case "hour":
-        return $plural(value, { one: `# hour`, other: `# hours` });
-      case "minute":
-        return $plural(value, { one: `# minute`, other: `# minutes` });
-      case "second":
-        return $plural(value, { one: `# second`, other: `# seconds` });
-    }
-  };
-
-  // A named preset's label, or a spelled-out label built from the duration's
-  // units for an off-preset one (e.g. an off-preset cap shown as "2 hours").
-  // Off-preset values are written out like the presets rather than compactly,
-  // so the dropdown doesn't mix "10 minutes" with "20m".
+  // A named preset's label, or — for an off-preset duration such as a cap the
+  // app asked for — its units spelled out by the locale ("2 hours"), so the
+  // dropdown doesn't mix "10 minutes" with a compact "20m".
   const labelFor = (seconds: number): string =>
     presets.find((preset) => preset.value === seconds)?.label ??
-    sessionDurationParts(seconds).map(partLabel).join(" ");
+    $formatDuration(sessionDurationBreakdown(seconds));
 
   // Every preset up to the cap, plus the cap itself when it isn't a preset, each
   // with its label and a flag for the current selection.

--- a/src/frontend/src/lib/components/ui/SessionDurationSelect.svelte
+++ b/src/frontend/src/lib/components/ui/SessionDurationSelect.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import Select from "$lib/components/ui/Select.svelte";
   import { ChevronDownIcon } from "@lucide/svelte";
-  import { t } from "$lib/stores/locale.store";
+  import { plural, t } from "$lib/stores/locale.store";
   import {
     cappedSessionDurations,
-    formatSessionDuration,
+    sessionDurationParts,
+    type SessionDurationPart,
   } from "$lib/utils/sessionDuration";
 
   type Align = "start" | "center" | "end";
@@ -47,11 +48,28 @@
     { value: 30 * DAY, label: $t`30 days` },
   ]);
 
-  // A named preset's label, or the compact format for an off-preset duration
-  // (e.g. an off-preset cap shown as "2h").
+  // One unit of an off-preset duration, spelled out and pluralized in the
+  // current locale, e.g. `{ unit: "minute", value: 20 } -> "20 minutes"`.
+  const partLabel = ({ unit, value }: SessionDurationPart): string => {
+    switch (unit) {
+      case "day":
+        return $plural(value, { one: `# day`, other: `# days` });
+      case "hour":
+        return $plural(value, { one: `# hour`, other: `# hours` });
+      case "minute":
+        return $plural(value, { one: `# minute`, other: `# minutes` });
+      case "second":
+        return $plural(value, { one: `# second`, other: `# seconds` });
+    }
+  };
+
+  // A named preset's label, or a spelled-out label built from the duration's
+  // units for an off-preset one (e.g. an off-preset cap shown as "2 hours").
+  // Off-preset values are written out like the presets rather than compactly,
+  // so the dropdown doesn't mix "10 minutes" with "20m".
   const labelFor = (seconds: number): string =>
     presets.find((preset) => preset.value === seconds)?.label ??
-    formatSessionDuration(seconds);
+    sessionDurationParts(seconds).map(partLabel).join(" ");
 
   // Every preset up to the cap, plus the cap itself when it isn't a preset, each
   // with its label and a flag for the current selection.

--- a/src/frontend/src/lib/stores/locale.store.test.ts
+++ b/src/frontend/src/lib/stores/locale.store.test.ts
@@ -1,0 +1,24 @@
+import { get } from "svelte/store";
+import { formatDuration } from "./locale.store";
+
+// The locale isn't switched here: loading a catalog needs the lingui Vite
+// plugin, which the test setup doesn't run. These cover the formatting itself,
+// in the default locale.
+describe("formatDuration", () => {
+  it("spells out and pluralizes a single unit", () => {
+    expect(get(formatDuration)({ minute: 20 })).toBe("20 minutes");
+    expect(get(formatDuration)({ hour: 1 })).toBe("1 hour");
+    expect(get(formatDuration)({ day: 5 })).toBe("5 days");
+  });
+
+  it("joins several units", () => {
+    expect(get(formatDuration)({ day: 1, hour: 1, minute: 1 })).toBe(
+      "1 day 1 hour 1 minute",
+    );
+  });
+
+  it("only formats the units it's given", () => {
+    expect(get(formatDuration)({ second: 0 })).toBe("0 seconds");
+    expect(get(formatDuration)({})).toBe("");
+  });
+});

--- a/src/frontend/src/lib/stores/locale.store.ts
+++ b/src/frontend/src/lib/stores/locale.store.ts
@@ -135,6 +135,48 @@ export const formatNumber = derived(
     i18n.number(value, format),
 );
 
+/** The units {@link formatDuration} can spell out, largest first. */
+const durationUnits = ["day", "hour", "minute", "second"] as const;
+
+/**
+ * A duration as a count per unit, e.g. `{ day: 1, hour: 2 }`. Only the units
+ * present are formatted, so leave a unit out to hide it — including a zero one,
+ * which the caller may still pass deliberately (`{ second: 0 }` -> "0 seconds").
+ */
+export type Duration = Partial<Record<(typeof durationUnits)[number], number>>;
+
+/**
+ * Usage: <span>{$formatDuration({ day: 1, hour: 2 })}</span>
+ *
+ * Each unit is spelled out by `Intl.NumberFormat`'s unit style, which pluralizes
+ * it for the locale, and the units are joined the way the locale joins a list of
+ * them ("1 day 2 hours", "1 Tag und 2 Stunden").
+ *
+ * `Intl.DurationFormat` would do both in a single call, and this is the place to
+ * switch to it once we can: it only reached the last of the browsers we support
+ * during 2025 (Safari 18.4, Firefox 140), so older ones would throw, and
+ * TypeScript doesn't declare it yet either. `NumberFormat`/`ListFormat` have
+ * been available for years and leave the wording to the locale just the same.
+ */
+export const formatDuration = derived(
+  localeStore,
+  (locale) => (duration: Duration) =>
+    new Intl.ListFormat(locale, { type: "unit", style: "narrow" }).format(
+      durationUnits.flatMap((unit) => {
+        const value = duration[unit];
+        return value === undefined
+          ? []
+          : [
+              new Intl.NumberFormat(locale, {
+                style: "unit",
+                unit,
+                unitDisplay: "long",
+              }).format(value),
+            ];
+      }),
+    ),
+);
+
 // Current time, used in below `formatRelative`
 const now = readable(Date.now(), (set) => {
   const interval = setInterval(() => set(Date.now()), 1000);

--- a/src/frontend/src/lib/utils/sessionDuration.test.ts
+++ b/src/frontend/src/lib/utils/sessionDuration.test.ts
@@ -1,8 +1,8 @@
 import {
   cappedSessionDurations,
   MAX_SESSION_DURATION_SECONDS,
+  sessionDurationBreakdown,
   sessionDurationCeilingSeconds,
-  sessionDurationParts,
   sessionDurationToNanos,
 } from "./sessionDuration";
 
@@ -14,32 +14,28 @@ const NANOS_PER_SECOND = BigInt(1_000_000_000);
 
 const PRESETS = [10 * MINUTE, HOUR, 8 * HOUR, DAY, WEEK, 30 * DAY];
 
-describe("sessionDurationParts", () => {
-  it("splits out a single unit", () => {
-    expect(sessionDurationParts(2 * HOUR)).toEqual([
-      { unit: "hour", value: 2 },
-    ]);
-    expect(sessionDurationParts(10 * MINUTE)).toEqual([
-      { unit: "minute", value: 10 },
-    ]);
-    expect(sessionDurationParts(DAY)).toEqual([{ unit: "day", value: 1 }]);
+describe("sessionDurationBreakdown", () => {
+  it("breaks out a single unit", () => {
+    expect(sessionDurationBreakdown(2 * HOUR)).toEqual({ hour: 2 });
+    expect(sessionDurationBreakdown(10 * MINUTE)).toEqual({ minute: 10 });
+    expect(sessionDurationBreakdown(DAY)).toEqual({ day: 1 });
   });
 
-  it("lists units largest first, skipping zeroes", () => {
-    expect(sessionDurationParts(DAY + HOUR + MINUTE + 1)).toEqual([
-      { unit: "day", value: 1 },
-      { unit: "hour", value: 1 },
-      { unit: "minute", value: 1 },
-      { unit: "second", value: 1 },
-    ]);
-    expect(sessionDurationParts(DAY + MINUTE)).toEqual([
-      { unit: "day", value: 1 },
-      { unit: "minute", value: 1 },
-    ]);
+  it("breaks out every non-zero unit", () => {
+    expect(sessionDurationBreakdown(DAY + HOUR + MINUTE + 1)).toEqual({
+      day: 1,
+      hour: 1,
+      minute: 1,
+      second: 1,
+    });
+    expect(sessionDurationBreakdown(DAY + MINUTE)).toEqual({
+      day: 1,
+      minute: 1,
+    });
   });
 
-  it("splits zero into a single zero-second part", () => {
-    expect(sessionDurationParts(0)).toEqual([{ unit: "second", value: 0 }]);
+  it("keeps a zero duration as zero seconds", () => {
+    expect(sessionDurationBreakdown(0)).toEqual({ second: 0 });
   });
 });
 

--- a/src/frontend/src/lib/utils/sessionDuration.test.ts
+++ b/src/frontend/src/lib/utils/sessionDuration.test.ts
@@ -1,8 +1,8 @@
 import {
   cappedSessionDurations,
-  formatSessionDuration,
   MAX_SESSION_DURATION_SECONDS,
   sessionDurationCeilingSeconds,
+  sessionDurationParts,
   sessionDurationToNanos,
 } from "./sessionDuration";
 
@@ -14,19 +14,32 @@ const NANOS_PER_SECOND = BigInt(1_000_000_000);
 
 const PRESETS = [10 * MINUTE, HOUR, 8 * HOUR, DAY, WEEK, 30 * DAY];
 
-describe("formatSessionDuration", () => {
-  it("formats a single unit", () => {
-    expect(formatSessionDuration(2 * HOUR)).toBe("2h");
-    expect(formatSessionDuration(10 * MINUTE)).toBe("10m");
-    expect(formatSessionDuration(DAY)).toBe("1d");
+describe("sessionDurationParts", () => {
+  it("splits out a single unit", () => {
+    expect(sessionDurationParts(2 * HOUR)).toEqual([
+      { unit: "hour", value: 2 },
+    ]);
+    expect(sessionDurationParts(10 * MINUTE)).toEqual([
+      { unit: "minute", value: 10 },
+    ]);
+    expect(sessionDurationParts(DAY)).toEqual([{ unit: "day", value: 1 }]);
   });
 
-  it("combines units, largest first", () => {
-    expect(formatSessionDuration(DAY + HOUR + MINUTE + 1)).toBe("1d 1h 1m 1s");
+  it("lists units largest first, skipping zeroes", () => {
+    expect(sessionDurationParts(DAY + HOUR + MINUTE + 1)).toEqual([
+      { unit: "day", value: 1 },
+      { unit: "hour", value: 1 },
+      { unit: "minute", value: 1 },
+      { unit: "second", value: 1 },
+    ]);
+    expect(sessionDurationParts(DAY + MINUTE)).toEqual([
+      { unit: "day", value: 1 },
+      { unit: "minute", value: 1 },
+    ]);
   });
 
-  it("formats zero", () => {
-    expect(formatSessionDuration(0)).toBe("0s");
+  it("splits zero into a single zero-second part", () => {
+    expect(sessionDurationParts(0)).toEqual([{ unit: "second", value: 0 }]);
   });
 });
 

--- a/src/frontend/src/lib/utils/sessionDuration.ts
+++ b/src/frontend/src/lib/utils/sessionDuration.ts
@@ -21,22 +21,36 @@ const NANOS_PER_SECOND = BigInt(1_000_000_000);
 const MAX_SESSION_DURATION_NANOS =
   BigInt(MAX_SESSION_DURATION_SECONDS) * NANOS_PER_SECOND;
 
+/** The units an off-preset duration is broken down into, largest first. */
+export type SessionDurationUnit = "day" | "hour" | "minute" | "second";
+
+/** One unit of a duration, e.g. `{ unit: "minute", value: 20 }`. */
+export interface SessionDurationPart {
+  unit: SessionDurationUnit;
+  value: number;
+}
+
 /**
- * Compact label for an off-preset duration, e.g. `7200 -> "2h"`,
- * `90_060 -> "1d 1h 1m"`. Used when the selected/cap value isn't one of the
- * named presets.
+ * An off-preset duration split into its non-zero units, largest first, e.g.
+ * `7200 -> [{ hour, 2 }]`, `90_060 -> [{ day, 1 }, { hour, 1 }, { minute, 1 }]`.
+ * The caller turns each part into a localized, spelled-out label (see
+ * `SessionDurationSelect`) so an off-preset value reads like the named presets
+ * ("20 minutes") instead of a compact "20m". A zero duration yields a single
+ * zero-second part, so a label is never empty.
  */
-export const formatSessionDuration = (seconds: number): string => {
-  const parts: string[] = [];
-  const d = Math.floor(seconds / DAY);
-  const h = Math.floor((seconds % DAY) / HOUR);
-  const m = Math.floor((seconds % HOUR) / MINUTE);
-  const s = seconds % MINUTE;
-  if (d > 0) parts.push(`${d}d`);
-  if (h > 0) parts.push(`${h}h`);
-  if (m > 0) parts.push(`${m}m`);
-  if (s > 0) parts.push(`${s}s`);
-  return parts.length > 0 ? parts.join(" ") : "0s";
+export const sessionDurationParts = (
+  seconds: number,
+): SessionDurationPart[] => {
+  const parts: SessionDurationPart[] = [];
+  const day = Math.floor(seconds / DAY);
+  const hour = Math.floor((seconds % DAY) / HOUR);
+  const minute = Math.floor((seconds % HOUR) / MINUTE);
+  const second = seconds % MINUTE;
+  if (day > 0) parts.push({ unit: "day", value: day });
+  if (hour > 0) parts.push({ unit: "hour", value: hour });
+  if (minute > 0) parts.push({ unit: "minute", value: minute });
+  if (second > 0) parts.push({ unit: "second", value: second });
+  return parts.length > 0 ? parts : [{ unit: "second", value: 0 }];
 };
 
 /**

--- a/src/frontend/src/lib/utils/sessionDuration.ts
+++ b/src/frontend/src/lib/utils/sessionDuration.ts
@@ -7,6 +7,8 @@
  * only at the boundary via {@link sessionDurationToNanos}.
  */
 
+import type { Duration } from "$lib/stores/locale.store";
+
 const MINUTE = 60;
 const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
@@ -21,36 +23,25 @@ const NANOS_PER_SECOND = BigInt(1_000_000_000);
 const MAX_SESSION_DURATION_NANOS =
   BigInt(MAX_SESSION_DURATION_SECONDS) * NANOS_PER_SECOND;
 
-/** The units an off-preset duration is broken down into, largest first. */
-export type SessionDurationUnit = "day" | "hour" | "minute" | "second";
-
-/** One unit of a duration, e.g. `{ unit: "minute", value: 20 }`. */
-export interface SessionDurationPart {
-  unit: SessionDurationUnit;
-  value: number;
-}
-
 /**
- * An off-preset duration split into its non-zero units, largest first, e.g.
- * `7200 -> [{ hour, 2 }]`, `90_060 -> [{ day, 1 }, { hour, 1 }, { minute, 1 }]`.
- * The caller turns each part into a localized, spelled-out label (see
- * `SessionDurationSelect`) so an off-preset value reads like the named presets
- * ("20 minutes") instead of a compact "20m". A zero duration yields a single
- * zero-second part, so a label is never empty.
+ * An off-preset duration broken into its non-zero units, ready to be spelled out
+ * by `$formatDuration`: `7200 -> { hour: 2 }`, `90_060 -> { day: 1, hour: 1,
+ * minute: 1 }`. Zero units are left out so they don't show up in the label, with
+ * one exception: a zero duration keeps `{ second: 0 }`, so the label is never
+ * empty. Off-preset durations are spelled out like the named presets ("20
+ * minutes") rather than compactly ("20m"), see `SessionDurationSelect`.
  */
-export const sessionDurationParts = (
-  seconds: number,
-): SessionDurationPart[] => {
-  const parts: SessionDurationPart[] = [];
+export const sessionDurationBreakdown = (seconds: number): Duration => {
   const day = Math.floor(seconds / DAY);
   const hour = Math.floor((seconds % DAY) / HOUR);
   const minute = Math.floor((seconds % HOUR) / MINUTE);
   const second = seconds % MINUTE;
-  if (day > 0) parts.push({ unit: "day", value: day });
-  if (hour > 0) parts.push({ unit: "hour", value: hour });
-  if (minute > 0) parts.push({ unit: "minute", value: minute });
-  if (second > 0) parts.push({ unit: "second", value: second });
-  return parts.length > 0 ? parts : [{ unit: "second", value: 0 }];
+  const breakdown: Duration = {};
+  if (day > 0) breakdown.day = day;
+  if (hour > 0) breakdown.hour = hour;
+  if (minute > 0) breakdown.minute = minute;
+  if (second > 0) breakdown.second = second;
+  return Object.keys(breakdown).length > 0 ? breakdown : { second: 0 };
 };
 
 /**


### PR DESCRIPTION
# Motivation

The session-duration dropdown on the sign-in screen labels its named presets in words ("10 minutes", "1 hour", "8 hours", …), but fell back to a compact format for a duration that isn't a preset — the cap an app requests via `maxTimeToLive`, which is always offered as the top option. A 20-minute cap therefore rendered as "20m" directly below "10 minutes" in the same list, mixing two label styles in one dropdown. The compact form was also untranslated: `d`/`h`/`m`/`s` are hardcoded English abbreviations.

# Changes

- `locale.store.ts`: new `formatDuration` method, alongside the existing `formatDate`/`formatNumber`/`formatRelative`. It takes a duration as a count per unit (`{ day: 1, hour: 2 }`) and lets Intl do the wording: `Intl.NumberFormat` with `style: "unit"` / `unitDisplay: "long"` spells each unit out and pluralizes it for the locale, and `Intl.ListFormat` with `type: "unit"` joins them the way the locale joins a list of units — "1 day 2 hours", "1 Tag und 2 Stunden". Because the plural form comes from the locale, this is also correct for locales whose rules need more than one/other.
- `sessionDuration.ts`: `formatSessionDuration` (which returned `"1d 1h 1m"`) is replaced by `sessionDurationBreakdown`, which splits a duration into its non-zero units for `formatDuration`. Zero yields `{ second: 0 }` so a label is never empty.
- `SessionDurationSelect.svelte`: off-preset durations get their label from `$formatDuration`, so a 20-minute cap reads "20 minutes". Presets keep their existing labels. No new translatable strings.

`Intl.DurationFormat` would replace the two Intl calls with one, but it only reached the last of the browsers we support during 2025 (Safari 18.4, Firefox 140) and TypeScript 5.9.3 doesn't declare it under our `lib` setting, so `formatDuration` is the single place to switch once both land — there's a comment there saying so.

# Tests

- `locale.store.test.ts` (new): `formatDuration` spells out and pluralizes a single unit, joins several, and formats only the units it's given (including a deliberate `{ second: 0 }`).
- `sessionDuration.test.ts`: the `formatSessionDuration` cases are rewritten for `sessionDurationBreakdown` (single unit, every non-zero unit, zero duration).
- `npx vitest run` on both files: 19 passed. `tsc --noEmit` (via `tsconfig.all.json`), `svelte-check` (0 errors), `eslint --max-warnings 0` and `prettier --check` on the changed files all clean.
- Checked the rendered output across all locales in the catalogs (en, de, es, fr, id, it, nl, pl, ru, uk, ur) for single-unit and multi-unit durations; sample in [this thread](https://github.com/dfinity/internet-identity/pull/4156#discussion_r3667067685).