### PR TITLE
refactor(be): share one helper for From-header parsing

### DIFF
--- a/src/internet_identity/src/dmarc/from_header.rs
+++ b/src/internet_identity/src/dmarc/from_header.rs
@@ -40,6 +40,36 @@ pub fn extract_from_domain(message: &SmtpMessage) -> Result<String, String> {
 /// lowercased. Tolerates an optional display name and angle-bracket
 /// `<addr-spec>`; rejects address-lists and group syntax.
 fn parse_single_mailbox_domain(value: &str) -> Result<String, String> {
+    let address_part = parse_single_mailbox_addr_spec(value)?;
+    let (_, domain) = address_part
+        .split_once('@')
+        .ok_or_else(|| format!("From: value missing '@': {address_part}"))?;
+    let domain = domain.trim().trim_end_matches('.').to_ascii_lowercase();
+    if domain.is_empty() {
+        return Err("From: value has empty domain".to_string());
+    }
+    if domain.contains(char::is_whitespace) {
+        return Err("From: domain contains whitespace".to_string());
+    }
+    Ok(domain)
+}
+
+/// Parse an RFC 5322 `From:` value down to its single `addr-spec`
+/// (`local@domain`, no angle brackets, no display name).
+///
+/// This is the shared front half of [`parse_single_mailbox_domain`]:
+/// it locates the address-spec and enforces the "exactly one mailbox"
+/// rule (rejecting address-lists, group syntax, and whitespace inside
+/// a bare addr-spec), but returns the whole `local@domain` slice
+/// instead of only the domain. Callers that need the full mailbox —
+/// the email-recovery inbound path, which matches the verified sender
+/// against the anchor's registered address — reuse this rather than
+/// re-implementing the mailbox scan.
+///
+/// The returned slice borrows from `value` (trimmed); it still
+/// contains the `@`, and the caller is responsible for any further
+/// splitting / length bounds.
+pub(crate) fn parse_single_mailbox_addr_spec(value: &str) -> Result<&str, String> {
     let value = value.trim();
     if value.is_empty() {
         return Err("empty From: value".to_string());
@@ -63,17 +93,7 @@ fn parse_single_mailbox_domain(value: &str) -> Result<String, String> {
         return Err("From: addr-spec contains whitespace".to_string());
     }
 
-    let (_, domain) = address_part
-        .split_once('@')
-        .ok_or_else(|| format!("From: value missing '@': {value}"))?;
-    let domain = domain.trim().trim_end_matches('.').to_ascii_lowercase();
-    if domain.is_empty() {
-        return Err("From: value has empty domain".to_string());
-    }
-    if domain.contains(char::is_whitespace) {
-        return Err("From: domain contains whitespace".to_string());
-    }
-    Ok(domain)
+    Ok(address_part)
 }
 
 /// Walk the value looking for the address-spec. The grammar we accept:

--- a/src/internet_identity/src/dmarc/mod.rs
+++ b/src/internet_identity/src/dmarc/mod.rs
@@ -68,4 +68,5 @@ pub use verify::verify_email;
 // without re-running the full `verify_email` pipeline (which expects
 // the message body the body has already been dropped).
 pub(crate) use alignment::aligns;
+pub(crate) use from_header::parse_single_mailbox_addr_spec;
 pub(crate) use parse::parse_dmarc_txt;

--- a/src/internet_identity/src/email_inbound/smtp.rs
+++ b/src/internet_identity/src/email_inbound/smtp.rs
@@ -656,22 +656,17 @@ pub(super) fn extract_from_address(
         .iter()
         .find(|h| h.name.eq_ignore_ascii_case("From"))
         .ok_or(EmailChallengeError::AddressMismatch)?;
-    let value = from_header.value.trim();
-    // `From:` is RFC 5322 `address-list` in the general case, but
-    // DMARC requires exactly one mailbox. The DMARC verifier already
-    // enforced that, so by the time we're here the value is a
-    // single mailbox in either `addr-spec` or `name-addr` form.
-    let addr_spec = if let Some(start) = value.rfind('<') {
-        let end = value
-            .rfind('>')
-            .ok_or(EmailChallengeError::AddressMismatch)?;
-        if end <= start + 1 {
-            return Err(EmailChallengeError::AddressMismatch);
-        }
-        &value[start + 1..end]
-    } else {
-        value
-    };
+    // `From:` is RFC 5322 `address-list` in the general case, but the
+    // recovery flow needs exactly one mailbox. Parse it with the same
+    // single-mailbox parser DMARC alignment uses (`dmarc::from_header`)
+    // rather than a second, looser scan here — one parser, one set of
+    // rules for what counts as a single mailbox (no address-list, no
+    // group syntax, display name tolerated). Any parse failure maps to
+    // `AddressMismatch`: by this point DKIM verify has accepted the
+    // message, so a `From:` we can't resolve to one mailbox is
+    // observably "doesn't match".
+    let addr_spec = crate::dmarc::parse_single_mailbox_addr_spec(&from_header.value)
+        .map_err(|_| EmailChallengeError::AddressMismatch)?;
     // Apply the same RFC 5321 §4.5.3.1 caps as `prepare_add` did
     // when accepting the claimed address. Defense in depth: a real
     // SMTP path won't deliver an oversized address (RFC 5321 line
@@ -1101,6 +1096,29 @@ mod tests {
             body: ByteBuf::new(),
         };
         assert_eq!(extract_from_address(&msg).unwrap(), "alice@gmail.com");
+    }
+
+    #[test]
+    fn extract_from_single_mailbox() {
+        use internet_identity_interface::internet_identity::types::smtp::{
+            SmtpHeader, SmtpMessage,
+        };
+        use serde_bytes::ByteBuf;
+        let msg = |value: &str| SmtpMessage {
+            headers: vec![SmtpHeader {
+                name: "From".into(),
+                value: value.into(),
+            }],
+            body: ByteBuf::new(),
+        };
+        assert!(matches!(
+            extract_from_address(&msg("Alice <alice@example.com>, Bob <bob@example.com>")),
+            Err(EmailChallengeError::AddressMismatch)
+        ));
+        assert!(matches!(
+            extract_from_address(&msg("group: alice@example.com;")),
+            Err(EmailChallengeError::AddressMismatch)
+        ));
     }
 
     fn smtp_envelope(user: &str, domain: &str) -> SmtpRequest {


### PR DESCRIPTION
Share a single helper for parsing the `From:` address instead of having two. No functional change.