### PR TITLE
fix(be,fe): read the MCP config with a certified update call

### DIFF
--- a/docs/mcp-server-guide.md
+++ b/docs/mcp-server-guide.md
@@ -35,7 +35,7 @@ sequenceDiagram
     note over U,C: Phase 1 — connect handshake (once per session)
     M->>U: redirect to /mcp#registration_key, callback, state, ttl
     U->>F: open /mcp, authenticate and consent (pick TTL)
-    F->>C: mcp_get_config(anchor)
+    F->>C: mcp_get_config(anchor) — update call, certified reply
     C-->>F: enabled + trusted URL (verify callback origin)
     F->>M: GET /.well-known/ii-auth-callbacks
     M-->>F: {"callbacks": [...]} — link's callback must exact-match

--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -573,7 +573,32 @@ pub fn mcp_set_config(
     .map(|(x,)| x)
 }
 
+/// `mcp_get_config` is an update, not a query: it is the read that decides which
+/// origin the `/mcp` connect flow will deliver a registration delegation to, so
+/// its reply must be certified by the subnet rather than signed by whichever
+/// node answered. See [`mcp_get_config_as_query`] for the regression guard.
 pub fn mcp_get_config(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+    identity_number: IdentityNumber,
+) -> Result<Option<McpConfig>, RejectResponse> {
+    call_candid_as(
+        env,
+        canister_id,
+        RawEffectivePrincipal::None,
+        sender,
+        "mcp_get_config",
+        (identity_number,),
+    )
+    .map(|(x,)| x)
+}
+
+/// Deliberately calls `mcp_get_config` on the *query* path, so a test can assert
+/// the uncertified read is unavailable. Only ever expected to fail — flipping the
+/// endpoint back to `#[query]` would make it succeed and hand the connect flow's
+/// trust decision back to a single node.
+pub fn mcp_get_config_as_query(
     env: &PocketIc,
     canister_id: CanisterId,
     sender: Principal,

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -1190,7 +1190,7 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
-    'mcp_get_config' : IDL.Func([UserNumber], [IDL.Opt(McpConfig)], ['query']),
+    'mcp_get_config' : IDL.Func([UserNumber], [IDL.Opt(McpConfig)], []),
     'mcp_get_delegation' : IDL.Func(
         [FrontendHostname, IDL.Opt(AccountNumber), SessionKey, Timestamp],
         [

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -2205,6 +2205,12 @@ export interface _SERVICE {
    * stored one that is switched off. The two behave differently at /mcp: the
    * first may connect the deployment's official connector (completing the
    * consent is what enables it), the second is sent back to Settings.
+   * 
+   * Deliberately an update rather than a query, even though it only reads:
+   * this answer decides which origin /mcp hands a registration delegation to,
+   * and a query reply is signed by the single node that served it — so a
+   * malicious replica or boundary node could name a trusted server the user
+   * never set. Going through consensus makes the reply certified.
    */
   'mcp_get_config' : ActorMethod<[UserNumber], [] | [McpConfig]>,
   /**

--- a/src/frontend/src/lib/utils/mcpConfig.test.ts
+++ b/src/frontend/src/lib/utils/mcpConfig.test.ts
@@ -1,13 +1,37 @@
 import { describe, it, expect, vi } from "vitest";
 import type { ActorSubclass } from "@icp-sdk/core/agent";
+import { IDL } from "@icp-sdk/core/candid";
 import type { _SERVICE } from "$lib/generated/internet_identity_types";
+import { idlFactory } from "$lib/generated/internet_identity_idl";
 import {
   originOf,
+  readMcpConfig,
   setMcpEnabled,
   trustAndEnableMcp,
   clearMcpTrustedServer,
   type McpConfig,
 } from "./mcpConfig";
+
+describe("mcp_get_config in the canister interface", () => {
+  // The whole trust decision at /mcp rests on this read, so the actor must send
+  // it as an update (certified by consensus) and never as a query (signed by the
+  // single node that answered, hence forgeable by a malicious replica or
+  // boundary node — see `readMcpConfig`). agent-js picks the call type straight
+  // from the IDL annotation, so asserting on the generated interface is what
+  // actually pins the behaviour: a regenerated binding from a `.did` that put
+  // `query` back would silently downgrade every call site.
+  const service = idlFactory({ IDL }) as IDL.ServiceClass;
+  const method = service._fields.find(([name]) => name === "mcp_get_config");
+
+  it("is declared", () => {
+    expect(method).toBeDefined();
+  });
+
+  it("is not annotated as a query, so the actor makes an update call", () => {
+    expect(method?.[1].annotations).not.toContain("query");
+    expect(method?.[1].annotations).toEqual([]);
+  });
+});
 
 describe("originOf", () => {
   it("returns the origin (scheme + host + port), dropping path/query/hash", () => {
@@ -50,6 +74,27 @@ const CUSTOM = "https://mcp.acme.com/mcp";
 const cfg = (enabled: boolean, url: string | undefined): McpConfig => ({
   enabled,
   url,
+});
+
+describe("readMcpConfig", () => {
+  it("maps the canister's optionals onto the frontend shape", async () => {
+    const actor = makeActor(cfg(true, CUSTOM));
+
+    await expect(readMcpConfig(asActor(actor), ANCHOR)).resolves.toEqual(
+      cfg(true, CUSTOM),
+    );
+  });
+
+  it("reports an identity that never wrote a config as undefined", async () => {
+    const actor = makeActor(cfg(false, undefined));
+    // `opt McpConfig` = `null`: never configured, which /mcp treats differently
+    // from a stored config that is switched off.
+    actor.mcp_get_config.mockResolvedValue([]);
+
+    await expect(
+      readMcpConfig(asActor(actor), ANCHOR),
+    ).resolves.toBeUndefined();
+  });
 });
 
 describe("setMcpEnabled", () => {

--- a/src/frontend/src/lib/utils/mcpConfig.ts
+++ b/src/frontend/src/lib/utils/mcpConfig.ts
@@ -2,9 +2,11 @@
  * The user's trusted-MCP-server configuration, persisted on-chain (keyed by
  * anchor) so it syncs across all of the identity's devices — unlike the
  * CLI-access toggle, which is device-local. It is read via `mcp_get_config` and
- * written via `mcp_set_config`, both authenticated as the identity, so only the
- * user (never a page that initiates a connect request) can change it. The `/mcp`
- * connect flow reads it as the source of truth at connect time.
+ * written via `mcp_set_config`, both authenticated as the identity and both
+ * update calls, so only the user (never a page that initiates a connect request)
+ * can change it and no single node can misreport it. The `/mcp` connect flow
+ * reads it as the source of truth at connect time (see `readMcpConfig` for why
+ * the read must be certified).
  *
  * The config has two parts:
  *  - `enabled`: the feature's master toggle for this identity.
@@ -49,7 +51,23 @@ export const originOf = (url: string): string | undefined => {
   }
 };
 
-/** Read the identity's synced MCP config from the canister. */
+/**
+ * Read the identity's synced MCP config from the canister.
+ *
+ * `mcp_get_config` is declared as an **update** in the canister interface, so
+ * this goes through consensus and the reply is certified — never a query. That
+ * is load-bearing rather than incidental: this read is what tells the `/mcp`
+ * connect flow which origin the identity trusts, and a query reply is signed by
+ * the single node that served it. A malicious replica or boundary node could
+ * answer with a trusted-server URL the user never set, and the connect flow
+ * would then mint and deliver a registration delegation to it — a server the
+ * user never approved acting as them at any app. The backend can't catch that
+ * either: `prepare_mcp_registration_delegation` records the anchor's *real*
+ * trusted URL, so the check at redemption still passes. Certification is the
+ * only thing that makes the answer trustworthy, which is why the endpoint is an
+ * update (see the `mcp_get_config` comment in `internet_identity.did`) and why
+ * `readMcpConfig` must stay the single way the frontend obtains this config.
+ */
 export const readMcpConfig = async (
   actor: ActorSubclass<_SERVICE>,
   identityNumber: bigint,

--- a/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/mcp/+page.svelte
@@ -169,7 +169,9 @@
   // regaining focus here is exactly the moment the synced config may have
   // changed. The read reuses the actor the untrusted screen already holds
   // (reaching it authenticated the identity); minting still waits for an explicit
-  // "Allow access" on the connect screen.
+  // "Allow access" on the connect screen. It is an update call (the trust
+  // decision must rest on a certified reply — see `readMcpConfig`), so the
+  // `checking` guard also keeps focus churn from stacking round trips.
   $effect(() => {
     if (phase.kind !== "untrusted" || mcpServer === undefined) {
       return;
@@ -253,6 +255,15 @@
         // server's origin. Verifying here (post-authentication) means the result
         // is the same on every device, regardless of any local state — and the
         // backend re-checks it when registering.
+        //
+        // `readMcpConfig` is an update call, so this answer is certified by the
+        // subnet rather than by the single node that served it. That matters
+        // precisely here: this check is the *only* thing standing between an
+        // attacker-crafted connect link and a registration delegation delivered
+        // to an origin the user never trusted (the backend records the anchor's
+        // real trusted URL, so its own check at redemption can't tell the
+        // difference). A node that could forge this reply could impersonate the
+        // user at any app.
         const config = await readMcpConfig(
           authenticated.actor,
           authenticated.identityNumber,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1892,7 +1892,13 @@ service : (opt InternetIdentityInit) -> {
     // stored one that is switched off. The two behave differently at /mcp: the
     // first may connect the deployment's official connector (completing the
     // consent is what enables it), the second is sent back to Settings.
-    mcp_get_config : (anchor_number : UserNumber) -> (opt McpConfig) query;
+    //
+    // Deliberately an update rather than a query, even though it only reads:
+    // this answer decides which origin /mcp hands a registration delegation to,
+    // and a query reply is signed by the single node that served it — so a
+    // malicious replica or boundary node could name a trusted server the user
+    // never set. Going through consensus makes the reply certified.
+    mcp_get_config : (anchor_number : UserNumber) -> (opt McpConfig);
 
     // Persist the identity's trusted-MCP-server config so it syncs across the
     // identity's devices. Authenticated as the identity, so only the user — never

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -643,7 +643,20 @@ fn get_account_delegation(
 /// devices. Read by the Settings UI and by the `/mcp` connect flow, which
 /// verifies the connecting origin against it at connect time. `null` means the
 /// anchor has never written a config.
-#[query]
+///
+/// Deliberately an **update**, not a query: this is the one read whose answer
+/// decides which origin the `/mcp` connect flow will hand a registration
+/// delegation to. A query reply is signed by the single answering node, so a
+/// malicious replica or boundary node could answer with a trusted-server URL
+/// the user never set; combined with a link that names that server as its
+/// callback, the frontend would then mint and deliver a registration delegation
+/// to an origin the identity does not trust — and the backend cannot catch it
+/// (`prepare_mcp_registration_delegation` records the anchor's *real* trusted
+/// URL, so redemption's URL check still passes). Going through consensus makes
+/// the reply certified, so the trust decision rests on the subnet rather than
+/// on whichever node served the read. The body is read-only: keep it that way,
+/// so this stays a plain replicated read.
+#[update]
 fn mcp_get_config(anchor_number: AnchorNumber) -> Option<McpConfig> {
     if check_session_authorization(anchor_number).is_err() {
         // Deliberately the switched-off shape rather than `None`: `None` means

--- a/src/internet_identity/src/mcp.rs
+++ b/src/internet_identity/src/mcp.rs
@@ -239,6 +239,11 @@ pub fn register(
 /// off stays blocked. The caller must already be authorized for
 /// `anchor_number` (checked by the canister method). The stored
 /// `session_principal` pointer is internal bookkeeping and not exposed.
+///
+/// Read-only, but exposed through an **update** endpoint on purpose (see
+/// `mcp_get_config` in `main.rs`): the `/mcp` frontend decides from this answer
+/// which origin it hands a registration delegation to, and an uncertified query
+/// reply would let a single malicious node redirect that decision.
 pub fn get_mcp_config(anchor_number: AnchorNumber) -> Option<McpConfig> {
     storage_borrow(|storage| storage.lookup_mcp_config(anchor_number)).map(|config| McpConfig {
         enabled: config.enabled,

--- a/src/internet_identity/tests/integration/mcp.rs
+++ b/src/internet_identity/tests/integration/mcp.rs
@@ -12,9 +12,9 @@ use candid::Principal;
 use canister_tests::{
     api::internet_identity::api_v2::{
         create_account, get_mcp_registration_delegation, mcp_get_accounts, mcp_get_config,
-        mcp_get_delegation, mcp_prepare_delegation, mcp_register_v2, mcp_set_config,
-        prepare_account_delegation, prepare_mcp_registration_delegation, set_default_account,
-        AccountDelegationParams,
+        mcp_get_config_as_query, mcp_get_delegation, mcp_prepare_delegation, mcp_register_v2,
+        mcp_set_config, prepare_account_delegation, prepare_mcp_registration_delegation,
+        set_default_account, AccountDelegationParams,
     },
     flows,
     framework::{
@@ -1055,6 +1055,47 @@ fn mcp_config_round_trips_and_persists_across_upgrade() -> Result<(), RejectResp
     assert_eq!(
         mcp_get_config(&env, canister_id, principal_1(), anchor).unwrap(),
         Some(config.clone())
+    );
+
+    Ok(())
+}
+
+/// `mcp_get_config` must not be reachable as a query. It is the read that tells
+/// the `/mcp` connect flow which origin this identity trusts, and a query reply
+/// carries only the answering node's signature: a malicious replica or boundary
+/// node could name a trusted server the user never set, and the frontend would
+/// mint and deliver a registration delegation to it. The backend cannot catch
+/// that afterwards — `prepare_mcp_registration_delegation` records the anchor's
+/// *real* trusted URL, so `mcp_register_v2`'s URL check still passes and the
+/// attacker's session key ends up bound to the identity. Only consensus makes
+/// the answer trustworthy, so the endpoint is an update and the uncertified read
+/// path must stay closed; this test fails the moment it is reopened.
+#[test]
+fn mcp_get_config_is_not_available_as_a_query() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_with_mcp(&env);
+    let anchor = flows::register_anchor(&env, canister_id);
+
+    let config = McpConfig {
+        enabled: true,
+        url: Some(format!("{MCP_ORIGIN}/mcp")),
+    };
+    mcp_set_config(&env, canister_id, principal_1(), anchor, config.clone())
+        .unwrap()
+        .unwrap();
+
+    // The identity's own authenticated query is rejected too: there is no
+    // uncertified way to read this config, not merely no *useful* one.
+    let rejected = mcp_get_config_as_query(&env, canister_id, principal_1(), anchor);
+    assert!(
+        rejected.is_err(),
+        "mcp_get_config must not answer on the query path, got {rejected:?}"
+    );
+
+    // The update path still serves it.
+    assert_eq!(
+        mcp_get_config(&env, canister_id, principal_1(), anchor).unwrap(),
+        Some(config)
     );
 
     Ok(())


### PR DESCRIPTION
# Motivation

Addresses audit finding **II01: [FE] mcp_get_config called as query** (Medium).

`mcp_get_config` was a `query`, and the `/mcp` connect flow makes its entire trust
decision from that reply. `isOriginTrusted` compares the connect link's callback
origin against the identity's synced trusted-server URL, and only if it matches
does the frontend mint a registration delegation and hand it to that origin.

A query reply carries only the answering node's signature, so a malicious replica
or boundary node could answer with a trusted-server URL the user never set. Paired
with a phishing link straight to `/mcp` naming that server as its `callback`, the
frontend would mint and deliver a registration delegation to it — and with write
permissions approved, that server can act as the user at any app.

The backend cannot catch this after the fact:
`prepare_mcp_registration_delegation` records the anchor's *real* trusted URL on
the registration entry, so `mcp_register_v2`'s "config unchanged since consent"
check compares the real URL against itself, passes, and binds the attacker's
session key to the identity.

The connect flow's other inputs were already certified, so this was the one
uncertified link in the chain: the official-connector URL comes from the
`/.config.did.bin` certified asset, and the callback allow-list is fetched over
TLS from the server's own origin.

# Changes

- `mcp_get_config` becomes `#[update]` and drops the `query` annotation from the
  Candid interface. It is still read-only and still gated by
  `check_session_authorization` — only the call type changes, so the reply now
  goes through consensus and is certified. Dropping the annotation is what makes
  the actor send an update: agent-js picks the call type straight from the IDL.
- Regenerated `internet_identity_idl.js` / `internet_identity_types.d.ts` with the
  pinned `didc` (`npm run generate:js` / `generate:types`).
- `canister_tests`: `mcp_get_config` now calls through `call_candid_as`; added
  `mcp_get_config_as_query`, which exists only so a test can assert the query path
  is closed.
- Documented why the read must be certified where each side would be tempted to
  change it back: the endpoint in `main.rs`, `mcp::get_mcp_config`, the `.did`,
  `readMcpConfig`, and the two `/mcp` call sites.
- No frontend call-site changes were needed — `readMcpConfig` is the single way
  the frontend reads this config, and its actor call is unchanged.

Guarded in both directions so this can't silently regress:

- an integration test asserts the query path is rejected — it would answer again
  the moment the endpoint went back to `#[query]`;
- a frontend test asserts the generated IDL carries no `query` annotation for
  `mcp_get_config`, which catches a binding regenerated from a `.did` that put it
  back.

# Tests

- `cargo test -p internet_identity --test integration mcp::` — 36 passed,
  including the new `mcp_get_config_is_not_available_as_a_query` (query rejected,
  update path still serves the config) and the existing round-trip /
  upgrade-persistence and gating tests now exercising the update path.
- `cargo test -p internet_identity --bins -p canister_tests` — 648 passed,
  including `check_candid_interface_compatibility`, which confirms the `.did` and
  the Rust service still describe the same interface after the annotation change.
- `npx vitest run src/frontend/src/lib/utils/mcpConfig.test.ts` — 13 passed
  (2 new IDL-annotation tests, 2 new `readMcpConfig` mapping tests).
- `npx tsc --project ./tsconfig.all.json --noEmit`, `npx svelte-check` (0 errors),
  `eslint`, `prettier --check`, `cargo fmt --check`, `cargo clippy -- -D warnings`
  — all clean.
- Full `npx vitest run`: 602 passed, 18 failed in `iiConnection.test.ts` /
  `findWebAuthnFlows.test.ts`. Those failures reproduce on `main` with this branch
  stashed — pre-existing and unrelated.

## Rollout note

A frontend that still calls this as a query gets a reject after the backend
upgrade (the AI-access settings section and the `/mcp` connect screen show a retry
error and recover on reload). A new frontend's update call works against either
backend version — a query method invoked as an update executes in replicated mode
— so deploy the frontend first.

---
_Generated by [Claude Code](https://claude.ai/code/session_018H4qR2henYnQVxAr72iLnL)_