### PR TITLE
feat(fe): show AI access on by default so users can opt out

### DIFF
--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -44,7 +44,6 @@
 
   const official = backendCanisterConfig.mcp_official_url[0];
 
-  const enabled = $derived(config?.enabled ?? false);
   const trusted = $derived(config?.url);
   const active = $derived.by(() => {
     const url = trustedUrl(config, backendCanisterConfig);
@@ -52,6 +51,13 @@
       ? undefined
       : { url, custom: trusted !== undefined };
   });
+  // The toggle reflects whether a connect would currently be honoured (i.e.
+  // `active`), not the raw stored flag. So a never-configured identity with an
+  // official connector reads as on — which is the truth, since it can connect
+  // that connector by default — and turning it off writes the disabled config
+  // that actually blocks it (the opt-out). An explicitly disabled config reads
+  // as off and stays off.
+  const enabled = $derived(active !== undefined);
 
   const hostOf = (url: string): string => {
     try {

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -46,6 +46,17 @@
 
   const trusted = $derived(config?.url);
   const active = $derived.by(() => {
+    // Resolve nothing until the real config is loaded. `config` is `undefined`
+    // both while the read is in flight and when the identity genuinely never
+    // configured MCP, and `trustedUrl` maps `undefined` to the official
+    // connector — so without this guard an opted-out (explicitly disabled)
+    // identity would briefly flash the official connector and "Customize"
+    // before its config arrives. The toggle is already behind the `loaded`
+    // guard; this extends the same protection to `enabled` and the connector
+    // section below.
+    if (!loaded) {
+      return undefined;
+    }
     const url = trustedUrl(config, backendCanisterConfig);
     return url === undefined
       ? undefined

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/utils.test.ts
@@ -28,6 +28,17 @@ describe("trustedUrl", () => {
     expect(trustedUrl(cfg(true, CUSTOM), OFFICIAL)).toBe(CUSTOM);
   });
 
+  it("offers the official connector to a never-configured identity", () => {
+    // A brand-new identity (no stored config) can connect the official
+    // connector by default, so Settings shows AI access as on — mirrors the
+    // canister's connect_trusted_url.
+    expect(trustedUrl(undefined, OFFICIAL)).toBe(OFFICIAL.mcp_official_url[0]);
+  });
+
+  it("trusts nothing for a never-configured identity with no official connector", () => {
+    expect(trustedUrl(undefined, NO_OFFICIAL)).toBeUndefined();
+  });
+
   it("trusts nothing while the feature is disabled", () => {
     expect(trustedUrl(cfg(false, undefined), OFFICIAL)).toBeUndefined();
     expect(trustedUrl(cfg(false, CUSTOM), OFFICIAL)).toBeUndefined();

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/utils.ts
@@ -2,10 +2,18 @@ import type { BackendCanisterConfig } from "$lib/globals";
 import type { McpConfig } from "$lib/utils/mcpConfig";
 
 /**
- * The URL `config` trusts for display: the identity's own server when they set
- * one, otherwise the deployment's official connector. Nothing while the feature
- * is off, or when the identity has never configured it. Mirrors
- * `session_trusted_url` in the canister.
+ * The URL a connect from this identity would currently target — what Settings
+ * shows as the active connector: the identity's own server when they set one,
+ * otherwise the deployment's official connector. Mirrors the canister's
+ * `connect_trusted_url` (not `session_trusted_url`), so the two cases where they
+ * differ are handled the same as the connect flow:
+ *
+ *  - **never configured** (`config === undefined`) → the official connector.
+ *    A brand-new identity can connect the official connector by default, so
+ *    Settings shows AI access as on; turning it off writes the disabled config
+ *    that actually blocks it (the opt-out).
+ *  - **explicitly disabled** (`enabled === false`) → nothing. Switching the
+ *    feature off is the opt-out and is not silently undone.
  *
  * Takes the canister config rather than a bare URL so the official connector
  * can only come from the deployment, never from an arbitrary string at a call
@@ -15,6 +23,8 @@ export const trustedUrl = (
   config: McpConfig | undefined,
   { mcp_official_url }: Pick<BackendCanisterConfig, "mcp_official_url">,
 ): string | undefined =>
-  config !== undefined && config.enabled
-    ? (config.url ?? mcp_official_url[0])
-    : undefined;
+  config === undefined
+    ? mcp_official_url[0]
+    : config.enabled
+      ? (config.url ?? mcp_official_url[0])
+      : undefined;

--- a/src/frontend/src/routes/(new-styling)/mcp/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/mcp/utils.ts
@@ -219,10 +219,10 @@ export const mcpAuthorize = async ({
  * what enables the feature for them. One that switched the feature off may not:
  * they are sent back to Settings rather than silently re-enabled by a link.
  *
- * Deliberately not the same rule as Settings' `trustedUrl`, which answers what
- * the identity trusts *now*. The canister enforces the same split in
- * `connect_trusted_url` / `session_trusted_url`; this lives here, next to the
- * consent flow that needs it, so the two can't be confused at a call site.
+ * Same rule as Settings' `trustedUrl` (both mirror the canister's
+ * `connect_trusted_url`): a never-configured identity may connect the official
+ * connector, an explicitly disabled one may not. This variant answers it as a
+ * boolean against a specific origin, next to the consent flow that needs it.
  *
  * Takes the canister config rather than a bare URL so the official connector
  * can only come from the deployment, never from an arbitrary string at a call

--- a/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/mcp.ts
@@ -381,9 +381,9 @@ export const test = base.extend<{ mcp: McpFixture }>({
       }
       await page.locator('a[href="/manage/settings"]').click();
       await page.waitForURL(`${II_URL}/manage/settings`);
-      await page.getByRole("switch", { name: "AI access" }).click();
-      // Enabling lands on the deployment's official connector, so the custom
-      // URL goes in behind "Customize" rather than a dialog that opens itself.
+      // AI access is on by default (the deployment ships an official
+      // connector), so the custom URL goes in behind "Customize" rather than
+      // toggling the feature on first.
       await page.getByRole("button", { name: "Customize" }).click();
       await page.getByLabel("MCP server URL").fill(`${MCP_SERVER_ORIGIN}/mcp`);
       await holdToConfirm(page, "Hold to continue");

--- a/src/frontend/tests/e2e-playwright/routes/manage/mcp-settings.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/manage/mcp-settings.spec.ts
@@ -69,21 +69,35 @@ test.describe("MCP settings", () => {
     ).toBeVisible();
   });
 
-  test("shows the official connector once AI access is enabled", async ({
-    page,
-  }) => {
-    // Enabling with no custom URL set falls back to the configured official
-    // connector rather than opening the add dialog.
-    await toggleAiAccess(page);
-
+  test("shows the official connector on by default", async ({ page }) => {
+    // A never-configured identity can connect the official connector by
+    // default, so AI access reads as on and the official connector is shown
+    // with no action — the state a user would turn off to opt out.
+    await expect(page.getByRole("switch", { name: "AI access" })).toBeChecked();
     await expect(page.getByText("Internet Computer MCP")).toBeVisible();
     await expect(page.getByText("Official · Hosted by DFINITY")).toBeVisible();
     await expect(page.getByText(OFFICIAL_URL)).toBeVisible();
     await expect(page.getByRole("button", { name: "Customize" })).toBeVisible();
   });
 
-  test("refuses the official connector as a custom one", async ({ page }) => {
+  test("turning AI access off opts out and hides the connector", async ({
+    page,
+  }) => {
+    // The opt-out: from the default-on state, switching off writes the disabled
+    // config that blocks even the official connector.
+    await expect(page.getByRole("switch", { name: "AI access" })).toBeChecked();
+
     await toggleAiAccess(page);
+
+    await expect(
+      page.getByRole("switch", { name: "AI access" }),
+    ).not.toBeChecked();
+    await expect(page.getByText("Trusted connector")).toBeHidden();
+    await expect(page.getByText("Internet Computer MCP")).toBeHidden();
+  });
+
+  test("refuses the official connector as a custom one", async ({ page }) => {
+    // AI access is on by default, so "Customize" is available immediately.
     await page.getByRole("button", { name: "Customize" }).click();
     await page.getByLabel("MCP server URL").fill(OFFICIAL_URL);
 
@@ -99,7 +113,6 @@ test.describe("MCP settings", () => {
     page,
     mcp,
   }) => {
-    await toggleAiAccess(page);
     const customUrl = await addCustomConnector(page, mcp);
 
     await expect(page.getByText("mcp.id.ai", { exact: true })).toBeVisible();
@@ -115,7 +128,6 @@ test.describe("MCP settings", () => {
     page,
     mcp,
   }) => {
-    await toggleAiAccess(page);
     await addCustomConnector(page, mcp);
 
     await Promise.all([
@@ -134,7 +146,6 @@ test.describe("MCP settings", () => {
     page,
     mcp,
   }) => {
-    await toggleAiAccess(page);
     await addCustomConnector(page, mcp);
 
     // Turning the master toggle off clears the custom URL by design.

--- a/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/mcp.spec.ts
@@ -157,7 +157,8 @@ test("Trusting the server in the Settings tab auto-advances the untrusted screen
         }),
       }),
   );
-  await settingsPage.getByRole("switch", { name: "AI access" }).click();
+  // AI access is on by default (an official connector is configured), so the
+  // custom server goes in behind "Customize" — no need to toggle it on first.
   await settingsPage.getByRole("button", { name: "Customize" }).click();
   await settingsPage.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
   await holdToConfirm(settingsPage, "Hold to continue");
@@ -268,7 +269,8 @@ test("Adding a trusted server in Settings unlocks the connect screen", async ({
   }
   await page.locator('a[href="/manage/settings"]').click();
   await page.waitForURL(II_URL + "/manage/settings");
-  await page.getByRole("switch", { name: "AI access" }).click();
+  // AI access is on by default (an official connector is configured), so the
+  // custom server goes in behind "Customize" — no need to toggle it on first.
   await page.getByRole("button", { name: "Customize" }).click();
   await page.getByLabel("MCP server URL").fill(`${mcp.mcpOrigin}/mcp`);
   await holdToConfirm(page, "Hold to continue");


### PR DESCRIPTION
# Motivation

A newly created (never-configured) identity showed **AI access: OFF** in
Settings — but the canister already treats such an identity as
*official-connector-available*: `connect_trusted_url(None)` falls back to the
deployment's official connector, and the connect flow's `isOriginTrusted` uses
the same rule. So the official connector was in fact connectable while Settings
said the feature was off, and there was **no way to opt out**: from an
already-"off" toggle the only action is to turn it on.

# Changes

Make Settings reflect the **effective connect availability** instead of the raw
stored flag:

- `settings/utils.ts` `trustedUrl` now mirrors the canister's
  `connect_trusted_url` (never-configured → official; explicitly disabled →
  nothing) rather than `session_trusted_url`.
- `McpTrustedServersSection` derives the toggle from that (`enabled = active !== undefined`).

Result:

- A never-configured identity with an official connector reads **ON** and shows
  the official connector card.
- Turning it **OFF** writes the `{ enabled: false }` config that actually
  blocks the official connector — **the opt-out**. (The merged II03 fix already
  makes such a revoking write clean up any in-flight registration.)
- An explicitly disabled config still reads OFF and is not silently re-enabled.

This is **frontend-only** — the canister already behaves this way, so we're only
making the UI honest about the existing default and granting **no new
capability** (nothing acts until a per-connect consent completes). Note the
user-facing consequence: every *never-configured* identity (existing and new)
now displays AI access as on.

# Tests

- **Unit** (`settings/utils.test.ts`): add coverage for the never-configured
  case (official offered; nothing when no official connector). Existing cases
  unchanged. `vitest` green (36 passed across the settings + mcp util suites).
- **e2e**: update the MCP Settings/connect specs and the `trustServer` fixture
  that previously toggled AI access **on** for a fresh anchor (now on by
  default), and add an explicit "on by default + opt-out" test in
  `mcp-settings.spec.ts`.
- `npm run check`, prettier, and eslint clean on all changed files.

Note: I can't run Playwright locally, so the e2e edits are validated by CI — I'll drive them to green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbjCCqTjsMn57fczTNGaKf)_