### PR TITLE
fix(fe): don't establish the authorize channel while redirecting to the primary origin

### DIFF
--- a/src/frontend/src/lib/stores/channelStore.ts
+++ b/src/frontend/src/lib/stores/channelStore.ts
@@ -53,9 +53,16 @@ type ChannelStore = Readable<Channel | undefined> & {
 
 const getTransports = (): Transport[] => {
   const primaryOrigin = getPrimaryOrigin();
+  // Off the primary origin this document is on its way there, and both of these
+  // transports pin the signer origin the moment the client answers their
+  // handshake — stranding it on a document that is being replaced. Only the
+  // legacy transport belongs here; it carries its request across the redirect.
+  const offPrimaryOrigin =
+    primaryOrigin !== undefined && window.location.origin !== primaryOrigin;
   return [
-    new PostMessageTransport(),
-    new UrlTransport(),
+    ...(offPrimaryOrigin
+      ? []
+      : [new PostMessageTransport(), new UrlTransport()]),
     new LegacyTransport(
       // Redirect requests and responses between related origins and primary origin
       primaryOrigin !== undefined

--- a/src/frontend/src/lib/stores/channelStore.ts
+++ b/src/frontend/src/lib/stores/channelStore.ts
@@ -53,10 +53,12 @@ type ChannelStore = Readable<Channel | undefined> & {
 
 const getTransports = (): Transport[] => {
   const primaryOrigin = getPrimaryOrigin();
-  // Off the primary origin this document is on its way there, and both of these
-  // transports pin the signer origin the moment the client answers their
-  // handshake — stranding it on a document that is being replaced. Only the
-  // legacy transport belongs here; it carries its request across the redirect.
+  // A document loaded from a related origin is already redirecting to the
+  // primary origin. An ICRC-29 client pins the signer origin as soon as it
+  // answers the handshake, so establishing one here would leave it talking to a
+  // document that is about to be replaced, until its disconnect timeout closes
+  // the window. The legacy transport is exempt: it takes its own request to the
+  // primary origin rather than handshaking here.
   const offPrimaryOrigin =
     primaryOrigin !== undefined && window.location.origin !== primaryOrigin;
   return [

--- a/src/frontend/src/lib/utils/primaryOrigin.test.ts
+++ b/src/frontend/src/lib/utils/primaryOrigin.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetPrimaryOrigin } = vi.hoisted(() => ({
+  mockGetPrimaryOrigin: vi.fn<() => string | undefined>(),
+}));
+
+vi.mock("$lib/globals", () => ({
+  getPrimaryOrigin: mockGetPrimaryOrigin,
+}));
+
+const PRIMARY_ORIGIN = "https://id.ai";
+const LEGACY_ORIGIN = "https://identity.ic0.app";
+
+// `window.location` is read-only, so swap it for a stand-in pointed at the URL
+// under test. Capture the original property descriptor (not just the value) so
+// `afterEach` can restore `location` exactly as it was.
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "location",
+);
+const replace = vi.fn();
+
+const setLocation = (href: string) => {
+  const { origin, pathname, search, hash } = new URL(href);
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { origin, pathname, search, hash, replace },
+  });
+};
+
+// The redirect is latched in module state, so every case needs a fresh module.
+const loadPrimaryOrigin = () => {
+  vi.resetModules();
+  return import("./primaryOrigin");
+};
+
+const legacyRedirectHash = (sourceOrigin: string) => {
+  const params = new URLSearchParams();
+  params.set(
+    "redirect_message",
+    JSON.stringify({ origin: "https://dapp.example", data: {} }),
+  );
+  params.set("redirect_origin", sourceOrigin);
+  return `#${params.toString()}`;
+};
+
+beforeEach(() => {
+  replace.mockClear();
+  mockGetPrimaryOrigin.mockReturnValue(PRIMARY_ORIGIN);
+});
+
+afterEach(() => {
+  if (originalLocationDescriptor !== undefined) {
+    Object.defineProperty(window, "location", originalLocationDescriptor);
+  } else {
+    delete (window as { location?: unknown }).location;
+  }
+});
+
+describe("redirectToPrimaryOrigin", () => {
+  it("redirects an authorize page loaded from a related origin", async () => {
+    setLocation(`${LEGACY_ORIGIN}/authorize?foo=bar`);
+    const { redirectToPrimaryOrigin, isRedirectingToPrimaryOrigin } =
+      await loadPrimaryOrigin();
+
+    expect(redirectToPrimaryOrigin()).toBe(true);
+    expect(replace).toHaveBeenCalledWith(`${PRIMARY_ORIGIN}/authorize?foo=bar`);
+    expect(isRedirectingToPrimaryOrigin()).toBe(true);
+  });
+
+  it("keeps a legacy response bounced back from the primary origin", async () => {
+    setLocation(
+      `${LEGACY_ORIGIN}/authorize${legacyRedirectHash(PRIMARY_ORIGIN)}`,
+    );
+    const { redirectToPrimaryOrigin, isRedirectingToPrimaryOrigin } =
+      await loadPrimaryOrigin();
+
+    expect(redirectToPrimaryOrigin()).toBe(false);
+    expect(replace).not.toHaveBeenCalled();
+    expect(isRedirectingToPrimaryOrigin()).toBe(false);
+  });
+
+  it("redirects when the redirect message comes from another origin", async () => {
+    setLocation(
+      `${LEGACY_ORIGIN}/authorize${legacyRedirectHash("https://attacker.example")}`,
+    );
+    const { redirectToPrimaryOrigin } = await loadPrimaryOrigin();
+
+    expect(redirectToPrimaryOrigin()).toBe(true);
+    expect(replace).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/lib/utils/primaryOrigin.ts
+++ b/src/frontend/src/lib/utils/primaryOrigin.ts
@@ -37,13 +37,15 @@ export const redirectToPrimaryOrigin = (): boolean => {
     return false;
   }
   const { pathname, search, hash } = window.location;
-  // Legacy AuthClient, the legacy transport carries the request across the
-  // redirect itself and bounces the response back to this origin.
+  // Legacy transport, outgoing leg: the dapp posts its request to this document
+  // and the transport takes it to the primary origin itself.
   if (pathname === "/" && hash === "#authorize") {
     return false;
   }
-  // Same exchange, response leg: only this document can finish it, the redirect
-  // session that re-wraps the delegation lives in this origin's `sessionStorage`.
+  // Legacy transport, return leg: the primary origin bounced the response back
+  // to this origin, and only this document can finish it — the redirect session
+  // that re-wraps the delegation for the dapp lives in this origin's
+  // `sessionStorage`, and the dapp is holding this window.
   const bounced = new URLSearchParams(hash.replace(/^#/, ""));
   if (
     bounced.has("redirect_message") &&

--- a/src/frontend/src/lib/utils/primaryOrigin.ts
+++ b/src/frontend/src/lib/utils/primaryOrigin.ts
@@ -42,6 +42,15 @@ export const redirectToPrimaryOrigin = (): boolean => {
   if (pathname === "/" && hash === "#authorize") {
     return false;
   }
+  // Same exchange, response leg: only this document can finish it, the redirect
+  // session that re-wraps the delegation lives in this origin's `sessionStorage`.
+  const bounced = new URLSearchParams(hash.replace(/^#/, ""));
+  if (
+    bounced.has("redirect_message") &&
+    bounced.get("redirect_origin") === primaryOrigin
+  ) {
+    return false;
+  }
   if (KEEP_ON_CURRENT_ORIGIN.includes(pathname)) {
     return false;
   }


### PR DESCRIPTION
`legacy.spec.ts:52` — a dapp pointing its ICRC-25 transport at a legacy domain — fails on mobile with `Target page, context or browser has been closed`, on `main` as well as here (e.g. [run 32347808452](https://github.com/dfinity/internet-identity/actions/runs/32347808452), both legacy domains, 3/3 attempts). #4210's redirect to the primary origin is supposed to happen before anything talks to the dapp, but nothing enforces that: `location.replace` only schedules the navigation, the app hydrates on the legacy document anyway, and the channel is established right there.

## Changes

`redirectToPrimaryOrigin`, in the client `init` hook, no longer redirects a document whose hash carries a redirect message from the primary origin. That leg of the legacy relay has to finish where the dapp opened it, since `endRedirectSession` needs the key `startRedirectSession` left in this origin's `sessionStorage`. It reads the two params the relay uses straight off the hash, and requires the primary origin as the sender so a crafted hash can't pin an authorize page to a legacy domain.

`getTransports` then only constructs the postMessage and URL transports on the primary origin — or when no primary origin is configured, which is also when nothing redirects. Both pin the signer origin the moment the client answers their handshake, so off-primary that hands the client a window which is about to be replaced. Restricting where they exist makes it impossible instead of a race the navigation usually wins. The legacy transport is unaffected: it carries its own request across the redirect.

## Tests

`primaryOrigin.test.ts` covers the redirect decision per leg: the bounced response stays, a plain `/authorize` redirects, a message from any other origin still redirects. `legacy.spec.ts:18` and `:52` cover the two flows end to end.
