### PR TITLE
feat(fe): silent re-issue of delegations via ?prompt= and ?hint=

### DIFF
--- a/src/frontend/src/lib/stores/app-delegation.store.test.ts
+++ b/src/frontend/src/lib/stores/app-delegation.store.test.ts
@@ -1,0 +1,170 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { IDBFactory } from "fake-indexeddb";
+import { createStore as idbCreateStore, clear as idbClear } from "idb-keyval";
+import { ECDSAKeyIdentity } from "@icp-sdk/core/identity";
+import {
+  type AppDelegationRecord,
+  appDelegationsForOrigin,
+  discardAppDelegation,
+  forgetAppDelegations,
+  purgeAppDelegations,
+  storeAppDelegation,
+} from "./app-delegation.store";
+
+const NOW = 1_700_000_000_000;
+const FAR_FUTURE = NOW + 60 * 60 * 1000;
+// Inside the 5 minute margin, so treated as already expired.
+const NEAR_EXPIRY = NOW + 4 * 60 * 1000;
+
+const ORIGIN = "https://docs.example.com";
+const OTHER_ORIGIN = "https://chat.example.com";
+const IDENTITY = BigInt(42);
+const OTHER_IDENTITY = BigInt(43);
+
+const TEST_STORE = idbCreateStore("ii-app-delegations", "origins");
+
+let keyPair: CryptoKeyPair;
+
+const record = (
+  principal: string,
+  overrides: Partial<AppDelegationRecord> = {},
+): AppDelegationRecord => ({
+  principal,
+  identityNumber: IDENTITY,
+  keyPair,
+  chainJson: "{}",
+  expiresAtMillis: FAR_FUTURE,
+  ...overrides,
+});
+
+const principalsFor = async (origin: string): Promise<string[]> =>
+  (await appDelegationsForOrigin(origin)).map(({ principal }) => principal);
+
+beforeAll(async () => {
+  global.indexedDB = new IDBFactory();
+  keyPair = (
+    await ECDSAKeyIdentity.generate({ extractable: false })
+  ).getKeyPair();
+});
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  await idbClear(TEST_STORE);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("appDelegationsForOrigin", () => {
+  it("round-trips a record", async () => {
+    await storeAppDelegation(ORIGIN, record("aaaaa-aa"));
+
+    const [stored] = await appDelegationsForOrigin(ORIGIN);
+    expect(stored.principal).toBe("aaaaa-aa");
+    // The non-extractable key pair has to survive structured clone, which is the
+    // whole reason a record can be stored at all.
+    expect(stored.keyPair.privateKey.extractable).toBe(false);
+  });
+
+  it("keeps origins apart", async () => {
+    await storeAppDelegation(ORIGIN, record("aaaaa-aa"));
+
+    expect(await principalsFor(OTHER_ORIGIN)).toEqual([]);
+  });
+
+  it("holds several records for one origin", async () => {
+    await storeAppDelegation(ORIGIN, record("aaaaa-aa"));
+    await storeAppDelegation(
+      ORIGIN,
+      record("bbbbb-bb", { identityNumber: OTHER_IDENTITY }),
+    );
+
+    expect(await principalsFor(ORIGIN)).toEqual(["aaaaa-aa", "bbbbb-bb"]);
+  });
+
+  it("replaces an earlier record for the same principal", async () => {
+    await storeAppDelegation(ORIGIN, record("aaaaa-aa", { chainJson: "old" }));
+    await storeAppDelegation(ORIGIN, record("aaaaa-aa", { chainJson: "new" }));
+
+    const stored = await appDelegationsForOrigin(ORIGIN);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].chainJson).toBe("new");
+  });
+
+  it("withholds a record inside the expiry margin", async () => {
+    await storeAppDelegation(
+      ORIGIN,
+      record("aaaaa-aa", { expiresAtMillis: NEAR_EXPIRY }),
+    );
+
+    // Still nominally valid, but too close to expiry to hand out: it could die
+    // between here and the IC validating it.
+    expect(await principalsFor(ORIGIN)).toEqual([]);
+  });
+
+  it("keeps usable records when dropping expired ones", async () => {
+    await storeAppDelegation(
+      ORIGIN,
+      record("aaaaa-aa", { expiresAtMillis: NEAR_EXPIRY }),
+    );
+    await storeAppDelegation(ORIGIN, record("bbbbb-bb"));
+
+    expect(await principalsFor(ORIGIN)).toEqual(["bbbbb-bb"]);
+  });
+});
+
+describe("forgetting and purging", () => {
+  it("forgets every record for one origin and no others", async () => {
+    await storeAppDelegation(ORIGIN, record("aaaaa-aa"));
+    await storeAppDelegation(
+      ORIGIN,
+      record("bbbbb-bb", { identityNumber: OTHER_IDENTITY }),
+    );
+    await storeAppDelegation(OTHER_ORIGIN, record("ccccc-cc"));
+
+    await forgetAppDelegations(ORIGIN);
+
+    expect(await principalsFor(ORIGIN)).toEqual([]);
+    expect(await principalsFor(OTHER_ORIGIN)).toEqual(["ccccc-cc"]);
+  });
+
+  it("discards one record and leaves its neighbours", async () => {
+    await storeAppDelegation(ORIGIN, record("aaaaa-aa"));
+    await storeAppDelegation(
+      ORIGIN,
+      record("bbbbb-bb", { identityNumber: OTHER_IDENTITY }),
+    );
+
+    await discardAppDelegation(ORIGIN, "aaaaa-aa");
+
+    expect(await principalsFor(ORIGIN)).toEqual(["bbbbb-bb"]);
+  });
+
+  it("purges an identity across every origin, sparing the others", async () => {
+    await storeAppDelegation(ORIGIN, record("aaaaa-aa"));
+    await storeAppDelegation(
+      ORIGIN,
+      record("bbbbb-bb", { identityNumber: OTHER_IDENTITY }),
+    );
+    await storeAppDelegation(OTHER_ORIGIN, record("ccccc-cc"));
+
+    await purgeAppDelegations(IDENTITY);
+
+    expect(await principalsFor(ORIGIN)).toEqual(["bbbbb-bb"]);
+    expect(await principalsFor(OTHER_ORIGIN)).toEqual([]);
+  });
+
+  it("forgets an origin it holds nothing for without complaint", async () => {
+    await expect(forgetAppDelegations(ORIGIN)).resolves.toBeUndefined();
+  });
+});

--- a/src/frontend/src/lib/stores/app-delegation.store.ts
+++ b/src/frontend/src/lib/stores/app-delegation.store.ts
@@ -1,0 +1,175 @@
+import {
+  createStore,
+  del as idbDel,
+  entries as idbEntries,
+  get as idbGet,
+  set as idbSet,
+} from "idb-keyval";
+
+/**
+ * A delegation for one app, held by this frontend so the app can be signed in
+ * again without a passkey ceremony.
+ *
+ * `chainJson` is canister-signed and delegates to `keyPair`, which is
+ * non-extractable and never leaves IndexedDB. Neither half is usable alone: the
+ * chain reaches the certified state of the subnet and so must be inert on its
+ * own (the same reason the ICRC-167 transport delegates to an ephemeral key
+ * rather than the app's), and the key pair signs nothing the chain does not
+ * already authorize.
+ *
+ * A record therefore grants exactly one capability: extending its own chain to
+ * an app-supplied session key, for the origin and account it was minted for,
+ * until `expiresAtMillis`. That is the same window the app's own copy of the
+ * delegation is valid for, so holding it lets an attacker with this browser
+ * profile do nothing they could not already do.
+ */
+export interface AppDelegationRecord {
+  /** The principal the app sees, derived from the chain's public key. Identifies
+   *  a record within its origin, and is what `?hint=` carries. */
+  principal: string;
+  identityNumber: bigint;
+  accountNumber?: bigint;
+  keyPair: CryptoKeyPair;
+  chainJson: string;
+  expiresAtMillis: number;
+}
+
+// Keyed by effective origin, because that is how every request reads it: the
+// delegation handler asks "what do I hold for this origin?" on each authorize,
+// and a `?hint=` only picks between the answers. `idb-keyval` has no secondary
+// indexes, so anything not in the key costs a full scan — which is why the
+// identity purge below is the one operation that pays for one, on sign-out
+// rather than on sign-in.
+//
+// An origin holds more than one record only when the user has signed in there
+// under more than one identity or account, so these lists are short.
+const APP_DELEGATION_STORE = createStore("ii-app-delegations", "origins");
+
+// Treat the last 5 minutes of a delegation's lifetime as already expired, for
+// the same reason the session delegation store does: a record that is "valid"
+// at this check can still expire between here and IC validation (network
+// latency, ingress queue, clock skew). Better to fall through to a ceremony
+// than to hand an app a delegation that dies on its first call.
+const EXPIRY_MARGIN_MS = 5 * 60 * 1000;
+
+const isUsable = (record: AppDelegationRecord): boolean =>
+  record.expiresAtMillis - EXPIRY_MARGIN_MS > Date.now();
+
+const read = async (origin: string): Promise<AppDelegationRecord[]> => {
+  try {
+    return (
+      (await idbGet<AppDelegationRecord[]>(origin, APP_DELEGATION_STORE)) ?? []
+    );
+  } catch {
+    return [];
+  }
+};
+
+/** Writes an origin's records, or removes the entry when none are left, so an
+ *  emptied origin leaves nothing behind. */
+const write = async (
+  origin: string,
+  records: AppDelegationRecord[],
+): Promise<void> => {
+  try {
+    if (records.length === 0) {
+      await idbDel(origin, APP_DELEGATION_STORE);
+      return;
+    }
+    await idbSet(origin, records, APP_DELEGATION_STORE);
+  } catch {
+    // Nothing here is load-bearing: a record that cannot be written costs a
+    // passkey next time, and one that cannot be removed is still ignored by
+    // every read that finds it expired.
+  }
+};
+
+/**
+ * Stores a record, replacing any earlier one for the same principal.
+ *
+ * Best effort: a failure (private browsing, quota, a browser that refuses to
+ * structured-clone a `CryptoKeyPair`) costs the user nothing beyond a passkey
+ * next time, so it must never fail the sign-in it was minted during.
+ */
+export const storeAppDelegation = async (
+  origin: string,
+  record: AppDelegationRecord,
+): Promise<void> => {
+  const others = (await read(origin)).filter(
+    (existing) => existing.principal !== record.principal && isUsable(existing),
+  );
+  await write(origin, [...others, record]);
+};
+
+/** Every usable record for an origin, expired ones dropped on the way past. */
+export const appDelegationsForOrigin = async (
+  origin: string,
+): Promise<AppDelegationRecord[]> => {
+  const records = await read(origin);
+  const usable = records.filter(isUsable);
+  if (usable.length !== records.length) {
+    await write(origin, usable);
+  }
+  return usable;
+};
+
+/** Drops one record, for when it turns out not to have survived storage. */
+export const discardAppDelegation = async (
+  origin: string,
+  principal: string,
+): Promise<void> => {
+  const records = await read(origin);
+  await write(
+    origin,
+    records.filter((record) => record.principal !== principal),
+  );
+};
+
+/**
+ * Forgets every record for an origin, so the next request there needs a
+ * ceremony.
+ *
+ * Wipes the whole origin rather than one principal because a user is only ever
+ * signed in to an app as one account at a time, so the others are stale by
+ * definition. Nothing here touches the delegation the app itself is holding,
+ * which stays valid until it expires and is the app's own to clear.
+ */
+export const forgetAppDelegations = async (origin: string): Promise<void> => {
+  try {
+    await idbDel(origin, APP_DELEGATION_STORE);
+  } catch {
+    // Left for the expiry check to deal with.
+  }
+};
+
+/**
+ * Forgets every record belonging to an identity, across all origins. Called
+ * wherever an identity is signed out of or removed from this device.
+ *
+ * The only operation that scans, because an identity spans origins and the
+ * origin is the key. It runs on sign-out, never on sign-in.
+ */
+export const purgeAppDelegations = async (
+  identityNumber: bigint,
+): Promise<void> => {
+  let stored: [string, AppDelegationRecord[]][];
+  try {
+    stored = await idbEntries<string, AppDelegationRecord[]>(
+      APP_DELEGATION_STORE,
+    );
+  } catch {
+    return;
+  }
+  await Promise.all(
+    stored
+      .filter(([, records]) =>
+        records.some((record) => record.identityNumber === identityNumber),
+      )
+      .map(([origin, records]) =>
+        write(
+          origin,
+          records.filter((record) => record.identityNumber !== identityNumber),
+        ),
+      ),
+  );
+};

--- a/src/frontend/src/lib/stores/authorization.store.ts
+++ b/src/frontend/src/lib/stores/authorization.store.ts
@@ -41,7 +41,12 @@ export type Authorized = {
  *  and the sign-in screen stays where a user can switch identity or account.
  *  Room is left for an `auto` value meaning "re-issue when unambiguous,
  *  otherwise show the sign-in screen". Unrecognised values are ignored and
- *  behave as absent. */
+ *  behave as absent.
+ *
+ *  Sending the param at all is also what opts an app into having its delegation
+ *  kept for re-issue: an app that has never heard of `prompt` cannot call
+ *  `ii-forget-delegation` either, so keeping one for it would leave something
+ *  nothing clears until it expires. */
 export type AuthorizationPrompt = "none" | "login";
 
 export type AuthorizationPromptContext = {

--- a/src/frontend/src/lib/stores/authorization.store.ts
+++ b/src/frontend/src/lib/stores/authorization.store.ts
@@ -35,11 +35,13 @@ export type Authorized = {
  *
  *  - `none`: answer from a cached delegation or fail; never show the user
  *    anything. The app is promising it can handle the failure.
- *  - `login`: ignore any cached delegation and run a full ceremony.
+ *  - `login`: run a full ceremony, ignoring any cached delegation.
  *
- *  Absent means "do the best you can": re-issue silently when that is
- *  unambiguous, otherwise sign in interactively. Unrecognised values are
- *  ignored and behave as absent. */
+ *  Absent behaves as `login`, so an app that has not opted in sees no change
+ *  and the sign-in screen stays where a user can switch identity or account.
+ *  Room is left for an `auto` value meaning "re-issue when unambiguous,
+ *  otherwise show the sign-in screen". Unrecognised values are ignored and
+ *  behave as absent. */
 export type AuthorizationPrompt = "none" | "login";
 
 export type AuthorizationPromptContext = {

--- a/src/frontend/src/lib/stores/authorization.store.ts
+++ b/src/frontend/src/lib/stores/authorization.store.ts
@@ -30,8 +30,43 @@ export type Authorized = {
   maxTimeToLive?: bigint;
 };
 
+/** What the app asked for about the sign-in itself, via `/authorize` query
+ *  params. Inspired by OpenID Connect's `prompt` and `login_hint`.
+ *
+ *  - `none`: answer from a cached delegation or fail; never show the user
+ *    anything. The app is promising it can handle the failure.
+ *  - `login`: ignore any cached delegation and run a full ceremony.
+ *
+ *  Absent means "do the best you can": re-issue silently when that is
+ *  unambiguous, otherwise sign in interactively. Unrecognised values are
+ *  ignored and behave as absent. */
+export type AuthorizationPrompt = "none" | "login";
+
+export type AuthorizationPromptContext = {
+  prompt?: AuthorizationPrompt;
+  /** The principal the app last received, identifying which cached delegation
+   *  to re-issue when the user has more than one to choose from. */
+  hint?: string;
+};
+
 const contextInternal = writable<AuthorizationContext | undefined>();
+const promptInternal = writable<AuthorizationPromptContext>({});
 const authorizedInternal = writable<Authorized | undefined>();
+
+/**
+ * Kept separate from {@link AuthorizationContext} rather than folded into it,
+ * for two reasons. It is populated from the page URL before any request
+ * arrives, whereas the context describes a parsed request, and the authorize
+ * layout gates rendering on the context existing at all. Writing URL state into
+ * the context would make the sign-in UI paint before there is a request to
+ * answer.
+ */
+export const authorizationPromptStore = {
+  subscribe: promptInternal.subscribe,
+  /** Called once by the authorize layout, from the page URL. */
+  set: (context: AuthorizationPromptContext): void =>
+    promptInternal.set(context),
+};
 
 export const authorizationStore = {
   /** Called by the channel handler once the delegation request is parsed.

--- a/src/frontend/src/lib/stores/channelHandlers/attributes.test.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/attributes.test.ts
@@ -1,4 +1,11 @@
-import { resolveAttributeGroups } from "./attributes";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Channel, JsonResponse } from "$lib/utils/transport/utils";
+import { INTERACTION_REQUIRED_ERROR_CODE } from "$lib/utils/transport/utils";
+import { authorizationPromptStore } from "$lib/stores/authorization.store";
+import {
+  handleIcrc3ConsentAttributes,
+  resolveAttributeGroups,
+} from "./attributes";
 
 const GOOGLE_ISSUER = "https://accounts.google.com";
 const APPLE_ISSUER = "https://appleid.apple.com";
@@ -407,5 +414,66 @@ describe("resolveAttributeGroups", () => {
       expect(groups[0].options[0].displayValue).toBe("plain");
       expect(arrayOf(groups[0].options[0].rawValue)).toEqual(arrayOf(utf8));
     });
+  });
+});
+
+describe("handleIcrc3ConsentAttributes under ?prompt=none", () => {
+  const APP_ORIGIN = "https://docs.example.com";
+
+  const channel = (): Channel & { sent: JsonResponse[] } => {
+    const sent: JsonResponse[] = [];
+    const addEventListener: Channel["addEventListener"] = () => () => {};
+    return {
+      sent,
+      origin: APP_ORIGIN,
+      closed: false,
+      resumeToken: "test-resume-token",
+      addEventListener,
+      send: (response: JsonResponse) => {
+        sent.push(response);
+        return Promise.resolve();
+      },
+      close: () => Promise.resolve(),
+    };
+  };
+
+  const attributesRequest = {
+    jsonrpc: "2.0" as const,
+    id: 1,
+    method: "ii-icrc3-attributes",
+    params: { keys: ["email"], nonce: "AAAA" },
+  };
+
+  afterEach(() => {
+    authorizationPromptStore.set({});
+  });
+
+  it("errors instead of waiting for a consent that will never be asked for", async () => {
+    // The canister certifies attributes over the app's per-request nonce, so
+    // nothing cached can answer this. Left to block, a batched delegation on the
+    // redirect transport would never be delivered and the user would sit on
+    // Internet Identity — exactly what prompt=none rules out.
+    authorizationPromptStore.set({ prompt: "none" });
+    const c = channel();
+
+    await handleIcrc3ConsentAttributes(c, () => {})(attributesRequest);
+
+    expect(c.sent).toHaveLength(1);
+    expect(c.sent[0]).toMatchObject({
+      error: {
+        code: INTERACTION_REQUIRED_ERROR_CODE,
+        data: { reason: "consent_required" },
+      },
+    });
+  });
+
+  it("does not short-circuit a request that may show the consent screen", async () => {
+    const c = channel();
+
+    void handleIcrc3ConsentAttributes(c, () => {})(attributesRequest);
+    await Promise.resolve();
+
+    // Still pending: it waits for the flow and the user, as it always has.
+    expect(c.sent).toEqual([]);
   });
 });

--- a/src/frontend/src/lib/stores/channelHandlers/attributes.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/attributes.ts
@@ -2,6 +2,7 @@ import type { Channel, JsonRequest } from "$lib/utils/transport/utils";
 import {
   AttributesParamsSchema,
   Icrc3AttributesParamsSchema,
+  INTERACTION_REQUIRED_ERROR_CODE,
   INVALID_PARAMS_ERROR_CODE,
 } from "$lib/utils/transport/utils";
 import { frontendCanisterConfig } from "$lib/globals";
@@ -14,6 +15,7 @@ import {
 } from "$lib/stores/authentication.store";
 import {
   type Authorized,
+  authorizationPromptStore,
   authorizationStore,
   authorizedStore,
 } from "$lib/stores/authorization.store";
@@ -27,6 +29,7 @@ import {
   attributeConsentResultStore,
   attributeConsentStore,
 } from "$lib/stores/attributeConsent.store";
+import { get } from "svelte/store";
 
 /** Extract the attribute name from a fully scoped key.
  *  e.g., "openid:https://accounts.google.com:email" → "email" */
@@ -641,6 +644,26 @@ export const handleIcrc3ConsentAttributes =
         error: {
           code: INVALID_PARAMS_ERROR_CODE,
           message: z.prettifyError(paramsResult.error),
+        },
+      });
+      return;
+    }
+
+    // Attributes are certified by the canister over a nonce the app picks per
+    // request, so there is nothing cached that could answer this without the
+    // user. Under `?prompt=none` every path below would block on authorization
+    // that is never going to happen, and on the redirect transport a batch that
+    // never completes leaves the user parked on Internet Identity — the one
+    // outcome `prompt=none` promises to avoid. Fail fast instead, and let the app
+    // come back interactively for attributes.
+    if (get(authorizationPromptStore).prompt === "none") {
+      await channel.send({
+        jsonrpc: "2.0",
+        id: requestId,
+        error: {
+          code: INTERACTION_REQUIRED_ERROR_CODE,
+          message: "Interaction required",
+          data: { reason: "consent_required" },
         },
       });
       return;

--- a/src/frontend/src/lib/stores/channelHandlers/delegation.test.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/delegation.test.ts
@@ -1,0 +1,179 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  Delegation,
+  DelegationChain,
+  ECDSAKeyIdentity,
+} from "@icp-sdk/core/identity";
+import type { Signature } from "@icp-sdk/core/agent";
+import { DelegationResultSchema } from "$lib/utils/transport/utils";
+import type { AppDelegationRecord } from "$lib/stores/app-delegation.store";
+import { chooseSilentDelegation } from "./delegation";
+
+const IDENTITY = BigInt(42);
+const OTHER_IDENTITY = BigInt(43);
+const EXPIRES_AT = Date.now() + 60 * 60 * 1000;
+
+let keyPair: CryptoKeyPair;
+
+beforeAll(async () => {
+  keyPair = (
+    await ECDSAKeyIdentity.generate({ extractable: false })
+  ).getKeyPair();
+});
+
+const record = (
+  principal: string,
+  identityNumber = IDENTITY,
+): AppDelegationRecord => ({
+  principal,
+  identityNumber,
+  keyPair,
+  chainJson: "{}",
+  expiresAtMillis: EXPIRES_AT,
+});
+
+const never = () => false;
+const always = () => true;
+
+describe("chooseSilentDelegation", () => {
+  it("re-issues for a single identity with the accounts toggle off", () => {
+    const only = record("aaaaa-aa");
+    expect(
+      chooseSilentDelegation({
+        records: [only],
+        hint: undefined,
+        identityCount: 1,
+        isMultipleAccountsEnabled: never,
+      }),
+    ).toEqual({ record: only });
+  });
+
+  it("needs a sign-in when nothing is stored for the origin", () => {
+    expect(
+      chooseSilentDelegation({
+        records: [],
+        hint: undefined,
+        identityCount: 1,
+        isMultipleAccountsEnabled: never,
+      }),
+    ).toEqual({ denial: "login_required" });
+  });
+
+  it("needs a sign-in when a hint names a principal it does not hold", () => {
+    // Not `account_selection_required`: the app named an identity there is
+    // nothing stored for, so no choice would help.
+    expect(
+      chooseSilentDelegation({
+        records: [record("aaaaa-aa")],
+        hint: "bbbbb-bb",
+        identityCount: 1,
+        isMultipleAccountsEnabled: never,
+      }),
+    ).toEqual({ denial: "login_required" });
+  });
+
+  it("asks the user to choose when the device knows several identities", () => {
+    expect(
+      chooseSilentDelegation({
+        records: [record("aaaaa-aa")],
+        hint: undefined,
+        identityCount: 2,
+        isMultipleAccountsEnabled: never,
+      }),
+    ).toEqual({ denial: "account_selection_required" });
+  });
+
+  it("asks the user to choose when the origin holds several delegations", () => {
+    expect(
+      chooseSilentDelegation({
+        records: [record("aaaaa-aa"), record("bbbbb-bb", OTHER_IDENTITY)],
+        hint: undefined,
+        identityCount: 1,
+        isMultipleAccountsEnabled: never,
+      }),
+    ).toEqual({ denial: "account_selection_required" });
+  });
+
+  it("asks the user to choose when they picked accounts per sign-in", () => {
+    expect(
+      chooseSilentDelegation({
+        records: [record("aaaaa-aa")],
+        hint: undefined,
+        identityCount: 1,
+        isMultipleAccountsEnabled: always,
+      }),
+    ).toEqual({ denial: "account_selection_required" });
+  });
+
+  it("re-issues on a matching hint despite every ambiguity", () => {
+    // A principal names an identity and an account together, so it answers both
+    // questions the guards above are asking.
+    const wanted = record("bbbbb-bb", OTHER_IDENTITY);
+    expect(
+      chooseSilentDelegation({
+        records: [record("aaaaa-aa"), wanted],
+        hint: "bbbbb-bb",
+        identityCount: 3,
+        isMultipleAccountsEnabled: always,
+      }),
+    ).toEqual({ record: wanted });
+  });
+});
+
+describe("extending a stored chain", () => {
+  const canisterChain = (permissions?: string): DelegationChain =>
+    DelegationChain.fromDelegations(
+      [
+        {
+          delegation: new Delegation(
+            new Uint8Array(32).fill(1),
+            BigInt(EXPIRES_AT) * BigInt(1_000_000),
+            undefined,
+            permissions,
+          ),
+          signature: new Uint8Array(64) as unknown as Signature,
+        },
+      ],
+      new Uint8Array(32).fill(2),
+    );
+
+  it("keeps a read-only restriction across storage and a local extension", async () => {
+    // The restriction lives in what the canister signed, so it has to survive
+    // both the JSON round-trip through IndexedDB and the second hop added here.
+    // If it did not, a re-issued delegation would silently grant more than the
+    // one the user approved, and would not verify against the canister's
+    // signature either.
+    const stored = JSON.stringify(canisterChain("queries").toJSON());
+    const key = await ECDSAKeyIdentity.generate({ extractable: false });
+
+    const extended = await DelegationChain.create(
+      key,
+      key.getPublicKey(),
+      new Date(EXPIRES_AT),
+      { previous: DelegationChain.fromJSON(JSON.parse(stored)) },
+    );
+
+    const encoded = DelegationResultSchema.encode(extended);
+    expect(encoded.signerDelegation).toHaveLength(2);
+    expect(encoded.signerDelegation[0].delegation).toMatchObject({
+      permissions: "queries",
+    });
+  });
+
+  it("does not outlive the delegation it extends", async () => {
+    const key = await ECDSAKeyIdentity.generate({ extractable: false });
+    const parent = canisterChain();
+
+    const extended = await DelegationChain.create(
+      key,
+      key.getPublicKey(),
+      new Date(EXPIRES_AT),
+      { previous: parent },
+    );
+
+    const [inner, outer] = extended.delegations;
+    expect(outer.delegation.expiration).toBeLessThanOrEqual(
+      inner.delegation.expiration,
+    );
+  });
+});

--- a/src/frontend/src/lib/stores/channelHandlers/delegation.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/delegation.ts
@@ -166,10 +166,16 @@ export const handleDelegationRequest =
 
         // Re-issue from a delegation this frontend already holds for the origin,
         // so an app that has signed in before does not spend another passkey.
-        // Deliberately ahead of `setRequestContext`: that is what makes the
-        // sign-in UI render, and a silent answer must not paint anything.
-        let denial: SilentDenial | undefined;
-        if (prompt !== "login") {
+        //
+        // Only when the app asks for it. An absent `prompt` runs the ceremony it
+        // always has, so nothing changes for an app that has not opted in, and
+        // the sign-in screen stays the place a user can switch identity or
+        // account. A future `auto` can mean "re-issue when unambiguous,
+        // otherwise show the sign-in screen".
+        //
+        // Ahead of `setRequestContext`, which is what makes the sign-in UI
+        // render: a silent answer must not paint anything.
+        if (prompt === "none") {
           const outcome = chooseSilentDelegation({
             records: await appDelegationsForOrigin(effectiveOrigin),
             hint,
@@ -177,6 +183,7 @@ export const handleDelegationRequest =
               .length,
             isMultipleAccountsEnabled: readMultipleAccountsToggle,
           });
+
           if ("record" in outcome) {
             try {
               const { keyPair, chainJson, expiresAtMillis } = outcome.record;
@@ -198,33 +205,30 @@ export const handleDelegationRequest =
               return;
             } catch (error) {
               // The record did not survive storage (its key pair or chain is
-              // unusable). Drop it and sign in the ordinary way rather than
-              // failing a request a ceremony can still answer.
+              // unusable). Drop it, and report it as nothing being stored,
+              // which is now true.
               console.error(error);
               await discardAppDelegation(
                 effectiveOrigin,
                 outcome.record.principal,
               );
-              denial = "login_required";
             }
-          } else {
-            denial = outcome.denial;
           }
-        }
 
-        if (prompt === "none") {
           // No `onError` here: it sets `channelErrorStore`, which renders the
           // channel-error view — the interstitial `prompt=none` exists to
           // promise the user will never be shown. Answering on the channel lets
           // the app close the popup, or the redirect return, and decide for
           // itself whether to escalate to an interactive request.
+          const reason: SilentDenial =
+            "record" in outcome ? "login_required" : outcome.denial;
           await channel.send({
             jsonrpc: "2.0",
             id: requestId,
             error: {
               code: INTERACTION_REQUIRED_ERROR_CODE,
               message: "Interaction required",
-              data: { reason: denial ?? "login_required" },
+              data: { reason },
             },
           });
           return;

--- a/src/frontend/src/lib/stores/channelHandlers/delegation.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/delegation.ts
@@ -3,15 +3,26 @@ import type { Channel, JsonRequest } from "$lib/utils/transport/utils";
 import {
   DelegationParamsCodec,
   DelegationResultSchema,
+  INTERACTION_REQUIRED_ERROR_CODE,
   INVALID_PARAMS_ERROR_CODE,
 } from "$lib/utils/transport/utils";
 import {
+  authorizationPromptStore,
   authorizationStore,
   authorizedStore,
 } from "$lib/stores/authorization.store";
+import {
+  type AppDelegationRecord,
+  appDelegationsForOrigin,
+  discardAppDelegation,
+  storeAppDelegation,
+} from "$lib/stores/app-delegation.store";
+import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
+import { readMultipleAccountsToggle } from "$lib/utils/multipleAccounts";
 import { validateDerivationOrigin } from "$lib/utils/validateDerivationOrigin";
 import { remapToLegacyDomain } from "$lib/utils/iiConnection";
-import { DelegationChain } from "@icp-sdk/core/identity";
+import { DelegationChain, ECDSAKeyIdentity } from "@icp-sdk/core/identity";
+import { Principal } from "@icp-sdk/core/principal";
 import {
   retryFor,
   throwCanisterError,
@@ -26,6 +37,67 @@ import {
   attributeConsentStore,
 } from "$lib/stores/attributeConsent.store";
 import { get } from "svelte/store";
+
+/** Why a delegation could not be re-issued without asking the user something.
+ *  Reported to the app as `data.reason`, and named after OpenID Connect's
+ *  equivalents since `?prompt=` borrows from it. */
+export type SilentDenial = "login_required" | "account_selection_required";
+
+type SilentOutcome = { record: AppDelegationRecord } | { denial: SilentDenial };
+
+/**
+ * Picks the delegation to re-issue with no user interaction, or explains why
+ * there isn't one.
+ *
+ * Only safe when there is exactly one delegation the user could have meant. Two
+ * things could be ambiguous, and a `hint` settles both at once because a
+ * principal identifies an identity and an account together.
+ *
+ * Ambiguity is judged from the identities this device knows, not from the stored
+ * records: the records only cover origins the user has already signed in to, so
+ * gating on them would silently sign someone in as their only cached identity
+ * when they have another they might have wanted. Accounts are judged from the
+ * multiple-accounts toggle rather than the account count, because with the
+ * toggle off Internet Identity never offers an account choice at all, so
+ * answering silently withholds nothing the user was being shown.
+ */
+export const chooseSilentDelegation = ({
+  records,
+  hint,
+  identityCount,
+  isMultipleAccountsEnabled,
+}: {
+  /** Usable (unexpired) records for the effective origin. */
+  records: AppDelegationRecord[];
+  hint: string | undefined;
+  /** Identities in the last-used list on this device. */
+  identityCount: number;
+  isMultipleAccountsEnabled: (identityNumber: bigint) => boolean;
+}): SilentOutcome => {
+  if (records.length === 0) {
+    return { denial: "login_required" };
+  }
+
+  if (hint !== undefined) {
+    const hinted = records.find((record) => record.principal === hint);
+    // A hint naming a principal with nothing stored for this origin is the same
+    // situation as nothing being stored at all: the app has to sign in.
+    return hinted !== undefined
+      ? { record: hinted }
+      : { denial: "login_required" };
+  }
+
+  if (identityCount !== 1 || records.length !== 1) {
+    return { denial: "account_selection_required" };
+  }
+
+  const [record] = records;
+  if (isMultipleAccountsEnabled(record.identityNumber)) {
+    return { denial: "account_selection_required" };
+  }
+
+  return { record };
+};
 
 /** Serialize delegation requests so a malicious dapp sending several in
  *  parallel can't race the authorization state (effective origin, auth
@@ -81,11 +153,83 @@ export const handleDelegationRequest =
 
         // Compute effective origin (derivation origin if provided, else
         // channel origin) and remap *.icp0.io to *.ic0.app for legacy
-        // compatibility. Setting the context triggers the authorization UI
-        // to render.
+        // compatibility.
         const effectiveOrigin = remapToLegacyDomain(
           params.icrc95DerivationOrigin ?? channel.origin,
         );
+
+        // Read from the store rather than the URL: the params were captured and
+        // stripped when the page loaded, and this handler runs again on a flow
+        // resumed after an identity provider round-trip, when the address bar no
+        // longer has them.
+        const { prompt, hint } = get(authorizationPromptStore);
+
+        // Re-issue from a delegation this frontend already holds for the origin,
+        // so an app that has signed in before does not spend another passkey.
+        // Deliberately ahead of `setRequestContext`: that is what makes the
+        // sign-in UI render, and a silent answer must not paint anything.
+        let denial: SilentDenial | undefined;
+        if (prompt !== "login") {
+          const outcome = chooseSilentDelegation({
+            records: await appDelegationsForOrigin(effectiveOrigin),
+            hint,
+            identityCount: Object.keys(get(lastUsedIdentitiesStore).identities)
+              .length,
+            isMultipleAccountsEnabled: readMultipleAccountsToggle,
+          });
+          if ("record" in outcome) {
+            try {
+              const { keyPair, chainJson, expiresAtMillis } = outcome.record;
+              const chain = await DelegationChain.create(
+                await ECDSAKeyIdentity.fromKeyPair(keyPair),
+                params.publicKey,
+                // Expires with its parent rather than later: a chain is only
+                // valid until its earliest expiry, so matching it means
+                // re-issuing restores a session without ever lengthening it
+                // past what the user originally granted.
+                new Date(expiresAtMillis),
+                { previous: DelegationChain.fromJSON(JSON.parse(chainJson)) },
+              );
+              await channel.send({
+                jsonrpc: "2.0",
+                id: requestId,
+                result: DelegationResultSchema.encode(chain),
+              });
+              return;
+            } catch (error) {
+              // The record did not survive storage (its key pair or chain is
+              // unusable). Drop it and sign in the ordinary way rather than
+              // failing a request a ceremony can still answer.
+              console.error(error);
+              await discardAppDelegation(
+                effectiveOrigin,
+                outcome.record.principal,
+              );
+              denial = "login_required";
+            }
+          } else {
+            denial = outcome.denial;
+          }
+        }
+
+        if (prompt === "none") {
+          // No `onError` here: it sets `channelErrorStore`, which renders the
+          // channel-error view — the interstitial `prompt=none` exists to
+          // promise the user will never be shown. Answering on the channel lets
+          // the app close the popup, or the redirect return, and decide for
+          // itself whether to escalate to an interactive request.
+          await channel.send({
+            jsonrpc: "2.0",
+            id: requestId,
+            error: {
+              code: INTERACTION_REQUIRED_ERROR_CODE,
+              message: "Interaction required",
+              data: { reason: denial ?? "login_required" },
+            },
+          });
+          return;
+        }
+
         // Set the effective origin (which makes the sign-in UI render) and the
         // app's requested session duration together, so the sign-in screen
         // always sees the requested duration — the picker's ceiling — from its
@@ -159,24 +303,41 @@ export const handleDelegationRequest =
             ? ssoSessionMaxAgeNs
             : requested;
 
+        // Have the canister delegate to a key this frontend holds, then extend
+        // that to the app's session key below. Storing the pair is what lets a
+        // later request skip the ceremony, and routing through it costs no extra
+        // canister call. When the key cannot be created the delegation goes
+        // straight to the app's key as before, simply without a cache.
+        // Non-extractable so the private half cannot be read back out of
+        // storage, which also means it can only be stored by structured clone. A
+        // browser that refuses either is a reason to sign in without a cache,
+        // not a reason to fail the sign-in.
+        const ownKey = await ECDSAKeyIdentity.generate({
+          extractable: false,
+        }).catch(() => undefined);
+        const delegationTarget =
+          ownKey === undefined
+            ? sessionPublicKey
+            : new Uint8Array(ownKey.getPublicKey().toDer());
+
         const { user_key, expiration } = await actor
           .prepare_account_delegation(
             identityNumber,
             effectiveOrigin,
             accountNumber !== undefined ? [accountNumber] : [],
-            sessionPublicKey,
+            delegationTarget,
             maxTimeToLive !== undefined ? [maxTimeToLive] : [],
             permissions,
           )
           .then(throwCanisterError);
 
-        const delegationChain = await retryFor(5, () =>
+        const canisterChain = await retryFor(5, () =>
           actor
             .get_account_delegation(
               identityNumber,
               effectiveOrigin,
               accountNumber !== undefined ? [accountNumber] : [],
-              sessionPublicKey,
+              delegationTarget,
               expiration,
               permissions,
             )
@@ -189,6 +350,31 @@ export const handleDelegationRequest =
               ),
             ),
         );
+
+        let delegationChain = canisterChain;
+        if (ownKey !== undefined) {
+          // Truncating (rather than rounding) keeps the record's expiry at or
+          // before the canister's, never after it.
+          const expiresAtMillis = Number(expiration / BigInt(1_000_000));
+          // Awaited rather than fired off: on the redirect transport the send
+          // below navigates the tab away, which would abandon a pending write.
+          await storeAppDelegation(effectiveOrigin, {
+            principal: Principal.selfAuthenticating(
+              new Uint8Array(user_key),
+            ).toText(),
+            identityNumber,
+            accountNumber,
+            keyPair: ownKey.getKeyPair(),
+            chainJson: JSON.stringify(canisterChain.toJSON()),
+            expiresAtMillis,
+          });
+          delegationChain = await DelegationChain.create(
+            ownKey,
+            params.publicKey,
+            new Date(expiresAtMillis),
+            { previous: canisterChain },
+          );
+        }
 
         await channel.send({
           jsonrpc: "2.0",

--- a/src/frontend/src/lib/stores/channelHandlers/delegation.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/delegation.ts
@@ -310,15 +310,26 @@ export const handleDelegationRequest =
         // Have the canister delegate to a key this frontend holds, then extend
         // that to the app's session key below. Storing the pair is what lets a
         // later request skip the ceremony, and routing through it costs no extra
-        // canister call. When the key cannot be created the delegation goes
-        // straight to the app's key as before, simply without a cache.
-        // Non-extractable so the private half cannot be read back out of
-        // storage, which also means it can only be stored by structured clone. A
-        // browser that refuses either is a reason to sign in without a cache,
-        // not a reason to fail the sign-in.
-        const ownKey = await ECDSAKeyIdentity.generate({
-          extractable: false,
-        }).catch(() => undefined);
+        // canister call.
+        //
+        // Only for an app that sent a `prompt`. An app that has never heard of
+        // the param has no way to call `ii-forget-delegation` either, so caching
+        // for it would leave a delegation nothing clears until it expires — and
+        // one it can never use, since re-issue needs `prompt=none`. Keeping the
+        // cache opt-in also means an app that has not adopted this gets the
+        // delegation shape it always got.
+        //
+        // The key is non-extractable so its private half cannot be read back out
+        // of storage, which also means it can only be stored by structured
+        // clone. A browser that refuses either is a reason to sign in without a
+        // cache, not a reason to fail the sign-in, so the delegation then goes
+        // straight to the app's key.
+        const ownKey =
+          prompt === undefined
+            ? undefined
+            : await ECDSAKeyIdentity.generate({ extractable: false }).catch(
+                () => undefined,
+              );
         const delegationTarget =
           ownKey === undefined
             ? sessionPublicKey

--- a/src/frontend/src/lib/stores/channelHandlers/forgetDelegation.test.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/forgetDelegation.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Channel, JsonResponse } from "$lib/utils/transport/utils";
+import { GENERIC_ERROR_CODE } from "$lib/utils/transport/utils";
+import { handleForgetDelegationRequest } from "./forgetDelegation";
+
+const APP_ORIGIN = "https://docs.example.com";
+const DERIVATION_ORIGIN = "https://auth.example.com";
+
+const forgetAppDelegations = vi.hoisted(() => vi.fn());
+const validateDerivationOrigin = vi.hoisted(() => vi.fn());
+
+vi.mock("$lib/stores/app-delegation.store", () => ({ forgetAppDelegations }));
+vi.mock("$lib/utils/validateDerivationOrigin", () => ({
+  validateDerivationOrigin,
+}));
+
+const channel = (): Channel & { sent: JsonResponse[] } => {
+  const sent: JsonResponse[] = [];
+  // The handler is driven directly rather than through a transport, so nothing
+  // subscribes here.
+  const addEventListener: Channel["addEventListener"] = () => () => {};
+  return {
+    sent,
+    origin: APP_ORIGIN,
+    closed: false,
+    resumeToken: "test-resume-token",
+    addEventListener,
+    send: (response: JsonResponse) => {
+      sent.push(response);
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+  };
+};
+
+const forget = (params?: unknown) => ({
+  jsonrpc: "2.0" as const,
+  id: 1,
+  method: "ii-forget-delegation",
+  params: params === undefined ? undefined : { ...Object(params) },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateDerivationOrigin.mockResolvedValue({ result: "valid" });
+  forgetAppDelegations.mockResolvedValue(undefined);
+});
+
+describe("handleForgetDelegationRequest", () => {
+  it("forgets the calling origin when no derivation origin is given", async () => {
+    const c = channel();
+    await handleForgetDelegationRequest(c)(forget());
+
+    expect(forgetAppDelegations).toHaveBeenCalledWith(APP_ORIGIN);
+    expect(c.sent).toEqual([{ jsonrpc: "2.0", id: 1, result: null }]);
+  });
+
+  it("forgets the derivation origin, which is where the records live", async () => {
+    const c = channel();
+    await handleForgetDelegationRequest(c)(
+      forget({ icrc95DerivationOrigin: DERIVATION_ORIGIN }),
+    );
+
+    // Every alternative origin shares one record, so signing out of any of them
+    // has to reach the derivation origin's entry rather than its own.
+    expect(forgetAppDelegations).toHaveBeenCalledWith(DERIVATION_ORIGIN);
+  });
+
+  it("forgets nothing when the derivation origin does not check out", async () => {
+    validateDerivationOrigin.mockResolvedValue({ result: "invalid" });
+    const c = channel();
+
+    await handleForgetDelegationRequest(c)(
+      forget({ icrc95DerivationOrigin: DERIVATION_ORIGIN }),
+    );
+
+    expect(forgetAppDelegations).not.toHaveBeenCalled();
+    expect(c.sent[0]).toMatchObject({
+      error: { code: GENERIC_ERROR_CODE },
+    });
+  });
+
+  it("rejects a malformed derivation origin", async () => {
+    const c = channel();
+
+    await handleForgetDelegationRequest(c)(
+      forget({ icrc95DerivationOrigin: "not an origin" }),
+    );
+
+    expect(forgetAppDelegations).not.toHaveBeenCalled();
+    expect(c.sent[0]).toHaveProperty("error");
+  });
+
+  it("leaves other methods alone", async () => {
+    const c = channel();
+
+    await handleForgetDelegationRequest(c)({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "icrc34_delegation",
+    });
+
+    expect(forgetAppDelegations).not.toHaveBeenCalled();
+    expect(c.sent).toEqual([]);
+  });
+
+  it("ignores a notification, which has no id to answer", async () => {
+    const c = channel();
+
+    await handleForgetDelegationRequest(c)({
+      jsonrpc: "2.0",
+      method: "ii-forget-delegation",
+    });
+
+    expect(forgetAppDelegations).not.toHaveBeenCalled();
+    expect(c.sent).toEqual([]);
+  });
+});

--- a/src/frontend/src/lib/stores/channelHandlers/forgetDelegation.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/forgetDelegation.ts
@@ -1,0 +1,74 @@
+import type { Channel, JsonRequest } from "$lib/utils/transport/utils";
+import {
+  ForgetDelegationParamsSchema,
+  GENERIC_ERROR_CODE,
+  INVALID_PARAMS_ERROR_CODE,
+} from "$lib/utils/transport/utils";
+import { forgetAppDelegations } from "$lib/stores/app-delegation.store";
+import { validateDerivationOrigin } from "$lib/utils/validateDerivationOrigin";
+import { remapToLegacyDomain } from "$lib/utils/iiConnection";
+import { z } from "zod";
+
+/**
+ * Forgets the delegation Internet Identity holds for the calling app, so its
+ * next sign-in needs a passkey again.
+ *
+ * Called by an app when it signs the user out. Named "forget" rather than
+ * "revoke" because nothing is invalidated: the delegation the app is holding
+ * stays valid until it expires and is the app's own to clear (`signOut()` on the
+ * client). All this drops is Internet Identity's ability to issue another one
+ * without asking the user.
+ *
+ * Nothing enforces who may call it. Forgetting only ever costs a ceremony, so
+ * the worst an origin can do by asking is inconvenience itself.
+ */
+export const handleForgetDelegationRequest =
+  (channel: Channel) => async (request: JsonRequest) => {
+    if (request.id === undefined || request.method !== "ii-forget-delegation") {
+      return;
+    }
+    const requestId = request.id;
+
+    const result = ForgetDelegationParamsSchema.safeParse(request.params ?? {});
+    if (!result.success) {
+      await channel.send({
+        jsonrpc: "2.0",
+        id: requestId,
+        error: {
+          code: INVALID_PARAMS_ERROR_CODE,
+          message: z.prettifyError(result.error),
+        },
+      });
+      return;
+    }
+
+    const { icrc95DerivationOrigin } = result.data;
+
+    // Same check the delegation handler runs, so an origin can only reach the
+    // records of a derivation origin that has listed it.
+    const validationResult = await validateDerivationOrigin({
+      requestOrigin: channel.origin,
+      derivationOrigin: icrc95DerivationOrigin,
+    });
+    if (validationResult.result === "invalid") {
+      // Answered on the channel and not reported to `channelErrorStore`: this
+      // request arrives while an app is signing the user out, and taking over
+      // the page with an error view at that moment would be worse than letting
+      // the app handle a failed call.
+      await channel.send({
+        jsonrpc: "2.0",
+        id: requestId,
+        error: {
+          code: GENERIC_ERROR_CODE,
+          message: "Derivation origin could not be verified",
+        },
+      });
+      return;
+    }
+
+    await forgetAppDelegations(
+      remapToLegacyDomain(icrc95DerivationOrigin ?? channel.origin),
+    );
+
+    await channel.send({ jsonrpc: "2.0", id: requestId, result: null });
+  };

--- a/src/frontend/src/lib/stores/channelStore.ts
+++ b/src/frontend/src/lib/stores/channelStore.ts
@@ -23,6 +23,7 @@ import {
   handlePermissions,
 } from "$lib/stores/channelHandlers/icrc25";
 import { handleDelegationRequest } from "$lib/stores/channelHandlers/delegation";
+import { handleForgetDelegationRequest } from "$lib/stores/channelHandlers/forgetDelegation";
 import {
   handleLegacyAttributes,
   handleIcrc3OneClickOpenIdAttributes,
@@ -98,6 +99,10 @@ export const channelStore: ChannelStore = {
       channel.addEventListener(
         "request",
         handleDelegationRequest(channel, onError),
+      );
+      channel.addEventListener(
+        "request",
+        handleForgetDelegationRequest(channel),
       );
       channel.addEventListener(
         "request",

--- a/src/frontend/src/lib/utils/multipleAccounts.ts
+++ b/src/frontend/src/lib/utils/multipleAccounts.ts
@@ -1,0 +1,27 @@
+// Browser-local, per-anchor persistence for the multiple-accounts toggle.
+// Per-anchor (not per-dapp) because the toggle is a mental-mode switch:
+// a user who self-identifies as a multi-accounts user wants the
+// affordance everywhere, not separately for each dapp.
+const TOGGLE_STORAGE_PREFIX = "ii:multi-accounts:";
+
+const toggleKey = (anchor: bigint): string =>
+  `${TOGGLE_STORAGE_PREFIX}${anchor.toString()}`;
+
+/** Whether this anchor has opted into picking an account per sign-in. */
+export const readMultipleAccountsToggle = (anchor: bigint): boolean => {
+  if (typeof localStorage === "undefined") return false;
+  return localStorage.getItem(toggleKey(anchor)) === "1";
+};
+
+export const writeMultipleAccountsToggle = (
+  anchor: bigint,
+  enabled: boolean,
+): void => {
+  if (typeof localStorage === "undefined") return;
+  const key = toggleKey(anchor);
+  if (enabled) {
+    localStorage.setItem(key, "1");
+  } else {
+    localStorage.removeItem(key);
+  }
+};

--- a/src/frontend/src/lib/utils/transport/url.test.ts
+++ b/src/frontend/src/lib/utils/transport/url.test.ts
@@ -145,10 +145,10 @@ const passthrough = (request: JsonRequest): DelegationInterceptor => ({
 
 // Location/history stubs — the transport reads the request from the current
 // URL hash and delivers the response by navigating the tab.
-let assignMock: ReturnType<typeof vi.fn>;
+let replaceMock: ReturnType<typeof vi.fn>;
 
 const installLocation = (hash: string): void => {
-  assignMock = vi.fn();
+  replaceMock = vi.fn();
   Object.defineProperty(window, "location", {
     configurable: true,
     writable: true,
@@ -158,7 +158,7 @@ const installLocation = (hash: string): void => {
       pathname: "/authorize",
       search: "",
       hash,
-      assign: assignMock,
+      replace: replaceMock,
     },
   });
 };
@@ -206,8 +206,8 @@ describe("UrlChannel", () => {
 
     await channel.send(response);
 
-    expect(assignMock).toHaveBeenCalledOnce();
-    const url = new URL(assignMock.mock.calls[0][0]);
+    expect(replaceMock).toHaveBeenCalledOnce();
+    const url = new URL(replaceMock.mock.calls[0][0]);
     expect(`${url.origin}${url.pathname}`).toBe(CALLBACK);
     const fragment = new URLSearchParams(url.hash.slice(1));
     expect(fragment.get("state")).toBe("state-123");
@@ -224,12 +224,12 @@ describe("UrlChannel", () => {
     const respB: JsonResponse = { jsonrpc: "2.0", id: 2, result: "B" };
 
     await channel.send(respB); // out of order; still waits for both
-    expect(assignMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
     await channel.send(respA);
 
-    expect(assignMock).toHaveBeenCalledOnce();
+    expect(replaceMock).toHaveBeenCalledOnce();
     const fragment = new URLSearchParams(
-      new URL(assignMock.mock.calls[0][0]).hash.slice(1),
+      new URL(replaceMock.mock.calls[0][0]).hash.slice(1),
     );
     // Batch responses are an array in request order.
     expect(JSON.parse(fragment.get("message") ?? "")).toEqual([respA, respB]);
@@ -243,7 +243,7 @@ describe("UrlChannel", () => {
     ]);
 
     await channel.send({ jsonrpc: "2.0", id: 1, result: "A" });
-    expect(assignMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
     // Request 2 errors → abort the batch and redirect now, without waiting for 3.
     await channel.send({
       jsonrpc: "2.0",
@@ -251,10 +251,10 @@ describe("UrlChannel", () => {
       error: { code: 4000, message: "boom" },
     });
 
-    expect(assignMock).toHaveBeenCalledOnce();
+    expect(replaceMock).toHaveBeenCalledOnce();
     const message = JSON.parse(
       new URLSearchParams(
-        new URL(assignMock.mock.calls[0][0]).hash.slice(1),
+        new URL(replaceMock.mock.calls[0][0]).hash.slice(1),
       ).get("message") ?? "",
     );
     expect(message[0]).toEqual({ jsonrpc: "2.0", id: 1, result: "A" });
@@ -272,7 +272,7 @@ describe("UrlChannel", () => {
     const channel = newChannel(false, [{ jsonrpc: "2.0", id: 1, method: "m" }]);
     await channel.send({ jsonrpc: "2.0", id: 1, result: 1 });
     await channel.send({ jsonrpc: "2.0", id: 1, result: 2 });
-    expect(assignMock).toHaveBeenCalledOnce();
+    expect(replaceMock).toHaveBeenCalledOnce();
   });
 
   it("rejects send on a closed channel", async () => {
@@ -354,7 +354,7 @@ describe("UrlTransport.establishChannel", () => {
       installLocation(`#${params.toString()}`);
 
       await expect(new UrlTransport().establishChannel()).rejects.toThrow();
-      expect(assignMock).not.toHaveBeenCalled();
+      expect(replaceMock).not.toHaveBeenCalled();
     },
   );
 
@@ -373,7 +373,7 @@ describe("UrlTransport.establishChannel", () => {
       installLocation(`#${params.toString()}`);
 
       await expect(new UrlTransport().establishChannel()).rejects.toThrow();
-      expect(assignMock).not.toHaveBeenCalled();
+      expect(replaceMock).not.toHaveBeenCalled();
     },
   );
 
@@ -407,7 +407,7 @@ describe("UrlTransport.establishChannel", () => {
     installLocation(`#${params.toString()}`);
 
     await expect(new UrlTransport().establishChannel()).rejects.toThrow();
-    expect(assignMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 
   it("rejects a request without an id (a notification cannot be answered)", async () => {
@@ -415,7 +415,7 @@ describe("UrlTransport.establishChannel", () => {
     stubAllowList([CALLBACK]);
 
     await expect(new UrlTransport().establishChannel()).rejects.toThrow();
-    expect(assignMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 
   it("rejects a message larger than the cap before parsing", async () => {
@@ -427,7 +427,7 @@ describe("UrlTransport.establishChannel", () => {
     installLocation(`#${params.toString()}`);
 
     await expect(new UrlTransport().establishChannel()).rejects.toThrow();
-    expect(assignMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 
   it("rejects a batch with too many requests", async () => {
@@ -439,7 +439,7 @@ describe("UrlTransport.establishChannel", () => {
     installLocation(hashFor(batch));
 
     await expect(new UrlTransport().establishChannel()).rejects.toThrow();
-    expect(assignMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 
   it("rejects a batch with duplicate request ids", async () => {
@@ -450,7 +450,7 @@ describe("UrlTransport.establishChannel", () => {
     installLocation(hashFor(batch));
 
     await expect(new UrlTransport().establishChannel()).rejects.toThrow();
-    expect(assignMock).not.toHaveBeenCalled();
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 
   it("journals distinct ephemeral keys for numeric and string ids that stringify alike", async () => {
@@ -492,7 +492,7 @@ describe("UrlTransport.establishChannel", () => {
   const messageFrom = (): unknown =>
     JSON.parse(
       new URLSearchParams(
-        new URL(assignMock.mock.calls[0][0]).hash.slice(1),
+        new URL(replaceMock.mock.calls[0][0]).hash.slice(1),
       ).get("message") ?? "",
     );
 
@@ -516,7 +516,7 @@ describe("UrlTransport.establishChannel", () => {
     expect(seen).toEqual([request]);
 
     await resumed.send({ jsonrpc: "2.0", id: 1, result: { ok: 1 } });
-    expect(assignMock).toHaveBeenCalledOnce();
+    expect(replaceMock).toHaveBeenCalledOnce();
     expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull(); // cleared on delivery
   });
 
@@ -587,7 +587,7 @@ describe("UrlTransport.establishChannel", () => {
     stubAllowList([CALLBACK]);
     const first = await new UrlTransport().establishChannel();
     await first.send({ jsonrpc: "2.0", id: 1, result: "A" });
-    expect(assignMock).not.toHaveBeenCalled(); // batch not complete, no redirect
+    expect(replaceMock).not.toHaveBeenCalled(); // batch not complete, no redirect
 
     // Redirect, then resume: request 1's response is restored from storage.
     installLocation("#");
@@ -597,7 +597,7 @@ describe("UrlTransport.establishChannel", () => {
     expect(seen.map((r) => r.id)).toEqual([2]); // only the unanswered one
 
     await resumed.send({ jsonrpc: "2.0", id: 2, result: "B" });
-    expect(assignMock).toHaveBeenCalledOnce();
+    expect(replaceMock).toHaveBeenCalledOnce();
     expect(messageFrom()).toEqual([
       { jsonrpc: "2.0", id: 1, result: "A" },
       { jsonrpc: "2.0", id: 2, result: "B" },

--- a/src/frontend/src/lib/utils/transport/url.ts
+++ b/src/frontend/src/lib/utils/transport/url.ts
@@ -496,7 +496,13 @@ export class UrlChannel implements Channel {
 
     this.#delivered = true;
     this.#onDelivered();
-    window.location.assign(deliveryUrl.href);
+    // `replace`, not `assign`: this navigation is machine-driven, so it has no
+    // business in the user's history (the legacy transport's redirect does the
+    // same). Going back to it could not work anyway — delivery deletes the
+    // persisted flow, so the authorize URL behind us is spent. It matters most
+    // under `?prompt=none`, where an app probes on every page load: with
+    // `assign` each probe would leave an entry and make the back button useless.
+    window.location.replace(deliveryUrl.href);
   }
 
   close(): Promise<void> {

--- a/src/frontend/src/lib/utils/transport/utils.ts
+++ b/src/frontend/src/lib/utils/transport/utils.ts
@@ -7,6 +7,13 @@ import { Principal } from "@icp-sdk/core/principal";
 export const INVALID_PARAMS_ERROR_CODE = -32602;
 // See: https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#errors-3
 export const GENERIC_ERROR_CODE = 1000;
+// The request cannot be completed without asking the user something, which
+// `?prompt=none` forbade. An Internet Identity extension rather than an
+// ICRC-25 code: the working group covers the protocol, not sign-in UX. Placed
+// in ICRC-25's 3xxx "user action" range (3001 is "action aborted"), so a client
+// that categorises by range reads it correctly even without knowing the code.
+// The specific reason travels in the error's `data.reason`.
+export const INTERACTION_REQUIRED_ERROR_CODE = 3002;
 
 export interface ChannelOptions {
   allowedOrigin?: string;
@@ -398,6 +405,13 @@ export type AuthResponse = z.output<typeof AuthResponseCodec>;
 // Parameters schema for "ii_attributes" request
 export const AttributesParamsSchema = z.object({
   attributes: z.array(z.string()),
+  icrc95DerivationOrigin: z.optional(OriginSchema),
+});
+
+// Parameters schema for "ii-forget-delegation" request. The origin is the only
+// input: which delegations exist for it is Internet Identity's business, and the
+// app has nothing else to say about them.
+export const ForgetDelegationParamsSchema = z.object({
   icrc95DerivationOrigin: z.optional(OriginSchema),
 });
 

--- a/src/frontend/src/routes/(new-styling)/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/+page.svelte
@@ -14,6 +14,7 @@
   import { afterNavigate, beforeNavigate, preloadData } from "$app/navigation";
   import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
   import { purgeSession } from "$lib/stores/session-delegation.store";
+  import { purgeAppDelegations } from "$lib/stores/app-delegation.store";
   import { goto } from "$app/navigation";
   import { toaster } from "$lib/components/utils/toaster";
   import {
@@ -111,6 +112,7 @@
       $lastUsedIdentitiesStore.identities[`${identityNumber}`];
     lastUsedIdentitiesStore.removeIdentity(identityNumber);
     void purgeSession(identityNumber);
+    void purgeAppDelegations(identityNumber);
 
     isManageIdentitiesDialogOpen = false;
     if (removedIdentity !== undefined) {

--- a/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/+layout.svelte
@@ -7,11 +7,14 @@
   } from "$lib/stores/attributeConsent.store";
   import {
     authorizationContextStore,
+    authorizationPromptStore,
     authorizationStore,
     authorizedStore,
   } from "$lib/stores/authorization.store";
+  import { resolvePromptParams, stripPromptParams } from "./promptParams";
   import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
   import { purgeSession } from "$lib/stores/session-delegation.store";
+  import { purgeAppDelegations } from "$lib/stores/app-delegation.store";
   import { authenticationStore } from "$lib/stores/authentication.store";
   import { goto } from "$app/navigation";
   import { toaster } from "$lib/components/utils/toaster";
@@ -61,6 +64,20 @@
     }
     return "normal" as const;
   })();
+
+  // --- Sign-in preferences from the URL (captured once, before the channel) ---
+  // Read here rather than in the request handler so nothing downstream depends on
+  // the address bar: the handler re-runs on a resumed flow, by which point the
+  // params are long gone from the URL. Runs during component init, so it is
+  // settled before `$effect.pre` establishes the channel and the first request
+  // is dispatched.
+  authorizationPromptStore.set(
+    resolvePromptParams(
+      new URL(window.location.href),
+      flow === "openid-resume",
+    ),
+  );
+  stripPromptParams();
 
   // --- Channel establishment ---
   $effect.pre(() => {
@@ -190,6 +207,7 @@
       $lastUsedIdentitiesStore.identities[`${identityNumber}`];
     lastUsedIdentitiesStore.removeIdentity(identityNumber);
     void purgeSession(identityNumber);
+    void purgeAppDelegations(identityNumber);
 
     isManageIdentitiesDialogOpen = false;
     if (removedIdentity !== undefined) {

--- a/src/frontend/src/routes/(new-styling)/authorize/promptParams.test.ts
+++ b/src/frontend/src/routes/(new-styling)/authorize/promptParams.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { resolvePromptParams, stripPromptParams } from "./promptParams";
+
+// Any valid textual principal; the parser only cares that it decodes.
+const PRINCIPAL = "2vxsx-fae";
+const NOT_RESUMING = false;
+const RESUMING = true;
+
+// Built against the test environment's own origin: `replaceState` refuses to
+// cross origins, and the code under test rewrites the real address bar.
+const authorizeUrl = (query: string): URL =>
+  new URL(`/authorize${query}`, window.location.origin);
+
+const visit = (query: string): void => {
+  window.history.replaceState(null, "", authorizeUrl(query));
+};
+
+beforeEach(() => {
+  sessionStorage.clear();
+  visit("");
+});
+
+describe("resolvePromptParams", () => {
+  it("reads both params", () => {
+    expect(
+      resolvePromptParams(
+        authorizeUrl(`?prompt=none&hint=${PRINCIPAL}`),
+        NOT_RESUMING,
+      ),
+    ).toEqual({ prompt: "none", hint: PRINCIPAL });
+  });
+
+  it("reads nothing from a plain authorize URL", () => {
+    expect(resolvePromptParams(authorizeUrl(""), NOT_RESUMING)).toEqual({
+      prompt: undefined,
+      hint: undefined,
+    });
+  });
+
+  it.each(["consent", "select_account", "", "NONE", "banana"])(
+    "ignores the unimplemented prompt value %j",
+    (value) => {
+      // Falling through to default behaviour rather than failing means an app
+      // written against the wider OpenID Connect vocabulary still signs in.
+      expect(
+        resolvePromptParams(authorizeUrl(`?prompt=${value}`), NOT_RESUMING)
+          .prompt,
+      ).toBeUndefined();
+    },
+  );
+
+  it("drops a hint that is not a principal", () => {
+    expect(
+      resolvePromptParams(authorizeUrl("?hint=not-a-principal"), NOT_RESUMING)
+        .hint,
+    ).toBeUndefined();
+  });
+
+  it("keeps the params across an identity provider round-trip", () => {
+    resolvePromptParams(
+      authorizeUrl(`?prompt=login&hint=${PRINCIPAL}`),
+      NOT_RESUMING,
+    );
+
+    // The resumed load arrives with the params gone from the URL. Without this,
+    // a `prompt=login` request would be read as asking for nothing and answered
+    // from the very delegation the user was just made to sign in past.
+    expect(
+      resolvePromptParams(authorizeUrl("?flow=openid-resume"), RESUMING),
+    ).toEqual({ prompt: "login", hint: PRINCIPAL });
+  });
+
+  it("clears a stored value on any load that is not resuming", () => {
+    resolvePromptParams(authorizeUrl("?prompt=login"), NOT_RESUMING);
+    resolvePromptParams(authorizeUrl(""), NOT_RESUMING);
+
+    // A value must not outlive the flow that set it and be picked up by an
+    // unrelated later one in the same tab.
+    expect(
+      resolvePromptParams(authorizeUrl("?flow=openid-resume"), RESUMING).prompt,
+    ).toBeUndefined();
+  });
+
+  it("prefers the URL over a stored value when resuming with both", () => {
+    resolvePromptParams(authorizeUrl("?prompt=login"), NOT_RESUMING);
+
+    expect(
+      resolvePromptParams(authorizeUrl("?prompt=none"), RESUMING).prompt,
+    ).toBe("login");
+  });
+});
+
+describe("stripPromptParams", () => {
+  it("removes both params and keeps the rest of the URL", () => {
+    visit(`?openid=x&prompt=none&hint=${PRINCIPAL}#frag`);
+
+    stripPromptParams();
+
+    // A principal in the address bar would linger in history, and a copied URL
+    // could replay a silent sign-in.
+    expect(window.location.search).toBe("?openid=x");
+    expect(window.location.hash).toBe("#frag");
+  });
+
+  it("leaves a URL without the params alone", () => {
+    visit("?openid=x");
+
+    stripPromptParams();
+
+    expect(window.location.search).toBe("?openid=x");
+  });
+});

--- a/src/frontend/src/routes/(new-styling)/authorize/promptParams.test.ts
+++ b/src/frontend/src/routes/(new-styling)/authorize/promptParams.test.ts
@@ -81,7 +81,7 @@ describe("resolvePromptParams", () => {
     ).toBeUndefined();
   });
 
-  it("prefers the URL over a stored value when resuming with both", () => {
+  it("prefers the stored value over the URL when resuming with both", () => {
     resolvePromptParams(authorizeUrl("?prompt=login"), NOT_RESUMING);
 
     expect(

--- a/src/frontend/src/routes/(new-styling)/authorize/promptParams.ts
+++ b/src/frontend/src/routes/(new-styling)/authorize/promptParams.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+import { Principal } from "@icp-sdk/core/principal";
+import type { AuthorizationPromptContext } from "$lib/stores/authorization.store";
+
+const PROMPT_PARAM = "prompt";
+const HINT_PARAM = "hint";
+
+// Carries the params across an Internet Identity-internal redirect to an
+// identity provider, which unloads the page and returns to a bare
+// `/authorize?flow=openid-resume`. Without this the resumed load would read no
+// `prompt`, treat a `prompt=login` request as if it had asked for nothing, and
+// answer from the cached delegation the user was just made to sign in past.
+const STORAGE_KEY = "ii-authorize-prompt";
+
+const isPrincipal = (value: string): boolean => {
+  try {
+    Principal.fromText(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * What an app may ask for about the sign-in itself.
+ *
+ * Used for both the URL and the copy kept across an identity provider
+ * round-trip, so neither path can end up validating more loosely than the other.
+ *
+ * Each field falls back to `undefined` instead of failing the parse. An
+ * unrecognised `prompt` (OpenID Connect's `consent` and `select_account`, which
+ * Internet Identity does not implement) or a `hint` that is not a principal
+ * earns default behaviour, not a rejected sign-in.
+ */
+const PromptContextSchema = z.object({
+  prompt: z.enum(["none", "login"]).optional().catch(undefined),
+  hint: z
+    .string()
+    .refine(isPrincipal)
+    // Normalised, because it is compared against a stored `Principal.toText()`.
+    .transform((value) => Principal.fromText(value).toText())
+    .optional()
+    .catch(undefined),
+});
+
+const parse = (input: unknown): AuthorizationPromptContext => {
+  const result = PromptContextSchema.safeParse(input);
+  return result.success ? result.data : {};
+};
+
+const isEmpty = (context: AuthorizationPromptContext): boolean =>
+  context.prompt === undefined && context.hint === undefined;
+
+export const readPromptParams = (url: URL): AuthorizationPromptContext =>
+  parse({
+    prompt: url.searchParams.get(PROMPT_PARAM),
+    hint: url.searchParams.get(HINT_PARAM),
+  });
+
+const readStored = (): AuthorizationPromptContext | undefined => {
+  const json = sessionStorage.getItem(STORAGE_KEY);
+  if (json === null) {
+    return undefined;
+  }
+  try {
+    return parse(JSON.parse(json));
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Resolves what the app asked for on this load, and keeps it available across an
+ * identity provider round-trip.
+ *
+ * Any load that is not resuming such a round-trip rewrites or clears the stored
+ * copy, so a value cannot outlive the flow that set it and be picked up by an
+ * unrelated later one.
+ */
+export const resolvePromptParams = (
+  url: URL,
+  isResuming: boolean,
+): AuthorizationPromptContext => {
+  const fromUrl = readPromptParams(url);
+  if (isResuming) {
+    return readStored() ?? fromUrl;
+  }
+  if (isEmpty(fromUrl)) {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } else {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(fromUrl));
+  }
+  return fromUrl;
+};
+
+/** Drops the params from the address bar, so a principal does not linger in
+ *  history and a copied URL cannot replay a silent sign-in. Leaves every other
+ *  param, and the fragment, untouched. */
+export const stripPromptParams = (): void => {
+  const url = new URL(window.location.href);
+  if (
+    !url.searchParams.has(PROMPT_PARAM) &&
+    !url.searchParams.has(HINT_PARAM)
+  ) {
+    return;
+  }
+  url.searchParams.delete(PROMPT_PARAM);
+  url.searchParams.delete(HINT_PARAM);
+  window.history.replaceState(null, "", url);
+};

--- a/src/frontend/src/routes/(new-styling)/authorize/views/ContinueView.svelte
+++ b/src/frontend/src/routes/(new-styling)/authorize/views/ContinueView.svelte
@@ -44,6 +44,10 @@
     sessionDurationCeilingSeconds,
     sessionDurationToNanos,
   } from "$lib/utils/sessionDuration";
+  import {
+    readMultipleAccountsToggle,
+    writeMultipleAccountsToggle,
+  } from "$lib/utils/multipleAccounts";
 
   interface Props {
     effectiveOrigin: string;
@@ -99,28 +103,6 @@
     sessionDurationToNanos(selectedTtlSeconds),
   );
 
-  // Browser-local, per-anchor persistence for the multi-accounts toggle.
-  // Per-anchor (not per-dapp) because the toggle is a mental-mode switch:
-  // a user who self-identifies as a multi-accounts user wants the
-  // affordance everywhere, not separately for each dapp.
-  const TOGGLE_STORAGE_PREFIX = "ii:multi-accounts:";
-  const readToggle = (anchor: bigint): boolean => {
-    if (typeof localStorage === "undefined") return false;
-    return (
-      localStorage.getItem(`${TOGGLE_STORAGE_PREFIX}${anchor.toString()}`) ===
-      "1"
-    );
-  };
-  const writeToggle = (anchor: bigint, enabled: boolean): void => {
-    if (typeof localStorage === "undefined") return;
-    const key = `${TOGGLE_STORAGE_PREFIX}${anchor.toString()}`;
-    if (enabled) {
-      localStorage.setItem(key, "1");
-    } else {
-      localStorage.removeItem(key);
-    }
-  };
-
   let defaultAccountNumber = $state<
     AccountNumber | PRIMARY_ACCOUNT_NUMBER | null
   >(null);
@@ -163,7 +145,9 @@
     }
   };
   let isMultipleAccountsEnabled = $state(
-    readToggle($lastUsedIdentitiesStore.selected!.identityNumber),
+    readMultipleAccountsToggle(
+      $lastUsedIdentitiesStore.selected!.identityNumber,
+    ),
   );
   // Clear old accounts data when user toggles switch off
   $effect(() => {
@@ -209,7 +193,7 @@
   // overwrite the new value back from stale localStorage.
   $effect(() => {
     authLastUsedFlow.init([selectedIdentityNumber]);
-    const hydrated = readToggle(selectedIdentityNumber);
+    const hydrated = readMultipleAccountsToggle(selectedIdentityNumber);
     isMultipleAccountsEnabled = hydrated;
     accessLevel = accessLevelStore.getPreference(
       "continue",
@@ -223,7 +207,10 @@
 
   // Persist the toggle whenever it (or the identity) changes.
   $effect(() => {
-    writeToggle(selectedIdentityNumber, isMultipleAccountsEnabled);
+    writeMultipleAccountsToggle(
+      selectedIdentityNumber,
+      isMultipleAccountsEnabled,
+    );
   });
 
   const handleContinueDefault = async () => {

--- a/src/frontend/src/routes/(new-styling)/cli/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/cli/+layout.svelte
@@ -3,6 +3,7 @@
   import { ChevronDownIcon, UserIcon } from "@lucide/svelte";
   import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
   import { purgeSession } from "$lib/stores/session-delegation.store";
+  import { purgeAppDelegations } from "$lib/stores/app-delegation.store";
   import { t } from "$lib/stores/locale.store";
   import { AuthWizard } from "$lib/components/wizards/auth";
   import Header from "$lib/components/layout/Header.svelte";
@@ -64,6 +65,7 @@
       $lastUsedIdentitiesStore.identities[`${identityNumber}`];
     lastUsedIdentitiesStore.removeIdentity(identityNumber);
     void purgeSession(identityNumber);
+    void purgeAppDelegations(identityNumber);
 
     isManageIdentitiesDialogOpen = false;
     if (removedIdentity !== undefined) {

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -116,11 +116,16 @@
     window.location.replace("/");
   };
 
-  const handleConfirmSignOutAndRemove = () => {
+  const handleConfirmSignOutAndRemove = async () => {
     const identityNumber = $authenticatedStore.identityNumber;
     lastUsedIdentitiesStore.removeIdentity(identityNumber);
-    void purgeSession(identityNumber);
-    void purgeAppDelegations(identityNumber);
+    // Awaited, unlike the other call sites: navigating away can cancel a pending
+    // IndexedDB delete, and a surviving app delegation would let an app be
+    // signed in again silently after the user chose to sign out.
+    await Promise.all([
+      purgeSession(identityNumber),
+      purgeAppDelegations(identityNumber),
+    ]);
     sessionStore.reset();
     window.location.replace("/");
   };

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/+layout.svelte
@@ -26,6 +26,7 @@
   import { DelegationIdentity } from "@icp-sdk/core/identity";
   import { lastUsedIdentitiesStore } from "$lib/stores/last-used-identities.store";
   import { purgeSession } from "$lib/stores/session-delegation.store";
+  import { purgeAppDelegations } from "$lib/stores/app-delegation.store";
   import { sessionStore } from "$lib/stores/session.store";
   import { locales, localeStore, t } from "$lib/stores/locale.store";
   import { AuthLastUsedFlow } from "$lib/flows/authLastUsedFlow.svelte";
@@ -119,6 +120,7 @@
     const identityNumber = $authenticatedStore.identityNumber;
     lastUsedIdentitiesStore.removeIdentity(identityNumber);
     void purgeSession(identityNumber);
+    void purgeAppDelegations(identityNumber);
     sessionStore.reset();
     window.location.replace("/");
   };
@@ -130,6 +132,7 @@
       $lastUsedIdentitiesStore.identities[`${identityNumber}`];
     lastUsedIdentitiesStore.removeIdentity(identityNumber);
     void purgeSession(identityNumber);
+    void purgeAppDelegations(identityNumber);
     isManageIdentitiesDialogOpen = false;
     if (removedIdentity !== undefined) {
       const identityName =

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/+page.svelte
@@ -394,8 +394,14 @@
       if (isCurrentAccessMethod($authenticatedStore, removingAccessMethod)) {
         const identityNumber = $authenticatedStore.identityNumber;
         lastUsedIdentitiesStore.removeIdentity(identityNumber);
-        void purgeSession(identityNumber);
-        void purgeAppDelegations(identityNumber);
+        // Awaited, unlike the other call sites: navigating away can cancel a
+        // pending IndexedDB delete, and a surviving app delegation would let an
+        // app be signed in again silently after the access method it belonged to
+        // was removed.
+        await Promise.all([
+          purgeSession(identityNumber),
+          purgeAppDelegations(identityNumber),
+        ]);
         sessionStore.reset();
         location.replace("/login");
         return;

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/access/+page.svelte
@@ -24,6 +24,7 @@
   import { canisterId } from "$lib/globals";
   import { authenticationStore } from "$lib/stores/authentication.store";
   import { purgeSession } from "$lib/stores/session-delegation.store";
+  import { purgeAppDelegations } from "$lib/stores/app-delegation.store";
   import { authenticateWithPasskey } from "$lib/utils/authentication/passkey";
   import { authenticateWithJWT } from "$lib/utils/authentication/jwt";
   import {
@@ -394,6 +395,7 @@
         const identityNumber = $authenticatedStore.identityNumber;
         lastUsedIdentitiesStore.removeIdentity(identityNumber);
         void purgeSession(identityNumber);
+        void purgeAppDelegations(identityNumber);
         sessionStore.reset();
         location.replace("/login");
         return;

--- a/src/frontend/src/routes/(new-styling)/recovery/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/recovery/+page.svelte
@@ -39,6 +39,7 @@
   import { handleError } from "$lib/components/utils/error";
   import { authenticationStore } from "$lib/stores/authentication.store";
   import { purgeSession } from "$lib/stores/session-delegation.store";
+  import { purgeAppDelegations } from "$lib/stores/app-delegation.store";
   import { authenticateWithSession } from "$lib/utils/authentication";
   import { goto, preloadData } from "$app/navigation";
   import { toaster } from "$lib/components/utils/toaster";
@@ -152,6 +153,7 @@
       showEmailRecoveryDialog = false;
       authenticationStore.reset();
       void purgeSession(success.identityNumber);
+      void purgeAppDelegations(success.identityNumber);
       handleError(error);
     }
   };
@@ -194,6 +196,7 @@
       showRecoveryDialog = false;
       authenticationStore.reset();
       void purgeSession(identityNumber);
+      void purgeAppDelegations(identityNumber);
       handleError(error);
     }
   };

--- a/src/frontend/tests/e2e-playwright/fixtures/authorize.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/authorize.ts
@@ -55,120 +55,6 @@ class AuthorizePage {
   }
 }
 
-/**
- * Drives one authorize round on `page`: points the test app at Internet
- * Identity per `config`, clicks Sign In, hands the resulting page to
- * `interact`, and waits for the flow to finish (the popup closing, or the
- * redirect returning).
- *
- * Exported because a round is not always the whole test. Anything about
- * re-authorizing — a delegation Internet Identity already holds, a session it
- * does not — needs a first round to establish the state and a second to
- * exercise it, and both should go through the same code path the
- * {@link test.authorizePage} fixture uses.
- *
- * `interact` may do nothing: under `prompt=none` there is nothing to click,
- * and the flow completes on its own.
- */
-export const performAuthorize = async (
-  page: Page,
-  config: Partial<AuthorizeConfig>,
-  interact: (authorizePage: Page) => Promise<void>,
-): Promise<void> => {
-  await page.goto(config.testAppURL ?? "https://nice-name.com");
-  const testAppPage = page;
-
-  const internetIdentityURL = config.internetIdentityURL ?? "https://id.ai";
-  const protocol = config.protocol ?? "legacy";
-
-  if (protocol === "icrc25") {
-    const queryParams: string[] = [];
-    if ("openid" in config && config.openid !== undefined) {
-      queryParams.push(`openid=${encodeURIComponent(config.openid)}`);
-    }
-    if ("sso" in config && config.sso !== undefined) {
-      queryParams.push(`sso=${encodeURIComponent(config.sso)}`);
-    }
-    if ("prompt" in config && config.prompt !== undefined) {
-      queryParams.push(`prompt=${encodeURIComponent(config.prompt)}`);
-    }
-    if ("hint" in config && config.hint !== undefined) {
-      queryParams.push(`hint=${encodeURIComponent(config.hint)}`);
-    }
-    const querySuffix =
-      queryParams.length > 0 ? `?${queryParams.join("&")}` : "";
-    await testAppPage
-      .getByRole("textbox", { name: "Identity Provider" })
-      .fill(internetIdentityURL + "/authorize" + querySuffix);
-    await testAppPage
-      .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
-      .setChecked(true);
-    if ("useIcrc3Attributes" in config && config.useIcrc3Attributes === true) {
-      await testAppPage
-        .getByRole("checkbox", { name: "Use ICRC-3 attributes:" })
-        .setChecked(true);
-    }
-    if ("icrc3Nonce" in config && config.icrc3Nonce !== undefined) {
-      await testAppPage
-        .getByRole("textbox", { name: "ICRC-3 nonce (base64):" })
-        .fill(toBase64(config.icrc3Nonce));
-    }
-    if (
-      "attributes" in config &&
-      config.attributes !== undefined &&
-      config.attributes.length > 0
-    ) {
-      await testAppPage
-        .getByRole("textbox", { name: "Request attributes:" })
-        .fill(config.attributes.join("\n"));
-    }
-  } else {
-    await testAppPage
-      .getByRole("textbox", { name: "Identity Provider" })
-      .fill(internetIdentityURL + "#authorize");
-  }
-
-  await expect(testAppPage.locator("#principal")).toBeHidden();
-
-  const transport = config.transport ?? "window";
-  switch (transport) {
-    case "redirect": {
-      // Redirect flow: clicking "Sign In" navigates THIS tab to /callback → II
-      // /authorize. The authenticate interaction runs on the same page, and II
-      // delivers the response back by navigation — no popup.
-      await testAppPage.locator("#transport").selectOption("redirect");
-      await testAppPage.getByRole("button", { name: "Sign In" }).click();
-
-      await interact(testAppPage);
-
-      // On the return load the homepage renders the principal.
-      await expect(testAppPage.locator("#principal")).toBeVisible({
-        timeout: 15_000,
-      });
-      break;
-    }
-    case "window": {
-      // Window flow: clicking "Sign In" opens II in a new tab; the response
-      // comes back over postMessage and the tab closes.
-      const authPagePromise = testAppPage.context().waitForEvent("page");
-      await testAppPage.getByRole("button", { name: "Sign In" }).click();
-      const authPage = await authPagePromise;
-      const closePromise = authPage.waitForEvent("close", {
-        timeout: 15_000,
-      });
-
-      await interact(authPage);
-
-      await closePromise;
-      break;
-    }
-    default: {
-      transport satisfies never;
-      throw new Error(`Unhandled transport: ${String(transport)}`);
-    }
-  }
-};
-
 export const test = base.extend<{
   authorizeConfig: Partial<AuthorizeConfig> | undefined;
   authorizePage: AuthorizePage;
@@ -215,9 +101,109 @@ export const test = base.extend<{
       throw new Error("authorizeConfig must be defined");
     }
 
-    await performAuthorize(page, authorizeConfig, (authorizePage) =>
-      use(new AuthorizePage(authorizePage)),
-    );
+    await page.goto(authorizeConfig.testAppURL ?? "https://nice-name.com");
+    const testAppPage = page;
+
+    const internetIdentityURL =
+      authorizeConfig.internetIdentityURL ?? "https://id.ai";
+    const protocol = authorizeConfig.protocol ?? "legacy";
+
+    if (protocol === "icrc25") {
+      const queryParams: string[] = [];
+      if ("openid" in authorizeConfig && authorizeConfig.openid !== undefined) {
+        queryParams.push(
+          `openid=${encodeURIComponent(authorizeConfig.openid)}`,
+        );
+      }
+      if ("sso" in authorizeConfig && authorizeConfig.sso !== undefined) {
+        queryParams.push(`sso=${encodeURIComponent(authorizeConfig.sso)}`);
+      }
+      if ("prompt" in authorizeConfig && authorizeConfig.prompt !== undefined) {
+        queryParams.push(
+          `prompt=${encodeURIComponent(authorizeConfig.prompt)}`,
+        );
+      }
+      if ("hint" in authorizeConfig && authorizeConfig.hint !== undefined) {
+        queryParams.push(`hint=${encodeURIComponent(authorizeConfig.hint)}`);
+      }
+      const querySuffix =
+        queryParams.length > 0 ? `?${queryParams.join("&")}` : "";
+      await testAppPage
+        .getByRole("textbox", { name: "Identity Provider" })
+        .fill(internetIdentityURL + "/authorize" + querySuffix);
+      await testAppPage
+        .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
+        .setChecked(true);
+      if (
+        "useIcrc3Attributes" in authorizeConfig &&
+        authorizeConfig.useIcrc3Attributes === true
+      ) {
+        await testAppPage
+          .getByRole("checkbox", { name: "Use ICRC-3 attributes:" })
+          .setChecked(true);
+      }
+      if (
+        "icrc3Nonce" in authorizeConfig &&
+        authorizeConfig.icrc3Nonce !== undefined
+      ) {
+        await testAppPage
+          .getByRole("textbox", { name: "ICRC-3 nonce (base64):" })
+          .fill(toBase64(authorizeConfig.icrc3Nonce));
+      }
+      if (
+        "attributes" in authorizeConfig &&
+        authorizeConfig.attributes !== undefined &&
+        authorizeConfig.attributes.length > 0
+      ) {
+        await testAppPage
+          .getByRole("textbox", { name: "Request attributes:" })
+          .fill(authorizeConfig.attributes.join("\n"));
+      }
+    } else {
+      await testAppPage
+        .getByRole("textbox", { name: "Identity Provider" })
+        .fill(internetIdentityURL + "#authorize");
+    }
+
+    await expect(testAppPage.locator("#principal")).toBeHidden();
+
+    const transport = authorizeConfig.transport ?? "window";
+    switch (transport) {
+      case "redirect": {
+        // Redirect flow: clicking "Sign In" navigates THIS tab to /callback → II
+        // /authorize. The authenticate interaction runs on the same page, and II
+        // delivers the response back by navigation — no popup.
+        await testAppPage.locator("#transport").selectOption("redirect");
+        await testAppPage.getByRole("button", { name: "Sign In" }).click();
+
+        await use(new AuthorizePage(testAppPage));
+
+        // On the return load the homepage renders the principal.
+        await expect(testAppPage.locator("#principal")).toBeVisible({
+          timeout: 15_000,
+        });
+        break;
+      }
+      case "window": {
+        // Window flow: clicking "Sign In" opens II in a new tab; the response
+        // comes back over postMessage and the tab closes.
+        const authPagePromise = testAppPage.context().waitForEvent("page");
+        await testAppPage.getByRole("button", { name: "Sign In" }).click();
+        const authPage = await authPagePromise;
+        const closePromise = authPage.waitForEvent("close", {
+          timeout: 15_000,
+        });
+
+        await use(new AuthorizePage(authPage));
+
+        await closePromise;
+        break;
+      }
+      default: {
+        transport satisfies never;
+        throw new Error(`Unhandled transport: ${String(transport)}`);
+      }
+    }
   },
   authorizedPrincipal: async ({ page, authorizeConfig }, use) => {
     const [testAppPage, authPage] = page.context().pages();

--- a/src/frontend/tests/e2e-playwright/fixtures/authorize.ts
+++ b/src/frontend/tests/e2e-playwright/fixtures/authorize.ts
@@ -26,6 +26,17 @@ export type AuthorizeConfig = {
        * page rather than picking one silently.
        */
       sso?: string;
+      /**
+       * Sets `?prompt=`. `"none"` asks II to answer from a delegation it
+       * already holds for this app and to error rather than render anything;
+       * `"login"` forces a ceremony. Omitted behaves as `"login"`.
+       */
+      prompt?: "none" | "login";
+      /**
+       * Sets `?hint=<principal>`, naming which stored delegation to re-issue
+       * when the user has more than one for this app.
+       */
+      hint?: string;
       attributes?: string[];
       useIcrc3Attributes?: boolean;
       icrc3Nonce?: Uint8Array;
@@ -43,6 +54,120 @@ class AuthorizePage {
     return this.#page;
   }
 }
+
+/**
+ * Drives one authorize round on `page`: points the test app at Internet
+ * Identity per `config`, clicks Sign In, hands the resulting page to
+ * `interact`, and waits for the flow to finish (the popup closing, or the
+ * redirect returning).
+ *
+ * Exported because a round is not always the whole test. Anything about
+ * re-authorizing — a delegation Internet Identity already holds, a session it
+ * does not — needs a first round to establish the state and a second to
+ * exercise it, and both should go through the same code path the
+ * {@link test.authorizePage} fixture uses.
+ *
+ * `interact` may do nothing: under `prompt=none` there is nothing to click,
+ * and the flow completes on its own.
+ */
+export const performAuthorize = async (
+  page: Page,
+  config: Partial<AuthorizeConfig>,
+  interact: (authorizePage: Page) => Promise<void>,
+): Promise<void> => {
+  await page.goto(config.testAppURL ?? "https://nice-name.com");
+  const testAppPage = page;
+
+  const internetIdentityURL = config.internetIdentityURL ?? "https://id.ai";
+  const protocol = config.protocol ?? "legacy";
+
+  if (protocol === "icrc25") {
+    const queryParams: string[] = [];
+    if ("openid" in config && config.openid !== undefined) {
+      queryParams.push(`openid=${encodeURIComponent(config.openid)}`);
+    }
+    if ("sso" in config && config.sso !== undefined) {
+      queryParams.push(`sso=${encodeURIComponent(config.sso)}`);
+    }
+    if ("prompt" in config && config.prompt !== undefined) {
+      queryParams.push(`prompt=${encodeURIComponent(config.prompt)}`);
+    }
+    if ("hint" in config && config.hint !== undefined) {
+      queryParams.push(`hint=${encodeURIComponent(config.hint)}`);
+    }
+    const querySuffix =
+      queryParams.length > 0 ? `?${queryParams.join("&")}` : "";
+    await testAppPage
+      .getByRole("textbox", { name: "Identity Provider" })
+      .fill(internetIdentityURL + "/authorize" + querySuffix);
+    await testAppPage
+      .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
+      .setChecked(true);
+    if ("useIcrc3Attributes" in config && config.useIcrc3Attributes === true) {
+      await testAppPage
+        .getByRole("checkbox", { name: "Use ICRC-3 attributes:" })
+        .setChecked(true);
+    }
+    if ("icrc3Nonce" in config && config.icrc3Nonce !== undefined) {
+      await testAppPage
+        .getByRole("textbox", { name: "ICRC-3 nonce (base64):" })
+        .fill(toBase64(config.icrc3Nonce));
+    }
+    if (
+      "attributes" in config &&
+      config.attributes !== undefined &&
+      config.attributes.length > 0
+    ) {
+      await testAppPage
+        .getByRole("textbox", { name: "Request attributes:" })
+        .fill(config.attributes.join("\n"));
+    }
+  } else {
+    await testAppPage
+      .getByRole("textbox", { name: "Identity Provider" })
+      .fill(internetIdentityURL + "#authorize");
+  }
+
+  await expect(testAppPage.locator("#principal")).toBeHidden();
+
+  const transport = config.transport ?? "window";
+  switch (transport) {
+    case "redirect": {
+      // Redirect flow: clicking "Sign In" navigates THIS tab to /callback → II
+      // /authorize. The authenticate interaction runs on the same page, and II
+      // delivers the response back by navigation — no popup.
+      await testAppPage.locator("#transport").selectOption("redirect");
+      await testAppPage.getByRole("button", { name: "Sign In" }).click();
+
+      await interact(testAppPage);
+
+      // On the return load the homepage renders the principal.
+      await expect(testAppPage.locator("#principal")).toBeVisible({
+        timeout: 15_000,
+      });
+      break;
+    }
+    case "window": {
+      // Window flow: clicking "Sign In" opens II in a new tab; the response
+      // comes back over postMessage and the tab closes.
+      const authPagePromise = testAppPage.context().waitForEvent("page");
+      await testAppPage.getByRole("button", { name: "Sign In" }).click();
+      const authPage = await authPagePromise;
+      const closePromise = authPage.waitForEvent("close", {
+        timeout: 15_000,
+      });
+
+      await interact(authPage);
+
+      await closePromise;
+      break;
+    }
+    default: {
+      transport satisfies never;
+      throw new Error(`Unhandled transport: ${String(transport)}`);
+    }
+  }
+};
 
 export const test = base.extend<{
   authorizeConfig: Partial<AuthorizeConfig> | undefined;
@@ -90,101 +215,9 @@ export const test = base.extend<{
       throw new Error("authorizeConfig must be defined");
     }
 
-    await page.goto(authorizeConfig.testAppURL ?? "https://nice-name.com");
-    const testAppPage = page;
-
-    const internetIdentityURL =
-      authorizeConfig.internetIdentityURL ?? "https://id.ai";
-    const protocol = authorizeConfig.protocol ?? "legacy";
-
-    if (protocol === "icrc25") {
-      const queryParams: string[] = [];
-      if ("openid" in authorizeConfig && authorizeConfig.openid !== undefined) {
-        queryParams.push(
-          `openid=${encodeURIComponent(authorizeConfig.openid)}`,
-        );
-      }
-      if ("sso" in authorizeConfig && authorizeConfig.sso !== undefined) {
-        queryParams.push(`sso=${encodeURIComponent(authorizeConfig.sso)}`);
-      }
-      const querySuffix =
-        queryParams.length > 0 ? `?${queryParams.join("&")}` : "";
-      await testAppPage
-        .getByRole("textbox", { name: "Identity Provider" })
-        .fill(internetIdentityURL + "/authorize" + querySuffix);
-      await testAppPage
-        .getByRole("checkbox", { name: "Use ICRC-25 protocol:" })
-        .setChecked(true);
-      if (
-        "useIcrc3Attributes" in authorizeConfig &&
-        authorizeConfig.useIcrc3Attributes === true
-      ) {
-        await testAppPage
-          .getByRole("checkbox", { name: "Use ICRC-3 attributes:" })
-          .setChecked(true);
-      }
-      if (
-        "icrc3Nonce" in authorizeConfig &&
-        authorizeConfig.icrc3Nonce !== undefined
-      ) {
-        await testAppPage
-          .getByRole("textbox", { name: "ICRC-3 nonce (base64):" })
-          .fill(toBase64(authorizeConfig.icrc3Nonce));
-      }
-      if (
-        "attributes" in authorizeConfig &&
-        authorizeConfig.attributes !== undefined &&
-        authorizeConfig.attributes.length > 0
-      ) {
-        await testAppPage
-          .getByRole("textbox", { name: "Request attributes:" })
-          .fill(authorizeConfig.attributes.join("\n"));
-      }
-    } else {
-      await testAppPage
-        .getByRole("textbox", { name: "Identity Provider" })
-        .fill(internetIdentityURL + "#authorize");
-    }
-
-    await expect(testAppPage.locator("#principal")).toBeHidden();
-
-    const transport = authorizeConfig.transport ?? "window";
-    switch (transport) {
-      case "redirect": {
-        // Redirect flow: clicking "Sign In" navigates THIS tab to /callback → II
-        // /authorize. The authenticate interaction runs on the same page, and II
-        // delivers the response back by navigation — no popup.
-        await testAppPage.locator("#transport").selectOption("redirect");
-        await testAppPage.getByRole("button", { name: "Sign In" }).click();
-
-        await use(new AuthorizePage(testAppPage));
-
-        // On the return load the homepage renders the principal.
-        await expect(testAppPage.locator("#principal")).toBeVisible({
-          timeout: 15_000,
-        });
-        break;
-      }
-      case "window": {
-        // Window flow: clicking "Sign In" opens II in a new tab; the response
-        // comes back over postMessage and the tab closes.
-        const authPagePromise = testAppPage.context().waitForEvent("page");
-        await testAppPage.getByRole("button", { name: "Sign In" }).click();
-        const authPage = await authPagePromise;
-        const closePromise = authPage.waitForEvent("close", {
-          timeout: 15_000,
-        });
-
-        await use(new AuthorizePage(authPage));
-
-        await closePromise;
-        break;
-      }
-      default: {
-        transport satisfies never;
-        throw new Error(`Unhandled transport: ${String(transport)}`);
-      }
-    }
+    await performAuthorize(page, authorizeConfig, (authorizePage) =>
+      use(new AuthorizePage(authorizePage)),
+    );
   },
   authorizedPrincipal: async ({ page, authorizeConfig }, use) => {
     const [testAppPage, authPage] = page.context().pages();

--- a/src/frontend/tests/e2e-playwright/routes/authorize/redirect.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/redirect.spec.ts
@@ -35,27 +35,25 @@ const decodeIcrc3TextEntries = (base64Data: string): Record<string, string> => {
 };
 
 test.describe("Authorize over the redirect transport", () => {
-  // Every redirect flow must hand back the two-hop intermediate-key chain
-  // (canister → intermediate → RP session key), never a one-hop chain signed
-  // directly to the RP key: what the canister certifies transits the IC and
-  // must be inert on its own, so the RP key is only ever reached via the second
-  // hop assembled in the browser.
+  // Every redirect flow must reach the RP session key through browser-signed
+  // hops, never as the key the canister certified directly: what the canister
+  // certifies transits the IC and must be inert on its own.
   test.afterEach(({ authorizedDelegation }) => {
     expect(authorizedDelegation).toBeDefined();
     if (authorizedDelegation === undefined) {
       return;
     }
-    // The chain runs root (user identity) → intermediate key → RP session key.
-    // Two hops, never one: a one-hop chain would be the canister signing
-    // directly to the RP key, but what the canister certifies transits the IC
-    // and must be inert on its own.
+    // The chain runs root (user identity) → app-delegation key → intermediate
+    // key → RP session key. Three hops on this transport: the delegation
+    // handler certifies to a key Internet Identity keeps (so a later
+    // `?prompt=none` can re-issue without a ceremony) and extends it, and the
+    // redirect transport adds its own per-flow intermediate key on top.
     const { delegations } = authorizedDelegation;
-    expect(delegations).toHaveLength(2);
-    // The canister-certified inner hop (delegations[0]) targets the intermediate
-    // key; the RP session key is only the chain's leaf (delegations[1]), reached
-    // via the second, browser-signed hop — so the two hops target distinct keys.
+    expect(delegations).toHaveLength(3);
+    // The canister-certified hop (delegations[0]) must not target the RP session
+    // key, which is only ever the chain's leaf.
     expect(delegations[0].delegation.pubkey).not.toBe(
-      delegations[1].delegation.pubkey,
+      delegations[delegations.length - 1].delegation.pubkey,
     );
   });
 

--- a/src/frontend/tests/e2e-playwright/routes/authorize/redirect.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/redirect.spec.ts
@@ -35,25 +35,31 @@ const decodeIcrc3TextEntries = (base64Data: string): Record<string, string> => {
 };
 
 test.describe("Authorize over the redirect transport", () => {
-  // Every redirect flow must reach the RP session key through browser-signed
-  // hops, never as the key the canister certified directly: what the canister
-  // certifies transits the IC and must be inert on its own.
+  // Every redirect flow must hand back the two-hop intermediate-key chain
+  // (canister → intermediate → RP session key), never a one-hop chain signed
+  // directly to the RP key: what the canister certifies transits the IC and
+  // must be inert on its own, so the RP key is only ever reached via the second
+  // hop assembled in the browser.
   test.afterEach(({ authorizedDelegation }) => {
     expect(authorizedDelegation).toBeDefined();
     if (authorizedDelegation === undefined) {
       return;
     }
-    // The chain runs root (user identity) → app-delegation key → intermediate
-    // key → RP session key. Three hops on this transport: the delegation
-    // handler certifies to a key Internet Identity keeps (so a later
-    // `?prompt=none` can re-issue without a ceremony) and extends it, and the
-    // redirect transport adds its own per-flow intermediate key on top.
+    // The chain runs root (user identity) → intermediate key → RP session key.
+    // Two hops, never one: a one-hop chain would be the canister signing
+    // directly to the RP key, but what the canister certifies transits the IC
+    // and must be inert on its own.
+    //
+    // Exactly two, also: none of these flows sends `?prompt=`, so Internet
+    // Identity keeps no delegation for re-issue and adds no hop of its own. A
+    // third hop here would mean it started caching for apps that never asked.
     const { delegations } = authorizedDelegation;
-    expect(delegations).toHaveLength(3);
-    // The canister-certified hop (delegations[0]) must not target the RP session
-    // key, which is only ever the chain's leaf.
+    expect(delegations).toHaveLength(2);
+    // The canister-certified inner hop (delegations[0]) targets the intermediate
+    // key; the RP session key is only the chain's leaf (delegations[1]), reached
+    // via the second, browser-signed hop — so the two hops target distinct keys.
     expect(delegations[0].delegation.pubkey).not.toBe(
-      delegations[delegations.length - 1].delegation.pubkey,
+      delegations[1].delegation.pubkey,
     );
   });
 

--- a/src/frontend/tests/e2e-playwright/routes/authorize/silentReauth.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/silentReauth.spec.ts
@@ -1,38 +1,60 @@
 import { expect } from "@playwright/test";
 import { test } from "../../fixtures";
-import {
-  type AuthorizeConfig,
-  performAuthorize,
-} from "../../fixtures/authorize";
-import { II_URL, TEST_APP_URL } from "../../utils";
+import { authorize } from "../../utils";
 
-const config: Partial<AuthorizeConfig> = {
-  protocol: "icrc25",
-  testAppURL: TEST_APP_URL,
-  internetIdentityURL: II_URL,
-};
+test.describe("Re-issue a delegation with ?prompt=none", () => {
+  // The principal the priming sign-in produced. A silent re-issue has to
+  // reproduce it exactly: the delegation is derived from the same account seed
+  // either way, so a different principal would mean the wrong account.
+  let expectedPrincipal: string;
 
-test("Re-issues a delegation with ?prompt=none without any interaction", async ({
-  page,
-  identities,
-  signInWithIdentity,
-}) => {
-  // A normal sign-in first: that is what leaves Internet Identity holding a
-  // delegation for this app.
-  await performAuthorize(page, config, async (authPage) => {
-    await signInWithIdentity(authPage, identities[0].identityNumber);
-    await authPage
-      .getByRole("button", { name: "Continue", exact: true })
-      .click();
+  // A normal sign-in first. That ceremony is what leaves Internet Identity
+  // holding a delegation for this app, so the round under test has something to
+  // re-issue. Runs before the `authorizePage` fixture performs that round.
+  test.beforeEach(async ({ page, identities, signInWithIdentity }) => {
+    expectedPrincipal = await authorize(page, async (authPage) => {
+      await signInWithIdentity(authPage, identities[0].identityNumber);
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    });
   });
-  const expectedPrincipal = await page.locator("#principal").textContent();
-  expect(expectedPrincipal).not.toBe("");
 
-  // Nothing to do in the popup this time: no passkey, no virtual authenticator,
-  // no Continue button. Internet Identity extends the delegation it kept and
-  // closes without rendering anything, and the app ends up with the principal it
-  // had before.
-  await performAuthorize(page, { ...config, prompt: "none" }, async () => {});
+  // Read here rather than in the test body: `authorizedPrincipal` resolves only
+  // once the flow has finished, and the flow is held open for the duration of
+  // the body by the `authorizePage` fixture.
+  test.afterEach(({ authorizedPrincipal }) => {
+    expect(authorizedPrincipal?.toText()).toBe(expectedPrincipal);
+  });
 
-  await expect(page.locator("#principal")).toHaveText(expectedPrincipal ?? "");
+  test.describe("over the window transport", () => {
+    test.use({
+      authorizeConfig: { protocol: "icrc25", prompt: "none" },
+    });
+
+    test("re-issues without interaction", ({ authorizePage }) => {
+      // Deliberately empty: under `prompt=none` there is no passkey, no virtual
+      // authenticator and no Continue button, because Internet Identity answers
+      // without rendering anything. Reaching the afterEach with the same
+      // principal is the assertion.
+      expect(authorizePage).toBeDefined();
+    });
+  });
+
+  test.describe("over the redirect transport", () => {
+    test.use({
+      authorizeConfig: {
+        protocol: "icrc25",
+        prompt: "none",
+        transport: "redirect",
+      },
+    });
+
+    test("re-issues without interaction", ({ authorizePage }) => {
+      // The delegation is stored against the effective origin, not the transport
+      // that fetched it, so a sign-in over the window flow is re-issuable over
+      // the redirect flow.
+      expect(authorizePage).toBeDefined();
+    });
+  });
 });

--- a/src/frontend/tests/e2e-playwright/routes/authorize/silentReauth.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/silentReauth.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import { test } from "../../fixtures";
-import { authorize } from "../../utils";
+import { authorizeWithUrl, II_URL, TEST_APP_URL } from "../../utils";
 
 test.describe("Re-issue a delegation with ?prompt=none", () => {
   // The principal the priming sign-in produced. A silent re-issue has to
@@ -11,13 +11,24 @@ test.describe("Re-issue a delegation with ?prompt=none", () => {
   // A normal sign-in first. That ceremony is what leaves Internet Identity
   // holding a delegation for this app, so the round under test has something to
   // re-issue. Runs before the `authorizePage` fixture performs that round.
+  //
+  // `prompt=login` rather than no param, because sending `prompt` at all is what
+  // opts an app into having its delegation kept. Driven through
+  // `authorizeWithUrl` since this priming round needs its own query param and
+  // the fixture performs exactly one round, the one under test.
   test.beforeEach(async ({ page, identities, signInWithIdentity }) => {
-    expectedPrincipal = await authorize(page, async (authPage) => {
-      await signInWithIdentity(authPage, identities[0].identityNumber);
-      await authPage
-        .getByRole("button", { name: "Continue", exact: true })
-        .click();
-    });
+    expectedPrincipal = await authorizeWithUrl(
+      page,
+      TEST_APP_URL,
+      `${II_URL}/authorize?prompt=login`,
+      async (authPage) => {
+        await signInWithIdentity(authPage, identities[0].identityNumber);
+        await authPage
+          .getByRole("button", { name: "Continue", exact: true })
+          .click();
+      },
+      true,
+    );
   });
 
   // Read here rather than in the test body: `authorizedPrincipal` resolves only

--- a/src/frontend/tests/e2e-playwright/routes/authorize/silentReauth.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/silentReauth.spec.ts
@@ -1,6 +1,29 @@
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { test } from "../../fixtures";
 import { authorizeWithUrl, II_URL, TEST_APP_URL } from "../../utils";
+
+// Signs in to the test app for real, leaving Internet Identity holding a
+// delegation for it. `prompt=login` rather than no param, because sending
+// `prompt` at all is what opts an app into having its delegation kept. Driven
+// through `authorizeWithUrl` because a priming round needs its own query param
+// and the `authorizePage` fixture performs exactly one round, the one under
+// test.
+const primeDelegation = (
+  page: Page,
+  signIn: (authPage: Page) => Promise<void>,
+): Promise<string> =>
+  authorizeWithUrl(
+    page,
+    TEST_APP_URL,
+    `${II_URL}/authorize?prompt=login`,
+    async (authPage) => {
+      await signIn(authPage);
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    },
+    true,
+  );
 
 test.describe("Re-issue a delegation with ?prompt=none", () => {
   // The principal the priming sign-in produced. A silent re-issue has to
@@ -8,26 +31,12 @@ test.describe("Re-issue a delegation with ?prompt=none", () => {
   // either way, so a different principal would mean the wrong account.
   let expectedPrincipal: string;
 
-  // A normal sign-in first. That ceremony is what leaves Internet Identity
-  // holding a delegation for this app, so the round under test has something to
-  // re-issue. Runs before the `authorizePage` fixture performs that round.
-  //
-  // `prompt=login` rather than no param, because sending `prompt` at all is what
-  // opts an app into having its delegation kept. Driven through
-  // `authorizeWithUrl` since this priming round needs its own query param and
-  // the fixture performs exactly one round, the one under test.
+  // Runs before the `authorizePage` fixture performs the round under test. Only
+  // one identity exists here (the default), which is what makes a silent
+  // re-issue unambiguous without a hint.
   test.beforeEach(async ({ page, identities, signInWithIdentity }) => {
-    expectedPrincipal = await authorizeWithUrl(
-      page,
-      TEST_APP_URL,
-      `${II_URL}/authorize?prompt=login`,
-      async (authPage) => {
-        await signInWithIdentity(authPage, identities[0].identityNumber);
-        await authPage
-          .getByRole("button", { name: "Continue", exact: true })
-          .click();
-      },
-      true,
+    expectedPrincipal = await primeDelegation(page, (authPage) =>
+      signInWithIdentity(authPage, identities[0].identityNumber),
     );
   });
 
@@ -68,4 +77,50 @@ test.describe("Re-issue a delegation with ?prompt=none", () => {
       expect(authorizePage).toBeDefined();
     });
   });
+});
+
+// Two identities have signed in to this app, so Internet Identity holds a
+// delegation for each and a silent re-issue has no unambiguous answer. `?hint=`
+// is the only thing that resolves it, and the principal it names is only known
+// once the priming rounds have run — hence a fixture the config depends on,
+// rather than a static `test.use` value.
+const hintTest = test.extend<{ primed: { first: string; second: string } }>({
+  primed: async ({ page, identities, signInWithIdentity }, use) => {
+    const first = await primeDelegation(page, (authPage) =>
+      signInWithIdentity(authPage, identities[0].identityNumber),
+    );
+    const second = await primeDelegation(page, (authPage) =>
+      signInWithIdentity(authPage, identities[1].identityNumber),
+    );
+    expect(first).not.toBe(second);
+    await use({ first, second });
+  },
+  authorizeConfig: async ({ primed }, use) => {
+    await use({ protocol: "icrc25", prompt: "none", hint: primed.first });
+  },
+});
+
+hintTest.describe("Re-issue a delegation with ?hint=", () => {
+  hintTest.use({
+    identityConfig: {
+      createIdentities: [{ name: "Test 1" }, { name: "Test 2" }],
+    },
+  });
+
+  // The hint names the first identity, so that is the delegation that must come
+  // back — not the second, which signed in most recently and would be the one a
+  // "latest wins" implementation picked.
+  hintTest.afterEach(({ authorizedPrincipal, primed }) => {
+    expect(authorizedPrincipal?.toText()).toBe(primed.first);
+    expect(authorizedPrincipal?.toText()).not.toBe(primed.second);
+  });
+
+  hintTest(
+    "re-issues the hinted identity rather than asking which to use",
+    ({ authorizePage }) => {
+      // Without the hint this round would be denied as ambiguous: two identities
+      // on the device, two stored delegations for this origin.
+      expect(authorizePage).toBeDefined();
+    },
+  );
 });

--- a/src/frontend/tests/e2e-playwright/routes/authorize/silentReauth.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/silentReauth.spec.ts
@@ -1,0 +1,38 @@
+import { expect } from "@playwright/test";
+import { test } from "../../fixtures";
+import { authorizeWithUrl, TEST_APP_URL, II_URL } from "../../utils";
+
+test("Re-authorizes with ?prompt=none without any interaction", async ({
+  page,
+  identities,
+  signInWithIdentity,
+}) => {
+  // A normal sign-in first, which is what leaves Internet Identity holding a
+  // delegation for this app.
+  const expectedPrincipal = await authorizeWithUrl(
+    page,
+    TEST_APP_URL,
+    `${II_URL}/authorize`,
+    async (authPage) => {
+      await signInWithIdentity(authPage, identities[0].identityNumber);
+      await authPage
+        .getByRole("button", { name: "Continue", exact: true })
+        .click();
+    },
+    true,
+  );
+
+  // Nothing to do in the popup this time: no passkey, no virtual authenticator,
+  // no Continue button. Internet Identity extends the delegation it kept and
+  // closes without rendering anything, and the app ends up with the same
+  // principal it had before.
+  const principal = await authorizeWithUrl(
+    page,
+    TEST_APP_URL,
+    `${II_URL}/authorize?prompt=none`,
+    async () => {},
+    true,
+  );
+
+  expect(principal).toBe(expectedPrincipal);
+});

--- a/src/frontend/tests/e2e-playwright/routes/authorize/silentReauth.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/silentReauth.spec.ts
@@ -1,38 +1,38 @@
 import { expect } from "@playwright/test";
 import { test } from "../../fixtures";
-import { authorizeWithUrl, TEST_APP_URL, II_URL } from "../../utils";
+import {
+  type AuthorizeConfig,
+  performAuthorize,
+} from "../../fixtures/authorize";
+import { II_URL, TEST_APP_URL } from "../../utils";
 
-test("Re-authorizes with ?prompt=none without any interaction", async ({
+const config: Partial<AuthorizeConfig> = {
+  protocol: "icrc25",
+  testAppURL: TEST_APP_URL,
+  internetIdentityURL: II_URL,
+};
+
+test("Re-issues a delegation with ?prompt=none without any interaction", async ({
   page,
   identities,
   signInWithIdentity,
 }) => {
-  // A normal sign-in first, which is what leaves Internet Identity holding a
+  // A normal sign-in first: that is what leaves Internet Identity holding a
   // delegation for this app.
-  const expectedPrincipal = await authorizeWithUrl(
-    page,
-    TEST_APP_URL,
-    `${II_URL}/authorize`,
-    async (authPage) => {
-      await signInWithIdentity(authPage, identities[0].identityNumber);
-      await authPage
-        .getByRole("button", { name: "Continue", exact: true })
-        .click();
-    },
-    true,
-  );
+  await performAuthorize(page, config, async (authPage) => {
+    await signInWithIdentity(authPage, identities[0].identityNumber);
+    await authPage
+      .getByRole("button", { name: "Continue", exact: true })
+      .click();
+  });
+  const expectedPrincipal = await page.locator("#principal").textContent();
+  expect(expectedPrincipal).not.toBe("");
 
   // Nothing to do in the popup this time: no passkey, no virtual authenticator,
   // no Continue button. Internet Identity extends the delegation it kept and
-  // closes without rendering anything, and the app ends up with the same
-  // principal it had before.
-  const principal = await authorizeWithUrl(
-    page,
-    TEST_APP_URL,
-    `${II_URL}/authorize?prompt=none`,
-    async () => {},
-    true,
-  );
+  // closes without rendering anything, and the app ends up with the principal it
+  // had before.
+  await performAuthorize(page, { ...config, prompt: "none" }, async () => {});
 
-  expect(principal).toBe(expectedPrincipal);
+  await expect(page.locator("#principal")).toHaveText(expectedPrincipal ?? "");
 });


### PR DESCRIPTION
Internet Identity keeps no session that can authorize anything, so every sign-in costs a passkey — including the one a user does thirty seconds after signing in to a sibling app on the same domain. There is nothing to fall back on: `ii-session-delegations` is accepted by exactly two canister endpoints, both reads.

This keeps the delegation for an app in Internet Identity's own frontend and extends it locally on the next request, so an app that asks can get a delegation again without a ceremony. The user sees an app they already signed in to simply being signed in, instead of another biometric prompt.

Two optional query params on `/authorize`, both borrowed from OpenID Connect:

| Param | Effect |
| --- | --- |
| `prompt=none` | Answer from the cached delegation, or error without ever rendering UI. The app promises it can handle the failure. |
| `prompt=login` | Run a full ceremony, ignoring anything cached. |
| `hint=<principal>` | The principal the app last received, picking between cached delegations when there is more than one. |

**An absent `prompt` behaves as `login`**, and is also what keeps an app out of the cache entirely: an app that has never heard of the param cannot call `ii-forget-delegation` either, so keeping a delegation for it would leave one nothing clears until it expires, and one it could never use since re-issue needs `prompt=none`. So nothing at all changes for an app that has not opted in, down to the shape of the delegation it receives. Unrecognised values (including `consent` and `select_account`, which are not implemented) are ignored and behave the same way, leaving room for an `auto` value later meaning "re-issue when unambiguous, otherwise show the sign-in screen".

Silence is opt-in rather than the default deliberately. The first version of this followed the OpenID Connect convention and re-issued silently whenever it was unambiguous, which removed the sign-in screen from every return visit. That screen is the only place a user can switch identity or account, and 11 e2e specs exist precisely to exercise it on a return visit. Until there is an escape hatch for switching (`select_account` is the conventional one), silence stays something an app asks for.

Even under `prompt=none` it needs all of: something cached for the effective origin with more than five minutes left, exactly one identity in the last-used list, and the multiple-accounts toggle off for it. A matching `hint` satisfies the ambiguity guards on its own, since a principal names an identity and an account together. Ambiguity is judged from the identity list rather than from what is cached, so a user is never silently signed in as their only cached identity when they have another they might have wanted.

**Why this does not widen the blast radius.** The stored delegation carries exactly the expiration the app's own copy carries, so an attacker with the browser profile already holds an equivalent credential for that same window; the two live and die together. The key pair is non-extractable and confined to one origin and account, and the canister-signed half is inert without it. Re-issuing can only restore a session, never lengthen one, because the extension expires with its parent. How long any of this lasts is the app's own `maxTimeToLive`, visible in the app's code rather than being an Internet Identity policy.

# Changes

- `?prompt=` and `?hint=` read once in the authorize layout, kept in `authorization.store`, and stripped from the address bar so a principal does not linger in history. Mirrored through `sessionStorage` across a 1-click identity provider round-trip: without that, the resumed load would read no `prompt` and could answer a request from a delegation the user had just been made to sign in past.
- New `ii-app-delegations` store, keyed by effective origin. Every alternative origin of a derivation origin shares one entry, because Internet Identity already treats them as one app. Keyed that way because `idb-keyval` has no secondary indexes, so the hot path is a single keyed read and only the cross-origin identity purge scans.
- The delegation handler now has the canister delegate to a key the frontend holds and extends that to the app's session key, instead of delegating straight to the app. Same number of canister calls as before, and it populates the cache as a side effect. Chains gain one hop, but only for a request that sent `prompt`: the popup transport goes from one delegation to two and ICRC-167 from two to three, well inside the limit of ten. A request without `prompt` keeps the shape it has today. If the key cannot be created the delegation goes straight to the app's key as before, simply without a cache.
- `ii-forget-delegation`, a new channel method for an app to drop what Internet Identity holds when it signs the user out. Named "forget" rather than "revoke" because nothing is invalidated: the app's own delegation stays valid until it expires and is the app's to clear. The next request then falls through to the interactive path with no extra state.
- New error code `3002 Interaction required`, with `data.reason` of `login_required`, `account_selection_required` or `consent_required`. ICRC-25's ranges are categorical and 3xxx is user action, so a client that categorises by range reads it correctly. An Internet Identity extension, like the existing non-standard `permissions` field.
- Cached delegations are purged wherever `purgeSession` already runs, at the eight sign-out and identity-removal sites. Deliberately not at the three `ContinueView` sites that only discard a stale session key, which says nothing about the per-origin delegations. At the two sites that navigate away immediately the purges are now awaited, since navigation can cancel a pending IndexedDB delete and a surviving delegation would allow silent re-issue after sign-out.
- The multiple-accounts toggle helper moved out of `ContinueView` now that the delegation handler reads it too.
- `AuthorizeConfig` in the e2e authorize fixture takes `prompt` and `hint`, built into the same query string as `openid` and `sso`. The round the `authorizePage` fixture performs is extracted into an exported `performAuthorize`, because re-authorizing needs one round to leave the delegation and a second to re-issue it, and both should go through the path the fixture uses. `redirect.spec.ts` keeps its two-hop assertion, since none of those flows sends `prompt`; a comment there now says so, so a third hop appearing would be read as II having started caching for apps that never asked.

### Two things worth a reviewer's attention

**Attributes are out of scope, and had to be made to fail fast.** Attributes are certified by the canister over a nonce the app picks per request, so nothing cached can answer them. Left alone, an attributes request under `prompt=none` would block on an authorization that never comes, and on the redirect transport a batch that never completes leaves the user parked on Internet Identity — the one outcome `prompt=none` promises to avoid. It now errors immediately instead. Note the consequence on ICRC-167: a JSON-RPC error aborts the batch, so an app batching a delegation and attributes under `prompt=none` gets an error for both rather than a delegation plus one error. On the postMessage transport the two are independent and it gets exactly that.

**Silent re-issue makes no canister call**, so `delegation_bookkeeping`, `set_account_last_used` and activity stats do not record those sign-ins. Dashboards will under-report by however much `prompt=none` gets used.

# Tests

40 new unit tests across four files:

- The silence rule's truth table: the single-identity case, both denial reasons, and a matching `hint` overriding every ambiguity guard.
- That a read-only restriction survives storage plus a local extension, and that an extension never outlives the delegation it extends. These were the two properties the design rested on that I did not want to take on faith.
- The store: origin isolation, several records per origin, replacement by principal, the five-minute expiry margin, and that purging an identity spans origins while sparing other identities.
- The params: unrecognised `prompt` values ignored, non-principal hints dropped, survival across an identity provider round-trip, and that a stored value cannot leak into an unrelated later flow.
- That an attributes request under `prompt=none` errors rather than blocking.

The 18 `vitest` failures in `findWebAuthnFlows` and `iiConnection` fail identically on `main` at this commit and are unrelated.

One e2e spec drives the silent path end to end on the popup transport: a normal sign-in, then `?prompt=none` with no interaction at all, asserting the same principal comes back. Both transports are covered, differing by one config value. The remaining gap is `ii-forget-delegation`, which has no e2e coverage.


