### PR TITLE
fix(fe): redirect ICRC-25 authorize from legacy domains to id.ai

### DIFF
--- a/src/frontend/src/hooks.client.ts
+++ b/src/frontend/src/hooks.client.ts
@@ -10,6 +10,7 @@ import {
   frontendCanisterConfig,
 } from "$lib/globals";
 import { initAnalytics } from "$lib/utils/analytics/analytics";
+import { redirectToPrimaryOrigin } from "$lib/utils/primaryOrigin";
 import { localeStore } from "$lib/stores/locale.store";
 import { getLocaleDirection } from "$lib/constants/locale.constants";
 
@@ -51,6 +52,17 @@ const overrideFeatureFlags = () => {
 
 export const init: ClientInit = async () => {
   await initGlobals();
+  // Redirect related origins to the primary origin here, before any component
+  // mounts, so it happens before the authorize layout establishes the ICRC-29
+  // channel. The client learns the signer origin from the handshake response,
+  // so redirecting before the handshake is invisible to it, while redirecting
+  // after it leaves the client pinned to the previous origin until its
+  // disconnect timeout closes the window.
+  //
+  // Nothing else is initialized on a document that is about to be replaced.
+  if (redirectToPrimaryOrigin()) {
+    return;
+  }
   // Initialize analytics here, in the client `init` hook, so the tracker exists
   // before any component mounts. Svelte runs a child component's `onMount`
   // before its parent's, so initializing in the root layout's `onMount` (as it

--- a/src/frontend/src/lib/utils/primaryOrigin.ts
+++ b/src/frontend/src/lib/utils/primaryOrigin.ts
@@ -36,7 +36,7 @@ export const redirectToPrimaryOrigin = (): boolean => {
   if (primaryOrigin === undefined || window.location.origin === primaryOrigin) {
     return false;
   }
-  const { pathname, search, hash, host } = window.location;
+  const { pathname, search, hash } = window.location;
   // Legacy AuthClient, the legacy transport carries the request across the
   // redirect itself and bounces the response back to this origin.
   if (pathname === "/" && hash === "#authorize") {
@@ -46,9 +46,7 @@ export const redirectToPrimaryOrigin = (): boolean => {
     return false;
   }
   const target = new URL(primaryOrigin);
-  // cli.id.ai serves only the CLI authorize entry point, every hit there
-  // lands on /cli on the primary origin, regardless of path.
-  target.pathname = host === "cli.id.ai" ? "/cli" : pathname;
+  target.pathname = pathname;
   target.search = search;
   target.hash = hash;
   redirecting = true;

--- a/src/frontend/src/lib/utils/primaryOrigin.ts
+++ b/src/frontend/src/lib/utils/primaryOrigin.ts
@@ -1,0 +1,57 @@
+import { getPrimaryOrigin } from "$lib/globals";
+
+// Paths that must keep running on the origin they were loaded from.
+const KEEP_ON_CURRENT_ORIGIN = [
+  // Legacy verifiable credentials
+  "/vc-flow",
+  // Support page, it links to itself on every related origin so passkey
+  // behaviour can be diagnosed per domain
+  "/self-service",
+  // WebAuthn iframe used for migration
+  "/iframe/webauthn",
+  // OpenID callback, the redirect_uri is registered per origin
+  "/callback",
+];
+
+let redirecting = false;
+
+/**
+ * Whether {@link redirectToPrimaryOrigin} has started a redirect, used to keep
+ * the page hidden instead of flashing this origin's render before it commits.
+ */
+export const isRedirectingToPrimaryOrigin = (): boolean => redirecting;
+
+/**
+ * Send the page to the primary origin when it was loaded from a related one.
+ *
+ * Called from the client `init` hook, before any component mounts, so it runs
+ * before the authorize layout establishes the ICRC-29 channel in `$effect.pre`.
+ * That ordering is load bearing: the client learns the signer origin from the
+ * handshake response, so a redirect before the handshake is invisible to it,
+ * while a redirect after it leaves the client pinned to the previous origin
+ * until its disconnect timeout closes the window.
+ */
+export const redirectToPrimaryOrigin = (): boolean => {
+  const primaryOrigin = getPrimaryOrigin();
+  if (primaryOrigin === undefined || window.location.origin === primaryOrigin) {
+    return false;
+  }
+  const { pathname, search, hash, host } = window.location;
+  // Legacy AuthClient, the legacy transport carries the request across the
+  // redirect itself and bounces the response back to this origin.
+  if (pathname === "/" && hash === "#authorize") {
+    return false;
+  }
+  if (KEEP_ON_CURRENT_ORIGIN.includes(pathname)) {
+    return false;
+  }
+  const target = new URL(primaryOrigin);
+  // cli.id.ai serves only the CLI authorize entry point, every hit there
+  // lands on /cli on the primary origin, regardless of path.
+  target.pathname = host === "cli.id.ai" ? "/cli" : pathname;
+  target.search = search;
+  target.hash = hash;
+  redirecting = true;
+  window.location.replace(target);
+  return true;
+};

--- a/src/frontend/src/lib/utils/primaryOrigin.ts
+++ b/src/frontend/src/lib/utils/primaryOrigin.ts
@@ -52,6 +52,6 @@ export const redirectToPrimaryOrigin = (): boolean => {
   target.search = search;
   target.hash = hash;
   redirecting = true;
-  window.location.replace(target);
+  window.location.replace(target.href);
   return true;
 };

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -1,43 +1,14 @@
 <script lang="ts">
-  import { getPrimaryOrigin } from "$lib/globals";
+  import { isRedirectingToPrimaryOrigin } from "$lib/utils/primaryOrigin";
   import { onMount } from "svelte";
   import { page } from "$app/state";
 
   const { children } = $props();
 
   onMount(() => {
-    // Always redirect to primary origin
-    const primaryOrigin = getPrimaryOrigin();
-    if (
-      primaryOrigin !== undefined &&
-      window.location.origin !== primaryOrigin &&
-      // Don't redirect if we're coming from legacy AuthClient
-      !(
-        window.location.pathname === "/" &&
-        window.location.hash === "#authorize"
-      ) &&
-      // Don't redirect if we're visiting legacy verifiable credentials
-      window.location.pathname !== "/vc-flow" &&
-      // Don't redirect if we're visiting self-service
-      window.location.pathname !== "/self-service" &&
-      // Don't redirect if we're visiting webauthn iframe used for migration
-      window.location.pathname !== "/iframe/webauthn" &&
-      // Don't redirect if we're visiting new authorize flow
-      // TODO: Implement redirect with pending ICRC-29 state
-      window.location.pathname !== "/authorize"
-    ) {
-      // cli.id.ai serves only the CLI authorize entry point — every hit
-      // there lands on /cli on the primary origin, regardless of path.
-      const pathname =
-        window.location.host === "cli.id.ai"
-          ? "/cli"
-          : window.location.pathname;
-      window.location.replace(
-        primaryOrigin +
-          pathname +
-          window.location.search +
-          window.location.hash,
-      );
+    // A redirect to the primary origin is in flight, keep the page hidden
+    // rather than flashing this origin's render before it commits.
+    if (isRedirectingToPrimaryOrigin()) {
       return;
     }
 

--- a/src/frontend/tests/e2e-playwright/routes/authorize/legacy.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/legacy.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { Principal } from "@icp-sdk/core/principal";
 import {
   II_URL,
   LEGACY_II_URL,
@@ -6,7 +7,12 @@ import {
   TEST_APP_URL,
   authorizeWithUrl,
   addVirtualAuthenticator,
+  createActorForCredential,
+  fromBase64,
+  getCredentialsFromVirtualAuthenticator,
+  type WebAuthnCredential,
 } from "../../utils";
+import { DEFAULT_HOST } from "../../fixtures/identity";
 [LEGACY_II_URL, ALT_LEGACY_II_URL].forEach((legacyURL) => {
   test.describe(`Legacy domain ${legacyURL}`, () => {
     test(`sees upgrade banner during authentication`, async ({ page }) => {
@@ -41,6 +47,79 @@ import {
             .click();
         },
       );
+    });
+
+    test(`creates the passkey for the primary origin when a dapp points the ICRC-25 transport at this domain`, async ({
+      page,
+    }) => {
+      let canisterId: Principal | undefined;
+      let credentials: WebAuthnCredential[] = [];
+
+      await authorizeWithUrl(
+        page,
+        TEST_APP_URL,
+        `${legacyURL}/authorize`,
+        async (authPage) => {
+          // The channel has to be established on the primary origin: the
+          // ICRC-29 client pins the signer origin once the handshake
+          // completes, so redirecting after that would strand the dapp.
+          await expect(authPage).toHaveURL((url) => url.origin === II_URL);
+          const authenticatorId = await addVirtualAuthenticator(authPage);
+          const canisterIdAttribute = await authPage
+            .locator("[data-canister-id]")
+            .getAttribute("data-canister-id");
+          if (canisterIdAttribute === null) {
+            throw new Error("Canister id is missing from the II page");
+          }
+          canisterId = Principal.fromText(canisterIdAttribute);
+          // Create new identity and continue to app
+          await authPage
+            .getByRole("button", { name: "Create", exact: true })
+            .click();
+          await authPage
+            .getByRole("button", { name: "Create with passkey" })
+            .click();
+          await authPage.getByLabel("Identity name").fill("Test");
+          await authPage
+            .getByRole("button", { name: "Create identity" })
+            .click();
+          // Read the credential before the window closes, the virtual
+          // authenticator is scoped to this page.
+          credentials = await getCredentialsFromVirtualAuthenticator(
+            authPage,
+            authenticatorId,
+          );
+          await authPage
+            .getByRole("button", { name: "Continue", exact: true })
+            .click();
+        },
+        true,
+      );
+
+      if (canisterId === undefined || credentials.length === 0) {
+        throw new Error("Identity was not created");
+      }
+      const actor = await createActorForCredential(
+        DEFAULT_HOST,
+        canisterId,
+        credentials[0],
+      );
+      const [deviceKeyWithAnchor] = await actor.lookup_device_key(
+        fromBase64(credentials[0].credentialId),
+      );
+      if (deviceKeyWithAnchor === undefined) {
+        throw new Error("Created passkey is not registered with an identity");
+      }
+      const devices = await actor.lookup(deviceKeyWithAnchor.anchor_number);
+      const passkeys = devices.filter(
+        (device) => device.credential_id.length > 0,
+      );
+      expect(passkeys.length).toBeGreaterThan(0);
+      // The passkey is scoped to the primary origin, a passkey stamped with
+      // the legacy origin is reported as unusable in /manage/access.
+      for (const passkey of passkeys) {
+        expect(passkey.origin).toEqual([II_URL]);
+      }
     });
   });
 });

--- a/src/frontend/tests/e2e-playwright/routes/authorize/legacy.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/legacy.spec.ts
@@ -115,8 +115,7 @@ import { DEFAULT_HOST } from "../../fixtures/identity";
         (device) => device.credential_id.length > 0,
       );
       expect(passkeys.length).toBeGreaterThan(0);
-      // The passkey is scoped to the primary origin, a passkey stamped with
-      // the legacy origin is reported as unusable in /manage/access.
+      // Assert all passkeys are created for the primary origin
       for (const passkey of passkeys) {
         expect(passkey.origin).toEqual([II_URL]);
       }

--- a/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/cli.spec.ts
@@ -7,16 +7,6 @@ import { addVirtualAuthenticator, authorize, II_URL } from "../utils";
 const hexToBytes = (hex: string): Uint8Array =>
   Uint8Array.from(hex.match(/.{1,2}/g) ?? [], (byte) => parseInt(byte, 16));
 
-const cliFragment = (params: {
-  publicKey: string;
-  callbackUrl: string;
-}): string => {
-  const fragment = new URLSearchParams();
-  fragment.set("public_key", params.publicKey);
-  fragment.set("callback", params.callbackUrl);
-  return fragment.toString();
-};
-
 const signUp = async (page: Page): Promise<void> => {
   const continueWithPasskey = page.getByRole("button", {
     name: "Continue with passkey",
@@ -87,19 +77,6 @@ const enableCliAccessInSettings = async (
     page.getByText("Enabled on this device", { exact: true }),
   ).toBeVisible();
 };
-
-test("cli.id.ai redirects to id.ai/cli, preserving the fragment", async ({
-  page,
-  cli,
-}) => {
-  const fragment = cliFragment({
-    publicKey: cli.publicKey,
-    callbackUrl: cli.callbackUrl,
-  });
-  await page.goto(`https://cli.id.ai/#${fragment}`);
-  await page.waitForURL(`${II_URL}/cli**`);
-  expect(page.url()).toBe(`${II_URL}/cli#${fragment}`);
-});
 
 test("Invalid params show the error screen", async ({ page }) => {
   await page.goto(II_URL + "/cli");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -80,7 +80,6 @@ export default defineConfig(({ command, mode }): UserConfig => {
                   {
                     hosts: [
                       "id.ai",
-                      "cli.id.ai",
                       "identity.ic0.app",
                       "identity.internetcomputer.org",
                     ],


### PR DESCRIPTION
# Motivation

A dapp that points the new ICRC-25 transport at a legacy domain — for example `identityProvider: "https://identity.ic0.app/authorize"` instead of the default `https://id.ai/authorize` — kept the user on that domain for the entire sign-in. Everything appeared to work, so nothing surfaced the misconfiguration.

The passkey created that way is scoped to the primary origin's RP ID (`getRpId()` returns `id.ai` on a related origin), but it is recorded with `window.location.origin`, i.e. the legacy domain. On **Access methods** that passkey then shows a "Legacy" badge and the message "This legacy passkey is no longer usable and should be removed" — about the passkey the user is currently signed in with. Removing it is blocked at the same time, so the user is told to delete a working passkey and prevented from doing so.

`/authorize` was the one path excluded from the primary-origin redirect, on the assumption that redirecting would break the ICRC-29 channel. It doesn't. The client posts `icrc29_status` with a `*` target origin, filters incoming messages by source window rather than by origin, and *learns* the signer origin from the handshake response — so a redirect before the handshake completes is invisible to it, and the resulting principal is unchanged (derivation uses the dapp's origin and the II canister, not the domain serving II).

Redirecting *after* the handshake would break it: the client pins the signer origin at that point, ignores responses from the new one, and closes the window when its disconnect timeout elapses. The redirect previously ran in the root layout's `onMount`, which happens *after* the authorize layout establishes the channel in `$effect.pre` — so simply removing the exclusion would have been a race.

# Changes

- Moved the primary-origin redirect out of the root layout's `onMount` into the client `init` hook (`src/frontend/src/hooks.client.ts`), where it runs before any component mounts and therefore before the channel is established. Extracted it to `src/frontend/src/lib/utils/primaryOrigin.ts`.
- Removed `/authorize` from the list of paths kept on the current origin. Every other exclusion is unchanged:
  - `/` + `#authorize` — the legacy transport carries the request across its own redirect and bounces the response back to the legacy origin.
  - `/self-service` — links to itself on every related origin so passkey behaviour can be diagnosed per domain; redirecting would defeat its purpose.
  - `/vc-flow`, `/iframe/webauthn`, `/callback` — all verified to create no passkeys.
- The root layout keeps the page hidden while a redirect is in flight, as before.
- Dropped the `cli.id.ai` special case, which rewrote every hit on that host to `/cli` on the primary origin. The domain is intentionally retired, so its e2e test, the test's helper, and the dev server host entry go with it. `CLI_GENERIC_DERIVATION_ORIGIN` keeps its value — it is a derivation origin seed rather than a served domain, and changing it would change the principal of every generic CLI sign-in.

This stops new passkeys from being stamped with a legacy origin. It does not repair passkeys already created that way — that needs a separate change to rewrite the `origin` metadata on successful authentication at the primary origin, plus recording the RP origin rather than `window.location.origin` at creation time.

# Tests

Added an e2e case to `routes/authorize/legacy.spec.ts`, run against both legacy domains, that drives the ICRC-25 transport at `<legacy domain>/authorize` and asserts:

- the authorize window ends up on the primary origin,
- authorization completes and the dapp receives a valid principal,
- the newly created passkey's `origin` is the primary origin.

The second assertion is what catches a regression in the redirect timing: a client that never completes its handshake would hang rather than fail an assertion.

Removed `cli.spec.ts`'s "cli.id.ai redirects to id.ai/cli" test along with the behaviour it covered.
