### PR TITLE
test(fe): fix flaky gated-SSO 1-click e2e test

### DIFF
--- a/src/frontend/tests/e2e-playwright/routes/authorize/sso.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/sso.spec.ts
@@ -1102,6 +1102,9 @@ test.describe("Authorize with gated non-sub (Entra) SSO", () => {
     userId: string,
   ): Promise<void> => {
     const popup = await startGatedLogin(page, signInWithOpenId, userId);
+    // Armed early (60s to span the steps below) so the close isn't missed; the
+    // app reuses a named window, so the next login needs a fresh one to open.
+    const popupClosePromise = popup.waitForEvent("close", { timeout: 60_000 });
     await expect(
       popup.getByRole("heading", {
         name: `First sign-in with ${SSO_ENTRA_NAME}`,
@@ -1112,6 +1115,7 @@ test.describe("Authorize with gated non-sub (Entra) SSO", () => {
     const normalPopup = await normalPopupPromise;
     await signInWithOpenId(normalPopup, userId);
     await expect(page.locator("#principal")).toBeVisible({ timeout: 25_000 });
+    await popupClosePromise;
   };
 
   test("first gated 1-click prompts one normal sign-in, then reaches the app", async ({


### PR DESCRIPTION
The `Authorize with gated non-sub (Entra) SSO › once bridged, a later gated 1-click resolves in one shot` e2e test fails intermittently on CI, timing out at `page.context().waitForEvent("page")` after clicking Sign In for the second gated login — no new page ever opens.

The gated-SSO first-login helper returned as soon as the app showed the signed-in principal, while the II window it had opened was still closing. The test app opens II in a reusable named window, so when the second gated login opened II again the browser navigated the still-open first window instead of opening a new one — so no `page` event fired and the wait hung to its 60s timeout. It only loses the race on slow CI (locally the window closes before the second Sign In), which is why it flakes.

## Changes

`bridgeOnFirstLogin` now waits for the first login's II window to close before returning, so a follow-up gated login opens a fresh window and its `waitForEvent("page")` fires. This mirrors the close-wait the shared `signIn` helper in `utils.ts` already does after every II round-trip.

Test-only change; no production code touched.