### PR TITLE
feat(be): resolve an SSO domain's session_max_age_seconds

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -534,6 +534,7 @@ export const idlFactory = ({ IDL }) => {
     'resolved_client_id' : IDL.Opt(IDL.Text),
     'discovery_domain' : IDL.Text,
     'client_id' : IDL.Text,
+    'session_max_age_ns' : IDL.Nat64,
   });
   const SsoDiscoveryStatus = IDL.Variant({
     'Resolved' : SsoDiscovery,
@@ -738,8 +739,8 @@ export const idlFactory = ({ IDL }) => {
   });
   const PrepareMcpRegistrationDelegation = IDL.Record({
     'user_key' : UserKey,
-    'expiration' : Timestamp,
     'trusted_url' : IDL.Text,
+    'expiration' : Timestamp,
   });
   const PrepareSessionDelegation = IDL.Record({
     'user_key' : UserKey,

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1027,10 +1027,11 @@ export interface InternetIdentityInit {
    */
   'is_production' : [] | [boolean],
   /**
-   * One-shot upgrade arg driving the MCP config migration: `opt true`
-   * rewrites every stored config to "enabled, official connector", since a
-   * value stored before the official connector existed was never a choice
-   * about it. Runs at most once per deployment; unset means no migration.
+   * One-shot upgrade arg driving the MCP config migration: `opt true` gives
+   * every anchor "enabled, official connector", since neither a value stored
+   * before the official connector existed nor an absent config was ever a
+   * choice about it. Unset means no migration, and the migration is refused
+   * when the deployment ships no `mcp_official_url`.
    */
   'mcp_config_migration' : [] | [boolean],
   /**
@@ -1430,15 +1431,19 @@ export interface PrepareIdAliasRequest {
 }
 /**
  * Result of prepare_mcp_registration_delegation: the canister-signature public
- * key the registration delegation is rooted at (P_reg), and the (short)
- * expiration of that delegation. The frontend fetches the signed delegation via
- * get_mcp_registration_delegation and delivers the chain to the trusted MCP
+ * key the registration delegation is rooted at (P_reg), the (short) expiration
+ * of that delegation, and the identity's resolved trusted_url (the anchor's own
+ * server if set, else the official connector). trusted_url is certified (this
+ * is an update call), so the frontend can gate delivery on it - delivering the
+ * chain only when the connect link's origin matches - rather than trusting an
+ * uncertified mcp_get_config query. The frontend fetches the signed delegation
+ * via get_mcp_registration_delegation and delivers the chain to the trusted MCP
  * server, which redeems it with mcp_register_v2.
  */
 export interface PrepareMcpRegistrationDelegation {
   'user_key' : UserKey,
-  'expiration' : Timestamp,
   'trusted_url' : string,
+  'expiration' : Timestamp,
 }
 export interface PrepareSessionDelegation {
   'user_key' : UserKey,
@@ -1665,6 +1670,12 @@ export interface SsoDiscovery {
    * The org's primary OIDC client.
    */
   'client_id' : string,
+  /**
+   * How long a sign-in through this domain stays valid, in nanoseconds, from
+   * the domain's optional `session_max_age_seconds` (8 hours when unset). The
+   * sign-in flow caps the account delegation it requests at this value.
+   */
+  'session_max_age_ns' : bigint,
 }
 /**
  * Status of a domain's SSO discovery, read by `get_sso_discovery_status`. A

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -1672,8 +1672,7 @@ export interface SsoDiscovery {
   'client_id' : string,
   /**
    * How long a sign-in through this domain stays valid, in nanoseconds, from
-   * the domain's optional `session_max_age_seconds` (8 hours when unset). The
-   * sign-in flow caps the account delegation it requests at this value.
+   * the domain's optional `session_max_age_seconds` (8 hours when unset).
    */
   'session_max_age_ns' : bigint,
 }

--- a/src/frontend/src/lib/utils/ssoDiscovery.test.ts
+++ b/src/frontend/src/lib/utils/ssoDiscovery.test.ts
@@ -22,6 +22,7 @@ const DISCOVERY: SsoDiscovery = {
   scopes: ["openid", "profile", "email"],
   name: ["DFINITY"],
   resolved_client_id: ["dfinity-sso-client-id"],
+  session_max_age_ns: BigInt(28_800_000_000_000),
 };
 
 describe("ssoDiscovery", () => {
@@ -108,6 +109,7 @@ describe("ssoDiscovery", () => {
         clientId: "dfinity-sso-client-id",
         resolvedClientId: "dfinity-sso-client-id",
         name: "DFINITY",
+        sessionMaxAgeNs: BigInt(28_800_000_000_000),
         discovery: {
           issuer: "https://dfinity.okta.com",
           authorization_endpoint:

--- a/src/frontend/src/lib/utils/ssoDiscovery.ts
+++ b/src/frontend/src/lib/utils/ssoDiscovery.ts
@@ -22,6 +22,12 @@ export interface SsoDiscoveryResult {
   /** The client to run the ceremony against for the target origin; equals {@link clientId} when no origin was passed. */
   resolvedClientId: string;
   /**
+   * How long a sign-in through this domain stays valid, in nanoseconds, from the
+   * domain's `session_max_age_seconds`. The sign-in flow caps the account
+   * delegation it requests at this value.
+   */
+  sessionMaxAgeNs: bigint;
+  /**
    * Human-readable name for the SSO, if the domain publishes one. Used by the
    * consent UI to render `sso:<domain>:<key>` attribute rows with a friendly
    * prefix (e.g. "DFINITY email:"); falls back to `domain` when absent.
@@ -121,6 +127,7 @@ const toResult = (discovery: SsoDiscovery): SsoDiscoveryResult => {
     domain: discovery.discovery_domain,
     clientId: discovery.client_id,
     resolvedClientId,
+    sessionMaxAgeNs: discovery.session_max_age_ns,
     name: discovery.name[0],
     discovery: {
       issuer: discovery.issuer,

--- a/src/frontend/src/lib/utils/ssoDiscovery.ts
+++ b/src/frontend/src/lib/utils/ssoDiscovery.ts
@@ -23,8 +23,7 @@ export interface SsoDiscoveryResult {
   resolvedClientId: string;
   /**
    * How long a sign-in through this domain stays valid, in nanoseconds, from the
-   * domain's `session_max_age_seconds`. The sign-in flow caps the account
-   * delegation it requests at this value.
+   * domain's `session_max_age_seconds`, defaulting to eight hours.
    */
   sessionMaxAgeNs: bigint;
   /**

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -501,6 +501,10 @@ type SsoDiscovery = record {
     name : opt text;
     // Client the target origin runs its ceremony against; `null` when denied.
     resolved_client_id : opt text;
+    // How long a sign-in through this domain stays valid, in nanoseconds, from
+    // the domain's optional `session_max_age_seconds` (8 hours when unset). The
+    // sign-in flow caps the account delegation it requests at this value.
+    session_max_age_ns : nat64;
 };
 
 // Status of a domain's SSO discovery, read by `get_sso_discovery_status`. A

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -502,8 +502,7 @@ type SsoDiscovery = record {
     // Client the target origin runs its ceremony against; `null` when denied.
     resolved_client_id : opt text;
     // How long a sign-in through this domain stays valid, in nanoseconds, from
-    // the domain's optional `session_max_age_seconds` (8 hours when unset). The
-    // sign-in flow caps the account delegation it requests at this value.
+    // the domain's optional `session_max_age_seconds` (8 hours when unset).
     session_max_age_ns : nat64;
 };
 

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -372,6 +372,7 @@ pub fn get_sso_discovery_status(domain: &str, origin: Option<&str>) -> SsoDiscov
                 scopes: discovery_config.scopes,
                 name: discovery_config.name,
                 resolved_client_id,
+                session_max_age_ns: discovery_config.session_max_age_ns,
             })
         }
         Cached::Pending => SsoDiscoveryStatus::Pending,

--- a/src/internet_identity/src/openid/sso.rs
+++ b/src/internet_identity/src/openid/sso.rs
@@ -18,6 +18,7 @@ use super::verify::{Descriptor, SsoProvider};
 use super::OpenIDJWTVerificationError;
 use crate::openid::AudClaim;
 use crate::single_flight_cache::{self, CacheConfig, Cached, RetryBackoff, SingleFlightCache};
+use crate::HOUR_NS;
 use identity_jose::jwk::Jwk;
 use sha2::{Digest, Sha256};
 use std::cell::RefCell;
@@ -34,6 +35,11 @@ pub(super) const DEFAULT_STABLE_IDENTIFIER_CLAIM: &str = "sub";
 pub(super) fn non_default_stable_claim(claim: &str) -> Option<String> {
     (claim != DEFAULT_STABLE_IDENTIFIER_CLAIM).then(|| claim.to_string())
 }
+
+/// Default session length for an org that doesn't set `session_max_age_seconds`
+/// in its well-known: how long II's assertions about a user stay valid before
+/// they authenticate against the org's IdP again.
+pub(super) const DEFAULT_SESSION_MAX_AGE_NS: u64 = 8 * HOUR_NS;
 
 /// Max `app_clients` entries accepted from an org's well-known. The parsed map
 /// is retained in the in-memory SSO discovery cache (one per cached domain), so
@@ -132,6 +138,10 @@ pub(super) struct DiscoveredConfig {
     pub gate_all_apps: bool,
     /// Claim holding the cross-client-stable identifier (default `sub`).
     pub stable_identifier_claim: String,
+    /// How long a sign-in through this domain stays valid, in nanoseconds.
+    /// Seconds exist only in the well-known and its parser; everything from
+    /// here on is nanoseconds.
+    pub session_max_age_ns: u64,
 }
 
 /// One `origin -> client_id` entry from `app_clients`.
@@ -445,6 +455,10 @@ struct IIOpenIdConfiguration {
     /// Cross-client-stable identifier claim (default `sub`).
     #[serde(default)]
     stable_identifier_claim: Option<String>,
+    /// How long a sign-in stays valid, in seconds. The only place seconds
+    /// appear: `validate_session_max_age` converts once, to nanoseconds.
+    #[serde(default)]
+    session_max_age_seconds: Option<u64>,
 }
 
 /// OIDC discovery document — only the fields the canister needs.
@@ -458,9 +472,29 @@ struct DiscoveryDocument {
     scopes_supported: Option<Vec<String>>,
 }
 
-/// Reject over-length values from the untrusted well-known configuration.
+/// The hop-1 document once every field has been checked, bounded, defaulted and
+/// converted. Produced only by [`validate_ii_config`], which consumes the raw
+/// [`IIOpenIdConfiguration`], so nothing downstream can reach an unvalidated
+/// field by accident.
 #[cfg(not(test))]
-fn validate_ii_config(config: &IIOpenIdConfiguration) -> Result<(), String> {
+struct ValidatedIIOpenIdConfiguration {
+    client_id: String,
+    /// The hop-2 URL, checked before it is fetched.
+    openid_configuration: String,
+    name: Option<String>,
+    app_clients: Vec<AppClient>,
+    gate_all_apps: bool,
+    stable_identifier_claim: String,
+    session_max_age_ns: u64,
+}
+
+/// Validate the untrusted well-known configuration: bound its lengths, parse its
+/// `app_clients` keys, default its stable-identifier claim, and convert its
+/// session length to nanoseconds.
+#[cfg(not(test))]
+fn validate_ii_config(
+    config: IIOpenIdConfiguration,
+) -> Result<ValidatedIIOpenIdConfiguration, String> {
     if config.client_id.len() > MAX_CLIENT_ID_LENGTH {
         return Err(format!(
             "SSO client_id exceeds {MAX_CLIENT_ID_LENGTH} bytes"
@@ -473,19 +507,104 @@ fn validate_ii_config(config: &IIOpenIdConfiguration) -> Result<(), String> {
     {
         return Err(format!("SSO name exceeds {MAX_SSO_NAME_LENGTH} bytes"));
     }
-    Ok(())
+    let openid_configuration = validate_discovery_url(config.openid_configuration)?;
+    let app_clients = validate_app_clients(&config.app_clients)?;
+    let session_max_age_ns = validate_session_max_age(config.session_max_age_seconds)?;
+    let stable_identifier_claim = config
+        .stable_identifier_claim
+        .filter(|claim| !claim.is_empty())
+        .unwrap_or_else(|| DEFAULT_STABLE_IDENTIFIER_CLAIM.to_string());
+
+    Ok(ValidatedIIOpenIdConfiguration {
+        client_id: config.client_id,
+        openid_configuration,
+        name: config.name,
+        app_clients,
+        gate_all_apps: config.gate_all_apps,
+        stable_identifier_claim,
+        session_max_age_ns,
+    })
 }
 
-/// Reject over-length values from the untrusted OIDC discovery document.
+/// Convert `session_max_age_seconds` from the well-known into nanoseconds,
+/// rejecting a value that is zero or over the delegation ceiling. This is the
+/// only seconds-to-nanoseconds conversion in the SSO path: an invalid value is
+/// rejected here, so it never reaches the cache as a nanosecond number.
+fn validate_session_max_age(seconds: Option<u64>) -> Result<u64, String> {
+    const NS_PER_SECOND: u64 = 1_000_000_000;
+    let Some(seconds) = seconds else {
+        return Ok(DEFAULT_SESSION_MAX_AGE_NS);
+    };
+    if seconds == 0 {
+        return Err("SSO session_max_age_seconds must be greater than zero".to_string());
+    }
+    // `checked_mul` rather than saturating: a garbage value must be rejected,
+    // not silently clamped to the ceiling.
+    let max_age_ns = seconds
+        .checked_mul(NS_PER_SECOND)
+        .ok_or_else(|| format!("SSO session_max_age_seconds is out of range: {seconds}"))?;
+    if max_age_ns > crate::delegation::MAX_EXPIRATION_PERIOD_NS {
+        return Err(format!(
+            "SSO session_max_age_seconds exceeds the {} second maximum",
+            crate::delegation::MAX_EXPIRATION_PERIOD_NS / NS_PER_SECOND
+        ));
+    }
+    Ok(max_age_ns)
+}
+
+/// The hop-2 document once its URLs have been checked against each other and
+/// against the hop-1 URL, its lengths bounded and its scopes defaulted. Produced
+/// only by [`validate_discovery_document`], which consumes the raw
+/// [`DiscoveryDocument`].
 #[cfg(not(test))]
-fn validate_discovery_document(doc: &DiscoveryDocument) -> Result<(), String> {
+struct ValidatedDiscoveryDocument {
+    issuer: String,
+    jwks_uri: String,
+    authorization_endpoint: String,
+    scopes: Vec<String>,
+}
+
+/// Validate the untrusted OIDC discovery document against the hop-1 document it
+/// was fetched from: bound its lengths, enforce the host relationships, and
+/// default its scopes. Takes the validated hop-1 document, so the URL the
+/// self-assertion checks compare against is itself already checked.
+#[cfg(not(test))]
+fn validate_discovery_document(
+    doc: DiscoveryDocument,
+    ii_config: &ValidatedIIOpenIdConfiguration,
+) -> Result<ValidatedDiscoveryDocument, String> {
+    let openid_configuration = &ii_config.openid_configuration;
     if doc.issuer.len() > MAX_ISSUER_LENGTH {
         return Err(format!("SSO issuer exceeds {MAX_ISSUER_LENGTH} bytes"));
     }
     if doc.jwks_uri.len() > MAX_JWKS_URI_LENGTH {
         return Err(format!("SSO jwks_uri exceeds {MAX_JWKS_URI_LENGTH} bytes"));
     }
-    Ok(())
+    // The discovered issuer's host must match the openid_configuration host
+    // (standard OIDC self-assertion; defends against a compromised hop-1 that
+    // points jwks_uri at an unrelated issuer). The discovery domain itself is
+    // allowed to differ — it hosts a custom SSO indirection.
+    validate_issuer_host(openid_configuration, &doc.issuer)?;
+    let jwks_uri = validate_discovery_url(doc.jwks_uri)?;
+    // The authorization_endpoint must live on the same host as the issuer, so a
+    // tampered discovery doc can't bounce the user's auth off-host after we've
+    // committed to a provider.
+    validate_same_host(&doc.issuer, &doc.authorization_endpoint)?;
+    let authorization_endpoint = validate_discovery_url(doc.authorization_endpoint)?;
+
+    let mut scopes = doc
+        .scopes_supported
+        .filter(|scopes| !scopes.is_empty())
+        .unwrap_or_else(|| DEFAULT_SCOPES.iter().map(|s| (*s).to_string()).collect());
+    // Bound the only unbounded field stored per discovery entry.
+    scopes.truncate(DISCOVERY_MAX_SCOPES);
+
+    Ok(ValidatedDiscoveryDocument {
+        issuer: doc.issuer,
+        jwks_uri,
+        authorization_endpoint,
+        scopes,
+    })
 }
 
 /// The discovery cache fill: hop 1 (`ii-openid-configuration`) then hop 2 (the
@@ -499,50 +618,28 @@ async fn discovery_fill(domain: String) -> Result<DiscoveredConfig, String> {
     // (the e2e mock provider, which can't serve TLS).
     let hop1_scheme = scheme_for_host(&domain);
     let hop1_url = format!("{hop1_scheme}://{domain}/.well-known/ii-openid-configuration");
-    let ii_config = fetch_ii_openid_configuration(hop1_url).await?;
-    validate_discovery_url(&ii_config.openid_configuration)?;
-
-    let app_clients = validate_app_clients(&ii_config.app_clients)?;
-    let stable_identifier_claim = ii_config
-        .stable_identifier_claim
-        .clone()
-        .filter(|c| !c.is_empty())
-        .unwrap_or_else(|| DEFAULT_STABLE_IDENTIFIER_CLAIM.to_string());
-    let gate_all_apps = ii_config.gate_all_apps;
+    let ii_config = validate_ii_config(fetch_ii_openid_configuration(hop1_url).await?)?;
 
     // Hop 2: fetch the standard OIDC discovery document.
-    let doc = fetch_discovery(ii_config.openid_configuration.clone()).await?;
+    let doc = validate_discovery_document(
+        fetch_discovery(ii_config.openid_configuration.clone()).await?,
+        &ii_config,
+    )?;
 
-    // The discovered issuer's host must match the openid_configuration host
-    // (standard OIDC self-assertion; defends against a compromised hop-1 that
-    // points jwks_uri at an unrelated issuer). The discovery domain itself is
-    // allowed to differ — it hosts a custom SSO indirection.
-    validate_issuer_host(&ii_config.openid_configuration, &doc.issuer)?;
-    validate_discovery_url(&doc.jwks_uri)?;
-    // The authorization_endpoint must live on the same host as the issuer, so a
-    // tampered discovery doc can't bounce the user's auth off-host after we've
-    // committed to a provider.
-    validate_same_host(&doc.issuer, &doc.authorization_endpoint)?;
-    validate_discovery_url(&doc.authorization_endpoint)?;
-
-    validate_ii_config(&ii_config)?;
-    validate_discovery_document(&doc)?;
-
-    let mut scopes = doc
-        .scopes_supported
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| DEFAULT_SCOPES.iter().map(|s| (*s).to_string()).collect());
-    // Bound the only unbounded field stored per discovery entry.
-    scopes.truncate(DISCOVERY_MAX_SCOPES);
-
-    let DiscoveryDocument {
+    let ValidatedDiscoveryDocument {
         issuer,
         jwks_uri,
         authorization_endpoint,
-        ..
+        scopes,
     } = doc;
-    let IIOpenIdConfiguration {
-        client_id, name, ..
+    let ValidatedIIOpenIdConfiguration {
+        client_id,
+        name,
+        app_clients,
+        gate_all_apps,
+        stable_identifier_claim,
+        session_max_age_ns,
+        ..
     } = ii_config;
 
     Ok(DiscoveredConfig {
@@ -555,6 +652,7 @@ async fn discovery_fill(domain: String) -> Result<DiscoveredConfig, String> {
         app_clients,
         gate_all_apps,
         stable_identifier_claim,
+        session_max_age_ns,
     })
 }
 
@@ -669,17 +767,18 @@ fn transform_discovery(
     }
 }
 
-/// Ensure a URL is syntactically valid and uses an acceptable scheme. `https`
-/// is always accepted; `http` only when the host is on the SSO allowlist.
+/// Check that a URL is syntactically valid and uses an acceptable scheme, and
+/// hand it back so the caller uses the checked value rather than the input.
+/// `https` is always accepted; `http` only when the host is on the SSO allowlist.
 #[cfg(not(test))]
-fn validate_discovery_url(url: &str) -> Result<(), String> {
-    let parsed = url::Url::parse(url).map_err(|e| format!("parse error: {e}"))?;
+fn validate_discovery_url(url: String) -> Result<String, String> {
+    let parsed = url::Url::parse(&url).map_err(|e| format!("parse error: {e}"))?;
     match parsed.scheme() {
-        "https" => Ok(()),
+        "https" => Ok(url),
         "http" => {
             let host = host_with_port(&parsed).ok_or_else(|| format!("URL has no host: {url}"))?;
             if allow_insecure_scheme(&host) {
-                Ok(())
+                Ok(url)
             } else {
                 Err(format!(
                     "http scheme not allowed for non-allowlisted host '{host}'"
@@ -790,6 +889,38 @@ mod tests {
         JWKS_CACHE.with(|c| *c.borrow_mut() = new_jwks_cache());
     }
 
+    #[test]
+    fn session_max_age_defaults_when_absent() {
+        assert_eq!(
+            validate_session_max_age(None),
+            Ok(DEFAULT_SESSION_MAX_AGE_NS)
+        );
+    }
+
+    #[test]
+    fn session_max_age_converts_seconds_once() {
+        assert_eq!(validate_session_max_age(Some(28_800)), Ok(8 * HOUR_NS));
+        assert_eq!(validate_session_max_age(Some(1)), Ok(1_000_000_000));
+    }
+
+    #[test]
+    fn session_max_age_rejects_zero() {
+        assert!(validate_session_max_age(Some(0)).is_err());
+    }
+
+    #[test]
+    fn session_max_age_rejects_above_the_delegation_ceiling() {
+        let max_seconds = crate::delegation::MAX_EXPIRATION_PERIOD_NS / 1_000_000_000;
+        assert!(validate_session_max_age(Some(max_seconds)).is_ok());
+        assert!(validate_session_max_age(Some(max_seconds + 1)).is_err());
+    }
+
+    #[test]
+    fn session_max_age_rejects_a_value_that_overflows_nanoseconds() {
+        // Rejected outright rather than saturated to the ceiling.
+        assert!(validate_session_max_age(Some(u64::MAX)).is_err());
+    }
+
     fn sample_config() -> DiscoveredConfig {
         DiscoveredConfig {
             issuer: "https://idp.example.org".to_string(),
@@ -801,6 +932,7 @@ mod tests {
             app_clients: vec![],
             gate_all_apps: false,
             stable_identifier_claim: DEFAULT_STABLE_IDENTIFIER_CLAIM.to_string(),
+            session_max_age_ns: DEFAULT_SESSION_MAX_AGE_NS,
         }
     }
 

--- a/src/internet_identity/src/openid/sso_gating.rs
+++ b/src/internet_identity/src/openid/sso_gating.rs
@@ -292,6 +292,7 @@ mod tests {
             app_clients,
             gate_all_apps,
             stable_identifier_claim: "sub".to_string(),
+            session_max_age_ns: sso::DEFAULT_SESSION_MAX_AGE_NS,
         }
     }
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -516,6 +516,11 @@ pub struct SsoDiscovery {
     /// Client the frontend runs the ceremony against for the requested origin;
     /// `None` when the origin is denied.
     pub resolved_client_id: Option<String>,
+    /// How long a sign-in through this domain stays valid, in nanoseconds, from
+    /// the domain's `session_max_age_seconds`. The sign-in flow caps the account
+    /// delegation it requests at this value. Nanoseconds, like every other
+    /// duration on this interface: seconds exist only in the well-known itself.
+    pub session_max_age_ns: u64,
 }
 
 /// Status of a domain's SSO discovery, read by `get_sso_discovery_status`. A

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -517,9 +517,7 @@ pub struct SsoDiscovery {
     /// `None` when the origin is denied.
     pub resolved_client_id: Option<String>,
     /// How long a sign-in through this domain stays valid, in nanoseconds, from
-    /// the domain's `session_max_age_seconds`, defaulting to eight hours.
-    /// Nanoseconds, like every other duration on this interface: seconds exist
-    /// only in the well-known itself.
+    /// the domain's optional `session_max_age_seconds` (8 hours when unset).
     pub session_max_age_ns: u64,
 }
 

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -517,9 +517,9 @@ pub struct SsoDiscovery {
     /// `None` when the origin is denied.
     pub resolved_client_id: Option<String>,
     /// How long a sign-in through this domain stays valid, in nanoseconds, from
-    /// the domain's `session_max_age_seconds`. The sign-in flow caps the account
-    /// delegation it requests at this value. Nanoseconds, like every other
-    /// duration on this interface: seconds exist only in the well-known itself.
+    /// the domain's `session_max_age_seconds`, defaulting to eight hours.
+    /// Nanoseconds, like every other duration on this interface: seconds exist
+    /// only in the well-known itself.
     pub session_max_age_ns: u64,
 }
 


### PR DESCRIPTION
Bottom of stack #4191. Resolves the policy; nothing consumes it yet.

# Motivation

An SSO organization has no way to say how long a sign-in through its domain stays valid. This adds `session_max_age_seconds` to the `ii-openid-configuration` document and resolves it through discovery, so the layers above can act on it.

While in there: both discovery documents were validated in place and then read field by field, so using an unchecked value was a matter of remembering to call the right helper first.

# Changes

- `session_max_age_seconds` is parsed from the well-known document, defaults to eight hours, and is rejected if zero or above the 30-day delegation ceiling. The seconds-to-nanoseconds conversion happens once, in the parser, and uses `checked_mul` so a garbage value is rejected rather than saturated to the ceiling. Seconds exist only in the document.
- The resolved value rides the existing discovery cache on `DiscoveredConfig` and is exposed on `SsoDiscovery` as `session_max_age_ns`, alongside the other durations on that interface, which are all nanoseconds.
- `validate_ii_config` and `validate_discovery_document` now consume the raw documents and return `ValidatedIIOpenIdConfiguration` and `ValidatedDiscoveryDocument`, absorbing the length bounds, the URL checks, the `app_clients` parse, the stable-claim default, the host self-assertion checks and the scope defaulting. The hop-2 validator takes the validated hop-1 document, so the URL its host comparison comes from is itself checked. `discovery_fill` is now a fetch and a validate per hop.
- `validate_discovery_url` returns the URL it checked instead of `()`, so its callers bind the checked value.

# Tests

- New unit tests for the conversion: the default when absent, a plain conversion, zero, the ceiling boundary either side, and a value that overflows nanoseconds.
- `cargo test -p internet_identity --lib --bins`: 662 pass. `cargo clippy -p internet_identity -p internet_identity_interface --all-targets`: clean. `tsc --project tsconfig.all.json`: clean.
- Integration tests were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)