### PR TITLE
feat(be,fe): cap SSO sessions with session_max_age_seconds

### DIFF
--- a/src/frontend/src/lib/flows/authFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authFlow.svelte.ts
@@ -271,7 +271,13 @@ export class AuthFlow {
       }
     | undefined
   > => {
-    const { resolvedClientId, discovery, domain, name: ssoName } = ssoResult;
+    const {
+      resolvedClientId,
+      discovery,
+      domain,
+      name: ssoName,
+      sessionMaxAgeNs,
+    } = ssoResult;
     authenticationV2Funnel.addProperties({ provider: "SSO" });
     const sso = dappOrigin !== undefined ? { origin: dappOrigin } : undefined;
     const result = await this.#openIdJwtSignIn(
@@ -283,6 +289,7 @@ export class AuthFlow {
       undefined,
       domain,
       sso,
+      sessionMaxAgeNs,
     );
     if (result.type === "signIn") {
       const lastUsedEntry: PendingLastUsedEntry | undefined = this.#options
@@ -585,6 +592,10 @@ export class AuthFlow {
     discoveryDomain?: string,
     // Dapp SSO context; when set, redeems the JWT via the SSO gate path (`discoveryDomain` is always present alongside).
     sso?: { origin: string },
+    // The org's session length, from its discovery document. Carried onto the
+    // authenticated session so the delegation handler can cap the account
+    // delegation it requests.
+    ssoSessionMaxAgeNs?: bigint,
   ): Promise<
     | {
         type: "signIn";
@@ -645,6 +656,7 @@ export class AuthFlow {
         identity,
         identityNumber,
         authMethod: { openid: { iss, sub } },
+        ssoSessionMaxAgeNs,
       });
       const info =
         await get(authenticatedStore).actor.get_anchor_info(identityNumber);

--- a/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
+++ b/src/frontend/src/lib/flows/authLastUsedFlow.svelte.ts
@@ -124,16 +124,21 @@ export class AuthLastUsedFlow {
         // the popup shows about:blank, then navigates to the IdP. Awaiting
         // discovery before `window.open` would let Safari block the popup.
         const { domain, loginHint } = lastUsedIdentity.authMethod.sso;
+        // Captured out of the discovery promise so it survives to
+        // `authenticationStore.set` below; the popup must open in the same task
+        // as the click, so discovery can't be awaited before this call.
+        let ssoSessionMaxAgeNs: bigint | undefined;
         const jwt = await requestWithPopup(
-          discoverSsoConfig(domain, undefined, dappOrigin).then(
-            (ssoResult) => ({
+          discoverSsoConfig(domain, undefined, dappOrigin).then((ssoResult) => {
+            ssoSessionMaxAgeNs = ssoResult.sessionMaxAgeNs;
+            return {
               clientId: ssoResult.resolvedClientId,
               authURL: ssoResult.discovery.authorization_endpoint,
               authScope: selectAuthScopes(
                 ssoResult.discovery.scopes_supported,
               ).join(" "),
-            }),
-          ),
+            };
+          }),
           {
             nonce: get(sessionStore).nonce,
             mediation: "optional",
@@ -161,6 +166,7 @@ export class AuthLastUsedFlow {
           identity,
           identityNumber,
           authMethod: { openid: { iss, sub } },
+          ssoSessionMaxAgeNs,
         });
         // Re-record the original entry so it stays SSO-tagged; the session's `authMethod` has no `sso` variant.
         lastUsedIdentitiesStore.addLastUsedIdentity(lastUsedIdentity);

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -534,6 +534,7 @@ export const idlFactory = ({ IDL }) => {
     'resolved_client_id' : IDL.Opt(IDL.Text),
     'discovery_domain' : IDL.Text,
     'client_id' : IDL.Text,
+    'session_max_age_ns' : IDL.Nat64,
   });
   const SsoDiscoveryStatus = IDL.Variant({
     'Resolved' : SsoDiscovery,
@@ -738,8 +739,8 @@ export const idlFactory = ({ IDL }) => {
   });
   const PrepareMcpRegistrationDelegation = IDL.Record({
     'user_key' : UserKey,
-    'expiration' : Timestamp,
     'trusted_url' : IDL.Text,
+    'expiration' : Timestamp,
   });
   const PrepareSessionDelegation = IDL.Record({
     'user_key' : UserKey,

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1027,10 +1027,11 @@ export interface InternetIdentityInit {
    */
   'is_production' : [] | [boolean],
   /**
-   * One-shot upgrade arg driving the MCP config migration: `opt true`
-   * rewrites every stored config to "enabled, official connector", since a
-   * value stored before the official connector existed was never a choice
-   * about it. Runs at most once per deployment; unset means no migration.
+   * One-shot upgrade arg driving the MCP config migration: `opt true` gives
+   * every anchor "enabled, official connector", since neither a value stored
+   * before the official connector existed nor an absent config was ever a
+   * choice about it. Unset means no migration, and the migration is refused
+   * when the deployment ships no `mcp_official_url`.
    */
   'mcp_config_migration' : [] | [boolean],
   /**
@@ -1430,15 +1431,19 @@ export interface PrepareIdAliasRequest {
 }
 /**
  * Result of prepare_mcp_registration_delegation: the canister-signature public
- * key the registration delegation is rooted at (P_reg), and the (short)
- * expiration of that delegation. The frontend fetches the signed delegation via
- * get_mcp_registration_delegation and delivers the chain to the trusted MCP
+ * key the registration delegation is rooted at (P_reg), the (short) expiration
+ * of that delegation, and the identity's resolved trusted_url (the anchor's own
+ * server if set, else the official connector). trusted_url is certified (this
+ * is an update call), so the frontend can gate delivery on it - delivering the
+ * chain only when the connect link's origin matches - rather than trusting an
+ * uncertified mcp_get_config query. The frontend fetches the signed delegation
+ * via get_mcp_registration_delegation and delivers the chain to the trusted MCP
  * server, which redeems it with mcp_register_v2.
  */
 export interface PrepareMcpRegistrationDelegation {
   'user_key' : UserKey,
-  'expiration' : Timestamp,
   'trusted_url' : string,
+  'expiration' : Timestamp,
 }
 export interface PrepareSessionDelegation {
   'user_key' : UserKey,
@@ -1665,6 +1670,12 @@ export interface SsoDiscovery {
    * The org's primary OIDC client.
    */
   'client_id' : string,
+  /**
+   * How long a sign-in through this domain stays valid, in nanoseconds, from
+   * the domain's optional `session_max_age_seconds` (8 hours when unset). The
+   * sign-in flow caps the account delegation it requests at this value.
+   */
+  'session_max_age_ns' : bigint,
 }
 /**
  * Status of a domain's SSO discovery, read by `get_sso_discovery_status`. A

--- a/src/frontend/src/lib/stores/authentication.store.ts
+++ b/src/frontend/src/lib/stores/authentication.store.ts
@@ -24,6 +24,12 @@ export interface Authenticated {
     | { openid: { iss: string; sub: string } }
     | { recoveryPhrase: { principal: Principal } }
     | { emailRecovery: { principal: Principal } };
+  /**
+   * For an SSO sign-in, how long the org allows the session to stay valid, in
+   * nanoseconds. The delegation handler caps the account delegation it requests
+   * at this value; `undefined` for every other sign-in method.
+   */
+  ssoSessionMaxAgeNs?: bigint;
 }
 
 // `agent`/`actor` are created once in `init()` and shared by the store;

--- a/src/frontend/src/lib/stores/channelHandlers/delegation.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/delegation.ts
@@ -1,4 +1,5 @@
 import { toPermissionsArg } from "$lib/utils/accessLevel";
+import { cappedMaxTimeToLive } from "$lib/utils/sessionDuration";
 import type { Channel, JsonRequest } from "$lib/utils/transport/utils";
 import {
   DelegationParamsCodec,
@@ -117,10 +118,11 @@ export const handleDelegationRequest =
 
         // Read the identity *after* authorization so we capture whichever
         // identity the user settled on (they may have switched mid-flow).
-        const [accountNumber, { identityNumber, actor }] = await Promise.all([
-          authorized.accountNumberPromise,
-          waitForStore(authenticationStore),
-        ]);
+        const [accountNumber, { identityNumber, actor, ssoSessionMaxAgeNs }] =
+          await Promise.all([
+            authorized.accountNumberPromise,
+            waitForStore(authenticationStore),
+          ]);
 
         const sessionPublicKey = new Uint8Array(params.publicKey.toDer());
 
@@ -144,7 +146,12 @@ export const handleDelegationRequest =
         // capped at the app's request. Fall back to the app's requested value
         // for flows without a picker (e.g. 1-click OpenID/SSO), and to the
         // backend default when neither is set.
-        const maxTimeToLive = authorized.maxTimeToLive ?? params.maxTimeToLive;
+        // An SSO organization caps how long its sign-ins stay valid, so the
+        // delegation must not outlive that.
+        const maxTimeToLive = cappedMaxTimeToLive(
+          authorized.maxTimeToLive ?? params.maxTimeToLive,
+          ssoSessionMaxAgeNs,
+        );
 
         const { user_key, expiration } = await actor
           .prepare_account_delegation(

--- a/src/frontend/src/lib/utils/sessionDuration.test.ts
+++ b/src/frontend/src/lib/utils/sessionDuration.test.ts
@@ -4,6 +4,7 @@ import {
   sessionDurationBreakdown,
   sessionDurationCeilingSeconds,
   sessionDurationToNanos,
+  cappedMaxTimeToLive,
 } from "./sessionDuration";
 
 const MINUTE = 60;
@@ -122,5 +123,28 @@ describe("sessionDurationToNanos", () => {
       sessionDurationToNanos(8 * HOUR),
     );
     expect(seconds).toBe(8 * HOUR);
+  });
+});
+
+describe("cappedMaxTimeToLive", () => {
+  const EIGHT_HOURS = BigInt(8 * HOUR) * NANOS_PER_SECOND;
+  const THIRTY_DAYS = BigInt(30 * DAY) * NANOS_PER_SECOND;
+
+  it("returns the requested duration when the session is not SSO", () => {
+    expect(cappedMaxTimeToLive(THIRTY_DAYS, undefined)).toBe(THIRTY_DAYS);
+    expect(cappedMaxTimeToLive(undefined, undefined)).toBeUndefined();
+  });
+
+  it("caps a longer request at the organization's session length", () => {
+    expect(cappedMaxTimeToLive(THIRTY_DAYS, EIGHT_HOURS)).toBe(EIGHT_HOURS);
+  });
+
+  it("leaves a shorter request alone", () => {
+    const oneHour = BigInt(HOUR) * NANOS_PER_SECOND;
+    expect(cappedMaxTimeToLive(oneHour, EIGHT_HOURS)).toBe(oneHour);
+  });
+
+  it("applies the organization's session length when nothing was requested", () => {
+    expect(cappedMaxTimeToLive(undefined, EIGHT_HOURS)).toBe(EIGHT_HOURS);
   });
 });

--- a/src/frontend/src/lib/utils/sessionDuration.ts
+++ b/src/frontend/src/lib/utils/sessionDuration.ts
@@ -94,3 +94,30 @@ export const sessionDurationCeilingSeconds = (
 /** Convert a duration in seconds to the nanoseconds the canister expects. */
 export const sessionDurationToNanos = (seconds: number): bigint =>
   BigInt(seconds) * NANOS_PER_SECOND;
+
+/**
+ * The `maxTimeToLive` to request for an account delegation, in nanoseconds: the
+ * duration the app (or the picker) asked for, bounded by the SSO organization's
+ * session length when the user signed in through SSO.
+ *
+ * `undefined` in means "no limit of our own", so the org's value becomes the
+ * limit; `undefined` out means the backend applies its own default.
+ *
+ * This is a UX cap rather than a security boundary: it lets the frontend's
+ * delegation-expiry check drive re-authentication. The org's deadline is
+ * enforced by the expiry inside the certified attribute bundle.
+ */
+export const cappedMaxTimeToLive = (
+  requestedNanos: bigint | undefined,
+  ssoSessionMaxAgeNanos: bigint | undefined,
+): bigint | undefined => {
+  if (ssoSessionMaxAgeNanos === undefined) {
+    return requestedNanos;
+  }
+  if (requestedNanos === undefined) {
+    return ssoSessionMaxAgeNanos;
+  }
+  return requestedNanos > ssoSessionMaxAgeNanos
+    ? ssoSessionMaxAgeNanos
+    : requestedNanos;
+};

--- a/src/frontend/src/lib/utils/ssoDiscovery.test.ts
+++ b/src/frontend/src/lib/utils/ssoDiscovery.test.ts
@@ -22,6 +22,7 @@ const DISCOVERY: SsoDiscovery = {
   scopes: ["openid", "profile", "email"],
   name: ["DFINITY"],
   resolved_client_id: ["dfinity-sso-client-id"],
+  session_max_age_ns: BigInt(28_800_000_000_000),
 };
 
 describe("ssoDiscovery", () => {
@@ -108,6 +109,7 @@ describe("ssoDiscovery", () => {
         clientId: "dfinity-sso-client-id",
         resolvedClientId: "dfinity-sso-client-id",
         name: "DFINITY",
+        sessionMaxAgeNs: BigInt(28_800_000_000_000),
         discovery: {
           issuer: "https://dfinity.okta.com",
           authorization_endpoint:

--- a/src/frontend/src/lib/utils/ssoDiscovery.ts
+++ b/src/frontend/src/lib/utils/ssoDiscovery.ts
@@ -22,6 +22,12 @@ export interface SsoDiscoveryResult {
   /** The client to run the ceremony against for the target origin; equals {@link clientId} when no origin was passed. */
   resolvedClientId: string;
   /**
+   * How long a sign-in through this domain stays valid, in nanoseconds, from the
+   * domain's `session_max_age_seconds`. The sign-in flow caps the account
+   * delegation it requests at this value.
+   */
+  sessionMaxAgeNs: bigint;
+  /**
    * Human-readable name for the SSO, if the domain publishes one. Used by the
    * consent UI to render `sso:<domain>:<key>` attribute rows with a friendly
    * prefix (e.g. "DFINITY email:"); falls back to `domain` when absent.
@@ -121,6 +127,7 @@ const toResult = (discovery: SsoDiscovery): SsoDiscoveryResult => {
     domain: discovery.discovery_domain,
     clientId: discovery.client_id,
     resolvedClientId,
+    sessionMaxAgeNs: discovery.session_max_age_ns,
     name: discovery.name[0],
     discovery: {
       issuer: discovery.issuer,

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -501,6 +501,10 @@ type SsoDiscovery = record {
     name : opt text;
     // Client the target origin runs its ceremony against; `null` when denied.
     resolved_client_id : opt text;
+    // How long a sign-in through this domain stays valid, in nanoseconds, from
+    // the domain's optional `session_max_age_seconds` (8 hours when unset). The
+    // sign-in flow caps the account delegation it requests at this value.
+    session_max_age_ns : nat64;
 };
 
 // Status of a domain's SSO discovery, read by `get_sso_discovery_status`. A

--- a/src/internet_identity/src/attributes.rs
+++ b/src/internet_identity/src/attributes.rs
@@ -324,6 +324,32 @@ fn insert_certified_attribute(
     }
 }
 
+/// The SSO session deadline entry for a certified bundle, or `None` when the
+/// bundle carries no attribute for that SSO domain.
+///
+/// The deadline is scoped to the domain whose policy set it rather than living
+/// under `implicit:`, because one bundle can carry attributes from several
+/// scopes with different lifetimes and a verifier must enforce the deadline
+/// belonging to the scope it reads.
+fn sso_session_expiry_entry(
+    certified_pairs: &BTreeMap<String, Icrc3Value>,
+    sso_session_domain: Option<&str>,
+    sso_session_expires_at_ns: Option<u64>,
+) -> Option<(String, Icrc3Value)> {
+    let domain = sso_session_domain?;
+    let expires_at_ns = sso_session_expires_at_ns?;
+    let scope_prefix = format!("sso:{domain}:");
+    certified_pairs
+        .keys()
+        .any(|key| key.starts_with(&scope_prefix))
+        .then(|| {
+            (
+                format!("{scope_prefix}expires_at_timestamp_ns"),
+                Icrc3Value::Nat(candid::Nat::from(expires_at_ns)),
+            )
+        })
+}
+
 impl Anchor {
     /// Resolves an unscoped `email` / `verified_email` spec to a stored
     /// verified-email entry. The user picked the address in the consent
@@ -377,6 +403,9 @@ impl Anchor {
         // SSO domain this session signed in through, or `None` for non-SSO
         // sessions; `sso:<domain>` attributes certify only when it matches.
         sso_session_domain: Option<String>,
+        // When the session signed in through SSO, the instant its assertions
+        // stop being valid, from the domain's `session_max_age_seconds`.
+        sso_session_expires_at_ns: Option<u64>,
     ) -> Result<Vec<u8>, PrepareIcrc3AttributeError> {
         let mut certified_pairs: BTreeMap<String, Icrc3Value> = BTreeMap::new();
         let mut problems = Vec::new();
@@ -489,6 +518,14 @@ impl Anchor {
 
         if !problems.is_empty() {
             return Err(PrepareIcrc3AttributeError::AttributeMismatch { problems });
+        }
+
+        if let Some((key, value)) = sso_session_expiry_entry(
+            &certified_pairs,
+            sso_session_domain.as_deref(),
+            sso_session_expires_at_ns,
+        ) {
+            certified_pairs.insert(key, value);
         }
 
         certified_pairs.insert("implicit:nonce".to_string(), Icrc3Value::Blob(nonce));
@@ -759,6 +796,77 @@ mod tests {
                 attribute_name: name,
             },
             value: value.as_bytes().to_vec(),
+        }
+    }
+
+    mod sso_session_expiry_entry_tests {
+        use super::super::sso_session_expiry_entry;
+        use candid::Nat;
+        use internet_identity_interface::internet_identity::types::icrc3::Icrc3Value;
+        use std::collections::BTreeMap;
+
+        const DOMAIN: &str = "acme.example";
+        const EXPIRES_AT: u64 = 1_700_028_800_000_000_000;
+
+        fn pairs(keys: &[&str]) -> BTreeMap<String, Icrc3Value> {
+            keys.iter()
+                .map(|k| ((*k).to_string(), Icrc3Value::Text("v".to_string())))
+                .collect()
+        }
+
+        #[test]
+        fn stamps_the_deadline_scoped_to_the_domain() {
+            let entry = sso_session_expiry_entry(
+                &pairs(&["sso:acme.example:email"]),
+                Some(DOMAIN),
+                Some(EXPIRES_AT),
+            );
+            assert_eq!(
+                entry,
+                Some((
+                    "sso:acme.example:expires_at_timestamp_ns".to_string(),
+                    Icrc3Value::Nat(Nat::from(EXPIRES_AT))
+                ))
+            );
+        }
+
+        #[test]
+        fn skips_a_bundle_without_attributes_for_that_domain() {
+            let entry = sso_session_expiry_entry(
+                &pairs(&["openid:https://accounts.google.com:email"]),
+                Some(DOMAIN),
+                Some(EXPIRES_AT),
+            );
+            assert_eq!(entry, None);
+        }
+
+        #[test]
+        fn stamps_only_the_signed_in_domain() {
+            let entry = sso_session_expiry_entry(
+                &pairs(&["sso:other.example:email", "sso:acme.example:name"]),
+                Some(DOMAIN),
+                Some(EXPIRES_AT),
+            );
+            assert_eq!(
+                entry.map(|(key, _)| key),
+                Some("sso:acme.example:expires_at_timestamp_ns".to_string())
+            );
+        }
+
+        #[test]
+        fn skips_a_non_sso_session() {
+            assert_eq!(
+                sso_session_expiry_entry(
+                    &pairs(&["sso:acme.example:email"]),
+                    None,
+                    Some(EXPIRES_AT)
+                ),
+                None
+            );
+            assert_eq!(
+                sso_session_expiry_entry(&pairs(&["sso:acme.example:email"]), Some(DOMAIN), None),
+                None
+            );
         }
     }
 
@@ -1932,6 +2040,7 @@ mod tests {
                 1_000_000_000,
                 account,
                 None,
+                None,
             );
 
             match result {
@@ -1971,6 +2080,7 @@ mod tests {
                 1_000_000_000,
                 account,
                 None,
+                None,
             );
 
             match result {
@@ -2009,6 +2119,7 @@ mod tests {
                 1_000_000_000,
                 account,
                 None,
+                None,
             );
 
             match result {
@@ -2040,6 +2151,7 @@ mod tests {
                 None,
                 1_000_000_000,
                 account,
+                None,
                 None,
             );
 
@@ -2490,6 +2602,7 @@ mod tests {
                 account,
                 // SSO session for this domain, so the request reaches the verified_email branch.
                 Some(SSO_DOMAIN.to_string()),
+                None,
             );
             match res {
                 Err(PrepareIcrc3AttributeError::AttributeMismatch { problems }) => {
@@ -2539,6 +2652,7 @@ mod tests {
                 None,
                 1_000_000_000,
                 account,
+                None,
                 None,
             );
             match res {
@@ -2770,6 +2884,7 @@ mod tests {
                 1_000_000_000,
                 account,
                 None,
+                None,
             );
             match result {
                 Err(PrepareIcrc3AttributeError::AttributeMismatch { problems }) => {
@@ -2808,6 +2923,7 @@ mod tests {
                 1_000_000_000,
                 account,
                 None,
+                None,
             );
             match result {
                 Err(PrepareIcrc3AttributeError::AttributeMismatch { problems }) => {
@@ -2843,6 +2959,7 @@ mod tests {
                 None,
                 1_000_000_000,
                 account,
+                None,
                 None,
             );
             match result {
@@ -2886,6 +3003,7 @@ mod tests {
                     None,
                     1_000_000_000,
                     account,
+                    None,
                     None,
                 )
             }));

--- a/src/internet_identity/src/attributes.rs
+++ b/src/internet_identity/src/attributes.rs
@@ -334,10 +334,10 @@ fn insert_certified_attribute(
 fn sso_session_expiry_entry(
     certified_pairs: &BTreeMap<String, Icrc3Value>,
     sso_session_domain: Option<&str>,
-    sso_session_expires_at_ns: Option<u64>,
+    sso_session_expiry_ns: Option<u64>,
 ) -> Option<(String, Icrc3Value)> {
     let domain = sso_session_domain?;
-    let expires_at_ns = sso_session_expires_at_ns?;
+    let expiry_ns = sso_session_expiry_ns?;
     let scope_prefix = format!("sso:{domain}:");
     certified_pairs
         .keys()
@@ -345,7 +345,7 @@ fn sso_session_expiry_entry(
         .then(|| {
             (
                 format!("{scope_prefix}expires_at_timestamp_ns"),
-                Icrc3Value::Nat(candid::Nat::from(expires_at_ns)),
+                Icrc3Value::Nat(candid::Nat::from(expiry_ns)),
             )
         })
 }
@@ -405,7 +405,7 @@ impl Anchor {
         sso_session_domain: Option<String>,
         // When the session signed in through SSO, the instant its assertions
         // stop being valid, from the domain's `session_max_age_seconds`.
-        sso_session_expires_at_ns: Option<u64>,
+        sso_session_expiry_ns: Option<u64>,
     ) -> Result<Vec<u8>, PrepareIcrc3AttributeError> {
         let mut certified_pairs: BTreeMap<String, Icrc3Value> = BTreeMap::new();
         let mut problems = Vec::new();
@@ -523,7 +523,7 @@ impl Anchor {
         if let Some((key, value)) = sso_session_expiry_entry(
             &certified_pairs,
             sso_session_domain.as_deref(),
-            sso_session_expires_at_ns,
+            sso_session_expiry_ns,
         ) {
             certified_pairs.insert(key, value);
         }

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1899,6 +1899,7 @@ mod openid_api {
             Err(err) => return OpenIdResult::Err(err.into()),
         };
 
+        let session_max_age_ns = verification.session_max_age_ns;
         let identity = match openid::resolve_ii_client_identity(&verification) {
             Ok(identity) => identity,
             Err(err) => return OpenIdResult::Err(err),
@@ -1922,6 +1923,12 @@ mod openid_api {
                 .prepare_jwt_delegation(session_key, anchor_number)
                 .await;
 
+            // The session deadline is fixed here, at the ceremony, from the
+            // policy captured while the discovery cache was warm. Everything
+            // downstream reads this value rather than the cache, so an evicted
+            // entry or a refreshed policy can't move a live session's deadline.
+            let session_expires_at_ns = ic_cdk::api::time().saturating_add(session_max_age_ns);
+
             let (sso_attr_bundle, _bundle_expiration) = openid::prepare_sso_attr_bundle(
                 &identity.credential.iss,
                 &identity.credential.sub,
@@ -1929,6 +1936,7 @@ mod openid_api {
                 anchor_number,
                 &discovery_domain,
                 &origin,
+                session_expires_at_ns,
             );
 
             // The association could change during the `.await`.
@@ -2517,9 +2525,12 @@ mod attribute_sharing {
         } = request.try_into()?;
 
         // SSO session iff a certified bundle for this origin is attached; gates `sso:<domain>` attributes.
-        let sso_session_domain = openid::read_certified_sso_bundle()
-            .filter(|bundle| bundle.origin == origin)
-            .map(|bundle| bundle.sso_domain);
+        let sso_session =
+            openid::read_certified_sso_bundle().filter(|bundle| bundle.origin == origin);
+        let sso_session_expires_at_ns = sso_session
+            .as_ref()
+            .map(|bundle| bundle.session_expires_at_ns);
+        let sso_session_domain = sso_session.map(|bundle| bundle.sso_domain);
         let (anchor, _) =
             check_authorization(identity_number).map_err(|AuthorizationError { principal }| {
                 PrepareIcrc3AttributeError::AuthorizationError(principal)
@@ -2540,6 +2551,7 @@ mod attribute_sharing {
             issued_at_timestamp_ns,
             account,
             sso_session_domain,
+            sso_session_expires_at_ns,
         )?;
 
         Ok(PrepareIcrc3AttributeResponse { message })

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1927,7 +1927,7 @@ mod openid_api {
             // policy captured while the discovery cache was warm. Everything
             // downstream reads this value rather than the cache, so an evicted
             // entry or a refreshed policy can't move a live session's deadline.
-            let session_expires_at_ns = ic_cdk::api::time().saturating_add(session_max_age_ns);
+            let session_expiry_ns = ic_cdk::api::time().saturating_add(session_max_age_ns);
 
             let (sso_attr_bundle, _bundle_expiration) = openid::prepare_sso_attr_bundle(
                 &identity.credential.iss,
@@ -1936,7 +1936,7 @@ mod openid_api {
                 anchor_number,
                 &discovery_domain,
                 &origin,
-                session_expires_at_ns,
+                session_expiry_ns,
             );
 
             // The association could change during the `.await`.
@@ -2527,9 +2527,7 @@ mod attribute_sharing {
         // SSO session iff a certified bundle for this origin is attached; gates `sso:<domain>` attributes.
         let sso_session =
             openid::read_certified_sso_bundle().filter(|bundle| bundle.origin == origin);
-        let sso_session_expires_at_ns = sso_session
-            .as_ref()
-            .map(|bundle| bundle.session_expires_at_ns);
+        let sso_session_expiry_ns = sso_session.as_ref().map(|bundle| bundle.session_expiry_ns);
         let sso_session_domain = sso_session.map(|bundle| bundle.sso_domain);
         let (anchor, _) =
             check_authorization(identity_number).map_err(|AuthorizationError { principal }| {
@@ -2551,7 +2549,7 @@ mod attribute_sharing {
             issued_at_timestamp_ns,
             account,
             sso_session_domain,
-            sso_session_expires_at_ns,
+            sso_session_expiry_ns,
         )?;
 
         Ok(PrepareIcrc3AttributeResponse { message })

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -372,6 +372,7 @@ pub fn get_sso_discovery_status(domain: &str, origin: Option<&str>) -> SsoDiscov
                 scopes: discovery_config.scopes,
                 name: discovery_config.name,
                 resolved_client_id,
+                session_max_age_ns: discovery_config.session_max_age_ns,
             })
         }
         Cached::Pending => SsoDiscoveryStatus::Pending,

--- a/src/internet_identity/src/openid/sso.rs
+++ b/src/internet_identity/src/openid/sso.rs
@@ -472,9 +472,11 @@ struct DiscoveryDocument {
     scopes_supported: Option<Vec<String>>,
 }
 
-/// Reject over-length values from the untrusted well-known configuration.
+/// Reject over-length values from the untrusted well-known configuration, and
+/// return its session length in nanoseconds — the one value from this document
+/// that needs converting rather than only bounding.
 #[cfg(not(test))]
-fn validate_ii_config(config: &IIOpenIdConfiguration) -> Result<(), String> {
+fn validate_ii_config(config: &IIOpenIdConfiguration) -> Result<u64, String> {
     if config.client_id.len() > MAX_CLIENT_ID_LENGTH {
         return Err(format!(
             "SSO client_id exceeds {MAX_CLIENT_ID_LENGTH} bytes"
@@ -487,7 +489,7 @@ fn validate_ii_config(config: &IIOpenIdConfiguration) -> Result<(), String> {
     {
         return Err(format!("SSO name exceeds {MAX_SSO_NAME_LENGTH} bytes"));
     }
-    Ok(())
+    validate_session_max_age(config.session_max_age_seconds)
 }
 
 /// Convert `session_max_age_seconds` from the well-known into nanoseconds,
@@ -565,9 +567,8 @@ async fn discovery_fill(domain: String) -> Result<DiscoveredConfig, String> {
     validate_same_host(&doc.issuer, &doc.authorization_endpoint)?;
     validate_discovery_url(&doc.authorization_endpoint)?;
 
-    validate_ii_config(&ii_config)?;
+    let session_max_age_ns = validate_ii_config(&ii_config)?;
     validate_discovery_document(&doc)?;
-    let session_max_age_ns = validate_session_max_age(ii_config.session_max_age_seconds)?;
 
     let mut scopes = doc
         .scopes_supported

--- a/src/internet_identity/src/openid/sso.rs
+++ b/src/internet_identity/src/openid/sso.rs
@@ -472,11 +472,29 @@ struct DiscoveryDocument {
     scopes_supported: Option<Vec<String>>,
 }
 
-/// Reject over-length values from the untrusted well-known configuration, and
-/// return its session length in nanoseconds — the one value from this document
-/// that needs converting rather than only bounding.
+/// The hop-1 document once every field has been checked, bounded, defaulted and
+/// converted. Produced only by [`validate_ii_config`], which consumes the raw
+/// [`IIOpenIdConfiguration`], so nothing downstream can reach an unvalidated
+/// field by accident.
 #[cfg(not(test))]
-fn validate_ii_config(config: &IIOpenIdConfiguration) -> Result<u64, String> {
+struct ValidatedIIOpenIdConfiguration {
+    client_id: String,
+    /// The hop-2 URL, checked before it is fetched.
+    openid_configuration: String,
+    name: Option<String>,
+    app_clients: Vec<AppClient>,
+    gate_all_apps: bool,
+    stable_identifier_claim: String,
+    session_max_age_ns: u64,
+}
+
+/// Validate the untrusted well-known configuration: bound its lengths, parse its
+/// `app_clients` keys, default its stable-identifier claim, and convert its
+/// session length to nanoseconds.
+#[cfg(not(test))]
+fn validate_ii_config(
+    config: IIOpenIdConfiguration,
+) -> Result<ValidatedIIOpenIdConfiguration, String> {
     if config.client_id.len() > MAX_CLIENT_ID_LENGTH {
         return Err(format!(
             "SSO client_id exceeds {MAX_CLIENT_ID_LENGTH} bytes"
@@ -489,7 +507,23 @@ fn validate_ii_config(config: &IIOpenIdConfiguration) -> Result<u64, String> {
     {
         return Err(format!("SSO name exceeds {MAX_SSO_NAME_LENGTH} bytes"));
     }
-    validate_session_max_age(config.session_max_age_seconds)
+    let openid_configuration = validate_discovery_url(config.openid_configuration)?;
+    let app_clients = validate_app_clients(&config.app_clients)?;
+    let session_max_age_ns = validate_session_max_age(config.session_max_age_seconds)?;
+    let stable_identifier_claim = config
+        .stable_identifier_claim
+        .filter(|claim| !claim.is_empty())
+        .unwrap_or_else(|| DEFAULT_STABLE_IDENTIFIER_CLAIM.to_string());
+
+    Ok(ValidatedIIOpenIdConfiguration {
+        client_id: config.client_id,
+        openid_configuration,
+        name: config.name,
+        app_clients,
+        gate_all_apps: config.gate_all_apps,
+        stable_identifier_claim,
+        session_max_age_ns,
+    })
 }
 
 /// Convert `session_max_age_seconds` from the well-known into nanoseconds,
@@ -518,16 +552,59 @@ fn validate_session_max_age(seconds: Option<u64>) -> Result<u64, String> {
     Ok(max_age_ns)
 }
 
-/// Reject over-length values from the untrusted OIDC discovery document.
+/// The hop-2 document once its URLs have been checked against each other and
+/// against the hop-1 URL, its lengths bounded and its scopes defaulted. Produced
+/// only by [`validate_discovery_document`], which consumes the raw
+/// [`DiscoveryDocument`].
 #[cfg(not(test))]
-fn validate_discovery_document(doc: &DiscoveryDocument) -> Result<(), String> {
+struct ValidatedDiscoveryDocument {
+    issuer: String,
+    jwks_uri: String,
+    authorization_endpoint: String,
+    scopes: Vec<String>,
+}
+
+/// Validate the untrusted OIDC discovery document against the hop-1 document it
+/// was fetched from: bound its lengths, enforce the host relationships, and
+/// default its scopes. Takes the validated hop-1 document, so the URL the
+/// self-assertion checks compare against is itself already checked.
+#[cfg(not(test))]
+fn validate_discovery_document(
+    doc: DiscoveryDocument,
+    ii_config: &ValidatedIIOpenIdConfiguration,
+) -> Result<ValidatedDiscoveryDocument, String> {
+    let openid_configuration = &ii_config.openid_configuration;
     if doc.issuer.len() > MAX_ISSUER_LENGTH {
         return Err(format!("SSO issuer exceeds {MAX_ISSUER_LENGTH} bytes"));
     }
     if doc.jwks_uri.len() > MAX_JWKS_URI_LENGTH {
         return Err(format!("SSO jwks_uri exceeds {MAX_JWKS_URI_LENGTH} bytes"));
     }
-    Ok(())
+    // The discovered issuer's host must match the openid_configuration host
+    // (standard OIDC self-assertion; defends against a compromised hop-1 that
+    // points jwks_uri at an unrelated issuer). The discovery domain itself is
+    // allowed to differ — it hosts a custom SSO indirection.
+    validate_issuer_host(openid_configuration, &doc.issuer)?;
+    let jwks_uri = validate_discovery_url(doc.jwks_uri)?;
+    // The authorization_endpoint must live on the same host as the issuer, so a
+    // tampered discovery doc can't bounce the user's auth off-host after we've
+    // committed to a provider.
+    validate_same_host(&doc.issuer, &doc.authorization_endpoint)?;
+    let authorization_endpoint = validate_discovery_url(doc.authorization_endpoint)?;
+
+    let mut scopes = doc
+        .scopes_supported
+        .filter(|scopes| !scopes.is_empty())
+        .unwrap_or_else(|| DEFAULT_SCOPES.iter().map(|s| (*s).to_string()).collect());
+    // Bound the only unbounded field stored per discovery entry.
+    scopes.truncate(DISCOVERY_MAX_SCOPES);
+
+    Ok(ValidatedDiscoveryDocument {
+        issuer: doc.issuer,
+        jwks_uri,
+        authorization_endpoint,
+        scopes,
+    })
 }
 
 /// The discovery cache fill: hop 1 (`ii-openid-configuration`) then hop 2 (the
@@ -541,50 +618,28 @@ async fn discovery_fill(domain: String) -> Result<DiscoveredConfig, String> {
     // (the e2e mock provider, which can't serve TLS).
     let hop1_scheme = scheme_for_host(&domain);
     let hop1_url = format!("{hop1_scheme}://{domain}/.well-known/ii-openid-configuration");
-    let ii_config = fetch_ii_openid_configuration(hop1_url).await?;
-    validate_discovery_url(&ii_config.openid_configuration)?;
-
-    let app_clients = validate_app_clients(&ii_config.app_clients)?;
-    let stable_identifier_claim = ii_config
-        .stable_identifier_claim
-        .clone()
-        .filter(|c| !c.is_empty())
-        .unwrap_or_else(|| DEFAULT_STABLE_IDENTIFIER_CLAIM.to_string());
-    let gate_all_apps = ii_config.gate_all_apps;
+    let ii_config = validate_ii_config(fetch_ii_openid_configuration(hop1_url).await?)?;
 
     // Hop 2: fetch the standard OIDC discovery document.
-    let doc = fetch_discovery(ii_config.openid_configuration.clone()).await?;
+    let doc = validate_discovery_document(
+        fetch_discovery(ii_config.openid_configuration.clone()).await?,
+        &ii_config,
+    )?;
 
-    // The discovered issuer's host must match the openid_configuration host
-    // (standard OIDC self-assertion; defends against a compromised hop-1 that
-    // points jwks_uri at an unrelated issuer). The discovery domain itself is
-    // allowed to differ — it hosts a custom SSO indirection.
-    validate_issuer_host(&ii_config.openid_configuration, &doc.issuer)?;
-    validate_discovery_url(&doc.jwks_uri)?;
-    // The authorization_endpoint must live on the same host as the issuer, so a
-    // tampered discovery doc can't bounce the user's auth off-host after we've
-    // committed to a provider.
-    validate_same_host(&doc.issuer, &doc.authorization_endpoint)?;
-    validate_discovery_url(&doc.authorization_endpoint)?;
-
-    let session_max_age_ns = validate_ii_config(&ii_config)?;
-    validate_discovery_document(&doc)?;
-
-    let mut scopes = doc
-        .scopes_supported
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_SCOPES.iter().map(|s| (*s).to_string()).collect());
-    // Bound the only unbounded field stored per discovery entry.
-    scopes.truncate(DISCOVERY_MAX_SCOPES);
-
-    let DiscoveryDocument {
+    let ValidatedDiscoveryDocument {
         issuer,
         jwks_uri,
         authorization_endpoint,
-        ..
+        scopes,
     } = doc;
-    let IIOpenIdConfiguration {
-        client_id, name, ..
+    let ValidatedIIOpenIdConfiguration {
+        client_id,
+        name,
+        app_clients,
+        gate_all_apps,
+        stable_identifier_claim,
+        session_max_age_ns,
+        ..
     } = ii_config;
 
     Ok(DiscoveredConfig {
@@ -712,17 +767,18 @@ fn transform_discovery(
     }
 }
 
-/// Ensure a URL is syntactically valid and uses an acceptable scheme. `https`
-/// is always accepted; `http` only when the host is on the SSO allowlist.
+/// Check that a URL is syntactically valid and uses an acceptable scheme, and
+/// hand it back so the caller uses the checked value rather than the input.
+/// `https` is always accepted; `http` only when the host is on the SSO allowlist.
 #[cfg(not(test))]
-fn validate_discovery_url(url: &str) -> Result<(), String> {
-    let parsed = url::Url::parse(url).map_err(|e| format!("parse error: {e}"))?;
+fn validate_discovery_url(url: String) -> Result<String, String> {
+    let parsed = url::Url::parse(&url).map_err(|e| format!("parse error: {e}"))?;
     match parsed.scheme() {
-        "https" => Ok(()),
+        "https" => Ok(url),
         "http" => {
             let host = host_with_port(&parsed).ok_or_else(|| format!("URL has no host: {url}"))?;
             if allow_insecure_scheme(&host) {
-                Ok(())
+                Ok(url)
             } else {
                 Err(format!(
                     "http scheme not allowed for non-allowlisted host '{host}'"

--- a/src/internet_identity/src/openid/sso.rs
+++ b/src/internet_identity/src/openid/sso.rs
@@ -18,6 +18,7 @@ use super::verify::{Descriptor, SsoProvider};
 use super::OpenIDJWTVerificationError;
 use crate::openid::AudClaim;
 use crate::single_flight_cache::{self, CacheConfig, Cached, RetryBackoff, SingleFlightCache};
+use crate::HOUR_NS;
 use identity_jose::jwk::Jwk;
 use sha2::{Digest, Sha256};
 use std::cell::RefCell;
@@ -34,6 +35,11 @@ pub(super) const DEFAULT_STABLE_IDENTIFIER_CLAIM: &str = "sub";
 pub(super) fn non_default_stable_claim(claim: &str) -> Option<String> {
     (claim != DEFAULT_STABLE_IDENTIFIER_CLAIM).then(|| claim.to_string())
 }
+
+/// Default session length for an org that doesn't set `session_max_age_seconds`
+/// in its well-known: how long II's assertions about a user stay valid before
+/// they authenticate against the org's IdP again.
+pub(super) const DEFAULT_SESSION_MAX_AGE_NS: u64 = 8 * HOUR_NS;
 
 /// Max `app_clients` entries accepted from an org's well-known. The parsed map
 /// is retained in the in-memory SSO discovery cache (one per cached domain), so
@@ -132,6 +138,10 @@ pub(super) struct DiscoveredConfig {
     pub gate_all_apps: bool,
     /// Claim holding the cross-client-stable identifier (default `sub`).
     pub stable_identifier_claim: String,
+    /// How long a sign-in through this domain stays valid, in nanoseconds.
+    /// Seconds exist only in the well-known and its parser; everything from
+    /// here on is nanoseconds.
+    pub session_max_age_ns: u64,
 }
 
 /// One `origin -> client_id` entry from `app_clients`.
@@ -445,6 +455,10 @@ struct IIOpenIdConfiguration {
     /// Cross-client-stable identifier claim (default `sub`).
     #[serde(default)]
     stable_identifier_claim: Option<String>,
+    /// How long a sign-in stays valid, in seconds. The only place seconds
+    /// appear: `validate_session_max_age` converts once, to nanoseconds.
+    #[serde(default)]
+    session_max_age_seconds: Option<u64>,
 }
 
 /// OIDC discovery document — only the fields the canister needs.
@@ -474,6 +488,32 @@ fn validate_ii_config(config: &IIOpenIdConfiguration) -> Result<(), String> {
         return Err(format!("SSO name exceeds {MAX_SSO_NAME_LENGTH} bytes"));
     }
     Ok(())
+}
+
+/// Convert `session_max_age_seconds` from the well-known into nanoseconds,
+/// rejecting a value that is zero or over the delegation ceiling. This is the
+/// only seconds-to-nanoseconds conversion in the SSO path: an invalid value is
+/// rejected here, so it never reaches the cache as a nanosecond number.
+fn validate_session_max_age(seconds: Option<u64>) -> Result<u64, String> {
+    const NS_PER_SECOND: u64 = 1_000_000_000;
+    let Some(seconds) = seconds else {
+        return Ok(DEFAULT_SESSION_MAX_AGE_NS);
+    };
+    if seconds == 0 {
+        return Err("SSO session_max_age_seconds must be greater than zero".to_string());
+    }
+    // `checked_mul` rather than saturating: a garbage value must be rejected,
+    // not silently clamped to the ceiling.
+    let max_age_ns = seconds
+        .checked_mul(NS_PER_SECOND)
+        .ok_or_else(|| format!("SSO session_max_age_seconds is out of range: {seconds}"))?;
+    if max_age_ns > crate::delegation::MAX_EXPIRATION_PERIOD_NS {
+        return Err(format!(
+            "SSO session_max_age_seconds exceeds the {} second maximum",
+            crate::delegation::MAX_EXPIRATION_PERIOD_NS / NS_PER_SECOND
+        ));
+    }
+    Ok(max_age_ns)
 }
 
 /// Reject over-length values from the untrusted OIDC discovery document.
@@ -527,6 +567,7 @@ async fn discovery_fill(domain: String) -> Result<DiscoveredConfig, String> {
 
     validate_ii_config(&ii_config)?;
     validate_discovery_document(&doc)?;
+    let session_max_age_ns = validate_session_max_age(ii_config.session_max_age_seconds)?;
 
     let mut scopes = doc
         .scopes_supported
@@ -555,6 +596,7 @@ async fn discovery_fill(domain: String) -> Result<DiscoveredConfig, String> {
         app_clients,
         gate_all_apps,
         stable_identifier_claim,
+        session_max_age_ns,
     })
 }
 
@@ -790,6 +832,38 @@ mod tests {
         JWKS_CACHE.with(|c| *c.borrow_mut() = new_jwks_cache());
     }
 
+    #[test]
+    fn session_max_age_defaults_when_absent() {
+        assert_eq!(
+            validate_session_max_age(None),
+            Ok(DEFAULT_SESSION_MAX_AGE_NS)
+        );
+    }
+
+    #[test]
+    fn session_max_age_converts_seconds_once() {
+        assert_eq!(validate_session_max_age(Some(28_800)), Ok(8 * HOUR_NS));
+        assert_eq!(validate_session_max_age(Some(1)), Ok(1_000_000_000));
+    }
+
+    #[test]
+    fn session_max_age_rejects_zero() {
+        assert!(validate_session_max_age(Some(0)).is_err());
+    }
+
+    #[test]
+    fn session_max_age_rejects_above_the_delegation_ceiling() {
+        let max_seconds = crate::delegation::MAX_EXPIRATION_PERIOD_NS / 1_000_000_000;
+        assert!(validate_session_max_age(Some(max_seconds)).is_ok());
+        assert!(validate_session_max_age(Some(max_seconds + 1)).is_err());
+    }
+
+    #[test]
+    fn session_max_age_rejects_a_value_that_overflows_nanoseconds() {
+        // Rejected outright rather than saturated to the ceiling.
+        assert!(validate_session_max_age(Some(u64::MAX)).is_err());
+    }
+
     fn sample_config() -> DiscoveredConfig {
         DiscoveredConfig {
             issuer: "https://idp.example.org".to_string(),
@@ -801,6 +875,7 @@ mod tests {
             app_clients: vec![],
             gate_all_apps: false,
             stable_identifier_claim: DEFAULT_STABLE_IDENTIFIER_CLAIM.to_string(),
+            session_max_age_ns: DEFAULT_SESSION_MAX_AGE_NS,
         }
     }
 

--- a/src/internet_identity/src/openid/sso_bundle.rs
+++ b/src/internet_identity/src/openid/sso_bundle.rs
@@ -6,7 +6,7 @@
 //! u64-BE len || sso_domain bytes       SSO discovery domain
 //! u64-BE len || origin bytes           certified dapp origin
 //! u64-BE len || expiry_ns (u64 BE)     bundle expiry, ns since epoch
-//! u64-BE len || session_expires_at_ns  session deadline, ns since epoch
+//! u64-BE len || session_expiry_ns  session deadline, ns since epoch
 //! ```
 
 use super::{calculate_delegation_seed, SSO_ATTR_BUNDLE_TTL_NS};
@@ -39,7 +39,7 @@ pub struct SsoAttrBundle {
     /// org's `session_max_age_seconds`. Computed at the ceremony, where the
     /// discovery cache is warm, and carried here so attribute certification
     /// never has to re-read it. Outlives `expiry_ns`.
-    pub session_expires_at_ns: u64,
+    pub session_expiry_ns: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -63,14 +63,14 @@ pub fn encode_sso_attr_bundle(
     sso_domain: &str,
     origin: &str,
     expiry_ns: u64,
-    session_expires_at_ns: u64,
+    session_expiry_ns: u64,
 ) -> Vec<u8> {
     let mut blob: Vec<u8> = Vec::new();
     blob.extend_from_slice(SSO_ATTR_BUNDLE_DOMAIN);
     write_field(&mut blob, sso_domain.as_bytes());
     write_field(&mut blob, origin.as_bytes());
     write_field(&mut blob, &expiry_ns.to_be_bytes());
-    write_field(&mut blob, &session_expires_at_ns.to_be_bytes());
+    write_field(&mut blob, &session_expiry_ns.to_be_bytes());
     blob
 }
 
@@ -140,13 +140,13 @@ pub fn decode_sso_attr_bundle(bytes: &[u8]) -> Result<SsoAttrBundle, SsoBundleDe
     let session_expiry_arr: [u8; 8] = session_expiry_bytes
         .try_into()
         .map_err(|_| SsoBundleDecodeError::BadSessionExpiryWidth)?;
-    let session_expires_at_ns = u64::from_be_bytes(session_expiry_arr);
+    let session_expiry_ns = u64::from_be_bytes(session_expiry_arr);
 
     Ok(SsoAttrBundle {
         sso_domain,
         origin,
         expiry_ns,
-        session_expires_at_ns,
+        session_expiry_ns,
     })
 }
 
@@ -203,10 +203,10 @@ pub fn prepare_sso_attr_bundle(
     anchor_number: AnchorNumber,
     sso_domain: &str,
     origin: &str,
-    session_expires_at_ns: Timestamp,
+    session_expiry_ns: Timestamp,
 ) -> (Vec<u8>, Timestamp) {
     let expiration = time().saturating_add(SSO_ATTR_BUNDLE_TTL_NS);
-    let message = encode_sso_attr_bundle(sso_domain, origin, expiration, session_expires_at_ns);
+    let message = encode_sso_attr_bundle(sso_domain, origin, expiration, session_expiry_ns);
     let seed = calculate_delegation_seed(
         &(iss.to_string(), sub.to_string(), aud.to_string()),
         anchor_number,
@@ -256,13 +256,13 @@ mod tests {
             sso_domain: "idp.example.com".to_string(),
             origin: "https://nice-name.com".to_string(),
             expiry_ns: 1_700_000_000_000_000_000,
-            session_expires_at_ns: 1_700_028_800_000_000_000,
+            session_expiry_ns: 1_700_028_800_000_000_000,
         };
         let encoded = encode_sso_attr_bundle(
             &bundle.sso_domain,
             &bundle.origin,
             bundle.expiry_ns,
-            bundle.session_expires_at_ns,
+            bundle.session_expiry_ns,
         );
         assert_eq!(decode_sso_attr_bundle(&encoded), Ok(bundle));
     }
@@ -279,7 +279,7 @@ mod tests {
             assert_eq!(decoded.sso_domain, sso_domain);
             assert_eq!(decoded.origin, origin);
             assert_eq!(decoded.expiry_ns, 0);
-            assert_eq!(decoded.session_expires_at_ns, 0);
+            assert_eq!(decoded.session_expiry_ns, 0);
         }
     }
 

--- a/src/internet_identity/src/openid/sso_bundle.rs
+++ b/src/internet_identity/src/openid/sso_bundle.rs
@@ -6,6 +6,7 @@
 //! u64-BE len || sso_domain bytes       SSO discovery domain
 //! u64-BE len || origin bytes           certified dapp origin
 //! u64-BE len || expiry_ns (u64 BE)     bundle expiry, ns since epoch
+//! u64-BE len || session_expires_at_ns  session deadline, ns since epoch
 //! ```
 
 use super::{calculate_delegation_seed, SSO_ATTR_BUNDLE_TTL_NS};
@@ -32,7 +33,13 @@ pub struct SsoAttrBundle {
     /// The dapp origin II certified this session for.
     pub origin: String,
     /// Nanoseconds since the Unix epoch after which the bundle is invalid.
+    /// Short-lived: this marks the sign-in ceremony as fresh.
     pub expiry_ns: u64,
+    /// Nanoseconds since the Unix epoch at which the SSO session ends, from the
+    /// org's `session_max_age_seconds`. Computed at the ceremony, where the
+    /// discovery cache is warm, and carried here so attribute certification
+    /// never has to re-read it. Outlives `expiry_ns`.
+    pub session_expires_at_ns: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,6 +48,7 @@ pub enum SsoBundleDecodeError {
     Truncated,
     TrailingBytes,
     BadExpiryWidth,
+    BadSessionExpiryWidth,
     InvalidOriginUtf8,
     InvalidSsoDomainUtf8,
 }
@@ -51,12 +59,18 @@ fn write_field(blob: &mut Vec<u8>, data: &[u8]) {
     blob.extend_from_slice(data);
 }
 
-pub fn encode_sso_attr_bundle(sso_domain: &str, origin: &str, expiry_ns: u64) -> Vec<u8> {
+pub fn encode_sso_attr_bundle(
+    sso_domain: &str,
+    origin: &str,
+    expiry_ns: u64,
+    session_expires_at_ns: u64,
+) -> Vec<u8> {
     let mut blob: Vec<u8> = Vec::new();
     blob.extend_from_slice(SSO_ATTR_BUNDLE_DOMAIN);
     write_field(&mut blob, sso_domain.as_bytes());
     write_field(&mut blob, origin.as_bytes());
     write_field(&mut blob, &expiry_ns.to_be_bytes());
+    write_field(&mut blob, &session_expires_at_ns.to_be_bytes());
     blob
 }
 
@@ -109,6 +123,7 @@ pub fn decode_sso_attr_bundle(bytes: &[u8]) -> Result<SsoAttrBundle, SsoBundleDe
     let sso_domain_bytes = reader.read_field()?;
     let origin_bytes = reader.read_field()?;
     let expiry_bytes = reader.read_field()?;
+    let session_expiry_bytes = reader.read_field()?;
 
     if !reader.is_exhausted() {
         return Err(SsoBundleDecodeError::TrailingBytes);
@@ -122,11 +137,16 @@ pub fn decode_sso_attr_bundle(bytes: &[u8]) -> Result<SsoAttrBundle, SsoBundleDe
         .try_into()
         .map_err(|_| SsoBundleDecodeError::BadExpiryWidth)?;
     let expiry_ns = u64::from_be_bytes(expiry_arr);
+    let session_expiry_arr: [u8; 8] = session_expiry_bytes
+        .try_into()
+        .map_err(|_| SsoBundleDecodeError::BadSessionExpiryWidth)?;
+    let session_expires_at_ns = u64::from_be_bytes(session_expiry_arr);
 
     Ok(SsoAttrBundle {
         sso_domain,
         origin,
         expiry_ns,
+        session_expires_at_ns,
     })
 }
 
@@ -173,8 +193,9 @@ pub fn read_certified_sso_bundle() -> Option<SsoAttrBundle> {
 }
 
 /// Prepare the certified SSO attribute bundle: encode `(sso_domain, origin,
-/// expiry)` and sign it under the credential seed. Returns the message bytes and
-/// its expiry; [`get_sso_attr_bundle_signature`] witnesses the signature.
+/// expiry, session deadline)` and sign it under the credential seed. Returns the
+/// message bytes and its expiry; [`get_sso_attr_bundle_signature`] witnesses the
+/// signature.
 pub fn prepare_sso_attr_bundle(
     iss: &str,
     sub: &str,
@@ -182,9 +203,10 @@ pub fn prepare_sso_attr_bundle(
     anchor_number: AnchorNumber,
     sso_domain: &str,
     origin: &str,
+    session_expires_at_ns: Timestamp,
 ) -> (Vec<u8>, Timestamp) {
     let expiration = time().saturating_add(SSO_ATTR_BUNDLE_TTL_NS);
-    let message = encode_sso_attr_bundle(sso_domain, origin, expiration);
+    let message = encode_sso_attr_bundle(sso_domain, origin, expiration, session_expires_at_ns);
     let seed = calculate_delegation_seed(
         &(iss.to_string(), sub.to_string(), aud.to_string()),
         anchor_number,
@@ -234,8 +256,14 @@ mod tests {
             sso_domain: "idp.example.com".to_string(),
             origin: "https://nice-name.com".to_string(),
             expiry_ns: 1_700_000_000_000_000_000,
+            session_expires_at_ns: 1_700_028_800_000_000_000,
         };
-        let encoded = encode_sso_attr_bundle(&bundle.sso_domain, &bundle.origin, bundle.expiry_ns);
+        let encoded = encode_sso_attr_bundle(
+            &bundle.sso_domain,
+            &bundle.origin,
+            bundle.expiry_ns,
+            bundle.session_expires_at_ns,
+        );
         assert_eq!(decode_sso_attr_bundle(&encoded), Ok(bundle));
     }
 
@@ -246,24 +274,25 @@ mod tests {
             ("xn--tst-6la.example", "https://xn--tst-6la.example"),
             ("a", "b"),
         ] {
-            let encoded = encode_sso_attr_bundle(sso_domain, origin, 0);
+            let encoded = encode_sso_attr_bundle(sso_domain, origin, 0, 0);
             let decoded = decode_sso_attr_bundle(&encoded).unwrap();
             assert_eq!(decoded.sso_domain, sso_domain);
             assert_eq!(decoded.origin, origin);
             assert_eq!(decoded.expiry_ns, 0);
+            assert_eq!(decoded.session_expires_at_ns, 0);
         }
     }
 
     #[test]
     fn distinct_fields_do_not_alias() {
-        let a = encode_sso_attr_bundle("ab", "c", 0);
-        let b = encode_sso_attr_bundle("a", "bc", 0);
+        let a = encode_sso_attr_bundle("ab", "c", 0, 0);
+        let b = encode_sso_attr_bundle("a", "bc", 0, 0);
         assert_ne!(a, b);
     }
 
     #[test]
     fn rejects_unknown_domain() {
-        let mut encoded = encode_sso_attr_bundle("idp", "https://a.com", 1);
+        let mut encoded = encode_sso_attr_bundle("idp", "https://a.com", 1, 2);
         encoded[0] ^= 0xff;
         assert_eq!(
             decode_sso_attr_bundle(&encoded),
@@ -271,7 +300,7 @@ mod tests {
         );
         let mut wrong_domain = b"xx-sso-attr".to_vec();
         wrong_domain.extend_from_slice(
-            &encode_sso_attr_bundle("idp", "https://a.com", 1)[SSO_ATTR_BUNDLE_DOMAIN.len()..],
+            &encode_sso_attr_bundle("idp", "https://a.com", 1, 2)[SSO_ATTR_BUNDLE_DOMAIN.len()..],
         );
         assert_eq!(
             decode_sso_attr_bundle(&wrong_domain),
@@ -281,7 +310,7 @@ mod tests {
 
     #[test]
     fn rejects_trailing_bytes() {
-        let mut encoded = encode_sso_attr_bundle("idp", "https://a.com", 1);
+        let mut encoded = encode_sso_attr_bundle("idp", "https://a.com", 1, 2);
         encoded.push(0);
         assert_eq!(
             decode_sso_attr_bundle(&encoded),
@@ -291,7 +320,7 @@ mod tests {
 
     #[test]
     fn rejects_truncated_field() {
-        let encoded = encode_sso_attr_bundle("idp", "https://a.com", 1);
+        let encoded = encode_sso_attr_bundle("idp", "https://a.com", 1, 2);
         let truncated = &encoded[..encoded.len() - 1];
         assert_eq!(
             decode_sso_attr_bundle(truncated),
@@ -337,9 +366,23 @@ mod tests {
         write_field(&mut buf, b"idp");
         write_field(&mut buf, b"https://a.com");
         write_field(&mut buf, &[0, 0, 0, 1]);
+        write_field(&mut buf, &0u64.to_be_bytes());
         assert_eq!(
             decode_sso_attr_bundle(&buf),
             Err(SsoBundleDecodeError::BadExpiryWidth)
+        );
+    }
+
+    #[test]
+    fn rejects_bad_session_expiry_width() {
+        let mut buf = SSO_ATTR_BUNDLE_DOMAIN.to_vec();
+        write_field(&mut buf, b"idp");
+        write_field(&mut buf, b"https://a.com");
+        write_field(&mut buf, &0u64.to_be_bytes());
+        write_field(&mut buf, &[0, 0, 0, 1]);
+        assert_eq!(
+            decode_sso_attr_bundle(&buf),
+            Err(SsoBundleDecodeError::BadSessionExpiryWidth)
         );
     }
 
@@ -348,6 +391,7 @@ mod tests {
         let mut buf = SSO_ATTR_BUNDLE_DOMAIN.to_vec();
         write_field(&mut buf, &[0xff, 0xfe]);
         write_field(&mut buf, b"https://a.com");
+        write_field(&mut buf, &0u64.to_be_bytes());
         write_field(&mut buf, &0u64.to_be_bytes());
         assert_eq!(
             decode_sso_attr_bundle(&buf),
@@ -360,6 +404,7 @@ mod tests {
         let mut buf = SSO_ATTR_BUNDLE_DOMAIN.to_vec();
         write_field(&mut buf, b"idp");
         write_field(&mut buf, &[0xff, 0xfe]);
+        write_field(&mut buf, &0u64.to_be_bytes());
         write_field(&mut buf, &0u64.to_be_bytes());
         assert_eq!(
             decode_sso_attr_bundle(&buf),

--- a/src/internet_identity/src/openid/sso_gating.rs
+++ b/src/internet_identity/src/openid/sso_gating.rs
@@ -35,6 +35,9 @@ pub struct VerifiedSsoLogin {
     pub stable_identifier_claim: String,
     /// The cross-client-stable identifier; `None` when the claim is `sub`.
     pub stable_id: Option<String>,
+    /// The org's session length in nanoseconds, captured here while the
+    /// discovery cache is warm so later paths never have to re-read it.
+    pub session_max_age_ns: u64,
 }
 
 impl VerifiedSsoLogin {
@@ -95,6 +98,7 @@ pub fn verify_sso_jwt(
         credential,
         ii_client_id: discovery_config.client_id,
         stable_identifier_claim: discovery_config.stable_identifier_claim,
+        session_max_age_ns: discovery_config.session_max_age_ns,
     }))
 }
 
@@ -292,6 +296,7 @@ mod tests {
             app_clients,
             gate_all_apps,
             stable_identifier_claim: "sub".to_string(),
+            session_max_age_ns: sso::DEFAULT_SESSION_MAX_AGE_NS,
         }
     }
 
@@ -364,6 +369,7 @@ mod tests {
             ii_client_id: ii_client_id.to_string(),
             stable_identifier_claim: claim.to_string(),
             stable_id: stable_id.map(str::to_string),
+            session_max_age_ns: sso::DEFAULT_SESSION_MAX_AGE_NS,
         }
     }
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -516,6 +516,11 @@ pub struct SsoDiscovery {
     /// Client the frontend runs the ceremony against for the requested origin;
     /// `None` when the origin is denied.
     pub resolved_client_id: Option<String>,
+    /// How long a sign-in through this domain stays valid, in nanoseconds, from
+    /// the domain's `session_max_age_seconds`. The sign-in flow caps the account
+    /// delegation it requests at this value. Nanoseconds, like every other
+    /// duration on this interface: seconds exist only in the well-known itself.
+    pub session_max_age_ns: u64,
 }
 
 /// Status of a domain's SSO discovery, read by `get_sso_discovery_status`. A


### PR DESCRIPTION
Lets an SSO organization say how long a sign-in through its domain stays valid, and carries that deadline to the two places that can act on it.

Adds `session_max_age_seconds` to the `ii-openid-configuration` document. It defaults to eight hours, is rejected if zero or above the 30-day delegation ceiling, and is converted to nanoseconds once, in the parser: seconds exist only in that document.

## How the deadline travels

1. **Discovery** parses and bounds the value, and `DiscoveredConfig` carries it as `session_max_age_ns` in the existing cache, refreshed on the same one-hour TTL.
2. **The ceremony** (`sso_prepare_delegation`) reads it off `VerifiedSsoLogin` and computes `session_expires_at_ns` once. This is deliberate: it is the one place with a warm cache, so an evicted entry or a policy refresh can never move a live session's deadline.
3. **The internal SSO bundle** gains a fourth length-prefixed field carrying that deadline, so attribute certification never has to re-read the cache. Its own five-minute `expiry_ns` is untouched, because "this ceremony just happened" is a different question from "the session ends here".
4. **Attribute certification** stamps `sso:<domain>:expires_at_timestamp_ns` as a `Nat` when the bundle carries any attribute for that domain.
5. **The sign-in flow** carries the value from discovery onto the authenticated session, and the delegation handler bounds the `maxTimeToLive` it requests by it.

## Why the key is domain-scoped rather than `implicit:`

One bundle can carry attributes from several scopes with different lifetimes, since `prepare_icrc3_attributes` matches per spec into one map. A single top-level expiry would have to be the minimum across scopes, which either shortens an unrelated OpenID attribute or misstates the deadline for one of them. A verifier must enforce the deadline belonging to the scope it reads, so the deadline is keyed to the domain whose policy set it.

The key can't be requested, only stamped: `AttributeName` accepts `email`, `name`, and `verified_email` only, so a request for it fails validation, and `list_available_attributes` iterates `AttributeName::all()` and won't list it.

## Enforcement, and what this PR does not do

The delegation cap is a **UX** measure: it lets the frontend's existing expiry check drive re-authentication, and it is applied in the sign-in flow, so it is not a boundary anything relies on. A delegation identifies the identity rather than the SSO session, so any other access method on the anchor can mint a fresh one regardless.

The security property is the bundle expiry, and it is **fail-open until verifiers check it**. This PR only signs the deadline. `mo:identity-attributes` and any hand-rolled verifier need to reject a bundle whose `sso:<domain>:expires_at_timestamp_ns` has passed, and only once II always stamps it can a missing key be treated as invalid rather than as an older II. Until then the field is a claim, not a control.

## Testing

- New unit tests for the seconds-to-nanoseconds conversion, including the default, zero, the ceiling boundary, and a value that overflows nanoseconds (rejected rather than saturated).
- New unit tests for the stamping decision, covering the scoped key, a bundle with no attributes for that domain, two SSO domains in one bundle, and non-SSO sessions.
- New bundle round-trip and malformed-field coverage for the added field.
- New frontend tests for the clamp.
- `cargo test -p internet_identity --lib --bins`: 667 pass. `cargo clippy -p internet_identity -p internet_identity_interface --all-targets`: clean. `tsc --project tsconfig.all.json`: clean. `eslint`: clean.
- Integration tests were not run locally. The 18 pre-existing failures in `findWebAuthnFlows.test.ts` and `iiConnection.test.ts` reproduce on `main` unchanged.

Docs for the administrator-facing half are in https://github.com/dfinity/developer-docs/pull/340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)