### PR TITLE
test(be): regression coverage for DKIM From-header forgery in email recovery

### DIFF
--- a/src/internet_identity/src/email_inbound/smtp.rs
+++ b/src/internet_identity/src/email_inbound/smtp.rs
@@ -1162,9 +1162,12 @@ mod tests {
         use serde_bytes::ByteBuf;
 
         // A DKIM-Signature covering From:To (order matters for the hash
-        // input). Tag values other than `h=` are irrelevant to
-        // build_header_hash_input, which only canonicalises the listed
-        // headers plus the signature header with `b=` blanked.
+        // input). Its other tag values (d=, s=, bh=, ...) are arbitrary
+        // only because the *same* DKIM-Signature value is reused for both
+        // the honest and forged messages: build_header_hash_input
+        // canonicalises the signature header itself (with `b=` blanked)
+        // into the signed bytes, so those tags do contribute — identically
+        // on both sides.
         let dkim_value = "v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com; \
                           s=sel; h=From:To; bh=MTIzNDU2; b=YWJj";
         let sig = crate::dkim::parse_dkim_signature(dkim_value).expect("parse DKIM-Signature");

--- a/src/internet_identity/src/email_inbound/smtp.rs
+++ b/src/internet_identity/src/email_inbound/smtp.rs
@@ -1121,6 +1121,105 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn extract_from_rejects_crlf_spliced_header() {
+        // A `From:` value carrying a second mailbox smuggled behind an
+        // embedded CRLF must not resolve to that second mailbox — it is
+        // not a single mailbox, so
+        // extraction fails closed. Before the single-mailbox parser
+        // this returned the *last* angle-bracket pair, i.e. the
+        // attacker-chosen `victim@`.
+        use internet_identity_interface::internet_identity::types::smtp::{
+            SmtpHeader, SmtpMessage,
+        };
+        use serde_bytes::ByteBuf;
+        let msg = SmtpMessage {
+            headers: vec![SmtpHeader {
+                name: "From".into(),
+                value: "Attacker <attacker@example.com>\r\nto:Victim <victim@example.com>".into(),
+            }],
+            body: ByteBuf::new(),
+        };
+        assert!(matches!(
+            extract_from_address(&msg),
+            Err(EmailChallengeError::AddressMismatch)
+        ));
+    }
+
+    #[test]
+    fn crlf_splice_preserves_dkim_signed_bytes() {
+        // Documents *why* the forgery kept a valid signature: relocating
+        // the `To:` header's canonical bytes into the `From:` value (via
+        // an embedded CRLF) and dropping the `To:` header leaves the DKIM
+        // signed-header input byte-for-byte identical. So a genuine
+        // signature over the honest message also verifies over the forged
+        // one — the only thing that changes is which mailbox the sender
+        // resolves to. The fix is therefore in `extract_from_address`
+        // (asserted above), not in the signature check.
+        use internet_identity_interface::internet_identity::types::smtp::{
+            SmtpHeader, SmtpMessage,
+        };
+        use serde_bytes::ByteBuf;
+
+        // A DKIM-Signature covering From:To (order matters for the hash
+        // input). Tag values other than `h=` are irrelevant to
+        // build_header_hash_input, which only canonicalises the listed
+        // headers plus the signature header with `b=` blanked.
+        let dkim_value = "v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com; \
+                          s=sel; h=From:To; bh=MTIzNDU2; b=YWJj";
+        let sig = crate::dkim::parse_dkim_signature(dkim_value).expect("parse DKIM-Signature");
+
+        let honest = vec![
+            SmtpHeader {
+                name: "From".into(),
+                value: "Attacker <attacker@example.com>".into(),
+            },
+            SmtpHeader {
+                name: "To".into(),
+                value: "Victim <victim@example.com>".into(),
+            },
+            SmtpHeader {
+                name: "DKIM-Signature".into(),
+                value: dkim_value.into(),
+            },
+        ];
+        // The forged message: the `To:` canonical line is smuggled into
+        // the `From:` value behind a CRLF, and the real `To:` header is
+        // dropped.
+        let forged = vec![
+            SmtpHeader {
+                name: "From".into(),
+                value: "Attacker <attacker@example.com>\r\nto:Victim <victim@example.com>".into(),
+            },
+            SmtpHeader {
+                name: "DKIM-Signature".into(),
+                value: dkim_value.into(),
+            },
+        ];
+
+        let honest_signed = crate::dkim::build_header_hash_input(&honest, &sig, dkim_value);
+        let forged_signed = crate::dkim::build_header_hash_input(&forged, &sig, dkim_value);
+        assert_eq!(
+            honest_signed, forged_signed,
+            "CRLF splice must reproduce the honest signed-header bytes exactly"
+        );
+
+        // ...yet the two resolve to different senders: the honest message
+        // to the real sender, the forged one to nothing (rejected).
+        let with_body = |headers: Vec<SmtpHeader>| SmtpMessage {
+            headers,
+            body: ByteBuf::new(),
+        };
+        assert_eq!(
+            extract_from_address(&with_body(honest)).unwrap(),
+            "attacker@example.com"
+        );
+        assert!(matches!(
+            extract_from_address(&with_body(forged)),
+            Err(EmailChallengeError::AddressMismatch)
+        ));
+    }
+
     fn smtp_envelope(user: &str, domain: &str) -> SmtpRequest {
         smtp_envelope_with_recipients(&[(user, domain)])
     }

--- a/src/internet_identity/tests/integration/email_recovery.rs
+++ b/src/internet_identity/tests/integration/email_recovery.rs
@@ -2009,18 +2009,24 @@ fn recovery_succeeds_for_honest_single_mailbox_from() {
     };
     assert!(!user_key.is_empty());
 
-    // The delegation is actually retrievable for the session key we bound.
-    api::email_recovery_get_delegation(
+    // The delegation is retrievable, cryptographically valid against the
+    // IC root key, and bound to exactly the session key and expiration we
+    // requested — not just an `Ok` from the lookup.
+    let signed_delegation = api::email_recovery_get_delegation(
         &env,
         canister_id,
         internet_identity_interface::internet_identity::types::email_recovery::EmailRecoveryGetDelegationArgs {
             nonce: challenge.nonce,
-            session_key,
+            session_key: session_key.clone(),
             expiration,
         },
     )
     .expect("get_delegation call failed")
     .expect("delegation should be retrievable for honest recovery");
+
+    verify_delegation(&env, user_key, &signed_delegation, &env.root_key().unwrap());
+    assert_eq!(signed_delegation.delegation.pubkey, session_key);
+    assert_eq!(signed_delegation.delegation.expiration, expiration);
 }
 
 // ===================================================================

--- a/src/internet_identity/tests/integration/email_recovery.rs
+++ b/src/internet_identity/tests/integration/email_recovery.rs
@@ -1785,6 +1785,245 @@ fn fake_dkim_dns_response(txt: &[u8]) -> Vec<u8> {
 }
 
 // ===================================================================
+// Regression: DKIM From-header forgery via CRLF header smuggling
+// ===================================================================
+//
+// Reproduces the header-forgery attack end-to-end against a real
+// canister: an unauthenticated caller drives the recovery flow claiming a
+// victim's address, and delivers an email that is *genuinely* signed
+// by the victim's domain but whose signed `From:` is `attacker@domain`
+// — with the victim's mailbox smuggled into the delivered `From:`
+// header behind an embedded CRLF (and the `To:` header dropped), so
+// the DKIM signed-header bytes are byte-identical to an honest message
+// and the signature still verifies.
+//
+// The exploit only works if the canister resolves the *smuggled*
+// mailbox as the sender. The strict single-mailbox `From:` parser
+// rejects the multi-line value, so recovery fails closed with
+// `AddressMismatch` and mints no delegation. The negative control
+// confirms honest single-mailbox recovery still completes.
+
+const VICTIM_ADDRESS: &str = TEST_ADDRESS; // alice@test.example.com
+const ATTACKER_ADDRESS: &str = "mallory@test.example.com"; // same signing domain
+const RECOVERY_DATE: &str = "Mon, 5 May 2026 12:00:00 +0000";
+
+/// Bind `VICTIM_ADDRESS` as a recovery credential on a fresh anchor via
+/// the DoH setup flow, so the recovery flow has an anchor to resolve.
+fn bind_victim_recovery_credential(
+    env: &PocketIc,
+    canister_id: candid::Principal,
+    signer: &dkim_signer::TestSigner,
+) {
+    let (id, p) = fresh_identity(env, canister_id);
+    let challenge = api::email_recovery_credential_prepare_add(
+        env,
+        canister_id,
+        p,
+        id,
+        EmailChallengeDnsInput {
+            address: VICTIM_ADDRESS.into(),
+            dns_proof: None,
+        },
+    )
+    .expect("prepare_add call failed")
+    .expect("prepare_add should succeed");
+    let signed = signer.sign_email(SignedEmailParams {
+        from: VICTIM_ADDRESS,
+        to: "register@id.ai",
+        subject: &challenge.nonce,
+        body: TEST_BODY,
+        timestamp: time(env) / 1_000_000_000,
+    });
+    let resp = api::smtp_request(env, canister_id, &signed.request).expect("smtp_request call");
+    assert!(matches!(resp, SmtpResponse::Ok {}));
+    let status = drive_doh_resolution(
+        env,
+        canister_id,
+        &challenge.nonce,
+        &signer.public_txt_record(),
+    );
+    assert!(
+        matches!(status, EmailChallengeStatus::RegistrationSucceeded),
+        "victim credential bind should succeed, got {status:?}"
+    );
+}
+
+#[test]
+fn recovery_rejects_crlf_spliced_from_header() {
+    let env = env();
+    let canister_id = setup_canister(&env);
+    // One signer = the shared-domain provider's DKIM key. The attacker
+    // holds an ordinary signed message from their *own* account at that
+    // domain; they never possess the victim's mailbox.
+    let signer = dkim_signer::TestSigner::new(TEST_DOMAIN, TEST_SELECTOR);
+    bind_victim_recovery_credential(&env, canister_id, &signer);
+
+    // Attacker, unauthenticated, opens a recovery challenge claiming the
+    // victim's address, bound to a session key the attacker controls.
+    let attacker_session_key = ByteBuf::from(vec![7u8; 32]);
+    let challenge = api::email_recovery_prepare_delegation(
+        &env,
+        canister_id,
+        EmailChallengeDnsInput {
+            address: VICTIM_ADDRESS.into(),
+            dns_proof: None,
+        },
+        attacker_session_key.clone(),
+    )
+    .expect("prepare_delegation call failed")
+    .expect("prepare_delegation should issue a challenge");
+
+    // Genuinely sign a message from the attacker's own mailbox, covering
+    // From:To:Subject:Date:Message-ID (name-addr form).
+    let attacker_name_addr = format!("Mallory <{ATTACKER_ADDRESS}>");
+    let victim_name_addr = format!("Victim <{VICTIM_ADDRESS}>");
+    let msg_id = format!("<forge@{TEST_DOMAIN}>");
+    let dkim_value = signer.sign_headers(
+        &[
+            ("From", &attacker_name_addr),
+            ("To", &victim_name_addr),
+            ("Subject", &challenge.nonce),
+            ("Date", RECOVERY_DATE),
+            ("Message-ID", &msg_id),
+        ],
+        TEST_BODY,
+        time(&env) / 1_000_000_000,
+    );
+
+    // Deliver the forgery: the `To:` canonical line is smuggled into the
+    // `From:` value behind a CRLF and the real `To:` header is dropped —
+    // the signed bytes are unchanged, so the signature still verifies,
+    // but a lenient parser would read the sender as the victim.
+    let spliced_from = format!("{attacker_name_addr}\r\nto:{victim_name_addr}");
+    let forged = SmtpRequest {
+        envelope: Some(SmtpEnvelope {
+            from: SmtpAddress {
+                user: "mallory".into(),
+                domain: TEST_DOMAIN.into(),
+            },
+            to: vec![SmtpAddress {
+                user: "recover".into(),
+                domain: "id.ai".into(),
+            }],
+        }),
+        message: Some(SmtpMessage {
+            headers: vec![
+                SmtpHeader {
+                    name: "DKIM-Signature".into(),
+                    value: dkim_value,
+                },
+                SmtpHeader {
+                    name: "From".into(),
+                    value: spliced_from,
+                },
+                SmtpHeader {
+                    name: "Subject".into(),
+                    value: challenge.nonce.clone(),
+                },
+                SmtpHeader {
+                    name: "Date".into(),
+                    value: RECOVERY_DATE.into(),
+                },
+                SmtpHeader {
+                    name: "Message-ID".into(),
+                    value: msg_id,
+                },
+            ],
+            body: ByteBuf::from(TEST_BODY.to_vec()),
+        }),
+        gateway_flags: None,
+        message_id: None,
+    };
+    let resp = api::smtp_request(&env, canister_id, &forged).expect("smtp_request call");
+    assert!(matches!(resp, SmtpResponse::Ok {}));
+
+    // The attack must fail closed: the forged sender doesn't resolve to a
+    // single mailbox, so verification ends in AddressMismatch and never
+    // reaches RecoveryReady. (Pre-fix, the lenient parser resolved the
+    // smuggled `victim@` and this reached RecoveryReady — a takeover.)
+    let status = drive_doh_resolution(
+        &env,
+        canister_id,
+        &challenge.nonce,
+        &signer.public_txt_record(),
+    );
+    assert!(
+        matches!(
+            status,
+            EmailChallengeStatus::Failed(EmailChallengeError::AddressMismatch)
+        ),
+        "CRLF-spliced From must be rejected with AddressMismatch, got {status:?}"
+    );
+    assert!(
+        !matches!(status, EmailChallengeStatus::RecoveryReady { .. }),
+        "recovery must not complete for a forged sender"
+    );
+}
+
+#[test]
+fn recovery_succeeds_for_honest_single_mailbox_from() {
+    // Negative control: the same flow with an honest, single-mailbox
+    // `From:` completes and mints a delegation — proving the strict
+    // parser doesn't break legitimate recovery.
+    let env = env();
+    let canister_id = setup_canister(&env);
+    let signer = dkim_signer::TestSigner::new(TEST_DOMAIN, TEST_SELECTOR);
+    bind_victim_recovery_credential(&env, canister_id, &signer);
+
+    let session_key = ByteBuf::from(vec![9u8; 32]);
+    let challenge = api::email_recovery_prepare_delegation(
+        &env,
+        canister_id,
+        EmailChallengeDnsInput {
+            address: VICTIM_ADDRESS.into(),
+            dns_proof: None,
+        },
+        session_key.clone(),
+    )
+    .expect("prepare_delegation call failed")
+    .expect("prepare_delegation should issue a challenge");
+
+    let signed = signer.sign_email(SignedEmailParams {
+        from: VICTIM_ADDRESS,
+        to: "recover@id.ai",
+        subject: &challenge.nonce,
+        body: TEST_BODY,
+        timestamp: time(&env) / 1_000_000_000,
+    });
+    let resp = api::smtp_request(&env, canister_id, &signed.request).expect("smtp_request call");
+    assert!(matches!(resp, SmtpResponse::Ok {}));
+
+    let status = drive_doh_resolution(
+        &env,
+        canister_id,
+        &challenge.nonce,
+        &signer.public_txt_record(),
+    );
+    let (user_key, expiration) = match status {
+        EmailChallengeStatus::RecoveryReady {
+            user_key,
+            expiration,
+            ..
+        } => (user_key, expiration),
+        other => panic!("honest recovery should reach RecoveryReady, got {other:?}"),
+    };
+    assert!(!user_key.is_empty());
+
+    // The delegation is actually retrievable for the session key we bound.
+    api::email_recovery_get_delegation(
+        &env,
+        canister_id,
+        internet_identity_interface::internet_identity::types::email_recovery::EmailRecoveryGetDelegationArgs {
+            nonce: challenge.nonce,
+            session_key,
+            expiration,
+        },
+    )
+    .expect("get_delegation call failed")
+    .expect("delegation should be retrievable for honest recovery");
+}
+
+// ===================================================================
 // Args structs
 // ===================================================================
 
@@ -1956,6 +2195,53 @@ pub(crate) mod dkim_signer {
             };
 
             super::SignedEmail { request }
+        }
+
+        /// Sign an explicit, ordered set of headers — `h=` is exactly
+        /// those names, in order — over `body`, and return the final
+        /// `DKIM-Signature` header value (with `b=` filled).
+        ///
+        /// Unlike [`Self::sign_email`], which couples the signed headers
+        /// to the delivered message, this lets a test deliver a message
+        /// whose headers differ from the signed set as long as they
+        /// canonicalise to the same bytes — e.g. a forged `From:` that
+        /// absorbs a `To:` line behind an embedded CRLF.
+        pub fn sign_headers(
+            &self,
+            signed_headers: &[(&str, &str)],
+            body: &[u8],
+            timestamp: u64,
+        ) -> String {
+            let canon_body = relaxed_body(body);
+            let bh_b64 = base64_encode(&Sha256::digest(&canon_body));
+            let h = signed_headers
+                .iter()
+                .map(|(name, _)| *name)
+                .collect::<Vec<_>>()
+                .join(":");
+            let sig_value_no_b = format!(
+                "v=1; a=rsa-sha256; c=relaxed/relaxed; d={d}; s={s}; \
+                 t={t}; h={h}; bh={bh}; b=",
+                d = self.domain,
+                s = self.selector,
+                t = timestamp,
+                bh = bh_b64,
+            );
+            let mut hash_input = Vec::new();
+            for (name, value) in signed_headers {
+                hash_input.extend(relaxed_header(name, value));
+            }
+            let mut canon_dkim = relaxed_header("DKIM-Signature", &sig_value_no_b);
+            if canon_dkim.ends_with(b"\r\n") {
+                canon_dkim.truncate(canon_dkim.len() - 2);
+            }
+            hash_input.extend(canon_dkim);
+            let digest: [u8; 32] = Sha256::digest(&hash_input).into();
+            let sig = self
+                .private_key
+                .sign(Pkcs1v15Sign::new::<Sha256>(), &digest)
+                .expect("RSA sign");
+            format!("{sig_value_no_b}{}", base64_encode(&sig))
         }
     }
 


### PR DESCRIPTION
## Why
Email recovery could be tricked into treating a genuinely DKIM-signed message as coming from a *different* mailbox in the same signing domain, by carrying two mailboxes in the `From:` header — either as an address-list, or smuggled via an embedded `\r\n` that expands into a second canonical header line while the original signature stays valid. Because DKIM for a shared-domain provider (e.g. Gmail) only proves "some user at this domain sent this," an attacker holding an ordinary signed message from their own account at that domain could resolve the verified sender to a *victim's* address and complete anonymous recovery for the victim's anchor — account takeover with no victim interaction.

The exploitable path was closed in #4203, which routes `From:` extraction through the strict RFC 5322 single-mailbox parser (rejecting address-lists and multi-line values). That fix currently rests on a refactor with only light unit coverage; this PR adds explicit regression tests so it cannot silently regress.

## What
- **Unit** — `extract_from_address` rejects a CRLF-spliced `From:` with `AddressMismatch`; and a byte-equality assertion showing the spliced message reproduces the honest message's DKIM signed-input, documenting *why* the forged message kept a valid signature.
- **Integration (PocketIC)** — reproduces the full attack: anonymous `email_recovery_prepare_delegation` claiming the victim's address, plus a genuinely-signed email whose `From:` is spliced to resolve to the victim. Asserts the flow ends in `Failed(AddressMismatch)`, never reaches `RecoveryReady`, and mints no delegation. A negative control confirms honest single-mailbox recovery still succeeds.

Verified the integration test reaches `RecoveryReady` (i.e. fails) against the pre-fix build and passes against current `main`.

No production code changes — regression coverage only.