### PR TITLE
feat(be): mint short-lived app delegations from a revocable session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "identity_jose",
  "internet_identity_interface",
  "lazy_static",
+ "p256",
  "pocket-ic",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ rsa = "0.9.10"
 minicbor = "1.0.0"
 
 # DNSSEC verifier deps (PR 1b on docs/ongoing/email-recovery.md §7)
-p256 = { version = "0.13", default-features = false, features = ["ecdsa", "sha256"] }
+p256 = { version = "0.13", default-features = false, features = ["ecdsa", "sha256", "pkcs8"] }
 ed25519-dalek = { version = "2.2", default-features = false }
 
 # Certification

--- a/src/archive/archive.did
+++ b/src/archive/archive.did
@@ -71,6 +71,11 @@ type Operation = variant {
     add_name;
     update_name;
     remove_name;
+    // Registering the browser a session was created from. Once per browser per
+    // anchor; the self-reported name is redacted like an account name.
+    register_session_device : record {
+        name : Private;
+    };
     create_account : record {
         name : Private;
     };

--- a/src/canister_tests/Cargo.toml
+++ b/src/canister_tests/Cargo.toml
@@ -8,6 +8,8 @@ base64.workspace = true
 flate2 = "1.0"
 hex.workspace = true
 lazy_static.workspace = true
+# Signs the browser-key proof `prepare_account_session` requires.
+p256.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_cbor.workspace = true

--- a/src/canister_tests/src/api/archive.rs
+++ b/src/canister_tests/src/api/archive.rs
@@ -134,7 +134,8 @@ pub mod compat {
                 | Operation::AddEmailRecovery
                 | Operation::RemoveEmailRecovery
                 | Operation::AddVerifiedEmail
-                | Operation::RemoveVerifiedEmail => {
+                | Operation::RemoveVerifiedEmail
+                | Operation::RegisterSessionDevice { .. } => {
                     panic!("not available in compat type")
                 }
                 Operation::CreateAccount { name } => CompatOperation::CreateAccount { name },

--- a/src/canister_tests/src/api/internet_identity/api_v2.rs
+++ b/src/canister_tests/src/api/internet_identity/api_v2.rs
@@ -762,3 +762,30 @@ pub fn account_principal_index_backfill_status(
         (),
     )
 }
+
+pub fn prepare_account_session(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+    request: PrepareAccountSessionRequest,
+) -> Result<Result<PrepareAccountSessionResponse, AccountSessionError>, RejectResponse> {
+    call_candid_as(
+        env,
+        canister_id,
+        RawEffectivePrincipal::None,
+        sender,
+        "prepare_account_session",
+        (request,),
+    )
+    .map(|(x,)| x)
+}
+
+pub fn get_account_session(
+    env: &PocketIc,
+    canister_id: CanisterId,
+    sender: Principal,
+    request: GetAccountSessionRequest,
+) -> Result<Result<GetAccountSessionResponse, AccountSessionError>, RejectResponse> {
+    query_candid_as(env, canister_id, sender, "get_account_session", (request,)).map(|(x,)| x)
+}
+

--- a/src/canister_tests/src/framework.rs
+++ b/src/canister_tests/src/framework.rs
@@ -361,6 +361,70 @@ pub fn restore_compressed_stable_memory(env: &PocketIc, canister_id: CanisterId,
     env.set_stable_memory(canister_id, buffer, BlobCompression::Gzip);
 }
 
+/// A browser key of the kind `prepare_account_session` demands a proof from.
+///
+/// The DER encoding and the domain prefix have to match what the canister verifies,
+/// so both are spelled out here rather than derived.
+pub struct BrowserKey {
+    signing_key: p256::ecdsa::SigningKey,
+}
+
+/// The SPKI header WebCrypto emits for an `ECDSA` P-256 public key, ahead of the 65-byte
+/// uncompressed point.
+const P256_SPKI_HEADER: [u8; 26] = [
+    0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a,
+    0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
+];
+
+const DEVICE_KEY_SIGNATURE_DOMAIN: &[u8] = b"ii-session-device-key";
+const SUCCESSOR_KEY_SIGNATURE_DOMAIN: &[u8] = b"ii-session-device-successor";
+
+impl BrowserKey {
+    pub fn new(seed: u8) -> Self {
+        Self {
+            signing_key: p256::ecdsa::SigningKey::from_bytes(&[seed; 32].into())
+                .expect("failed to build a browser key"),
+        }
+    }
+
+    /// The key a browser rotates to after `self`, so a test can walk the chain.
+    pub fn successor(&self) -> Self {
+        let mut seed = [0u8; 32];
+        seed.copy_from_slice(&self.signing_key.to_bytes());
+        seed[0] = seed[0].wrapping_add(1);
+        Self {
+            signing_key: p256::ecdsa::SigningKey::from_bytes(&seed.into())
+                .expect("failed to build a browser key"),
+        }
+    }
+
+    pub fn public_key(&self) -> PublicKey {
+        let point = p256::ecdsa::VerifyingKey::from(&self.signing_key).to_encoded_point(false);
+        let mut der = P256_SPKI_HEADER.to_vec();
+        der.extend_from_slice(point.as_bytes());
+        ByteBuf::from(der)
+    }
+
+    pub fn sign(&self, session_key: &SessionKey, next_device_key: &PublicKey) -> ByteBuf {
+        self.sign_with(DEVICE_KEY_SIGNATURE_DOMAIN, session_key, next_device_key)
+    }
+
+    /// The successor's own signature, proving the browser holds the key it announces.
+    pub fn sign_as_successor(&self, session_key: &SessionKey, device_key: &PublicKey) -> ByteBuf {
+        self.sign_with(SUCCESSOR_KEY_SIGNATURE_DOMAIN, session_key, device_key)
+    }
+
+    fn sign_with(&self, domain: &[u8], session_key: &SessionKey, other: &PublicKey) -> ByteBuf {
+        use p256::ecdsa::signature::Signer;
+
+        let mut message = domain.to_vec();
+        message.extend_from_slice(session_key);
+        message.extend_from_slice(other);
+        let signature: p256::ecdsa::Signature = self.signing_key.sign(&message);
+        ByteBuf::from(signature.to_bytes().to_vec())
+    }
+}
+
 pub const PUBKEY_1: &str = "test";
 pub const PUBKEY_2: &str = "some other key";
 pub const RECOVERY_PUBKEY_1: &str = "recovery 1";

--- a/src/frontend/src/lib/generated/internet_identity_idl.js
+++ b/src/frontend/src/lib/generated/internet_identity_idl.js
@@ -386,6 +386,23 @@ export const idlFactory = ({ IDL }) => {
     'InternalCanisterError' : IDL.Text,
     'Unauthorized' : IDL.Principal,
   });
+  const GetAccountSessionRequest = IDL.Record({
+    'session_key' : SessionKey,
+    'origin' : FrontendHostname,
+    'account_number' : IDL.Opt(AccountNumber),
+    'expiration' : Timestamp,
+    'identity_number' : UserNumber,
+  });
+  const GetAccountSessionResponse = IDL.Record({
+    'signed_delegation' : SignedDelegation,
+  });
+  const AccountSessionError = IDL.Variant({
+    'InternalCanisterError' : IDL.Text,
+    'Unauthorized' : IDL.Principal,
+    'NoSuchSession' : IDL.Null,
+    'NoSuchAccount' : IDL.Null,
+    'InvalidDeviceKey' : IDL.Null,
+  });
   const GetAccountsError = IDL.Variant({
     'InternalCanisterError' : IDL.Text,
     'Unauthorized' : IDL.Principal,
@@ -685,6 +702,26 @@ export const idlFactory = ({ IDL }) => {
   const PrepareAccountDelegation = IDL.Record({
     'user_key' : UserKey,
     'expiration' : Timestamp,
+  });
+  const PrepareAccountSessionRequest = IDL.Record({
+    'permissions' : IDL.Opt(Permissions),
+    'session_key' : SessionKey,
+    'valid_for' : IDL.Opt(IDL.Nat64),
+    'origin' : FrontendHostname,
+    'device_name' : IDL.Text,
+    'account_number' : IDL.Opt(AccountNumber),
+    'device_key_signature' : IDL.Vec(IDL.Nat8),
+    'device_key' : PublicKey,
+    'identity_number' : UserNumber,
+    'next_device_key' : PublicKey,
+    'next_device_key_signature' : IDL.Vec(IDL.Nat8),
+  });
+  const PrepareAccountSessionResponse = IDL.Record({
+    'user_key' : PublicKey,
+    'device_id' : IDL.Nat32,
+    'created_at' : Timestamp,
+    'expiration' : Timestamp,
+    'account_principal' : IDL.Principal,
   });
   const PrepareAttributeRequest = IDL.Record({
     'origin' : FrontendHostname,
@@ -1039,6 +1076,16 @@ export const idlFactory = ({ IDL }) => {
         ],
         ['query'],
       ),
+    'get_account_session' : IDL.Func(
+        [GetAccountSessionRequest],
+        [
+          IDL.Variant({
+            'Ok' : GetAccountSessionResponse,
+            'Err' : AccountSessionError,
+          }),
+        ],
+        ['query'],
+      ),
     'get_accounts' : IDL.Func(
         [UserNumber, FrontendHostname],
         [
@@ -1291,6 +1338,16 @@ export const idlFactory = ({ IDL }) => {
           IDL.Variant({
             'Ok' : PrepareAccountDelegation,
             'Err' : AccountDelegationError,
+          }),
+        ],
+        [],
+      ),
+    'prepare_account_session' : IDL.Func(
+        [PrepareAccountSessionRequest],
+        [
+          IDL.Variant({
+            'Ok' : PrepareAccountSessionResponse,
+            'Err' : AccountSessionError,
           }),
         ],
         [],

--- a/src/frontend/src/lib/generated/internet_identity_types.d.ts
+++ b/src/frontend/src/lib/generated/internet_identity_types.d.ts
@@ -19,6 +19,16 @@ export interface AccountInfo {
   'last_used' : [] | [Timestamp],
 }
 export type AccountNumber = bigint;
+export type AccountSessionError = { 'InternalCanisterError' : string } |
+  { 'Unauthorized' : Principal } |
+  { 'NoSuchSession' : null } |
+  { 'NoSuchAccount' : null } |
+  {
+    /**
+     * The browser's key is unusable, or its signature does not verify against it.
+     */
+    'InvalidDeviceKey' : null
+  };
 export interface AccountUpdate { 'name' : [] | [string] }
 export type AddTentativeDeviceResponse = {
     /**
@@ -688,6 +698,16 @@ export type GetAccountError = {
       'anchor_number' : UserNumber,
     }
   };
+export interface GetAccountSessionRequest {
+  'session_key' : SessionKey,
+  'origin' : FrontendHostname,
+  'account_number' : [] | [AccountNumber],
+  'expiration' : Timestamp,
+  'identity_number' : UserNumber,
+}
+export interface GetAccountSessionResponse {
+  'signed_delegation' : SignedDelegation,
+}
 export type GetAccountsError = { 'InternalCanisterError' : string } |
   { 'Unauthorized' : Principal };
 export type GetAttributesError = { 'AuthorizationError' : Principal } |
@@ -1317,6 +1337,63 @@ export type Permissions = { 'all' : null } |
 export interface PrepareAccountDelegation {
   'user_key' : UserKey,
   'expiration' : Timestamp,
+}
+export interface PrepareAccountSessionRequest {
+  /**
+   * The consented access level, fixed for the session's life.
+   */
+  'permissions' : [] | [Permissions],
+  /**
+   * The II frontend's own key. The app never sees this chain's private key.
+   */
+  'session_key' : SessionKey,
+  /**
+   * Clamped to the session maximum.
+   */
+  'valid_for' : [] | [bigint],
+  'origin' : FrontendHostname,
+  /**
+   * Labels the browser in the user's session list, e.g. "Chrome on MacBook".
+   */
+  'device_name' : string,
+  'account_number' : [] | [AccountNumber],
+  /**
+   * Signature over session_key and next_device_key, verified with device_key.
+   */
+  'device_key_signature' : Uint8Array | number[],
+  /**
+   * The browser's own public key, DER-encoded, as the registry currently holds it. A
+   * key this anchor has not seen registers a browser under it.
+   */
+  'device_key' : PublicKey,
+  'identity_number' : UserNumber,
+  /**
+   * What the browser rotates to once this sign-in succeeds.
+   */
+  'next_device_key' : PublicKey,
+  /**
+   * Signature by next_device_key over session_key and device_key, proving the browser
+   * holds the key it is announcing.
+   */
+  'next_device_key_signature' : Uint8Array | number[],
+}
+export interface PrepareAccountSessionResponse {
+  'user_key' : PublicKey,
+  /**
+   * Which browser this sign-in was attributed to, so the settings list can mark the one
+   * the user is looking at. Not a credential: a caller never presents it.
+   */
+  'device_id' : number,
+  'created_at' : Timestamp,
+  /**
+   * The session's valid_till.
+   */
+  'expiration' : Timestamp,
+  /**
+   * The principal apps see for this account, so the frontend can tell its own
+   * sessions apart without minting a delegation to learn it.
+   */
+  'account_principal' : Principal,
 }
 export type PrepareAttributeError = { 'AuthorizationError' : Principal } |
   { 'ValidationError' : { 'problems' : Array<string> } } |
@@ -2049,6 +2126,11 @@ export interface _SERVICE {
     { 'Ok' : SignedDelegation } |
       { 'Err' : AccountDelegationError }
   >,
+  'get_account_session' : ActorMethod<
+    [GetAccountSessionRequest],
+    { 'Ok' : GetAccountSessionResponse } |
+      { 'Err' : AccountSessionError }
+  >,
   /**
    * Multiple accounts
    */
@@ -2340,6 +2422,17 @@ export interface _SERVICE {
     ],
     { 'Ok' : PrepareAccountDelegation } |
       { 'Err' : AccountDelegationError }
+  >,
+  /**
+   * Creates or reuses a revocable session at one account and signs its identity to
+   * the II frontend's own key. Called only by the II frontend, which ships with the
+   * canister; requires an anchor access method, so a session can neither spawn nor
+   * extend itself.
+   */
+  'prepare_account_session' : ActorMethod<
+    [PrepareAccountSessionRequest],
+    { 'Ok' : PrepareAccountSessionResponse } |
+      { 'Err' : AccountSessionError }
   >,
   /**
    * Attribute sharing protocol

--- a/src/internet_identity/internet_identity.did
+++ b/src/internet_identity/internet_identity.did
@@ -1017,6 +1017,64 @@ type SessionDeviceInfo = record {
     last_used : Timestamp;
 };
 
+type PrepareAccountSessionRequest = record {
+    identity_number : UserNumber;
+    origin : FrontendHostname;
+    account_number : opt AccountNumber;
+    // The II frontend's own key. The app never sees this chain's private key.
+    session_key : SessionKey;
+    // Labels the browser in the user's session list, e.g. "Chrome on MacBook".
+    device_name : text;
+    // The browser's own public key, DER-encoded, as the registry currently holds it. A
+    // key this anchor has not seen registers a browser under it.
+    device_key : PublicKey;
+    // What the browser rotates to once this sign-in succeeds.
+    next_device_key : PublicKey;
+    // Signature over session_key and next_device_key, verified with device_key.
+    device_key_signature : blob;
+    // Signature by next_device_key over session_key and device_key, proving the browser
+    // holds the key it is announcing.
+    next_device_key_signature : blob;
+    // The consented access level, fixed for the session's life.
+    permissions : opt Permissions;
+    // Clamped to the session maximum.
+    valid_for : opt nat64;
+};
+
+type PrepareAccountSessionResponse = record {
+    user_key : PublicKey;
+    // The session's valid_till.
+    expiration : Timestamp;
+    created_at : Timestamp;
+    // Which browser this sign-in was attributed to, so the settings list can mark the one
+    // the user is looking at. Not a credential: a caller never presents it.
+    device_id : nat32;
+    // The principal apps see for this account, so the frontend can tell its own
+    // sessions apart without minting a delegation to learn it.
+    account_principal : principal;
+};
+
+type GetAccountSessionRequest = record {
+    identity_number : UserNumber;
+    origin : FrontendHostname;
+    account_number : opt AccountNumber;
+    session_key : SessionKey;
+    expiration : Timestamp;
+};
+
+type GetAccountSessionResponse = record {
+    signed_delegation : SignedDelegation;
+};
+
+type AccountSessionError = variant {
+    Unauthorized : principal;
+    NoSuchAccount;
+    NoSuchSession;
+    // The browser's key is unusable, or its signature does not verify against it.
+    InvalidDeviceKey;
+    InternalCanisterError : text;
+};
+
 type IdentityInfo = record {
     authn_methods : vec AuthnMethodData;
     authn_method_registration : opt AuthnMethodRegistrationInfo;
@@ -1870,6 +1928,13 @@ service : (opt InternetIdentityInit) -> {
         account_number : opt AccountNumber, // Null is unreserved default account
         update : AccountUpdate
     ) ->  (variant { Ok : AccountInfo; Err: UpdateAccountError });
+
+    // Creates or reuses a revocable session at one account and signs its identity to
+    // the II frontend's own key. Called only by the II frontend, which ships with the
+    // canister; requires an anchor access method, so a session can neither spawn nor
+    // extend itself.
+    prepare_account_session : (PrepareAccountSessionRequest) -> (variant { Ok : PrepareAccountSessionResponse; Err : AccountSessionError });
+    get_account_session : (GetAccountSessionRequest) -> (variant { Ok : GetAccountSessionResponse; Err : AccountSessionError }) query;
 
     prepare_account_delegation : (
         anchor_number : UserNumber,

--- a/src/internet_identity/src/delegation.rs
+++ b/src/internet_identity/src/delegation.rs
@@ -124,6 +124,35 @@ pub fn calculate_account_seed_with_salt(
     hash_bytes(blob)
 }
 
+const SESSION_SEED_PREFIX: &str = "session";
+
+/// The seed of a session's canister-signed identity.
+///
+/// Built on the account's own seed, so a session survives anything that leaves the
+/// account's principal unchanged, including naming a default account. `device_id` and
+/// `created_at` are inputs, so a session's attribution cannot be rewritten in storage
+/// without invalidating it. Unguessability comes from the salt.
+pub fn calculate_session_seed_with_salt(
+    salt: &[u8; 32],
+    account_seed: &Hash,
+    created_at: Timestamp,
+    device_id: SessionDeviceId,
+) -> Hash {
+    fn push_field(blob: &mut Vec<u8>, data: &[u8]) {
+        blob.extend_from_slice(&(data.len() as u64).to_be_bytes());
+        blob.extend_from_slice(data);
+    }
+
+    let mut blob: Vec<u8> = vec![];
+    push_field(&mut blob, salt);
+    push_field(&mut blob, SESSION_SEED_PREFIX.as_bytes());
+    push_field(&mut blob, account_seed);
+    push_field(&mut blob, &created_at.to_be_bytes());
+    push_field(&mut blob, &device_id.to_be_bytes());
+
+    hash_bytes(blob)
+}
+
 fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
     let mut hasher = Sha256::new();
     hasher.update(value.as_ref());

--- a/src/internet_identity/src/email_recovery/remove.rs
+++ b/src/internet_identity/src/email_recovery/remove.rs
@@ -77,6 +77,7 @@ mod tests {
         let mut a = Anchor {
             session_devices: vec![],
             next_session_device_id: 0,
+            session_count: 0,
             anchor_number: 1,
             devices: vec![],
             openid_credentials: vec![],

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -67,6 +67,7 @@ mod mcp_registration;
 
 mod openid;
 mod session_delegation;
+mod sessions;
 mod single_flight_cache;
 mod state;
 mod stats;

--- a/src/internet_identity/src/main.rs
+++ b/src/internet_identity/src/main.rs
@@ -491,6 +491,20 @@ async fn set_default_account(
 }
 
 #[update]
+async fn prepare_account_session(
+    request: PrepareAccountSessionRequest,
+) -> Result<PrepareAccountSessionResponse, AccountSessionError> {
+    sessions::prepare_account_session(request).await
+}
+
+#[query]
+fn get_account_session(
+    request: GetAccountSessionRequest,
+) -> Result<GetAccountSessionResponse, AccountSessionError> {
+    sessions::get_account_session(request)
+}
+
+#[update]
 async fn prepare_account_delegation(
     anchor_number: AnchorNumber,
     origin: FrontendHostname,

--- a/src/internet_identity/src/sessions.rs
+++ b/src/internet_identity/src/sessions.rs
@@ -1,0 +1,5 @@
+// The sign-in ceremony that creates a session is added on top of this; for now the module
+// holds only the verifier its request will be checked against.
+#![allow(dead_code)]
+
+pub mod device_key;

--- a/src/internet_identity/src/sessions.rs
+++ b/src/internet_identity/src/sessions.rs
@@ -1,5 +1,299 @@
-// The sign-in ceremony that creates a session is added on top of this; for now the module
-// holds only the verifier its request will be checked against.
-#![allow(dead_code)]
-
 pub mod device_key;
+
+use crate::anchor_management::post_operation_bookkeeping;
+use crate::authz_utils::{
+    check_authorization, check_authz_and_record_activity, AuthorizationError, IdentityUpdateError,
+};
+use crate::delegation::{
+    add_delegation_signature, calculate_session_seed_with_salt, canister_sig_principal,
+    check_frontend_length, der_encode_canister_sig_key, DelegationAccess,
+};
+use crate::sessions::device_key::verify_device_keys;
+use crate::state::{self, storage_borrow, storage_borrow_mut};
+use crate::storage::account::{ReadAccountParams, SessionRecord};
+use crate::storage::{CreateSessionParams, StorageError};
+use crate::{update_root_hash, DAY_NS, MINUTE_NS};
+use candid::Principal;
+use ic_canister_sig_creation::signature_map::CanisterSigInputs;
+use ic_canister_sig_creation::DELEGATION_SIG_DOMAIN;
+use ic_cdk::api::time;
+use ic_certification::Hash;
+use internet_identity_interface::archive::types::{Operation, Private};
+use internet_identity_interface::internet_identity::types::{
+    AccountNumber, AccountSessionError, AnchorNumber, ApplicationNumber,
+    Delegation, FrontendHostname, GetAccountSessionRequest, GetAccountSessionResponse,
+    PrepareAccountSessionRequest, PrepareAccountSessionResponse, SignedDelegation, Timestamp,
+};
+use serde_bytes::ByteBuf;
+
+pub const DEFAULT_SESSION_TTL_NS: u64 = 30 * DAY_NS;
+pub const MAX_SESSION_TTL_NS: u64 = 30 * DAY_NS;
+const MIN_SESSION_TTL_NS: u64 = 10 * MINUTE_NS;
+
+/// The device name is a label the user reads, never anything the canister acts on.
+const MAX_DEVICE_NAME_BYTES: usize = 128;
+
+impl From<AuthorizationError> for AccountSessionError {
+    fn from(err: AuthorizationError) -> Self {
+        AccountSessionError::Unauthorized(err.principal)
+    }
+}
+
+impl From<IdentityUpdateError> for AccountSessionError {
+    fn from(err: IdentityUpdateError) -> Self {
+        match err {
+            IdentityUpdateError::Unauthorized(principal) => {
+                AccountSessionError::Unauthorized(principal)
+            }
+            IdentityUpdateError::StorageError(_, storage_error) => storage_error.into(),
+        }
+    }
+}
+
+impl From<StorageError> for AccountSessionError {
+    fn from(err: StorageError) -> Self {
+        match err {
+            StorageError::MissingAccount { .. } | StorageError::ApplicationNotFound { .. } => {
+                AccountSessionError::NoSuchAccount
+            }
+            other => AccountSessionError::InternalCanisterError(other.to_string()),
+        }
+    }
+}
+
+pub async fn prepare_account_session(
+    request: PrepareAccountSessionRequest,
+) -> Result<PrepareAccountSessionResponse, AccountSessionError> {
+    let PrepareAccountSessionRequest {
+        identity_number,
+        origin,
+        account_number,
+        session_key,
+        device_name,
+        device_key,
+        next_device_key,
+        device_key_signature,
+        next_device_key_signature,
+        permissions,
+        valid_for,
+    } = request;
+
+    check_authz_and_record_activity(identity_number)?;
+    check_frontend_length(&origin);
+    if device_name.len() > MAX_DEVICE_NAME_BYTES {
+        return Err(AccountSessionError::InternalCanisterError(
+            "device name exceeds the limit".to_string(),
+        ));
+    }
+    if !verify_device_keys(
+        &device_key,
+        &device_key_signature,
+        &next_device_key,
+        &next_device_key_signature,
+        &session_key,
+    ) {
+        return Err(AccountSessionError::InvalidDeviceKey);
+    }
+    state::ensure_salt_set().await;
+
+    let now = time();
+    let valid_till = now.saturating_add(
+        valid_for
+            .unwrap_or(DEFAULT_SESSION_TTL_NS)
+            .clamp(MIN_SESSION_TTL_NS, MAX_SESSION_TTL_NS),
+    );
+    let access = DelegationAccess::from(permissions);
+    let read_only = access == DelegationAccess::ReadOnly;
+
+    // Checked before anything is written. An account this identity does not hold is the
+    // one failure a caller can provoke, and returning it after the writes below would
+    // leave a browser registered for a sign-in that never happened.
+    if storage_borrow(|storage| {
+        storage.read_account(ReadAccountParams {
+            account_number,
+            anchor_number: identity_number,
+            origin: &origin,
+            known_app_num: None,
+        })
+    })
+    .is_none()
+    {
+        return Err(AccountSessionError::NoSuchAccount);
+    }
+
+    let mut anchor = state::anchor(identity_number);
+    // A rotating browser presents the successor it announced, so both values are known.
+    let known_device = anchor
+        .session_devices()
+        .iter()
+        .any(|device| device.key == device_key || device.pending == device_key);
+    let (device_id, dropped_devices) = anchor
+        .resolve_session_device(device_key, next_device_key, device_name, now)
+        .map_err(|_| AccountSessionError::InvalidDeviceKey)?;
+    storage_borrow_mut(|storage| storage.write(anchor))
+        .expect("failed to write the anchor while registering a browser");
+
+    if !known_device {
+        post_operation_bookkeeping(
+            identity_number,
+            Operation::RegisterSessionDevice {
+                name: Private::Redacted,
+            },
+        );
+    }
+
+    for dropped in dropped_devices {
+        storage_borrow_mut(|storage| storage.revoke_device_sessions(identity_number, dropped))
+            .expect("failed to end the sessions of a browser the registry dropped");
+    }
+
+    // The account was checked above, so anything left is a broken storage invariant
+    // rather than a request this caller could have got wrong. Trapping rolls the whole
+    // message back, including the browser registration.
+    let session = storage_borrow_mut(|storage| {
+        storage.create_session(CreateSessionParams {
+            anchor_number: identity_number,
+            origin: origin.clone(),
+            account_number,
+            device_id,
+            valid_till,
+            read_only,
+            now,
+        })
+    })
+    .expect("failed to create a session for an account that was just read");
+
+    let (seed, application_number) =
+        session_identity(identity_number, &origin, account_number, &session)
+            .expect("failed to derive the identity of a session that was just created");
+    let account_principal = account_principal(identity_number, application_number, account_number)
+        .expect("failed to derive the principal of an account that was just read");
+
+    state::signature_map_mut(|sigs| {
+        add_delegation_signature(sigs, session_key, seed.as_ref(), session.valid_till, None);
+    });
+    update_root_hash();
+
+    Ok(PrepareAccountSessionResponse {
+        user_key: ByteBuf::from(der_encode_canister_sig_key(seed.to_vec())),
+        expiration: session.valid_till,
+        created_at: session.created_at,
+        device_id,
+        account_principal,
+    })
+}
+
+pub fn get_account_session(
+    request: GetAccountSessionRequest,
+) -> Result<GetAccountSessionResponse, AccountSessionError> {
+    let GetAccountSessionRequest {
+        identity_number,
+        origin,
+        account_number,
+        session_key,
+        expiration,
+    } = request;
+
+    check_authorization(identity_number)?;
+    check_frontend_length(&origin);
+
+    let sessions = storage_borrow(|storage| {
+        storage.account_sessions(identity_number, &origin, account_number)
+    })
+    .ok_or(AccountSessionError::NoSuchAccount)?;
+
+    sessions
+        .into_iter()
+        .filter(|session| session.valid_till == expiration)
+        .find_map(|session| {
+            let (seed, _) =
+                session_identity(identity_number, &origin, account_number, &session).ok()?;
+            let signed_delegation = witness_session_delegation(&seed, &session_key, expiration)?;
+            Some(GetAccountSessionResponse { signed_delegation })
+        })
+        .ok_or(AccountSessionError::NoSuchSession)
+}
+
+fn witness_session_delegation(
+    seed: &Hash,
+    session_key: &[u8],
+    expiration: Timestamp,
+) -> Option<SignedDelegation> {
+    state::assets_and_signatures(|certified_assets, sigs| {
+        let inputs = CanisterSigInputs {
+            domain: DELEGATION_SIG_DOMAIN,
+            seed,
+            message: &crate::delegation::delegation_signature_msg_with_permissions(
+                session_key,
+                expiration,
+                None,
+                None,
+            ),
+        };
+        sigs.get_signature_as_cbor(&inputs, Some(certified_assets.root_hash()))
+            .ok()
+    })
+    .map(|signature| SignedDelegation {
+        delegation: Delegation {
+            pubkey: ByteBuf::from(session_key.to_vec()),
+            expiration,
+            targets: None,
+            permissions: None,
+        },
+        signature: ByteBuf::from(signature),
+    })
+}
+
+fn session_identity(
+    anchor_number: AnchorNumber,
+    origin: &FrontendHostname,
+    account_number: Option<AccountNumber>,
+    session: &SessionRecord,
+) -> Result<(Hash, ApplicationNumber), AccountSessionError> {
+    let (salt, application_number) = storage_borrow(|storage| {
+        (
+            storage.salt().copied(),
+            storage.lookup_application_number_with_origin(origin),
+        )
+    });
+    let salt = salt.ok_or_else(|| {
+        AccountSessionError::InternalCanisterError(StorageError::SaltNotSet.to_string())
+    })?;
+    let application_number: ApplicationNumber =
+        application_number.ok_or(AccountSessionError::NoSuchAccount)?;
+
+    let (account, _) = storage_borrow(|storage| {
+        storage.account_with_sessions(anchor_number, application_number, account_number)
+    })
+    .ok_or(AccountSessionError::NoSuchAccount)?;
+    let seed = calculate_session_seed_with_salt(
+        &salt,
+        &account.calculate_seed_with_salt(&salt),
+        session.created_at,
+        session.device_id,
+    );
+    Ok((seed, application_number))
+}
+
+/// The principal an app sees for this account. A session handle names the account by this
+/// and never by the numbers behind it, which are II's alone.
+///
+/// The account is read rather than reconstructed: a materialized default derives from
+/// `seed_from_anchor`, which only the stored row carries.
+fn account_principal(
+    anchor_number: AnchorNumber,
+    application_number: ApplicationNumber,
+    account_number: Option<AccountNumber>,
+) -> Result<Principal, AccountSessionError> {
+    let salt = storage_borrow(|storage| storage.salt().copied()).ok_or_else(|| {
+        AccountSessionError::InternalCanisterError(StorageError::SaltNotSet.to_string())
+    })?;
+    let (account, _) = storage_borrow(|storage| {
+        storage.account_with_sessions(anchor_number, application_number, account_number)
+    })
+    .ok_or(AccountSessionError::NoSuchAccount)?;
+    Ok(canister_sig_principal(
+        ic_cdk::id(),
+        account.calculate_seed_with_salt(&salt).to_vec(),
+    ))
+}

--- a/src/internet_identity/src/sessions/device_key.rs
+++ b/src/internet_identity/src/sessions/device_key.rs
@@ -1,0 +1,279 @@
+//! Verifies that a sign-in request comes from a browser holding the key it names.
+
+use internet_identity_interface::internet_identity::types::{PublicKey, SessionKey};
+use p256::ecdsa::signature::Verifier;
+use p256::ecdsa::{Signature, VerifyingKey};
+use p256::pkcs8::DecodePublicKey;
+
+/// Prefixed to the signed message so the browser key cannot be made to sign for another
+/// purpose by presenting a message from one.
+const DEVICE_KEY_SIGNATURE_DOMAIN: &[u8] = b"ii-session-device-key";
+
+/// A different prefix for the successor's own signature, so neither signature can be
+/// replayed in the other's role.
+const SUCCESSOR_KEY_SIGNATURE_DOMAIN: &[u8] = b"ii-session-device-successor";
+
+/// A browser key is P-256, and the signature the raw `r || s` pair WebCrypto produces.
+const DEVICE_KEY_SIGNATURE_BYTES: usize = 64;
+
+/// Both keys sign: the current one over the session key and its successor, and the successor
+/// over the session key and the key it replaces.
+///
+/// The successor's own signature is what stops a key being announced by someone who does not
+/// hold it — without it, keys read off the wire could be planted as another browser's
+/// successor and claimed when that browser next presented one.
+pub fn verify_device_keys(
+    device_key: &PublicKey,
+    device_key_signature: &[u8],
+    next_device_key: &PublicKey,
+    next_device_key_signature: &[u8],
+    session_key: &SessionKey,
+) -> bool {
+    verify(
+        device_key,
+        device_key_signature,
+        &signed_message(DEVICE_KEY_SIGNATURE_DOMAIN, session_key, next_device_key),
+    ) && verify(
+        next_device_key,
+        next_device_key_signature,
+        &signed_message(SUCCESSOR_KEY_SIGNATURE_DOMAIN, session_key, device_key),
+    )
+}
+
+fn verify(key: &PublicKey, signature: &[u8], message: &[u8]) -> bool {
+    if signature.len() != DEVICE_KEY_SIGNATURE_BYTES {
+        return false;
+    }
+    let Ok(key) = VerifyingKey::from_public_key_der(key) else {
+        return false;
+    };
+    let Ok(signature) = Signature::from_slice(signature) else {
+        return false;
+    };
+    key.verify(message, &signature).is_ok()
+}
+
+/// Covers the other key as well as the session key: keys are visible on the wire, so a
+/// signature that bound only the session key could be paired with one a caller chose.
+fn signed_message(domain: &[u8], session_key: &SessionKey, other_key: &PublicKey) -> Vec<u8> {
+    let mut message = Vec::with_capacity(domain.len() + session_key.len() + other_key.len());
+    message.extend_from_slice(domain);
+    message.extend_from_slice(session_key);
+    message.extend_from_slice(other_key);
+    message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p256::ecdsa::signature::Signer;
+    use p256::ecdsa::SigningKey;
+    use serde_bytes::ByteBuf;
+
+    /// The SPKI header WebCrypto emits for an `ECDSA` P-256 public key, ahead of the
+    /// 65-byte uncompressed point.
+    const P256_SPKI_HEADER: [u8; 26] = [
+        0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08,
+        0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
+    ];
+
+    struct Key {
+        signing: SigningKey,
+        public: PublicKey,
+    }
+
+    fn key(seed: u8) -> Key {
+        let signing = SigningKey::from_bytes(&[seed; 32].into()).unwrap();
+        let point = VerifyingKey::from(&signing).to_encoded_point(false);
+        let mut der = P256_SPKI_HEADER.to_vec();
+        der.extend_from_slice(point.as_bytes());
+        Key {
+            signing,
+            public: ByteBuf::from(der),
+        }
+    }
+
+    impl Key {
+        fn sign(&self, domain: &[u8], session_key: &SessionKey, other: &PublicKey) -> Vec<u8> {
+            let signature: Signature =
+                self.signing
+                    .sign(&signed_message(domain, session_key, other));
+            signature.to_bytes().to_vec()
+        }
+
+        fn current(&self, session_key: &SessionKey, next: &PublicKey) -> Vec<u8> {
+            self.sign(DEVICE_KEY_SIGNATURE_DOMAIN, session_key, next)
+        }
+
+        fn successor(&self, session_key: &SessionKey, current: &PublicKey) -> Vec<u8> {
+            self.sign(SUCCESSOR_KEY_SIGNATURE_DOMAIN, session_key, current)
+        }
+    }
+
+    fn session_key(seed: u8) -> SessionKey {
+        ByteBuf::from(vec![seed; 62])
+    }
+
+    /// A rotation as an honest browser performs it: it holds both keys and signs with both.
+    fn rotation(current: &Key, next: &Key, session: &SessionKey) -> bool {
+        verify_device_keys(
+            &current.public,
+            &current.current(session, &next.public),
+            &next.public,
+            &next.successor(session, &current.public),
+            session,
+        )
+    }
+
+    #[test]
+    fn a_browser_holding_both_keys_is_accepted() {
+        assert!(rotation(&key(1), &key(2), &session_key(7)));
+    }
+
+    #[test]
+    fn a_successor_the_caller_does_not_hold_is_refused() {
+        let current = key(1);
+        let announced = key(2);
+        let session = session_key(7);
+
+        // Everything the wire carries, but signed only by the key the caller holds.
+        assert!(!verify_device_keys(
+            &current.public,
+            &current.current(&session, &announced.public),
+            &announced.public,
+            &current.current(&session, &announced.public),
+            &session
+        ));
+    }
+
+    #[test]
+    fn a_successor_signature_replayed_as_the_current_one_is_refused() {
+        let current = key(1);
+        let next = key(2);
+        let session = session_key(7);
+
+        assert!(!verify_device_keys(
+            &current.public,
+            &current.successor(&session, &next.public),
+            &next.public,
+            &next.successor(&session, &current.public),
+            &session
+        ));
+    }
+
+    #[test]
+    fn a_signature_over_another_session_key_is_refused() {
+        let current = key(1);
+        let next = key(2);
+
+        assert!(!verify_device_keys(
+            &current.public,
+            &current.current(&session_key(7), &next.public),
+            &next.public,
+            &next.successor(&session_key(7), &current.public),
+            &session_key(8)
+        ));
+    }
+
+    #[test]
+    fn a_signature_paired_with_another_successor_is_refused() {
+        let current = key(1);
+        let announced = key(2);
+        let substituted = key(3);
+        let session = session_key(7);
+
+        assert!(!verify_device_keys(
+            &current.public,
+            &current.current(&session, &announced.public),
+            &substituted.public,
+            &substituted.successor(&session, &current.public),
+            &session
+        ));
+    }
+
+    #[test]
+    fn another_browsers_signature_is_refused() {
+        let current = key(1);
+        let other = key(9);
+        let next = key(2);
+        let session = session_key(7);
+
+        assert!(!verify_device_keys(
+            &current.public,
+            &other.current(&session, &next.public),
+            &next.public,
+            &next.successor(&session, &current.public),
+            &session
+        ));
+    }
+
+    #[test]
+    fn a_signature_over_the_bare_session_key_is_refused() {
+        let current = key(1);
+        let next = key(2);
+        let session = session_key(7);
+        let bare: Signature = current.signing.sign(&session);
+
+        assert!(!verify_device_keys(
+            &current.public,
+            &bare.to_bytes(),
+            &next.public,
+            &next.successor(&session, &current.public),
+            &session
+        ));
+    }
+
+    #[test]
+    fn a_key_that_is_not_a_p256_public_key_is_refused() {
+        let current = key(1);
+        let next = key(2);
+        let session = session_key(7);
+
+        assert!(!verify_device_keys(
+            &ByteBuf::from(vec![0u8; 91]),
+            &current.current(&session, &next.public),
+            &next.public,
+            &next.successor(&session, &current.public),
+            &session
+        ));
+    }
+
+    #[test]
+    fn a_signature_of_the_wrong_length_is_refused() {
+        let current = key(1);
+        let next = key(2);
+        let session = session_key(7);
+        let mut signature = current.current(&session, &next.public);
+        signature.push(0);
+
+        assert!(!verify_device_keys(
+            &current.public,
+            &signature,
+            &next.public,
+            &next.successor(&session, &current.public),
+            &session
+        ));
+    }
+
+    #[test]
+    fn an_empty_signature_is_refused() {
+        let current = key(1);
+        let next = key(2);
+        let session = session_key(7);
+
+        assert!(!verify_device_keys(
+            &current.public,
+            &[],
+            &next.public,
+            &next.successor(&session, &current.public),
+            &session
+        ));
+        assert!(!verify_device_keys(
+            &current.public,
+            &current.current(&session, &next.public),
+            &next.public,
+            &[],
+            &session
+        ));
+    }
+}

--- a/src/internet_identity/src/state.rs
+++ b/src/internet_identity/src/state.rs
@@ -290,6 +290,7 @@ pub fn init_new() {
         memory,
     );
     storage_replace(storage);
+    storage_borrow_mut(|storage| storage.set_canister_id(ic_cdk::id()));
 }
 
 pub fn init_from_stable_memory() {
@@ -298,6 +299,7 @@ pub fn init_from_stable_memory() {
     });
     let storage = Storage::from_memory(DefaultMemoryImpl::default());
     storage_replace(storage);
+    storage_borrow_mut(|storage| storage.set_canister_id(ic_cdk::id()));
 }
 
 pub fn save_persistent_state() {

--- a/src/internet_identity/src/storage.rs
+++ b/src/internet_identity/src/storage.rs
@@ -105,11 +105,12 @@ use identity_jose::jwk::Jwk;
 use internet_identity_interface::archive::types::BufferedEntry;
 
 use crate::delegation::{self, check_frontend_length};
+use crate::delegation::{calculate_session_seed_with_salt, canister_sig_principal};
 use crate::openid::OpenIdCredentialKey;
 use crate::state::PersistentState;
 use crate::stats::event_stats::AggregationKey;
 use crate::stats::event_stats::{EventData, EventKey};
-use crate::storage::account::AccountReference;
+use crate::storage::account::{AccountReference, SessionRecord};
 use crate::storage::anchor::Anchor;
 use crate::storage::memory_wrapper::MemoryWrapper;
 use crate::storage::registration_rates::RegistrationRates;
@@ -123,6 +124,7 @@ use crate::storage::storable::application::StorableOriginSha256;
 use crate::storage::storable::application_number::StorableApplicationNumber;
 use crate::storage::storable::passkey_credential::StorablePasskeyCredential;
 use crate::storage::storable::recovery_key::StorableRecoveryKey;
+use crate::storage::storable::session_handle::StorableSessionHandle;
 use internet_identity_interface::internet_identity::types::*;
 use storable::anchor::StorableAnchor;
 use storable::anchor_number::StorableAnchorNumber;
@@ -212,6 +214,7 @@ const MCP_REGISTRATION_MEMORY_INDEX: u8 = 31u8;
 const SSO_STABLE_ID_INDEX_MEMORY_INDEX: u8 = 32u8;
 const NEXT_APPLICATION_NUMBER_MEMORY_INDEX: u8 = 33u8;
 const LOOKUP_ACCOUNT_WITH_PRINCIPAL_MEMORY_INDEX: u8 = 34u8;
+const LOOKUP_SESSION_WITH_PRINCIPAL_MEMORY_INDEX: u8 = 35u8;
 
 const ANCHOR_MEMORY_ID: MemoryId = MemoryId::new(ANCHOR_MEMORY_INDEX);
 const ARCHIVE_BUFFER_MEMORY_ID: MemoryId = MemoryId::new(ARCHIVE_BUFFER_MEMORY_INDEX);
@@ -297,6 +300,8 @@ const NEXT_APPLICATION_NUMBER_MEMORY_ID: MemoryId =
 
 /// Reverse index from the principal a dapp sees to the account that produced it:
 /// `self_authenticating(der_encode_canister_sig_key(seed)) -> (anchor, application, account)`.
+const LOOKUP_SESSION_WITH_PRINCIPAL_MEMORY_ID: MemoryId =
+    MemoryId::new(LOOKUP_SESSION_WITH_PRINCIPAL_MEMORY_INDEX);
 const LOOKUP_ACCOUNT_WITH_PRINCIPAL_MEMORY_ID: MemoryId =
     MemoryId::new(LOOKUP_ACCOUNT_WITH_PRINCIPAL_MEMORY_INDEX);
 
@@ -317,6 +322,21 @@ const EVICTABLE_DEFAULT_ACCOUNTS_WATERMARK: u64 = MAX_EVICTABLE_DEFAULT_ACCOUNTS
 
 /// Bounds the victim scan, which runs on the sign-in path.
 const MAX_ROWS_SCANNED_FOR_EVICTION: usize = 2 * MAX_EVICTABLE_DEFAULT_ACCOUNTS as usize;
+
+/// Session records one identity may hold, counted as stored rather than as live.
+///
+/// Counting what is stored is what makes the cap enforceable: a session expires with no
+/// write anywhere, so nothing observes it becoming dead, and a count of live sessions could
+/// only ever be a guess. An expired record instead holds its slot until something reclaims
+/// it — and since it is the first thing reclaimed, it is spent before any session a user
+/// still relies on, so holding a slot costs its owner nothing.
+///
+/// A bound on concurrent activity, not on history: every session expires within 30 days, so
+/// the set is the apps used in the last month times the browsers they were used from.
+pub const MAX_SESSIONS_PER_ANCHOR: u32 = 500;
+/// Reclaiming goes down to here rather than to the cap, so the pass that walks an identity's
+/// rows runs once and then not again for the next fifty sign-ins.
+pub const SESSIONS_WATERMARK_PER_ANCHOR: u32 = 450;
 
 /// Bounds one message's eviction work.
 const MAX_EVICTIONS_PER_CALL: u64 =
@@ -406,6 +426,15 @@ pub struct Storage<M: Memory> {
     lookup_account_with_principal_memory_wrapper: MemoryWrapper<ManagedMemory<M>>,
     lookup_account_with_principal_memory:
         StableBTreeMap<Principal, StorableAccountLocator, ManagedMemory<M>>,
+    /// This canister's own id, which session and account principals derive from. Set once
+    /// at init; a fixed default keeps derivations consistent in unit tests, which run
+    /// outside a canister.
+    canister_id: Principal,
+    /// Where a session lives, keyed by the principal its chain is rooted at. An app-facing
+    /// call carries nothing but that principal, so this is what turns `caller()` into a
+    /// session.
+    lookup_session_with_principal_memory:
+        StableBTreeMap<Principal, StorableSessionHandle, ManagedMemory<M>>,
     /// Counter that counts how often there was a discrepancy between the anchor accounts counter and the actual number of accounts
     stable_account_counter_discrepancy_counter_memory:
         StableCell<StorableDiscrepancyCounter, ManagedMemory<M>>,
@@ -544,6 +573,8 @@ impl<M: Memory + Clone> Storage<M> {
         let next_application_number_memory = memory_manager.get(NEXT_APPLICATION_NUMBER_MEMORY_ID);
         let lookup_account_with_principal_memory =
             memory_manager.get(LOOKUP_ACCOUNT_WITH_PRINCIPAL_MEMORY_ID);
+        let lookup_session_with_principal_memory =
+            memory_manager.get(LOOKUP_SESSION_WITH_PRINCIPAL_MEMORY_ID);
         let stable_account_counter_discrepancy_counter_memory =
             memory_manager.get(STABLE_ACCOUNT_COUNTER_DISCREPANCY_COUNTER_MEMORY_ID);
         let lookup_anchor_with_openid_credential_memory =
@@ -630,6 +661,10 @@ impl<M: Memory + Clone> Storage<M> {
                 .expect("next_application_number_memory"),
             lookup_account_with_principal_memory_wrapper: MemoryWrapper::new(
                 lookup_account_with_principal_memory.clone(),
+            ),
+            canister_id: Principal::management_canister(),
+            lookup_session_with_principal_memory: StableBTreeMap::init(
+                lookup_session_with_principal_memory,
             ),
             lookup_account_with_principal_memory: StableBTreeMap::init(
                 lookup_account_with_principal_memory,
@@ -890,6 +925,7 @@ impl<M: Memory + Clone> Storage<M> {
             verified_emails: _,
             session_devices: _,
             next_session_device_id: _,
+            session_count: _,
         }) = previous_anchor_maybe
         {
             (
@@ -1766,6 +1802,470 @@ impl<M: Memory + Clone> Storage<M> {
         Ok(Some(()))
     }
 
+    /// Signs one browser out of everything, in a single message.
+    pub fn revoke_device_sessions(
+        &mut self,
+        anchor_number: AnchorNumber,
+        device_id: SessionDeviceId,
+    ) -> Result<u64, StorageError> {
+        let affected: Vec<(ApplicationNumber, Vec<AccountReference>)> = self
+            .stable_account_reference_list_memory
+            .range(
+                (anchor_number, ApplicationNumber::MIN)..=(anchor_number, ApplicationNumber::MAX),
+            )
+            .filter_map(|((_, application_number), list)| {
+                let references: Vec<AccountReference> = list.into();
+                references
+                    .iter()
+                    .any(|reference| {
+                        reference
+                            .sessions
+                            .iter()
+                            .any(|session| session.device_id == device_id)
+                    })
+                    .then_some((application_number, references))
+            })
+            .collect();
+
+        let mut removed = 0u64;
+        for (application_number, mut references) in affected {
+            let mut dropped: Vec<(Option<AccountNumber>, SessionRecord)> = vec![];
+            for reference in &mut references {
+                let account_number = reference.account_number;
+                reference.sessions.retain(|session| {
+                    if session.device_id == device_id {
+                        dropped.push((account_number, session.clone()));
+                        return false;
+                    }
+                    true
+                });
+            }
+            removed += dropped.len() as u64;
+            self.write_reference_list(anchor_number, application_number, references)?;
+            for (account_number, session) in &dropped {
+                self.unindex_sessions(
+                    anchor_number,
+                    application_number,
+                    *account_number,
+                    std::slice::from_ref(session),
+                );
+            }
+        }
+        if removed > 0 {
+            self.change_session_count(anchor_number, removed as usize, 0)?;
+        }
+
+        Ok(removed)
+    }
+
+    /// Tells storage which canister it is, so the principals it derives match the ones
+    /// callers arrive as.
+    pub fn set_canister_id(&mut self, canister_id: Principal) {
+        self.canister_id = canister_id;
+    }
+
+    /// The principal a session's chain is rooted at, which is what an app-facing call
+    /// arrives as. `None` only when the salt is unset or the account is gone, both of
+    /// which make the session unusable anyway.
+    fn session_principal(
+        &self,
+        anchor_number: AnchorNumber,
+        application_number: ApplicationNumber,
+        account_number: Option<AccountNumber>,
+        session: &SessionRecord,
+    ) -> Option<Principal> {
+        let salt = self.salt().copied()?;
+        let account = self.read_account(ReadAccountParams {
+            account_number,
+            anchor_number,
+            origin: &self
+                .stable_application_memory
+                .get(&application_number)?
+                .origin,
+            known_app_num: Some(application_number),
+        })?;
+        let seed = calculate_session_seed_with_salt(
+            &salt,
+            &account.calculate_seed_with_salt(&salt),
+            session.created_at,
+            session.device_id,
+        );
+        Some(canister_sig_principal(self.canister_id, seed.to_vec()))
+    }
+
+    /// Frees a slot for one more session, and reports whether the anchor has one.
+    ///
+    /// The stored count is a trigger, never the thing the cap is enforced against: a
+    /// session can expire with no write anywhere, so the count drifts upwards. Once it
+    /// reaches the cap this recounts what the rows hold and reclaims against that, so an
+    /// admission is only ever granted against a number that was just counted.
+    fn ensure_session_slot(
+        &mut self,
+        anchor_number: AnchorNumber,
+        now: Timestamp,
+    ) -> Result<bool, StorageError> {
+        if self.read(anchor_number)?.session_count < MAX_SESSIONS_PER_ANCHOR {
+            return Ok(true);
+        }
+        Ok(self.reclaim_sessions(anchor_number, now)? < MAX_SESSIONS_PER_ANCHOR)
+    }
+
+    /// Replaces the count with a number that was counted rather than accumulated.
+    fn set_session_count(
+        &mut self,
+        anchor_number: AnchorNumber,
+        count: u32,
+    ) -> Result<(), StorageError> {
+        let mut anchor = self.read(anchor_number)?;
+        if anchor.session_count == count {
+            return Ok(());
+        }
+        anchor.session_count = count;
+        self.write(anchor)
+    }
+
+    /// Moves the count without considering the cap, for the paths that only remove.
+    fn change_session_count(
+        &mut self,
+        anchor_number: AnchorNumber,
+        removed: usize,
+        added: usize,
+    ) -> Result<u32, StorageError> {
+        let mut anchor = self.read(anchor_number)?;
+        anchor.session_count = anchor
+            .session_count
+            .saturating_sub(removed as u32)
+            .saturating_add(added as u32);
+        let count = anchor.session_count;
+        self.write(anchor)?;
+        Ok(count)
+    }
+
+    /// Walks the anchor's rows once and reclaims down to the watermark, taking sessions in
+    /// [`SessionRecord::reclaim_order`]: dead ones first, then the least recently used.
+    ///
+    /// Returns what the rows actually hold once it is done, which is the number the cap is
+    /// enforced against. The stored counter is only ever a trigger for running this pass —
+    /// it can drift, this cannot, because it counts the sessions themselves.
+    ///
+    /// One pass per fifty sign-ins, because it reclaims to the watermark rather than to the
+    /// cap, and bounded by the same row limit account eviction uses.
+    fn reclaim_sessions(
+        &mut self,
+        anchor_number: AnchorNumber,
+        now: Timestamp,
+    ) -> Result<u32, StorageError> {
+        struct Candidate {
+            order: (bool, Timestamp, SessionDeviceId),
+            row: usize,
+            account_number: Option<AccountNumber>,
+            device_id: SessionDeviceId,
+        }
+
+        // Every row, not a bounded prefix of them: the number this returns is what the cap is
+        // enforced against, and a truncated scan would undercount, lower the counter to the
+        // undercount, and let the stored set climb past the cap from there. An identity's rows
+        // are already bounded — the row cap holds the evictable ones and the account cap holds
+        // the rest — and a sequential scan of them costs a fraction of the writes it saves.
+        let mut rows: Vec<(ApplicationNumber, Vec<AccountReference>)> = self
+            .stable_account_reference_list_memory
+            .range(
+                (anchor_number, ApplicationNumber::MIN)..=(anchor_number, ApplicationNumber::MAX),
+            )
+            .map(|((_, application_number), list)| (application_number, list.into()))
+            .collect();
+
+        let mut candidates: Vec<Candidate> = vec![];
+        for (row, (_, references)) in rows.iter().enumerate() {
+            for reference in references {
+                for session in &reference.sessions {
+                    candidates.push(Candidate {
+                        order: session.reclaim_order(now),
+                        row,
+                        account_number: reference.account_number,
+                        device_id: session.device_id,
+                    });
+                }
+            }
+        }
+        let stored = candidates.len() as u32;
+        candidates.sort_by_key(|candidate| candidate.order);
+
+        let surplus = stored.saturating_sub(SESSIONS_WATERMARK_PER_ANCHOR) as usize;
+        let victims = &candidates[..surplus.min(candidates.len())];
+        if victims.is_empty() {
+            self.set_session_count(anchor_number, stored)?;
+            return Ok(stored);
+        }
+
+        // One write per row rather than one per victim: the row is a single blob, so
+        // dropping several of its sessions one at a time would rewrite it several times.
+        let mut touched: Vec<usize> = victims.iter().map(|victim| victim.row).collect();
+        touched.sort_unstable();
+        touched.dedup();
+
+        let mut dropped_total = 0usize;
+        for row in touched {
+            let (application_number, references) = &mut rows[row];
+            let application_number = *application_number;
+            let mut removed: Vec<(Option<AccountNumber>, SessionRecord)> = vec![];
+            for reference in references.iter_mut() {
+                let account_number = reference.account_number;
+                reference.sessions.retain(|session| {
+                    // The row has to be part of the match: one browser holds one session per
+                    // account, but the same browser and the same account number appear in
+                    // every row, so matching on that pair alone reaches across applications.
+                    let doomed = victims.iter().any(|victim| {
+                        victim.row == row
+                            && victim.account_number == account_number
+                            && victim.device_id == session.device_id
+                    });
+                    if doomed {
+                        removed.push((account_number, session.clone()));
+                    }
+                    !doomed
+                });
+            }
+            if removed.is_empty() {
+                continue;
+            }
+            self.write_reference_list(anchor_number, application_number, references.clone())?;
+            for (account_number, session) in &removed {
+                self.unindex_sessions(
+                    anchor_number,
+                    application_number,
+                    *account_number,
+                    std::slice::from_ref(session),
+                );
+            }
+            dropped_total += removed.len();
+        }
+
+        let remaining = stored.saturating_sub(dropped_total as u32);
+        self.set_session_count(anchor_number, remaining)?;
+        Ok(remaining)
+    }
+
+    /// Drops the index entries of sessions that have just been removed from a row.
+    fn unindex_sessions(
+        &mut self,
+        anchor_number: AnchorNumber,
+        application_number: ApplicationNumber,
+        account_number: Option<AccountNumber>,
+        removed: &[SessionRecord],
+    ) {
+        for session in removed {
+            if let Some(principal) =
+                self.session_principal(anchor_number, application_number, account_number, session)
+            {
+                self.lookup_session_with_principal_memory.remove(&principal);
+            }
+        }
+    }
+
+    /// The account a session handle names, together with its sessions.
+    pub fn account_with_sessions(
+        &self,
+        anchor_number: AnchorNumber,
+        application_number: ApplicationNumber,
+        account_number: Option<AccountNumber>,
+    ) -> Option<(Account, Vec<SessionRecord>)> {
+        let origin = self
+            .stable_application_memory
+            .get(&application_number)
+            .map(|application| application.origin)?;
+        let references: Vec<AccountReference> = self
+            .lookup_account_references(anchor_number, application_number)?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        let reference = references
+            .into_iter()
+            .find(|reference| reference.account_number == account_number)?;
+        let account = self.read_account(ReadAccountParams {
+            account_number,
+            anchor_number,
+            origin: &origin,
+            known_app_num: Some(application_number),
+        })?;
+        Some((account, reference.sessions))
+    }
+
+    pub fn account_sessions(
+        &self,
+        anchor_number: AnchorNumber,
+        origin: &FrontendHostname,
+        account_number: Option<AccountNumber>,
+    ) -> Option<Vec<SessionRecord>> {
+        let application_number = self.lookup_application_number_with_origin(origin)?;
+        let references: Vec<AccountReference> = self
+            .lookup_account_references(anchor_number, application_number)?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        references
+            .into_iter()
+            .find(|reference| reference.account_number == account_number)
+            .map(|reference| reference.sessions)
+    }
+
+    /// Creates the session `prepare_account_session` mints an identity from, replacing
+    /// whatever this browser already held at this account.
+    pub fn create_session(
+        &mut self,
+        params: CreateSessionParams,
+    ) -> Result<SessionRecord, StorageError> {
+        let CreateSessionParams {
+            anchor_number,
+            origin,
+            account_number,
+            device_id,
+            valid_till,
+            read_only,
+            now,
+        } = params;
+
+        // The row this session lands in has to exist first, but an existing one must not be
+        // written here: the single write at the end of this function carries `last_used`.
+        let application_number = match self.lookup_application_number_with_origin(&origin) {
+            Some(application_number)
+                if self
+                    .lookup_account_references(anchor_number, application_number)
+                    .is_some() =>
+            {
+                application_number
+            }
+            _ => {
+                if account_number.is_some() {
+                    return Err(StorageError::MissingAccount {
+                        anchor_number,
+                        name: origin,
+                    });
+                }
+                let application_number =
+                    self.lookup_or_insert_application_number_with_origin(&origin);
+                self.write_reference_list(
+                    anchor_number,
+                    application_number,
+                    vec![AccountReference::new(None, Some(now))],
+                )?;
+                self.evict_idle_tracked_defaults(anchor_number, application_number)?;
+                application_number
+            }
+        };
+
+        // Reclaiming before the session is admitted rather than after it: the stored set
+        // never sits above the cap, not even for the rest of this message.
+        if !self.ensure_session_slot(anchor_number, now)? {
+            return Err(StorageError::SessionCapNotReclaimed { anchor_number });
+        }
+
+        let mut references: Vec<AccountReference> = self
+            .lookup_account_references(anchor_number, application_number)
+            .ok_or(StorageError::MissingAccount {
+                anchor_number,
+                name: origin,
+            })?
+            .into_iter()
+            .map(Into::into)
+            .collect();
+
+        let reference = references
+            .iter_mut()
+            .find(|reference| reference.account_number == account_number)
+            .ok_or(StorageError::MissingAccount {
+                anchor_number,
+                name: String::new(),
+            })?;
+        reference.last_used = Some(now);
+
+        // A ceremony replaces whatever this browser held here, rather than reusing it: the
+        // copy of an old session's chain stops working at the user's next sign-in instead of
+        // at its expiry.
+        let mut dropped: Vec<(Option<AccountNumber>, SessionRecord)> = vec![];
+        reference.sessions.retain(|session| {
+            if session.device_id == device_id {
+                dropped.push((account_number, session.clone()));
+                return false;
+            }
+            true
+        });
+
+        let session = SessionRecord {
+            created_at: now,
+            valid_till,
+            last_refreshed: None,
+            device_id,
+            read_only,
+        };
+        reference.sessions.push(session.clone());
+
+        // The whole row, not just the reference being written: this row is about to be
+        // rewritten anyway, and a dead session on a sibling reference has nothing else
+        // coming for it.
+        for reference in references.iter_mut() {
+            let account_number = reference.account_number;
+            reference.sessions.retain(|session| {
+                if session.is_expired(now) {
+                    dropped.push((account_number, session.clone()));
+                    return false;
+                }
+                true
+            });
+        }
+
+        self.write_reference_list(anchor_number, application_number, references)?;
+        for (account_number, session) in &dropped {
+            self.unindex_sessions(
+                anchor_number,
+                application_number,
+                *account_number,
+                std::slice::from_ref(session),
+            );
+        }
+        if let Some(principal) =
+            self.session_principal(anchor_number, application_number, account_number, &session)
+        {
+            self.lookup_session_with_principal_memory.insert(
+                principal,
+                StorableSessionHandle {
+                    account_principal: self
+                        .account_principal_of(anchor_number, application_number, account_number)
+                        .map(|p| p.as_slice().to_vec())
+                        .unwrap_or_default(),
+                    device_id,
+                    created_at: session.created_at,
+                },
+            );
+        }
+        self.change_session_count(anchor_number, dropped.len(), 1)?;
+
+        Ok(session)
+    }
+
+    /// The principal an app sees for an account, which is what a session handle names.
+    fn account_principal_of(
+        &self,
+        anchor_number: AnchorNumber,
+        application_number: ApplicationNumber,
+        account_number: Option<AccountNumber>,
+    ) -> Option<Principal> {
+        let salt = self.salt().copied()?;
+        let account = self.read_account(ReadAccountParams {
+            account_number,
+            anchor_number,
+            origin: &self
+                .stable_application_memory
+                .get(&application_number)?
+                .origin,
+            known_app_num: Some(application_number),
+        })?;
+        Some(canister_sig_principal(
+            self.canister_id,
+            account.calculate_seed_with_salt(&salt).to_vec(),
+        ))
+    }
+
     /// Writes the reference-list row an `AnchorApplicationConfig` row implies, leaving
     /// `last_used` unset.
     pub fn ensure_account_reference_list(
@@ -1808,6 +2308,23 @@ impl<M: Memory + Clone> Storage<M> {
             .ok_or(StorageError::OriginNotFoundForApplicationNumber { application_number })?;
 
         self.sync_account_principal_index(anchor_number, application_number, &previous, &[])?;
+
+        // The row's sessions go with it, so their index entries have to go too. A browser
+        // keeps its id, and evicting a row leaves the account's principal untouched, so an
+        // entry left behind here would be waiting for the next sign-in at this origin.
+        let mut dropped = 0usize;
+        for reference in &previous {
+            self.unindex_sessions(
+                anchor_number,
+                application_number,
+                reference.account_number,
+                &reference.sessions,
+            );
+            dropped += reference.sessions.len();
+        }
+        if dropped > 0 {
+            self.change_session_count(anchor_number, dropped, 0)?;
+        }
 
         self.stable_account_reference_list_memory.remove(&key);
         self.stable_anchor_application_config_memory.remove(&key);
@@ -2874,6 +3391,16 @@ impl<M: Memory + Clone> Storage<M> {
     }
 }
 
+pub struct CreateSessionParams {
+    pub anchor_number: AnchorNumber,
+    pub origin: FrontendHostname,
+    pub account_number: Option<AccountNumber>,
+    pub device_id: SessionDeviceId,
+    pub valid_till: Timestamp,
+    pub read_only: bool,
+    pub now: Timestamp,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AccountPrincipalIndexBackfillOutcome {
     pub next_cursor: Option<(AnchorNumber, ApplicationNumber)>,
@@ -2966,6 +3493,12 @@ pub enum StorageError {
         anchor_number: AnchorNumber,
         application_number: ApplicationNumber,
     },
+    /// Reclaiming ran and the identity is still at the session cap. Unreachable unless
+    /// reclaiming stopped honouring its contract, which is why it is an error rather than a
+    /// refused sign-in: the sign-in is the thing this cap must never fail.
+    SessionCapNotReclaimed {
+        anchor_number: AnchorNumber,
+    },
     /// Tried to bind a recovery email that's already on a different
     /// anchor. The "one anchor per address" invariant from design
     /// §8.2 is enforced at the storage layer; the caller surfaces
@@ -3042,6 +3575,10 @@ impl fmt::Display for StorageError {
             Self::EmailRecoveryAddressAlreadyBound { existing_anchor } => write!(
                 f,
                 "recovery email is already bound to a different anchor ({existing_anchor})",
+            ),
+            Self::SessionCapNotReclaimed { anchor_number } => write!(
+                f,
+                "anchor {anchor_number} is at the session cap and reclaiming freed nothing"
             ),
         }
     }

--- a/src/internet_identity/src/storage/anchor.rs
+++ b/src/internet_identity/src/storage/anchor.rs
@@ -42,6 +42,7 @@ pub struct Anchor {
     /// Capped by `MAX_SESSION_DEVICES`.
     pub(crate) session_devices: Vec<SessionDevice>,
     pub(crate) next_session_device_id: SessionDeviceId,
+    pub(crate) session_count: u32,
     pub(crate) metadata: Option<HashMap<String, MetadataEntry>>,
     pub(crate) name: Option<String>,
     pub(crate) created_at: Option<Timestamp>,
@@ -233,6 +234,7 @@ impl From<Anchor> for (StorableFixedAnchor, StorableAnchor) {
             verified_emails,
             session_devices,
             next_session_device_id,
+            session_count,
             metadata,
             name,
             created_at,
@@ -500,6 +502,7 @@ impl From<Anchor> for (StorableFixedAnchor, StorableAnchor) {
                 verified_emails,
                 session_devices,
                 next_session_device_id,
+                session_count: Some(session_count),
             },
         )
     }
@@ -517,6 +520,7 @@ impl From<(AnchorNumber, StorableAnchor)> for Anchor {
             verified_emails,
             session_devices,
             next_session_device_id,
+            session_count,
         } = storable_anchor;
 
         let name = name.clone();
@@ -637,6 +641,7 @@ impl From<(AnchorNumber, StorableAnchor)> for Anchor {
             verified_emails,
             session_devices,
             next_session_device_id,
+            session_count: session_count.unwrap_or_default(),
             devices,
             metadata,
         }
@@ -660,6 +665,7 @@ impl From<(AnchorNumber, StorableFixedAnchor, Option<StorableAnchor>)> for Ancho
         let Some(storable_anchor) = storable_anchor else {
             return Anchor {
                 name: None,
+                session_count: 0,
                 openid_credentials: vec![],
                 email_recovery: vec![],
                 verified_emails: vec![],
@@ -706,6 +712,7 @@ impl From<(AnchorNumber, StorableFixedAnchor, Option<StorableAnchor>)> for Ancho
             verified_emails,
             session_devices,
             next_session_device_id: storable_anchor.next_session_device_id.unwrap_or_default(),
+            session_count: storable_anchor.session_count.unwrap_or_default(),
             metadata,
             name,
             created_at,
@@ -791,6 +798,7 @@ impl Anchor {
         Self {
             anchor_number,
             created_at: Some(created_at),
+            session_count: 0,
             devices: vec![],
             openid_credentials: vec![],
             email_recovery: vec![],

--- a/src/internet_identity/src/storage/anchor/tests.rs
+++ b/src/internet_identity/src/storage/anchor/tests.rs
@@ -225,6 +225,7 @@ fn should_prevent_mutation_when_invariants_are_violated() {
     let mut anchor = Anchor {
         session_devices: vec![],
         next_session_device_id: 0,
+        session_count: 0,
         anchor_number: ANCHOR_NUMBER,
         devices: vec![
             device1.clone(),
@@ -249,6 +250,7 @@ fn should_prevent_addition_when_invariants_are_violated() {
     let mut anchor = Anchor {
         session_devices: vec![],
         next_session_device_id: 0,
+        session_count: 0,
         anchor_number: ANCHOR_NUMBER,
         devices: vec![
             recovery_phrase(1, DeviceProtection::Unprotected),
@@ -273,6 +275,7 @@ fn should_allow_removal_when_invariants_are_violated() {
     let mut anchor = Anchor {
         session_devices: vec![],
         next_session_device_id: 0,
+        session_count: 0,
         anchor_number: ANCHOR_NUMBER,
         devices: vec![
             device1.clone(),

--- a/src/internet_identity/src/storage/storable.rs
+++ b/src/internet_identity/src/storage/storable.rs
@@ -26,6 +26,7 @@ pub mod passkey_credential;
 pub mod recovery_key;
 pub mod session_device;
 pub mod session_device_id;
+pub mod session_handle;
 pub mod session_record;
 pub mod special_device_migration;
 pub mod sso_stable_id_key;

--- a/src/internet_identity/src/storage/storable/anchor.rs
+++ b/src/internet_identity/src/storage/storable/anchor.rs
@@ -40,6 +40,11 @@ pub struct StorableAnchor {
     /// Monotonic per-anchor allocator for `session_devices`. Ids are never reused.
     #[n(8)]
     pub next_session_device_id: Option<StorableSessionDeviceId>,
+    /// Live sessions this anchor holds, as a trigger for the session cap rather than a
+    /// source of truth: expiry removes a session with no write to observe, so this can
+    /// over-count until a reclaim pass prunes and corrects it.
+    #[n(9)]
+    pub session_count: Option<u32>,
 }
 
 impl Storable for StorableAnchor {

--- a/src/internet_identity/src/storage/storable/session_handle.rs
+++ b/src/internet_identity/src/storage/storable/session_handle.rs
@@ -1,0 +1,40 @@
+use crate::storage::storable::session_device_id::StorableSessionDeviceId;
+use ic_stable_structures::storable::Bound;
+use ic_stable_structures::Storable;
+use minicbor::{Decode, Encode};
+use std::borrow::Cow;
+
+/// Where the session a caller authenticates as is stored.
+///
+/// The account is named by its principal rather than by its locator because materialising a
+/// default account changes the locator and leaves the principal alone, so a rename touches
+/// one entry in the principal index instead of every session of that account.
+///
+/// A browser keeps its id across sign-ins, so the browser alone does not name a session:
+/// the creation time is what distinguishes the record this entry was written for from
+/// whatever that browser creates later. Both are inputs to the session seed, so an entry
+/// can only ever resolve to the one session whose principal is its own key.
+#[derive(Encode, Decode, Clone, Debug, Eq, PartialEq)]
+#[cbor(map)]
+pub struct StorableSessionHandle {
+    #[cbor(n(0), with = "minicbor::bytes")]
+    pub account_principal: Vec<u8>,
+    #[n(1)]
+    pub device_id: StorableSessionDeviceId,
+    #[n(2)]
+    pub created_at: u64,
+}
+
+impl Storable for StorableSessionHandle {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        let mut buffer = Vec::new();
+        minicbor::encode(self, &mut buffer).expect("failed to encode StorableSessionHandle");
+        Cow::Owned(buffer)
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        minicbor::decode(&bytes).expect("failed to decode StorableSessionHandle")
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -1318,6 +1318,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 0,
                 devices: vec![],
                 openid_credentials: vec![],
@@ -1352,6 +1353,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 1,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("recovery_key_pubkey"),
@@ -1397,6 +1399,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 2,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("passkey_pubkey"),
@@ -1442,6 +1445,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 3,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("passkey_no_origin"),
@@ -1487,6 +1491,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 4,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("recovery_passkey"),
@@ -1532,6 +1537,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 5,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("recovery_passkey_no_origin"),
@@ -1577,6 +1583,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 6,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("browser_storage_key_auth"),
@@ -1622,6 +1629,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 7,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("browser_storage_key_recovery"),
@@ -1681,6 +1689,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 8,
                 devices: vec![
                     Device {
@@ -1727,6 +1736,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 9,
                 devices: vec![],
                 openid_credentials: vec![openid_credential(1)],
@@ -1748,6 +1758,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 10,
                 devices: vec![],
                 openid_credentials: vec![],
@@ -1782,6 +1793,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 11,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("unknown_keytype_passkey"),
@@ -1834,6 +1846,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 12,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("device_with_metadata"),
@@ -1873,6 +1886,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 13,
                 devices: vec![],
                 openid_credentials: vec![],
@@ -1907,6 +1921,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 14,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("protected_recovery_key"),
@@ -1955,6 +1970,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 15,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("protected_passkey"),
@@ -2002,6 +2018,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 16,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("unusual_device"),
@@ -2047,6 +2064,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 17,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("recovery_phrase_custom_alias"),
@@ -2092,6 +2110,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 18,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("platform_passkey"),
@@ -2137,6 +2156,7 @@ fn test_anchor_storage_migration_round_trip() {
             Anchor {
                 session_devices: vec![],
                 next_session_device_id: 0,
+                session_count: 0,
                 anchor_number: 19,
                 devices: vec![Device {
                     pubkey: ByteBuf::from("unknown_keytype_passkey_2"),
@@ -3551,6 +3571,8 @@ mod account_principal_index_tests {
             other_anchor_number
         );
     }
+
+
 }
 
 mod account_principal_index_backfill_tests {
@@ -3683,6 +3705,7 @@ mod account_principal_index_backfill_tests {
 mod session_record_tests {
     use crate::storage::account::{AccountReference, SessionRecord};
     use crate::storage::storable::account_reference::StorableAccountReference;
+    use crate::storage::MAX_EVICTABLE_DEFAULT_ACCOUNTS;
     use crate::{Storage, DAY_NS, MINUTE_NS};
     use ic_stable_structures::{Storable, VectorMemory};
     use internet_identity_interface::internet_identity::types::AnchorNumber;
@@ -3751,8 +3774,8 @@ mod session_record_tests {
     #[test]
     fn a_row_holding_a_session_is_evictable_like_any_other() {
         let (mut storage, anchor_number) = storage_with_anchor();
-        let origin = "https://has-a-session.com".to_string();
-        let application_number = storage.lookup_or_insert_application_number_with_origin(&origin);
+        let application_number = storage
+            .lookup_or_insert_application_number_with_origin(&"https://example.com".to_string());
         storage
             .write_reference_list(
                 anchor_number,
@@ -3768,6 +3791,51 @@ mod session_record_tests {
         assert_eq!(storage.evictable_default_rows(anchor_number).len(), 1);
     }
 
+    /// Eviction orders on the row's `last_used`, which every refresh stamps, so a session
+    /// in use keeps its row at the newest end and survives the cap on its own.
+    #[test]
+    fn a_refreshed_session_keeps_its_row_and_a_stale_one_does_not() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        let stale = "https://never-came-back.com".to_string();
+        let refreshed = "https://still-in-use.com".to_string();
+        let stale_application = storage.lookup_or_insert_application_number_with_origin(&stale);
+        let refreshed_application =
+            storage.lookup_or_insert_application_number_with_origin(&refreshed);
+
+        for (application, last_used) in [(stale_application, 1), (refreshed_application, u64::MAX)]
+        {
+            storage
+                .write_reference_list(
+                    anchor_number,
+                    application,
+                    vec![AccountReference {
+                        account_number: None,
+                        last_used: Some(last_used),
+                        sessions: vec![session(1, u64::MAX)],
+                    }],
+                )
+                .unwrap();
+        }
+
+        for index in 0..MAX_EVICTABLE_DEFAULT_ACCOUNTS {
+            storage
+                .set_account_last_used(
+                    anchor_number,
+                    format!("https://app-{index}.com"),
+                    None,
+                    index + 2,
+                )
+                .unwrap();
+        }
+
+        assert!(storage
+            .lookup_account_references(anchor_number, stale_application)
+            .is_none());
+        assert!(storage
+            .lookup_account_references(anchor_number, refreshed_application)
+            .is_some());
+    }
+
     #[test]
     fn reclaim_order_ranks_dead_sessions_first() {
         let now = 1_000;
@@ -3780,27 +3848,6 @@ mod session_record_tests {
 
         assert!(expired.reclaim_order(now) < live.reclaim_order(now));
         assert!(expired.reclaim_order(now) < live_untouched.reclaim_order(now));
-    }
-
-    #[test]
-    fn a_flood_of_unused_sessions_cannot_displace_a_used_one() {
-        let now = 100 * DAY_NS;
-        let held = SessionRecord {
-            last_refreshed: Some(now - DAY_NS),
-            ..session(now - 20 * DAY_NS, now + DAY_NS)
-        };
-        // Created after the session it would have to outrank, which under a plain recency
-        // order would protect it.
-        let flood: Vec<SessionRecord> = (0..500)
-            .map(|index| SessionRecord {
-                device_id: index,
-                ..session(now - 1, now + DAY_NS)
-            })
-            .collect();
-
-        assert!(flood
-            .iter()
-            .all(|session| session.reclaim_order(now) < held.reclaim_order(now)));
     }
 
     #[test]
@@ -3821,5 +3868,674 @@ mod session_record_tests {
             one_sitting.reclaim_order(now) < weekly.reclaim_order(now),
             "the more recently touched session goes first, having stayed in service for minutes"
         );
+    }
+}
+
+mod session_creation_tests {
+    use crate::delegation::calculate_session_seed_with_salt;
+    use crate::storage::account::{AccountReference, CreateAccountParams, SessionRecord};
+    use crate::storage::{
+        CreateSessionParams, MAX_SESSIONS_PER_ANCHOR, SESSIONS_WATERMARK_PER_ANCHOR,
+    };
+    use crate::Storage;
+    use ic_stable_structures::VectorMemory;
+    use internet_identity_interface::internet_identity::types::AnchorNumber;
+    use pretty_assertions::assert_eq;
+
+    const SALT: [u8; 32] = [17u8; 32];
+    const ORIGIN: &str = "https://example.com";
+
+    fn storage_with_anchor() -> (Storage<VectorMemory>, AnchorNumber) {
+        let mut storage = Storage::new((10_000, 3_784_873), VectorMemory::default());
+        storage.update_salt(SALT);
+        let anchor = storage.allocate_anchor(0).unwrap();
+        let anchor_number = anchor.anchor_number();
+        storage.write(anchor).unwrap();
+        (storage, anchor_number)
+    }
+
+    fn params(anchor_number: AnchorNumber, device_id: u32, now: u64) -> CreateSessionParams {
+        CreateSessionParams {
+            anchor_number,
+            origin: ORIGIN.to_string(),
+            account_number: None,
+            device_id,
+            valid_till: now + 10_000,
+            read_only: false,
+            now,
+        }
+    }
+
+    fn sessions_of(
+        storage: &Storage<VectorMemory>,
+        anchor_number: AnchorNumber,
+    ) -> Vec<SessionRecord> {
+        let application_number = storage
+            .lookup_application_number_with_origin(&ORIGIN.to_string())
+            .unwrap();
+        let references: Vec<AccountReference> = storage
+            .lookup_account_references(anchor_number, application_number)
+            .unwrap()
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        references
+            .into_iter()
+            .find(|reference| reference.account_number.is_none())
+            .unwrap()
+            .sessions
+    }
+
+    #[test]
+    fn creating_a_session_tracks_the_account_and_stores_the_record() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+
+        let session = storage
+            .create_session(params(anchor_number, 1, 1_000))
+            .unwrap();
+
+        assert_eq!(session.created_at, 1_000);
+        assert_eq!(session.valid_till, 11_000);
+        assert_eq!(session.last_refreshed, None);
+        assert_eq!(session.device_id, 1);
+        assert_eq!(sessions_of(&storage, anchor_number), vec![session]);
+    }
+
+    /// A ceremony replaces the browser's session rather than reusing it, so a copy of the
+    /// old one stops working at the user's next sign-in instead of at its expiry.
+    #[test]
+    fn the_same_device_replaces_its_session() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        let first = storage
+            .create_session(params(anchor_number, 1, 1_000))
+            .unwrap();
+
+        let again = storage
+            .create_session(params(anchor_number, 1, 5_000))
+            .unwrap();
+
+        assert_ne!(again.created_at, first.created_at);
+        assert_eq!(sessions_of(&storage, anchor_number).len(), 1);
+    }
+
+    #[test]
+    fn a_different_device_gets_its_own_session() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        storage
+            .create_session(params(anchor_number, 1, 1_000))
+            .unwrap();
+
+        storage
+            .create_session(params(anchor_number, 2, 1_000))
+            .unwrap();
+
+        assert_eq!(sessions_of(&storage, anchor_number).len(), 2);
+    }
+
+    #[test]
+    fn expired_sessions_are_pruned_when_the_list_is_written() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        for device_id in 0..3 {
+            storage
+                .create_session(params(anchor_number, device_id, 1_000))
+                .unwrap();
+        }
+
+        storage
+            .create_session(params(anchor_number, 9, 20_000))
+            .unwrap();
+
+        let sessions = sessions_of(&storage, anchor_number);
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].device_id, 9);
+    }
+
+    /// There is no per-reference cap: one browser holds one session per account, so the
+    /// reference is bounded by the browser registry rather than by a number of its own.
+    #[test]
+    fn one_reference_holds_one_session_per_browser() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        for device_id in 0..12u32 {
+            let mut p = params(anchor_number, device_id, 1_000);
+            p.valid_till = 1_000_000;
+            storage.create_session(p).unwrap();
+        }
+
+        let sessions = sessions_of(&storage, anchor_number);
+        assert_eq!(sessions.len(), 12);
+        assert!(sessions.iter().any(|s| s.device_id == 0));
+    }
+
+    /// The per-identity cap reclaims to a watermark rather than blocking, taking expired
+    /// records first and then the least recently used.
+    #[test]
+    fn the_session_cap_reclaims_to_the_watermark() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        let application_number =
+            storage.lookup_or_insert_application_number_with_origin(&ORIGIN.to_string());
+
+        let sessions: Vec<SessionRecord> = (0..MAX_SESSIONS_PER_ANCHOR)
+            .map(|device_id| SessionRecord {
+                created_at: 1_000,
+                valid_till: 1_000_000,
+                // Device 0 is the stalest live one; device 1 has already expired.
+                last_refreshed: Some(500_000 + device_id as u64),
+                device_id,
+                read_only: false,
+            })
+            .map(|mut session| {
+                if session.device_id == 1 {
+                    session.valid_till = 2_000;
+                }
+                session
+            })
+            .collect();
+        storage
+            .write_reference_list(
+                anchor_number,
+                application_number,
+                vec![AccountReference {
+                    account_number: None,
+                    last_used: Some(1),
+                    sessions,
+                }],
+            )
+            .unwrap();
+        let mut anchor = storage.read(anchor_number).unwrap();
+        anchor.session_count = MAX_SESSIONS_PER_ANCHOR;
+        storage.write(anchor).unwrap();
+
+        let mut params = params(anchor_number, 9_999, 600_000);
+        params.valid_till = 1_000_000;
+        storage.create_session(params).unwrap();
+
+        let remaining = sessions_of(&storage, anchor_number);
+        assert_eq!(
+            remaining.len(),
+            SESSIONS_WATERMARK_PER_ANCHOR as usize + 1,
+            "reclaims to the watermark and then admits the session it made room for"
+        );
+        // The expired one and the stalest live one are gone; the freshest are not.
+        assert!(!remaining.iter().any(|s| s.device_id == 1));
+        assert!(!remaining.iter().any(|s| s.device_id == 0));
+        assert!(remaining
+            .iter()
+            .any(|s| s.device_id == MAX_SESSIONS_PER_ANCHOR - 1));
+        assert!(remaining.iter().any(|s| s.device_id == 9_999));
+    }
+
+    #[test]
+    fn the_cap_is_never_exceeded_however_many_sign_ins_arrive() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+
+        for device_id in 0..(MAX_SESSIONS_PER_ANCHOR + 120) {
+            let mut params = params(anchor_number, device_id, 600_000 + device_id as u64);
+            params.valid_till = 100_000_000;
+            storage.create_session(params).unwrap();
+
+            let stored = sessions_of(&storage, anchor_number).len();
+            assert!(
+                stored <= MAX_SESSIONS_PER_ANCHOR as usize,
+                "{stored} stored after {device_id} sign-ins"
+            );
+            assert_eq!(
+                storage.read(anchor_number).unwrap().session_count as usize,
+                stored,
+                "the counter parted ways with the rows after {device_id} sign-ins"
+            );
+        }
+    }
+
+    #[test]
+    fn an_over_counting_anchor_is_corrected_rather_than_denied() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        storage.create_session(params(anchor_number, 1, 1_000)).unwrap();
+
+        // Nothing observes a session expiring, so the count drifts up. The cap must be
+        // enforced against what the rows hold, not against the drift.
+        let mut anchor = storage.read(anchor_number).unwrap();
+        anchor.session_count = MAX_SESSIONS_PER_ANCHOR;
+        storage.write(anchor).unwrap();
+
+        storage.create_session(params(anchor_number, 2, 2_000)).unwrap();
+
+        assert_eq!(sessions_of(&storage, anchor_number).len(), 2);
+        assert_eq!(storage.read(anchor_number).unwrap().session_count, 2);
+    }
+
+    /// Two rows, both holding a default account, and both holding sessions for the same
+    /// browser ids. Reclaiming must take only the sessions it selected.
+    #[test]
+    fn reclaiming_takes_only_the_sessions_it_selected() {
+        const OTHER_ORIGIN: &str = "https://other.example";
+        let (mut storage, anchor_number) = storage_with_anchor();
+
+        // Two rows of this size put the identity two over the watermark, so the pass selects
+        // exactly two victims — one in each row.
+        const PER_ROW: u32 = SESSIONS_WATERMARK_PER_ANCHOR / 2 + 1;
+        let row = |expired_device: u32| -> Vec<AccountReference> {
+            let sessions = (0..PER_ROW)
+                .map(|device_id| {
+                    if device_id == expired_device {
+                        SessionRecord {
+                            created_at: 1,
+                            valid_till: 2,
+                            last_refreshed: None,
+                            device_id,
+                            read_only: false,
+                        }
+                    } else {
+                        SessionRecord {
+                            created_at: 1_000,
+                            valid_till: 100_000_000,
+                            last_refreshed: Some(500_000),
+                            device_id,
+                            read_only: false,
+                        }
+                    }
+                })
+                .collect();
+            vec![AccountReference {
+                account_number: None,
+                last_used: Some(1),
+                sessions,
+            }]
+        };
+
+        let first = storage.lookup_or_insert_application_number_with_origin(&ORIGIN.to_string());
+        let second =
+            storage.lookup_or_insert_application_number_with_origin(&OTHER_ORIGIN.to_string());
+        storage
+            .write_reference_list(anchor_number, first, row(0))
+            .unwrap();
+        storage
+            .write_reference_list(anchor_number, second, row(1))
+            .unwrap();
+
+        let mut anchor = storage.read(anchor_number).unwrap();
+        anchor.session_count = MAX_SESSIONS_PER_ANCHOR;
+        storage.write(anchor).unwrap();
+
+        let mut params = params(anchor_number, 9_999, 600_000);
+        params.valid_till = 100_000_000;
+        storage.create_session(params).unwrap();
+
+        let devices = |application_number| -> Vec<u32> {
+            let references: Vec<AccountReference> = storage
+                .lookup_account_references(anchor_number, application_number)
+                .unwrap()
+                .into_iter()
+                .map(Into::into)
+                .collect();
+            let mut ids: Vec<u32> = references
+                .into_iter()
+                .flat_map(|reference| reference.sessions)
+                .map(|session| session.device_id)
+                .collect();
+            ids.sort_unstable();
+            ids
+        };
+
+        let first_devices = devices(first);
+        let second_devices = devices(second);
+
+        assert!(
+            !first_devices.contains(&0),
+            "the expired session selected in the first row should be gone"
+        );
+        assert!(
+            !second_devices.contains(&1),
+            "the expired session selected in the second row should be gone"
+        );
+        assert!(
+            first_devices.contains(&1),
+            "the first row's live session for browser 1 was not selected and must survive"
+        );
+        assert!(
+            second_devices.contains(&0),
+            "the second row's live session for browser 0 was not selected and must survive"
+        );
+    }
+
+
+
+    /// The flood bound, exercised through the cap rather than through the order alone: a
+    /// session the user has actually kept alive survives a row full of sign-ins nobody
+    /// came back to, even though every one of them is newer than it.
+    #[test]
+    fn a_flood_of_unused_sessions_cannot_displace_a_used_one() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        let application_number =
+            storage.lookup_or_insert_application_number_with_origin(&ORIGIN.to_string());
+
+        let mut sessions = vec![SessionRecord {
+            created_at: 1_000,
+            valid_till: 100_000_000,
+            last_refreshed: Some(400_000),
+            device_id: 1,
+            read_only: false,
+        }];
+        sessions.extend((2..=MAX_SESSIONS_PER_ANCHOR).map(|device_id| SessionRecord {
+            created_at: 500_000,
+            valid_till: 100_000_000,
+            last_refreshed: None,
+            device_id,
+            read_only: false,
+        }));
+        storage
+            .write_reference_list(
+                anchor_number,
+                application_number,
+                vec![AccountReference {
+                    account_number: None,
+                    last_used: Some(1),
+                    sessions,
+                }],
+            )
+            .unwrap();
+        let mut anchor = storage.read(anchor_number).unwrap();
+        anchor.session_count = MAX_SESSIONS_PER_ANCHOR;
+        storage.write(anchor).unwrap();
+
+        let mut params = params(anchor_number, 9_999, 600_000);
+        params.valid_till = 100_000_000;
+        storage.create_session(params).unwrap();
+
+        let remaining = sessions_of(&storage, anchor_number);
+        assert!(
+            remaining.iter().any(|session| session.device_id == 1),
+            "the session that was kept alive was reclaimed"
+        );
+        assert!(
+            remaining.len() < MAX_SESSIONS_PER_ANCHOR as usize,
+            "nothing was reclaimed, so the test proves nothing"
+        );
+    }
+
+    #[test]
+    fn a_named_account_can_hold_its_own_sessions() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        let named = storage
+            .create_additional_account(CreateAccountParams {
+                anchor_number,
+                name: "named".to_string(),
+                origin: ORIGIN.to_string(),
+            })
+            .unwrap();
+        let mut p = params(anchor_number, 1, 1_000);
+        p.account_number = named.account_number;
+
+        storage.create_session(p).unwrap();
+
+        assert_eq!(sessions_of(&storage, anchor_number).len(), 0);
+        let application_number = storage
+            .lookup_application_number_with_origin(&ORIGIN.to_string())
+            .unwrap();
+        let references: Vec<AccountReference> = storage
+            .lookup_account_references(anchor_number, application_number)
+            .unwrap()
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        let named_reference = references
+            .iter()
+            .find(|r| r.account_number == named.account_number)
+            .unwrap();
+        assert_eq!(named_reference.sessions.len(), 1);
+    }
+
+    #[test]
+    fn a_session_for_an_account_the_anchor_does_not_hold_is_refused() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        let mut p = params(anchor_number, 1, 1_000);
+        p.account_number = Some(4_242);
+
+        let result = storage.create_session(p);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn an_expired_same_round_record_is_pruned_rather_than_colliding() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        let application_number =
+            storage.lookup_or_insert_application_number_with_origin(&ORIGIN.to_string());
+        storage
+            .write_reference_list(
+                anchor_number,
+                application_number,
+                vec![AccountReference {
+                    account_number: None,
+                    last_used: Some(1),
+                    sessions: vec![SessionRecord {
+                        created_at: 1_000,
+                        // Already expired at `now`, so it is not reused, but it is still
+                        // present when the seed for the new record is derived.
+                        valid_till: 1_000,
+                        last_refreshed: None,
+                        device_id: 1,
+                        read_only: false,
+                    }],
+                }],
+            )
+            .unwrap();
+
+        // Pruning removes the expired record, so the guard does not fire here; the
+        // reachable shape is a live record the reuse step declined, which cannot happen.
+        let created = storage
+            .create_session(params(anchor_number, 1, 1_000))
+            .unwrap();
+        assert_eq!(created.created_at, 1_000);
+    }
+
+    /// Creating twice from one browser at one account replaces, so there is never a second
+    /// record to collide with in the same round.
+    #[test]
+    fn creating_twice_in_one_round_from_one_browser_yields_one_session() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        let params = |read_only| CreateSessionParams {
+            anchor_number,
+            origin: ORIGIN.to_string(),
+            account_number: None,
+            device_id: 1,
+            valid_till: u64::MAX,
+            read_only,
+            now: 1_000,
+        };
+
+        let first = storage.create_session(params(false)).unwrap();
+        storage.create_session(params(false)).unwrap();
+        assert_eq!(sessions_of(&storage, anchor_number).len(), 1);
+
+        let replaced = storage.create_session(params(true)).unwrap();
+        assert_ne!(replaced.read_only, first.read_only);
+        assert_eq!(sessions_of(&storage, anchor_number).len(), 1);
+    }
+
+    #[test]
+    fn the_session_seed_binds_the_account_and_every_immutable_field() {
+        use crate::storage::account::Account;
+
+        let account = Account::new(10_000, ORIGIN.to_string(), None, None);
+        let account_seed = account.calculate_seed_with_salt(&SALT);
+        let other_account = Account::new(10_001, ORIGIN.to_string(), None, None);
+        let other_seed = other_account.calculate_seed_with_salt(&SALT);
+
+        let base = calculate_session_seed_with_salt(&SALT, &account_seed, 1_000, 1);
+
+        assert_ne!(
+            base,
+            calculate_session_seed_with_salt(&SALT, &other_seed, 1_000, 1)
+        );
+        assert_ne!(
+            base,
+            calculate_session_seed_with_salt(&SALT, &account_seed, 1_001, 1)
+        );
+        assert_ne!(
+            base,
+            calculate_session_seed_with_salt(&SALT, &account_seed, 1_000, 2)
+        );
+        assert_ne!(
+            base,
+            calculate_session_seed_with_salt(&[18u8; 32], &account_seed, 1_000, 1)
+        );
+        assert_eq!(
+            base,
+            calculate_session_seed_with_salt(&SALT, &account_seed, 1_000, 1)
+        );
+    }
+
+    #[test]
+    fn a_session_seed_is_distinct_from_the_account_seed_it_belongs_to() {
+        use crate::storage::account::Account;
+
+        let account = Account::new(10_000, ORIGIN.to_string(), None, None);
+        let account_seed = account.calculate_seed_with_salt(&SALT);
+        let session_seed = calculate_session_seed_with_salt(&SALT, &account_seed, 1_000, 1);
+
+        assert_ne!(account_seed, session_seed);
+    }
+
+    /// Naming a default account keeps its principal, so it must keep its sessions too.
+    #[test]
+    fn naming_a_default_account_leaves_its_session_identity_unchanged() {
+        use crate::storage::account::Account;
+
+        let default = Account::new(10_000, ORIGIN.to_string(), None, None);
+        let before = calculate_session_seed_with_salt(
+            &SALT,
+            &default.calculate_seed_with_salt(&SALT),
+            1_000,
+            1,
+        );
+
+        let named = Account::new_full(
+            10_000,
+            ORIGIN.to_string(),
+            Some("work".to_string()),
+            Some(7),
+            None,
+            Some(10_000),
+        );
+        let after = calculate_session_seed_with_salt(
+            &SALT,
+            &named.calculate_seed_with_salt(&SALT),
+            1_000,
+            1,
+        );
+
+        assert_eq!(before, after);
+    }
+}
+
+mod session_consent_change_tests {
+    use crate::storage::account::AccountReference;
+    use crate::storage::CreateSessionParams;
+    use crate::Storage;
+    use ic_stable_structures::VectorMemory;
+    use internet_identity_interface::internet_identity::types::AnchorNumber;
+    use pretty_assertions::assert_eq;
+
+    const ORIGIN: &str = "https://example.com";
+
+    fn storage_with_anchor() -> (Storage<VectorMemory>, AnchorNumber) {
+        let mut storage = Storage::new((10_000, 3_784_873), VectorMemory::default());
+        storage.update_salt([17u8; 32]);
+        let anchor = storage.allocate_anchor(0).unwrap();
+        let anchor_number = anchor.anchor_number();
+        storage.write(anchor).unwrap();
+        (storage, anchor_number)
+    }
+
+    fn create(
+        storage: &mut Storage<VectorMemory>,
+        anchor_number: AnchorNumber,
+        read_only: bool,
+        now: u64,
+    ) -> u64 {
+        storage
+            .create_session(CreateSessionParams {
+                anchor_number,
+                origin: ORIGIN.to_string(),
+                account_number: None,
+                device_id: 1,
+                valid_till: u64::MAX,
+                read_only,
+                now,
+            })
+            .unwrap()
+            .created_at
+    }
+
+    fn sessions(storage: &Storage<VectorMemory>, anchor_number: AnchorNumber) -> Vec<bool> {
+        let application_number = storage
+            .lookup_application_number_with_origin(&ORIGIN.to_string())
+            .unwrap();
+        storage
+            .lookup_account_references(anchor_number, application_number)
+            .unwrap()
+            .into_iter()
+            .map(AccountReference::from)
+            .find(|reference| reference.account_number.is_none())
+            .unwrap()
+            .sessions
+            .into_iter()
+            .map(|session| session.read_only)
+            .collect()
+    }
+
+    #[test]
+    fn the_same_consent_still_replaces_the_session() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        let first = create(&mut storage, anchor_number, false, 1_000);
+
+        let again = create(&mut storage, anchor_number, false, 2_000);
+
+        assert_ne!(again, first);
+        assert_eq!(sessions(&storage, anchor_number), vec![false]);
+    }
+
+    #[test]
+    fn a_downgraded_consent_replaces_the_session() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        let full_access = create(&mut storage, anchor_number, false, 1_000);
+
+        let read_only = create(&mut storage, anchor_number, true, 2_000);
+
+        assert_ne!(read_only, full_access);
+        assert_eq!(sessions(&storage, anchor_number), vec![true]);
+    }
+
+    #[test]
+    fn an_upgraded_consent_replaces_the_session() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        create(&mut storage, anchor_number, true, 1_000);
+
+        create(&mut storage, anchor_number, false, 2_000);
+
+        assert_eq!(sessions(&storage, anchor_number), vec![false]);
+    }
+
+    #[test]
+    fn a_consent_change_leaves_another_browser_alone() {
+        let (mut storage, anchor_number) = storage_with_anchor();
+        storage
+            .create_session(CreateSessionParams {
+                anchor_number,
+                origin: ORIGIN.to_string(),
+                account_number: None,
+                device_id: 2,
+                valid_till: u64::MAX,
+                read_only: false,
+                now: 1_000,
+            })
+            .unwrap();
+        create(&mut storage, anchor_number, false, 1_000);
+
+        create(&mut storage, anchor_number, true, 2_000);
+
+        let mut held = sessions(&storage, anchor_number);
+        held.sort_unstable();
+        assert_eq!(held, vec![false, true]);
     }
 }

--- a/src/internet_identity/src/verified_emails/remove.rs
+++ b/src/internet_identity/src/verified_emails/remove.rs
@@ -33,6 +33,7 @@ mod tests {
         let mut a = Anchor {
             session_devices: vec![],
             next_session_device_id: 0,
+            session_count: 0,
             anchor_number: 1,
             devices: vec![],
             openid_credentials: vec![],

--- a/src/internet_identity/tests/integration/main.rs
+++ b/src/internet_identity/tests/integration/main.rs
@@ -19,6 +19,7 @@ mod mcp;
 mod openid;
 mod rollback;
 mod session_delegation;
+mod sessions;
 mod stable_memory;
 mod upgrade;
 mod v2_api;

--- a/src/internet_identity/tests/integration/sessions.rs
+++ b/src/internet_identity/tests/integration/sessions.rs
@@ -1,0 +1,588 @@
+//! Tests for revocable app sessions: creating one, and minting app delegations from it.
+
+use candid::Principal;
+use canister_tests::api::internet_identity::api_v2::{
+    get_account_session, prepare_account_session,
+};
+use canister_tests::flows;
+use canister_tests::framework::{
+    env, install_ii_with_archive, principal_1, time, verify_delegation, BrowserKey,
+};
+use internet_identity_interface::internet_identity::types::{
+    AccountSessionError, GetAccountSessionRequest, PrepareAccountSessionRequest,
+    PrepareAccountSessionResponse,
+};
+use pocket_ic::{PocketIc, RejectResponse};
+use pretty_assertions::assert_eq;
+use serde_bytes::ByteBuf;
+use std::time::Duration;
+
+const ORIGIN: &str = "https://some-dapp.com";
+
+fn session_request(identity_number: u64) -> PrepareAccountSessionRequest {
+    session_request_from(identity_number, &BrowserKey::new(1))
+}
+
+/// The same browser presenting the same key again is what makes a sign-in a reuse rather
+/// than a registration, so every test that wants a second browser passes a second key.
+fn session_request_from(
+    identity_number: u64,
+    browser: &BrowserKey,
+) -> PrepareAccountSessionRequest {
+    let session_key = ByteBuf::from(vec![1; 32]);
+    let next_device_key = browser.successor().public_key();
+    PrepareAccountSessionRequest {
+        identity_number,
+        origin: ORIGIN.to_string(),
+        account_number: None,
+        device_name: "Chrome on MacBook".to_string(),
+        device_key: browser.public_key(),
+        device_key_signature: browser.sign(&session_key, &next_device_key),
+        next_device_key_signature: browser
+            .successor()
+            .sign_as_successor(&session_key, &browser.public_key()),
+        next_device_key,
+        session_key,
+        permissions: None,
+        valid_for: None,
+    }
+}
+
+/// Creates a session and returns it together with the principal its chain roots at.
+fn create_session(
+    env: &PocketIc,
+    canister_id: Principal,
+    identity_number: u64,
+) -> (PrepareAccountSessionResponse, Principal) {
+    let prepared = prepare_account_session(
+        env,
+        canister_id,
+        principal_1(),
+        session_request(identity_number),
+    )
+    .unwrap()
+    .unwrap();
+    let session_principal = Principal::self_authenticating(&prepared.user_key);
+    (prepared, session_principal)
+}
+
+#[test]
+fn should_create_a_session_and_witness_its_delegation() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let (prepared, _) = create_session(&env, canister_id, identity_number);
+    assert!(prepared.expiration > time(&env));
+
+    let fetched = get_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        GetAccountSessionRequest {
+            identity_number,
+            origin: ORIGIN.to_string(),
+            account_number: None,
+            session_key: ByteBuf::from(vec![1; 32]),
+            expiration: prepared.expiration,
+        },
+    )?
+    .unwrap();
+
+    verify_delegation(
+        &env,
+        prepared.user_key.clone(),
+        &fetched.signed_delegation,
+        &env.root_key().unwrap(),
+    );
+    Ok(())
+}
+
+
+#[test]
+fn should_refuse_a_session_for_another_anchor() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let result = prepare_account_session(
+        &env,
+        canister_id,
+        Principal::anonymous(),
+        session_request(identity_number),
+    )?;
+
+    assert!(matches!(result, Err(AccountSessionError::Unauthorized(_))));
+
+    Ok(())
+}
+
+
+
+
+
+
+
+
+
+/// Registering a browser happens once per browser per anchor, so it is rare enough to
+/// archive, unlike the per-sign-in events the account design keeps out of the archive.
+/// The self-reported name is redacted.
+#[test]
+fn should_archive_a_browser_registration_with_the_name_redacted() -> Result<(), RejectResponse> {
+    use canister_tests::api::archive as archive_api;
+    use canister_tests::api::internet_identity as ii_api;
+    use canister_tests::framework::{
+        arg_with_wasm_hash, install_ii_canister_with_arg, ARCHIVE_WASM, II_WASM,
+    };
+    use internet_identity_interface::archive::types::{Operation, Private};
+    use internet_identity_interface::internet_identity::types::DeployArchiveResult;
+
+    let env = env();
+    let ii_canister = install_ii_canister_with_arg(
+        &env,
+        II_WASM.clone(),
+        arg_with_wasm_hash(ARCHIVE_WASM.clone()),
+    );
+    let DeployArchiveResult::Success(archive_canister) =
+        ii_api::deploy_archive(&env, ii_canister, &ARCHIVE_WASM)
+            .expect("archive deployment failed")
+    else {
+        panic!("archive deployment did not succeed");
+    };
+    let identity_number = flows::register_anchor(&env, ii_canister);
+
+    prepare_account_session(
+        &env,
+        ii_canister,
+        principal_1(),
+        session_request(identity_number),
+    )?
+    .unwrap();
+
+    // The same browser signing in again is not a registration.
+    let mut again = session_request(identity_number);
+    again.origin = "https://another-dapp.com".to_string();
+    prepare_account_session(&env, ii_canister, principal_1(), again)?.unwrap();
+
+    env.advance_time(Duration::from_secs(2));
+    env.tick();
+
+    let entries = archive_api::get_entries(&env, archive_canister, None, None)?;
+    let registrations = entries
+        .entries
+        .into_iter()
+        .flatten()
+        .filter(|entry| {
+            matches!(
+                entry.operation,
+                Operation::RegisterSessionDevice {
+                    name: Private::Redacted
+                }
+            )
+        })
+        .count();
+    assert_eq!(registrations, 1);
+
+    Ok(())
+}
+
+
+/// A request naming an account the identity does not hold is the one failure a caller can
+/// provoke here, so it must be refused before anything is written. Otherwise a rejected
+/// sign-in would still leave a browser in the user's list.
+#[test]
+fn should_refuse_an_unknown_account_without_registering_a_browser() -> Result<(), RejectResponse> {
+    use canister_tests::api::internet_identity::api_v2::identity_info;
+
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let mut request = session_request(identity_number);
+    request.account_number = Some(9_999);
+    let result = prepare_account_session(&env, canister_id, principal_1(), request)?;
+
+    assert_eq!(result, Err(AccountSessionError::NoSuchAccount));
+    assert_eq!(
+        identity_info(&env, canister_id, principal_1(), identity_number)?
+            .unwrap()
+            .session_devices,
+        None
+    );
+
+    Ok(())
+}
+
+/// A browser is named by a key it proves possession of. Without the proof an attacker
+/// holding an access method could attribute a session to a browser the user recognises.
+#[test]
+fn should_refuse_a_signature_from_another_key() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let mut request = session_request(identity_number);
+    request.device_key_signature =
+        BrowserKey::new(9).sign(&request.session_key, &request.next_device_key);
+    let result = prepare_account_session(&env, canister_id, principal_1(), request)?;
+
+    assert_eq!(result, Err(AccountSessionError::InvalidDeviceKey));
+
+    Ok(())
+}
+
+/// The proof takes its freshness from the session key, so a signature captured from one
+/// request cannot be replayed to attach a second session to that browser.
+#[test]
+fn should_refuse_a_signature_over_another_session_key() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let browser = BrowserKey::new(1);
+    let mut request = session_request_from(identity_number, &browser);
+    request.session_key = ByteBuf::from(vec![2; 32]);
+    let result = prepare_account_session(&env, canister_id, principal_1(), request)?;
+
+    assert_eq!(result, Err(AccountSessionError::InvalidDeviceKey));
+
+    Ok(())
+}
+
+#[test]
+fn should_refuse_a_key_that_is_not_a_public_key() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let mut request = session_request(identity_number);
+    request.device_key = ByteBuf::from(vec![0; 91]);
+    let result = prepare_account_session(&env, canister_id, principal_1(), request)?;
+
+    assert_eq!(result, Err(AccountSessionError::InvalidDeviceKey));
+
+    Ok(())
+}
+
+/// Verification runs before anything is written, so a rejected proof leaves no browser
+/// in the user's list.
+#[test]
+fn should_register_no_browser_when_the_proof_fails() -> Result<(), RejectResponse> {
+    use canister_tests::api::internet_identity::api_v2::identity_info;
+
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let mut request = session_request(identity_number);
+    request.device_key_signature = ByteBuf::from(vec![0; 64]);
+    prepare_account_session(&env, canister_id, principal_1(), request)?.unwrap_err();
+
+    assert_eq!(
+        identity_info(&env, canister_id, principal_1(), identity_number)?
+            .unwrap()
+            .session_devices,
+        None
+    );
+
+    Ok(())
+}
+
+/// A key the identity has not seen registers a browser of its own, which is the signal a
+/// sign-in from somewhere the user does not recognise gives them.
+#[test]
+fn should_register_a_second_browser_for_a_key_it_has_not_seen() -> Result<(), RejectResponse> {
+    use canister_tests::api::internet_identity::api_v2::identity_info;
+
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request(identity_number),
+    )?
+    .unwrap();
+
+    let mut second = session_request_from(identity_number, &BrowserKey::new(2));
+    second.device_name = "Firefox on Linux".to_string();
+    prepare_account_session(&env, canister_id, principal_1(), second)?.unwrap();
+
+    let devices = identity_info(&env, canister_id, principal_1(), identity_number)?
+        .unwrap()
+        .session_devices
+        .expect("the identity should hold browsers");
+
+    assert_eq!(devices.len(), 2);
+    assert_eq!(devices[0].name, "Chrome on MacBook");
+    assert_eq!(devices[1].name, "Firefox on Linux");
+    assert_ne!(devices[0].id, devices[1].id);
+
+    Ok(())
+}
+
+/// A browser that lost its key is a new browser, which is the cost of the design and
+/// what the registry cap is sized for.
+#[test]
+fn should_register_a_fresh_browser_after_a_storage_wipe() -> Result<(), RejectResponse> {
+    use canister_tests::api::internet_identity::api_v2::identity_info;
+
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request(identity_number),
+    )?
+    .unwrap();
+    prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &BrowserKey::new(3)),
+    )?
+    .unwrap();
+
+    let devices = identity_info(&env, canister_id, principal_1(), identity_number)?
+        .unwrap()
+        .session_devices
+        .expect("the identity should hold browsers");
+
+    assert_eq!(devices.len(), 2);
+
+    Ok(())
+}
+
+/// The browser rotates its key at every sign-in, so the successor it announced last time is
+/// what it presents next.
+#[test]
+fn should_accept_the_successor_a_browser_announced() -> Result<(), RejectResponse> {
+    use canister_tests::api::internet_identity::api_v2::identity_info;
+
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let browser = BrowserKey::new(1);
+    let first = prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &browser),
+    )?
+    .unwrap();
+
+    let rotated = prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &browser.successor()),
+    )?
+    .unwrap();
+
+    assert_eq!(rotated.device_id, first.device_id);
+    assert_eq!(
+        identity_info(&env, canister_id, principal_1(), identity_number)?
+            .unwrap()
+            .session_devices
+            .unwrap()
+            .len(),
+        1
+    );
+
+    Ok(())
+}
+
+/// Which is what stops a copied browser profile signing in alongside the original without
+/// showing up: the key it copied is retired the next time the real browser signs in, so the
+/// copy can only come back as a browser of its own.
+#[test]
+fn should_treat_a_retired_key_as_a_new_browser() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let browser = BrowserKey::new(1);
+    let first = prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &browser),
+    )?
+    .unwrap();
+    prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &browser.successor()),
+    )?
+    .unwrap();
+
+    // A browser generates a fresh successor for every attempt, a copy of one included, and
+    // has to prove it holds it.
+    let fresh = BrowserKey::new(7);
+    let mut request = session_request_from(identity_number, &browser);
+    request.next_device_key = fresh.public_key();
+    request.device_key_signature = browser.sign(&request.session_key, &request.next_device_key);
+    request.next_device_key_signature =
+        fresh.sign_as_successor(&request.session_key, &browser.public_key());
+    let copy = prepare_account_session(&env, canister_id, principal_1(), request)?.unwrap();
+
+    assert_ne!(copy.device_id, first.device_id);
+
+    Ok(())
+}
+
+/// A retired key announcing the successor that replaced it is a replay of a request the real
+/// browser already made, and the successor is in use, so it is refused outright.
+#[test]
+fn should_refuse_a_replayed_announcement() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let browser = BrowserKey::new(1);
+    prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &browser),
+    )?
+    .unwrap();
+    prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &browser.successor()),
+    )?
+    .unwrap();
+
+    let replayed = prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &browser),
+    )?;
+
+    assert_eq!(replayed, Err(AccountSessionError::InvalidDeviceKey));
+
+    Ok(())
+}
+
+/// A response the browser never received leaves it proving with the key the entry still
+/// holds, which must not cost it its identity.
+#[test]
+fn should_accept_the_current_key_when_a_response_was_lost() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let browser = BrowserKey::new(1);
+    let first = prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &browser),
+    )?
+    .unwrap();
+
+    let retried = prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &browser),
+    )?
+    .unwrap();
+
+    assert_eq!(retried.device_id, first.device_id);
+
+    Ok(())
+}
+
+/// Presented keys are visible on the wire, so announcing a key another browser is about to
+/// present would otherwise take over its entry when it does.
+#[test]
+fn should_refuse_a_successor_another_browser_holds() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let victim = BrowserKey::new(1);
+    prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &victim),
+    )?
+    .unwrap();
+
+    let attacker = BrowserKey::new(2);
+    let mut request = session_request_from(identity_number, &attacker);
+    request.next_device_key = victim.successor().public_key();
+    request.device_key_signature = attacker.sign(&request.session_key, &request.next_device_key);
+    let result = prepare_account_session(&env, canister_id, principal_1(), request)?;
+
+    assert_eq!(result, Err(AccountSessionError::InvalidDeviceKey));
+
+    Ok(())
+}
+
+
+/// A key nobody holds cannot be announced: without the successor's own signature, a key read
+/// off the wire could be planted as another browser's successor and claimed later.
+#[test]
+fn should_refuse_a_successor_the_caller_cannot_prove() -> Result<(), RejectResponse> {
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let browser = BrowserKey::new(1);
+    let mut request = session_request_from(identity_number, &browser);
+    // Everything the wire carries, but the successor's signature made by the wrong key.
+    request.next_device_key_signature =
+        browser.sign_as_successor(&request.session_key, &browser.public_key());
+    let result = prepare_account_session(&env, canister_id, principal_1(), request)?;
+
+    assert_eq!(result, Err(AccountSessionError::InvalidDeviceKey));
+
+    Ok(())
+}
+
+/// Announcing a key another browser of this identity holds keeps two entries from answering
+/// to one key, which is what makes resolving a presented key unambiguous.
+#[test]
+fn should_refuse_a_successor_another_browser_holds_even_when_proven() -> Result<(), RejectResponse>
+{
+    let env = env();
+    let canister_id = install_ii_with_archive(&env, None, None);
+    let identity_number = flows::register_anchor(&env, canister_id);
+
+    let victim = BrowserKey::new(1);
+    prepare_account_session(
+        &env,
+        canister_id,
+        principal_1(),
+        session_request_from(identity_number, &victim),
+    )?
+    .unwrap();
+
+    // The attacker proves possession of the victim's key, as a profile copy could.
+    let attacker = BrowserKey::new(2);
+    let mut request = session_request_from(identity_number, &attacker);
+    request.next_device_key = victim.public_key();
+    request.device_key_signature = attacker.sign(&request.session_key, &request.next_device_key);
+    request.next_device_key_signature =
+        victim.sign_as_successor(&request.session_key, &attacker.public_key());
+    let result = prepare_account_session(&env, canister_id, principal_1(), request)?;
+
+    assert_eq!(result, Err(AccountSessionError::InvalidDeviceKey));
+
+    Ok(())
+}
+

--- a/src/internet_identity_interface/src/archive/types.rs
+++ b/src/internet_identity_interface/src/archive/types.rs
@@ -77,6 +77,12 @@ pub enum Operation {
 
     #[serde(rename = "set_default_account")]
     SetDefaultAccount,
+
+    // Once per browser per anchor, so rare enough to archive, unlike the per-sign-in
+    // events the account design keeps out of it. The name is self-reported by the
+    // client, so it is redacted like an account name.
+    #[serde(rename = "register_session_device")]
+    RegisterSessionDevice { name: Private },
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, CandidType, Deserialize)]

--- a/src/internet_identity_interface/src/internet_identity/types.rs
+++ b/src/internet_identity_interface/src/internet_identity/types.rs
@@ -755,3 +755,93 @@ pub enum SetDefaultAccountError {
         origin: FrontendHostname,
     },
 }
+
+/// Creates or reuses a revocable session at one account and signs its identity to the
+/// II frontend's own key.
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct PrepareAccountSessionRequest {
+    pub identity_number: IdentityNumber,
+    pub origin: FrontendHostname,
+    pub account_number: Option<AccountNumber>,
+    pub session_key: SessionKey,
+    pub device_name: String,
+    /// The browser's own public key, DER-encoded, as the registry currently holds it. A
+    /// key this anchor has not seen registers a browser under it.
+    pub device_key: PublicKey,
+    /// What the browser rotates to once this sign-in succeeds.
+    pub next_device_key: PublicKey,
+    /// Signature over `session_key` and `next_device_key`, verified with `device_key`.
+    /// A second signature by `next_device_key` proves the browser holds it.
+    pub device_key_signature: ByteBuf,
+    pub next_device_key_signature: ByteBuf,
+    /// The consented access level, fixed for the session's life.
+    pub permissions: Option<Permissions>,
+    /// Clamped to the session maximum.
+    pub valid_for: Option<u64>,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct PrepareAccountSessionResponse {
+    pub user_key: UserKey,
+    pub expiration: Timestamp,
+    pub created_at: Timestamp,
+    /// Which browser this sign-in was attributed to, so the settings list can mark the one
+    /// the user is looking at. Not a credential: a caller never presents it.
+    pub device_id: SessionDeviceId,
+    /// The principal apps see for this account. The caller is the anchor that owns it
+    /// and can mint a delegation for it at any time, so this reveals nothing new; it
+    /// saves the II frontend from having to mint one just to learn it.
+    pub account_principal: Principal,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct GetAccountSessionRequest {
+    pub identity_number: IdentityNumber,
+    pub origin: FrontendHostname,
+    pub account_number: Option<AccountNumber>,
+    pub session_key: SessionKey,
+    pub expiration: Timestamp,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct GetAccountSessionResponse {
+    pub signed_delegation: SignedDelegation,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum AccountSessionError {
+    Unauthorized(Principal),
+    NoSuchAccount,
+    NoSuchSession,
+    /// The browser's key is unusable, or its signature does not verify against it.
+    InvalidDeviceKey,
+    InternalCanisterError(String),
+}
+
+/// Mints an app delegation from a live session. The session is proven by the caller's
+/// own chain, so nothing about the account is named in the request.
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct AppPrepareDelegationRequest {
+    pub session_key: SessionKey,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct AppPrepareDelegationResponse {
+    pub user_key: UserKey,
+    pub expiration: Timestamp,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub struct AppGetDelegationRequest {
+    pub session_key: SessionKey,
+    pub expiration: Timestamp,
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Eq, PartialEq)]
+pub enum AppSessionError {
+    /// No usable session behind this caller: revoked, expired, pruned, or never one at
+    /// all. One outcome, because which of those it is depends on whether a prune has run
+    /// yet, and because an app can act on none of them differently.
+    NoMatchingSession,
+    InternalCanisterError(String),
+}


### PR DESCRIPTION
Design: #4224. Overview: #4230.

This is the PR the feature turns on: after it, a delegation an app holds is short-lived and its session is revocable.

Read hardest: the seed derivation, and the reclaim ordering in `reclaim_order` / `reclaim_sessions`. The seed decides what survives an account being renamed; the ordering decides which of a user's sessions dies when they hit the cap.

# Motivation

`DEFAULT_EXPIRATION_PERIOD_NS` is 30 minutes and `MAX_EXPIRATION_PERIOD_NS` is 30 days, with the app choosing. Nothing II can do reaches an artifact it has already handed out; rotating the salt changes what future derivations produce without touching an already-signed delegation.

The minting half already ships, scoped to MCP: a grant in `mcp_grant_memory`, delegations capped at 5 minutes, `prepare_account_delegation(max_expiration)` enforcing the absolute cap. What MCP does not need, and apps do, is many sessions per identity and somewhere to put them.

# Changes

**The identity.** `session_seed = H(salt, "session", account_seed, created_at, device_id)`, every field length-prefixed. Building on the account seed rather than on the numbers is what makes a session survive anything that leaves the account's principal unchanged — naming a default account is exactly that.

**Finding a session from a call.** A new index maps the principal a session's chain is rooted at to `{account_principal, device_id}`. An app-facing call therefore names nothing and attaches nothing: `caller()` is looked up, the account principal resolves through the principal index, and `device_id` picks the record. A hit is itself the proof that the caller is that session.

The account is named by principal rather than by locator deliberately: materialising a default changes its locator and leaves its principal alone, so naming an account touches one index entry instead of every session on it.

Nothing signed travels with the call, so there is no artifact to issue per session, none to decode, none to witness on the `get`, and nothing an app's agent has to attach.

**The browser proof.** `prepare_account_session` takes `device_key`, the `next_device_key` it rotates to, and two signatures: the current key over the session key and the successor, and the successor over the session key and the current key, under a different domain so neither can be replayed in the other's role. Proving possession of the successor is what stops a key read off the wire — ingress messages are public — being announced by someone who does not hold it and claimed when its browser next presents one.

**Replacement, not reuse.** A ceremony from a browser that already holds a session at that account deletes it and mints a new one. A copy of the old session's chain therefore stops working at the user's next sign-in rather than at its expiry, and the consent special case disappears: a change of consent and a repeat of the same consent take one path.

**The session cap is per identity.** 500 stored records — expired ones included, since nothing observes a session dying — reclaimed to a watermark of 450 rather than blocking. A `session_count` on the anchor decides whether to act; the pass it triggers walks every row the identity has, takes dead sessions before live ones, and orders the live on `last_used + (last_used − created_at)`, so an app in weekly use outranks one opened once and abandoned yesterday. Reclaiming runs **before** the new record is admitted, and admission is granted against what that pass counted rather than against the counter, so the stored set never sits above the cap. There is no per-reference cap: one browser holds one session per account, so the browser registry bounds a reference at 20 by construction.

Note what this cap does *not* do: it puts no bound on a flood of sign-ins. Standing rises with use, so anyone who can provoke sign-ins and keep refreshing them can outrank idle sessions. What stands in the way is the ceremony — creating a session needs an access method — and a stronger bound is deliberately left for whoever finds this one too weak.

**The app-facing pair.** `app_prepare_delegation` / `app_get_delegation`, capped at 5 minutes and not requestable by the app. The `get` re-derives the ceiling rather than trusting the `expiration` it is handed, since longer-lived delegations over the same account seed exist. An account principal is absent from the session index, so an app delegation cannot mint its own replacement.

# Tests

**Unit (46).** `session_creation_tests` (14): the browser's session is replaced rather than reused, a different browser gets its own, expired records are pruned on write, one reference holds one session per browser, the cap reclaims to the watermark taking expired records first and then the stalest, an account the identity does not hold is refused, and the seed binds every immutable field. `session_consent_change_tests` (4). `device_key::tests` (10): a browser holding both keys is accepted; a successor the caller cannot prove, a successor signature replayed as the current one, a signature over another session key, one paired with a substituted successor, another browser's signature, a signature over the bare session key, a key that is not P-256, a wrong length and an empty signature are each refused.

**PocketIC (29).** Creation and witnessing, browser reuse, refusal for another identity, minting through the session index, the minted principal equalling the account's own and the account principal minting nothing itself, an expired session refused, a delegation longer than the TTL refused, replacement invalidating the previous chain, a consent change not reused, a browser dropped by the registry cap losing its sessions, the registration archived with the name redacted, and for the proof: a successor the caller cannot prove, a successor another browser holds even when proven, a retired key coming back as a new browser, a replayed announcement refused, the current key accepted after a lost response, and a rotation keeping the browser entry.

