### PR TITLE
test(be): cover the discovery domain in the OpenID anchor lookup

### DIFF
--- a/src/internet_identity/src/storage/anchor/tests.rs
+++ b/src/internet_identity/src/storage/anchor/tests.rs
@@ -588,6 +588,38 @@ fn should_update_openid_credential() {
 }
 
 #[test]
+fn should_reject_openid_credential_update_with_a_different_sso_domain() {
+    let mut anchor = Anchor::new(ANCHOR_NUMBER, 0);
+    let mut stored = openid_credential(0);
+    stored.sso_domain = Some("gate.example.org".to_string());
+    anchor.add_openid_credential(stored.clone()).unwrap();
+
+    let mut foreign_domain = stored.clone();
+    foreign_domain.sso_domain = Some("other.example.org".to_string());
+    assert_eq!(
+        anchor.update_openid_credential(foreign_domain),
+        Err(AnchorError::OpenIdCredentialSsoDomainMismatch)
+    );
+
+    let mut no_domain = stored.clone();
+    no_domain.sso_domain = None;
+    assert_eq!(
+        anchor.update_openid_credential(no_domain),
+        Err(AnchorError::OpenIdCredentialSsoDomainMismatch)
+    );
+
+    assert_eq!(anchor.openid_credentials, vec![stored.clone()]);
+
+    let mut same_domain = stored.clone();
+    same_domain.metadata = HashMap::from([(
+        "name".to_string(),
+        MetadataEntryV2::String("Updated Name".to_string()),
+    )]);
+    assert_eq!(anchor.update_openid_credential(same_domain.clone()), Ok(()));
+    assert_eq!(anchor.openid_credentials, vec![same_domain]);
+}
+
+#[test]
 fn should_enforce_max_number_of_openid_credentials() {
     let mut anchor = Anchor::new(ANCHOR_NUMBER, 0);
     for i in 0..100 {

--- a/src/internet_identity/src/storage/tests.rs
+++ b/src/internet_identity/src/storage/tests.rs
@@ -236,6 +236,57 @@ fn should_write_and_update_openid_credential_lookup() {
     );
 }
 
+#[test]
+fn should_look_up_openid_credential_only_for_its_own_sso_domain() {
+    let memory = VectorMemory::default();
+    let mut storage = Storage::new((10_000, 3_784_873), memory);
+
+    let mut sso_credential = openid_credential(0);
+    sso_credential.sso_domain = Some("gate.example.org".to_string());
+    let direct_credential = openid_credential(1);
+
+    let mut anchor = storage.allocate_anchor(0).unwrap();
+    anchor
+        .add_openid_credential(sso_credential.clone())
+        .unwrap();
+    anchor
+        .add_openid_credential(direct_credential.clone())
+        .unwrap();
+    let anchor_number = anchor.anchor_number();
+    storage.write(anchor).unwrap();
+
+    assert_eq!(
+        storage
+            .lookup_anchor_with_openid_credential(&sso_credential.key(), Some("gate.example.org")),
+        Some(anchor_number)
+    );
+    assert_eq!(
+        storage
+            .lookup_anchor_with_openid_credential(&sso_credential.key(), Some("other.example.org")),
+        None
+    );
+    assert_eq!(
+        storage.lookup_anchor_with_openid_credential(&sso_credential.key(), None),
+        None
+    );
+
+    assert_eq!(
+        storage.lookup_anchor_with_openid_credential(&direct_credential.key(), None),
+        Some(anchor_number)
+    );
+    assert_eq!(
+        storage.lookup_anchor_with_openid_credential(
+            &direct_credential.key(),
+            Some("gate.example.org")
+        ),
+        None
+    );
+
+    assert!(storage.is_openid_credential_registered(&sso_credential.key()));
+    assert!(storage.is_openid_credential_registered(&direct_credential.key()));
+    assert!(!storage.is_openid_credential_registered(&openid_credential(2).key()));
+}
+
 /// The SSO stable-id index is reconciled from the anchors' stored credentials
 /// on every `write()`: a credential carrying a `stable_id` gets an entry, and
 /// removing or moving that credential removes or moves the entry — no orphans.

--- a/src/internet_identity/tests/integration/openid.rs
+++ b/src/internet_identity/tests/integration/openid.rs
@@ -1814,6 +1814,129 @@ mod sso_gating {
         Ok(())
     }
 
+    #[test]
+    fn foreign_discovery_domain_cannot_resolve_or_relabel() -> Result<(), RejectResponse> {
+        let env = env();
+        let canister_id = install(&env);
+
+        let (ii_client_jwt, jwks) = token(II_CLIENT, II_CLIENT_SUB, &[]);
+        let app_clients_a = format!(r#"{{"{GATED_ORIGIN}":"{PER_APP_CLIENT}"}}"#);
+        let responses_a = responses(well_known(&app_clients_a, false, "sub"), jwks.clone());
+        let identity_number =
+            register_with_ii_client_credential(&env, canister_id, &responses_a, &ii_client_jwt);
+
+        let app_clients_b = format!(r#"{{"{GATED_ORIGIN}":"{FOREIGN_PER_APP_CLIENT}"}}"#);
+        let responses_b = responses_on_domain(
+            FOREIGN_DOMAIN,
+            well_known(&app_clients_b, false, "sub"),
+            jwks,
+        );
+        let session_key = ByteBuf::from("dapp session key");
+
+        let ungated_via_b = drive_sso_until_ready(&env, &responses_b, || {
+            api::sso_prepare_delegation(
+                &env,
+                canister_id,
+                test_principal(),
+                &ii_client_jwt,
+                &test_salt(),
+                &session_key,
+                FOREIGN_DOMAIN,
+                UNGATED_ORIGIN,
+            )
+            .unwrap()
+        });
+        assert!(
+            matches!(ungated_via_b, Err(OpenIdDelegationError::NoSuchAnchor)),
+            "sso_prepare_delegation through a foreign domain must not resolve, got {ungated_via_b:?}"
+        );
+
+        let openid_via_b = drive_sso_until_ready(&env, &responses_b, || {
+            api::openid_prepare_delegation_with_discovery(
+                &env,
+                canister_id,
+                test_principal(),
+                &ii_client_jwt,
+                &test_salt(),
+                &session_key,
+                Some(FOREIGN_DOMAIN),
+            )
+            .unwrap()
+        });
+        assert!(
+            matches!(openid_via_b, Err(OpenIdDelegationError::NoSuchAnchor)),
+            "openid_prepare_delegation through a foreign domain must not resolve, got {openid_via_b:?}"
+        );
+
+        assert_eq!(
+            stored_sso_domain(&env, canister_id, identity_number)?,
+            Some(GATE_DOMAIN.to_string()),
+            "the stored discovery domain must survive a login through another domain"
+        );
+
+        let (gated_b_jwt, _) = token_for(
+            &test_principal_b(),
+            FOREIGN_PER_APP_CLIENT,
+            II_CLIENT_SUB,
+            &[],
+        );
+        let gated_via_b = drive_sso_until_ready(&env, &responses_b, || {
+            api::sso_prepare_delegation(
+                &env,
+                canister_id,
+                test_principal_b(),
+                &gated_b_jwt,
+                &test_salt(),
+                &session_key,
+                FOREIGN_DOMAIN,
+                GATED_ORIGIN,
+            )
+            .unwrap()
+        });
+        assert!(
+            matches!(gated_via_b, Err(OpenIdDelegationError::NoSuchAnchor)),
+            "got {gated_via_b:?}"
+        );
+
+        let via_a = expect_ready(drive_sso_until_ready(&env, &responses_a, || {
+            api::sso_prepare_delegation(
+                &env,
+                canister_id,
+                test_principal(),
+                &ii_client_jwt,
+                &test_salt(),
+                &session_key,
+                GATE_DOMAIN,
+                UNGATED_ORIGIN,
+            )
+            .unwrap()
+        }));
+        assert_eq!(via_a.anchor_number, identity_number);
+
+        Ok(())
+    }
+
+    fn stored_sso_domain(
+        env: &PocketIc,
+        canister_id: Principal,
+        identity_number: u64,
+    ) -> Result<Option<String>, RejectResponse> {
+        let info = canister_tests::api::internet_identity::api_v2::identity_info(
+            env,
+            canister_id,
+            test_principal(),
+            identity_number,
+        )?
+        .expect("identity_info");
+        Ok(info
+            .openid_credentials
+            .expect("openid credentials")
+            .into_iter()
+            .find(|cred| cred.aud == II_CLIENT)
+            .expect("II-client credential")
+            .sso_domain)
+    }
+
     /// A token minted for a different client is refused at a gated origin.
     #[test]
     fn refused_gate_mints_no_delegation() -> Result<(), RejectResponse> {


### PR DESCRIPTION
## What

Regression coverage for the lookup and update paths reworked in #4220.

**Unit**

- `should_look_up_openid_credential_only_for_its_own_sso_domain` — the lookup resolves a credential only for the domain it carries (a different domain and `None` both miss, and a credential with no domain is not reachable via one), while `is_openid_credential_registered` matches regardless of domain.
- `should_reject_openid_credential_update_with_a_different_sso_domain` — an update carrying another domain, or none, is refused and leaves the stored credential untouched; an update carrying the same domain still refreshes metadata.

**Integration**

- `foreign_discovery_domain_cannot_resolve_or_relabel` — an anchor establishes its credential through one discovery domain; a login driven through a second domain declaring the same client and issuer resolves to nothing on both `sso_prepare_delegation` and `openid_prepare_delegation`, leaves the stored `sso_domain` in place, and does not enable a subsequent gated login. A login back through the original domain still resolves.

## Tests

662 unit, 483 integration, fmt and clippy clean.

The integration test was run against a build of `21ab317` (the commit before #4220) and fails there on each of its four assertions independently; it passes against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)