### PR TITLE
fix(fe): abort a stale passkey ceremony instead of blocking the next one

### DIFF
--- a/src/frontend/src/lib/utils/discoverablePasskeyIdentity.test.ts
+++ b/src/frontend/src/lib/utils/discoverablePasskeyIdentity.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { DiscoverablePasskeyIdentity } from "$lib/utils/discoverablePasskeyIdentity";
 
 describe("DiscoverablePasskeyIdentity", () => {
@@ -27,6 +28,7 @@ describe("DiscoverablePasskeyIdentity", () => {
       expect(signals).toHaveLength(2);
       expect(signals[0]?.aborted).toBe(true);
       expect(signals[1]?.aborted).toBe(false);
+      expect(signals[1]).not.toBe(signals[0]);
     });
   });
 });

--- a/src/frontend/src/lib/utils/discoverablePasskeyIdentity.test.ts
+++ b/src/frontend/src/lib/utils/discoverablePasskeyIdentity.test.ts
@@ -1,0 +1,32 @@
+import { DiscoverablePasskeyIdentity } from "$lib/utils/discoverablePasskeyIdentity";
+
+describe("DiscoverablePasskeyIdentity", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("sign", () => {
+    it("aborts the ceremony still in flight when a new one starts", () => {
+      const signals: (AbortSignal | undefined)[] = [];
+      const get = vi.fn((options: CredentialRequestOptions) => {
+        signals.push(options.signal);
+        // A pending ceremony: the platform settles it once the user picks a
+        // passkey, so nothing resolves this on its own.
+        return new Promise<Credential | null>(() => {});
+      });
+      vi.stubGlobal("navigator", { credentials: { get } });
+      const identity = new DiscoverablePasskeyIdentity({
+        credentialRequestOptions: {
+          publicKey: { userVerification: "required" },
+        },
+      });
+
+      void identity.sign(new Uint8Array([1]));
+      void identity.sign(new Uint8Array([2]));
+
+      expect(signals).toHaveLength(2);
+      expect(signals[0]?.aborted).toBe(true);
+      expect(signals[1]?.aborted).toBe(false);
+    });
+  });
+});

--- a/src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts
+++ b/src/frontend/src/lib/utils/discoverablePasskeyIdentity.ts
@@ -183,6 +183,30 @@ enum PubKeyCoseAlgo {
   RSA_WITH_SHA256 = -257,
 }
 
+// How long the browser may keep a ceremony pending before giving up. Without a
+// timeout the platform default applies, which is several minutes: long enough
+// for an abandoned ceremony to keep blocking the ones after it.
+const CREATION_TIMEOUT_MS = 120_000;
+const REQUEST_TIMEOUT_MS = 60_000;
+
+// A ceremony that is started but never settled keeps occupying the browser's
+// slot for pending credential requests, and Chrome rejects every later ceremony
+// in the same tab with `OperationError: A request is already pending.` II is a
+// single page app, so no navigation comes along to clear that state — hold on
+// to the controller instead, and abort the ceremony still in flight before
+// starting the next one.
+let ceremonyController: AbortController | undefined;
+
+// A fresh signal per ceremony: an identity can be signed with more than once,
+// and an already aborted signal would reject the next ceremony immediately.
+const newCeremonySignal = (): AbortSignal => {
+  ceremonyController?.abort(
+    new DOMException("Cancelling existing WebAuthn ceremony", "AbortError"),
+  );
+  ceremonyController = new AbortController();
+  return ceremonyController.signal;
+};
+
 export class DiscoverablePasskeyIdentity extends SignIdentity {
   #credentialCreationOptions?: CredentialCreationOptionsWithoutChallenge;
   #credentialRequestOptions?: CredentialRequestOptionsWithoutChallenge;
@@ -261,9 +285,11 @@ export class DiscoverablePasskeyIdentity extends SignIdentity {
   }
 
   async sign(blob: Uint8Array): Promise<Signature> {
+    const signal = newCeremonySignal();
     const credential = await (this.#credentialCreationOptions !== undefined
       ? navigator.credentials.create({
           ...this.#credentialCreationOptions,
+          signal,
           publicKey: {
             ...this.#credentialCreationOptions.publicKey,
             challenge: new Uint8Array(blob),
@@ -272,6 +298,7 @@ export class DiscoverablePasskeyIdentity extends SignIdentity {
       : this.#credentialRequestOptions !== undefined
         ? navigator.credentials.get({
             ...this.#credentialRequestOptions,
+            signal,
             publicKey: {
               ...this.#credentialRequestOptions.publicKey,
               challenge: new Uint8Array(blob),
@@ -331,6 +358,7 @@ export const creationOptions = (
   rpId?: string,
 ): CredentialCreationOptionsWithoutChallenge => ({
   publicKey: {
+    timeout: CREATION_TIMEOUT_MS,
     // Identify the AAGUID of the passkey provider
     attestation: "direct",
     authenticatorSelection: {
@@ -373,6 +401,7 @@ export const requestOptions = (
 ): CredentialRequestOptionsWithoutChallenge => ({
   publicKey: {
     rpId,
+    timeout: REQUEST_TIMEOUT_MS,
     // Either use the specified credential ids or let the user pick a passkey
     allowCredentials:
       credentialIds !== undefined && credentialIds.length > 0


### PR DESCRIPTION
## Problem

Android users report `A request is already pending` when signing in with a passkey on id.ai. The error is sticky: it keeps coming back for the rest of the session, and users work around it by restarting the browser or the device.

Chrome keeps a single slot for an in-flight credential request and refuses anything further while it is taken:

- `AuthenticatorCommonImpl::GetCredential` / `MakeCredential` bail out with `PENDING_REQUEST` when the document already has a ceremony in flight ([`authenticator_common_impl.cc`](https://chromium.googlesource.com/chromium/src/+/HEAD/content/browser/webauth/authenticator_common_impl.cc)).
- The delegate that a new ceremony needs is refused when the tab already has an active request — the holder is `WebContentsUserData`, so the slot is per tab, not per frame ([`authenticator_request_scheduler.cc`](https://chromium.googlesource.com/chromium/src/+/HEAD/chrome/browser/webauthn/authenticator_request_scheduler.cc)).
- Either way Blink surfaces `OperationError: A request is already pending.` ([`authentication_credentials_container.cc`](https://chromium.googlesource.com/chromium/src/+/HEAD/third_party/blink/renderer/modules/credentialmanagement/authentication_credentials_container.cc)).

So a ceremony that is started but never settles — the platform sheet is dismissed by the system, the tab is backgrounded while the Credential Manager sheet is open — blocks every later attempt. II passed no `AbortSignal`, so it had no way to clear a ceremony it had walked away from, and since II is a single page app, no navigation resets the state either. Hence "stuck until restart".

The same failure mode elsewhere: [w3c/webauthn#1790](https://github.com/w3c/webauthn/issues/1790) (unspecified behaviour, the recommendation is an abort controller), [keycloak#41037](https://github.com/keycloak/keycloak/issues/41037), [pypi/warehouse#6050](https://github.com/pypi/warehouse/issues/6050). SimpleWebAuthn ships [`WebAuthnAbortService`](https://github.com/MasterKale/SimpleWebAuthn/discussions/687) for exactly this, and calls out client-side-routed apps as the case that needs it.

## Change

Both in `discoverablePasskeyIdentity.ts`:

1. **Abort the previous ceremony.** A module-level `AbortController` whose signal is passed to `navigator.credentials.create`/`get`. Starting a ceremony aborts the one still in flight, so a retry replaces a stuck ceremony instead of being refused by it. The signal is created inside `sign()` rather than stored in the options, because an identity can be signed with more than once and an already-aborted signal would reject the next ceremony immediately.
2. **Set `timeout`** — 120s for creation, 60s for assertion. This bounds how long a ceremony can hold the slot when no abort follows.

## Testing

- New unit test asserting a second ceremony aborts the first one's signal and gets a fresh one.
- `npx tsc --project ./tsconfig.all.json --noEmit`, eslint and prettier clean.
- Full vitest run: the 18 failures in `findWebAuthnFlows.test.ts` / `iiConnection.test.ts` reproduce identically on a clean `main` (they hit `getPrimaryOrigin()`), so they are pre-existing and unrelated.

## Out of scope

- The legacy identities (`webAuthnIdentity`, `multiWebAuthnIdentity`, `iiConnection`) are untouched, so a ceremony abandoned by a legacy path in the same tab still cannot be cleared.
- No teardown hook yet. If we want one — cancelling on navigation or wizard destroy — the controller only needs an exported cancel function. Note it must not be hooked to `visibilitychange`: on Android the Credential Manager sheet backgrounds the page, so that would cancel legitimate ceremonies.
- The error is still reported as a generic "Unexpected error" toast and is not distinguished in the funnel, so this change cannot be measured yet.
- Nothing here addresses Google Play Services' own stuck states (see [Chromium 476437881](https://issues.chromium.org/issues/476437881), [GMS passkey error codes](https://www.corbado.com/blog/google-play-services-passkey-error-codes) incl. `CreateCredentialInterruptedException`). If reports continue after this ships, that is the signal it is the platform rather than II.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
