### PR TITLE
fix(be): reject email addresses containing more than one @

### DIFF
--- a/src/internet_identity/src/dmarc/from_header.rs
+++ b/src/internet_identity/src/dmarc/from_header.rs
@@ -21,8 +21,9 @@ const FROM_HEADER: &str = "From";
 ///
 /// Returns `Err` with a human-readable reason on:
 /// - zero or more than one `From:` header,
-/// - a header value that's empty / has no `@` / has trailing list
-///   syntax / uses RFC 5322 group syntax (`name:addrs;`),
+/// - a header value that's empty / has no `@` / has more than one `@`
+///   / has trailing list syntax / uses RFC 5322 group syntax
+///   (`name:addrs;`),
 /// - a domain that's empty after `@`.
 pub fn extract_from_domain(message: &SmtpMessage) -> Result<String, String> {
     let mut iter = message
@@ -59,12 +60,12 @@ fn parse_single_mailbox_domain(value: &str) -> Result<String, String> {
 ///
 /// This is the shared front half of [`parse_single_mailbox_domain`]:
 /// it locates the address-spec and enforces the "exactly one mailbox"
-/// rule (rejecting address-lists, group syntax, and whitespace inside
-/// a bare addr-spec), but returns the whole `local@domain` slice
-/// instead of only the domain. Callers that need the full mailbox —
-/// the email-recovery inbound path, which matches the verified sender
-/// against the anchor's registered address — reuse this rather than
-/// re-implementing the mailbox scan.
+/// rule (rejecting address-lists, group syntax, whitespace inside a
+/// bare addr-spec, and a second `@`), but returns the whole
+/// `local@domain` slice instead of only the domain. Callers that need
+/// the full mailbox — the email-recovery inbound path, which matches
+/// the verified sender against the anchor's registered address —
+/// reuse this rather than re-implementing the mailbox scan.
 ///
 /// The returned slice borrows from `value` (trimmed); it still
 /// contains the `@`, and the caller is responsible for any further
@@ -91,6 +92,15 @@ pub(crate) fn parse_single_mailbox_addr_spec(value: &str) -> Result<&str, String
     // would otherwise slip through with domain == example.com.
     if !in_angle_brackets && address_part.chars().any(char::is_whitespace) {
         return Err("From: addr-spec contains whitespace".to_string());
+    }
+
+    // Exactly one `@`, so "the domain" is the same slice no matter
+    // which side a caller splits from. RFC 5322 does permit a quoted
+    // local-part to carry an `@` (`"a@b"@example.com`), but accepting
+    // one means a first-`@` split and a last-`@` split disagree about
+    // the domain — and this parser feeds both.
+    if address_part.matches('@').count() != 1 {
+        return Err("From: addr-spec must contain exactly one '@'".to_string());
     }
 
     Ok(address_part)
@@ -336,6 +346,29 @@ mod tests {
         let m = message_with(&["alice @example.com"]);
         let err = extract_from_domain(&m).unwrap_err();
         assert!(err.contains("whitespace"));
+    }
+
+    #[test]
+    fn rejects_second_at_in_bare_addr_spec() {
+        let m = message_with(&["alice@example.com@example.org"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("exactly one '@'"));
+    }
+
+    #[test]
+    fn rejects_second_at_in_quoted_local_part() {
+        // Legal RFC 5322, deliberately refused: a left split and a right
+        // split disagree about the domain, and both happen downstream.
+        let m = message_with(&["\"alice@example.com\"@example.org"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("exactly one '@'"));
+    }
+
+    #[test]
+    fn rejects_second_at_inside_angle_brackets() {
+        let m = message_with(&["Alice <alice@example.com@example.org>"]);
+        let err = extract_from_domain(&m).unwrap_err();
+        assert!(err.contains("exactly one '@'"));
     }
 
     #[test]

--- a/src/internet_identity/src/email_inbound/prepare.rs
+++ b/src/internet_identity/src/email_inbound/prepare.rs
@@ -254,8 +254,8 @@ fn verify_dnssec_skeleton(
 
 /// Normalise an email address to the canonical `lowercase(local) +
 /// "@" + lowercase(domain)` form. Returns `None` if the address is
-/// obviously malformed (no `@`, empty local-part, empty domain,
-/// embedded whitespace).
+/// obviously malformed (no `@`, more than one `@`, empty local-part,
+/// empty domain, embedded whitespace).
 ///
 /// Stricter normalisation (IDN, RFC 5322 quoted local-parts) is the
 /// mail-auth verifier's job — here we just want to reject the
@@ -278,6 +278,12 @@ fn normalize_address(input: &str) -> Option<String> {
     if local.is_empty() || domain.is_empty() {
         return None;
     }
+    // `registered_domain_of` splits from the right and the verifier
+    // splits from the left, so a second `@` would leave them naming
+    // different domains for one address. Require one answer.
+    if domain.contains('@') {
+        return None;
+    }
     if local.len() > super::MAX_LOCAL_PART || domain.len() > super::MAX_DOMAIN {
         return None;
     }
@@ -295,4 +301,47 @@ fn normalize_address(input: &str) -> Option<String> {
 /// value, which is what the operator configures.
 fn registered_domain_of(address: &str) -> Option<String> {
     address.rsplit_once('@').map(|(_, d)| d.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_lowercases_both_parts() {
+        assert_eq!(
+            normalize_address(" Alice@GMAIL.com ").as_deref(),
+            Some("alice@gmail.com")
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_malformed() {
+        for input in ["", "alice", "@gmail.com", "alice@", "ali ce@gmail.com"] {
+            assert_eq!(normalize_address(input), None, "accepted {input:?}");
+        }
+    }
+
+    #[test]
+    fn normalize_rejects_second_at() {
+        for input in [
+            "alice@example.org@example.com",
+            "\"alice@example.org\"@example.com",
+            "alice@example.com@example.org",
+        ] {
+            assert_eq!(normalize_address(input), None, "accepted {input:?}");
+        }
+    }
+
+    #[test]
+    fn accepted_addresses_agree_on_their_domain() {
+        // The invariant the `@` cap buys: for anything
+        // `normalize_address` accepts, a left split and a right split
+        // name the same domain.
+        let address = normalize_address("alice@example.com").unwrap();
+        assert_eq!(
+            registered_domain_of(&address).as_deref(),
+            address.split_once('@').map(|(_, d)| d)
+        );
+    }
 }

--- a/src/internet_identity/src/email_inbound/prepare.rs
+++ b/src/internet_identity/src/email_inbound/prepare.rs
@@ -326,7 +326,7 @@ mod tests {
     fn normalize_rejects_second_at() {
         for input in [
             "alice@example.org@example.com",
-            "\"alice@example.org\"@example.com",
+            "\"a@b\"@example.com",
             "alice@example.com@example.org",
         ] {
             assert_eq!(normalize_address(input), None, "accepted {input:?}");

--- a/src/internet_identity/src/email_inbound/smtp.rs
+++ b/src/internet_identity/src/email_inbound/smtp.rs
@@ -1121,6 +1121,36 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn extract_from_rejects_second_at() {
+        use internet_identity_interface::internet_identity::types::smtp::{
+            SmtpHeader, SmtpMessage,
+        };
+        use serde_bytes::ByteBuf;
+        let msg = |value: &str| SmtpMessage {
+            headers: vec![SmtpHeader {
+                name: "From".into(),
+                value: value.into(),
+            }],
+            body: ByteBuf::new(),
+        };
+        // `prepare` splits from the right to name the domain, this
+        // extractor splits from the left. One `@` per address keeps
+        // the two from ever disagreeing.
+        assert!(matches!(
+            extract_from_address(&msg("alice@example.org@example.com")),
+            Err(EmailChallengeError::AddressMismatch)
+        ));
+        assert!(matches!(
+            extract_from_address(&msg("\"alice@example.org\"@example.com")),
+            Err(EmailChallengeError::AddressMismatch)
+        ));
+        assert!(matches!(
+            extract_from_address(&msg("Alice <alice@example.org@example.com>")),
+            Err(EmailChallengeError::AddressMismatch)
+        ));
+    }
+
     fn smtp_envelope(user: &str, domain: &str) -> SmtpRequest {
         smtp_envelope_with_recipients(&[(user, domain)])
     }

--- a/src/internet_identity/src/email_inbound/smtp.rs
+++ b/src/internet_identity/src/email_inbound/smtp.rs
@@ -1142,7 +1142,7 @@ mod tests {
             Err(EmailChallengeError::AddressMismatch)
         ));
         assert!(matches!(
-            extract_from_address(&msg("\"alice@example.org\"@example.com")),
+            extract_from_address(&msg("\"a@b\"@example.com")),
             Err(EmailChallengeError::AddressMismatch)
         ));
         assert!(matches!(


### PR DESCRIPTION
Two places derive the domain from an email address, and they disagree about where the domain starts. `registered_domain_of` splits from the right; `extract_from_address` and `parse_single_mailbox_domain` split from the left. For an address carrying more than one `@` those return different answers, which is needless ambiguity in a value the inbound path matches on.

RFC 5322 does permit a quoted local-part to contain an `@`. No provider we accept mail from issues one, and this module already fails closed by design, so the cheapest way to remove the ambiguity is to require exactly one.

# Changes

- `parse_single_mailbox_addr_spec` requires exactly one `@`. This is the parser [#4203](https://github.com/dfinity/internet-identity/pull/4203) made shared, so the inbound path and DMARC alignment both pick the rule up, and the left split now always agrees with the right split in `submit_leaf`.
- `normalize_address` applies the same rule at `prepare`, so a claimed address can't carry a second `@` either.

# Tests

- `from_header`: rejected bare, inside angle brackets, and inside a quoted local-part.
- `smtp`: `extract_from_address` maps all three shapes to `AddressMismatch`.
- `email_inbound::prepare`: first tests for `normalize_address` — lowercasing, the existing malformed cases, the new rule, and a check that both splits name the same domain for anything it accepts.
