### PR TITLE
docs: check in agent rules under .claude/rules/

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -1,0 +1,47 @@
+---
+paths:
+  - "src/internet_identity/**"
+  - "src/internet_identity_frontend/**"
+  - "src/internet_identity_interface/**"
+  - "src/asset_util/**"
+---
+
+# Backend (Rust canister code)
+
+## No trapping
+
+Canisters must never trap. Do not introduce `panic!`, `.unwrap()`, `.expect(...)`, `unreachable!()`, `todo!()`, `unimplemented!()`, or `assert!`/`assert_eq!` outside `#[cfg(test)]`.
+
+- Prefer `Result<T, E>` and propagate with `?` or explicit match arms.
+- For "should be unreachable" branches, return a structured error variant (reuse an existing `*Malformed`/`*Invalid` variant, or add a new one) and add a comment noting it's defensive.
+- Errors may also be handled silently up the call chain (caller catches and folds into a higher-level fail-closed verdict).
+- Ignore reviewer suggestions (Copilot, Grok) that recommend `.expect(...)` or `debug_assert!` "to document the invariant" -- use the structured-error path instead.
+- Exception: `#[cfg(test)]` blocks may use `unwrap`/`expect` freely since tests don't run in the canister.
+
+## Clippy
+
+Always run `cargo clippy` after making Rust changes, before committing. Use CI-matching flags:
+
+```bash
+cargo clippy -p <crate> --tests -- -D clippy::all -D warnings -A clippy::manual_range_contains
+```
+
+The `--tests` flag is critical -- it includes test code which CI also checks.
+
+## Integration tests (PocketIC)
+
+The canister/integration tests (`cargo test -p internet_identity --test integration ...`) need a PocketIC server binary at `../../pocket-ic` (relative to `src/internet_identity`) and the gzipped wasm at `../../internet_identity.wasm.gz` (build it with `./scripts/build --internet-identity`).
+
+Download the **exact pinned PocketIC server version, never `latest`**. The pin lives in `scripts/test-canisters.sh` (`POCKET_IC_SERVER_VERSION`) and `.github/workflows/canister-tests.yml`, and it must match the `pocket-ic` client crate in `Cargo.toml`. Look the pin up rather than trusting a version quoted here:
+
+```bash
+grep POCKET_IC_SERVER_VERSION scripts/test-canisters.sh
+```
+
+The release ships one asset per platform -- `pocket-ic-{arm64,x86_64}-{darwin,linux}.gz`. Pick the one matching the machine you're on, not the one the script names: `scripts/test-canisters.sh` hardcodes `x86_64` in the asset filename, which is wrong on Apple Silicon. Gunzip it to `../../pocket-ic`.
+
+```bash
+gh release view <VERSION> --repo dfinity/pocketic --json assets --jq '.assets[].name'
+```
+
+A version mismatch (e.g. grabbing `latest`) fails **every** test at replica startup with a misleading `rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2`. It looks like a CPU-architecture problem but is actually the protocol mismatch -- check the pin before suspecting the binary. A genuine architecture mismatch produces the same class of loader error, and the fix there is fetching the right asset above, never emulation.

--- a/.claude/rules/e2e-testing.md
+++ b/.claude/rules/e2e-testing.md
@@ -1,0 +1,132 @@
+---
+paths:
+  - "src/frontend/tests/**"
+  - "scripts/dev-e2e*"
+  - "playwright.config.ts"
+---
+
+# E2E testing (Playwright)
+
+## Dev scripts
+
+Three scripts in `scripts/` wrap the full e2e stack — use them instead of
+running icp-cli + canister installs by hand:
+
+- **`scripts/dev-e2e-setup`** — idempotent setup. Builds canisters, starts the
+  icp network, OpenID providers, and dev server. Exits 0 when the stack is
+  ready. Re-running rebuilds only what changed (~1s no-op, ~25s after a backend
+  change).
+- **`scripts/dev-e2e-setup --teardown`** — tears the stack down.
+- **`scripts/dev-e2e`** — interactive: calls setup + file watcher + opens
+  Playwright in `--ui` mode. Tears down on Ctrl+C.
+
+The `e2e-playwright` job in `.github/workflows/canister-tests.yml` is the CI
+reference if the scripts ever drift from it.
+
+## Running tests (agent workflow)
+
+```bash
+./scripts/dev-e2e-setup
+npx playwright test --project=desktop --grep "Authorize ready message"
+# or a whole spec file:
+npx playwright test --project=desktop src/frontend/tests/e2e-playwright/routes/recovery.spec.ts
+
+# After more code changes, just re-run setup:
+./scripts/dev-e2e-setup
+
+# When done:
+./scripts/dev-e2e-setup --teardown
+```
+
+## Running for the user (interactive)
+
+```bash
+./scripts/dev-e2e
+```
+
+Builds canisters, starts the stack + file watcher, opens Playwright `--ui`.
+
+## Environment the scripts set
+
+- `TLS_DEV_SERVER=1` — dev server serves HTTPS; tests use HTTPS URLs.
+- `NO_HOT_RELOAD=1` — tests run against deployed canister code, not vite JIT.
+- `SEPARATE_FRONTEND_CANISTER=1` — `https://backend.id.ai` maps to backend
+  canister, `https://id.ai` to frontend canister. Backend's `backend_origin`
+  must be `https://backend.id.ai`.
+
+## Local OpenID providers
+
+The ports are declared at the top of `scripts/dev-e2e-setup` — read them from
+there rather than hardcoding a list, since they change as providers are added:
+
+- `OPENID_PORTS` — every provider the stack starts.
+- `DIRECT_OPENID_PORTS` — the subset configured as direct providers.
+- `PAIRWISE_OPENID_PORT` — an Entra-style provider issuing a pairwise `sub`
+  (per client) plus a stable `oid`, used by the non-`sub` gating tests. It is
+  the same provider as one of the SSO discovery hosts but under a distinct
+  host, so the gating tests get a discovery-cache entry the un-gated tests
+  never touch. See `SSO_ENTRA_DISCOVERY_DOMAIN` in `fixtures/sso.ts`.
+
+## Key gotchas
+
+- `--workers=1` is non-negotiable. Tests share canister state; parallelism
+  causes false negatives.
+- With `NO_HOT_RELOAD=1` + `SEPARATE_FRONTEND_CANISTER=1` the browser loads
+  assets from the canister, not vite. `.svelte` changes don't take effect
+  until the canister is reinstalled — re-run `dev-e2e-setup`.
+- Test fixture cookie gotcha: when a test signs up via OpenID/SSO then signs
+  in again in the same context, the IdP popup auto-redirects. Fix with
+  `await page.context().clearCookies()` between flows.
+
+## Bisecting a regression
+
+1. Confirm the test passes on `main`'s frontend src.
+2. Re-apply branch changes one directory at a time, re-run `dev-e2e-setup`.
+3. Once a directory breaks the test, bisect within it.
+4. Watch for keyed `{#each}` where the key prop isn't unique in the test
+   setup (e.g. fixtures sharing `client_id = "internet_identity"`).
+
+## Useful invocations
+
+```bash
+npm run test:e2e-playwright                                              # full suite
+npx playwright test routes/authorize/delegationTtl.spec.ts --workers=1   # single file
+npx playwright test routes/index.spec.ts -g "Sign in with last used"     # by name pattern
+npx playwright test --ui                                                 # UI mode
+npx playwright test routes/... --workers=1 --trace on                    # with trace
+```
+
+## Stopping everything
+
+`./scripts/dev-e2e-setup --teardown` handles the normal case. If something is
+stuck (Ctrl+C'd partway), kill what's left manually:
+
+1. Replica: `icp network stop` or kill `icp-cli-network-launcher`.
+2. Dev server: `lsof -iTCP:5173 -sTCP:LISTEN -nP` and kill.
+3. OpenID providers: resolve `OPENID_PORTS` from `scripts/dev-e2e-setup`, then
+   `lsof -iTCP:<port> -sTCP:LISTEN -nP` for each and kill.
+4. Playwright workers: `ps aux | grep -iE 'playwright|chromedriver'`.
+
+## Flaky-looking failures that are really stale-environment artifacts
+
+Before treating an intermittent e2e failure as a test or product bug, rule out
+two environment causes — both look exactly like flakes:
+
+- **pocket-ic clock drift.** In long sessions (many full-suite runs) or after a
+  VM resume, the `icp network` (pocket-ic) replica keeps its own clock while the
+  host wall clock can jump forward (e.g. a resume bumping the date by hours).
+  Once they diverge by >5 min, the browser's IC agent rejects the replica's
+  delegation certificates with `TrustError: Certificate is signed more than 5
+  minutes in the past`, and every flow that round-trips a delegation
+  (OpenID/SSO sign-in, cross-device, CLI authorize) fails — usually as a 60s
+  test-timeout hang, sometimes a whole cluster of failures in one run. Suspect
+  this when time-sensitive IC flows start failing late in a long run, especially
+  several at once or with that `TrustError` in the browser console. Confirm by
+  comparing `date -u` to the replica's cert timestamps; fix by restarting the
+  stack (`scripts/dev-e2e-setup --teardown && scripts/dev-e2e-setup`) to
+  re-sync the replica clock. Do not "fix" tests for this.
+
+- **Editing a spec mid-run.** Don't edit e2e test files while a run is in
+  flight. Playwright recompiles the changed spec against an already-cached
+  `utils.ts`, producing a one-off `SyntaxError: does not provide an export
+  named X`. It's not a real failure — it disappears on the next clean run.

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,55 @@
+---
+paths:
+  - "src/frontend/**"
+---
+
+# Frontend
+
+## Design tokens and components
+
+- Always use Tailwind design token classes instead of hardcoded values. Colors: `bg-bg-primary`, `text-text-tertiary`, `border-border-secondary` -- never raw hex like `bg-[#ecfdf3]`. Border radius: `rounded-lg`, `rounded-xl`, `rounded-full` -- never `rounded-[10px]`. Avoid arbitrary bracket values when a named token exists.
+- Check `src/frontend/src/lib/components/ui/` for existing components before writing raw markup. The codebase has a design system; duplicating its markup inline leads to inconsistency.
+
+## Template comments
+
+- Don't write template comments that solely narrate Tailwind utility classes (e.g. "`-mx-4` bleeds outside the padding", "`@container` switches breakpoints to container query"). Utility classes are self-documenting; the only thing worth committing is the non-obvious WHY — the constraint, the bug avoided, the visual intent. If after stripping the class-paraphrase nothing remains, drop the comment entirely.
+  - Good: `<!-- React to the manage pane's actual width, not the viewport — the sidebar can narrow it -->`.
+  - Bad: `<!-- @container sets up a container query, @xl:grid-cols-3 switches to 3 columns at 36rem container width -->`.
+
+## Buttons
+
+- Never assign color classes (e.g. `text-fg-quaternary`) to icons inside `btn` elements. The button component handles icon colors; adding explicit color classes overrides built-in states (hover, focus, disabled). Only add sizing classes (e.g. `size-5`).
+- Don't add `rounded-*` classes to `btn` elements unless explicitly asked or visible in a design. Exception: standalone `btn-icon` buttons (not in a row of icon buttons) should get `rounded-full`.
+- `btn-danger` is a separate modifier class added alongside the variant. Correct: `btn btn-tertiary btn-danger`. Wrong: `btn btn-tertiary-danger`.
+
+## i18n
+
+- Content inside `<Trans>` must be on its own indented line, not inline with the tags:
+  ```svelte
+  <Trans>
+    Content here.
+  </Trans>
+  ```
+- Use `<Trans>` for paragraph (`<p>`) text content, not `$t` tagged template literals. `$t` is fine for short inline strings (button labels, headings).
+
+## Svelte patterns
+
+- When a derived value is only used within a single snippet, use `{@const}` inside the snippet rather than a script-level `$derived`. Reference the snippet's local parameter instead of component-level state.
+
+## TypeScript
+
+- Never use `as` type casts or `!` non-null assertions. Use control flow narrowing (guards, early returns) or utility functions that narrow the type. Restructure code so TypeScript can narrow through the pattern.
+- Never use inline `import("module").Type` syntax. Always import the type at the top of the file with `import type { Foo } from "module"`.
+- Use explicit checks like `!== undefined` instead of truthy checks for non-boolean values. `if (flag)` is fine for booleans; for everything else use `!== undefined`, `!== null`, `.length > 0`, etc.
+- When a catch block doesn't use the error, write bare `catch { ... }` (no parameter) rather than `catch (_error) { ... }`.
+
+## APIs and utilities
+
+- Never use Node's `Buffer` class (e.g. `Buffer.from(str, "base64")`). Search for existing utilities in this order: local utils in the same directory, project-level shared utils in `$lib/utils/`, library helpers, browser-native APIs as last resort.
+- Never concatenate URL parts. Use `new URL()` and pass the URL object directly to `goto()`, `fetch()`, etc. Never do `goto(url.pathname + url.search)`.
+- Never use inline `import()` calls at runtime. Use static imports at the top of the file.
+- Co-locate utility functions with the route or component that uses them. Only move to `$lib/utils/` if multiple unrelated routes need the same function.
+
+## UX copy
+
+- After writing UI text, check how it wraps visually in the browser at the actual component width. Avoid orphaned words (a single word on its own line). Adjust wording to get balanced line breaks. Keep distinct ideas as separate sentences -- don't merge them into one.

--- a/.claude/rules/handle-all-type-variants.md
+++ b/.claude/rules/handle-all-type-variants.md
@@ -1,0 +1,31 @@
+# Handle every variant a type can carry — never assume the backend won't use one
+
+When code consumes a value of a union/variant type (a candid `variant`, a TS
+discriminated union, a Rust `enum`), handle **every** case the type permits.
+Never narrow the handling to "the cases the producer happens to return today."
+
+**Why:** the type is the contract. The set of values that can cross the
+boundary is defined by the type, not by the current behaviour of the code on
+the other side. Relying on "the canister only ever returns `Ok(Succeeded)`
+here, so I don't need to handle `Ok(Failed)`" couples the consumer to a runtime
+detail invisible at the call site and free to change. When it changes — a new
+backend release, a refactor, a different deploy — the consumer silently
+mishandles the new value with no compiler error and no failing test. Branches
+that match the type are cheap; a silent gap is a latent bug.
+
+**How to apply:**
+
+- Enumerate variants from the type definition, not from your model of what the
+  other side returns.
+- Write the "can't happen today" branch anyway: handle it, or fall through with
+  an explicit comment that it is non-terminal / ignored on purpose.
+- Prefer exhaustive constructs that fail loudly when a case is added (Rust
+  `match` without a catch-all `_`; TS narrowing a reviewer can see is total).
+- Don't delete a "redundant" branch because the current producer can't trigger
+  it — if it matches the type, it's part of the contract.
+- Cuts both ways: a frontend handles every variant the backend's return type
+  allows; a backend handles every variant of the input type.
+
+**Smell:** "this branch is unreachable because the other side never returns it"
+— if the type says it can, it's reachable as far as the contract is concerned.
+Handle it.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,75 @@
+# Workflow
+
+## Formatting and linting
+
+Before committing:
+
+- Rust: `cargo fmt`, `cargo clippy` (see `.claude/rules/backend.md` for the full clippy flags).
+- JS/TS/Svelte: `npm run format`, `npm run lint -- --fix`.
+
+Run these even if a pre-commit hook would normally do it — hooks aren't installed in fresh clones, containers, or CI.
+
+## Code style
+
+- Prefer early-return guard clauses over nested if/else. Flatten the happy path.
+- Comments must describe the current state of the code — never reference removed code, previous implementations, or what's deliberately absent. History belongs in git.
+
+## Full-stack mindset
+
+- Don't limit fixes to frontend or backend only. When a behavior change is needed, consider whether the fix belongs in the Rust canister code, the frontend handler, the test app, or a combination. Fix the root cause in the right layer.
+
+## PR titles
+
+PR titles must follow conventional-commit format with a scope naming the affected side(s). The scope tracks which *product surface* changed (which changelog the commit lands in), **not** which language -- the frontend canister is Rust + candid but still counts as `fe`:
+
+- `feat(be)` -- the backend II canister only: `src/internet_identity` (auth/storage logic) and its candid.
+- `feat(fe)` -- the frontend: TS/JS/Svelte, **and** the frontend canister (`src/internet_identity_frontend`, including its `.did` and `main.rs`) plus its init-args type `InternetIdentityFrontendArgs` in `src/internet_identity_interface`.
+- `feat(be,fe)` -- touches both surfaces.
+- Same pattern for `fix(...)`, `chore(...)`, `refactor(...)`, `docs(...)`, `test(...)`.
+
+`src/internet_identity_interface` is shared, so scope a change to it by which canister the changed type serves (e.g. `InternetIdentityFrontendArgs` -> `fe`, `InternetIdentityInit` -> `be`), not by the crate.
+
+Release scripts split squash-merged commits across separate frontend and backend changelogs by parsing the scope. A PR without a `be`/`fe` scope breaks the split, and a frontend-canister change mistagged `be` lands in the wrong changelog. Commit titles inside the PR can use semantic scopes since they get squashed away.
+
+## PR descriptions
+
+- Write PR titles and descriptions from the user's perspective. Instead of "Reset continue screen state when switching identity", write "Fix multiple accounts toggle staying on after switching identity". Describe what the user sees going wrong and how it's fixed.
+- When changes are pushed to an open PR, always update the PR description to reflect the current state. Don't wait to be asked. Use `gh pr edit` after pushing changes that affect scope.
+- PR template has three sections: Motivation, Changes, Tests. Motivation should NOT have a heading -- just the text. Only include Tests if there are new or updated tests.
+
+## Stacked PRs
+
+When creating stacked PRs, add a footer section linking them together:
+
+- First PR: `<div align="right">Next: #XXXX</div>`
+- Middle PR: `<div align="left">Previous: #XXXX</div>` and `<div align="right">Next: #XXXX</div>`
+- Last PR: `<div align="left">Previous: #XXXX</div>`
+
+Update all PRs in the stack when a new one is added.
+
+## CI and reviews
+
+- After pushing changes to a PR, monitor the CI pipeline for failures and fix them proactively. Poll with a loop that emits one event per check as it resolves and exits when the run completes:
+  ```bash
+  prev=""
+  while true; do
+    s=$(gh pr checks <PR> --json name,bucket)
+    cur=$(jq -r '.[] | select(.bucket!="pending") | "\(.name): \(.bucket)"' <<<"$s" | sort)
+    comm -13 <(echo "$prev") <(echo "$cur")
+    prev=$cur
+    jq -e 'all(.bucket!="pending")' <<<"$s" >/dev/null && break
+    sleep 30
+  done
+  ```
+  Events stream in as each check lands; the loop exits when the run completes.
+- For PRs targeting `main`, Copilot is auto-assigned as reviewer by repo rules. For stacked PRs, request Copilot via the REST API:
+  ```bash
+  gh api -X POST repos/OWNER/REPO/pulls/NUMBER/requested_reviewers --raw-field 'reviewers[]=Copilot'
+  ```
+  Wait for Copilot feedback and address valid suggestions before considering the PR ready.
+- After pushing changes that address a reviewer's feedback, re-request a review from that reviewer — GitHub does not re-request automatically once a reviewer has left comments or requested changes, so without this the reviewer has to notice the update on their own and the PR can stall.
+
+## Writing
+
+- Bullet points that are complete sentences must end with punctuation.
+- Always include `https://` in URLs so they render as clickable links.

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@
 .idea/
 **/*~
 .windsurf/
-.claude/
+# Agent rules under .claude/rules/ are checked in; everything else Claude Code
+# writes there (settings.local.json, worktrees, shell snapshots) is local state.
+.claude/*
+!.claude/rules/
 
 # Mac OSX temporary files
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,19 @@ Guidance for AI coding agents (e.g. Claude Code) working in this repository.
 For the human-facing docs, see [CONTRIBUTING.md](CONTRIBUTING.md) and
 [HACKING.md](HACKING.md).
 
-## Pull request reviews
+## Rules
 
-- After pushing changes that address a reviewer's feedback on a pull request,
-  re-request a review from that reviewer — use GitHub's "Re-request review"
-  control (the circular-arrow button next to the reviewer in the "Reviewers"
-  sidebar) or the equivalent API. GitHub does not re-request automatically
-  after a reviewer has left comments or requested changes, so without this the
-  reviewer has to notice the update on their own and the PR can stall.
+Conventions live in `.claude/rules/`, one file per topic. Most are scoped to the
+paths they apply to via `paths:` frontmatter, so they load only when the files
+they govern are in play:
+
+| File | Applies to |
+| --- | --- |
+| `workflow.md` | all files — formatting, PR titles and descriptions, stacked PRs, CI and reviews |
+| `handle-all-type-variants.md` | all files — exhaustive handling of candid variants, Rust enums, TS unions |
+| `backend.md` | `src/internet_identity*/**`, `src/asset_util/**` — no-trap rule, clippy flags, PocketIC tests |
+| `frontend.md` | `src/frontend/**` — design tokens, buttons, i18n, Svelte and TypeScript style |
+| `e2e-testing.md` | `src/frontend/tests/**`, `scripts/dev-e2e*`, `playwright.config.ts` — the dev-e2e stack |
+
+Add a new convention as a file in `.claude/rules/` rather than expanding this
+one, and give it `paths:` frontmatter unless it genuinely applies everywhere.


### PR DESCRIPTION
The conventions coding agents follow in this repo have been maintained in a separate repository and symlinked into each developer's working copy by a `SessionStart` hook. That has two costs: the rules are invisible to anyone reading this repository — including new contributors and reviewers — and they drift from the code they describe, because nothing ties a rule change to the commit that invalidates it.

Checking them in fixes both. The rules land in code review alongside the code, and a change that moves a port or removes an init arg can update its rule in the same PR.

Reviewing them against the current tree turned up three claims that had already gone stale, corrected here.

# Changes

Add five rules under `.claude/rules/`, one topic per file. Each carries `paths:` frontmatter where it applies to a subtree, so it only enters an agent's context when the files it governs are being worked on:

| File | Applies to |
| --- | --- |
| `workflow.md` | all files — formatting, PR titles and descriptions, stacked PRs, CI and reviews |
| `handle-all-type-variants.md` | all files — exhaustive handling of candid variants, Rust enums, TS unions |
| `backend.md` | `src/internet_identity*/**`, `src/asset_util/**` — no-trap rule, clippy flags, PocketIC tests |
| `frontend.md` | `src/frontend/**` — design tokens, buttons, i18n, Svelte and TypeScript style |
| `e2e-testing.md` | `src/frontend/tests/**`, `scripts/dev-e2e*`, `playwright.config.ts` — the dev-e2e stack |

Correct three stale facts rather than importing them as-is:

- The e2e rule listed the local OpenID providers as `11105/11106/11107`. A fourth provider on `11108` (Entra-style, pairwise `sub` plus stable `oid`) has since been added. Rather than restate a list that just drifted, the rule now points at `OPENID_PORTS`, `DIRECT_OPENID_PORTS` and `PAIRWISE_OPENID_PORT` in `scripts/dev-e2e-setup`, and the teardown steps resolve ports from there too.
- The same rule documented a `sso_discoverable_domains` init arg and a matching-precedence gotcha. That field no longer exists anywhere in `src/` — SSO discovery is domain-based now. Removed.
- The backend rule hardcoded the `arm64-linux` PocketIC asset. The release ships all four arch/OS combinations, so it now says to match the host, and notes that `scripts/test-canisters.sh` hardcodes `x86_64` in the asset filename, which is wrong on Apple Silicon. It also points at `POCKET_IC_SERVER_VERSION` for the pin instead of quoting a version that would itself go stale.

Un-ignore the rules directory in `.gitignore`. `.claude/` becomes `.claude/*` plus `!.claude/rules/` — a directory-level ignore stops git descending, so a bare negation inside it never fires. Everything else Claude Code writes there (`settings.local.json`, worktrees, shell snapshots) stays ignored.

Reduce `CLAUDE.md` to an index of the rules directory. Its previous content, the PR review re-request guidance from #4104, moves into the "CI and reviews" section of `workflow.md` rather than being duplicated.
