### PR TITLE
fix(be,fe): base the Settings MCP config on the certified identity_info

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -559,6 +559,10 @@ export const idlFactory = ({ IDL }) => {
     'address' : IDL.Text,
     'last_used' : IDL.Opt(Timestamp),
   });
+  const McpConfig = IDL.Record({
+    'url' : IDL.Opt(IDL.Text),
+    'enabled' : IDL.Bool,
+  });
   const AuthnMethodRegistrationInfo = IDL.Record({
     'expiration' : Timestamp,
     'session' : IDL.Opt(IDL.Principal),
@@ -571,6 +575,7 @@ export const idlFactory = ({ IDL }) => {
     'name' : IDL.Opt(IDL.Text),
     'email_recovery' : IDL.Opt(IDL.Vec(EmailRecoveryCredential)),
     'created_at' : IDL.Opt(Timestamp),
+    'mcp_config' : IDL.Opt(McpConfig),
     'authn_method_registration' : IDL.Opt(AuthnMethodRegistrationInfo),
     'openid_credentials' : IDL.Opt(IDL.Vec(OpenIdCredential)),
   });
@@ -627,10 +632,6 @@ export const idlFactory = ({ IDL }) => {
   const DeviceKeyWithAnchor = IDL.Record({
     'pubkey' : DeviceKey,
     'anchor_number' : UserNumber,
-  });
-  const McpConfig = IDL.Record({
-    'url' : IDL.Opt(IDL.Text),
-    'enabled' : IDL.Bool,
   });
   const McpPrepareDelegation = IDL.Record({
     'user_key' : UserKey,

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -660,6 +660,14 @@ export interface EmailChallengeSubmitDkimLeafArg {
   'hops' : Array<SignedRRset>,
   'nonce' : string,
 }
+/**
+ * Email-recovery types
+ * ====================
+ * See `docs/ongoing/email-recovery.md` for the full design. Covers
+ * both halves of the flow: setup (binding a recovery email to an
+ * anchor) and recovery (proving control of a previously-bound
+ * address to obtain a signed delegation).
+ */
 export interface EmailRecoveryCredential {
   'created_at' : Timestamp,
   'address' : string,
@@ -802,6 +810,10 @@ export interface HttpResponse {
   'upgrade' : [] | [boolean],
   'status_code' : number,
 }
+/**
+ * ICRC-3 attribute sharing types
+ * ==============================
+ */
 export type Icrc3Value = { 'Int' : bigint } |
   { 'Map' : Array<[string, Icrc3Value]> } |
   { 'Nat' : bigint } |
@@ -930,6 +942,15 @@ export interface IdentityInfo {
    * The timestamp at which the anchor was created
    */
   'created_at' : [] | [Timestamp],
+  /**
+   * The anchor's synced trusted-MCP-server config (absent when the
+   * anchor never wrote one). Carried here rather than read from the
+   * mcp_get_config query so the Settings UI has a certified value to
+   * render and to base its writes on: identity_info is an update
+   * call, so its response is certified through consensus, whereas a
+   * query reply a single malicious node could forge is not.
+   */
+  'mcp_config' : [] | [McpConfig],
   'authn_method_registration' : [] | [AuthnMethodRegistrationInfo],
   'openid_credentials' : [] | [Array<OpenIdCredential>],
 }
@@ -2172,9 +2193,13 @@ export interface _SERVICE {
   /**
    * Read the identity's synced trusted-MCP-server config (master toggle + the
    * trusted server URL). Persisted on-chain, so it follows the identity across
-   * devices. Read by the Settings UI and the /mcp connect flow (which verifies
-   * the connecting origin against it). Returns the disabled, no-server default
-   * for an unauthorized caller or an anchor that never wrote a config.
+   * devices. Being a query, the reply is signed by a single node: the /mcp
+   * connect flow uses it only to pick which screen to show, and gates delivery
+   * on the certified trusted_url from prepare_mcp_registration_delegation.
+   * Callers that render trust, or write the config back, take it from
+   * IdentityInfo.mcp_config on the identity_info update call instead. Returns
+   * the disabled, no-server default for an unauthorized caller or an anchor
+   * that never wrote a config.
    * `null` means the identity has never written a config — distinct from a
    * stored one that is switched off. The two behave differently at /mcp: the
    * first may connect the deployment's official connector (completing the

--- a/src/frontend/src/lib/utils/mcpConfig.test.ts
+++ b/src/frontend/src/lib/utils/mcpConfig.test.ts
@@ -1,13 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { ActorSubclass } from "@icp-sdk/core/agent";
 import type { _SERVICE } from "$lib/generated/internet_identity_types";
-import {
-  originOf,
-  setMcpEnabled,
-  trustAndEnableMcp,
-  clearMcpTrustedServer,
-  type McpConfig,
-} from "./mcpConfig";
+import { originOf, fromCanisterMcpConfig, readMcpConfig } from "./mcpConfig";
 
 describe("originOf", () => {
   it("returns the origin (scheme + host + port), dropping path/query/hash", () => {
@@ -29,97 +23,49 @@ describe("originOf", () => {
   });
 });
 
-const ANCHOR = BigInt(10_000);
-
-const makeActor = (current: McpConfig) => ({
-  mcp_get_config: vi.fn().mockResolvedValue([
-    {
-      enabled: current.enabled,
-      url: current.url === undefined ? [] : [current.url],
-    },
-  ]),
-  mcp_set_config: vi.fn().mockResolvedValue({ Ok: null }),
-});
-
-const asActor = (actor: ReturnType<typeof makeActor>) =>
-  actor as unknown as ActorSubclass<_SERVICE>;
-
 const CUSTOM = "https://mcp.acme.com/mcp";
 
-/** A stored config. `undefined` stands for an identity that never wrote one. */
-const cfg = (enabled: boolean, url: string | undefined): McpConfig => ({
-  enabled,
-  url,
-});
-
-describe("setMcpEnabled", () => {
-  it("forgets the custom URL when turning the feature off", async () => {
-    const actor = makeActor(cfg(true, CUSTOM));
-
-    await setMcpEnabled(asActor(actor), ANCHOR, false);
-
-    expect(actor.mcp_set_config).toHaveBeenCalledWith(ANCHOR, {
-      enabled: false,
-      url: [],
-    });
-  });
-
-  it("leaves the custom URL alone when turning the feature on", async () => {
-    const actor = makeActor(cfg(false, CUSTOM));
-
-    await setMcpEnabled(asActor(actor), ANCHOR, true);
-
-    expect(actor.mcp_set_config).toHaveBeenCalledWith(ANCHOR, {
+describe("fromCanisterMcpConfig", () => {
+  it("decodes a config with a trusted URL", () => {
+    expect(fromCanisterMcpConfig([{ enabled: true, url: [CUSTOM] }])).toEqual({
       enabled: true,
-      url: [CUSTOM],
+      url: CUSTOM,
     });
   });
-});
 
-describe("trustAndEnableMcp", () => {
-  it("enables the feature and stores the URL in a single write", async () => {
-    const actor = makeActor(cfg(false, undefined));
-
-    await trustAndEnableMcp(asActor(actor), ANCHOR, CUSTOM);
-
-    expect(actor.mcp_set_config).toHaveBeenCalledWith(ANCHOR, {
+  it("decodes an absent URL as undefined", () => {
+    expect(fromCanisterMcpConfig([{ enabled: true, url: [] }])).toEqual({
       enabled: true,
-      url: [CUSTOM],
+      url: undefined,
     });
+  });
+
+  it("returns undefined for an identity that never wrote a config", () => {
+    expect(fromCanisterMcpConfig([])).toBeUndefined();
   });
 });
 
-describe("clearMcpTrustedServer", () => {
-  it("forgets the custom URL without turning the feature off", async () => {
-    const actor = makeActor(cfg(true, CUSTOM));
+const ANCHOR = BigInt(10_000);
 
-    await clearMcpTrustedServer(asActor(actor), ANCHOR);
+describe("readMcpConfig", () => {
+  it("decodes what the query returns", async () => {
+    const actor = {
+      mcp_get_config: vi
+        .fn()
+        .mockResolvedValue([{ enabled: true, url: [CUSTOM] }]),
+    } as unknown as ActorSubclass<_SERVICE>;
 
-    expect(actor.mcp_set_config).toHaveBeenCalledWith(ANCHOR, {
+    expect(await readMcpConfig(actor, ANCHOR)).toEqual({
       enabled: true,
-      url: [],
+      url: CUSTOM,
     });
   });
 
-  it("keeps the feature off when it was already off", async () => {
-    const actor = makeActor(cfg(false, CUSTOM));
+  it("reports an identity that never wrote a config", async () => {
+    const actor = {
+      mcp_get_config: vi.fn().mockResolvedValue([]),
+    } as unknown as ActorSubclass<_SERVICE>;
 
-    await clearMcpTrustedServer(asActor(actor), ANCHOR);
-
-    expect(actor.mcp_set_config).toHaveBeenCalledWith(ANCHOR, {
-      enabled: false,
-      url: [],
-    });
-  });
-});
-
-describe("write failures", () => {
-  it("rejects with the canister's error so callers can roll back", async () => {
-    const actor = makeActor(cfg(true, CUSTOM));
-    actor.mcp_set_config.mockResolvedValue({ Err: "config is too large" });
-
-    await expect(setMcpEnabled(asActor(actor), ANCHOR, false)).rejects.toThrow(
-      "config is too large",
-    );
+    expect(await readMcpConfig(actor, ANCHOR)).toBeUndefined();
   });
 });

--- a/src/frontend/src/lib/utils/mcpConfig.ts
+++ b/src/frontend/src/lib/utils/mcpConfig.ts
@@ -1,15 +1,19 @@
 /**
  * The user's trusted-MCP-server configuration, persisted on-chain (keyed by
  * anchor) so it syncs across all of the identity's devices — unlike the
- * CLI-access toggle, which is device-local. It is read via `mcp_get_config` and
- * written via `mcp_set_config`, both authenticated as the identity, so only the
- * user (never a page that initiates a connect request) can change it. The `/mcp`
- * connect flow reads it as the source of truth at connect time.
+ * CLI-access toggle, which is device-local. It is written via `mcp_set_config`,
+ * authenticated as the identity, so only the user (never a page that initiates
+ * a connect request) can change it. The `/mcp` connect flow reads it as the
+ * source of truth at connect time.
  *
  * The config has two parts:
  *  - `enabled`: the feature's master toggle for this identity.
  *  - `url`: the trusted server URL, kept verbatim (so the Settings UI can probe
  *    a path-based endpoint like `https://host/mcp`); trust matching is by origin.
+ *
+ * It reaches the frontend two ways: certified, as `IdentityInfo.mcp_config` on
+ * the `identity_info` update call, and uncertified, from the `mcp_get_config`
+ * query below.
  */
 import type { ActorSubclass } from "@icp-sdk/core/agent";
 import type {
@@ -24,21 +28,20 @@ export interface McpConfig {
   url: string | undefined;
 }
 
-// Candid `opt text` <-> `string | undefined`.
+// Candid `opt text` -> `string | undefined`.
 const fromOpt = (opt: [] | [string]): string | undefined =>
   opt.length === 0 ? undefined : opt[0];
-const toOpt = (value: string | undefined): [] | [string] =>
-  value === undefined ? [] : [value];
 
-const fromCanister = (config: CanisterMcpConfig): McpConfig => ({
-  enabled: config.enabled,
-  url: fromOpt(config.url),
-});
-
-const toCanister = (config: McpConfig): CanisterMcpConfig => ({
-  enabled: config.enabled,
-  url: toOpt(config.url),
-});
+/**
+ * Decode a candid `opt McpConfig` — `IdentityInfo.mcp_config` or a
+ * `mcp_get_config` reply. `undefined` when the identity never wrote a config.
+ */
+export const fromCanisterMcpConfig = (
+  config: [] | [CanisterMcpConfig],
+): McpConfig | undefined =>
+  config.length === 0
+    ? undefined
+    : { enabled: config[0].enabled, url: fromOpt(config[0].url) };
 
 /** Origin (scheme + host[:port], no path) of a URL, or undefined if unparsable. */
 export const originOf = (url: string): string | undefined => {
@@ -49,64 +52,18 @@ export const originOf = (url: string): string | undefined => {
   }
 };
 
-/** Read the identity's synced MCP config from the canister. */
+/**
+ * Read the identity's synced MCP config with the `mcp_get_config` query.
+ *
+ * The reply is **uncertified** — a single malicious node can forge it — so it
+ * may only steer UX that a certified value decides for real: the `/mcp`
+ * pre-check and the untrusted screen's auto-advance, both of which end in
+ * `mcpAuthorize` gating delivery on `prepare`'s certified `trusted_url`. Never
+ * render trust from it, and never feed it into an `mcp_set_config` write: use
+ * `IdentityInfo.mcp_config`, certified by the `identity_info` update call.
+ */
 export const readMcpConfig = async (
   actor: ActorSubclass<_SERVICE>,
   identityNumber: bigint,
-): Promise<McpConfig | undefined> => {
-  const config = await actor.mcp_get_config(identityNumber);
-  return config.length === 0 ? undefined : fromCanister(config[0]);
-};
-
-// Read-modify-write a single field of the synced config and persist it. Reads
-// the current config first so an unrelated field (toggle vs URL) isn't clobbered
-// by the wholesale `mcp_set_config`.
-const updateConfig = async (
-  actor: ActorSubclass<_SERVICE>,
-  identityNumber: bigint,
-  patch: Partial<McpConfig>,
-): Promise<McpConfig> => {
-  const current = (await readMcpConfig(actor, identityNumber)) ?? {
-    enabled: false,
-    url: undefined,
-  };
-  const next: McpConfig = { ...current, ...patch };
-  const result = await actor.mcp_set_config(identityNumber, toCanister(next));
-  if ("Err" in result) {
-    throw new Error(result.Err);
-  }
-  return next;
-};
-
-/** Turn the master toggle on/off (synced). */
-export const setMcpEnabled = (
-  actor: ActorSubclass<_SERVICE>,
-  identityNumber: bigint,
-  enabled: boolean,
-): Promise<McpConfig> =>
-  updateConfig(
-    actor,
-    identityNumber,
-    enabled ? { enabled: true } : { enabled: false, url: undefined },
-  );
-
-/** Set the trusted server URL (synced). */
-export const setMcpTrustedServer = (
-  actor: ActorSubclass<_SERVICE>,
-  identityNumber: bigint,
-  url: string,
-): Promise<McpConfig> => updateConfig(actor, identityNumber, { url });
-
-export const trustAndEnableMcp = (
-  actor: ActorSubclass<_SERVICE>,
-  identityNumber: bigint,
-  url: string,
-): Promise<McpConfig> =>
-  updateConfig(actor, identityNumber, { url, enabled: true });
-
-/** Forget the trusted server URL (synced). */
-export const clearMcpTrustedServer = (
-  actor: ActorSubclass<_SERVICE>,
-  identityNumber: bigint,
-): Promise<McpConfig> =>
-  updateConfig(actor, identityNumber, { url: undefined });
+): Promise<McpConfig | undefined> =>
+  fromCanisterMcpConfig(await actor.mcp_get_config(identityNumber));

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/smartActions.test.ts
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/(home)/smartActions.test.ts
@@ -40,6 +40,7 @@ const baseIdentityInfo: IdentityInfo = {
   created_at: [],
   authn_method_registration: [],
   openid_credentials: [],
+  mcp_config: [],
 };
 
 const withVerifiedRecoveryPhrase = (info: IdentityInfo): IdentityInfo => ({

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/+page.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/+page.svelte
@@ -2,8 +2,19 @@
   import { authenticatedStore } from "$lib/stores/authentication.store";
   import { Trans } from "$lib/components/locale";
   import { t } from "$lib/stores/locale.store";
+  import { fromCanisterMcpConfig } from "$lib/utils/mcpConfig";
   import CliAccessSection from "./components/CliAccessSection.svelte";
   import McpTrustedServersSection from "./components/McpTrustedServersSection.svelte";
+  import type { PageProps } from "./$types";
+
+  const { data }: PageProps = $props();
+
+  // The MCP config comes from `identity_info`, an update call, so what the
+  // section renders — and what it writes back — rests on a certified value
+  // rather than on the forgeable `mcp_get_config` query.
+  const mcpConfig = $derived(
+    fromCanisterMcpConfig(data.identityInfo.mcp_config),
+  );
 </script>
 
 <header class="flex flex-col gap-3">
@@ -19,5 +30,6 @@
   <CliAccessSection identityNumber={$authenticatedStore.identityNumber} />
   <McpTrustedServersSection
     identityNumber={$authenticatedStore.identityNumber}
+    {mcpConfig}
   />
 </div>

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/components/McpTrustedServersSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { invalidateAll } from "$app/navigation";
   import {
     BotIcon,
     RotateCcwIcon,
@@ -9,36 +9,34 @@
   import McpIcon from "$lib/components/icons/McpIcon.svelte";
   import Badge from "$lib/components/ui/Badge.svelte";
   import Toggle from "$lib/components/ui/Toggle.svelte";
-  import ProgressRing from "$lib/components/ui/ProgressRing.svelte";
   import { toaster } from "$lib/components/utils/toaster";
   import { t } from "$lib/stores/locale.store";
   import { authenticatedStore } from "$lib/stores/authentication.store";
-  import {
-    readMcpConfig,
-    setMcpEnabled,
-    trustAndEnableMcp,
-    clearMcpTrustedServer,
-    type McpConfig,
-  } from "$lib/utils/mcpConfig";
-  import { trustedUrl } from "../utils";
+  import type { McpConfig } from "$lib/utils/mcpConfig";
+  import { trustedUrl, writeMcpConfig } from "../utils";
   import { backendCanisterConfig } from "$lib/globals";
   import McpAddConnectorDialog from "./McpAddConnectorDialog.svelte";
 
   interface Props {
     identityNumber: bigint;
+    /**
+     * The identity's synced MCP config as the route load read it — certified,
+     * since `identity_info` is an update call. `undefined` when the identity
+     * never wrote one.
+     */
+    mcpConfig: McpConfig | undefined;
   }
 
-  const { identityNumber }: Props = $props();
+  const { identityNumber, mcpConfig }: Props = $props();
   const titleId = $props.id();
 
   // The synced (on-chain) MCP config: a master toggle and the custom server
   // URL for this identity. Persisted on-chain (keyed by anchor), so it follows
-  // the identity across devices. Read once on mount and kept in local state
-  // that the handlers update after each canister write.
-  let config = $state<McpConfig | undefined>(undefined);
-  // True until the initial config read completes, so the toggle doesn't flicker
-  // off-then-on and writes can't race the load.
-  let loaded = $state(false);
+  // the identity across devices. Derived from the route load so the section
+  // renders its real state on first paint; the handlers assign the value they
+  // wrote so the UI moves with the click, and `invalidateAll` re-derives this
+  // from the canister once the write lands.
+  let config = $derived(mcpConfig);
   let showAdd = $state(false);
   let adding = $state(false);
 
@@ -68,20 +66,22 @@
     }
   };
 
-  onMount(() => {
-    void (async () => {
-      try {
-        config = await readMcpConfig($authenticatedStore.actor, identityNumber);
-      } catch {
-        toaster.error({
-          title: $t`Couldn't load your AI access settings.`,
-          duration: 4000,
-        });
-      } finally {
-        loaded = true;
-      }
-    })();
-  });
+  // Every write states the complete config, so nothing the user didn't choose
+  // can ride along into it. On failure the previous value goes back and the
+  // user is told; on success the route load re-reads the certified config.
+  const write = async (next: McpConfig, error: string): Promise<boolean> => {
+    const previous = config;
+    config = next;
+    try {
+      await writeMcpConfig($authenticatedStore.actor, identityNumber, next);
+    } catch {
+      config = previous;
+      toaster.error({ title: error, duration: 4000 });
+      return false;
+    }
+    void invalidateAll();
+    return true;
+  };
 
   const handleToggle = async (next: boolean) => {
     // Enabling with nothing to enable — no custom server and no official
@@ -96,19 +96,15 @@
       showAdd = true;
       return;
     }
-    const previous = config;
-    config = next
-      ? { enabled: true, url: trusted }
-      : { enabled: false, url: undefined };
-    try {
-      await setMcpEnabled($authenticatedStore.actor, identityNumber, next);
-    } catch {
-      config = previous;
-      toaster.error({
-        title: $t`Couldn't save your change. Please try again.`,
-        duration: 4000,
-      });
-    }
+    // Turning the feature off forgets the custom server too, so re-enabling
+    // starts from the official connector rather than silently restoring a
+    // server the user last trusted before switching off.
+    await write(
+      next
+        ? { enabled: true, url: trusted }
+        : { enabled: false, url: undefined },
+      $t`Couldn't save your change. Please try again.`,
+    );
   };
 
   const handleAddClose = () => {
@@ -117,39 +113,25 @@
   };
 
   const handleAddSave = async (url: string) => {
-    try {
-      await trustAndEnableMcp($authenticatedStore.actor, identityNumber, url);
-      config = { enabled: true, url };
+    const saved = await write(
+      { enabled: true, url },
+      $t`Couldn't save your connector. Please try again.`,
+    );
+    if (saved) {
       showAdd = false;
       adding = false;
-    } catch {
-      toaster.error({
-        title: $t`Couldn't save your connector. Please try again.`,
-        duration: 4000,
-      });
     }
   };
 
   const handleRestoreDefault = async () => {
     if (trusted === undefined) return;
-    const previous = config;
     // Without an official connector to fall back to, dropping the custom one
     // would leave the feature on with nothing trusted, so turn it off instead.
     const fallsBack = official !== undefined;
-    config = { enabled: fallsBack, url: undefined };
-    try {
-      if (fallsBack) {
-        await clearMcpTrustedServer($authenticatedStore.actor, identityNumber);
-      } else {
-        await setMcpEnabled($authenticatedStore.actor, identityNumber, false);
-      }
-    } catch {
-      config = previous;
-      toaster.error({
-        title: $t`Couldn't remove the connector. Please try again.`,
-        duration: 4000,
-      });
-    }
+    await write(
+      { enabled: fallsBack, url: undefined },
+      $t`Couldn't remove the connector. Please try again.`,
+    );
   };
 </script>
 
@@ -183,15 +165,11 @@
     </div>
 
     <div class="flex h-6 shrink-0 items-center">
-      {#if loaded}
-        <Toggle
-          checked={switchOn}
-          onchange={() => handleToggle(!switchOn)}
-          aria-labelledby={titleId}
-        />
-      {:else}
-        <ProgressRing class="text-fg-tertiary size-5" />
-      {/if}
+      <Toggle
+        checked={switchOn}
+        onchange={() => handleToggle(!switchOn)}
+        aria-labelledby={titleId}
+      />
     </div>
   </div>
 

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/utils.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import type { ActorSubclass } from "@icp-sdk/core/agent";
+import type { _SERVICE } from "$lib/generated/internet_identity_types";
 import type { BackendCanisterConfig } from "$lib/globals";
 import type { McpConfig } from "$lib/utils/mcpConfig";
-import { trustedUrl } from "./utils";
+import { trustedUrl, writeMcpConfig } from "./utils";
 
 const OFFICIAL: Pick<BackendCanisterConfig, "mcp_official_url"> = {
   mcp_official_url: ["https://official-mcp.id.ai/mcp"],
@@ -35,5 +37,67 @@ describe("trustedUrl", () => {
 
   it("trusts nothing when enabled with no custom and no official connector", () => {
     expect(trustedUrl(cfg(true, undefined), NO_OFFICIAL)).toBeUndefined();
+  });
+});
+
+const ANCHOR = BigInt(10_000);
+
+const makeActor = () => ({
+  // Present so a read-modify-write would have something to read: the
+  // "never reads" test below asserts nothing calls it.
+  mcp_get_config: vi
+    .fn()
+    .mockResolvedValue([{ enabled: false, url: ["https://mcp.attacker.tld"] }]),
+  mcp_set_config: vi.fn().mockResolvedValue({ Ok: null }),
+});
+
+const asActor = (actor: ReturnType<typeof makeActor>) =>
+  actor as unknown as ActorSubclass<_SERVICE>;
+
+describe("writeMcpConfig", () => {
+  it("writes the config it is given, verbatim", async () => {
+    const actor = makeActor();
+
+    await writeMcpConfig(asActor(actor), ANCHOR, cfg(true, CUSTOM));
+
+    expect(actor.mcp_set_config).toHaveBeenCalledWith(ANCHOR, {
+      enabled: true,
+      url: [CUSTOM],
+    });
+  });
+
+  it("writes an absent URL as an empty candid opt", async () => {
+    const actor = makeActor();
+
+    await writeMcpConfig(asActor(actor), ANCHOR, cfg(false, undefined));
+
+    expect(actor.mcp_set_config).toHaveBeenCalledWith(ANCHOR, {
+      enabled: false,
+      url: [],
+    });
+  });
+
+  // The uncertified `mcp_get_config` query is forgeable by a single malicious
+  // node. Reading it here would copy the forged URL into a write the user
+  // signs, so the write path must never consult it.
+  it("never reads the config it is about to overwrite", async () => {
+    const actor = makeActor();
+
+    await writeMcpConfig(asActor(actor), ANCHOR, cfg(true, undefined));
+
+    expect(actor.mcp_get_config).not.toHaveBeenCalled();
+    expect(actor.mcp_set_config).toHaveBeenCalledWith(ANCHOR, {
+      enabled: true,
+      url: [],
+    });
+  });
+
+  it("rejects with the canister's error so callers can roll back", async () => {
+    const actor = makeActor();
+    actor.mcp_set_config.mockResolvedValue({ Err: "config is too large" });
+
+    await expect(
+      writeMcpConfig(asActor(actor), ANCHOR, cfg(true, CUSTOM)),
+    ).rejects.toThrow("config is too large");
   });
 });

--- a/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/manage/(authenticated)/settings/utils.ts
@@ -1,3 +1,5 @@
+import type { ActorSubclass } from "@icp-sdk/core/agent";
+import type { _SERVICE } from "$lib/generated/internet_identity_types";
 import type { BackendCanisterConfig } from "$lib/globals";
 import type { McpConfig } from "$lib/utils/mcpConfig";
 
@@ -18,3 +20,28 @@ export const trustedUrl = (
   config !== undefined && config.enabled
     ? (config.url ?? mcp_official_url[0])
     : undefined;
+
+/**
+ * Persist the identity's synced MCP config, replacing whatever is stored.
+ *
+ * `config` is the user's complete intent — both fields, as the Settings screen
+ * shows them. Deliberately no read-modify-write: merging in a field the caller
+ * left out would mean reading the stored config first, and the read available
+ * here is the uncertified `mcp_get_config` query — which would let a single
+ * malicious node pick the trusted server in a write the user then signs. The
+ * screen takes its starting point from `IdentityInfo.mcp_config` instead,
+ * certified by the `identity_info` update call.
+ */
+export const writeMcpConfig = async (
+  actor: ActorSubclass<_SERVICE>,
+  identityNumber: bigint,
+  config: McpConfig,
+): Promise<void> => {
+  const result = await actor.mcp_set_config(identityNumber, {
+    enabled: config.enabled,
+    url: config.url === undefined ? [] : [config.url],
+  });
+  if ("Err" in result) {
+    throw new Error(result.Err);
+  }
+};

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1026,6 +1026,13 @@ type IdentityInfo = record {
     // shows a "limit reached" notice in the wizard when adding
     // beyond the cap.
     verified_emails : opt vec VerifiedEmail;
+    // The anchor's synced trusted-MCP-server config (absent when the
+    // anchor never wrote one). Carried here rather than read from the
+    // mcp_get_config query so the Settings UI has a certified value to
+    // render and to base its writes on: identity_info is an update
+    // call, so its response is certified through consensus, whereas a
+    // query reply a single malicious node could forge is not.
+    mcp_config : opt McpConfig;
 };
 
 type IdentityInfoError = variant {
@@ -1876,9 +1883,13 @@ service : (opt InternetIdentityInit) -> {
 
     // Read the identity's synced trusted-MCP-server config (master toggle + the
     // trusted server URL). Persisted on-chain, so it follows the identity across
-    // devices. Read by the Settings UI and the /mcp connect flow (which verifies
-    // the connecting origin against it). Returns the disabled, no-server default
-    // for an unauthorized caller or an anchor that never wrote a config.
+    // devices. Being a query, the reply is signed by a single node: the /mcp
+    // connect flow uses it only to pick which screen to show, and gates delivery
+    // on the certified trusted_url from prepare_mcp_registration_delegation.
+    // Callers that render trust, or write the config back, take it from
+    // IdentityInfo.mcp_config on the identity_info update call instead. Returns
+    // the disabled, no-server default for an unauthorized caller or an anchor
+    // that never wrote a config.
     // `null` means the identity has never written a config — distinct from a
     // stored one that is switched off. The two behave differently at /mcp: the
     // first may connect the deployment's official connector (completing the

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -538,9 +538,14 @@ fn get_account_delegation(
 
 /// Read `anchor_number`'s synced trusted-MCP-server config (master toggle +
 /// trusted server URL). Persisted on-chain, so it follows the identity across
-/// devices. Read by the Settings UI and by the `/mcp` connect flow, which
-/// verifies the connecting origin against it at connect time. `null` means the
-/// anchor has never written a config.
+/// devices. `null` means the anchor has never written a config.
+///
+/// A query, so the reply is signed by one node rather than by consensus: the
+/// `/mcp` connect flow uses it only to pick which screen to show, and gates
+/// delivery on the certified `trusted_url` from
+/// `prepare_mcp_registration_delegation`. Anything that renders trust or feeds
+/// a write reads the config from `IdentityInfo::mcp_config` instead, certified
+/// by the `identity_info` update call.
 #[query]
 fn mcp_get_config(anchor_number: AnchorNumber) -> Option<McpConfig> {
     if check_session_authorization(anchor_number).is_err() {
@@ -1089,6 +1094,11 @@ mod v2_api {
             created_at: anchor_info.created_at,
             email_recovery,
             verified_emails,
+            // The same config `mcp_get_config` serves, but certified: this is
+            // an update call, so the Settings UI can render the trusted server
+            // — and base the config it writes back — on a value no single node
+            // can forge.
+            mcp_config: mcp::get_mcp_config(identity_number),
         };
         Ok(identity_info)
     }

--- a/src/internet_identity/src/mcp.rs
+++ b/src/internet_identity/src/mcp.rs
@@ -243,8 +243,9 @@ pub fn register(
 
 /// Read `anchor_number`'s synced trusted-MCP-server config (master toggle +
 /// trusted server URL), or `None` when the anchor has never written one, which
-/// Settings renders the same as switched off. The caller must already be
-/// authorized for `anchor_number` (checked by the canister method). The stored
+/// Settings renders the same as switched off. Serves both the `mcp_get_config`
+/// query and `IdentityInfo::mcp_config`. The caller must already be authorized
+/// for `anchor_number` (checked by the canister method). The stored
 /// `session_principal` pointer is internal bookkeeping and not exposed.
 pub fn get_mcp_config(anchor_number: AnchorNumber) -> Option<McpConfig> {
     storage_borrow(|storage| storage.lookup_mcp_config(anchor_number)).map(|config| McpConfig {

--- a/src/internet_identity/src/storage/storable/mcp_config.rs
+++ b/src/internet_identity/src/storage/storable/mcp_config.rs
@@ -7,8 +7,9 @@ use std::borrow::Cow;
 /// (see [`crate::storage`]) so it syncs across all of the identity's devices —
 /// unlike the CLI-access toggle, which is device-local. It is written via the
 /// authenticated `mcp_set_config` method and read by the `/mcp` connect flow
-/// (verify-at-connect) and the Settings UI via `mcp_get_config`. Kept separate
-/// from the core anchor record so it never touches anchor serialization.
+/// (verify-at-connect) via `mcp_get_config`, and by the Settings UI as
+/// `IdentityInfo::mcp_config`. Kept separate from the core anchor record so it
+/// never touches anchor serialization.
 ///
 /// `Default` is the disabled, no-server state, returned for anchors that have
 /// never written a config.

--- a/src/internet_identity/tests/integration/mcp.rs
+++ b/src/internet_identity/tests/integration/mcp.rs
@@ -14,10 +14,10 @@ use crate::v2_api::authn_method_test_helpers::{
 use candid::Principal;
 use canister_tests::{
     api::internet_identity::api_v2::{
-        create_account, get_mcp_registration_delegation, mcp_get_accounts, mcp_get_config,
-        mcp_get_delegation, mcp_prepare_delegation, mcp_register_v2, mcp_set_config,
-        prepare_account_delegation, prepare_mcp_registration_delegation, set_default_account,
-        AccountDelegationParams,
+        create_account, get_mcp_registration_delegation, identity_info, mcp_get_accounts,
+        mcp_get_config, mcp_get_delegation, mcp_prepare_delegation, mcp_register_v2,
+        mcp_set_config, prepare_account_delegation, prepare_mcp_registration_delegation,
+        set_default_account, AccountDelegationParams,
     },
     flows,
     framework::{
@@ -1100,6 +1100,52 @@ fn mcp_config_round_trips_and_persists_across_upgrade() -> Result<(), RejectResp
     assert_eq!(
         mcp_get_config(&env, canister_id, principal_1(), anchor).unwrap(),
         Some(config.clone())
+    );
+
+    Ok(())
+}
+
+/// `identity_info` carries the same config `mcp_get_config` serves. That is
+/// what lets Settings render the trusted server — and base the config it
+/// writes back — on a certified value: `identity_info` is an update call,
+/// whereas a query reply is signed by a single node and can be forged.
+#[test]
+fn identity_info_carries_the_mcp_config() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_with_mcp(&env);
+    let authn_method = test_authn_method();
+    let anchor = create_identity_with_authn_method(&env, canister_id, &authn_method);
+
+    // This deployment ships no official connector, so registration wrote no
+    // config and the identity starts out with nothing stored.
+    assert_eq!(
+        identity_info(&env, canister_id, authn_method.principal(), anchor)
+            .unwrap()
+            .unwrap()
+            .mcp_config,
+        None
+    );
+
+    let config = McpConfig {
+        enabled: true,
+        url: Some(format!("{MCP_ORIGIN}/mcp")),
+    };
+    mcp_set_config(
+        &env,
+        canister_id,
+        authn_method.principal(),
+        anchor,
+        config.clone(),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(
+        identity_info(&env, canister_id, authn_method.principal(), anchor)
+            .unwrap()
+            .unwrap()
+            .mcp_config,
+        Some(config)
     );
 
     Ok(())

--- a/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/api_v2.rs
@@ -99,6 +99,16 @@ pub struct IdentityInfo {
     /// `MAX_VERIFIED_EMAILS_PER_ANCHOR`.
     pub verified_emails:
         Option<Vec<crate::internet_identity::types::verified_email::VerifiedEmail>>,
+    /// The anchor's synced trusted-MCP-server config (master toggle +
+    /// trusted server URL). `None` for an anchor that never wrote one.
+    ///
+    /// Carried here — rather than read from the `mcp_get_config` query —
+    /// so the Settings UI has a *certified* value: `identity_info` is an
+    /// update call, so its response goes through consensus, while a single
+    /// malicious node can forge a query reply. Settings both renders the
+    /// trusted server from this value and uses it as the basis of the
+    /// config it writes back with `mcp_set_config`.
+    pub mcp_config: Option<crate::internet_identity::types::McpConfig>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
# Motivation

`mcp_get_config` is a query, so its response is signed by a single node rather than certified through consensus — the codebase already treats it as attacker-controlled, which is why #4161 moved the connect flow's delivery gate onto `prepare`'s certified `trusted_url`.

Settings, however, is not a display-only reader of that query. It read-modify-wrote it: `updateConfig` read the config, patched one field and inherited the rest verbatim into an `mcp_set_config` update call. A field the user never chose could therefore end up in a write signed by their identity — including `url`, the trusted server. The stored row is what `trusted_url` resolves from, so a value that lands there is trusted on every device from then on, and the connect flow's certified gate compares against it. The screen also rendered the trusted server from that same query, so what a user checks to see what their identity trusts came from an uncertified read too.

# Changes

- `IdentityInfo` gains `mcp_config`, filled from `mcp::get_mcp_config`. `identity_info` is an update call, so the value is certified through consensus, and `/manage` already loads it in the route load.
- Settings renders from `IdentityInfo.mcp_config` and no longer reads the query. The toggle's load spinner goes with it — the config arrives with the route load — and the section keeps its optimistic update by reassigning the derived value, re-derived by `invalidateAll` after each write.
- The read-modify-write is removed rather than moved onto a certified base: `writeMcpConfig` (co-located with the screen in `settings/utils.ts`) takes the user's complete intent and writes it. The four subset helpers in `mcpConfig.ts` are deleted, so no caller can reintroduce a merge.
- `mcp_get_config` stays for `/mcp`'s pre-check and untrusted-screen auto-advance, where a forged reply only picks a screen and delivery is gated on `prepare`'s certified `trusted_url`. Its docs now say it may never render trust or feed a write.

# Tests

- `identity_info_carries_the_mcp_config`: `None` before any write, the stored config after one.
- `writeMcpConfig` unit tests, including that it never calls `mcp_get_config` — the property this change turns on.
- Full canister integration suite green locally (478 tests); `npm run check` and vitest clean. Playwright e2e not run locally (the local network port was held by another checkout) — relying on CI, where `mcp-settings.spec.ts` covers this screen.
