### PR TITLE
feat(be): carry the SSO session deadline into the attribute bundle

### DIFF
--- a/src/internet_identity/src/attributes.rs
+++ b/src/internet_identity/src/attributes.rs
@@ -324,6 +324,32 @@ fn insert_certified_attribute(
     }
 }
 
+/// The SSO session deadline entry for a certified bundle, or `None` when the
+/// bundle carries no attribute for that SSO domain.
+///
+/// The deadline is scoped to the domain whose policy set it rather than living
+/// under `implicit:`, because one bundle can carry attributes from several
+/// scopes with different lifetimes and a verifier must enforce the deadline
+/// belonging to the scope it reads.
+fn sso_session_expiry_entry(
+    certified_pairs: &BTreeMap<String, Icrc3Value>,
+    sso_session_domain: Option<&str>,
+    sso_session_expiry_ns: Option<u64>,
+) -> Option<(String, Icrc3Value)> {
+    let domain = sso_session_domain?;
+    let expiry_ns = sso_session_expiry_ns?;
+    let scope_prefix = format!("sso:{domain}:");
+    certified_pairs
+        .keys()
+        .any(|key| key.starts_with(&scope_prefix))
+        .then(|| {
+            (
+                format!("{scope_prefix}expires_at_timestamp_ns"),
+                Icrc3Value::Nat(candid::Nat::from(expiry_ns)),
+            )
+        })
+}
+
 impl Anchor {
     /// Resolves an unscoped `email` / `verified_email` spec to a stored
     /// verified-email entry. The user picked the address in the consent
@@ -377,6 +403,9 @@ impl Anchor {
         // SSO domain this session signed in through, or `None` for non-SSO
         // sessions; `sso:<domain>` attributes certify only when it matches.
         sso_session_domain: Option<String>,
+        // When the session signed in through SSO, the instant its assertions
+        // stop being valid, from the domain's `session_max_age_seconds`.
+        sso_session_expiry_ns: Option<u64>,
     ) -> Result<Vec<u8>, PrepareIcrc3AttributeError> {
         let mut certified_pairs: BTreeMap<String, Icrc3Value> = BTreeMap::new();
         let mut problems = Vec::new();
@@ -489,6 +518,14 @@ impl Anchor {
 
         if !problems.is_empty() {
             return Err(PrepareIcrc3AttributeError::AttributeMismatch { problems });
+        }
+
+        if let Some((key, value)) = sso_session_expiry_entry(
+            &certified_pairs,
+            sso_session_domain.as_deref(),
+            sso_session_expiry_ns,
+        ) {
+            certified_pairs.insert(key, value);
         }
 
         certified_pairs.insert("implicit:nonce".to_string(), Icrc3Value::Blob(nonce));
@@ -759,6 +796,77 @@ mod tests {
                 attribute_name: name,
             },
             value: value.as_bytes().to_vec(),
+        }
+    }
+
+    mod sso_session_expiry_entry_tests {
+        use super::super::sso_session_expiry_entry;
+        use candid::Nat;
+        use internet_identity_interface::internet_identity::types::icrc3::Icrc3Value;
+        use std::collections::BTreeMap;
+
+        const DOMAIN: &str = "acme.example";
+        const EXPIRES_AT: u64 = 1_700_028_800_000_000_000;
+
+        fn pairs(keys: &[&str]) -> BTreeMap<String, Icrc3Value> {
+            keys.iter()
+                .map(|k| ((*k).to_string(), Icrc3Value::Text("v".to_string())))
+                .collect()
+        }
+
+        #[test]
+        fn stamps_the_deadline_scoped_to_the_domain() {
+            let entry = sso_session_expiry_entry(
+                &pairs(&["sso:acme.example:email"]),
+                Some(DOMAIN),
+                Some(EXPIRES_AT),
+            );
+            assert_eq!(
+                entry,
+                Some((
+                    "sso:acme.example:expires_at_timestamp_ns".to_string(),
+                    Icrc3Value::Nat(Nat::from(EXPIRES_AT))
+                ))
+            );
+        }
+
+        #[test]
+        fn skips_a_bundle_without_attributes_for_that_domain() {
+            let entry = sso_session_expiry_entry(
+                &pairs(&["openid:https://accounts.google.com:email"]),
+                Some(DOMAIN),
+                Some(EXPIRES_AT),
+            );
+            assert_eq!(entry, None);
+        }
+
+        #[test]
+        fn stamps_only_the_signed_in_domain() {
+            let entry = sso_session_expiry_entry(
+                &pairs(&["sso:other.example:email", "sso:acme.example:name"]),
+                Some(DOMAIN),
+                Some(EXPIRES_AT),
+            );
+            assert_eq!(
+                entry.map(|(key, _)| key),
+                Some("sso:acme.example:expires_at_timestamp_ns".to_string())
+            );
+        }
+
+        #[test]
+        fn skips_a_non_sso_session() {
+            assert_eq!(
+                sso_session_expiry_entry(
+                    &pairs(&["sso:acme.example:email"]),
+                    None,
+                    Some(EXPIRES_AT)
+                ),
+                None
+            );
+            assert_eq!(
+                sso_session_expiry_entry(&pairs(&["sso:acme.example:email"]), Some(DOMAIN), None),
+                None
+            );
         }
     }
 
@@ -1932,6 +2040,7 @@ mod tests {
                 1_000_000_000,
                 account,
                 None,
+                None,
             );
 
             match result {
@@ -1971,6 +2080,7 @@ mod tests {
                 1_000_000_000,
                 account,
                 None,
+                None,
             );
 
             match result {
@@ -2009,6 +2119,7 @@ mod tests {
                 1_000_000_000,
                 account,
                 None,
+                None,
             );
 
             match result {
@@ -2040,6 +2151,7 @@ mod tests {
                 None,
                 1_000_000_000,
                 account,
+                None,
                 None,
             );
 
@@ -2490,6 +2602,7 @@ mod tests {
                 account,
                 // SSO session for this domain, so the request reaches the verified_email branch.
                 Some(SSO_DOMAIN.to_string()),
+                None,
             );
             match res {
                 Err(PrepareIcrc3AttributeError::AttributeMismatch { problems }) => {
@@ -2539,6 +2652,7 @@ mod tests {
                 None,
                 1_000_000_000,
                 account,
+                None,
                 None,
             );
             match res {
@@ -2770,6 +2884,7 @@ mod tests {
                 1_000_000_000,
                 account,
                 None,
+                None,
             );
             match result {
                 Err(PrepareIcrc3AttributeError::AttributeMismatch { problems }) => {
@@ -2808,6 +2923,7 @@ mod tests {
                 1_000_000_000,
                 account,
                 None,
+                None,
             );
             match result {
                 Err(PrepareIcrc3AttributeError::AttributeMismatch { problems }) => {
@@ -2843,6 +2959,7 @@ mod tests {
                 None,
                 1_000_000_000,
                 account,
+                None,
                 None,
             );
             match result {
@@ -2886,6 +3003,7 @@ mod tests {
                     None,
                     1_000_000_000,
                     account,
+                    None,
                     None,
                 )
             }));

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -1899,6 +1899,7 @@ mod openid_api {
             Err(err) => return OpenIdResult::Err(err.into()),
         };
 
+        let session_max_age_ns = verification.session_max_age_ns;
         let identity = match openid::resolve_ii_client_identity(&verification) {
             Ok(identity) => identity,
             Err(err) => return OpenIdResult::Err(err),
@@ -1922,6 +1923,12 @@ mod openid_api {
                 .prepare_jwt_delegation(session_key, anchor_number)
                 .await;
 
+            // The session deadline is fixed here, at the ceremony, from the
+            // policy captured while the discovery cache was warm. Everything
+            // downstream reads this value rather than the cache, so an evicted
+            // entry or a refreshed policy can't move a live session's deadline.
+            let session_expiry_ns = ic_cdk::api::time().saturating_add(session_max_age_ns);
+
             let (sso_attr_bundle, _bundle_expiration) = openid::prepare_sso_attr_bundle(
                 &identity.credential.iss,
                 &identity.credential.sub,
@@ -1929,6 +1936,7 @@ mod openid_api {
                 anchor_number,
                 &discovery_domain,
                 &origin,
+                session_expiry_ns,
             );
 
             // The association could change during the `.await`.
@@ -2517,9 +2525,10 @@ mod attribute_sharing {
         } = request.try_into()?;
 
         // SSO session iff a certified bundle for this origin is attached; gates `sso:<domain>` attributes.
-        let sso_session_domain = openid::read_certified_sso_bundle()
-            .filter(|bundle| bundle.origin == origin)
-            .map(|bundle| bundle.sso_domain);
+        let sso_session =
+            openid::read_certified_sso_bundle().filter(|bundle| bundle.origin == origin);
+        let sso_session_expiry_ns = sso_session.as_ref().map(|bundle| bundle.session_expiry_ns);
+        let sso_session_domain = sso_session.map(|bundle| bundle.sso_domain);
         let (anchor, _) =
             check_authorization(identity_number).map_err(|AuthorizationError { principal }| {
                 PrepareIcrc3AttributeError::AuthorizationError(principal)
@@ -2540,6 +2549,7 @@ mod attribute_sharing {
             issued_at_timestamp_ns,
             account,
             sso_session_domain,
+            sso_session_expiry_ns,
         )?;
 
         Ok(PrepareIcrc3AttributeResponse { message })

--- a/src/internet_identity/src/openid/sso_bundle.rs
+++ b/src/internet_identity/src/openid/sso_bundle.rs
@@ -6,6 +6,7 @@
 //! u64-BE len || sso_domain bytes       SSO discovery domain
 //! u64-BE len || origin bytes           certified dapp origin
 //! u64-BE len || expiry_ns (u64 BE)     bundle expiry, ns since epoch
+//! u64-BE len || session_expiry_ns  session deadline, ns since epoch
 //! ```
 
 use super::{calculate_delegation_seed, SSO_ATTR_BUNDLE_TTL_NS};
@@ -32,7 +33,13 @@ pub struct SsoAttrBundle {
     /// The dapp origin II certified this session for.
     pub origin: String,
     /// Nanoseconds since the Unix epoch after which the bundle is invalid.
+    /// Short-lived: this marks the sign-in ceremony as fresh.
     pub expiry_ns: u64,
+    /// Nanoseconds since the Unix epoch at which the SSO session ends, from the
+    /// org's `session_max_age_seconds`. Computed at the ceremony, where the
+    /// discovery cache is warm, and carried here so attribute certification
+    /// never has to re-read it. Outlives `expiry_ns`.
+    pub session_expiry_ns: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,6 +48,7 @@ pub enum SsoBundleDecodeError {
     Truncated,
     TrailingBytes,
     BadExpiryWidth,
+    BadSessionExpiryWidth,
     InvalidOriginUtf8,
     InvalidSsoDomainUtf8,
 }
@@ -51,12 +59,18 @@ fn write_field(blob: &mut Vec<u8>, data: &[u8]) {
     blob.extend_from_slice(data);
 }
 
-pub fn encode_sso_attr_bundle(sso_domain: &str, origin: &str, expiry_ns: u64) -> Vec<u8> {
+pub fn encode_sso_attr_bundle(
+    sso_domain: &str,
+    origin: &str,
+    expiry_ns: u64,
+    session_expiry_ns: u64,
+) -> Vec<u8> {
     let mut blob: Vec<u8> = Vec::new();
     blob.extend_from_slice(SSO_ATTR_BUNDLE_DOMAIN);
     write_field(&mut blob, sso_domain.as_bytes());
     write_field(&mut blob, origin.as_bytes());
     write_field(&mut blob, &expiry_ns.to_be_bytes());
+    write_field(&mut blob, &session_expiry_ns.to_be_bytes());
     blob
 }
 
@@ -109,6 +123,7 @@ pub fn decode_sso_attr_bundle(bytes: &[u8]) -> Result<SsoAttrBundle, SsoBundleDe
     let sso_domain_bytes = reader.read_field()?;
     let origin_bytes = reader.read_field()?;
     let expiry_bytes = reader.read_field()?;
+    let session_expiry_bytes = reader.read_field()?;
 
     if !reader.is_exhausted() {
         return Err(SsoBundleDecodeError::TrailingBytes);
@@ -122,11 +137,16 @@ pub fn decode_sso_attr_bundle(bytes: &[u8]) -> Result<SsoAttrBundle, SsoBundleDe
         .try_into()
         .map_err(|_| SsoBundleDecodeError::BadExpiryWidth)?;
     let expiry_ns = u64::from_be_bytes(expiry_arr);
+    let session_expiry_arr: [u8; 8] = session_expiry_bytes
+        .try_into()
+        .map_err(|_| SsoBundleDecodeError::BadSessionExpiryWidth)?;
+    let session_expiry_ns = u64::from_be_bytes(session_expiry_arr);
 
     Ok(SsoAttrBundle {
         sso_domain,
         origin,
         expiry_ns,
+        session_expiry_ns,
     })
 }
 
@@ -173,8 +193,9 @@ pub fn read_certified_sso_bundle() -> Option<SsoAttrBundle> {
 }
 
 /// Prepare the certified SSO attribute bundle: encode `(sso_domain, origin,
-/// expiry)` and sign it under the credential seed. Returns the message bytes and
-/// its expiry; [`get_sso_attr_bundle_signature`] witnesses the signature.
+/// expiry, session deadline)` and sign it under the credential seed. Returns the
+/// message bytes and its expiry; [`get_sso_attr_bundle_signature`] witnesses the
+/// signature.
 pub fn prepare_sso_attr_bundle(
     iss: &str,
     sub: &str,
@@ -182,9 +203,10 @@ pub fn prepare_sso_attr_bundle(
     anchor_number: AnchorNumber,
     sso_domain: &str,
     origin: &str,
+    session_expiry_ns: Timestamp,
 ) -> (Vec<u8>, Timestamp) {
     let expiration = time().saturating_add(SSO_ATTR_BUNDLE_TTL_NS);
-    let message = encode_sso_attr_bundle(sso_domain, origin, expiration);
+    let message = encode_sso_attr_bundle(sso_domain, origin, expiration, session_expiry_ns);
     let seed = calculate_delegation_seed(
         &(iss.to_string(), sub.to_string(), aud.to_string()),
         anchor_number,
@@ -234,8 +256,14 @@ mod tests {
             sso_domain: "idp.example.com".to_string(),
             origin: "https://nice-name.com".to_string(),
             expiry_ns: 1_700_000_000_000_000_000,
+            session_expiry_ns: 1_700_028_800_000_000_000,
         };
-        let encoded = encode_sso_attr_bundle(&bundle.sso_domain, &bundle.origin, bundle.expiry_ns);
+        let encoded = encode_sso_attr_bundle(
+            &bundle.sso_domain,
+            &bundle.origin,
+            bundle.expiry_ns,
+            bundle.session_expiry_ns,
+        );
         assert_eq!(decode_sso_attr_bundle(&encoded), Ok(bundle));
     }
 
@@ -246,24 +274,25 @@ mod tests {
             ("xn--tst-6la.example", "https://xn--tst-6la.example"),
             ("a", "b"),
         ] {
-            let encoded = encode_sso_attr_bundle(sso_domain, origin, 0);
+            let encoded = encode_sso_attr_bundle(sso_domain, origin, 0, 0);
             let decoded = decode_sso_attr_bundle(&encoded).unwrap();
             assert_eq!(decoded.sso_domain, sso_domain);
             assert_eq!(decoded.origin, origin);
             assert_eq!(decoded.expiry_ns, 0);
+            assert_eq!(decoded.session_expiry_ns, 0);
         }
     }
 
     #[test]
     fn distinct_fields_do_not_alias() {
-        let a = encode_sso_attr_bundle("ab", "c", 0);
-        let b = encode_sso_attr_bundle("a", "bc", 0);
+        let a = encode_sso_attr_bundle("ab", "c", 0, 0);
+        let b = encode_sso_attr_bundle("a", "bc", 0, 0);
         assert_ne!(a, b);
     }
 
     #[test]
     fn rejects_unknown_domain() {
-        let mut encoded = encode_sso_attr_bundle("idp", "https://a.com", 1);
+        let mut encoded = encode_sso_attr_bundle("idp", "https://a.com", 1, 2);
         encoded[0] ^= 0xff;
         assert_eq!(
             decode_sso_attr_bundle(&encoded),
@@ -271,7 +300,7 @@ mod tests {
         );
         let mut wrong_domain = b"xx-sso-attr".to_vec();
         wrong_domain.extend_from_slice(
-            &encode_sso_attr_bundle("idp", "https://a.com", 1)[SSO_ATTR_BUNDLE_DOMAIN.len()..],
+            &encode_sso_attr_bundle("idp", "https://a.com", 1, 2)[SSO_ATTR_BUNDLE_DOMAIN.len()..],
         );
         assert_eq!(
             decode_sso_attr_bundle(&wrong_domain),
@@ -281,7 +310,7 @@ mod tests {
 
     #[test]
     fn rejects_trailing_bytes() {
-        let mut encoded = encode_sso_attr_bundle("idp", "https://a.com", 1);
+        let mut encoded = encode_sso_attr_bundle("idp", "https://a.com", 1, 2);
         encoded.push(0);
         assert_eq!(
             decode_sso_attr_bundle(&encoded),
@@ -291,7 +320,7 @@ mod tests {
 
     #[test]
     fn rejects_truncated_field() {
-        let encoded = encode_sso_attr_bundle("idp", "https://a.com", 1);
+        let encoded = encode_sso_attr_bundle("idp", "https://a.com", 1, 2);
         let truncated = &encoded[..encoded.len() - 1];
         assert_eq!(
             decode_sso_attr_bundle(truncated),
@@ -337,9 +366,23 @@ mod tests {
         write_field(&mut buf, b"idp");
         write_field(&mut buf, b"https://a.com");
         write_field(&mut buf, &[0, 0, 0, 1]);
+        write_field(&mut buf, &0u64.to_be_bytes());
         assert_eq!(
             decode_sso_attr_bundle(&buf),
             Err(SsoBundleDecodeError::BadExpiryWidth)
+        );
+    }
+
+    #[test]
+    fn rejects_bad_session_expiry_width() {
+        let mut buf = SSO_ATTR_BUNDLE_DOMAIN.to_vec();
+        write_field(&mut buf, b"idp");
+        write_field(&mut buf, b"https://a.com");
+        write_field(&mut buf, &0u64.to_be_bytes());
+        write_field(&mut buf, &[0, 0, 0, 1]);
+        assert_eq!(
+            decode_sso_attr_bundle(&buf),
+            Err(SsoBundleDecodeError::BadSessionExpiryWidth)
         );
     }
 
@@ -348,6 +391,7 @@ mod tests {
         let mut buf = SSO_ATTR_BUNDLE_DOMAIN.to_vec();
         write_field(&mut buf, &[0xff, 0xfe]);
         write_field(&mut buf, b"https://a.com");
+        write_field(&mut buf, &0u64.to_be_bytes());
         write_field(&mut buf, &0u64.to_be_bytes());
         assert_eq!(
             decode_sso_attr_bundle(&buf),
@@ -360,6 +404,7 @@ mod tests {
         let mut buf = SSO_ATTR_BUNDLE_DOMAIN.to_vec();
         write_field(&mut buf, b"idp");
         write_field(&mut buf, &[0xff, 0xfe]);
+        write_field(&mut buf, &0u64.to_be_bytes());
         write_field(&mut buf, &0u64.to_be_bytes());
         assert_eq!(
             decode_sso_attr_bundle(&buf),

--- a/src/internet_identity/src/openid/sso_gating.rs
+++ b/src/internet_identity/src/openid/sso_gating.rs
@@ -35,6 +35,9 @@ pub struct VerifiedSsoLogin {
     pub stable_identifier_claim: String,
     /// The cross-client-stable identifier; `None` when the claim is `sub`.
     pub stable_id: Option<String>,
+    /// The org's session length in nanoseconds, captured here while the
+    /// discovery cache is warm so later paths never have to re-read it.
+    pub session_max_age_ns: u64,
 }
 
 impl VerifiedSsoLogin {
@@ -95,6 +98,7 @@ pub fn verify_sso_jwt(
         credential,
         ii_client_id: discovery_config.client_id,
         stable_identifier_claim: discovery_config.stable_identifier_claim,
+        session_max_age_ns: discovery_config.session_max_age_ns,
     }))
 }
 
@@ -365,6 +369,7 @@ mod tests {
             ii_client_id: ii_client_id.to_string(),
             stable_identifier_claim: claim.to_string(),
             stable_id: stable_id.map(str::to_string),
+            session_max_age_ns: sso::DEFAULT_SESSION_MAX_AGE_NS,
         }
     }
 

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -1603,8 +1603,22 @@ mod sso_gating {
 
     /// Assemble the well-known (`app_clients` map JSON, gate flag, stable claim).
     fn well_known(app_clients_json: &str, gate_all_apps: bool, stable_claim: &str) -> String {
+        well_known_with_session_max_age(app_clients_json, gate_all_apps, stable_claim, None)
+    }
+
+    /// Like [`well_known`] but declares `session_max_age_seconds`. `None` omits
+    /// the field, so the canister's eight-hour default applies.
+    fn well_known_with_session_max_age(
+        app_clients_json: &str,
+        gate_all_apps: bool,
+        stable_claim: &str,
+        session_max_age_seconds: Option<u64>,
+    ) -> String {
+        let session_max_age = session_max_age_seconds
+            .map(|seconds| format!(r#","session_max_age_seconds":{seconds}"#))
+            .unwrap_or_default();
         format!(
-            r#"{{"client_id":"{II_CLIENT}","openid_configuration":"{GATE_ISSUER}/.well-known/openid-configuration","name":"Gate","app_clients":{app_clients_json},"gate_all_apps":{gate_all_apps},"stable_identifier_claim":"{stable_claim}"}}"#
+            r#"{{"client_id":"{II_CLIENT}","openid_configuration":"{GATE_ISSUER}/.well-known/openid-configuration","name":"Gate","app_clients":{app_clients_json},"gate_all_apps":{gate_all_apps},"stable_identifier_claim":"{stable_claim}"{session_max_age}}}"#
         )
     }
 
@@ -2938,6 +2952,110 @@ mod sso_gating {
         assert!(
             with_bundle.iter().any(|(k, _)| *k == sso_email_key),
             "an SSO session with a certified bundle must be offered sso:<domain> rows, got {with_bundle:?}"
+        );
+        Ok(())
+    }
+
+    /// Reads `sso:<domain>:expires_at_timestamp_ns` out of a certified bundle.
+    fn session_expiry_from_message(message: &[u8]) -> u64 {
+        use candid::Decode;
+        use internet_identity_interface::internet_identity::types::icrc3::Icrc3Value;
+        let key = format!("sso:{GATE_DOMAIN}:expires_at_timestamp_ns");
+        let value: Icrc3Value =
+            candid::Decode!(message, Icrc3Value).expect("failed to decode ICRC-3 value");
+        let Icrc3Value::Map(entries) = value else {
+            panic!("expected a map, got {value:?}");
+        };
+        let (_, expiry) = entries
+            .iter()
+            .find(|(k, _)| *k == key)
+            .unwrap_or_else(|| panic!("expected {key} in {entries:?}"));
+        match expiry {
+            Icrc3Value::Nat(nat) => u64::try_from(nat.0.clone()).expect("expiry fits in u64"),
+            other => panic!("expected {key} to be a Nat, got {other:?}"),
+        }
+    }
+
+    /// The certified bundle carries the domain's session deadline, and it is the
+    /// org's value rather than the bundle's own five-minute freshness window.
+    #[test]
+    fn sso_attributes_carry_the_domains_session_deadline() -> Result<(), RejectResponse> {
+        const SESSION_MAX_AGE_SECONDS: u64 = 15 * 60;
+        let env = env();
+        let canister_id = install(&env);
+        let (ii_client_jwt, jwks) = token(II_CLIENT, II_CLIENT_SUB, &[]);
+        let app_clients = format!(r#"{{"{GATED_ORIGIN}":"{PER_APP_CLIENT}"}}"#);
+        let responses = responses(
+            well_known_with_session_max_age(
+                &app_clients,
+                false,
+                "sub",
+                Some(SESSION_MAX_AGE_SECONDS),
+            ),
+            jwks,
+        );
+
+        // The deadline is stamped from the ceremony's clock, so bracket it.
+        let before_ns = env.get_time().as_nanos_since_unix_epoch();
+        let (identity_number, bundle) = gated_bundle(&env, canister_id, &responses, &ii_client_jwt);
+        let after_ns = env.get_time().as_nanos_since_unix_epoch();
+
+        let prepared = api::prepare_icrc3_attributes_with_bundle(
+            &env,
+            canister_id,
+            test_principal(),
+            sso_attr_request(identity_number, GATED_ORIGIN),
+            &bundle,
+            canister_id,
+        )?
+        .expect("prepare_icrc3_attributes succeeds");
+
+        let expiry = session_expiry_from_message(&prepared.message);
+        let max_age_ns = SESSION_MAX_AGE_SECONDS * 1_000_000_000;
+        assert!(
+            expiry >= before_ns + max_age_ns && expiry <= after_ns + max_age_ns,
+            "expected a deadline {max_age_ns}ns after the ceremony (between {} and {}), got {expiry}",
+            before_ns + max_age_ns,
+            after_ns + max_age_ns
+        );
+        // Distinct from the bundle's own freshness window, which is five minutes.
+        assert!(
+            expiry > after_ns + 5 * 60 * 1_000_000_000,
+            "the session deadline must outlive the bundle's freshness window, got {expiry}"
+        );
+        Ok(())
+    }
+
+    /// A domain that declares no `session_max_age_seconds` gets the eight-hour default.
+    #[test]
+    fn sso_attributes_default_to_an_eight_hour_session() -> Result<(), RejectResponse> {
+        let env = env();
+        let canister_id = install(&env);
+        let (ii_client_jwt, jwks) = token(II_CLIENT, II_CLIENT_SUB, &[]);
+        let app_clients = format!(r#"{{"{GATED_ORIGIN}":"{PER_APP_CLIENT}"}}"#);
+        let responses = responses(well_known(&app_clients, false, "sub"), jwks);
+
+        let before_ns = env.get_time().as_nanos_since_unix_epoch();
+        let (identity_number, bundle) = gated_bundle(&env, canister_id, &responses, &ii_client_jwt);
+        let after_ns = env.get_time().as_nanos_since_unix_epoch();
+
+        let prepared = api::prepare_icrc3_attributes_with_bundle(
+            &env,
+            canister_id,
+            test_principal(),
+            sso_attr_request(identity_number, GATED_ORIGIN),
+            &bundle,
+            canister_id,
+        )?
+        .expect("prepare_icrc3_attributes succeeds");
+
+        let expiry = session_expiry_from_message(&prepared.message);
+        let eight_hours_ns = 8 * 60 * 60 * 1_000_000_000;
+        assert!(
+            expiry >= before_ns + eight_hours_ns && expiry <= after_ns + eight_hours_ns,
+            "expected the eight-hour default (between {} and {}), got {expiry}",
+            before_ns + eight_hours_ns,
+            after_ns + eight_hours_ns
         );
         Ok(())
     }


### PR DESCRIPTION
Stacked on #4188.

# Motivation

The organization's deadline has to reach the relying party that consumes the user's SSO attributes. The ICRC-3 bundle carries an issued-at and nothing else today, so a canister has no basis to decide when the organization's claims about a user stop being true.

# Changes

- `VerifiedSsoLogin` carries the resolved policy, and `sso_prepare_delegation` computes `session_expiry_ns` once, at the ceremony. That is deliberate: it is the only point with a warm discovery cache, so an evicted entry or a refreshed policy can never move a live session's deadline.
- The internal SSO bundle gains a fourth length-prefixed field carrying that deadline, so attribute certification never re-reads the cache. Its own five-minute `SSO_ATTR_BUNDLE_TTL_NS` is untouched: marking a ceremony as fresh is a different question from when the session ends.
- Attribute certification stamps `sso:<domain>:expires_at_timestamp_ns` as a `Nat` when the bundle carries an attribute for that domain.

The key is scoped to the domain whose policy set it rather than living under `implicit:`, because one bundle can carry attributes from several scopes with different lifetimes and a verifier must enforce the deadline belonging to the scope it reads. It cannot be requested, only stamped: `AttributeName` accepts `email`, `name` and `verified_email` only, so a request for it fails validation, and `list_available_attributes` iterates `AttributeName::all()` and won't list it.

**This is fail-open until verifiers check it.** This PR only signs the deadline. `mo:identity-attributes` and any hand-rolled verifier need to reject a bundle whose deadline has passed, and only once II always stamps it can a missing key be treated as invalid rather than as an older II.

# Tests

- New unit tests for the stamping decision: the scoped key, a bundle with no attribute for that domain, two SSO domains in one bundle, and non-SSO sessions. The success path of `prepare_icrc3_attributes` needs canister salt, so the decision is tested through an extracted helper, matching how the existing ICRC-3 tests in that module are structured.
- New round-trip and malformed-field coverage for the bundle's added field.
- `cargo test -p internet_identity --lib --bins`: 667 pass. `cargo clippy -p internet_identity --all-targets`: clean.
- Integration tests were not run locally. The one exact-count assertion on a bundle (`entries.len(), 5`) is a non-SSO session, so the new key is not added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)