### PR TITLE
chore(ci): allow the bots to update the pinned external releases

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -2,6 +2,8 @@
 # This is to increase security and prevent accidentally updating files that shouldn't be changed by a bot
 .didc-checksums
 .didc-release
+.github/versions/test-app
+.github/versions/vc-issuer
 .icp-cli-version
 .node-version
 .nvmrc
@@ -9,3 +11,6 @@ README.md
 rust-toolchain.toml
 src/frontend/src/lib/assets/aaguid/password_managers.json
 src/frontend/src/lib/assets/aaguid/security_keys.json
+src/frontend/src/lib/generated/vc_issuer_idl.js
+src/vc-api/src/generated/vc_issuer_types.ts
+src/vc-api/vc_demo_issuer.did


### PR DESCRIPTION
`.github/repo_policies/BOT_APPROVED_FILES` never listed the files our two
external-release update workflows commit, so the PRs they open fail
`check-repo-policies / Check Bot Policies` and the bump has to be applied by
hand. #4262 is the current instance.

## What was missing

| Workflow | Commits | Was allowlisted |
| --- | --- | --- |
| `update-test-app.yml` | `.github/versions/test-app` | no |
| `update-vc-issuer.yml` | `.github/versions/vc-issuer` | no |
| `update-vc-issuer.yml` | `src/vc-api/vc_demo_issuer.did` | no |
| `update-vc-issuer.yml` | `src/vc-api/src/generated/vc_issuer_types.ts` | no |
| `update-vc-issuer.yml` | `src/frontend/src/lib/generated/vc_issuer_idl.js` | no |

The VC-issuer bot regenerates the Candid, types and idl in the same commit as
its pin, so all four are listed rather than just the pin — its PRs touch the
whole set or none of it, and allowlisting only the pin would leave them just as
blocked.

I checked the other two bot workflows while I was here: `update-deps.yml`
(`rust-toolchain.toml`, `.node-version`, `.nvmrc`, `.didc-release`,
`.didc-checksums`, `.icp-cli-version`) and `update-passkey-aaguid.yml` (the two
aaguid JSONs) are already fully covered. With this change every path any bot
workflow writes is listed, and nothing beyond them.

Entries are inserted in the file's existing sort order. The trailing newline the
file was missing comes along with it.

## After this merges

Re-running the failed check on #4262 should pass, since the policy check reads
the allowlist from the PR's merge with `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
