### PR TITLE
fix(be,fe): scope account delegations with an optional targets allowlist

### DIFF
--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -1028,6 +1028,7 @@ export const idlFactory = ({ IDL }) => {
           SessionKey,
           Timestamp,
           IDL.Opt(Permissions),
+          IDL.Opt(IDL.Vec(IDL.Principal)),
         ],
         [
           IDL.Variant({
@@ -1304,6 +1305,7 @@ export const idlFactory = ({ IDL }) => {
           SessionKey,
           IDL.Opt(IDL.Nat64),
           IDL.Opt(Permissions),
+          IDL.Opt(IDL.Vec(IDL.Principal)),
         ],
         [
           IDL.Variant({

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -2028,6 +2028,7 @@ export interface _SERVICE {
       SessionKey,
       Timestamp,
       [] | [Permissions],
+      [] | [Array<Principal>],
     ],
     { 'Ok' : SignedDelegation } |
       { 'Err' : AccountDelegationError }
@@ -2344,6 +2345,7 @@ export interface _SERVICE {
       SessionKey,
       [] | [bigint],
       [] | [Permissions],
+      [] | [Array<Principal>],
     ],
     { 'Ok' : PrepareAccountDelegation } |
       { 'Err' : AccountDelegationError }

--- a/src/frontend/src/lib/stores/channelHandlers/delegation.ts
+++ b/src/frontend/src/lib/stores/channelHandlers/delegation.ts
@@ -167,6 +167,7 @@ export const handleDelegationRequest =
             sessionPublicKey,
             maxTimeToLive !== undefined ? [maxTimeToLive] : [],
             permissions,
+            [],
           )
           .then(throwCanisterError);
 
@@ -179,6 +180,7 @@ export const handleDelegationRequest =
               sessionPublicKey,
               expiration,
               permissions,
+              [],
             )
             .then(throwCanisterError)
             .then(transformSignedDelegation)

--- a/src/frontend/src/routes/(new-styling)/cli/utils.test.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/utils.test.ts
@@ -71,6 +71,7 @@ describe("cliAuthorize access-level wiring", () => {
       expect.anything(),
       [BigInt(TTL_MINUTES) * BigInt(60) * BigInt(1_000_000_000)],
       [{ queries: null }],
+      [],
     );
     // `get` must echo the same value or the signature lookup fails.
     expect(actor.get_account_delegation.mock.calls[0][5]).toEqual([

--- a/src/frontend/src/routes/(new-styling)/cli/utils.ts
+++ b/src/frontend/src/routes/(new-styling)/cli/utils.ts
@@ -85,6 +85,7 @@ export const cliAuthorize = async ({
       // The user's choice (read-only by default); passed explicitly so it
       // is honored regardless of the backend's omitted-arg default.
       toPermissionsArg(accessLevel),
+      [],
     )
     .then(throwCanisterError);
 
@@ -98,6 +99,7 @@ export const cliAuthorize = async ({
         expiration,
         // Must match the value passed to `prepare_account_delegation` above.
         toPermissionsArg(accessLevel),
+        [],
       )
       .then(throwCanisterError)
       .then(transformSignedDelegation)

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1882,7 +1882,11 @@ service : (opt InternetIdentityInit) -> {
         // calls authenticated through it. Omitted (`null`) or `opt (all)`
         // yields an unrestricted delegation — the original behavior, preserved
         // for existing callers and matching the interface spec.
-        permissions : opt Permissions
+        permissions : opt Permissions,
+        // Restricts the delegation to these canisters; omitted/`null` is
+        // unrestricted. Must match the value passed to `get_account_delegation`
+        // (it is folded into the signed delegation).
+        targets : opt vec principal
     ) -> (variant { Ok : PrepareAccountDelegation; Err : AccountDelegationError });
 
     get_account_delegation : (
@@ -1893,7 +1897,9 @@ service : (opt InternetIdentityInit) -> {
         expiration : Timestamp,
         // Must match the value passed to `prepare_account_delegation` (including
         // the omitted/`null` case, which means unrestricted).
-        permissions : opt Permissions
+        permissions : opt Permissions,
+        // Must match the value passed to `prepare_account_delegation`.
+        targets : opt vec principal
     ) -> (variant { Ok : SignedDelegation; Err : AccountDelegationError }) query;
 
     // Read the identity's synced trusted-MCP-server config (master toggle + the

--- a/src/internet_identity/src/account_management.rs
+++ b/src/internet_identity/src/account_management.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     update_root_hash,
 };
+use candid::Principal;
 use ic_canister_sig_creation::{signature_map::CanisterSigInputs, DELEGATION_SIG_DOMAIN};
 use ic_cdk::{api::time, caller};
 use ic_stable_structures::DefaultMemoryImpl;
@@ -305,6 +306,7 @@ pub async fn prepare_account_delegation(
     session_key: SessionKey,
     max_ttl: Option<u64>,
     max_expiration: Option<Timestamp>,
+    targets: Option<Vec<Principal>>,
     access: DelegationAccess,
     ii_domain: &Option<IIDomain>,
 ) -> Result<PrepareAccountDelegation, AccountDelegationError> {
@@ -351,12 +353,16 @@ pub async fn prepare_account_delegation(
     let effective_duration_ns = expiration.saturating_sub(time());
     let seed = account.calculate_seed();
 
+    let target_bytes: Option<Vec<Vec<u8>>> = targets
+        .as_ref()
+        .map(|ts| ts.iter().map(|p| p.as_slice().to_vec()).collect());
     state::signature_map_mut(|sigs| {
         add_delegation_signature(
             sigs,
             session_key,
             seed.as_ref(),
             expiration,
+            target_bytes.as_ref(),
             access.permissions(),
         );
     });
@@ -381,9 +387,14 @@ pub fn get_account_delegation(
     account_number: Option<AccountNumber>,
     session_key: SessionKey,
     expiration: Timestamp,
+    targets: Option<Vec<Principal>>,
     access: DelegationAccess,
 ) -> Result<SignedDelegation, AccountDelegationError> {
     check_frontend_length(origin);
+
+    let target_bytes: Option<Vec<Vec<u8>>> = targets
+        .as_ref()
+        .map(|ts| ts.iter().map(|p| p.as_slice().to_vec()).collect());
 
     storage_borrow(|storage| {
         let account = storage
@@ -403,7 +414,7 @@ pub fn get_account_delegation(
                 message: &delegation_signature_msg_with_permissions(
                     &session_key,
                     expiration,
-                    None,
+                    target_bytes.as_ref(),
                     permissions,
                 ),
             };
@@ -412,7 +423,7 @@ pub fn get_account_delegation(
                     delegation: Delegation {
                         pubkey: session_key,
                         expiration,
-                        targets: None,
+                        targets,
                         permissions: permissions.map(str::to_string),
                     },
                     signature: ByteBuf::from(signature),

--- a/src/internet_identity/src/delegation.rs
+++ b/src/internet_identity/src/delegation.rs
@@ -127,21 +127,21 @@ pub(crate) fn der_encode_canister_sig_key(seed: Vec<u8>) -> Vec<u8> {
     CanisterSigPublicKey::new(my_canister_id, seed).to_der()
 }
 
-/// Adds a delegation signature for `pk` to the signature map. `permissions`
-/// is the delegation's optional `permissions` field (folded into the signed
-/// message when present) — pass `access.permissions()` of a
-/// [`DelegationAccess`], or `None` for flows that never restrict.
+/// Adds a delegation signature for `pk` to the signature map. `targets` and
+/// `permissions` are the delegation's optional restricting fields, folded into
+/// the signed message when present — pass `None` for flows that never restrict.
 pub fn add_delegation_signature(
     sigs: &mut SignatureMap,
     pk: PublicKey,
     seed: &[u8],
     expiration: Timestamp,
+    targets: Option<&Vec<Vec<u8>>>,
     permissions: Option<&str>,
 ) {
     let inputs = CanisterSigInputs {
         domain: DELEGATION_SIG_DOMAIN,
         seed,
-        message: &delegation_signature_msg_with_permissions(&pk, expiration, None, permissions),
+        message: &delegation_signature_msg_with_permissions(&pk, expiration, targets, permissions),
     };
     sigs.add_signature(&inputs);
 }
@@ -266,6 +266,42 @@ mod test {
     /// independently, so any drift in the composition silently invalidates
     /// every read-only delegation — this test makes drift a visible failure
     /// and doubles as a reference vector for agent implementers.
+    #[test]
+    fn should_fold_targets_into_message() {
+        let targets = vec![b"canister-a".to_vec(), b"canister-b".to_vec()];
+        let scoped = delegation_signature_msg_with_permissions(
+            SESSION_PUBKEY,
+            EXPIRATION,
+            Some(&targets),
+            None,
+        );
+        assert_ne!(
+            scoped,
+            delegation_signature_msg_with_permissions(SESSION_PUBKEY, EXPIRATION, None, None),
+            "targets must change the signable"
+        );
+        assert_eq!(
+            scoped,
+            delegation_signature_msg_with_permissions(
+                SESSION_PUBKEY,
+                EXPIRATION,
+                Some(&targets),
+                None
+            ),
+            "same targets must produce the same signable"
+        );
+        assert_ne!(
+            scoped,
+            delegation_signature_msg_with_permissions(
+                SESSION_PUBKEY,
+                EXPIRATION,
+                Some(&vec![b"canister-b".to_vec(), b"canister-a".to_vec()]),
+                None
+            ),
+            "target order is part of the signable"
+        );
+    }
+
     #[test]
     fn should_pin_queries_permissions_msg() {
         let msg = delegation_signature_msg_with_permissions(

--- a/src/internet_identity/src/email_inbound/smtp.rs
+++ b/src/internet_identity/src/email_inbound/smtp.rs
@@ -912,6 +912,7 @@ pub(super) async fn stamp_recovery_delegation(
             &seed,
             expiration,
             None,
+            None,
         );
     });
     crate::update_root_hash();

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -435,6 +435,7 @@ async fn prepare_delegation(
         session_key,
         max_time_to_live,
         None,
+        None,
         // The legacy endpoint has no read-only option.
         DelegationAccess::Unrestricted,
         &ii_domain,
@@ -465,6 +466,7 @@ fn get_delegation(
         None,
         session_key,
         expiration,
+        None,
         // The legacy endpoint has no read-only option.
         DelegationAccess::Unrestricted,
     )
@@ -573,6 +575,7 @@ async fn prepare_account_delegation(
     session_key: SessionKey,
     max_ttl: Option<u64>,
     permissions: Option<Permissions>,
+    targets: Option<Vec<Principal>>,
 ) -> Result<PrepareAccountDelegation, AccountDelegationError> {
     match check_authz_and_record_activity(anchor_number) {
         Ok(ii_domain) => {
@@ -583,6 +586,7 @@ async fn prepare_account_delegation(
                 session_key,
                 max_ttl,
                 None,
+                targets,
                 // An omitted `permissions` argument means unrestricted (see
                 // `impl From<Option<Permissions>> for DelegationAccess`): this
                 // preserves the original behavior for callers of the
@@ -605,6 +609,7 @@ fn get_account_delegation(
     session_key: SessionKey,
     expiration: Timestamp,
     permissions: Option<Permissions>,
+    targets: Option<Vec<Principal>>,
 ) -> Result<SignedDelegation, AccountDelegationError> {
     match check_authorization(anchor_number) {
         Ok(_) => account_management::get_account_delegation(
@@ -613,6 +618,7 @@ fn get_account_delegation(
             account_number,
             session_key,
             expiration,
+            targets,
             // See `prepare_account_delegation`: an omitted `permissions`
             // argument means an unrestricted delegation (backwards-compatible
             // with the original form).

--- a/src/internet_identity/src/mcp.rs
+++ b/src/internet_identity/src/mcp.rs
@@ -511,6 +511,7 @@ impl McpSession {
             session_key,
             capped_ttl,
             Some(self.grant.expires_at_ns),
+            None,
             DelegationAccess::from_read_only(self.grant.read_only),
             &None,
         )
@@ -543,6 +544,7 @@ impl McpSession {
             account_number,
             session_key,
             expiration,
+            None,
             DelegationAccess::from_read_only(self.grant.read_only),
         )
     }

--- a/src/internet_identity/src/mcp_registration.rs
+++ b/src/internet_identity/src/mcp_registration.rs
@@ -265,7 +265,7 @@ pub async fn prepare(
         // No queries-only restriction on the registration delegation itself: it
         // authenticates one update (mcp_register_v2). The read-only choice is
         // recorded on the index entry below, not on this signature.
-        add_delegation_signature(sigs, registration_key, &seed, expiration, None);
+        add_delegation_signature(sigs, registration_key, &seed, expiration, None, None);
     });
     update_root_hash();
 

--- a/src/internet_identity/src/openid.rs
+++ b/src/internet_identity/src/openid.rs
@@ -140,7 +140,7 @@ impl OpenIdCredential {
 
         state::signature_map_mut(|sigs| {
             // Unrestricted: the OpenID flow has no read-only option.
-            add_delegation_signature(sigs, session_key, seed.as_ref(), expiration, None);
+            add_delegation_signature(sigs, session_key, seed.as_ref(), expiration, None, None);
         });
         update_root_hash();
 

--- a/src/internet_identity/src/session_delegation.rs
+++ b/src/internet_identity/src/session_delegation.rs
@@ -63,7 +63,7 @@ pub async fn prepare_session_delegation(
 
     state::signature_map_mut(|sigs| {
         // Unrestricted: session delegations have no read-only option.
-        add_delegation_signature(sigs, session_key, &seed, expiration, None);
+        add_delegation_signature(sigs, session_key, &seed, expiration, None, None);
     });
     update_root_hash();
 


### PR DESCRIPTION
Account delegations couldn't be restricted to specific canisters: the delegation's `targets` field was always empty, so any session delegated for an app could call every canister that identity can reach. This adds an optional allowlist so a delegation can be scoped to named canisters, which the IC enforces at the request boundary. Nothing scopes delegations yet — this is the capability the push pull credential (a later PR in this stack) needs to be restricted to just the sending dApp's canister.

Stacked on #4219.

## Changes

The candid `prepare_account_delegation` and `get_account_delegation` gain a trailing `targets : opt vec principal`. The thin `main.rs` wrappers pass it into `account_management`, where the principals' bytes are folded into the signed delegation message through the existing `delegation_signature_msg_with_permissions` — the same helper that already carries `permissions`. `add_delegation_signature` grows a `targets` param as a sibling to `permissions`; `get_account_delegation` reconstructs the identical message and echoes the targets in the returned `Delegation`. Prepare and verify must derive byte-identical messages, so both build the target bytes the same way.

Everything else passes no targets, so behavior is unchanged: the five other `add_delegation_signature` callers (session, MCP registration, OpenID, email recovery), the two legacy delegation endpoints and the MCP delegation flow all pass `None`, and the frontend account and CLI callers pass an empty list.

## Tests

A unit test pins that a non-empty `targets` changes the delegation signable, that the same targets produce the same signable, and that target order is part of it — so any drift in the composition (which would silently break target-scoped delegations against the replica) fails the build. The prepare-then-get round trip is PocketIC-tier and follows.

<div align="left">Previous: #4219</div>
