### PR TITLE
refactor(be): additional input bounds

### DIFF
--- a/src/internet_identity/src/email_inbound/smtp.rs
+++ b/src/internet_identity/src/email_inbound/smtp.rs
@@ -64,8 +64,8 @@ use internet_identity_interface::internet_identity::types::email_challenge::{
 };
 use internet_identity_interface::internet_identity::types::email_recovery::EmailRecoveryCredential;
 use internet_identity_interface::internet_identity::types::smtp::{
-    smtp_err, validate_smtp_request, SmtpRequest, SmtpResponse, SMTP_ERR_MAILBOX_UNAVAILABLE,
-    SMTP_ERR_SYNTAX_ERROR, SMTP_ERR_USER_NOT_LOCAL,
+    smtp_err, validate_header_values, validate_smtp_request, SmtpRequest, SmtpResponse,
+    SMTP_ERR_MAILBOX_UNAVAILABLE, SMTP_ERR_SYNTAX_ERROR, SMTP_ERR_USER_NOT_LOCAL,
 };
 use internet_identity_interface::internet_identity::types::{AnchorNumber, SessionKey};
 
@@ -236,6 +236,15 @@ pub fn handle_smtp_request(request: SmtpRequest) -> SmtpResponse {
             return SmtpResponse::Ok {};
         }
     };
+
+    // A header value carrying a control character or a bare CR/LF did
+    // not come from a conforming MTA, and is not the value that was
+    // signed. Drop it here rather than returning an error: the response
+    // goes back as a bounce to whatever envelope sender the message
+    // claimed, so per-message problems answer `Ok` (see the module note).
+    if validate_header_values(message).is_err() {
+        return SmtpResponse::Ok {};
+    }
 
     // Extract the canister-issued nonce from the Subject header. If
     // there's no Subject, no II-Recovery- prefix, or no pending

--- a/src/internet_identity/tests/integration/email_recovery.rs
+++ b/src/internet_identity/tests/integration/email_recovery.rs
@@ -2251,10 +2251,12 @@ fn recovery_rejects_crlf_spliced_from_header() {
     let resp = api::smtp_request(&env, canister_id, &forged).expect("smtp_request call");
     assert!(matches!(resp, SmtpResponse::Ok {}));
 
-    // The attack must fail closed: the forged sender doesn't resolve to a
-    // single mailbox, so verification ends in AddressMismatch and never
-    // reaches RecoveryReady. (Pre-fix, the lenient parser resolved the
-    // smuggled `victim@` and this reached RecoveryReady — a takeover.)
+    // The attack must fail closed. The spliced value carries a bare CRLF,
+    // so the message is dropped on arrival and the challenge is left
+    // untouched rather than flipped to `Failed` — an unauthenticated
+    // sender must not be able to cancel someone else's pending challenge.
+    // (Pre-fix, the lenient parser resolved the smuggled `victim@` and
+    // this reached RecoveryReady — a takeover.)
     let status = drive_doh_resolution(
         &env,
         canister_id,
@@ -2262,11 +2264,8 @@ fn recovery_rejects_crlf_spliced_from_header() {
         &signer.public_txt_record(),
     );
     assert!(
-        matches!(
-            status,
-            EmailChallengeStatus::Failed(EmailChallengeError::AddressMismatch)
-        ),
-        "CRLF-spliced From must be rejected with AddressMismatch, got {status:?}"
+        matches!(status, EmailChallengeStatus::Pending),
+        "CRLF-spliced From must leave the challenge pending, got {status:?}"
     );
     assert!(
         !matches!(status, EmailChallengeStatus::RecoveryReady { .. }),

--- a/src/internet_identity_interface/src/internet_identity/types/smtp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/smtp.rs
@@ -261,7 +261,6 @@ pub fn validate_message(message: &SmtpMessage) -> Result<(), SmtpResponse> {
                 ),
             ));
         }
-        validate_header_value_chars(&header.name, &header.value)?;
     }
     if message.body.len() > MAX_BODY_BYTES {
         return Err(smtp_err(
@@ -273,6 +272,21 @@ pub fn validate_message(message: &SmtpMessage) -> Result<(), SmtpResponse> {
         ));
     }
     validate_header_occurrences(&message.headers)?;
+    Ok(())
+}
+
+/// Reject header field bodies carrying characters a conforming MTA
+/// would not send.
+///
+/// Deliberately not part of [`validate_message`]: an `Err` from that
+/// becomes the `SmtpResponse` the gateway bounces on, and a bounce for
+/// a malformed value would be addressed to whatever envelope sender the
+/// message claimed. The inbound path calls this and drops the message
+/// while still answering `Ok`.
+pub fn validate_header_values(message: &SmtpMessage) -> Result<(), SmtpResponse> {
+    for header in &message.headers {
+        validate_header_value_chars(&header.name, &header.value)?;
+    }
     Ok(())
 }
 
@@ -558,61 +572,61 @@ mod tests {
     }
 
     #[test]
-    fn validate_message_rejects_embedded_bare_newline() {
+    fn validate_header_values_rejects_embedded_bare_newline() {
         let mut headers = minimal_headers();
         headers.push(header("Subject", "hello\nX-Injected: yes"));
-        let resp = validate_message(&message_with(headers)).unwrap_err();
+        let resp = validate_header_values(&message_with(headers)).unwrap_err();
         assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
         assert!(err_msg(&resp).contains("malformed CR/LF"));
     }
 
     #[test]
-    fn validate_message_rejects_embedded_crlf_without_folding_wsp() {
+    fn validate_header_values_rejects_embedded_crlf_without_folding_wsp() {
         let mut headers = minimal_headers();
         headers.push(header("Subject", "hello\r\nX-Injected: yes"));
-        let resp = validate_message(&message_with(headers)).unwrap_err();
+        let resp = validate_header_values(&message_with(headers)).unwrap_err();
         assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
         assert!(err_msg(&resp).contains("malformed CR/LF"));
     }
 
     #[test]
-    fn validate_message_rejects_lone_cr() {
+    fn validate_header_values_rejects_lone_cr() {
         let mut headers = minimal_headers();
         headers.push(header("Subject", "hello\rworld"));
-        let resp = validate_message(&message_with(headers)).unwrap_err();
+        let resp = validate_header_values(&message_with(headers)).unwrap_err();
         assert!(err_msg(&resp).contains("malformed CR/LF"));
     }
 
     #[test]
-    fn validate_message_accepts_folded_value() {
+    fn validate_header_values_accepts_folded_value() {
         let mut headers = minimal_headers();
         headers.push(header(
             "Subject",
             "first line\r\n second line\r\n\tthird line",
         ));
-        assert!(validate_message(&message_with(headers)).is_ok());
+        assert!(validate_header_values(&message_with(headers)).is_ok());
     }
 
     #[test]
-    fn validate_message_accepts_value_with_gateway_trailing_crlf() {
+    fn validate_header_values_accepts_value_with_gateway_trailing_crlf() {
         let mut headers = minimal_headers();
         headers.push(header("Subject", "hello\r\n"));
-        assert!(validate_message(&message_with(headers)).is_ok());
+        assert!(validate_header_values(&message_with(headers)).is_ok());
     }
 
     #[test]
-    fn validate_message_accepts_htab_in_value() {
+    fn validate_header_values_accepts_htab_in_value() {
         let mut headers = minimal_headers();
         headers.push(header("Subject", "hello\tworld"));
-        assert!(validate_message(&message_with(headers)).is_ok());
+        assert!(validate_header_values(&message_with(headers)).is_ok());
     }
 
     #[test]
-    fn validate_message_rejects_c0_control_characters() {
+    fn validate_header_values_rejects_c0_control_characters() {
         for value in ["hello\0world", "hello\x07world", "hello\x1bworld"] {
             let mut headers = minimal_headers();
             headers.push(header("Subject", value));
-            let resp = validate_message(&message_with(headers)).unwrap_err();
+            let resp = validate_header_values(&message_with(headers)).unwrap_err();
             assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
             assert!(err_msg(&resp).contains("control character"));
         }

--- a/src/internet_identity_interface/src/internet_identity/types/smtp.rs
+++ b/src/internet_identity_interface/src/internet_identity/types/smtp.rs
@@ -261,6 +261,7 @@ pub fn validate_message(message: &SmtpMessage) -> Result<(), SmtpResponse> {
                 ),
             ));
         }
+        validate_header_value_chars(&header.name, &header.value)?;
     }
     if message.body.len() > MAX_BODY_BYTES {
         return Err(smtp_err(
@@ -272,6 +273,49 @@ pub fn validate_message(message: &SmtpMessage) -> Result<(), SmtpResponse> {
         ));
     }
     validate_header_occurrences(&message.headers)?;
+    Ok(())
+}
+
+/// Reject C0 control characters in a header field body. HTAB is legal
+/// inside a field body (RFC 5322 §3.2.2), and a `CRLF` immediately
+/// followed by SP or HTAB is folding white space (§2.2.3) rather than a
+/// line break. Every other CR or LF ends the field early, so a value
+/// carrying one describes two headers instead of the one the caller
+/// declared; the remaining C0 bytes cannot appear in a field body at
+/// all.
+///
+/// The gateway can hand us the field body with its terminating CRLF
+/// still attached, so one trailing CR/LF run is dropped before the scan.
+fn validate_header_value_chars(name: &str, value: &str) -> Result<(), SmtpResponse> {
+    let bytes = value.trim_end_matches(['\r', '\n']).as_bytes();
+    let crlf_err = || {
+        smtp_err(
+            SMTP_ERR_SYNTAX_ERROR,
+            format!("Header '{name}' value contains a malformed CR/LF sequence"),
+        )
+    };
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\t' => i += 1,
+            b'\r' => {
+                if bytes.get(i + 1).copied() != Some(b'\n')
+                    || !matches!(bytes.get(i + 2).copied(), Some(b' ' | b'\t'))
+                {
+                    return Err(crlf_err());
+                }
+                i += 2;
+            }
+            b'\n' => return Err(crlf_err()),
+            b if b < 0x20 => {
+                return Err(smtp_err(
+                    SMTP_ERR_SYNTAX_ERROR,
+                    format!("Header '{name}' value contains a control character"),
+                ));
+            }
+            _ => i += 1,
+        }
+    }
     Ok(())
 }
 
@@ -511,6 +555,67 @@ mod tests {
         };
         let resp = validate_message(&msg).unwrap_err();
         assert!(err_msg(&resp).contains("Body size"));
+    }
+
+    #[test]
+    fn validate_message_rejects_embedded_bare_newline() {
+        let mut headers = minimal_headers();
+        headers.push(header("Subject", "hello\nX-Injected: yes"));
+        let resp = validate_message(&message_with(headers)).unwrap_err();
+        assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
+        assert!(err_msg(&resp).contains("malformed CR/LF"));
+    }
+
+    #[test]
+    fn validate_message_rejects_embedded_crlf_without_folding_wsp() {
+        let mut headers = minimal_headers();
+        headers.push(header("Subject", "hello\r\nX-Injected: yes"));
+        let resp = validate_message(&message_with(headers)).unwrap_err();
+        assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
+        assert!(err_msg(&resp).contains("malformed CR/LF"));
+    }
+
+    #[test]
+    fn validate_message_rejects_lone_cr() {
+        let mut headers = minimal_headers();
+        headers.push(header("Subject", "hello\rworld"));
+        let resp = validate_message(&message_with(headers)).unwrap_err();
+        assert!(err_msg(&resp).contains("malformed CR/LF"));
+    }
+
+    #[test]
+    fn validate_message_accepts_folded_value() {
+        let mut headers = minimal_headers();
+        headers.push(header(
+            "Subject",
+            "first line\r\n second line\r\n\tthird line",
+        ));
+        assert!(validate_message(&message_with(headers)).is_ok());
+    }
+
+    #[test]
+    fn validate_message_accepts_value_with_gateway_trailing_crlf() {
+        let mut headers = minimal_headers();
+        headers.push(header("Subject", "hello\r\n"));
+        assert!(validate_message(&message_with(headers)).is_ok());
+    }
+
+    #[test]
+    fn validate_message_accepts_htab_in_value() {
+        let mut headers = minimal_headers();
+        headers.push(header("Subject", "hello\tworld"));
+        assert!(validate_message(&message_with(headers)).is_ok());
+    }
+
+    #[test]
+    fn validate_message_rejects_c0_control_characters() {
+        for value in ["hello\0world", "hello\x07world", "hello\x1bworld"] {
+            let mut headers = minimal_headers();
+            headers.push(header("Subject", value));
+            let resp = validate_message(&message_with(headers)).unwrap_err();
+            assert_eq!(err_code(&resp), SMTP_ERR_SYNTAX_ERROR);
+            assert!(err_msg(&resp).contains("control character"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Bound the characters a header field body may carry:

- C0 control characters are refused.
- HTAB is allowed (RFC 5322 §3.2.2).
- `CRLF` immediately followed by SP or HTAB is allowed as folding white space (§2.2.3); any other CR or LF is refused.
- One trailing CR/LF run is dropped before the scan, since the gateway can leave its terminating CRLF attached.

The check lives beside `validate_message` rather than inside it. An `Err` from that path becomes the `SmtpResponse` the gateway acts on, and `handle_smtp_request` reserves those for envelope and request shape — per-message outcomes answer `Ok` (module note in `email_inbound/smtp.rs`). So the inbound path runs the check and drops the message while still answering `Ok`, alongside the other silent-drop cases.

`validate_message` itself is unchanged, and errors keep the existing `smtp_err(SMTP_ERR_SYNTAX_ERROR, …)` shape.

## Tests

- `cargo test -p internet_identity_interface --lib` — 85 passed
- `cargo test -p internet_identity --bins` — 660 passed
- `scripts/test-canisters.sh email_recovery::` — 33 passed

New cases in `types::smtp::tests`: embedded bare LF, embedded CRLF without folding WSP, lone CR, folded value, value carrying a trailing CRLF, HTAB in value, and NUL / BEL / ESC.

`recovery_rejects_crlf_spliced_from_header` keeps asserting `Ok` on the wire and that recovery never completes. Since the spliced message is now dropped on arrival, the challenge is left pending rather than reaching `Failed(AddressMismatch)` — leaving it untouched also means an unauthenticated sender cannot cancel someone else's pending challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
