### PR TITLE
chore(ci): fix invalid dependabot config that stopped all dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ version: 2
 # separately per ecosystem via `groups` with `applies-to: security-updates`, so
 # advisory-driven bumps arrive as one grouped PR per ecosystem (across all
 # directories) instead of one PR per dependency.
+#
+# `commit-message` and `open-pull-requests-limit` belong to the multi-ecosystem
+# group: they describe the single consolidated PR, so Dependabot rejects them on
+# the individual ecosystem entries.
 multi-ecosystem-groups:
   weekly-version-updates:
     schedule:
@@ -14,6 +18,10 @@ multi-ecosystem-groups:
       timezone: Etc/UTC
     labels:
       - dependencies
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
 
 updates:
   # ── cargo ──────────────────────────────────────────────
@@ -28,10 +36,6 @@ updates:
       day: monday
       time: "08:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "chore(deps)"
-      include: scope
     ignore:
       - dependency-name: "*"
         update-types:
@@ -63,11 +67,6 @@ updates:
       day: monday
       time: "09:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
-      include: scope
     ignore:
       - dependency-name: "*"
         update-types:
@@ -89,10 +88,6 @@ updates:
       day: monday
       time: "10:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "chore(deps)"
-      include: scope
     ignore:
       - dependency-name: "*"
         update-types:
@@ -114,10 +109,6 @@ updates:
       day: monday
       time: "10:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 2
-    commit-message:
-      prefix: "chore(deps)"
-      include: scope
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
Dependabot has been rejecting `.github/dependabot.yml` outright since #4131 merged, so no version-update PRs have been opened at all:

> "commit-message" should only be set on the associated multi-ecosystem group, not directly on updates that are part of a multi-ecosystem update group.
> "open-pull-requests-limit" should only be set on the associated multi-ecosystem group, not directly on updates that are part of a multi-ecosystem update group.

#4131 introduced the `weekly-version-updates` multi-ecosystem group but left `commit-message` and `open-pull-requests-limit` on the four ecosystem entries. Both keys describe the single consolidated PR, so Dependabot only accepts them on the group itself.

## Changes

- Moved `open-pull-requests-limit: 5` and `commit-message` (`prefix: chore(deps)`, `include: scope`) onto the `weekly-version-updates` group.
- Removed both keys from the cargo, npm, github-actions and docker entries.

Everything else stays as-is: `schedule`, the semver-major `ignore`, `patterns`, and the per-ecosystem `*-security` groups are all valid alongside `multi-ecosystem-group`.

Two side effects of the keys being group-only:

- npm's `prefix-development: chore(deps-dev)` is gone. One PR now spans every ecosystem, so there is a single prefix and no prod/dev distinction to make.
- The per-ecosystem security-update PRs fall back to Dependabot's default `Bump x from a to b` titles. Nothing in CI checks commit or PR title format, so this only affects readability.

Note: #4172 was opened by the previous config and references the now-removed `cargo-all` group, so it can be closed.