### PR TITLE
Increase maximum number of alternative origins to 100

### DIFF
--- a/docs/ii-spec.mdx
+++ b/docs/ii-spec.mdx
@@ -282,7 +282,7 @@ sequenceDiagram
 
 Requirements:
 
-- No more than 10 alternative origins can be listed in the `/.well-known/ii-alternative-origins` file.
+- No more than 100 alternative origins can be listed in the `/.well-known/ii-alternative-origins` file.
 - Derivation Origin must expose the `/.well-known/ii-alternative-origins` file.
 - The `/.well-known/ii-alternative-origins` file must be hosted by an ICP canister that must implement the `http_request` query call.
 - The alternative origins must be present in the file `/.well-known/ii-alternative-origins` of the derivation origin requested.
@@ -304,7 +304,7 @@ Requirements:
         "type": "string"
       },
       "minItems": 0,
-      "maxItems": 10,
+      "maxItems": 100,
       "uniqueItems": true
     }
   },
@@ -328,7 +328,7 @@ The path `/.well-known/ii-alternative-origins` will always be requested using th
 :::
 
 :::note
-To prevent misuse of this feature, the number of alternative origins _must not_ be greater than 10.
+To prevent misuse of this feature, the number of alternative origins _must not_ be greater than 100.
 :::
 
 :::note

--- a/src/frontend/src/lib/utils/validateDerivationOrigin.test.ts
+++ b/src/frontend/src/lib/utils/validateDerivationOrigin.test.ts
@@ -154,6 +154,57 @@ test("should not validate if canister id resolution fails", async () => {
   expect(result.result).toBe("invalid");
 });
 
+// Spelled out rather than imported from the implementation so that lowering
+// the limit there makes these boundary tests fail instead of following along.
+const MAX_ALTERNATIVE_ORIGINS = 100;
+
+// A list of the given length whose last entry is the request origin used by
+// the boundary tests below, so that only the number of entries decides the
+// outcome.
+const alternativeOriginsOfLength = (length: number): string[] => [
+  ...Array.from({ length: length - 1 }, (_, index) => `https://a${index}.com`),
+  "https://example.com",
+];
+
+test("should validate if alternative origins file has the maximum number of entries", async () => {
+  setupMocks({
+    iiUrl: "https://id.ai",
+    response: Response.json({
+      alternativeOrigins: alternativeOriginsOfLength(MAX_ALTERNATIVE_ORIGINS),
+    }),
+  });
+
+  const result = await validateDerivationOrigin({
+    requestOrigin: "https://example.com",
+    derivationOrigin: "https://some-url.com", // different from requestOrigin so that we need to fetch the alternative origins
+    resolveCanisterId: () => Promise.resolve({ ok: TEST_CANISTER_ID }),
+  });
+
+  expect(result).toEqual({ result: "valid" });
+});
+
+test("should not validate if alternative origins file has too many entries", async () => {
+  setupMocks({
+    iiUrl: "https://id.ai",
+    response: Response.json({
+      alternativeOrigins: alternativeOriginsOfLength(
+        MAX_ALTERNATIVE_ORIGINS + 1,
+      ),
+    }),
+  });
+
+  const result = await validateDerivationOrigin({
+    requestOrigin: "https://example.com",
+    derivationOrigin: "https://some-url.com", // different from requestOrigin so that we need to fetch the alternative origins
+    resolveCanisterId: () => Promise.resolve({ ok: TEST_CANISTER_ID }),
+  });
+
+  expect(result).toEqual({
+    result: "invalid",
+    message: expect.stringContaining("has too many entries"),
+  });
+});
+
 const validIIUrls = [
   "https://identity.ic0.app",
   "https://identity.internetcomputer.org",

--- a/src/frontend/src/lib/utils/validateDerivationOrigin.ts
+++ b/src/frontend/src/lib/utils/validateDerivationOrigin.ts
@@ -3,7 +3,7 @@ import { remapToLegacyDomain } from "$lib/utils/iiConnection";
 import { wrapError } from "$lib/utils/utils";
 import { Principal } from "@icp-sdk/core/principal";
 
-const MAX_ALTERNATIVE_ORIGINS = 10;
+const MAX_ALTERNATIVE_ORIGINS = 100;
 type ValidationResult =
   { result: "valid" } | { result: "invalid"; message: string };
 

--- a/src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts
@@ -131,12 +131,14 @@ test("Should not issue delegation when /.well-known/ii-alternative-origins has t
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
   await page.locator("#hostUrl").fill("https://localhost:5173");
 
-  // Set up alternative origins with 101 entries (exceeding the 100 limit)
+  // Set up alternative origins with 101 entries (exceeding the 100 limit).
+  // The requesting origin is one of them, so the only thing that can make
+  // this sign-in fail is the entry limit itself.
   const tooManyOrigins = JSON.stringify({
-    alternativeOrigins: Array.from(
-      { length: 101 },
-      (_, index) => `https://a${index}.com`,
-    ),
+    alternativeOrigins: [
+      ...Array.from({ length: 100 }, (_, index) => `https://a${index}.com`),
+      TEST_APP_URL,
+    ],
   });
 
   await page.locator("#newAlternativeOrigins").fill(tooManyOrigins);

--- a/src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts
+++ b/src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts
@@ -131,21 +131,12 @@ test("Should not issue delegation when /.well-known/ii-alternative-origins has t
   await page.getByRole("textbox", { name: "Identity Provider" }).fill(II_URL);
   await page.locator("#hostUrl").fill("https://localhost:5173");
 
-  // Set up alternative origins with 11 entries (exceeding the 10 limit)
+  // Set up alternative origins with 101 entries (exceeding the 100 limit)
   const tooManyOrigins = JSON.stringify({
-    alternativeOrigins: [
-      "https://a0.com",
-      "https://a1.com",
-      "https://a2.com",
-      "https://a3.com",
-      "https://a4.com",
-      "https://a5.com",
-      "https://a6.com",
-      "https://a7.com",
-      "https://a8.com",
-      "https://a9.com",
-      "https://a10.com",
-    ],
+    alternativeOrigins: Array.from(
+      { length: 101 },
+      (_, index) => `https://a${index}.com`,
+    ),
   });
 
   await page.locator("#newAlternativeOrigins").fill(tooManyOrigins);


### PR DESCRIPTION
# Motivation

The `/.well-known/ii-alternative-origins` file was capped at 10 entries, which is
restrictive for services that legitimately run many frontends under a single
derivation origin. This raises the cap to 100.

# Changes

- `src/frontend/src/lib/utils/validateDerivationOrigin.ts`: `MAX_ALTERNATIVE_ORIGINS`
  raised from `10` to `100`. The user-facing error message interpolates the constant,
  so it now reports the new limit automatically.
- `docs/ii-spec.mdx`: updated the three places stating the limit — the requirements
  list, the JSON schema's `maxItems`, and the "to prevent misuse" note.
- `src/frontend/tests/e2e-playwright/routes/authorize/alternativeOrigins.spec.ts`:
  the "too many entries" test now lists 101 origins. The requesting origin is one
  of them, so the entry limit is the only thing that can reject the sign-in —
  previously the fixture listed only unrelated origins, meaning the test failed at
  the "origin not allowed" check and would have kept passing with the limit removed.
- `src/frontend/src/lib/utils/validateDerivationOrigin.test.ts`: new unit cases for
  both sides of the boundary — exactly 100 entries validates, 101 is rejected with
  the "has too many entries" message. The expected maximum is spelled out in the
  test rather than imported from the implementation, so lowering the limit fails
  the test instead of silently following along.

No backend/Rust change was needed — the limit is enforced only in the frontend
validation of the fetched `ii-alternative-origins` document.

# Tests

- `validateDerivationOrigin.test.ts`: 25/25 pass, including the two new boundary cases.
- Mutation-checked the boundary coverage: temporarily setting the constant back to
  `10` fails the 100-entry case; restoring `100` makes the file green again.
- `prettier --check`, `eslint --max-warnings 0`, and
  `tsc --project tsconfig.all.json --noEmit` are clean on the changed files.
- The Playwright e2e suite was not run locally (it needs a replica and the built
  canisters); CI covers it.
- Unrelated pre-existing local failures in `findWebAuthnFlows`, `iiConnection`, and
  `appMetadata` reproduce identically without these changes — they are environment
  gaps in the sandbox, not regressions.