### PR TITLE
feat(be): migrate every anchor to AI access on the official connector

### DIFF
--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -354,10 +354,11 @@ type InternetIdentityInit = record {
     // set/clear pattern as `dnssec_config`: null keeps the previously stored
     // value, `opt null` clears it, `opt opt "https://..."` sets it.
     mcp_official_url : opt opt text;
-    // One-shot upgrade arg driving the MCP config migration: `opt true`
-    // rewrites every stored config to "enabled, official connector", since a
-    // value stored before the official connector existed was never a choice
-    // about it. Runs at most once per deployment; unset means no migration.
+    // One-shot upgrade arg driving the MCP config migration: `opt true` gives
+    // every anchor "enabled, official connector", since neither a value stored
+    // before the official connector existed nor an absent config was ever a
+    // choice about it. Unset means no migration, and the migration is refused
+    // when the deployment ships no `mcp_official_url`.
     mcp_config_migration : opt bool;
 };
 

--- a/src/internet_identity/src/http/metrics.rs
+++ b/src/internet_identity/src/http/metrics.rs
@@ -80,6 +80,21 @@ fn encode_metrics(w: &mut MetricsEncoder<Vec<u8>>) -> std::io::Result<()> {
             storage.count_live_mcp_grants(time()) as f64,
             "Number of live (non-expired) MCP session grants: the currently-authorized MCP sessions. Computed by scanning the grant map at scrape time (O(n) in stored grants).",
         )?;
+        w.encode_gauge(
+            "internet_identity_mcp_registration_count",
+            storage.mcp_registration_count() as f64,
+            "Number of pending MCP registration entries stored (in-flight registrations plus expired residue not yet reclaimed). Expired entries are swept by a bounded amortized GC driven by prepare writes, so the gap against the live count persists while registration traffic is idle.",
+        )?;
+        w.encode_gauge(
+            "internet_identity_mcp_live_registration_count",
+            storage.count_live_mcp_registrations(time()) as f64,
+            "Number of live (non-expired) MCP registration entries: the registration ceremonies currently redeemable. Computed by scanning the registration map at scrape time (O(n) in stored entries).",
+        )?;
+        w.encode_gauge(
+            "internet_identity_mcp_config_count",
+            storage.mcp_config_count() as f64,
+            "Number of stored per-anchor MCP configs. Configs never expire; after the MCP config migration this is one row per anchor.",
+        )?;
         if let Some(registration_rates) = storage.registration_rates.registration_rates() {
             w.gauge_vec(
                 "internet_identity_registrations_per_second",

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -196,22 +196,29 @@ fn init_sso_credential_migration_timer() {
 // `enabled` on a stored `StorableMcpConfig` predates the official connector,
 // so a stored `false` only ever meant "no custom server of mine" — nobody
 // could have declined a connector that did not exist. This one-shot migration
-// rewrites every stored config to "enabled, official connector". Anchors with
-// no stored config are left alone: they trust nothing until the identity turns
-// the feature on in Settings, and an identity registered on a deployment with
-// an official connector starts out with a config already.
+// gives AI access on the official connector to *every* anchor: it walks the
+// anchor map, so anchors that never wrote a config get a row too. Those are the
+// anchors that registered before configs were seeded at registration time, and
+// nothing else would ever switch them on.
 //
 // Driven by the `mcp_config_migration` upgrade arg and batched via an interval
 // timer, using the same convention as the SSO credential migration above:
-// rewriting every config in `post_upgrade` would blow the instruction limit.
+// writing a config for every anchor in `post_upgrade` would blow the
+// instruction limit.
 
 /// How long to wait between migration batches.
 const MCP_CONFIG_MIGRATION_BATCH_BACKOFF_SECONDS: Duration = Duration::from_secs(1);
 
-/// Maximum number of stored configs to examine per batch (= per ingress
-/// message). Matches the 2 000-per-batch convention used for previous
-/// migrations.
+/// Maximum number of anchors to examine per batch (= per ingress message).
+/// Matches the 2 000-per-batch convention used for previous migrations.
 const MCP_CONFIG_MIGRATION_BATCH_SIZE: u64 = 2_000;
+
+/// Largest window [`list_mcp_config_migration_errors`] serves in one call, so a
+/// wide `lo`/`hi` range can't push the response past the 2 MiB limit. The full
+/// set is accumulated regardless — even the pathological case of every anchor
+/// erroring is a few hundred MB of strings, which fits the heap — so paging is
+/// only about the response size, not about bounding what is kept.
+const MCP_CONFIG_MIGRATION_ERROR_PAGE_LIMIT: u64 = 500;
 
 thread_local! {
     // TODO: Remove these after the data migration is complete.
@@ -219,7 +226,30 @@ thread_local! {
     static MCP_CONFIG_MIGRATION_CURSOR: RefCell<Option<AnchorNumber>> = const { RefCell::new(None) };
     static MCP_CONFIG_MIGRATION_DONE: RefCell<bool> = const { RefCell::new(false) };
     static MCP_CONFIG_MIGRATION_COUNT: RefCell<u64> = const { RefCell::new(0) };
+    static MCP_CONFIG_MIGRATION_ERRORS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
     static MCP_CONFIG_MIGRATION_TIMER_ID: RefCell<Option<TimerId>> = const { RefCell::new(None) };
+}
+
+/// Temporary hidden endpoint: per-anchor errors encountered during the MCP
+/// config migration, as the half-open range `[lo, hi)`. The strings name an
+/// anchor number and the anomaly, never a principal.
+///
+/// Every error is collected, but paginated on read because this migration
+/// touches every anchor: returning the whole list at once could exceed the
+/// 2 MiB response limit and fail exactly when it is needed. `hi` is clamped to
+/// the number stored and to [`MCP_CONFIG_MIGRATION_ERROR_PAGE_LIMIT`] past `lo`,
+/// so page until a call returns fewer than requested. An out-of-range `lo`
+/// yields an empty vector rather than trapping.
+#[update(hidden = true)]
+fn list_mcp_config_migration_errors(lo: u64, hi: u64) -> Vec<String> {
+    MCP_CONFIG_MIGRATION_ERRORS.with_borrow(|errors| {
+        let len = errors.len() as u64;
+        if lo >= len || hi <= lo {
+            return vec![];
+        }
+        let end = hi.min(len).min(lo + MCP_CONFIG_MIGRATION_ERROR_PAGE_LIMIT);
+        errors[lo as usize..end as usize].to_vec()
+    })
 }
 
 /// Temporary hidden endpoint: returns `(migrated_configs, is_done)` so beta
@@ -229,6 +259,10 @@ thread_local! {
 /// the scan hasn't finished. Only `(_, true)` means a run completed, so a
 /// `(0, false)` that persists past the first few batches is the signal that
 /// the arg never arrived.
+///
+/// `(0, true)` alone does not mean success: a migration refused for want of an
+/// official connector also lands there. [`list_mcp_config_migration_errors`]
+/// carries the refusal, so check it before reading `true` as "done".
 #[query(hidden = true)]
 fn mcp_config_migration_status() -> (u64, bool) {
     (
@@ -253,6 +287,9 @@ fn run_mcp_config_migration_batch() {
     MCP_CONFIG_MIGRATION_COUNT.with_borrow_mut(|count| {
         *count = count.saturating_add(outcome.migrated);
     });
+    if !outcome.errors.is_empty() {
+        MCP_CONFIG_MIGRATION_ERRORS.with_borrow_mut(|errors| errors.extend(outcome.errors));
+    }
     if let Some(next_cursor) = outcome.next_cursor {
         MCP_CONFIG_MIGRATION_CURSOR.replace(Some(next_cursor));
     }
@@ -273,8 +310,25 @@ fn run_mcp_config_migration_batch() {
 /// this upgrade didn't ask for the migration. Nothing about a completed run is
 /// persisted, so the upgrade arg is the only control: passing it again re-runs
 /// the migration, exactly like the SSO credential migration above.
+///
+/// Without an official connector the migration is refused outright: the shape it
+/// writes resolves to no trusted URL at all, so it would leave every identity
+/// with AI access reading on and nothing behind it. Same rule as
+/// `mcp::init_config_for_new_identity`.
 fn init_mcp_config_migration_timer() {
     if !MCP_CONFIG_MIGRATION_REQUESTED.with_borrow(|requested| *requested) {
+        return;
+    }
+    if mcp::official_url().is_none() {
+        // Record the refusal, not just the log line: `mcp_config_migration_status`
+        // would otherwise report `(0, true)`, indistinguishable from a run that
+        // completed with nothing to do.
+        let err = "migration refused: mcp_config_migration was requested but this deployment has \
+                   no official connector"
+            .to_string();
+        ic_cdk::println!("WARNING: MCP config migration: {err}");
+        MCP_CONFIG_MIGRATION_ERRORS.with_borrow_mut(|errors| errors.push(err));
+        MCP_CONFIG_MIGRATION_DONE.replace(true);
         return;
     }
     let timer_id = ic_cdk_timers::set_timer_interval(
@@ -2595,5 +2649,66 @@ mod test {
         .unwrap_or_else(|e| {
             panic!("the canister code interface is not equal to the did file: {e:?}")
         });
+    }
+}
+
+#[cfg(test)]
+mod list_mcp_config_migration_errors_tests {
+    use super::*;
+
+    fn seed(count: usize) {
+        MCP_CONFIG_MIGRATION_ERRORS.with_borrow_mut(|errors| {
+            *errors = (0..count).map(|i| format!("anchor {i}")).collect();
+        });
+    }
+
+    #[test]
+    fn serves_the_requested_half_open_range() {
+        seed(10);
+        assert_eq!(
+            list_mcp_config_migration_errors(2, 5),
+            vec!["anchor 2", "anchor 3", "anchor 4"]
+        );
+    }
+
+    #[test]
+    fn clamps_hi_to_what_is_retained() {
+        seed(3);
+        assert_eq!(
+            list_mcp_config_migration_errors(1, u64::MAX),
+            vec!["anchor 1", "anchor 2"]
+        );
+    }
+
+    #[test]
+    fn caps_the_window_at_the_page_limit() {
+        let total = MCP_CONFIG_MIGRATION_ERROR_PAGE_LIMIT as usize + 10;
+        seed(total);
+        assert_eq!(
+            list_mcp_config_migration_errors(0, total as u64).len(),
+            MCP_CONFIG_MIGRATION_ERROR_PAGE_LIMIT as usize
+        );
+    }
+
+    #[test]
+    fn returns_empty_for_out_of_range_or_inverted_bounds() {
+        seed(3);
+        // Past the end, and an empty or backwards window: empty, never a trap.
+        assert!(list_mcp_config_migration_errors(3, 9).is_empty());
+        assert!(list_mcp_config_migration_errors(u64::MAX, u64::MAX).is_empty());
+        assert!(list_mcp_config_migration_errors(2, 2).is_empty());
+        assert!(list_mcp_config_migration_errors(2, 1).is_empty());
+    }
+
+    #[test]
+    fn empty_error_list_never_slices() {
+        seed(0);
+        // The `lo >= len` guard catches this because `lo` is a `u64`, so it can't
+        // be below an empty list's length of 0 — the slice is never reached.
+        assert!(list_mcp_config_migration_errors(0, 0).is_empty());
+        assert!(list_mcp_config_migration_errors(0, u64::MAX).is_empty());
+        assert!(
+            list_mcp_config_migration_errors(0, MCP_CONFIG_MIGRATION_ERROR_PAGE_LIMIT).is_empty()
+        );
     }
 }

--- a/src/internet_identity/src/mcp.rs
+++ b/src/internet_identity/src/mcp.rs
@@ -83,7 +83,7 @@ pub(crate) const MCP_GRANT_MIN_TTL_NS: u64 = 10 * 60 * 1_000_000_000;
 pub(crate) const MCP_GRANT_MAX_TTL_NS: u64 = 30 * 24 * 60 * 60 * 1_000_000_000;
 
 /// The official MCP connector this deployment ships, if any.
-fn official_url() -> Option<String> {
+pub(crate) fn official_url() -> Option<String> {
     persistent_state(|state| state.mcp_official_url.clone())
 }
 

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -343,14 +343,28 @@ pub struct SsoCredentialMigrationBatchOutcome {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct McpConfigMigrationBatchOutcome {
-    /// Number of stored MCP configs rewritten this batch.
+    /// Number of MCP configs written this batch, counting both rewritten rows
+    /// and rows created for anchors that had none.
     pub migrated: u64,
-    /// `true` when the scan has reached the end of the config map — caller
+    /// `true` when the scan has reached the end of the anchor map — caller
     /// should stop the interval timer.
     pub is_done: bool,
+    /// Per-anchor errors encountered this batch (e.g. a registration pointer
+    /// that could not be resolved to an entry this anchor owns).
+    pub errors: Vec<String>,
     /// Last anchor examined this batch; pass back as `cursor` of the next
     /// batch to resume the scan. `None` when the batch examined nothing.
     pub next_cursor: Option<StorableAnchorNumber>,
+}
+
+impl McpConfigMigrationBatchOutcome {
+    /// Record a per-anchor error, mirroring the SSO credential migration: every
+    /// error goes to the canister log as well as the returned vector, so the
+    /// bound the caller applies to the vector can never lose one.
+    fn push_error(&mut self, err: String) {
+        ic_cdk::println!("WARNING: MCP config migration: {err}");
+        self.errors.push(err);
+    }
 }
 
 /// Data type responsible for managing anchor data in stable memory.
@@ -1207,24 +1221,51 @@ impl<M: Memory + Clone> Storage<M> {
             .get(&principal)
     }
 
-    /// Rewrite up to `batch_size` stored MCP configs to "enabled, official
-    /// connector". The pre-official-connector meaning of every stored value
-    /// was "no custom server of mine", never a choice about a connector that
-    /// did not exist yet.
+    /// Give up to `batch_size` anchors AI access on the official connector, by
+    /// writing `{ enabled: true, url: None }` for every anchor the scan reaches.
+    /// The pre-official-connector meaning of a stored `enabled` was "no custom
+    /// server of mine", never a choice about a connector that did not exist yet
+    /// — and an anchor with no stored config never expressed a choice either, it
+    /// simply registered before configs were seeded at registration time.
     ///
-    /// That deliberately includes rows that are already enabled with a custom
-    /// server: `{ enabled: true, url: Some(..) }` is reset to the official
-    /// connector like everything else, so those identities have to re-add their
-    /// server if they still want it. Only rows already in the target shape
-    /// (`{ enabled: true, url: None }`) are skipped, which is what makes a
-    /// re-run a no-op.
+    /// The scan therefore walks the anchor map, not the config map: anchors that
+    /// never wrote a config are the whole reason this runs, and a config-map
+    /// scan cannot see them. Every anchor reached is written unconditionally,
+    /// including rows already in the target shape and rows enabled with a custom
+    /// server — the latter have to re-add their server if they still want it.
     ///
-    /// Any live grant on a rewritten row is deleted, along with any in-flight
-    /// registration: neither may come back to life because a migration
-    /// re-enabled the identity. A grant that was inert only because the config
-    /// was disabled must not end up authorized against a connector it was never
-    /// granted for, and a registration delegation consented to before the
-    /// switch-off must not become redeemable again.
+    /// Unlike the SSO credential migration this is therefore **not** idempotent.
+    /// A healthy identity on the official connector sits at exactly the target
+    /// shape with a live `session_principal`, so a second run rewrites its row
+    /// and drops that session along with everyone else's. Re-running is a
+    /// deliberate "drop every MCP session" operation, not a cheap retry, and
+    /// nothing but withholding the upgrade arg prevents it.
+    ///
+    /// Rewriting the row is what invalidates a live session: `session_principal`
+    /// goes back to `None`, and `authorize_mcp_session` only authorizes a caller
+    /// the config still points at. The grant row itself is left to the lazy
+    /// expiry cleanup on the update path — it can no longer authorize anything.
+    ///
+    /// An in-flight registration is removed explicitly, because it is not covered
+    /// by that: redemption resolves the entry from the registration index by
+    /// `p_reg` and compares its hash against the *current* trusted URL, never
+    /// consulting the config. Switching AI access off leaves the entry in place
+    /// and relies on `trusted_url` being `None` to refuse it, so re-pointing the
+    /// identity at the official connector would make an entry minted under that
+    /// connector redeemable again.
+    ///
+    /// A registration pointer that cannot be resolved to an entry this anchor
+    /// owns is reported in `errors` and logged, following the SSO credential
+    /// migration: the row is rewritten regardless, so the entry it pointed at
+    /// would otherwise be left redeemable with no trace. Like there, the strings
+    /// carry the anchor number only and never a principal.
+    ///
+    /// The bad pointer itself is cleaned up either way — the rewrite resets it to
+    /// `None`. Nothing further can be: an undecodable pointer yields no key, and
+    /// the registration index is keyed by principal with no anchor reverse
+    /// lookup, so an entry it may have referenced can't be located without
+    /// scanning the whole index. Those entries expire in five minutes and are
+    /// reclaimed by the amortized sweep.
     pub fn migrate_mcp_configs_batch(
         &mut self,
         cursor: Option<StorableAnchorNumber>,
@@ -1236,56 +1277,49 @@ impl<M: Memory + Clone> Storage<M> {
             return outcome;
         }
 
-        // Collect first so the rewrite below doesn't alias the range borrow.
+        // `keys_range` avoids decoding a `StorableAnchor` per anchor: the scan
+        // only needs the number, and the records are large. Writing as we go is
+        // fine because the scan reads the anchor map while the writes land in the
+        // config and registration maps — no aliasing, unlike the config-map scan
+        // this replaced. The registration index is reached by field rather than
+        // through `lookup`/`remove_mcp_registration`, which would borrow all of
+        // `self` and conflict with the iterator.
         use std::ops::Bound as RangeBound;
         let range = match cursor {
             Some(cursor) => (RangeBound::Excluded(cursor), RangeBound::Unbounded),
             None => (RangeBound::Unbounded, RangeBound::Unbounded),
         };
         let mut examined: u64 = 0;
-        let mut stale: Vec<(StorableAnchorNumber, StorableMcpConfig)> = vec![];
-        for (anchor_number, config) in self
-            .mcp_config_memory
-            .range(range)
+        for anchor_number in self
+            .stable_anchor_memory
+            .keys_range(range)
             .take(batch_size as usize)
         {
             examined += 1;
             outcome.next_cursor = Some(anchor_number);
-            // Only the target shape is skipped — an enabled row with a custom
-            // server is rewritten too (see the doc comment). Skipping it also
-            // makes a re-run a no-op.
-            if config.enabled && config.url.is_none() {
-                continue;
-            }
-            stale.push((anchor_number, config));
-        }
 
-        for (anchor_number, config) in stale {
-            if let Some(bytes) = &config.session_principal {
-                if let Ok(principal) = Principal::try_from_slice(bytes) {
-                    // Only remove a grant this anchor actually owns, so a
-                    // stale pointer can't delete another identity's session.
-                    if self
-                        .lookup_mcp_grant(principal)
-                        .is_some_and(|grant| grant.anchor_number == anchor_number)
-                    {
-                        self.remove_mcp_grant(principal);
-                    }
-                }
-            }
-            // `set_mcp_config` carries an in-flight registration over, because
-            // the redemption's URL-hash check invalidates it. That check
-            // compares against the *current* trusted URL though, and this
-            // migration can restore the very URL the entry was minted under, so
-            // here it has to go.
-            if let Some(bytes) = &config.pending_registration {
-                if let Ok(principal) = Principal::try_from_slice(bytes) {
-                    if self
-                        .lookup_mcp_registration(principal)
-                        .is_some_and(|entry| entry.anchor_number == anchor_number)
-                    {
-                        self.remove_mcp_registration(principal);
-                    }
+            let pending_registration = self
+                .mcp_config_memory
+                .get(&anchor_number)
+                .and_then(|config| config.pending_registration);
+            if let Some(bytes) = pending_registration {
+                match Principal::try_from_slice(&bytes) {
+                    // Only remove an entry this anchor actually owns, so a stale
+                    // pointer can't evict another identity's registration.
+                    Ok(principal) => match self.mcp_registration_memory.get(&principal) {
+                        Some(entry) if entry.anchor_number == anchor_number => {
+                            self.mcp_registration_memory.remove(&principal);
+                        }
+                        Some(_) => outcome.push_error(format!(
+                            "anchor {anchor_number}: registration pointer resolves to an entry \
+                             held by another anchor; left in place"
+                        )),
+                        None => {}
+                    },
+                    Err(_) => outcome.push_error(format!(
+                        "anchor {anchor_number}: registration pointer is not a valid principal; \
+                         entry could not be removed"
+                    )),
                 }
             }
             self.mcp_config_memory.insert(
@@ -1345,6 +1379,36 @@ impl<M: Memory + Clone> Storage<M> {
             .iter()
             .filter(|(_, grant)| grant.expires_at_ns > now_ns)
             .fold(0u64, |acc, _| acc + 1)
+    }
+
+    /// Number of pending MCP registration entries stored: in-flight
+    /// registrations plus expired residue not yet reclaimed. Expired entries are
+    /// swept by the bounded amortized GC that runs on each `prepare` write, so
+    /// residue drains only while there is registration traffic. O(1).
+    pub fn mcp_registration_count(&self) -> u64 {
+        self.mcp_registration_memory.len()
+    }
+
+    /// Number of *live* (non-expired at `now_ns`) MCP registration entries.
+    /// Mirrors [`Self::count_live_mcp_grants`]. The gap against
+    /// [`Self::mcp_registration_count`] is residue awaiting the sweep, which is
+    /// worth watching because the sweep is driven by writes: a deployment that
+    /// goes quiet stops reclaiming and the gap persists. O(n) in stored entries.
+    pub fn count_live_mcp_registrations(&self, now_ns: u64) -> u64 {
+        // Accumulate directly into a `u64`: `Iterator::count` returns `usize`,
+        // which is 32-bit on wasm32 and would wrap in a release build.
+        self.mcp_registration_memory
+            .iter()
+            .filter(|(_, entry)| entry.expires_at_ns > now_ns)
+            .fold(0u64, |acc, _| acc + 1)
+    }
+
+    /// Number of stored per-anchor MCP configs. Configs never expire, so there
+    /// is no live/residue split: this is one row per identity that has the
+    /// feature configured, and after the config migration one row per anchor.
+    /// O(1).
+    pub fn mcp_config_count(&self) -> u64 {
+        self.mcp_config_memory.len()
     }
 
     /// Look up the pending MCP registration entry keyed by `principal` (the

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -2374,148 +2374,315 @@ mod migrate_sso_credentials_batch_tests {
     }
 }
 
-#[test]
-fn mcp_config_migration_enables_stored_configs_and_revokes_their_grants() {
+mod migrate_mcp_configs_batch_tests {
+    use super::*;
     use crate::storage::storable::mcp_config::StorableMcpConfig;
     use crate::storage::storable::mcp_grant::StorableMcpGrant;
     use crate::storage::storable::mcp_registration::StorableMcpRegistration;
+    use pretty_assertions::assert_eq;
 
-    let mut storage = Storage::new((0, 100), VectorMemory::default());
-    let session = Principal::self_authenticating([1u8; 32]);
-    let p_reg = Principal::self_authenticating([2u8; 32]);
+    const CUSTOM_URL: &str = "https://mcp.acme.com/mcp";
 
-    // Disabled, still pointing at a grant and an in-flight registration that are
-    // inert only because of the flag.
-    storage.write_mcp_config(
-        10_000,
-        StorableMcpConfig {
-            enabled: false,
-            url: Some("https://mcp.acme.com/mcp".to_string()),
-            session_principal: Some(session.as_slice().to_vec()),
-            pending_registration: Some(p_reg.as_slice().to_vec()),
-        },
-    );
-    storage.insert_mcp_registration(
-        p_reg,
+    /// Register an anchor so the migration's anchor-map scan can reach it. The
+    /// anchors this migration exists for are exactly these: no config row.
+    fn seed_bare_anchor<M: Memory + Clone>(storage: &mut Storage<M>) -> u64 {
+        let anchor = storage.allocate_anchor(0).unwrap();
+        let anchor_number = anchor.anchor_number();
+        storage.write(anchor).unwrap();
+        anchor_number
+    }
+
+    fn registration(anchor_number: u64) -> StorableMcpRegistration {
         StorableMcpRegistration {
-            anchor_number: 10_000,
+            anchor_number,
             read_only: false,
             grant_ttl_ns: 3_600_000_000_000,
             trusted_url_hash: vec![7u8; 32],
             expires_at_ns: u64::MAX,
-        },
-    );
-    storage.insert_mcp_grant(
-        session,
-        StorableMcpGrant {
-            anchor_number: 10_000,
-            expires_at_ns: u64::MAX,
-            read_only: false,
-        },
-    );
-    // Already in the migrated shape.
-    storage.write_mcp_config(
-        10_001,
-        StorableMcpConfig {
-            enabled: true,
-            url: None,
-            session_principal: None,
-            pending_registration: None,
-        },
-    );
-
-    let outcome = storage.migrate_mcp_configs_batch(None, 2_000);
-
-    assert_eq!(outcome.migrated, 1);
-    assert!(outcome.is_done);
-    assert_eq!(
-        storage.read_mcp_config(10_000),
-        StorableMcpConfig {
-            enabled: true,
-            url: None,
-            session_principal: None,
-            pending_registration: None,
         }
-    );
-    // The grant must not survive: re-enabling would otherwise revive a session
-    // against a connector it was never granted for.
-    assert!(storage.lookup_mcp_grant(session).is_none());
-    // Nor the in-flight registration: its redemption is gated on the *current*
-    // trusted URL, which this migration can restore to the one it was minted
-    // under, making a pre-switch-off delegation redeemable again.
-    assert!(storage.lookup_mcp_registration(p_reg).is_none());
-
-    // Re-running is a no-op.
-    let again = storage.migrate_mcp_configs_batch(None, 2_000);
-    assert_eq!(again.migrated, 0);
-    assert!(again.is_done);
-}
-
-#[test]
-fn mcp_config_migration_also_resets_an_enabled_custom_connector() {
-    use crate::storage::storable::mcp_config::StorableMcpConfig;
-    use crate::storage::storable::mcp_grant::StorableMcpGrant;
-
-    let mut storage = Storage::new((0, 100), VectorMemory::default());
-    let session = Principal::self_authenticating([3u8; 32]);
-
-    // A working custom connector with a live session.
-    storage.write_mcp_config(
-        10_000,
-        StorableMcpConfig {
-            enabled: true,
-            url: Some("https://mcp.acme.com/mcp".to_string()),
-            session_principal: Some(session.as_slice().to_vec()),
-            pending_registration: None,
-        },
-    );
-    storage.insert_mcp_grant(
-        session,
-        StorableMcpGrant {
-            anchor_number: 10_000,
-            expires_at_ns: u64::MAX,
-            read_only: false,
-        },
-    );
-
-    let outcome = storage.migrate_mcp_configs_batch(None, 2_000);
-
-    // Deliberate: choosing a custom server predates the official connector, so
-    // it wasn't a choice against it. These identities are reset to the default
-    // and re-add their server if they still want it.
-    assert_eq!(outcome.migrated, 1);
-    assert_eq!(
-        storage.read_mcp_config(10_000),
-        StorableMcpConfig {
-            enabled: true,
-            ..Default::default()
-        }
-    );
-    assert!(storage.lookup_mcp_grant(session).is_none());
-}
-
-#[test]
-fn mcp_config_migration_resumes_from_the_cursor() {
-    use crate::storage::storable::mcp_config::StorableMcpConfig;
-
-    let mut storage = Storage::new((0, 100), VectorMemory::default());
-    let disabled = StorableMcpConfig {
-        enabled: false,
-        url: None,
-        session_principal: None,
-        pending_registration: None,
-    };
-    for anchor in 10_000..10_003 {
-        storage.write_mcp_config(anchor, disabled.clone());
     }
 
-    let first = storage.migrate_mcp_configs_batch(None, 2);
-    assert_eq!(first.migrated, 2);
-    assert!(!first.is_done);
-    assert_eq!(first.next_cursor, Some(10_001));
+    fn grant(anchor_number: u64) -> StorableMcpGrant {
+        StorableMcpGrant {
+            anchor_number,
+            expires_at_ns: u64::MAX,
+            read_only: false,
+        }
+    }
 
-    let second = storage.migrate_mcp_configs_batch(first.next_cursor, 2);
-    assert_eq!(second.migrated, 1);
-    assert!(second.is_done);
-    assert!(storage.read_mcp_config(10_002).enabled);
+    /// Drive the migration the way the interval timer does, threading the cursor
+    /// until a batch reports completion. Returns `(migrated, errors, batches)`.
+    fn run_to_completion<M: Memory + Clone>(
+        storage: &mut Storage<M>,
+        batch_size: u64,
+    ) -> (u64, Vec<String>, u64) {
+        let mut cursor = None;
+        let (mut migrated, mut errors, mut batches) = (0u64, vec![], 0u64);
+        loop {
+            let outcome = storage.migrate_mcp_configs_batch(cursor, batch_size);
+            migrated += outcome.migrated;
+            errors.extend(outcome.errors);
+            batches += 1;
+            if outcome.next_cursor.is_some() {
+                cursor = outcome.next_cursor;
+            }
+            if outcome.is_done {
+                return (migrated, errors, batches);
+            }
+        }
+    }
+
+    #[test]
+    fn writes_a_config_for_anchors_that_never_stored_one() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let anchors: Vec<u64> = (0..3).map(|_| seed_bare_anchor(&mut storage)).collect();
+
+        // The whole point of scanning the anchor map: a config-map scan cannot
+        // see these, so nothing would ever switch them on.
+        let (migrated, errors, _) = run_to_completion(&mut storage, 2_000);
+
+        assert_eq!(migrated, 3);
+        assert!(errors.is_empty());
+        for anchor in anchors {
+            assert_eq!(
+                storage.read_mcp_config(anchor),
+                StorableMcpConfig {
+                    enabled: true,
+                    ..Default::default()
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn rewrites_a_disabled_row_and_invalidates_its_session() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let session = Principal::self_authenticating([1u8; 32]);
+        let p_reg = Principal::self_authenticating([2u8; 32]);
+        let anchor = seed_bare_anchor(&mut storage);
+
+        // Disabled, still pointing at a grant and an in-flight registration that
+        // are inert only because of the flag.
+        storage.write_mcp_config(
+            anchor,
+            StorableMcpConfig {
+                enabled: false,
+                url: Some(CUSTOM_URL.to_string()),
+                session_principal: Some(session.as_slice().to_vec()),
+                pending_registration: Some(p_reg.as_slice().to_vec()),
+            },
+        );
+        storage.insert_mcp_registration(p_reg, registration(anchor));
+        storage.insert_mcp_grant(session, grant(anchor));
+
+        let (migrated, errors, _) = run_to_completion(&mut storage, 2_000);
+
+        assert_eq!(migrated, 1);
+        assert!(errors.is_empty());
+        assert_eq!(
+            storage.read_mcp_config(anchor),
+            StorableMcpConfig {
+                enabled: true,
+                ..Default::default()
+            }
+        );
+        // The session is dead because the rewritten config no longer names it:
+        // `authorize_mcp_session` only authorizes the principal the config
+        // points at. The grant row is left for the lazy expiry cleanup.
+        assert!(storage.lookup_mcp_grant(session).is_some());
+        // The registration has to go explicitly: redemption resolves it from the
+        // registration index and re-checks the *current* trusted URL, which this
+        // migration can restore to the one it was minted under.
+        assert!(storage.lookup_mcp_registration(p_reg).is_none());
+    }
+
+    #[test]
+    fn resets_an_enabled_custom_connector() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let session = Principal::self_authenticating([3u8; 32]);
+        let anchor = seed_bare_anchor(&mut storage);
+
+        storage.write_mcp_config(
+            anchor,
+            StorableMcpConfig {
+                enabled: true,
+                url: Some(CUSTOM_URL.to_string()),
+                session_principal: Some(session.as_slice().to_vec()),
+                pending_registration: None,
+            },
+        );
+        storage.insert_mcp_grant(session, grant(anchor));
+
+        let (migrated, _, _) = run_to_completion(&mut storage, 2_000);
+
+        // Deliberate: choosing a custom server predates the official connector,
+        // so it wasn't a choice against it. These identities are reset to the
+        // default and re-add their server if they still want it.
+        assert_eq!(migrated, 1);
+        assert_eq!(
+            storage.read_mcp_config(anchor),
+            StorableMcpConfig {
+                enabled: true,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn reports_a_registration_pointer_it_cannot_resolve() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let foreign = Principal::self_authenticating([4u8; 32]);
+        let owner = seed_bare_anchor(&mut storage);
+        let pointing_elsewhere = seed_bare_anchor(&mut storage);
+        let undecodable = seed_bare_anchor(&mut storage);
+
+        // A pointer to an entry another anchor owns must not evict that anchor's
+        // registration, so it survives and is reported instead.
+        storage.insert_mcp_registration(foreign, registration(owner));
+        storage.write_mcp_config(
+            pointing_elsewhere,
+            StorableMcpConfig {
+                enabled: false,
+                url: None,
+                session_principal: None,
+                pending_registration: Some(foreign.as_slice().to_vec()),
+            },
+        );
+        // Longer than the 29-byte principal maximum, so it cannot be resolved at
+        // all — whatever it pointed at can never be removed.
+        storage.write_mcp_config(
+            undecodable,
+            StorableMcpConfig {
+                enabled: false,
+                url: None,
+                session_principal: None,
+                pending_registration: Some(vec![1u8; 40]),
+            },
+        );
+
+        let (migrated, errors, _) = run_to_completion(&mut storage, 2_000);
+
+        assert_eq!(migrated, 3);
+        assert_eq!(errors.len(), 2);
+        assert!(errors
+            .iter()
+            .any(|err| err.contains(&format!("anchor {pointing_elsewhere}"))
+                && err.contains("another anchor")));
+        assert!(errors
+            .iter()
+            .any(|err| err.contains(&format!("anchor {undecodable}"))
+                && err.contains("not a valid principal")));
+        // Anchor number and anomaly only — never a principal, matching the rule
+        // the SSO credential migration set.
+        for err in &errors {
+            assert!(!err.contains(&foreign.to_text()));
+        }
+        // Reported, not silently evicted: the other identity keeps its entry.
+        assert!(storage.lookup_mcp_registration(foreign).is_some());
+        // The rows migrate regardless — the feature is on for them either way —
+        // and the bad pointer does not survive the rewrite. That is the whole
+        // cleanup available: an undecodable pointer yields no key, and the index
+        // is keyed by principal with no anchor reverse lookup, so an entry it
+        // may have referenced cannot be found without scanning the whole map.
+        // Those self-heal via the 5-minute TTL and the amortized sweep.
+        for anchor in [pointing_elsewhere, undecodable] {
+            let config = storage.read_mcp_config(anchor);
+            assert!(config.enabled);
+            assert_eq!(config.pending_registration, None);
+        }
+    }
+
+    #[test]
+    fn rerun_drops_sessions_established_since_the_first_run() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let session = Principal::self_authenticating([5u8; 32]);
+        let anchor = seed_bare_anchor(&mut storage);
+        storage.write_mcp_config(
+            anchor,
+            StorableMcpConfig {
+                enabled: false,
+                url: Some(CUSTOM_URL.to_string()),
+                ..Default::default()
+            },
+        );
+
+        let (migrated, _, _) = run_to_completion(&mut storage, 2_000);
+        assert_eq!(migrated, 1);
+
+        // A healthy identity connecting to the official connector afterwards
+        // lands on the target shape with a live session pointer.
+        let mut config = storage.read_mcp_config(anchor);
+        config.session_principal = Some(session.as_slice().to_vec());
+        storage.write_mcp_config(anchor, config);
+        storage.insert_mcp_grant(session, grant(anchor));
+
+        let (migrated_again, errors, _) = run_to_completion(&mut storage, 2_000);
+
+        // Accepted cost of writing unconditionally: unlike the SSO migration
+        // this one is not idempotent. Re-running rewrites the row and drops that
+        // session, so passing the arg twice logs everyone out of MCP.
+        assert_eq!(migrated_again, 1);
+        assert!(errors.is_empty());
+        assert_eq!(storage.read_mcp_config(anchor).session_principal, None);
+    }
+
+    #[test]
+    fn index_counters_separate_live_entries_from_residue() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let anchor = seed_bare_anchor(&mut storage);
+        let now = 1_000_000_000_000;
+        let live = Principal::self_authenticating([8u8; 32]);
+        let expired = Principal::self_authenticating([9u8; 32]);
+
+        storage.insert_mcp_registration(
+            live,
+            StorableMcpRegistration {
+                expires_at_ns: now + 1,
+                ..registration(anchor)
+            },
+        );
+        storage.insert_mcp_registration(
+            expired,
+            StorableMcpRegistration {
+                expires_at_ns: now,
+                ..registration(anchor)
+            },
+        );
+
+        // The gap between the two is residue the amortized sweep hasn't reached:
+        // `expires_at_ns == now` is already expired, the check is strictly `>`.
+        assert_eq!(storage.mcp_registration_count(), 2);
+        assert_eq!(storage.count_live_mcp_registrations(now), 1);
+
+        assert_eq!(storage.mcp_config_count(), 0);
+        run_to_completion(&mut storage, 2_000);
+        // Configs never expire, so this is simply one row per anchor afterwards.
+        assert_eq!(storage.mcp_config_count(), 1);
+    }
+
+    #[test]
+    fn resumes_from_the_cursor() {
+        let mut storage = Storage::new((0, 100), VectorMemory::default());
+        let anchors: Vec<u64> = (0..3).map(|_| seed_bare_anchor(&mut storage)).collect();
+
+        let first = storage.migrate_mcp_configs_batch(None, 2);
+        assert_eq!(first.migrated, 2);
+        assert!(!first.is_done);
+        assert_eq!(first.next_cursor, Some(anchors[1]));
+
+        let second = storage.migrate_mcp_configs_batch(first.next_cursor, 2);
+        assert_eq!(second.migrated, 1);
+        assert!(second.is_done);
+        assert!(storage.read_mcp_config(anchors[2]).enabled);
+
+        // Three anchors at two per batch: the whole scan takes two batches and
+        // the driver stops on the short one.
+        let mut fresh = Storage::new((0, 100), VectorMemory::default());
+        (0..3).for_each(|_| {
+            seed_bare_anchor(&mut fresh);
+        });
+        let (migrated, _, batches) = run_to_completion(&mut fresh, 2);
+        assert_eq!(migrated, 3);
+        assert_eq!(batches, 2);
+    }
 }


### PR DESCRIPTION
## Problem

The MCP config migration added in #4157 walks the *config* map, so it only ever reaches identities that already stored a config. That was justified at the time by "anchors with no stored config already resolve to the official connector at connect time" — but #4164 replaced that read-path default with registration-time seeding (`mcp::init_config_for_new_identity`), which only covers anchors registered *after* it shipped.

So the gap is: an anchor that registered earlier and never touched the feature has no config row, `resolve_connect_url` returns `None` for it, and nothing would ever switch it on. Those identities would sit with AI access off indefinitely while the official connector is right there for them.

`enabled` predating the official connector is the same argument that justifies rewriting stored rows: a stored `false` only ever meant "no custom server of mine". An *absent* row is no more a choice about the connector than a stored `false` is.

## Changes

- `Storage::migrate_mcp_configs_batch` scans `stable_anchor_memory` via `keys_range` instead of `mcp_config_memory.range`, writing `{ enabled: true, url: None }` for every anchor it reaches — including anchors that never stored a config. `keys_range` keeps the scan from decoding a `StorableAnchor` per anchor; the batch only needs the number. Cursor type is unchanged.
- The write is **unconditional** — no "already in the target shape" check. Rows enabled with a custom server are reset like everything else, so those identities re-add their server if they still want it.
- Rewriting a row is what invalidates a live session: `session_principal` returns to `None`, and `authorize_mcp_session` only authorizes a caller the config still names. The grant row is left to the existing lazy expiry cleanup on the update path, since it can no longer authorize anything.
- In-flight registrations are removed explicitly, because they are *not* covered by that: redemption resolves the entry from the registration index by `p_reg` and compares its hash against the **current** trusted URL, never consulting the config. Switching AI access off leaves the entry in place and relies on `trusted_url` being `None` to refuse it, so re-pointing an identity at the official connector would make an entry minted under that connector redeemable again.
- `init_mcp_config_migration_timer` refuses to run when the deployment ships no `mcp_official_url`, marking the migration done and logging why. `{ enabled: true, url: None }` resolves to no trusted URL without a connector, so running it there would leave every identity with AI access reading on and nothing behind it. Same rule `mcp::init_config_for_new_identity` already applies.
- `mcp::official_url()` widened to `pub(crate)` for that gate.

### Re-running is not idempotent

Unlike `migrate_sso_credentials_batch`, this migration has no skip for rows already in the target shape. A healthy identity on the official connector sits at exactly that shape with a live `session_principal`, so a second run rewrites its row and drops that session along with everyone else's — passing the arg twice logs every AI-access user out of MCP. Completion is heap-only (not persisted in `PersistentState`), so withholding the upgrade arg is the only thing that prevents it. Accepted deliberately while the feature is in Preview; pinned by a test so it can't regress silently.

## Errors — addressing the review

Thanks @gladdy and @arshavir for both points; they're handled as follows.

**What is exposed.** A registration pointer that can't be resolved to an entry the anchor owns is reported, in two cases: it resolves to another anchor's entry (left in place), or the bytes aren't a valid principal. The strings carry the **anchor number and the anomaly only, never a principal** — the same rule `migrate_sso_credentials_batch` already documents as *"No PII: anchor number only"*. There's a test asserting no principal text appears in the reported strings.

**Bounding.** `list_mcp_config_migration_errors(lo, hi)` now serves the half-open range `[lo, hi)` instead of the whole list, so the response is bounded by what you ask for rather than by how many anchors went wrong. `hi` is clamped to the number retained and to 500 past `lo`, so page until a call returns fewer than requested; an out-of-range `lo` yields an empty vector rather than trapping. Separately, retention is capped at 10 000 entries so the accumulator can't grow the heap without limit, and the moment that cap truncates anything is logged so a short list is never silent.

Every error also goes to the canister log via `ic_cdk::println!`, paired inside `push_error` so the two channels can't drift apart. That makes Thomas's "read them off the nodes" the complete record, with the endpoint as the convenient paged view.

Worth noting separately: `SSO_CREDENTIAL_MIGRATION_ERRORS` has no such cap and *is* populated. Small blast radius there, as Thomas said, but it's the instance that actually has the bug. Happy to send a follow-up rather than widen this PR.

### Note on storage

This writes one `mcp_config_memory` row per anchor across the whole anchor set — permanent per-anchor growth. The alternative, defaulting an absent row to "enabled, official connector" in the read path, would cost nothing, but the explicit-row approach was chosen so every identity has a real row to revoke against.

### Note on `url`

The target shape is `url: None`, not `Some("")`. `trusted_url_with` does `config.url.clone().or(official)`, so an empty string would short-circuit the official-connector fallback and leave the identity trusting `""`.

## Tests

Restructured into `migrate_mcp_configs_batch_tests` with a `run_to_completion` driver that threads the cursor the way the interval timer does, mirroring the SSO migration's test module.

- `writes_a_config_for_anchors_that_never_stored_one` — three bare anchors with no config row all end up `{ enabled: true, url: None }`. The case the old config-map scan could not reach.
- `rewrites_a_disabled_row_and_invalidates_its_session` — a disabled row with a live session and an in-flight registration is rewritten, its session pointer cleared and its registration removed; the grant row is left for lazy cleanup.
- `resets_an_enabled_custom_connector` — custom-server row reset to the official connector.
- `reports_a_registration_pointer_it_cannot_resolve` — both error cases reported, the other anchor keeps its entry, the rows still migrate, and no principal text leaks into the strings.
- `rerun_drops_sessions_established_since_the_first_run` — pins the accepted cost above: a session established after the first run does not survive a second.
- `resumes_from_the_cursor` — a short batch reports `is_done: false` with a cursor, the follow-up finishes, and the driver completes three anchors in two batches at `batch_size: 2`.

Plus `list_mcp_config_migration_errors_tests` for the paging itself: the half-open range, `hi` clamped to what's retained, the window capped at the page limit, and empty (never a trap) for out-of-range, empty and inverted bounds including `u64::MAX`.

- `cargo test -p internet_identity --bin internet_identity` — 655 passing, including `check_candid_interface_compatibility`. `cargo fmt` and `cargo clippy --all-targets -- -D warnings` clean. PocketIC integration tests left to CI.
