### PR TITLE
fix(fe): don't track last-used identities in the 1-click SSO flow

### DIFF
--- a/src/frontend/src/lib/flows/authFlow.svelte.test.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.test.ts
@@ -627,4 +627,48 @@ describe("AuthFlow — last-used tracking (openid vs sso)", () => {
     expect(entry.authMethod).not.toHaveProperty("openid");
     expect(entry.authMethod.sso).toMatchObject({ domain: SSO_DOMAIN });
   });
+
+  it("commits nothing on the sso sign-up path when trackLastUsed is false", async () => {
+    authenticateWithJWTMock
+      .mockRejectedValueOnce(noSuchAnchorError)
+      .mockResolvedValue({ identity: {}, identityNumber: BigInt(22) });
+
+    const flow = new AuthFlow({ trackLastUsed: false });
+    const signUp = await flow.continueWithOpenId(
+      testConfig,
+      "fake-jwt",
+      "both",
+      SSO_DOMAIN,
+    );
+    expect(signUp?.type).toBe("signUp");
+
+    const identityNumber = await flow.completeOpenIdRegistration("Alice");
+
+    expect(identityNumber).toBe(BigInt(22));
+    expect(
+      lastUsedIdentitiesStoreValue.addLastUsedIdentity,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("commits nothing on the sso sign-in path when trackLastUsed is false", async () => {
+    authenticateWithJWTMock.mockResolvedValue({
+      identity: {},
+      identityNumber: BigInt(23),
+    });
+
+    const flow = new AuthFlow({ trackLastUsed: false });
+    const result = await flow.continueWithOpenId(
+      testConfig,
+      "fake-jwt",
+      "both",
+      SSO_DOMAIN,
+    );
+
+    expect(result?.type).toBe("signIn");
+    if (result?.type !== "signIn") throw new Error("expected signIn");
+    expect(result.pendingLastUsedEntry).toBeUndefined();
+    expect(
+      lastUsedIdentitiesStoreValue.addLastUsedIdentity,
+    ).not.toHaveBeenCalled();
+  });
 });

--- a/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+page.svelte
@@ -131,7 +131,8 @@
     const { discovery, jwt, config, domain, origin } = ssoNormalLogin;
     ssoNormalLoginBusy = true;
     try {
-      const authFlow = new AuthFlow();
+      // Reached only from the 1-click SSO flow, which isn't tracked.
+      const authFlow = new AuthFlow({ trackLastUsed: false });
       const primaryResult: SsoDiscoveryResult = {
         ...discovery,
         resolvedClientId: discovery.clientId,
@@ -327,10 +328,6 @@
       // start sign-in again.
       return;
     }
-    // Track the last-used identity: a 1-click sign-up (or a sign-in on a
-    // device with no local entry yet) must land in localStorage so the
-    // identity shows up when the user later visits II directly.
-    const authFlow = new AuthFlow();
     const { iss, aud, ...metadata } = decodeJWT(jwt);
     // The marker is set by `initiateSso` for the `?sso=<domain>` path.
     // If present, treat the returning JWT as a 1-click SSO flow so the
@@ -339,6 +336,8 @@
     // marker can't leak into a subsequent direct-OpenID round-trip.
     const ssoDomain = sessionStorage.getItem("ii-sso-1-click-domain");
     sessionStorage.removeItem("ii-sso-1-click-domain");
+    // SSO is never tracked as a last-used identity.
+    const authFlow = new AuthFlow({ trackLastUsed: ssoDomain === null });
     // Show the redirect animation now so the wait below doesn't flash the wizard.
     openIdResumeProcessing = true;
     // Redeem through the origin-bound gate path so the session certifies

--- a/src/frontend/tests/e2e-playwright/routes/authorize/sso.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/sso.spec.ts
@@ -98,13 +98,10 @@ test.describe("Authorize with 1-click SSO", () => {
       await signInWithOpenId(authorizePage.page, openIdUsers[0].id);
     });
 
-    // Regression guard: the 1-click flow used to sign up without recording
-    // the new identity. It must land in `ii-last-used-identities` on the II
-    // origin, and — because the resume flow redeems the SSO JWT through
-    // `continueWithOpenId` — it must be tagged `sso` (keyed by domain), not
-    // `openid`. An `openid` entry would break a later "last used" sign-in,
-    // whose SSO branch needs the discovery domain to re-run discovery.
-    test("records the new identity as an sso entry in last-used storage", async ({
+    // 1-click SSO must not record a last-used identity, so nothing lands in
+    // `ii-last-used-identities` on the II origin. Contrast `openid.spec.ts`,
+    // where the equivalent 1-click OpenID sign-up is recorded.
+    test("does not record the new identity in last-used storage", async ({
       page,
       authorizePage,
       signInWithOpenId,
@@ -121,17 +118,16 @@ test.describe("Authorize with 1-click SSO", () => {
         const lastUsedRaw = await iiPage.evaluate(() =>
           localStorage.getItem("ii-last-used-identities"),
         );
-        expect(lastUsedRaw).not.toBeNull();
-        const lastUsed = JSON.parse(lastUsedRaw!) as {
-          data: Record<string, { authMethod: Record<string, unknown> }>;
-        };
-        // A brand-new identity was recorded (the buggy code left this empty).
-        const entries = Object.values(lastUsed.data);
-        expect(entries).toHaveLength(1);
-        expect(entries[0]?.authMethod).toHaveProperty("sso");
-        expect(entries[0]?.authMethod).not.toHaveProperty("openid");
-        const sso = (entries[0]!.authMethod as { sso: { domain: string } }).sso;
-        expect(sso.domain).toBe(SSO_DISCOVERY_DOMAIN);
+        // The store is either absent entirely or present but holding no
+        // identities; both mean the flow recorded nothing.
+        const entries =
+          lastUsedRaw === null
+            ? []
+            : Object.values(
+                (JSON.parse(lastUsedRaw) as { data: Record<string, unknown> })
+                  .data,
+              );
+        expect(entries).toHaveLength(0);
       } finally {
         await iiPage.close();
       }
@@ -909,11 +905,11 @@ test.describe("Continue as a last-used SSO identity", () => {
       defaultPort: SSO_OPENID_PORT,
       createUsers: [{ claims: { name, email } }],
     },
-    // First authorize (`?sso=` 1-click) seeds the last-used SSO entry; the second
-    // drops `?sso=` to run the ContinueView path.
+    // No `sso:` field: the first authorize seeds the last-used SSO entry via the
+    // manual wizard entry (1-click SSO records nothing), and the second reuses
+    // that entry to run the ContinueView path.
     authorizeConfig: {
       protocol: "icrc25",
-      sso: SSO_DISCOVERY_DOMAIN,
       useIcrc3Attributes: true,
       attributes: [
         `sso:${SSO_DISCOVERY_DOMAIN}:name`,
@@ -938,16 +934,35 @@ test.describe("Continue as a last-used SSO identity", () => {
     page,
     attributeConsentView,
     authorizePage,
+    openSsoPopup,
     signInWithOpenId,
     openIdUsers,
   }) => {
-    // FIRST authorize: 1-click SSO seeds the last-used SSO identity.
-    await signInWithOpenId(authorizePage.page, openIdUsers[0].id);
+    // FIRST authorize: the manual wizard entry seeds the last-used SSO identity.
+    const firstConsent = attributeConsentView(authorizePage.page);
+    const ssoPage = await openSsoPopup(
+      authorizePage.page,
+      SSO_DISCOVERY_DOMAIN,
+      "signin",
+    );
+    const closePromise = ssoPage.waitForEvent("close", { timeout: 15_000 });
+    await signInWithOpenId(ssoPage, openIdUsers[0].id);
+    await closePromise;
+    // Fresh SSO user → IdentityNotConnectedDialog; confirm sign-up.
+    await authorizePage.page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Sign up" })
+      .click();
+    await authorizePage.page
+      .getByRole("button", { name: "Continue", exact: true })
+      .click();
+    await firstConsent.waitForVisible();
+    await firstConsent.continue();
     await expect(page.locator("#principal")).toBeVisible({ timeout: 15_000 });
 
-    // SECOND authorize: re-navigate test_app and drive a regular authorize (no
-    // `?sso=`). The last-used SSO identity persists across the reload, so the II
-    // popup shows the ContinueView "Continue" path.
+    // SECOND authorize: re-navigate test_app and drive another authorize. The
+    // last-used SSO identity persists across the reload, so the II popup shows
+    // the ContinueView "Continue" path.
     await page.goto("https://nice-name.com");
     await page
       .getByRole("textbox", { name: "Identity Provider" })


### PR DESCRIPTION
SSO identities must not be recorded as last-used identities, so they no longer show up in II's identity switcher after a 1-click sign-in. Regular 1-click OpenID still tracks.

Construct `AuthFlow` with `trackLastUsed: false` on the two 1-click SSO paths:

- `resumeOpenId` — `trackLastUsed: ssoDomain === null`, so only the `?sso=<domain>` round-trip is affected.
- `handleSsoNormalLoginContinue` — the normal-login fail-safe, reachable only from that flow.

The 1-click OpenID path and the interactive wizard are unchanged.

## Tests

Two e2e tests in `sso.spec.ts` encoded the old behaviour:

- "records the new identity as an sso entry in last-used storage" → now `does not record the new identity in last-used storage`, asserting the store stays empty.
- "Continue as a last-used SSO identity" used a `?sso=` 1-click authorize purely to seed its last-used entry, which no longer works. It now seeds via the manual "Sign in with SSO" wizard entry, which still tracks. The test's actual subject — ContinueView re-auth attaching the certified attribute bundle — is unchanged.

The guard for the OpenID side is `openid.spec.ts`, which asserts 1-click OpenID still records both sign-up (`:95`) and sign-in (`:191`).

Unaffected, checked: `manage/access.spec.ts` (switch-access-method flow), `redirect.spec.ts` and `consent.spec.ts` (no last-used dependency), and the gated non-`sub` tests (bridging is server-side via `oid`).